### PR TITLE
[TECH] déplace getCsvAssmentExport dans son bounded context (pix-10409)

### DIFF
--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -129,25 +129,6 @@ const register = async function (server) {
     },
     {
       method: 'GET',
-      path: '/api/campaigns/{id}/csv-assessment-results',
-      config: {
-        auth: false,
-        validate: {
-          params: Joi.object({
-            id: identifiersType.campaignId,
-          }),
-        },
-        handler: campaignController.getCsvAssessmentResults,
-        notes: [
-          "- **Cette route est restreinte via un token dédié passé en paramètre avec l'id de l'utilisateur.**\n" +
-            "- Récupération d'un CSV avec les résultats de la campagne d‘évaluation\n" +
-            '- L‘utilisateur doit avoir les droits d‘accès à l‘organisation liée à la campagne à créer',
-        ],
-        tags: ['api', 'campaign'],
-      },
-    },
-    {
-      method: 'GET',
       path: '/api/campaigns/{id}/collective-results',
       config: {
         validate: {

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -32,11 +32,9 @@ import * as campaignAssessmentParticipationResultRepository from '../../infrastr
 import * as codeGenerator from '../services/code-generator.js';
 import * as campaignCollectiveResultRepository from '../../infrastructure/repositories/campaign-collective-result-repository.js';
 import * as campaignCreatorRepository from '../../../src/prescription/campaign/infrastructure/repositories/campaign-creator-repository.js';
-import * as campaignCsvExportService from '../../domain/services/campaign-csv-export-service.js';
 import * as campaignForArchivingRepository from '../../infrastructure/repositories/campaign/campaign-for-archiving-repository.js';
 import * as campaignManagementRepository from '../../infrastructure/repositories/campaign-management-repository.js';
 import * as campaignParticipantRepository from '../../infrastructure/repositories/campaign-participant-repository.js';
-import * as campaignParticipationInfoRepository from '../../infrastructure/repositories/campaign-participation-info-repository.js';
 import * as campaignParticipationOverviewRepository from '../../infrastructure/repositories/campaign-participation-overview-repository.js';
 import * as campaignParticipationRepository from '../../infrastructure/repositories/campaign-participation-repository.js';
 import * as campaignProfileRepository from '../../infrastructure/repositories/campaign-profile-repository.js';
@@ -234,12 +232,10 @@ const dependencies = {
   campaignAssessmentParticipationResultRepository,
   campaignCollectiveResultRepository,
   campaignCreatorRepository,
-  campaignCsvExportService,
   campaignForArchivingRepository,
   campaignManagementRepository,
   campaignParticipantActivityRepository,
   campaignParticipantRepository,
-  campaignParticipationInfoRepository,
   campaignParticipationOverviewRepository,
   campaignParticipationRepository,
   campaignParticipationResultRepository,

--- a/api/lib/infrastructure/repositories/target-profile-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-repository.js
@@ -49,19 +49,6 @@ const get = async function (id, domainTransaction = DomainTransaction.emptyTrans
   });
 };
 
-const getByCampaignId = async function (campaignId) {
-  const bookshelfTargetProfile = await BookshelfTargetProfile.query((qb) => {
-    qb.innerJoin('campaigns', 'campaigns.targetProfileId', 'target-profiles.id');
-  })
-    .where({ 'campaigns.id': campaignId })
-    .fetch({
-      withRelated: ['badges'],
-    });
-  return targetProfileAdapter.fromDatasourceObjects({
-    bookshelfTargetProfile,
-  });
-};
-
 const findByIds = async function (targetProfileIds) {
   const targetProfilesBookshelf = await BookshelfTargetProfile.query((qb) => {
     qb.whereIn('id', targetProfileIds);
@@ -126,4 +113,4 @@ const hasTubesWithLevels = async function (
   }
 };
 
-export { create, get, getByCampaignId, findByIds, update, findOrganizationIds, hasTubesWithLevels };
+export { create, get, findByIds, update, findOrganizationIds, hasTubesWithLevels };

--- a/api/src/prescription/campaign/application/campaign-detail-route.js
+++ b/api/src/prescription/campaign/application/campaign-detail-route.js
@@ -56,6 +56,25 @@ const register = async function (server) {
         tags: ['api', 'campaign'],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/campaigns/{id}/csv-assessment-results',
+      config: {
+        auth: false,
+        validate: {
+          params: Joi.object({
+            id: identifiersType.campaignId,
+          }),
+        },
+        handler: campaignDetailController.getCsvAssessmentResults,
+        notes: [
+          "- **Cette route est restreinte via un token dédié passé en paramètre avec l'id de l'utilisateur.**\n" +
+            "- Récupération d'un CSV avec les résultats de la campagne d‘évaluation\n" +
+            '- L‘utilisateur doit avoir les droits d‘accès à l‘organisation liée à la campagne à créer',
+        ],
+        tags: ['api', 'campaign'],
+      },
+    },
   ]);
 };
 

--- a/api/src/prescription/campaign/domain/services/campaign-csv-export-service.js
+++ b/api/src/prescription/campaign/domain/services/campaign-csv-export-service.js
@@ -1,6 +1,6 @@
-import { CampaignAssessmentCsvLine } from '../../infrastructure/utils/CampaignAssessmentCsvLine.js';
-import * as csvSerializer from '../../infrastructure/serializers/csv/csv-serializer.js';
-import * as campaignParticipationService from '../services/campaign-participation-service.js';
+import { CampaignAssessmentCsvLine } from '../../../../../lib/infrastructure/utils/CampaignAssessmentCsvLine.js';
+import * as csvSerializer from '../../../../../lib/infrastructure/serializers/csv/csv-serializer.js';
+import * as campaignParticipationService from '../../../../../lib/domain/services/campaign-participation-service.js';
 
 export { createOneCsvLine };
 

--- a/api/src/prescription/campaign/domain/usecases/index.js
+++ b/api/src/prescription/campaign/domain/usecases/index.js
@@ -1,41 +1,55 @@
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import * as badgeRepository from '../../../../shared/infrastructure/repositories/badge-repository.js';
-import * as campaignRepository from '../../../../../lib/infrastructure/repositories/campaign-repository.js';
 import * as campaignAdministrationRepository from '../../infrastructure/repositories/campaign-administration-repository.js';
 import * as campaignCreatorRepository from '../../infrastructure/repositories/campaign-creator-repository.js';
 import * as campaignParticipationRepository from '../../infrastructure/repositories/campaign-participation-repository.js';
+import * as campaignParticipationInfoRepository from '../../infrastructure/repositories/campaign-participation-info-repository.js';
 import * as campaignReportRepository from '../../infrastructure/repositories/campaign-report-repository.js';
-import * as campaignAssessmentParticipationResultListRepository from '../../infrastructure/repositories/campaign-assessment-participation-result-list-repository.js';
 import * as campaignProfilesCollectionParticipationSummaryRepository from '../../infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js';
+import * as campaignAssessmentParticipationResultListRepository from '../../infrastructure/repositories/campaign-assessment-participation-result-list-repository.js';
+import * as targetProfileRepository from '../../infrastructure/repositories/target-profile-repository.js';
 
-import * as codeGenerator from '../../../../../lib/domain/services/code-generator.js';
+import * as campaignCsvExportService from '../services/campaign-csv-export-service.js';
+
+import * as badgeRepository from '../../../../shared/infrastructure/repositories/badge-repository.js';
 import * as competenceRepository from '../../../../shared/infrastructure/repositories/competence-repository.js';
+import * as userRepository from '../../../../shared/infrastructure/repositories/user-repository.js';
+
+import * as badgeAcquisitionRepository from '../../../../../lib/infrastructure/repositories/badge-acquisition-repository.js';
+import * as campaignRepository from '../../../../../lib/infrastructure/repositories/campaign-repository.js';
+import * as codeGenerator from '../../../../../lib/domain/services/code-generator.js';
+import * as knowledgeElementRepository from '../../../../../lib/infrastructure/repositories/knowledge-element-repository.js';
+import * as learningContentRepository from '../../../../../lib/infrastructure/repositories/learning-content-repository.js';
 import * as membershipRepository from '../../../../../lib/infrastructure/repositories/membership-repository.js';
 import * as organizationRepository from '../../../../../lib/infrastructure/repositories/organization-repository.js';
 import * as placementProfileService from '../../../../../lib/domain/services/placement-profile-service.js';
 import * as stageCollectionRepository from '../../../../../lib/infrastructure/repositories/user-campaign-results/stage-collection-repository.js';
-import * as userRepository from '../../../../shared/infrastructure/repositories/user-repository.js';
 
 import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
 
 const dependencies = {
+  badgeAcquisitionRepository,
   badgeRepository,
   campaignRepository,
   campaignAdministrationRepository,
   campaignCreatorRepository,
+  campaignCsvExportService,
   campaignParticipationRepository,
   campaignProfilesCollectionParticipationSummaryRepository,
+  campaignParticipationInfoRepository,
   campaignReportRepository,
   campaignAssessmentParticipationResultListRepository,
   codeGenerator,
   competenceRepository,
+  knowledgeElementRepository,
+  learningContentRepository,
   membershipRepository,
   organizationRepository,
   placementProfileService,
   stageCollectionRepository,
+  targetProfileRepository, // TODO
   userRepository,
 };
 

--- a/api/src/prescription/campaign/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
+++ b/api/src/prescription/campaign/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
@@ -6,10 +6,13 @@ import timezone from 'dayjs/plugin/timezone.js';
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
-import { CONCURRENCY_HEAVY_OPERATIONS, CHUNK_SIZE_CAMPAIGN_RESULT_PROCESSING } from '../../infrastructure/constants.js';
-import { UserNotAuthorizedToGetCampaignResultsError, CampaignTypeError } from '../errors.js';
-import * as csvSerializer from '../../infrastructure/serializers/csv/csv-serializer.js';
-import { CampaignLearningContent } from '../models/CampaignLearningContent.js';
+import {
+  CONCURRENCY_HEAVY_OPERATIONS,
+  CHUNK_SIZE_CAMPAIGN_RESULT_PROCESSING,
+} from '../../../../../lib/infrastructure/constants.js';
+import { UserNotAuthorizedToGetCampaignResultsError, CampaignTypeError } from '../../../../../lib/domain/errors.js';
+import * as csvSerializer from '../../../../../lib/infrastructure/serializers/csv/csv-serializer.js';
+import { CampaignLearningContent } from '../../../../../lib/domain/models/CampaignLearningContent.js';
 
 const startWritingCampaignAssessmentResultsToStream = async function ({
   userId,
@@ -30,6 +33,7 @@ const startWritingCampaignAssessmentResultsToStream = async function ({
   const campaign = await campaignRepository.get(campaignId);
   const translate = i18n.__;
 
+  // Todo : à migrer dans un prehandler pour limiter l'injection de repository
   await _checkCreatorHasAccessToCampaignOrganization(userId, campaign.organizationId, userRepository);
 
   if (!campaign.isAssessment()) {

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-participation-info-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-participation-info-repository.js
@@ -1,6 +1,6 @@
-import { knex } from '../../../db/knex-database-connection.js';
-import { Assessment } from '../../../src/shared/domain/models/Assessment.js';
-import { CampaignParticipationInfo } from '../../domain/read-models/CampaignParticipationInfo.js';
+import { knex } from '../../../../../db/knex-database-connection.js';
+import { Assessment } from '../../../../shared/domain/models/Assessment.js';
+import { CampaignParticipationInfo } from '../../../../../lib/domain/read-models/CampaignParticipationInfo.js';
 
 const findByCampaignId = async function (campaignId) {
   const results = await knex

--- a/api/src/prescription/campaign/infrastructure/repositories/target-profile-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/target-profile-repository.js
@@ -1,0 +1,17 @@
+import * as targetProfileAdapter from '../../../../../lib/infrastructure/adapters/target-profile-adapter.js';
+import { BookshelfTargetProfile } from '../../../../../lib/infrastructure/orm-models/TargetProfile.js';
+
+const getByCampaignId = async function (campaignId) {
+  const bookshelfTargetProfile = await BookshelfTargetProfile.query((qb) => {
+    qb.innerJoin('campaigns', 'campaigns.targetProfileId', 'target-profiles.id');
+  })
+    .where({ 'campaigns.id': campaignId })
+    .fetch({
+      withRelated: ['badges'],
+    });
+  return targetProfileAdapter.fromDatasourceObjects({
+    bookshelfTargetProfile,
+  });
+};
+
+export { getByCampaignId };

--- a/api/tests/acceptance/application/campaigns/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaigns/campaign-controller_test.js
@@ -1,5 +1,3 @@
-import jwt from 'jsonwebtoken';
-
 import { CampaignParticipationStatuses } from '../../../../src/prescription/shared/domain/constants.js';
 import {
   databaseBuilder,
@@ -9,7 +7,6 @@ import {
   mockLearningContent,
 } from '../../../test-helper.js';
 
-import { config as settings } from '../../../../lib/config.js';
 import { Membership } from '../../../../lib/domain/models/Membership.js';
 import { createServer } from '../../../../server.js';
 
@@ -184,96 +181,6 @@ describe('Acceptance | API | Campaign Controller', function () {
       // then
       expect(response.statusCode).to.equal(200, response.payload);
       expect(response.result).to.deep.equal(expectedResult);
-    });
-  });
-
-  describe('GET /api/campaigns/{id}/csv-assessment-results', function () {
-    let accessToken;
-
-    function _createTokenWithAccessId({ userId, campaignId }) {
-      return jwt.sign(
-        {
-          access_id: userId,
-          campaign_id: campaignId,
-        },
-        settings.authentication.secret,
-        { expiresIn: settings.authentication.accessTokenLifespanMs },
-      );
-    }
-
-    beforeEach(async function () {
-      const skillId = 'rec123';
-      const userId = databaseBuilder.factory.buildUser().id;
-      organization = databaseBuilder.factory.buildOrganization();
-      campaign = databaseBuilder.factory.buildCampaign({
-        organizationId: organization.id,
-      });
-      databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: skillId });
-      accessToken = _createTokenWithAccessId({ userId, campaignId: campaign.id });
-
-      databaseBuilder.factory.buildMembership({
-        userId,
-        organizationId: organization.id,
-        organizationRole: Membership.roles.MEMBER,
-      });
-
-      await databaseBuilder.commit();
-
-      const learningContent = [
-        {
-          id: 'recArea1',
-          title_i18n: {
-            fr: 'area1_Title',
-          },
-          color: 'specialColor',
-          competences: [
-            {
-              id: 'recCompetence1',
-              name_i18n: { fr: 'Fabriquer un meuble' },
-              index: '1.1',
-              tubes: [
-                {
-                  id: 'recTube1',
-                  skills: [
-                    {
-                      id: skillId,
-                      nom: '@web2',
-                      challenges: [],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      ];
-
-      const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-      mockLearningContent(learningContentObjects);
-    });
-
-    it('should return csv file with statusCode 200', async function () {
-      // given & when
-      const { statusCode, payload } = await server.inject({
-        method: 'GET',
-        url: `/api/campaigns/${campaign.id}/csv-assessment-results?accessToken=${accessToken}`,
-      });
-
-      // then
-      expect(statusCode).to.equal(200, payload);
-    });
-
-    context('when accessing another campaign with the wrong access token', function () {
-      it('should return an error response with an HTTP status code 403', async function () {
-        // given & when
-        const { statusCode } = await server.inject({
-          method: 'GET',
-          url: `/api/campaigns/1234567890/csv-assessment-results?accessToken=${accessToken}`,
-        });
-
-        // then
-        expect(statusCode).to.equal(403);
-      });
     });
   });
 

--- a/api/tests/integration/application/campaigns/index_test.js
+++ b/api/tests/integration/application/campaigns/index_test.js
@@ -6,22 +6,10 @@ describe('Integration | Application | Route | campaignRouter', function () {
   let httpTestServer;
 
   beforeEach(async function () {
-    sinon.stub(campaignController, 'getCsvAssessmentResults').callsFake((request, h) => h.response('ok').code(200));
-
-    sinon.stub(campaignController, 'getAnalysis').callsFake((request, h) => h.response('ok').code(200));
+    sinon.stub(campaignController, 'getAnalysis').callsFake((_, h) => h.response('ok').code(200));
 
     httpTestServer = new HttpTestServer();
     await httpTestServer.register(moduleUnderTest);
-  });
-
-  describe('GET /api/campaigns/{id}/csv-assessment-results', function () {
-    it('should exist', async function () {
-      // when
-      const response = await httpTestServer.request('GET', '/api/campaigns/1/csv-assessment-results');
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
   });
 
   describe('GET /api/campaigns/{id}/analyses', function () {

--- a/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
@@ -146,29 +146,6 @@ describe('Integration | Repository | Target-profile', function () {
     });
   });
 
-  describe('#getByCampaignId', function () {
-    let campaignId, targetProfileId;
-
-    beforeEach(async function () {
-      targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
-      campaignId = databaseBuilder.factory.buildCampaign({ targetProfileId }).id;
-      databaseBuilder.factory.buildTargetProfile();
-      databaseBuilder.factory.buildCampaign();
-      databaseBuilder.factory.buildStage({ targetProfileId, threshold: 40 });
-      databaseBuilder.factory.buildStage({ targetProfileId, threshold: 20 });
-
-      await databaseBuilder.commit();
-    });
-
-    it('should return the target profile matching the campaign id', async function () {
-      // when
-      const targetProfile = await targetProfileRepository.getByCampaignId(campaignId);
-
-      // then
-      expect(targetProfile.id).to.equal(targetProfileId);
-    });
-  });
-
   describe('#findByIds', function () {
     let targetProfile1;
     let targetProfileIds;

--- a/api/tests/prescription/campaign/acceptance/application/campaign-detail-controller_test.js
+++ b/api/tests/prescription/campaign/acceptance/application/campaign-detail-controller_test.js
@@ -164,4 +164,96 @@ describe('Acceptance | API | Campaign Detail Controller', function () {
       });
     });
   });
+
+  describe('GET /api/campaigns/{id}/csv-assessment-results', function () {
+    let accessToken;
+    let campaign;
+    let organization;
+
+    function _createTokenWithAccessId({ userId, campaignId }) {
+      return jwt.sign(
+        {
+          access_id: userId,
+          campaign_id: campaignId,
+        },
+        settings.authentication.secret,
+        { expiresIn: settings.authentication.accessTokenLifespanMs },
+      );
+    }
+
+    beforeEach(async function () {
+      const skillId = 'rec123';
+      const userId = databaseBuilder.factory.buildUser().id;
+      organization = databaseBuilder.factory.buildOrganization();
+      campaign = databaseBuilder.factory.buildCampaign({
+        organizationId: organization.id,
+      });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: skillId });
+      accessToken = _createTokenWithAccessId({ userId, campaignId: campaign.id });
+
+      databaseBuilder.factory.buildMembership({
+        userId,
+        organizationId: organization.id,
+        organizationRole: Membership.roles.MEMBER,
+      });
+
+      await databaseBuilder.commit();
+
+      const learningContent = [
+        {
+          id: 'recArea1',
+          title_i18n: {
+            fr: 'area1_Title',
+          },
+          color: 'specialColor',
+          competences: [
+            {
+              id: 'recCompetence1',
+              name_i18n: { fr: 'Fabriquer un meuble' },
+              index: '1.1',
+              tubes: [
+                {
+                  id: 'recTube1',
+                  skills: [
+                    {
+                      id: skillId,
+                      nom: '@web2',
+                      challenges: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
+      mockLearningContent(learningContentObjects);
+    });
+
+    it('should return csv file with statusCode 200', async function () {
+      // given & when
+      const { statusCode, payload } = await server.inject({
+        method: 'GET',
+        url: `/api/campaigns/${campaign.id}/csv-assessment-results?accessToken=${accessToken}`,
+      });
+
+      // then
+      expect(statusCode).to.equal(200, payload);
+    });
+
+    context('when accessing another campaign with the wrong access token', function () {
+      it('should return an error response with an HTTP status code 403', async function () {
+        // given & when
+        const { statusCode } = await server.inject({
+          method: 'GET',
+          url: `/api/campaigns/1234567890/csv-assessment-results?accessToken=${accessToken}`,
+        });
+
+        // then
+        expect(statusCode).to.equal(403);
+      });
+    });
+  });
 });

--- a/api/tests/prescription/campaign/integration/application/campaign-detail-route_test.js
+++ b/api/tests/prescription/campaign/integration/application/campaign-detail-route_test.js
@@ -7,11 +7,42 @@ describe('Integration | Application | Route | campaign detail router', function 
   let httpTestServer;
 
   beforeEach(async function () {
+    sinon.stub(campaignDetailController, 'getCsvAssessmentResults').callsFake((_, h) => h.response('ok').code(200));
     sinon
       .stub(campaignDetailController, 'getCsvProfilesCollectionResults')
       .callsFake((_, h) => h.response('ok').code(200));
+
     httpTestServer = new HttpTestServer();
     await httpTestServer.register(moduleUnderTest);
+  });
+
+  describe('GET /api/campaigns/{id}/csv-profiles-collection-results', function () {
+    it('should exist', async function () {
+      // given
+      const method = 'GET';
+      const url = '/api/campaigns/1/csv-profiles-collection-results';
+
+      // when
+      const response = await httpTestServer.request(method, url);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+
+  describe('GET /api/campaigns/{id}/csv-assessment-results', function () {
+    it('should exist', async function () {
+      // given
+      const method = 'GET';
+      const url = '/api/campaigns/1/csv-assessment-results';
+
+      // when
+      const response = await httpTestServer.request(method, url);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(campaignDetailController.getCsvAssessmentResults).to.have.been.calledOnce;
+    });
   });
 
   describe('GET /api/organizations/:id/campaigns', function () {
@@ -22,8 +53,7 @@ describe('Integration | Application | Route | campaign detail router', function 
       // given
       const method = 'GET';
       const url = '/api/organizations/1/campaigns';
-
-      const httpTestServer = new HttpTestServer();
+      httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 
       // when
@@ -32,16 +62,6 @@ describe('Integration | Application | Route | campaign detail router', function 
       // then
       expect(response.statusCode).to.equal(200);
       expect(campaignDetailController.findPaginatedFilteredCampaigns).to.have.been.calledOnce;
-    });
-  });
-
-  describe('GET /api/campaigns/{id}/csv-profiles-collection-results', function () {
-    it('should exist', async function () {
-      // when
-      const response = await httpTestServer.request('GET', '/api/campaigns/1/csv-profiles-collection-results');
-
-      // then
-      expect(response.statusCode).to.equal(200);
     });
   });
 });

--- a/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -2,10 +2,10 @@ import stream from 'stream';
 
 const { PassThrough } = stream;
 
-import { expect, mockLearningContent, databaseBuilder, streamToPromise } from '../../../test-helper.js';
-import { usecases } from '../../../../lib/domain/usecases/index.js';
-import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
-import { getI18n } from '../../../tooling/i18n/i18n.js';
+import { expect, mockLearningContent, databaseBuilder, streamToPromise } from '../../../../../test-helper.js';
+import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
+import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
+import { getI18n } from '../../../../../tooling/i18n/i18n.js';
 
 describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-results-to-stream', function () {
   describe('#startWritingCampaignAssessmentResultsToStream', function () {

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participation-info-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participation-info-repository_test.js
@@ -1,7 +1,7 @@
-import { expect, databaseBuilder } from '../../../test-helper.js';
-import { CampaignTypes } from '../../../../src/prescription/campaign/domain/read-models/CampaignTypes.js';
-import * as campaignParticipationInfoRepository from '../../../../lib/infrastructure/repositories/campaign-participation-info-repository.js';
-import { CampaignParticipationStatuses } from '../../../../src/prescription/shared/domain/constants.js';
+import { expect, databaseBuilder } from '../../../../../test-helper.js';
+import { CampaignTypes } from '../../../../../../src/prescription/campaign/domain/read-models/CampaignTypes.js';
+import * as campaignParticipationInfoRepository from '../../../../../../src/prescription/campaign/infrastructure/repositories/campaign-participation-info-repository.js';
+import { CampaignParticipationStatuses } from '../../../../../../src/prescription/shared/domain/constants.js';
 
 const { STARTED } = CampaignParticipationStatuses;
 

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/target-profile-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/target-profile-repository_test.js
@@ -1,0 +1,27 @@
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+import * as targetProfileRepository from '../../../../../../src/prescription/campaign/infrastructure/repositories/target-profile-repository.js';
+
+describe('Integration | Repository | Target-profile', function () {
+  describe('#getByCampaignId', function () {
+    let campaignId, targetProfileId;
+
+    beforeEach(async function () {
+      targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      campaignId = databaseBuilder.factory.buildCampaign({ targetProfileId }).id;
+      databaseBuilder.factory.buildTargetProfile();
+      databaseBuilder.factory.buildCampaign();
+      databaseBuilder.factory.buildStage({ targetProfileId, threshold: 40 });
+      databaseBuilder.factory.buildStage({ targetProfileId, threshold: 20 });
+
+      await databaseBuilder.commit();
+    });
+
+    it('should return the target profile matching the campaign id', async function () {
+      // when
+      const targetProfile = await targetProfileRepository.getByCampaignId(campaignId);
+
+      // then
+      expect(targetProfile.id).to.equal(targetProfileId);
+    });
+  });
+});

--- a/api/tests/prescription/campaign/unit/application/campaign-detail-route_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-detail-route_test.js
@@ -76,4 +76,33 @@ describe('Unit | Application | Router | campaign-detail-router ', function () {
       expect(response.statusCode).to.equal(400);
     });
   });
+
+  describe('GET /api/campaigns/{id}/csv-assessment-results', function () {
+    it('should return 200', async function () {
+      // given
+      sinon
+        .stub(campaignDetailController, 'getCsvAssessmentResults')
+        .callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('GET', '/api/campaigns/1/csv-assessment-results');
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should return 400 with an invalid campaign id', async function () {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('GET', '/api/campaigns/invalid/csv-assessment-results');
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+  });
 });

--- a/api/tests/prescription/campaign/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -2,12 +2,12 @@ import stream from 'stream';
 
 const { PassThrough } = stream;
 
-import { expect, sinon, domainBuilder, streamToPromise, catchErr } from '../../../test-helper.js';
-import { startWritingCampaignAssessmentResultsToStream } from '../../../../lib/domain/usecases/start-writing-campaign-assessment-results-to-stream.js';
-import { UserNotAuthorizedToGetCampaignResultsError, CampaignTypeError } from '../../../../lib/domain/errors.js';
-import * as campaignCsvExportService from '../../../../lib/domain/services/campaign-csv-export-service.js';
-import { getI18n } from '../../../tooling/i18n/i18n.js';
-import { StageCollection } from '../../../../src/shared/domain/models/user-campaign-results/StageCollection.js';
+import { expect, sinon, domainBuilder, streamToPromise, catchErr } from '../../../../../test-helper.js';
+import { startWritingCampaignAssessmentResultsToStream } from '../../../../../../src/prescription/campaign/domain/usecases/start-writing-campaign-assessment-results-to-stream.js';
+import { UserNotAuthorizedToGetCampaignResultsError, CampaignTypeError } from '../../../../../../lib/domain/errors.js';
+import * as campaignCsvExportService from '../../../../../../src/prescription/campaign/domain/services/campaign-csv-export-service.js';
+import { getI18n } from '../../../../../tooling/i18n/i18n.js';
+import { StageCollection } from '../../../../../../src/shared/domain/models/user-campaign-results/StageCollection.js';
 
 describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-to-stream', function () {
   const campaignRepository = { get: () => undefined };

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -3,123 +3,10 @@ import { campaignController } from '../../../../lib/application/campaigns/campai
 import { usecases } from '../../../../lib/domain/usecases/index.js';
 import { UserNotAuthorizedToAccessEntityError } from '../../../../lib/domain/errors.js';
 import { LOCALE } from '../../../../src/shared/domain/constants.js';
-import { ForbiddenAccess } from '../../../../src/shared/domain/errors.js';
 
 const { FRENCH_SPOKEN } = LOCALE;
 
 describe('Unit | Application | Controller | Campaign', function () {
-  describe('#getCsvAssessmentResults', function () {
-    it('should call the use case to get result campaign in csv', async function () {
-      // given
-      const userId = 1;
-      const campaignId = 2;
-      const request = _getRequestForCampaignId(campaignId);
-
-      const tokenServiceStub = {
-        extractCampaignResultsTokenContent: sinon.stub().returns({ userId, campaignId }),
-      };
-      sinon.stub(usecases, 'startWritingCampaignAssessmentResultsToStream').resolves({ fileName: 'any file name' });
-      const dependencies = { tokenService: tokenServiceStub };
-
-      // when
-      await campaignController.getCsvAssessmentResults(request, hFake, dependencies);
-
-      // then
-      expect(usecases.startWritingCampaignAssessmentResultsToStream).to.have.been.calledOnce;
-      const getResultsCampaignArgs = usecases.startWritingCampaignAssessmentResultsToStream.firstCall.args[0];
-      expect(getResultsCampaignArgs).to.have.property('userId');
-      expect(getResultsCampaignArgs).to.have.property('campaignId');
-    });
-
-    it('should return a response with correct headers', async function () {
-      // given
-      const userId = 1;
-      const campaignId = 2;
-      const request = _getRequestForCampaignId(campaignId);
-
-      const tokenServiceStub = {
-        extractCampaignResultsTokenContent: sinon.stub().returns({ userId, campaignId }),
-      };
-      sinon
-        .stub(usecases, 'startWritingCampaignAssessmentResultsToStream')
-        .resolves({ fileName: 'expected file name' });
-      const dependencies = { tokenService: tokenServiceStub };
-
-      // when
-      const response = await campaignController.getCsvAssessmentResults(request, hFake, dependencies);
-
-      // then
-      expect(response.headers['content-type']).to.equal('text/csv;charset=utf-8');
-      expect(response.headers['content-disposition']).to.equal('attachment; filename="expected file name"');
-      expect(response.headers['content-encoding']).to.equal('identity');
-    });
-
-    it('should fix invalid header chars in filename', async function () {
-      // given
-      const userId = 1;
-      const campaignId = 2;
-      const request = _getRequestForCampaignId(campaignId);
-
-      const tokenServiceStub = {
-        extractCampaignResultsTokenContent: sinon.stub().returns({ userId, campaignId }),
-      };
-      sinon.stub(usecases, 'startWritingCampaignAssessmentResultsToStream').resolves({
-        fileName: 'file-name with invalid_chars •’<>:"/\\|?*"\n.csv',
-      });
-      const dependencies = { tokenService: tokenServiceStub };
-
-      // when
-      const response = await campaignController.getCsvAssessmentResults(request, hFake, dependencies);
-
-      // then
-      expect(response.headers['content-disposition']).to.equal(
-        'attachment; filename="file-name with invalid_chars _____________.csv"',
-      );
-    });
-
-    context('when the campaign id is not the same as provided in the access token', function () {
-      it('should throw an error', async function () {
-        // given
-        const userId = 1;
-        const campaignId = 2;
-        const request = _getRequestForCampaignId(campaignId);
-
-        const tokenServiceStub = {
-          extractCampaignResultsTokenContent: sinon.stub().returns({ userId, campaignId: 19 }),
-        };
-        sinon.stub(usecases, 'startWritingCampaignAssessmentResultsToStream').resolves();
-        const dependencies = { tokenService: tokenServiceStub };
-
-        // when
-        const error = await catchErr(campaignController.getCsvAssessmentResults)(request, hFake, dependencies);
-
-        // then
-        expect(error).to.be.an.instanceOf(ForbiddenAccess);
-        expect(usecases.startWritingCampaignAssessmentResultsToStream).to.not.have.been.called;
-      });
-    });
-
-    context('when the access token is invalid', function () {
-      it('should throw an error', async function () {
-        // given
-        const request = _getRequestForCampaignId(1);
-
-        const tokenServiceStub = {
-          extractCampaignResultsTokenContent: sinon.stub().throws(new ForbiddenAccess()),
-        };
-        sinon.stub(usecases, 'startWritingCampaignAssessmentResultsToStream').resolves();
-        const dependencies = { tokenService: tokenServiceStub };
-
-        // when
-        const error = await catchErr(campaignController.getCsvAssessmentResults)(request, hFake, dependencies);
-
-        // then
-        expect(error).to.be.an.instanceOf(ForbiddenAccess);
-        expect(usecases.startWritingCampaignAssessmentResultsToStream).to.not.have.been.called;
-      });
-    });
-  });
-
   describe('#getByCode', function () {
     it('should return the serialized campaign', async function () {
       // given
@@ -406,18 +293,3 @@ describe('Unit | Application | Controller | Campaign', function () {
     });
   });
 });
-
-// TODO TO REMOVE when both csv export will be merged
-function _getRequestForCampaignId(campaignId) {
-  return {
-    query: {
-      accessToken: 'token',
-    },
-    params: {
-      id: campaignId,
-    },
-    i18n: {
-      __: sinon.stub(),
-    },
-  };
-}

--- a/api/tests/unit/application/campaign/index_test.js
+++ b/api/tests/unit/application/campaign/index_test.js
@@ -38,33 +38,6 @@ describe('Unit | Application | Router | campaign-router ', function () {
     });
   });
 
-  describe('GET /api/campaigns/{id}/csv-assessment-results', function () {
-    it('should return 200', async function () {
-      // given
-      sinon.stub(campaignController, 'getCsvAssessmentResults').callsFake((request, h) => h.response('ok').code(200));
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('GET', '/api/campaigns/1/csv-assessment-results');
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-
-    it('should return 400 with an invalid campaign id', async function () {
-      // given
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('GET', '/api/campaigns/invalid/csv-assessment-results');
-
-      // then
-      expect(response.statusCode).to.equal(400);
-    });
-  });
-
   describe('PATCH /api/admin/campaigns/{id}', function () {
     it('should return 204', async function () {
       // given


### PR DESCRIPTION
## :christmas_tree: Problème
Dans le cadre de la migration vers les bounded context, on souhaite déplacer l'export des résultats d'une campagne d'évaluation.

## :gift: Proposition
Migrer l'export des résultat CSV d'une collecte de profil dans son Bounded Context

## :socks: Remarques
Le usecase embarque beacoup de repository. Certains liés à des question d'authorization pourraient être déplacer dans des pré-handler

## :santa: Pour tester
Se connecter sur une orga du sup
afficher une campagne   
cliquer sur exporter les résultats
