### PR TITLE
[BUGFIX] Modifier la page détails des parcours autonomes sur Pix-Admin (PIX-10475)

### DIFF
--- a/admin/app/components/autonomous-courses/details.hbs
+++ b/admin/app/components/autonomous-courses/details.hbs
@@ -1,10 +1,10 @@
 <section class="page-section">
-  <h2 class="page-section__title">{{@autonomousCourse.publicTitle}}</h2>
+  <h2 class="page-section__title">{{@autonomousCourse.internalTitle}}</h2>
   <dl class="autonomous-course-card__details">
     <dt class="autonomous-course-card__details-label">ID&nbsp;:&nbsp;</dt>
     <dd class="autonomous-course-card__details-value">{{@autonomousCourse.id}}</dd>
-    <dt class="autonomous-course-card__details-label">Nom interne&nbsp;:&nbsp;</dt>
-    <dd class="autonomous-course-card__details-value">{{@autonomousCourse.internalTitle}}</dd>
+    <dt class="autonomous-course-card__details-label">Nom public&nbsp;:&nbsp;</dt>
+    <dd class="autonomous-course-card__details-value">{{@autonomousCourse.publicTitle}}</dd>
     <dt class="autonomous-course-card__details-label">Date de création&nbsp;:&nbsp;</dt>
     <dd class="autonomous-course-card__details-value">{{this.formattedCreatedAt}}</dd>
     <dt class="autonomous-course-card__details-label">Lien public&nbsp;:&nbsp;</dt>
@@ -36,5 +36,9 @@
         <:tooltip>{{if this.isLinkCopied "Lien copié !" "Copier le lien de la campagne"}}</:tooltip>
       </PixTooltip>
     </dd>
+    {{#if @autonomousCourse.customLandingPageText}}
+      <dt class="autonomous-course-card__details-label">Texte de la page d'accueil&nbsp;:&nbsp;</dt>
+      <dd class="autonomous-course-card__details-value">{{@autonomousCourse.customLandingPageText}}</dd>
+    {{/if}}
   </dl>
 </section>

--- a/admin/app/templates/authenticated/autonomous-courses/autonomous-course/details.hbs
+++ b/admin/app/templates/authenticated/autonomous-courses/autonomous-course/details.hbs
@@ -2,7 +2,7 @@
   <div class="page-title">
     <LinkTo @route="authenticated.autonomous-courses.list">Tous les parcours autonomes</LinkTo>
     <span class="wire">&nbsp;>&nbsp;</span>
-    <h1>{{@model.publicTitle}}</h1>
+    <h1>{{@model.internalTitle}}</h1>
   </div>
 </header>
 

--- a/admin/tests/acceptance/authenticated/autonomous-courses/autonomous-courses_test.js
+++ b/admin/tests/acceptance/authenticated/autonomous-courses/autonomous-courses_test.js
@@ -78,8 +78,9 @@ module('Acceptance | Autonomous courses | Autonomous course', function (hooks) {
 
         // then
         assert.strictEqual(currentURL(), '/autonomous-courses/1/details');
-        assert.dom(screen.getAllByRole('heading', { name: 'nom public', level: 1 })[0]).exists();
-        assert.dom(screen.getByText('nom interne')).exists();
+        assert.dom(screen.getAllByRole('heading', { name: 'nom interne', level: 1 })[0]).exists();
+        assert.dom(screen.getByText('nom public')).exists();
+        assert.dom(screen.getByText("texte page d'accueil")).exists();
         assert.dom(screen.getByText('01/01/2020')).exists();
         assert.dom(screen.getByRole('link', { name: 'Lien vers la campagne CODE (nouvelle fenêtre)' })).exists();
       });

--- a/admin/tests/integration/components/autonomous-courses/details_test.js
+++ b/admin/tests/integration/components/autonomous-courses/details_test.js
@@ -14,6 +14,7 @@ module('Integration | Component | AutonomousCourses::Details', function (hooks) 
       internalTitle: 'titre interne',
       code: 'CODE',
       createdAt: new Date('2021-01-01'),
+      customLandingPageText: 'un texte',
     };
     this.set('autonomousCourse', autonomousCourse);
 
@@ -26,6 +27,7 @@ module('Integration | Component | AutonomousCourses::Details', function (hooks) 
     assert.dom(screen.getByText('Parcours autonome')).exists();
     assert.dom(screen.getByText('titre interne')).exists();
     assert.dom(screen.getByText('01/01/2021')).exists();
+    assert.dom(screen.getByText('un texte')).exists();
     assert.ok(link.trim().endsWith('/campagnes/CODE'));
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
La page de détails nécessite quelques modifications au niveau des champs.

## :gift: Proposition
Inverser le titre public avec le titre interne.
Ajouter le texte de page d'accueil

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Aller sur la page de détails et vérifier les champs.