### PR TITLE
[FEATURE] Edit wording in change referer button (Pix 10364)

### DIFF
--- a/certif/app/styles/pages/authenticated/team.scss
+++ b/certif/app/styles/pages/authenticated/team.scss
@@ -18,7 +18,6 @@
   }
 
   &__update-referer-button {
-    width: 180px;
     height: 50px;
     font-weight: 500;
     border-radius: 6px;

--- a/certif/tests/acceptance/team/list/list_test.js
+++ b/certif/tests/acceptance/team/list/list_test.js
@@ -218,9 +218,7 @@ module('Acceptance | authenticated | team', function (hooks) {
               const screen = await visitScreen('/equipe');
 
               // then
-              assert
-                .dom(screen.queryByRole('button', { name: this.intl.t('pages.team.update-referer-button') }))
-                .doesNotExist();
+              assert.dom(screen.queryByRole('button', { name: 'Changer de référent CléA' })).doesNotExist();
             });
 
             test('does display a tooltip to inform of what is a Pix Referer', async function (assert) {
@@ -271,9 +269,7 @@ module('Acceptance | authenticated | team', function (hooks) {
               const screen = await visitScreen('/equipe');
 
               // then
-              assert
-                .dom(screen.getByRole('button', { name: this.intl.t('pages.team.update-referer-button') }))
-                .exists();
+              assert.dom(screen.getByRole('button', { name: 'Changer de référent CléA' })).exists();
             });
           });
         });
@@ -443,9 +439,7 @@ module('Acceptance | authenticated | team', function (hooks) {
               const screen = await visitScreen('/equipe');
 
               // then
-              assert
-                .dom(screen.queryByRole('button', { name: this.intl.t('pages.team.update-referer-button') }))
-                .doesNotExist();
+              assert.dom(screen.queryByRole('button', { name: 'Changer de référent CléA' })).doesNotExist();
             });
           });
         });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -909,7 +909,7 @@
         "invitation": "Invitations ({count, plural, =0 {-} other {{count}}})",
         "member": "Members ({count, plural, =0 {-} other {{count}}})"
       },
-      "update-referer-button": "Changer de référent"
+      "update-referer-button": "Changer de référent CléA"
     },
     "team-invitations": {
       "actions": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -909,7 +909,7 @@
         "invitation": "Invitations ({count, plural, =0 {-} other {{count}}})",
         "member": "Membres ({count, plural, =0 {-} other {{count}}})"
       },
-      "update-referer-button": "Changer de référent"
+      "update-referer-button": "Changer de référent CléA"
     },
     "team-invitations": {
       "actions": {


### PR DESCRIPTION
## :christmas_tree: Problème
Le wording est confusant car il désigne un “référent Pix” sans préciser plus exactement qu’il s’agit d’un référent CléA Numérique alors que ça peut être une personne différente du référent Pix du CDC.

Lors de la désignation ou de la modification du référent, aucune indication explicite ne précise que l’action de l’utilisateur a bien été prise en compte.

**Le changement de texte sur la page a déjà été effectué au préalable. Mais il y avait un oubli sur le bouton `[Changer de référent]`.**

## :gift: Proposition
Modifier le texte contenu dans le bouton de changement de référent sur la page **Équipe** en remplaçant **"Changer de référent" par "Changer de référent cléA"** (et non pas "Changer de référent cléA numérique" comme spécifié dans le ticket, car le bouton devenait trop grand. Proposition validée côté métier)

## :socks: Remarques
RAS

## :santa: Pour tester

1. Se connecter sur Pix Admin avec le compte : `superadmin@example.net`
2. Dans https://admin-pr7736.review.pix.fr/certification-centers/7002 changer le membre en administrateur
3. Se connecter à [Pix Certif](https://certif-pr7736.review.pix.fr/connexion) avec le compte `certif-pro@example.net / pix123`
4. Dans équipe/membres constater que le contenu du bouton de changement de référent contient le texte "**Changer de référent cléA**" (voir screenshots avant/après pour plus de précision) - **Attention l'équipe doit comporter au moins 2 membres pour activer l'affichage du bouton**

avant : 
![Capture d’écran 2023-12-20 à 17 04 12](https://github.com/1024pix/pix/assets/152303583/0f0caedc-d503-4791-9227-053a5d2fb5d9)

après :
![Capture d’écran 2023-12-20 à 16 58 16](https://github.com/1024pix/pix/assets/152303583/305f4ba1-bf0a-4e22-b09f-fb83fb3a434d)

