### PR TITLE
[BUGFIX] Améliorer l'accessibilité de l'hexagone score sur Pix-App (PIX-9640)

### DIFF
--- a/mon-pix/app/components/hexagon-score.hbs
+++ b/mon-pix/app/components/hexagon-score.hbs
@@ -16,17 +16,17 @@
           </button>
         </:triggerElement>
         <:tooltip>
-          <div class="hexagon-score__information hexagon-score-information__text">
-            <p class="hexagon-score-information__text--strong">
+          <p class="hexagon-score__information hexagon-score-information__text">
+            <span class="hexagon-score-information__text--strong">
               {{t "pages.profile.total-score-helper.title"}}
-            </p>
+            </span>
             {{t
               "pages.profile.total-score-helper.explanation"
               maxReachablePixScore=@maxReachablePixScore
               maxReachableLevel=@maxReachableLevel
               htmlSafe=true
             }}
-          </div>
+          </p>
         </:tooltip>
       </PixTooltip>
     </div>

--- a/mon-pix/app/styles/components/_hexagon-score.scss
+++ b/mon-pix/app/styles/components/_hexagon-score.scss
@@ -78,25 +78,19 @@
 
 .hexagon-score__information {
   padding: 24px 16px;
-
-  p {
-    margin-top: 0;
-    margin-bottom: 1rem;
-
-    &:last-child {
-      margin-bottom: 0;
-    }
-  }
 }
 
 .hexagon-score-information__text {
-  display: block;
   font-size: 1rem;
   font-family: $font-open-sans;
   line-height: 1.6rem;
 
   &--strong {
     font-weight: $font-bold;
+  }
+
+  p {
+    padding-top: 1rem;
   }
 }
 


### PR DESCRIPTION
## :christmas_tree: Problème
Il y a des éléments `<div>` enfant d'éléments `<span>`. Les éléments `<span>` ne peuvent englober que du contenu phrasé.

## :gift: Proposition
Changer la div par un span.

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Vérifier qu'aucun span ne contient de div dans l'hexagone score
