### PR TITLE
[BUGFIX] Réparer le support des vieux navigateurs (PIX-10476).

### DIFF
--- a/mon-pix/ember-cli-build.js
+++ b/mon-pix/ember-cli-build.js
@@ -23,6 +23,13 @@ module.exports = function (defaults) {
     'ember-simple-auth': {
       useSessionSetupMethod: true,
     },
+    '@embroider/macros': {
+      setConfig: {
+        '@ember-data/store': {
+          polyfillUUID: true,
+        },
+      },
+    },
   });
 
   // Use `app.import` to add additional libraries to the generated


### PR DESCRIPTION
## :christmas_tree: Problème
Depuis la montée de version d'ember-data en 4.7 dans la PR #7686  certaines action du store ne fonctionnent plus pour des anciens navigateurs que nous supportons toujours.

![Screenshot 2023-12-20 at 17 13 55](https://github.com/1024pix/pix/assets/26384707/3876922a-4fc2-4841-ae17-d15f924625b1)


## :gift: Proposition
Ajouter le polyfill qui va bien

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Essayer de répondre à une question sur Firefox 90 par exemple