### PR TITLE
[FEATURE] Permettre de définaliser une session depuis Pix Admin (PIX-10316)

### DIFF
--- a/admin/app/adapters/session.js
+++ b/admin/app/adapters/session.js
@@ -42,6 +42,10 @@ export default class SessionAdapter extends ApplicationAdapter {
       const url = this.urlForUpdateRecord(snapshot.id, type.modelName, snapshot) + '/certification-officer-assignment';
       return this.ajax(url, 'PATCH');
     }
+    if (snapshot.adapterOptions.unfinalize) {
+      const url = this.urlForUpdateRecord(snapshot.id, type.modelName, snapshot) + '/unfinalize';
+      return this.ajax(url, 'PATCH');
+    }
 
     return super.updateRecord(...arguments);
   }

--- a/admin/app/controllers/authenticated/sessions/session/informations.js
+++ b/admin/app/controllers/authenticated/sessions/session/informations.js
@@ -41,6 +41,16 @@ export default class IndexController extends Controller {
   }
 
   @action
+  async unfinalizeSession() {
+    try {
+      await this.sessionModel.save({ adapterOptions: { unfinalize: true } });
+      this.notifications.success('La session a bien été définalisée');
+    } catch (err) {
+      this.notifications.error('Erreur lors de la définalisation de la session');
+    }
+  }
+
+  @action
   async checkForAssignment() {
     if (this.isAssigned) {
       this.isShowingAssignmentModal = true;

--- a/admin/app/controllers/authenticated/sessions/session/informations.js
+++ b/admin/app/controllers/authenticated/sessions/session/informations.js
@@ -44,6 +44,7 @@ export default class IndexController extends Controller {
   async unfinalizeSession() {
     try {
       await this.sessionModel.save({ adapterOptions: { unfinalize: true } });
+      await this.sessionModel.reload();
       this.notifications.success('La session a bien été définalisée');
     } catch (err) {
       this.notifications.error('Erreur lors de la définalisation de la session');

--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -1,6 +1,5 @@
 import isEmpty from 'lodash/isEmpty';
 import sumBy from 'lodash/sumBy';
-import some from 'lodash/some';
 import trim from 'lodash/trim';
 
 import Model, { belongsTo, hasMany, attr } from '@ember-data/model';
@@ -67,12 +66,9 @@ export default class Session extends Model {
     return Boolean(this.hasIncident || this.hasJoiningIssue);
   }
 
-  @computed('juryCertificationSummaries.@each.isPublished')
+  @computed('status')
   get isPublished() {
-    return some(
-      this.juryCertificationSummaries.toArray(),
-      (juryCertificationSummary) => juryCertificationSummary.isPublished,
-    );
+    return this.status === PROCESSED;
   }
 
   @computed('juryCertificationSummaries.[]')

--- a/admin/app/styles/authenticated/sessions/session/informations.scss
+++ b/admin/app/styles/authenticated/sessions/session/informations.scss
@@ -39,13 +39,13 @@
   &__actions {
     display: flex;
     flex-wrap: wrap;
+    gap: 20px;
   }
 
   &__copy-button {
     position: relative;
     display: flex;
     justify-content: center;
-    margin-right: 20px;
     margin-left: auto;
 
     p {

--- a/admin/app/templates/authenticated/sessions/session/informations.hbs
+++ b/admin/app/templates/authenticated/sessions/session/informations.hbs
@@ -123,12 +123,31 @@
       <div class="session-info__actions">
         {{#if this.sessionModel.finalizedAt}}
           {{#if this.isCurrentUserAssignedToSession}}
-            <PixButton @size="small" @isDisabled={{true}}>Vous êtes assigné à cette session</PixButton>
+            <PixButton @size="big" @isDisabled={{true}}>Vous êtes assigné à cette session</PixButton>
           {{else}}
-            <PixButton @size="small" @triggerAction={{this.checkForAssignment}}>M'assigner la session</PixButton>
+            <PixButton @size="big" @triggerAction={{this.checkForAssignment}}>M'assigner la session</PixButton>
           {{/if}}
-          <PixButton @size="small" @triggerAction={{this.unfinalizeSession}} @backgroundColor="error">Définaliser la
-            session</PixButton>
+          {{#if this.sessionModel.isPublished}}
+            <PixTooltip @position="right" @isWide={{true}}>
+              <:triggerElement>
+                <PixButton
+                  @size="big"
+                  @isDisabled={{true}}
+                  @triggerAction={{this.unfinalizeSession}}
+                  @backgroundColor="error"
+                >Définaliser la session
+                </PixButton>
+              </:triggerElement>
+
+              <:tooltip>Vous ne pouvez pas définaliser une session publiée. Merci de dépublier la session avant de la
+                définaliser.
+              </:tooltip>
+            </PixTooltip>
+          {{else}}
+            <PixButton @size="big" @triggerAction={{this.unfinalizeSession}} @backgroundColor="error">Définaliser la
+              session
+            </PixButton>
+          {{/if}}
         {{/if}}
 
         <div class="session-info__copy-button">

--- a/admin/app/templates/authenticated/sessions/session/informations.hbs
+++ b/admin/app/templates/authenticated/sessions/session/informations.hbs
@@ -127,7 +127,8 @@
           {{else}}
             <PixButton @size="small" @triggerAction={{this.checkForAssignment}}>M'assigner la session</PixButton>
           {{/if}}
-          <PixButton @size="small" @backgroundColor="error">Définaliser la session</PixButton>
+          <PixButton @size="small" @triggerAction={{this.unfinalizeSession}} @backgroundColor="error">Définaliser la
+            session</PixButton>
         {{/if}}
 
         <div class="session-info__copy-button">

--- a/admin/app/templates/authenticated/sessions/session/informations.hbs
+++ b/admin/app/templates/authenticated/sessions/session/informations.hbs
@@ -127,6 +127,7 @@
           {{else}}
             <PixButton @size="small" @triggerAction={{this.checkForAssignment}}>M'assigner la session</PixButton>
           {{/if}}
+          <PixButton @size="small" @backgroundColor="error">Définaliser la session</PixButton>
         {{/if}}
 
         <div class="session-info__copy-button">

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -114,6 +114,12 @@ function routes() {
   this.post('/admin/sessions/publish-in-batch', () => {
     return new Response(200);
   });
+  this.patch('/admin/sessions/:id/unfinalize', (schema, request) => {
+    const sessionId = request.params.id;
+    const session = schema.sessions.findBy({ id: sessionId });
+    session.update({ finalizedAt: null, assignedCertificationOfficerId: null });
+    return new Response(204);
+  });
   this.get('/admin/sessions/:id/generate-results-download-link', {
     sessionResultsLink: 'http://link-to-results.fr?lang=fr',
   });

--- a/admin/tests/acceptance/authenticated/sessions/session/informations_test.js
+++ b/admin/tests/acceptance/authenticated/sessions/session/informations_test.js
@@ -36,6 +36,25 @@ module('Acceptance | authenticated/sessions/session/informations', function (hoo
     });
 
     module('When session is finalized', function () {
+      module('When unfinalize button is clicked', function () {
+        test('it should unfinalize the session', async function (assert) {
+          // given
+          server.create('session', {
+            id: '3',
+            finalizedAt: new Date('2023-01-31'),
+            examinerGlobalComment: 'Vraiment, super session!',
+          });
+          const screen = await visit('/sessions/3');
+
+          // when
+          await clickByName('Définaliser la session');
+
+          // then
+          assert.dom(screen.queryByText('Date de finalisation :')).doesNotExist();
+          assert.dom(screen.queryByRole('button', { name: 'Définaliser la session' })).doesNotExist();
+        });
+      });
+
       module('When session has a global comment', function () {
         test('it should display the global comment section', async function (assert) {
           // given

--- a/admin/tests/acceptance/authenticated/sessions/session/informations_test.js
+++ b/admin/tests/acceptance/authenticated/sessions/session/informations_test.js
@@ -43,6 +43,7 @@ module('Acceptance | authenticated/sessions/session/informations', function (hoo
             id: '3',
             finalizedAt: new Date('2023-01-31'),
             examinerGlobalComment: 'Vraiment, super session!',
+            status: 'finalized',
           });
           const screen = await visit('/sessions/3');
 
@@ -51,6 +52,24 @@ module('Acceptance | authenticated/sessions/session/informations', function (hoo
 
           // then
           assert.dom(screen.queryByText('Date de finalisation :')).doesNotExist();
+          assert.dom(screen.queryByRole('button', { name: 'Définaliser la session' })).doesNotExist();
+        });
+      });
+
+      module('When session is published', function () {
+        test('it should hide unfinalize button', async function (assert) {
+          // given
+          server.create('session', {
+            id: '3',
+            finalizedAt: null,
+            examinerGlobalComment: 'Vraiment, super session!',
+            status: 'processed',
+          });
+
+          // when
+          const screen = await visit('/sessions/3');
+
+          // then
           assert.dom(screen.queryByRole('button', { name: 'Définaliser la session' })).doesNotExist();
         });
       });

--- a/admin/tests/acceptance/session_test.js
+++ b/admin/tests/acceptance/session_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { click, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
-import { FINALIZED } from 'pix-admin/models/session';
+import { FINALIZED, PROCESSED } from 'pix-admin/models/session';
 import { clickByName, fillByLabel, visit } from '@1024pix/ember-testing-library';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import sinon from 'sinon';
@@ -134,10 +134,10 @@ module('Acceptance | Session pages', function (hooks) {
         module('When the session has been published', function () {
           test('it shows the certificates download button', async function (assert) {
             // given
-            const juryCertificationSummary = this.server.create('jury-certification-summary', {
-              isPublished: true,
+            this.server.create('session', {
+              id: 2,
+              status: PROCESSED,
             });
-            this.server.create('session', { juryCertificationSummaries: [juryCertificationSummary] });
 
             // when
             const screen = await visit('/sessions/2');

--- a/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations_test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations_test.js
@@ -52,7 +52,7 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
       assert.dom(screen.queryByText("Nombre d'écrans de fin de test non renseignés :")).doesNotExist();
     });
 
-    test('it does not render the "M\'assigner la session" button', async function (assert) {
+    test('it does not render the action buttons', async function (assert) {
       // given
       await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
       const session = this.server.create('session', 'created');
@@ -77,6 +77,18 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
 
       // when
       assert.dom(screen.getByText('01/04/2022')).exists();
+    });
+
+    test('it renders the unfinalize button', async function (assert) {
+      // given
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+      const session = _buildSessionWithTwoJuryCertificationSummary({}, server);
+
+      // when
+      const screen = await visit(`/sessions/${session.id}`);
+
+      // when
+      assert.dom(screen.queryByRole('button', { name: 'Définaliser la session' })).exists();
     });
 
     test('it renders all the stats of the session', async function (assert) {

--- a/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations_test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations_test.js
@@ -62,6 +62,7 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
 
       // then
       assert.dom(screen.queryByRole('button', { name: "M'assigner la session" })).doesNotExist();
+      assert.dom(screen.queryByRole('button', { name: 'Définaliser la session' })).doesNotExist();
     });
   });
 
@@ -202,6 +203,7 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
 
           // then
           assert.dom(screen.queryByText("M'assigner la session")).doesNotExist();
+          assert.dom(screen.queryByText('Définaliser la session')).doesNotExist();
           assert.dom(screen.queryByText('Lien de téléchargement des résultats')).doesNotExist();
           assert.dom(screen.queryByText('Résultats transmis au prescripteur')).doesNotExist();
         });
@@ -219,6 +221,7 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
 
         // then
         assert.dom(screen.getByRole('button', { name: "M'assigner la session" })).exists();
+        assert.dom(screen.getByRole('button', { name: 'Définaliser la session' })).exists();
         assert.dom(screen.getByRole('button', { name: 'Lien de téléchargement des résultats' })).exists();
         assert.dom(screen.getByRole('button', { name: 'Résultats transmis au prescripteur' })).exists();
       });

--- a/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations_test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations_test.js
@@ -6,6 +6,7 @@ import { visit } from '@1024pix/ember-testing-library';
 import { statusToDisplayName } from 'pix-admin/models/session';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 import dayjs from 'dayjs';
+import { FINALIZED } from 'pix-admin/models/session';
 
 module('Integration | Component | routes/authenticated/sessions/session | informations', function (hooks) {
   setupApplicationTest(hooks);
@@ -82,7 +83,7 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
     test('it renders the unfinalize button', async function (assert) {
       // given
       await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-      const session = _buildSessionWithTwoJuryCertificationSummary({}, server);
+      const session = this.server.create('session', { status: FINALIZED, finalizedAt: new Date('2022-04-01') });
 
       // when
       const screen = await visit(`/sessions/${session.id}`);
@@ -208,7 +209,7 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
         test('it does not render the buttons section', async function (assert) {
           // given
           await authenticateAdminMemberWithRole({ isMetier: true })(server);
-          const session = _buildSessionWithTwoJuryCertificationSummary({}, server);
+          const session = this.server.create('session', { status: FINALIZED, finalizedAt: new Date('2022-04-01') });
 
           // when
           const screen = await visit(`/sessions/${session.id}`);
@@ -226,7 +227,7 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
       test('it renders the buttons section', async function (assert) {
         // given
         await authenticateAdminMemberWithRole({ isCertif: true })(server);
-        const session = _buildSessionWithTwoJuryCertificationSummary({}, server);
+        const session = this.server.create('session', { status: FINALIZED, finalizedAt: new Date('2022-04-01') });
 
         // when
         const screen = await visit(`/sessions/${session.id}`);

--- a/admin/tests/unit/adapters/session_test.js
+++ b/admin/tests/unit/adapters/session_test.js
@@ -96,5 +96,27 @@ module('Unit | Adapter | session', function (hooks) {
         assert.ok(adapter); /* required because QUnit wants at least one expect (and does not accept Sinon's one) */
       });
     });
+
+    module('when unfinalize adapterOption passed', function (hooks) {
+      hooks.beforeEach(function () {
+        sinon.stub(adapter, 'ajax');
+      });
+
+      hooks.afterEach(function () {
+        adapter.ajax.restore();
+      });
+
+      test('should send a patch request to unfinalize a session', async function (assert) {
+        // given
+        adapter.ajax.resolves();
+
+        // when
+        await adapter.updateRecord(null, { modelName: 'session' }, { id: 123, adapterOptions: { unfinalize: true } });
+
+        // then
+        sinon.assert.calledWith(adapter.ajax, 'http://localhost:3000/api/admin/sessions/123/unfinalize', 'PATCH');
+        assert.ok(adapter); /* required because QUnit wants at least one expect (and does not accept Sinon's one) */
+      });
+    });
   });
 });

--- a/admin/tests/unit/controllers/authenticated/sessions/session/informations_test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/session/informations_test.js
@@ -15,6 +15,39 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
     controller.notifications = { success, error };
   });
 
+  module('#unfinalizeSession', function () {
+    test('it should call the unfinalize route', async function (assert) {
+      // given
+      controller.model = { save: sinon.stub(), reload: sinon.stub() };
+      controller.model.save.withArgs({ adapterOptions: { unfinalize: true } }).resolves();
+      controller.model.reload.resolves();
+
+      // when
+      await controller.actions.unfinalizeSession.call(controller);
+
+      // then
+      assert.ok(controller.model.save.calledWithExactly({ adapterOptions: { unfinalize: true } }));
+      assert.ok(controller.model.reload.calledOnce);
+      assert.ok(controller.notifications.success.calledWithExactly('La session a bien été définalisée'));
+    });
+
+    module('when save failed', function () {
+      test('it should show a notification error', async function (assert) {
+        // given
+        controller.model = { save: sinon.stub(), reload: sinon.stub() };
+        controller.model.save.withArgs({ adapterOptions: { unfinalize: true } }).rejects();
+
+        // when
+        await controller.actions.unfinalizeSession.call(controller);
+
+        // then
+        assert.ok(controller.model.save.calledOnce);
+        assert.ok(controller.model.reload.notCalled);
+        assert.ok(controller.notifications.error.calledWithExactly('Erreur lors de la définalisation de la session'));
+      });
+    });
+  });
+
   module('#checkForAssignment', function (hooks) {
     hooks.beforeEach(function () {
       const save = sinon.stub();

--- a/admin/tests/unit/models/session_test.js
+++ b/admin/tests/unit/models/session_test.js
@@ -129,72 +129,33 @@ module('Unit | Model | session', function (hooks) {
   });
 
   module('#isPublished', function () {
-    module('when there is no certification', function () {
-      let sessionWithoutCertifications;
-
+    module('when status is not PROCESSED', function () {
       test('isPublished should be false', function (assert) {
         // given
-        sessionWithoutCertifications = run(() => {
-          return store.createRecord('session', { juryCertificationSummaries: [] });
+        const unprocessedSession = run(() => {
+          return store.createRecord('session', { status: 'created' });
         });
 
         // when
-        const isPublished = sessionWithoutCertifications.get('isPublished');
+        const isPublished = unprocessedSession.get('isPublished');
 
         // then
         assert.false(isPublished);
       });
     });
 
-    module('when there are multiple certifications', function () {
-      module('when all certifications are published', function (hooks) {
-        let sessionWithAllCertificationsPublished;
-
-        hooks.beforeEach(async function () {
-          sessionWithAllCertificationsPublished = run(() => {
-            const certif1 = store.createRecord('jury-certification-summary', { isPublished: true });
-            const certif2 = store.createRecord('jury-certification-summary', { isPublished: true });
-            return store.createRecord('session', { juryCertificationSummaries: [certif1, certif2] });
-          });
+    module('when status is PROCESSED', function () {
+      test('isPublished should be true', function (assert) {
+        // given
+        const processedSession = run(() => {
+          return store.createRecord('session', { status: 'processed' });
         });
 
-        test('isPublished should be true', function (assert) {
-          const isPublished = sessionWithAllCertificationsPublished.get('isPublished');
-          assert.true(isPublished);
-        });
-      });
+        // when
+        const isPublished = processedSession.get('isPublished');
 
-      module('when not all certifications are published', function (hooks) {
-        let sessionWithoutAllCertificationsPublished;
-
-        hooks.beforeEach(async function () {
-          sessionWithoutAllCertificationsPublished = run(() => {
-            const certif1 = store.createRecord('jury-certification-summary', { isPublished: true });
-            const certif2 = store.createRecord('jury-certification-summary', { isPublished: false });
-            return store.createRecord('session', { juryCertificationSummaries: [certif1, certif2] });
-          });
-        });
-
-        test('isPublished from session should be true', function (assert) {
-          const isPublished = sessionWithoutAllCertificationsPublished.get('isPublished');
-          assert.true(isPublished);
-        });
-      });
-      module('when all certifications are not published', function (hooks) {
-        let sessionWithoutAllCertificationsPublished;
-
-        hooks.beforeEach(async function () {
-          sessionWithoutAllCertificationsPublished = run(() => {
-            const certif1 = store.createRecord('jury-certification-summary', { isPublished: false });
-            const certif2 = store.createRecord('jury-certification-summary', { isPublished: false });
-            return store.createRecord('session', { juryCertificationSummaries: [certif1, certif2] });
-          });
-        });
-
-        test('isPublished from session should be false', function (assert) {
-          const isPublished = sessionWithoutAllCertificationsPublished.get('isPublished');
-          assert.false(isPublished);
-        });
+        // then
+        assert.true(isPublished);
       });
     });
   });

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -744,12 +744,6 @@ class SessionWithIdAndInformationOnMassImportError extends DomainError {
   }
 }
 
-class SessionAlreadyPublishedError extends DomainError {
-  constructor(message = 'La session est déjà publiée.') {
-    super(message);
-  }
-}
-
 class SessionNotAccessible extends DomainError {
   constructor(message = "La session de certification n'est plus accessible.") {
     super(message);
@@ -1230,7 +1224,6 @@ export {
   SendingEmailToInvalidEmailAddressError,
   SendingEmailToRefererError,
   SendingEmailToResultRecipientError,
-  SessionAlreadyPublishedError,
   SessionNotAccessible,
   SessionWithIdAndInformationOnMassImportError,
   SIECLE_ERRORS,

--- a/api/lib/domain/services/session-publication-service.js
+++ b/api/lib/domain/services/session-publication-service.js
@@ -4,11 +4,8 @@
  * @typedef {import('../../../lib/domain/usecases/index.js').SessionRepository} SessionRepository
  * @typedef {import('../../../lib/domain/usecases/index.js').MailService} MailService
  */
-import {
-  SendingEmailToResultRecipientError,
-  SessionAlreadyPublishedError,
-  SendingEmailToRefererError,
-} from '../../domain/errors.js';
+import { SendingEmailToResultRecipientError, SendingEmailToRefererError } from '../../domain/errors.js';
+import { SessionAlreadyPublishedError } from '../../../src/certification/session/domain/errors.js';
 import * as mailService from '../../domain/services/mail-service.js';
 import lodash from 'lodash';
 

--- a/api/lib/domain/usecases/publish-session.js
+++ b/api/lib/domain/usecases/publish-session.js
@@ -3,6 +3,7 @@
  * @typedef {import ('../../../lib/domain/usecases/index.js').FinalizedSessionRepository} FinalizedSessionRepository
  * @typedef {import ('../../../lib/domain/usecases/index.js').SessionRepository} SessionRepository
  * @typedef {import ('../../../lib/domain/usecases/index.js').MailService} MailService
+ * @typedef {import ('../../../lib/domain/usecases/index.js').SessionPublicationService} SessionPublicationService
  */
 
 /**

--- a/api/lib/infrastructure/DomainTransaction.js
+++ b/api/lib/infrastructure/DomainTransaction.js
@@ -1,18 +1,1 @@
-import { knex } from '../../db/knex-database-connection.js';
-
-class DomainTransaction {
-  constructor(knexTransaction) {
-    this.knexTransaction = knexTransaction;
-  }
-
-  static execute(lambda) {
-    return knex.transaction((trx) => {
-      return lambda(new DomainTransaction(trx));
-    });
-  }
-
-  static emptyTransaction() {
-    return new DomainTransaction(null);
-  }
-}
-export { DomainTransaction };
+export * from '../../src/shared/domain/DomainTransaction.js';

--- a/api/src/certification/session/application/http-error-mapper-configuration.js
+++ b/api/src/certification/session/application/http-error-mapper-configuration.js
@@ -1,9 +1,10 @@
 import { HttpErrors } from '../../../shared/application/http-errors.js';
 import {
-  SessionWithoutStartedCertificationError,
-  SessionWithAbortReasonOnCompletedCertificationCourseError,
-  SessionAlreadyFinalizedError,
   CertificationCandidateForbiddenDeletionError,
+  SessionAlreadyFinalizedError,
+  SessionAlreadyPublishedError,
+  SessionWithAbortReasonOnCompletedCertificationCourseError,
+  SessionWithoutStartedCertificationError,
 } from '../domain/errors.js';
 import { DomainErrorMappingConfiguration } from '../../../shared/application/models/domain-error-mapping-configuration.js';
 
@@ -19,6 +20,10 @@ const sessionDomainErrorMappingConfiguration = [
   {
     name: SessionAlreadyFinalizedError.name,
     httpErrorFn: (error) => new HttpErrors.ConflictError(error.message, error.code),
+  },
+  {
+    name: SessionAlreadyPublishedError.name,
+    httpErrorFn: (error) => new HttpErrors.BadRequestError(error.message, error.code),
   },
   {
     name: CertificationCandidateForbiddenDeletionError.name,

--- a/api/src/certification/session/application/session-unfinalize-controller.js
+++ b/api/src/certification/session/application/session-unfinalize-controller.js
@@ -1,0 +1,5 @@
+import { usecases } from '../../shared/domain/usecases/index.js';
+
+export const unfinalizeSession = function (request) {
+  return usecases.unfinalizeSession(request);
+};

--- a/api/src/certification/session/application/session-unfinalize-controller.js
+++ b/api/src/certification/session/application/session-unfinalize-controller.js
@@ -1,5 +1,14 @@
 import { usecases } from '../../shared/domain/usecases/index.js';
 
-export const unfinalizeSession = function (request) {
-  return usecases.unfinalizeSession(request);
+export const unfinalizeSession = async function (request, h) {
+  const sessionId = request.params.id;
+  await usecases.unfinalizeSession({ sessionId });
+
+  return h.response().code(204);
 };
+
+const sessionUnfinalizeController = {
+  unfinalizeSession,
+};
+
+export { sessionUnfinalizeController };

--- a/api/src/certification/session/application/session-unfinalize-route.js
+++ b/api/src/certification/session/application/session-unfinalize-route.js
@@ -1,4 +1,4 @@
-import { sessionUnfinalizeController } from './session-unfinalize-controller.js';
+import { unfinalizeController } from './unfinalize-controller.js';
 import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
 import Joi from 'joi';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
@@ -20,7 +20,7 @@ const register = async function (server) {
             assign: 'hasAuthorizationToAccessAdminScope',
           },
         ],
-        handler: sessionUnfinalizeController.unfinalizeSession,
+        handler: unfinalizeController.unfinalizeSession,
         validate: {
           params: Joi.object({ id: identifiersType.sessionId }),
         },

--- a/api/src/certification/session/application/session-unfinalize-route.js
+++ b/api/src/certification/session/application/session-unfinalize-route.js
@@ -1,0 +1,38 @@
+import { sessionUnfinalizeController } from './session-unfinalize-controller.js';
+import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import Joi from 'joi';
+import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'PATCH',
+      path: '/api/admin/sessions/{id}/unfinalize',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: sessionUnfinalizeController.unfinalizeSession,
+        validate: {
+          params: Joi.object({ id: identifiersType.sessionId }),
+        },
+        tags: ['api', 'admin', 'sessions', 'unfinalization'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés avec le rôle Super Admin, Support, Certif **\n' +
+            '- Elle permet de définaliser une sessions finalisée',
+        ],
+      },
+    },
+  ]);
+};
+
+const name = 'session-unfinalize-api';
+export { register, name };

--- a/api/src/certification/session/application/unfinalize-controller.js
+++ b/api/src/certification/session/application/unfinalize-controller.js
@@ -7,8 +7,8 @@ export const unfinalizeSession = async function (request, h) {
   return h.response().code(204);
 };
 
-const sessionUnfinalizeController = {
+const unfinalizeController = {
   unfinalizeSession,
 };
 
-export { sessionUnfinalizeController };
+export { unfinalizeController };

--- a/api/src/certification/session/application/unfinalize-route.js
+++ b/api/src/certification/session/application/unfinalize-route.js
@@ -34,5 +34,5 @@ const register = async function (server) {
   ]);
 };
 
-const name = 'session-unfinalize-api';
+const name = 'unfinalize-api';
 export { register, name };

--- a/api/src/certification/session/domain/errors.js
+++ b/api/src/certification/session/domain/errors.js
@@ -13,6 +13,12 @@ class SessionAlreadyFinalizedError extends DomainError {
   }
 }
 
+class SessionAlreadyPublishedError extends DomainError {
+  constructor(message = 'La session est déjà publiée.') {
+    super(message);
+  }
+}
+
 class SessionWithoutStartedCertificationError extends DomainError {
   constructor(message = "This session hasn't started, you can't finalise it. However, you can delete it.") {
     super(message);
@@ -49,5 +55,6 @@ export {
   SessionWithoutStartedCertificationError,
   SessionWithAbortReasonOnCompletedCertificationCourseError,
   SessionAlreadyFinalizedError,
+  SessionAlreadyPublishedError,
   CertificationCandidateForbiddenDeletionError,
 };

--- a/api/src/certification/session/domain/usecases/create-sessions.js
+++ b/api/src/certification/session/domain/usecases/create-sessions.js
@@ -4,7 +4,7 @@
 
 import { NotFoundError } from '../../../../../lib/domain/errors.js';
 import bluebird from 'bluebird';
-import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { Session } from '../models/Session.js';
 import { CertificationCandidate } from '../../../../../lib/domain/models/CertificationCandidate.js';
 import { CertificationVersion } from '../../../../shared/domain/models/CertificationVersion.js';

--- a/api/src/certification/session/domain/usecases/finalize-session.js
+++ b/api/src/certification/session/domain/usecases/finalize-session.js
@@ -1,3 +1,11 @@
+/**
+ * @typedef {import('../../../shared/domain/usecases/index.js').SessionRepository} SessionRepository
+ *
+ * @typedef {import('../../../shared/domain/usecases/index.js').CertificationCourseRepository} CertificationCourseRepository
+ *
+ * @typedef {import('../../../shared/domain/usecases/index.js').CertificationReportRepository} CertificationReportRepository
+ */
+
 import {
   SessionAlreadyFinalizedError,
   SessionWithoutStartedCertificationError,
@@ -8,6 +16,12 @@ import {
 import { SessionFinalized } from '../../../../../lib/domain/events/SessionFinalized.js';
 import bluebird from 'bluebird';
 
+/**
+ * @param {Object} params
+ * @param {SessionRepository} params.sessionRepository
+ * @param {CertificationCourseRepository} params.certificationCourseRepository
+ * @param {CertificationReportRepository} params.certificationReportRepository
+ */
 const finalizeSession = async function ({
   sessionId,
   examinerGlobalComment,

--- a/api/src/certification/session/domain/usecases/unfinalize-session.js
+++ b/api/src/certification/session/domain/usecases/unfinalize-session.js
@@ -17,7 +17,7 @@ const unfinalizeSession = async function ({ sessionId, sessionRepository, finali
   }
 
   return DomainTransaction.execute(async (domainTransaction) => {
-    await finalizedSessionRepository.delete({ sessionId, domainTransaction });
+    await finalizedSessionRepository.remove({ sessionId, domainTransaction });
     await sessionRepository.unfinalize({ sessionId, domainTransaction });
   });
 };

--- a/api/src/certification/session/domain/usecases/unfinalize-session.js
+++ b/api/src/certification/session/domain/usecases/unfinalize-session.js
@@ -3,6 +3,7 @@
  * @typedef {import('../../../shared/domain/usecases/index.js').FinalizedSessionRepository} FinalizedSessionRepository
  */
 
+import { SessionAlreadyPublishedError } from '../errors.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 
 /**
@@ -11,6 +12,10 @@ import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.j
  * @param {FinalizedSessionRepository} params.finalizedSessionRepository
  */
 const unfinalizeSession = async function ({ sessionId, sessionRepository, finalizedSessionRepository }) {
+  if (await sessionRepository.isPublished(sessionId)) {
+    throw new SessionAlreadyPublishedError();
+  }
+
   return DomainTransaction.execute(async (domainTransaction) => {
     await finalizedSessionRepository.delete({ sessionId, domainTransaction });
     await sessionRepository.unfinalize({ sessionId, domainTransaction });

--- a/api/src/certification/session/domain/usecases/unfinalize-session.js
+++ b/api/src/certification/session/domain/usecases/unfinalize-session.js
@@ -1,0 +1,20 @@
+/**
+ * @typedef {import('../../../shared/domain/usecases/index.js').SessionRepository} SessionRepository
+ * @typedef {import('../../../shared/domain/usecases/index.js').FinalizedSessionRepository} FinalizedSessionRepository
+ */
+
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+
+/**
+ * @param {Object} params
+ * @param {SessionRepository} params.sessionRepository
+ * @param {FinalizedSessionRepository} params.finalizedSessionRepository
+ */
+const unfinalizeSession = async function ({ sessionId, sessionRepository, finalizedSessionRepository }) {
+  return DomainTransaction.execute(async (domainTransaction) => {
+    await finalizedSessionRepository.delete({ sessionId, domainTransaction });
+    await sessionRepository.unfinalize({ sessionId, domainTransaction });
+  });
+};
+
+export { unfinalizeSession };

--- a/api/src/certification/session/infrastructure/repositories/finalized-session-repository.js
+++ b/api/src/certification/session/infrastructure/repositories/finalized-session-repository.js
@@ -9,7 +9,7 @@ const save = async function (finalizedSession) {
   return finalizedSession;
 };
 
-const _delete = async function ({ sessionId, domainTransaction = DomainTransaction.emptyTransaction() }) {
+const remove = async function ({ sessionId, domainTransaction = DomainTransaction.emptyTransaction() }) {
   const knexConn = domainTransaction.knexTransaction ?? knex;
   return knexConn('finalized-sessions').where({ sessionId }).delete();
 };
@@ -55,7 +55,7 @@ const findFinalizedSessionsWithRequiredAction = async function ({ version } = {}
   return publishableFinalizedSessions.map(_toDomainObject);
 };
 
-export { save, get, _delete as delete, findFinalizedSessionsToPublish, findFinalizedSessionsWithRequiredAction };
+export { save, get, remove, findFinalizedSessionsToPublish, findFinalizedSessionsWithRequiredAction };
 
 function _toDomainObject({ date, time, ...finalizedSession }) {
   return new FinalizedSession({

--- a/api/src/certification/session/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/session/infrastructure/repositories/session-repository.js
@@ -29,6 +29,11 @@ const isFinalized = async function (id) {
   return Boolean(session);
 };
 
+const isPublished = async function (id) {
+  const isPublished = await knex.select(1).from('sessions').where({ id }).whereNotNull('publishedAt').first();
+  return Boolean(isPublished);
+};
+
 const get = async function (sessionId) {
   const foundSession = await knex.select('*').from('sessions').where({ id: sessionId }).first();
   if (!foundSession) {
@@ -219,6 +224,7 @@ export {
   save,
   saveSessions,
   isFinalized,
+  isPublished,
   get,
   isSessionExisting,
   isSessionExistingBySessionAndCertificationCenterIds,

--- a/api/src/certification/session/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/session/infrastructure/repositories/session-repository.js
@@ -120,6 +120,15 @@ const finalize = async function ({ id, examinerGlobalComment, hasIncident, hasJo
   return new Session(finalizedSession);
 };
 
+const unfinalize = async function (id) {
+  const updates = await knex('sessions')
+    .where({ id })
+    .update({ finalizedAt: null, assignedCertificationOfficerId: null });
+  if (updates === 0) {
+    throw new NotFoundError("La session n'existe pas ou son accès est restreint");
+  }
+};
+
 const flagResultsAsSentToPrescriber = async function ({ id, resultsSentToPrescriberAt }) {
   const [flaggedSession] = await knex('sessions').where({ id }).update({ resultsSentToPrescriberAt }).returning('*');
   return new Session(flaggedSession);
@@ -216,6 +225,7 @@ export {
   updateSessionInfo,
   doesUserHaveCertificationCenterMembershipForSession,
   finalize,
+  unfinalize,
   flagResultsAsSentToPrescriber,
   updatePublishedAt,
   isSco,

--- a/api/src/certification/session/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/session/infrastructure/repositories/session-repository.js
@@ -120,9 +120,10 @@ const finalize = async function ({ id, examinerGlobalComment, hasIncident, hasJo
   return new Session(finalizedSession);
 };
 
-const unfinalize = async function (id) {
-  const updates = await knex('sessions')
-    .where({ id })
+const unfinalize = async function ({ sessionId, domainTransaction = DomainTransaction.emptyTransaction() }) {
+  const knexConn = domainTransaction.knexTransaction ?? knex;
+  const updates = await knexConn('sessions')
+    .where({ id: sessionId })
     .update({ finalizedAt: null, assignedCertificationOfficerId: null });
   if (updates === 0) {
     throw new NotFoundError("La session n'existe pas ou son accès est restreint");

--- a/api/src/certification/session/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/session/infrastructure/repositories/session-repository.js
@@ -7,7 +7,7 @@ import { CertificationCenter } from '../../../../../lib/domain/models/Certificat
 import { CertificationCandidate } from '../../../../../lib/domain/models/CertificationCandidate.js';
 import { ComplementaryCertification } from '../../../session/domain/models/ComplementaryCertification.js';
 import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
-import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 
 const save = async function (sessionData, { knexTransaction } = DomainTransaction.emptyTransaction()) {
   const knexConn = knexTransaction ?? knex;

--- a/api/src/certification/session/routes.js
+++ b/api/src/certification/session/routes.js
@@ -6,6 +6,7 @@ import * as invigilatorKit from './application/invigilator-kit-route.js';
 import * as updateCpfImportStatus from './application/update-cpf-import-status-route.js';
 import * as sessionMassImport from './application/session-mass-import-route.js';
 import * as certificationOfficer from './application/certification-officer-route.js';
+import * as sessionUnfinalize from './application/session-unfinalize-route.js';
 
 const certificationSessionRoutes = [
   session,
@@ -16,6 +17,7 @@ const certificationSessionRoutes = [
   updateCpfImportStatus,
   sessionMassImport,
   certificationOfficer,
+  sessionUnfinalize,
 ];
 
 export { certificationSessionRoutes };

--- a/api/src/certification/session/routes.js
+++ b/api/src/certification/session/routes.js
@@ -6,7 +6,7 @@ import * as invigilatorKit from './application/invigilator-kit-route.js';
 import * as updateCpfImportStatus from './application/update-cpf-import-status-route.js';
 import * as sessionMassImport from './application/session-mass-import-route.js';
 import * as certificationOfficer from './application/certification-officer-route.js';
-import * as sessionUnfinalize from './application/session-unfinalize-route.js';
+import * as unfinalize from './application/unfinalize-route.js';
 
 const certificationSessionRoutes = [
   session,
@@ -17,7 +17,7 @@ const certificationSessionRoutes = [
   updateCpfImportStatus,
   sessionMassImport,
   certificationOfficer,
-  sessionUnfinalize,
+  unfinalize,
 ];
 
 export { certificationSessionRoutes };

--- a/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
@@ -7,7 +7,7 @@ import bluebird from 'bluebird';
 import { BookshelfCertificationCourse } from '../../../../../lib/infrastructure/orm-models/CertificationCourse.js';
 import { BookshelfAssessment } from '../../../../../lib/infrastructure/orm-models/Assessment.js';
 import * as bookshelfToDomainConverter from '../../../../../lib/infrastructure/utils/bookshelf-to-domain-converter.js';
-import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { CertificationCourse, ComplementaryCertificationCourse } from '../../../../../lib/domain/models/index.js';
 import { NotFoundError } from '../../../../../lib/domain/errors.js';
 import * as certificationChallengeRepository from '../../../../../lib/infrastructure/repositories/certification-challenge-repository.js';

--- a/api/src/devcomp/application/trainings/training-controller.js
+++ b/api/src/devcomp/application/trainings/training-controller.js
@@ -4,7 +4,7 @@ import * as trainingTriggerSerializer from '../../infrastructure/serializers/jso
 import * as targetProfileSummaryForAdminSerializer from '../../../../lib/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer.js';
 import { usecases } from '../../domain/usecases/index.js';
 import { usecases as libUsecases } from '../../../../lib/domain/usecases/index.js';
-import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import * as queryParamsUtils from '../../../../lib/infrastructure/utils/query-params-utils.js';
 
 const findPaginatedTrainingSummaries = async function (

--- a/api/src/devcomp/infrastructure/repositories/training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/training-repository.js
@@ -2,7 +2,7 @@ import { Training } from '../../domain/models/Training.js';
 import { TrainingSummary } from '../../domain/read-models/TrainingSummary.js';
 import { knex } from '../../../../db/knex-database-connection.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
-import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { UserRecommendedTraining } from '../../domain/read-models/UserRecommendedTraining.js';
 import { fetchPage } from '../../../../lib/infrastructure/utils/knex-utils.js';
 import lodash from 'lodash';

--- a/api/src/devcomp/infrastructure/repositories/training-trigger-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/training-trigger-repository.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { knex } from '../../../../db/knex-database-connection.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
-import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { TrainingTriggerForAdmin } from '../../domain/read-models/TrainingTriggerForAdmin.js';
 import { TrainingTriggerTube } from '../../domain/models/TrainingTriggerTube.js';
 import * as areaRepository from '../../../../lib/infrastructure/repositories/area-repository.js';

--- a/api/src/devcomp/infrastructure/repositories/user-recommended-training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/user-recommended-training-repository.js
@@ -1,5 +1,5 @@
 import { knex } from '../../../../db/knex-database-connection.js';
-import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { UserRecommendedTraining } from '../../domain/read-models/UserRecommendedTraining.js';
 
 const TABLE_NAME = 'user-recommended-trainings';

--- a/api/src/evaluation/application/competence-evaluations/competence-evaluation-controller.js
+++ b/api/src/evaluation/application/competence-evaluations/competence-evaluation-controller.js
@@ -1,6 +1,6 @@
 import { evaluationUsecases as usecases } from '../../../evaluation/domain/usecases/index.js';
 import * as competenceEvaluationSerializer from '../../infrastructure/serializers/jsonapi/competence-evaluation-serializer.js';
-import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 
 const startOrResume = async function (request, h, dependencies = { competenceEvaluationSerializer }) {
   const userId = request.auth.credentials.userId;

--- a/api/src/evaluation/infrastructure/repositories/competence-evaluation-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/competence-evaluation-repository.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
+
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { knex } from '../../../../db/knex-database-connection.js';
 import { CompetenceEvaluation } from '../../domain/models/CompetenceEvaluation.js';
 import { Assessment } from '../../../shared/domain/models/Assessment.js';

--- a/api/src/prescription/learner-management/application/organization-learners-controller.js
+++ b/api/src/prescription/learner-management/application/organization-learners-controller.js
@@ -1,5 +1,5 @@
 import { usecases } from '../domain/usecases/index.js';
-import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 
 const deleteOrganizationLearners = async function (request, h) {
   const authenticatedUserId = request.auth.credentials.userId;

--- a/api/src/shared/application/assessments/assessment-controller.js
+++ b/api/src/shared/application/assessments/assessment-controller.js
@@ -1,4 +1,4 @@
-import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { Serializer as JSONAPISerializer } from 'jsonapi-serializer';
 import { AssessmentEndedError } from '../../../../lib/domain/errors.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';

--- a/api/src/shared/domain/DomainTransaction.js
+++ b/api/src/shared/domain/DomainTransaction.js
@@ -1,0 +1,18 @@
+import { knex } from '../../../db/knex-database-connection.js';
+
+class DomainTransaction {
+  constructor(knexTransaction) {
+    this.knexTransaction = knexTransaction;
+  }
+
+  static execute(lambda) {
+    return knex.transaction((trx) => {
+      return lambda(new DomainTransaction(trx));
+    });
+  }
+
+  static emptyTransaction() {
+    return new DomainTransaction(null);
+  }
+}
+export { DomainTransaction };

--- a/api/src/shared/domain/usecases/delete-unassociated-badge.js
+++ b/api/src/shared/domain/usecases/delete-unassociated-badge.js
@@ -1,4 +1,4 @@
-import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import {
   AcquiredBadgeForbiddenDeletionError,
   CertificationBadgeForbiddenDeletionError,

--- a/api/src/shared/infrastructure/repositories/assessment-repository.js
+++ b/api/src/shared/infrastructure/repositories/assessment-repository.js
@@ -1,4 +1,4 @@
-import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { Assessment } from '../../domain/models/Assessment.js';
 import lodash from 'lodash';
 import { NotFoundError } from '../../../../lib/domain/errors.js';

--- a/api/src/shared/infrastructure/repositories/assessment-result-repository.js
+++ b/api/src/shared/infrastructure/repositories/assessment-result-repository.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { knex } from '../../../../db/knex-database-connection.js';
 import { AssessmentResultNotCreatedError, MissingAssessmentId } from '../../domain/errors.js';
-import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { AssessmentResult } from '../../domain/models/AssessmentResult.js';
 import { CompetenceMark } from '../../../../lib/domain/models/CompetenceMark.js';
 

--- a/api/src/shared/infrastructure/repositories/badge-repository.js
+++ b/api/src/shared/infrastructure/repositories/badge-repository.js
@@ -2,7 +2,7 @@ import { knex } from '../../../../db/knex-database-connection.js';
 import { Badge } from '../../../../src/shared/domain/models/Badge.js';
 import * as knexUtils from '../../../../lib/infrastructure/utils/knex-utils.js';
 import { AlreadyExistingEntityError, NotFoundError } from '../../domain/errors.js';
-import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import omit from 'lodash/omit.js';
 
 const TABLE_NAME = 'badges';

--- a/api/src/shared/infrastructure/repositories/user-repository.js
+++ b/api/src/shared/infrastructure/repositories/user-repository.js
@@ -1,5 +1,5 @@
 import { knex } from '../../../../db/knex-database-connection.js';
-import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { BookshelfUser } from '../../../../lib/infrastructure/orm-models/User.js';
 import { isUniqConstraintViolated, fetchPage } from '../../../../lib/infrastructure/utils/knex-utils.js';
 

--- a/api/tests/certification/session/acceptance/application/session-unfinalize-controller_test.js
+++ b/api/tests/certification/session/acceptance/application/session-unfinalize-controller_test.js
@@ -1,0 +1,28 @@
+import { expect, databaseBuilder, generateValidRequestAuthorizationHeader } from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+
+describe('Acceptance | Controller | Session | unfinalize-session', function () {
+  describe('PATCH /api/admin/sessions/{id}/unfinalize', function () {
+    it('should return status 204', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser.withRole().id;
+      databaseBuilder.factory.buildSession({ id: 123 });
+      databaseBuilder.factory.buildFinalizedSession({ sessionId: 123 });
+      await databaseBuilder.commit();
+
+      const server = await createServer();
+      const options = {
+        method: 'PATCH',
+        url: '/api/admin/sessions/123/unfinalize',
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(userId),
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+      // then
+      expect(response.statusCode).to.equal(204);
+    });
+  });
+});

--- a/api/tests/certification/session/integration/infrastructure/repositories/finalized-session-repository_test.js
+++ b/api/tests/certification/session/integration/infrastructure/repositories/finalized-session-repository_test.js
@@ -124,14 +124,14 @@ describe('Integration | Repository | Finalized-session', function () {
     });
   });
 
-  describe('#delete', function () {
-    it('deletes the record', async function () {
+  describe('#remove', function () {
+    it('removes the record', async function () {
       // given
       databaseBuilder.factory.buildFinalizedSession({ sessionId: 1234 });
       await databaseBuilder.commit();
 
       // when
-      await finalizedSessionRepository.delete({ sessionId: 1234 });
+      await finalizedSessionRepository.remove({ sessionId: 1234 });
 
       /// then
       const records = await knex('finalized-sessions').select(1);
@@ -147,7 +147,7 @@ describe('Integration | Repository | Finalized-session', function () {
 
         // when
         await DomainTransaction.execute(async (domainTransaction) => {
-          await finalizedSessionRepository.delete({ sessionId: 1234, domainTransaction });
+          await finalizedSessionRepository.remove({ sessionId: 1234, domainTransaction });
           return domainTransaction.knexTransaction.rollback();
         });
 

--- a/api/tests/certification/session/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/certification/session/integration/infrastructure/repositories/session-repository_test.js
@@ -85,6 +85,36 @@ describe('Integration | Repository | Session', function () {
     });
   });
 
+  describe('#isPublished', function () {
+    context('when the session has a published date', function () {
+      it('should return true', async function () {
+        //given
+        databaseBuilder.factory.buildSession({ id: 40, publishedAt: new Date() });
+        await databaseBuilder.commit();
+
+        // when
+        const isPublished = await sessionRepository.isPublished(40);
+
+        // then
+        expect(isPublished).to.be.equal(true);
+      });
+    });
+
+    context('when the session has no published date', function () {
+      it('should return tre', async function () {
+        //given
+        databaseBuilder.factory.buildSession({ id: 40, publishedAt: null });
+        await databaseBuilder.commit();
+
+        // when
+        const isPublished = await sessionRepository.isPublished(40);
+
+        // then
+        expect(isPublished).to.be.equal(false);
+      });
+    });
+  });
+
   describe('#get', function () {
     let session;
     let expectedSessionValues;

--- a/api/tests/certification/session/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/certification/session/integration/infrastructure/repositories/session-repository_test.js
@@ -445,6 +445,38 @@ describe('Integration | Repository | Session', function () {
     });
   });
 
+  describe('#unfinalize', function () {
+    it('should update the session', async function () {
+      // given
+      const { id: userId } = databaseBuilder.factory.buildUser();
+      const session = databaseBuilder.factory.buildSession({
+        id: 99,
+        finalizedAt: new Date(),
+        assignedCertificationOfficerId: userId,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      await sessionRepository.unfinalize(99);
+
+      // then
+      const dbSession = await knex('sessions').select('*').where({ id: 99 }).first();
+      expect(dbSession).to.deep.equal({ ...session, finalizedAt: null, assignedCertificationOfficerId: null });
+    });
+
+    context('when the session does not exists', function () {
+      it('should throw a not found error', async function () {
+        // given
+        // when
+        const error = await catchErr(sessionRepository.unfinalize)(99);
+
+        // then
+        expect(error).to.be.instanceOf(NotFoundError);
+      });
+    });
+  });
+
   describe('#flagResultsAsSentToPrescriber', function () {
     let id;
     const resultsSentToPrescriberAt = new Date('2017-09-01T12:14:33Z');

--- a/api/tests/certification/session/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/certification/session/unit/application/http-error-mapper-configuration_test.js
@@ -5,6 +5,7 @@ import {
   SessionWithAbortReasonOnCompletedCertificationCourseError,
   SessionAlreadyFinalizedError,
   CertificationCandidateForbiddenDeletionError,
+  SessionAlreadyPublishedError,
 } from '../../../../../src/certification/session/domain/errors.js';
 import { sessionDomainErrorMappingConfiguration } from '../../../../../src/certification/session/application/http-error-mapper-configuration.js';
 import { DomainErrorMappingConfiguration } from '../../../../../src/shared/application/models/domain-error-mapping-configuration.js';
@@ -75,6 +76,23 @@ describe('Unit | Certification | Session | Application | HttpErrorMapperConfigur
       expect(error).to.be.instanceOf(HttpErrors.ConflictError);
       expect(error.message).to.equal(message);
       expect(error.code).to.equal(code);
+    });
+  });
+
+  context('when mapping "SessionAlreadyPublishedError"', function () {
+    it('returns an BadRequest Http Error', function () {
+      //given
+      const httpErrorMapper = sessionDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === SessionAlreadyPublishedError.name,
+      );
+      const message = 'Test message error';
+
+      //when
+      const error = httpErrorMapper.httpErrorFn(new SessionAlreadyPublishedError(message));
+
+      //then
+      expect(error).to.be.instanceOf(HttpErrors.BadRequestError);
+      expect(error.message).to.equal(message);
     });
   });
 

--- a/api/tests/certification/session/unit/application/session-unfinalize-controller_test.js
+++ b/api/tests/certification/session/unit/application/session-unfinalize-controller_test.js
@@ -1,0 +1,23 @@
+import { expect, hFake, sinon } from '../../../../test-helper.js';
+import { unfinalizeSession } from '../../../../../src/certification/session/application/session-unfinalize-controller.js';
+import { usecases } from '../../../../../src/certification/shared/domain/usecases/index.js';
+
+describe('Unit | Controller | unfinalize-controller', function () {
+  describe('#unfinalizeSession', function () {
+    it('should unfinalize the session', async function () {
+      // given
+      const request = {
+        params: { id: 123 },
+      };
+      sinon.stub(usecases, 'unfinalizeSession');
+
+      // when
+      await unfinalizeSession(request, hFake);
+
+      // then
+      expect(usecases.unfinalizeSession).to.have.been.calledWithExactly({
+        sessionId: 123,
+      });
+    });
+  });
+});

--- a/api/tests/certification/session/unit/application/session-unfinalize-route_test.js
+++ b/api/tests/certification/session/unit/application/session-unfinalize-route_test.js
@@ -1,0 +1,75 @@
+import { HttpTestServer } from '../../../../tooling/server/http-test-server.js';
+import * as moduleUnderTest from '../../../../../src/certification/session/application/session-unfinalize-route.js';
+import { expect, sinon } from '../../../../test-helper.js';
+import { sessionUnfinalizeController } from '../../../../../src/certification/session/application/session-unfinalize-controller.js';
+import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+
+describe('Unit | Router | session-unfinalize', function () {
+  describe('PATCH /api/admin/sessions/{id}/unfinalize', function () {
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    [
+      {
+        condition: 'session ID params is not a number',
+        request: { method: 'PATCH', url: '/api/admin/sessions/wrong/unfinalize' },
+      },
+      {
+        condition: 'session ID params is out of range for database integer (> 2147483647)',
+        request: { method: 'PATCH', url: '/api/admin/sessions/9999999999/unfinalize' },
+      },
+    ].forEach(({ condition, request }) => {
+      describe(`when ${condition}`, function () {
+        it(`should return 400`, async function () {
+          // given
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          // when
+          const response = await httpTestServer.request(request.method, request.url, request.payload || null);
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+      });
+    });
+
+    describe(`when user has no role`, function () {
+      it(`should return 403`, async function () {
+        // given
+        sinon.stub(sessionUnfinalizeController, 'unfinalizeSession').callsFake((_, h) => h.response().code(204));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+          .callsFake((_, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleCertif')
+          .callsFake((_, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+          .callsFake((_, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('PATCH', '/api/admin/sessions/123/unfinalize');
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+
+    it('should exist', async function () {
+      // given
+      sinon.stub(sessionUnfinalizeController, 'unfinalizeSession').callsFake((_, h) => h.response().code(204));
+      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').callsFake((_, h) => h.response(true));
+      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleCertif').callsFake((_, h) => h.response(true));
+      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport').callsFake((_, h) => h.response(true));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('PATCH', '/api/admin/sessions/123/unfinalize');
+
+      // then
+      expect(response.statusCode).to.equal(204);
+    });
+  });
+});

--- a/api/tests/certification/session/unit/application/session-unfinalize-route_test.js
+++ b/api/tests/certification/session/unit/application/session-unfinalize-route_test.js
@@ -1,7 +1,7 @@
 import { HttpTestServer } from '../../../../tooling/server/http-test-server.js';
 import * as moduleUnderTest from '../../../../../src/certification/session/application/session-unfinalize-route.js';
 import { expect, sinon } from '../../../../test-helper.js';
-import { sessionUnfinalizeController } from '../../../../../src/certification/session/application/session-unfinalize-controller.js';
+import { unfinalizeController } from '../../../../../src/certification/session/application/unfinalize-controller.js';
 import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
 
 describe('Unit | Router | session-unfinalize', function () {
@@ -35,7 +35,7 @@ describe('Unit | Router | session-unfinalize', function () {
     describe(`when user has no role`, function () {
       it(`should return 403`, async function () {
         // given
-        sinon.stub(sessionUnfinalizeController, 'unfinalizeSession').callsFake((_, h) => h.response().code(204));
+        sinon.stub(unfinalizeController, 'unfinalizeSession').callsFake((_, h) => h.response().code(204));
         sinon
           .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
           .callsFake((_, h) => h.response({ errors: new Error('forbidden') }).code(403));
@@ -58,7 +58,7 @@ describe('Unit | Router | session-unfinalize', function () {
 
     it('should exist', async function () {
       // given
-      sinon.stub(sessionUnfinalizeController, 'unfinalizeSession').callsFake((_, h) => h.response().code(204));
+      sinon.stub(unfinalizeController, 'unfinalizeSession').callsFake((_, h) => h.response().code(204));
       sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').callsFake((_, h) => h.response(true));
       sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleCertif').callsFake((_, h) => h.response(true));
       sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport').callsFake((_, h) => h.response(true));

--- a/api/tests/certification/session/unit/application/unfinalize-controller_test.js
+++ b/api/tests/certification/session/unit/application/unfinalize-controller_test.js
@@ -1,5 +1,5 @@
 import { expect, hFake, sinon } from '../../../../test-helper.js';
-import { unfinalizeSession } from '../../../../../src/certification/session/application/session-unfinalize-controller.js';
+import { unfinalizeSession } from '../../../../../src/certification/session/application/unfinalize-controller.js';
 import { usecases } from '../../../../../src/certification/shared/domain/usecases/index.js';
 
 describe('Unit | Controller | unfinalize-controller', function () {

--- a/api/tests/certification/session/unit/application/unfinalize-route_test.js
+++ b/api/tests/certification/session/unit/application/unfinalize-route_test.js
@@ -1,5 +1,5 @@
 import { HttpTestServer } from '../../../../tooling/server/http-test-server.js';
-import * as moduleUnderTest from '../../../../../src/certification/session/application/session-unfinalize-route.js';
+import * as moduleUnderTest from '../../../../../src/certification/session/application/unfinalize-route.js';
 import { expect, sinon } from '../../../../test-helper.js';
 import { unfinalizeController } from '../../../../../src/certification/session/application/unfinalize-controller.js';
 import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';

--- a/api/tests/certification/session/unit/domain/usecases/unfinalize-session_test.js
+++ b/api/tests/certification/session/unit/domain/usecases/unfinalize-session_test.js
@@ -1,34 +1,55 @@
-import { sinon, expect } from '../../../../../test-helper.js';
+import { catchErr, expect, sinon } from '../../../../../test-helper.js';
 import { unfinalizeSession } from '../../../../../../src/certification/session/domain/usecases/unfinalize-session.js';
 import { knex } from '../../../../../../db/knex-database-connection.js';
+import { SessionAlreadyPublishedError } from '../../../../../../src/certification/session/domain/errors.js';
 
 describe('Unit | UseCase | unfinalize-session', function () {
   let sessionRepository;
   let finalizedSessionRepository;
 
-  it('should call repositories with transaction', async function () {
-    // given
-    sinon.stub(knex, 'transaction').callsFake((fn) => fn());
+  describe('when session is not published', function () {
+    it('should call repositories with transaction', async function () {
+      // given
+      sinon.stub(knex, 'transaction').callsFake((fn) => fn());
 
-    sessionRepository = {
-      unfinalize: sinon.stub(),
-    };
-    finalizedSessionRepository = {
-      delete: sinon.stub(),
-    };
+      sessionRepository = {
+        unfinalize: sinon.stub(),
+        isPublished: sinon.stub().resolves(false),
+      };
+      finalizedSessionRepository = {
+        delete: sinon.stub(),
+      };
 
-    // when
-    await unfinalizeSession({ sessionId: 99, sessionRepository, finalizedSessionRepository });
+      // when
+      await unfinalizeSession({ sessionId: 99, sessionRepository, finalizedSessionRepository });
 
-    // then
-    expect(sessionRepository.unfinalize).to.have.been.calledWithMatch({
-      sessionId: 99,
-      domainTransaction: sinon.match.object,
+      // then
+      expect(sessionRepository.unfinalize).to.have.been.calledWithMatch({
+        sessionId: 99,
+        domainTransaction: sinon.match.object,
+      });
+
+      expect(sessionRepository.isPublished).to.have.been.calledWithMatch(99);
+
+      expect(finalizedSessionRepository.delete).to.have.been.calledWithMatch({
+        sessionId: 99,
+        domainTransaction: sinon.match.object,
+      });
     });
+  });
 
-    expect(finalizedSessionRepository.delete).to.have.been.calledWithMatch({
-      sessionId: 99,
-      domainTransaction: sinon.match.object,
+  describe('when session is published', function () {
+    it('should throw an SessionAlreadyPublishedError', async function () {
+      // given
+      sessionRepository = {
+        isPublished: sinon.stub().resolves(true),
+      };
+
+      // when
+      const error = await catchErr(unfinalizeSession)({ sessionId: 99, sessionRepository });
+
+      // then
+      expect(error).to.be.instanceOf(SessionAlreadyPublishedError);
     });
   });
 });

--- a/api/tests/certification/session/unit/domain/usecases/unfinalize-session_test.js
+++ b/api/tests/certification/session/unit/domain/usecases/unfinalize-session_test.js
@@ -1,0 +1,34 @@
+import { sinon, expect } from '../../../../../test-helper.js';
+import { unfinalizeSession } from '../../../../../../src/certification/session/domain/usecases/unfinalize-session.js';
+import { knex } from '../../../../../../db/knex-database-connection.js';
+
+describe('Unit | UseCase | unfinalize-session', function () {
+  let sessionRepository;
+  let finalizedSessionRepository;
+
+  it('should call repositories with transaction', async function () {
+    // given
+    sinon.stub(knex, 'transaction').callsFake((fn) => fn());
+
+    sessionRepository = {
+      unfinalize: sinon.stub(),
+    };
+    finalizedSessionRepository = {
+      delete: sinon.stub(),
+    };
+
+    // when
+    await unfinalizeSession({ sessionId: 99, sessionRepository, finalizedSessionRepository });
+
+    // then
+    expect(sessionRepository.unfinalize).to.have.been.calledWithMatch({
+      sessionId: 99,
+      domainTransaction: sinon.match.object,
+    });
+
+    expect(finalizedSessionRepository.delete).to.have.been.calledWithMatch({
+      sessionId: 99,
+      domainTransaction: sinon.match.object,
+    });
+  });
+});

--- a/api/tests/certification/session/unit/domain/usecases/unfinalize-session_test.js
+++ b/api/tests/certification/session/unit/domain/usecases/unfinalize-session_test.js
@@ -17,7 +17,7 @@ describe('Unit | UseCase | unfinalize-session', function () {
         isPublished: sinon.stub().resolves(false),
       };
       finalizedSessionRepository = {
-        delete: sinon.stub(),
+        remove: sinon.stub(),
       };
 
       // when
@@ -31,7 +31,7 @@ describe('Unit | UseCase | unfinalize-session', function () {
 
       expect(sessionRepository.isPublished).to.have.been.calledWithMatch(99);
 
-      expect(finalizedSessionRepository.delete).to.have.been.calledWithMatch({
+      expect(finalizedSessionRepository.remove).to.have.been.calledWithMatch({
         sessionId: 99,
         domainTransaction: sinon.match.object,
       });

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -534,14 +534,6 @@ describe('Integration | API | Controller Error', function () {
       expect(responseDetail(response)).to.equal('Format de date invalide.');
     });
 
-    it('responds Bad Request when a SessionAlreadyPublishedError error occurs', async function () {
-      routeHandler.throws(new DomainErrors.SessionAlreadyPublishedError());
-      const response = await server.requestObject(request);
-
-      expect(response.statusCode).to.equal(BAD_REQUEST_ERROR);
-      expect(responseDetail(response)).to.equal('La session est déjà publiée.');
-    });
-
     it('responds Bad Request when a UserOrgaSettingsCreationError error occurs', async function () {
       routeHandler.throws(
         new DomainErrors.UserOrgaSettingsCreationError(

--- a/api/tests/unit/domain/services/session-publication-service_test.js
+++ b/api/tests/unit/domain/services/session-publication-service_test.js
@@ -2,11 +2,8 @@ import { domainBuilder, sinon, expect, catchErr } from '../../../test-helper.js'
 import { manageEmails, publishSession } from '../../../../lib/domain/services/session-publication-service.js';
 import { FinalizedSession, EmailingAttempt } from '../../../../lib/domain/models/index.js';
 
-import {
-  SendingEmailToResultRecipientError,
-  SessionAlreadyPublishedError,
-  SendingEmailToRefererError,
-} from '../../../../lib/domain/errors.js';
+import { SendingEmailToResultRecipientError, SendingEmailToRefererError } from '../../../../lib/domain/errors.js';
+import { SessionAlreadyPublishedError } from '../../../../src/certification/session/domain/errors.js';
 
 import { getI18n } from '../../../tooling/i18n/i18n.js';
 


### PR DESCRIPTION
## :christmas_tree: Problème
La definalisation d'une session n'est pas possible via les interface. Il est necessaire de faire des manipulations de base de données

## :gift: Proposition
Permettre de le faire sur clic boutton dans l'interface d'administration

## :socks: Remarques
~~On peut définaliser meme si la session est deja publié~~
On ne peut pas definaliser une session deja publiée, cf:
https://github.com/1024pix/pix/pull/7771



## :santa: Pour tester
Aller sur admin sur la [page d'une session finalisée](https://admin-pr7739.review.pix.fr/sessions/7006)
Definaliser la session via le boutton de definalisation, voir que la session est definalisé, que le boutton n'apparait plus et qu'une notification de succès apparaît.

