### PR TITLE
[FEATURE] Ajouter les textes de transition (PIX-10297)

### DIFF
--- a/api/src/devcomp/domain/models/Module.js
+++ b/api/src/devcomp/domain/models/Module.js
@@ -2,38 +2,28 @@ import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.
 import { NotFoundError } from '../../../shared/domain/errors.js';
 
 class Module {
-  #id;
-  #slug;
-  #title;
-  #grains;
-
-  constructor({ id, slug, title, grains }) {
+  constructor({ id, slug, title, grains, transitionTexts = [] }) {
     assertNotNullOrUndefined(id, "L'id est obligatoire pour un module");
     assertNotNullOrUndefined(title, 'Le titre est obligatoire pour un module');
     assertNotNullOrUndefined(slug, 'Le slug est obligatoire pour un module');
     assertNotNullOrUndefined(grains, 'Une liste de grains est obligatoire pour un module');
     this.#assertGrainsIsAnArray(grains);
+    this.#assertTransitionTextsLinkedToGrain(transitionTexts, grains);
 
-    this.#id = id;
-    this.#slug = slug;
-    this.#title = title;
-    this.#grains = grains;
+    this.id = id;
+    this.slug = slug;
+    this.title = title;
+    this.grains = grains;
+    this.transitionTexts = transitionTexts;
   }
 
-  get id() {
-    return this.#id;
-  }
-
-  get slug() {
-    return this.#slug;
-  }
-
-  get title() {
-    return this.#title;
-  }
-
-  get grains() {
-    return this.#grains;
+  #assertTransitionTextsLinkedToGrain(transitionTexts, grains) {
+    const isTransitionTextsLinkedToGrain = transitionTexts.every(
+      ({ grainId }) => !!grains.find(({ id }) => grainId === id),
+    );
+    if (!isTransitionTextsLinkedToGrain) {
+      throw new Error('Tous les textes de transition doivent être lié à un grain présent dans le module');
+    }
   }
 
   #assertGrainsIsAnArray(grains) {
@@ -53,7 +43,7 @@ class Module {
   }
 
   #getAllElements() {
-    return this.#grains.flatMap(({ elements }) => elements);
+    return this.grains.flatMap(({ elements }) => elements);
   }
 }
 

--- a/api/src/devcomp/domain/models/TransitionText.js
+++ b/api/src/devcomp/domain/models/TransitionText.js
@@ -1,0 +1,13 @@
+import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.js';
+
+class TransitionText {
+  constructor({ content, grainId }) {
+    assertNotNullOrUndefined(content, 'Le contenu est obligatoire pour un texte de transition');
+    assertNotNullOrUndefined(grainId, "L'id de grain est obligatoire pour un texte de transition");
+
+    this.content = content;
+    this.grainId = grainId;
+  }
+}
+
+export { TransitionText };

--- a/api/src/devcomp/infrastructure/datasources/learning-content/module.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module.json
@@ -4,6 +4,24 @@
       "id": "f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d",
       "slug": "bien-ecrire-son-adresse-mail",
       "title": "Bien écrire son adresse mail",
+      "transitionTexts": [
+        {
+          "content": "<p>Naomi a perdu l’adresse mail de son ami Mickaël. Elle n’arrive pas à retrouver cette adresse <span aria-hidden='true'>🤷‍♀</span>️. Elle a besoin de l’adresse mail de Mickaël pour lui envoyer un document. Elle demande donc à Mickaël par SMS. <br> Lancez la vidéo pour voir leur discussion <span aria-hidden='true'>👀▶️</span></p>",
+          "grainId": "34d225e8-5d52-4ebd-9acd-8bde8438cfc9"
+        },
+        {
+          "content": "<p>Et oui ! Naomi le sait : les adresses mail ont un certain format.</p><p>Étudions en détails l’adresse mail de Mickaël <span aria-hidden='true'>👨‍🏫👩‍🏫</span></p>",
+          "grainId": "af860b1e-0566-4b06-bcb4-a68a5151d621"
+        },
+        {
+          "content": "<p>Pour être sûr que tout est clair, voici un texte à trous ! <span aria-hidden='true'>🧩</span></p>",
+          "grainId": "edd7fec3-a649-425b-b8e3-65b13c6c47ea"
+        },
+        {
+          "content": "<p>Maintenant, à vous de jouer pour trouvez l'adresse mail de Naomi.</p>",
+          "grainId": "b7ea7630-824a-4a49-83d1-abb9b8d0d120"
+        }
+      ],
       "grains": [
         {
           "id": "34d225e8-5d52-4ebd-9acd-8bde8438cfc9",
@@ -73,8 +91,12 @@
                   "placeholder": "",
                   "ariaLabel": "Réponse 1",
                   "defaultValue": "",
-                  "tolerances": ["t1"],
-                  "solutions": ["@"]
+                  "tolerances": [
+                    "t1"
+                  ],
+                  "solutions": [
+                    "@"
+                  ]
                 },
                 {
                   "type": "text",
@@ -98,7 +120,9 @@
                       "content": "le fournisseur d'adresse mail"
                     }
                   ],
-                  "solutions": ["1"]
+                  "solutions": [
+                    "1"
+                  ]
                 },
                 {
                   "type": "text",
@@ -122,7 +146,9 @@
                       "content": "le fournisseur d'adresse mail"
                     }
                   ],
-                  "solutions": ["2"]
+                  "solutions": [
+                    "2"
+                  ]
                 }
               ],
               "feedbacks": {
@@ -255,7 +281,10 @@
                   "ariaLabel": "Adresse mail de Naomi",
                   "defaultValue": "",
                   "tolerances": [],
-                  "solutions": ["naomizao@yahoo.com", "naomizao@yahoo.fr"]
+                  "solutions": [
+                    "naomizao@yahoo.com",
+                    "naomizao@yahoo.fr"
+                  ]
                 }
               ],
               "feedbacks": {

--- a/api/src/devcomp/infrastructure/repositories/module-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-repository.js
@@ -5,6 +5,7 @@ import { Image } from '../../domain/models/element/Image.js';
 import { QCU } from '../../domain/models/element/QCU.js';
 import { QcuProposal } from '../../domain/models/QcuProposal.js';
 import { Grain } from '../../domain/models/Grain.js';
+import { TransitionText } from '../../domain/models/TransitionText.js';
 import { LearningContentResourceNotFound } from '../../../shared/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
 import { QCUForAnswerVerification } from '../../domain/models/element/QCU-for-answer-verification.js';
 import { BlockText } from '../../domain/models/block/BlockText.js';
@@ -47,6 +48,7 @@ function _toDomain(moduleData) {
     id: moduleData.id,
     slug: moduleData.slug,
     title: moduleData.title,
+    transitionTexts: moduleData.transitionTexts?.map((transitionText) => new TransitionText(transitionText)) ?? [],
     grains: moduleData.grains.map((grain) => {
       return new Grain({
         id: grain.id,

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
@@ -8,6 +8,7 @@ function serialize(module) {
       return {
         id: module.slug,
         title: module.title,
+        transitionTexts: module.transitionTexts,
         grains: module.grains.map((grain) => {
           return {
             id: grain.id,
@@ -67,7 +68,7 @@ function serialize(module) {
         }),
       };
     },
-    attributes: ['title', 'grains'],
+    attributes: ['title', 'grains', 'transitionTexts'],
     grains: {
       ref: 'id',
       includes: true,

--- a/api/tests/devcomp/integration/domain/models/Module_test.js
+++ b/api/tests/devcomp/integration/domain/models/Module_test.js
@@ -1,0 +1,35 @@
+import { Module } from '../../../../../src/devcomp/domain/models/Module.js';
+import { expect } from '../../../../test-helper.js';
+import { Grain } from '../../../../../src/devcomp/domain/models/Grain.js';
+import { Text } from '../../../../../src/devcomp/domain/models/element/Text.js';
+
+describe('Integration | Devcomp | Domain | Models | Module', function () {
+  describe('When a transition text is related to a missing grain', function () {
+    it('should throw an error', function () {
+      // given
+      const grain = new Grain({
+        id: '1',
+        title: 'Le format des adresses email',
+        elements: [new Text({ id: 'id', content: 'content' })],
+      });
+      const id = '1';
+      const slug = 'les-adresses-email';
+      const title = 'Les adresses email';
+      const grains = [grain];
+      const transitionTexts = [
+        {
+          grainId: '1',
+          content: 'content grain 1',
+        },
+        {
+          grainId: '2',
+          content: 'content grain 2',
+        },
+      ];
+
+      expect(() => new Module({ id, slug, title, grains, transitionTexts })).to.throw(
+        'Tous les textes de transition doivent être lié à un grain présent dans le module',
+      );
+    });
+  });
+});

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -15,6 +15,7 @@ import { BlockText } from '../../../../src/devcomp/domain/models/block/BlockText
 import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
 import { Video } from '../../../../src/devcomp/domain/models/element/Video.js';
 import { QROCMForAnswerVerification } from '../../../../src/devcomp/domain/models/element/QROCM-for-answer-verification.js';
+import { TransitionText } from '../../../../src/devcomp/domain/models/TransitionText.js';
 
 describe('Integration | DevComp | Repositories | ModuleRepository', function () {
   describe('#getBySlug', function () {
@@ -64,6 +65,20 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       // then
       expect(module).to.be.instanceOf(Module);
       expect(module.grains.every((grain) => grain instanceof Grain)).to.be.true;
+    });
+
+    it('should return a module with transition texts if it exists', async function () {
+      // given
+      const existingModuleSlug = 'bien-ecrire-son-adresse-mail';
+
+      // when
+      const module = await moduleRepository.getBySlug({
+        slug: existingModuleSlug,
+        moduleDatasource,
+      });
+
+      // then
+      expect(module.transitionTexts.every((transitionText) => transitionText instanceof TransitionText)).to.be.true;
     });
 
     it('should return a module which contains elements of type Text if it exists', async function () {

--- a/api/tests/devcomp/unit/domain/models/Module_test.js
+++ b/api/tests/devcomp/unit/domain/models/Module_test.js
@@ -10,14 +10,16 @@ describe('Unit | Devcomp | Domain | Models | Module', function () {
       const slug = 'les-adresses-email';
       const title = 'Les adresses email';
       const grains = [Symbol('text')];
+      const transitionTexts = [];
 
       // when
-      const module = new Module({ id, slug, title, grains });
+      const module = new Module({ id, slug, title, grains, transitionTexts });
 
       // then
       expect(module.id).to.equal(id);
       expect(module.slug).to.equal(slug);
       expect(module.title).to.equal(title);
+      expect(module.transitionTexts).to.equal(transitionTexts);
       expect(module.grains).to.have.length(grains.length);
     });
 

--- a/api/tests/devcomp/unit/domain/models/TransitionText_test.js
+++ b/api/tests/devcomp/unit/domain/models/TransitionText_test.js
@@ -1,0 +1,29 @@
+import { TransitionText } from '../../../../../src/devcomp/domain/models/TransitionText.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | TransitionText', function () {
+  describe('#constructor', function () {
+    it('should create a module and keep attributes', function () {
+      // when
+      const transitionText = new TransitionText({ content: 'content', grainId: 'grain-id' });
+
+      // then
+      expect(transitionText.content).to.equal('content');
+      expect(transitionText.grainId).to.equal('grain-id');
+    });
+  });
+
+  describe('if a transition text does not have a content', function () {
+    it('should throw an error', function () {
+      expect(() => new TransitionText({})).to.throw('Le contenu est obligatoire pour un texte de transition');
+    });
+  });
+
+  describe('if a transition text does not have a grain id', function () {
+    it('should throw an error', function () {
+      expect(() => new TransitionText({ content: '' })).to.throw(
+        "L'id de grain est obligatoire pour un texte de transition",
+      );
+    });
+  });
+});

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
@@ -11,6 +11,11 @@ describe('Unit | Infrastructure | Datasources | Learning Content | ModuleDatasou
       before(function () {
         const uuidSchema = Joi.string().guid().required();
 
+        const transitionTextSchema = Joi.object({
+          grainId: uuidSchema,
+          content: Joi.string().required(),
+        }).required();
+
         const textElementSchema = Joi.object({
           id: uuidSchema,
           type: Joi.string().valid('text').required(),
@@ -111,6 +116,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | ModuleDatasou
             .regex(/^[a-z0-9-]+$/)
             .required(),
           title: Joi.string().required(),
+          transitionTexts: Joi.array().items(transitionTextSchema),
           grains: Joi.array()
             .items(
               Joi.object({

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -25,6 +25,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
           id: slug,
           attributes: {
             title,
+            'transition-texts': [],
           },
           relationships: {
             grains: {
@@ -46,10 +47,17 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
       const id = 'id';
       const slug = 'bien-ecrire-son-adresse-mail';
       const title = 'Bien écrire son adresse mail';
+      const transitionTexts = [
+        {
+          content: '<p>content</p>',
+          grainId: '1',
+        },
+      ];
       const moduleFromDomain = new Module({
         id,
         slug,
         title,
+        transitionTexts,
         grains: [
           {
             id: '1',
@@ -125,6 +133,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
         data: {
           attributes: {
             title: 'Bien écrire son adresse mail',
+            'transition-texts': transitionTexts,
           },
           id: 'bien-ecrire-son-adresse-mail',
           relationships: {

--- a/mon-pix/app/pods/components/module/details/component.js
+++ b/mon-pix/app/pods/components/module/details/component.js
@@ -27,4 +27,9 @@ export default class ModuleDetails extends Component {
   grainCanDisplayContinueButton(index) {
     return this.lastIndex === index && this.hasNextGrain;
   }
+
+  @action
+  grainTransition(grainId) {
+    return this.args.module.transitionTexts.find((transition) => transition.grainId === grainId);
+  }
 }

--- a/mon-pix/app/pods/components/module/details/template.hbs
+++ b/mon-pix/app/pods/components/module/details/template.hbs
@@ -9,6 +9,7 @@
     {{#each this.grainsToDisplay as |grain index|}}
       <Module::Grain
         @grain={{grain}}
+        @transition={{this.grainTransition grain.id}}
         @submitAnswer={{@submitAnswer}}
         @canDisplayContinueButton={{this.grainCanDisplayContinueButton index}}
         @continueAction={{this.addNextGrainToDisplay}}

--- a/mon-pix/app/pods/components/module/grain/style.scss
+++ b/mon-pix/app/pods/components/module/grain/style.scss
@@ -4,6 +4,13 @@
   border: 1px solid $pix-neutral-22;
   border-radius: $pix-spacing-s;
 
+  &__header {
+    margin: $pix-spacing-m $pix-spacing-s $pix-spacing-s;
+    padding: $pix-spacing-xs $pix-spacing-m;
+    background: $pix-tertiary-5;
+    border-radius: $pix-spacing-xs;
+  }
+
   &__footer {
     padding: $pix-spacing-s;
     background: $pix-tertiary-5;

--- a/mon-pix/app/pods/components/module/grain/template.hbs
+++ b/mon-pix/app/pods/components/module/grain/template.hbs
@@ -1,5 +1,10 @@
 <article class="grain">
   <h2 class="screen-reader-only">{{@grain.title}}</h2>
+  {{#if @transition}}
+    <header class="grain__header">
+      {{html-unsafe @transition.content}}
+    </header>
+  {{/if}}
   {{#each @grain.elements as |element|}}
     {{#if element.isText}}
       <Module::Text @text={{element}} />

--- a/mon-pix/app/pods/module/model.js
+++ b/mon-pix/app/pods/module/model.js
@@ -2,6 +2,7 @@ import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class Module extends Model {
   @attr('string') title;
+  @attr({ defaultValue: () => [] }) transitionTexts;
 
   @hasMany('grain', { async: false, inverse: 'module' }) grains;
 }

--- a/mon-pix/tests/integration/components/module/details_test.js
+++ b/mon-pix/tests/integration/components/module/details_test.js
@@ -17,9 +17,10 @@ module('Integration | Component | Module | Details', function (hooks) {
       type: 'qcus',
     });
     const elements = [textElement, qcuElement];
-    const grain = store.createRecord('grain', { elements });
+    const grain = store.createRecord('grain', { id: 'grainId1', elements });
+    const transitionTexts = [{ grainId: 'grainId1', content: 'transition text' }];
 
-    const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
+    const module = store.createRecord('module', { title: 'Module title', grains: [grain], transitionTexts });
     this.set('module', module);
 
     // when
@@ -27,6 +28,7 @@ module('Integration | Component | Module | Details', function (hooks) {
 
     // then
     assert.ok(screen.getByRole('heading', { name: module.title, level: 1 }));
+    assert.ok(screen.getByRole('banner').innerText.includes('transition text'));
     assert.strictEqual(findAll('.element-text').length, 1);
     assert.strictEqual(findAll('.element-qcu').length, 1);
 

--- a/mon-pix/tests/integration/components/module/grain_test.js
+++ b/mon-pix/tests/integration/components/module/grain_test.js
@@ -20,6 +20,38 @@ module('Integration | Component | Module | Grain', function (hooks) {
     assert.ok(screen.getByRole('heading', { name: grain.title, level: 2 }));
   });
 
+  module('when grain has transition', function () {
+    test('should display transition', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const grain = store.createRecord('grain', { title: 'Grain title' });
+      const transition = { content: 'transition text' };
+      this.set('grain', grain);
+      this.set('transition', transition);
+
+      // when
+      const screen = await render(hbs`<Module::Grain @grain={{this.grain}} @transition={{this.transition}} />`);
+
+      // then
+      assert.ok(screen.getByText('transition text'));
+    });
+  });
+
+  module('when grain has not transition', function () {
+    test('should not create header', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const grain = store.createRecord('grain', { title: 'Grain title' });
+      this.set('grain', grain);
+
+      // when
+      await render(hbs`<Module::Grain @grain={{this.grain}} />`);
+
+      // then
+      assert.dom('.grain__header').doesNotExist();
+    });
+  });
+
   module('when element is a text', function () {
     test('should display text element', async function (assert) {
       // given


### PR DESCRIPTION
## :christmas_tree: Problème
En tant qu’apprenant je souhaite voir des textes afin d’avoir un lien entre les différents grain de mon module.

## :gift: Proposition
Ajouter dans le reférentiel au niveau des modules des transitions

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Sur Pix App, aller sur le module `/modules/bien-ecrire-son-adresse-mail`
Constater les textes de transition 
Constater qu'il n'y a pas d'erreurs lorsqu'il n'y en a pas 