### PR TITLE
[TECH] Suppression d'un PixButton avec un paramètre déprécié. (PIX-10495)

### DIFF
--- a/certif/app/templates/authenticated/team/list.hbs
+++ b/certif/app/templates/authenticated/team/list.hbs
@@ -12,9 +12,7 @@
       >{{t "pages.team.update-referer-button"}}</PixButton>
     {{/if}}
     {{#if this.shouldDisplayInviteMemberButton}}
-      <PixButton @isBorderVisible={{true}} @route="authenticated.team.invite">{{t
-          "pages.team.invite-button"
-        }}</PixButton>
+      <PixButtonLink @route="authenticated.team.invite">{{t "pages.team.invite-button"}}</PixButtonLink>
     {{/if}}
   </div>
 </div>


### PR DESCRIPTION
## :christmas_tree: Problème
Dans cette PR https://github.com/1024pix/pix-ui/pull/515 , les paramètres route et model vont etre enlevé du PixButton.
Il existe un PixButton qui utilise encore la paramètre route dans Pix Certif.

## :gift: Proposition
Changer le composant en PixButtonLink

## :santa: Pour tester
- Se connecter sur Pix Certif avec le compte `certif-pro@example.net`
- Aller sur la page Equipe https://certif-pr7746.review.pix.fr/equipe/membres
- Cliquer sur le bouton `Inviter un membre`
- Voir que la magie opère correctement 🧚 