### PR TITLE
[TECH] Améliorer la liste des candidats d'une session aux membres du centre de certification qui héberge la session (PIX-10512)

### DIFF
--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -235,6 +235,12 @@ const register = async function (server) {
             'page[size]': Joi.number().integer(),
           }),
         },
+        pre: [
+          {
+            method: securityPreHandlers.checkUserIsMemberOfCertificationCenter,
+            assign: 'isMemberOfCertificationCenter',
+          },
+        ],
         handler: certificationCenterController.getStudents,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +

--- a/api/tests/unit/application/certification-centers/index_test.js
+++ b/api/tests/unit/application/certification-centers/index_test.js
@@ -38,6 +38,7 @@ describe('Unit | Router | certification-center-router', function () {
     it('should accept a string array of one element as division filter ', async function () {
       // given
       sinon.stub(certificationCenterController, 'getStudents').callsFake((request, h) => h.response().code(200));
+      sinon.stub(securityPreHandlers, 'checkUserIsMemberOfCertificationCenter').returns(() => true);
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 
@@ -54,6 +55,7 @@ describe('Unit | Router | certification-center-router', function () {
     it('should accept a string array of several elements as division filter ', async function () {
       // given
       sinon.stub(certificationCenterController, 'getStudents').callsFake((request, h) => h.response().code(200));
+      sinon.stub(securityPreHandlers, 'checkUserIsMemberOfCertificationCenter').returns(() => true);
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 
@@ -85,6 +87,7 @@ describe('Unit | Router | certification-center-router', function () {
     it('should accept a pagination', async function () {
       // given
       sinon.stub(certificationCenterController, 'getStudents').callsFake((request, h) => h.response().code(200));
+      sinon.stub(securityPreHandlers, 'checkUserIsMemberOfCertificationCenter').returns(() => true);
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
       // when
@@ -129,6 +132,7 @@ describe('Unit | Router | certification-center-router', function () {
     it('should accept an empty query string', async function () {
       // given
       sinon.stub(certificationCenterController, 'getStudents').returns('ok');
+      sinon.stub(securityPreHandlers, 'checkUserIsMemberOfCertificationCenter').returns(() => true);
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 


### PR DESCRIPTION
## :gift: Proposition
Améliorer l'accès à cette route aux membres du centre de certification qui héberge la session.

## :socks: Remarques
nope 🧶 
## :santa: Pour tester
1. Non régression depuis certif en listant les élèves d'une session.
2. Faire un fetch depuis mon-pix vers l'api sur la route