### PR TITLE
[FEATURE] Afficher la liste des parcours autonomes existants dans Admin (PIX-10342).

### DIFF
--- a/admin/app/components/autonomous-courses/list-items.hbs
+++ b/admin/app/components/autonomous-courses/list-items.hbs
@@ -1,0 +1,53 @@
+<div class="content-text content-text--small">
+  <div class="table-admin">
+    <table>
+      <caption class="sr-only">Liste des parcours autonomes</caption>
+      <thead>
+        <tr>
+          <th scope="col" class="table__column table__column--id">Id</th>
+          <th scope="col">Nom</th>
+          <th scope="col" class="table__column table__medium">Date de création</th>
+          <th scope="col" class="table__column table__medium">Statut</th>
+        </tr>
+      </thead>
+
+      {{#if @items}}
+        <tbody>
+          {{#each @items as |autonomousCourseListItem|}}
+            <tr>
+              <td>
+                {{autonomousCourseListItem.id}}
+              </td>
+              <td>
+                <LinkTo
+                  @route="authenticated.autonomous-courses.autonomous-course"
+                  @model={{autonomousCourseListItem.id}}
+                >
+                  {{autonomousCourseListItem.name}}
+                </LinkTo>
+              </td>
+              <td>
+                {{format-date autonomousCourseListItem.createdAt}}
+              </td>
+              <td>
+                {{#if autonomousCourseListItem.archivedAt}}
+                  <PixTag @color={{"grey-light"}}>
+                    Archivé
+                  </PixTag>
+                {{else}}
+                  <PixTag @color={{"green-light"}}>
+                    Actif
+                  </PixTag>
+                {{/if}}
+              </td>
+            </tr>
+          {{/each}}
+        </tbody>
+      {{/if}}
+    </table>
+
+    {{#unless @items}}
+      <div class="table__empty">Aucun résultat</div>
+    {{/unless}}
+  </div>
+</div>

--- a/admin/app/controllers/authenticated/autonomous-courses/list.js
+++ b/admin/app/controllers/authenticated/autonomous-courses/list.js
@@ -1,2 +1,0 @@
-import Controller from '@ember/controller';
-export default class ListController extends Controller {}

--- a/admin/app/models/autonomous-course-list-item.js
+++ b/admin/app/models/autonomous-course-list-item.js
@@ -1,0 +1,7 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class AutonomousCourseListItem extends Model {
+  @attr('string') name;
+  @attr('date') createdAt;
+  @attr('date') archivedAt;
+}

--- a/admin/app/routes/authenticated/autonomous-courses/list.js
+++ b/admin/app/routes/authenticated/autonomous-courses/list.js
@@ -3,7 +3,23 @@ import { service } from '@ember/service';
 
 export default class ListRoute extends Route {
   @service accessControl;
+  @service store;
+
+  queryParams = {
+    pageNumber: { refreshModel: true },
+    pageSize: { refreshModel: true },
+  };
+
   beforeModel() {
     this.accessControl.restrictAccessTo(['isSuperAdmin', 'isSupport', 'isMetier'], 'authenticated');
+  }
+
+  model(params) {
+    return this.store.query('autonomous-course', {
+      page: {
+        number: params.pageNumber || 1,
+        size: params.pageSize || 100,
+      },
+    });
   }
 }

--- a/admin/app/templates/authenticated/autonomous-courses/list.hbs
+++ b/admin/app/templates/authenticated/autonomous-courses/list.hbs
@@ -10,5 +10,7 @@
 </header>
 
 <main class="page-body">
-  Liste des parcours autonomes
+  <section class="page-section">
+    <AutonomousCourses::ListItems @items={{@model}} />
+  </section>
 </main>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -44,6 +44,7 @@ import {
   findAutonomousCourseTargetProfiles,
   createAutonomousCourse,
   getAutonomousCourseDetails,
+  getPaginatedAutonomousCourses,
 } from './handlers/autonomous-courses';
 
 export default function makeServer(config) {
@@ -68,6 +69,7 @@ function routes() {
 
   this.get('/admin/autonomous-courses/target-profiles', findAutonomousCourseTargetProfiles);
   this.post('/admin/autonomous-courses', createAutonomousCourse);
+  this.get('/admin/autonomous-courses', getPaginatedAutonomousCourses);
   this.get('/admin/autonomous-courses/:id', getAutonomousCourseDetails);
 
   this.get('/admin/campaigns/:id');

--- a/admin/mirage/handlers/autonomous-courses.js
+++ b/admin/mirage/handlers/autonomous-courses.js
@@ -1,3 +1,5 @@
+import { getPaginationFromQueryParams, applyPagination } from './pagination-utils';
+
 export const findAutonomousCourseTargetProfiles = (schema) => {
   return schema.autonomousCourseTargetProfiles.all();
 };
@@ -14,3 +16,25 @@ export const getAutonomousCourseDetails = (schema, request) => {
   const autonomousCourseId = request.params.id;
   return schema.autonomousCourses.find(autonomousCourseId);
 };
+
+export function getPaginatedAutonomousCourses(schema, request) {
+  const autonomousCourseListItems = schema.autonomousCourseListItems.all().models;
+
+  const queryParams = request.queryParams;
+
+  const pagination = getPaginationFromQueryParams(queryParams);
+  const paginatedAutonomousCourses = applyPagination(autonomousCourseListItems, pagination);
+
+  const json = this.serialize(
+    { modelName: 'autonomous-course-list-item', models: paginatedAutonomousCourses },
+    'autonomous-course-list-item',
+  );
+  json.meta = {
+    page: pagination.page,
+    pageSize: pagination.pageSize,
+    rowCount: autonomousCourseListItems.length,
+    pageCount: 1,
+  };
+
+  return json;
+}

--- a/admin/mirage/serializers/autonomous-course-list-item.js
+++ b/admin/mirage/serializers/autonomous-course-list-item.js
@@ -1,0 +1,3 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({});

--- a/admin/tests/acceptance/authenticated/autonomous-courses/autonomous-courses_test.js
+++ b/admin/tests/acceptance/authenticated/autonomous-courses/autonomous-courses_test.js
@@ -51,16 +51,6 @@ module('Acceptance | Autonomous courses | Autonomous course', function (hooks) {
       });
     });
 
-    module('list page', function () {
-      test('it should set autonomous course menubar item active', async function (assert) {
-        // when
-        const screen = await visit('/autonomous-courses/list');
-
-        // then
-        assert.dom(screen.getByRole('link', { name: 'Parcours autonomes' })).hasClass('active');
-      });
-    });
-
     module('details page', function () {
       test('it should display details of the autonomous course', async function (assert) {
         // given
@@ -83,6 +73,42 @@ module('Acceptance | Autonomous courses | Autonomous course', function (hooks) {
         assert.dom(screen.getByText("texte page d'accueil")).exists();
         assert.dom(screen.getByText('01/01/2020')).exists();
         assert.dom(screen.getByRole('link', { name: 'Lien vers la campagne CODE (nouvelle fenêtre)' })).exists();
+      });
+    });
+
+    module('list page', function () {
+      test('it should display a list of autonomous-courses', async function (assert) {
+        // given
+        for (let index = 1; index < 6; index++) {
+          server.create('autonomous-course', {
+            id: index,
+          });
+
+          server.create('autonomous-course-list-item', {
+            id: index,
+            name: `Parcours autonome n°${index}`,
+            createdAt: new Date(`2020-01-0${index}`),
+            archiveAt: null,
+          });
+        }
+
+        // when
+        const screen = await visit('/autonomous-courses/list');
+
+        await click(screen.getByRole('link', { name: 'Parcours autonome n°3' }));
+
+        // then
+        assert.strictEqual(currentURL(), '/autonomous-courses/3/details');
+      });
+
+      test('it should display a button to create a new autonomous course', async function (assert) {
+        // when
+        const screen = await visit('/autonomous-courses/list');
+
+        await click(screen.getByRole('link', { name: 'Nouveau parcours autonome' }));
+
+        // then
+        assert.strictEqual(currentURL(), '/autonomous-courses/new');
       });
     });
   });

--- a/admin/tests/integration/components/autonomous-courses/list-items_test.js
+++ b/admin/tests/integration/components/autonomous-courses/list-items_test.js
@@ -1,0 +1,63 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | AutonomousCourses::ListItems', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it should display a autonomous courses list', async function (assert) {
+    // given
+    const autonomousCoursesList = [
+      {
+        id: 1002,
+        name: 'Parcours autonome 2023',
+        createdAt: new Date('2023-01-01'),
+      },
+      {
+        id: 1001,
+        name: 'Parcours autonome 2020',
+        createdAt: new Date('2020-01-01'),
+      },
+    ];
+    this.set('autonomousCoursesList', autonomousCoursesList);
+
+    // when
+    const screen = await render(hbs`<AutonomousCourses::ListItems @items={{this.autonomousCoursesList}} />`);
+
+    // then
+    assert.dom(screen.getByText('Id')).exists();
+    assert.dom(screen.getByText('1002')).exists();
+    assert.dom(screen.getByText('1001')).exists();
+
+    assert.dom(screen.getByText('Nom')).exists();
+    assert.dom(screen.getByRole('link', { name: 'Parcours autonome 2023' })).exists();
+    assert.dom(screen.getByRole('link', { name: 'Parcours autonome 2020' })).exists();
+
+    assert.dom(screen.getByText('Date de création')).exists();
+    assert.dom(screen.getByText('01/01/2023')).exists();
+    assert.dom(screen.getByText('01/01/2020')).exists();
+
+    assert.dom(screen.getByText('Statut')).exists();
+    assert.strictEqual(screen.getAllByText('Actif').length, 2);
+  });
+
+  test('it should display a autonomous course with archived tag', async function (assert) {
+    // given
+    const autonomousCoursesList = [
+      {
+        id: 1002,
+        name: 'Parcours autonome 2023',
+        createdAt: new Date('2023-01-01'),
+        archivedAt: new Date('2023-02-02'),
+      },
+    ];
+    this.set('autonomousCoursesList', autonomousCoursesList);
+
+    // when
+    const screen = await render(hbs`<AutonomousCourses::ListItems @items={{this.autonomousCoursesList}} />`);
+
+    // then
+    assert.dom(screen.getByText('Archivé')).exists();
+  });
+});

--- a/admin/tests/unit/routes/authenticated/autonomous-courses/list_test.js
+++ b/admin/tests/unit/routes/authenticated/autonomous-courses/list_test.js
@@ -1,0 +1,57 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+import Service from '@ember/service';
+
+module('Unit | Route | authenticated/autonomous-courses/list', function (hooks) {
+  setupTest(hooks);
+
+  let route;
+
+  hooks.beforeEach(function () {
+    route = this.owner.lookup('route:authenticated/autonomous-courses/list');
+  });
+
+  module('#beforeModel', function () {
+    test('it should check if current user is "SUPER_ADMIN", "METIER" or "SUPPORT"', function (assert) {
+      // given
+      const restrictAccessToStub = sinon.stub().returns();
+      class AccessControlStub extends Service {
+        restrictAccessTo = restrictAccessToStub;
+      }
+      this.owner.register('service:access-control', AccessControlStub);
+
+      // when
+      route.beforeModel();
+
+      // then
+      assert.ok(restrictAccessToStub.calledWith(['isSuperAdmin', 'isSupport', 'isMetier'], 'authenticated'));
+    });
+  });
+
+  module('#model', function () {
+    test('it should call store.query with expected page arguments', async function (assert) {
+      // given
+      route.store.query = sinon.stub().resolves();
+
+      const params = {
+        pageNumber: 'somePageNumber',
+        pageSize: 'somePageSize',
+      };
+
+      const expectedQueryArgs = {
+        page: {
+          number: 'somePageNumber',
+          size: 'somePageSize',
+        },
+      };
+
+      // when
+      await route.model(params);
+
+      // then
+      sinon.assert.calledWith(route.store.query, 'autonomous-course', expectedQueryArgs);
+      assert.ok(true);
+    });
+  });
+});

--- a/api/src/evaluation/application/autonomous-courses/autonomous-course-controller.js
+++ b/api/src/evaluation/application/autonomous-courses/autonomous-course-controller.js
@@ -1,6 +1,8 @@
+import * as queryParamsUtils from '../../../../lib/infrastructure/utils/query-params-utils.js';
 import * as requestResponseUtils from '../../../../lib/infrastructure/utils/request-response-utils.js';
 import { evaluationUsecases as usecases } from '../../domain/usecases/index.js';
 import * as autonomousCourseSerializer from '../../infrastructure/serializers/jsonapi/autonomous-course-serializer.js';
+import * as autonomousCoursePaginatedListSerializer from '../../infrastructure/serializers/jsonapi/autonomous-course-paginated-list-serializer.js';
 
 const save = async (request, h, dependencies = { requestResponseUtils, usecases, autonomousCourseSerializer }) => {
   const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
@@ -23,6 +25,16 @@ const getById = async function (request, h, dependencies = { usecases, autonomou
   return dependencies.autonomousCourseSerializer.serialize(autonomousCourse);
 };
 
-const autonomousCourseController = { save, getById };
+const findPaginatedList = async (
+  request,
+  h,
+  dependencies = { queryParamsUtils, usecases, autonomousCoursePaginatedListSerializer },
+) => {
+  const { page } = dependencies.queryParamsUtils.extractParameters(request.query);
+  const { autonomousCourses, meta } = await dependencies.usecases.findAllPaginatedAutonomousCourses({ page });
+  return dependencies.autonomousCoursePaginatedListSerializer.serialize(autonomousCourses, meta);
+};
+
+const autonomousCourseController = { save, getById, findPaginatedList };
 
 export { autonomousCourseController };

--- a/api/src/evaluation/domain/usecases/find-all-paginated-autonomous-courses.js
+++ b/api/src/evaluation/domain/usecases/find-all-paginated-autonomous-courses.js
@@ -1,0 +1,13 @@
+/**
+ * @param {Object} page custom pagination properties
+ * @param {number} page.size pagination items per page
+ * @param {number} page.number current pagination page
+ * @param autonomousCourseRepository
+ *
+ * @returns {Promise<{autonomousCourses: Array<CampaignListItem>, meta: { page: number, pageSize: number, rowCount: number, pageCount: number} }>} returns a paginated list of autonomous courses
+ */
+const findAllPaginatedAutonomousCourses = async ({ page, autonomousCourseRepository }) => {
+  return autonomousCourseRepository.findAllPaginated({ page });
+};
+
+export { findAllPaginatedAutonomousCourses };

--- a/api/src/evaluation/infrastructure/repositories/autonomous-course-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/autonomous-course-repository.js
@@ -53,4 +53,19 @@ async function get({ autonomousCourseId, campaignApi }) {
   return _toDomain(autonomousCourseDTO);
 }
 
-export { save, get };
+/**
+ * @param {Object} page custom pagination properties
+ * @param {number} page.size pagination items per page
+ * @param {number} page.number current pagination page
+ * @param {CampaignApi} campaignApi prescription campaign API
+ * @returns {Promise<{autonomousCourses: Array<CampaignListItem>, meta: { page: number, pageSize: number, rowCount: number, pageCount: number} }>} returns a paginated list of autonomous courses
+ */
+const findAllPaginated = async function ({ page, campaignApi }) {
+  const { models: autonomousCourses, meta } = await campaignApi.findAllForOrganization({
+    organizationId: constants.AUTONOMOUS_COURSES_ORGANIZATION_ID,
+    page,
+  });
+  return { autonomousCourses, meta };
+};
+
+export { save, get, findAllPaginated };

--- a/api/src/evaluation/infrastructure/serializers/jsonapi/autonomous-course-paginated-list-serializer.js
+++ b/api/src/evaluation/infrastructure/serializers/jsonapi/autonomous-course-paginated-list-serializer.js
@@ -1,0 +1,12 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (autonomousCourses, meta) {
+  return new Serializer('autonomous-course-list-item', {
+    attributes: ['name', 'createdAt', 'archivedAt'],
+    meta,
+  }).serialize(autonomousCourses);
+};
+
+export { serialize };

--- a/api/tests/evaluation/unit/application/autonomous-courses/autonomous-course-controller_test.js
+++ b/api/tests/evaluation/unit/application/autonomous-courses/autonomous-course-controller_test.js
@@ -1,6 +1,6 @@
 import { expect, sinon, hFake } from '../../../../test-helper.js';
 import { autonomousCourseController } from '../../../../../src/evaluation/application/autonomous-courses/autonomous-course-controller.js';
-import { evaluationUsecases as usecases } from '../../../../../src/evaluation/domain/usecases/index.js';
+import { evaluationUsecases } from '../../../../../src/evaluation/domain/usecases/index.js';
 
 describe('Unit | Controller | autonomous-course-controller', function () {
   describe('#save', function () {
@@ -76,7 +76,7 @@ describe('Unit | Controller | autonomous-course-controller', function () {
       const autonomousCourse = Symbol('autonomousCourse');
       const autonomousCourseId = 1;
 
-      sinon.stub(usecases, 'getAutonomousCourse').resolves(autonomousCourse);
+      sinon.stub(evaluationUsecases, 'getAutonomousCourse').resolves(autonomousCourse);
       const autonomousCourseSerializer = { serialize: sinon.stub().returns(expectedResult) };
 
       // when
@@ -91,8 +91,44 @@ describe('Unit | Controller | autonomous-course-controller', function () {
       );
 
       // then
-      expect(usecases.getAutonomousCourse).to.have.been.calledWithExactly({ autonomousCourseId });
+      expect(evaluationUsecases.getAutonomousCourse).to.have.been.calledWithExactly({ autonomousCourseId });
       expect(autonomousCourseSerializer.serialize).to.have.been.calledOnce;
+      expect(response).to.deep.equal(expectedResult);
+    });
+  });
+
+  describe('#findPaginatedList', function () {
+    it('should find all paginated autonomous courses for given pagination', async function () {
+      // given
+      const expectedResult = Symbol('serialized-result');
+      const autonomousCourses = Symbol('trainingSummary');
+      const meta = Symbol('meta');
+      const queryParameters = {
+        page: { size: 2, number: 1 },
+      };
+
+      const evaluationUsecases = {
+        findAllPaginatedAutonomousCourses: sinon.stub().resolves({ autonomousCourses, meta }),
+      };
+
+      const autonomousCoursePaginatedListSerializer = { serialize: sinon.stub().returns(expectedResult) };
+      const queryParamsUtils = { extractParameters: sinon.stub().returns(queryParameters) };
+
+      // when
+      const response = await autonomousCourseController.findPaginatedList(
+        {
+          params: {
+            page: { size: 2, number: 1 },
+          },
+        },
+        hFake,
+        { autonomousCoursePaginatedListSerializer, queryParamsUtils, usecases: evaluationUsecases },
+      );
+
+      // then
+      expect(evaluationUsecases.findAllPaginatedAutonomousCourses).to.have.been.calledWithExactly(queryParameters);
+      expect(autonomousCoursePaginatedListSerializer.serialize).to.have.been.calledOnce;
+      expect(queryParamsUtils.extractParameters).to.have.been.calledOnce;
       expect(response).to.deep.equal(expectedResult);
     });
   });

--- a/api/tests/evaluation/unit/application/autonomous-courses/index_test.js
+++ b/api/tests/evaluation/unit/application/autonomous-courses/index_test.js
@@ -1,0 +1,59 @@
+import { expect, sinon, HttpTestServer } from '../../../../test-helper.js';
+import { autonomousCourseController } from '../../../../../src/evaluation/application/autonomous-courses/autonomous-course-controller.js';
+import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import * as autonomousCoursesRouter from '../../../../../src/evaluation/application/autonomous-courses/index.js';
+
+describe('Unit | Application | Badges | Routes', function () {
+  describe('GET /api/admin/autonomous-courses', function () {
+    context('when user has role "SUPER_ADMIN", "SUPPORT" or "METIER"', function () {
+      it('should return an HTTP status code 200', async function () {
+        // given
+        sinon
+          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .withArgs([
+            securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+            securityPreHandlers.checkAdminMemberHasRoleSupport,
+            securityPreHandlers.checkAdminMemberHasRoleMetier,
+          ])
+          .callsFake(() => (request, h) => h.response(true));
+        sinon.stub(autonomousCourseController, 'findPaginatedList').returns({});
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(autonomousCoursesRouter);
+
+        // when
+        const { statusCode } = await httpTestServer.request('GET', '/api/admin/autonomous-courses');
+
+        // then
+        expect(statusCode).to.equal(200);
+      });
+
+      context('when user has role "CERTIF"', function () {
+        it('should return a response with an HTTP status code 403', async function () {
+          // given
+          sinon
+            .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+            .withArgs([
+              securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+              securityPreHandlers.checkAdminMemberHasRoleSupport,
+              securityPreHandlers.checkAdminMemberHasRoleMetier,
+            ])
+            .callsFake(
+              () => (request, h) =>
+                h
+                  .response({ errors: new Error('forbidden') })
+                  .code(403)
+                  .takeover(),
+            );
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(autonomousCoursesRouter);
+
+          // when
+          const { statusCode } = await httpTestServer.request('GET', '/api/admin/autonomous-courses');
+
+          // then
+          expect(statusCode).to.equal(403);
+        });
+      });
+    });
+  });
+});

--- a/api/tests/evaluation/unit/domain/usecases/find-all-paginated-autonomous-courses_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/find-all-paginated-autonomous-courses_test.js
@@ -1,0 +1,31 @@
+import { expect, sinon } from '../../../../test-helper.js';
+import { findAllPaginatedAutonomousCourses } from '../../../../../src/evaluation/domain/usecases/find-all-paginated-autonomous-courses.js';
+import { constants } from '../../../../../lib/domain/constants.js';
+
+describe('Unit | UseCase | find-all-paginated-autonomous-courses', function () {
+  it('should return a paginated list of autonomous courses', async function () {
+    // given
+    sinon.stub(constants, 'AUTONOMOUS_COURSES_ORGANIZATION_ID').value(777);
+
+    const page = {
+      size: 10,
+      number: 1,
+    };
+
+    const autonomousCourses = Symbol('autonomousCourses');
+
+    const autonomousCourseRepository = {
+      findAllPaginated: sinon.stub().resolves(autonomousCourses),
+    };
+
+    // when
+    const paginatedAutonomousCourses = await findAllPaginatedAutonomousCourses({
+      page,
+      autonomousCourseRepository,
+    });
+
+    // then
+    expect(autonomousCourseRepository.findAllPaginated).to.be.calledOnceWithExactly({ page });
+    expect(paginatedAutonomousCourses).to.equal(autonomousCourses);
+  });
+});

--- a/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/autonomous-course-paginated-list-serializer_test.js
+++ b/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/autonomous-course-paginated-list-serializer_test.js
@@ -1,0 +1,53 @@
+import { expect } from '../../../../../test-helper.js';
+import * as serializer from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/autonomous-course-paginated-list-serializer.js';
+
+describe('Unit | Serializer | JSONAPI | autonomous-course-paginated-list-serializer', function () {
+  describe('#serialize', function () {
+    it('should serialize an array of autonomous-courses list items', function () {
+      const autonomousCoursesList = [
+        {
+          id: 1,
+          name: 'name',
+          createdAt: new Date('2017-09-01T12:14:33Z'),
+          archivedAt: new Date('2019-09-01T12:14:33Z'),
+        },
+        {
+          id: 2,
+          name: 'name',
+          createdAt: new Date('2018-09-01T12:14:33Z'),
+          archivedAt: new Date('2020-09-01T12:14:33Z'),
+        },
+      ];
+
+      const meta = { some: 'meta' };
+
+      const expectedResponse = {
+        data: [
+          {
+            type: 'autonomous-course-list-items',
+            id: String(autonomousCoursesList[0].id),
+            attributes: {
+              'archived-at': autonomousCoursesList[0].archivedAt,
+              'created-at': autonomousCoursesList[0].createdAt,
+              name: autonomousCoursesList[0].name,
+            },
+          },
+          {
+            type: 'autonomous-course-list-items',
+            id: String(autonomousCoursesList[1].id),
+            attributes: {
+              'archived-at': autonomousCoursesList[1].archivedAt,
+              'created-at': autonomousCoursesList[1].createdAt,
+              name: autonomousCoursesList[1].name,
+            },
+          },
+        ],
+        meta,
+      };
+
+      const serializedResult = serializer.serialize(autonomousCoursesList, meta);
+
+      return expect(serializedResult).to.deep.equal(expectedResponse);
+    });
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème

Aujourd'hui, la page `/autonomous-courses/list` n'affiche qu'un texte provisoire.

## :gift: Proposition

Afficher la liste des parcours autonomes dans un tableau.

## :socks: Remarques

- On utilise pas encore la pagination
- On ne gère pas encore les parcours autonomes archivés
- 🚨 Dans un handler mirage, si on utilise une fonction fléchée, on ne peut pas utiliser le `this.serialize`.

## :santa: Pour tester

- Visiter la page `/autonomous-courses/list` et vérifier que tout s'affiche comme souhaité
