### PR TITLE
[TECH] Remplacer bookshelf par knex sur des repositories du scope Accès (PIX-10522)

### DIFF
--- a/api/lib/domain/usecases/accept-certification-center-invitation.js
+++ b/api/lib/domain/usecases/accept-certification-center-invitation.js
@@ -36,7 +36,7 @@ const acceptCertificationCenterInvitation = async function ({
   }
 
   if (localeFromCookie) {
-    const user = await userRepository.getById(userId);
+    const user = await userRepository.get(userId);
     user.setLocaleIfNotAlreadySet(localeFromCookie);
     if (user.hasBeenModified) {
       await userRepository.update({ id: user.id, locale: user.locale });

--- a/api/lib/domain/usecases/accept-organization-invitation.js
+++ b/api/lib/domain/usecases/accept-organization-invitation.js
@@ -21,7 +21,7 @@ const acceptOrganizationInvitation = async function ({
   }
 
   if (localeFromCookie) {
-    const user = await userRepository.getById(organizationInvitedUser.userId);
+    const user = await userRepository.get(organizationInvitedUser.userId);
     user.setLocaleIfNotAlreadySet(localeFromCookie);
     if (user.hasBeenModified) {
       await userRepository.update({ id: user.id, locale: user.locale });

--- a/api/lib/domain/usecases/generate-username-with-temporary-password.js
+++ b/api/lib/domain/usecases/generate-username-with-temporary-password.js
@@ -31,7 +31,7 @@ const generateUsernameWithTemporaryPassword = async function ({
   });
 
   if (hasStudentAccountAnIdentityProviderPIX) {
-    const updatedUser = await userRepository.addUsername(studentAccount.id, username);
+    const updatedUser = await userRepository.updateUsername({ id: studentAccount.id, username });
     return { username: updatedUser.username };
   } else {
     const generatedPassword = passwordGenerator.generateSimplePassword();

--- a/api/lib/domain/usecases/update-expired-password.js
+++ b/api/lib/domain/usecases/update-expired-password.js
@@ -19,7 +19,7 @@ const updateExpiredPassword = async function ({
 
   let foundUser;
   try {
-    foundUser = await userRepository.getById(userId);
+    foundUser = await userRepository.get(userId);
   } catch (error) {
     if (error instanceof UserNotFoundError) {
       logger.warn('Trying to change his password with incorrect user id');

--- a/api/lib/infrastructure/repositories/organization-invitation-repository.js
+++ b/api/lib/infrastructure/repositories/organization-invitation-repository.js
@@ -1,58 +1,39 @@
-import { BookshelfOrganizationInvitation } from '../orm-models/OrganizationInvitation.js';
-import * as bookshelfToDomainConverter from '../utils/bookshelf-to-domain-converter.js';
 import { NotFoundError } from '../../domain/errors.js';
 import { OrganizationInvitation } from '../../domain/models/OrganizationInvitation.js';
 import { knex } from '../../../db/knex-database-connection.js';
 import _ from 'lodash';
 
-function _toDomain(bookshelfInvitation) {
-  if (bookshelfInvitation) {
-    return bookshelfToDomainConverter.buildDomainObject(BookshelfOrganizationInvitation, bookshelfInvitation);
-  }
-  return null;
-}
-
-function _checkNotFoundError(error, id) {
-  if (error instanceof BookshelfOrganizationInvitation.NotFoundError) {
-    throw new NotFoundError(`Not found organization-invitation for ID ${id}`);
-  }
-  throw error;
-}
-
-function _checkNotFoundErrorWithCode({ error, id, code }) {
-  if (error instanceof BookshelfOrganizationInvitation.NotFoundError) {
-    throw new NotFoundError(`Not found organization-invitation for ID ${id} and code ${code}`);
-  }
-  throw error;
-}
-
-const create = function ({ organizationId, email, code, role }) {
+const create = async function ({ organizationId, email, code, role }) {
   const status = OrganizationInvitation.StatusType.PENDING;
-  return new BookshelfOrganizationInvitation({ organizationId, email, status, code, role }).save().then(_toDomain);
+  const [organizationInvitationCreated] = await knex('organization-invitations')
+    .insert({ organizationId, email, status, code, role })
+    .returning('*');
+
+  return new OrganizationInvitation(organizationInvitationCreated);
 };
 
-const get = function (id) {
-  return BookshelfOrganizationInvitation.where({ id })
-    .fetch()
-    .then(_toDomain)
-    .catch((err) => _checkNotFoundError(err, id));
+const get = async function (id) {
+  const organizationInvitation = await knex('organization-invitations').where('id', id).first();
+  if (!organizationInvitation) throw new NotFoundError(`Not found organization-invitation for ID ${id}`);
+  return new OrganizationInvitation(organizationInvitation);
 };
 
-const getByIdAndCode = function ({ id, code }) {
-  return BookshelfOrganizationInvitation.where({ id, code })
-    .fetch()
-    .then(_toDomain)
-    .catch((error) => _checkNotFoundErrorWithCode({ error, id, code }));
+const getByIdAndCode = async function ({ id, code }) {
+  const organizationInvitation = await knex('organization-invitations').where({ id, code }).first();
+  if (!organizationInvitation)
+    throw new NotFoundError(`Not found organization-invitation for ID ${id} and code ${code}`);
+  return new OrganizationInvitation(organizationInvitation);
 };
 
-const markAsAccepted = function (id) {
+const markAsAccepted = async function (id) {
   const status = OrganizationInvitation.StatusType.ACCEPTED;
 
-  return new BookshelfOrganizationInvitation({ id })
-    .save({ status }, { patch: true, require: true })
-    .then((model) => model.refresh())
-    .then(_toDomain)
-    .catch((err) => _checkNotFoundError(err, id));
+  const [organizationInvitationAccepted] = await knex('organization-invitations')
+    .where({ id })
+    .update({ status, updatedAt: new Date() })
+    .returning('*');
+  if (!organizationInvitationAccepted) throw new NotFoundError(`Not found organization-invitation for ID ${id}`);
+  return new OrganizationInvitation(organizationInvitationAccepted);
 };
 
 const markAsCancelled = async function ({ id }) {
@@ -70,21 +51,22 @@ const markAsCancelled = async function ({ id }) {
   return new OrganizationInvitation(organizationInvitation);
 };
 
-const findPendingByOrganizationId = function ({ organizationId }) {
-  return BookshelfOrganizationInvitation.where({ organizationId, status: OrganizationInvitation.StatusType.PENDING })
-    .orderBy('updatedAt', 'desc')
-    .fetchAll()
-    .then((results) => bookshelfToDomainConverter.buildDomainObjects(BookshelfOrganizationInvitation, results));
+const findPendingByOrganizationId = async function ({ organizationId }) {
+  const pendingOrganizationInvitations = await knex('organization-invitations')
+    .where({ organizationId, status: OrganizationInvitation.StatusType.PENDING })
+    .orderBy('updatedAt', 'desc');
+  return pendingOrganizationInvitations.map((pendingOrganizationInvitation) => {
+    return new OrganizationInvitation(pendingOrganizationInvitation);
+  });
 };
 
-const findOnePendingByOrganizationIdAndEmail = function ({ organizationId, email }) {
-  return BookshelfOrganizationInvitation.query((qb) =>
-    qb
-      .where({ organizationId, status: OrganizationInvitation.StatusType.PENDING })
-      .whereRaw('LOWER("email") = ?', `${email.toLowerCase()}`),
-  )
-    .fetch({ require: false })
-    .then(_toDomain);
+const findOnePendingByOrganizationIdAndEmail = async function ({ organizationId, email }) {
+  const pendingOrganizationInvitation = await knex('organization-invitations')
+    .where({ organizationId, status: OrganizationInvitation.StatusType.PENDING })
+    .whereRaw('LOWER("email") = ?', `${email.toLowerCase()}`)
+    .first();
+  if (!pendingOrganizationInvitation) return null;
+  return new OrganizationInvitation(pendingOrganizationInvitation);
 };
 
 const updateModificationDate = async function (id) {

--- a/api/src/shared/infrastructure/repositories/user-repository.js
+++ b/api/src/shared/infrastructure/repositories/user-repository.js
@@ -77,14 +77,6 @@ const get = async function (userId) {
   if (!foundUser) throw new UserNotFoundError(`User not found for ID ${userId}`);
   return new User(foundUser);
 };
-//Doublon ici entre le get & getById ?
-const getById = async function (userId) {
-  const foundUser = await knex.from('users').where({ id: userId }).first();
-  if (!foundUser) {
-    throw new UserNotFoundError();
-  }
-  return new User(foundUser);
-};
 
 const getByIds = async function (userIds) {
   const dbUsers = await knex('users').whereIn('id', userIds);
@@ -212,6 +204,7 @@ const getBySamlId = async function (samlId) {
         .andOnVal('authentication-methods.externalIdentifier', samlId);
     });
   }).fetch({ require: false, withRelated: 'authenticationMethods' });
+
   return bookshelfUser ? _toDomain(bookshelfUser) : null;
 };
 
@@ -413,7 +406,6 @@ export {
   findPaginatedFiltered,
   get,
   getByEmail,
-  getById,
   getByIds,
   getBySamlId,
   getByUsernameOrEmailWithRolesAndPassword,

--- a/api/src/shared/infrastructure/repositories/user-repository.js
+++ b/api/src/shared/infrastructure/repositories/user-repository.js
@@ -2,7 +2,6 @@ import { knex } from '../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
 import { BookshelfUser } from '../../../../lib/infrastructure/orm-models/User.js';
 import { isUniqConstraintViolated, fetchPage } from '../../../../lib/infrastructure/utils/knex-utils.js';
-import * as bookshelfToDomainConverter from '../../../../lib/infrastructure/utils/bookshelf-to-domain-converter.js';
 
 import {
   AlreadyExistingEntityError,
@@ -73,18 +72,12 @@ const getByUsernameOrEmailWithRolesAndPassword = async function (username) {
   return _toDomainFromDTO({ userDTO, membershipsDTO, certificationCenterMembershipsDTO, authenticationMethodsDTO });
 };
 
-const get = function (userId) {
-  return BookshelfUser.where({ id: userId })
-    .fetch()
-    .then((user) => bookshelfToDomainConverter.buildDomainObject(BookshelfUser, user))
-    .catch((err) => {
-      if (err instanceof BookshelfUser.NotFoundError) {
-        throw new UserNotFoundError(`User not found for ID ${userId}`);
-      }
-      throw err;
-    });
+const get = async function (userId) {
+  const foundUser = await knex('users').where('id', userId).first();
+  if (!foundUser) throw new UserNotFoundError(`User not found for ID ${userId}`);
+  return new User(foundUser);
 };
-
+//Doublon ici entre le get & getById ?
 const getById = async function (userId) {
   const foundUser = await knex.from('users').where({ id: userId }).first();
   if (!foundUser) {
@@ -181,21 +174,34 @@ const getWithMemberships = async function (userId) {
   return _toDomainFromDTO({ userDTO, membershipsDTO });
 };
 
-const getWithCertificationCenterMemberships = function (userId) {
-  return BookshelfUser.where({ id: userId })
-    .fetch({
-      withRelated: [
-        { certificationCenterMemberships: (qb) => qb.where({ disabledAt: null }) },
-        'certificationCenterMemberships.certificationCenter',
-      ],
-    })
-    .then(_toDomain)
-    .catch((err) => {
-      if (err instanceof BookshelfUser.NotFoundError) {
-        throw new UserNotFoundError(`User not found for ID ${userId}`);
-      }
-      throw err;
-    });
+const getWithCertificationCenterMemberships = async function (userId) {
+  const user = await knex('users').where({ id: userId }).first();
+  if (!user) throw new UserNotFoundError(`User not found for ID ${userId}`);
+
+  const certificationCenterMemberships = await knex('certification-center-memberships')
+    .where({ userId })
+    .whereNull('disabledAt');
+  const certificationCenters = await knex('certification-centers').whereIn(
+    'id',
+    certificationCenterMemberships.map(
+      (certificationCenterMembership) => certificationCenterMembership.certificationCenterId,
+    ),
+  );
+
+  return new User({
+    ...user,
+    certificationCenterMemberships: certificationCenterMemberships.map(
+      (certificationCenterMembership) =>
+        new CertificationCenterMembership({
+          ...certificationCenterMembership,
+          certificationCenter: new CertificationCenter(
+            certificationCenters.find(
+              (certificationCenter) => certificationCenter.id === certificationCenterMembership.certificationCenterId,
+            ),
+          ),
+        }),
+    ),
+  });
 };
 
 const getBySamlId = async function (samlId) {
@@ -220,42 +226,31 @@ const updateWithEmailConfirmed = function ({
   userAttributes,
   domainTransaction: { knexTransaction } = DomainTransaction.emptyTransaction(),
 }) {
-  const query = knex('users').where({ id }).update(userAttributes);
+  const query = knex('users')
+    .where({ id })
+    .update({ ...userAttributes, updatedAt: new Date() });
   if (knexTransaction) query.transacting(knexTransaction);
   return query;
 };
 
-const checkIfEmailIsAvailable = function (email) {
-  return BookshelfUser.query((qb) => qb.whereRaw('LOWER("email") = ?', email.toLowerCase()))
-    .fetch({ require: false })
-    .then((user) => {
-      if (user) {
-        return Promise.reject(new AlreadyRegisteredEmailError());
-      }
+const checkIfEmailIsAvailable = async function (email) {
+  const existingUserEmail = await knex('users').whereRaw('LOWER("email") = ?', email.toLowerCase()).first();
 
-      return Promise.resolve(email);
-    });
+  if (existingUserEmail) throw new AlreadyRegisteredEmailError();
+
+  return email;
 };
 
-const isUserExistingByEmail = function (email) {
-  return BookshelfUser.where({ email: email.toLowerCase() })
-    .fetch()
-    .then(() => true)
-    .catch(() => {
-      throw new UserNotFoundError();
-    });
+const isUserExistingByEmail = async function (email) {
+  const existingUser = await knex('users').where('email', email.toLowerCase()).first();
+  if (!existingUser) throw new UserNotFoundError();
+  return true;
 };
 
-const updateEmail = function ({ id, email }) {
-  return BookshelfUser.where({ id })
-    .save({ email }, { patch: true, method: 'update' })
-    .then((bookshelfUser) => _toDomain(bookshelfUser))
-    .catch((err) => {
-      if (err instanceof BookshelfUser.NoRowsUpdatedError) {
-        throw new UserNotFoundError(`User not found for ID ${id}`);
-      }
-      throw err;
-    });
+const updateEmail = async function ({ id, email }) {
+  const [updatedUserEmail] = await knex('users').where({ id }).update({ email, updatedAt: new Date() }).returning('*');
+  if (!updatedUserEmail) throw new UserNotFoundError(`User not found for ID ${id}`);
+  return new User(updatedUserEmail);
 };
 
 const updateUserDetailsForAdministration = async function ({
@@ -265,7 +260,10 @@ const updateUserDetailsForAdministration = async function ({
 }) {
   try {
     const knexConn = domainTransaction.knexTransaction ?? knex;
-    const [userDTO] = await knexConn('users').where({ id }).update(userAttributes).returning('*');
+    const [userDTO] = await knexConn('users')
+      .where({ id })
+      .update({ ...userAttributes, updatedAt: new Date() })
+      .returning('*');
 
     if (!userDTO) {
       throw new UserNotFoundError(`User not found for ID ${id}`);
@@ -279,9 +277,12 @@ const updateUserDetailsForAdministration = async function ({
 };
 
 const updateHasSeenAssessmentInstructionsToTrue = async function (id) {
-  const user = await BookshelfUser.where({ id }).fetch({ require: false });
-  await user.save({ hasSeenAssessmentInstructions: true }, { patch: true, method: 'update' });
-  return bookshelfToDomainConverter.buildDomainObject(BookshelfUser, user);
+  const [user] = await knex('users')
+    .where({ id })
+    .update({ hasSeenAssessmentInstructions: true, updatedAt: new Date() })
+    .returning('*');
+
+  return new User(user);
 };
 
 const updateHasSeenLevelSevenInfoToTrue = async function (id) {
@@ -295,32 +296,38 @@ const updateHasSeenLevelSevenInfoToTrue = async function (id) {
 };
 
 const updateHasSeenNewDashboardInfoToTrue = async function (id) {
-  const user = await BookshelfUser.where({ id }).fetch({ require: false });
-  await user.save({ hasSeenNewDashboardInfo: true }, { patch: true, method: 'update' });
-  return bookshelfToDomainConverter.buildDomainObject(BookshelfUser, user);
+  const [user] = await knex('users')
+    .where({ id })
+    .update({ hasSeenNewDashboardInfo: true, updatedAt: new Date() })
+    .returning('*');
+
+  return new User(user);
 };
 
 const updateHasSeenChallengeTooltip = async function ({ userId, challengeType }) {
-  const user = await BookshelfUser.where({ id: userId }).fetch({ require: false });
+  let user;
   if (challengeType === 'focused') {
-    await user.save({ hasSeenFocusedChallengeTooltip: true }, { patch: true, method: 'update' });
+    [user] = await knex('users')
+      .where({ id: userId })
+      .update({ hasSeenFocusedChallengeTooltip: true, updatedAt: new Date() })
+      .returning('*');
   }
   if (challengeType === 'other') {
-    await user.save({ hasSeenOtherChallengesTooltip: true }, { patch: true, method: 'update' });
+    [user] = await knex('users')
+      .where({ id: userId })
+      .update({ hasSeenOtherChallengesTooltip: true, updatedAt: new Date() })
+      .returning('*');
   }
-  return bookshelfToDomainConverter.buildDomainObject(BookshelfUser, user);
+  return new User(user);
 };
 
 const acceptPixLastTermsOfService = async function (id) {
-  const user = await BookshelfUser.where({ id }).fetch({ require: false });
-  await user.save(
-    {
-      lastTermsOfServiceValidatedAt: new Date(),
-      mustValidateTermsOfService: false,
-    },
-    { patch: true, method: 'update' },
-  );
-  return bookshelfToDomainConverter.buildDomainObject(BookshelfUser, user);
+  const [user] = await knex('users')
+    .where({ id })
+    .update({ lastTermsOfServiceValidatedAt: new Date(), mustValidateTermsOfService: false, updatedAt: new Date() })
+    .returning('*');
+
+  return new User(user);
 };
 
 const updatePixOrgaTermsOfServiceAcceptedToTrue = async function (id) {
@@ -346,42 +353,21 @@ const updatePixCertifTermsOfServiceAcceptedToTrue = async function (id) {
 };
 
 const isUsernameAvailable = async function (username) {
-  const foundUser = await BookshelfUser.where({ username }).fetch({ require: false });
-  if (foundUser) {
-    throw new AlreadyRegisteredUsernameError();
-  }
+  const foundUser = await knex('users').where({ username }).first();
+
+  if (foundUser) throw new AlreadyRegisteredUsernameError();
+
   return username;
 };
 
-const updateUsername = function ({ id, username, domainTransaction = DomainTransaction.emptyTransaction() }) {
-  return BookshelfUser.where({ id })
-    .save(
-      { username },
-      {
-        transacting: domainTransaction.knexTransaction,
-        patch: true,
-        method: 'update',
-      },
-    )
-    .then((bookshelfUser) => _toDomain(bookshelfUser))
-    .catch((err) => {
-      if (err instanceof BookshelfUser.NoRowsUpdatedError) {
-        throw new UserNotFoundError(`User not found for ID ${id}`);
-      }
-      throw err;
-    });
-};
-
-const addUsername = function (id, username) {
-  return BookshelfUser.where({ id })
-    .save({ username }, { patch: true, method: 'update' })
-    .then((bookshelfUser) => _toDomain(bookshelfUser))
-    .catch((err) => {
-      if (err instanceof BookshelfUser.NoRowsUpdatedError) {
-        throw new UserNotFoundError(`User not found for ID ${id}`);
-      }
-      throw err;
-    });
+const updateUsername = async function ({ id, username, domainTransaction = DomainTransaction.emptyTransaction() }) {
+  const knexConn = domainTransaction.knexTransaction || knex;
+  const [updatedUsername] = await knexConn('users')
+    .where({ id })
+    .update({ username, updatedAt: new Date() })
+    .returning('*');
+  if (!updatedUsername) throw new UserNotFoundError(`User not found for ID ${id}`);
+  return new User(updatedUsername);
 };
 
 const findByExternalIdentifier = async function ({ externalIdentityId, identityProvider }) {
@@ -396,17 +382,15 @@ const findByExternalIdentifier = async function ({ externalIdentityId, identityP
 };
 
 const findAnotherUserByEmail = async function (userId, email) {
-  return BookshelfUser.where('id', '!=', userId)
-    .where({ email: email.toLowerCase() })
-    .fetchAll()
-    .then((users) => bookshelfToDomainConverter.buildDomainObjects(BookshelfUser, users));
+  const anotherUsers = await knex('users').whereNot('id', userId).where({ email: email.toLowerCase() });
+
+  return anotherUsers.map((anotherUser) => new User(anotherUser));
 };
 
 const findAnotherUserByUsername = async function (userId, username) {
-  return BookshelfUser.where('id', '!=', userId)
-    .where({ username })
-    .fetchAll()
-    .then((users) => bookshelfToDomainConverter.buildDomainObjects(BookshelfUser, users));
+  const anotherUsers = await knex('users').whereNot('id', userId).where({ username });
+
+  return anotherUsers.map((anotherUser) => new User(anotherUser));
 };
 
 const updateLastDataProtectionPolicySeenAt = async function ({ userId }) {
@@ -414,7 +398,7 @@ const updateLastDataProtectionPolicySeenAt = async function ({ userId }) {
 
   const [user] = await knex('users')
     .where({ id: userId })
-    .update({ lastDataProtectionPolicySeenAt: now })
+    .update({ lastDataProtectionPolicySeenAt: now, updatedAt: new Date() })
     .returning('*');
 
   return new User(user);
@@ -422,7 +406,6 @@ const updateLastDataProtectionPolicySeenAt = async function ({ userId }) {
 
 export {
   acceptPixLastTermsOfService,
-  addUsername,
   checkIfEmailIsAvailable,
   findAnotherUserByEmail,
   findAnotherUserByUsername,

--- a/api/tests/integration/infrastructure/repositories/organization-invitation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-invitation-repository_test.js
@@ -1,10 +1,9 @@
 import _ from 'lodash';
-import { expect, databaseBuilder, catchErr, sinon } from '../../../test-helper.js';
+import { expect, databaseBuilder, catchErr, sinon, knex } from '../../../test-helper.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
 import { Membership } from '../../../../lib/domain/models/Membership.js';
 import { OrganizationInvitation } from '../../../../lib/domain/models/OrganizationInvitation.js';
 import * as organizationInvitationRepository from '../../../../lib/infrastructure/repositories/organization-invitation-repository.js';
-import { BookshelfOrganizationInvitation } from '../../../../lib/infrastructure/orm-models/OrganizationInvitation.js';
 
 describe('Integration | Repository | OrganizationInvitationRepository', function () {
   describe('#create', function () {
@@ -126,13 +125,13 @@ describe('Integration | Repository | OrganizationInvitationRepository', function
 
     it('should not add row in table organization-invitations', async function () {
       // given
-      const nbOrganizationInvitationsBeforeUpdate = await BookshelfOrganizationInvitation.count();
+      const { count: nbOrganizationInvitationsBeforeUpdate } = await knex('organization-invitations').count().first();
 
       // when
       await organizationInvitationRepository.markAsAccepted(organizationInvitation.id);
 
       // then
-      const nbOrganizationInvitationsAfterUpdate = await BookshelfOrganizationInvitation.count();
+      const { count: nbOrganizationInvitationsAfterUpdate } = await knex('organization-invitations').count().first();
       expect(nbOrganizationInvitationsAfterUpdate).to.equal(nbOrganizationInvitationsBeforeUpdate);
     });
 

--- a/api/tests/integration/shared/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/shared/infrastructure/repositories/user-repository_test.js
@@ -691,34 +691,6 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
       });
     });
 
-    describe('#getById', function () {
-      it('should return the found user', async function () {
-        // given
-        const user = databaseBuilder.factory.buildUser({
-          id: 1092,
-        });
-        await databaseBuilder.commit();
-
-        // when
-        const result = await userRepository.getById(user.id);
-
-        // then
-        expect(result).to.be.an.instanceOf(User);
-        expect(result.id).to.equal(1092);
-      });
-
-      it('should return a UserNotFoundError if no user is found', async function () {
-        // given
-        const nonExistentUserId = 678;
-
-        // when
-        const result = await catchErr(userRepository.getById)(nonExistentUserId);
-
-        // then
-        expect(result).to.be.instanceOf(UserNotFoundError);
-      });
-    });
-
     describe('#getByIds', function () {
       it('returns users from provided ids', async function () {
         // given

--- a/api/tests/unit/domain/usecases/accept-certification-center-invitation_test.js
+++ b/api/tests/unit/domain/usecases/accept-certification-center-invitation_test.js
@@ -206,10 +206,10 @@ function _buildInvitationContext() {
   certificationCenterMembershipRepository.isMemberOfCertificationCenter.resolves(false);
 
   const userRepository = {
-    getById: sinon.stub(),
+    get: sinon.stub(),
     update: sinon.stub(),
   };
-  userRepository.getById.resolves(user);
+  userRepository.get.resolves(user);
 
   return {
     certificationCenterInvitedUserRepository,

--- a/api/tests/unit/domain/usecases/accept-organization-invitation_test.js
+++ b/api/tests/unit/domain/usecases/accept-organization-invitation_test.js
@@ -17,7 +17,7 @@ describe('Unit | UseCase | accept-organization-invitation', function () {
       markAsAccepted: sinon.stub(),
     };
     userRepository = {
-      getById: sinon.stub(),
+      get: sinon.stub(),
       update: sinon.stub(),
     };
   });
@@ -168,6 +168,6 @@ function createContext({ organizationInvitedUserRepository, userRepository, user
 
   sinon.stub(organizationInvitedUser, 'acceptInvitation').resolves();
 
-  userRepository.getById.withArgs(user.id).resolves(user);
+  userRepository.get.withArgs(user.id).resolves(user);
   return { organizationInvitationId, organizationInvitedUser, organization, code, email, localeFromCookie, user };
 }

--- a/api/tests/unit/domain/usecases/generate-username-with-temporary-password_test.js
+++ b/api/tests/unit/domain/usecases/generate-username-with-temporary-password_test.js
@@ -51,7 +51,7 @@ describe('Unit | UseCase | generate-username-with-temporary-password', function 
       updatePasswordThatShouldBeChanged: sinon.stub().resolves(),
     };
     userRepository = {
-      addUsername: sinon.stub(),
+      updateUsername: sinon.stub(),
       get: sinon.stub().resolves(userRelatedToStudent),
       updateUsernameAndPassword: sinon.stub().resolves(),
     };
@@ -154,7 +154,7 @@ describe('Unit | UseCase | generate-username-with-temporary-password', function 
 
       organizationLearnerRepository.get.withArgs(organizationLearner.id).resolves(organizationLearner);
       userRepository.get.resolves(userWithEmail);
-      userRepository.addUsername.resolves({ ...userWithEmail, username });
+      userRepository.updateUsername.resolves({ ...userWithEmail, username });
 
       authenticationMethodRepository.hasIdentityProviderPIX.resolves(true);
     });

--- a/api/tests/unit/domain/usecases/update-expired-password_test.js
+++ b/api/tests/unit/domain/usecases/update-expired-password_test.js
@@ -25,7 +25,7 @@ describe('Unit | UseCase | update-expired-password', function () {
     user.authenticationMethods = [authenticationMethod];
 
     userRepository = {
-      getById: sinon.stub(),
+      get: sinon.stub(),
     };
     encryptionService = {
       hashPassword: sinon.stub(),
@@ -39,7 +39,7 @@ describe('Unit | UseCase | update-expired-password', function () {
     };
 
     tokenService.extractUserId.resolves(user.id);
-    userRepository.getById.resolves(user);
+    userRepository.get.resolves(user);
     authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(authenticationMethod);
     encryptionService.hashPassword.resolves(hashedPassword);
   });
@@ -57,7 +57,7 @@ describe('Unit | UseCase | update-expired-password', function () {
 
     // then
     expect(tokenService.extractUserId).to.have.been.calledOnceWith(passwordResetToken);
-    expect(userRepository.getById).to.have.been.calledOnceWith(user.id);
+    expect(userRepository.get).to.have.been.calledOnceWith(user.id);
     expect(encryptionService.hashPassword).to.have.been.calledOnceWith(newPassword);
     expect(authenticationMethodRepository.findOneByUserIdAndIdentityProvider).to.have.been.calledOnceWith({
       userId: user.id,
@@ -74,7 +74,7 @@ describe('Unit | UseCase | update-expired-password', function () {
     it('should return user email', async function () {
       // given
       const user = domainBuilder.buildUser({ username: null, email: 'armand.talo@example.net' });
-      userRepository.getById.resolves(user);
+      userRepository.get.resolves(user);
 
       // when
       const login = await updateExpiredPassword({
@@ -94,7 +94,7 @@ describe('Unit | UseCase | update-expired-password', function () {
   context('when userId not exist', function () {
     it('should throw UserNotFoundError', async function () {
       // given
-      userRepository.getById.rejects(new UserNotFoundError());
+      userRepository.get.rejects(new UserNotFoundError());
 
       // when
       const error = await catchErr(updateExpiredPassword)({
@@ -109,7 +109,7 @@ describe('Unit | UseCase | update-expired-password', function () {
 
     it('should log error', async function () {
       // given
-      userRepository.getById.rejects(new UserNotFoundError());
+      userRepository.get.rejects(new UserNotFoundError());
       sinon.stub(logger, 'warn');
 
       // when
@@ -134,7 +134,7 @@ describe('Unit | UseCase | update-expired-password', function () {
       const user = domainBuilder.buildUser({ id: 100, authenticationMethods: [authenticationMethod] });
 
       tokenService.extractUserId.resolves(user.id);
-      userRepository.getById.resolves(user);
+      userRepository.get.resolves(user);
       authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(authenticationMethod);
 
       // when


### PR DESCRIPTION
## :christmas_tree: Problème
Application de l'ADR https://github.com/1024pix/pix/blob/dev/docs/adr/0028-remplacer-orm-bookshelfjs-par-query-builder-knexjs.md

## :gift: Proposition
Remplacer les occurences de bookshelf par knex

## :socks: Remarques
- Le dernier commit est un bsr pour retirer la méthode getById, qui faisait strictement la même chose que le get, dans les tests également. Je laisse libre choix à l'équipe Accès de conserver ce commit ou non, ou bien d'inverser et de garder seulement la méthode getById à la place du get
- Il reste deux méthodes utilisant bookshelf : `getBySamlId` & `findByExternalIdentifier`, elles seront faites dans une prochaine PR 👼 

## :santa: Pour tester

- Vérifier la CI
- Faire un tour sur l'application et vérifier le bon fonctionnement liés aux repositories modifiés
- 🐈‍⬛
