### PR TITLE
[BUGFIX] Corriger la validation des CGU lors de l'inscription (PIX-10490)

### DIFF
--- a/mon-pix/app/components/signup-form.hbs
+++ b/mon-pix/app/components/signup-form.hbs
@@ -79,7 +79,7 @@
       </div>
 
       <div class="signup-form__cgu-container">
-        <PixCheckbox {{on "change" this.onChange}} aria-describedby="sign-up-cgu-error-message">
+        <PixCheckbox {{on "change" this.onCguCheckboxChange}} aria-describedby="sign-up-cgu-error-message">
           {{t
             "common.cgu.message"
             cguUrl=this.cguUrl

--- a/mon-pix/app/components/signup-form.js
+++ b/mon-pix/app/components/signup-form.js
@@ -112,7 +112,7 @@ export default class SignupForm extends Component {
   }
 
   @action
-  onChange(event) {
+  onCguCheckboxChange(event) {
     this.args.user.cgu = !!event.target.checked;
   }
 

--- a/mon-pix/app/components/signup-form.js
+++ b/mon-pix/app/components/signup-form.js
@@ -114,6 +114,7 @@ export default class SignupForm extends Component {
   @action
   onCguCheckboxChange(event) {
     this.args.user.cgu = !!event.target.checked;
+    this.validation.cgu.status = 'default';
   }
 
   @action

--- a/mon-pix/tests/unit/components/signup-form_test.js
+++ b/mon-pix/tests/unit/components/signup-form_test.js
@@ -149,15 +149,18 @@ module('Unit | Component | signup-form', function (hooks) {
 
   module('#onCguCheckboxChange', function () {
     module('when checkbox is checked', function () {
-      test('it registers the cgu as accepted', function (assert) {
+      test('it registers the cgu as accepted and resets validation status', function (assert) {
         // given
         const event = {
           target: {
             checked: true,
           },
         };
-        component.args.user = {
-          cgu: false,
+        component.args.user = {};
+        component.validation = {
+          cgu: {
+            status: 'error',
+          },
         };
 
         // when
@@ -165,19 +168,23 @@ module('Unit | Component | signup-form', function (hooks) {
 
         // then
         assert.true(component.args.user.cgu);
+        assert.strictEqual(component.validation.cgu.status, 'default');
       });
     });
 
     module('when checkbox is unchecked', function () {
-      test('it registers the cgu as not accepted', function (assert) {
+      test('it registers the cgu as not accepted and resets validation status', function (assert) {
         // given
         const event = {
           target: {
             checked: false,
           },
         };
-        component.args.user = {
-          cgu: true,
+        component.args.user = {};
+        component.validation = {
+          cgu: {
+            status: 'success',
+          },
         };
 
         // when
@@ -185,6 +192,7 @@ module('Unit | Component | signup-form', function (hooks) {
 
         // then
         assert.false(component.args.user.cgu);
+        assert.strictEqual(component.validation.cgu.status, 'default');
       });
     });
   });

--- a/mon-pix/tests/unit/components/signup-form_test.js
+++ b/mon-pix/tests/unit/components/signup-form_test.js
@@ -146,4 +146,46 @@ module('Unit | Component | signup-form', function (hooks) {
       });
     });
   });
+
+  module('#onCguCheckboxChange', function () {
+    module('when checkbox is checked', function () {
+      test('it registers the cgu as accepted', function (assert) {
+        // given
+        const event = {
+          target: {
+            checked: true,
+          },
+        };
+        component.args.user = {
+          cgu: false,
+        };
+
+        // when
+        component.onCguCheckboxChange(event);
+
+        // then
+        assert.true(component.args.user.cgu);
+      });
+    });
+
+    module('when checkbox is unchecked', function () {
+      test('it registers the cgu as not accepted', function (assert) {
+        // given
+        const event = {
+          target: {
+            checked: false,
+          },
+        };
+        component.args.user = {
+          cgu: true,
+        };
+
+        // when
+        component.onCguCheckboxChange(event);
+
+        // then
+        assert.false(component.args.user.cgu);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## :christmas_tree: Problème

Lors de l'inscription si l'utilisateur clique sur "Je m'inscris" sans avoir coché la case des CGU, il aura une erreur (ce qui est normal). Mais il lui est ensuite impossible de valider l'inscription, même si la case est bien coché (ce qui est un problème).

## :gift: Proposition

Faire en sorte que l'utilisateur puisse s'inscrire s'il coche la case des CGU après avoir validé une première avec la case décochée.

## :socks: Remarques

Aujourd'hui, la vérification que la case des CGU est bien cochée se fait uniquement côté back-end. Le problème était que le statut de validation était mis à `error` lorsqu'une erreur est retournée par l'API, mais n'est pas changé lorsque la case est modifiée.

J'ai choisi pour corriger le problème de réinitialiser le statut à `default` lorsque la case est changée, la validation restant la responsabilité de l'API. Ajouter une validation côté front aurait été introduire une nouvelle fonctionnalité ce qui serait sorti du cadre de cette PR.

## :santa: Pour tester

### Non reproductibilité du bug

- Se rendre sur la page d'inscription de Pix App
- Remplir tous les champs
- NE PAS cocher la case "J'accepte les conditions…"
- Cliquer sur **Je m'inscris**
- Constater qu'une erreur apparaît
- Cocher la case "J'accepte les conditions…"
- Cliquer sur **Je m'inscris**
- Constater que l'inscription puis l'authentification réussit

### Non régression : inscription réussie

- Se rendre sur la page d'inscription de Pix App
- Remplir tous les champs
- Cocher la case "J'accepte les conditions…"
- Cliquer sur **Je m'inscris**
- Constater que l'inscription puis l'authentification réussit