### PR TITLE
[BUGFIX] Éviter la modification de propriétés de RT non-souhaitées (PIX-10119).

### DIFF
--- a/admin/app/adapters/badge.js
+++ b/admin/app/adapters/badge.js
@@ -6,4 +6,14 @@ export default class BadgeAdapter extends ApplicationAdapter {
   urlForCreateRecord(modelName, { adapterOptions: { targetProfileId } }) {
     return `${this.host}/${this.namespace}/target-profiles/${targetProfileId}/badges`;
   }
+
+  updateRecord(store, type, snapshot) {
+    const payload = this.serialize(snapshot);
+
+    delete payload.data.attributes['campaign-threshold'];
+    delete payload.data.attributes['capped-tubes-criteria'];
+
+    const url = this.buildURL(type.modelName, snapshot.id, snapshot, 'updateRecord');
+    return this.ajax(url, 'PATCH', { data: payload });
+  }
 }

--- a/admin/tests/unit/adapters/badge_test.js
+++ b/admin/tests/unit/adapters/badge_test.js
@@ -1,3 +1,4 @@
+import sinon from 'sinon';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
@@ -18,6 +19,56 @@ module('Unit | Adapters | badge', function (hooks) {
 
       // then
       assert.true(url.endsWith('/api/admin/target-profiles/788/badges'));
+    });
+  });
+
+  module('#updateRecord', function () {
+    test('should trigger an ajax call with the right method and payload', function (assert) {
+      // given
+      const updatedBadgeData = {
+        key: 'dummy-key',
+        title: 'Dummy title',
+        message: 'dummy message',
+        'image-url': 'dummy.svg',
+        'alt-message': 'gummy alt message',
+        'is-certifiable': true,
+        'is-always-visible': true,
+      };
+
+      const expectedPayload = {
+        data: {
+          data: {
+            attributes: { ...updatedBadgeData },
+          },
+        },
+      };
+
+      const snapshot = {
+        id: 99,
+        serialize: sinon.stub().returns({
+          data: {
+            attributes: {
+              ...updatedBadgeData,
+              'campaign-threshold': Symbol('should-be-removed'),
+              'capped-tubes-criteria': Symbol('should-be-removed'),
+            },
+          },
+        }),
+      };
+
+      adapter.ajax = sinon.stub();
+
+      // when
+      adapter.updateRecord(null, { modelName: 'badge' }, snapshot);
+
+      // then
+      sinon.assert.calledWithExactly(
+        adapter.ajax,
+        'http://localhost:3000/api/admin/badges/99',
+        'PATCH',
+        expectedPayload,
+      );
+      assert.ok(adapter);
     });
   });
 });

--- a/api/src/shared/application/badges/index.js
+++ b/api/src/shared/application/badges/index.js
@@ -26,7 +26,6 @@ const register = async function (server) {
           }),
           payload: Joi.object({
             data: Joi.object({
-              id: Joi.string().required(),
               attributes: Joi.object({
                 key: Joi.string().required(),
                 'alt-message': Joi.string().required(),
@@ -35,7 +34,6 @@ const register = async function (server) {
                 title: Joi.string().required().allow(null),
                 'is-certifiable': Joi.boolean().required(),
                 'is-always-visible': Joi.boolean().required(),
-                'campaign-threshold': Joi.number().allow(null),
               }).required(),
               type: Joi.string().required(),
               relationships: Joi.object(),

--- a/api/tests/shared/acceptance/application/badges/badge-controller_test.js
+++ b/api/tests/shared/acceptance/application/badges/badge-controller_test.js
@@ -41,7 +41,6 @@ describe('Acceptance | API | Badges', function () {
         'image-url': 'url_image_modifiée',
         'is-certifiable': true,
         'is-always-visible': true,
-        'campaign-threshold': null,
       };
 
       options = {
@@ -50,7 +49,6 @@ describe('Acceptance | API | Badges', function () {
         headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
         payload: {
           data: {
-            id: '1',
             type: 'badges',
             attributes: badgeWithUpdatedInfo,
             relationships: {

--- a/api/tests/shared/unit/application/badges/index_test.js
+++ b/api/tests/shared/unit/application/badges/index_test.js
@@ -4,6 +4,90 @@ import { securityPreHandlers } from '../../../../../lib/application/security-pre
 import * as badgesRouter from '../../../../../src/shared/application/badges/index.js';
 
 describe('Unit | Application | Badges | Routes', function () {
+  describe('PATCH /api/admin/badges/{id}', function () {
+    const validPayload = {};
+
+    beforeEach(function () {
+      validPayload.data = {
+        type: 'badges',
+        attributes: {
+          key: '1',
+          title: 'titre du badge modifié',
+          message: 'Message modifié',
+          'alt-message': 'Message alternatif modifié',
+          'image-url': 'url_image_modifiée',
+          'is-certifiable': true,
+          'is-always-visible': true,
+        },
+      };
+    });
+
+    context('when user has role "SUPER_ADMIN", "SUPPORT" or "METIER"', function () {
+      it('should return an HTTP status code 204', async function () {
+        // given
+        sinon
+          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .withArgs([
+            securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+            securityPreHandlers.checkAdminMemberHasRoleSupport,
+            securityPreHandlers.checkAdminMemberHasRoleMetier,
+          ])
+          .callsFake(() => (request, h) => h.response(true));
+        sinon.stub(badgesController, 'updateBadge').returns(null);
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(badgesRouter);
+
+        // when
+        const { statusCode } = await httpTestServer.request('PATCH', '/api/admin/badges/1', validPayload);
+
+        // then
+        expect(statusCode).to.equal(204);
+      });
+
+      context('when user has role "CERTIF"', function () {
+        it('should return a response with an HTTP status code 403', async function () {
+          // given
+          sinon
+            .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+            .withArgs([
+              securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+              securityPreHandlers.checkAdminMemberHasRoleSupport,
+              securityPreHandlers.checkAdminMemberHasRoleMetier,
+            ])
+            .callsFake(
+              () => (request, h) =>
+                h
+                  .response({ errors: new Error('forbidden') })
+                  .code(403)
+                  .takeover(),
+            );
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(badgesRouter);
+
+          // when
+          const { statusCode } = await httpTestServer.request('PATCH', '/api/admin/badges/1', validPayload);
+
+          // then
+          expect(statusCode).to.equal(403);
+        });
+      });
+
+      context('when badge id is invalid', function () {
+        it('should return an HTTP status code 400', async function () {
+          // given
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(badgesRouter);
+
+          // when
+          const { statusCode } = await httpTestServer.request('PATCH', '/api/admin/badges/invalid-id', validPayload);
+
+          // then
+          expect(statusCode).to.equal(400);
+        });
+      });
+    });
+  });
+
   describe('DELETE /api/admin/badges/{id}', function () {
     context('when user has role "SUPER_ADMIN", "SUPPORT" or "METIER"', function () {
       it('should return an HTTP status code 204', async function () {


### PR DESCRIPTION
## :christmas_tree: Problème

Lors de la mise à jour d'un RT, on passait encore les propriétés `campaignThreshold` et `cappedTubesCriteria` dans la payload du `PATCH`.
Alors que, [comme indiqué ici](https://github.com/1024pix/pix/blob/dev/admin/app/models/badge.js#L14), ce sont des champs uniquement dédiés à la création du RT.

Cela déclenchait une erreur lorsqu'on essayait d'éditer un RT qui venait tout juste d'être créé.

## :gift: Proposition

Supprimer ces propriétés lors de l'`updateRecord`.

## :santa: Pour tester

- Sur Admin en RA, créer un nouveau RT dans un profil-cible
- Directement après, essayer de l'éditer.
- Vérifier que tout se passe comme prévu ✅