### PR TITLE
[TECH] Monter les versions des images postgresql et redis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,11 +42,11 @@ executors:
         type: string
     docker:
       - image: cimg/node:<<parameters.node-version>>
-      - image: postgres:14.8-alpine
+      - image: postgres:14.10-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
-      - image: redis:7.0.12-alpine
+      - image: redis:7.2.3-alpine
     resource_class: small
   node-browsers-docker:
     parameters:
@@ -67,11 +67,11 @@ executors:
         type: string
     docker:
       - image: cimg/node:<<parameters.node-version>>-browsers
-      - image: postgres:14.8-alpine
+      - image: postgres:14.10-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
-      - image: redis:7.0.12-alpine
+      - image: redis:7.2.3-alpine
     resource_class: medium+
   node-postgres-docker:
     parameters:
@@ -81,7 +81,7 @@ executors:
         type: string
     docker:
       - image: cimg/node:<<parameters.node-version>>
-      - image: postgres:14.8-alpine
+      - image: postgres:14.10-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   postgres:
-    image: postgres:14.8-alpine
+    image: postgres:14.10-alpine
     container_name: pix-api-postgres
     ports:
       - '${PIX_DATABASE_PORT:-5432}:5432'
@@ -10,7 +10,7 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
 
   redis:
-    image: redis:7.0.12-alpine
+    image: redis:7.2.3-alpine
     container_name: pix-api-redis
     ports:
       - '${PIX_CACHE_PORT:-6379}:6379'

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -4,7 +4,7 @@ version: '3'
 services:
 
   postgres:
-    image: postgres:14.8-alpine
+    image: postgres:14.10-alpine
     container_name: pix-api-postgres
     ports:
       - '${PIX_DATABASE_PORT:-5432}:5432'
@@ -14,7 +14,7 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
 
   redis:
-    image: redis:7.0.12-alpine
+    image: redis:7.2.3-alpine
     container_name: pix-api-redis
     ports:
       - '${PIX_CACHE_PORT:-6379}:6379'
@@ -23,12 +23,12 @@ services:
     image: pix/api
     depends_on:
       - postgres
-      - redis 
-    build: 
+      - redis
+    build:
       dockerfile: ../docker/dockerfiles/Dockerfile.hapi
       context: ../api/
     volumes:
-      - .env:/code/.env 
+      - .env:/code/.env
     ports:
       - "3000:3000"
 
@@ -36,7 +36,7 @@ services:
     image: pix/orga
     depends_on:
       - api
-    build: 
+    build:
       dockerfile: ../docker/dockerfiles/Dockerfile.ember
       context: ../orga
     ports:
@@ -48,7 +48,7 @@ services:
     image: pix/admin
     depends_on:
       - api
-    build: 
+    build:
       dockerfile: ../docker/dockerfiles/Dockerfile.ember
       context: ../admin/
     ports:
@@ -60,7 +60,7 @@ services:
     image: pix/certif
     depends_on:
       - api
-    build: 
+    build:
       dockerfile: ../docker/dockerfiles/Dockerfile.ember
       context: ../certif/
     ports:
@@ -72,7 +72,7 @@ services:
     image: pix/mon-pix
     depends_on:
       - api
-    build: 
+    build:
       dockerfile: ../docker/dockerfiles/Dockerfile.ember
       context: ../mon-pix/
     ports:


### PR DESCRIPTION
## :christmas_tree: Problème
Une nouvelle version des addons postgresql et redis est proposée par Scalingo et la montée de version va être effectuée. Cependant, les images docker sont encore sur les anciennes versions. 

## :gift: Proposition
- Mettre à jour la version de l'image postgresql de la version 14.8 à la version 14.10
- Mettre à jour la version de l'imae redis de la version 7.0.12 à la version 7.2.3
