### PR TITLE
[FEATURE] Afficher le détail d'un signalement validé lors d'une certification sur Pix Admin (PIX-10313).

### DIFF
--- a/admin/app/components/certifications/certification/details-v3.hbs
+++ b/admin/app/components/certifications/certification/details-v3.hbs
@@ -74,6 +74,18 @@
                 >
                   <FaIcon @icon="eye" />
                 </a>
+
+                {{#if certificationChallenge.validatedLiveAlert}}
+                  <button
+                    title="Afficher le signalement de la question"
+                    aria-label="Afficher le signalement de la question"
+                    type="button"
+                    {{on "click" (fn this.openModal certificationChallenge)}}
+                  >
+                    <FaIcon @icon="warning" />
+                  </button>
+                {{/if}}
+
                 {{#if certificationChallenge.answerValue}}
                   <button
                     title="Afficher la réponse du candidat"
@@ -94,13 +106,16 @@
 </section>
 
 <PixModal
-  @title="Réponse question {{this.certificationChallenge.questionNumber}}"
+  @title="{{this.modalTitle}} question {{this.certificationChallenge.questionNumber}}"
   @showModal={{this.showModal}}
   @onCloseButtonClick={{this.closeModal}}
 >
   <:content>
+    {{#if this.certificationChallenge.validatedLiveAlert}}
+      <span class="certification-details-v3-modal__live-alert-subcategory">{{this.subCategory}}</span>
+    {{/if}}
     <p>
-      {{this.certificationChallenge.answerValue}}
+      {{this.modalContent}}
     </p>
   </:content>
   <:footer>

--- a/admin/app/components/certifications/certification/details-v3.js
+++ b/admin/app/components/certifications/certification/details-v3.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { subcategoryToCode, subcategoryToLabel } from '../../../models/certification-issue-report';
 
 const options = [
   { value: 'ok', label: 'OK', color: 'success' },
@@ -11,6 +12,9 @@ const options = [
 export default class DetailsV3 extends Component {
   @tracked showModal = false;
   @tracked certificationChallenge = null;
+  @tracked modalTitle = null;
+  @tracked modalContent = null;
+  @tracked subCategory = null;
 
   answerStatusLabel(status) {
     return options.find((option) => option.value === status).label;
@@ -32,10 +36,19 @@ export default class DetailsV3 extends Component {
   openModal(certificationChallenge) {
     this.showModal = true;
     this.certificationChallenge = certificationChallenge;
+    this.modalTitle = this._isReportedQuestion() ? 'Signalement' : 'Réponse';
+    this.modalContent = this._isReportedQuestion()
+      ? subcategoryToLabel[this.certificationChallenge.validatedLiveAlert.issueReportSubcategory]
+      : this.certificationChallenge.answerValue;
+    this.subCategory = subcategoryToCode[this.certificationChallenge.validatedLiveAlert.issueReportSubcategory];
   }
 
   @action
   closeModal() {
     this.showModal = false;
+  }
+
+  _isReportedQuestion() {
+    return this.certificationChallenge.validatedLiveAlert;
   }
 }

--- a/admin/app/models/certification-issue-report.js
+++ b/admin/app/models/certification-issue-report.js
@@ -76,11 +76,17 @@ export const subcategoryToLabel = {
     'Problème avec l’accessibilité de la question (ex : daltonisme)',
 };
 
-export const subcategoryToTextareaLabel = {
-  [certificationIssueReportSubcategories.LEFT_EXAM_ROOM]: 'Précisez et indiquez l’heure de sortie',
-  [certificationIssueReportSubcategories.SIGNATURE_ISSUE]: 'Précisez',
-  [certificationIssueReportSubcategories.NAME_OR_BIRTHDATE]: 'Précisez les informations à modifier',
-  [certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE]: 'Précisez le temps majoré',
+export const subcategoryToCode = {
+  [certificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING]: 'E1',
+  [certificationIssueReportSubcategories.EMBED_NOT_WORKING]: 'E2',
+  [certificationIssueReportSubcategories.FILE_NOT_OPENING]: 'E3',
+  [certificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]: 'E4',
+  [certificationIssueReportSubcategories.WEBSITE_BLOCKED]: 'E5',
+  [certificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED]: 'E8',
+  [certificationIssueReportSubcategories.SOFTWARE_NOT_WORKING]: 'E9',
+  [certificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT]: 'E10',
+  [certificationIssueReportSubcategories.SKIP_ON_OOPS]: 'E11',
+  [certificationIssueReportSubcategories.ACCESSIBILITY_ISSUE]: 'E12',
 };
 
 export default class CertificationIssueReportModel extends Model {

--- a/admin/app/styles/authenticated/certifications/certification/details-v3.scss
+++ b/admin/app/styles/authenticated/certifications/certification/details-v3.scss
@@ -72,3 +72,9 @@
     }
   }
 }
+
+.certification-details-v3-modal{
+  &__live-alert-subcategory {
+    font-weight: $font-bold;
+  }
+}

--- a/api/db/database-builder/factory/build-certification-issue-report.js
+++ b/api/db/database-builder/factory/build-certification-issue-report.js
@@ -14,6 +14,7 @@ const buildCertificationIssueReport = function ({
   questionNumber = null,
   resolvedAt = null,
   resolution = null,
+  liveAlertId = null,
 } = {}) {
   certificationCourseId = _.isUndefined(certificationCourseId) ? buildCertificationCourse().id : certificationCourseId;
   categoryId = _.isUndefined(categoryId) ? buildIssueReportCategory().id : categoryId;
@@ -29,6 +30,7 @@ const buildCertificationIssueReport = function ({
     hasBeenAutomaticallyResolved,
     resolvedAt,
     resolution,
+    liveAlertId,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'certification-issue-reports',

--- a/api/db/migrations/20240102100106_add-live-alert-id-to-issue-report.js
+++ b/api/db/migrations/20240102100106_add-live-alert-id-to-issue-report.js
@@ -1,0 +1,17 @@
+const TABLE_NAME = 'certification-issue-reports';
+const COLUMN_NAME = 'liveAlertId';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME).unsigned();
+    table.foreign(COLUMN_NAME).references('certification-challenge-live-alerts.id');
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { up, down };

--- a/api/src/certification/course/domain/models/V3CertificationChallengeLiveAlertForAdministration.js
+++ b/api/src/certification/course/domain/models/V3CertificationChallengeLiveAlertForAdministration.js
@@ -1,5 +1,6 @@
 export class V3CertificationChallengeLiveAlertForAdministration {
-  constructor({ id }) {
+  constructor({ id, issueReportSubcategory }) {
     this.id = id;
+    this.issueReportSubcategory = issueReportSubcategory;
   }
 }

--- a/api/src/certification/course/infrastructure/repositories/v3-certification-course-details-for-administration-repository.js
+++ b/api/src/certification/course/infrastructure/repositories/v3-certification-course-details-for-administration-repository.js
@@ -6,7 +6,7 @@ import { V3CertificationChallengeLiveAlertForAdministration } from '../../domain
 import { CertificationChallengeLiveAlertStatus } from '../../../session/domain/models/CertificationChallengeLiveAlert.js';
 
 const getV3DetailsByCertificationCourseId = async function ({ certificationCourseId }) {
-  const liveAlerts = await knex
+  const liveAlertsDTO = await knex
     .with('validated-live-alerts', (queryBuilder) => {
       queryBuilder
         .select('*')
@@ -16,22 +16,13 @@ const getV3DetailsByCertificationCourseId = async function ({ certificationCours
     .select({
       id: 'validated-live-alerts.id',
       challengeId: 'validated-live-alerts.challengeId',
+      issueReportSubcategory: 'certification-issue-reports.subcategory',
     })
     .from('assessments')
     .leftJoin('validated-live-alerts', 'validated-live-alerts.assessmentId', 'assessments.id')
+    .leftJoin('certification-issue-reports', 'certification-issue-reports.liveAlertId', 'validated-live-alerts.id')
     .where({ 'assessments.certificationCourseId': certificationCourseId })
     .orderBy('validated-live-alerts.createdAt', 'ASC');
-
-  const certificationIssueReports = await knex('certification-issue-reports')
-    .select('subcategory')
-    .where({ certificationCourseId })
-    .orderBy('certification-issue-reports.createdAt', 'ASC');
-
-  const liveAlertsDTO = certificationIssueReports.map((certificationIssueReport, index) => ({
-    id: liveAlerts[index].id,
-    issueReportSubcategory: certificationIssueReport.subcategory,
-    challengeId: liveAlerts[index].challengeId,
-  }));
 
   const certificationChallengesDetailsDTO = await knex
     .select({

--- a/api/src/certification/session/domain/usecases/validate-live-alert.js
+++ b/api/src/certification/session/domain/usecases/validate-live-alert.js
@@ -51,6 +51,7 @@ export const validateLiveAlert = async ({
     category: CertificationIssueReportCategory.IN_CHALLENGE,
     subcategory,
     categoryId: issueReportCategory.id,
+    liveAlertId: certificationChallengeLiveAlert.id,
   });
 
   await certificationIssueReportRepository.save(certificationIssueReport);

--- a/api/src/certification/shared/domain/models/CertificationIssueReport.js
+++ b/api/src/certification/shared/domain/models/CertificationIssueReport.js
@@ -98,6 +98,7 @@ class CertificationIssueReport {
     subcategory,
     questionNumber,
     hasBeenAutomaticallyResolved,
+    liveAlertId,
     resolvedAt,
     resolution,
   } = {}) {
@@ -111,6 +112,7 @@ class CertificationIssueReport {
     this.hasBeenAutomaticallyResolved = hasBeenAutomaticallyResolved;
     this.resolvedAt = resolvedAt;
     this.resolution = resolution;
+    this.liveAlertId = liveAlertId;
     this.isImpactful = _isImpactful({ category, subcategory });
 
     if (
@@ -128,13 +130,23 @@ class CertificationIssueReport {
     }
   }
 
-  static create({ id, certificationCourseId, category, categoryId, description, subcategory, questionNumber }) {
+  static create({
+    id,
+    certificationCourseId,
+    category,
+    categoryId,
+    description,
+    subcategory,
+    questionNumber,
+    liveAlertId,
+  }) {
     const certificationIssueReport = new CertificationIssueReport({
       id,
       certificationCourseId,
       category,
       categoryId,
       description,
+      liveAlertId,
       subcategory,
       questionNumber,
       hasBeenAutomaticallyResolved: null,

--- a/api/tests/certification/course/integration/infrastructure/repositories/v3-certification-course-details-for-administration-repository_test.js
+++ b/api/tests/certification/course/integration/infrastructure/repositories/v3-certification-course-details-for-administration-repository_test.js
@@ -107,6 +107,7 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
         category: CertificationIssueReportCategory.IN_CHALLENGE,
         subcategory: CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
         questionNumber: 1,
+        liveAlertId: firstValidatedLiveAlertId,
       });
 
       databaseBuilder.factory.buildCertificationIssueReport({
@@ -114,6 +115,7 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
         category: CertificationIssueReportCategory.IN_CHALLENGE,
         subcategory: CertificationIssueReportSubcategories.FILE_NOT_OPENING,
         questionNumber: 1,
+        liveAlertId: secondValidatedLiveAlertId,
       });
 
       databaseBuilder.factory.buildCertificationChallengeLiveAlert({
@@ -134,6 +136,7 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
         category: CertificationIssueReportCategory.IN_CHALLENGE,
         subcategory: CertificationIssueReportSubcategories.ACCESSIBILITY_ISSUE,
         questionNumber: 2,
+        liveAlertId: thirdValidatedLiveAlertId,
       });
 
       await databaseBuilder.commit();

--- a/api/tests/certification/course/integration/infrastructure/repositories/v3-certification-course-details-for-administration-repository_test.js
+++ b/api/tests/certification/course/integration/infrastructure/repositories/v3-certification-course-details-for-administration-repository_test.js
@@ -1,6 +1,10 @@
 import { expect, databaseBuilder, domainBuilder } from '../../../../../test-helper.js';
 import * as v3CertificationCourseDetailsForAdministrationRepository from '../../../../../../src/certification/course/infrastructure/repositories/v3-certification-course-details-for-administration-repository.js';
 import { AnswerStatus } from '../../../../../../src/shared/domain/models/AnswerStatus.js';
+import {
+  CertificationIssueReportCategory,
+  CertificationIssueReportSubcategories,
+} from '../../../../../../src/certification/shared/domain/models/CertificationIssueReportCategory.js';
 
 describe('Integration | Infrastructure | Repository | v3-certification-course-details-for-administration', function () {
   describe('#getV3DetailsByCertificationCourseId', function () {
@@ -57,6 +61,7 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
       const certificationCourseId = 123;
       const firstChallengeId = 'recCHAL456';
       const secondChallengeId = 'recCHAL789';
+      const thirdChallengeId = 'recCHAL123';
       const assessmentId = 78;
 
       databaseBuilder.factory.buildCertificationCourse({ id: certificationCourseId });
@@ -69,6 +74,12 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
       databaseBuilder.factory.buildCertificationChallenge({
         courseId: certificationCourseId,
         challengeId: secondChallengeId,
+        createdAt: new Date('2020-01-01T17:03:00Z'),
+      });
+
+      databaseBuilder.factory.buildCertificationChallenge({
+        courseId: certificationCourseId,
+        challengeId: thirdChallengeId,
         createdAt: new Date('2020-01-01T17:05:00Z'),
       });
 
@@ -81,7 +92,29 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
         assessmentId,
         challengeId: firstChallengeId,
         status: 'validated',
+        questionNumber: 1,
       }).id;
+
+      const secondValidatedLiveAlertId = databaseBuilder.factory.buildCertificationChallengeLiveAlert({
+        assessmentId,
+        challengeId: secondChallengeId,
+        status: 'validated',
+        questionNumber: 1,
+      }).id;
+
+      databaseBuilder.factory.buildCertificationIssueReport({
+        certificationCourseId,
+        category: CertificationIssueReportCategory.IN_CHALLENGE,
+        subcategory: CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
+        questionNumber: 1,
+      });
+
+      databaseBuilder.factory.buildCertificationIssueReport({
+        certificationCourseId,
+        category: CertificationIssueReportCategory.IN_CHALLENGE,
+        subcategory: CertificationIssueReportSubcategories.FILE_NOT_OPENING,
+        questionNumber: 1,
+      });
 
       databaseBuilder.factory.buildCertificationChallengeLiveAlert({
         assessmentId,
@@ -89,11 +122,20 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
         status: 'rejected',
       });
 
-      const secondValidatedLiveAlertId = databaseBuilder.factory.buildCertificationChallengeLiveAlert({
+      const thirdValidatedLiveAlertId = databaseBuilder.factory.buildCertificationChallengeLiveAlert({
         assessmentId,
-        challengeId: secondChallengeId,
+        challengeId: thirdChallengeId,
         status: 'validated',
+        questionNumber: 2,
       }).id;
+
+      databaseBuilder.factory.buildCertificationIssueReport({
+        certificationCourseId,
+        category: CertificationIssueReportCategory.IN_CHALLENGE,
+        subcategory: CertificationIssueReportSubcategories.ACCESSIBILITY_ISSUE,
+        questionNumber: 2,
+      });
+
       await databaseBuilder.commit();
 
       // when
@@ -105,10 +147,17 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
       // then
       const firstValidatedLiveAlert = domainBuilder.buildV3CertificationChallengeLiveAlertForAdministration({
         id: firstValidatedLiveAlertId,
+        issueReportSubcategory: CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
       });
 
       const secondValidatedLiveAlert = domainBuilder.buildV3CertificationChallengeLiveAlertForAdministration({
         id: secondValidatedLiveAlertId,
+        issueReportSubcategory: CertificationIssueReportSubcategories.FILE_NOT_OPENING,
+      });
+
+      const thirdValidatedLiveAlert = domainBuilder.buildV3CertificationChallengeLiveAlertForAdministration({
+        id: thirdValidatedLiveAlertId,
+        issueReportSubcategory: CertificationIssueReportSubcategories.ACCESSIBILITY_ISSUE,
       });
 
       const firstCertificationChallengeForAdministration = domainBuilder.buildV3CertificationChallengeForAdministration(
@@ -128,11 +177,21 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
           skillName: certificationChallenges.certificationChallengesForAdministration[1].skillName,
         });
 
+      const thirdCertificationChallengeForAdministration = domainBuilder.buildV3CertificationChallengeForAdministration(
+        {
+          challengeId: thirdChallengeId,
+          validatedLiveAlert: thirdValidatedLiveAlert,
+          competenceId: certificationChallenges.certificationChallengesForAdministration[2].competenceId,
+          skillName: certificationChallenges.certificationChallengesForAdministration[2].skillName,
+        },
+      );
+
       const expectedCertificationCourseDetails = domainBuilder.buildV3CertificationCourseDetailsForAdministration({
         certificationCourseId,
         certificationChallengesForAdministration: [
           firstCertificationChallengeForAdministration,
           secondCertificationChallengeForAdministration,
+          thirdCertificationChallengeForAdministration,
         ],
       });
       expect(certificationChallenges).to.deep.equal(expectedCertificationCourseDetails);

--- a/api/tests/certification/course/unit/infrasctructure/serializers/jsonapi/v3-certification-course-details-for-administration-serializer_test.js
+++ b/api/tests/certification/course/unit/infrasctructure/serializers/jsonapi/v3-certification-course-details-for-administration-serializer_test.js
@@ -8,7 +8,7 @@ import { V3CertificationChallengeLiveAlertForAdministration } from '../../../../
 
 describe('Unit | Serializer | JSONAPI | v3-certification-details-for-administration-serializer', function () {
   describe('#serialize()', function () {
-    it('should convert a Session model object into JSON API data including supervisor password', function () {
+    it('should convert a V3CertificationChallengeForAdministration model object into JSON API', function () {
       // given
       const certificationCourseId = 123;
       const liveAlertId = 789;
@@ -22,7 +22,10 @@ describe('Unit | Serializer | JSONAPI | v3-certification-details-for-administrat
       const certificationChallenge = new V3CertificationChallengeForAdministration({
         challengeId,
         answerStatus,
-        validatedLiveAlert: new V3CertificationChallengeLiveAlertForAdministration({ id: liveAlertId }),
+        validatedLiveAlert: new V3CertificationChallengeLiveAlertForAdministration({
+          id: liveAlertId,
+          issueReportSubcategory: 'WEBSITE_BLOCKED',
+        }),
         answeredAt: new Date('2020-01-02'),
         answerValue,
         competenceName,
@@ -49,7 +52,10 @@ describe('Unit | Serializer | JSONAPI | v3-certification-details-for-administrat
             id: challengeId,
             attributes: {
               'answer-status': 'ok',
-              'validated-live-alert': { id: liveAlertId },
+              'validated-live-alert': {
+                id: liveAlertId,
+                issueReportSubcategory: certificationChallenge.validatedLiveAlert.issueReportSubcategory,
+              },
               'answered-at': certificationChallenge.answeredAt,
               'answer-value': answerValue,
               'competence-name': competenceName,

--- a/api/tests/certification/session/acceptance/application/session-live-alert-controller_test.js
+++ b/api/tests/certification/session/acceptance/application/session-live-alert-controller_test.js
@@ -149,6 +149,7 @@ describe('Certification | Session | Acceptance | Controller | session-live-alert
         expect(response.statusCode).to.equal(204);
         expect(liveAlert.status).to.equal(CertificationChallengeLiveAlertStatus.VALIDATED);
         expect(certificationIssueReport.subcategory).to.equal('IMAGE_NOT_DISPLAYING');
+        expect(certificationIssueReport.liveAlertId).to.equal(liveAlert.id);
       });
     });
 

--- a/api/tests/certification/session/unit/domain/usecases/validate-live-alert_test.js
+++ b/api/tests/certification/session/unit/domain/usecases/validate-live-alert_test.js
@@ -126,6 +126,7 @@ describe('Unit | UseCase | validate-live-alert', function () {
         categoryId: issueReportCategory.id,
         category,
         questionNumber,
+        liveAlertId: liveAlert.id,
       });
       expectedCertificationIssueReport.id = undefined;
       expectedCertificationIssueReport.description = undefined;

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-issue-report-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-issue-report-repository_test.js
@@ -174,8 +174,8 @@ describe('Integration | Repository | Certification Issue Report', function () {
 
       // then
       const expectedIssueReports = [
-        new CertificationIssueReport(issueReportForTargetCourse1),
-        new CertificationIssueReport(issueReportForTargetCourse2),
+        domainBuilder.buildCertificationIssueReport(issueReportForTargetCourse1),
+        domainBuilder.buildCertificationIssueReport(issueReportForTargetCourse2),
       ];
       expect(results).to.deep.equal(expectedIssueReports);
       expect(results[0]).to.be.instanceOf(CertificationIssueReport);

--- a/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
@@ -1,6 +1,5 @@
 import { databaseBuilder, domainBuilder, expect } from '../../../test-helper.js';
 import { JuryCertificationSummary } from '../../../../lib/domain/read-models/JuryCertificationSummary.js';
-import { CertificationIssueReport } from '../../../../src/certification/shared/domain/models/CertificationIssueReport.js';
 
 import {
   CertificationIssueReportCategory,
@@ -93,17 +92,14 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
           pixScore: latestAssessmentResult.pixScore,
           status: latestAssessmentResult.status,
           certificationIssueReports: [
-            new CertificationIssueReport({
+            domainBuilder.buildCertificationIssueReport({
               id: certificationIssueReport.id,
               certificationCourseId: manyAsrCertification.id,
               description,
               categoryId,
               subcategory: null,
-              questionNumber: null,
               category: CertificationIssueReportCategory.OTHER,
               hasBeenAutomaticallyResolved: null,
-              resolvedAt: null,
-              resolution: null,
             }),
           ],
           complementaryCertificationTakenLabel: null,
@@ -220,7 +216,7 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
         expect(juryCertificationSummaries).to.have.lengthOf(1);
         expect(certificationIssueReports).to.have.lengthOf(2);
         expect(certificationIssueReports).to.deep.equal([
-          new CertificationIssueReport({
+          domainBuilder.buildCertificationIssueReport({
             id: issueReport1.id,
             category: issueReport1.category,
             categoryId: issueReport1.categoryId,
@@ -228,11 +224,8 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
             description: 'first certification issue report',
             hasBeenAutomaticallyResolved: false,
             subcategory: null,
-            questionNumber: null,
-            resolvedAt: null,
-            resolution: null,
           }),
-          new CertificationIssueReport({
+          domainBuilder.buildCertificationIssueReport({
             id: issueReport2.id,
             category: issueReport2.category,
             categoryId: issueReport2.categoryId,
@@ -240,9 +233,6 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
             description: 'second certification issue report',
             hasBeenAutomaticallyResolved: false,
             subcategory: null,
-            questionNumber: null,
-            resolvedAt: null,
-            resolution: null,
           }),
         ]);
       });
@@ -378,7 +368,7 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
         expect(juryCertificationSummary.hasSeendEndTestScreen).to.equal(manyAsrCertification.hasSeendEndTestScreen);
         expect(juryCertificationSummary.complementaryCertificationTakenLabel).to.equal(label);
         expect(juryCertificationSummary.certificationIssueReports).to.deep.equal([
-          new CertificationIssueReport({
+          domainBuilder.buildCertificationIssueReport({
             id: issueReport1.id,
             category: issueReport1.category,
             categoryId,
@@ -386,11 +376,8 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
             description: 'first certification issue report',
             hasBeenAutomaticallyResolved: false,
             subcategory: null,
-            questionNumber: null,
-            resolvedAt: null,
-            resolution: null,
           }),
-          new CertificationIssueReport({
+          domainBuilder.buildCertificationIssueReport({
             id: issueReport2.id,
             category: issueReport2.category,
             categoryId,
@@ -398,9 +385,6 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
             description: 'second certification issue report',
             hasBeenAutomaticallyResolved: false,
             subcategory: null,
-            questionNumber: null,
-            resolvedAt: null,
-            resolution: null,
           }),
         ]);
       });

--- a/api/tests/tooling/domain-builder/factory/build-certification-issue-report.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-issue-report.js
@@ -15,6 +15,7 @@ const buildCertificationIssueReport = function ({
   hasBeenAutomaticallyResolved = null,
   resolvedAt = null,
   resolution = null,
+  liveAlertId = null,
 } = {}) {
   return new CertificationIssueReport({
     id,
@@ -27,6 +28,7 @@ const buildCertificationIssueReport = function ({
     hasBeenAutomaticallyResolved,
     resolvedAt,
     resolution,
+    liveAlertId,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/build-v3-certification-challenge-live-alert-for-administration.js
+++ b/api/tests/tooling/domain-builder/factory/build-v3-certification-challenge-live-alert-for-administration.js
@@ -1,8 +1,9 @@
 import { V3CertificationChallengeLiveAlertForAdministration } from '../../../../src/certification/course/domain/models/V3CertificationChallengeLiveAlertForAdministration.js';
 
-const buildV3CertificationChallengeLiveAlertForAdministration = function ({ id = 456 } = {}) {
+const buildV3CertificationChallengeLiveAlertForAdministration = function ({ id = 456, issueReportSubcategory } = {}) {
   return new V3CertificationChallengeLiveAlertForAdministration({
     id,
+    issueReportSubcategory,
   });
 };
 


### PR DESCRIPTION
## :christmas_tree: Problème
Une page de détails spécifique à la certif v3 est nécessaire car celle pour la v2 n’est pas pertinente. Cette nouvelle page propose une organisation de l’information différente de la page de détails certif v2.

La détail du signalement d'une question n’est pour le moment pas accessible pour le pôle certif depuis cette nouvelle page de détails certif v3.

## :gift: Proposition
Afficher le détail du signalement en cas de signalement validé dans le tableau des questions V3.

## :santa: Pour tester

- Passer une certification V3
- Se connecter sur Pix Certif avec [certifv3@example.net](mailto:certifv3@example.net)
- Créer une session et ajouter un candidat
- Se connecter sur Pix App avec [certifiable-contenu-user@example.net](mailto:certifiable-contenu-user@example.net)
- Entrer les infos candidat, le code candidat
- Coté espace surveillant, autoriser le candidat à passer la certif
- Passer la certification avec au minimum : une question OK, une question KO, une question passée et une question dont le signalement a été validé par le surveillant.
- Finaliser la session sur Pix Certif
- Sur Pix Admin, aller sur Sessions de certification, puis sur Session à publier V3
- Cliquer sur l'id du candidat, puis sur l'onglet détails
- Constater que le tableau contient coté colonne "Actions" un nouveau bouton (uniquement pour les lignes en Signalement validé) (icône warning)
- Cliquer sur le bouton, constater qu'une modale apparaît avec le détail du signalement effectué.
- Constater la non présence de ce bouton pour les questions qui n'ont pas été signalées.
