### PR TITLE
Pix 10547 ajouter une route api pour désactiver un membre depuis pix certif

### DIFF
--- a/api/lib/application/certification-center-memberships/certification-center-membership-controller.js
+++ b/api/lib/application/certification-center-memberships/certification-center-membership-controller.js
@@ -15,6 +15,17 @@ const disableFromPixAdmin = async function (request, h, dependencies = { request
   return h.response().code(204);
 };
 
+const disableFromPixCertif = async function (request, h, dependencies = { requestResponseUtils }) {
+  const certificationCenterMembershipId = request.params.certificationCenterMembershipId;
+  const currentUserId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+
+  await usecases.disableCertificationCenterMembership({
+    certificationCenterMembershipId,
+    updatedByUserId: currentUserId,
+  });
+  return h.response().code(204);
+};
+
 const updateFromPixAdmin = async function (
   request,
   h,
@@ -69,6 +80,11 @@ const updateFromPixCertif = async function (
   );
 };
 
-const certificationCenterMembershipController = { disableFromPixAdmin, updateFromPixAdmin, updateFromPixCertif };
+const certificationCenterMembershipController = {
+  disableFromPixAdmin,
+  disableFromPixCertif,
+  updateFromPixAdmin,
+  updateFromPixCertif,
+};
 
 export { certificationCenterMembershipController };

--- a/api/lib/application/certification-center-memberships/certification-center-membership-controller.js
+++ b/api/lib/application/certification-center-memberships/certification-center-membership-controller.js
@@ -4,11 +4,11 @@ import * as certificationCenterMembershipSerializer from '../../infrastructure/s
 import { BadRequestError, ForbiddenError } from '../http-errors.js';
 import { getCertificationCenterId } from '../../infrastructure/repositories/certification-center-membership-repository.js';
 
-const disable = async function (request, h, dependencies = { requestResponseUtils }) {
+const disableFromPixAdmin = async function (request, h, dependencies = { requestResponseUtils }) {
   const certificationCenterMembershipId = request.params.id;
   const pixAgentUserId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
 
-  await usecases.disableCertificationCenterMembership({
+  await usecases.disableCertificationCenterMembershipFromPixAdmin({
     certificationCenterMembershipId,
     updatedByUserId: pixAgentUserId,
   });
@@ -69,6 +69,6 @@ const updateFromPixCertif = async function (
   );
 };
 
-const certificationCenterMembershipController = { disable, updateFromPixAdmin, updateFromPixCertif };
+const certificationCenterMembershipController = { disableFromPixAdmin, updateFromPixAdmin, updateFromPixCertif };
 
 export { certificationCenterMembershipController };

--- a/api/lib/application/certification-center-memberships/index.js
+++ b/api/lib/application/certification-center-memberships/index.js
@@ -36,7 +36,7 @@ const register = async function (server) {
       method: 'DELETE',
       path: '/api/admin/certification-center-memberships/{id}',
       config: {
-        handler: certificationCenterMembershipController.disable,
+        handler: certificationCenterMembershipController.disableFromPixAdmin,
         pre: [
           {
             method: (request, h) =>

--- a/api/lib/application/certification-center-memberships/index.js
+++ b/api/lib/application/certification-center-memberships/index.js
@@ -30,6 +30,29 @@ const register = async function (server) {
         tags: ['api', 'certification-center-membership'],
       },
     },
+    {
+      method: 'DELETE',
+      path: '/api/certification-center-memberships/{certificationCenterMembershipId}',
+      config: {
+        validate: {
+          params: Joi.object({
+            certificationCenterMembershipId: identifiersType.certificationCenterMembershipId,
+          }),
+        },
+        pre: [
+          {
+            method: securityPreHandlers.checkUserIsAdminOfCertificationCenterWithCertificationCenterMembershipId,
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: certificationCenterMembershipController.disableFromPixCertif,
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès**\n" +
+            "- Suppression d'un membre d'un centre de certification\n",
+        ],
+        tags: ['api', 'certification-center-membership'],
+      },
+    },
   ];
   const adminRoutes = [
     {

--- a/api/lib/application/security-pre-handlers.js
+++ b/api/lib/application/security-pre-handlers.js
@@ -18,6 +18,7 @@ import * as checkUserCanDisableHisOrganizationMembershipUseCase from './usecases
 import * as checkUserIsAdminAndManagingStudentsForOrganization from './usecases/checkUserIsAdminAndManagingStudentsForOrganization.js';
 import * as checkUserIsAdminOfCertificationCenterUsecase from './usecases/checkUserIsAdminOfCertificationCenter.js';
 import * as checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationIdUseCase from './usecases/check-user-is-admin-of-certification-center-with-certification-center-invitation-id.js';
+import * as checkUserIsAdminOfCertificationCenterWithCertificationCenterMembershipIdUseCase from './usecases/check-user-is-admin-of-certification-center-with-certification-center-membership-id.js';
 import * as checkUserIsMemberOfCertificationCenterUsecase from './usecases/checkUserIsMemberOfCertificationCenter.js';
 import * as checkUserIsMemberOfCertificationCenterSessionUsecase from './usecases/checkUserIsMemberOfCertificationCenterSession.js';
 import * as checkAuthorizationToManageCampaignUsecase from './usecases/checkAuthorizationToManageCampaign.js';
@@ -228,6 +229,30 @@ function checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationI
 
   return dependencies.checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationIdUseCase
     .execute({ certificationCenterInvitationId, userId })
+    .then((isAdminInCertificationCenter) => {
+      return isAdminInCertificationCenter ? h.response(true) : _replyForbiddenError(h);
+    })
+    .catch(() => _replyForbiddenError(h));
+}
+
+function checkUserIsAdminOfCertificationCenterWithCertificationCenterMembershipId(
+  request,
+  h,
+  dependencies = { checkUserIsAdminOfCertificationCenterWithCertificationCenterMembershipIdUseCase },
+) {
+  if (
+    !request.auth.credentials ||
+    !request.auth.credentials.userId ||
+    !request.params.certificationCenterMembershipId
+  ) {
+    return _replyForbiddenError(h);
+  }
+
+  const userId = request.auth.credentials.userId;
+  const certificationCenterMembershipId = request.params.certificationCenterMembershipId;
+
+  return dependencies.checkUserIsAdminOfCertificationCenterWithCertificationCenterMembershipIdUseCase
+    .execute({ certificationCenterMembershipId, userId })
     .then((isAdminInCertificationCenter) => {
       return isAdminInCertificationCenter ? h.response(true) : _replyForbiddenError(h);
     })
@@ -703,6 +728,7 @@ const securityPreHandlers = {
   checkUserIsMemberOfAnOrganization,
   checkUserIsAdminOfCertificationCenter,
   checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationId,
+  checkUserIsAdminOfCertificationCenterWithCertificationCenterMembershipId,
   checkUserIsMemberOfCertificationCenter,
   checkUserIsMemberOfCertificationCenterSessionFromCertificationCourseId,
   checkUserIsMemberOfCertificationCenterSessionFromCertificationIssueReportId,

--- a/api/lib/application/usecases/check-user-is-admin-of-certification-center-with-certification-center-membership-id.js
+++ b/api/lib/application/usecases/check-user-is-admin-of-certification-center-with-certification-center-membership-id.js
@@ -1,0 +1,20 @@
+import * as certificationCenterMembershipRepository from '../../infrastructure/repositories/certification-center-membership-repository.js';
+
+async function execute({
+  certificationCenterMembershipId,
+  userId,
+  dependencies = { certificationCenterMembershipRepository },
+}) {
+  const certificationCenterMembership = await dependencies.certificationCenterMembershipRepository.findById(
+    certificationCenterMembershipId,
+  );
+
+  if (!certificationCenterMembership) return false;
+
+  return await dependencies.certificationCenterMembershipRepository.isAdminOfCertificationCenter({
+    certificationCenterId: certificationCenterMembership.certificationCenter.id,
+    userId,
+  });
+}
+
+export { execute };

--- a/api/lib/domain/models/CertificationCenterMembership.js
+++ b/api/lib/domain/models/CertificationCenterMembership.js
@@ -38,6 +38,12 @@ class CertificationCenterMembership {
       this.updatedByUserId = updatedByUserId;
     }
   }
+
+  disableMembership(updatedByUserId) {
+    this.disabledAt = new Date();
+    this.updatedByUserId = updatedByUserId;
+    this.updatedAt = new Date();
+  }
 }
 
 export { CertificationCenterMembership, CERTIFICATION_CENTER_MEMBERSHIP_ROLES };

--- a/api/lib/domain/usecases/disable-certification-center-membership-from-pix-admin.js
+++ b/api/lib/domain/usecases/disable-certification-center-membership-from-pix-admin.js
@@ -1,4 +1,4 @@
-const disableCertificationCenterMembership = async function ({
+const disableCertificationCenterMembershipFromPixAdmin = async function ({
   certificationCenterMembershipId,
   updatedByUserId,
   certificationCenterMembershipRepository,
@@ -6,4 +6,4 @@ const disableCertificationCenterMembership = async function ({
   return certificationCenterMembershipRepository.disableById({ certificationCenterMembershipId, updatedByUserId });
 };
 
-export { disableCertificationCenterMembership };
+export { disableCertificationCenterMembershipFromPixAdmin };

--- a/api/lib/domain/usecases/disable-certification-center-membership.js
+++ b/api/lib/domain/usecases/disable-certification-center-membership.js
@@ -1,0 +1,48 @@
+import { NotFoundError } from '../errors.js';
+import { CERTIFICATION_CENTER_MEMBERSHIP_ROLES } from '../models/CertificationCenterMembership.js';
+import { ForbiddenError } from '../../application/http-errors.js';
+
+const disableCertificationCenterMembership = async function ({
+  certificationCenterMembershipId,
+  updatedByUserId,
+  certificationCenterMembershipRepository,
+}) {
+  const certificationCenterMembership = await certificationCenterMembershipRepository.findById(
+    certificationCenterMembershipId,
+  );
+
+  if (!certificationCenterMembership) {
+    throw new NotFoundError(`Cannot find a certification center membership for id ${certificationCenterMembershipId}`);
+  }
+
+  const membershipCanBeDisabled = await _membershipCanBeDisabled({
+    certificationCenterMembership,
+    certificationCenterMembershipRepository,
+  });
+
+  if (!membershipCanBeDisabled) {
+    throw new ForbiddenError(`Cannot disabled membership with id ${certificationCenterMembershipId}`);
+  }
+
+  certificationCenterMembership.disableMembership(updatedByUserId);
+
+  certificationCenterMembershipRepository.update(certificationCenterMembership);
+};
+
+async function _membershipCanBeDisabled({ certificationCenterMembership, certificationCenterMembershipRepository }) {
+  if (certificationCenterMembership.role === CERTIFICATION_CENTER_MEMBERSHIP_ROLES.MEMBER) {
+    return true;
+  }
+
+  const currentActiveAdmins = await certificationCenterMembershipRepository.findActiveAdminsByCertificationCenterId(
+    certificationCenterMembership.certificationCenter?.id,
+  );
+
+  const activeAdminsLeftAfterDisablingCurrentUser = currentActiveAdmins.filter(
+    (currentActiveAdmin) => currentActiveAdmin.user.id !== certificationCenterMembership.user?.id,
+  );
+
+  return activeAdminsLeftAfterDisablingCurrentUser.length > 0;
+}
+
+export { disableCertificationCenterMembership };

--- a/api/lib/infrastructure/repositories/certification-center-membership-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-membership-repository.js
@@ -294,11 +294,36 @@ const findOneWithCertificationCenterIdAndUserId = async function ({ certificatio
   return _toDomain(certificationCenterMembership);
 };
 
+async function findActiveAdminsByCertificationCenterId(certificationCenterId) {
+  const certificationCenterMemberships = await knex(CERTIFICATION_CENTER_MEMBERSHIP_TABLE_NAME)
+    .select(
+      'certification-center-memberships.*',
+      'users.lastName',
+      'users.firstName',
+      'users.email',
+      'certification-centers.name',
+      'certification-centers.type',
+      'certification-centers.externalId',
+      'certification-centers.createdAt AS certificationCenterCreatedAt',
+      'certification-centers.updatedAt AS certificationCenterUpdatedAt',
+    )
+    .join('users', 'certification-center-memberships.userId', 'users.id')
+    .join('certification-centers', 'certification-center-memberships.certificationCenterId', 'certification-centers.id')
+    .where({
+      certificationCenterId,
+      disabledAt: null,
+      role: 'ADMIN',
+    });
+
+  return certificationCenterMemberships.map(_toDomain);
+}
+
 export {
   countActiveMembersForCertificationCenter,
   create,
   disableById,
   disableMembershipsByUserId,
+  findActiveAdminsByCertificationCenterId,
   findActiveByCertificationCenterIdSortedByRole,
   findByCertificationCenterIdAndUserId,
   findOneWithCertificationCenterIdAndUserId,

--- a/api/tests/acceptance/application/certification-center-memberships/certification-center-membership-controller_test.js
+++ b/api/tests/acceptance/application/certification-center-memberships/certification-center-membership-controller_test.js
@@ -4,7 +4,6 @@ import {
   generateValidRequestAuthorizationHeader,
   insertUserWithRoleSuperAdmin,
   databaseBuilder,
-  sinon,
 } from '../../../test-helper.js';
 
 import { createServer } from '../../../../server.js';
@@ -15,37 +14,6 @@ describe('Acceptance | API | Certification Center Membership', function () {
   beforeEach(async function () {
     server = await createServer();
     await insertUserWithRoleSuperAdmin();
-  });
-
-  describe('DELETE /api/admin/certification-center-memberships/{id}', function () {
-    it('should return 200 HTTP status', async function () {
-      // given
-      const now = new Date();
-      const clock = sinon.useFakeTimers({
-        now,
-        toFake: ['Date'],
-      });
-      const userId = databaseBuilder.factory.buildUser().id;
-      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-      const certificationCenterMembershipId = databaseBuilder.factory.buildCertificationCenterMembership({
-        userId,
-        certificationCenterId,
-      }).id;
-      await databaseBuilder.commit();
-
-      const options = {
-        method: 'DELETE',
-        url: `/api/admin/certification-center-memberships/${certificationCenterMembershipId}`,
-        headers: { authorization: generateValidRequestAuthorizationHeader() },
-      };
-
-      // when
-      const response = await server.inject(options);
-
-      // then
-      expect(response.statusCode).to.equal(204);
-      clock.restore();
-    });
   });
 
   context('Admin routes', function () {

--- a/api/tests/acceptance/application/certification-center-memberships/certification-center-membership-controller_test.js
+++ b/api/tests/acceptance/application/certification-center-memberships/certification-center-membership-controller_test.js
@@ -444,5 +444,72 @@ describe('Acceptance | API | Certification Center Membership', function () {
         });
       });
     });
+
+    describe('DELETE /api/certification-center-memberships/{id}', function () {
+      let certificationCenter;
+      let certificationCenterMembership;
+      let user;
+
+      beforeEach(async function () {
+        certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+        user = databaseBuilder.factory.buildUser();
+        certificationCenterMembership = databaseBuilder.factory.buildCertificationCenterMembership({
+          certificationCenterId: certificationCenter.id,
+          userId: user.id,
+        });
+        await databaseBuilder.commit();
+      });
+
+      context('Success cases', function () {
+        context('when parameters are valid', function () {
+          it('returns a 204 HTTP status code', async function () {
+            const pixCertifAdminUser = databaseBuilder.factory.buildUser.withCertificationCenterMembership({
+              role: 'ADMIN',
+              certificationCenterId: certificationCenter.id,
+            });
+
+            const request = {
+              method: 'DELETE',
+              url: `/api/certification-center-memberships/${certificationCenterMembership.id}`,
+              headers: {
+                authorization: generateValidRequestAuthorizationHeader(pixCertifAdminUser.id),
+              },
+            };
+
+            await databaseBuilder.commit();
+
+            // when
+            const { statusCode } = await server.inject(request);
+
+            // then
+            expect(statusCode).to.equal(204);
+          });
+        });
+      });
+
+      context('Error cases', function () {
+        context('when user does not have a valid role', function () {
+          it('returns a 403 HTTP status code', async function () {
+            const userWithoutRole = databaseBuilder.factory.buildUser();
+
+            const request = {
+              method: 'DELETE',
+              url: `/api/certification-center-memberships/${certificationCenterMembership.id}`,
+              headers: {
+                authorization: generateValidRequestAuthorizationHeader(userWithoutRole.id),
+              },
+            };
+
+            await databaseBuilder.commit();
+
+            // when
+            const { statusCode } = await server.inject(request);
+
+            // then
+            expect(statusCode).to.equal(403);
+          });
+        });
+      });
+    });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-membership-repository_test.js
@@ -275,6 +275,25 @@ describe('Integration | Repository | Certification Center Membership', function 
     });
   });
 
+  describe('#findActiveAdminsByCertificationCenterId', function () {
+    it('returns a list of active members with the role "ADMIN"', async function () {
+      // given
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      databaseBuilder.factory.buildUser.withCertificationCenterMembership({ certificationCenterId, role: 'ADMIN' });
+      databaseBuilder.factory.buildUser.withCertificationCenterMembership({ certificationCenterId, role: 'ADMIN' });
+
+      await databaseBuilder.commit();
+
+      // when
+      const certificationCenterMemberships =
+        await certificationCenterMembershipRepository.findActiveAdminsByCertificationCenterId(certificationCenterId);
+
+      // then
+      expect(certificationCenterMemberships).to.be.an('array');
+      expect(certificationCenterMemberships[0]).to.be.an.instanceof(CertificationCenterMembership);
+    });
+  });
+
   describe('#findActiveByCertificationCenterIdSortedByRole', function () {
     it('should return certification center membership associated to the certification center', async function () {
       // given

--- a/api/tests/unit/application/certification-center-memberships/certification-center-memberships-controller_test.js
+++ b/api/tests/unit/application/certification-center-memberships/certification-center-memberships-controller_test.js
@@ -1,0 +1,32 @@
+import { expect, sinon, hFake } from '../../../test-helper.js';
+import { certificationCenterMembershipController } from '../../../../lib/application/certification-center-memberships/certification-center-membership-controller.js';
+import { usecases } from '../../../../lib/domain/usecases/index.js';
+
+describe('Unit | Application | certification-center-memberships | certification-center-membership-controller', function () {
+  describe('#acceptCertificationCenterMembership', function () {
+    it('calls disableCertificationMembership usecase', async function () {
+      // given
+      const currentUserId = 1234;
+      const certificationCenterMembershipId = 5678;
+      const request = {
+        params: { certificationCenterMembershipId },
+      };
+
+      const requestResponseUtils = {
+        extractUserIdFromRequest: () => currentUserId,
+      };
+      const dependencies = { requestResponseUtils };
+      sinon.stub(usecases, 'disableCertificationCenterMembership').resolves();
+
+      // when
+      const response = await certificationCenterMembershipController.disableFromPixCertif(request, hFake, dependencies);
+
+      // then
+      expect(usecases.disableCertificationCenterMembership).to.have.been.calledWithExactly({
+        certificationCenterMembershipId: 5678,
+        updatedByUserId: 1234,
+      });
+      expect(response.statusCode).to.equal(204);
+    });
+  });
+});

--- a/api/tests/unit/application/security-pre-handlers_test.js
+++ b/api/tests/unit/application/security-pre-handlers_test.js
@@ -1206,6 +1206,111 @@ describe('Unit | Application | SecurityPreHandlers', function () {
     });
   });
 
+  describe('#checkUserIsAdminOfCertificationCenterWithCertificationCenterMembershipId', function () {
+    context('successful cases', function () {
+      context('when user is an admin of the certification center', function () {
+        it('authorizes access to the resource', async function () {
+          // given
+          const adminUser = domainBuilder.buildUser();
+          const certificationCenter = domainBuilder.buildCertificationCenter();
+          const certificationCenterMembership = domainBuilder.buildCertificationCenterMembership({
+            certificationCenterId: certificationCenter.id,
+          });
+          const request = {
+            auth: {
+              credentials: {
+                accessToken: 'valid.access.token',
+                userId: adminUser.id,
+              },
+            },
+            params: {
+              certificationCenterMembershipId: certificationCenterMembership.id,
+            },
+          };
+          const checkUserIsAdminOfCertificationCenterWithCertificationCenterMembershipIdUseCase = {
+            execute: sinon.stub().resolves(true),
+          };
+
+          // when
+          const response =
+            await securityPreHandlers.checkUserIsAdminOfCertificationCenterWithCertificationCenterMembershipId(
+              request,
+              hFake,
+              { checkUserIsAdminOfCertificationCenterWithCertificationCenterMembershipIdUseCase },
+            );
+
+          // then
+          expect(response.source).to.be.true;
+        });
+      });
+    });
+
+    context('error cases', function () {
+      context('when user is not an admin of the certification center', function () {
+        it('forbids access to the resource', async function () {
+          // given
+          const user = domainBuilder.buildUser();
+          const certificationCenterMembership = domainBuilder.buildCertificationCenterMembership();
+          const request = {
+            auth: {
+              credentials: {
+                accessToken: 'valid.access.token',
+                userId: user.id,
+              },
+            },
+            params: {
+              certificationCenterMembershipId: certificationCenterMembership.id,
+            },
+          };
+          const checkUserIsAdminOfCertificationCenterWithCertificationCenterMembershipIdUseCase = {
+            execute: sinon.stub().resolves(false),
+          };
+
+          // when
+          const response =
+            await securityPreHandlers.checkUserIsAdminOfCertificationCenterWithCertificationCenterMembershipId(
+              request,
+              hFake,
+              { checkUserIsAdminOfCertificationCenterWithCertificationCenterMembershipIdUseCase },
+            );
+
+          // then
+          expect(response.statusCode).to.equal(403);
+        });
+      });
+
+      context('when certification center invitation id is not provided', function () {
+        it('forbids access to the resource', async function () {
+          // given
+          const user = domainBuilder.buildUser();
+          const request = {
+            auth: {
+              credentials: {
+                accessToken: 'valid.access.token',
+                userId: user.id,
+              },
+            },
+            params: {},
+          };
+          const checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationIdUseCase = {
+            execute: sinon.stub().resolves(false),
+          };
+
+          // when
+          const response =
+            await securityPreHandlers.checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationId(
+              request,
+              hFake,
+              { checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationIdUseCase },
+            );
+
+          // then
+          expect(response.statusCode).to.equal(403);
+        });
+      });
+    });
+  });
+
   describe('#checkUserIsMemberOfCertificationCenter', function () {
     context('Successful case', function () {
       it('should authorize access to resource when the user is authenticated and is member in certification center', async function () {

--- a/api/tests/unit/application/usecases/check-user-is-admin-of-certification-center-with-certification-center-membership-id_test.js
+++ b/api/tests/unit/application/usecases/check-user-is-admin-of-certification-center-with-certification-center-membership-id_test.js
@@ -1,0 +1,80 @@
+import { domainBuilder, expect, sinon } from '../../../test-helper.js';
+import * as checkUserIsAdminOfCertificationCenterWithCertificationCenterMembershipIdUseCase from '../../../../lib/application/usecases/check-user-is-admin-of-certification-center-with-certification-center-membership-id.js';
+
+describe('Unit | Application | UseCases | checkUserIsAdminOfCertificationCenterWithCertificationCenterMembershipIdUseCase', function () {
+  let certificationCenterMembership, certificationCenterMembershipRepository, dependencies, user;
+
+  beforeEach(function () {
+    certificationCenterMembership = domainBuilder.buildCertificationCenterMembership();
+    user = domainBuilder.buildUser();
+
+    certificationCenterMembershipRepository = {
+      findById: sinon.stub(),
+      isAdminOfCertificationCenter: sinon.stub(),
+    };
+
+    certificationCenterMembershipRepository.findById.withArgs(certificationCenterMembership.id);
+    certificationCenterMembershipRepository.isAdminOfCertificationCenter.withArgs({
+      certificationCenterId: certificationCenterMembership.certificationCenterId,
+      userId: user.id,
+    });
+
+    dependencies = {
+      certificationCenterMembershipRepository,
+    };
+  });
+
+  context('when user is admin of the certification center', function () {
+    it('returns true', async function () {
+      // given
+      certificationCenterMembershipRepository.findById.resolves(certificationCenterMembership);
+      certificationCenterMembershipRepository.isAdminOfCertificationCenter.resolves(true);
+
+      // when
+      const response = await checkUserIsAdminOfCertificationCenterWithCertificationCenterMembershipIdUseCase.execute({
+        certificationCenterMembershipId: certificationCenterMembership.id,
+        userId: user.id,
+        dependencies,
+      });
+
+      // then
+      expect(response).to.be.true;
+    });
+  });
+
+  context('when user is not admin of the certification center', function () {
+    it('returns false', async function () {
+      // given
+      certificationCenterMembershipRepository.findById.resolves(certificationCenterMembership);
+      certificationCenterMembershipRepository.isAdminOfCertificationCenter.resolves(false);
+
+      // when
+      const response = await checkUserIsAdminOfCertificationCenterWithCertificationCenterMembershipIdUseCase.execute({
+        certificationCenterMembershipId: certificationCenterMembership.id,
+        userId: user.id,
+        dependencies,
+      });
+
+      // then
+      expect(response).to.be.false;
+    });
+  });
+
+  context('when there is no certification center membership', function () {
+    it('returns false', async function () {
+      // given
+      certificationCenterMembershipRepository.findById.resolves();
+
+      // when
+      const response = await checkUserIsAdminOfCertificationCenterWithCertificationCenterMembershipIdUseCase.execute({
+        certificationCenterMembershipId: certificationCenterMembership.id,
+        userId: user.id,
+        dependencies,
+      });
+
+      // then
+      expect(response).to.be.false;
+      expect(certificationCenterMembershipRepository.isAdminOfCertificationCenter).to.not.have.been.called;
+    });
+  });
+});

--- a/api/tests/unit/domain/models/CertificationCenterMembership_test.js
+++ b/api/tests/unit/domain/models/CertificationCenterMembership_test.js
@@ -1,4 +1,4 @@
-import { expect, sinon } from '../../../test-helper.js';
+import { expect, sinon, domainBuilder } from '../../../test-helper.js';
 import {
   CERTIFICATION_CENTER_MEMBERSHIP_ROLES,
   CertificationCenterMembership,
@@ -70,6 +70,22 @@ describe('Unit | Domain | Models | CertificationCenterMembership', function () {
         // then
         expect(certificationCenterMembership).to.deep.equal(expectedCertificationCenterMembership);
       });
+    });
+  });
+
+  describe('#disableMembership', function () {
+    it('updates certification center membership "disabledAt", "updatedAt" and "updatedByUserId" attributes', function () {
+      // given
+      const certificationCenterMembership = domainBuilder.buildCertificationCenterMembership();
+      const updatedByUserId = certificationCenterMembership.user.id;
+
+      // when
+      certificationCenterMembership.disableMembership(updatedByUserId);
+
+      // then
+      expect(certificationCenterMembership.updatedByUserId).to.equal(updatedByUserId);
+      expect(certificationCenterMembership.disabledAt).to.deep.equal(now);
+      expect(certificationCenterMembership.updatedAt).to.deep.equal(now);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/disable-certification-center-membership-from-pix-admin_test.js
+++ b/api/tests/unit/domain/usecases/disable-certification-center-membership-from-pix-admin_test.js
@@ -1,7 +1,7 @@
 import { expect, sinon } from '../../../test-helper.js';
-import { disableCertificationCenterMembership } from '../../../../lib/domain/usecases/disable-certification-center-membership.js';
+import { disableCertificationCenterMembershipFromPixAdmin } from '../../../../lib/domain/usecases/disable-certification-center-membership-from-pix-admin.js';
 
-describe('Unit | UseCase | disable-certification-center-membership', function () {
+describe('Unit | UseCase | disable-certification-center-membership-from-pix-admin', function () {
   let certificationCenterMembershipRepository;
   beforeEach(function () {
     certificationCenterMembershipRepository = {
@@ -15,7 +15,7 @@ describe('Unit | UseCase | disable-certification-center-membership', function ()
     const updatedByUserId = 10;
 
     // when
-    await disableCertificationCenterMembership({
+    await disableCertificationCenterMembershipFromPixAdmin({
       certificationCenterMembershipId,
       updatedByUserId,
       certificationCenterMembershipRepository,

--- a/api/tests/unit/domain/usecases/disable-certification-center-membership_test.js
+++ b/api/tests/unit/domain/usecases/disable-certification-center-membership_test.js
@@ -1,0 +1,161 @@
+import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';
+import { NotFoundError } from '../../../../lib/domain/errors.js';
+import { disableCertificationCenterMembership } from '../../../../lib/domain/usecases/disable-certification-center-membership.js';
+import { ForbiddenError } from '../../../../lib/application/http-errors.js';
+
+describe('Unit | UseCase | disable-certification-center-membership', function () {
+  let certificationCenterMembershipRepository;
+  let clock;
+  const certificationCenterMembershipId = 100;
+  const certificationCenterId = 101;
+  const updatedByUserId = 10;
+
+  beforeEach(function () {
+    const now = new Date('2023-12-15T14:57:12Z');
+
+    certificationCenterMembershipRepository = {
+      findActiveAdminsByCertificationCenterId: sinon.stub(),
+      findById: sinon.stub(),
+      update: sinon.stub(),
+    };
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
+  context('when certification-center-membership does not exist', function () {
+    it('throws a NotFoundError', async function () {
+      // given
+      certificationCenterMembershipRepository.findById.resolves(undefined);
+
+      // when
+      const error = await catchErr(disableCertificationCenterMembership)({
+        certificationCenterMembershipId,
+        updatedByUserId,
+        certificationCenterMembershipRepository,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+      expect(certificationCenterMembershipRepository.findById).to.have.been.called;
+      expect(certificationCenterMembershipRepository.findActiveAdminsByCertificationCenterId).to.not.have.been.called;
+    });
+  });
+  context('when certification-center-membership exists', function () {
+    let certificationCenterMembership;
+
+    beforeEach(function () {
+      certificationCenterMembership = domainBuilder.buildCertificationCenterMembership({
+        id: 100,
+        user: domainBuilder.buildUser({
+          id: 4567,
+        }),
+        certificationCenter: domainBuilder.buildCertificationCenter({
+          id: certificationCenterId,
+        }),
+      });
+    });
+
+    context('when certification-center-membership has a role "MEMBER"', function () {
+      it('disables the certification-center-membership', async function () {
+        // given
+        certificationCenterMembership.role = 'MEMBER';
+
+        certificationCenterMembershipRepository.findById.resolves(certificationCenterMembership);
+        const updatedFieldsOfCertificationCenterMembership = {
+          disabledAt: new Date(),
+          updatedByUserId,
+          updatedAt: new Date(),
+        };
+
+        // when
+        await disableCertificationCenterMembership({
+          certificationCenterMembershipId,
+          updatedByUserId,
+          certificationCenterMembershipRepository,
+        });
+
+        // then
+        expect(certificationCenterMembershipRepository.findById).to.have.been.called;
+        expect(certificationCenterMembershipRepository.update).to.have.been.calledWithMatch(
+          updatedFieldsOfCertificationCenterMembership,
+        );
+        expect(certificationCenterMembershipRepository.findActiveAdminsByCertificationCenterId).to.not.have.been.called;
+      });
+    });
+    context('when certification-center-membership has a role "ADMIN"', function () {
+      let otherAdminMembership;
+      beforeEach(function () {
+        certificationCenterMembership.role = 'ADMIN';
+        otherAdminMembership = domainBuilder.buildCertificationCenterMembership({
+          role: 'ADMIN',
+          certificationCenter: {
+            id: certificationCenterId,
+          },
+          user: {
+            id: 100,
+          },
+        });
+
+        certificationCenterMembershipRepository.findById.resolves(certificationCenterMembership);
+      });
+      context('when certification-center have at least 2 admins', function () {
+        it('disables the certification-center-membership', async function () {
+          // given
+          const adminMembershipsOfCertificationCenter = [certificationCenterMembership, otherAdminMembership];
+
+          certificationCenterMembershipRepository.findActiveAdminsByCertificationCenterId.resolves(
+            adminMembershipsOfCertificationCenter,
+          );
+
+          const updatedFieldsOfCertificationCenterMembership = {
+            disabledAt: new Date(),
+            updatedByUserId,
+            updatedAt: new Date(),
+          };
+
+          // when
+          await disableCertificationCenterMembership({
+            certificationCenterMembershipId,
+            updatedByUserId,
+            certificationCenterMembershipRepository,
+          });
+
+          // then
+          expect(certificationCenterMembershipRepository.findById).to.have.been.called;
+          expect(certificationCenterMembershipRepository.update).to.have.been.calledWithMatch(
+            updatedFieldsOfCertificationCenterMembership,
+          );
+          expect(
+            certificationCenterMembershipRepository.findActiveAdminsByCertificationCenterId,
+          ).have.been.calledWithExactly(certificationCenterId);
+        });
+      });
+      context('when certification-center have only 1 admin', function () {
+        it('throws a forbidden error', async function () {
+          // given
+          certificationCenterMembershipRepository.findActiveAdminsByCertificationCenterId.resolves([
+            certificationCenterMembership,
+          ]);
+
+          // when
+          const error = await catchErr(disableCertificationCenterMembership)({
+            certificationCenterMembershipId,
+            updatedByUserId,
+            certificationCenterMembershipRepository,
+          });
+
+          // then
+          expect(error).to.be.instanceOf(ForbiddenError);
+          expect(certificationCenterMembershipRepository.findById).to.have.been.called;
+          expect(certificationCenterMembershipRepository.update).to.not.have.been.called;
+          expect(
+            certificationCenterMembershipRepository.findActiveAdminsByCertificationCenterId,
+          ).have.been.calledWithExactly(certificationCenterId);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Problème

Il existe une route pour désactiver un membre depuis Pix Admin, mais pas depuis Pix Certif. La route existante ne peut pas être réutilisée car les droits d’accès et les règles métiers sont différentes.



Solution

Ajouter une route DELETE /api/certification-center-memberships/{id}.

Règles :

L’utilisateur courant doit être admin du centre de certification auquel appartient le membre à désactiver

La désactivation doit provoquer une erreur si le membre à désactiver est le dernier administrateur du centre de certif



Remarques

Ces deux règles s’appliquant pour toute suppression de membre depuis Pix Certif, elle pourra être utilisée pour les deux cas d’usage suivant :

https://1024pix.atlassian.net/browse/PIX-4998

https://1024pix.atlassian.net/browse/PIX-8639