### PR TITLE
[BUGFIX] Réparer les liens vers Pix Editor sur la page de détails d'une certification sur Pix Admin (PIX-10526).

### DIFF
--- a/admin/app/components/certifications/certification/details-v3.hbs
+++ b/admin/app/components/certifications/certification/details-v3.hbs
@@ -58,6 +58,7 @@
                   href={{this.externalUrlForPixEditor certificationChallenge.id}}
                   target="_blank"
                   rel="noopener noreferrer"
+                  aria-label="Lien vers les informations de la question (Ouverture dans une nouvelle fenêtre)"
                 >
                   {{certificationChallenge.id}}
                   <FaIcon @icon="external-link" />

--- a/admin/app/components/certifications/details-answer.js
+++ b/admin/app/components/certifications/details-answer.js
@@ -36,7 +36,7 @@ export default class CertificationDetailsAnswer extends Component {
   }
 
   get linkToChallengeInfoInPixEditor() {
-    return `https://editor.pix.fr/#/challenge/${this.args.answer.challengeId}`;
+    return `https://editor.pix.fr/challenge/${this.args.answer.challengeId}`;
   }
 
   _answerResultValue() {

--- a/admin/tests/integration/components/certifications/certification/details-v3_test.js
+++ b/admin/tests/integration/components/certifications/certification/details-v3_test.js
@@ -98,6 +98,32 @@ module('Integration | Component | Certifications | certification > details v3', 
       assert.deepEqual(expected, result);
     });
 
+    test('displays links to challenge info', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      this.model = store.createRecord('v3-certification-course-details-for-administration', {
+        certificationChallengesForAdministration: [
+          store.createRecord('certification-challenges-for-administration', {
+            id: 'rec1234',
+            answerStatus: 'ok',
+            validatedLiveAlert: null,
+          }),
+        ],
+      });
+
+      // when
+      const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
+
+      // then
+      assert
+        .dom(
+          screen.getByRole('link', {
+            name: 'Lien vers les informations de la question (Ouverture dans une nouvelle fenêtre)',
+          }),
+        )
+        .hasAttribute('href', 'https://editor.pix.fr/challenge/rec1234');
+    });
+
     test('displays the table with every questions asked during certification', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');

--- a/admin/tests/integration/components/certifications/details-answer_test.js
+++ b/admin/tests/integration/components/certifications/details-answer_test.js
@@ -96,7 +96,7 @@ module('Integration | Component | certifications/details-answer', function (hook
       .hasAttribute('href', 'https://app.recette.pix.fr/challenges/rec1234/preview');
     assert
       .dom(screen.getByRole('link', { name: 'Info' }))
-      .hasAttribute('href', 'https://editor.pix.fr/#/challenge/rec1234');
+      .hasAttribute('href', 'https://editor.pix.fr/challenge/rec1234');
   });
 
   module('when certification is not finished', function () {


### PR DESCRIPTION
## :christmas_tree: Problème
Sur l’onglet “Détails” d’une certification dans Pix Admin, un lien “Info” pour chaque question posée au candidat en certification. Or, lorsque l’utilisateur Pix Admin clique sur le lien Info, il est dirigé vers la page d'accueil de Pix Editor au lieu de la page du challenge directement concerné par la question.

## :gift: Proposition
Réparer le lien vers Pix Editor

## :socks: Remarques
Ajout d'un aria-label pour la page V3 de Pix Admin.

## :santa: Pour tester
- Se connecter sur Pix Editor en prod https://pix.editor.fr (info sur ticket Jira)
- Aller ici https://admin-pr7768.review.pix.fr/certifications/144983/details
- Cliquer sur les liens "Infos" et constater que l'on est bien redirigé vers le challenge de la question

Pour visualiser l'aria-label de la page V3  : 

- Aller ici https://admin-pr7768.review.pix.fr/certifications/145450/details
- Ouvrir Voice Over et passer sur les liens du tableau
