### PR TITLE
[FEATURE] Inverser l'ordre des boutons sur la première étape de l'import en masse de session sur Pix Certif (PIX-10150).

### DIFF
--- a/certif/app/components/import/step-one-section.hbs
+++ b/certif/app/components/import/step-one-section.hbs
@@ -60,12 +60,20 @@
     </div>
   {{/if}}
 
-  <div class="import-page__section--link-buttons">
-    <PixButtonLink @route="authenticated.sessions.list" @backgroundColor="transparent-light" @isBorderVisible={{true}}>
-      {{t "common.actions.cancel"}}
-    </PixButtonLink>
-    <PixButton @triggerAction={{@validateSessions}} @isDisabled={{@isImportDisabled}}>
-      {{t "common.actions.continue"}}
-    </PixButton>
-  </div>
+  <ul class="import-page__section--link-buttons">
+    <li>
+      <PixButton @triggerAction={{@validateSessions}} @isDisabled={{@isImportDisabled}}>
+        {{t "common.actions.continue"}}
+      </PixButton>
+    </li>
+    <li>
+      <PixButtonLink
+        @route="authenticated.sessions.list"
+        @backgroundColor="transparent-light"
+        @isBorderVisible={{true}}
+      >
+        {{t "common.actions.cancel"}}
+      </PixButtonLink>
+    </li>
+  </ul>
 </section>


### PR DESCRIPTION
## :christmas_tree: Problème
La gestion massive des sessions est une nouvelle fonctionnalité qui a été mise à disposition de nos utilisateurs en juillet 2023.

Les boutons “Continuer” et “Annuler” sont dans un ordre tel que l’action principale de “Continuer” se trouve à droite de l’action d'“Annuler” ce qui n’est pas très logique lors d’une lecture de gauche à droite.

## :gift: Proposition
Inverser les boutons

## :santa: Pour tester

- Se connecter sur Pix Certif avec [certif-pro@example.net](mailto:certif-pro@example.net)
- Aller sur Créer/éditer plusieurs sessions
- Constater que les boutons continuer en annuler ont été inversés et que le changement d'une div à une liste n'ai pas changé le design

