### PR TITLE
[FEATURE] Empêcher le rejet d'une certification si celle-ci est publiée (PIX-10492).

### DIFF
--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -26,9 +26,28 @@
         {{/if}}
 
         {{#if this.shouldDisplayRejectCertificationButton}}
-          <PixButton @backgroundColor="red" @size="small" @triggerAction={{this.onRejectCertificationButtonClick}}>
-            Rejeter la certification
-          </PixButton>
+          {{#if this.certification.isPublished}}
+            <PixTooltip @position="left" @isWide={{true}}>
+              <:triggerElement>
+                <PixButton
+                  @backgroundColor="red"
+                  @size="small"
+                  @triggerAction={{this.onRejectCertificationButtonClick}}
+                  @isDisabled={{true}}
+                >
+                  Rejeter la certification
+                </PixButton>
+              </:triggerElement>
+
+              <:tooltip>Vous ne pouvez pas rejeter une certification publiée. Merci de dépublier la session avant de
+                rejeter cette certification.
+              </:tooltip>
+            </PixTooltip>
+          {{else}}
+            <PixButton @backgroundColor="red" @size="small" @triggerAction={{this.onRejectCertificationButtonClick}}>
+              Rejeter la certification
+            </PixButton>
+          {{/if}}
         {{/if}}
       </span>
     {{/if}}

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -954,6 +954,46 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
         assert.dom(screen.queryByText('Rejetée')).doesNotExist();
         assert.dom(screen.getByRole('button', { name: 'Rejeter la certification' })).exists();
       });
+
+      test('rejection button should be disabled if the certification is published', async function (assert) {
+        // given
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+        const otherCertification = this.server.create('certification', {
+          id: 123,
+          isPublished: true,
+        });
+        const screen = await visit(`/certifications/${otherCertification.id}`);
+
+        // then
+        assert.dom(screen.getByRole('button', { name: 'Rejeter la certification' })).hasAttribute('disabled');
+        assert
+          .dom(
+            screen.getByText(
+              'Vous ne pouvez pas rejeter une certification publiée. Merci de dépublier la session avant de rejeter cette certification.',
+            ),
+          )
+          .exists();
+      });
+
+      test('rejection button should be enabled if the certification is not published', async function (assert) {
+        // given
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+        const otherCertification = this.server.create('certification', {
+          id: 123,
+          isPublished: false,
+        });
+        const screen = await visit(`/certifications/${otherCertification.id}`);
+
+        // then
+        assert.dom(screen.getByRole('button', { name: 'Rejeter la certification' })).hasNoAttribute('disabled');
+        assert
+          .dom(
+            screen.queryByText(
+              'Vous ne pouvez pas rejeter une certification publiée. Merci de dépublier la session avant de rejeter cette certification.',
+            ),
+          )
+          .doesNotExist();
+      });
     });
 
     module('Certification unrejection', function (hooks) {


### PR DESCRIPTION
## :christmas_tree: Problème

Le process pour rejeter manuellement une certification pour fraude a été simplifié par l’ajout d’un bouton sur la page de détails d’une certification (v2 et v3) sur Pix Admin.
Il est actuellement possible de rejeter pour fraude une certif qui a été déjà été publiée, sans dépublier celle-ci. Or, ça ne renvoie pas le fichier csv des résultats au prescripteur avec l’information à jour.

## :gift: Proposition

Bloquer le rejet manuel d’une certification pour les certif publiées. Dans Pix Admin > page de détails d’une certif v2 ET v3 > onglet “Informations” : 

- rendre inactif le bouton “Rejeter la certification” 
- afficher un message au survol (voir ce qui a été fait pour le blocage de la publication d’une session lorsqu’une certif est ‘started” ou 'en erreur’) : “Vous ne pouvez pas rejeter une certification publiée. Merci de dépublier la session avant de rejeter cette certification.”

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester

Dans Pix Admin, trouver une certification qui n’est pas déjà au statut “Rejetée”
Le bouton “Rejeter la certification” est actif
Publier la session dans laquelle se trouve cette certification
Retourner sur la page de détails de la certif
Le bouton “Rejeter la certification” est devenu inactif avec un message indiquant qu’il n’est pas possible de rejeter une certification publiée
