### PR TITLE
[FEATURE] Créer la page de fin de parcours pour les parcours autonomes sur PIx-App (PIX-9741)

### DIFF
--- a/api/db/seeds/data/team-evaluation/autonomous-courses/create-autonomous-courses.js
+++ b/api/db/seeds/data/team-evaluation/autonomous-courses/create-autonomous-courses.js
@@ -73,7 +73,7 @@ export default async function initUser(databaseBuilder) {
       targetProfileId: targetProfileId,
       cappedTubesDTO: cappedTubesDTO,
       type: 'LEVEL',
-      countStages: 1,
+      countStages: 3,
       includeFirstSkill: false,
     });
   }

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -88,7 +88,7 @@
                 </LinkTo>
               </div>
             {{else}}
-              {{#if (or @model.campaign.isForAbsoluteNovice this.isAutonomousCourse)}}
+              {{#if this.displayContinueToPixLink}}
                 <a
                   href="#"
                   {{on "click" this.redirectToSignupIfUserIsAnonymous}}
@@ -185,7 +185,7 @@
           </div>
         </div>
       {{/if}}
-      {{#if (or (and @model.trainings this.isShared) (and @model.trainings this.isAutonomousCourse))}}
+      {{#if this.displayTrainings}}
         <section class="skill-review__trainings">
           <h2 class="skill-review-trainings__title">{{t "pages.skill-review.trainings.title"}}</h2>
           <p class="skill-review-trainings__description">{{t "pages.skill-review.trainings.description"}}</p>

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -88,7 +88,7 @@
                 </LinkTo>
               </div>
             {{else}}
-              {{#if @model.campaign.isForAbsoluteNovice}}
+              {{#if (or @model.campaign.isForAbsoluteNovice this.isAutonomousCourse)}}
                 <a
                   href="#"
                   {{on "click" this.redirectToSignupIfUserIsAnonymous}}
@@ -185,7 +185,7 @@
           </div>
         </div>
       {{/if}}
-      {{#if (and @model.trainings this.isShared)}}
+      {{#if (or (and @model.trainings this.isShared) (and @model.trainings this.isAutonomousCourse))}}
         <section class="skill-review__trainings">
           <h2 class="skill-review-trainings__title">{{t "pages.skill-review.trainings.title"}}</h2>
           <p class="skill-review-trainings__description">{{t "pages.skill-review.trainings.description"}}</p>

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -2,6 +2,7 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import isNil from 'lodash/isNil';
+import ENV from 'mon-pix/config/environment';
 
 import Component from '@glimmer/component';
 
@@ -100,8 +101,9 @@ export default class SkillReview extends Component {
   get displayOrganizationCustomMessage() {
     const hasCustomBlock = this.showOrganizationMessage || this.showOrganizationButton;
     const showCustomBlock = this.isShared || this.args.model.campaign.isForAbsoluteNovice;
+    const showAutonomousCourseCustomBlock = this.isAutonomousCourse || this.args.model.campaign.isForAbsoluteNovice;
 
-    return hasCustomBlock && showCustomBlock;
+    return (hasCustomBlock && showCustomBlock) || (hasCustomBlock && showAutonomousCourseCustomBlock);
   }
 
   get showOrganizationMessage() {
@@ -174,13 +176,12 @@ export default class SkillReview extends Component {
     return this.args.model.campaignParticipationResult.canImprove && !this.isShareButtonClicked;
   }
 
+  get showBadges() {
+    return this.showCertifiableBadges || this.showNotCertifiableBadges;
+  }
+
   get showHeavyBlock() {
-    return (
-      this.showCertifiableBadges ||
-      this.showNotCertifiableBadges ||
-      this.showImproveButton ||
-      !this.args.model.campaign.isForAbsoluteNovice
-    );
+    return this.showBadges || this.showImproveButton || !this.args.model.campaign.isForAbsoluteNovice;
   }
 
   get competenceResultsGroupedByAreas() {
@@ -203,6 +204,10 @@ export default class SkillReview extends Component {
       }
       return acc;
     }, {});
+  }
+
+  get isAutonomousCourse() {
+    return this.args.model.campaign.organizationId === ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID;
   }
 
   _buildUrl(baseUrl, params) {

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -98,6 +98,14 @@ export default class SkillReview extends Component {
     return !this.showOrganizationButton;
   }
 
+  get displayContinueToPixLink() {
+    return this.args.model.campaign.isForAbsoluteNovice || this.isAutonomousCourse;
+  }
+
+  get displayTrainings() {
+    return Boolean(this.args.model.trainings) && (this.isShared || this.isAutonomousCourse);
+  }
+
   get displayOrganizationCustomMessage() {
     const hasCustomBlock = this.showOrganizationMessage || this.showOrganizationButton;
     const showCustomBlock = this.isShared || this.args.model.campaign.isForAbsoluteNovice;

--- a/mon-pix/tests/integration/components/campaign/skill-review_test.js
+++ b/mon-pix/tests/integration/components/campaign/skill-review_test.js
@@ -3,10 +3,12 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import { click } from '@ember/test-helpers';
+import ENV from 'mon-pix/config/environment';
 
 module('Integration | Component | Campaign | skill-review', function (hooks) {
   setupIntlRenderingTest(hooks);
   let model;
+  const autonomousCourseOrganizationId = ENV.APP.AUTONOMOUS_COURSES_ORGANIZATION_ID;
 
   hooks.beforeEach(function () {
     const store = this.owner.lookup('service:store');
@@ -262,5 +264,25 @@ module('Integration | Component | Campaign | skill-review', function (hooks) {
 
     assert.notOk(screen.queryByText(this.intl.t('pages.skill-review.stage.title')));
     assert.notOk(screen.queryByText(this.intl.t('pages.skill-review.details.title')));
+  });
+
+  module('when the campaign is an autonomous course', () => {
+    test('it should display continue link instead of the share results button', async function (assert) {
+      // given
+      const customResultPageText = 'Je suis Iron Man';
+      model.campaign.set('organizationId', autonomousCourseOrganizationId);
+      model.campaign.set('customResultPageText', customResultPageText);
+
+      this.set('model', model);
+
+      // when
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
+      const continueLink = screen.getByRole('link', { name: this.intl.t('pages.skill-review.actions.continue') });
+
+      assert.notOk(screen.queryByText(this.intl.t('pages.skill-review.actions.send')));
+      assert.notOk(screen.queryByText(this.intl.t('pages.skill-review.send-results')));
+
+      assert.dom(continueLink).exists();
+    });
   });
 });

--- a/mon-pix/tests/unit/components/campaigns/assessment/skill-review/skill-review_test.js
+++ b/mon-pix/tests/unit/components/campaigns/assessment/skill-review/skill-review_test.js
@@ -874,6 +874,116 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
     });
   });
 
+  module('#displayContinueToPixLink', function () {
+    test("should return true if it's an autonomous course OR the campaign is for absolute novice", function (assert) {
+      // given
+      sinon.stub(ENV.APP, 'AUTONOMOUS_COURSES_ORGANIZATION_ID').value(777);
+      component.args.model.campaign.organizationId = 777;
+      component.args.model.campaign.isForAbsoluteNovice = true;
+
+      // when
+      const result = component.displayContinueToPixLink;
+
+      // then
+      assert.true(result);
+    });
+
+    test("should return true if it's an autonomous course", function (assert) {
+      // given
+      sinon.stub(ENV.APP, 'AUTONOMOUS_COURSES_ORGANIZATION_ID').value(777);
+      component.args.model.campaign.organizationId = 777;
+
+      // when
+      const result = component.displayContinueToPixLink;
+
+      // then
+      assert.true(result);
+    });
+
+    test('should return true if the campaign is for absolute novice', function (assert) {
+      // given
+      component.args.model.campaign.isForAbsoluteNovice = true;
+
+      // when
+      const result = component.displayContinueToPixLink;
+
+      // then
+      assert.true(result);
+    });
+
+    test("should return false if it's not an autonomous course nor is the campaign for absolute novice", function (assert) {
+      // given
+      sinon.stub(ENV.APP, 'AUTONOMOUS_COURSES_ORGANIZATION_ID').value(777);
+      component.args.model.campaign.organizationId = 123;
+      component.args.model.campaign.isForAbsoluteNovice = false;
+
+      // when
+      const result = component.displayContinueToPixLink;
+
+      // then
+      assert.false(result);
+    });
+  });
+
+  module('#displayTrainings', function () {
+    test('should return true if the campaign participation result is shared AND there are trainings', function (assert) {
+      // given
+      component.args.model.campaignParticipationResult.isShared = true;
+      component.args.model.trainings = {
+        title: 'Mon super training',
+        link: 'https://training.net/',
+        type: 'webinaire',
+        locale: 'fr-fr',
+        duration: { hours: 6 },
+        editorName: "Ministère de l'éducation nationale et de la jeunesse. Liberté égalité fraternité",
+        editorLogoUrl:
+          'https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
+      };
+
+      // when
+      const result = component.displayTrainings;
+
+      // then
+      assert.true(result);
+    });
+
+    test("should return true if it's an autonomous course and there are trainings", function (assert) {
+      // given
+      sinon.stub(ENV.APP, 'AUTONOMOUS_COURSES_ORGANIZATION_ID').value(777);
+      component.args.model.campaign.organizationId = 777;
+      component.args.model.trainings = {
+        title: 'Mon super training',
+        link: 'https://training.net/',
+        type: 'webinaire',
+        locale: 'fr-fr',
+        duration: { hours: 6 },
+        editorName: "Ministère de l'éducation nationale et de la jeunesse. Liberté égalité fraternité",
+        editorLogoUrl:
+          'https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
+      };
+
+      // when
+      const result = component.displayTrainings;
+
+      // then
+      assert.true(result);
+    });
+
+    test('should return false if there are no trainings', function (assert) {
+      // given
+      component.args.model.trainings = {};
+      delete component.args.model.trainings;
+      sinon.stub(ENV.APP, 'AUTONOMOUS_COURSES_ORGANIZATION_ID').value(777);
+      component.args.model.campaign.organizationId = 777;
+
+      // when
+      const result = component.displayTrainings;
+
+      // then
+      assert.false(result);
+    });
+  });
+
   module('#displayPixLink', function () {
     test('should return false when there are customResultPageButtonText and customResultPageButtonUrl', function (assert) {
       // given

--- a/mon-pix/tests/unit/components/campaigns/assessment/skill-review/skill-review_test.js
+++ b/mon-pix/tests/unit/components/campaigns/assessment/skill-review/skill-review_test.js
@@ -4,6 +4,7 @@ import sinon from 'sinon';
 import EmberObject from '@ember/object';
 import createGlimmerComponent from '../../../../../helpers/create-glimmer-component';
 import Service from '@ember/service';
+import ENV from '../../../../../../config/environment';
 
 module('Unit | component | Campaigns | Evaluation | Skill Review', function (hooks) {
   setupTest(hooks);
@@ -844,6 +845,32 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
 
       // then
       assert.true(result);
+    });
+  });
+
+  module('#isAutonomousCourse', function () {
+    test("should return true if it's an autonomous course", function (assert) {
+      // given
+      sinon.stub(ENV.APP, 'AUTONOMOUS_COURSES_ORGANIZATION_ID').value(777);
+      component.args.model.campaign.organizationId = 777;
+
+      // when
+      const result = component.isAutonomousCourse;
+
+      // then
+      assert.true(result);
+    });
+
+    test("should return false if it's not an autonomous course", function (assert) {
+      // given
+      sinon.stub(ENV.APP, 'AUTONOMOUS_COURSES_ORGANIZATION_ID').value(777);
+      component.args.model.campaign.organizationId = 123;
+
+      // when
+      const result = component.isAutonomousCourse;
+
+      // then
+      assert.false(result);
     });
   });
 

--- a/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
@@ -891,6 +891,29 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
     });
   });
 
+  module('#showBadges', function () {
+    test('should return false when there are no badges', function (assert) {
+      // when
+      component.args.model.campaignParticipationResult.campaignParticipationBadges = [];
+
+      const result = component.showBadges;
+
+      // then
+      assert.false(result);
+    });
+
+    test('should return true when there are badges', function (assert) {
+      // given
+      component.args.model.campaignParticipationResult.campaignParticipationBadges = possibleBadgesCombinations;
+
+      // when
+      const result = component.showBadges;
+
+      // then
+      assert.true(result);
+    });
+  });
+
   module('#competenceResultsGroupedByAreas', function () {
     test('should return a competence results object with area keys', function (assert) {
       // given


### PR DESCRIPTION
## :christmas_tree: Problème
Dans le cas des parcours autonomes, sur la page de fin de parcours, on veut : 
- Enlever le bouton de partage des résultats et afficher directement le bouton "Continuez votre expérience Pix" 
- Permettre l'affichage des contenus formatifs bien que la campagne n'a pas été partagé.
- Garder le comportement actuel (les résultats thématiques, les paliers, message customizé de l'organisation...)

## :gift: Proposition
Ajouter des seeds. 
Contionner l'affichage en fonction du parcours autonomes.

## :socks: Remarques
Le NPS se faisant au niveau de l'organisation, on ne souhaite pas pouvoir afficher le bloc NPS pour les parcours autonomes.

## :santa: Pour tester
- Aller sur le parcours autonomes `AUTOCOURS1` en fin de parcours 
- Vérifier la présence des éléments spécifiques au parcours (palier, formation, badges...)
- Vérifier qu'on ne peut pas envoyer la campagne
