### PR TITLE
[FEATURE] Ajouter des informations aux étapes "Téléchargement" et "Import" de l'import en masse sur Pix Certif (PIX-10151).

### DIFF
--- a/certif/app/components/import/step-one-section.hbs
+++ b/certif/app/components/import/step-one-section.hbs
@@ -21,8 +21,13 @@
     </PixMessage>
   </div>
   <div class="import-page__section--download-button">
-    <FaIcon @icon="file-arrow-down" class="fa-2x download-icon" />
-    <span>{{t "pages.sessions.import.step-one.actions.session-import-template.extra-information"}}</span>
+    <FaIcon @icon="file-arrow-down" class="download-icon" />
+    <div>
+      <span class="download-title">{{t
+          "pages.sessions.import.step-one.actions.session-import-template.extra-information"
+        }}</span>
+      <p>{{t "pages.sessions.import.step-one.actions.session-import-template.information" htmlSafe=true}}</p>
+    </div>
     <PixButton
       @backgroundColor="transparent-light"
       @isBorderVisible="{{true}}"
@@ -34,8 +39,13 @@
   </div>
 
   <div tabindex="0" class="import-page__section--download-button">
-    <FaIcon @icon="cloud-arrow-up" class="fa-2x download-icon" />
-    <span>{{t "pages.sessions.import.step-one.actions.session-import-upload.extra-information"}}</span>
+    <FaIcon @icon="cloud-arrow-up" class="import-icon" />
+    <div>
+      <span class="download-title">{{t
+          "pages.sessions.import.step-one.actions.session-import-upload.extra-information"
+        }}</span>
+      <p>{{t "pages.sessions.import.step-one.actions.session-import-upload.information"}}</p>
+    </div>
     <PixButtonUpload
       @backgroundColor="transparent-light"
       @isBorderVisible="{{true}}"

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -60,23 +60,45 @@
 
   &__section--download-button {
     align-items: center;
-    background-color: $pix-neutral-10;
-    border: 1px solid $pix-neutral-15;
+    background-color: var(--pix-neutral-20);
+    border: 1px solid var(--pix-neutral-100);
     border-radius: 8px;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-800);
     display: grid;
+    font-size: 0.875rem;
     grid-template-columns: 1fr 10fr 2fr;
-    padding: 24px 16px 24px 0;
+    padding: var(--pix-spacing-6x) var(--pix-spacing-4x);
 
     > label,
     button {
       width: 164px;
     }
+
+    p {
+      line-height: 21px;
+      padding-top: var(--pix-spacing-1x);
+    }
+  }
+
+  &__section--download-button .download-icon,
+  &__section--download-button .import-icon, {
+    color: var(--pix-neutral-500);
+    height: auto;
   }
 
   &__section--download-button .download-icon {
-    color: $pix-neutral-25;
-    margin: auto;
+    padding: 0 var(--pix-spacing-8x);
+    width: 30px;
+  }
+
+  &__section--download-button .import-icon {
+    padding: 0 var(--pix-spacing-6x);
+    width: 50px;
+  }
+
+  &__section--download-button .download-title {
+    font-size: 1rem;
+    font-weight: 500;
   }
 
   &__section--link-buttons {

--- a/certif/tests/integration/components/sessions-import/step-one-section_test.js
+++ b/certif/tests/integration/components/sessions-import/step-one-section_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { hbs } from 'ember-cli-htmlbars';
-import { render, within } from '@1024pix/ember-testing-library';
+import { render, within, getByTextWithHtml } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | Import::StepOneSection', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -66,5 +66,17 @@ module('Integration | Component | Import::StepOneSection', function (hooks) {
       'Pour remplacer une liste pré-existante dans le fichier modèle,',
     );
     assert.strictEqual(secondListItems[1].textContent, 'Pour inscrire des candidats dans une session vide.');
+
+    assert
+      .dom(getByText('Sélectionnez le modèle préalablement rempli. Seul un fichier .csv pourra être importé.'))
+      .exists();
+    assert
+      .dom(getByText('Sélectionnez le modèle préalablement rempli. Seul un fichier .csv pourra être importé.'))
+      .exists();
+    assert.ok(
+      getByTextWithHtml(
+        'Attention à ne modifier ni les noms des colonnes ni leur ordre afin de ne pas altérer le modèle. <br> Vous pouvez ouvrir le fichier .csv téléchargé soit dans un logiciel tableur soit dans un éditeur de code (valeurs séparées par des points virgules).',
+      ),
+    );
   });
 });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -655,10 +655,12 @@
             },
             "session-import-template": {
               "extra-information": "Télécharger le modèle vierge",
+              "information": "Attention à ne modifier ni les noms des colonnes ni leur ordre afin de ne pas altérer le modèle. '<br>' Vous pouvez ouvrir le fichier .csv téléchargé soit dans un logiciel tableur soit dans un éditeur de code (valeurs séparées par des points virgules).",
               "label": "Télécharger (.csv)"
             },
             "session-import-upload": {
               "extra-information": "Importer le modèle complété",
+              "information": "Sélectionnez le modèle préalablement rempli. Seul un fichier .csv pourra être importé.",
               "label": "Importer (.csv)"
             }
           },

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -655,10 +655,12 @@
             },
             "session-import-template": {
               "extra-information": "Télécharger le modèle vierge",
+              "information": "Attention à ne modifier ni les noms des colonnes ni leur ordre afin de ne pas altérer le modèle. '<br>' Vous pouvez ouvrir le fichier .csv téléchargé soit dans un logiciel tableur soit dans un éditeur de code (valeurs séparées par des points virgules).",
               "label": "Télécharger (.csv)"
             },
             "session-import-upload": {
               "extra-information": "Importer le modèle complété",
+              "information": "Sélectionnez le modèle préalablement rempli. Seul un fichier .csv pourra être importé.",
               "label": "Importer (.csv)"
             }
           },


### PR DESCRIPTION
## :christmas_tree: Problème
La gestion massive des sessions est une nouvelle fonctionnalité qui a été mise à disposition de nos utilisateurs en juillet 2023.

Les boutons “Télécharger le modèle vierge” et “Importer le modèle complété” ne semblent pas assez explicites.

## :gift: Proposition
Ajouter des informations pour ces deux parties.

## :santa: Pour tester

- Se connecter sur Pix Certif avec certif-pro@example.net
- Aller sur Créer/éditer plusieurs sessions
- Constater la présence des informations

<img width="1511" alt="Capture d’écran 2023-12-29 à 11 47 16" src="https://github.com/1024pix/pix/assets/58915422/f7a435d1-e6c8-46f0-8b83-493a60ea7825">

