### PR TITLE
[FEATURE] Changer la couleur du bouton en cas de d'import en masse avec erreur non bloquante (PIX-10156).

### DIFF
--- a/api/db/seeds/data/team-certification/data-builder.js
+++ b/api/db/seeds/data/team-certification/data-builder.js
@@ -16,10 +16,11 @@ const TEAM_CERTIFICATION_OFFSET_ID = 7000;
 /// USERS
 const SCO_CERTIFICATION_MANAGING_STUDENTS_ORGANIZATION_USER_ID = TEAM_CERTIFICATION_OFFSET_ID;
 const SCO_CERTIFICATION_MANAGING_STUDENTS_CERTIFICATION_CENTER_USER_ID = TEAM_CERTIFICATION_OFFSET_ID + 1;
-const PRO_CERTIFICATION_CENTER_USER_ID = TEAM_CERTIFICATION_OFFSET_ID + 2;
+const PRO_ADMIN_CERTIFICATION_CENTER_USER_ID = TEAM_CERTIFICATION_OFFSET_ID + 2;
 const PRO_ORGANIZATION_USER_ID = TEAM_CERTIFICATION_OFFSET_ID + 3;
 const V3_CERTIFICATION_CENTER_USER_ID = TEAM_CERTIFICATION_OFFSET_ID + 4;
 const CERTIFIABLE_SUCCESS_USER_ID = TEAM_CERTIFICATION_OFFSET_ID + 5;
+const PRO_MEMBER_CERTIFICATION_CENTER_USER_ID = TEAM_CERTIFICATION_OFFSET_ID + 6;
 /// ORGAS
 const SCO_MANAGING_STUDENTS_ORGANIZATION_ID = TEAM_CERTIFICATION_OFFSET_ID;
 const PRO_ORGANIZATION_ID = TEAM_CERTIFICATION_OFFSET_ID + 1;
@@ -132,10 +133,27 @@ async function _createV3PilotCertificationCenter({ databaseBuilder }) {
 
 async function _createProCertificationCenter({ databaseBuilder }) {
   databaseBuilder.factory.buildUser.withRawPassword({
-    id: PRO_CERTIFICATION_CENTER_USER_ID,
-    firstName: 'Centre de certif Pro',
-    lastName: 'Certification',
+    id: PRO_ADMIN_CERTIFICATION_CENTER_USER_ID,
+    firstName: 'PRO',
+    lastName: 'ADMIN',
     email: 'certif-pro@example.net',
+    cgu: true,
+    lang: 'fr',
+    lastTermsOfServiceValidatedAt: new Date(),
+    lastPixOrgaTermsOfServiceValidatedAt: new Date(),
+    mustValidateTermsOfService: false,
+    pixOrgaTermsOfServiceAccepted: false,
+    pixCertifTermsOfServiceAccepted: false,
+    hasSeenAssessmentInstructions: false,
+    rawPassword: 'pix123',
+    shouldChangePassword: false,
+  });
+
+  databaseBuilder.factory.buildUser.withRawPassword({
+    id: PRO_MEMBER_CERTIFICATION_CENTER_USER_ID,
+    firstName: 'PRO',
+    lastName: 'MEMBER',
+    email: 'certif-pro-member@example.net',
     cgu: true,
     lang: 'fr',
     lastTermsOfServiceValidatedAt: new Date(),
@@ -156,7 +174,10 @@ async function _createProCertificationCenter({ databaseBuilder }) {
     externalId: PRO_EXTERNAL_ID,
     createdAt: new Date(),
     updatedAt: new Date(),
-    members: [{ id: PRO_CERTIFICATION_CENTER_USER_ID }],
+    members: [
+      { id: PRO_ADMIN_CERTIFICATION_CENTER_USER_ID, role: 'ADMIN' },
+      { id: PRO_MEMBER_CERTIFICATION_CENTER_USER_ID, role: 'MEMBER' },
+    ],
     complementaryCertificationIds,
   });
 }

--- a/certif/app/components/import/step-two-section.hbs
+++ b/certif/app/components/import/step-two-section.hbs
@@ -85,11 +85,7 @@
 
   <div class="import-page__section--link-buttons">
     {{#if this.hasOnlyNonBlockingErrorReports}}
-      <PixButton
-        @backgroundColor="yellow"
-        class="import-page__section--confirm-button--non-blocking"
-        @triggerAction={{@createSessions}}
-      >
+      <PixButton class="import-page__section--confirm-button--non-blocking" @triggerAction={{@createSessions}}>
         {{t "pages.sessions.import.step-two.actions.confirm-with-warning.label"}}
       </PixButton>
       <PixButton

--- a/certif/tests/acceptance/session-import_test.js
+++ b/certif/tests/acceptance/session-import_test.js
@@ -243,7 +243,7 @@ module('Acceptance | Session Import', function (hooks) {
               await settled();
 
               // then
-              assert.dom(screen.getByRole('button', { name: 'Finaliser quand même la création/édition' })).exists();
+              assert.dom(screen.getByRole('button', { name: 'Créer/éditer les sessions' })).exists();
             });
           });
 

--- a/certif/tests/integration/components/sessions-import/step-two-section_test.js
+++ b/certif/tests/integration/components/sessions-import/step-two-section_test.js
@@ -228,7 +228,7 @@ module('Integration | Component | Import::StepTwoSection', function (hooks) {
       const { getByRole } = await render(hbs`<Import::StepTwoSection @errorReports={{this.errorReports}} />`);
 
       // then
-      assert.dom(getByRole('button', { name: 'Finaliser quand même la création/édition' })).exists();
+      assert.dom(getByRole('button', { name: 'Créer/éditer les sessions' })).exists();
     });
   });
 

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -692,7 +692,7 @@
               "label": "Finaliser la création/édition"
             },
             "confirm-with-warning": {
-              "label": "Finaliser quand même la création/édition"
+              "label": "Créer/éditer les sessions"
             },
             "import-again": {
               "extra-information": "Revenir à l'étape précédente pour importer le fichier à nouveau",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -692,7 +692,7 @@
               "label": "Finaliser la création/édition"
             },
             "confirm-with-warning": {
-              "label": "Finaliser quand même la création/édition"
+              "label": "Créer/éditer les sessions"
             },
             "import-again": {
               "extra-information": "Revenir à l'étape précédente pour importer le fichier à nouveau",


### PR DESCRIPTION
## :christmas_tree: Problème
La gestion massive des sessions est une nouvelle fonctionnalité qui a été mise à disposition de nos utilisateurs en juillet 2023.

Lors de l’import du fichier .csv, un certain nombre de points d’attention non bloquants peuvent être détectées. L’utilisateur peut choisir de continuer la création/édition de ses sessions.

Le bouton “Finaliser quand même la création/édition” en jaune semble indiquer qu’il y a une erreur à procéder ainsi alors qu’il s’agit d’une feature souhaitée de pouvoir créer des sessions sans candidats dans un premier temps (par exemple). La couleur et le wording peuvent inquiéter l’utilisateur et le faire hésiter.

## :gift: Proposition
- Remplacer la couleur jaune du bouton “Finaliser quand même la création/l'édition” par un bouton bleu/violet.
- Remplacer le wording du bouton “Finaliser quand même la création/l'édition” par “Créer/éditer les sessions”

## :socks: Remarques
Ajout dans les seed d'un rôle ADMIN au membre certif-pro@example.net et ajout d'un autre membre au centre, afin de pouvoir accéder à la fonctionnalité du référent CléA Numérique

## :santa: Pour tester

- Se connecter sur Pix Certif avec [certif-pro@example.net](mailto:certif-pro@example.net)
- Aller sur Créer/éditer plusieurs sessions
- Ajouter le csv suivant : 
```
Numéro de session préexistante;* Nom du site;* Nom de la salle;* Date de début (format: JJ/MM/AAAA);* Heure de début (heure locale format: HH:MM);* Surveillant(s);Observations (optionnel);* Nom de naissance;* Prénom;* Date de naissance (format: JJ/MM/AAAA);* Sexe (M ou F);Code INSEE de la commune de naissance;Code postal de la commune de naissance;Nom de la commune de naissance;* Pays de naissance;E-mail du destinataire des résultats (formateur, enseignant…);E-mail de convocation;Identifiant externe;Temps majoré ? (exemple format: 33%);* Tarification part Pix (Gratuite, Prépayée ou Payante);Code de prépaiement (si Tarification part Pix Prépayée);CléA Numérique ('oui' ou laisser vide);Pix+ Édu 2nd degré ('oui' ou laisser vide);Pix+ Édu 1er degré ('oui' ou laisser vide);Pix+ Droit ('oui' ou laisser vide)
;Paris;Pix;01/01/2024;12:00;Surveillant A;;;;;;;;;;;;;;;;;;;
```
- Constater que le bouton est violet avec le wording différent

<img width="1505" alt="Capture d’écran 2023-12-29 à 15 27 45" src="https://github.com/1024pix/pix/assets/58915422/bda8a766-3db0-4a74-bd46-784483c32c94">
