### PR TITLE
[BUGFIX] Modifier la couleur des réponses valides d'une correction de QROC (PIX-10558).

### DIFF
--- a/mon-pix/app/styles/components/_qroc-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qroc-solution-panel.scss
@@ -21,20 +21,24 @@
   }
 
   &--correct {
-    textarea, input {
+    textarea,
+    input,
+    [disabled] {
       color: $pix-success-70;
       font-weight: $font-bold;
     }
   }
 
   &--wrong {
-    textarea, input {
+    textarea,
+    input {
       text-decoration: line-through;
     }
   }
 
   &--aband {
-    textarea, input {
+    textarea,
+    input {
       color: $pix-neutral-80;
       font-style: italic;
     }


### PR DESCRIPTION
## :christmas_tree: Problème

Sur les champs corrects d'une épreuve QROC, les bonnes réponses étaient en vert, elles sont passées en gris.

## :gift: Proposition

Dans les champs où l’utilisateur a répondu correctement, la réponse s’affiche en vert.

## :santa: Pour tester

- Bien répondre à [cette épreuve](https://app-pr7777.review.pix.fr/challenges/recNanzf3oEjJ7vA9/preview)
- Ouvrir la modale "réponses et tutos"
- ✅ Attester que la couleur du texte dans l'input est celle souhaitée.
