### PR TITLE
[FEATURE] Déplacer le champ qui comporte le nom du fichier .csv importé sur Pix Certif (PIX-10153).

### DIFF
--- a/certif/app/components/import/step-one-section.hbs
+++ b/certif/app/components/import/step-one-section.hbs
@@ -29,6 +29,7 @@
       <p>{{t "pages.sessions.import.step-one.actions.session-import-template.information" htmlSafe=true}}</p>
     </div>
     <PixButton
+      class="download-buttons"
       @backgroundColor="transparent-light"
       @isBorderVisible="{{true}}"
       aria-label={{t "pages.sessions.import.step-one.actions.session-import-template.extra-information"}}
@@ -45,6 +46,18 @@
           "pages.sessions.import.step-one.actions.session-import-upload.extra-information"
         }}</span>
       <p>{{t "pages.sessions.import.step-one.actions.session-import-upload.information"}}</p>
+
+      {{#if @file}}
+        <div class="import-page__file-name" aria-label={{@fileName}}>
+          {{@fileName}}
+          <PixIconButton
+            @ariaLabel={{t "pages.sessions.import.step-one.actions.cancel.label"}}
+            @icon="circle-xmark"
+            @triggerAction={{@removeImport}}
+            class="import-page-file-name__cancel"
+          />
+        </div>
+      {{/if}}
     </div>
     <PixButtonUpload
       @backgroundColor="transparent-light"
@@ -57,18 +70,6 @@
       {{t "pages.sessions.import.step-one.actions.session-import-upload.label"}}
     </PixButtonUpload>
   </div>
-
-  {{#if @file}}
-    <div class="import-page__file-name" aria-label={{@fileName}}>
-      {{@fileName}}
-      <PixIconButton
-        @ariaLabel={{t "pages.sessions.import.step-one.actions.cancel.label"}}
-        @icon="circle-xmark"
-        @triggerAction={{@removeImport}}
-        class="import-page-file-name__cancel"
-      />
-    </div>
-  {{/if}}
 
   <ul class="import-page__section--link-buttons">
     <li>

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -69,14 +69,13 @@
     grid-template-columns: 1fr 10fr 2fr;
     padding: var(--pix-spacing-6x) var(--pix-spacing-4x);
 
-    > label,
-    button {
-      width: 164px;
-    }
-
     p {
       line-height: 21px;
       padding-top: var(--pix-spacing-1x);
+    }
+
+    & .download-buttons, & .pix-button-upload {
+      width: 164px;
     }
   }
 
@@ -107,18 +106,16 @@
   }
 
   &__file-name {
-    display: flex;
-    justify-content: center;
     align-items: center;
-    padding: 16px 24px;
-    width: fit-content;
-    border: 1px solid $pix-neutral-15;
+    background-color: var(--pix-neutral-0);
+    border: 1px solid var(--pix-neutral-100);
     border-radius: 8px;
     box-shadow: 0 4px 8px 0 rgba($pix-neutral-110, 8%);
-    background-color: $pix-neutral-10;
-    color: $pix-neutral-70;
+    color: var(--pix-neutral-500);
+    display: inline-flex;
     font-size: 1rem;
-    line-height: 1.5rem;
+    margin-top: var(--pix-spacing-2x);
+    padding: var(--pix-spacing-2x) var(--pix-spacing-1x) var(--pix-spacing-2x) var(--pix-spacing-4x);
   }
 }
 


### PR DESCRIPTION
## :christmas_tree: Problème
Lorsque l’utilisateur clique sur “Créer/éditer plusieurs sessions”, il arrive sur le parcours qui lui permettra de créer plusieurs sessions à la fois ou bien d'éditer la liste de candidats de plusieurs sessions en même temps.

Lors de l’import d’un fichier .csv complété, son nom apparaît pour que l’utilisateur puisse vérifier son opération avant validation de l’import.

Le nom du fichier apparaît séparé du bloc d’import ce qui peut questionner l’utilisateur quant au lien entre les deux.

## :gift: Proposition
Modifier le champ avec le nom du fichier importé notamment sa position pour l’intégrer au bloc “Importer le modèle complété”

## :santa: Pour tester
- Se connecter sur Pix Certif avec certif-pro@example.net
- Aller sur Créer/éditer plusieurs sessions
- importer un fichier csv
- constater que le champ se retrouve dans le bloc d'import

<img width="1497" alt="Capture d’écran 2023-12-29 à 17 28 59" src="https://github.com/1024pix/pix/assets/58915422/808b8c92-5edc-48f3-888a-172277207084">

