### PR TITLE
[FEATURE] Filtrer les profils-cibles de parcours autonomes publics et sans accès simplifié (PIX-10560).

### DIFF
--- a/api/db/seeds/data/team-evaluation/autonomous-courses/create-autonomous-courses.js
+++ b/api/db/seeds/data/team-evaluation/autonomous-courses/create-autonomous-courses.js
@@ -32,7 +32,7 @@ export default async function initUser(databaseBuilder) {
       databaseBuilder,
       ownerOrganizationId: specificOrganizationId,
       targetProfileId: AUTONOMOUS_COURSES_ID + i,
-      isPublic: true,
+      isPublic: false,
       isSimplifiedAccess: true,
       name: `Profil-cible pour parcours autonome n°${i}`,
       description: 'Profil cible pour parcours autonome',

--- a/api/src/evaluation/infrastructure/repositories/autonomous-course-target-profile-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/autonomous-course-target-profile-repository.js
@@ -9,8 +9,10 @@ function _toDomain(AutonomousCourseTargetProfileDTO) {
 }
 
 const get = async function ({ targetProfileApi }) {
-  const autonomousCourseTargetProfileDTO = await targetProfileApi.getByOrganizationId(
-    constants.AUTONOMOUS_COURSES_ORGANIZATION_ID,
+  const targetProfiles = await targetProfileApi.getByOrganizationId(constants.AUTONOMOUS_COURSES_ORGANIZATION_ID);
+
+  const autonomousCourseTargetProfileDTO = targetProfiles.filter(
+    (targetProfile) => !targetProfile.isPublic && targetProfile.isSimplifiedAccess,
   );
 
   if (!autonomousCourseTargetProfileDTO.length) {

--- a/api/tests/evaluation/acceptance/application/autonomous-courses/autonomous-course-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/autonomous-courses/autonomous-course-controller_test.js
@@ -242,6 +242,7 @@ describe('Acceptance | API | Autonomous Course', function () {
   describe('GET /api/admin/autonomous-courses/target-profiles', function () {
     let mainOrganization, otherOrganization;
     let targetProfiles;
+
     beforeEach(async function () {
       sinon.stub(constants, 'AUTONOMOUS_COURSES_ORGANIZATION_ID').value(777);
       const userId = databaseBuilder.factory.buildUser().id;
@@ -276,11 +277,18 @@ describe('Acceptance | API | Autonomous Course', function () {
         isPublic: false,
       });
 
+      const publicTargetProfile = databaseBuilder.factory.buildTargetProfile({
+        ownerOrganizationId: mainOrganization.id,
+        isSimplifiedAccess: true,
+        isPublic: true,
+      });
+
       targetProfiles = [
         validTargetProfile1,
         validTargetProfile2,
         targetProfileFromAnotherOrganization,
         targetProfileNotSimplifiedAccess,
+        publicTargetProfile,
       ];
 
       await databaseBuilder.commit();
@@ -311,14 +319,6 @@ describe('Acceptance | API | Autonomous Course', function () {
           id: targetProfiles[1].id.toString(),
           type: 'autonomous-course-target-profiles',
         },
-        {
-          attributes: {
-            name: targetProfiles[3].name,
-            category: targetProfiles[3].category,
-          },
-          id: targetProfiles[3].id.toString(),
-          type: 'autonomous-course-target-profiles',
-        },
       ];
 
       // when
@@ -326,7 +326,7 @@ describe('Acceptance | API | Autonomous Course', function () {
 
       // then
       expect(response.statusCode).to.equal(200);
-      expect(response.result.data.length).to.equal(3);
+      expect(response.result.data.length).to.equal(2);
       expect(response.result.data).to.deep.have.members(expectedResult);
     });
   });

--- a/api/tests/evaluation/integration/infrastructure/repositories/autonomous-course-target-profile-repository_test.js
+++ b/api/tests/evaluation/integration/infrastructure/repositories/autonomous-course-target-profile-repository_test.js
@@ -27,24 +27,28 @@ describe('Integration | Repository | Autonomous Course Target Profile', function
         databaseBuilder.factory.buildMembership({ organizationId: organization.id, userId });
 
         const targetProfile1 = databaseBuilder.factory.buildTargetProfile({
-          isPublic: false,
           ownerOrganizationId: organization.id,
+          isPublic: true,
           isSimplifiedAccess: true,
+          name: 'Target profile 1',
         });
         const targetProfile2 = databaseBuilder.factory.buildTargetProfile({
-          isPublic: false,
           ownerOrganizationId: organization.id,
+          isPublic: false,
           isSimplifiedAccess: true,
+          name: 'Target profile 2',
         });
         const targetProfile3 = databaseBuilder.factory.buildTargetProfile({
           ownerOrganizationId: otherOrganization.id,
           isPublic: false,
           isSimplifiedAccess: false,
+          name: 'Target profile 3',
         });
         const targetProfile4 = databaseBuilder.factory.buildTargetProfile({
-          isPublic: false,
           ownerOrganizationId: organization.id,
+          isPublic: true,
           isSimplifiedAccess: false,
+          name: 'Target profile 4',
         });
         databaseBuilder.factory.buildTargetProfileShare({
           organizationId: organization.id,
@@ -67,19 +71,9 @@ describe('Integration | Repository | Autonomous Course Target Profile', function
 
         const expectedResult = [
           {
-            id: targetProfile1.id,
-            category: 'OTHER',
-            name: 'Remplir un tableur',
-          },
-          {
             id: targetProfile2.id,
-            category: 'OTHER',
-            name: 'Remplir un tableur',
-          },
-          {
-            id: targetProfile4.id,
-            category: 'OTHER',
-            name: 'Remplir un tableur',
+            category: targetProfile2.category,
+            name: targetProfile2.name,
           },
         ];
         // when


### PR DESCRIPTION
## :christmas_tree: Problème

Les profils cibles **publics** et **sans accès simplifié** apparaissent dans la liste de profil cible en page de création de parcours autonome.

Or si on les selectionne le parcours autonome ne peut pas être créé.
On veut donc les enlever. 

## :gift: Proposition

Filtrer la liste des profils-cibles pour parcours autonomes qui ont : `isPublic = true` ou `isSimplifiedAccess = false`

## :santa: Pour tester

- Visiter la [page de création des parcours autonomes](https://admin-pr7780.review.pix.fr/autonomous-courses/new)
- Constater que seuls les profils-cibles dédiés aux parcours autonomes sont affichés.
