### PR TITLE
[FEATURE] Afficher un message d'erreur explicite dans la création d'un contenu formatif (PIX-10567).

### DIFF
--- a/admin/app/controllers/authenticated/trainings/new.js
+++ b/admin/app/controllers/authenticated/trainings/new.js
@@ -24,7 +24,19 @@ export default class NewController extends Controller {
       this.notifications.success('Le contenu formatif a été créé avec succès.');
       this.goToTrainingDetails(id);
     } catch (error) {
-      this.notifications.error('Une erreur est survenue.');
+      this._handleResponseError(error);
     }
+  }
+
+  _handleResponseError({ errors }) {
+    if (!errors) {
+      return this.notifications.error('Une erreur est survenue.');
+    }
+    errors.forEach((error) => {
+      if (['400', '404', '412', '422'].includes(error.status)) {
+        return this.notifications.error(error.detail);
+      }
+      return this.notifications.error('Une erreur est survenue.');
+    });
   }
 }


### PR DESCRIPTION
## :christmas_tree: Problème
J'étais bien embêté par l'absence de message d'erreur lors de la création d'un contenu formatif, j'ai donc décidé d'afficher le message d'erreur renvoyé par l'API.

## :gift: Proposition
Afficher le message d'erreur non traduit renvoyé par l'API car c'est déjà mieux que rien. 

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Depuis Pix Admin, aller sur la page Contenus Formatif, puis créer un contenu formatif en renseignant par exemple un lien cassé.
Constater qu'une erreur en anglais apparait pour ce champ. 