### PR TITLE
[TECH] Remplacer l'usage de l'accessToken par une validation via pre handler sur la route pour les exports de résultat (Pix-10515)

### DIFF
--- a/api/src/prescription/campaign/application/campaign-detail-controller.js
+++ b/api/src/prescription/campaign/application/campaign-detail-controller.js
@@ -5,7 +5,6 @@ import * as campaignReportSerializer from '../infrastructure/serializers/jsonapi
 import { tokenService } from '../../../shared/domain/services/token-service.js';
 import * as queryParamsUtils from '../../../../lib/infrastructure/utils/query-params-utils.js';
 import { escapeFileName } from '../../../../lib/infrastructure/utils/request-response-utils.js';
-import { ForbiddenAccess } from '../../../shared/domain/errors.js';
 
 const { PassThrough } = stream;
 
@@ -51,68 +50,50 @@ const findPaginatedFilteredCampaigns = async function (
   return dependencies.campaignReportSerializer.serialize(campaigns, meta);
 };
 
-const getCsvAssessmentResults = async function (request, h, dependencies = { tokenService }) {
-  const token = request.query.accessToken;
-  const { userId, campaignId: extractedCampaignId } =
-    dependencies.tokenService.extractCampaignResultsTokenContent(token);
+const getCsvAssessmentResults = async function (request, h) {
   const campaignId = request.params.id;
-
-  if (extractedCampaignId !== campaignId) {
-    throw new ForbiddenAccess();
-  }
 
   const writableStream = new PassThrough();
 
   const { fileName } = await usecases.startWritingCampaignAssessmentResultsToStream({
-    userId,
     campaignId,
     writableStream,
     i18n: request.i18n,
   });
   const escapedFileName = escapeFileName(fileName);
 
-  writableStream.headers = {
-    'content-type': 'text/csv;charset=utf-8',
-    'content-disposition': `attachment; filename="${escapedFileName}"`,
-
-    // WHY: to avoid compression because when compressing, the server buffers
-    // for too long causing a response timeout.
-    'content-encoding': 'identity',
-  };
-
-  return writableStream;
+  return (
+    h
+      .response(writableStream)
+      .header('content-type', 'text/csv;charset=utf-8')
+      // WHY: to avoid compression because when compressing, the server buffers
+      // for too long causing a response timeout.
+      .header('content-encoding', 'identity')
+      .header('content-disposition', `attachment; filename="${escapedFileName}"`)
+  );
 };
 
-const getCsvProfilesCollectionResults = async function (request, h, dependencies = { tokenService }) {
-  const token = request.query.accessToken;
-  const { userId, campaignId: extractedCampaignId } =
-    dependencies.tokenService.extractCampaignResultsTokenContent(token);
+const getCsvProfilesCollectionResults = async function (request, h) {
   const campaignId = request.params.id;
-
-  if (extractedCampaignId !== campaignId) {
-    throw new ForbiddenAccess();
-  }
 
   const writableStream = new PassThrough();
 
   const { fileName } = await usecases.startWritingCampaignProfilesCollectionResultsToStream({
-    userId,
     campaignId,
     writableStream,
     i18n: request.i18n,
   });
   const escapedFileName = escapeFileName(fileName);
 
-  writableStream.headers = {
-    'content-type': 'text/csv;charset=utf-8',
-    'content-disposition': `attachment; filename="${escapedFileName}"`,
-
-    // WHY: to avoid compression because when compressing, the server buffers
-    // for too long causing a response timeout.
-    'content-encoding': 'identity',
-  };
-
-  return writableStream;
+  return (
+    h
+      .response(writableStream)
+      .header('content-type', 'text/csv;charset=utf-8')
+      // WHY: to avoid compression because when compressing, the server buffers
+      // for too long causing a response timeout.
+      .header('content-encoding', 'identity')
+      .header('content-disposition', `attachment; filename="${escapedFileName}"`)
+  );
 };
 
 const campaignDetailController = {

--- a/api/src/prescription/campaign/application/campaign-detail-route.js
+++ b/api/src/prescription/campaign/application/campaign-detail-route.js
@@ -41,7 +41,7 @@ const register = async function (server) {
       method: 'GET',
       path: '/api/campaigns/{id}/csv-profiles-collection-results',
       config: {
-        auth: false,
+        pre: [{ method: securityPreHandlers.checkAuthorizationToAccessCampaign }],
         validate: {
           params: Joi.object({
             id: identifiersType.campaignId,
@@ -60,7 +60,7 @@ const register = async function (server) {
       method: 'GET',
       path: '/api/campaigns/{id}/csv-assessment-results',
       config: {
-        auth: false,
+        pre: [{ method: securityPreHandlers.checkAuthorizationToAccessCampaign }],
         validate: {
           params: Joi.object({
             id: identifiersType.campaignId,

--- a/api/src/prescription/campaign/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
+++ b/api/src/prescription/campaign/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
@@ -4,26 +4,14 @@ import timezone from 'dayjs/plugin/timezone.js';
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
-import { CampaignTypeError, UserNotAuthorizedToGetCampaignResultsError } from '../../../../../lib/domain/errors.js';
+import { CampaignTypeError } from '../../../../../lib/domain/errors.js';
 import { CampaignProfilesCollectionExport } from '../../infrastructure/serializers/csv/campaign-profiles-collection-export.js';
 
-async function _checkCreatorHasAccessToCampaignOrganization(userId, organizationId, userRepository) {
-  const user = await userRepository.getWithMemberships(userId);
-
-  if (!user.hasAccessToOrganization(organizationId)) {
-    throw new UserNotAuthorizedToGetCampaignResultsError(
-      `User does not have an access to the organization ${organizationId}`,
-    );
-  }
-}
-
 const startWritingCampaignProfilesCollectionResultsToStream = async function ({
-  userId,
   campaignId,
   writableStream,
   i18n,
   campaignRepository,
-  userRepository,
   competenceRepository,
   campaignParticipationRepository,
   organizationRepository,
@@ -31,8 +19,6 @@ const startWritingCampaignProfilesCollectionResultsToStream = async function ({
 }) {
   const campaign = await campaignRepository.get(campaignId);
   const translate = i18n.__;
-
-  await _checkCreatorHasAccessToCampaignOrganization(userId, campaign.organizationId, userRepository);
 
   if (!campaign.isProfilesCollection()) {
     throw new CampaignTypeError();

--- a/api/tests/prescription/campaign/acceptance/application/campaign-detail-controller_test.js
+++ b/api/tests/prescription/campaign/acceptance/application/campaign-detail-controller_test.js
@@ -1,5 +1,3 @@
-import jwt from 'jsonwebtoken';
-
 import {
   databaseBuilder,
   expect,
@@ -8,7 +6,6 @@ import {
   mockLearningContent,
 } from '../../../../test-helper.js';
 
-import { config as settings } from '../../../../../lib/config.js';
 import { Membership } from '../../../../../lib/domain/models/Membership.js';
 import { createServer } from '../../../../../server.js';
 
@@ -77,18 +74,11 @@ describe('Acceptance | API | Campaign Detail Controller', function () {
   });
 
   describe('GET /api/campaigns/{id}/csv-profiles-collection-results', function () {
-    let accessToken;
-
-    function _createTokenWithAccessId({ userId, campaignId }) {
-      return jwt.sign(
-        {
-          access_id: userId,
-          campaign_id: campaignId,
-        },
-        settings.authentication.secret,
-        { expiresIn: settings.authentication.accessTokenLifespanMs },
-      );
-    }
+    const options = {
+      headers: { authorization: null },
+      method: 'GET',
+      url: null,
+    };
 
     beforeEach(async function () {
       const userId = databaseBuilder.factory.buildUser().id;
@@ -97,13 +87,15 @@ describe('Acceptance | API | Campaign Detail Controller', function () {
         organizationId: organization.id,
         type: 'PROFILES_COLLECTION',
       });
-      accessToken = _createTokenWithAccessId({ userId, campaignId: campaign.id });
 
       databaseBuilder.factory.buildMembership({
         userId,
         organizationId: organization.id,
         organizationRole: Membership.roles.MEMBER,
       });
+
+      options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
+      options.url = `/api/campaigns/${campaign.id}/csv-profiles-collection-results`;
 
       await databaseBuilder.commit();
 
@@ -142,10 +134,7 @@ describe('Acceptance | API | Campaign Detail Controller', function () {
 
     it('should return csv file with statusCode 200', async function () {
       // given & when
-      const { statusCode, payload } = await server.inject({
-        method: 'GET',
-        url: `/api/campaigns/${campaign.id}/csv-profiles-collection-results?accessToken=${accessToken}`,
-      });
+      const { statusCode, payload } = await server.inject(options);
 
       // then
       expect(statusCode).to.equal(200, payload);
@@ -156,7 +145,8 @@ describe('Acceptance | API | Campaign Detail Controller', function () {
         // given & when
         const { statusCode } = await server.inject({
           method: 'GET',
-          url: `/api/campaigns/1234567890/csv-profiles-collection-results?accessToken=${accessToken}`,
+          url: `/api/campaigns/1234567890/csv-profiles-collection-results`,
+          headers: options.headers,
         });
 
         // then
@@ -166,20 +156,14 @@ describe('Acceptance | API | Campaign Detail Controller', function () {
   });
 
   describe('GET /api/campaigns/{id}/csv-assessment-results', function () {
-    let accessToken;
     let campaign;
     let organization;
 
-    function _createTokenWithAccessId({ userId, campaignId }) {
-      return jwt.sign(
-        {
-          access_id: userId,
-          campaign_id: campaignId,
-        },
-        settings.authentication.secret,
-        { expiresIn: settings.authentication.accessTokenLifespanMs },
-      );
-    }
+    const options = {
+      headers: { authorization: null },
+      method: 'GET',
+      url: null,
+    };
 
     beforeEach(async function () {
       const skillId = 'rec123';
@@ -189,13 +173,15 @@ describe('Acceptance | API | Campaign Detail Controller', function () {
         organizationId: organization.id,
       });
       databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: skillId });
-      accessToken = _createTokenWithAccessId({ userId, campaignId: campaign.id });
 
       databaseBuilder.factory.buildMembership({
         userId,
         organizationId: organization.id,
         organizationRole: Membership.roles.MEMBER,
       });
+
+      options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
+      options.url = `/api/campaigns/${campaign.id}/csv-assessment-results`;
 
       await databaseBuilder.commit();
 
@@ -234,10 +220,7 @@ describe('Acceptance | API | Campaign Detail Controller', function () {
 
     it('should return csv file with statusCode 200', async function () {
       // given & when
-      const { statusCode, payload } = await server.inject({
-        method: 'GET',
-        url: `/api/campaigns/${campaign.id}/csv-assessment-results?accessToken=${accessToken}`,
-      });
+      const { statusCode, payload } = await server.inject(options);
 
       // then
       expect(statusCode).to.equal(200, payload);
@@ -248,7 +231,8 @@ describe('Acceptance | API | Campaign Detail Controller', function () {
         // given & when
         const { statusCode } = await server.inject({
           method: 'GET',
-          url: `/api/campaigns/1234567890/csv-assessment-results?accessToken=${accessToken}`,
+          url: `/api/campaigns/1234567890/csv-assessment-results`,
+          headers: options.headers,
         });
 
         // then

--- a/api/tests/prescription/campaign/integration/application/campaign-detail-route_test.js
+++ b/api/tests/prescription/campaign/integration/application/campaign-detail-route_test.js
@@ -6,21 +6,19 @@ import * as moduleUnderTest from '../../../../../src/prescription/campaign/appli
 describe('Integration | Application | Route | campaign detail router', function () {
   let httpTestServer;
 
-  beforeEach(async function () {
-    sinon.stub(campaignDetailController, 'getCsvAssessmentResults').callsFake((_, h) => h.response('ok').code(200));
-    sinon
-      .stub(campaignDetailController, 'getCsvProfilesCollectionResults')
-      .callsFake((_, h) => h.response('ok').code(200));
-
-    httpTestServer = new HttpTestServer();
-    await httpTestServer.register(moduleUnderTest);
-  });
-
   describe('GET /api/campaigns/{id}/csv-profiles-collection-results', function () {
     it('should exist', async function () {
       // given
+      sinon.stub(securityPreHandlers, 'checkAuthorizationToAccessCampaign').callsFake((request, h) => h.response(true));
+      sinon
+        .stub(campaignDetailController, 'getCsvProfilesCollectionResults')
+        .callsFake((_, h) => h.response('ok').code(200));
+
       const method = 'GET';
       const url = '/api/campaigns/1/csv-profiles-collection-results';
+
+      httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
 
       // when
       const response = await httpTestServer.request(method, url);
@@ -33,8 +31,13 @@ describe('Integration | Application | Route | campaign detail router', function 
   describe('GET /api/campaigns/{id}/csv-assessment-results', function () {
     it('should exist', async function () {
       // given
+      sinon.stub(securityPreHandlers, 'checkAuthorizationToAccessCampaign').callsFake((request, h) => h.response(true));
+      sinon.stub(campaignDetailController, 'getCsvAssessmentResults').callsFake((_, h) => h.response('ok').code(200));
       const method = 'GET';
       const url = '/api/campaigns/1/csv-assessment-results';
+
+      httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
 
       // when
       const response = await httpTestServer.request(method, url);

--- a/api/tests/prescription/campaign/unit/application/campaign-detail-controller_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-detail-controller_test.js
@@ -1,7 +1,6 @@
-import { sinon, expect, hFake, domainBuilder, catchErr } from '../../../../test-helper.js';
+import { sinon, expect, hFake, domainBuilder } from '../../../../test-helper.js';
 import { campaignDetailController } from '../../../../../src/prescription/campaign/application/campaign-detail-controller.js';
 import { usecases } from '../../../../../src/prescription/campaign/domain/usecases/index.js';
-import { ForbiddenAccess } from '../../../../../src/shared/domain/errors.js';
 
 describe('Unit | Application | Controller | Campaign detail', function () {
   describe('#getById', function () {
@@ -166,7 +165,6 @@ describe('Unit | Application | Controller | Campaign detail', function () {
   describe('#getCsvProfilesCollectionResults', function () {
     it('should call the use case to get result campaign in csv', async function () {
       // given
-      const userId = 1;
       const campaignId = 2;
       const request = _getRequestForCampaignId(campaignId);
 
@@ -174,25 +172,17 @@ describe('Unit | Application | Controller | Campaign detail', function () {
         .stub(usecases, 'startWritingCampaignProfilesCollectionResultsToStream')
         .resolves({ fileName: 'any file name' });
 
-      const tokenServiceStub = {
-        extractCampaignResultsTokenContent: sinon.stub().returns({ userId, campaignId }),
-      };
-
       // when
-      await campaignDetailController.getCsvProfilesCollectionResults(request, hFake, {
-        tokenService: tokenServiceStub,
-      });
+      await campaignDetailController.getCsvProfilesCollectionResults(request, hFake);
 
       // then
       expect(usecases.startWritingCampaignProfilesCollectionResultsToStream).to.have.been.calledOnce;
       const getResultsCampaignArgs = usecases.startWritingCampaignProfilesCollectionResultsToStream.firstCall.args[0];
-      expect(getResultsCampaignArgs).to.have.property('userId');
       expect(getResultsCampaignArgs).to.have.property('campaignId');
     });
 
     it('should return a response with correct headers', async function () {
       // given
-      const userId = 1;
       const campaignId = 2;
       const request = _getRequestForCampaignId(campaignId);
 
@@ -200,14 +190,8 @@ describe('Unit | Application | Controller | Campaign detail', function () {
         .stub(usecases, 'startWritingCampaignProfilesCollectionResultsToStream')
         .resolves({ fileName: 'expected file name' });
 
-      const tokenServiceStub = {
-        extractCampaignResultsTokenContent: sinon.stub().returns({ userId, campaignId }),
-      };
-
       // when
-      const response = await campaignDetailController.getCsvProfilesCollectionResults(request, hFake, {
-        tokenService: tokenServiceStub,
-      });
+      const response = await campaignDetailController.getCsvProfilesCollectionResults(request, hFake);
 
       // then
       expect(response.headers['content-type']).to.equal('text/csv;charset=utf-8');
@@ -217,7 +201,6 @@ describe('Unit | Application | Controller | Campaign detail', function () {
 
     it('should fix invalid header chars in filename', async function () {
       // given
-      const userId = 1;
       const campaignId = 2;
       const request = _getRequestForCampaignId(campaignId);
 
@@ -225,105 +208,44 @@ describe('Unit | Application | Controller | Campaign detail', function () {
         fileName: 'file-name with invalid_chars •’<>:"/\\|?*"\n.csv',
       });
 
-      const tokenServiceStub = {
-        extractCampaignResultsTokenContent: sinon.stub().returns({ userId, campaignId }),
-      };
-
       // when
-      const response = await campaignDetailController.getCsvProfilesCollectionResults(request, hFake, {
-        tokenService: tokenServiceStub,
-      });
+      const response = await campaignDetailController.getCsvProfilesCollectionResults(request, hFake);
 
       // then
       expect(response.headers['content-disposition']).to.equal(
         'attachment; filename="file-name with invalid_chars _____________.csv"',
       );
     });
-
-    context('when the campaign id is not the same as provided in the access token', function () {
-      it('should throw an error', async function () {
-        // given
-        const userId = 1;
-        const campaignId = 2;
-        const request = _getRequestForCampaignId(campaignId);
-
-        sinon.stub(usecases, 'startWritingCampaignProfilesCollectionResultsToStream');
-        const tokenServiceStub = {
-          extractCampaignResultsTokenContent: sinon.stub().returns({ userId, campaignId: 19 }),
-        };
-
-        // when
-        const error = await catchErr(campaignDetailController.getCsvProfilesCollectionResults)(request, hFake, {
-          tokenService: tokenServiceStub,
-        });
-
-        // then
-        expect(error).to.be.an.instanceOf(ForbiddenAccess);
-        expect(usecases.startWritingCampaignProfilesCollectionResultsToStream).to.not.have.been.called;
-      });
-    });
-
-    context('when the access token is invalid', function () {
-      it('should throw an error', async function () {
-        // given
-        const request = _getRequestForCampaignId(1);
-
-        sinon.stub(usecases, 'startWritingCampaignProfilesCollectionResultsToStream').resolves();
-        const tokenServiceStub = {
-          extractCampaignResultsTokenContent: sinon.stub().throws(new ForbiddenAccess()),
-        };
-
-        // when
-        const error = await catchErr(campaignDetailController.getCsvProfilesCollectionResults)(request, hFake, {
-          tokenService: tokenServiceStub,
-        });
-
-        // then
-        expect(error).to.be.an.instanceOf(ForbiddenAccess);
-        expect(usecases.startWritingCampaignProfilesCollectionResultsToStream).to.not.have.been.called;
-      });
-    });
   });
 
   describe('#getCsvAssessmentResults', function () {
     it('should call the use case to get result campaign in csv', async function () {
       // given
-      const userId = 1;
       const campaignId = 2;
       const request = _getRequestForCampaignId(campaignId);
 
-      const tokenServiceStub = {
-        extractCampaignResultsTokenContent: sinon.stub().returns({ userId, campaignId }),
-      };
       sinon.stub(usecases, 'startWritingCampaignAssessmentResultsToStream').resolves({ fileName: 'any file name' });
-      const dependencies = { tokenService: tokenServiceStub };
 
       // when
-      await campaignDetailController.getCsvAssessmentResults(request, hFake, dependencies);
+      await campaignDetailController.getCsvAssessmentResults(request, hFake);
 
       // then
       expect(usecases.startWritingCampaignAssessmentResultsToStream).to.have.been.calledOnce;
       const getResultsCampaignArgs = usecases.startWritingCampaignAssessmentResultsToStream.firstCall.args[0];
-      expect(getResultsCampaignArgs).to.have.property('userId');
       expect(getResultsCampaignArgs).to.have.property('campaignId');
     });
 
     it('should return a response with correct headers', async function () {
       // given
-      const userId = 1;
       const campaignId = 2;
       const request = _getRequestForCampaignId(campaignId);
 
-      const tokenServiceStub = {
-        extractCampaignResultsTokenContent: sinon.stub().returns({ userId, campaignId }),
-      };
       sinon
         .stub(usecases, 'startWritingCampaignAssessmentResultsToStream')
         .resolves({ fileName: 'expected file name' });
-      const dependencies = { tokenService: tokenServiceStub };
 
       // when
-      const response = await campaignDetailController.getCsvAssessmentResults(request, hFake, dependencies);
+      const response = await campaignDetailController.getCsvAssessmentResults(request, hFake);
 
       // then
       expect(response.headers['content-type']).to.equal('text/csv;charset=utf-8');
@@ -333,67 +255,20 @@ describe('Unit | Application | Controller | Campaign detail', function () {
 
     it('should fix invalid header chars in filename', async function () {
       // given
-      const userId = 1;
       const campaignId = 2;
       const request = _getRequestForCampaignId(campaignId);
 
-      const tokenServiceStub = {
-        extractCampaignResultsTokenContent: sinon.stub().returns({ userId, campaignId }),
-      };
       sinon.stub(usecases, 'startWritingCampaignAssessmentResultsToStream').resolves({
         fileName: 'file-name with invalid_chars •’<>:"/\\|?*"\n.csv',
       });
-      const dependencies = { tokenService: tokenServiceStub };
 
       // when
-      const response = await campaignDetailController.getCsvAssessmentResults(request, hFake, dependencies);
+      const response = await campaignDetailController.getCsvAssessmentResults(request, hFake);
 
       // then
       expect(response.headers['content-disposition']).to.equal(
         'attachment; filename="file-name with invalid_chars _____________.csv"',
       );
-    });
-
-    context('when the campaign id is not the same as provided in the access token', function () {
-      it('should throw an error', async function () {
-        // given
-        const userId = 1;
-        const campaignId = 2;
-        const request = _getRequestForCampaignId(campaignId);
-
-        const tokenServiceStub = {
-          extractCampaignResultsTokenContent: sinon.stub().returns({ userId, campaignId: 19 }),
-        };
-        sinon.stub(usecases, 'startWritingCampaignAssessmentResultsToStream').resolves();
-        const dependencies = { tokenService: tokenServiceStub };
-
-        // when
-        const error = await catchErr(campaignDetailController.getCsvAssessmentResults)(request, hFake, dependencies);
-
-        // then
-        expect(error).to.be.an.instanceOf(ForbiddenAccess);
-        expect(usecases.startWritingCampaignAssessmentResultsToStream).to.not.have.been.called;
-      });
-    });
-
-    context('when the access token is invalid', function () {
-      it('should throw an error', async function () {
-        // given
-        const request = _getRequestForCampaignId(1);
-
-        const tokenServiceStub = {
-          extractCampaignResultsTokenContent: sinon.stub().throws(new ForbiddenAccess()),
-        };
-        sinon.stub(usecases, 'startWritingCampaignAssessmentResultsToStream').resolves();
-        const dependencies = { tokenService: tokenServiceStub };
-
-        // when
-        const error = await catchErr(campaignDetailController.getCsvAssessmentResults)(request, hFake, dependencies);
-
-        // then
-        expect(error).to.be.an.instanceOf(ForbiddenAccess);
-        expect(usecases.startWritingCampaignAssessmentResultsToStream).to.not.have.been.called;
-      });
     });
   });
 });

--- a/api/tests/prescription/campaign/unit/application/campaign-detail-route_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-detail-route_test.js
@@ -51,6 +51,7 @@ describe('Unit | Application | Router | campaign-detail-router ', function () {
   describe('GET /api/campaigns/{id}/csv-profiles-collection-results', function () {
     it('should return 200', async function () {
       // given
+      sinon.stub(securityPreHandlers, 'checkAuthorizationToAccessCampaign').callsFake((request, h) => h.response(true));
       sinon
         .stub(campaignDetailController, 'getCsvProfilesCollectionResults')
         .callsFake((_, h) => h.response('ok').code(200));
@@ -62,6 +63,24 @@ describe('Unit | Application | Router | campaign-detail-router ', function () {
 
       // then
       expect(response.statusCode).to.equal(200);
+    });
+
+    it('should return 403', async function () {
+      // given
+      sinon
+        .stub(campaignDetailController, 'getCsvProfilesCollectionResults')
+        .callsFake((request, h) => h.response('ok').code(200));
+      sinon
+        .stub(securityPreHandlers, 'checkAuthorizationToAccessCampaign')
+        .callsFake((request, h) => h.response().code(403).takeover());
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('GET', '/api/campaigns/1/csv-profiles-collection-results');
+
+      // then
+      expect(response.statusCode).to.equal(403);
     });
 
     it('should return 400 with an invalid campaign id', async function () {
@@ -80,6 +99,7 @@ describe('Unit | Application | Router | campaign-detail-router ', function () {
   describe('GET /api/campaigns/{id}/csv-assessment-results', function () {
     it('should return 200', async function () {
       // given
+      sinon.stub(securityPreHandlers, 'checkAuthorizationToAccessCampaign').callsFake((request, h) => h.response(true));
       sinon
         .stub(campaignDetailController, 'getCsvAssessmentResults')
         .callsFake((request, h) => h.response('ok').code(200));
@@ -91,6 +111,24 @@ describe('Unit | Application | Router | campaign-detail-router ', function () {
 
       // then
       expect(response.statusCode).to.equal(200);
+    });
+
+    it('should return 403', async function () {
+      // given
+      sinon
+        .stub(campaignDetailController, 'getCsvAssessmentResults')
+        .callsFake((request, h) => h.response('ok').code(200));
+      sinon
+        .stub(securityPreHandlers, 'checkAuthorizationToAccessCampaign')
+        .callsFake((request, h) => h.response().code(403).takeover());
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('GET', '/api/campaigns/1/csv-profiles-collection-results');
+
+      // then
+      expect(response.statusCode).to.equal(403);
     });
 
     it('should return 400 with an invalid campaign id', async function () {

--- a/api/tests/prescription/campaign/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -4,7 +4,7 @@ const { PassThrough } = stream;
 
 import { expect, sinon, domainBuilder, streamToPromise, catchErr } from '../../../../../test-helper.js';
 import { startWritingCampaignAssessmentResultsToStream } from '../../../../../../src/prescription/campaign/domain/usecases/start-writing-campaign-assessment-results-to-stream.js';
-import { UserNotAuthorizedToGetCampaignResultsError, CampaignTypeError } from '../../../../../../lib/domain/errors.js';
+import { CampaignTypeError } from '../../../../../../lib/domain/errors.js';
 import * as campaignCsvExportService from '../../../../../../src/prescription/campaign/domain/services/campaign-csv-export-service.js';
 import { getI18n } from '../../../../../tooling/i18n/i18n.js';
 import { StageCollection } from '../../../../../../src/shared/domain/models/user-campaign-results/StageCollection.js';
@@ -26,35 +26,6 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
     i18n = getI18n();
     writableStream = new PassThrough();
     csvPromise = streamToPromise(writableStream);
-  });
-
-  it('should throw a UserNotAuthorizedToGetCampaignResultsError when user is not authorized', async function () {
-    // given
-    const notAuthorizedUser = domainBuilder.buildUser({ memberships: [] });
-    const campaign = domainBuilder.buildCampaign();
-    sinon.stub(campaignRepository, 'get').withArgs(campaign.id).resolves(campaign);
-    sinon.stub(userRepository, 'getWithMemberships').withArgs(notAuthorizedUser.id).resolves(notAuthorizedUser);
-
-    // when
-    const err = await catchErr(startWritingCampaignAssessmentResultsToStream)({
-      userId: notAuthorizedUser.id,
-      campaignId: campaign.id,
-      writableStream,
-      i18n,
-      campaignRepository,
-      userRepository,
-      targetProfileRepository,
-      learningContentRepository,
-      organizationRepository,
-      campaignParticipationInfoRepository,
-      knowledgeElementRepository,
-      campaignCsvExportService,
-      stageCollectionRepository,
-    });
-
-    // then
-    expect(err).to.be.instanceOf(UserNotAuthorizedToGetCampaignResultsError);
-    expect(err.message).to.equal(`User does not have an access to the organization ${campaign.organization.id}`);
   });
 
   it('should throw a CampaignTypeError when campaign is not ASSESSMENT type', async function () {

--- a/api/tests/prescription/campaign/unit/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -4,7 +4,7 @@ const { PassThrough } = stream;
 
 import { expect, sinon, domainBuilder, streamToPromise, catchErr } from '../../../../../test-helper.js';
 import { startWritingCampaignProfilesCollectionResultsToStream } from '../../../../../../src/prescription/campaign/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js';
-import { UserNotAuthorizedToGetCampaignResultsError, CampaignTypeError } from '../../../../../../lib/domain/errors.js';
+import { CampaignTypeError } from '../../../../../../lib/domain/errors.js';
 import { CampaignProfilesCollectionExport } from '../../../../../../src/prescription/campaign/infrastructure/serializers/csv/campaign-profiles-collection-export.js';
 import { getI18n } from '../../../../../tooling/i18n/i18n.js';
 
@@ -36,32 +36,6 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collection
       .rejects('CampaignProfilesCollectionExport.prototype.export');
     writableStream = new PassThrough();
     csvPromise = streamToPromise(writableStream);
-  });
-
-  it('should throw a UserNotAuthorizedToGetCampaignResultsError when user is not authorized', async function () {
-    // given
-    const notAuthorizedUser = domainBuilder.buildUser({ memberships: [] });
-    const campaign = domainBuilder.buildCampaign();
-    campaignRepository.get.withArgs(campaign.id).resolves(campaign);
-    userRepository.getWithMemberships.withArgs(notAuthorizedUser.id).resolves(notAuthorizedUser);
-
-    // when
-    const err = await catchErr(startWritingCampaignProfilesCollectionResultsToStream)({
-      userId: notAuthorizedUser.id,
-      campaignId: campaign.id,
-      writableStream,
-      i18n,
-      campaignRepository,
-      userRepository,
-      competenceRepository,
-      campaignParticipationRepository,
-      organizationRepository,
-      placementProfileService,
-    });
-
-    // then
-    expect(err).to.be.instanceOf(UserNotAuthorizedToGetCampaignResultsError);
-    expect(err.message).to.equal(`User does not have an access to the organization ${campaign.organization.id}`);
   });
 
   it('should throw a CampaignTypeError when campaign is not PROFILES_COLLECTION type', async function () {

--- a/orga/app/components/campaign/header/tabs.hbs
+++ b/orga/app/components/campaign/header/tabs.hbs
@@ -29,8 +29,8 @@
   </nav>
 
   <div class="campaign-header-tabs__export-button hide-on-mobile">
-    <PixButtonLink @href={{this.downloadUrl}} target="_blank" rel="noopener noreferrer" download>
+    <PixButton @backgroundColor="primary" @triggerAction={{this.exportData}}>
       {{t "pages.campaign.actions.export-results"}}
-    </PixButtonLink>
+    </PixButton>
   </div>
 </div>

--- a/orga/app/components/campaign/header/tabs.js
+++ b/orga/app/components/campaign/header/tabs.js
@@ -1,10 +1,19 @@
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
-
+import { action } from '@ember/object';
 export default class CampaignTabs extends Component {
   @service intl;
+  @service notifications;
+  @service fileSaver;
+  @service session;
 
-  get downloadUrl() {
-    return this.args.campaign.urlToResult + `&lang=${this.intl.locale[0]}`;
+  @action
+  async exportData() {
+    try {
+      const token = this.session.data.authenticated.access_token;
+      await this.fileSaver.save({ url: this.args.campaign.urlToResult, token });
+    } catch (err) {
+      this.notifications.sendError(this.intl.t('api-error-messages.global'));
+    }
   }
 }

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -67,9 +67,9 @@ export default class Campaign extends Model {
 
   get urlToResult() {
     if (this.isTypeAssessment) {
-      return `${ENV.APP.API_HOST}/api/campaigns/${this.id}/csv-assessment-results?accessToken=${this.tokenForCampaignResults}`;
+      return `${ENV.APP.API_HOST}/api/campaigns/${this.id}/csv-assessment-results`;
     }
-    return `${ENV.APP.API_HOST}/api/campaigns/${this.id}/csv-profiles-collection-results?accessToken=${this.tokenForCampaignResults}`;
+    return `${ENV.APP.API_HOST}/api/campaigns/${this.id}/csv-profiles-collection-results`;
   }
 
   get hasParticipations() {

--- a/orga/app/services/file-saver.js
+++ b/orga/app/services/file-saver.js
@@ -1,7 +1,9 @@
 import Service from '@ember/service';
 import fetch from 'fetch';
-
+import { service } from '@ember/service';
 export default class FileSaverService extends Service {
+  @service intl;
+
   async save({
     url,
     token,
@@ -9,7 +11,7 @@ export default class FileSaverService extends Service {
     downloadFileForIEBrowser = _downloadFileForIEBrowser,
     downloadFileForModernBrowsers = _downloadFileForModernBrowsers,
   }) {
-    const response = await fetcher({ url, token });
+    const response = await fetcher({ url, token, locale: this.locale });
 
     if (response.status !== 200) {
       const jsonResponse = await response.json();
@@ -25,11 +27,16 @@ export default class FileSaverService extends Service {
       ? downloadFileForIEBrowser({ fileContent, fileName })
       : downloadFileForModernBrowsers({ fileContent, fileName });
   }
+
+  get locale() {
+    const [currentLocale] = this.intl.get('locale');
+    return currentLocale;
+  }
 }
 
-function _fetchData({ url, token }) {
+function _fetchData({ url, token, locale }) {
   return fetch(url, {
-    headers: { Authorization: `Bearer ${token}` },
+    headers: { Authorization: `Bearer ${token}`, 'Accept-Language': locale },
   });
 }
 

--- a/orga/tests/integration/components/campaign/header/tabs_test.js
+++ b/orga/tests/integration/components/campaign/header/tabs_test.js
@@ -1,39 +1,74 @@
 import { module, test } from 'qunit';
+import { click } from '@ember/test-helpers';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+import ENV from 'pix-orga/config/environment';
 import Service from '@ember/service';
-
-class CurrentUserStub extends Service {
-  prescriber = {
-    lang: 'fr',
-  };
-}
 
 module('Integration | Component | Campaign::Header::Tabs', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  let store;
+  const originalAppHost = ENV.APP.API_HOST;
+
+  hooks.afterEach(function () {
+    ENV.APP.API_HOST = originalAppHost;
+  });
+
+  let store, screen, fileSaver, notifications, access_token;
 
   hooks.beforeEach(function () {
+    class sessionService extends Service {
+      isAuthenticated = true;
+      data = {
+        authenticated: {
+          access_token,
+        },
+      };
+    }
+    this.owner.register('service:session', sessionService);
+
+    ENV.APP.API_HOST = 'https://myapp.com';
+    access_token = Symbol('ACCESS_TOKEN');
     store = this.owner.lookup('service:store');
-    this.owner.register('service:current-user', CurrentUserStub);
-    this.owner.lookup('service:current-user', CurrentUserStub);
+    this.owner.lookup('service:current-user');
+    fileSaver = this.owner.lookup('service:file-saver');
+    notifications = this.owner.lookup('service:notifications');
     this.owner.setupRouter();
+
+    sinon.stub(fileSaver, 'save');
+    sinon.stub(notifications, 'sendError');
+
+    fileSaver.save.resolves();
   });
 
   module('Common campaign navigation', function (hooks) {
     hooks.beforeEach(async function () {
       this.campaign = store.createRecord('campaign', { id: 12 });
-      await render(hbs`<Campaign::Header::Tabs @campaign={{this.campaign}} />`);
+      screen = await render(hbs`<Campaign::Header::Tabs @campaign={{this.campaign}} />`);
     });
 
     test('it should display campaign settings item', async function (assert) {
-      assert.dom('nav a[href="/campagnes/12/parametres"]').hasText('Paramètres');
+      const settingsLink = screen.getByRole('link', { name: this.intl.t('pages.campaign.tab.settings') });
+
+      assert.dom(settingsLink).hasAttribute('href', '/campagnes/12/parametres');
     });
 
     test('it should display activity item', async function (assert) {
-      assert.dom('nav a[href="/campagnes/12"]').hasText('Activité');
+      const activityLink = screen.getByRole('link', { name: this.intl.t('pages.campaign.tab.activity') });
+      assert.dom(activityLink).hasAttribute('href', '/campagnes/12');
+    });
+
+    test('it should display export button result', async function (assert) {
+      assert.ok(screen.getByRole('button', { name: this.intl.t('pages.campaign.actions.export-results') }));
+    });
+
+    test('dipslay notification error on data export', async function (assert) {
+      fileSaver.save.rejects();
+      await click(screen.getByRole('button', { name: this.intl.t('pages.campaign.actions.export-results') }));
+
+      assert.ok(notifications.sendError.calledWithExactly(this.intl.t('api-error-messages.global')));
     });
   });
 
@@ -45,15 +80,31 @@ module('Integration | Component | Campaign::Header::Tabs', function (hooks) {
         type: 'ASSESSMENT',
       });
 
-      await render(hbs`<Campaign::Header::Tabs @campaign={{this.campaign}} />`);
+      screen = await render(hbs`<Campaign::Header::Tabs @campaign={{this.campaign}} />`);
     });
 
     test('it should display evaluation results item', async function (assert) {
-      assert.dom('nav a[href="/campagnes/13/resultats-evaluation"]').hasText('Résultats (10)');
+      const resultsLink = screen.getByRole('link', { name: this.intl.t('pages.campaign.tab.results', { count: 10 }) });
+
+      assert.dom(resultsLink).hasAttribute('href', '/campagnes/13/resultats-evaluation');
     });
 
     test('it should display campaign analyse item', async function (assert) {
-      assert.dom('nav a[href="/campagnes/13/analyse"]').hasText('Analyse');
+      const resultsLink = screen.getByRole('link', { name: this.intl.t('pages.campaign.tab.review') });
+
+      assert.dom(resultsLink).hasAttribute('href', '/campagnes/13/analyse');
+    });
+
+    test('it should call export result with right context', async function (assert) {
+      await click(screen.getByRole('button', { name: this.intl.t('pages.campaign.actions.export-results') }));
+
+      assert.ok(notifications.sendError.notCalled);
+      assert.ok(
+        fileSaver.save.calledWithExactly({
+          url: `${ENV.APP.API_HOST}/api/campaigns/13/csv-assessment-results`,
+          token: access_token,
+        }),
+      );
     });
   });
 
@@ -66,23 +117,29 @@ module('Integration | Component | Campaign::Header::Tabs', function (hooks) {
         sharedParticipationsCount: 6,
       });
 
-      await render(hbs`<Campaign::Header::Tabs @campaign={{this.campaign}} />`);
+      screen = await render(hbs`<Campaign::Header::Tabs @campaign={{this.campaign}} />`);
     });
 
-    test('it should display profile results item', async function (assert) {
-      assert.dom('nav a[href="/campagnes/13/profils"]').hasText('Résultats (6)');
-    });
+    test('it should display  profile results item', async function (assert) {
+      const resultsLink = screen.getByRole('link', { name: this.intl.t('pages.campaign.tab.results', { count: 6 }) });
 
-    test('it should not display participation item', async function (assert) {
-      assert.dom('nav a[href="/campagnes/13/evaluations"]').doesNotExist();
+      assert.dom(resultsLink).hasAttribute('href', '/campagnes/13/profils');
     });
 
     test('it should not display analyse item', async function (assert) {
-      assert.dom('nav a[href="/campagnes/13/analyse"]').doesNotExist();
+      assert.notOk(screen.queryByRole('link', { name: this.intl.t('pages.campaign.tab.review') }));
     });
 
-    test('it should not display evaluation results item', async function (assert) {
-      assert.dom('nav a[href="/campagnes/13/resultats-evaluation"]').doesNotExist();
+    test('it should call export result with right context', async function (assert) {
+      await click(screen.getByRole('button', { name: this.intl.t('pages.campaign.actions.export-results') }));
+
+      assert.ok(notifications.sendError.notCalled);
+      assert.ok(
+        fileSaver.save.calledWithExactly({
+          url: `${ENV.APP.API_HOST}/api/campaigns/13/csv-profiles-collection-results`,
+          token: access_token,
+        }),
+      );
     });
   });
 });

--- a/orga/tests/unit/models/campaign_test.js
+++ b/orga/tests/unit/models/campaign_test.js
@@ -24,10 +24,7 @@ module('Unit | Model | campaign', function (hooks) {
         tokenForCampaignResults: 'token',
         type: 'ASSESSMENT',
       });
-      assert.strictEqual(
-        model.urlToResult,
-        'http://localhost:3000/api/campaigns/1/csv-assessment-results?accessToken=token',
-      );
+      assert.strictEqual(model.urlToResult, 'http://localhost:3000/api/campaigns/1/csv-assessment-results');
     });
 
     test('it should construct the url to result of the campaign with type profiles collection', function (assert) {
@@ -39,10 +36,7 @@ module('Unit | Model | campaign', function (hooks) {
         tokenForCampaignResults: 'token',
         type: 'PROFILES_COLLECTION',
       });
-      assert.strictEqual(
-        model.urlToResult,
-        'http://localhost:3000/api/campaigns/1/csv-profiles-collection-results?accessToken=token',
-      );
+      assert.strictEqual(model.urlToResult, 'http://localhost:3000/api/campaigns/1/csv-profiles-collection-results');
     });
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème
l'access token n'est pas assez protégé. il permet de diffuser un lien valide qui ne nécessite pas d'être connecter pour accéder aux données

## :gift: Proposition
Remplacer cette access token pour une validation de pre handler sur la route des exports de résultat

## :socks: Remarques
RAS

## :santa: Pour tester
Télécharger les csv de résultat de campagne, en FR et EN, vérifier d'avoir la bonne langue prise en compte