### PR TITLE
[FEATURE] Utiliser un scope lors de la création et vérification des tokens utilisés pour le téléchargement des résultats de certification (PIX-10574)

### DIFF
--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -116,7 +116,7 @@ const getSessionResultsToDownload = async function (
   dependencies = { tokenService, getSessionCertificationResultsCsv },
 ) {
   const token = request.params.token;
-  const { sessionId } = dependencies.tokenService.extractSessionId(token);
+  const { sessionId } = dependencies.tokenService.extractCertificationResultsLink(token);
   const { session, certificationResults } = await usecases.getSessionResults({ sessionId });
 
   const csvResult = await dependencies.getSessionCertificationResultsCsv({
@@ -138,7 +138,8 @@ const getSessionResultsByRecipientEmail = async function (
 ) {
   const token = request.params.token;
 
-  const { resultRecipientEmail, sessionId } = dependencies.tokenService.extractResultRecipientEmailAndSessionId(token);
+  const { resultRecipientEmail, sessionId } =
+    dependencies.tokenService.extractCertificationResultsByRecipientEmailLink(token);
   const { session, certificationResults } = await usecases.getSessionResultsByResultRecipientEmail({
     sessionId,
     resultRecipientEmail,

--- a/api/sample.env
+++ b/api/sample.env
@@ -1013,6 +1013,13 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: false
 # FT_ENABLE_PIX_PLUS_LOWER_LEVEL=false
 
+# Enable the verification of the scope in certification tokens
+#
+# presence: optional
+# type: boolean
+# default: false
+# FT_ENABLE_CERTIF_TOKEN_SCOPE=false
+
 # =====
 # CPF
 # =====

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -191,6 +191,7 @@ const configuration = (function () {
       ),
       isPix1dEnabled: isFeatureEnabled(process.env.FT_PIX_1D_ENABLED),
       isPixPlusLowerLeverEnabled: isFeatureEnabled(process.env.FT_ENABLE_PIX_PLUS_LOWER_LEVEL),
+      isCertificationTokenScopeEnabled: isFeatureEnabled(process.env.FT_ENABLE_CERTIF_TOKEN_SCOPE),
     },
     fwb: {
       isEnabledForPixAdmin: false,
@@ -396,6 +397,7 @@ const configuration = (function () {
 
     config.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled = false;
     config.featureToggles.isPix1dEnabled = true;
+    config.featureToggles.isCertificationTokenScopeEnabled = false;
 
     config.mailing.enabled = false;
     config.mailing.provider = 'brevo';

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -59,7 +59,7 @@ class InvalidResultRecipientTokenError extends DomainError {
   }
 }
 
-class InvalidSessionResultError extends DomainError {
+class InvalidSessionResultTokenError extends DomainError {
   constructor(message = 'Le token de récupération des résultats de la session de certification est invalide.') {
     super(message);
   }
@@ -175,7 +175,7 @@ export {
   CsvImportError,
   InvalidExternalUserTokenError,
   InvalidResultRecipientTokenError,
-  InvalidSessionResultError,
+  InvalidSessionResultTokenError,
   InvalidTemporaryKeyError,
   MissingAssessmentId,
   NotFoundError,

--- a/api/src/shared/domain/services/token-service.js
+++ b/api/src/shared/domain/services/token-service.js
@@ -9,6 +9,8 @@ import {
   InvalidTemporaryKeyError,
 } from '../errors.js';
 
+const CERTIFICATION_RESULTS_LINK_SCOPE = 'certificationResultsLink';
+
 function _createAccessToken({ userId, source, expirationDelaySeconds }) {
   return jsonwebtoken.sign({ user_id: userId, source }, config.authentication.secret, {
     expiresIn: expirationDelaySeconds,
@@ -94,7 +96,7 @@ function createCertificationResultsLinkToken({ sessionId, daysBeforeExpiration }
   return jsonwebtoken.sign(
     {
       session_id: sessionId,
-      scope: 'certificationResultsLink',
+      scope: CERTIFICATION_RESULTS_LINK_SCOPE,
     },
     config.authentication.secret,
     {
@@ -160,6 +162,12 @@ function extractCertificationResultsLink(token) {
   const decoded = getDecodedToken(token);
   if (!decoded.session_id) {
     throw new InvalidSessionResultError();
+  }
+
+  if (config.featureToggles.isCertificationTokenScopeEnabled) {
+    if (decoded.scope !== CERTIFICATION_RESULTS_LINK_SCOPE) {
+      throw new InvalidSessionResultError();
+    }
   }
 
   return {

--- a/api/src/shared/domain/services/token-service.js
+++ b/api/src/shared/domain/services/token-service.js
@@ -81,6 +81,7 @@ function createCertificationResultsByRecipientEmailLinkToken({
     {
       session_id: sessionId,
       result_recipient_email: resultRecipientEmail,
+      scope: 'certificationResultsByRecipientEmailLink',
     },
     config.authentication.secret,
     {
@@ -93,6 +94,7 @@ function createCertificationResultsLinkToken({ sessionId, daysBeforeExpiration }
   return jsonwebtoken.sign(
     {
       session_id: sessionId,
+      scope: 'certificationResultsLink',
     },
     config.authentication.secret,
     {

--- a/api/src/shared/domain/services/token-service.js
+++ b/api/src/shared/domain/services/token-service.js
@@ -10,6 +10,7 @@ import {
 } from '../errors.js';
 
 const CERTIFICATION_RESULTS_LINK_SCOPE = 'certificationResultsLink';
+const CERTIFICATION_RESULTS_BY_RECIPIENT_EMAIL_LINK_SCOPE = 'certificationResultsByRecipientEmailLink';
 
 function _createAccessToken({ userId, source, expirationDelaySeconds }) {
   return jsonwebtoken.sign({ user_id: userId, source }, config.authentication.secret, {
@@ -83,7 +84,7 @@ function createCertificationResultsByRecipientEmailLinkToken({
     {
       session_id: sessionId,
       result_recipient_email: resultRecipientEmail,
-      scope: 'certificationResultsByRecipientEmailLink',
+      scope: CERTIFICATION_RESULTS_BY_RECIPIENT_EMAIL_LINK_SCOPE,
     },
     config.authentication.secret,
     {
@@ -150,6 +151,12 @@ function extractCertificationResultsByRecipientEmailLink(token) {
   const decoded = getDecodedToken(token);
   if (!decoded.session_id || !decoded.result_recipient_email) {
     throw new InvalidResultRecipientTokenError();
+  }
+
+  if (config.featureToggles.isCertificationTokenScopeEnabled) {
+    if (decoded.scope !== CERTIFICATION_RESULTS_BY_RECIPIENT_EMAIL_LINK_SCOPE) {
+      throw new InvalidResultRecipientTokenError();
+    }
   }
 
   return {

--- a/api/src/shared/domain/services/token-service.js
+++ b/api/src/shared/domain/services/token-service.js
@@ -142,7 +142,7 @@ function extractSamlId(token) {
   return decoded.saml_id || null;
 }
 
-function extractResultRecipientEmailAndSessionId(token) {
+function extractCertificationResultsByRecipientEmailLink(token) {
   const decoded = getDecodedToken(token);
   if (!decoded.session_id || !decoded.result_recipient_email) {
     throw new InvalidResultRecipientTokenError();
@@ -154,7 +154,7 @@ function extractResultRecipientEmailAndSessionId(token) {
   };
 }
 
-function extractSessionId(token) {
+function extractCertificationResultsLink(token) {
   const decoded = getDecodedToken(token);
   if (!decoded.session_id) {
     throw new InvalidSessionResultError();
@@ -211,9 +211,9 @@ const tokenService = {
   decodeIfValid,
   getDecodedToken,
   extractExternalUserFromIdToken,
-  extractResultRecipientEmailAndSessionId,
+  extractCertificationResultsByRecipientEmailLink,
   extractSamlId,
-  extractSessionId,
+  extractCertificationResultsLink,
   extractTokenFromAuthChain,
   extractUserId,
   extractClientId,
@@ -234,9 +234,9 @@ export {
   decodeIfValid,
   getDecodedToken,
   extractExternalUserFromIdToken,
-  extractResultRecipientEmailAndSessionId,
+  extractCertificationResultsByRecipientEmailLink,
   extractSamlId,
-  extractSessionId,
+  extractCertificationResultsLink,
   extractTokenFromAuthChain,
   extractUserId,
   extractClientId,

--- a/api/src/shared/domain/services/token-service.js
+++ b/api/src/shared/domain/services/token-service.js
@@ -5,7 +5,7 @@ import {
   ForbiddenAccess,
   InvalidExternalUserTokenError,
   InvalidResultRecipientTokenError,
-  InvalidSessionResultError,
+  InvalidSessionResultTokenError,
   InvalidTemporaryKeyError,
 } from '../errors.js';
 
@@ -161,12 +161,12 @@ function extractCertificationResultsByRecipientEmailLink(token) {
 function extractCertificationResultsLink(token) {
   const decoded = getDecodedToken(token);
   if (!decoded.session_id) {
-    throw new InvalidSessionResultError();
+    throw new InvalidSessionResultTokenError();
   }
 
   if (config.featureToggles.isCertificationTokenScopeEnabled) {
     if (decoded.scope !== CERTIFICATION_RESULTS_LINK_SCOPE) {
-      throw new InvalidSessionResultError();
+      throw new InvalidSessionResultTokenError();
     }
   }
 

--- a/api/tests/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -24,6 +24,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
             'is-always-ok-validate-next-challenge-endpoint-enabled': false,
             'is-pix1d-enabled': true,
             'is-pix-plus-lower-lever-enabled': false,
+            'is-certification-token-scope-enabled': false,
           },
         },
       };

--- a/api/tests/shared/unit/domain/services/token-service_test.js
+++ b/api/tests/shared/unit/domain/services/token-service_test.js
@@ -215,7 +215,7 @@ describe('Unit | Shared | Domain | Services | Token Service', function () {
     });
   });
 
-  describe('#extractSessionId', function () {
+  describe('#extractCertificationResultsLink', function () {
     it('should return the session id if the token is valid', function () {
       // given
       const token = jsonwebtoken.sign(
@@ -227,7 +227,7 @@ describe('Unit | Shared | Domain | Services | Token Service', function () {
       );
 
       // when
-      const tokenData = tokenService.extractSessionId(token);
+      const tokenData = tokenService.extractCertificationResultsLink(token);
 
       // then
       expect(tokenData).to.deep.equal({
@@ -240,7 +240,7 @@ describe('Unit | Shared | Domain | Services | Token Service', function () {
       const invalidIdToken = jsonwebtoken.sign({}, settings.authentication.secret, { expiresIn: '30d' });
 
       // when
-      const error = await catchErr(tokenService.extractSessionId)(invalidIdToken);
+      const error = await catchErr(tokenService.extractCertificationResultsLink)(invalidIdToken);
 
       // then
       expect(error).to.be.an.instanceof(InvalidSessionResultError);
@@ -260,14 +260,14 @@ describe('Unit | Shared | Domain | Services | Token Service', function () {
       setTimeout(async () => {
         return;
       }, 100);
-      const error = await catchErr(tokenService.extractSessionId)(invalidIdToken);
+      const error = await catchErr(tokenService.extractCertificationResultsLink)(invalidIdToken);
 
       // then
       expect(error).to.be.an.instanceof(InvalidSessionResultError);
     });
   });
 
-  describe('#extractResultRecipientEmailAndSessionId', function () {
+  describe('#extractCertificationResultsByRecipientEmailLink', function () {
     it('should return the session id and result recipient email if the token is valid', function () {
       // given
       const token = jsonwebtoken.sign(
@@ -280,7 +280,7 @@ describe('Unit | Shared | Domain | Services | Token Service', function () {
       );
 
       // when
-      const tokenData = tokenService.extractResultRecipientEmailAndSessionId(token);
+      const tokenData = tokenService.extractCertificationResultsByRecipientEmailLink(token);
 
       // then
       expect(tokenData).to.deep.equal({
@@ -300,7 +300,7 @@ describe('Unit | Shared | Domain | Services | Token Service', function () {
       );
 
       // when
-      const error = await catchErr(tokenService.extractResultRecipientEmailAndSessionId)(invalidIdToken);
+      const error = await catchErr(tokenService.extractCertificationResultsByRecipientEmailLink)(invalidIdToken);
 
       // then
       expect(error).to.be.an.instanceof(InvalidResultRecipientTokenError);
@@ -321,7 +321,7 @@ describe('Unit | Shared | Domain | Services | Token Service', function () {
       setTimeout(async () => {
         return;
       }, 100);
-      const error = await catchErr(tokenService.extractResultRecipientEmailAndSessionId)(invalidIdToken);
+      const error = await catchErr(tokenService.extractCertificationResultsByRecipientEmailLink)(invalidIdToken);
 
       // then
       expect(error).to.be.an.instanceof(InvalidResultRecipientTokenError);

--- a/api/tests/shared/unit/domain/services/token-service_test.js
+++ b/api/tests/shared/unit/domain/services/token-service_test.js
@@ -10,7 +10,7 @@ import {
   ForbiddenAccess,
   InvalidExternalUserTokenError,
   InvalidResultRecipientTokenError,
-  InvalidSessionResultError,
+  InvalidSessionResultTokenError,
   InvalidTemporaryKeyError,
 } from '../../../../../src/shared/domain/errors.js';
 
@@ -258,7 +258,7 @@ describe('Unit | Shared | Domain | Services | Token Service', function () {
           const error = await catchErr(tokenService.extractCertificationResultsLink)(invalidToken);
 
           // then
-          expect(error).to.be.an.instanceof(InvalidSessionResultError);
+          expect(error).to.be.an.instanceof(InvalidSessionResultTokenError);
         });
       });
     });
@@ -298,7 +298,7 @@ describe('Unit | Shared | Domain | Services | Token Service', function () {
       const error = await catchErr(tokenService.extractCertificationResultsLink)(invalidIdToken);
 
       // then
-      expect(error).to.be.an.instanceof(InvalidSessionResultError);
+      expect(error).to.be.an.instanceof(InvalidSessionResultTokenError);
     });
 
     it('should throw if token is expired', async function () {
@@ -318,7 +318,7 @@ describe('Unit | Shared | Domain | Services | Token Service', function () {
       const error = await catchErr(tokenService.extractCertificationResultsLink)(invalidIdToken);
 
       // then
-      expect(error).to.be.an.instanceof(InvalidSessionResultError);
+      expect(error).to.be.an.instanceof(InvalidSessionResultTokenError);
     });
   });
 

--- a/api/tests/shared/unit/domain/services/token-service_test.js
+++ b/api/tests/shared/unit/domain/services/token-service_test.js
@@ -337,6 +337,7 @@ describe('Unit | Shared | Domain | Services | Token Service', function () {
       const expectedTokenAttributes = {
         session_id: 'abcd1234',
         result_recipient_email: 'results@college-romain-rolland.edu',
+        scope: 'certificationResultsByRecipientEmailLink',
       };
 
       // when
@@ -359,6 +360,7 @@ describe('Unit | Shared | Domain | Services | Token Service', function () {
       const daysBeforeExpiration = 30;
       const expectedTokenAttributes = {
         session_id: 'abcd1234',
+        scope: 'certificationResultsLink',
       };
 
       // when

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -164,10 +164,10 @@ describe('Unit | Controller | sessionController', function () {
       const dependencies = {
         getSessionCertificationResultsCsv: sinon.stub(),
         tokenService: {
-          extractResultRecipientEmailAndSessionId: sinon.stub(),
+          extractCertificationResultsByRecipientEmailLink: sinon.stub(),
         },
       };
-      dependencies.tokenService.extractResultRecipientEmailAndSessionId
+      dependencies.tokenService.extractCertificationResultsByRecipientEmailLink
         .withArgs('abcd1234')
         .returns({ sessionId: 1, resultRecipientEmail: 'user@example.net' });
 
@@ -217,10 +217,10 @@ describe('Unit | Controller | sessionController', function () {
       const dependencies = {
         getSessionCertificationResultsCsv: sinon.stub(),
         tokenService: {
-          extractSessionId: sinon.stub(),
+          extractCertificationResultsLink: sinon.stub(),
         },
       };
-      dependencies.tokenService.extractSessionId.withArgs(token).returns({ sessionId });
+      dependencies.tokenService.extractCertificationResultsLink.withArgs(token).returns({ sessionId });
       dependencies.getSessionCertificationResultsCsv
         .withArgs({
           session,


### PR DESCRIPTION
## :christmas_tree: Problème

Le token créé et utilisé pour le téléchargement de résultats de certification ne contient pas de scope et n'est donc pas restreint aux usages attendus.

## :gift: Proposition
Les routes impactées sont:
/api/sessions/download-all-results/{token} 
/api/sessions/download-results/{token}

On ajoute le scope `certificationResultsLink` lors de la création du token `CertificationResultsLinkToken` et le scope `certificationResultsByRecipientEmailLink` lors de la création du token `CertificationResultsByRecipientEmailLinkToken`.
On vérifie ce scope lors de l'utilisation du token, uniquement si le Feature Toggle `FT_ENABLE_CERTIF_TOKEN_SCOPE` est activé.
Ceci afin d'éviter des mauvaises surprises aux utilisateurs qui ont un lien sans scope.

## :socks: Remarques

La durée de vie des tokens étant de 30 jours, on activera la vérification des scopes 30 jours après la mise en production de cette fonctionnalité.

## :santa: Pour tester

Activer le feature flag `FT_ENABLE_CERTIF_TOKEN_SCOPE`

1) Se mettre en destinataire de résultat de session `update "certification-candidates" set resultRecipientEmail"='mon_email@pix.fr';`
2) depublier puis republier la session [7006](https://admin.integration.pix.fr/sessions/7006/certifications)
3) Recuperer le token dans l'email
4) Verifier que le lien fonctionne correctement
5) Utiliser ce token dans la route /api/sessions/download-all-results/{token} et constater que cela ne fonctionne pas

Recuperer le lien via une autre RA en effectuant les etapes 1 à 3
Verifier que le token recuperé sur l'autre RA ne fonctionne pas sur cette RA

Desactiver le feature flag `FT_ENABLE_CERTIF_TOKEN_SCOPE`
Verifier que le token recuperé sur l'autre RA fonctionne correctement




