### PR TITLE
[TECH] Uniformisation des prehandlers (sur la route /api/user-orga-settings/{id}) (PIX-10568)

### DIFF
--- a/api/db/seeds/data/team-acces/build-sco-organizations.js
+++ b/api/db/seeds/data/team-acces/build-sco-organizations.js
@@ -6,6 +6,7 @@ import { SCO_ORGANIZATION_ID } from './constants.js';
 
 export function buildScoOrganizations(databaseBuilder) {
   _buildCollegeTheNightWatchOrganization(databaseBuilder);
+  _buildJosephineBaker(databaseBuilder);
 }
 
 function _buildCollegeTheNightWatchOrganization(databaseBuilder) {
@@ -49,6 +50,28 @@ function _buildCollegeTheNightWatchOrganization(databaseBuilder) {
     idPixLabel: null,
     createdAt: new Date('2023-07-27'),
   });
+}
+
+function _buildJosephineBaker(databaseBuilder) {
+  const organization = databaseBuilder.factory.buildOrganization({
+    type: 'SCO',
+    name: 'Lycée Joséphine Baker',
+    isManagingStudents: true,
+    email: 'josephine.baker@example.net',
+    externalId: 'ACCESS_SCO_BAUDELAIRE',
+    documentationUrl: 'https://pix.fr/',
+    provinceCode: '13',
+    identityProviderForCampaigns: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
+    createdBy: REAL_PIX_SUPER_ADMIN_ID,
+  });
+
+  [
+    {
+      userId: PIX_ORGA_ALL_ORGA_ID,
+      organizationId: organization.id,
+      organizationRole: Membership.roles.ADMIN,
+    },
+  ].forEach(_buildAdminMembership(databaseBuilder));
 }
 
 function _buildAdminMembership(databaseBuilder) {

--- a/api/db/seeds/data/team-acces/build-sco-organizations.js
+++ b/api/db/seeds/data/team-acces/build-sco-organizations.js
@@ -5,11 +5,11 @@ import { PIX_ORGA_ADMIN_LEAVING_ID, PIX_ORGA_ALL_ORGA_ID } from './build-organiz
 import { SCO_ORGANIZATION_ID } from './constants.js';
 
 export function buildScoOrganizations(databaseBuilder) {
-  _buildCollegeTheNightWatchOrganization(databaseBuilder);
+  _buildCollegeHouseOfTheDragonOrganization(databaseBuilder);
   _buildJosephineBaker(databaseBuilder);
 }
 
-function _buildCollegeTheNightWatchOrganization(databaseBuilder) {
+function _buildCollegeHouseOfTheDragonOrganization(databaseBuilder) {
   const organization = databaseBuilder.factory.buildOrganization({
     id: SCO_ORGANIZATION_ID,
     type: 'SCO',

--- a/api/lib/application/user-orga-settings/index.js
+++ b/api/lib/application/user-orga-settings/index.js
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 
+import { securityPreHandlers } from '../security-pre-handlers.js';
 import { userOrgaSettingsController } from './user-orga-settings-controller.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
 
@@ -9,7 +10,12 @@ const register = async function (server) {
       method: 'PUT',
       path: '/api/user-orga-settings/{id}',
       config: {
-        handler: userOrgaSettingsController.createOrUpdate,
+        pre: [
+          {
+            method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
+            assign: 'requestedUserIsAuthenticatedUser',
+          },
+        ],
         validate: {
           options: {
             allowUnknown: true,
@@ -29,9 +35,10 @@ const register = async function (server) {
             },
           }),
         },
+        handler: userOrgaSettingsController.createOrUpdate,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
-            '- Création ou Mise à jour des paramètres utilisateurs liés à Pix Orga\n' +
+            '- Création ou Mise à jour des paramètres utilisateurs liés à Pix Orga, permet notamment d’enregistrer les préférences d’un prescripteur vis à vis de son espace Orga.\n' +
             '- L’id en paramètre doit correspondre à celui de l’utilisateur authentifié',
         ],
         tags: ['api', 'user-orga-settings'],

--- a/api/lib/application/user-orga-settings/user-orga-settings-controller.js
+++ b/api/lib/application/user-orga-settings/user-orga-settings-controller.js
@@ -1,16 +1,9 @@
 import * as userOrgaSettingsSerializer from '../../infrastructure/serializers/jsonapi/user-orga-settings-serializer.js';
-import { UserNotAuthorizedToCreateResourceError } from '../../domain/errors.js';
 import { usecases } from '../../domain/usecases/index.js';
 
 const createOrUpdate = async function (request, h, dependencies = { userOrgaSettingsSerializer }) {
-  const authenticatedUserId = request.auth.credentials.userId;
   const userId = request.params.id;
   const organizationId = request.payload.data.relationships.organization.data.id;
-
-  if (userId !== authenticatedUserId) {
-    throw new UserNotAuthorizedToCreateResourceError();
-  }
-
   const result = await usecases.createOrUpdateUserOrgaSettings({ userId, organizationId });
 
   return dependencies.userOrgaSettingsSerializer.serialize(result);

--- a/api/tests/unit/application/user-orga-settings/index_test.js
+++ b/api/tests/unit/application/user-orga-settings/index_test.js
@@ -35,6 +35,35 @@ describe('Unit | Router | user-orga-settings-router', function () {
       expect(response.statusCode).to.equal(200);
     });
 
+    context('when requested user is not the authenticated user', function () {
+      it('returns a 403 HTTP status code', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const method = 'PUT';
+        const url = `/api/user-orga-settings/99`;
+        const payload = {
+          data: {
+            relationships: {
+              organization: {
+                data: {
+                  id: 1,
+                  type: 'organizations',
+                },
+              },
+            },
+          },
+        };
+
+        // when
+        const response = await httpTestServer.request(method, url, payload, auth);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+
     describe('Payload schema validation', function () {
       it('should be mandatory', async function () {
         // given


### PR DESCRIPTION
## :christmas_tree: Problème

La route `/api/user-orga-settings/{id}` fait une vérification de sécurité dans le controller alors qu'un securityPreHandler existe déjà pour gérer ce cas.

## :gift: Proposition

Utiliser le securityPreHandler `securityPreHandlers.checkRequestedUserIsAuthenticatedUser` déjà existant.

## :socks: Remarques

Une nouvelle organisation `Lycée Joséphine Baker` a été ajoutée dans les seeds pour pouvoir tester fonctionnellement le cas de passage d'une organisation à une autre dans Pix Orga.

## :santa: Pour tester

1. Se connecter à Pix Orga avec un compte ayant accès à plusieurs organisations (par exemple `allorga@example.net`)
2. Une fois connecté à Pix Orga, passer d'une organisation à l'autre (par exemple de l’organisation `Collège House of The Dragon` à l'organisation `Lycée Joséphine Baker`)
3. Vérifier que la route `/api/user-orga-settings/{id}` est bien appelée et qu'il n'y a pas de régression
4. (Par exemple avec Firefox) _Modifier et renvoyer_ une des requêtes faite sur la route `/api/user-orga-settings/{id}` en remplaçant `{id}` par l'ID d'un autre utilisateur et constater que la requête renvoie `403`
5. (Par exemple avec Firefox) _Modifier et renvoyer_ une des requêtes faite sur la route `/api/user-orga-settings/{id}` en remplaçant `{data.user.data.id}` des POST parameters par l'ID d'un autre utilisateur et constater que cette modification n'a pas d'effet car c'est uniquement `params.id` qui est pris en compte.