### PR TITLE
[TECH][APP | CERTIF | ORGA]  Utiliser la nouvelle font du DS pour les titres sur les mires de connexions (PIX-10384)

### DIFF
--- a/certif/app/components/auth/login-or-register.hbs
+++ b/certif/app/components/auth/login-or-register.hbs
@@ -7,7 +7,7 @@
       }}</span>
     <div class="login-or-register-panel__forms-container">
       <div class="login-or-register-panel__form">
-        <h1 class="form-title">{{t "pages.login-or-register.register-form.title"}}</h1>
+        <h1 class="login-or-register-panel-form__title">{{t "pages.login-or-register.register-form.title"}}</h1>
         {{#unless this.displayRegisterForm}}
           <PixButton
             id="register"
@@ -34,7 +34,7 @@
       </div>
       <div class="login-or-register-panel__divider"></div>
       <div class="login-or-register-panel__form">
-        <h1 class="form-title">{{t "pages.login-or-register.login-form.title"}}</h1>
+        <h1 class="login-or-register-panel-form__title">{{t "pages.login-or-register.login-form.title"}}</h1>
         {{#if this.displayRegisterForm}}
           <PixButton
             id="login"

--- a/certif/app/components/login-form.hbs
+++ b/certif/app/components/login-form.hbs
@@ -5,7 +5,7 @@
 
     <h1 class="login-header__title">{{t "pages.login.title"}}</h1>
 
-    <p class="login-header__information paragraph">
+    <p class="login-header__information">
       {{t "pages.login.accessible-to"}}
     </p>
 
@@ -22,7 +22,7 @@
 
     <form class="login-main__form" {{on "submit" this.authenticate}}>
 
-      <p class="login-main-form__mandatory-information paragraph">
+      <p class="login-main-form__mandatory-information">
         {{t "common.form-errors.mandatory-all-fields"}}
       </p>
 

--- a/certif/app/styles/components/login-form.scss
+++ b/certif/app/styles/components/login-form.scss
@@ -21,17 +21,17 @@
 .login-header {
   &__title {
     @extend %pix-title-m;
-    
-    color: $pix-neutral-80;
+
     margin-top: var(--pix-spacing-8x);
     margin-bottom: var(--pix-spacing-4x);
+    color: $pix-neutral-80;
   }
 
   &__information {
-    width: 100%;
-    max-width: 400px;
-    margin-bottom: 32px;
-    font-family: $font-roboto;
+    @extend %pix-body-s;
+
+    color: var(--pix-neutral-900);
+    text-align: center;
   }
 
   &__invitation-error {
@@ -54,8 +54,10 @@
 
 .login-main-form {
   &__mandatory-information {
+    @extend %pix-body-s;
+
+    margin-top: var(--pix-spacing-4x);
     color: $pix-neutral-80;
-    font-family: $font-roboto;
     text-align: center;
   }
 

--- a/certif/app/styles/components/login-form.scss
+++ b/certif/app/styles/components/login-form.scss
@@ -20,12 +20,11 @@
 
 .login-header {
   &__title {
-    margin-top: 32px;
-    margin-bottom: 8px;
+    @extend %pix-title-m;
+    
     color: $pix-neutral-80;
-    font-weight: 400;
-    font-size: 2rem;
-    font-family: $font-open-sans;
+    margin-top: var(--pix-spacing-8x);
+    margin-bottom: var(--pix-spacing-4x);
   }
 
   &__information {

--- a/certif/app/styles/components/login-or-register.scss
+++ b/certif/app/styles/components/login-or-register.scss
@@ -95,4 +95,12 @@
       max-height: 720px;
     }
   }
+
+  &__title {
+    @extend %pix-title-m;
+
+    margin: var(--pix-spacing-4x) 0;
+    color: $pix-neutral-100;
+    text-align: center;
+  }
 }

--- a/certif/app/styles/globals/titles.scss
+++ b/certif/app/styles/globals/titles.scss
@@ -5,12 +5,3 @@
   font-size: 2.25rem;
   font-family: $font-open-sans;
 }
-
-.form-title {
-  margin: 16px 0;
-  color: $pix-neutral-100;
-  font-weight: 300;
-  font-size: 1.9rem;
-  font-family: $font-open-sans;
-  text-align: center;
-}

--- a/mon-pix/app/styles/pages/_sign-form.scss
+++ b/mon-pix/app/styles/pages/_sign-form.scss
@@ -21,7 +21,6 @@
   &__container {
     display: flex;
     flex-direction: column;
-    gap: $pix-spacing-m;
     align-items: center;
     max-width: 609px;
     margin-bottom: $pix-spacing-s;
@@ -30,20 +29,20 @@
     border-radius: 10px;
 
     @include device-is('tablet') {
-      padding: 40px 80px;
+      padding: 40px 60px;
     }
   }
 
   &__header {
     display: flex;
     flex-direction: column;
-    gap: $pix-spacing-s;
     align-items: center;
   }
 
   &__body {
     display: flex;
     flex-direction: column;
+    gap: var(--pix-spacing-4x);
     align-items: center;
     width: 100%;
   }
@@ -72,38 +71,33 @@
 
 .sign-form-header {
   &__title {
-    margin: 0;
-    color: $pix-neutral-80;
-    font-size: 1.563rem;
-    font-family: $font-open-sans;
+    @extend %pix-title-m;
 
-    @include device-is('desktop') {
-      font-size: 2.25rem;
-    }
+    margin-top: var(--pix-spacing-8x);
+    margin-bottom: var(--pix-spacing-4x);
+    color: $pix-neutral-80;
   }
 
   &__subtitle {
-    display: flex;
-    flex-direction: column;
-    font-size: 1rem;
-    font-family: $font-open-sans;
-    text-align: center;
+    @extend %pix-body-s;
 
-    @include device-is('tablet') {
-      flex-direction: row;
-    }
+    color: var(--pix-neutral-900);
+    text-align: center;
   }
 }
 
 .sign-form-header-subtitle {
   margin-right: 3px;
-  color: $pix-neutral-80;
+  color: var(--pix-neutral-900);
 }
 
 .sign-form-body {
   &__instruction {
-    margin: 10px 0 24px;
-    font-size: 0.875rem;
+    @extend %pix-body-s;
+
+    margin-top: var(--pix-spacing-4x);
+    color: $pix-neutral-80;
+    text-align: center;
   }
 
   &__inputs {
@@ -139,7 +133,7 @@
 
   &__bottom-decoration {
     width: 100%;
-    margin: 30px 0 40px;
+    margin: var(--pix-spacing-4x) 0;
     line-height: 0.1rem;
     text-align: center;
     border-bottom: 1.5px solid $pix-neutral-20;
@@ -183,9 +177,10 @@
   }
 
   &__forgotten-password-link {
+    @extend %pix-body-s;
+
     align-self: flex-end;
-    margin: 5px 0 20px;
-    font-size: 0.875rem;
+    margin-top: var(--pix-spacing-1x);
   }
 
   &__fwb-oidc-connect-link {

--- a/orga/app/components/auth/login-form.hbs
+++ b/orga/app/components/auth/login-form.hbs
@@ -19,7 +19,7 @@
   {{/if}}
 
   <form class="login-form__input-container" {{on "submit" this.authenticate}}>
-    <p class="login-form__information">{{t "common.form.mandatory-all-fields"}}</p>
+    <p class="login-form__mandatory-information">{{t "common.form.mandatory-all-fields"}}</p>
 
     <PixInput
       @id="login-email"

--- a/orga/app/styles/components/login-form.scss
+++ b/orga/app/styles/components/login-form.scss
@@ -7,8 +7,15 @@
   &__information {
     @extend %pix-body-s;
 
-    margin-top: var(--pix-spacing-4x);
     color: var(--pix-neutral-900);
+    text-align: center;
+  }
+
+  &__mandatory-information {
+    @extend %pix-body-s;
+
+    margin-top: var(--pix-spacing-4x);
+    color: $pix-neutral-80;
     text-align: center;
   }
 

--- a/orga/app/styles/pages/login.scss
+++ b/orga/app/styles/pages/login.scss
@@ -13,6 +13,10 @@
 
   &__title {
     @extend %pix-title-m;
+
+    margin-top: var(--pix-spacing-8x);
+    margin-bottom: var(--pix-spacing-4x);
+    color: $pix-neutral-80;
   }
 
   &__container {


### PR DESCRIPTION
## :christmas_tree: Problème
Suite à une mise à jour du Design System de Pix, la police des titres a changé.

## :gift: Proposition
Mise à jour de la police des titres sur les mires et double mires de connexion de Pix Certif et les mires de connexion/inscription de Pix App (celles de Pix Orga étant déjà à jour).

## :socks: Remarques
Les mires de connexion de Pix App, Pix Certif et Pix Orga ont été unifiées au niveau du code et visuellement.

## :santa: Pour tester
Faire des tests de non régression sur les pages de connexion des 3 applications front en comparant les RA avec ce qu'il y a en intégration ou en production et vérifier que rien n'a été cassé.

- Pix App : `/connexion` & `/inscription`
- Pix Certif : `/connexion` & `/rejoindre?invitationId=107107&code=ABCDEF456`
- Pix Orga : `/connexion` & `/rejoindre?invitationId=1&code=ABCDEF123`
