### PR TITLE
[TECH] Activer la redirection automatique HTTPS sur Caddy (PIX-10578)

### DIFF
--- a/scripts/local-domains/Caddyfile
+++ b/scripts/local-domains/Caddyfile
@@ -1,13 +1,16 @@
 {
 	local_certs
-	auto_https disable_redirects
 }
 
-app.dev.pix.fr app.dev.pix.org:443, :80 {
+http://app.dev.pix.fr,
+https://app.dev.pix.fr,
+http://app.dev.pix.org,
+https://app.dev.pix.org {
 	reverse_proxy host.docker.internal:4200
 }
 
-orga.dev.pix.fr orga.dev.pix.org {
+orga.dev.pix.fr,
+orga.dev.pix.org {
 	reverse_proxy host.docker.internal:4201
 }
 
@@ -15,10 +18,12 @@ admin.dev.pix.fr {
 	reverse_proxy host.docker.internal:4202
 }
 
-certif.dev.pix.fr certif.dev.pix.org {
+certif.dev.pix.fr,
+certif.dev.pix.org {
 	reverse_proxy host.docker.internal:4203
 }
 
-1d.dev.pix.fr 1d.dev.pix.org {
+1d.dev.pix.fr,
+1d.dev.pix.org {
 	reverse_proxy host.docker.internal:4205
 }


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, le serveur web Caddy en local ne redirige pas automatiquement en HTTPS sur tous les autres domaines que [app.pix.dev.fr](http://app.pix.dev.fr/) et [app.dev.pix.org](http://app.dev.pix.org/). 

Cela peut être frustrant car : 

- On ne profite pas de la redirection automatique HTTPS que fournit Caddy qui est une grosse plus-value !
- Le fait de saisir dans la barre d’URL du navigateur, un domaine autre que ceux de Pix App ,va déclencher une erreur 502. Caddy va vouloir rediriger sur la seule référence qui écoute sur le port 80, en l’occurence encore Pix App ! Ce qui fait qu’on opeut saisir http://certif.dev.pix.fr/ et tomber sur Pix App si l’app est démarré en local :sweat_smile:

## :gift: Proposition
Activer la redirection automatique en HTTPS sur Caddy, sauf pour Pix App afin qu’on puisse toujours tester la conf SSO en local.


## :socks: Remarques
- Le travail se base sur ce wiki https://caddy.community/t/making-sense-of-auto-https-and-why-disabling-it-still-serves-https-instead-of-http/9761

## :santa: Pour tester
### Pré-requis 
- Avoir fait le processus d'installation listé sur cette PR https://github.com/1024pix/pix/pull/7269 dans la partie Pour Tester
### Test en local
- Si vous avez démarrer la partie local-domains, faites un `npm run domains:stop` à la racine pour arrêter les containers.
- Lancer la commande `npm run domains:start`
- Lancer la commande `npm run domains:trust-self-signed-certificate:mac`ou `npm run domains:trust-self-signed-certificate:linux` selon l'OS sur lequel vous êtes.
#### Test sur Pix App HTTP
- Démarrer l'application Pix App en local
- Saisir l'url http://app.dev.pix.fr dans votre navigateur
- Se connecter avec Pôle Emploi
- Vérifier qu'on est bien redirigé sur une url en app.dev.pix.fr

#### Test sur Pix App HTTPS
- Démarrer l'application Pix App en local
- Saisir l'url https://app.dev.pix.org dans votre navigateur
- Se connecter avec la FWB 
- Vérifier qu'on est bien redirigé sur une url en https://app.dev.pix.org

#### Test de la redirection automatique HTTPS
- Démarrer les autres applications
- Vérifier qu'en saisissant une url (ex: certif.dev.pix.fr) on est bien automatiquement redirigé vers celui en HTTPS (ex: https://certif.dev.pix.fr)