### PR TITLE
[FEATURE] Enregistrer le passage des utilisateurs sur Modulix (PIX-10581).

### DIFF
--- a/api/config/server-setup-error-handling.js
+++ b/api/config/server-setup-error-handling.js
@@ -4,6 +4,7 @@ import * as sharedPreResponseUtils from '../src/shared/application/pre-response-
 import { authenticationDomainErrorMappingConfiguration } from '../src/authentication/application/http-error-mapper-configuration.js';
 import { sessionDomainErrorMappingConfiguration } from '../src/certification/session/application/http-error-mapper-configuration.js';
 import { certificationDomainErrorMappingConfiguration } from '../src/certification/shared/application/http-error-mapper-configuration.js';
+import { devcompDomainErrorMappingConfiguration } from '../src/devcomp/application/http-error-mapper-configuration.js';
 import { domainErrorMapper } from '../src/shared/application/domain-error-mapper.js';
 
 const setupErrorHandling = function (server) {
@@ -11,6 +12,7 @@ const setupErrorHandling = function (server) {
     ...authenticationDomainErrorMappingConfiguration,
     ...sessionDomainErrorMappingConfiguration,
     ...certificationDomainErrorMappingConfiguration,
+    ...devcompDomainErrorMappingConfiguration,
   ];
 
   domainErrorMapper.configure(configuration);

--- a/api/db/migrations/20231228151516_add-passages.js
+++ b/api/db/migrations/20231228151516_add-passages.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'passages';
+
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.increments('id');
+    table.string('moduleId').notNullable();
+    table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    table.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { up, down };

--- a/api/src/devcomp/application/http-error-mapper-configuration.js
+++ b/api/src/devcomp/application/http-error-mapper-configuration.js
@@ -1,0 +1,14 @@
+import { HttpErrors } from '../../shared/application/http-errors.js';
+import { ModuleDoesNotExistError } from '../domain/errors.js';
+import { DomainErrorMappingConfiguration } from '../../shared/application/models/domain-error-mapping-configuration.js';
+
+const devcompDomainErrorMappingConfiguration = [
+  {
+    name: ModuleDoesNotExistError.name,
+    httpErrorFn: (error) => {
+      return new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta);
+    },
+  },
+].map((domainErrorMappingConfiguration) => new DomainErrorMappingConfiguration(domainErrorMappingConfiguration));
+
+export { devcompDomainErrorMappingConfiguration };

--- a/api/src/devcomp/application/passages/controller.js
+++ b/api/src/devcomp/application/passages/controller.js
@@ -1,0 +1,11 @@
+const create = async function (request, h, { usecases, passageSerializer }) {
+  const { 'module-id': moduleId } = request.payload.data.attributes;
+  const passage = await usecases.createPassage({ moduleId });
+
+  const serializedPassage = passageSerializer.serialize(passage);
+  return h.response(serializedPassage).created();
+};
+
+const passageController = { create };
+
+export { passageController };

--- a/api/src/devcomp/application/passages/index.js
+++ b/api/src/devcomp/application/passages/index.js
@@ -1,0 +1,33 @@
+import Joi from 'joi';
+import { passageController } from './controller.js';
+import { handlerWithDependencies } from '../../infrastructure/utils/handlerWithDependencies.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'POST',
+      path: '/api/passages',
+      config: {
+        auth: false,
+        handler: handlerWithDependencies(passageController.create),
+        validate: {
+          payload: Joi.object({
+            data: Joi.object({
+              attributes: Joi.object({
+                'module-id': Joi.string().required(),
+              }).required(),
+            }).required(),
+          }).required(),
+          options: {
+            allowUnknown: true,
+          },
+        },
+        notes: ['- Permet de créer un passage pour un module'],
+        tags: ['api', 'passages', 'modules'],
+      },
+    },
+  ]);
+};
+
+const name = 'passages-api';
+export { register, name };

--- a/api/src/devcomp/domain/errors.js
+++ b/api/src/devcomp/domain/errors.js
@@ -6,4 +6,10 @@ class UserNotAuthorizedToFindTrainings extends DomainError {
   }
 }
 
-export { UserNotAuthorizedToFindTrainings };
+class ModuleDoesNotExistError extends DomainError {
+  constructor(message = "Le module id n'existe pas") {
+    super(message);
+  }
+}
+
+export { ModuleDoesNotExistError, UserNotAuthorizedToFindTrainings };

--- a/api/src/devcomp/domain/models/Passage.js
+++ b/api/src/devcomp/domain/models/Passage.js
@@ -1,0 +1,10 @@
+class Passage {
+  constructor({ id, moduleId, createdAt, updatedAt }) {
+    this.id = id;
+    this.moduleId = moduleId;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+}
+
+export { Passage };

--- a/api/src/devcomp/domain/usecases/create-passage.js
+++ b/api/src/devcomp/domain/usecases/create-passage.js
@@ -1,0 +1,21 @@
+import { ModuleDoesNotExistError } from '../errors.js';
+import { NotFoundError } from '../../../shared/domain/errors.js';
+
+const createPassage = async function ({ moduleId, moduleRepository, passageRepository }) {
+  await _verifyIfModuleExists({ moduleId, moduleRepository });
+
+  return passageRepository.save({ moduleId });
+};
+
+async function _verifyIfModuleExists({ moduleId, moduleRepository }) {
+  try {
+    await moduleRepository.getBySlug({ slug: moduleId });
+  } catch (e) {
+    if (e instanceof NotFoundError) {
+      throw new ModuleDoesNotExistError();
+    }
+    throw e;
+  }
+}
+
+export { createPassage };

--- a/api/src/devcomp/infrastructure/repositories/index.js
+++ b/api/src/devcomp/infrastructure/repositories/index.js
@@ -1,6 +1,7 @@
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 
 import * as moduleRepository from './module-repository.js';
+import * as passageRepository from './passage-repository.js';
 import * as trainingRepository from './training-repository.js';
 import * as trainingTriggerRepository from './training-trigger-repository.js';
 import * as userRecommendedTrainingRepository from './user-recommended-training-repository.js';
@@ -9,6 +10,7 @@ import moduleDatasource from '../datasources/learning-content/module-datasource.
 
 const repositoriesWithoutInjectedDependencies = {
   moduleRepository,
+  passageRepository,
   trainingRepository,
   trainingTriggerRepository,
   userRecommendedTrainingRepository,

--- a/api/src/devcomp/infrastructure/repositories/passage-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/passage-repository.js
@@ -1,0 +1,17 @@
+import { knex } from '../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
+import { Passage } from '../../domain/models/Passage.js';
+
+const save = async function ({ moduleId, domainTransaction = DomainTransaction.emptyTransaction() }) {
+  const knexConn = domainTransaction?.knexTransaction || knex;
+  const [passage] = await knexConn('passages')
+    .insert({
+      moduleId,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .returning('*');
+  return new Passage(passage);
+};
+
+export { save };

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/passage-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/passage-serializer.js
@@ -1,0 +1,11 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+function serialize(passage) {
+  return new Serializer('passage', {
+    attributes: ['moduleId'],
+  }).serialize(passage);
+}
+
+export { serialize };

--- a/api/src/devcomp/infrastructure/utils/handlerWithDependencies.js
+++ b/api/src/devcomp/infrastructure/utils/handlerWithDependencies.js
@@ -1,11 +1,13 @@
 import { usecases } from '../../domain/usecases/index.js';
 import * as elementAnswerSerializer from '../serializers/jsonapi/element-answer-serializer.js';
 import * as moduleSerializer from '../serializers/jsonapi/module-serializer.js';
+import * as passageSerializer from '../serializers/jsonapi/passage-serializer.js';
 
 const dependencies = {
   usecases,
   elementAnswerSerializer,
   moduleSerializer,
+  passageSerializer,
 };
 
 const handlerWithDependencies = (handler) => {

--- a/api/src/devcomp/routes.js
+++ b/api/src/devcomp/routes.js
@@ -1,6 +1,7 @@
 import * as modulesRoutes from './application/modules/index.js';
+import * as passages from './application/passages/index.js';
 import * as trainings from './application/trainings/index.js';
 
-const devcompRoutes = [modulesRoutes, trainings];
+const devcompRoutes = [modulesRoutes, passages, trainings];
 
 export { devcompRoutes };

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -1,0 +1,43 @@
+import { expect } from '../../../../test-helper.js';
+
+import { createServer } from '../../../../../server.js';
+
+describe('Acceptance | Controller | passage-controller', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('POST /api/passages', function () {
+    it('should create a new passage and response with a 201', async function () {
+      // given
+      const expectedResponse = {
+        type: 'passages',
+        attributes: {
+          'module-id': 'bien-ecrire-son-adresse-mail',
+        },
+      };
+
+      // when
+      const response = await server.inject({
+        method: 'POST',
+        url: '/api/passages',
+        payload: {
+          data: {
+            type: 'passages',
+            attributes: {
+              'module-id': 'bien-ecrire-son-adresse-mail',
+            },
+          },
+        },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(201);
+      expect(response.result.data.type).to.equal(expectedResponse.type);
+      expect(response.result.data.id).to.exist;
+      expect(response.result.data.attributes).to.deep.equal(expectedResponse.attributes);
+    });
+  });
+});

--- a/api/tests/devcomp/integration/application/passages/index_test.js
+++ b/api/tests/devcomp/integration/application/passages/index_test.js
@@ -1,0 +1,30 @@
+import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
+import * as moduleUnderTest from '../../../../../src/devcomp/application/passages/index.js';
+import { passageController } from '../../../../../src/devcomp/application/passages/controller.js';
+import { ModuleDoesNotExistError } from '../../../../../src/devcomp/domain/errors.js';
+
+describe('Unit | Devcomp | Application | Passage | Router | passage-router', function () {
+  describe('POST /api/passages/', function () {
+    describe('when controller throw a ModuleDoesNotExistError', function () {
+      it('should return a 422', async function () {
+        // given
+        sinon.stub(passageController, 'create').throws(new ModuleDoesNotExistError());
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+        const invalidPayload = {
+          data: {
+            attributes: {
+              'module-id': 'not existing id',
+            },
+          },
+        };
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/passages', invalidPayload);
+
+        // then
+        expect(response.statusCode).to.equal(422);
+      });
+    });
+  });
+});

--- a/api/tests/devcomp/integration/repositories/passage-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/passage-repository_test.js
@@ -1,0 +1,38 @@
+import { expect, sinon, knex } from '../../../test-helper.js';
+import * as passageRepository from '../../../../src/devcomp/infrastructure/repositories/passage-repository.js';
+import { Passage } from '../../../../src/devcomp/domain/models/Passage.js';
+
+describe('Integration | DevComp | Repositories | PassageRepository', function () {
+  describe('#save', function () {
+    let clock;
+
+    beforeEach(function () {
+      clock = sinon.useFakeTimers(new Date('2023-12-31'), 'Date');
+    });
+
+    afterEach(function () {
+      clock.restore();
+    });
+
+    it('should save a passage', async function () {
+      // given
+      const passage = {
+        moduleId: 'recModuleId',
+      };
+
+      // when
+      const returnedPassage = await passageRepository.save(passage);
+
+      // then
+      expect(returnedPassage).to.be.instanceOf(Passage);
+      expect(returnedPassage.moduleId).to.equal(passage.moduleId);
+      expect(returnedPassage.createdAt).to.deep.equal(new Date('2023-12-31'));
+      expect(returnedPassage.updatedAt).to.deep.equal(new Date('2023-12-31'));
+
+      const savedPassage = await knex('passages').where({ id: returnedPassage.id }).first();
+      expect(savedPassage.moduleId).to.equal(passage.moduleId);
+      expect(savedPassage.createdAt).to.deep.equal(new Date('2023-12-31'));
+      expect(savedPassage.updatedAt).to.deep.equal(new Date('2023-12-31'));
+    });
+  });
+});

--- a/api/tests/devcomp/unit/application/passages/controller_test.js
+++ b/api/tests/devcomp/unit/application/passages/controller_test.js
@@ -1,0 +1,35 @@
+import { expect, sinon } from '../../../../test-helper.js';
+import { passageController } from '../../../../../src/devcomp/application/passages/controller.js';
+
+describe('Unit | Devcomp | Application | Passages | Controller', function () {
+  describe('#create', function () {
+    it('should call createPassage use-case and return serialized passage', async function () {
+      // given
+      const serializedPassage = Symbol('serialized modules');
+      const moduleId = Symbol('module-id');
+      const passage = Symbol('passage');
+      const usecases = {
+        createPassage: sinon.stub(),
+      };
+      usecases.createPassage.withArgs({ moduleId }).returns(passage);
+      const passageSerializer = {
+        serialize: sinon.stub(),
+      };
+      passageSerializer.serialize.withArgs(passage).returns(serializedPassage);
+      const hStub = {
+        response: sinon.stub(),
+      };
+      const created = sinon.stub();
+      hStub.response.withArgs(serializedPassage).returns({ created });
+
+      // when
+      await passageController.create({ payload: { data: { attributes: { 'module-id': moduleId } } } }, hStub, {
+        passageSerializer,
+        usecases,
+      });
+
+      // then
+      expect(created).to.have.been.called;
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
@@ -1,0 +1,52 @@
+import { catchErr, expect, sinon } from '../../../../test-helper.js';
+import { createPassage } from '../../../../../src/devcomp/domain/usecases/create-passage.js';
+import { ModuleDoesNotExistError } from '../../../../../src/devcomp/domain/errors.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+
+describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
+  describe('when module does not exist', function () {
+    it('should throw an ModuleNotExists', async function () {
+      // given
+      const moduleId = Symbol('moduleId');
+
+      const moduleRepositoryStub = {
+        getBySlug: sinon.stub(),
+      };
+      moduleRepositoryStub.getBySlug.withArgs({ slug: moduleId }).throws(new NotFoundError());
+
+      // when
+      const error = await catchErr(createPassage)({ moduleId, moduleRepository: moduleRepositoryStub });
+
+      // then
+      expect(error).to.be.instanceOf(ModuleDoesNotExistError);
+    });
+  });
+
+  it('should call passage repository to save the passage', async function () {
+    // given
+    const moduleId = Symbol('moduleId');
+    const repositoryResult = Symbol('repository-result');
+
+    const moduleRepositoryStub = {
+      getBySlug: sinon.stub(),
+    };
+    moduleRepositoryStub.getBySlug.withArgs({ slug: moduleId }).resolves();
+    const passageRepositoryStub = {
+      save: sinon.stub(),
+    };
+    passageRepositoryStub.save.resolves(repositoryResult);
+
+    // when
+    const result = await createPassage({
+      moduleId,
+      passageRepository: passageRepositoryStub,
+      moduleRepository: moduleRepositoryStub,
+    });
+
+    // then
+    expect(passageRepositoryStub.save).to.have.been.calledWithExactly({
+      moduleId,
+    });
+    expect(result).to.equal(repositoryResult);
+  });
+});

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/passage-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/passage-serializer_test.js
@@ -1,0 +1,29 @@
+import { expect } from '../../../../../test-helper.js';
+import { Passage } from '../../../../../../src/devcomp/domain/models/Passage.js';
+import * as passageSerializer from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/passage-serializer.js';
+
+describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | PassageSerializer', function () {
+  describe('#serialize', function () {
+    it('should serialize', function () {
+      // given
+      const id = 123;
+      const moduleId = 'bien-ecrire-son-adresse-mail';
+      const moduleFromDomain = new Passage({ id, moduleId });
+      const expectedJson = {
+        data: {
+          type: 'passages',
+          id: id.toString(),
+          attributes: {
+            'module-id': moduleId,
+          },
+        },
+      };
+
+      // when
+      const json = passageSerializer.serialize(moduleFromDomain);
+
+      // then
+      expect(json).to.deep.equal(expectedJson);
+    });
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, nous n'enregistrons pas le passage d'un module de nos utilisateurs, alors que nous souhaitons recueillir leurs réponses afin d'affiner au mieux les modules.  

## :gift: Proposition
Ajouter la notion de Passage dans l'API. Cette PR, propose un endpoint qui permet de créer un passage. 
Un passage correspond à la même notion que pour l'évaluation les `assessments`. Seulement un passage, n'a pas vocation à évaluer, d'où le nommage plus doux. 

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Faire un POST sur /api/passages avec le bon payload 