### PR TITLE
[FEATURE] Enregistrer les réponses faites durant un passage de module (PIX-10581).

### DIFF
--- a/api/db/migrations/20231229135121_add-element-answers.js
+++ b/api/db/migrations/20231229135121_add-element-answers.js
@@ -1,0 +1,18 @@
+const TABLE_NAME = 'element-answers';
+
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.bigIncrements('id');
+    table.integer('passageId').notNullable().references('id').inTable('passages');
+    table.string('elementId').notNullable();
+    table.string('grainId').notNullable();
+    table.string('value').notNullable();
+    table.string('status').notNullable();
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { up, down };

--- a/api/src/devcomp/domain/usecases/verify-and-save-answer.js
+++ b/api/src/devcomp/domain/usecases/verify-and-save-answer.js
@@ -1,0 +1,7 @@
+async function verifyAndSaveAnswer({ moduleSlug, userResponse, elementId, moduleRepository }) {
+  const foundModule = await moduleRepository.getBySlugForVerification({ slug: moduleSlug });
+  const element = foundModule.getElementById(elementId);
+  return element.assess(userResponse);
+}
+
+export { verifyAndSaveAnswer };

--- a/api/tests/devcomp/unit/domain/usecases/verify-and-save-answer_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/verify-and-save-answer_test.js
@@ -1,0 +1,44 @@
+import { verifyAndSaveAnswer } from '../../../../../src/devcomp/domain/usecases/verify-and-save-answer.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | UseCases | verify-and-save-answer', function () {
+  describe('#verifyAndSaveAnswer', function () {
+    describe('When the selected proposal is valid', function () {
+      it('should return a valid Correction Response', async function () {
+        // given
+        const moduleSlug = 'moduleSlug';
+        const elementId = 'elementId';
+        const userResponse = ['totoId'];
+
+        const mockedModuleRepo = {
+          getBySlugForVerification: sinon.stub(),
+        };
+
+        const expectedModule = {
+          getElementById: sinon.stub(),
+        };
+
+        mockedModuleRepo.getBySlugForVerification.withArgs({ slug: moduleSlug }).resolves(expectedModule);
+
+        const stubElement = {
+          assess: sinon.stub(),
+        };
+        expectedModule.getElementById.withArgs(elementId).returns(stubElement);
+
+        const expectedQcuResponse = Symbol('answer');
+        stubElement.assess.withArgs(userResponse).returns(expectedQcuResponse);
+
+        // when
+        const validateQcu = await verifyAndSaveAnswer({
+          moduleSlug: moduleSlug,
+          elementId: elementId,
+          userResponse: userResponse,
+          moduleRepository: mockedModuleRepo,
+        });
+
+        // then
+        expect(validateQcu).to.deep.equal(expectedQcuResponse);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, nous avons de quoi créer un passage, mais ce dernier ne sert à rien en l'état. Nous voulons enregistrer les réponses des apprenants pour ainsi affiner au mieux les modules.

## :gift: Proposition
Ajouter la notion `element-answers`, qui correspond à la réponse d'un élément. Nous préfixons par `element`, pour distinguer des `answers` faites sur des challenges.

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
