### PR TITLE
[FEATURE] Ne pas afficher le tag de signalement pour la dernière question d'une session non terminée (PIX-10552).

### DIFF
--- a/admin/app/components/certifications/certification/details-v3.hbs
+++ b/admin/app/components/certifications/certification/details-v3.hbs
@@ -47,9 +47,13 @@
                 {{/if}}
               </td>
               <td>
-                <PixTag @color={{this.answerStatusColor certificationChallenge.answerStatus}}>
-                  {{this.answerStatusLabel certificationChallenge.answerStatus}}
-                </PixTag>
+                {{#if (this.shouldDisplayAnswerStatus certificationChallenge)}}
+                  <PixTag @color={{this.answerStatusColor certificationChallenge.answerStatus}}>
+                    {{this.answerStatusLabel certificationChallenge.answerStatus}}
+                  </PixTag>
+                {{else}}
+                  -
+                {{/if}}
               </td>
               <td>{{certificationChallenge.competenceIndex}} {{certificationChallenge.competenceName}}</td>
               <td>{{certificationChallenge.skillName}}</td>

--- a/admin/app/components/certifications/certification/details-v3.js
+++ b/admin/app/components/certifications/certification/details-v3.js
@@ -24,6 +24,10 @@ export default class DetailsV3 extends Component {
     return options.find((option) => option.value === status).color;
   }
 
+  shouldDisplayAnswerStatus(certificationChallenge) {
+    return certificationChallenge.validatedLiveAlert || certificationChallenge.answeredAt;
+  }
+
   externalUrlForPreviewChallenge(challengeId) {
     return `https://app.pix.fr/challenges/${challengeId}/preview`;
   }

--- a/admin/tests/integration/components/certifications/certification/details-v3_test.js
+++ b/admin/tests/integration/components/certifications/certification/details-v3_test.js
@@ -232,6 +232,31 @@ module('Integration | Component | Certifications | certification > details v3', 
           .exists();
       });
     });
+
+    module('when the candidate does not finish the session', function () {
+      test('should not display a tag', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        this.model = store.createRecord('v3-certification-course-details-for-administration', {
+          certificationChallengesForAdministration: [
+            store.createRecord('certification-challenges-for-administration', {
+              validatedLiveAlert: false,
+              answeredAt: null,
+            }),
+          ],
+        });
+
+        // when
+        const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
+
+        // then
+        const detailTable = screen.getByRole('table');
+        const statusCellIndex = within(detailTable).getByRole('columnheader', { name: 'Statut' }).cellIndex;
+        const lastQuestionDetail = within(detailTable).getAllByRole('row').at(-1);
+        const lastQuestionStatus = within(lastQuestionDetail).getAllByRole('cell')[statusCellIndex - 1].innerText;
+        assert.strictEqual(lastQuestionStatus, '-');
+      });
+    });
   });
 });
 


### PR DESCRIPTION
## :christmas_tree: Problème

Actuellement, lors d’une session de certification, si le candidat ne répond pas à l’intégralité des questions, la dernière question qui lui aura été posée aura le tag Signalement validé même si aucun signalement n’aura été validé.

![image](https://github.com/1024pix/pix/assets/36371437/8bac4e64-08a0-41d9-bd21-5b2cbc9e6e00)

## :gift: Proposition

N'afficher le tag que s'il y a vraiment un signalement

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester

- Créer une certif V3 (certifv3@example.net)
- Inscrire un candidat
- Passer la certification (certifiable-contenu-user@example.net) mais NE PAS LA TERMINER
- finaliser la session
- Dans la page de détails de la certif dans pix-admin, vérifier que la dernière question n'a pas de tag associé.
