### PR TITLE
[BUGFIX] Les vidéos en webm ne se lisent pas sur Safari mobile (PIX-10584)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/module.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module.json
@@ -32,7 +32,7 @@
               "id": "3a9f2269-99ba-4631-b6fd-6802c88d5c26",
               "type": "video",
               "title": "Le format des adresses mail",
-              "url": "https://videos.pix.fr/modulix/chat_animation_2.webm",
+              "url": "https://videos.pix.fr/modulix/chat_animation_2.mp4",
               "subtitles": "https://videos.pix.fr/modulix/chat_animation_2.vtt",
               "transcription": "<ul><li>Naomi : Salut, tu peux me redonner ton adresse mail stp ? <span aria-hidden='true'>😇</span></li> <li>Mickaël : Oui, c’est mickael.aubert123#laposte.net</li><li>Naomi : T’es sûr ? <span aria-hidden='true'>😬</span></li><li>Naomi : Tu veux dire mickael.aubert123@laposte.net</li><li>Mickaël : Ah oui désolé ! <span aria-hidden='true'>😣</span></li><li>Mickaël : comment tu as su ? </li><li>Naomi : …</li>",
               "alternativeText": "Conversation entre Naomi et Mickaël de le format d'adresse mail"

--- a/mon-pix/app/pods/components/module/video/template.hbs
+++ b/mon-pix/app/pods/components/module/video/template.hbs
@@ -10,7 +10,7 @@
       controls
       crossorigin
     >
-      <source src={{@video.url}} type="video/webm" />
+      <source src={{@video.url}} type="video/mp4" />
       <track kind="captions" label="Français" src={{@video.subtitles}} srclang="fr" default />
     </video>
 


### PR DESCRIPTION
## :christmas_tree: Problème
Tout est dans le titre : sur mobile avec Android on peut lire les éléments Vidéos, mais pas sur Safari.

## :gift: Proposition
La faute à Apple qui ne supporte pas le format WEBM ainsi que certains formats MP4. Voir cette réponse sur [Stackoverflow](https://stackoverflow.com/questions/30199261/why-wont-safari-play-file-without-extension-in-video/58830846#58830846) ainsi que [cette issue](https://github.com/sampotts/plyr/issues/2036) sur le repo de plyr.
Il faut donc convertir notre vidéo actuelle en MP4 avec le codec adéquat.

## :socks: Remarques
Nous nous sommes servis de `ffmpeg` pour convertir le fichier webm en mp4. Ceci avec la commande suivante:
`ffmpeg -i chat_animation_2.webm -vf 'scale=1280:720' chat_animation_2.mp4`
Cela nous a aussi permis d'obtenir un gain de poids de +- 50%.

💡 Bien penser à modifier l'attribut type de la balise source lorsqu'on passe d'un format de vidéo à un autre.

```html
<source src={{@video.url}} type="video/mp4" />
```

## :santa: Pour tester
Se rendre sur [la page du module](https://app-pr7792.review.pix.fr/modules/bien-ecrire-son-adresse-mail) et valider que la vidéo se lance bien sur iOS ET sur Android
