### PR TITLE
[FEATURE] Clarifier le message d'erreur lors de l'import en masse des sessions sur Pix Certif (PIX-10154).

### DIFF
--- a/certif/app/components/import/step-one-section.hbs
+++ b/certif/app/components/import/step-one-section.hbs
@@ -71,6 +71,10 @@
     </PixButtonUpload>
   </div>
 
+  {{#if @importErrorMessage}}
+    <PixMessage @type="error" @withIcon={{true}}>{{@importErrorMessage}}</PixMessage>
+  {{/if}}
+
   <ul class="import-page__section--link-buttons">
     <li>
       <PixButton @triggerAction={{@validateSessions}} @isDisabled={{@isImportDisabled}}>

--- a/certif/app/controllers/authenticated/sessions/import.js
+++ b/certif/app/controllers/authenticated/sessions/import.js
@@ -24,6 +24,7 @@ export default class ImportController extends Controller {
   @tracked candidatesCount;
 
   @tracked errorReports;
+  @tracked importErrorMessage = null;
   @tracked isImportInError = false;
 
   get fileName() {
@@ -39,9 +40,10 @@ export default class ImportController extends Controller {
       await this.fileSaver.save({ url, token });
     } catch (error) {
       if (error[0]?.code === 403) {
-        return this.notifications.error(this.intl.t('pages.sessions.import.step-one.errors.forbidden'));
+        this.importErrorMessage = this.intl.t('pages.sessions.import.step-one.errors.forbidden');
+        return;
       }
-      this.notifications.error(this.intl.t('pages.sessions.import.step-one.errors.download'));
+      this.importErrorMessage = this.intl.t('pages.sessions.import.step-one.errors.download');
     }
   }
 
@@ -49,6 +51,7 @@ export default class ImportController extends Controller {
   preImportSessions() {
     this.file = document.getElementById('file-upload').files[0];
     this.isImportDisabled = false;
+    this.importErrorMessage = null;
   }
 
   @action
@@ -80,9 +83,10 @@ export default class ImportController extends Controller {
       this.errorReports = errorReports;
     } catch (responseError) {
       if (responseError.errors[0].code === 403) {
-        return this.notifications.error(this.intl.t('pages.sessions.import.step-one.errors.forbidden'));
+        this.importErrorMessage = this.intl.t('pages.sessions.import.step-one.errors.forbidden');
+        return;
       }
-      this.notifications.error(this.intl.t(this._handleApiError(responseError)));
+      this.importErrorMessage = this.intl.t(this._handleApiError(responseError));
       return;
     }
     this.isImportStepOne = false;
@@ -114,6 +118,7 @@ export default class ImportController extends Controller {
   removeImport() {
     this.file = null;
     this.isImportDisabled = true;
+    this.importErrorMessage = null;
   }
 
   reset() {

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -15,6 +15,7 @@
       @removeImport={{this.removeImport}}
       @validateSessions={{this.validateSessions}}
       @isImportDisabled={{this.isImportDisabled}}
+      @importErrorMessage={{this.importErrorMessage}}
     />
   {{else}}
     <Import::StepTwoSection

--- a/certif/tests/acceptance/session-import_test.js
+++ b/certif/tests/acceptance/session-import_test.js
@@ -371,171 +371,173 @@ module('Acceptance | Session Import', function (hooks) {
           });
         });
 
-        module('when the file is not valid', function () {
-          test('it should display an error notification', async function (assert) {
-            //given
-            const file = new Blob(['foo']);
-            this.server.post(
-              '/certification-centers/:id/sessions/validate-for-mass-import',
-              () =>
-                new Response(
-                  422,
-                  { some: 'header' },
-                  {
-                    errors: [
-                      {
-                        code: 'CSV_HEADERS_NOT_VALID',
-                        status: '422',
-                        title: 'Unprocessable Entity',
-                      },
-                    ],
-                  },
-                ),
-            );
+        module('error cases', function () {
+          module('when the file is not valid', function () {
+            test('it should display an error message', async function (assert) {
+              //given
+              const file = new Blob(['foo']);
+              this.server.post(
+                '/certification-centers/:id/sessions/validate-for-mass-import',
+                () =>
+                  new Response(
+                    422,
+                    { some: 'header' },
+                    {
+                      errors: [
+                        {
+                          code: 'CSV_HEADERS_NOT_VALID',
+                          status: '422',
+                          title: 'Unprocessable Entity',
+                        },
+                      ],
+                    },
+                  ),
+              );
 
-            // when
-            screen = await visit('/sessions/import');
-            const input = await screen.findByLabelText('Importer le modèle complété');
-            await triggerEvent(input, 'change', { files: [file] });
-            const importButton = screen.getByRole('button', { name: 'Continuer' });
-            await click(importButton);
-            await settled();
+              // when
+              screen = await visit('/sessions/import');
+              const input = await screen.findByLabelText('Importer le modèle complété');
+              await triggerEvent(input, 'change', { files: [file] });
+              const importButton = screen.getByRole('button', { name: 'Continuer' });
+              await click(importButton);
+              await settled();
 
-            // then
-            assert.dom(screen.getByText('Le modèle a été altéré, merci de le télécharger à nouveau')).exists();
+              // then
+              assert.dom(screen.getByText('Le modèle a été altéré, merci de le télécharger à nouveau')).exists();
+            });
+
+            test('it should not go to step two', async function (assert) {
+              //given
+              const file = new Blob(['foo']);
+              this.server.post(
+                '/certification-centers/:id/sessions/validate-for-mass-import',
+                () =>
+                  new Response(
+                    422,
+                    { some: 'header' },
+                    {
+                      errors: [
+                        {
+                          code: 'INVALID_DOCUMENT',
+                          status: '422',
+                          title: 'Unprocessable Entity',
+                          detail: 'Fichier non valide',
+                        },
+                      ],
+                    },
+                  ),
+              );
+
+              // when
+              screen = await visit('/sessions/import');
+              const input = await screen.findByLabelText('Importer le modèle complété');
+              await triggerEvent(input, 'change', { files: [file] });
+              const importButton = screen.getByRole('button', { name: 'Continuer' });
+              await click(importButton);
+
+              // then
+              assert.dom(screen.getByRole('button', { name: 'Télécharger le modèle vierge' })).exists();
+            });
           });
 
-          test('it should not go to step two', async function (assert) {
-            //given
-            const file = new Blob(['foo']);
-            this.server.post(
-              '/certification-centers/:id/sessions/validate-for-mass-import',
-              () =>
-                new Response(
-                  422,
-                  { some: 'header' },
-                  {
-                    errors: [
-                      {
-                        code: 'INVALID_DOCUMENT',
-                        status: '422',
-                        title: 'Unprocessable Entity',
-                        detail: 'Fichier non valide',
-                      },
-                    ],
-                  },
-                ),
-            );
+          module('when file headers have been modified', function () {
+            test('it should display an error message', async function (assert) {
+              //given
+              const blob = new Blob(['foo']);
+              const file = new File([blob], 'fichier.csv', { type: 'text/csv' });
+              this.server.post(
+                '/certification-centers/:id/sessions/validate-for-mass-import',
+                () =>
+                  new Response(
+                    422,
+                    { some: 'header' },
+                    {
+                      errors: [
+                        {
+                          code: 'CSV_HEADERS_NOT_VALID',
+                        },
+                      ],
+                    },
+                  ),
+              );
 
-            // when
-            screen = await visit('/sessions/import');
-            const input = await screen.findByLabelText('Importer le modèle complété');
-            await triggerEvent(input, 'change', { files: [file] });
-            const importButton = screen.getByRole('button', { name: 'Continuer' });
-            await click(importButton);
+              // when
+              screen = await visit('/sessions/import');
+              const input = await screen.findByLabelText('Importer le modèle complété');
+              await triggerEvent(input, 'change', { files: [file] });
+              const importButton = screen.getByRole('button', { name: 'Continuer' });
+              await click(importButton);
+              await settled();
 
-            // then
-            assert.dom(screen.getByRole('button', { name: 'Télécharger le modèle vierge' })).exists();
+              // then
+              assert.dom(screen.getByText('Le modèle a été altéré, merci de le télécharger à nouveau')).exists();
+            });
           });
-        });
 
-        module('when file headers have been modified', function () {
-          test('it should display an error notification', async function (assert) {
-            //given
-            const blob = new Blob(['foo']);
-            const file = new File([blob], 'fichier.csv', { type: 'text/csv' });
-            this.server.post(
-              '/certification-centers/:id/sessions/validate-for-mass-import',
-              () =>
-                new Response(
-                  422,
-                  { some: 'header' },
-                  {
-                    errors: [
-                      {
-                        code: 'CSV_HEADERS_NOT_VALID',
-                      },
-                    ],
-                  },
-                ),
-            );
+          module('when the file is empty', function () {
+            test('it should display an error message', async function (assert) {
+              //given
+              const blob = new Blob(['foo']);
+              const file = new File([blob], 'fichier.csv', { type: 'text/csv' });
+              this.server.post(
+                '/certification-centers/:id/sessions/validate-for-mass-import',
+                () =>
+                  new Response(
+                    422,
+                    { some: 'header' },
+                    {
+                      errors: [
+                        {
+                          code: 'CSV_DATA_REQUIRED',
+                        },
+                      ],
+                    },
+                  ),
+              );
 
-            // when
-            screen = await visit('/sessions/import');
-            const input = await screen.findByLabelText('Importer le modèle complété');
-            await triggerEvent(input, 'change', { files: [file] });
-            const importButton = screen.getByRole('button', { name: 'Continuer' });
-            await click(importButton);
-            await settled();
+              // when
+              screen = await visit('/sessions/import');
+              const input = await screen.findByLabelText('Importer le modèle complété');
+              await triggerEvent(input, 'change', { files: [file] });
+              const importButton = screen.getByRole('button', { name: 'Continuer' });
+              await click(importButton);
+              await settled();
 
-            // then
-            assert.dom(screen.getByText('Le modèle a été altéré, merci de le télécharger à nouveau')).exists();
+              // then
+              assert
+                .dom(
+                  screen.getByText(
+                    "Le modèle importé n'a pas été rempli, merci de le compléter avant de l'importer à nouveau",
+                  ),
+                )
+                .exists();
+            });
           });
-        });
 
-        module('when the file is empty', function () {
-          test('it should display an error notification', async function (assert) {
-            //given
-            const blob = new Blob(['foo']);
-            const file = new File([blob], 'fichier.csv', { type: 'text/csv' });
-            this.server.post(
-              '/certification-centers/:id/sessions/validate-for-mass-import',
-              () =>
-                new Response(
-                  422,
-                  { some: 'header' },
-                  {
-                    errors: [
-                      {
-                        code: 'CSV_DATA_REQUIRED',
-                      },
-                    ],
-                  },
-                ),
-            );
+          module('when sessions validation fails with a 500 http error', function () {
+            test('it should display the default error message', async function (assert) {
+              //given
+              const blob = new Blob(['foo']);
+              const file = new File([blob], 'fichier.csv', { type: 'text/csv' });
+              this.server.post('/certification-centers/:id/sessions/validate-for-mass-import', () => new Response(500));
 
-            // when
-            screen = await visit('/sessions/import');
-            const input = await screen.findByLabelText('Importer le modèle complété');
-            await triggerEvent(input, 'change', { files: [file] });
-            const importButton = screen.getByRole('button', { name: 'Continuer' });
-            await click(importButton);
-            await settled();
+              // when
+              screen = await visit('/sessions/import');
+              const input = await screen.findByLabelText('Importer le modèle complété');
+              await triggerEvent(input, 'change', { files: [file] });
+              const importButton = screen.getByRole('button', { name: 'Continuer' });
+              await click(importButton);
+              await settled();
 
-            // then
-            assert
-              .dom(
-                screen.getByText(
-                  "Le modèle importé n'a pas été rempli, merci de le compléter avant de l'importer à nouveau",
-                ),
-              )
-              .exists();
-          });
-        });
-
-        module('when sessions validation fails with a 500 http error', function () {
-          test('it should display an error notification with the default error message', async function (assert) {
-            //given
-            const blob = new Blob(['foo']);
-            const file = new File([blob], 'fichier.csv', { type: 'text/csv' });
-            this.server.post('/certification-centers/:id/sessions/validate-for-mass-import', () => new Response(500));
-
-            // when
-            screen = await visit('/sessions/import');
-            const input = await screen.findByLabelText('Importer le modèle complété');
-            await triggerEvent(input, 'change', { files: [file] });
-            const importButton = screen.getByRole('button', { name: 'Continuer' });
-            await click(importButton);
-            await settled();
-
-            // then
-            assert
-              .dom(
-                screen.getByText(
-                  'Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.',
-                ),
-              )
-              .exists();
+              // then
+              assert
+                .dom(
+                  screen.getByText(
+                    'Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.',
+                  ),
+                )
+                .exists();
+            });
           });
         });
       });

--- a/certif/tests/acceptance/session-import_test.js
+++ b/certif/tests/acceptance/session-import_test.js
@@ -514,32 +514,6 @@ module('Acceptance | Session Import', function (hooks) {
             });
           });
 
-          module('when sessions validation fails with a 500 http error', function () {
-            test('it should display the default error message', async function (assert) {
-              //given
-              const blob = new Blob(['foo']);
-              const file = new File([blob], 'fichier.csv', { type: 'text/csv' });
-              this.server.post('/certification-centers/:id/sessions/validate-for-mass-import', () => new Response(500));
-
-              // when
-              screen = await visit('/sessions/import');
-              const input = await screen.findByLabelText('Importer le modèle complété');
-              await triggerEvent(input, 'change', { files: [file] });
-              const importButton = screen.getByRole('button', { name: 'Continuer' });
-              await click(importButton);
-              await settled();
-
-              // then
-              assert
-                .dom(
-                  screen.getByText(
-                    'Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.',
-                  ),
-                )
-                .exists();
-            });
-          });
-
           module('when sessions validation fails', function () {
             module('when cancelling the import', function () {
               test('it should remove the error message', async function (assert) {
@@ -643,6 +617,35 @@ module('Acceptance | Session Import', function (hooks) {
                     ),
                   )
                   .doesNotExist();
+              });
+            });
+
+            module('when an internal server error occurs', function () {
+              test('it should display the default error message', async function (assert) {
+                //given
+                const blob = new Blob(['foo']);
+                const file = new File([blob], 'fichier.csv', { type: 'text/csv' });
+                this.server.post(
+                  '/certification-centers/:id/sessions/validate-for-mass-import',
+                  () => new Response(500),
+                );
+
+                // when
+                screen = await visit('/sessions/import');
+                const input = await screen.findByLabelText('Importer le modèle complété');
+                await triggerEvent(input, 'change', { files: [file] });
+                const importButton = screen.getByRole('button', { name: 'Continuer' });
+                await click(importButton);
+                await settled();
+
+                // then
+                assert
+                  .dom(
+                    screen.getByText(
+                      'Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.',
+                    ),
+                  )
+                  .exists();
               });
             });
           });

--- a/certif/tests/unit/controllers/authenticated/sessions/import_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/import_test.js
@@ -14,8 +14,9 @@ module('Unit | Controller | authenticated/sessions/import', function (hooks) {
     controller = this.owner.lookup('controller:authenticated/sessions/import');
   });
 
-  module('#downloadSessionImportTemplate', function (hooks) {
-    hooks.beforeEach(function () {
+  module('#downloadSessionImportTemplate', function () {
+    test('should call the file-saver service for downloadSessionImportTemplate with the right parameters', async function (assert) {
+      // given
       const store = this.owner.lookup('service:store');
       const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
         id: 123,
@@ -25,10 +26,6 @@ module('Unit | Controller | authenticated/sessions/import', function (hooks) {
       }
 
       this.owner.register('service:current-user', CurrentUserStub);
-    });
-
-    test('should call the file-saver service for downloadSessionImportTemplate with the right parameters', async function (assert) {
-      // given
       const token = 'a token';
 
       controller.session = {
@@ -52,52 +49,6 @@ module('Unit | Controller | authenticated/sessions/import', function (hooks) {
           token,
           url: '/api/certification-centers/123/import',
         }),
-      );
-    });
-
-    test('should call the notifications service in case of an error', async function (assert) {
-      // given
-      controller.session = {
-        isAuthenticated: true,
-        data: {
-          authenticated: {
-            access_token: 'wrong token',
-          },
-        },
-      };
-      controller.fileSaver = { save: sinon.stub().rejects() };
-      controller.notifications = { error: sinon.spy() };
-
-      // when
-      await controller.downloadSessionImportTemplate(event);
-
-      // then
-      sinon.assert.calledOnce(controller.notifications.error);
-      assert.ok(controller);
-    });
-
-    test('should call the notifications service when access is forbidden', async function (assert) {
-      // given
-      controller.session = {
-        isAuthenticated: true,
-        data: {
-          authenticated: {
-            access_token: 'wrong token',
-          },
-        },
-      };
-      controller.fileSaver = { save: sinon.stub().rejects([{ code: 403 }]) };
-      controller.notifications = { error: sinon.spy() };
-
-      // when
-      await controller.downloadSessionImportTemplate(event);
-
-      // then
-      sinon.assert.calledOnce(controller.notifications.error);
-      assert.ok(controller);
-      sinon.assert.calledWith(
-        controller.notifications.error,
-        "La création et l'édition de plusieurs sessions à la fois n'est pas disponible pour votre centre de certification. Veuillez utiliser la création et l'édition individuelle de session.",
       );
     });
   });
@@ -141,90 +92,6 @@ module('Unit | Controller | authenticated/sessions/import', function (hooks) {
 
       // then
       sinon.assert.calledWith(adapter.validateSessionsForMassImport, file, '123');
-      assert.ok(controller);
-    });
-
-    test('should call the notifications service in case of an error', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const adapter = store.adapterFor('validate-sessions-for-mass-import');
-      const sessionsImportStub = sinon.stub(adapter, 'validateSessionsForMassImport');
-      sessionsImportStub.rejects({
-        errors: [{ detail: 'API error' }],
-      });
-      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
-        id: 123,
-      });
-
-      class CurrentUserStub extends Service {
-        currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
-      }
-
-      this.owner.register('service:current-user', CurrentUserStub);
-      const token = 'a token';
-
-      controller.file = Symbol('file 1');
-
-      controller.session = {
-        isAuthenticated: true,
-        data: {
-          authenticated: {
-            access_token: token,
-          },
-        },
-      };
-
-      controller.notifications = { error: sinon.stub(), clearAll: sinon.stub() };
-
-      // when
-      await controller.validateSessions();
-
-      // then
-      sinon.assert.calledOnce(controller.notifications.error);
-      assert.ok(controller);
-    });
-
-    test('should call the notifications service when access is forbidden', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const adapter = store.adapterFor('validate-sessions-for-mass-import');
-      const sessionsImportStub = sinon.stub(adapter, 'validateSessionsForMassImport');
-      sessionsImportStub.rejects({
-        errors: [{ code: 403 }],
-      });
-      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
-        id: 123,
-        type: 'SCO',
-      });
-
-      class CurrentUserStub extends Service {
-        currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
-      }
-
-      this.owner.register('service:current-user', CurrentUserStub);
-      const token = 'a token';
-
-      controller.file = Symbol('file 1');
-
-      controller.session = {
-        isAuthenticated: true,
-        data: {
-          authenticated: {
-            access_token: token,
-          },
-        },
-      };
-
-      controller.notifications = { error: sinon.stub(), clearAll: sinon.stub() };
-
-      // when
-      await controller.validateSessions();
-
-      // then
-      sinon.assert.calledWith(
-        controller.notifications.error,
-        "La création et l'édition de plusieurs sessions à la fois n'est pas disponible pour votre centre de certification. Veuillez utiliser la création et l'édition individuelle de session.",
-      );
       assert.ok(controller);
     });
   });


### PR DESCRIPTION
## :christmas_tree: Problème
Lorsque l’utilisateur clique sur “Créer/éditer plusieurs sessions”, il arrive sur le parcours qui lui permettra de créer plusieurs sessions à la fois ou bien d'éditer la liste de candidats de plusieurs sessions en même temps.

En cas d’erreur lors de l’import du fichier .csv, par exemple si le modèle du fichier a été altéré, un toaster apparaît pour prévenir l’utilisateur. Mais ce toaster n’apparaît pas assez visible pour l’utilisateur.

## :gift: Proposition
Afficher un message d'erreur à la place 

## :santa: Pour tester
- Se connecter sur Pix Certif avec [certif-pro@example.net](mailto:certif-pro@example.net)
- Aller sur Créer/éditer plusieurs sessions
- Télécharger un modèle vide
- L'importer sans y toucher
- Cliquer sur le bouton Continuer
- Constater qu'un message d'erreur apparaît entre le bloc d'import et les boutons d'action
- Cliquer sur le bouton de fermeture sur le bloc contenant le nom du fichier
- Constater que le message d'erreur disparaît
- Ouvrir la console et passer en Offline
- Télécharger un modèle vide
- Constater qu'un nouveau message d'erreur apparaît
- Repasser sur No throlling
- Cliquer le bouton pour importer et importer un fichier
- Constater que le message d'erreur disparaît.

