### PR TITLE
[TECH] Fixer les versions de postgres et redis dans le fichier de configuration de Scalingo (PIX-9281).

### DIFF
--- a/scalingo.json
+++ b/scalingo.json
@@ -22,8 +22,18 @@
     "first-deploy": "./scripts/scalingo-post-ra-creation.sh"
   },
   "addons": [
-    "postgresql:postgresql-sandbox",
-    "redis:redis-sandbox"
+    {
+      "plan": "postgresql:postgresql-sandbox",
+      "options": {
+        "version": "14.10"
+      }
+    },
+    {
+      "plan": "redis:redis-sandbox",
+      "options": {
+        "version": "7.2.3"
+      }
+    }
   ],
   "formation": {
     "web": {


### PR DESCRIPTION
## :christmas_tree: Problème
De [nouvelles configurations](https://github.com/1024pix/renovate-config/pull/46) ont été rajoutées à la configuration de renovate et vont permettre d'aligner la version des addons/images postgres et redis de nos fichiers docker-compose, circleci et scalingo.json avec les versions publiées par Scalingo. Cependant, pour que cela puisse fonctionner, nous devons d'abord fixer les versions des addons de Scalingo dans le fichier de configuration.   

## :gift: Proposition
- Définir la version en dur dans le fichier `scalingo.json` plutôt que laisser Scalingo utiliser automatiquement la dernière version disponible lors de la création d'une RA.

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Vérifier que les test passent
- Vérifier que les RA sont bien déployées 