### PR TITLE
[TECH] Retirer le token de la route de telechargement de la feuille d'émargement (PIX-10575).

### DIFF
--- a/api/src/certification/session/application/attendance-sheet-controller.js
+++ b/api/src/certification/session/application/attendance-sheet-controller.js
@@ -1,12 +1,9 @@
 import { usecases } from '../../shared/domain/usecases/index.js';
-import { tokenService } from '../../../shared/domain/services/token-service.js';
 
-const getAttendanceSheet = async function (request, h, dependencies = { tokenService }) {
+const getAttendanceSheet = async function (request, h) {
   const sessionId = request.params.id;
-  const token = request.query.accessToken;
+  const { userId } = request.auth.credentials;
   const i18n = request.i18n;
-
-  const userId = dependencies.tokenService.extractUserId(token);
 
   const { attendanceSheet, fileName } = await usecases.getAttendanceSheet({ sessionId, userId, i18n });
   return h

--- a/api/src/certification/session/application/attendance-sheet-route.js
+++ b/api/src/certification/session/application/attendance-sheet-route.js
@@ -1,8 +1,7 @@
 import Joi from 'joi';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
 import { attendanceSheetController } from './attendance-sheet-controller.js';
-import { LOCALE } from '../../../shared/domain/constants.js';
-const { FRENCH_SPOKEN, ENGLISH_SPOKEN } = LOCALE;
+import { authorization } from '../../../../lib/application/preHandlers/authorization.js';
 
 const register = async function (server) {
   server.route([
@@ -10,16 +9,17 @@ const register = async function (server) {
       method: 'GET',
       path: '/api/sessions/{id}/attendance-sheet',
       config: {
-        auth: false,
         validate: {
-          query: Joi.object({
-            lang: Joi.string().valid(FRENCH_SPOKEN, ENGLISH_SPOKEN),
-            accessToken: Joi.string().required(),
-          }),
           params: Joi.object({
             id: identifiersType.sessionId,
           }),
         },
+        pre: [
+          {
+            method: authorization.verifySessionAuthorization,
+            assign: 'authorizationCheck',
+          },
+        ],
         handler: attendanceSheetController.getAttendanceSheet,
         tags: ['api', 'sessions'],
         notes: [

--- a/api/src/certification/session/domain/usecases/get-attendance-sheet.js
+++ b/api/src/certification/session/domain/usecases/get-attendance-sheet.js
@@ -1,33 +1,19 @@
 /**
- * @typedef {import('../../../shared/domain/usecases/index.js').SessionRepository} SessionRepository
- *
  * @typedef {import('../../../shared/domain/usecases/index.js').SessionForAttendanceSheetRepository} SessionForAttendanceSheetRepository
- *
- *
  * @typedef {import('../../../shared/domain/usecases/index.js').AttendanceSheetPdfUtils} AttendanceSheetPdfUtils
  */
 
-import { UserNotAuthorizedToAccessEntityError } from '../../../../shared/domain/errors.js';
-
 /**
  * @param {Object} params
- * @param {SessionRepository} params.sessionRepository
  * @param {SessionForAttendanceSheetRepository} params.sessionForAttendanceSheetRepository
  * @param {AttendanceSheetPdfUtils} params.attendanceSheetPdfUtils
  */
 const getAttendanceSheet = async function ({
-  userId,
   sessionId,
   i18n,
-  sessionRepository,
   sessionForAttendanceSheetRepository,
   attendanceSheetPdfUtils,
 }) {
-  const hasMembership = await sessionRepository.doesUserHaveCertificationCenterMembershipForSession(userId, sessionId);
-  if (!hasMembership) {
-    throw new UserNotAuthorizedToAccessEntityError('User is not allowed to access session.');
-  }
-
   const session = await sessionForAttendanceSheetRepository.getWithCertificationCandidates(sessionId);
 
   const { attendanceSheet, fileName } = await attendanceSheetPdfUtils.getAttendanceSheetPdfBuffer({

--- a/api/tests/certification/session/unit/application/attendance-sheet-controller_test.js
+++ b/api/tests/certification/session/unit/application/attendance-sheet-controller_test.js
@@ -12,29 +12,22 @@ describe('Unit | Controller | attendance-sheet-controller', function () {
       const userId = 1;
       const fileName = `feuille-emargement-session-${sessionId}.pdf`;
       const attendanceSheet = Buffer.alloc(5);
-      const accessToken = 'ABC123';
 
-      const tokenService = {
-        extractUserId: sinon.stub(),
-      };
       sinon.stub(usecases, 'getAttendanceSheet');
       const request = {
         i18n,
         params: { id: sessionId },
         payload: {},
-        query: {
-          accessToken,
-        },
+        auth: { credentials: { userId } },
       };
 
-      tokenService.extractUserId.withArgs(accessToken).returns(userId);
       usecases.getAttendanceSheet.withArgs({ sessionId, userId, i18n }).resolves({
         fileName,
         attendanceSheet,
       });
 
       // when
-      const response = await attendanceSheetController.getAttendanceSheet(request, hFake, { tokenService });
+      const response = await attendanceSheetController.getAttendanceSheet(request, hFake);
 
       // then
       const expectedHeaders = {

--- a/api/tests/certification/session/unit/application/attendance-sheet-route_test.js
+++ b/api/tests/certification/session/unit/application/attendance-sheet-route_test.js
@@ -1,17 +1,21 @@
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 import * as moduleUnderTest from '../../../../../src/certification/session/application/attendance-sheet-route.js';
 import { attendanceSheetController } from '../../../../../src/certification/session/application/attendance-sheet-controller.js';
+import { authorization } from '../../../../../lib/application/preHandlers/authorization.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 
 describe('Unit | Router | attendance-sheet-route', function () {
   describe('GET /api/sessions/{id}/attendance-sheet', function () {
     it('should exist', async function () {
       // given
+      sinon.stub(authorization, 'verifySessionAuthorization').resolves(true);
       sinon.stub(attendanceSheetController, 'getAttendanceSheet').returns('ok');
+      const auth = { credentials: { userId: 99 }, strategy: {} };
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 
       // when
-      const response = await httpTestServer.request('GET', '/api/sessions/1/attendance-sheet?accessToken=toto&lang=fr');
+      const response = await httpTestServer.request('GET', '/api/sessions/1/attendance-sheet', {}, auth);
 
       // then
       expect(response.statusCode).to.equal(200);
@@ -20,14 +24,12 @@ describe('Unit | Router | attendance-sheet-route', function () {
     describe('when ID params is out of range for database integer (> 2147483647)', function () {
       it(`should return 400`, async function () {
         // given
+        sinon.stub(authorization, 'verifySessionAuthorization').resolves(true);
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
 
         // when
-        const response = await httpTestServer.request(
-          'GET',
-          '/api/sessions/9999999999/attendance-sheet?accessToken=toto&lang=fr',
-        );
+        const response = await httpTestServer.request('GET', '/api/sessions/9999999999/attendance-sheet');
 
         // then
         expect(response.statusCode).to.equal(400);
@@ -37,18 +39,30 @@ describe('Unit | Router | attendance-sheet-route', function () {
     describe('when session ID params is not a number', function () {
       it(`should return 400`, async function () {
         // given
+        sinon.stub(authorization, 'verifySessionAuthorization').resolves(true);
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
 
         // when
-        const response = await httpTestServer.request(
-          'GET',
-          '/api/sessions/salut/attendance-sheet?accessToken=toto&lang=fr',
-        );
+        const response = await httpTestServer.request('GET', '/api/sessions/salut/attendance-sheet');
 
         // then
         expect(response.statusCode).to.equal(400);
       });
+    });
+
+    it('should return 404 if the user is not authorized on the session', async function () {
+      // given
+      sinon.stub(authorization, 'verifySessionAuthorization').throws(new NotFoundError());
+
+      const auth = { credentials: { userId: 99 }, strategy: {} };
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const response = await httpTestServer.request('GET', '/api/sessions/3/attendance-sheet', {}, auth);
+
+      // then
+      expect(response.statusCode).to.equal(404);
     });
   });
 });

--- a/api/tests/certification/session/unit/domain/usecases/get-attendance-sheet_test.js
+++ b/api/tests/certification/session/unit/domain/usecases/get-attendance-sheet_test.js
@@ -1,61 +1,42 @@
-import { catchErr, expect, sinon } from '../../../../../test-helper.js';
+import { expect, sinon } from '../../../../../test-helper.js';
 import { getAttendanceSheet } from '../../../../../../src/certification/session/domain/usecases/get-attendance-sheet.js';
-import { UserNotAuthorizedToAccessEntityError } from '../../../../../../src/shared/domain/errors.js';
 
 describe('Unit | UseCase | get-attendance-sheet', function () {
   describe('getAttendanceSheet', function () {
-    context('user has access to the session', function () {
-      it('should return the attendance sheet in pdf format', async function () {
-        // given
-        const userId = 'dummyUserId';
-        const i18n = 'dummyi18n';
-        const sessionRepository = { doesUserHaveCertificationCenterMembershipForSession: sinon.stub() };
-        const sessionForAttendanceSheetRepository = { getWithCertificationCandidates: sinon.stub() };
-        const session = _buildSessionWithCandidate('SUP', true);
+    it('should return the attendance sheet in pdf format', async function () {
+      // given
+      const userId = 'dummyUserId';
+      const i18n = 'dummyi18n';
+      const sessionRepository = { doesUserHaveCertificationCenterMembershipForSession: sinon.stub() };
+      const sessionForAttendanceSheetRepository = { getWithCertificationCandidates: sinon.stub() };
+      const session = _buildSessionWithCandidate('SUP', true);
 
-        sessionRepository.doesUserHaveCertificationCenterMembershipForSession.resolves(true);
-        sessionForAttendanceSheetRepository.getWithCertificationCandidates.withArgs(1).resolves(session);
+      sessionRepository.doesUserHaveCertificationCenterMembershipForSession.resolves(true);
+      sessionForAttendanceSheetRepository.getWithCertificationCandidates.withArgs(1).resolves(session);
 
-        const pdfBuffer = Buffer.from('some pdf file');
-        const fileName = 'attendance-sheet-example.pdf';
+      const pdfBuffer = Buffer.from('some pdf file');
+      const fileName = 'attendance-sheet-example.pdf';
 
-        const attendanceSheetPdfUtilsStub = {
-          getAttendanceSheetPdfBuffer: sinon.stub(),
-        };
-        attendanceSheetPdfUtilsStub.getAttendanceSheetPdfBuffer
-          .withArgs({ session, i18n })
-          .resolves({ attendanceSheet: pdfBuffer, fileName });
+      const attendanceSheetPdfUtilsStub = {
+        getAttendanceSheetPdfBuffer: sinon.stub(),
+      };
+      attendanceSheetPdfUtilsStub.getAttendanceSheetPdfBuffer
+        .withArgs({ session, i18n })
+        .resolves({ attendanceSheet: pdfBuffer, fileName });
 
-        // when
-        const { attendanceSheet, fileName: expectedFileName } = await getAttendanceSheet({
-          userId,
-          sessionId: 1,
-          i18n,
-          sessionRepository,
-          sessionForAttendanceSheetRepository,
-          attendanceSheetPdfUtils: attendanceSheetPdfUtilsStub,
-        });
-
-        // then
-        expect(attendanceSheet).to.deep.equal(pdfBuffer);
-        expect(expectedFileName).to.equal('attendance-sheet-example.pdf');
+      // when
+      const { attendanceSheet, fileName: expectedFileName } = await getAttendanceSheet({
+        userId,
+        sessionId: 1,
+        i18n,
+        sessionRepository,
+        sessionForAttendanceSheetRepository,
+        attendanceSheetPdfUtils: attendanceSheetPdfUtilsStub,
       });
-    });
 
-    context('user does not have access to the session', function () {
-      it('should return an error', async function () {
-        // given
-        const userId = 'dummyUserId';
-        const sessionId = 'dummySessionId';
-        const sessionRepository = { doesUserHaveCertificationCenterMembershipForSession: sinon.stub() };
-        sessionRepository.doesUserHaveCertificationCenterMembershipForSession.resolves(false);
-
-        // when
-        const result = await catchErr(getAttendanceSheet)({ userId, sessionId, sessionRepository });
-
-        // then
-        expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
-      });
+      // then
+      expect(attendanceSheet).to.deep.equal(pdfBuffer);
+      expect(expectedFileName).to.equal('attendance-sheet-example.pdf');
     });
   });
 });

--- a/certif/app/controllers/authenticated/sessions/details.js
+++ b/certif/app/controllers/authenticated/sessions/details.js
@@ -26,6 +26,16 @@ export default class SessionsDetailsController extends Controller {
     }
   }
 
+  @action
+  async fetchAttendanceSheet() {
+    try {
+      const token = this.session.data.authenticated.access_token;
+      await this.fileSaver.save({ url: this.model.session.urlToDownloadAttendanceSheet, token });
+    } catch (err) {
+      this.notifications.error(this.intl.t('common.api-error-messages.internal-server-error'));
+    }
+  }
+
   get pageTitle() {
     return `${this.intl.t('pages.sessions.detail.page-title')} | Session ${this.model.session.id} | Pix Certif`;
   }

--- a/certif/app/models/session.js
+++ b/certif/app/models/session.js
@@ -37,10 +37,9 @@ export default class Session extends Model {
     return this.status === FINALIZED || this.status === IN_PROCESS || this.status === PROCESSED;
   }
 
-  @computed('id', 'intl.locale', 'session.data.authenticated.access_token')
+  @computed('id')
   get urlToDownloadAttendanceSheet() {
-    const locale = this.intl.locale[0];
-    return `${ENV.APP.API_HOST}/api/sessions/${this.id}/attendance-sheet?accessToken=${this.session.data.authenticated.access_token}&lang=${locale}`;
+    return `${ENV.APP.API_HOST}/api/sessions/${this.id}/attendance-sheet`;
   }
 
   @computed('id')

--- a/certif/app/templates/authenticated/sessions/details.hbs
+++ b/certif/app/templates/authenticated/sessions/details.hbs
@@ -67,20 +67,18 @@
         {{t "pages.sessions.detail.downloads.invigilator-kit.label"}}
       </PixButton>
       {{#if this.shouldDisplayDownloadButton}}
-        <PixButtonLink
+        <PixButton
           class="session-details__controls-download-button"
-          @href="{{this.model.session.urlToDownloadAttendanceSheet}}"
+          @triggerAction={{this.fetchAttendanceSheet}}
           @backgroundColor="transparent-light"
           @isBorderVisible={{true}}
           @size="small"
           target="_blank"
           aria-label={{t "pages.sessions.detail.downloads.attendance-sheet.extra-information"}}
-          rel="noopener noreferrer"
-          download
         >
           <FaIcon @icon="file-download" class="session-details__controls-icon" />
           {{t "pages.sessions.detail.downloads.attendance-sheet.label"}}
-        </PixButtonLink>
+        </PixButton>
       {{/if}}
     </div>
   </div>

--- a/certif/tests/acceptance/session-details_test.js
+++ b/certif/tests/acceptance/session-details_test.js
@@ -141,7 +141,7 @@ module('Acceptance | Session Details', function (hooks) {
         const screen = await visit(`/sessions/${sessionWithCandidates.id}`);
 
         // then
-        assert.dom(screen.getByRole('link', { name: "Télécharger la feuille d'émargement" })).exists();
+        assert.dom(screen.getByRole('button', { name: "Télécharger la feuille d'émargement" })).exists();
       });
 
       test('it should not show download attendance sheet button where there is no candidate', async function (assert) {
@@ -152,7 +152,7 @@ module('Acceptance | Session Details', function (hooks) {
         const screen = await visit(`/sessions/${sessionWithoutCandidate.id}`);
 
         // then
-        assert.dom(screen.queryByRole('link', { name: "Télécharger la feuille d'émargement" })).doesNotExist();
+        assert.dom(screen.queryByRole('button', { name: "Télécharger la feuille d'émargement" })).doesNotExist();
       });
     });
 

--- a/certif/tests/unit/models/session_test.js
+++ b/certif/tests/unit/models/session_test.js
@@ -42,26 +42,10 @@ module('Unit | Model | session', function (hooks) {
     test('it should return the correct urlToDownloadAttendanceSheet', function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      class SessionStub extends Service {
-        data = {
-          authenticated: {
-            access_token: '123',
-          },
-        };
-      }
-      class IntlStub extends Service {
-        locale = ['pt'];
-      }
-
       const model = store.createRecord('session', { id: 1 });
-      this.owner.register('service:session', SessionStub);
-      this.owner.register('service:intl', IntlStub);
 
       // when/then
-      assert.strictEqual(
-        model.urlToDownloadAttendanceSheet,
-        `${config.APP.API_HOST}/api/sessions/1/attendance-sheet?accessToken=123&lang=pt`,
-      );
+      assert.strictEqual(model.urlToDownloadAttendanceSheet, `${config.APP.API_HOST}/api/sessions/1/attendance-sheet`);
     });
   });
 
@@ -69,21 +53,7 @@ module('Unit | Model | session', function (hooks) {
     test('it should return the correct urlToDownloadCandidatesImportTemplate', function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-
-      class SessionStub extends Service {
-        data = {
-          authenticated: {
-            access_token: '123',
-          },
-        };
-      }
-      class IntlStub extends Service {
-        locale = ['dk'];
-      }
-
       const model = store.createRecord('session', { id: 1 });
-      this.owner.register('service:session', SessionStub);
-      this.owner.register('service:intl', IntlStub);
 
       // when/then
       assert.strictEqual(


### PR DESCRIPTION
## :christmas_tree: Problème
On ne souhaite plus passer par un token en query parameter pour télécharger la feuille d'emargement
Cela permet par ailleurs d'utiliser l'authentification "classique"

## :gift: Proposition
Utiliser le service file-saver qui permet de ne pas passer le token sur la route /api/sessions/{id}/attendance-sheet

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
s’assurer que l’on peut telecharger la feuille d’émargement