### PR TITLE
[TECH] Retirer le token de la route de telechargement de la feuille d'import des candidats (PIX-10576).

### DIFF
--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -136,12 +136,17 @@ const register = async function (server) {
       method: 'GET',
       path: '/api/sessions/{id}/candidates-import-sheet',
       config: {
-        auth: false,
         validate: {
           params: Joi.object({
             id: identifiersType.sessionId,
           }),
         },
+        pre: [
+          {
+            method: authorization.verifySessionAuthorization,
+            assign: 'authorizationCheck',
+          },
+        ],
         handler: sessionController.getCandidatesImportSheet,
         tags: ['api', 'sessions'],
         notes: [

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -53,15 +53,10 @@ const get = async function (request, h, dependencies = { sessionSerializer }) {
   return dependencies.sessionSerializer.serialize({ session, hasSupervisorAccess, hasSomeCleaAcquired });
 };
 
-const getCandidatesImportSheet = async function (
-  request,
-  h,
-  dependencies = { tokenService, fillCandidatesImportSheet },
-) {
+const getCandidatesImportSheet = async function (request, h, dependencies = { fillCandidatesImportSheet }) {
   const translate = request.i18n.__;
   const sessionId = request.params.id;
-  const token = request.query.accessToken;
-  const userId = dependencies.tokenService.extractUserId(token);
+  const { userId } = request.auth.credentials;
   const filename = translate('candidate-list-template.filename');
 
   const { session, certificationCenterHabilitations, isScoCertificationCenter } =

--- a/api/lib/domain/usecases/get-candidate-import-sheet-data.js
+++ b/api/lib/domain/usecases/get-candidate-import-sheet-data.js
@@ -1,16 +1,4 @@
-import { UserNotAuthorizedToAccessEntityError } from '../errors.js';
-
-const getCandidateImportSheetData = async function ({
-  userId,
-  sessionId,
-  sessionRepository,
-  certificationCenterRepository,
-}) {
-  const hasMembership = await sessionRepository.doesUserHaveCertificationCenterMembershipForSession(userId, sessionId);
-  if (!hasMembership) {
-    throw new UserNotAuthorizedToAccessEntityError('User is not allowed to access session.');
-  }
-
+const getCandidateImportSheetData = async function ({ sessionId, sessionRepository, certificationCenterRepository }) {
   const session = await sessionRepository.getWithCertificationCandidates(sessionId);
   const certificationCenter = await certificationCenterRepository.getBySessionId(sessionId);
 

--- a/api/tests/acceptance/application/session/session-controller-get-candidates-import-sheet_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-candidates-import-sheet_test.js
@@ -9,10 +9,9 @@ describe('Acceptance | Controller | session-controller-get-candidates-import-she
   });
 
   describe('GET /api/sessions/{id}/candidates-import-sheet', function () {
-    let user, sessionIdAllowed, sessionIdNotAllowed;
-    beforeEach(async function () {
+    it('should respond with a 200 when session can be found', async function () {
       // given
-      user = databaseBuilder.factory.buildUser();
+      const user = databaseBuilder.factory.buildUser();
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
       databaseBuilder.factory.buildCertificationCenterMembership({ userId: user.id, certificationCenterId });
 
@@ -23,22 +22,16 @@ describe('Acceptance | Controller | session-controller-get-candidates-import-she
         certificationCenterId: otherCertificationCenterId,
       });
 
-      sessionIdAllowed = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
-      sessionIdNotAllowed = databaseBuilder.factory.buildSession({
-        certificationCenterId: otherCertificationCenterId,
-      }).id;
+      const sessionIdAllowed = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
 
       await databaseBuilder.commit();
-    });
 
-    it('should respond with a 200 when session can be found', async function () {
       // when
-      const authHeader = generateValidRequestAuthorizationHeader(user.id);
-      const token = authHeader.replace('Bearer ', '');
       const options = {
         method: 'GET',
-        url: `/api/sessions/${sessionIdAllowed}/candidates-import-sheet?accessToken=${token}`,
+        url: `/api/sessions/${sessionIdAllowed}/candidates-import-sheet`,
         payload: {},
+        headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
       };
       // when
       const promise = server.inject(options);
@@ -46,24 +39,6 @@ describe('Acceptance | Controller | session-controller-get-candidates-import-she
       // then
       return promise.then((response) => {
         expect(response.statusCode).to.equal(200);
-      });
-    });
-
-    it('should respond with a 403 when user cant access the session', async function () {
-      // when
-      const authHeader = generateValidRequestAuthorizationHeader(user.id);
-      const token = authHeader.replace('Bearer ', '');
-      const options = {
-        method: 'GET',
-        url: `/api/sessions/${sessionIdNotAllowed}/candidates-import-sheet?accessToken=${token}`,
-        payload: {},
-      };
-      // when
-      const promise = server.inject(options);
-
-      // then
-      return promise.then((response) => {
-        expect(response.statusCode).to.equal(403);
       });
     });
   });

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -781,4 +781,35 @@ describe('Unit | Application | Sessions | Routes', function () {
       expect(response.statusCode).to.equal(200);
     });
   });
+
+  describe('GET /api/sessions/{id}//candidates-import-sheet', function () {
+    it('should return 200', async function () {
+      // when
+      sinon.stub(authorization, 'verifySessionAuthorization').resolves(true);
+      sinon.stub(sessionController, 'getCandidatesImportSheet').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const auth = { credentials: { userId: 99 }, strategy: {} };
+
+      const response = await httpTestServer.request('GET', '/api/sessions/3/candidates-import-sheet', {}, auth);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should return 404 if the user is not authorized on the session', async function () {
+      // given
+      sinon.stub(authorization, 'verifySessionAuthorization').throws(new NotFoundError());
+
+      const auth = { credentials: { userId: 99 }, strategy: {} };
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const response = await httpTestServer.request('GET', '/api/sessions/3/candidates-import-sheet', {}, auth);
+
+      // then
+      expect(response.statusCode).to.equal(404);
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/get-candidate-import-sheet-data_test.js
+++ b/api/tests/unit/domain/usecases/get-candidate-import-sheet-data_test.js
@@ -1,6 +1,5 @@
-import { expect, catchErr, sinon, domainBuilder } from '../../../test-helper.js';
+import { expect, sinon, domainBuilder } from '../../../test-helper.js';
 import { getCandidateImportSheetData } from '../../../../lib/domain/usecases/get-candidate-import-sheet-data.js';
-import { UserNotAuthorizedToAccessEntityError } from '../../../../lib/domain/errors.js';
 
 describe('Unit | UseCase | get-candidate-import-sheet-data', function () {
   let sessionRepository;
@@ -14,26 +13,6 @@ describe('Unit | UseCase | get-candidate-import-sheet-data', function () {
     certificationCenterRepository = {
       getBySessionId: sinon.stub(),
     };
-  });
-
-  context('When user is not a member of the certification center which has created the session', function () {
-    it('should throw a UserNotAuthorizedToAccessEntityError', async function () {
-      // given
-      const userId = 123;
-      const sessionId = 456;
-      sessionRepository.doesUserHaveCertificationCenterMembershipForSession.withArgs(userId, sessionId).resolves(false);
-
-      // when
-      const error = await catchErr(getCandidateImportSheetData)({
-        userId,
-        sessionId,
-        sessionRepository,
-        certificationCenterRepository,
-      });
-
-      // then
-      expect(error).to.be.an.instanceOf(UserNotAuthorizedToAccessEntityError);
-    });
   });
 
   it('should get a session with candidates and the certification center habilitations', async function () {

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -92,7 +92,7 @@
     },
     "certification": "Additional",
     "complementary": "certification",
-    "filename": "session-candidate-list",
+    "filename": "session-candidate-list-",
     "headers": {
       "birth-date": "* Date of birth (DD/MM/YYYY format)",
       "birthcity": "Name of birth city",

--- a/certif/app/components/import-candidates.hbs
+++ b/certif/app/components/import-candidates.hbs
@@ -21,14 +21,9 @@
         </p>
       </div>
       <div class="panel-actions__button">
-        <PixButtonLink
-          href="{{@session.urlToDownloadCandidatesImportTemplate}}"
-          target="_blank"
-          rel="noopener noreferrer"
-          download
-        >
+        <PixButton @triggerAction={{@fetchCandidatesImportTemplateAction}} target="_blank">
           {{t "pages.sessions.detail.candidates.panel-actions.actions.download.label"}}
-        </PixButtonLink>
+        </PixButton>
       </div>
     </div>
     <div class="panel-actions__action-row">

--- a/certif/app/controllers/authenticated/sessions/details.js
+++ b/certif/app/controllers/authenticated/sessions/details.js
@@ -25,6 +25,7 @@ export default class SessionsDetailsController extends Controller {
       this.notifications.error(this.intl.t('common.api-error-messages.internal-server-error'));
     }
   }
+
   get pageTitle() {
     return `${this.intl.t('pages.sessions.detail.page-title')} | Session ${this.model.session.id} | Pix Certif`;
   }

--- a/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
@@ -9,6 +9,9 @@ import { service } from '@ember/service';
 export default class CertificationCandidatesController extends Controller {
   @service currentUser;
   @service intl;
+  @service notifications;
+  @service fileSaver;
+  @service session;
 
   @alias('model.session') currentSession;
   @alias('model.certificationCandidates') certificationCandidates;
@@ -36,6 +39,16 @@ export default class CertificationCandidatesController extends Controller {
 
   get shouldDisplayPrescriptionScoStudentRegistrationFeature() {
     return this.currentUser.currentAllowedCertificationCenterAccess.isScoManagingStudents;
+  }
+
+  @action
+  async fetchCandidatesImportTemplate() {
+    try {
+      const token = this.session.data.authenticated.access_token;
+      await this.fileSaver.save({ url: this.model.session.urlToDownloadCandidatesImportTemplate, token });
+    } catch (err) {
+      this.notifications.error(this.intl.t('common.api-error-messages.internal-server-error'));
+    }
   }
 
   @action

--- a/certif/app/models/session.js
+++ b/certif/app/models/session.js
@@ -43,10 +43,9 @@ export default class Session extends Model {
     return `${ENV.APP.API_HOST}/api/sessions/${this.id}/attendance-sheet?accessToken=${this.session.data.authenticated.access_token}&lang=${locale}`;
   }
 
-  @computed('id', 'intl.locale', 'session.data.authenticated.access_token')
+  @computed('id')
   get urlToDownloadCandidatesImportTemplate() {
-    const locale = this.intl.locale[0];
-    return `${ENV.APP.API_HOST}/api/sessions/${this.id}/candidates-import-sheet?accessToken=${this.session.data.authenticated.access_token}&lang=${locale}`;
+    return `${ENV.APP.API_HOST}/api/sessions/${this.id}/candidates-import-sheet`;
   }
 
   @computed('id')

--- a/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
+++ b/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
@@ -19,6 +19,7 @@
     @certificationCandidates={{this.certificationCandidates}}
     @reloadCertificationCandidate={{this.reloadCertificationCandidateInController}}
     @importAllowed={{this.importAllowed}}
+    @fetchCandidatesImportTemplateAction={{this.fetchCandidatesImportTemplate}}
   />
   <EnrolledCandidates
     @shouldDisplayPrescriptionScoStudentRegistrationFeature={{this.shouldDisplayPrescriptionScoStudentRegistrationFeature}}

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -80,7 +80,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
         const screen = await visit(`/sessions/${session.id}/candidats`);
 
         // then
-        assert.dom(screen.getByRole('link', { name: 'Télécharger (.ods)' })).exists();
+        assert.dom(screen.getByRole('button', { name: 'Télécharger (.ods)' })).exists();
         assert.dom(screen.getByRole('button', { name: 'Importer (.ods)' })).exists();
       });
 

--- a/certif/tests/unit/models/session_test.js
+++ b/certif/tests/unit/models/session_test.js
@@ -88,7 +88,7 @@ module('Unit | Model | session', function (hooks) {
       // when/then
       assert.strictEqual(
         model.urlToDownloadCandidatesImportTemplate,
-        `${config.APP.API_HOST}/api/sessions/1/candidates-import-sheet?accessToken=123&lang=dk`,
+        `${config.APP.API_HOST}/api/sessions/1/candidates-import-sheet`,
       );
     });
   });


### PR DESCRIPTION
## :christmas_tree: Problème
On ne souhaite plus passer par un token en query parameter pour télécharger la feuille d'import des candidats
Cela permet par ailleurs d'utiliser l'authentification "classique"

## :gift: Proposition
Utiliser le service file-saver qui permet de ne pas passer le token sur la route /api/sessions/{id}/candidates-import-sheet

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
s’assurer que l’on peut telecharger la feuille d’import des candidats