### PR TITLE
[TECH] Retirer le token de la route de telechargement du kit de surveillant (PIX-10577).

### DIFF
--- a/api/lib/application/preHandlers/authorization.js
+++ b/api/lib/application/preHandlers/authorization.js
@@ -2,11 +2,15 @@ import { NotFoundError } from '../http-errors.js';
 import * as certificationCourseRepository from '../../../src/certification/shared/infrastructure/repositories/certification-course-repository.js';
 import * as sessionRepository from '../../../src/certification/session/infrastructure/repositories/session-repository.js';
 
-const verifySessionAuthorization = async (request, h, dependencies = { sessionRepository }) => {
+const verifySessionAuthorization = (request, h, dependencies = { sessionRepository }) => {
   const userId = request.auth.credentials.userId;
   const sessionId = request.params.id;
 
-  return await _isAuthorizedToAccessSession({ userId, sessionId, sessionRepository: dependencies.sessionRepository });
+  return _isAuthorizedToAccessSession({
+    userId,
+    sessionId,
+    sessionRepository: dependencies.sessionRepository,
+  });
 };
 
 const verifyCertificationSessionAuthorization = async (
@@ -19,7 +23,7 @@ const verifyCertificationSessionAuthorization = async (
 
   const certificationCourse = await dependencies.certificationCourseRepository.get(certificationCourseId);
 
-  return await _isAuthorizedToAccessSession({
+  return _isAuthorizedToAccessSession({
     userId,
     sessionId: certificationCourse.getSessionId(),
     sessionRepository: dependencies.sessionRepository,

--- a/api/src/certification/session/application/invigilator-kit-controller.js
+++ b/api/src/certification/session/application/invigilator-kit-controller.js
@@ -1,22 +1,17 @@
 import { usecases } from '../../shared/domain/usecases/index.js';
-import { tokenService } from '../../../shared/domain/services/token-service.js';
 import * as requestResponseUtils from '../../../../lib/infrastructure/utils/request-response-utils.js';
 import * as invigilatorKitPdf from '../infrastructure/utils/pdf/invigilator-kit-pdf.js';
 
-const getInvigilatorKitPdf = async function (
-  request,
-  h,
-  dependencies = { tokenService, requestResponseUtils, invigilatorKitPdf },
-) {
+const getInvigilatorKitPdf = async function (request, h, dependencies = { requestResponseUtils, invigilatorKitPdf }) {
   const sessionId = request.params.id;
-  const token = request.query.accessToken;
-  const userId = dependencies.tokenService.extractUserId(token);
-  const { lang } = request.query;
+  const { userId } = request.auth.credentials;
+  const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
+
   const sessionForInvigilatorKit = await usecases.getInvigilatorKitSessionInfo({ sessionId, userId });
 
   const { buffer, fileName } = await dependencies.invigilatorKitPdf.getInvigilatorKitPdfBuffer({
     sessionForInvigilatorKit,
-    lang,
+    lang: locale,
   });
 
   return h

--- a/api/src/certification/session/application/invigilator-kit-controller.js
+++ b/api/src/certification/session/application/invigilator-kit-controller.js
@@ -1,17 +1,15 @@
 import { usecases } from '../../shared/domain/usecases/index.js';
-import * as requestResponseUtils from '../../../../lib/infrastructure/utils/request-response-utils.js';
 import * as invigilatorKitPdf from '../infrastructure/utils/pdf/invigilator-kit-pdf.js';
 
-const getInvigilatorKitPdf = async function (request, h, dependencies = { requestResponseUtils, invigilatorKitPdf }) {
+const getInvigilatorKitPdf = async function (request, h, dependencies = { invigilatorKitPdf }) {
   const sessionId = request.params.id;
   const { userId } = request.auth.credentials;
-  const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
-
+  const lang = request.i18n.getLocale();
   const sessionForInvigilatorKit = await usecases.getInvigilatorKitSessionInfo({ sessionId, userId });
 
   const { buffer, fileName } = await dependencies.invigilatorKitPdf.getInvigilatorKitPdfBuffer({
     sessionForInvigilatorKit,
-    lang: locale,
+    lang,
   });
 
   return h

--- a/api/src/certification/session/application/invigilator-kit-route.js
+++ b/api/src/certification/session/application/invigilator-kit-route.js
@@ -1,6 +1,7 @@
 import Joi from 'joi';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
 import { invigilatorKitController } from './invigilator-kit-controller.js';
+import { authorization } from '../../../../lib/application/preHandlers/authorization.js';
 
 const register = async function (server) {
   server.route([
@@ -8,12 +9,17 @@ const register = async function (server) {
       method: 'GET',
       path: '/api/sessions/{id}/supervisor-kit',
       config: {
-        auth: false,
         validate: {
           params: Joi.object({
             id: identifiersType.sessionId,
           }),
         },
+        pre: [
+          {
+            method: authorization.verifySessionAuthorization,
+            assign: 'authorizationCheck',
+          },
+        ],
         handler: invigilatorKitController.getInvigilatorKitPdf,
         tags: ['api', 'sessions', 'invigilator'],
         notes: [

--- a/api/src/certification/session/domain/usecases/get-invigilator-kit-session-info.js
+++ b/api/src/certification/session/domain/usecases/get-invigilator-kit-session-info.js
@@ -1,28 +1,13 @@
 /**
- * @typedef {import('../../../shared/domain/usecases/index.js').SessionRepository} SessionRepository
- *
  * @typedef {import('../../../shared/domain/usecases/index.js').SessionForInvigilatorKitRepository} SessionForInvigilatorKitRepository
  */
 
-import { UserNotAuthorizedToAccessEntityError } from '../../../../shared/domain/errors.js';
-
 /**
  * @param {Object} params
- * @param {SessionRepository} params.sessionRepository
  * @param {SessionForInvigilatorKitRepository} params.sessionForInvigilatorKitRepository
  */
-const getInvigilatorKitSessionInfo = async function ({
-  userId,
-  sessionId,
-  sessionRepository,
-  sessionForInvigilatorKitRepository,
-}) {
-  const hasMembership = await sessionRepository.doesUserHaveCertificationCenterMembershipForSession(userId, sessionId);
-  if (!hasMembership) {
-    throw new UserNotAuthorizedToAccessEntityError('User is not allowed to access session.');
-  }
-
-  return await sessionForInvigilatorKitRepository.get(sessionId);
+const getInvigilatorKitSessionInfo = async function ({ sessionId, sessionForInvigilatorKitRepository }) {
+  return sessionForInvigilatorKitRepository.get(sessionId);
 };
 
 export { getInvigilatorKitSessionInfo };

--- a/api/tests/acceptance/application/session/session-controller-get-supervisor-kit-PDF_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-supervisor-kit-PDF_test.js
@@ -9,7 +9,7 @@ describe('Acceptance | Controller | session-controller-get-supervisor-kit-pdf', 
   });
 
   describe('GET /api/sessions/{id}/supervisor-kit', function () {
-    let user, sessionIdAllowed, sessionIdNotAllowed;
+    let user, sessionIdAllowed;
     beforeEach(async function () {
       // given
       user = databaseBuilder.factory.buildUser();
@@ -25,21 +25,17 @@ describe('Acceptance | Controller | session-controller-get-supervisor-kit-pdf', 
       });
 
       sessionIdAllowed = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
-      sessionIdNotAllowed = databaseBuilder.factory.buildSession({
-        certificationCenterId: otherCertificationCenterId,
-      }).id;
 
       await databaseBuilder.commit();
     });
 
     it('should respond with a 200 when session can be found', async function () {
       // when
-      const authHeader = generateValidRequestAuthorizationHeader(user.id);
-      const token = authHeader.replace('Bearer ', '');
       const options = {
         method: 'GET',
-        url: `/api/sessions/${sessionIdAllowed}/supervisor-kit?accessToken=${token}&lang=fr`,
+        url: `/api/sessions/${sessionIdAllowed}/supervisor-kit`,
         payload: {},
+        headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
       };
       // when
       const promise = server.inject(options);
@@ -47,24 +43,6 @@ describe('Acceptance | Controller | session-controller-get-supervisor-kit-pdf', 
       // then
       return promise.then((response) => {
         expect(response.statusCode).to.equal(200);
-      });
-    });
-
-    it('should respond with a 403 when user cant access the session', async function () {
-      // when
-      const authHeader = generateValidRequestAuthorizationHeader(user.id);
-      const token = authHeader.replace('Bearer ', '');
-      const options = {
-        method: 'GET',
-        url: `/api/sessions/${sessionIdNotAllowed}/supervisor-kit?accessToken=${token}`,
-        payload: {},
-      };
-      // when
-      const promise = server.inject(options);
-
-      // then
-      return promise.then((response) => {
-        expect(response.statusCode).to.equal(403);
       });
     });
   });

--- a/api/tests/certification/session/unit/application/invigilator-kit-controller_test.js
+++ b/api/tests/certification/session/unit/application/invigilator-kit-controller_test.js
@@ -11,33 +11,30 @@ describe('Unit | Controller | invigilator-kit-controller', function () {
       const invigilatorKitBuffer = 'binary string';
       const userId = 1;
       const request = {
+        headers: {
+          'accept-language': 'fr',
+        },
         auth: { credentials: { userId } },
         params: { id: sessionMainInfo.id },
-        query: {
-          accessToken: 'ACCESS_TOKEN',
-        },
-      };
-      const tokenService = {
-        extractUserId: sinon.stub(),
       };
       const requestResponseUtils = {
         extractLocaleFromRequest: sinon.stub(),
       };
-      tokenService.extractUserId.withArgs(request.query.accessToken).returns(userId);
       const invigilatorKitPdf = {
         getInvigilatorKitPdfBuffer: sinon.stub(),
       };
+
+      requestResponseUtils.extractLocaleFromRequest.withArgs(request.headers['accept-language']).resolves('fr');
+      usecases.getInvigilatorKitSessionInfo.resolves(sessionMainInfo);
       invigilatorKitPdf.getInvigilatorKitPdfBuffer.resolves({
         buffer: invigilatorKitBuffer,
         fileName: `kit-surveillant-${sessionMainInfo.id}.pdf`,
       });
-      usecases.getInvigilatorKitSessionInfo.resolves(sessionMainInfo);
 
       // when
       const response = await invigilatorKitController.getInvigilatorKitPdf(request, hFake, {
-        tokenService,
-        requestResponseUtils,
         invigilatorKitPdf,
+        requestResponseUtils,
       });
 
       // then

--- a/api/tests/certification/session/unit/application/invigilator-kit-controller_test.js
+++ b/api/tests/certification/session/unit/application/invigilator-kit-controller_test.js
@@ -1,49 +1,57 @@
 import { domainBuilder, expect, hFake, sinon } from '../../../../test-helper.js';
 import { usecases } from '../../../../../src/certification/shared/domain/usecases/index.js';
 import { invigilatorKitController } from '../../../../../src/certification/session/application/invigilator-kit-controller.js';
+import { getI18n } from '../../../../tooling/i18n/i18n.js';
+import { LANG } from '../../../../../src/shared/domain/constants.js';
 
 describe('Unit | Controller | invigilator-kit-controller', function () {
   describe('#getInvigilatorKitPdf', function () {
-    it('should return invigilator kit', async function () {
-      // given
-      sinon.stub(usecases, 'getInvigilatorKitSessionInfo');
-      const sessionMainInfo = domainBuilder.buildSessionForInvigilatorKit({ id: 1 });
-      const invigilatorKitBuffer = 'binary string';
-      const userId = 1;
-      const request = {
-        headers: {
-          'accept-language': 'fr',
-        },
-        auth: { credentials: { userId } },
-        params: { id: sessionMainInfo.id },
-      };
-      const requestResponseUtils = {
-        extractLocaleFromRequest: sinon.stub(),
-      };
-      const invigilatorKitPdf = {
-        getInvigilatorKitPdfBuffer: sinon.stub(),
-      };
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
+    /* eslint-disable mocha/no-setup-in-describe */
+    [
+      { lang: LANG.ENGLISH, filename: 'invigilator-kit-1.pdf' },
+      { lang: LANG.FRENCH, filename: 'kit-surveillant-1.pdf' },
+    ].forEach(function ({ lang, filename }) {
+      /* eslint-enable mocha/no-setup-in-describe */
+      it(`should return invigilator kit in ${lang}`, async function () {
+        // given
+        sinon.stub(usecases, 'getInvigilatorKitSessionInfo');
+        const sessionMainInfo = domainBuilder.buildSessionForInvigilatorKit({ id: 1 });
+        const invigilatorKitBuffer = 'binary string';
+        const userId = 1;
+        const i18n = getI18n();
+        const request = {
+          i18n,
+          auth: { credentials: { userId } },
+          params: { id: sessionMainInfo.id },
+        };
+        i18n.setLocale(lang);
 
-      requestResponseUtils.extractLocaleFromRequest.withArgs(request.headers['accept-language']).resolves('fr');
-      usecases.getInvigilatorKitSessionInfo.resolves(sessionMainInfo);
-      invigilatorKitPdf.getInvigilatorKitPdfBuffer.resolves({
-        buffer: invigilatorKitBuffer,
-        fileName: `kit-surveillant-${sessionMainInfo.id}.pdf`,
-      });
+        const invigilatorKitPdf = {
+          getInvigilatorKitPdfBuffer: sinon.stub(),
+        };
 
-      // when
-      const response = await invigilatorKitController.getInvigilatorKitPdf(request, hFake, {
-        invigilatorKitPdf,
-        requestResponseUtils,
-      });
+        usecases.getInvigilatorKitSessionInfo.resolves(sessionMainInfo);
+        invigilatorKitPdf.getInvigilatorKitPdfBuffer
+          .withArgs({ sessionForInvigilatorKit: sessionMainInfo, lang })
+          .resolves({
+            buffer: invigilatorKitBuffer,
+            fileName: filename,
+          });
 
-      // then
-      expect(usecases.getInvigilatorKitSessionInfo).to.have.been.calledWithExactly({
-        userId,
-        sessionId: sessionMainInfo.id,
+        // when
+        const response = await invigilatorKitController.getInvigilatorKitPdf(request, hFake, {
+          invigilatorKitPdf,
+        });
+
+        // then
+        expect(usecases.getInvigilatorKitSessionInfo).to.have.been.calledWithExactly({
+          userId,
+          sessionId: sessionMainInfo.id,
+        });
+        expect(response.source).to.deep.equal(invigilatorKitBuffer);
+        expect(response.headers['Content-Disposition']).to.contains(`attachment; filename=${filename}`);
       });
-      expect(response.source).to.deep.equal(invigilatorKitBuffer);
-      expect(response.headers['Content-Disposition']).to.contains(`attachment; filename=kit-surveillant-1.pdf`);
     });
   });
 });

--- a/api/tests/certification/session/unit/application/invigilator-kit-route_test.js
+++ b/api/tests/certification/session/unit/application/invigilator-kit-route_test.js
@@ -1,19 +1,38 @@
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 import * as moduleUnderTest from '../../../../../src/certification/session/application/invigilator-kit-route.js';
 import { invigilatorKitController } from '../../../../../src/certification/session/application/invigilator-kit-controller.js';
+import { authorization } from '../../../../../lib/application/preHandlers/authorization.js';
+import { NotFoundError } from '../../../../../lib/domain/errors.js';
 
 describe('Unit | Router | invigilator-kit-route', function () {
   describe('GET /api/sessions/{id}/supervisor-kit', function () {
     it('should return 200', async function () {
       // when
+      sinon.stub(authorization, 'verifySessionAuthorization').resolves(true);
       sinon.stub(invigilatorKitController, 'getInvigilatorKitPdf').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 
-      const response = await httpTestServer.request('GET', '/api/sessions/3/supervisor-kit');
+      const auth = { credentials: { userId: 99 }, strategy: {} };
+
+      const response = await httpTestServer.request('GET', '/api/sessions/3/supervisor-kit', {}, auth);
 
       // then
       expect(response.statusCode).to.equal(200);
+    });
+
+    it('should return 404 if the user is not authorized on the session', async function () {
+      // given
+      sinon.stub(authorization, 'verifySessionAuthorization').throws(new NotFoundError());
+
+      const auth = { credentials: { userId: 99 }, strategy: {} };
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const response = await httpTestServer.request('GET', '/api/sessions/3/supervisor-kit', {}, auth);
+
+      // then
+      expect(response.statusCode).to.equal(404);
     });
   });
 });

--- a/api/tests/certification/session/unit/domain/usecases/get-invigilator-kit-session-info_test.js
+++ b/api/tests/certification/session/unit/domain/usecases/get-invigilator-kit-session-info_test.js
@@ -1,17 +1,39 @@
-import { expect, sinon, domainBuilder, catchErr } from '../../../../../test-helper.js';
+import { expect, sinon, domainBuilder } from '../../../../../test-helper.js';
 import { getInvigilatorKitSessionInfo } from '../../../../../../src/certification/session/domain/usecases/get-invigilator-kit-session-info.js';
-import { UserNotAuthorizedToAccessEntityError } from '../../../../../../src/shared/domain/errors.js';
 import { SessionForInvigilatorKit } from '../../../../../../src/certification/session/domain/read-models/SessionForInvigilatorKit.js';
 
 describe('Unit | UseCase | get-invigilator-kit-info', function () {
   describe('getInvigilatorKitSessionInfo', function () {
-    context('when user has access to the session', function () {
-      it('should return the session main info', async function () {
-        // given
-        const userId = 'dummyUserId';
-        const sessionId = 'dummySessionId';
-        const sessionForInvigilatorKitRepository = { get: sinon.stub() };
-        const sessionForInvigilatorKit = domainBuilder.buildSessionForInvigilatorKit({
+    it('should return the session main info', async function () {
+      // given
+      const userId = 'dummyUserId';
+      const sessionId = 'dummySessionId';
+      const sessionForInvigilatorKitRepository = { get: sinon.stub() };
+      const sessionForInvigilatorKit = domainBuilder.buildSessionForInvigilatorKit({
+        id: 1000,
+        examiner: 'Toto',
+        address: '3 rue ketanou',
+        room: '54',
+        date: '2021-01-01',
+        time: '10:53',
+        invigilatorPassword: '12AB5',
+        accessCode: '1B3DE6',
+      });
+      sessionForInvigilatorKitRepository.get.withArgs(sessionId).resolves(sessionForInvigilatorKit);
+      const sessionRepository = { doesUserHaveCertificationCenterMembershipForSession: sinon.stub() };
+      sessionRepository.doesUserHaveCertificationCenterMembershipForSession.resolves(true);
+
+      // when
+      const result = await getInvigilatorKitSessionInfo({
+        userId,
+        sessionId,
+        sessionRepository,
+        sessionForInvigilatorKitRepository,
+      });
+
+      // then
+      expect(result).to.deepEqualInstance(
+        new SessionForInvigilatorKit({
           id: 1000,
           examiner: 'Toto',
           address: '3 rue ketanou',
@@ -20,50 +42,9 @@ describe('Unit | UseCase | get-invigilator-kit-info', function () {
           time: '10:53',
           invigilatorPassword: '12AB5',
           accessCode: '1B3DE6',
-        });
-        sessionForInvigilatorKitRepository.get.withArgs(sessionId).resolves(sessionForInvigilatorKit);
-        const sessionRepository = { doesUserHaveCertificationCenterMembershipForSession: sinon.stub() };
-        sessionRepository.doesUserHaveCertificationCenterMembershipForSession.resolves(true);
-
-        // when
-        const result = await getInvigilatorKitSessionInfo({
-          userId,
-          sessionId,
-          sessionRepository,
-          sessionForInvigilatorKitRepository,
-        });
-
-        // then
-        expect(result).to.deepEqualInstance(
-          new SessionForInvigilatorKit({
-            id: 1000,
-            examiner: 'Toto',
-            address: '3 rue ketanou',
-            room: '54',
-            date: '2021-01-01',
-            time: '10:53',
-            invigilatorPassword: '12AB5',
-            accessCode: '1B3DE6',
-            version: 2,
-          }),
-        );
-      });
-    });
-
-    context('when user does not have access to the session', function () {
-      it('should return an error', async function () {
-        // given
-        const userId = 'dummyUserId';
-        const sessionId = 'dummySessionId';
-        const sessionRepository = { doesUserHaveCertificationCenterMembershipForSession: sinon.stub() };
-        sessionRepository.doesUserHaveCertificationCenterMembershipForSession.resolves(false);
-
-        // when
-        const error = await catchErr(getInvigilatorKitSessionInfo)({ userId, sessionId, sessionRepository });
-
-        // then
-        expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
-      });
+          version: 2,
+        }),
+      );
     });
   });
 });

--- a/certif/app/controllers/authenticated/sessions/details.js
+++ b/certif/app/controllers/authenticated/sessions/details.js
@@ -1,5 +1,6 @@
 import Controller from '@ember/controller';
 import { service } from '@ember/service';
+import { action } from '@ember/object';
 /* eslint-disable ember/no-computed-properties-in-native-classes*/
 import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
@@ -9,12 +10,23 @@ export default class SessionsDetailsController extends Controller {
   @service currentUser;
   @service intl;
   @service url;
+  @service session;
+  @service notifications;
+  @service fileSaver;
 
-  @alias('model.session') session;
   @alias('model.certificationCandidates') certificationCandidates;
 
+  @action
+  async fetchInvigilatorKit() {
+    try {
+      const token = this.session.data.authenticated.access_token;
+      await this.fileSaver.save({ url: this.model.session.urlToDownloadSupervisorKitPdf, token });
+    } catch (err) {
+      this.notifications.error(this.intl.t('common.api-error-messages.internal-server-error'));
+    }
+  }
   get pageTitle() {
-    return `${this.intl.t('pages.sessions.detail.page-title')} | Session ${this.session.id} | Pix Certif`;
+    return `${this.intl.t('pages.sessions.detail.page-title')} | Session ${this.model.session.id} | Pix Certif`;
   }
 
   @computed('certificationCandidates.length')
@@ -39,7 +51,7 @@ export default class SessionsDetailsController extends Controller {
   }
 
   get urlToDownloadSessionIssueReportSheet() {
-    if (this.session.version === 3) {
+    if (this.model.session.version === 3) {
       return this.url.urlToDownloadSessionV3IssueReportSheet;
     }
     return this.url.urlToDownloadSessionIssueReportSheet;

--- a/certif/app/models/session.js
+++ b/certif/app/models/session.js
@@ -49,10 +49,9 @@ export default class Session extends Model {
     return `${ENV.APP.API_HOST}/api/sessions/${this.id}/candidates-import-sheet?accessToken=${this.session.data.authenticated.access_token}&lang=${locale}`;
   }
 
-  @computed('id', 'intl.locale', 'session.data.authenticated.access_token')
+  @computed('id')
   get urlToDownloadSupervisorKitPdf() {
-    const locale = this.intl.locale[0];
-    return `${ENV.APP.API_HOST}/api/sessions/${this.id}/supervisor-kit?accessToken=${this.session.data.authenticated.access_token}&lang=${locale}`;
+    return `${ENV.APP.API_HOST}/api/sessions/${this.id}/supervisor-kit`;
   }
 
   @computed('id')

--- a/certif/app/services/file-saver.js
+++ b/certif/app/services/file-saver.js
@@ -1,7 +1,10 @@
 import Service from '@ember/service';
 import fetch from 'fetch';
+import { service } from '@ember/service';
 
 export default class FileSaverService extends Service {
+  @service intl;
+
   async save({
     url,
     token,
@@ -9,7 +12,7 @@ export default class FileSaverService extends Service {
     downloadFileForIEBrowser = _downloadFileForIEBrowser,
     downloadFileForModernBrowsers = _downloadFileForModernBrowsers,
   }) {
-    const response = await fetcher({ url, token });
+    const response = await fetcher({ url, token, locale: this.locale });
 
     if (response.status !== 200) {
       const jsonResponse = await response.json();
@@ -25,11 +28,16 @@ export default class FileSaverService extends Service {
       ? downloadFileForIEBrowser({ fileContent, fileName })
       : downloadFileForModernBrowsers({ fileContent, fileName });
   }
+
+  get locale() {
+    const [currentLocale] = this.intl.get('locale');
+    return currentLocale;
+  }
 }
 
-function _fetchData({ url, token }) {
+function _fetchData({ url, token, locale }) {
   return fetch(url, {
-    headers: { Authorization: `Bearer ${token}` },
+    headers: { Authorization: `Bearer ${token}`, 'Accept-Language': locale },
   });
 }
 

--- a/certif/app/styles/pages/authenticated/sessions/details.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details.scss
@@ -12,9 +12,9 @@
 
 .session-details__header {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
   flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
   margin-bottom: 16px;
 }
 
@@ -37,16 +37,16 @@
 .session-details-header-datetime {
 
   &__date {
-    padding-right: 40px;
     margin-right: 40px;
+    padding-right: 40px;
     border-right: 1px solid $pix-neutral-20;
   }
 
   &__text {
-    font-size: 0.875rem;
-    font-weight: 400;
     margin: 0;
     padding: 8px 0;
+    font-weight: 400;
+    font-size: 0.875rem;
   }
 }
 
@@ -75,10 +75,10 @@
   padding: 16px;
 
   &--multiple {
-    border-right: 1px solid $pix-neutral-20;
-    padding: 0 24px;
     margin: 16px 0;
+    padding: 0 24px;
     white-space: nowrap;
+    border-right: 1px solid $pix-neutral-20;
 
     &:last-child {
       border-right: 0;
@@ -86,11 +86,11 @@
   }
 
   &--copyable {
-    background: $pix-neutral-5;
     margin: 16px 0 16px 8px;
     padding: 8px 16px;
-    border-radius: 4px;
+    background: $pix-neutral-5;
     border: 0;
+    border-radius: 4px;
   }
 
   &--single {
@@ -98,14 +98,14 @@
   }
 
   &__label {
-    margin: 0;
-    min-height: 32px;
-    font-weight: 500;
-    font-size: 0.875rem;
-    color: $pix-neutral-90;
     display: flex;
     flex-direction: column;
     justify-content: center;
+    min-height: 32px;
+    margin: 0;
+    color: $pix-neutral-90;
+    font-weight: 500;
+    font-size: 0.875rem;
   }
 
   &__sub-label {
@@ -115,15 +115,15 @@
   }
 
   &__text {
-    font-size: 0.875rem;
     margin: 0;
     padding: 8px 0;
+    font-size: 0.875rem;
   }
 
   &__clipboard {
-    align-items: center;
     display: flex;
     flex-direction: row;
+    align-items: center;
   }
 
   &__return-button {
@@ -148,44 +148,44 @@
   }
 
   &__clea-results-download-grey {
+    display: flex;
     padding: 16px;
     background: $pix-neutral-5;
-    display: flex;
   }
 
   &__clea-results-download-title {
+    margin: 0 0 8px;
+    color: $pix-neutral-90;
     font-weight: 500;
     font-size: 20px;
-    color: $pix-neutral-90;
-    margin: 0 0 8px;
     font-family: $font-open-sans;
   }
 
   &__clea-results-download-description {
+    margin-bottom: 12px;
     color: $pix-neutral-60;
     font-size: 0.875rem;
-    margin-bottom: 12px;
   }
 
   &__clea-results-download-icon {
-    width: 80px;
-    padding: 2px;
-    margin-right: 16px;
-    justify-content: center;
-    align-items: center;
     display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 80px;
+    margin-right: 16px;
+    padding: 2px;
 
     svg {
-      font-size: 40px;
       color: $pix-neutral-40;
+      font-size: 40px;
     }
   }
 
   &__controls {
     display: flex;
+    flex-direction: column;
     justify-content: space-between;
     margin: 1em 0;
-    flex-direction: column;
 
     @include device-is("desktop") {
       flex-direction: row;
@@ -197,26 +197,23 @@
   }
 
   &__controls-title {
-    color: $pix-neutral-90;
-    font-size: 0.875rem;
-    font-weight: 500;
     margin-right: 8px;
+    color: $pix-neutral-90;
+    font-weight: 500;
+    font-size: 0.875rem;
   }
 
   &__controls-links {
-    align-items: center;
     display: flex;
     flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
     justify-content: right;
     padding: 12px 16px;
 
     @include device-is("desktop") {
       flex-direction: row;
     }
-  }
-
-  &__controls-download-button:not(:last-of-type) {
-    margin-right: 8px;
   }
 
   &__controls-icon {

--- a/certif/app/templates/authenticated/sessions/details.hbs
+++ b/certif/app/templates/authenticated/sessions/details.hbs
@@ -5,28 +5,28 @@
   </PixReturnTo>
   <div class="page__title session-details__header">
     <div class="session-details-header__title">
-      <h1 class="page-title">{{t "pages.sessions.detail.title" sessionId=this.session.id}}</h1>
+      <h1 class="page-title">{{t "pages.sessions.detail.title" sessionId=this.model.session.id}}</h1>
     </div>
 
     <div class="session-details-header__datetime">
       <div class="session-details-header-datetime__date">
         <h2 class="label-text session-details-content__label">{{t "common.forms.session-labels.date"}}</h2>
         <span class="content-text content-text--big session-details-header-datetime__text">
-          {{dayjs-format this.session.date "dddd DD MMM YYYY" allow-empty=true}}
+          {{dayjs-format this.model.session.date "dddd DD MMM YYYY" allow-empty=true}}
         </span>
       </div>
 
       <div>
         <h2 class="label-text session-details-content__label">{{t "common.forms.session-labels.time-start"}}</h2>
         <span class="content-text content-text--big session-details-header-datetime__text">
-          {{dayjs-format this.session.time "HH:mm" inputFormat="HH:mm:ss" allow-empty=true}}
+          {{dayjs-format this.model.session.time "HH:mm" inputFormat="HH:mm:ss" allow-empty=true}}
         </span>
       </div>
     </div>
   </div>
 
-  {{#if this.session.shouldDisplayCleaResultDownloadSection}}
-    <SessionCleaResultsDownload @session={{this.session}} />
+  {{#if this.model.session.shouldDisplayCleaResultDownloadSection}}
+    <SessionCleaResultsDownload @session={{this.model.session}} />
   {{/if}}
 
   <div class="panel session-details__controls">
@@ -55,24 +55,21 @@
         <FaIcon @icon="file-download" class="session-details__controls-icon" />
         {{t "pages.sessions.detail.downloads.incident-report.label"}}
       </PixButtonLink>
-      <PixButtonLink
+      <PixButton
         class="session-details__controls-download-button"
-        @href="{{this.session.urlToDownloadSupervisorKitPdf}}"
         @backgroundColor="transparent-light"
         @isBorderVisible={{true}}
         @size="small"
-        target="_blank"
         aria-label={{t "pages.sessions.detail.downloads.invigilator-kit.extra-information"}}
-        rel="noopener noreferrer"
-        download
+        @triggerAction={{this.fetchInvigilatorKit}}
       >
         <FaIcon @icon="file-download" class="session-details__controls-icon" />
         {{t "pages.sessions.detail.downloads.invigilator-kit.label"}}
-      </PixButtonLink>
+      </PixButton>
       {{#if this.shouldDisplayDownloadButton}}
         <PixButtonLink
           class="session-details__controls-download-button"
-          @href="{{this.session.urlToDownloadAttendanceSheet}}"
+          @href="{{this.model.session.urlToDownloadAttendanceSheet}}"
           @backgroundColor="transparent-light"
           @isBorderVisible={{true}}
           @size="small"

--- a/certif/tests/acceptance/session-details_test.js
+++ b/certif/tests/acceptance/session-details_test.js
@@ -117,7 +117,7 @@ module('Acceptance | Session Details', function (hooks) {
         assert
           .dom(screen.getByRole('link', { name: "Télécharger le PV d'incident" }))
           .hasAttribute('href', 'https://cloud.pix.fr/s/B76yA8ip9Radej9/download');
-        assert.dom(screen.getByRole('link', { name: 'Télécharger le kit surveillant' })).exists();
+        assert.dom(screen.getByRole('button', { name: 'Télécharger le kit surveillant' })).exists();
       });
 
       test('it should show issue report sheet download button', async function (assert) {

--- a/certif/tests/unit/models/session_test.js
+++ b/certif/tests/unit/models/session_test.js
@@ -20,18 +20,10 @@ module('Unit | Model | session', function (hooks) {
         };
       }
 
-      class IntlStub extends Service {
-        locale = ['dk'];
-      }
-
       this.owner.register('service:session', SessionStub);
-      this.owner.register('service:intl', IntlStub);
 
       // when/then
-      assert.strictEqual(
-        model.urlToDownloadSupervisorKitPdf,
-        `${config.APP.API_HOST}/api/sessions/1/supervisor-kit?accessToken=123&lang=dk`,
-      );
+      assert.strictEqual(model.urlToDownloadSupervisorKitPdf, `${config.APP.API_HOST}/api/sessions/1/supervisor-kit`);
     });
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème
On ne souhaite plus passer par un token **en query parameter** pour télécharger le kit surveillant

## :gift: Proposition
Utiliser le service file-saver qui permet de ne pas passer le token sur la route /api/sessions/{id}/supervisor-kit

## :santa: Pour tester
* Pix Certif, s’assurer que l’on peut telecharger le kit surveillant