### PR TITLE
[TECH] :recycle: migration API LearningContentResourceNotFound (PIX-10619)

### DIFF
--- a/api/lib/domain/usecases/get-correction-for-answer.js
+++ b/api/lib/domain/usecases/get-correction-for-answer.js
@@ -1,5 +1,5 @@
 import { AssessmentNotCompletedError, NotFoundError } from '../errors.js';
-import { LearningContentResourceNotFound } from '../../infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
+import { LearningContentResourceNotFound } from '../../../src/shared/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
 import { InternalServerError } from '../../application/http-errors.js';
 
 const getCorrectionForAnswer = async function ({

--- a/api/lib/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js
+++ b/api/lib/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js
@@ -1,8 +1,0 @@
-class LearningContentResourceNotFound extends Error {
-  constructor({ skillId } = {}) {
-    super();
-    this.skillId = skillId;
-  }
-}
-
-export { LearningContentResourceNotFound };

--- a/api/lib/infrastructure/datasources/learning-content/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/learning-content/challenge-datasource.js
@@ -1,6 +1,6 @@
 import isEmpty from 'lodash/isEmpty.js';
 import * as datasource from './datasource.js';
-import { LearningContentResourceNotFound } from './LearningContentResourceNotFound.js';
+import { LearningContentResourceNotFound } from '../../../../src/shared/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
 
 const VALIDATED_CHALLENGE = 'validé';
 // donnée temporaire pour pix1d le temps d'arriver en « prod »

--- a/api/lib/infrastructure/datasources/learning-content/datasource.js
+++ b/api/lib/infrastructure/datasources/learning-content/datasource.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { lcms } from '../../lcms.js';
-import { LearningContentResourceNotFound } from './LearningContentResourceNotFound.js';
+import { LearningContentResourceNotFound } from '../../../../src/shared/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
 import { LearningContentCache } from '../../caches/learning-content-cache.js';
 
 const _DatasourcePrototype = {

--- a/api/lib/infrastructure/repositories/course-repository.js
+++ b/api/lib/infrastructure/repositories/course-repository.js
@@ -1,6 +1,6 @@
 import { Course } from '../../domain/models/Course.js';
 import { courseDatasource } from '../datasources/learning-content/course-datasource.js';
-import { LearningContentResourceNotFound } from '../datasources/learning-content/LearningContentResourceNotFound.js';
+import { LearningContentResourceNotFound } from '../../../src/shared/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
 import { NotFoundError } from '../../domain/errors.js';
 
 function _toDomain(courseDataObject) {

--- a/api/lib/infrastructure/repositories/thematic-repository.js
+++ b/api/lib/infrastructure/repositories/thematic-repository.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { Thematic } from '../../domain/models/Thematic.js';
-import { thematicDatasource } from '../datasources/learning-content/thematic-datasource.js';
+import { thematicDatasource } from '../../../src/shared/infrastructure/datasources/learning-content/thematic-datasource.js';
 import { getTranslatedKey } from '../../domain/services/get-translated-text.js';
 import { LOCALE } from '../../../src/shared/domain/constants.js';
 

--- a/api/src/school/infrastructure/repositories/challenge-repository.js
+++ b/api/src/school/infrastructure/repositories/challenge-repository.js
@@ -1,4 +1,4 @@
-import { LearningContentResourceNotFound } from '../../../../lib/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
+import { LearningContentResourceNotFound } from '../../../shared/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
 import { Challenge } from '../../../../lib/domain/models/index.js';
 import {

--- a/api/src/school/infrastructure/repositories/mission-repository.js
+++ b/api/src/school/infrastructure/repositories/mission-repository.js
@@ -1,5 +1,5 @@
 import { Mission } from '../../domain/models/Mission.js';
-import { thematicDatasource } from '../../../../lib/infrastructure/datasources/learning-content/thematic-datasource.js';
+import { thematicDatasource } from '../../../shared/infrastructure/datasources/learning-content/thematic-datasource.js';
 import { getTranslatedKey } from '../../../../lib/domain/services/get-translated-text.js';
 import { LOCALE } from '../../../shared/domain/constants.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';

--- a/api/src/shared/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js
+++ b/api/src/shared/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js
@@ -1,6 +1,7 @@
 class LearningContentResourceNotFound extends Error {
-  constructor() {
+  constructor({ skillId } = {}) {
     super();
+    this.skillId = skillId;
   }
 }
 

--- a/api/src/shared/infrastructure/datasources/learning-content/thematic-datasource.js
+++ b/api/src/shared/infrastructure/datasources/learning-content/thematic-datasource.js
@@ -1,4 +1,4 @@
-import * as datasource from './datasource.js';
+import * as datasource from '../../../../../lib/infrastructure/datasources/learning-content/datasource.js';
 
 const thematicDatasource = datasource.extend({
   modelName: 'thematics',

--- a/api/src/shared/infrastructure/repositories/challenge-repository.js
+++ b/api/src/shared/infrastructure/repositories/challenge-repository.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { Challenge } from '../../../../lib/domain/models/index.js';
 import * as skillAdapter from '../../../../lib/infrastructure/adapters/skill-adapter.js';
 import * as solutionAdapter from '../../../../lib/infrastructure/adapters/solution-adapter.js';
-import { LearningContentResourceNotFound } from '../../../../lib/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
+import { LearningContentResourceNotFound } from '../datasources/learning-content/LearningContentResourceNotFound.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
 import { config } from '../../../../lib/config.js';
 import {

--- a/api/src/shared/infrastructure/repositories/competence-repository.js
+++ b/api/src/shared/infrastructure/repositories/competence-repository.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { LearningContentResourceNotFound } from '../../../../lib/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
+import { LearningContentResourceNotFound } from '../datasources/learning-content/LearningContentResourceNotFound.js';
 import { Competence } from '../../domain/models/Competence.js';
 import { competenceDatasource } from '../../../../lib/infrastructure/datasources/learning-content/competence-datasource.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';

--- a/api/tests/shared/unit/infrastructure/datasources/learning-content/datasource_test.js
+++ b/api/tests/shared/unit/infrastructure/datasources/learning-content/datasource_test.js
@@ -1,8 +1,8 @@
-import { expect, sinon } from '../../../../test-helper.js';
-import * as dataSource from '../../../../../lib/infrastructure/datasources/learning-content/datasource.js';
-import { lcms } from '../../../../../lib/infrastructure/lcms.js';
-import { LearningContentResourceNotFound } from '../../../../../lib/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
-import { learningContentCache } from '../../../../../lib/infrastructure/caches/learning-content-cache.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+import * as dataSource from '../../../../../../lib/infrastructure/datasources/learning-content/datasource.js';
+import { lcms } from '../../../../../../lib/infrastructure/lcms.js';
+import { LearningContentResourceNotFound } from '../../../../../../src/shared/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
+import { learningContentCache } from '../../../../../../lib/infrastructure/caches/learning-content-cache.js';
 
 describe('Unit | Infrastructure | Datasource | Learning Content | datasource', function () {
   let someDatasource;

--- a/api/tests/shared/unit/infrastructure/datasources/learning-content/thematic-datasource_test.js
+++ b/api/tests/shared/unit/infrastructure/datasources/learning-content/thematic-datasource_test.js
@@ -1,6 +1,6 @@
-import { sinon, expect } from '../../../../test-helper.js';
-import { lcms } from '../../../../../lib/infrastructure/lcms.js';
-import { thematicDatasource } from '../../../../../lib/infrastructure/datasources/learning-content/thematic-datasource.js';
+import { sinon, expect } from '../../../../../test-helper.js';
+import { lcms } from '../../../../../../lib/infrastructure/lcms.js';
+import { thematicDatasource } from '../../../../../../src/shared/infrastructure/datasources/learning-content/thematic-datasource.js';
 
 describe('Unit | Infrastructure | Datasource | Learning Content | ThematicDatasource', function () {
   describe('#findByCompetenceIds', function () {

--- a/api/tests/tooling/learning-content-builder/build-learning-content_test.js
+++ b/api/tests/tooling/learning-content-builder/build-learning-content_test.js
@@ -1,7 +1,7 @@
 import { expect, learningContentBuilder, mockLearningContent } from '../../test-helper.js';
 import { areaDatasource } from '../../../lib/infrastructure/datasources/learning-content/area-datasource.js';
 import { competenceDatasource } from '../../../lib/infrastructure/datasources/learning-content/competence-datasource.js';
-import { thematicDatasource } from '../../../lib/infrastructure/datasources/learning-content/thematic-datasource.js';
+import { thematicDatasource } from '../../../src/shared/infrastructure/datasources/learning-content/thematic-datasource.js';
 import { tubeDatasource } from '../../../lib/infrastructure/datasources/learning-content/tube-datasource.js';
 import { skillDatasource } from '../../../lib/infrastructure/datasources/learning-content/skill-datasource.js';
 import { challengeDatasource } from '../../../lib/infrastructure/datasources/learning-content/challenge-datasource.js';

--- a/api/tests/unit/domain/usecases/get-correction-for-answer_test.js
+++ b/api/tests/unit/domain/usecases/get-correction-for-answer_test.js
@@ -3,7 +3,7 @@ import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
 import { Answer } from '../../../../src/evaluation/domain/models/Answer.js';
 import { AssessmentNotCompletedError, NotFoundError } from '../../../../lib/domain/errors.js';
 import { expect, sinon, catchErr, domainBuilder } from '../../../test-helper.js';
-import { LearningContentResourceNotFound } from '../../../../lib/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
+import { LearningContentResourceNotFound } from '../../../../src/shared/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
 import { InternalServerError } from '../../../../lib/application/http-errors.js';
 
 describe('Unit | UseCase | getCorrectionForAnswer', function () {

--- a/api/tests/unit/infrastructure/datasources/learning-content/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/learning-content/challenge-datasource_test.js
@@ -3,7 +3,7 @@ import { expect, sinon, catchErr } from '../../../../test-helper.js';
 import { lcms } from '../../../../../lib/infrastructure/lcms.js';
 import { challengeDatasource } from '../../../../../lib/infrastructure/datasources/learning-content/challenge-datasource.js';
 import { learningContentCache } from '../../../../../lib/infrastructure/caches/learning-content-cache.js';
-import { LearningContentResourceNotFound } from '../../../../../lib/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
+import { LearningContentResourceNotFound } from '../../../../../src/shared/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
 
 describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatasource', function () {
   let competence1,


### PR DESCRIPTION
## :christmas_tree: Problème

Dans le repertoire API, la plupart des fichiers sont a plat dans les repertoires technique. C'est difficile de retrouver les éléments lié à un domaine / sous domaine.

## :gift: Proposition

Dans le cadre de la migration https://github.com/1024pix/pix/blob/dev/docs/adr/0051-nouvelle-arborescence-api.md cette PR déplace le fichier LearningContentResourceNotFound.

## :socks: Remarques

## :santa: Pour tester

La CI doit rester :heavy_check_mark: 