### PR TITLE
[FEATURE] Passer un grain (PIX-10296).

### DIFF
--- a/mon-pix/app/pods/components/module/details/template.hbs
+++ b/mon-pix/app/pods/components/module/details/template.hbs
@@ -13,6 +13,7 @@
         @submitAnswer={{@submitAnswer}}
         @canDisplayContinueButton={{this.grainCanDisplayContinueButton index}}
         @continueAction={{this.addNextGrainToDisplay}}
+        @skipAction={{this.addNextGrainToDisplay}}
       />
     {{/each}}
   </div>

--- a/mon-pix/app/pods/components/module/grain/component.js
+++ b/mon-pix/app/pods/components/module/grain/component.js
@@ -9,6 +9,10 @@ export default class ModuleGrain extends Component {
     return this.args.canDisplayContinueButton && this.allElementsAreAnswered;
   }
 
+  get shouldDisplaySkipButton() {
+    return this.args.grain.hasAnswerableElements && !this.allElementsAreAnswered;
+  }
+
   get allElementsAreAnswered() {
     return this.args.grain.allElementsAreAnswered;
   }
@@ -21,6 +25,17 @@ export default class ModuleGrain extends Component {
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.grain.module.id}`,
       'pix-event-name': `Click sur le bouton continuer du grain : ${this.args.grain.id}`,
+    });
+  }
+
+  @action
+  skipAction() {
+    this.args.skipAction();
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Modulix',
+      'pix-event-action': `Passage du module : ${this.args.grain.module.id}`,
+      'pix-event-name': `Click sur le bouton passer du grain : ${this.args.grain.id}`,
     });
   }
 }

--- a/mon-pix/app/pods/components/module/grain/template.hbs
+++ b/mon-pix/app/pods/components/module/grain/template.hbs
@@ -19,6 +19,19 @@
     {{/if}}
   {{/each}}
 
+  {{#if this.shouldDisplaySkipButton}}
+    <footer class="grain__footer">
+      <PixButton
+        @backgroundColor="transparent-light"
+        @isBorderVisible={{true}}
+        @shape="rounded"
+        @triggerAction={{this.skipAction}}
+      >
+        {{t "pages.modulix.buttons.grain.skip"}}
+      </PixButton>
+    </footer>
+  {{/if}}
+
   {{#if this.shouldDisplayContinueButton}}
     <footer class="grain__footer">
       <PixButton @backgroundColor="blue" @shape="rounded" @triggerAction={{this.continueAction}}>

--- a/mon-pix/app/pods/grain/model.js
+++ b/mon-pix/app/pods/grain/model.js
@@ -6,6 +6,10 @@ export default class Grain extends Model {
   @hasMany('element', { async: false, polymorphic: true, inverse: 'grain' }) elements;
   @belongsTo('module', { async: false, inverse: 'grains' }) module;
 
+  get hasAnswerableElements() {
+    return this.elements.some((element) => element.isAnswerable);
+  }
+
   get answerableElements() {
     return this.elements.filter((element) => {
       return element.isAnswerable;

--- a/mon-pix/tests/acceptance/module/visit-module-page_test.js
+++ b/mon-pix/tests/acceptance/module/visit-module-page_test.js
@@ -10,9 +10,13 @@ module('Acceptance | Module | Routes | get', function (hooks) {
 
   test('can visit /modules/:slug', async function (assert) {
     // given
+    const grain = server.create('grain', {
+      id: 'grain1',
+    });
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
       title: 'Bien écrire son adresse mail',
+      grains: [grain],
     });
 
     // when
@@ -24,6 +28,9 @@ module('Acceptance | Module | Routes | get', function (hooks) {
 
   test('should include the module title inside the page title', async function (assert) {
     // given
+    const grain = server.create('grain', {
+      id: 'grain1',
+    });
     const module = {
       title: 'Bien écrire son adresse mail',
     };
@@ -31,6 +38,7 @@ module('Acceptance | Module | Routes | get', function (hooks) {
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
       title: module.title,
+      grains: [grain],
     });
 
     // when

--- a/mon-pix/tests/integration/components/module/details_test.js
+++ b/mon-pix/tests/integration/components/module/details_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { render } from '@1024pix/ember-testing-library';
+import { clickByName, render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import { findAll } from '@ember/test-helpers';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
@@ -59,5 +59,33 @@ module('Integration | Component | Module | Details', function (hooks) {
     assert.strictEqual(findAll('.element-qcu').length, 0);
 
     assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists({ count: 1 });
+  });
+
+  module('when user click on skip button', function () {
+    test('should display next grain', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const textElement = store.createRecord('text', { content: 'content', type: 'texts' });
+      const qcuElement = store.createRecord('qcu', {
+        instruction: 'instruction',
+        proposals: ['radio1', 'radio2'],
+        type: 'qcus',
+        isAnswerable: true,
+      });
+      const grain1 = store.createRecord('grain', { elements: [qcuElement] });
+      const grain2 = store.createRecord('grain', { elements: [textElement] });
+
+      const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+      this.set('module', module);
+
+      await render(hbs`<Module::Details @module={{this.module}} />`);
+      assert.strictEqual(findAll('.element-text').length, 0);
+
+      // when
+      await clickByName(this.intl.t('pages.modulix.buttons.grain.skip'));
+
+      // then
+      assert.strictEqual(findAll('.element-text').length, 1);
+    });
   });
 });

--- a/mon-pix/tests/integration/components/module/grain_test.js
+++ b/mon-pix/tests/integration/components/module/grain_test.js
@@ -176,6 +176,27 @@ module('Integration | Component | Module | Grain', function (hooks) {
   });
 
   module('when all elements are answered', function () {
+    test('should not display skip button', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const element = store.createRecord('element', { type: 'qcus', isAnswerable: true });
+      const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+      this.set('grain', grain);
+
+      const correction = store.createRecord('correction-response');
+      store.createRecord('element-answer', { element, correction });
+      assert.true(grain.allElementsAreAnswered);
+
+      // when
+      const screen = await render(hbs`
+            <Module::Grain @grain={{this.grain}} @canDisplayContinueButton={{true}} />`);
+
+      // then
+      assert
+        .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') }))
+        .doesNotExist();
+    });
+
     module('when canDisplayContinueButton is true', function () {
       test('should display continue button', async function (assert) {
         // given
@@ -217,6 +238,23 @@ module('Integration | Component | Module | Grain', function (hooks) {
   });
 
   module('when not any element are answered', function () {
+    test('should display skip button', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const element = store.createRecord('element', { type: 'qcus', isAnswerable: true });
+      const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+      this.set('grain', grain);
+
+      assert.false(grain.allElementsAreAnswered);
+
+      // when
+      const screen = await render(hbs`
+            <Module::Grain @grain={{this.grain}} @canDisplayContinueButton={{true}} />`);
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') })).exists();
+    });
+
     module('when canDisplayContinueButton is true', function () {
       test('should not display continue button', async function (assert) {
         // given
@@ -282,6 +320,40 @@ module('Integration | Component | Module | Grain', function (hooks) {
         'pix-event-category': 'Modulix',
         'pix-event-action': `Passage du module : ${this.grain.module.id}`,
         'pix-event-name': `Click sur le bouton continuer du grain : ${this.grain.id}`,
+      });
+      assert.ok(true);
+    });
+  });
+
+  module('when skipAction is called', function () {
+    test('should call skipAction pass in argument and push event', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const element = store.createRecord('qcu', { type: 'qcus', isAnswerable: true });
+      const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+      store.createRecord('module', { id: 'module-id', grains: [grain] });
+      this.set('grain', grain);
+
+      const skipActionStub = sinon.stub();
+      this.set('skipAction', skipActionStub);
+      const metrics = this.owner.lookup('service:metrics');
+      metrics.add = sinon.stub();
+
+      this.set('continueAction', () => {});
+
+      // when
+      await render(
+        hbs`<Module::Grain @grain={{this.grain}} @canDisplayContinueButton={{true}} @continueAction={{this.continueAction}} @skipAction={{this.skipAction}} />`,
+      );
+      await clickByName(this.intl.t('pages.modulix.buttons.grain.skip'));
+
+      // then
+      sinon.assert.calledOnce(skipActionStub);
+      sinon.assert.calledWithExactly(metrics.add, {
+        event: 'custom-event',
+        'pix-event-category': 'Modulix',
+        'pix-event-action': `Passage du module : ${this.grain.module.id}`,
+        'pix-event-name': `Click sur le bouton passer du grain : ${this.grain.id}`,
       });
       assert.ok(true);
     });

--- a/mon-pix/tests/integration/components/module/grain_test.js
+++ b/mon-pix/tests/integration/components/module/grain_test.js
@@ -175,8 +175,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
     });
   });
 
-  module('when canDisplayContinueButton is true', function () {
-    module('when all elements are answered', function () {
+  module('when all elements are answered', function () {
+    module('when canDisplayContinueButton is true', function () {
       test('should display continue button', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
@@ -189,14 +189,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
         assert.true(grain.allElementsAreAnswered);
 
         // when
-        const screen = await render(hbs`<Module::Grain @grain={{this.grain}} @canDisplayContinueButton={{true}} />`);
+        const screen = await render(hbs`
+            <Module::Grain @grain={{this.grain}} @canDisplayContinueButton={{true}} />`);
 
         // then
         assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists();
       });
     });
-
-    module('when not any element are answered', function () {
+    module('when canDisplayContinueButton is false', function () {
       test('should not display continue button', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
@@ -207,7 +207,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
         assert.false(grain.allElementsAreAnswered);
 
         // when
-        const screen = await render(hbs`<Module::Grain @grain={{this.grain}} @canDisplayContinueButton={{true}} />`);
+        const screen = await render(hbs`
+            <Module::Grain @grain={{this.grain}} @canDisplayContinueButton={{false}} />`);
 
         // then
         assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
@@ -215,28 +216,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
     });
   });
 
-  module('when canDisplayContinueButton is false', function () {
-    module('when all elements are answered', function () {
-      test('should not display continue button', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const element = store.createRecord('element', { type: 'qcus', isAnswerable: true });
-        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
-        this.set('grain', grain);
-
-        const correction = store.createRecord('correction-response');
-        store.createRecord('element-answer', { element, correction });
-        assert.true(grain.allElementsAreAnswered);
-
-        // when
-        const screen = await render(hbs`<Module::Grain @grain={{this.grain}} @canDisplayContinueButton={{false}} />`);
-
-        // then
-        assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
-      });
-    });
-
-    module('when not any element are answered', function () {
+  module('when not any element are answered', function () {
+    module('when canDisplayContinueButton is true', function () {
       test('should not display continue button', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
@@ -247,7 +228,26 @@ module('Integration | Component | Module | Grain', function (hooks) {
         assert.false(grain.allElementsAreAnswered);
 
         // when
-        const screen = await render(hbs`<Module::Grain @grain={{this.grain}} @canDisplayContinueButton={{false}} />`);
+        const screen = await render(hbs`
+            <Module::Grain @grain={{this.grain}} @canDisplayContinueButton={{true}} />`);
+
+        // then
+        assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+      });
+    });
+    module('when canDisplayContinueButton is false', function () {
+      test('should not display continue button', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = store.createRecord('element', { type: 'qcus', isAnswerable: true });
+        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+        this.set('grain', grain);
+
+        assert.false(grain.allElementsAreAnswered);
+
+        // when
+        const screen = await render(hbs`
+            <Module::Grain @grain={{this.grain}} @canDisplayContinueButton={{false}} />`);
 
         // then
         assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();

--- a/mon-pix/tests/unit/models/modules/grain_test.js
+++ b/mon-pix/tests/unit/models/modules/grain_test.js
@@ -4,6 +4,44 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Model | Module | Grain', function (hooks) {
   setupTest(hooks);
 
+  module('#hasAnswerableElements', function () {
+    module('when there are answerable elements in grain', function () {
+      test('should return true', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const qcu = store.createRecord('qcu', { type: 'qcus', isAnswerable: true });
+        const qrocm = store.createRecord('qrocm', { type: 'qrocms', isAnswerable: true });
+        const text = store.createRecord('text', { type: 'texts', isAnswerable: false });
+        const grain = store.createRecord('grain', {
+          elements: [qcu, qrocm, text],
+        });
+
+        // when
+        const hasAnswerableElements = grain.hasAnswerableElements;
+
+        // then
+        assert.true(hasAnswerableElements);
+      });
+    });
+
+    module('when there are no answerable element in grain', function () {
+      test('should return false', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const text = store.createRecord('text', { type: 'texts', isAnswerable: false });
+        const grain = store.createRecord('grain', {
+          elements: [text],
+        });
+
+        // when
+        const hasAnswerableElements = grain.hasAnswerableElements;
+
+        // then
+        assert.false(hasAnswerableElements);
+      });
+    });
+  });
+
   module('#answerableElements', function () {
     module('when there are answerable elements in elements', function () {
       test('should return only answerable elements', function (assert) {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1192,7 +1192,8 @@
           "transcription": "Show transcription"
         },
         "grain": {
-          "continue": "Continue"
+          "continue": "Continue",
+          "skip": "Skip"
         }
       },
       "modals": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1192,7 +1192,8 @@
           "transcription": "Afficher la transcription"
         },
         "grain": {
-          "continue": "Continuer"
+          "continue": "Continuer",
+          "skip": "Passer"
         }
       },
       "modals": {


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, un apprenant doit répondre à tous les éléments pour accéder au grain suivant, c'est contraignant. 

## :gift: Proposition
Ajouter un bouton passer quand l'utilisateur n'a pas encore répondu à tous les grains et que le grain en question a des éléments qui nécessitent une réponse.

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Sur Pix App aller sur la page `/modules/bien-ecrire-son-adresse-mail`.
- Faire continuer sur les deux premier grain 
- En arrivant sur le troisième grain, vous devez voir le bouton Passer (car il y a un QROCM) 
- Répondre à tous les QROCM et voir que le bouton se transforme en Continuer
- Sur le grain d'après cliquer sur Passer et voir que le grain d'après s'affiche