### PR TITLE
[FEATURE] Ajout de la colonne parentOrganizationId dans la table organizations (PIX-10044)

### DIFF
--- a/api/db/database-builder/database-builder.js
+++ b/api/db/database-builder/database-builder.js
@@ -160,7 +160,9 @@ class DatabaseBuilder {
       from pg_class ref
       join pg_namespace rs on rs.oid = ref.relnamespace
       join pg_constraint c on c.contype = 'f' and c.conrelid = ref.oid
-      join fk_tree p on p.reloid = c.confrelid ), all_tables as (
+      join fk_tree p on p.reloid = c.confrelid
+      where ref.oid != p.reloid),
+      all_tables as (
       select schema_name, table_name, level, row_number() over (partition by schema_name, table_name order by level desc) as
       last_table_row from fk_tree )
       select table_name

--- a/api/db/database-builder/factory/build-organization.js
+++ b/api/db/database-builder/factory/build-organization.js
@@ -20,6 +20,7 @@ const buildOrganization = function buildOrganization({
   archivedBy = null,
   archivedAt = null,
   identityProviderForCampaigns = null,
+  parentOrganizationId = null,
 } = {}) {
   const values = {
     id,
@@ -41,6 +42,7 @@ const buildOrganization = function buildOrganization({
     archivedBy,
     archivedAt,
     identityProviderForCampaigns,
+    parentOrganizationId,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/db/migrations/20240104142232_add-parent-organization-id-field-in-organization-table.js
+++ b/api/db/migrations/20240104142232_add-parent-organization-id-field-in-organization-table.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'organizations';
+const COLUMN_NAME = 'parentOrganizationId';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME).defaultTo(null).references('organizations.id');
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { up, down };

--- a/api/db/seeds/data/common/tooling/organization-tooling.js
+++ b/api/db/seeds/data/common/tooling/organization-tooling.js
@@ -58,6 +58,7 @@ async function createOrganization({
   tagIds = [],
   featureIds = [],
   configOrganization,
+  parentOrganizationId,
 }) {
   organizationId = _buildOrganization({
     databaseBuilder,
@@ -80,6 +81,7 @@ async function createOrganization({
     archivedBy,
     archivedAt,
     identityProviderForCampaigns,
+    parentOrganizationId,
   }).id;
 
   _buildMemberships({
@@ -202,6 +204,7 @@ function _buildOrganization({
   archivedBy,
   archivedAt,
   identityProviderForCampaigns,
+  parentOrganizationId,
 }) {
   return databaseBuilder.factory.buildOrganization({
     id: organizationId,
@@ -223,5 +226,6 @@ function _buildOrganization({
     archivedBy,
     archivedAt,
     identityProviderForCampaigns,
+    parentOrganizationId,
   });
 }

--- a/api/tests/integration/tooling/database-builder/database-builder_test.js
+++ b/api/tests/integration/tooling/database-builder/database-builder_test.js
@@ -1,5 +1,6 @@
-import { expect, knex } from '../../../test-helper.js';
+import { databaseBuilder, expect, knex } from '../../../test-helper.js';
 import { DatabaseBuilder } from '../../../../db/database-builder/database-builder.js';
+import { createOrganization } from '../../../../db/seeds/data/common/tooling/organization-tooling.js';
 
 describe('Integration | Tooling | DatabaseBuilder | database-builder', function () {
   describe('#create', function () {
@@ -11,6 +12,31 @@ describe('Integration | Tooling | DatabaseBuilder | database-builder', function 
       // then
       expect(databaseBuilder).to.be.an.instanceOf(DatabaseBuilder);
       expect(databaseBuilder.isFirstCommit).to.be.false;
+    });
+  });
+
+  describe('#clean', function () {
+    context('when there is circular references', function () {
+      it('cleans properly the database', async function () {
+        // given
+        const grandParentOrganizationId = databaseBuilder.factory.buildOrganization().id;
+        const parentOrganizationId = databaseBuilder.factory.buildOrganization({
+          parentOrganizationId: grandParentOrganizationId,
+        }).id;
+        databaseBuilder.factory.buildOrganization({ parentOrganizationId });
+        const tagIds = [
+          databaseBuilder.factory.buildTag({ name: 'AGRICULTURE' }).id,
+          databaseBuilder.factory.buildTag({ name: 'PUBLIC' }).id,
+        ];
+
+        await createOrganization({ databaseBuilder, tagIds, parentOrganizationId });
+
+        await databaseBuilder.commit();
+
+        // when
+        // then
+        expect(async () => await databaseBuilder.clean()).to.not.throw();
+      });
     });
   });
 });

--- a/api/tests/shared/prescriber-management/integration/infrasctructure/repositories/user-orga-settings-repository_test.js
+++ b/api/tests/shared/prescriber-management/integration/infrasctructure/repositories/user-orga-settings-repository_test.js
@@ -32,6 +32,7 @@ describe('Integration | Repository | UserOrgaSettings', function () {
     'archivedAt',
     'archivedBy',
     'identityProviderForCampaigns',
+    'parentOrganizationId',
   ];
 
   let user;


### PR DESCRIPTION
## :christmas_tree: Problème
Nous avons besoin d'un champ parentOrganizationId dans la table `organizations`.

## :gift: Proposition
Ajouter la migration qui permet de faire ça.

## :socks: Remarques

- La requête pour lister les tables et les dépendances dans le database builder a été modifié pour pouvoir gérer les clés étrangères référençant la même table. On s'est basé sur cette discussion stackoverflow  : https://stackoverflow.com/questions/51279588/sort-tables-in-order-of-dependency-postgres pour ajouter la ligne `where ref.oid != p.reloid`

## :santa: Pour tester
- Lançer la commande `npm run db:migrate` en local
- Vérifier que la colonne `parentOrganizationId` a bien été ajouté dans la table organizations.
- Ajouter un id d'organization existant dans le champ `parentOrganizationId` et vérifier que ça fonctionne.
- Ajouter un id d'organization qui n'existe pas dans le champ `parentOrganizationId` et vérifier qu'il y a bien une erreur.
- Lançer la commande `npm run db:rollback:latest`et vérifier que la colonne `parentOrganizationId` n'existe plus.
