### PR TITLE
[TECH] Configurer Nodemon pour redémarrer quand on édite `module.json` (PIX-10621)

### DIFF
--- a/api/nodemon.json
+++ b/api/nodemon.json
@@ -17,5 +17,5 @@
     "db/migrations",
     "db/database-builder"
   ],
-  "ext": "js"
+  "ext": "js,json"
 }


### PR DESCRIPTION
## :christmas_tree: Problème
Lorsque l'API est lancée en local avec `start:watch` et que l'on fait des modifications sur le fichier `api/src/devcomp/infrastructure/datasources/learning-content/module.json` (ce qui arrive souvent), Nodemon ne redémarre pas le serveur car sa configuration ne prend pas en compte les fichiers JSON.

## :gift: Proposition
Rajouter JSON à la liste des extensions observées par Nodemon.

## :socks: Remarques
> _nope_

## :santa: Pour tester

1. Lancer l'API avec `npm run start:watch`
2. Modifier le fichier `api/src/devcomp/infrastructure/datasources/learning-content/module.json`
3. Observer que l'API se relance
