### PR TITLE
[BUGFIX] Affichage du niveau par compétence sur le certificat (PIX-10608).

### DIFF
--- a/mon-pix/app/models/area.js
+++ b/mon-pix/app/models/area.js
@@ -9,7 +9,7 @@ export default class Area extends Model {
   @attr('string') color;
 
   // includes
-  @hasMany('resultCompetence', { async: true, inverse: 'area' }) resultCompetences;
+  @hasMany('resultCompetence', { async: false, inverse: 'area' }) resultCompetences;
   @hasMany('competence', { async: false, inverse: 'area' }) competences;
 
   get sortedCompetences() {


### PR DESCRIPTION
## :christmas_tree: Problème

Le niveau par compétence ne s'affiche plus sur la page de certificat d'un candidat suite à la PR #7715 

## :gift: Proposition

Réafficher les informations manquantes.

## :socks: Remarques

Un test d'acceptance sera ajouté dans une PR ultérieure.

## :santa: Pour tester

Sur mon-pix (certif-success@example.net), aller voir les certificats
Constater que le niveau par compétence s'affiche de nouveau.
