### PR TITLE
[TECH] La locale d'une seed de CF ne fonctionne plus (PIX-10630)

### DIFF
--- a/api/db/seeds/data/team-devcomp/build-trainings.js
+++ b/api/db/seeds/data/team-devcomp/build-trainings.js
@@ -47,7 +47,7 @@ export function buildTrainings(databaseBuilder) {
 
   const enTrainingId = databaseBuilder.factory.buildTraining({
     title: 'Eat a croissant like the french',
-    locale: 'en',
+    locale: 'en-gb',
   }).id;
 
   databaseBuilder.factory.buildTargetProfileTraining({


### PR DESCRIPTION
## :christmas_tree: Problème
Lors de l'initialisation d'un env qui utilise les seeds, on demande la locale `en` sur un des CFs mais elle n'existe pas.

## :gift: Proposition
Utiliser la locale `en-gb`.

## :socks: Remarques
RAS

## :santa: Pour tester
Lancer les seeds de `dev`.

1. Sur le CF "Eat a croissant like the french" ;
2. Constater sur Admin que le champ locale est vide.

Constater sur la RA que :

3. Sur le CF "[Eat a croissant like the french](https://admin-pr7809.review.pix.fr/)" ;
4. Constater sur Admin que le champ locale est bien rempli.
