### PR TITLE
[FEATURE] Ajout de la propriété isV3Pilot à la création et l'édition d'un centre de certification (PIX-10618).

### DIFF
--- a/admin/app/components/certification-centers/creation-form.hbs
+++ b/admin/app/components/certification-centers/creation-form.hbs
@@ -55,6 +55,12 @@
       class="form-field"
     />
 
+    <div class="form-field">
+      <PixCheckbox @id="isV3Pilot" @labelSize="small" onChange={{this.handleIsV3PilotChange}}>
+        {{t "components.certification-centers.is-v3-pilot-label"}}
+      </PixCheckbox>
+    </div>
+
     <section>
       <h2 class="habilitations-title">Habilitations aux certifications complémentaires</h2>
       <ul class="form-field habilitations-checkbox-list">

--- a/admin/app/components/certification-centers/creation-form.js
+++ b/admin/app/components/certification-centers/creation-form.js
@@ -16,6 +16,11 @@ export default class CertificationCenterForm extends Component {
   }
 
   @action
+  handleIsV3PilotChange(event) {
+    this.args.certificationCenter.isV3Pilot = event.target.checked;
+  }
+
+  @action
   handleDataProtectionOfficerFirstNameChange(event) {
     this.args.certificationCenter.dataProtectionOfficerFirstName = event.target.value;
   }

--- a/admin/app/components/certification-centers/information-edit.hbs
+++ b/admin/app/components/certification-centers/information-edit.hbs
@@ -100,6 +100,18 @@
       />
     </div>
 
+    <div class="form-field">
+      <PixCheckbox
+        @id="isV3Pilot"
+        @labelSize="small"
+        onChange={{this.updateIsV3Pilot}}
+        @checked={{this.form.isV3Pilot}}
+        class="form-field certification-center-information__edit-form__is-v3-pilot-checkbox"
+      >
+        {{t "components.certification-centers.is-v3-pilot-label"}}
+      </PixCheckbox>
+    </div>
+
     <h2 class="field__label">Habilitations aux certifications complémentaires</h2>
     <ul class="form-field certification-center-information__edit-form__habilitations-checkbox-list">
       {{#each this.availableHabilitations as |habilitation|}}

--- a/admin/app/components/certification-centers/information-edit.js
+++ b/admin/app/components/certification-centers/information-edit.js
@@ -24,6 +24,11 @@ export default class InformationEdit extends Component {
   }
 
   @action
+  updateIsV3Pilot(event) {
+    this.form.set('isV3Pilot', event.target.checked);
+  }
+
+  @action
   updateGrantedHabilitation(habilitation) {
     const habilitations = this.form.habilitations;
     if (habilitations.includes(habilitation)) {
@@ -49,6 +54,7 @@ export default class InformationEdit extends Component {
     this.args.certificationCenter.set('dataProtectionOfficerFirstName', this.form.dataProtectionOfficerFirstName);
     this.args.certificationCenter.set('dataProtectionOfficerLastName', this.form.dataProtectionOfficerLastName);
     this.args.certificationCenter.set('dataProtectionOfficerEmail', this.form.dataProtectionOfficerEmail);
+    this.args.certificationCenter.set('isV3Pilot', this.form.isV3Pilot);
 
     this.args.toggleEditMode();
     return this.args.onSubmit();
@@ -63,6 +69,7 @@ export default class InformationEdit extends Component {
       'dataProtectionOfficerFirstName',
       'dataProtectionOfficerLastName',
       'dataProtectionOfficerEmail',
+      'isV3Pilot',
     );
     this.form.setProperties(properties);
   }

--- a/admin/app/models/certification-center-form.js
+++ b/admin/app/models/certification-center-form.js
@@ -74,6 +74,7 @@ export default class CertificationCenterFrom extends Model.extend(Validations) {
   @attr() dataProtectionOfficerFirstName;
   @attr() dataProtectionOfficerLastName;
   @attr() dataProtectionOfficerEmail;
+  @attr() isV3Pilot;
 
   @hasMany('complementary-certification') habilitations;
 }

--- a/admin/tests/integration/components/certification-centers/creation-form_test.js
+++ b/admin/tests/integration/components/certification-centers/creation-form_test.js
@@ -1,12 +1,11 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { render, fillByLabel } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { A as EmberArray } from '@ember/array';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | certification-centers/creation-form', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('it renders the new certification center form component', async function (assert) {
     // given
@@ -29,6 +28,42 @@ module('Integration | Component | certification-centers/creation-form', function
     assert.dom(screen.getByText('Identifiant externe')).exists();
     assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
     assert.dom(screen.getByText('Ajouter')).exists();
+    assert
+      .dom(
+        screen.getByRole('checkbox', {
+          name: 'Pilote Certification V3 (ce centre de certification ne pourra organiser que des sessions V3)',
+        }),
+      )
+      .exists();
+  });
+
+  module('#handleIsV3PilotChange', function () {
+    test('should add isV3Pilot to certification center on checked checkbox', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      this.certificationCenter = store.createRecord('certification-center');
+      this.habilitations = [];
+      this.stub = () => {};
+
+      const screen = await render(
+        hbs`<CertificationCenters::CreationForm
+          @certificationCenter={{this.certificationCenter}}
+          @habilitations={{this.habilitations}}
+          @onSubmit={{this.stub}}
+          @onCancel={{this.stub}}
+        />`,
+      );
+
+      // when
+      await click(
+        screen.getByRole('checkbox', {
+          name: 'Pilote Certification V3 (ce centre de certification ne pourra organiser que des sessions V3)',
+        }),
+      );
+
+      // then
+      assert.true(this.certificationCenter.isV3Pilot);
+    });
   });
 
   module('#selectCertificationCenterType', function () {
@@ -62,7 +97,7 @@ module('Integration | Component | certification-centers/creation-form', function
       const habilitation1 = store.createRecord('complementary-certification', { key: 'E', label: 'Pix+Edu' });
       const habilitation2 = store.createRecord('complementary-certification', { key: 'S', label: 'Pix+Surf' });
       this.certificationCenter = store.createRecord('certification-center');
-      this.habilitations = EmberArray([habilitation1, habilitation2]);
+      this.habilitations = [habilitation1, habilitation2];
       this.stub = () => {};
 
       const screen = await render(
@@ -89,7 +124,7 @@ module('Integration | Component | certification-centers/creation-form', function
       this.certificationCenter = store.createRecord('certification-center', {
         habilitations: [habilitation2],
       });
-      this.habilitations = EmberArray([habilitation1, habilitation2]);
+      this.habilitations = [habilitation1, habilitation2];
       this.stub = () => {};
 
       const screen = await render(

--- a/admin/tests/integration/components/certification-centers/information-edit_test.js
+++ b/admin/tests/integration/components/certification-centers/information-edit_test.js
@@ -1,13 +1,13 @@
 import { module, test } from 'qunit';
 import { render, fillByLabel } from '@1024pix/ember-testing-library';
-import { setupRenderingTest } from 'ember-qunit';
 import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 import sinon from 'sinon';
 import { click } from '@ember/test-helpers';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | certification-centers/information-edit', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   hooks.beforeEach(function () {
     const certificationCenter = EmberObject.create('certification-center', {
@@ -18,6 +18,7 @@ module('Integration | Component | certification-centers/information-edit', funct
       dataProtectionOfficerLastName: 'Ptipeu',
       dataProtectionOfficerEmail: 'justin.ptipeu@example.net',
       habilitations: [],
+      isV3Pilot: true,
     });
 
     this.set('certificationCenter', certificationCenter);
@@ -26,6 +27,22 @@ module('Integration | Component | certification-centers/information-edit', funct
   });
 
   module('certification center edit form validation', function () {
+    test('it should display a checkbox to edit the isV3Pilot certification center status ', async function (assert) {
+      // when
+      const screen = await render(
+        hbs`<CertificationCenters::InformationEdit @certificationCenter={{this.certificationCenter}} />`,
+      );
+
+      // then
+      assert
+        .dom(
+          screen.getByRole('checkbox', {
+            name: 'Pilote Certification V3 (ce centre de certification ne pourra organiser que des sessions V3)',
+          }),
+        )
+        .exists();
+    });
+
     test("it should show an error message if certification center's name is empty", async function (assert) {
       // given
       const screen = await render(

--- a/admin/tests/unit/components/certification-centers/information-edit_test.js
+++ b/admin/tests/unit/components/certification-centers/information-edit_test.js
@@ -46,6 +46,30 @@ module('Unit | Component | certification-centers/information-edit', function (ho
     });
   });
 
+  module('#updateIsV3Pilot', function () {
+    test('should add isV3Pilot to certification center on checked checkbox', async function (assert) {
+      // given
+      component.form.isV3Pilot = false;
+
+      // when
+      component.updateIsV3Pilot({ target: { checked: true } });
+
+      // then
+      assert.true(component.form.isV3Pilot);
+    });
+
+    test('should remove isV3Pilot to certification center on unchecked checkbox', async function (assert) {
+      // given
+      component.form.isV3Pilot = true;
+
+      // when
+      component.updateIsV3Pilot({ target: { checked: false } });
+
+      // then
+      assert.false(component.form.isV3Pilot);
+    });
+  });
+
   module('#availableHabilitations', function () {
     test('it should return a sorted list of available habilitations', async function (assert) {
       // given
@@ -83,6 +107,7 @@ module('Unit | Component | certification-centers/information-edit', function (ho
       component.form.dataProtectionOfficerFirstName = 'Justin';
       component.form.dataProtectionOfficerLastName = 'Ptipeu';
       component.form.dataProtectionOfficerEmail = 'justin.ptipeu@example.net';
+      component.form.isV3Pilot = true;
 
       // when
       await component.updateCertificationCenter({ preventDefault: sinon.stub() });
@@ -92,6 +117,7 @@ module('Unit | Component | certification-centers/information-edit', function (ho
       assert.strictEqual(component.args.certificationCenter.dataProtectionOfficerFirstName, 'Justin');
       assert.strictEqual(component.args.certificationCenter.dataProtectionOfficerLastName, 'Ptipeu');
       assert.strictEqual(component.args.certificationCenter.dataProtectionOfficerEmail, 'justin.ptipeu@example.net');
+      assert.true(component.args.certificationCenter.isV3Pilot);
     });
   });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -57,6 +57,7 @@
       }
     },
     "certification-centers": {
+      "is-v3-pilot-label": "V3 Certification Pilot (This center will only be able to organize v3 sessions)",
       "membership-item": {
         "actions": {
           "edit-role": "Edit role"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -65,6 +65,7 @@
       }
     },
     "certification-centers": {
+      "is-v3-pilot-label": "Pilote Certification V3 (ce centre de certification ne pourra organiser que des sessions V3)",
       "membership-item": {
         "actions": {
           "edit-role": "Modifier le rôle"

--- a/api/lib/infrastructure/repositories/certification-center-for-admin-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-for-admin-repository.js
@@ -55,13 +55,13 @@ const get = async function (id) {
 };
 
 const save = async function (certificationCenter) {
-  const data = _.pick(certificationCenter, ['name', 'type', 'externalId', 'isV3Pilot']);
+  const data = _toDTO(certificationCenter);
   const [certificationCenterCreated] = await knex(CERTIFICATION_CENTERS_TABLE_NAME).returning('*').insert(data);
   return _toDomain(certificationCenterCreated);
 };
 
 const update = async function (certificationCenter) {
-  const data = _.pick(certificationCenter, ['name', 'type', 'externalId']);
+  const data = _toDTO(certificationCenter);
 
   const [certificationCenterRow] = await knex(CERTIFICATION_CENTERS_TABLE_NAME)
     .update(data)
@@ -87,4 +87,8 @@ function _toDomain(certificationCenterDTO) {
     updatedAt: certificationCenterDTO.updatedAt,
     isV3Pilot: certificationCenterDTO.isV3Pilot,
   });
+}
+
+function _toDTO(certificationCenter) {
+  return _.pick(certificationCenter, ['name', 'type', 'externalId', 'isV3Pilot']);
 }

--- a/api/lib/infrastructure/repositories/certification-center-for-admin-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-for-admin-repository.js
@@ -55,7 +55,7 @@ const get = async function (id) {
 };
 
 const save = async function (certificationCenter) {
-  const data = _.pick(certificationCenter, ['name', 'type', 'externalId']);
+  const data = _.pick(certificationCenter, ['name', 'type', 'externalId', 'isV3Pilot']);
   const [certificationCenterCreated] = await knex(CERTIFICATION_CENTERS_TABLE_NAME).returning('*').insert(data);
   return _toDomain(certificationCenterCreated);
 };

--- a/api/lib/infrastructure/serializers/jsonapi/certification-center-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-center-for-admin-serializer.js
@@ -15,6 +15,7 @@ const deserialize = function ({ data }) {
     id: data.id,
     name: data.attributes.name,
     type: data.attributes.type,
+    isV3Pilot: data.attributes['is-v3-pilot'],
   });
 };
 

--- a/api/tests/acceptance/application/certification-centers/certification-center-controller_test.js
+++ b/api/tests/acceptance/application/certification-centers/certification-center-controller_test.js
@@ -182,6 +182,7 @@ describe('Acceptance | API | Certification Center', function () {
                 name: 'Nouveau Centre de Certif',
                 type: 'SCO',
                 'data-protection-officer-email': 'adrienne.quepourra@example.net',
+                'is-v3-pilot': true,
               },
               relationships: {
                 habilitations: {
@@ -203,6 +204,7 @@ describe('Acceptance | API | Certification Center', function () {
         expect(response.result.data.attributes['data-protection-officer-email']).to.equal(
           'adrienne.quepourra@example.net',
         );
+        expect(response.result.data.attributes['is-v3-pilot']).to.equal(true);
         expect(response.result.data.id).to.be.ok;
       });
     });

--- a/api/tests/acceptance/application/certification-centers/index_test.js
+++ b/api/tests/acceptance/application/certification-centers/index_test.js
@@ -38,6 +38,7 @@ describe('Acceptance | Route | Certification Centers', function () {
                 'data-protection-officer-first-name': 'Justin',
                 'data-protection-officer-last-name': 'Ptipeu',
                 'data-protection-officer-email': 'justin.ptipeu@example.net',
+                'is-v3-pilot': true,
                 name: 'Justin Ptipeu Orga',
                 type: 'PRO',
               },
@@ -51,6 +52,7 @@ describe('Acceptance | Route | Certification Centers', function () {
         expect(result.data.attributes['data-protection-officer-first-name']).to.equal('Justin');
         expect(result.data.attributes['data-protection-officer-last-name']).to.equal('Ptipeu');
         expect(result.data.attributes['data-protection-officer-email']).to.equal('justin.ptipeu@example.net');
+        expect(result.data.attributes['is-v3-pilot']).to.equal(true);
         expect(result.data.attributes.name).to.equal('Justin Ptipeu Orga');
       });
     });

--- a/api/tests/integration/infrastructure/repositories/certification-center-for-admin-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-for-admin-repository_test.js
@@ -173,6 +173,7 @@ describe('Integration | Repository | certification-center-for-admin', function (
         id: certificationCenter.id,
         name: 'Great Oak Certification Center',
         updatedAt: now,
+        isV3Pilot: true,
       });
 
       // then
@@ -182,6 +183,7 @@ describe('Integration | Repository | certification-center-for-admin', function (
           ...certificationCenter,
           name: 'Great Oak Certification Center',
           updatedAt: updatedCertificationCenter.updatedAt,
+          isV3Pilot: true,
         }),
       );
     });

--- a/api/tests/integration/infrastructure/repositories/certification-center-for-admin-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-for-admin-repository_test.js
@@ -143,6 +143,7 @@ describe('Integration | Repository | certification-center-for-admin', function (
       const certificationCenter = new CertificationCenterForAdmin({
         name: 'CertificationCenterName',
         type: 'SCO',
+        isV3Pilot: true,
       });
 
       // when
@@ -153,6 +154,7 @@ describe('Integration | Repository | certification-center-for-admin', function (
       expect(savedCertificationCenter.id).to.exist;
       expect(savedCertificationCenter.name).to.equal('CertificationCenterName');
       expect(savedCertificationCenter.type).to.equal('SCO');
+      expect(savedCertificationCenter.isV3Pilot).to.equal(true);
     });
   });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-for-admin-serializer_test.js
@@ -2,103 +2,92 @@ import { expect, domainBuilder } from '../../../../test-helper.js';
 import * as serializer from '../../../../../lib/infrastructure/serializers/jsonapi/certification-center-for-admin-serializer.js';
 
 describe('Unit | Serializer | JSONAPI | certification-center-for-admin-serializer', function () {
-  describe('#deserialize', function () {
-    it('should convert a JSON API data into a CertificationCenterForAdmin model object', function () {
-      // given
-      const jsonApi = {
-        data: {
-          type: 'certification-centers',
-          id: '123',
-          attributes: {
-            name: 'Centre des dés',
-            type: 'SCO',
-            'external-id': '12345',
-            'created-at': new Date('2018-02-01T01:02:03Z'),
-            'data-protection-officer-first-name': 'Justin',
-            'data-protection-officer-last-name': 'Ptipeu',
-            'data-protection-officer-email': 'justin.ptipeu@example.net',
-            'is-v3-pilot': true,
-          },
-          relationships: {},
-        },
-      };
+  let certificationCenterJsonApi;
+  let certificationCenterForAdmin;
 
-      // when
-      const deserializedCertificationCenterForAdmin = serializer.deserialize(jsonApi);
-
-      // then
-      const expectedCertificationCenterForAdmin = domainBuilder.buildCertificationCenterForAdmin({
+  beforeEach(function () {
+    certificationCenterJsonApi = {
+      data: {
+        type: 'certification-centers',
         id: '123',
-        name: 'Centre des dés',
-        type: 'SCO',
-        externalId: '12345',
-        createdAt: null,
-        habilitations: [],
-        dataProtectionOfficerFirstName: 'Justin',
-        dataProtectionOfficerLastName: 'Ptipeu',
-        dataProtectionOfficerEmail: 'justin.ptipeu@example.net',
-        isV3Pilot: true,
-      });
+        attributes: {
+          name: 'Centre des dés',
+          type: 'SCO',
+          'external-id': '12345',
+          'created-at': new Date('2018-02-01T01:02:03Z'),
+          'data-protection-officer-first-name': 'Justin',
+          'data-protection-officer-last-name': 'Ptipeu',
+          'data-protection-officer-email': 'justin.ptipeu@example.net',
+        },
+        relationships: {},
+      },
+    };
 
-      expect(deserializedCertificationCenterForAdmin).to.deepEqualInstance(expectedCertificationCenterForAdmin);
-    });
+    certificationCenterForAdmin = {
+      id: 123,
+      name: 'Centre des dés',
+      type: 'SCO',
+      externalId: '12345',
+      createdAt: null,
+      habilitations: [],
+      dataProtectionOfficerFirstName: 'Justin',
+      dataProtectionOfficerLastName: 'Ptipeu',
+      dataProtectionOfficerEmail: 'justin.ptipeu@example.net',
+    };
   });
 
-  describe('#serialize', function () {
-    it('should convert a CertificationCenterForAdmin model object into JSON API data', function () {
-      // given
-      const complementaryCertification = domainBuilder.buildComplementaryCertification({
-        id: 1,
-        label: 'Pix+surf',
-        key: 'SURF',
-      });
-      const certificationCenter = domainBuilder.buildCertificationCenterForAdmin({
-        id: 12,
-        name: 'Centre des dés',
-        type: 'SCO',
-        createdAt: new Date('2018-01-01T05:43:10Z'),
-        externalId: '12345',
-        dataProtectionOfficerFirstName: 'Justin',
-        dataProtectionOfficerLastName: 'Ptipeu',
-        dataProtectionOfficerEmail: 'justin.ptipeu@example.net',
-        habilitations: [complementaryCertification],
-      });
+  describe('when the center is for v2 certification', function () {
+    describe('#deserialize', function () {
+      it('should convert a JSON API data into a CertificationCenterForAdmin model object', function () {
+        // when
+        const deserializedCertificationCenterForAdmin = serializer.deserialize(certificationCenterJsonApi);
 
-      // when
-      const serializedCertificationCenter = serializer.serialize(certificationCenter);
+        // then
+        const expectedCertificationCenterForAdmin = domainBuilder.buildCertificationCenterForAdmin({
+          ...certificationCenterForAdmin,
+          id: '123',
+        });
 
-      // then
-      expect(serializedCertificationCenter).to.deep.equal({
-        data: {
-          type: 'certification-centers',
-          id: '12',
-          attributes: {
-            name: 'Centre des dés',
-            type: 'SCO',
-            'external-id': '12345',
-            'data-protection-officer-first-name': 'Justin',
-            'data-protection-officer-last-name': 'Ptipeu',
-            'data-protection-officer-email': 'justin.ptipeu@example.net',
-            'created-at': new Date('2018-01-01T05:43:10Z'),
-            'is-v3-pilot': false,
+        expect(deserializedCertificationCenterForAdmin).to.deepEqualInstance(expectedCertificationCenterForAdmin);
+      });
+    });
+
+    describe('#serialize', function () {
+      it('should convert a CertificationCenterForAdmin model object into JSON API data', function () {
+        // given
+        const complementaryCertification = domainBuilder.buildComplementaryCertification({
+          id: 1,
+          label: 'Pix+surf',
+          key: 'SURF',
+        });
+        const certificationCenter = domainBuilder.buildCertificationCenterForAdmin({
+          ...certificationCenterForAdmin,
+          createdAt: new Date('2018-01-01T05:43:10Z'),
+          habilitations: [complementaryCertification],
+        });
+
+        // when
+        const serializedCertificationCenter = serializer.serialize(certificationCenter);
+
+        // then
+        certificationCenterJsonApi.data.attributes['created-at'] = new Date('2018-01-01T05:43:10Z');
+        certificationCenterJsonApi.data.attributes['is-v3-pilot'] = false;
+        certificationCenterJsonApi.data.relationships = {
+          'certification-center-memberships': {
+            links: {
+              related: `/api/admin/certification-centers/${certificationCenter.id}/certification-center-memberships`,
+            },
           },
-          relationships: {
-            'certification-center-memberships': {
-              links: {
-                related: `/api/admin/certification-centers/${certificationCenter.id}/certification-center-memberships`,
+          habilitations: {
+            data: [
+              {
+                id: '1',
+                type: 'complementary-certifications',
               },
-            },
-            habilitations: {
-              data: [
-                {
-                  id: '1',
-                  type: 'complementary-certifications',
-                },
-              ],
-            },
+            ],
           },
-        },
-        included: [
+        };
+        certificationCenterJsonApi.included = [
           {
             id: '1',
             type: 'complementary-certifications',
@@ -107,7 +96,79 @@ describe('Unit | Serializer | JSONAPI | certification-center-for-admin-serialize
               label: 'Pix+surf',
             },
           },
-        ],
+        ];
+
+        expect(serializedCertificationCenter).to.deep.equal(certificationCenterJsonApi);
+      });
+    });
+  });
+
+  describe('when the center is for v3 certification', function () {
+    describe('#deserialize', function () {
+      it('should convert a JSON API data into a CertificationCenterForAdmin model object', function () {
+        // when
+        certificationCenterJsonApi.data.attributes['is-v3-pilot'] = true;
+        const deserializedCertificationCenterForAdmin = serializer.deserialize(certificationCenterJsonApi);
+
+        // then
+        const expectedCertificationCenterForAdmin = domainBuilder.buildCertificationCenterForAdmin({
+          ...certificationCenterForAdmin,
+          id: '123',
+          isV3Pilot: true,
+        });
+
+        expect(deserializedCertificationCenterForAdmin).to.deepEqualInstance(expectedCertificationCenterForAdmin);
+      });
+    });
+
+    describe('#serialize', function () {
+      it('should convert a CertificationCenterForAdmin model object into JSON API data', function () {
+        // given
+        const complementaryCertification = domainBuilder.buildComplementaryCertification({
+          id: 1,
+          label: 'Pix+surf',
+          key: 'SURF',
+        });
+        const certificationCenter = domainBuilder.buildCertificationCenterForAdmin({
+          ...certificationCenterForAdmin,
+          createdAt: new Date('2018-01-01T05:43:10Z'),
+          habilitations: [complementaryCertification],
+          isV3Pilot: true,
+        });
+
+        // when
+        const serializedCertificationCenter = serializer.serialize(certificationCenter);
+
+        // then
+        certificationCenterJsonApi.data.attributes['created-at'] = new Date('2018-01-01T05:43:10Z');
+        certificationCenterJsonApi.data.attributes['is-v3-pilot'] = true;
+        certificationCenterJsonApi.data.relationships = {
+          'certification-center-memberships': {
+            links: {
+              related: `/api/admin/certification-centers/${certificationCenter.id}/certification-center-memberships`,
+            },
+          },
+          habilitations: {
+            data: [
+              {
+                id: '1',
+                type: 'complementary-certifications',
+              },
+            ],
+          },
+        };
+        certificationCenterJsonApi.included = [
+          {
+            id: '1',
+            type: 'complementary-certifications',
+            attributes: {
+              key: 'SURF',
+              label: 'Pix+surf',
+            },
+          },
+        ];
+
+        expect(serializedCertificationCenter).to.deep.equal(certificationCenterJsonApi);
       });
     });
   });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-for-admin-serializer_test.js
@@ -17,6 +17,7 @@ describe('Unit | Serializer | JSONAPI | certification-center-for-admin-serialize
             'data-protection-officer-first-name': 'Justin',
             'data-protection-officer-last-name': 'Ptipeu',
             'data-protection-officer-email': 'justin.ptipeu@example.net',
+            'is-v3-pilot': true,
           },
           relationships: {},
         },
@@ -36,6 +37,7 @@ describe('Unit | Serializer | JSONAPI | certification-center-for-admin-serialize
         dataProtectionOfficerFirstName: 'Justin',
         dataProtectionOfficerLastName: 'Ptipeu',
         dataProtectionOfficerEmail: 'justin.ptipeu@example.net',
+        isV3Pilot: true,
       });
 
       expect(deserializedCertificationCenterForAdmin).to.deepEqualInstance(expectedCertificationCenterForAdmin);


### PR DESCRIPTION
## :christmas_tree: Problème

Dans le cadre de la nouvelle certification Pix, un pilote est organisé afin d’ouvrir progressivement cette nouvelle certif et ne pas généraliser dès le départ. Pour permettre aux CDC pilotes d’organiser des sessions certif v3 (en parallèle des sessions v2 qui continuent d'être organisées tout le temps du pilote), un champ a été ajouté pour identifier les centres pilotes.

Il n’est possible de tagguer un CDC comme pilote v3 qu’en base de données directement. Le pôle certif n’est donc pas autonome pour créer un CDC pilote certif v3.

## :gift: Proposition

Dans Pix Admin > menu “Centres de certification” > page de création d’un centre de certif : 
ajouter un champ “Pilote certification v3” avec une case à cocher. Par défaut, cette case n’est PAS cochée.

<img width="564" alt="Capture d’écran 2024-01-05 à 15 21 11" src="https://github.com/1024pix/pix/assets/36371437/645438fa-28d1-4598-a8d9-6369e5309fdc">

Faire de même pour la page d'édition des infos d’un CDC, accessible depuis la page de détails d’un CDC > bouton “Editer les informations”

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester

- Dans Pix Admin > menu “Centres de certification”, cliquer sur “Nouveau centre de certif”
- Un nouveau champ “Pilote certification v3” est affiché et non coché
- Cocher la case et remplir toutes les informations obligatoires
- Cliquer sur “Ajouter”
- La page de détails est affichée avec le champ “Pilote certification v3” = “Oui”
- Cliquer sur “Editer les informations”
- Le champ “Pilote certification v3” est affiché et coché 
- Décocher le champ 
- Cliquer sur “Enregistrer”
- La page de détails est affichée avec le champ “Pilote certification v3” = “Non”
