### PR TITLE
[TECH] Vérifier le contenu de tous les modules (PIX-10244)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/module-datasource.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module-datasource.js
@@ -11,6 +11,9 @@ const moduleDatasource = {
 
     return foundModule;
   },
+  list: async () => {
+    return referential.modules;
+  },
 };
 
 export default moduleDatasource;

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
@@ -3,19 +3,18 @@ import { expect } from '../../../../../test-helper.js';
 import { LearningContentResourceNotFound } from '../../../../../../src/shared/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
 import { moduleSchema } from './validation/module.js';
 
+const modules = await moduleDatasource.list();
+
 describe('Unit | Infrastructure | Datasources | Learning Content | ModuleDatasource', function () {
   describe('#getBySlug', function () {
     describe('when exists', function () {
-      it('should contain a valid structure', async function () {
+      it('should return something', async function () {
         // Given
         const slug = 'bien-ecrire-son-adresse-mail';
         const module = await moduleDatasource.getBySlug(slug);
 
-        // When
-        const result = moduleSchema.validate(module);
-
-        // Then
-        expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));
+        // When & then
+        expect(module).to.exist;
       });
     });
 
@@ -26,6 +25,22 @@ describe('Unit | Infrastructure | Datasources | Learning Content | ModuleDatasou
 
         // when & then
         await expect(moduleDatasource.getBySlug(slug)).to.have.been.rejectedWith(LearningContentResourceNotFound);
+      });
+    });
+  });
+
+  describe('#list', function () {
+    describe('modules content', function () {
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      modules.forEach((module) => {
+        it(`module "${module.slug}" should contain a valid structure`, function () {
+          // When
+          const result = moduleSchema.validate(module);
+
+          // Then
+          expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));
+        });
       });
     });
   });


### PR DESCRIPTION
## :christmas_tree: Problème
Pour le moment on ne vérifie que le contenu du module `bien-ecrire-son-adresse-mail`. On sera emmené à créer à d'autres contenus dans le futur.

## :gift: Proposition
Ajouter une méthode dans le `moduleDatasource` pour récupérer la totalité des modules et vérifier leur contenu.

## :socks: Remarques
Voir commentaire dans la PR.

## :santa: Pour tester
En local, ajouter un module incomplet par exemple : 

```json
{
      "id": "1A2",
      "slug": "dire-bonjour",
      "title": "Dire bonjour"
}
```

Et vérifier qu'un test correctement nommé casse.