### PR TITLE
[TECH] Mise en place de codeowners pour le code API de DevComp (PIX-10598)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# @1024pix/devcomp owns any file in the `/api/src/devcomp/` directory in the root of your repository and any of its subdirectories.
+/api/src/devcomp/ @1024pix/devcomp


### PR DESCRIPTION
## :christmas_tree: Problème
On a du mal à identifier les mainteneurs d'un domaine dans le code.

## :gift: Proposition
[Codeowners](https://github.blog/2017-07-06-introducing-code-owners/) permet de demander automatiquement une review d'un utilisateur ou d'un groupe d'utilisateurs lors de modifications sur une partie du code qui les concerne.

![image](https://github.com/1024pix/pix/assets/5855339/e22f156f-8ba5-49df-82c4-6b2c773a59aa)

Ici j'ai créé une [équipe `DevComp` sur GitHub](https://github.com/orgs/1024pix/teams/devcomp) et lui ai donné le scope `/api/src/devcomp/`.

> [!TIP]  
> Par défaut, la revue de l'équipe n'est pas obligatoire mais ça peut se paramétrer dans la > configuration des projets : 
> 
> ![image](https://github.com/1024pix/pix/assets/5855339/3811d641-0cd7-4841-adc2-1f6bda3c05d0)

## :socks: Remarques
C'est une expérimentation pour voir si ça peut servir !

## :santa: Pour tester
Merger et ouvrir une PR avec du code de `/api/src/devcomp/` modifié. Les membres de l'équipe @1024pix/DevComp devraient être reviewers automatiquement.
