### PR TITLE
[BUGFIX] Éviter une erreur de contrainte BDD lors de l'échange du code campagne (PIX-7500)

### DIFF
--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js
@@ -91,10 +91,8 @@ const swapCampaignCodes = async function ({ firstCampaignId, secondCampaignId })
 
     await trx('campaigns').where({ id: secondCampaignId }).update({ code: temporaryCode });
 
-    await Promise.all([
-      trx('campaigns').where({ id: firstCampaignId }).update({ code: secondCode }),
-      trx('campaigns').where({ id: secondCampaignId }).update({ code: firstCode }),
-    ]);
+    await trx('campaigns').where({ id: firstCampaignId }).update({ code: secondCode });
+    await trx('campaigns').where({ id: secondCampaignId }).update({ code: firstCode });
 
     return trx.commit();
   } catch (err) {


### PR DESCRIPTION
## :christmas_tree: Problème
La Promise.all ne garanti pas l'execution dans l'ordre écrite des requêtes. Il se pourrait qu'une contrainte remonte de la BDD dans le cas ou la 2nd requete passe avant la 1ere

## :gift: Proposition
Retirer cette Promise.all

## :socks: Remarques
RAS

## :santa: Pour tester
CI OK