### PR TITLE
[TECH] Changement d'alias du codeowner (PIX-10598)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # @1024pix/devcomp owns any file in the `/api/src/devcomp/` directory in the root of your repository and any of its subdirectories.
-/api/src/devcomp/ @1024pix/devcomp
+/api/src/devcomp/ @1024pix/team-devcomp


### PR DESCRIPTION
## :christmas_tree: Problème
Le nom d'équipe `devcomp` n'est pas bien uniformisé avec les labels des PRs, les alias Slack...

## :gift: Proposition
Changer de nom pour `team-devcomp`.

## :socks: Remarques
RAS

## :santa: Pour tester
No idea
