### PR TITLE
[BUGFIX] Afficher le nombre de jours d'une formation (PIX-10626)

### DIFF
--- a/mon-pix/app/components/training/card.hbs
+++ b/mon-pix/app/components/training/card.hbs
@@ -7,9 +7,7 @@
           <li class="training-card-content-infos-tag-list__type">
             {{this.type}}
           </li>
-          <li class="training-card-content-infos-tag-list__duration">
-            <time>{{this.durationFormatted}}</time>
-          </li>
+          <li class="training-card-content-infos-tag-list__duration"><time>{{this.durationFormatted}}</time></li>
         </ul>
       </PixTag>
     </div>

--- a/mon-pix/app/components/training/card.js
+++ b/mon-pix/app/components/training/card.js
@@ -5,18 +5,10 @@ export default class Card extends Component {
   @service intl;
 
   get durationFormatted() {
-    const formattedHours = [];
-    const { hours, minutes, seconds } = this.args.training.duration;
-    if (hours) {
-      formattedHours.push(hours + 'h');
-    }
-    if (minutes) {
-      formattedHours.push(minutes + 'm');
-    }
-    if (seconds) {
-      formattedHours.push(seconds + 's');
-    }
-    return formattedHours.join(' ');
+    const days = this.args.training.duration.days ? `${this.args.training.duration.days}j ` : '';
+    const hours = this.args.training.duration.hours ? `${this.args.training.duration.hours}h ` : '';
+    const minutes = this.args.training.duration.minutes ? `${this.args.training.duration.minutes}min` : '';
+    return `${days}${hours}${minutes}`.trim();
   }
 
   get type() {

--- a/mon-pix/app/styles/components/_training-card.scss
+++ b/mon-pix/app/styles/components/_training-card.scss
@@ -36,7 +36,7 @@
 
   & > * + *::before {
     margin: 0 1ch;
-    content: '-';
+    content: '•';
   }
 }
 

--- a/mon-pix/app/styles/components/_training-card.scss
+++ b/mon-pix/app/styles/components/_training-card.scss
@@ -44,6 +44,7 @@
   max-width: 100%;
   overflow: hidden;
   white-space: nowrap;
+  text-transform: lowercase;
   text-overflow: ellipsis;
 }
 

--- a/mon-pix/tests/unit/components/training/card_test.js
+++ b/mon-pix/tests/unit/components/training/card_test.js
@@ -13,53 +13,13 @@ module('Unit | Component | Training | card', function (hooks) {
 
   module('#durationFormatted', function () {
     [
-      {
-        duration: {
-          hours: 10,
-          minutes: 11,
-          seconds: 12,
-        },
-        expectedResult: '10h 11m 12s',
-      },
-      {
-        duration: {
-          hours: 10,
-        },
-        expectedResult: '10h',
-      },
-      {
-        duration: {
-          minutes: 11,
-        },
-        expectedResult: '11m',
-      },
-      {
-        duration: {
-          seconds: 12,
-        },
-        expectedResult: '12s',
-      },
-      {
-        duration: {
-          minutes: 11,
-          seconds: 12,
-        },
-        expectedResult: '11m 12s',
-      },
-      {
-        duration: {
-          hours: 10,
-          seconds: 12,
-        },
-        expectedResult: '10h 12s',
-      },
-      {
-        duration: {
-          hours: 10,
-          minutes: 11,
-        },
-        expectedResult: '10h 11m',
-      },
+      { duration: { days: 2 }, expectedResult: '2j' },
+      { duration: { hours: 2 }, expectedResult: '2h' },
+      { duration: { minutes: 2 }, expectedResult: '2min' },
+      { duration: { hours: 10, minutes: 2 }, expectedResult: '10h 2min' },
+      { duration: { days: 1, hours: 4 }, expectedResult: '1j 4h' },
+      { duration: { days: 1, minutes: 30 }, expectedResult: '1j 30min' },
+      { duration: { days: 1, hours: 4, minutes: 30 }, expectedResult: '1j 4h 30min' },
     ].forEach(({ duration, expectedResult }) => {
       test(`should return ${expectedResult} for given duration ${JSON.stringify(duration)}`, function (assert) {
         // given


### PR DESCRIPTION
## :christmas_tree: Problème
Pour le moment le nombre de jours d'une formation (si précisé) ne s'affiche pas sur Pix App.

![image](https://github.com/1024pix/pix/assets/5855339/91336dd4-06c2-4b35-a810-50d52d87817d)

De plus : 
- un tiret simple est utilisé pour séparer "type de formation" et "durée"
- un espace non nécessaire est présent avant la durée
- la durée est affichée en majuscules

## :gift: Proposition
1. Corriger la gestion d'affichage de la durée de formation (reprise de Pix Admin : on ne gère pas les secondes)

Revue par le design : 

2. Remplacer le tiret simple `-` par un `•`
3. Supprimer l'espace non volontaire
4. Afficher la durée en minuscules

## :socks: Remarques
Je n'ai pas constaté de régression d’accessibilité en testant avec VoiceOver.

Côté design on souhaiterai aussi revoir le formatage de la durée pour un autre format, je propose de le faire dans un prochain temps pour le traiter sur Admin également.

## :santa: Pour tester
Sur [la RA](https://app-pr7826.review.pix.fr/), s'assurer que pour un contenu formatif avec une durée supérieure ou égale à un jour cette durée s'affiche entièrement. Par exemple avec `learneremail1003_30@example.net` sur `EDUMULTIP` qui a déjà eu 3 CFs.