### PR TITLE
[BUGFIX] Corriger l'affichage du bloc des contenus formatifs en fin de parcours (PIX-10696)

### DIFF
--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -103,7 +103,7 @@ export default class SkillReview extends Component {
   }
 
   get displayTrainings() {
-    return Boolean(this.args.model.trainings) && (this.isShared || this.isAutonomousCourse);
+    return Boolean(Object.values(this.args.model.trainings).length) && (this.isShared || this.isAutonomousCourse);
   }
 
   get displayOrganizationCustomMessage() {

--- a/mon-pix/tests/integration/components/campaign/skill-review_test.js
+++ b/mon-pix/tests/integration/components/campaign/skill-review_test.js
@@ -32,6 +32,7 @@ module('Integration | Component | Campaign | skill-review', function (hooks) {
         competenceResults,
         campaignParticipationBadges: [],
       }),
+      trainings: {},
     };
   });
 
@@ -264,6 +265,42 @@ module('Integration | Component | Campaign | skill-review', function (hooks) {
 
     assert.notOk(screen.queryByText(this.intl.t('pages.skill-review.stage.title')));
     assert.notOk(screen.queryByText(this.intl.t('pages.skill-review.details.title')));
+  });
+
+  module('#displayTrainings', () => {
+    test('should not display trainings when none are associated', async function (assert) {
+      // given
+      model.campaignParticipationResult.set('isShared', true);
+      this.set('model', model);
+
+      // when
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
+
+      assert.notOk(screen.queryByText(this.intl.t('pages.skill-review.trainings.title')));
+      assert.notOk(screen.queryByText(this.intl.t('pages.skill-review.trainings.description')));
+    });
+
+    test('should display trainings', async function (assert) {
+      // given
+      model.trainings = {
+        title: 'Mon super training',
+        link: 'https://training.net/',
+        type: 'webinaire',
+        locale: 'fr-fr',
+        duration: { hours: 6 },
+        editorName: "Ministère de l'éducation nationale et de la jeunesse. Liberté égalité fraternité",
+        editorLogoUrl:
+          'https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
+      };
+      model.campaignParticipationResult.set('isShared', true);
+      this.set('model', model);
+
+      // when
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
+
+      assert.ok(screen.queryByText(this.intl.t('pages.skill-review.trainings.title')));
+      assert.ok(screen.queryByText(this.intl.t('pages.skill-review.trainings.description')));
+    });
   });
 
   module('when the campaign is an autonomous course', () => {

--- a/mon-pix/tests/unit/components/campaigns/assessment/skill-review/skill-review_test.js
+++ b/mon-pix/tests/unit/components/campaigns/assessment/skill-review/skill-review_test.js
@@ -972,7 +972,6 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
     test('should return false if there are no trainings', function (assert) {
       // given
       component.args.model.trainings = {};
-      delete component.args.model.trainings;
       sinon.stub(ENV.APP, 'AUTONOMOUS_COURSES_ORGANIZATION_ID').value(777);
       component.args.model.campaign.organizationId = 777;
 


### PR DESCRIPTION
## :christmas_tree: Problème
Depuis les parcours autonomes, une régression est apparue. Le bloc des contenus formatifs s'affichent alors qu'il n'y en a pas.

## :gift: Proposition
En effet, le conditionnement de ce bloc a été migré côté js. Toutefois, le model training renvoie un proxy qui est géré dans le hbs par ember à falsy (cf [Empty object proxies are no longer truthy in {{#if}](https://github.com/emberjs/ember.js/blob/main/CHANGELOG.md#ember-100-rc1-february-15-2013)}). Ainsi, côté js, on doit faire une vérification supplémentaire sur le proxy pour vérifier sa `length`

Pour les tests unitaires, j'ai simplement enlevé le delete qui n'avait rien à faire ici et créait un faux-positif.
J'ai ajouté des tests d'intégration sur la partie trainings.

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Vérifier l'affichage du bloc des contenus formatifs en fin de parcours sur une campagne ayant des contenus formatifs (`EDUSIMPLE`) et une qui n'en a pas (`AUTOCOURS2`)
