### PR TITLE
[FEATURE] Suppression de la contrainte sur la langue dans la table users (PIX-10681)

### DIFF
--- a/api/db/migrations/20240109085653_remove-lang-constraint-in-users-table.js
+++ b/api/db/migrations/20240109085653_remove-lang-constraint-in-users-table.js
@@ -1,0 +1,9 @@
+const up = async function (knex) {
+  return knex.raw('ALTER TABLE "users" DROP CONSTRAINT "users_lang_check"');
+};
+
+const down = async function (knex) {
+  return knex.raw('ALTER TABLE "users" ADD CONSTRAINT "users_lang_check" CHECK ( "lang" IN (\'fr\', \'en\') )');
+};
+
+export { up, down };


### PR DESCRIPTION
## :christmas_tree: Problème
La contrainte sur la colonne lang de la table `users` nous empêche d'ajouter d'autres langues que `fr` ou `en`.

## :gift: Proposition
Ajouter une migration pour supprimer cette contrainte.

## :socks: Remarques

- Dans le cas où cette migration devait être rollback, Il faudrait que toutes les valeurs dans la colonne lang soient `en` ou `fr`. Cela rendrait pénible un rollback si on a plusieurs valeurs différentes et un UPDATE massif devrait être fait.

## :santa: Pour tester
### Test de la migration
- Lançer la commande `npm run db:reset` en local
- Vérifier que la contrainte `users_lang_check` n'est plus présente.
- Modifier la langue d'un ou plusieurs utilisateurs en base de donnée avec une valeur autre que `fr` ou `en` (ex: `nl`). Vérifier que ça fonctionne.
### Test du rollback de la migration
- Annuler les changements afin de tester le `down` de la migration.
- Lançer la commande `npm run db:rollback:latest`.
- Modifier de nouveau la langue d'un utilisateur avec une valeur nl par exemple, et vérifier qu'il y a une erreur à cause de la contrainte.

