### PR TITLE
[BUGFIX] Ajout d'un return pour enregistrer le model des places dans PixOrga (PIX-10707)

### DIFF
--- a/orga/app/routes/authenticated/places.js
+++ b/orga/app/routes/authenticated/places.js
@@ -14,7 +14,7 @@ export default class AuthenticatedPlacesRoute extends Route {
 
   async model() {
     try {
-      await this.store.queryRecord('organization-place-statistic', {
+      return await this.store.queryRecord('organization-place-statistic', {
         organizationId: this.currentUser.organization.id,
       });
     } catch (_) {


### PR DESCRIPTION
## :christmas_tree: Problème
Suite au changement du retour de la 412, un oubli de taille est apparu. les données ne sont plus sauvegardé dans Ember-data

## :gift: Proposition
Ajouter le return qui permet de sauvegarder les données dans Ember

## :socks: Remarques
RAS

## :santa: Pour tester
Se conncter sur pro-orga@example.net et vérifier que vous avez bien la page de places qui s'affiche avec des données