### PR TITLE
[FEATURE] MAJ du nombre de réponses nécessaires à la validation d'une certification V3 (PIX-10698).

### DIFF
--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -363,7 +363,7 @@ const configuration = (function () {
       defaultCandidateCapacity: -3,
       challengesBetweenSameCompetence: 2,
       scoring: {
-        minimumAnswersRequiredToValidateACertification: 10,
+        minimumAnswersRequiredToValidateACertification: 20,
       },
     },
     version: process.env.CONTAINER_VERSION || 'development',


### PR DESCRIPTION
## :christmas_tree: Problème

Dans le cadres de la certif v3, de nouvelles règles métier ont été implémentées pour le scoring. Certaines règles, notamment dans le cas d’un test non terminé par le candidat, nécessite la prise en compte d’un paramètre qui est : le nombre de questions jugé acceptable pour délivrer un score (appelé V).

Aujourd’hui dans le code, V = 10, ce qui est trop bas. 

## :gift: Proposition

MAJ de ce nombre de 10 à 20

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester

• créer une session v3 et inscrire un candidat en renseignant un destinataire des résultats = soi-même (pour recevoir le csv des résultats après publication 😉 )
• lancer le test avec le candidat, et ne répondre qu'à 19 questions
• Dans Pix certif, cliquer sur “Finaliser la session”
• sélectionner l’option “Abandon : manque de temps ou départ prématuré” comme raison de l’abandon puis confirmer la finalisation
• dans Pix admin > ouvrir la page de détails de la certif
• résultat : le statut de la certif est “Rejetée”
• publier la session
• sur le compte app du candidat, ouvrir la page 'Mes certifications”
• résultat : la certif est au statut rejetée
• ouvrir le mail reçu avec les résultat de la certif
• résultat : pour cette certification, il est indiqué “Rejetée” dans la colonne “Statut”


