### PR TITLE
[FEATURE] Ne pas afficher l'icone de réponse si un candidat passe une question dans la page de détails (PIX-10682).

### DIFF
--- a/admin/app/components/certifications/certification/details-v3.hbs
+++ b/admin/app/components/certifications/certification/details-v3.hbs
@@ -90,7 +90,7 @@
                   </button>
                 {{/if}}
 
-                {{#if certificationChallenge.answerValue}}
+                {{#if (this.shouldDisplayAnswerValueIcon certificationChallenge)}}
                   <button
                     title="Afficher la réponse du candidat"
                     aria-label="Afficher la réponse du candidat"

--- a/admin/app/components/certifications/certification/details-v3.js
+++ b/admin/app/components/certifications/certification/details-v3.js
@@ -28,6 +28,14 @@ export default class DetailsV3 extends Component {
     return certificationChallenge.validatedLiveAlert || certificationChallenge.answeredAt;
   }
 
+  shouldDisplayAnswerValueIcon(certificationChallenge) {
+    return (
+      certificationChallenge.answerStatus !== 'aband' &&
+      certificationChallenge.answerStatus !== null &&
+      !certificationChallenge.validatedLiveAlert
+    );
+  }
+
   externalUrlForPreviewChallenge(challengeId) {
     return `https://app.pix.fr/challenges/${challengeId}/preview`;
   }


### PR DESCRIPTION
## :christmas_tree: Problème

Une nouvelle page de détails spécifique aux certifs v3 a été implémentée dans Pix Admin. Parmi les informations disponibles sur cette page, on trouve la réponse apportée à la question par un candidat. Cette information est accessible en cliquant sur une icône dans la colonne “Actions”.

L’icône permettant de voir la réponse apportée à la question est disponible pour une question au statut “Abandonnée” ce qui n’est pas pertinent car par défaut, question abandonnée = pas de réponse apportée par le candidat.

## :gift: Proposition

Dans Pix Admin > page de détails d’une certification v3 : ne pas afficher l’icône réponse pour une question au statut “Abandonnée”

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester

• trouver une certif v3 avec au moins une question qui a été passée (= abandonnée) 
OU
• créer une session dans un CDC taggué isV3Pilot > inscrire un candidat à cette session > rejoindre la session avec le candidat > cliquer sur le bouton “Je passe” pour au moins 1 question du test (et bien ou mal répondre à quelques questions)
• dans Pix Admin > Certifications > ouvrir la page de détails de la certif avec au moins 1 question passée/abandonnée
• résultat : l’icône “Réponse” n’est pas affichée pour la/les question(s) au statut “Abandonnée”
• l’icône “Réponse” reste visible pour les questions au statut “OK” ou “KO”
