### PR TITLE
[TECH] Ajout d'un script pour créer une configuration d'algo de certification V3 (PIX-10713).

### DIFF
--- a/api/scripts/certification/next-gen/generate-flash-algorithm-configuration.js
+++ b/api/scripts/certification/next-gen/generate-flash-algorithm-configuration.js
@@ -1,0 +1,47 @@
+import { logger } from '../../../lib/infrastructure/logger.js';
+import { disconnect } from '../../../db/knex-database-connection.js';
+import * as flashAlgorithmConfigurationRepository from '../../../src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js';
+import * as url from 'url';
+import { FlashAssessmentAlgorithmConfiguration } from '../../../src/certification/flash-certification/domain/models/FlashAssessmentAlgorithmConfiguration.js';
+
+const modulePath = url.fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === modulePath;
+const __filename = modulePath;
+
+async function main() {
+  logger.info(`Script ${__filename} est lancé !`);
+
+  const configurationData = {
+    warmUpLength: null,
+    forcedCompetences: [],
+    maximumAssessmentLength: 32,
+    challengesBetweenSameCompetence: null,
+    minimumEstimatedSuccessRateRanges: [],
+    limitToOneQuestionPerTube: true,
+    enablePassageByAllCompetences: true,
+    doubleMeasuresUntil: null,
+    variationPercent: 0.5,
+    variationPercentUntil: null,
+  };
+
+  const configuration = new FlashAssessmentAlgorithmConfiguration(configurationData);
+
+  await flashAlgorithmConfigurationRepository.save(configuration);
+
+  logger.info('La configuration a été créée.');
+}
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      console.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+    }
+  }
+})();
+
+export { main };

--- a/api/tests/integration/scripts/certification/next-gen/generate-flash-algorithm-configuration_test.js
+++ b/api/tests/integration/scripts/certification/next-gen/generate-flash-algorithm-configuration_test.js
@@ -1,0 +1,28 @@
+import { expect, knex } from '../../../../test-helper.js';
+import { main } from '../../../../../scripts/certification/next-gen/generate-flash-algorithm-configuration.js';
+import _ from 'lodash';
+
+describe('Integration | Scripts | Certification | generate-flash-algorithm-configuration', function () {
+  const TABLE_NAME = 'flash-algorithm-configurations';
+
+  it('should create a flash algorithm configuration', async function () {
+    // when
+    await main();
+
+    // then
+    const expectedFlashAlgorithmConfiguration = {
+      warmUpLength: null,
+      forcedCompetences: [],
+      maximumAssessmentLength: 32,
+      challengesBetweenSameCompetence: null,
+      minimumEstimatedSuccessRateRanges: [],
+      limitToOneQuestionPerTube: true,
+      enablePassageByAllCompetences: true,
+      doubleMeasuresUntil: null,
+      variationPercent: 0.5,
+      variationPercentUntil: null,
+    };
+    const flashAlgorithmConfiguration = await knex(TABLE_NAME).first();
+    expect(_.omit(flashAlgorithmConfiguration, 'id')).to.deep.equal(expectedFlashAlgorithmConfiguration);
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème

Nous ne pouvons actuellement pas générer de configuration pour l'algorithm de certif next-gen via une route API.

## :gift: Proposition

Création d'un script en attendant la création de la route API et en prévision des premiers tests utilisateurs.

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester

Exécuter le script sur la RA et vérifier qu'une configuration a bien été créée en base.
