### PR TITLE
[FEATURE] Utiliser un fichier de langues pour lister les languages disponibles sur Pix App (PIX-10684)

### DIFF
--- a/mon-pix/app/components/language-switcher.js
+++ b/mon-pix/app/components/language-switcher.js
@@ -2,17 +2,35 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
+import languages from 'mon-pix/languages';
+
+const FRENCH_LANGUAGE = 'fr';
+
 export default class LanguageSwitcher extends Component {
   @tracked selectedLanguage = this.args.selectedLanguage;
 
-  availableLanguages = [
-    { label: 'Français', value: 'fr' },
-    { label: 'English', value: 'en' },
-  ];
+  availableLanguages = this.mapToOptions(languages);
 
   @action
   onChange(value) {
     this.selectedLanguage = value;
     this.args.onLanguageChange(value);
+  }
+
+  mapToOptions(languages) {
+    const options = Object.entries(languages)
+      .filter(([_, config]) => config.languageSwitcherDisplayed)
+      .map(([key, config]) => ({
+        label: config.value,
+        value: key,
+      }));
+
+    const optionsWithoutFrSortedByLabel = options
+      .filter((option) => option.value !== FRENCH_LANGUAGE)
+      .sort((option) => option.label);
+
+    const frenchLanguageOption = options.find((option) => option.value === FRENCH_LANGUAGE);
+
+    return [frenchLanguageOption, ...optionsWithoutFrSortedByLabel];
   }
 }

--- a/mon-pix/app/languages.js
+++ b/mon-pix/app/languages.js
@@ -1,0 +1,11 @@
+export default {
+  en: {
+    value: 'English',
+    languageSwitcherDisplayed: true,
+  },
+
+  fr: {
+    value: 'Français',
+    languageSwitcherDisplayed: true,
+  },
+};

--- a/mon-pix/app/services/locale.js
+++ b/mon-pix/app/services/locale.js
@@ -1,5 +1,6 @@
 import Service, { inject as service } from '@ember/service';
 import config from 'mon-pix/config/environment';
+import languages from 'mon-pix/languages';
 
 const { COOKIE_LOCALE_LIFESPAN_IN_SECONDS } = config.APP;
 export const FRENCH_INTERNATIONAL_LOCALE = 'fr';
@@ -7,7 +8,7 @@ export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 export const FRENCH_FRANCE_LOCALE = 'fr-FR';
 export const DEFAULT_LOCALE = FRENCH_INTERNATIONAL_LOCALE;
 
-const supportedLanguages = [FRENCH_INTERNATIONAL_LOCALE, ENGLISH_INTERNATIONAL_LOCALE];
+const supportedLanguages = Object.keys(languages);
 
 export default class LocaleService extends Service {
   @service cookies;

--- a/mon-pix/tests/integration/components/language-switcher_test.js
+++ b/mon-pix/tests/integration/components/language-switcher_test.js
@@ -19,7 +19,7 @@ module('Integration | Component | Language Switcher', function (hooks) {
   });
 
   module('when component is clicked', function () {
-    test('displays a list of available languages', async function (assert) {
+    test('displays a list of available languages with french language first', async function (assert) {
       // given
       const screen = await render(hbs`<LanguageSwitcher @selectedLanguage="en" />`);
 
@@ -28,8 +28,12 @@ module('Integration | Component | Language Switcher', function (hooks) {
       await screen.findByRole('listbox');
 
       // then
-      assert.dom(screen.getByRole('option', { name: 'Français' })).exists();
-      assert.dom(screen.getByRole('option', { name: 'English' })).exists();
+      const options = await screen.findAllByRole('option');
+      const optionsInnerText = options.map((option) => {
+        return option.innerText;
+      });
+
+      assert.deepEqual(optionsInnerText, ['Français', 'English']);
     });
   });
 

--- a/mon-pix/tests/unit/components/language-switcher_test.js
+++ b/mon-pix/tests/unit/components/language-switcher_test.js
@@ -1,0 +1,110 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from 'mon-pix/tests/helpers/create-glimmer-component';
+
+module('Unit | Component | language-switcher', function (hooks) {
+  setupTest(hooks);
+
+  let component;
+
+  hooks.beforeEach(function () {
+    component = createGlimmerComponent('language-switcher');
+  });
+
+  module('#mapToOptions', function () {
+    test('sorts languages with french international language first', function (assert) {
+      // given
+      const languages = {
+        en: {
+          value: 'English',
+          languageSwitcherDisplayed: true,
+        },
+        fr: {
+          value: 'Français',
+          languageSwitcherDisplayed: true,
+        },
+      };
+
+      // when
+      const result = component.mapToOptions(languages);
+
+      // then
+      const expectedResult = {
+        label: 'Français',
+        value: 'fr',
+      };
+
+      assert.deepEqual(result[0], expectedResult);
+    });
+
+    test('sorts other languages by "value"', function (assert) {
+      // given
+      const languages = {
+        en: {
+          value: 'English',
+          languageSwitcherDisplayed: true,
+        },
+        es: {
+          value: 'Spanish',
+          languageSwitcherDisplayed: true,
+        },
+        fr: {
+          value: 'Français',
+          languageSwitcherDisplayed: true,
+        },
+      };
+
+      // when
+      const result = component.mapToOptions(languages);
+
+      // then
+      const expectedResult = [
+        {
+          label: 'Français',
+          value: 'fr',
+        },
+        {
+          label: 'English',
+          value: 'en',
+        },
+        {
+          label: 'Spanish',
+          value: 'es',
+        },
+      ];
+      assert.deepEqual(result, expectedResult);
+    });
+
+    module('when languages have attribute "languageSwitcherDisplayed" at "false"', function () {
+      test(`does not map these languages`, function (assert) {
+        // given
+        const languages = {
+          fr: {
+            value: 'Français',
+            languageSwitcherDisplayed: true,
+          },
+          en: {
+            value: 'English',
+            languageSwitcherDisplayed: false,
+          },
+          es: {
+            value: 'Spanish',
+            languageSwitcherDisplayed: false,
+          },
+        };
+
+        // when
+        const result = component.mapToOptions(languages);
+
+        // then
+        const expectedResult = [
+          {
+            label: 'Français',
+            value: 'fr',
+          },
+        ];
+        assert.deepEqual(result, expectedResult);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, la gestion des langues sur Pix App est décentralisée. 
Il faut pour ajouter une nouvelle langue : 
- Ajouter l'entrée dans le composant language switcher pour qu'il apparaisse sur les mires de connexions
- Ajouter la langue dans le service locale pour qu'il puisse gérer le cas où on met `?lang={newLang}`

## :gift: Proposition
Centraliser cette gestion dans un fichier de config languages.js

## :socks: Remarques
- Un champ languageSwitcherDisplayed a été ajouté dans le cas où on veut, lors de l'ajout d'une langue, qu'il puisse être disponible avec le paramètre `?lang=` mais non affiché sur les language switcher du site.

## :santa: Pour tester
### Test de non régression
#### Connexion / Inscription Language Switcher
- Aller sur la RA de Pix App .org https://app-pr7835.review.pix.org/
- Vérifier que Français est bien affiché lorsqu'on arrive sur cette page
- Sélectionner l'option `English` dans le language Switcher
- Vérifier que la page de connexion se met bien en anglais
- Répéter les même étapes sur la page d'inscription

#### Connexion / Inscription ?lang=en
- Aller sur la RA https://app-pr7835.review.pix.org/connexion?lang=en
- Vérifier que la page est en anglais.
- Vérifier que le language switcher affiche bien l'option English.
- Sélectionner l'option Français dans le language switcher.
- Vérifier que le contenu de la page passe en français.
- Vérifier que l'url ne contient plus ?lang=en

#### Page pour commencer une campagne (Language Switcher)
- Aller sur cette page https://app-pr7835.review.pix.org/campagnes/EDUMULTIP/presentation
- Sélectionner l'option `English` dans le language Switcher tout en bas de la page.
- Vérifier que le contenu de la page passe bien en anglais

#### Test après connexion (?lang=en)
- Aller sur la RA de Pix App .org https://app-pr7835.review.pix.org/
- Se connecter avec un compte utilisateur (ex: james-paledroits@example.net)
- Ajouter ?lang=en à l'url (https://app-pr7835.review.pix.org/accueil?lang=en)
- Vérifier que le contenu de la page passe bien en anglais.

#### Changement de la langue préférée
- Aller sur la page langue de mon compte : https://app-pr7835.review.pix.org/mon-compte/langue
- Changer la langue en English
- Vérifier que le changement fonctionne et que le contenu de la page passe bien en anglais


