### PR TITLE
[BUGFIX] Réparation de l'injection de dépendance pour les certifications complémentaires

### DIFF
--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -1,6 +1,6 @@
 import { SessionPublicationBatchError } from '../http-errors.js';
 import { usecases } from '../../domain/usecases/index.js';
-import { usecases as certificationUsecases } from '../../../src/certification/shared/domain/usecases/index.js';
+import { usecases as sessionUsecases } from '../../../src/certification/session/domain/usecases/index.js';
 import { tokenService } from '../../../src/shared/domain/services/token-service.js';
 import * as sessionResultsLinkService from '../../domain/services/session-results-link-service.js';
 import * as sessionValidator from '../../../src/certification/session/domain/validators/session-validator.js';
@@ -171,7 +171,7 @@ const enrolStudentsToSession = async function (
   const studentIds = request.deserializedPayload.organizationLearnerIds;
 
   await usecases.enrolStudentsToSession({ sessionId, referentId, studentIds });
-  const certificationCandidates = await certificationUsecases.getSessionCertificationCandidates({ sessionId });
+  const certificationCandidates = await sessionUsecases.getSessionCertificationCandidates({ sessionId });
   const certificationCandidatesSerialized =
     dependencies.certificationCandidateSerializer.serialize(certificationCandidates);
   return h.response(certificationCandidatesSerialized).created();

--- a/api/src/certification/session/application/certification-candidate-controller.js
+++ b/api/src/certification/session/application/certification-candidate-controller.js
@@ -1,12 +1,13 @@
 import * as certificationCandidateSerializer from '../../shared/infrastructure/serializers/jsonapi/certification-candidate-serializer.js';
 import * as sessionCertificationCandidateSerializer from '../../session/infrastructure/serializers/jsonapi/certification-candidate-serializer.js';
-import { usecases } from '../../shared/domain/usecases/index.js';
+import { usecases as sharedUsecases } from '../../shared/domain/usecases/index.js';
+import { usecases } from '../domain/usecases/index.js';
 
 const addCandidate = async function (request, h, dependencies = { certificationCandidateSerializer }) {
   const sessionId = request.params.id;
   const certificationCandidate = await dependencies.certificationCandidateSerializer.deserialize(request.payload);
   const complementaryCertification = request.payload.data.attributes['complementary-certification'] ?? null;
-  const addedCertificationCandidate = await usecases.addCertificationCandidateToSession({
+  const addedCertificationCandidate = await sharedUsecases.addCertificationCandidateToSession({
     sessionId,
     certificationCandidate,
     complementaryCertification,
@@ -25,7 +26,7 @@ const getCandidate = async function (request, h, dependencies = { sessionCertifi
 const deleteCandidate = async function (request) {
   const certificationCandidateId = request.params.certificationCandidateId;
 
-  await usecases.deleteUnlinkedCertificationCandidate({ certificationCandidateId });
+  await sharedUsecases.deleteUnlinkedCertificationCandidate({ certificationCandidateId });
 
   return null;
 };

--- a/api/src/certification/session/domain/usecases/get-session-certification-candidates.js
+++ b/api/src/certification/session/domain/usecases/get-session-certification-candidates.js
@@ -1,6 +1,6 @@
 /**
- * @typedef {import('../../../shared/domain/usecases/index.js').CandidateRepository} CandidateRepository
- * @typedef {import('../../../shared/domain/usecases/index.js').ComplementaryCertificationRepository} ComplementaryCertificationRepository
+ * @typedef {import('./index.js').CandidateRepository} CandidateRepository
+ * @typedef {import('./index.js').ComplementaryCertificationRepository} ComplementaryCertificationRepository
  * @typedef {import('../../../../shared/domain/errors.js').NotFoundError} NotFoundError
  */
 import { EnrolledCandidate } from '../read-models/EnrolledCandidate.js';

--- a/api/src/certification/session/domain/usecases/index.js
+++ b/api/src/certification/session/domain/usecases/index.js
@@ -1,0 +1,58 @@
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
+import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
+
+import * as candidateRepository from '../../infrastructure/repositories/candidate-repository.js';
+/**
+ * @typedef {import('../../infrastructure/repositories/index.js').ComplementaryCertificationRepository} ComplementaryCertificationRepository
+ **/
+import { sessionRepositories } from '../../../session/infrastructure/repositories/index.js';
+
+/**
+ * Using {@link https://jsdoc.app/tags-type "Closure Compiler's syntax"} to document injected dependencies
+ *
+ * @typedef {candidateRepository} CandidateRepository
+ * @typedef {complementaryCertificationRepository} ComplementaryCertificationRepository
+ **/
+const dependencies = {
+  candidateRepository,
+  complementaryCertificationRepository: sessionRepositories.complementaryCertificationRepository,
+};
+
+const path = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Note : current ignoredFileNames are injected in * {@link file://./../../../shared/domain/usecases/index.js}
+ * This is in progress, because they should be injected in this file and not by shared sub-domain
+ * The only remaining file ignored should be index.js
+ */
+const usecasesWithoutInjectedDependencies = {
+  ...(await importNamedExportsFromDirectory({
+    path: join(path, './'),
+    ignoredFileNames: [
+      'index.js',
+      'add-certification-candidate-to-session.js',
+      'assign-certification-officer-to-jury-session.js',
+      'create-session.js',
+      'create-sessions.js',
+      'delete-session.js',
+      'delete-unlinked-certification-candidate.js',
+      'dismiss-live-alert.js',
+      'finalize-session.js',
+      'get-attendance-sheet.js',
+      'get-cpf-presigned-urls.js',
+      'get-invigilator-kit-session-info.js',
+      'integrate-cpf-processing-receipts.js',
+      'update-session.js',
+      'upload-cpf-files.js',
+      'validate-live-alert.js',
+      'validate-sessions.js',
+    ],
+  })),
+};
+
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+
+export { usecases };

--- a/api/src/certification/session/infrastructure/repositories/index.js
+++ b/api/src/certification/session/infrastructure/repositories/index.js
@@ -2,6 +2,11 @@ import { injectDependencies } from '../../../../shared/infrastructure/utils/depe
 import * as complementaryCertificationApi from '../../../complementary-certification/application/api/complementary-certification-api.js';
 import * as complementaryCertificationRepository from './complementary-certification-repository.js';
 
+/**
+ * Using {@link https://jsdoc.app/tags-type "Closure Compiler's syntax"} to document injected dependencies
+ *
+ * @typedef {complementaryCertificationRepository} ComplementaryCertificationRepository
+ */
 const repositoriesWithoutInjectedDependencies = {
   complementaryCertificationRepository,
 };

--- a/api/src/certification/shared/domain/usecases/index.js
+++ b/api/src/certification/shared/domain/usecases/index.js
@@ -13,7 +13,7 @@ import * as certificationChallengeLiveAlertRepository from '../../../session/inf
 import * as certificationCourseRepository from '../../infrastructure/repositories/certification-course-repository.js';
 import * as certificationIssueReportRepository from '../../../shared/infrastructure/repositories/certification-issue-report-repository.js';
 import * as certificationReportRepository from '../../../shared/infrastructure/repositories/certification-report-repository.js';
-import { sessionRepositories } from '../../../session/infrastructure/repositories/index.js';
+import * as complementaryCertificationRepository from '../../../../../lib/infrastructure/repositories/complementary-certification-repository.js';
 import * as certificateRepository from '../../../course/infrastructure/repositories/certificate-repository.js';
 import * as challengeRepository from '../../../../shared/infrastructure/repositories/challenge-repository.js';
 import * as certificationCpfCountryRepository from '../../../shared/infrastructure/repositories/certification-cpf-country-repository.js';
@@ -62,7 +62,7 @@ import { injectDependencies } from '../../../../shared/infrastructure/utils/depe
  * @typedef {certificationOfficerRepository} CertificationOfficerRepository
  * @typedef {competenceMarkRepository} CompetenceMarkRepository
  * @typedef {competenceRepository} CompetenceRepository
- * @typedef {import('../../../session/infrastructure/repositories/complementary-certification-repository.js')} ComplementaryCertificationRepository
+ * @typedef {complementaryCertificationRepository} ComplementaryCertificationRepository
  * @typedef {cpfExportRepository} CpfExportRepository
  * @typedef {finalizedSessionRepository} FinalizedSessionRepository
  * @typedef {flashAlgorithmService} FlashAlgorithmService
@@ -99,7 +99,7 @@ const dependencies = {
   certificationCpfCountryRepository,
   competenceMarkRepository,
   competenceRepository,
-  complementaryCertificationRepository: sessionRepositories.complementaryCertificationRepository,
+  complementaryCertificationRepository,
   finalizedSessionRepository,
   flashAlgorithmService,
   issueReportCategoryRepository,
@@ -122,10 +122,14 @@ const dependencies = {
 
 const path = dirname(fileURLToPath(import.meta.url));
 
+/**
+ * TODO: move sub-domains usecases to their own index.js because it is currently crossing domains concerns
+ * This file should inject usecases from the shared sub-domain only.
+ */
 const usecasesWithoutInjectedDependencies = {
   ...(await importNamedExportsFromDirectory({
     path: join(path, '../../../session/domain/usecases/'),
-    ignoredFileNames: ['index.js'],
+    ignoredFileNames: ['index.js', 'get-session-certification-candidates.js'],
   })),
   ...(await importNamedExportsFromDirectory({
     path: join(path, '../../../flash-certification/domain/usecases/'),

--- a/api/tests/certification/session/acceptance/application/certification-candidate-route_test.js
+++ b/api/tests/certification/session/acceptance/application/certification-candidate-route_test.js
@@ -1,0 +1,72 @@
+import { expect, databaseBuilder, generateValidRequestAuthorizationHeader } from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
+import { ComplementaryCertificationKeys } from '../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
+import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
+import { CertificationCandidate } from '../../../../../lib/domain/models/CertificationCandidate.js';
+const { ROLES } = PIX_ADMIN;
+
+describe('Acceptance | Controller | Session | certification-candidate-route', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('GET /api/sessions/{id}/certification-candidates', function () {
+    it('should respond with a 200', async function () {
+      // given
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const certificationCenterUserId = databaseBuilder.factory.buildUser.withRole({
+        id: 1234,
+        firstName: 'Super',
+        lastName: 'Papa',
+        email: 'super.papa@example.net',
+        password: 'Password123',
+        role: ROLES.CERTIF,
+      }).id;
+      databaseBuilder.factory.buildCertificationCenterMembership({
+        userId: certificationCenterUserId,
+        certificationCenterId,
+      });
+      const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
+      const candidateUserId = databaseBuilder.factory.buildUser({}).id;
+      const candidateId = databaseBuilder.factory.buildCertificationCandidate({
+        id: 1001,
+        sessionId,
+        userId: candidateUserId,
+        billingMode: CertificationCandidate.BILLING_MODES.PREPAID,
+      }).id;
+      const cleaComplementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
+        id: 10000006,
+        key: ComplementaryCertificationKeys.CLEA,
+        label: 'CléA Numérique',
+      });
+      databaseBuilder.factory.buildComplementaryCertificationHabilitation({
+        certificationCenterId,
+        complementaryCertificationId: cleaComplementaryCertification.id,
+      });
+      databaseBuilder.factory.buildComplementaryCertificationSubscription({
+        certificationCandidateId: candidateId,
+        complementaryCertificationId: cleaComplementaryCertification.id,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const options = {
+        method: 'GET',
+        url: `/api/sessions/${sessionId}/certification-candidates`,
+        payload: {},
+        headers: { authorization: generateValidRequestAuthorizationHeader(certificationCenterUserId, 'pix-certif') },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.payload).to.equal(
+        '{"data":[{"type":"certification-candidates","id":"1001","attributes":{"first-name":"first-name","last-name":"last-name","birthdate":"2000-01-04","birth-province-code":null,"birth-city":"PARIS 1","birth-country":"France","email":"somemail@example.net","result-recipient-email":"somerecipientmail@example.net","external-id":"externalId","extra-time-percentage":0.3,"is-linked":true,"organization-learner-id":null,"sex":"M","birth-insee-code":"75101","birth-postal-code":null,"complementary-certification":{"id":10000006,"label":"CléA Numérique","key":"CLEA"},"billing-mode":"PREPAID","prepayment-code":null}}]}',
+      );
+    });
+  });
+});

--- a/api/tests/certification/session/acceptance/application/session-route_test.js
+++ b/api/tests/certification/session/acceptance/application/session-route_test.js
@@ -5,13 +5,13 @@ import {
   generateValidRequestAuthorizationHeader,
   learningContentBuilder,
   mockLearningContent,
-} from '../../../test-helper.js';
-import { createServer } from '../../../../server.js';
+} from '../../../../test-helper.js';
+import { createServer } from '../../../../../server.js';
 import {
   CertificationIssueReportCategory,
   CertificationIssueReportSubcategories,
-} from '../../../../src/certification/shared/domain/models/CertificationIssueReportCategory.js';
-import { AnswerStatus, CertificationResult } from '../../../../lib/domain/models/index.js';
+} from '../../../../../src/certification/shared/domain/models/CertificationIssueReportCategory.js';
+import { AnswerStatus, CertificationResult } from '../../../../../lib/domain/models/index.js';
 
 describe('Acceptance | Controller | Session | session-route', function () {
   let server;

--- a/api/tests/certification/session/unit/application/certification-candidate-controller_test.js
+++ b/api/tests/certification/session/unit/application/certification-candidate-controller_test.js
@@ -1,6 +1,7 @@
 import { expect, hFake, sinon } from '../../../../test-helper.js';
 import { certificationCandidateController } from '../../../../../src/certification/session/application/certification-candidate-controller.js';
-import { usecases } from '../../../../../src/certification/shared/domain/usecases/index.js';
+import { usecases as sharedUsecases } from '../../../../../src/certification/shared/domain/usecases/index.js';
+import { usecases } from '../../../../../src/certification/session/domain/usecases/index.js';
 
 describe('Unit | Controller | certification-candidate-controller', function () {
   describe('#add', function () {
@@ -20,8 +21,8 @@ describe('Unit | Controller | certification-candidate-controller', function () {
           },
         },
       };
-      sinon.stub(usecases, 'addCertificationCandidateToSession');
-      usecases.addCertificationCandidateToSession
+      sinon.stub(sharedUsecases, 'addCertificationCandidateToSession');
+      sharedUsecases.addCertificationCandidateToSession
         .withArgs({
           sessionId,
           certificationCandidate,
@@ -90,7 +91,10 @@ describe('Unit | Controller | certification-candidate-controller', function () {
       request = {
         params: { id: sessionId, certificationCandidateId },
       };
-      sinon.stub(usecases, 'deleteUnlinkedCertificationCandidate').withArgs({ certificationCandidateId }).resolves();
+      sinon
+        .stub(sharedUsecases, 'deleteUnlinkedCertificationCandidate')
+        .withArgs({ certificationCandidateId })
+        .resolves();
     });
 
     it('should return 204 when deleting successfully the candidate', async function () {

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -1,7 +1,7 @@
 import { catchErr, expect, hFake, sinon } from '../../../test-helper.js';
 import { sessionController } from '../../../../lib/application/sessions/session-controller.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
-import { usecases as certificationUsecases } from '../../../../src/certification/shared/domain/usecases/index.js';
+import { usecases as sessionUsecases } from '../../../../src/certification/session/domain/usecases/index.js';
 import { UserAlreadyLinkedToCertificationCandidate } from '../../../../lib/domain/events/UserAlreadyLinkedToCertificationCandidate.js';
 import { UserLinkedToCertificationCandidate } from '../../../../lib/domain/events/UserLinkedToCertificationCandidate.js';
 import { SessionPublicationBatchResult } from '../../../../lib/domain/models/index.js';
@@ -266,7 +266,7 @@ describe('Unit | Controller | sessionController', function () {
       };
       const requestResponseUtils = { extractUserIdFromRequest: sinon.stub() };
       sinon.stub(usecases, 'enrolStudentsToSession');
-      sinon.stub(certificationUsecases, 'getSessionCertificationCandidates');
+      sinon.stub(sessionUsecases, 'getSessionCertificationCandidates');
       const certificationCandidateSerializer = { serialize: sinon.stub() };
       dependencies = {
         requestResponseUtils,
@@ -278,7 +278,7 @@ describe('Unit | Controller | sessionController', function () {
       beforeEach(function () {
         dependencies.requestResponseUtils.extractUserIdFromRequest.withArgs(request).returns(userId);
         usecases.enrolStudentsToSession.withArgs({ sessionId, referentId: userId, studentIds }).resolves();
-        certificationUsecases.getSessionCertificationCandidates.withArgs({ sessionId }).resolves(studentList);
+        sessionUsecases.getSessionCertificationCandidates.withArgs({ sessionId }).resolves(studentList);
         dependencies.certificationCandidateSerializer.serialize
           .withArgs(studentList)
           .returns(serializedCertificationCandidate);


### PR DESCRIPTION
## :christmas_tree: Problème

La mise en recette est bloqué car sur des ajouts / lectures de candidats avec certification complémentaires, les dépendances logicielles injectées ne sont pas les bonnes.

## :gift: Proposition

* Ajouter le test d'Acceptance manquant sur le getCandidate
* Injecter les bonnes dépendances dans les bons usecases

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester

* Refaire les tests fonctionnels de la PR #7701, en particulier
  * ajouter un candidat avec des certif complémentaires via le bouton sur Pix Certif
  * ajouter des candidats avec **et** sans complémentaires via import en masse
  * afficher les détails des candidats ajoutés, vérifier que les complémentaires affichées sont bonnes
