### PR TITLE
[FEATURE] Ajout du néerlandais dans les langues disponibles côté API (PIX-10683)

### DIFF
--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -10,6 +10,7 @@ import { EntityValidationError } from '../../../src/shared/domain/errors.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
 import * as OidcIdentityProviders from '../../domain/constants/oidc-identity-providers.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../domain/constants/identity-providers.js';
+import { AVAILABLE_LANGUAGES } from '../../../src/shared/domain/services/language-service.js';
 
 const reassignAuthenticationMethodJoiSchema = Joi.object({
   data: {
@@ -238,7 +239,7 @@ const register = async function (server) {
                 'last-name': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
                 email: Joi.string().email().allow(null).optional(),
                 username: Joi.string().allow(null).optional(),
-                lang: Joi.string().valid('fr', 'en'),
+                lang: Joi.string().valid(...AVAILABLE_LANGUAGES),
                 locale: Joi.string().allow(null).optional().valid('en', 'fr', 'fr-BE', 'fr-FR'),
               },
             },
@@ -734,7 +735,7 @@ const register = async function (server) {
         validate: {
           params: Joi.object({
             id: identifiersType.userId,
-            lang: Joi.string().valid('fr', 'en'),
+            lang: Joi.string().valid(...AVAILABLE_LANGUAGES),
           }),
         },
         pre: [

--- a/api/lib/domain/models/User.js
+++ b/api/lib/domain/models/User.js
@@ -7,6 +7,7 @@ import dayjs from 'dayjs';
 import { config } from '../../config.js';
 import * as localeService from '../services/locale-service.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
+import * as languageService from '../../../src/shared/domain/services/language-service.js';
 
 class User {
   constructor(
@@ -43,11 +44,13 @@ class User {
       hasBeenAnonymised,
       hasBeenAnonymisedBy,
     } = {},
-    dependencies = { config, localeService },
+    dependencies = { config, localeService, languageService },
   ) {
     if (locale) {
       locale = dependencies.localeService.getCanonicalLocale(locale);
     }
+
+    dependencies.languageService.assertLanguageAvailability(lang);
 
     this.id = id;
     this.firstName = firstName;
@@ -69,7 +72,7 @@ class User {
     this.hasSeenLevelSevenInfo = hasSeenLevelSevenInfo;
     this.hasSeenFocusedChallengeTooltip = hasSeenFocusedChallengeTooltip;
     this.knowledgeElements = knowledgeElements;
-    this.lang = lang;
+    this.lang = lang ?? dependencies.languageService.LANGUAGES_CODE.FRENCH;
     this.locale = locale;
     this.isAnonymous = isAnonymous;
     this.pixScore = pixScore;

--- a/api/src/certification/course/infrastructure/utils/pdf/certification-attestation-pdf.js
+++ b/api/src/certification/course/infrastructure/utils/pdf/certification-attestation-pdf.js
@@ -11,8 +11,8 @@ import * as url from 'url';
 import { AttestationViewModel } from './AttestationViewModel.js';
 import { CertificationAttestationGenerationError } from '../../../../../shared/domain/errors.js';
 import { logger } from '../../../../../shared/infrastructure/utils/logger.js';
-import { LANG } from '../../../../../shared/domain/constants.js';
-const { ENGLISH } = LANG;
+import { LANGUAGES_CODE } from '../../../../../shared/domain/services/language-service.js';
+const { ENGLISH } = LANGUAGES_CODE;
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 const fonts = {

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -101,6 +101,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.LocaleFormatError) {
     return new HttpErrors.BadRequestError(error.message, error.code, error.meta);
   }
+  if (error instanceof DomainErrors.LanguageNotSupportedError) {
+    return new HttpErrors.BadRequestError(error.message, error.code, error.meta);
+  }
   if (error instanceof DomainErrors.LocaleNotSupportedError) {
     return new HttpErrors.BadRequestError(error.message, error.code, error.meta);
   }

--- a/api/src/shared/domain/constants.js
+++ b/api/src/shared/domain/constants.js
@@ -5,14 +5,11 @@ const LOCALE = {
   FRENCH_FRANCE: 'fr-fr',
   FRENCH_SPOKEN: 'fr',
 };
-const LANG = {
-  ENGLISH: 'en',
-  FRENCH: 'fr',
-};
+
 const SUPPORTED_LOCALES = ['en', 'fr', 'fr-BE', 'fr-FR'];
 
 const constants = {
   LEVENSHTEIN_DISTANCE_MAX_RATE,
 };
 
-export { constants, LEVENSHTEIN_DISTANCE_MAX_RATE, LANG, LOCALE, SUPPORTED_LOCALES };
+export { constants, LEVENSHTEIN_DISTANCE_MAX_RATE, LOCALE, SUPPORTED_LOCALES };

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -111,6 +111,14 @@ class MissingAssessmentId extends DomainError {
   }
 }
 
+class LanguageNotSupportedError extends DomainError {
+  constructor(languageCode) {
+    super(`Given language is not supported : "${languageCode}"`);
+    this.code = 'LANGUAGE_NOT_SUPPORTED';
+    this.meta = { languageCode };
+  }
+}
+
 class LocaleFormatError extends DomainError {
   constructor(locale) {
     super(`Given locale is in invalid format: "${locale}"`);
@@ -181,6 +189,7 @@ export {
   NotFoundError,
   UserNotAuthorizedToAccessEntityError,
   NoCertificationAttestationForDivisionError,
+  LanguageNotSupportedError,
   LocaleFormatError,
   LocaleNotSupportedError,
   MissingBadgeCriterionError,

--- a/api/src/shared/domain/services/language-service.js
+++ b/api/src/shared/domain/services/language-service.js
@@ -1,0 +1,19 @@
+import { LanguageNotSupportedError } from '../errors.js';
+
+const LANGUAGES_CODE = {
+  ENGLISH: 'en',
+  FRENCH: 'fr',
+  DUTCH: 'nl',
+};
+
+const AVAILABLE_LANGUAGES = Object.values(LANGUAGES_CODE);
+
+function assertLanguageAvailability(languageCode) {
+  if (!languageCode) return;
+
+  if (!AVAILABLE_LANGUAGES.includes(languageCode)) {
+    throw new LanguageNotSupportedError(languageCode);
+  }
+}
+
+export { LANGUAGES_CODE, AVAILABLE_LANGUAGES, assertLanguageAvailability };

--- a/api/tests/certification/course/unit/application/certification-attestation-controller_test.js
+++ b/api/tests/certification/course/unit/application/certification-attestation-controller_test.js
@@ -1,9 +1,9 @@
 import { expect, sinon, domainBuilder, hFake } from '../../../../test-helper.js';
 import { certificationAttestationController } from '../../../../../src/certification/course/application/certification-attestation-controller.js';
 import { usecases } from '../../../../../src/certification/shared/domain/usecases/index.js';
-import { LANG } from '../../../../../src/shared/domain/constants.js';
+import { LANGUAGES_CODE } from '../../../../../src/shared/domain/services/language-service.js';
 import { getI18n } from '../../../../tooling/i18n/i18n.js';
-const { FRENCH } = LANG;
+const { FRENCH } = LANGUAGES_CODE;
 describe('Unit | Controller | certification-attestation-controller', function () {
   describe('#getPDFAttestation', function () {
     it('should return attestation in PDF binary format', async function () {

--- a/api/tests/certification/session/unit/application/invigilator-kit-controller_test.js
+++ b/api/tests/certification/session/unit/application/invigilator-kit-controller_test.js
@@ -2,15 +2,15 @@ import { domainBuilder, expect, hFake, sinon } from '../../../../test-helper.js'
 import { usecases } from '../../../../../src/certification/shared/domain/usecases/index.js';
 import { invigilatorKitController } from '../../../../../src/certification/session/application/invigilator-kit-controller.js';
 import { getI18n } from '../../../../tooling/i18n/i18n.js';
-import { LANG } from '../../../../../src/shared/domain/constants.js';
+import { LANGUAGES_CODE } from '../../../../../src/shared/domain/services/language-service.js';
 
 describe('Unit | Controller | invigilator-kit-controller', function () {
   describe('#getInvigilatorKitPdf', function () {
     // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     /* eslint-disable mocha/no-setup-in-describe */
     [
-      { lang: LANG.ENGLISH, filename: 'invigilator-kit-1.pdf' },
-      { lang: LANG.FRENCH, filename: 'kit-surveillant-1.pdf' },
+      { lang: LANGUAGES_CODE.ENGLISH, filename: 'invigilator-kit-1.pdf' },
+      { lang: LANGUAGES_CODE.FRENCH, filename: 'kit-surveillant-1.pdf' },
     ].forEach(function ({ lang, filename }) {
       /* eslint-enable mocha/no-setup-in-describe */
       it(`should return invigilator kit in ${lang}`, async function () {

--- a/api/tests/shared/unit/domain/services/language-service_test.js
+++ b/api/tests/shared/unit/domain/services/language-service_test.js
@@ -1,0 +1,36 @@
+import { LanguageNotSupportedError } from '../../../../../src/shared/domain/errors.js';
+import * as languageService from '../../../../../src/shared/domain/services/language-service.js';
+
+import { catchErrSync, expect } from '../../../../test-helper.js';
+
+describe('Unit | Shared | Domain | Services | Language Service', function () {
+  describe('#assertLanguageAvailability', function () {
+    context('when language code is not provided', function () {
+      it('returns nothing', function () {
+        // then
+        expect(languageService.assertLanguageAvailability()).to.be.undefined;
+      });
+    });
+    context('when given language code is available', function () {
+      it('returns nothing', function () {
+        // given
+        const languageCode = 'nl';
+
+        // when & then
+        expect(languageService.assertLanguageAvailability(languageCode)).to.be.undefined;
+      });
+    });
+    context('when given language code is not available', function () {
+      it('throws an error', function () {
+        // given
+        const languageCode = 'it';
+
+        // when
+        const error = catchErrSync(languageService.assertLanguageAvailability)(languageCode);
+
+        // then
+        expect(error).to.be.instanceOf(LanguageNotSupportedError);
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/models/User_test.js
+++ b/api/tests/unit/domain/models/User_test.js
@@ -3,6 +3,7 @@ import { User } from '../../../../lib/domain/models/User.js';
 
 describe('Unit | Domain | Models | User', function () {
   let config;
+  let languageService;
   let localeService;
   let dependencies;
 
@@ -12,10 +13,14 @@ describe('Unit | Domain | Models | User', function () {
         updateDate: '2020-01-01',
       },
     };
+    languageService = {
+      assertLanguageAvailability: sinon.stub(),
+      LANGUAGES_CODE: { FRENCH: 'fr' },
+    };
     localeService = {
       getCanonicalLocale: sinon.stub(),
     };
-    dependencies = { config, localeService };
+    dependencies = { config, localeService, languageService };
   });
 
   describe('constructor', function () {
@@ -42,6 +47,25 @@ describe('Unit | Domain | Models | User', function () {
         // then
         expect(localeService.getCanonicalLocale).to.have.been.calledWithExactly('fr-be');
         expect(user.locale).to.equal('fr-BE');
+      });
+    });
+
+    context('language', function () {
+      it('returns user given language', function () {
+        // when
+        const user = new User({ lang: 'nl' }, dependencies);
+
+        // then
+        expect(user.lang).to.equal('nl');
+      });
+
+      context('when there is no language given', function () {
+        it('returns default language', function () {
+          // when
+          const user = new User({}, dependencies);
+          // then
+          expect(user.lang).to.equal('fr');
+        });
       });
     });
   });

--- a/api/tests/unit/domain/models/User_test.js
+++ b/api/tests/unit/domain/models/User_test.js
@@ -19,28 +19,30 @@ describe('Unit | Domain | Models | User', function () {
   });
 
   describe('constructor', function () {
-    it('accepts no locale', function () {
-      // given
-      const users = [
-        new User({ locale: '' }, dependencies),
-        new User({ locale: null }, dependencies),
-        new User({ locale: undefined }, dependencies),
-      ];
+    context('locale', function () {
+      it('accepts no locale', function () {
+        // given
+        const users = [
+          new User({ locale: '' }, dependencies),
+          new User({ locale: null }, dependencies),
+          new User({ locale: undefined }, dependencies),
+        ];
 
-      //then
-      expect(users.length).to.equal(3);
-    });
+        //then
+        expect(users.length).to.equal(3);
+      });
 
-    it('validates and canonicalizes the locale', function () {
-      // given
-      localeService.getCanonicalLocale.returns('fr-BE');
+      it('validates and canonicalizes the locale', function () {
+        // given
+        localeService.getCanonicalLocale.returns('fr-BE');
 
-      // when
-      const user = new User({ locale: 'fr-be' }, dependencies);
+        // when
+        const user = new User({ locale: 'fr-be' }, dependencies);
 
-      // then
-      expect(localeService.getCanonicalLocale).to.have.been.calledWithExactly('fr-be');
-      expect(user.locale).to.equal('fr-BE');
+        // then
+        expect(localeService.getCanonicalLocale).to.have.been.calledWithExactly('fr-be');
+        expect(user.locale).to.equal('fr-BE');
+      });
     });
   });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
@@ -105,7 +105,7 @@ describe('Unit | Serializer | JSONAPI | user-serializer', function () {
             'first-name': 'Luke',
             'last-name': 'Skywalker',
             email: 'lskywalker@deathstar.empire',
-            lang: 'jp',
+            lang: 'en',
             password: '',
           },
           relationships: {},
@@ -122,7 +122,7 @@ describe('Unit | Serializer | JSONAPI | user-serializer', function () {
       expect(user.firstName).to.equal('Luke');
       expect(user.lastName).to.equal('Skywalker');
       expect(user.email).to.equal('lskywalker@deathstar.empire');
-      expect(user.lang).to.equal('jp');
+      expect(user.lang).to.equal('en');
     });
 
     it('should contain an ID attribute', function () {


### PR DESCRIPTION
## ❄️ Problème
Afin de préparer l'arrivée de Pix App en néerlandais, nous avons besoin de gérer cette nouvelle langue dans l'API.

## ⛄️ Proposition

- Extraction de l'objet qui gère les langues du fichier `api/src/shared/domain/constants.js`
- Création d'un nouveau service `language-service.js` où l'on va centraliser toute la gestion des langues 
- Ajout de la langue `DUTCH: 'nl'`
- Suite à la [suppression de la contrainte sur les langues en BDD](https://github.com/1024pix/pix/pull/7828), ajout de la gestion d'erreur des langues disponibles dans ce nouveau service
- Ajout de langue par défaut `Français` directement dans le model `User.js` grâce au `language-service.js`
- Utilisation d'une variable `AVAILABLE_LANGUAGES` dans la validation Joi des routes, pour éviter de devoir modifier plusieurs fichiers lors du prochain ajout d'une nouvelle langue

## ☕️ Remarques
RAS.

## 🍫 Pour tester

### 🟡 Pix Admin 

#### ✅ Cas de succès
- Sur Postman, se connecter avec le compte `superadmin@example.net`
- Faire un appel `PATCH` sur la route `/api/admin/users/10002` avec comme payload : 

```
{
    "data": {
        "id": "10002",
        "attributes": {
            "first-name": "NextSuper",
            "last-name": "NextAdmin",
            "lang": "nl"
        }
    }
}
```
- Vous devez avoir une réponse avec un `statut 200` et un objet avec la langue de l'utilisateur définit à : `"lang": "nl"`

#### ❌ Cas d'erreurs
- Sur Postman, se connecter avec le compte `superadmin@example.net`
- Faire un appel `PATCH` sur la route `/api/admin/users/10002` avec comme payload : 

```
{
    "data": {
        "id": "10002",
        "attributes": {
            "first-name": "NextSuper",
            "last-name": "NextAdmin",
            "lang": "it"
        }
    }
}
```
- Vous devez avoir une réponse avec un `statut 400` et le message `"\"data.attributes.lang\" must be one of [en, fr, nl]"`

#### 🆒 Tests de non regression 
- Dans le payload, remplacer la langue par ` "lang": "en"` ou ` "lang": "fr"` et vérifier que vous avez bien une réponse avec un `statut 200` et un objet avec la langue de l'utilisateur définit à : ` "lang": "en"` ou ` "lang": "fr"`.

<HR>

### 🟣 Pix App

#### ✅ Cas de succès
- Sur Postman, se connecter avec un compte utilisateur, ex: `camille-onette@example.net`
- Faire un appel `PATCH` sur la route `/api/users/101670/lang/nl` : 
- Vous devez avoir une réponse avec un `statut 200` et un objet avec la langue de l'utilisateur définit à : `"lang": "nl"`


#### ❌ Cas d'erreurs
- Sur Postman, se connecter avec un compte utilisateur, ex: `camille-onette@example.net`
- Faire un appel `PATCH` sur la route `/api/users/101670/lang/jp` : 
- Vous devez avoir une réponse avec un `statut 400` et le message `"\"lang\" must be one of [en, fr, nl]"`

#### 🆒 Tests de non regression 
- Dans votre appel, remplacer la langue par ` /api/users/101670/lang/en` ou ` /api/users/101670/lang/fr` et vérifier que vous avez bien une réponse avec un `statut 200` et un objet avec la langue de l'utilisateur définit à : ` "lang": "en"` ou ` "lang": "fr"`.
