### PR TITLE
[FEATURE] Ajout du bloc "N° de certif" sur l'onglet détail d'une certif v3 (PIX-10287)

### DIFF
--- a/admin/app/components/certifications/certification/details-v3.hbs
+++ b/admin/app/components/certifications/certification/details-v3.hbs
@@ -1,5 +1,40 @@
 <div class="certification-details-v3__container">
-  <section class="page-section"></section>
+  <section class="page-section">
+    <div class="certification-details-v3-header">
+      <h2 class="certification-details-v3__title">Certification N°{{@details.certificationCourseId}}</h2>
+      <PixTag @color={{this.detailStatusColor}}>{{this.detailStatusLabel}}</PixTag>
+    </div>
+    <dl class="certification-details-v3__list">
+      <dt>Créée le :</dt>
+      <dd>{{dayjs-format @details.createdAt "DD/MM/YYYY HH:mm:ss"}}</dd>
+      {{#if @details.completedAt}}
+        <dt>Terminée le :</dt>
+        <dd>
+          <span class="certification-details-v3-list__completion-date">{{dayjs-format @details.completedAt "DD/MM/YYYY HH:mm:ss"}}</span>
+          {{#if (lt @details.duration this.twentyFourHoursInMs)}}
+            <PixTag @color={{this.durationTagColor}}>{{dayjs-format-duration @details.duration "H[h]mm"}}</PixTag>
+          {{else}}
+            <PixTag @color={{this.durationTagColor}}> > 24h</PixTag>
+          {{/if}}
+        </dd>
+      {{/if}}
+
+      {{#if @details.shouldDisplayEndedByBlock}}
+        <dt>Certification terminée par :</dt>
+        <dd>
+          <PixTag @color={{this.certificationEndedByTagColor}}>{{this.endedByLabel}}</PixTag>
+        </dd>
+      {{/if}}
+
+      {{#if @details.abortReason}}
+        <dt>Raison de l'abandon :</dt>
+        <dd>{{this.abortReasonLabel}}</dd>
+      {{/if}}
+
+      <dt>Score (en pix) :</dt>
+      <dd>{{@details.pixScore}}</dd>
+    </dl>
+  </section>
   <section class="page-section">
     <h2 class="certification-details-v3__title">Informations complémentaires</h2>
 
@@ -58,45 +93,24 @@
               <td>{{certificationChallenge.competenceIndex}} {{certificationChallenge.competenceName}}</td>
               <td>{{certificationChallenge.skillName}}</td>
               <td>
-                <a
-                  href={{this.externalUrlForPixEditor certificationChallenge.id}}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label="Lien vers les informations de la question (Ouverture dans une nouvelle fenêtre)"
-                >
+                <a href={{this.externalUrlForPixEditor certificationChallenge.id}} target="_blank" rel="noopener noreferrer" aria-label="Lien vers les informations de la question (Ouverture dans une nouvelle fenêtre)">
                   {{certificationChallenge.id}}
                   <FaIcon @icon="external-link" />
                 </a>
               </td>
               <td class="certification-details-v3-table__challenge-action-cell">
-                <a
-                  href={{this.externalUrlForPreviewChallenge certificationChallenge.id}}
-                  target="_blank"
-                  title="Lien vers l'aperçu de l'épreuve"
-                  aria-label="Lien vers l'aperçu de l'épreuve (Ouverture dans une nouvelle fenêtre)"
-                  rel="noopener noreferrer"
-                >
+                <a href={{this.externalUrlForPreviewChallenge certificationChallenge.id}} target="_blank" title="Lien vers l'aperçu de l'épreuve" aria-label="Lien vers l'aperçu de l'épreuve (Ouverture dans une nouvelle fenêtre)" rel="noopener noreferrer">
                   <FaIcon @icon="eye" />
                 </a>
 
                 {{#if certificationChallenge.validatedLiveAlert}}
-                  <button
-                    title="Afficher le signalement de la question"
-                    aria-label="Afficher le signalement de la question"
-                    type="button"
-                    {{on "click" (fn this.openModal certificationChallenge)}}
-                  >
+                  <button title="Afficher le signalement de la question" aria-label="Afficher le signalement de la question" type="button" {{on "click" (fn this.openModal certificationChallenge)}}>
                     <FaIcon @icon="warning" />
                   </button>
                 {{/if}}
 
                 {{#if (this.shouldDisplayAnswerValueIcon certificationChallenge)}}
-                  <button
-                    title="Afficher la réponse du candidat"
-                    aria-label="Afficher la réponse du candidat"
-                    type="button"
-                    {{on "click" (fn this.openModal certificationChallenge)}}
-                  >
+                  <button title="Afficher la réponse du candidat" aria-label="Afficher la réponse du candidat" type="button" {{on "click" (fn this.openModal certificationChallenge)}}>
                     <FaIcon @icon="message" />
                   </button>
                 {{/if}}
@@ -109,11 +123,7 @@
   </div>
 </section>
 
-<PixModal
-  @title="{{this.modalTitle}} question {{this.certificationChallenge.questionNumber}}"
-  @showModal={{this.showModal}}
-  @onCloseButtonClick={{this.closeModal}}
->
+<PixModal @title="{{this.modalTitle}} question {{this.certificationChallenge.questionNumber}}" @showModal={{this.showModal}} @onCloseButtonClick={{this.closeModal}}>
   <:content>
     {{#if this.certificationChallenge.validatedLiveAlert}}
       <span class="certification-details-v3-modal__live-alert-subcategory">{{this.subCategory}}</span>

--- a/admin/app/components/certifications/certification/details-v3.hbs
+++ b/admin/app/components/certifications/certification/details-v3.hbs
@@ -1,16 +1,30 @@
 <div class="certification-details-v3__container">
   <section class="page-section">
-    <div class="certification-details-v3-header">
-      <h2 class="certification-details-v3__title">Certification N°{{@details.certificationCourseId}}</h2>
-      <PixTag @color={{this.detailStatusColor}}>{{this.detailStatusLabel}}</PixTag>
+    <div class="certification-details-v3-header" id="general-informations">
+      <h2 class="certification-details-v3__title">
+        {{t
+          "pages.certifications.certification.details.v3.general-informations.title"
+          certificationCourseId=@details.certificationCourseId
+        }}
+      </h2>
+      <PixTag @color={{this.detailStatusColor}}>{{t this.detailStatusLabel}}</PixTag>
     </div>
-    <dl class="certification-details-v3__list">
-      <dt>Créée le :</dt>
-      <dd>{{dayjs-format @details.createdAt "DD/MM/YYYY HH:mm:ss"}}</dd>
+    <dl class="certification-details-v3__list" aria-labelledby="general-informations">
+      <dt id="creation-date">
+        {{t "pages.certifications.certification.details.v3.general-informations.labels.created-at"}}
+        :
+      </dt>
+      <dd aria-labelledby="creation-date">{{dayjs-format @details.createdAt "DD/MM/YYYY HH:mm:ss"}}</dd>
       {{#if @details.completedAt}}
-        <dt>Terminée le :</dt>
-        <dd>
-          <span class="certification-details-v3-list__completion-date">{{dayjs-format @details.completedAt "DD/MM/YYYY HH:mm:ss"}}</span>
+        <dt id="completion-date">
+          {{t "pages.certifications.certification.details.v3.general-informations.labels.ended-at"}}
+          :
+        </dt>
+        <dd aria-labelledby="completion-date">
+          <span class="certification-details-v3-list__completion-date">{{dayjs-format
+              @details.completedAt
+              "DD/MM/YYYY HH:mm:ss"
+            }}</span>
           {{#if (lt @details.duration this.twentyFourHoursInMs)}}
             <PixTag @color={{this.durationTagColor}}>{{dayjs-format-duration @details.duration "H[h]mm"}}</PixTag>
           {{else}}
@@ -20,52 +34,83 @@
       {{/if}}
 
       {{#if @details.shouldDisplayEndedByBlock}}
-        <dt>Certification terminée par :</dt>
-        <dd>
-          <PixTag @color={{this.certificationEndedByTagColor}}>{{this.endedByLabel}}</PixTag>
+        <dt id="ended-by">
+          {{t "pages.certifications.certification.details.v3.general-informations.labels.ended-by"}}
+          :
+        </dt>
+        <dd aria-labelledby="ended-by">
+          <PixTag @color={{this.certificationEndedByTagColor}}>{{t this.endedByLabel}}</PixTag>
         </dd>
       {{/if}}
 
       {{#if @details.abortReason}}
-        <dt>Raison de l'abandon :</dt>
-        <dd>{{this.abortReasonLabel}}</dd>
+        <dt id="abort-reason">
+          {{t "pages.certifications.certification.details.v3.general-informations.labels.abort-reason"}}
+          :
+        </dt>
+        <dd aria-labelledby="abort-reason">{{t this.abortReasonLabel}}</dd>
       {{/if}}
 
-      <dt>Score (en pix) :</dt>
-      <dd>{{@details.pixScore}}</dd>
+      <dt id="pix-score">
+        {{t "pages.certifications.certification.details.v3.general-informations.labels.pix-score"}}
+        :
+      </dt>
+      <dd aria-labelledby="pix-score">{{@details.pixScore}}</dd>
     </dl>
   </section>
   <section class="page-section">
-    <h2 class="certification-details-v3__title">Informations complémentaires</h2>
+    <h2 class="certification-details-v3__title" id="more-informations">
+      {{t "pages.certifications.certification.details.v3.more-informations.title"}}
+    </h2>
 
-    <dl class="certification-details-v3__list">
-      <dt>Nombre de question répondues <br /> / Nombre total de questions</dt>
+    <dl class="certification-details-v3__list" aria-labelledby="more-informations" role="list">
+      <dt>
+        {{t "pages.certifications.certification.details.v3.more-informations.labels.numberof-answered-questions"}}
+        <br />
+        /
+        {{t "pages.certifications.certification.details.v3.more-informations.labels.total-numberof-questions"}}
+      </dt>
       <dd>{{@details.numberOfAnsweredQuestions}}/{{@details.totalNumberOfQuestions}}</dd>
-      <dt>Nombre de question OK :</dt>
+      <dt>{{t "pages.certifications.certification.details.v3.more-informations.labels.numberof-ok-questions"}} :</dt>
       <dd>{{@details.numberOfOkAnswers}}</dd>
-      <dt>Nombre de question KO :</dt>
+      <dt>{{t "pages.certifications.certification.details.v3.more-informations.labels.numberof-ko-questions"}} :</dt>
       <dd>{{@details.numberOfKoAnswers}}</dd>
-      <dt>Nombre de question abandonnées :</dt>
+      <dt>{{t "pages.certifications.certification.details.v3.more-informations.labels.numberof-aband-answers"}} :</dt>
       <dd>{{@details.numberOfAbandAnswers}}</dd>
-      <dt>Nombre de problèmes techniques validés :</dt>
+      <dt>{{t "pages.certifications.certification.details.v3.more-informations.labels.numberof-validated-live-alerts"}}
+        :</dt>
       <dd>{{@details.numberOfValidatedLiveAlerts}}</dd>
     </dl>
   </section>
 </div>
 <section class="page-section">
-  <h2 class="certification-details-v3__title">Liste des questions</h2>
+  <h2 class="certification-details-v3__title">
+    {{t "pages.certifications.certification.details.v3.questions-list.title"}}
+  </h2>
   <div class="content-text content-text--small">
     <div class="table-admin">
       <table>
         <thead>
           <tr>
-            <th class="table__column--small">N°</th>
-            <th class="certification-details-v3-table__answered-at-column">Heure de réponse</th>
-            <th class="certification-details-v3-table__answer-status-column">Statut</th>
-            <th class="certification-details-v3-table__competence-column">Compétence concernée</th>
-            <th class="certification-details-v3-table__skill-column">Nom de l'acquis</th>
-            <th class="certification-details-v3-table__challenge-id-column">RecID (voir dans Pix Editor)</th>
-            <th>Actions</th>
+            <th class="table__column--small">
+              {{t "pages.certifications.certification.details.v3.questions-list.labels.number"}}
+            </th>
+            <th class="certification-details-v3-table__answered-at-column">
+              {{t "pages.certifications.certification.details.v3.questions-list.labels.answered-at"}}
+            </th>
+            <th class="certification-details-v3-table__answer-status-column">
+              {{t "pages.certifications.certification.details.v3.questions-list.labels.answer-status"}}
+            </th>
+            <th class="certification-details-v3-table__competence-column">
+              {{t "pages.certifications.certification.details.v3.questions-list.labels.competence"}}
+            </th>
+            <th class="certification-details-v3-table__skill-column">
+              {{t "pages.certifications.certification.details.v3.questions-list.labels.skill"}}
+            </th>
+            <th class="certification-details-v3-table__challenge-id-column">
+              {{t "pages.certifications.certification.details.v3.questions-list.labels.challenge-id"}}
+            </th>
+            <th>{{t "pages.certifications.certification.details.v3.questions-list.labels.actions"}}</th>
           </tr>
         </thead>
         <tbody>
@@ -84,7 +129,7 @@
               <td>
                 {{#if (this.shouldDisplayAnswerStatus certificationChallenge)}}
                   <PixTag @color={{this.answerStatusColor certificationChallenge.answerStatus}}>
-                    {{this.answerStatusLabel certificationChallenge.answerStatus}}
+                    {{t (this.answerStatusLabel certificationChallenge.answerStatus)}}
                   </PixTag>
                 {{else}}
                   -
@@ -93,24 +138,59 @@
               <td>{{certificationChallenge.competenceIndex}} {{certificationChallenge.competenceName}}</td>
               <td>{{certificationChallenge.skillName}}</td>
               <td>
-                <a href={{this.externalUrlForPixEditor certificationChallenge.id}} target="_blank" rel="noopener noreferrer" aria-label="Lien vers les informations de la question (Ouverture dans une nouvelle fenêtre)">
+                <a
+                  href={{this.externalUrlForPixEditor certificationChallenge.id}}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={{t
+                    "pages.certifications.certification.details.v3.questions-list.actions.informations.extra-information"
+                  }}
+                >
                   {{certificationChallenge.id}}
                   <FaIcon @icon="external-link" />
                 </a>
               </td>
               <td class="certification-details-v3-table__challenge-action-cell">
-                <a href={{this.externalUrlForPreviewChallenge certificationChallenge.id}} target="_blank" title="Lien vers l'aperçu de l'épreuve" aria-label="Lien vers l'aperçu de l'épreuve (Ouverture dans une nouvelle fenêtre)" rel="noopener noreferrer">
+                <a
+                  href={{this.externalUrlForPreviewChallenge certificationChallenge.id}}
+                  target="_blank"
+                  title={{t
+                    "pages.certifications.certification.details.v3.questions-list.actions.challenge-preview.label"
+                  }}
+                  aria-label={{t
+                    "pages.certifications.certification.details.v3.questions-list.actions.challenge-preview.extra-information"
+                  }}
+                  rel="noopener noreferrer"
+                >
                   <FaIcon @icon="eye" />
                 </a>
 
                 {{#if certificationChallenge.validatedLiveAlert}}
-                  <button title="Afficher le signalement de la question" aria-label="Afficher le signalement de la question" type="button" {{on "click" (fn this.openModal certificationChallenge)}}>
+                  <button
+                    title={{t
+                      "pages.certifications.certification.details.v3.questions-list.actions.display-live-alert.label"
+                    }}
+                    aria-label={{t
+                      "pages.certifications.certification.details.v3.questions-list.actions.display-live-alert.extra-information"
+                    }}
+                    type="button"
+                    {{on "click" (fn this.openModal certificationChallenge)}}
+                  >
                     <FaIcon @icon="warning" />
                   </button>
                 {{/if}}
 
                 {{#if (this.shouldDisplayAnswerValueIcon certificationChallenge)}}
-                  <button title="Afficher la réponse du candidat" aria-label="Afficher la réponse du candidat" type="button" {{on "click" (fn this.openModal certificationChallenge)}}>
+                  <button
+                    title={{t
+                      "pages.certifications.certification.details.v3.questions-list.actions.display-answer.label"
+                    }}
+                    aria-label={{t
+                      "pages.certifications.certification.details.v3.questions-list.actions.display-answer.extra-information"
+                    }}
+                    type="button"
+                    {{on "click" (fn this.openModal certificationChallenge)}}
+                  >
                     <FaIcon @icon="message" />
                   </button>
                 {{/if}}
@@ -123,7 +203,11 @@
   </div>
 </section>
 
-<PixModal @title="{{this.modalTitle}} question {{this.certificationChallenge.questionNumber}}" @showModal={{this.showModal}} @onCloseButtonClick={{this.closeModal}}>
+<PixModal
+  @title="{{t this.modalTitle}} question {{this.certificationChallenge.questionNumber}}"
+  @showModal={{this.showModal}}
+  @onCloseButtonClick={{this.closeModal}}
+>
   <:content>
     {{#if this.certificationChallenge.validatedLiveAlert}}
       <span class="certification-details-v3-modal__live-alert-subcategory">{{this.subCategory}}</span>
@@ -134,7 +218,7 @@
   </:content>
   <:footer>
     <PixButton @backgroundColor="transparent-light" @isBorderVisible={{true}} @triggerAction={{this.closeModal}}>
-      Fermer
+      {{t "common.actions.close"}}
     </PixButton>
   </:footer>
 </PixModal>

--- a/admin/app/components/certifications/certification/details-v3.hbs
+++ b/admin/app/components/certifications/certification/details-v3.hbs
@@ -7,7 +7,9 @@
           certificationCourseId=@details.certificationCourseId
         }}
       </h2>
-      <PixTag @color={{this.detailStatusColor}}>{{t this.detailStatusLabel}}</PixTag>
+      {{#if @details.assessmentResultStatus}}
+        <PixTag @color={{this.detailStatusColor}}>{{t this.detailStatusLabel}}</PixTag>
+      {{/if}}
     </div>
     <dl class="certification-details-v3__list" aria-labelledby="general-informations">
       <dt id="creation-date">
@@ -33,7 +35,7 @@
         </dd>
       {{/if}}
 
-      {{#if @details.shouldDisplayEndedByBlock}}
+      {{#if this.shouldDisplayEndedByBlock}}
         <dt id="ended-by">
           {{t "pages.certifications.certification.details.v3.general-informations.labels.ended-by"}}
           :

--- a/admin/app/components/certifications/certification/details-v3.js
+++ b/admin/app/components/certifications/certification/details-v3.js
@@ -107,7 +107,7 @@ export default class DetailsV3 extends Component {
   }
 
   get shouldDisplayEndedByBlock() {
-    return this.hasNotBeenCompletedByCandidate;
+    return this.args.details.hasNotBeenCompletedByCandidate;
   }
 
   get endedByLabel() {

--- a/admin/app/controllers/authenticated/certifications.js
+++ b/admin/app/controllers/authenticated/certifications.js
@@ -6,6 +6,7 @@ import trim from 'lodash/trim';
 
 export default class CertificationsController extends Controller {
   @service router;
+  @service intl;
 
   @tracked inputId;
 
@@ -15,5 +16,11 @@ export default class CertificationsController extends Controller {
     const certifId = trim(this.inputId);
     const routeName = 'authenticated.certifications.certification';
     this.router.transitionTo(routeName, certifId);
+  }
+
+  get pageTitle() {
+    const certifTitle = this.intl.t('pages.certifications.certification.title');
+
+    return `${certifTitle} ${this.model.id} | Pix Admin`;
   }
 }

--- a/admin/app/controllers/authenticated/certifications/certification/details.js
+++ b/admin/app/controllers/authenticated/certifications/certification/details.js
@@ -1,6 +1,9 @@
 import Controller from '@ember/controller';
+import { service } from '@ember/service';
 
 export default class DetailsController extends Controller {
+  @service intl;
+
   assignQuestionNumberForDisplay(model) {
     let index = 1;
     return model.certificationChallengesForAdministration.map((challenge) => {
@@ -14,5 +17,12 @@ export default class DetailsController extends Controller {
 
       return challenge;
     });
+  }
+
+  get pageTitle() {
+    const certifTitle = this.intl.t('pages.certifications.certification.title');
+    const detailsTitle = this.intl.t('pages.certifications.certification.details.title');
+
+    return `${certifTitle} ${this.model.id} ${detailsTitle} | Pix Admin`;
   }
 }

--- a/admin/app/helpers/dayjs-format-duration.js
+++ b/admin/app/helpers/dayjs-format-duration.js
@@ -1,0 +1,16 @@
+import Helper from '@ember/component/helper';
+import { service } from '@ember/service';
+
+export default class DayjsFormatDuration extends Helper {
+  @service dayjs;
+
+  compute(params, hash) {
+    this.dayjs.useLocale(hash.locale || this.dayjs.locale);
+    this.dayjs.extend('duration');
+
+    const durationValue = params[0];
+    const durationFormat = params[1];
+
+    return this.dayjs.self.duration(durationValue).format(durationFormat);
+  }
+}

--- a/admin/app/models/v3-certification-course-details-for-administration.js
+++ b/admin/app/models/v3-certification-course-details-for-administration.js
@@ -1,6 +1,31 @@
 import Model, { attr, hasMany } from '@ember-data/model';
+import dayjs from 'dayjs';
+
+const ONE_HOUR_45_MINUTES_IN_MS = 1 * 60 * 60 * 1000 + 45 * 60 * 1000;
+
+export const assessmentStates = {
+  COMPLETED: 'completed',
+  STARTED: 'started',
+  ABORTED: 'aborted',
+  ENDED_BY_SUPERVISOR: 'endedBySupervisor',
+  ENDED_DUE_TO_FINALIZATION: 'endedDueToFinalization',
+};
+
+export const abortReasons = {
+  CANDIDATE: 'candidate',
+  TECHNICAL: 'technical',
+};
+
 export default class V3CertificationCourseDetailsForAdministration extends Model {
-  @attr() certificationCourseId;
+  @attr('number') certificationCourseId;
+  @attr('boolean') isRejectedForFraud;
+  @attr('boolean') isCancelled;
+  @attr('date') createdAt;
+  @attr('date') completedAt;
+  @attr('string') assessmentResultStatus;
+  @attr('string') assessmentState;
+  @attr('string') abortReason;
+  @attr('number') pixScore;
   @hasMany('certification-challenges-for-administration') certificationChallengesForAdministration;
   version = 3;
 
@@ -29,5 +54,22 @@ export default class V3CertificationCourseDetailsForAdministration extends Model
 
   get numberOfValidatedLiveAlerts() {
     return this.certificationChallengesForAdministration.filter((challenge) => challenge.hasLiveAlert()).length;
+  }
+
+  get duration() {
+    const start = dayjs(this.createdAt);
+    const end = dayjs(this.completedAt);
+    return end.diff(start);
+  }
+
+  get hasExceededTimeLimit() {
+    const defaultDurationInMs = ONE_HOUR_45_MINUTES_IN_MS;
+    return this.duration > defaultDurationInMs;
+  }
+
+  get hasNotBeenCompletedByCandidate() {
+    return [assessmentStates.ENDED_BY_SUPERVISOR, assessmentStates.ENDED_DUE_TO_FINALIZATION].includes(
+      this.assessmentState,
+    );
   }
 }

--- a/admin/app/styles/authenticated/certifications/certification/details-v3.scss
+++ b/admin/app/styles/authenticated/certifications/certification/details-v3.scss
@@ -8,7 +8,6 @@
   &__title {
     @extend %pix-title-xs;
 
-    padding-bottom: var(--pix-spacing-6x);
     color : var(--pix-neutral-800);
   }
 
@@ -17,6 +16,8 @@
     grid-template-columns: 1fr 1fr;
 
     dd, dt {
+      display: flex;
+      align-items: center;
       padding: var(--pix-spacing-2x) 0;
       border-bottom: var(--pix-neutral-100) 1px solid;
     }
@@ -26,10 +27,21 @@
     }
 
     dd {
-      display: flex;
-      align-items: center;
       color: var(--pix-neutral-900);
     }
+  }
+}
+
+.certification-details-v3-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: var(--pix-spacing-6x);
+}
+
+.certification-details-v3-list {
+  &__completion-date {
+    margin-right: $pix-spacing-s;
   }
 }
 

--- a/admin/app/templates/authenticated/certifications.hbs
+++ b/admin/app/templates/authenticated/certifications.hbs
@@ -1,8 +1,8 @@
 {{! template-lint-disable require-input-label }}
-{{page-title "Certifications"}}
+{{page-title (t "pages.certifications.title")}}
 <div class="page">
   <header class="page-header">
-    <h1 class="page-title"> Certifications </h1>
+    <h1 class="page-title">{{t "pages.certifications.title"}}</h1>
     <div class="page-actions">
       <form class="form-inline" {{on "submit" this.loadCertification}}>
         <Input
@@ -11,7 +11,7 @@
           @type="text"
           @value={{this.inputId}}
         />
-        <PixButton @size="small" @type="submit">Charger</PixButton>
+        <PixButton @size="small" @type="submit">{{t "pages.certifications.actions.load.label"}}</PixButton>
       </form>
     </div>
   </header>

--- a/admin/app/templates/authenticated/certifications/certification.hbs
+++ b/admin/app/templates/authenticated/certifications/certification.hbs
@@ -1,4 +1,4 @@
-{{page-title "Certif " @model.id " | Pix Admin" replace=true}}
+{{page-title this.pageTitle replace=true}}
 <nav class="navbar">
   <LinkTo @route="authenticated.certifications.certification.informations" @model={{@model.id}} class="navbar-item">
     Informations
@@ -9,7 +9,7 @@
     </LinkTo>
   {{/unless}}
   <LinkTo @route="authenticated.certifications.certification.details" @model={{@model.id}} class="navbar-item">
-    Détails
+    {{t "pages.certifications.certification.details.title"}}
   </LinkTo>
   {{#unless @model.isV3}}
     <LinkTo @route="authenticated.certifications.certification.profile" @model={{@model.id}} class="navbar-item">

--- a/admin/app/templates/authenticated/certifications/certification/details.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/details.hbs
@@ -1,4 +1,4 @@
-{{page-title "Certif " @model.id " Détails | Pix Admin" replace=true}}
+{{page-title this.pageTitle replace=true}}
 {{#if (eq @model.version 3)}}
   <Certifications::Certification::DetailsV3 @details={{@model}} />
 {{else}}

--- a/admin/tests/integration/components/certifications/certification/details-v3_test.js
+++ b/admin/tests/integration/components/certifications/certification/details-v3_test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-// import { setupRenderingTest } from 'ember-qunit';
-import { render, waitFor, within } from '@1024pix/ember-testing-library';
+import { render, within } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import { click } from '@ember/test-helpers';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
@@ -61,236 +60,19 @@ module('Integration | Component | Certifications | certification > details v3', 
   });
 
   module('#display', function () {
-    test('displays the certification complementary info section with the right info', async function (assert) {
-      // given
-      const certificationChallengesForAdministration = createChallengesForAdministration(
-        ['ok', 'ok', 'ok', 'ok', 'ko', 'ko', 'ko', 'aband', 'aband', null],
-        store,
-      );
-      this.model = createCertificationCourseDetailsRecord({ certificationChallengesForAdministration, store });
+    module('certification "general informations" section', function (hooks) {
+      let certificationChallengesForAdministration;
+      let certificationCourseDetailsRecord;
 
-      // when
-      const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
-      const expected = [
-        {
-          term: 'Nombre de question répondues\n/ Nombre total de questions',
-          definition: '9/32',
-        },
-        {
-          term: 'Nombre de question OK :',
-          definition: '4',
-        },
-        {
-          term: 'Nombre de question KO :',
-          definition: '3',
-        },
-        {
-          term: 'Nombre de question abandonnées :',
-          definition: '2',
-        },
-        {
-          term: 'Nombre de problèmes techniques validés :',
-          definition: '1',
-        },
-      ];
-
-      const list = screen.getByRole('list', {
-        name: this.intl.t('pages.certifications.certification.details.v3.more-informations.title'),
-      });
-      const terms = within(list).getAllByRole('term');
-      const definitions = within(list).getAllByRole('definition');
-      const result = terms.map((term, i) => ({ term: term.innerText, definition: definitions[i].innerText }));
-
-      // then
-      assert.deepEqual(expected, result);
-    });
-
-    test('displays links to challenge info', async function (assert) {
-      // given
-      const certificationChallengesForAdministration = [
-        store.createRecord('certification-challenges-for-administration', {
-          id: 'rec1234',
-          answerStatus: 'ok',
-          validatedLiveAlert: null,
-        }),
-      ];
-      this.model = createCertificationCourseDetailsRecord({ certificationChallengesForAdministration, store });
-
-      // when
-      const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
-
-      // then
-      assert
-        .dom(
-          screen.getByRole('link', {
-            name: 'Lien vers les informations de la question (Ouverture dans une nouvelle fenêtre)',
-          }),
-        )
-        .hasAttribute('href', 'https://editor.pix.fr/challenge/rec1234');
-    });
-
-    test('displays the table with every questions asked during certification', async function (assert) {
-      // given
-      const certificationChallengesForAdministration = createDetailedAnswers(answers, store);
-      this.model = createCertificationCourseDetailsRecord({ certificationChallengesForAdministration, store });
-
-      // when
-      const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
-
-      // then
-      assert.dom(screen.getByRole('heading', { name: 'Liste des questions' })).exists();
-
-      const linesWithResults = screen.getAllByRole('row').slice(1);
-      assert.strictEqual(linesWithResults.length, 4);
-
-      const result = [];
-
-      linesWithResults.forEach((lineElement) => {
-        const line = _getAllCellsButAction(lineElement);
-        result.push(line.map((cell) => cell.innerText));
-      });
-
-      const expected = answers.map((answer) => [
-        answer.questionNumber,
-        `${answer.answeredAt.getHours()}:${answer.answeredAt.getMinutes()}:00`,
-        answer.answerStatusName,
-        `${answer.competenceIndex} ${answer.competenceName}`,
-        answer.skillName,
-        `${answer.id.toString()} `,
-      ]);
-      assert.deepEqual(expected, result);
-    });
-
-    module('when the candidate answers several questions', function () {
-      module('when the candidate gives an answer to the question', function () {
-        test('displays the modal with the candidate answer on icon click', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          this.model = store.createRecord('v3-certification-course-details-for-administration', {
-            certificationChallengesForAdministration: createChallengesForAdministration(['ok', 'ko'], store),
-          });
-
-          // when
-          const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
-
-          const modalButtons = screen.getAllByRole('button', { name: 'Afficher la réponse du candidat' });
-          await click(modalButtons[0]);
-
-          // then
-          const modal = within(await screen.findByRole('dialog'));
-          assert.dom(modal.getByRole('heading', { name: 'Réponse question 1' })).exists();
-          assert.dom(screen.getByText('Réponse 1')).exists();
-        });
-      });
-
-      module('when the candidate skips the question', function () {
-        test('does not display the answer icon', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          this.model = store.createRecord('v3-certification-course-details-for-administration', {
-            certificationChallengesForAdministration: [
-              store.createRecord('certification-challenges-for-administration', {
-                id: 1,
-                questionNumber: 1,
-                answerStatus: 'aband',
-              }),
-            ],
-          });
-
-          // when
-          const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
-
-          // then
-          assert.dom(screen.queryByRole('button', { name: 'Afficher la réponse du candidat' })).doesNotExist();
-        });
-      });
-    });
-
-    test('should not display the issue report button', async function (assert) {
-      // given
-      const certificationChallengesForAdministration = createChallengesForAdministration(['ok'], store);
-      this.model = createCertificationCourseDetailsRecord({ certificationChallengesForAdministration, store });
-
-      // when
-      const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
-
-      // then
-      assert.dom(screen.queryByRole('button', { name: 'Afficher le signalement de la question' })).doesNotExist();
-    });
-
-    module('when there is a reported question (question without an answer)', function () {
-      test('should not display the response button', async function (assert) {
-        // given
-        const certificationChallengesForAdministration = createChallengesForAdministration([null], store);
-        this.model = createCertificationCourseDetailsRecord({ certificationChallengesForAdministration, store });
-
-        // when
-        const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
-
-        // then
-        assert.dom(screen.queryByRole('button', { name: 'Afficher la réponse du candidat' })).doesNotExist();
-      });
-
-      test('displays the modal with the issue report subcategory', async function (assert) {
-        // given
-        const certificationChallengesForAdministration = createChallengesForAdministration(['ok', null], store);
-        this.model = createCertificationCourseDetailsRecord({ certificationChallengesForAdministration, store });
-
-        // when
-        const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
-
-        const modalButton = screen.getByRole('button', { name: 'Afficher le signalement de la question' });
-        await click(modalButton);
-
-        // then
-        const modal = within(await screen.findByRole('dialog'));
-        assert.dom(modal.getByRole('heading', { name: 'Signalement question 2' })).exists();
-        assert.dom(screen.getByText('E5')).exists();
-        assert
-          .dom(
-            screen.getByText(
-              "Le site est bloqué par les restrictions réseau de l'établissement (réseaux sociaux par ex.)",
-            ),
-          )
-          .exists();
-      });
-    });
-
-    module('when the candidate does not finish the session', function () {
-      test('should not display a tag and a response icon in the last question line', async function (assert) {
-        // given
-        const certificationChallengesForAdministration = [
-          store.createRecord('certification-challenges-for-administration', {
-            validatedLiveAlert: false,
-            answeredAt: null,
-            answerStatus: null,
-          }),
-        ];
-        this.model = createCertificationCourseDetailsRecord({ certificationChallengesForAdministration, store });
-
-        // when
-        const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
-
-        // then
-        const detailTable = screen.getByRole('table');
-        const statusCellIndex = within(detailTable).getByRole('columnheader', { name: 'Statut' }).cellIndex;
-        const lastQuestionDetail = within(detailTable).getAllByRole('row').at(-1);
-        const lastQuestionStatus = within(lastQuestionDetail).getAllByRole('cell')[statusCellIndex - 1].innerText;
-        assert.strictEqual(lastQuestionStatus, '-');
-        assert.dom(screen.queryByRole('button', { name: 'Afficher la réponse du candidat' })).doesNotExist();
-      });
-    });
-
-    module('certification general information', function () {
-      test('should display compulsory information', async function (assert) {
-        // given
-        const certificationChallengesForAdministration = [
+      hooks.beforeEach(function () {
+        certificationChallengesForAdministration = [
           store.createRecord('certification-challenges-for-administration', {
             validatedLiveAlert: false,
             answeredAt: null,
           }),
         ];
-        this.model = createCertificationCourseDetailsRecord({
+
+        certificationCourseDetailsRecord = {
           certificationChallengesForAdministration,
           store,
           params: {
@@ -299,19 +81,375 @@ module('Integration | Component | Certifications | certification > details v3', 
             createdAt: new Date('2023-01-13T08:00:00'),
             assessmentResultStatus: 'validated',
           },
-        });
+        };
+      });
+
+      test('should display the title, the creation date and the pix score', async function (assert) {
+        // given
+        this.model = createCertificationCourseDetailsRecord(certificationCourseDetailsRecord);
 
         // when
         const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
 
-        let creationDate;
-        await waitFor(async () => {
-          creationDate = await screen.getByLabelText('Créée le :').innerText;
-        });
+        const creationDate = await screen.getByLabelText('Créée le :').innerText;
 
         // then
+        const pixScoreLabel = this.intl.t(
+          'pages.certifications.certification.details.v3.general-informations.labels.pix-score',
+        );
+
         assert.dom(screen.getByRole('heading', { name: 'Certification N°123456', level: 2 })).exists();
+        assert.dom(screen.getByLabelText(`${pixScoreLabel} :`)).exists();
         assert.strictEqual(creationDate, '13/01/2023 08:00:00');
+      });
+
+      module('when the certification is valid', function () {
+        test('should display the validated assessment result status with the right color', async function (assert) {
+          // given
+          this.model = createCertificationCourseDetailsRecord(certificationCourseDetailsRecord);
+
+          // when
+          const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
+
+          // then
+          const assessmentResultStatusElement = screen.getByText(
+            this.intl.t('pages.certifications.certification.details.v3.assessment-result-status.validated'),
+          );
+
+          assert.dom(assessmentResultStatusElement).exists();
+          assert.true(assessmentResultStatusElement.classList.contains('pix-tag--success'));
+        });
+
+        test('should display the date of completion', async function (assert) {
+          // given
+          this.model = createCertificationCourseDetailsRecord(certificationCourseDetailsRecord);
+
+          // when
+          const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
+
+          // then
+          const endedAtLabel = this.intl.t(
+            'pages.certifications.certification.details.v3.general-informations.labels.ended-at',
+          );
+
+          assert.dom(screen.getByText(`${endedAtLabel} :`)).exists();
+        });
+
+        test('should NOT display the ended by info or the abort reason', async function (assert) {
+          // given
+          this.model = createCertificationCourseDetailsRecord(certificationCourseDetailsRecord);
+
+          // when
+          const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
+
+          // then
+          const endedAtLabel = this.intl.t(
+            'pages.certifications.certification.details.v3.general-informations.labels.ended-by',
+          );
+
+          const abortReasonLabel = this.intl.t(
+            'pages.certifications.certification.details.v3.general-informations.labels.abort-reason',
+          );
+
+          assert.strictEqual(screen.queryByText(`${endedAtLabel} :`), null);
+          assert.strictEqual(screen.queryByText(`${abortReasonLabel} :`), null);
+        });
+      });
+
+      module('when the certification is rejected', function (hooks) {
+        hooks.beforeEach(function () {
+          certificationCourseDetailsRecord = {
+            certificationChallengesForAdministration,
+            store,
+            params: {
+              certificationCourseId: 123456,
+              // eslint-disable-next-line no-restricted-syntax
+              createdAt: new Date('2023-01-13T08:00:00'),
+              abortReason: 'candidate',
+              assessmentResultStatus: 'rejected',
+              assessmentState: 'endedDueToFinalization',
+            },
+          };
+        });
+
+        test('should display the rejected assessment result status with the right color', async function (assert) {
+          // given
+          this.model = createCertificationCourseDetailsRecord(certificationCourseDetailsRecord);
+
+          // when
+          const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
+
+          // then
+          const assessmentResultStatusElement = screen.getByText(
+            this.intl.t('pages.certifications.certification.details.v3.assessment-result-status.rejected'),
+          );
+
+          assert.dom(assessmentResultStatusElement).exists();
+          assert.true(assessmentResultStatusElement.classList.contains('pix-tag--error'));
+        });
+
+        test('should display the date of completion', async function (assert) {
+          // given
+          this.model = createCertificationCourseDetailsRecord(certificationCourseDetailsRecord);
+
+          // when
+          const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
+
+          // then
+          const endedAtLabel = this.intl.t(
+            'pages.certifications.certification.details.v3.general-informations.labels.ended-at',
+          );
+
+          assert.dom(screen.getByText(`${endedAtLabel} :`)).exists();
+        });
+
+        test('should display the ended by info or the abort reason', async function (assert) {
+          // given
+          this.model = createCertificationCourseDetailsRecord(certificationCourseDetailsRecord);
+
+          // when
+          const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
+
+          // then
+          const endedAtLabel = this.intl.t(
+            'pages.certifications.certification.details.v3.general-informations.labels.ended-by',
+          );
+
+          const abortReasonLabel = this.intl.t(
+            'pages.certifications.certification.details.v3.general-informations.labels.abort-reason',
+          );
+          const abortReasonTranslation = this.intl.t(
+            'pages.certifications.certification.details.v3.abort-reason.candidate',
+          );
+          const abortReasonElement = screen.getByLabelText(`${abortReasonLabel} :`);
+
+          assert.dom(screen.getByLabelText(`${endedAtLabel} :`)).exists();
+          assert.strictEqual(abortReasonElement.innerText, abortReasonTranslation);
+        });
+      });
+    });
+
+    module('certification "more informations" section', function () {
+      test('displays the certification more informations section with the right info', async function (assert) {
+        // given
+        const certificationChallengesForAdministration = createChallengesForAdministration(
+          ['ok', 'ok', 'ok', 'ok', 'ko', 'ko', 'ko', 'aband', 'aband', null],
+          store,
+        );
+        this.model = createCertificationCourseDetailsRecord({ certificationChallengesForAdministration, store });
+
+        // when
+        const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
+        const expected = [
+          {
+            term: 'Nombre de question répondues\n/ Nombre total de questions',
+            definition: '9/32',
+          },
+          {
+            term: 'Nombre de question OK :',
+            definition: '4',
+          },
+          {
+            term: 'Nombre de question KO :',
+            definition: '3',
+          },
+          {
+            term: 'Nombre de question abandonnées :',
+            definition: '2',
+          },
+          {
+            term: 'Nombre de problèmes techniques validés :',
+            definition: '1',
+          },
+        ];
+
+        const list = screen.getByRole('list', {
+          name: this.intl.t('pages.certifications.certification.details.v3.more-informations.title'),
+        });
+        const terms = within(list).getAllByRole('term');
+        const definitions = within(list).getAllByRole('definition');
+        const result = terms.map((term, i) => ({ term: term.innerText, definition: definitions[i].innerText }));
+
+        // then
+        assert.deepEqual(expected, result);
+      });
+    });
+
+    module('questions list', function () {
+      test('displays links to challenge info', async function (assert) {
+        // given
+        const certificationChallengesForAdministration = [
+          store.createRecord('certification-challenges-for-administration', {
+            id: 'rec1234',
+            answerStatus: 'ok',
+            validatedLiveAlert: null,
+          }),
+        ];
+        this.model = createCertificationCourseDetailsRecord({ certificationChallengesForAdministration, store });
+
+        // when
+        const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
+
+        // then
+        assert
+          .dom(
+            screen.getByRole('link', {
+              name: 'Lien vers les informations de la question (Ouverture dans une nouvelle fenêtre)',
+            }),
+          )
+          .hasAttribute('href', 'https://editor.pix.fr/challenge/rec1234');
+      });
+
+      test('displays the table with every questions asked during certification', async function (assert) {
+        // given
+        const certificationChallengesForAdministration = createDetailedAnswers(answers, store);
+        this.model = createCertificationCourseDetailsRecord({ certificationChallengesForAdministration, store });
+
+        // when
+        const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
+
+        // then
+        assert.dom(screen.getByRole('heading', { name: 'Liste des questions' })).exists();
+
+        const linesWithResults = screen.getAllByRole('row').slice(1);
+        assert.strictEqual(linesWithResults.length, 4);
+
+        const result = [];
+
+        linesWithResults.forEach((lineElement) => {
+          const line = _getAllCellsButAction(lineElement);
+          result.push(line.map((cell) => cell.innerText));
+        });
+
+        const expected = answers.map((answer) => [
+          answer.questionNumber,
+          `${answer.answeredAt.getHours()}:${answer.answeredAt.getMinutes()}:00`,
+          answer.answerStatusName,
+          `${answer.competenceIndex} ${answer.competenceName}`,
+          answer.skillName,
+          `${answer.id.toString()} `,
+        ]);
+        assert.deepEqual(expected, result);
+      });
+
+      module('when the candidate answers several questions', function () {
+        module('when the candidate gives an answer to the question', function () {
+          test('displays the modal with the candidate answer on icon click', async function (assert) {
+            // given
+            const store = this.owner.lookup('service:store');
+            this.model = store.createRecord('v3-certification-course-details-for-administration', {
+              certificationChallengesForAdministration: createChallengesForAdministration(['ok', 'ko'], store),
+            });
+
+            // when
+            const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
+
+            const modalButtons = screen.getAllByRole('button', { name: 'Afficher la réponse du candidat' });
+            await click(modalButtons[0]);
+
+            // then
+            const modal = within(await screen.findByRole('dialog'));
+            assert.dom(modal.getByRole('heading', { name: 'Réponse question 1' })).exists();
+            assert.dom(screen.getByText('Réponse 1')).exists();
+          });
+        });
+
+        module('when the candidate skips the question', function () {
+          test('does not display the answer icon', async function (assert) {
+            // given
+            const store = this.owner.lookup('service:store');
+            this.model = store.createRecord('v3-certification-course-details-for-administration', {
+              certificationChallengesForAdministration: [
+                store.createRecord('certification-challenges-for-administration', {
+                  id: 1,
+                  questionNumber: 1,
+                  answerStatus: 'aband',
+                }),
+              ],
+            });
+
+            // when
+            const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
+
+            // then
+            assert.dom(screen.queryByRole('button', { name: 'Afficher la réponse du candidat' })).doesNotExist();
+          });
+        });
+      });
+
+      test('should not display the issue report button', async function (assert) {
+        // given
+        const certificationChallengesForAdministration = createChallengesForAdministration(['ok'], store);
+        this.model = createCertificationCourseDetailsRecord({ certificationChallengesForAdministration, store });
+
+        // when
+        const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
+
+        // then
+        assert.dom(screen.queryByRole('button', { name: 'Afficher le signalement de la question' })).doesNotExist();
+      });
+
+      module('when there is a reported question (question without an answer)', function () {
+        test('should not display the response button', async function (assert) {
+          // given
+          const certificationChallengesForAdministration = createChallengesForAdministration([null], store);
+          this.model = createCertificationCourseDetailsRecord({ certificationChallengesForAdministration, store });
+
+          // when
+          const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
+
+          // then
+          assert.dom(screen.queryByRole('button', { name: 'Afficher la réponse du candidat' })).doesNotExist();
+        });
+
+        test('displays the modal with the issue report subcategory', async function (assert) {
+          // given
+          const certificationChallengesForAdministration = createChallengesForAdministration(['ok', null], store);
+          this.model = createCertificationCourseDetailsRecord({ certificationChallengesForAdministration, store });
+
+          // when
+          const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
+
+          const modalButton = screen.getByRole('button', { name: 'Afficher le signalement de la question' });
+          await click(modalButton);
+
+          // then
+          const modal = within(await screen.findByRole('dialog'));
+          assert.dom(modal.getByRole('heading', { name: 'Signalement question 2' })).exists();
+          assert.dom(screen.getByText('E5')).exists();
+          assert
+            .dom(
+              screen.getByText(
+                "Le site est bloqué par les restrictions réseau de l'établissement (réseaux sociaux par ex.)",
+              ),
+            )
+            .exists();
+        });
+      });
+
+      module('when the candidate does not finish the session', function () {
+        test('should not display a tag and a response icon in the last question line', async function (assert) {
+          // given
+          const certificationChallengesForAdministration = [
+            store.createRecord('certification-challenges-for-administration', {
+              validatedLiveAlert: false,
+              answeredAt: null,
+              answerStatus: null,
+            }),
+          ];
+          this.model = createCertificationCourseDetailsRecord({ certificationChallengesForAdministration, store });
+
+          // when
+          const screen = await render(hbs`<Certifications::Certification::DetailsV3 @details={{this.model}} />`);
+
+          // then
+          const detailTable = screen.getByRole('table');
+          const statusCellIndex = within(detailTable).getByRole('columnheader', { name: 'Statut' }).cellIndex;
+          const lastQuestionDetail = within(detailTable).getAllByRole('row').at(-1);
+          const lastQuestionStatus = within(lastQuestionDetail).getAllByRole('cell')[statusCellIndex - 1].innerText;
+          assert.strictEqual(lastQuestionStatus, '-');
+          assert.dom(screen.queryByRole('button', { name: 'Afficher la réponse du candidat' })).doesNotExist();
+        });
       });
     });
   });

--- a/admin/tests/unit/components/certifications/certification/details-v3_test.js
+++ b/admin/tests/unit/components/certifications/certification/details-v3_test.js
@@ -12,10 +12,14 @@ module('Unit | Component | certifications/certification/details-v3', function (h
   });
 
   const answerStatusOptions = [
-    { value: 'ok', label: 'OK', color: 'success' },
-    { value: 'ko', label: 'KO', color: 'neutral' },
-    { value: null, label: 'Signalement validé', color: 'error' },
-    { value: 'aband', label: 'Abandonnée', color: 'tertiary' },
+    { value: 'ok', label: 'pages.certifications.certification.details.v3.answer-status.ok', color: 'success' },
+    { value: 'ko', label: 'pages.certifications.certification.details.v3.answer-status.ko', color: 'neutral' },
+    {
+      value: null,
+      label: 'pages.certifications.certification.details.v3.answer-status.validated-live-alert',
+      color: 'error',
+    },
+    { value: 'aband', label: 'pages.certifications.certification.details.v3.answer-status.aband', color: 'tertiary' },
   ];
 
   module('answerStatusLabel', function () {
@@ -50,7 +54,7 @@ module('Unit | Component | certifications/certification/details-v3', function (h
           isCancelled: false,
           assessmentResultStatus: 'validated',
         },
-        expectedValue: 'Validée',
+        expectedValue: 'pages.certifications.certification.details.v3.assessment-result-status.validated',
       },
       {
         details: {
@@ -58,7 +62,7 @@ module('Unit | Component | certifications/certification/details-v3', function (h
           isCancelled: false,
           assessmentResultStatus: 'rejected',
         },
-        expectedValue: 'Rejetée',
+        expectedValue: 'pages.certifications.certification.details.v3.assessment-result-status.rejected',
       },
       {
         details: {
@@ -66,7 +70,7 @@ module('Unit | Component | certifications/certification/details-v3', function (h
           isCancelled: false,
           assessmentResultStatus: 'error',
         },
-        expectedValue: 'Erreur',
+        expectedValue: 'pages.certifications.certification.details.v3.assessment-result-status.error',
       },
       {
         details: {
@@ -74,7 +78,7 @@ module('Unit | Component | certifications/certification/details-v3', function (h
           isCancelled: true,
           assessmentResultStatus: 'validated',
         },
-        expectedValue: 'Annulée',
+        expectedValue: 'pages.certifications.certification.details.v3.assessment-result-status.cancelled',
       },
       {
         details: {
@@ -82,7 +86,7 @@ module('Unit | Component | certifications/certification/details-v3', function (h
           isCancelled: false,
           assessmentResultStatus: 'validated',
         },
-        expectedValue: 'Rejetée pour fraude',
+        expectedValue: 'pages.certifications.certification.details.v3.assessment-result-status.fraud',
       },
     ];
     detailsStatusOptions.forEach(({ expectedValue, details }) => {

--- a/admin/tests/unit/components/certifications/certification/details-v3_test.js
+++ b/admin/tests/unit/components/certifications/certification/details-v3_test.js
@@ -160,6 +160,35 @@ module('Unit | Component | certifications/certification/details-v3', function (h
     });
   });
 
+  module('durationTagColor', function () {
+    const durationTagColorOptions = [
+      {
+        details: {
+          hasExceededTimeLimit: false,
+        },
+        expectedValue: 'success',
+      },
+      {
+        details: {
+          hasExceededTimeLimit: true,
+        },
+        expectedValue: 'error',
+      },
+    ];
+    durationTagColorOptions.forEach(({ expectedValue, details }) => {
+      test(`should return the detail status ${expectedValue} when the assessmentResult is validated`, function (assert) {
+        //given
+        component.args.details = details;
+
+        // when
+        const label = component.durationTagColor;
+
+        // then
+        assert.strictEqual(label, expectedValue);
+      });
+    });
+  });
+
   module('shouldDisplayAnswerStatus', function () {
     const certificationChallengeOptions = [
       {
@@ -203,32 +232,79 @@ module('Unit | Component | certifications/certification/details-v3', function (h
     });
   });
 
-  module('durationTagColor', function () {
-    const durationTagColorOptions = [
-      {
-        details: {
-          hasExceededTimeLimit: false,
-        },
-        expectedValue: 'success',
-      },
-      {
-        details: {
-          hasExceededTimeLimit: true,
-        },
-        expectedValue: 'error',
-      },
-    ];
-    durationTagColorOptions.forEach(({ expectedValue, details }) => {
-      test(`should return the detail status ${expectedValue} when the assessmentResult is validated`, function (assert) {
-        //given
-        component.args.details = details;
+  module('shouldDisplayAnswerValueIcon', function () {
+    let certificationChallenge;
 
-        // when
-        const label = component.durationTagColor;
+    test('should display the answer icon when there is an answer status AND no live alert', function (assert) {
+      certificationChallenge = {
+        answerStatus: 'ok',
+        validatedLiveAlert: null,
+      };
+      // when
+      const displayAnswerIcon = component.shouldDisplayAnswerValueIcon(certificationChallenge);
 
-        // then
-        assert.strictEqual(label, expectedValue);
-      });
+      //then
+      assert.true(displayAnswerIcon);
+    });
+
+    test('should NOT display the answer icon when there is NO answer status', function (assert) {
+      certificationChallenge = {
+        answerStatus: null,
+        validatedLiveAlert: null,
+      };
+      // when
+      const displayAnswerIcon = component.shouldDisplayAnswerValueIcon(certificationChallenge);
+
+      //then
+      assert.false(displayAnswerIcon);
+    });
+
+    test('should NOT display the answer icon when there answer status is aband', function (assert) {
+      certificationChallenge = {
+        answerStatus: 'aband',
+        validatedLiveAlert: null,
+      };
+      // when
+      const displayAnswerIcon = component.shouldDisplayAnswerValueIcon(certificationChallenge);
+
+      //then
+      assert.false(displayAnswerIcon);
+    });
+
+    test('should NOT display the answer icon when there is a live alert', function (assert) {
+      certificationChallenge = {
+        answerStatus: null,
+        validatedLiveAlert: { id: 123 },
+      };
+      // when
+      const displayAnswerIcon = component.shouldDisplayAnswerValueIcon(certificationChallenge);
+
+      //then
+      assert.false(displayAnswerIcon);
+    });
+  });
+
+  module('shouldDisplayEndedByBlock', function () {
+    test('should display the endedBy block when the certification has NOT been ended by the candidate', function (assert) {
+      component.args.details = {
+        hasNotBeenCompletedByCandidate: true,
+      };
+      // when
+      const displayEndedByBlock = component.shouldDisplayEndedByBlock;
+
+      //then
+      assert.true(displayEndedByBlock);
+    });
+
+    test('should NOT display the endedBy block when the certification has been ended by the candidate', function (assert) {
+      component.args.details = {
+        hasNotBeenCompletedByCandidate: false,
+      };
+      // when
+      const displayEndedByBlock = component.shouldDisplayEndedByBlock;
+
+      //then
+      assert.false(displayEndedByBlock);
     });
   });
 });

--- a/admin/tests/unit/components/certifications/certification/details-v3_test.js
+++ b/admin/tests/unit/components/certifications/certification/details-v3_test.js
@@ -1,0 +1,230 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../../../helpers/create-glimmer-component';
+
+module('Unit | Component | certifications/certification/details-v3', function (hooks) {
+  setupTest(hooks);
+
+  let component;
+
+  hooks.beforeEach(function () {
+    component = createGlimmerComponent('component:certifications/certification/details-v3');
+  });
+
+  const answerStatusOptions = [
+    { value: 'ok', label: 'OK', color: 'success' },
+    { value: 'ko', label: 'KO', color: 'neutral' },
+    { value: null, label: 'Signalement validé', color: 'error' },
+    { value: 'aband', label: 'Abandonnée', color: 'tertiary' },
+  ];
+
+  module('answerStatusLabel', function () {
+    answerStatusOptions.forEach(({ value, label: expectedLabel }) => {
+      test(`should return the ${expectedLabel} when the answer status is ${value}`, function (assert) {
+        // when
+        const label = component.answerStatusLabel(value);
+
+        // then
+        assert.strictEqual(label, expectedLabel);
+      });
+    });
+  });
+
+  module('answerStatusColor', function () {
+    answerStatusOptions.forEach(({ value, color: expectedColor }) => {
+      test(`should return the color ${expectedColor} when the answer status is ${value}`, function (assert) {
+        // when
+        const label = component.answerStatusColor(value);
+
+        // then
+        assert.strictEqual(label, expectedColor);
+      });
+    });
+  });
+
+  module('detailStatusLabel', function () {
+    const detailsStatusOptions = [
+      {
+        details: {
+          isRejectedForFraud: false,
+          isCancelled: false,
+          assessmentResultStatus: 'validated',
+        },
+        expectedValue: 'Validée',
+      },
+      {
+        details: {
+          isRejectedForFraud: false,
+          isCancelled: false,
+          assessmentResultStatus: 'rejected',
+        },
+        expectedValue: 'Rejetée',
+      },
+      {
+        details: {
+          isRejectedForFraud: false,
+          isCancelled: false,
+          assessmentResultStatus: 'error',
+        },
+        expectedValue: 'Erreur',
+      },
+      {
+        details: {
+          isRejectedForFraud: false,
+          isCancelled: true,
+          assessmentResultStatus: 'validated',
+        },
+        expectedValue: 'Annulée',
+      },
+      {
+        details: {
+          isRejectedForFraud: true,
+          isCancelled: false,
+          assessmentResultStatus: 'validated',
+        },
+        expectedValue: 'Rejetée pour fraude',
+      },
+    ];
+    detailsStatusOptions.forEach(({ expectedValue, details }) => {
+      test(`should return the detail status ${expectedValue} when the assessmentResult is validated`, function (assert) {
+        //given
+        component.args.details = details;
+
+        // when
+        const label = component.detailStatusLabel;
+
+        // then
+        assert.strictEqual(label, expectedValue);
+      });
+    });
+  });
+
+  module('detailStatusColor', function () {
+    const detailsStatusOptions = [
+      {
+        details: {
+          isRejectedForFraud: false,
+          isCancelled: false,
+          assessmentResultStatus: 'validated',
+        },
+        expectedValue: 'success',
+      },
+      {
+        details: {
+          isRejectedForFraud: false,
+          isCancelled: false,
+          assessmentResultStatus: 'rejected',
+        },
+        expectedValue: 'error',
+      },
+      {
+        details: {
+          isRejectedForFraud: false,
+          isCancelled: false,
+          assessmentResultStatus: 'error',
+        },
+        expectedValue: 'error',
+      },
+      {
+        details: {
+          isRejectedForFraud: false,
+          isCancelled: true,
+          assessmentResultStatus: 'validated',
+        },
+        expectedValue: 'error',
+      },
+      {
+        details: {
+          isRejectedForFraud: true,
+          isCancelled: false,
+          assessmentResultStatus: 'validated',
+        },
+        expectedValue: 'error',
+      },
+    ];
+    detailsStatusOptions.forEach(({ expectedValue, details }) => {
+      test(`should return the detail status ${expectedValue} when the assessmentResult is validated`, function (assert) {
+        //given
+        component.args.details = details;
+
+        // when
+        const label = component.detailStatusColor;
+
+        // then
+        assert.strictEqual(label, expectedValue);
+      });
+    });
+  });
+
+  module('shouldDisplayAnswerStatus', function () {
+    const certificationChallengeOptions = [
+      {
+        certificationChallenge: {
+          answeredAt: new Date(),
+          validatedLiveAlert: Symbol('validatedLiveAlert'),
+        },
+        expectedValue: true,
+      },
+      {
+        certificationChallenge: {
+          answeredAt: null,
+          validatedLiveAlert: Symbol('validatedLiveAlert'),
+        },
+        expectedValue: true,
+      },
+      {
+        certificationChallenge: {
+          answeredAt: new Date(),
+          validatedLiveAlert: null,
+        },
+        expectedValue: true,
+      },
+      {
+        certificationChallenge: {
+          answeredAt: null,
+          validatedLiveAlert: null,
+        },
+        expectedValue: false,
+      },
+    ];
+
+    certificationChallengeOptions.forEach(({ expectedValue, certificationChallenge }) => {
+      test(`when answeredAt is ${certificationChallenge.answeredAt} and answerStatus is ${certificationChallenge.answerStatus} should return ${expectedValue}`, function (assert) {
+        // when
+        const displayAnswerStatus = component.shouldDisplayAnswerStatus(certificationChallenge);
+
+        //then
+        assert.strictEqual(displayAnswerStatus, expectedValue);
+      });
+    });
+  });
+
+  module('durationTagColor', function () {
+    const durationTagColorOptions = [
+      {
+        details: {
+          hasExceededTimeLimit: false,
+        },
+        expectedValue: 'success',
+      },
+      {
+        details: {
+          hasExceededTimeLimit: true,
+        },
+        expectedValue: 'error',
+      },
+    ];
+    durationTagColorOptions.forEach(({ expectedValue, details }) => {
+      test(`should return the detail status ${expectedValue} when the assessmentResult is validated`, function (assert) {
+        //given
+        component.args.details = details;
+
+        // when
+        const label = component.durationTagColor;
+
+        // then
+        assert.strictEqual(label, expectedValue);
+      });
+    });
+  });
+});

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -2,6 +2,7 @@
   "common": {
     "actions": {
       "cancel": "Cancel",
+      "close": "Close",
       "deactivate": "Deactivate",
       "save": "Save"
     },
@@ -150,6 +151,99 @@
         },
         "success": {
           "update-certification-center-membership-role": "The member's role has been modified."
+        }
+      }
+    },
+    "certifications": {
+      "title": "Certifications",
+      "actions": {
+        "load": {
+          "label": "Charger"
+        }
+      },
+      "certification": {
+        "title": "Certif",
+        "details": {
+          "title": "Détails",
+          "v3": {
+            "abort-reason": {
+              "candidate": "Abandon : Manque de temps ou départ prématuré",
+              "technical": "Problème technique"
+            },
+            "answer-status": {
+              "aband": "Abandonnée",
+              "ko": "KO",
+              "ok": "OK",
+              "validated-live-alert": "Signalement validé"
+            },
+            "assessment-result-status": {
+              "cancelled": "Annulée",
+              "error": "Erreur",
+              "fraud": "Rejetée pour fraude",
+              "rejected": "Rejetée",
+              "validated": "Validée"
+            },
+            "assessment-state": {
+              "ended-by-supervisor": "Le surveillant",
+              "ended-due-to-finalization": "Finalisation session"
+            },
+            "general-informations": {
+              "title": "Certification N°{certificationCourseId}",
+              "labels": {
+                "abort-reason": "Raison de l'abandon",
+                "created-at": "Créée le",
+                "ended-at": "Terminée le",
+                "ended-by": "Certification terminée par",
+                "pix-score": "Score (en pix)"
+              }
+            },
+            "live-alert-modal": {
+              "title": {
+                "answer": "Réponse",
+                "report": "Signalement"
+              }
+            },
+            "more-informations": {
+              "title": "Informations complémentaires",
+              "labels": {
+                "numberof-aband-answers": "Nombre de question abandonnées",
+                "numberof-answered-questions": "Nombre de question répondues",
+                "numberof-ko-questions": "Nombre de question KO",
+                "numberof-ok-questions": "Nombre de question OK",
+                "numberof-validated-live-alerts": "Nombre de problèmes techniques validés",
+                "total-numberof-questions": "Nombre total de questions"
+              }
+            },
+            "questions-list": {
+              "title": "Liste des questions",
+              "actions": {
+                "challenge-preview": {
+                  "extra-information": "Lien vers l'aperçu de l'épreuve (Ouverture dans une nouvelle fenêtre)",
+                  "label": "Lien vers l'aperçu de l'épreuve"
+                },
+                "display-answer": {
+                  "extra-information": "Afficher la réponse du candidat",
+                  "label": "Afficher la réponse du candidat"
+                },
+                "display-live-alert": {
+                  "extra-information": "Afficher le signalement de la question",
+                  "label": "Afficher le signalement de la question"
+                },
+                "informations": {
+                  "extra-information": "Lien vers les informations de la question (Ouverture dans une nouvelle fenêtre)"
+                }
+              },
+              "labels": {
+                "actions": "Actions",
+                "answer-status": "Statut",
+                "answered-at": "Heure de réponse",
+                "challenge-id": "RecID (voir dans Pix Editor)",
+                "competence": "Compétence concernée",
+                "number": "N°",
+                "skill": "Nom de l'acquis"
+              }
+            }
+          }
         }
       }
     },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -2,6 +2,7 @@
   "common": {
     "actions": {
       "cancel": "Annuler",
+      "close": "Fermer",
       "deactivate": "Désactiver",
       "save": "Enregistrer"
     },
@@ -160,6 +161,99 @@
         },
         "success": {
           "update-certification-center-membership-role": "Le rôle du membre a été modifié."
+        }
+      }
+    },
+    "certifications": {
+      "title": "Certifications",
+      "actions": {
+        "load": {
+          "label": "Charger"
+        }
+      },
+      "certification": {
+        "title": "Certif",
+        "details": {
+          "title": "Détails",
+          "v3": {
+            "abort-reason": {
+              "candidate": "Abandon : Manque de temps ou départ prématuré",
+              "technical": "Problème technique"
+            },
+            "answer-status": {
+              "aband": "Abandonnée",
+              "ko": "KO",
+              "ok": "OK",
+              "validated-live-alert": "Signalement validé"
+            },
+            "assessment-result-status": {
+              "cancelled": "Annulée",
+              "error": "Erreur",
+              "fraud": "Rejetée pour fraude",
+              "rejected": "Rejetée",
+              "validated": "Validée"
+            },
+            "assessment-state": {
+              "ended-by-supervisor": "Le surveillant",
+              "ended-due-to-finalization": "Finalisation session"
+            },
+            "general-informations": {
+              "title": "Certification N°{certificationCourseId}",
+              "labels": {
+                "abort-reason": "Raison de l'abandon",
+                "created-at": "Créée le",
+                "ended-at": "Terminée le",
+                "ended-by": "Certification terminée par",
+                "pix-score": "Score (en pix)"
+              }
+            },
+            "live-alert-modal": {
+              "title": {
+                "answer": "Réponse",
+                "report": "Signalement"
+              }
+            },
+            "more-informations": {
+              "title": "Informations complémentaires",
+              "labels": {
+                "numberof-aband-answers": "Nombre de question abandonnées",
+                "numberof-answered-questions": "Nombre de question répondues",
+                "numberof-ko-questions": "Nombre de question KO",
+                "numberof-ok-questions": "Nombre de question OK",
+                "numberof-validated-live-alerts": "Nombre de problèmes techniques validés",
+                "total-numberof-questions": "Nombre total de questions"
+              }
+            },
+            "questions-list": {
+              "title": "Liste des questions",
+              "actions": {
+                "challenge-preview": {
+                  "extra-information": "Lien vers l'aperçu de l'épreuve (Ouverture dans une nouvelle fenêtre)",
+                  "label": "Lien vers l'aperçu de l'épreuve"
+                },
+                "display-answer": {
+                  "extra-information": "Afficher la réponse du candidat",
+                  "label": "Afficher la réponse du candidat"
+                },
+                "display-live-alert": {
+                  "extra-information": "Afficher le signalement de la question",
+                  "label": "Afficher le signalement de la question"
+                },
+                "informations": {
+                  "extra-information": "Lien vers les informations de la question (Ouverture dans une nouvelle fenêtre)"
+                }
+              },
+              "labels": {
+                "actions": "Actions",
+                "answer-status": "Statut",
+                "answered-at": "Heure de réponse",
+                "challenge-id": "RecID (voir dans Pix Editor)",
+                "competence": "Compétence concernée",
+                "number": "N°",
+                "skill": "Nom de l'acquis"
+              }
+            }
+          }
         }
       }
     },

--- a/api/src/certification/course/domain/models/V3CertificationCourseDetailsForAdministration.js
+++ b/api/src/certification/course/domain/models/V3CertificationCourseDetailsForAdministration.js
@@ -1,7 +1,26 @@
 export class V3CertificationCourseDetailsForAdministration {
-  constructor({ certificationCourseId, certificationChallengesForAdministration = [] }) {
+  constructor({
+    certificationCourseId,
+    certificationChallengesForAdministration = [],
+    isRejectedForFraud,
+    isCancelled,
+    createdAt,
+    completedAt,
+    assessmentState,
+    assessmentResultStatus,
+    abortReason,
+    pixScore,
+  }) {
     this.certificationCourseId = certificationCourseId;
+    this.isRejectedForFraud = isRejectedForFraud;
+    this.isCancelled = isCancelled;
     this.certificationChallengesForAdministration = certificationChallengesForAdministration;
+    this.createdAt = createdAt;
+    this.completedAt = completedAt;
+    this.assessmentState = assessmentState;
+    this.assessmentResultStatus = assessmentResultStatus;
+    this.abortReason = abortReason;
+    this.pixScore = pixScore;
   }
 
   setCompetencesDetails(competenceList) {

--- a/api/src/certification/course/infrastructure/serializers/jsonapi/v3-certification-course-details-for-administration-serializer.js
+++ b/api/src/certification/course/infrastructure/serializers/jsonapi/v3-certification-course-details-for-administration-serializer.js
@@ -3,7 +3,18 @@ import jsonapiSerializer from 'jsonapi-serializer';
 const { Serializer } = jsonapiSerializer;
 
 const serialize = function ({ certificationDetails }) {
-  const attributes = ['certificationCourseId', 'certificationChallengesForAdministration'];
+  const attributes = [
+    'certificationCourseId',
+    'certificationChallengesForAdministration',
+    'isRejectedForFraud',
+    'isCancelled',
+    'createdAt',
+    'completedAt',
+    'assessmentState',
+    'assessmentResultStatus',
+    'abortReason',
+    'pixScore',
+  ];
 
   return new Serializer('v3-certification-course-details-for-administration', {
     id: 'certificationCourseId',

--- a/api/tests/certification/course/acceptance/application/certification-course-route_test.js
+++ b/api/tests/certification/course/acceptance/application/certification-course-route_test.js
@@ -188,13 +188,14 @@ describe('Acceptance | Route | certification-course', function () {
   describe('POST /api/admin/certification-courses-v3/{id}/details', function () {
     let certificationCourse;
     let certificationChallenges;
+    let assessmentResult;
     let options;
     let server;
 
     beforeEach(async function () {
       certificationCourse = databaseBuilder.factory.buildCertificationCourse({ version: 3 });
       const user = await insertUserWithRoleSuperAdmin();
-      ({ certificationChallenges } = await createSuccessfulCertificationCourse({
+      ({ certificationChallenges, assessmentResult } = await createSuccessfulCertificationCourse({
         userId: user.id,
         certificationCourse,
       }));
@@ -228,7 +229,15 @@ describe('Acceptance | Route | certification-course', function () {
       const expectedResponse = {
         type: 'v3-certification-course-details-for-administrations',
         attributes: {
+          'abort-reason': null,
           'certification-course-id': certificationCourse.id,
+          'completed-at': certificationCourse.completedAt,
+          'created-at': certificationCourse.createdAt,
+          'is-rejected-for-fraud': false,
+          'is-cancelled': false,
+          'pix-score': assessmentResult.pixScore,
+          'assessment-state': 'completed',
+          'assessment-result-status': 'validated',
         },
         id: certificationCourse.id.toString(),
         relationships: {

--- a/api/tests/certification/course/integration/infrastructure/repositories/v3-certification-course-details-for-administration-repository_test.js
+++ b/api/tests/certification/course/integration/infrastructure/repositories/v3-certification-course-details-for-administration-repository_test.js
@@ -5,6 +5,9 @@ import {
   CertificationIssueReportCategory,
   CertificationIssueReportSubcategories,
 } from '../../../../../../src/certification/shared/domain/models/CertificationIssueReportCategory.js';
+import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
+import { ABORT_REASONS } from '../../../../../../lib/domain/models/CertificationCourse.js';
+import { AssessmentResult } from '../../../../../../src/shared/domain/models/AssessmentResult.js';
 
 describe('Integration | Infrastructure | Repository | v3-certification-course-details-for-administration', function () {
   describe('#getV3DetailsByCertificationCourseId', function () {
@@ -13,8 +16,23 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
       const certificationCourseId = 123;
       const challengeId = 'recCHAL456';
       const assessmentId = 78;
+      const isRejectedForFraud = true;
+      const createdAt = new Date('2022-02-02');
+      const completedAt = new Date('2022-02-03');
+      const assessmentState = Assessment.states.ENDED_DUE_TO_FINALIZATION;
+      const assessmentResultStatus = AssessmentResult.status.VALIDATED;
+      const abortReason = ABORT_REASONS.CANDIDATE;
+      const pixScore = 60;
+      const isCancelled = false;
 
-      databaseBuilder.factory.buildCertificationCourse({ id: certificationCourseId });
+      databaseBuilder.factory.buildCertificationCourse({
+        id: certificationCourseId,
+        isRejectedForFraud,
+        createdAt,
+        completedAt,
+        abortReason,
+        isCancelled,
+      });
       databaseBuilder.factory.buildCertificationChallenge({
         courseId: certificationCourseId,
         challengeId,
@@ -22,6 +40,13 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
       databaseBuilder.factory.buildAssessment({
         id: assessmentId,
         certificationCourseId,
+        state: assessmentState,
+      });
+      databaseBuilder.factory.buildAssessmentResult({
+        pixScore,
+        certificationCourseId,
+        assessmentId,
+        assessmentResultStatus,
       });
 
       const answer = databaseBuilder.factory.buildAnswer({
@@ -50,6 +75,14 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
 
       const expectedCertificationCourseDetails = domainBuilder.buildV3CertificationCourseDetailsForAdministration({
         certificationCourseId,
+        isRejectedForFraud,
+        createdAt,
+        completedAt,
+        assessmentState,
+        assessmentResultStatus,
+        abortReason,
+        pixScore,
+        isCancelled,
         certificationChallengesForAdministration: [certificationChallengeForAdministration],
       });
 
@@ -189,15 +222,14 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
         },
       );
 
-      const expectedCertificationCourseDetails = domainBuilder.buildV3CertificationCourseDetailsForAdministration({
-        certificationCourseId,
-        certificationChallengesForAdministration: [
-          firstCertificationChallengeForAdministration,
-          secondCertificationChallengeForAdministration,
-          thirdCertificationChallengeForAdministration,
-        ],
-      });
-      expect(certificationChallenges).to.deep.equal(expectedCertificationCourseDetails);
+      const expectedCertificationChallengesForAdministration = [
+        firstCertificationChallengeForAdministration,
+        secondCertificationChallengeForAdministration,
+        thirdCertificationChallengeForAdministration,
+      ];
+      expect(certificationChallenges.certificationChallengesForAdministration).to.deep.equal(
+        expectedCertificationChallengesForAdministration,
+      );
     });
   });
 });

--- a/api/tests/certification/course/unit/infrasctructure/serializers/jsonapi/v3-certification-course-details-for-administration-serializer_test.js
+++ b/api/tests/certification/course/unit/infrasctructure/serializers/jsonapi/v3-certification-course-details-for-administration-serializer_test.js
@@ -5,6 +5,9 @@ import { AnswerStatus } from '../../../../../../../src/shared/domain/models/Answ
 import { expect } from '../../../../../../test-helper.js';
 import { V3CertificationCourseDetailsForAdministration } from '../../../../../../../src/certification/course/domain/models/V3CertificationCourseDetailsForAdministration.js';
 import { V3CertificationChallengeLiveAlertForAdministration } from '../../../../../../../src/certification/course/domain/models/V3CertificationChallengeLiveAlertForAdministration.js';
+import { Assessment } from '../../../../../../../src/shared/domain/models/Assessment.js';
+import { ABORT_REASONS } from '../../../../../../../lib/domain/models/CertificationCourse.js';
+import { AssessmentResult } from '../../../../../../../src/shared/domain/models/AssessmentResult.js';
 
 describe('Unit | Serializer | JSONAPI | v3-certification-details-for-administration-serializer', function () {
   describe('#serialize()', function () {
@@ -18,6 +21,14 @@ describe('Unit | Serializer | JSONAPI | v3-certification-details-for-administrat
       const competenceIndex = '1.2';
       const skillName = '@toto';
       const answerValue = 'Some answer';
+      const isRejectedForFraud = true;
+      const isCancelled = true;
+      const createdAt = new Date('2022-02-02');
+      const completedAt = new Date('2022-02-03');
+      const assessmentState = Assessment.states.ENDED_DUE_TO_FINALIZATION;
+      const assessmentResultStatus = AssessmentResult.status.VALIDATED;
+      const abortReason = ABORT_REASONS.CANDIDATE;
+      const pixScore = 60;
 
       const certificationChallenge = new V3CertificationChallengeForAdministration({
         challengeId,
@@ -44,6 +55,14 @@ describe('Unit | Serializer | JSONAPI | v3-certification-details-for-administrat
           },
           attributes: {
             'certification-course-id': certificationCourseId,
+            'is-rejected-for-fraud': isRejectedForFraud,
+            'is-cancelled': isCancelled,
+            'created-at': createdAt,
+            'completed-at': completedAt,
+            'assessment-state': assessmentState,
+            'assessment-result-status': assessmentResultStatus,
+            'abort-reason': abortReason,
+            'pix-score': pixScore,
           },
         },
         included: [
@@ -68,6 +87,14 @@ describe('Unit | Serializer | JSONAPI | v3-certification-details-for-administrat
 
       const certificationDetails = new V3CertificationCourseDetailsForAdministration({
         certificationCourseId,
+        isRejectedForFraud,
+        isCancelled,
+        createdAt,
+        completedAt,
+        assessmentState,
+        assessmentResultStatus,
+        abortReason,
+        pixScore,
         certificationChallengesForAdministration: [certificationChallenge],
       });
 

--- a/api/tests/tooling/domain-builder/factory/build-v3-certification-course-details-for-administration.js
+++ b/api/tests/tooling/domain-builder/factory/build-v3-certification-course-details-for-administration.js
@@ -2,10 +2,26 @@ import { V3CertificationCourseDetailsForAdministration } from '../../../../src/c
 
 export const buildV3CertificationCourseDetailsForAdministration = ({
   certificationCourseId,
+  isRejectedForFraud = false,
+  isCancelled = false,
   certificationChallengesForAdministration = [],
+  createdAt,
+  completedAt,
+  assessmentState,
+  assessmentResultStatus,
+  abortReason,
+  pixScore,
 }) => {
   return new V3CertificationCourseDetailsForAdministration({
     certificationCourseId,
+    isRejectedForFraud,
+    isCancelled,
+    createdAt,
+    completedAt,
+    assessmentState,
+    assessmentResultStatus,
+    abortReason,
+    pixScore,
     certificationChallengesForAdministration,
   });
 };


### PR DESCRIPTION
## :christmas_tree: Problème
Une page de détails spécifique à la certif v3 est nécessaire car celle pour la v2 n’est pas pertinente. Le fait de créer une nouvelle page de détails permet également d’ajouter de nouvelles informations nécessaires pour le pôle certif en cas de questions par un candidat/prescripteur, notamment la durée du test et la raison de l’abandon pour un test non terminé par le candidat.

## 🎁 Proposition
Dans Pix Admin > page de détails certif v3 > onglet “Détails” : afficher les informations du bloc “Certification n°” : 
 - le numéro de la certification
 - le statut de la certification : Validée, Rejetée, Rejetée pour fraude, ou Annulée
 - Créée le : date de création du certif-course
 - Terminée le : renseigné uniquement si c’est le candidat qui a terminé son test
 - Durée de la certification : uniquement pour les certifs terminées par le candidat dans un premier temps
    + en vert si cette durée ne dépasse pas 1h45
    + en rouge si cette durée dépasse 1h45
 - Certification terminée par : affiché uniquement si ce n’est PAS le candidat qui a terminé son test. 2 options : 
    + Le surveillant (state de l’assessment = endedBySupervisor)
    + Finalisation session (state de l’assessment = endedDueToFinalization)
- Raison de l’abandon : abortReason du certif-course
- Score (en pix)

Maquette : [Pix Admin](https://www.figma.com/file/YOD6plwy3EfJLmC2Let0zV/Pix-Admin?type=design&node-id=2593%3A6814&mode=design&t=VRv3AVUKeHj34toe-1)

## :santa: Pour tester
1. créer une session de certif dans un CDC taggué isV3Pilot
2. inscrire 2 candidats à cette session
3. rejoindre la session avec un premier candidat
4. répondre à 1 question du test 
5. rejoindre la session avec le 2ème candidat
6. répondre bien à toutes les questions en plus d’1h45
7. dans Pix Certif, finaliser la session en sélectionnant la raison de l’abandon “Abandon” pour le 1er candidat
8. dans Pix Admin, ouvrir la page de détails de la certif du premier candidat 
   a. le statut de la certif, “Rejetée” est affiché en rouge
   b. la durée de la certif n’est pas affichée
   c. il est indiqué que la certif a été terminée par la finalisation de la session
   d. la raison de l’abandon est “Abandon : manque de temps ou départ prématuré”
9. ouvrir la page de détails de la certif du second candidat 
   a. le statut de la certif, “Validée” est affiché en vert
   b. la durée de la certif est affichée en rouge
   c. les champs “Certification terminée par” et “Raison de l’abandon” ne sont pas visibles
