### PR TITLE
[BUGFIX] limite l'accès aux résultats tant que le parcours n'est pas terminé (PIX-10705)

### DIFF
--- a/api/lib/domain/usecases/get-user-campaign-assessment-result.js
+++ b/api/lib/domain/usecases/get-user-campaign-assessment-result.js
@@ -5,6 +5,7 @@ import * as defaultStageRepository from '../../../src/evaluation/infrastructure/
 import * as defaultStageAcquisitionRepository from '../../../src/evaluation/infrastructure/repositories/stage-acquisition-repository.js';
 import * as defaultParticipantResultRepository from '../../infrastructure/repositories/participant-result-repository.js';
 import * as defaultCompareStageAndAcquiredStagesService from '../../../src/evaluation/domain/services/stages/stage-and-stage-acquisition-comparison-service.js';
+import { CampaignParticipationStatuses } from '../models/index.js';
 
 const getUserCampaignAssessmentResult = async function ({
   userId,
@@ -18,6 +19,15 @@ const getUserCampaignAssessmentResult = async function ({
   participantResultRepository = defaultParticipantResultRepository,
   compareStagesAndAcquiredStages = defaultCompareStageAndAcquiredStagesService,
 }) {
+  const { SHARED, TO_SHARE } = CampaignParticipationStatuses;
+  const campaignParticipationStatus = await participantResultRepository.getCampaignParticipationStatus({
+    userId,
+    campaignId,
+  });
+
+  if (![TO_SHARE, SHARED].includes(campaignParticipationStatus)) {
+    throw new NoCampaignParticipationForUserAndCampaign();
+  }
   try {
     const [badges, knowledgeElements] = await Promise.all([
       badgeRepository.findByCampaignId(campaignId),

--- a/api/lib/infrastructure/repositories/participant-result-repository.js
+++ b/api/lib/infrastructure/repositories/participant-result-repository.js
@@ -249,4 +249,16 @@ async function _isOrganizationLearnerActive(userId, campaignId) {
   return !organizationLearner?.isDisabled;
 }
 
-export { getByUserIdAndCampaignId };
+async function getCampaignParticipationStatus({ userId, campaignId }) {
+  const participationStatus = await knex('campaign-participations')
+    .select('status')
+    .where({ campaignId, userId, isImproved: false })
+    .first();
+
+  if (!participationStatus) {
+    throw new NotFoundError(`Participation not found for user ${userId} and campaign ${campaignId}`);
+  }
+  return participationStatus.status;
+}
+
+export { getCampaignParticipationStatus, getByUserIdAndCampaignId };

--- a/api/tests/integration/infrastructure/repositories/participant-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/participant-result-repository_test.js
@@ -1094,6 +1094,56 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
       });
     });
   });
+  describe('#getCampaignParticipationStatus', function () {
+    let campaign;
+    let user;
+    let learner;
+
+    beforeEach(async function () {
+      campaign = databaseBuilder.factory.buildCampaign();
+      user = databaseBuilder.factory.buildUser();
+      learner = databaseBuilder.factory.buildOrganizationLearner({
+        userId: user.id,
+        organization: campaign.organizationId,
+      });
+      await databaseBuilder.commit();
+    });
+
+    it('should return status of an existing campaign participation', async function () {
+      // given
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        organizationLearnerId: learner.id,
+        userId: user.id,
+        status: STARTED,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const status = await participantResultRepository.getCampaignParticipationStatus({
+        userId: user.id,
+        campaignId: campaign.id,
+      });
+
+      // then
+      expect(status).to.equals(STARTED);
+    });
+    it('should throws if there no user as no participation for a givent campaign and user', async function () {
+      // given
+      databaseBuilder.factory.buildCampaignParticipation();
+      await databaseBuilder.commit();
+
+      // when
+      const error = await catchErr(participantResultRepository.getCampaignParticipationStatus)({
+        userId: user.id,
+        campaignId: campaign.id,
+      });
+
+      // then
+      expect(error).to.be.an.instanceof(NotFoundError);
+    });
+  });
 });
 
 function _buildCampaignSkills(campaignId) {

--- a/api/tests/unit/domain/usecases/get-user-campaign-assessment-result_test.js
+++ b/api/tests/unit/domain/usecases/get-user-campaign-assessment-result_test.js
@@ -1,6 +1,7 @@
 import { expect, sinon, domainBuilder, catchErr } from '../../../test-helper.js';
 import { getUserCampaignAssessmentResult } from '../../../../lib/domain/usecases/get-user-campaign-assessment-result.js';
 import { NotFoundError, NoCampaignParticipationForUserAndCampaign } from '../../../../lib/domain/errors.js';
+import { CampaignParticipationStatuses } from '../../../../lib/domain/models/index.js';
 
 describe('Unit | UseCase | get-user-campaign-assessment-result', function () {
   const locale = 'locale',
@@ -15,7 +16,10 @@ describe('Unit | UseCase | get-user-campaign-assessment-result', function () {
     badgeForCalculationRepository = { findByCampaignId: sinon.stub() };
     knowledgeElementRepository = { findUniqByUserId: sinon.stub() };
     badgeRepository = { findByCampaignId: sinon.stub() };
-    participantResultRepository = { getByUserIdAndCampaignId: sinon.stub() };
+    participantResultRepository = {
+      getByUserIdAndCampaignId: sinon.stub(),
+      getCampaignParticipationStatus: sinon.stub(),
+    };
     stageRepository = { getByCampaignId: sinon.stub() };
     stageAcquisitionRepository = { getByCampaignIdAndUserId: sinon.stub() };
     compareStagesAndAcquiredStages = { compare: sinon.stub() };
@@ -39,8 +43,7 @@ describe('Unit | UseCase | get-user-campaign-assessment-result', function () {
       badgeRepository.findByCampaignId.rejects(new NotFoundError());
       knowledgeElementRepository.findUniqByUserId.rejects('I should not be called');
       badgeForCalculationRepository.findByCampaignId.rejects('I should not be called');
-      participantResultRepository.getByUserIdAndCampaignId.rejects('I should not be called');
-
+      participantResultRepository.getCampaignParticipationStatus.returns(CampaignParticipationStatuses.STARTED);
       // when
       const error = await catchErr(getUserCampaignAssessmentResult)(args);
 
@@ -108,7 +111,12 @@ describe('Unit | UseCase | get-user-campaign-assessment-result', function () {
           },
         })
         .resolves(expectedCampaignAssessmentResult);
-
+      participantResultRepository.getCampaignParticipationStatus
+        .withArgs({
+          userId,
+          campaignId,
+        })
+        .resolves(CampaignParticipationStatuses.SHARED);
       // when
       const campaignAssessmentResult = await getUserCampaignAssessmentResult(args);
 


### PR DESCRIPTION
## :christmas_tree: Problème
Si une personne ayant le code campagne et connaissant l’url d’affichage des résultats peut accèder à la route pour afficher les résultats de sa participation à une campagne même si la personne n'a pas terminé son parcours

## :gift: Proposition
On restreint la route pour les participations TO_SHARE et SHARED . 

## :socks: Remarques
La route renvoie une erreur `NoCampaignParticipationForUserAndCampaign`

## :santa: Pour tester
- se connecter sur la campagne `SCOASSIMP` avec le compte `learneremail1000_20@example.net`
- Essayer d'aller sur la page de résultat `/campagnes/{code_campagne}/evaluation/resultats`
- Etre redirigé sur la campagne en cours
