### PR TITLE
[FEATURE] Afficher les boutons de retour à la page précédente plus petit sur Pix Certif (PIX-10152).

### DIFF
--- a/certif/app/components/auth/login-or-register.hbs
+++ b/certif/app/components/auth/login-or-register.hbs
@@ -7,7 +7,9 @@
       }}</span>
     <div class="login-or-register-panel__forms-container">
       <div class="login-or-register-panel__form">
-        <h1 class="login-or-register-panel-form__title">{{t "pages.login-or-register.register-form.title"}}</h1>
+        <h1 class="login-or-register-panel-form__title page-title">{{t
+            "pages.login-or-register.register-form.title"
+          }}</h1>
         {{#unless this.displayRegisterForm}}
           <PixButton
             id="register"
@@ -34,7 +36,7 @@
       </div>
       <div class="login-or-register-panel__divider"></div>
       <div class="login-or-register-panel__form">
-        <h1 class="login-or-register-panel-form__title">{{t "pages.login-or-register.login-form.title"}}</h1>
+        <h1 class="login-or-register-panel-form__title page-title">{{t "pages.login-or-register.login-form.title"}}</h1>
         {{#if this.displayRegisterForm}}
           <PixButton
             id="login"

--- a/certif/app/components/login-form.hbs
+++ b/certif/app/components/login-form.hbs
@@ -3,7 +3,7 @@
   <header class="login__header">
     <img src="/pix-certif-logo.svg" alt="Pix Certif" />
 
-    <h1 class="login-header__title">{{t "pages.login.title"}}</h1>
+    <h1 class="page-title">{{t "pages.login.title"}}</h1>
 
     <p class="login-header__information">
       {{t "pages.login.accessible-to"}}

--- a/certif/app/styles/components/login-form.scss
+++ b/certif/app/styles/components/login-form.scss
@@ -19,14 +19,6 @@
 }
 
 .login-header {
-  &__title {
-    @extend %pix-title-m;
-
-    margin-top: var(--pix-spacing-8x);
-    margin-bottom: var(--pix-spacing-4x);
-    color: $pix-neutral-80;
-  }
-
   &__information {
     @extend %pix-body-s;
 

--- a/certif/app/styles/components/login-or-register.scss
+++ b/certif/app/styles/components/login-or-register.scss
@@ -97,10 +97,6 @@
   }
 
   &__title {
-    @extend %pix-title-m;
-
-    margin: var(--pix-spacing-4x) 0;
-    color: $pix-neutral-100;
     text-align: center;
   }
 }

--- a/certif/app/styles/globals/texts.scss
+++ b/certif/app/styles/globals/texts.scss
@@ -45,3 +45,9 @@
     color: $pix-tertiary-80;
   }
 }
+
+.previous-button {
+  width: fit-content;
+  color: var(--pix-neutral-500);
+  font-size: 0.875rem;
+}

--- a/certif/app/styles/globals/titles.scss
+++ b/certif/app/styles/globals/titles.scss
@@ -1,7 +1,6 @@
 .page-title {
+  @extend %pix-title-m;
+
   margin: 24px 0;
-  color: $pix-neutral-90;
-  font-weight: 500;
-  font-size: 2.25rem;
-  font-family: $font-open-sans;
+  color: var(--pix-neutral-800);
 }

--- a/certif/app/styles/pages/authenticated/sessions.scss
+++ b/certif/app/styles/pages/authenticated/sessions.scss
@@ -10,6 +10,7 @@
   &__mandatory-information {
     padding-bottom: $pix-spacing-m;
     color: $pix-neutral-70;
+    font-size: 1rem;
   }
 
   &__field {

--- a/certif/app/styles/pages/authenticated/sessions/add-student.scss
+++ b/certif/app/styles/pages/authenticated/sessions/add-student.scss
@@ -1,13 +1,6 @@
 .add-student {
   margin-bottom: 68px;
 
-  &__title {
-    color: $pix-neutral-70;
-    font-family: $font-open-sans;
-    font-size: 2.25rem;
-    font-weight: 300;
-  }
-
   &__info-message {
     align-items: center;
     display: flex;

--- a/certif/app/styles/pages/authenticated/sessions/details.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details.scss
@@ -10,15 +10,12 @@
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 16px;
+  margin-bottom: var(--pix-spacing-3x);
 }
 
 .session-details-header {
 
   &__title {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
     min-width: 300px;
   }
 

--- a/certif/app/styles/pages/authenticated/sessions/details.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details.scss
@@ -3,10 +3,6 @@
   flex-direction: column;
   flex-grow: 1;
   width: 100%;
-
-  &__return-to {
-    width: fit-content;
-  }
 }
 
 .session-details__header {

--- a/certif/app/styles/pages/authenticated/sessions/list-items.scss
+++ b/certif/app/styles/pages/authenticated/sessions/list-items.scss
@@ -14,12 +14,6 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    height: 78px;
-    margin: 16px 0 20px;
-
-    & > h1 {
-      margin: 0;
-    }
   }
 
   &-content__update-button {

--- a/certif/app/templates/authenticated/sessions/add-student.hbs
+++ b/certif/app/templates/authenticated/sessions/add-student.hbs
@@ -4,7 +4,7 @@
   <PixReturnTo
     @route="authenticated.sessions.details.certification-candidates"
     @model={{@model.session.id}}
-    class="add-student__return-to"
+    class="previous-button"
   >
     {{t "common.sessions.actions.return-to"}}
   </PixReturnTo>

--- a/certif/app/templates/authenticated/sessions/add-student.hbs
+++ b/certif/app/templates/authenticated/sessions/add-student.hbs
@@ -9,7 +9,7 @@
     {{t "common.sessions.actions.return-to"}}
   </PixReturnTo>
 
-  <h1 class="add-student__title">{{t "pages.sco.enrol-candidates-in-session.title"}}</h1>
+  <h1 class="page-title">{{t "pages.sco.enrol-candidates-in-session.title"}}</h1>
   <PixMessage @type="info" @withIcon={{true}} class="add-student__info-message">
     {{t "pages.sco.enrol-candidates-in-session.information" htmlSafe=true}}
     <a href={{this.supportUrl}} target="_blank" rel="noopener noreferrer">

--- a/certif/app/templates/authenticated/sessions/details.hbs
+++ b/certif/app/templates/authenticated/sessions/details.hbs
@@ -1,6 +1,6 @@
 {{page-title this.pageTitle replace=true}}
 <div class="session-details-page">
-  <PixReturnTo @route="authenticated.sessions.list" class="session-details-page__return-to">
+  <PixReturnTo @route="authenticated.sessions.list" class="previous-button">
     {{t "pages.sessions.actions.return"}}
   </PixReturnTo>
   <div class="page__title session-details__header">

--- a/certif/app/templates/authenticated/sessions/details.hbs
+++ b/certif/app/templates/authenticated/sessions/details.hbs
@@ -3,7 +3,7 @@
   <PixReturnTo @route="authenticated.sessions.list" class="previous-button">
     {{t "pages.sessions.actions.return"}}
   </PixReturnTo>
-  <div class="page__title session-details__header">
+  <div class="session-details__header">
     <div class="session-details-header__title">
       <h1 class="page-title">{{t "pages.sessions.detail.title" sessionId=this.model.session.id}}</h1>
     </div>

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -1,5 +1,5 @@
 {{page-title this.pageTitle replace=true}}
-<div class="page__title finalize">
+<div class="finalize">
   <div class="finalize__title">
     <PixReturnTo @route="authenticated.sessions.details" @model={{this.session.id}} class="previous-button">
       {{t "common.sessions.actions.return-to"}}

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -1,7 +1,7 @@
 {{page-title this.pageTitle replace=true}}
 <div class="page__title finalize">
   <div class="finalize__title">
-    <PixReturnTo @route="authenticated.sessions.details" @model={{this.session.id}}>
+    <PixReturnTo @route="authenticated.sessions.details" @model={{this.session.id}} class="previous-button">
       {{t "common.sessions.actions.return-to"}}
     </PixReturnTo>
     <h1 class="page-title">{{t "pages.session-finalization.title" sessionId=this.session.id}}</h1>

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -1,7 +1,7 @@
 {{! template-lint-disable link-href-attributes }}
 {{page-title (t "pages.sessions.import.title")}}
 <main class="import-page">
-  <PixReturnTo @route="authenticated.sessions.list" class="import-page__previous-page-button">
+  <PixReturnTo @route="authenticated.sessions.list" class="previous-button">
     {{t "pages.sessions.actions.return"}}
   </PixReturnTo>
   <h1 class="page-title">{{t "pages.sessions.import.title"}}</h1>

--- a/certif/app/templates/authenticated/sessions/new.hbs
+++ b/certif/app/templates/authenticated/sessions/new.hbs
@@ -1,6 +1,6 @@
 {{page-title this.pageTitle replace=true}}
 <div>
-  <h1 class="page__title page-title">{{t "pages.sessions.new.title"}}</h1>
+  <h1 class="page-title">{{t "pages.sessions.new.title"}}</h1>
 
   <form {{on "submit" this.createSession}} class="session-form">
     <p class="session-form__mandatory-information">

--- a/certif/app/templates/authenticated/sessions/update.hbs
+++ b/certif/app/templates/authenticated/sessions/update.hbs
@@ -1,6 +1,6 @@
 {{page-title this.pageTitle replace=true}}
 <div>
-  <h1 class="page__title page-title">{{t "pages.sessions.update.title"}}</h1>
+  <h1 class="page-title">{{t "pages.sessions.update.title"}}</h1>
 
   <form {{on "submit" this.updateSession}} class="session-form">
     <p class="session-form__mandatory-information">

--- a/certif/app/templates/authenticated/team/list.hbs
+++ b/certif/app/templates/authenticated/team/list.hbs
@@ -1,7 +1,7 @@
 {{page-title (t "pages.team.title")}}
 
 <div class="team__header">
-  <h1 class="page__title page-title">{{t "pages.team.title"}}</h1>
+  <h1 class="page-title">{{t "pages.team.title"}}</h1>
   <div class="team__header-admin-buttons">
     {{#if this.shouldDisplayUpdateRefererButton}}
       <PixButton


### PR DESCRIPTION
## :christmas_tree: Problème
Dans pix Certif, dans l'import en masse des session, le bouton “Revenir à la liste des sessions” est trop visible par rapport au reste du contenu de la page.

## :gift: Proposition
Eclaircir le bouton et le rendre plus petit, comme le montre la maquette.

Pour être iso dans toute l'application, j'opte pour modifier l'ensemble des boutons qui retournent à la page précédente.

## :socks: Remarques
Je profite ici de changer la font pour les h1, comme présent sur la maquette également

## :santa: Pour tester
- Se connecter avec certif-pro@example.net
- Aller sur `/sessions/import`

<img width="1516" alt="Capture d’écran 2024-01-12 à 09 44 14" src="https://github.com/1024pix/pix/assets/58915422/3cbe38d5-cc0c-414c-88e3-ee5ecc83a240">

- Aller sur `/sessions/7002`

<img width="1516" alt="Capture d’écran 2024-01-12 à 09 44 32" src="https://github.com/1024pix/pix/assets/58915422/1fbbdb0b-06d8-4590-9968-ee4730ff5002">

- Aller sur `/sessions/7005/finalisation`

<img width="1516" alt="Capture d’écran 2024-01-12 à 09 44 49" src="https://github.com/1024pix/pix/assets/58915422/95785e37-b575-47dd-8a20-832cb00f5dc7">

- Se connecter avec certif-sco@example.net
- Aller sur `/sessions/7000/inscription-eleves`

<img width="1516" alt="Capture d’écran 2024-01-12 à 09 45 09" src="https://github.com/1024pix/pix/assets/58915422/3a3c05f4-1cb1-4f7b-aa00-3a7f32cf6ca7">


