### PR TITLE
[BUGFIX] Corriger des typo sur le texte d'informations des campagnes en isForAbsoluteNovice dans PixAdmin (PIX-10738)

### DIFF
--- a/admin/app/components/campaigns/update.hbs
+++ b/admin/app/components/campaigns/update.hbs
@@ -114,7 +114,7 @@
             <div class="is-for-absolute-novice-warning">
               <p>Les campagnes
                 <strong><i>isForAbsoluteNovice</i></strong>
-                sont uniquement à destination des grand débutants et supprimant de ce fait les éléments suivant :</p>
+                sont uniquement à destination des grands débutants et suppriment de ce fait les éléments suivants :</p>
 
               <ul class="is-for-absolute-novice-warning__list">
                 <li>Didacticiel</li>


### PR DESCRIPTION
## :christmas_tree: Problème
quelques typos sur la phrase d'information dans la page de mis à jour d'une campagne

## :gift: Proposition
Corriger ces typos

## :socks: Remarques
RAS

## :santa: Pour tester
Vérifier que le texte est correct