### PR TITLE
[FEATURE] Ajouter la traduction néerlandaise sur Pix App (PIX-10687)

### DIFF
--- a/api/lib/infrastructure/utils/request-response-utils.js
+++ b/api/lib/infrastructure/utils/request-response-utils.js
@@ -1,8 +1,10 @@
 import accept from '@hapi/accept';
 import { tokenService } from '../../../src/shared/domain/services/token-service.js';
 import { LOCALE } from '../../../src/shared/domain/constants.js';
+import { LANGUAGES_CODE } from '../../../src/shared/domain/services/language-service.js';
 
 const { ENGLISH_SPOKEN, FRENCH_FRANCE, FRENCH_SPOKEN } = LOCALE;
+const { DUTCH } = LANGUAGES_CODE;
 const requestResponseUtils = { escapeFileName, extractUserIdFromRequest, extractLocaleFromRequest };
 
 export { escapeFileName, extractUserIdFromRequest, extractLocaleFromRequest, requestResponseUtils };
@@ -25,6 +27,6 @@ function extractLocaleFromRequest(request) {
   if (!languageHeader) {
     return defaultLocale;
   }
-  const acceptedLanguages = [ENGLISH_SPOKEN, FRENCH_SPOKEN, FRENCH_FRANCE];
+  const acceptedLanguages = [ENGLISH_SPOKEN, FRENCH_SPOKEN, FRENCH_FRANCE, DUTCH];
   return accept.language(languageHeader, acceptedLanguages) || defaultLocale;
 }

--- a/mon-pix/app/languages.js
+++ b/mon-pix/app/languages.js
@@ -3,9 +3,12 @@ export default {
     value: 'English',
     languageSwitcherDisplayed: true,
   },
-
   fr: {
     value: 'Français',
     languageSwitcherDisplayed: true,
+  },
+  nl: {
+    value: 'Nederlands',
+    languageSwitcherDisplayed: false,
   },
 };


### PR DESCRIPTION
## :christmas_tree: Problème
Dans le cadre de l'internationalisation de Pix, on veut ajouter la langue néerlandaise sur Pix

## :gift: Proposition
Ajouter le fichier de traduction néerlandais. Pour le moment la langue n'est pas affichée sur le language switcher.

## :socks: Remarques
RAS

## :santa: Pour tester
- Aller sur la RA de Pix App .org avec le paramètre ?lang=nl : https://app-pr7850.review.pix.org/connexion?lang=nl
- Vérifier que la page s'affiche bien en néerlandais et que le langage switcher n'affiche rien (option non traité pour le moment).
- Se connecter avec un compte Pix (ex: james-paledroits@example.net)
- Ajouter ?lang=nl à l'url après connexion et vérifier que la page s'affiche bien en néerlandais.