### PR TITLE
[FEATURE][ADMIN] Afficher la liste des organisations enfants d'une organisation parente (PIX-10048)

### DIFF
--- a/admin/app/components/organizations/children/list-item.hbs
+++ b/admin/app/components/organizations/children/list-item.hbs
@@ -1,0 +1,9 @@
+<tr aria-label={{@organization.name}}>
+  <td>
+    <LinkTo @route="authenticated.organizations.get" @model={{@organization.id}}>
+      {{@organization.id}}
+    </LinkTo>
+  </td>
+  <td>{{@organization.name}}</td>
+  <td>{{@organization.externalId}}</td>
+</tr>

--- a/admin/app/components/organizations/children/list.hbs
+++ b/admin/app/components/organizations/children/list.hbs
@@ -1,0 +1,14 @@
+<table aria-label={{t "components.organizations.children-list.table-name"}}>
+  <thead>
+    <tr>
+      <th>{{t "components.organizations.children-list.table-headers.id"}}</th>
+      <th>{{t "components.organizations.children-list.table-headers.name"}}</th>
+      <th>{{t "components.organizations.children-list.table-headers.external-id"}}</th>
+    </tr>
+  </thead>
+  <tbody>
+    {{#each @organizations as |organization|}}
+      <Organizations::Children::ListItem @organization={{organization}} />
+    {{/each}}
+  </tbody>
+</table>

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -35,6 +35,7 @@ export default class Organization extends Model {
   @hasMany('organizationMembership') organizationMemberships;
   @hasMany('targetProfileSummary') targetProfileSummaries;
   @hasMany('tag') tags;
+  @hasMany('organization', { inverse: null }) children;
 
   static get featureList() {
     return {

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -36,6 +36,7 @@ Router.map(function () {
           this.route('new');
         });
         this.route('invitations');
+        this.route('children');
       });
     });
 

--- a/admin/app/routes/authenticated/organizations/get/children.js
+++ b/admin/app/routes/authenticated/organizations/get/children.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+
+export default class AuthenticatedOrganizationsGetChildrenRoute extends Route {
+  async model() {
+    const organization = this.modelFor('authenticated.organizations.get');
+    return {
+      organizations: organization.children,
+    };
+  }
+}

--- a/admin/app/templates/authenticated/organizations/get.hbs
+++ b/admin/app/templates/authenticated/organizations/get.hbs
@@ -43,6 +43,9 @@
         Tags
       </LinkTo>
     {{/if}}
+    <LinkTo @route="authenticated.organizations.get.children" @model={{@model}} class="navbar-item">
+      {{t "pages.organization.navbar.children"}}
+    </LinkTo>
   </nav>
 
   {{outlet}}

--- a/admin/app/templates/authenticated/organizations/get/children.hbs
+++ b/admin/app/templates/authenticated/organizations/get/children.hbs
@@ -1,0 +1,16 @@
+{{page-title "Children"}}
+<section class="page-section">
+  <header class="page-section__header">
+    <h2 class="page-section__title">{{t "pages.organization-children.title"}}</h2>
+  </header>
+  <div class="content-text content-text--small">
+    <div class="table-admin">
+      <Organizations::Children::List @organizations={{@model.organizations}} />
+
+      {{#unless @model.organizations}}
+        <p class="table__empty">{{t "pages.organization-children.empty-table"}}</p>
+      {{/unless}}
+    </div>
+  </div>
+
+</section>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -591,4 +591,23 @@ function routes() {
       ],
     };
   });
+
+  _configureOrganizationsRoutes(this);
+}
+
+function _configureOrganizationsRoutes(context) {
+  context.get('/admin/organizations/:organizationId/children', () => {
+    return {
+      data: [
+        {
+          type: 'organization',
+          id: '1234',
+          attributes: {
+            name: 'UA',
+            'external-id': 'UA123456',
+          },
+        },
+      ],
+    };
+  });
 }

--- a/admin/mirage/serializers/organization.js
+++ b/admin/mirage/serializers/organization.js
@@ -3,6 +3,9 @@ import ApplicationSerializer from './application';
 export default ApplicationSerializer.extend({
   links(organization) {
     return {
+      children: {
+        related: `/api/admin/organizations/${organization.id}/children`,
+      },
       organizationMemberships: {
         related: `/api/admin/organizations/${organization.id}/memberships`,
       },

--- a/admin/tests/acceptance/authenticated/organizations/get/children_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get/children_test.js
@@ -1,0 +1,58 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { visit } from '@1024pix/ember-testing-library';
+import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
+import setupIntl from 'pix-admin/tests/helpers/setup-intl';
+import { currentURL } from '@ember/test-helpers';
+
+module('Acceptance | Organizations | Children', function (hooks) {
+  setupApplicationTest(hooks);
+  setupIntl(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function () {
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+  });
+
+  test('"Organisations enfants" tab exists', async function (assert) {
+    // given
+    const organizationId = this.server.create('organization').id;
+
+    // when
+    const screen = await visit(`/organizations/${organizationId}/children`);
+
+    // then
+    assert.strictEqual(currentURL(), `/organizations/${organizationId}/children`);
+    assert.dom(screen.getByRole('link', { name: 'Organisations enfants' })).hasClass('active');
+  });
+
+  module('when there is no child organization', function () {
+    test('displays a message', async function (assert) {
+      // given
+      const organizationId = this.server.create('organization').id;
+      this.server.get(`/admin/organizations/${organizationId}/children`, () => ({ data: [] }));
+
+      // when
+      const screen = await visit(`/organizations/${organizationId}/children`);
+
+      // then
+      assert.dom(screen.getByText('Aucune organisation enfant')).exists();
+      assert.dom(screen.getByRole('heading', { name: 'Organisations enfants', level: 2 })).exists();
+    });
+  });
+
+  module('when there is at least one child organization', function () {
+    test('displays a list of child organizations', async function (assert) {
+      // given
+      const parentOrganizationId = this.server.create('organization').id;
+
+      // when
+      const screen = await visit(`/organizations/${parentOrganizationId}/children`);
+
+      // then
+      assert.dom(screen.queryByText('Aucune organisation enfant')).doesNotExist();
+      assert.dom(screen.getByRole('table', { name: 'Liste des organisations enfants' })).exists();
+    });
+  });
+});

--- a/admin/tests/integration/components/organizations/children/list-item_test.js
+++ b/admin/tests/integration/components/organizations/children/list-item_test.js
@@ -1,0 +1,28 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { hbs } from 'ember-cli-htmlbars';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
+
+module('Integration | Component | organizations/children/list-item', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('displays child organization items', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const organization = store.createRecord('organization', {
+      id: 1,
+      name: 'Collège The Night Watch',
+      externalId: 'UA123456',
+    });
+    this.set('organization', organization);
+
+    // when
+    const screen = await renderScreen(hbs`<Organizations::Children::ListItem @organization={{this.organization}} />`);
+
+    // then
+    assert.dom(screen.getByRole('row', { name: 'Collège The Night Watch' })).exists();
+    assert.dom(screen.getByRole('cell', { name: '1' })).exists();
+    assert.dom(screen.getByRole('cell', { name: 'Collège The Night Watch' })).exists();
+    assert.dom(screen.getByRole('cell', { name: 'UA123456' })).exists();
+  });
+});

--- a/admin/tests/integration/components/organizations/children/list_test.js
+++ b/admin/tests/integration/components/organizations/children/list_test.js
@@ -1,0 +1,40 @@
+import { module, test } from 'qunit';
+import { hbs } from 'ember-cli-htmlbars';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | organizations/children/list', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('display children organizations list', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const organization1 = store.createRecord('organization', {
+      id: 1,
+      name: 'Collège The Night Watch',
+      externalId: 'UA123456',
+    });
+    const organization2 = store.createRecord('organization', {
+      id: 2,
+      name: 'Lycée KingsLanding',
+      externalId: 'UB64321',
+    });
+    this.set('organizations', [organization1, organization2]);
+
+    //  when
+    const screen = await renderScreen(hbs`<Organizations::Children::List @organizations={{this.organizations}}/>`);
+
+    // then
+    assert.dom(screen.getByRole('table', { name: 'Liste des organisations enfants' })).exists();
+
+    assert.dom(screen.getByRole('columnheader', { name: 'ID' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Nom' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Identifiant externe' })).exists();
+
+    assert.strictEqual((await screen.findAllByRole('row')).length, 3);
+
+    assert.dom(screen.getByRole('row', { name: 'Collège The Night Watch' })).exists();
+    assert.dom(screen.getByRole('row', { name: 'Lycée KingsLanding' })).exists();
+  });
+});

--- a/admin/tests/unit/routes/authenticated/organizations/get/children_test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/get/children_test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | authenticated/organizations/get/children', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:authenticated/organizations/get/children');
+    assert.ok(route);
+  });
+});

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -163,6 +163,10 @@
         "children": "Children organisations"
       }
     },
+    "organization-children": {
+      "title": "Children organisations",
+      "empty-table": "No child organisation"
+    },
     "target-profiles": {
       "resettable-checkbox": {
         "label": "Allow resetting for evaluation-type campaigns when multiple submissions are enabled for the organisation"

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -158,6 +158,11 @@
         "login-no-permission": "You don't have the permission to connect."
       }
     },
+    "organization": {
+      "navbar": {
+        "children": "Children organisations"
+      }
+    },
     "target-profiles": {
       "resettable-checkbox": {
         "label": "Allow resetting for evaluation-type campaigns when multiple submissions are enabled for the organisation"

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -99,6 +99,14 @@
     "organizations": {
       "all-tags": {
         "recently-used-tags": "List of tags recently used with {tagName}"
+      },
+      "children-list": {
+        "table-headers": {
+          "external-id": "External Identifier",
+          "id": "ID",
+          "name": "Name"
+        },
+        "table-name": "List of children organisations"
       }
     },
     "users": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -107,6 +107,14 @@
     "organizations": {
       "all-tags": {
         "recently-used-tags": "Liste de tags récemment utilisés avec {tagName}"
+      },
+      "children-list": {
+        "table-headers": {
+          "external-id": "Identifiant externe",
+          "id": "ID",
+          "name": "Nom"
+        },
+        "table-name": "Liste des organisations enfants"
       }
     },
     "users": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -168,6 +168,11 @@
         "login-no-permission": "Vous n'avez pas les droits pour vous connecter."
       }
     },
+    "organization": {
+      "navbar": {
+        "children": "Organisations enfants"
+      }
+    },
     "organizations": {
       "notifications": {
         "errors": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -173,6 +173,10 @@
         "children": "Organisations enfants"
       }
     },
+    "organization-children": {
+      "title": "Organisations enfants",
+      "empty-table": "Aucune organisation enfant"
+    },
     "organizations": {
       "notifications": {
         "errors": {

--- a/api/lib/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin-serializer.js
@@ -39,6 +39,7 @@ const serialize = function (organizations, meta) {
       'tags',
       'organizationMemberships',
       'targetProfileSummaries',
+      'children',
       'identityProviderForCampaigns',
       'features',
     ],
@@ -59,6 +60,16 @@ const serialize = function (organizations, meta) {
       relationshipLinks: {
         related(record, current, parent) {
           return `/api/admin/organizations/${parent.id}/target-profile-summaries`;
+        },
+      },
+    },
+    children: {
+      ref: 'id',
+      ignoreRelationshipData: true,
+      nullIfMissing: true,
+      relationshipLinks: {
+        related: function (record, current, parent) {
+          return `/api/admin/organizations/${parent.id}/children`;
         },
       },
     },

--- a/api/tests/acceptance/application/organizations-administration/organization-administration-get_test.js
+++ b/api/tests/acceptance/application/organizations-administration/organization-administration-get_test.js
@@ -100,6 +100,11 @@ describe('Acceptance | Routes | organization-administration-controller', functio
             },
             id: organization.id.toString(),
             relationships: {
+              children: {
+                links: {
+                  related: `/api/admin/organizations/${organization.id}/children`,
+                },
+              },
               'organization-memberships': {
                 links: {
                   related: `/api/organizations/${organization.id}/memberships`,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-for-admin-serializer_test.js
@@ -6,7 +6,7 @@ import * as apps from '../../../../../lib/domain/constants.js';
 
 describe('Unit | Serializer | organization-for-admin-serializer', function () {
   describe('#serialize', function () {
-    it('should return a JSON API serialized organization', function () {
+    it('returns a JSON API serialized organization', function () {
       // given
       const tags = [
         domainBuilder.buildTag({ id: 7, name: 'AEFE' }),
@@ -72,6 +72,11 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
             'target-profile-summaries': {
               links: {
                 related: `/api/admin/organizations/${organization.id}/target-profile-summaries`,
+              },
+            },
+            children: {
+              links: {
+                related: `/api/admin/organizations/${organization.id}/children`,
               },
             },
             tags: {


### PR DESCRIPTION
## :christmas_tree: Problème

Il n'est actuellement pas possible, sur Pix Admin, d'obtenir la liste des organisations enfants d'une organisation.

## :gift: Proposition

1. Ajouter un nouvel onglet `Organisations enfants`
2. Afficher la liste des organisations enfants

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester

#### Organisation avec une ou plusieurs organisations enfants

- Se connecter à Pix Admin avec l'un des comptes suivants : _superadmin@example.net_, _pixcertif@example.net_, _pixmetier@example.net_, _pixsupport@example.net_.
- Ouvrir la page de détails de l'organisation `Collège House of The Dragon` avec l'ID `2023`
- Constater l'affichage d'un nouvel onglet `Organisations enfants`
- Cliquer sur ce nouvel onglet `Organisations enfants`
- Constater l'affichage d'une liste d'organisations enfants avec son ID, nom et identifiant externe

#### Organisation sans enfant

- Se connecter à Pix Admin avec l'un des comptes suivants : _superadmin@example.net_, _pixcertif@example.net_, _pixmetier@example.net_, _pixsupport@example.net_.
- Ouvrir la page de détails de l'organisation `Child of "Collège House of The Dragon"`
- Constater l'affichage d'un nouvel onglet `Organisations enfants`
- Cliquer sur ce nouvel onglet `Organisations enfants`
- Constater l'affichage d'un message `Aucune organisation enfant`