### PR TITLE
[FIX] Adapter les couleurs des graphiques à celles du design system (PIX-10703)

### DIFF
--- a/orga/app/components/campaign/charts/participants-by-day.js
+++ b/orga/app/components/campaign/charts/participants-by-day.js
@@ -69,8 +69,8 @@ export default class ParticipantsByDay extends Component {
         {
           label: this.intl.t(this.labels.shared.legend),
           data: this.sharedDatasets,
-          borderColor: '#038a25',
-          backgroundColor: '#038a25',
+          borderColor: '#613fdd',
+          backgroundColor: '#613fdd',
           tension: 0.2,
           pointStyle: 'rect',
           order: 1,

--- a/orga/app/components/campaign/charts/participants-by-status.js
+++ b/orga/app/components/campaign/charts/participants-by-status.js
@@ -94,7 +94,7 @@ const LABELS_ASSESSMENT = {
     legend: 'charts.participants-by-status.labels-legend.started',
     legendTooltip: 'charts.participants-by-status.labels-legend.started-tooltip',
     a11y: 'charts.participants-by-status.labels-a11y.started',
-    color: '#da7601',
+    color: '#ffcb33',
     shape: 'diamond-box',
   },
   completed: {
@@ -102,7 +102,7 @@ const LABELS_ASSESSMENT = {
     legend: 'charts.participants-by-status.labels-legend.completed-assessment',
     legendTooltip: 'charts.participants-by-status.labels-legend.completed-assessment-tooltip',
     a11y: 'charts.participants-by-status.labels-a11y.completed',
-    color: '#8a49ff',
+    color: '#3D68FF',
     shape: 'zigzag',
   },
   shared: {
@@ -110,7 +110,7 @@ const LABELS_ASSESSMENT = {
     legend: 'charts.participants-by-status.labels-legend.shared',
     legendTooltip: 'charts.participants-by-status.labels-legend.shared-tooltip',
     a11y: 'charts.participants-by-status.labels-a11y.shared',
-    color: '#038a25',
+    color: '#1c825d',
     shape: 'weave',
   },
 };
@@ -121,7 +121,7 @@ const LABELS_PROFILE_COLLECTIONS = {
     legend: 'charts.participants-by-status.labels-legend.started',
     legendTooltip: 'charts.participants-by-status.labels-legend.started-tooltip',
     a11y: 'charts.participants-by-status.labels-a11y.started',
-    color: '#da7601',
+    color: '#ffcb33',
     shape: 'diamond-box',
   },
   completed: {
@@ -129,7 +129,7 @@ const LABELS_PROFILE_COLLECTIONS = {
     legend: 'charts.participants-by-status.labels-legend.completed-profile',
     legendTooltip: 'charts.participants-by-status.labels-legend.completed-profile-tooltip',
     a11y: 'charts.participants-by-status.labels-a11y.completed',
-    color: '#8a49ff',
+    color: '#613fdd',
     shape: 'zigzag',
   },
   shared: {
@@ -137,7 +137,7 @@ const LABELS_PROFILE_COLLECTIONS = {
     legend: 'charts.participants-by-status.labels-legend.shared-profile',
     legendTooltip: 'charts.participants-by-status.labels-legend.shared-profile-tooltip',
     a11y: 'charts.participants-by-status.labels-a11y.shared-profile',
-    color: '#038a25',
+    color: '#1c825d',
     shape: 'weave',
   },
 };


### PR DESCRIPTION
## :christmas_tree: Problème
Les couleurs du graphique qui présente l'avancée des participants dans une campagne n'ont été changées en même temps que les autres et ne correspondent donc plus aux couleurs des tag dans la liste des participants.

## :gift: Proposition
Mettre ces couleurs à jour avec les versions 500 du design system

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Se connecter sur Pix Orga
- Aller voir l'analyse d'une campagnequi a des charts
- 🎉 