### PR TITLE
[TECH] Nettoyer les pre-handlers des routes certification-issue-reports, certification-reports et certification-courses (PIX-10774).

### DIFF
--- a/api/lib/application/certification-center-memberships/index.js
+++ b/api/lib/application/certification-center-memberships/index.js
@@ -88,8 +88,8 @@ const register = async function (server) {
           {
             method: (request, h) =>
               securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
-                securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
               ])(request, h),

--- a/api/lib/application/certification-courses/index.js
+++ b/api/lib/application/certification-courses/index.js
@@ -105,7 +105,6 @@ const register = async function (server) {
           {
             method: (request, h) =>
               securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
-                securityPreHandlers.checkUserOwnsCertificationCourse,
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -150,15 +149,8 @@ const register = async function (server) {
       config: {
         pre: [
           {
-            method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
-                securityPreHandlers.checkUserOwnsCertificationCourse,
-                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-                securityPreHandlers.checkAdminMemberHasRoleCertif,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-                securityPreHandlers.checkAdminMemberHasRoleMetier,
-              ])(request, h),
-            assign: 'hasAuthorizationToAccessAdminScope',
+            method: securityPreHandlers.checkUserOwnsCertificationCourse,
+            assign: 'hasAuthorizationToAccessOwnCertificationCourse',
           },
         ],
         validate: {

--- a/api/lib/application/certification-issue-reports/index.js
+++ b/api/lib/application/certification-issue-reports/index.js
@@ -11,15 +11,8 @@ const register = async function (server) {
       config: {
         pre: [
           {
-            method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
-                securityPreHandlers.checkUserIsMemberOfCertificationCenterSessionFromCertificationIssueReportId,
-                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-                securityPreHandlers.checkAdminMemberHasRoleCertif,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-                securityPreHandlers.checkAdminMemberHasRoleMetier,
-              ])(request, h),
-            assign: 'hasAuthorizationToAccessAdminScope',
+            method: securityPreHandlers.checkUserIsMemberOfCertificationCenterSessionFromCertificationIssueReportId,
+            assign: 'hasAuthorizationToAccessSessionsOfCertificationCenters',
           },
         ],
         validate: {
@@ -30,8 +23,7 @@ const register = async function (server) {
         handler: certificationIssueReportController.deleteCertificationIssueReport,
         tags: ['api', 'certification-issue-reports'],
         notes: [
-          '- **Cette route est restreinte aux utilisateurs qui sont membres de la session du centre de certification**\n',
-          "ou à ceux avec un rôle sur l'application Pix Admin\n",
+          '- **Cette route est restreinte aux utilisateurs qui sont membres du centre de certification**\n',
           '- Elle permet de supprimer un signalement',
         ],
       },

--- a/api/lib/application/certification-reports/index.js
+++ b/api/lib/application/certification-reports/index.js
@@ -12,15 +12,8 @@ const register = async function (server) {
       config: {
         pre: [
           {
-            method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
-                securityPreHandlers.checkUserIsMemberOfCertificationCenterSessionFromCertificationCourseId,
-                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-                securityPreHandlers.checkAdminMemberHasRoleCertif,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-                securityPreHandlers.checkAdminMemberHasRoleMetier,
-              ])(request, h),
-            assign: 'hasAuthorizationToAccessAdminScope',
+            method: securityPreHandlers.checkUserIsMemberOfCertificationCenterSessionFromCertificationCourseId,
+            assign: 'hasAuthorizationToAccessSessionsOfCertificationCenters',
           },
         ],
         validate: {
@@ -31,8 +24,7 @@ const register = async function (server) {
         handler: certificationReportController.saveCertificationIssueReport,
         tags: ['api', 'certification-reports'],
         notes: [
-          '- **Cette route est restreinte aux utilisateurs qui sont membres de la session du centre de certification**\n',
-          "ou à ceux avec un rôle sur l'application Pix Admin\n",
+          '- **Cette route est restreinte aux utilisateurs qui sont membres du centre de certification**\n',
           "- Elle permet d'enregistrer un signalement relevé par un surveillant sur la certification d'un candidat",
         ],
       },

--- a/api/tests/unit/application/certification-courses/index_test.js
+++ b/api/tests/unit/application/certification-courses/index_test.js
@@ -117,7 +117,6 @@ describe('Unit | Application | Certifications Course | Route', function () {
       sinon
         .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
         .withArgs([
-          securityPreHandlers.checkUserOwnsCertificationCourse,
           securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
           securityPreHandlers.checkAdminMemberHasRoleCertif,
           securityPreHandlers.checkAdminMemberHasRoleSupport,

--- a/api/tests/unit/application/certification-issue-reports/index_test.js
+++ b/api/tests/unit/application/certification-issue-reports/index_test.js
@@ -21,6 +21,32 @@ describe('Unit | Application | Certifications Issue Report | Route', function ()
       // then
       expect(response.statusCode).to.equal(200);
     });
+
+    context(
+      'when the prehandler checkUserIsMemberOfCertificationCenterSessionFromCertificationIssueReportId respond a 403',
+      function () {
+        it('should return a 403', async function () {
+          // given
+          sinon
+            .stub(securityPreHandlers, 'checkUserIsMemberOfCertificationCenterSessionFromCertificationIssueReportId')
+            .callsFake((request, h) =>
+              h
+                .response({ errors: new Error('forbidden') })
+                .code(403)
+                .takeover(),
+            );
+
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          // when
+          const response = await httpTestServer.request('DELETE', '/api/certification-issue-reports/1');
+
+          // then
+          expect(response.statusCode).to.equal(403);
+        });
+      },
+    );
   });
 
   describe('PATCH /api/certification-issue-reports/{id}', function () {

--- a/api/tests/unit/application/certification-report/index_test.js
+++ b/api/tests/unit/application/certification-report/index_test.js
@@ -22,6 +22,35 @@ describe('Unit | Application | Certifications Report | Route', function () {
       // then
       expect(response.statusCode).to.equal(200);
     });
+
+    context(
+      'when the prehandler checkUserIsMemberOfCertificationCenterSessionFromCertificationIssueReportId respond a 403',
+      function () {
+        it('should return a 403', async function () {
+          // given
+          sinon
+            .stub(securityPreHandlers, 'checkUserIsMemberOfCertificationCenterSessionFromCertificationCourseId')
+            .callsFake((request, h) =>
+              h
+                .response({ errors: new Error('forbidden') })
+                .code(403)
+                .takeover(),
+            );
+
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          // when
+          const response = await httpTestServer.request(
+            'POST',
+            '/api/certification-reports/1/certification-issue-reports',
+          );
+
+          // then
+          expect(response.statusCode).to.equal(403);
+        });
+      },
+    );
   });
 
   describe('POST /api/certification-reports/{id}/abort', function () {


### PR DESCRIPTION
## :christmas_tree: Problème
Sur certaines routes, on peut observer que certains pre-handlers mélangent des vérifications de rôle Pix Admin et une vérification Pix Certif.

Pour la route `certification-courses`, elle n'est plus utilisée coté pix app.

## :gift: Proposition
Retirer les preHandler de sécurité qui ne sont plus nécessaire.
Les routes concernées : 
- GET "/api/certification-courses/{id}" => Pix App
- PATCH "/api/certification-courses/{id}" => Pix Admin
- DELETE "/api/certification-issue-reports/{id}" => Pix Certif
- POST '/api/certification-reports/{id}/certification-issue-reports' => Pix Certif

## ❄️ Remarques 
Cette PR à ajouté des pre-handlers sur plusieurs routes : https://github.com/1024pix/pix/pull/4449/files

- DELETE "/api/certification-issue-reports/{id}"
- POST '/api/certification-reports/{id}/certification-issue-reports'

On pouvait voir que les usecases suivants portait la vérification du membre d'un centre de certification **uniquement**

- api/lib/domain/usecases/delete-certification-issue-report.js
- api/lib/domain/usecases/save-certification-issue-report.js

Pourtant la PR introduit les rôles Admin dans les deux routes concernés alors qu'elles ne concernent que Pix Certif.

- GET "/api/certification-courses/{id}"

Son usecase portait bien des vérification de rôle Admin mais en creusant cela provient d'un travail de refacto pour supprimer la notion de PixMaster introduit dans cette PR https://github.com/1024pix/pix/commit/32b07123549c42c860e84c1510875ad5906338ae
Cette PR permettait à un PixMaster d'accéder à la données mais pourtant cette route n'est pas utilisé sur Pix Admin.

## :santa: Pour tester
- Pour la route PATCH : se connecter sur un compte mon-pix et essayer d'appeler la route en fetch depuis la console pour modifier un certification-course (appel à un ami ☎️ 💵 @mariannebost @Osirisxxl )
- Pour les routes des issues, se connecter sur admin et essayer d'appeler les routes en fetch