### PR TITLE
[BUGFIX] Afficher le style pour des liste à puces (PIX-10791)

### DIFF
--- a/1d/app/pods/components/bubble/bubble.scss
+++ b/1d/app/pods/components/bubble/bubble.scss
@@ -10,6 +10,11 @@
   background-color: #C3D0FF;
   border-radius: 16px 16px 16px 0;
 
+  ul, ol {
+    padding: revert;
+    list-style: auto;
+  }
+
   a {
     color: #3d68ff;
     text-decoration: underline;


### PR DESCRIPTION
## :christmas_tree: Problème
Par défaut, il y a une config  qui enlève tout style des liste à puces.
Or pour les consignes, l’usage de puces peut être envisagé.

## :gift: Proposition
Afficher le style par défaut des listes.

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- aller sur : `challenges/challenge26Yz2B7gZOSkQX/preview` pour afficher l'épreuve avec une consigne qui contient une liste ordonnée.