### PR TITLE
[BUGFIX] Corriger la page de réinitialisation de mot de passe non accessible sur les vieux navigateurs côté Pix App (PIX-10722)

### DIFF
--- a/api/db/seeds/data/team-acces/build-reset-password-users.js
+++ b/api/db/seeds/data/team-acces/build-reset-password-users.js
@@ -1,0 +1,17 @@
+import { DEFAULT_PASSWORD } from '../../../constants.js';
+
+function _buildUserWithShouldChangePassword(databaseBuilder) {
+  databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Kaa',
+    lastName: 'Reboot',
+    email: 'change-password@example.net',
+    username: 'kaa.reboot',
+    rawPassword: DEFAULT_PASSWORD,
+    shouldChangePassword: true,
+    cgu: false,
+  });
+}
+
+export function buildResetPasswordUsers(databaseBuilder) {
+  _buildUserWithShouldChangePassword(databaseBuilder);
+}

--- a/api/db/seeds/data/team-acces/data-builder.js
+++ b/api/db/seeds/data/team-acces/data-builder.js
@@ -7,11 +7,13 @@ import { buildOrganizationUsers } from './build-organization-users.js';
 import { buildArchivedOrganizations } from './build-archived-organizations.js';
 import { buildScoOrganizationLearners } from './build-sco-organization-learners.js';
 import { buildCertificationCenters } from './build-certification-centers.js';
+import { buildResetPasswordUsers } from './build-reset-password-users.js';
 
 async function teamAccesDataBuilder(databaseBuilder) {
   buildPixAdminRoles(databaseBuilder);
   buildUsers(databaseBuilder);
   buildBlockedUsers(databaseBuilder);
+  buildResetPasswordUsers(databaseBuilder);
   buildTemporaryBlockedUsers(databaseBuilder);
   buildOrganizationUsers(databaseBuilder);
   buildScoOrganizations(databaseBuilder);

--- a/mon-pix/app/pods/components/module/details/component.js
+++ b/mon-pix/app/pods/components/module/details/component.js
@@ -3,7 +3,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class ModuleDetails extends Component {
-  @tracked grainsToDisplay = [this.args.module.grains.at(0)];
+  @tracked grainsToDisplay = [this.args.module.grains[0]];
 
   get hasNextGrain() {
     return this.grainsToDisplay.length < this.args.module.grains.length;
@@ -19,7 +19,7 @@ export default class ModuleDetails extends Component {
       return;
     }
 
-    const nextGrain = this.args.module.grains.at(this.lastIndex + 1);
+    const nextGrain = this.args.module.grains[this.lastIndex + 1];
     this.grainsToDisplay = [...this.grainsToDisplay, nextGrain];
   }
 

--- a/mon-pix/app/routes/update-expired-password.js
+++ b/mon-pix/app/routes/update-expired-password.js
@@ -11,7 +11,7 @@ export default class UpdateExpiredPasswordRoute extends Route {
 
   model() {
     const resetExpiredPasswordDemands = this.store.peekAll('reset-expired-password-demand');
-    const resetExpiredPasswordDemand = resetExpiredPasswordDemands.at(0);
+    const resetExpiredPasswordDemand = resetExpiredPasswordDemands[0];
 
     if (!resetExpiredPasswordDemand) {
       return this.router.replaceWith('login');


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, la page avec le path `/mise-a-jour-mot-de-passe-expire` ne fonctionne pas sur des vieux navigateurs comme Firefox 72.

On a une erreur : _Error while processing route: update-expired-password resetExpiredPasswordDemands.at_

## :gift: Proposition
Corriger l'utilisation de _Array.at_ non supporté par les vieux navigateurs.

## :socks: Remarques
Un seed a été ajouté pour tester la fonctionnalité de réinitialisation de mot de passe.

## :santa: Pour tester
### Pré-requis
- Avoir un Firefox 72 en local en le téléchargeant par exemple à partir du ftp de mozilla.
### Reproduire le bug
- Rollback, en local, dans le fichier mon-pix/app/routes/update-expired-password.js l.14, le changement de `const resetExpiredPasswordDemand = resetExpiredPasswordDemands.[0];` en const resetExpiredPasswordDemand = resetExpiredPasswordDemands.at(0);
- Aller sur Pix App avec Firefox 72
- Se connecter avec le compte `change-password@example.net`
- Vérifier qu'il y a une erreur dans la console `Error while processing route: update-expired-password resetExpiredPasswordDemands.at`
- Vérifier qu'on arrive sur une page Oups

### Tester le fix
- Aller sur Pix App avec Firefox 72
- Se connecter avec le compte `change-password@example.net`
- Vérifier qu'on arrive bien sur la page de réinitialisation de mot de passe sans erreur

