### PR TITLE
[FEATURE] Ajout de endpoints de gestion de la configuration de la certif nextgen (PIX-10794)

### DIFF
--- a/api/db/database-builder/factory/build-flash-algorithm-configuration.js
+++ b/api/db/database-builder/factory/build-flash-algorithm-configuration.js
@@ -11,6 +11,7 @@ const buildFlashAlgorithmConfiguration = function ({
   doubleMeasuresUntil = null,
   variationPercent = null,
   variationPercentUntil = null,
+  createdAt = new Date(),
 } = {}) {
   const values = {
     warmUpLength,
@@ -23,6 +24,7 @@ const buildFlashAlgorithmConfiguration = function ({
     doubleMeasuresUntil,
     variationPercent,
     variationPercentUntil,
+    createdAt,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/db/migrations/20240116101040_add-createdAt-column-to-flash-algorithm-configuration.js
+++ b/api/db/migrations/20240116101040_add-createdAt-column-to-flash-algorithm-configuration.js
@@ -1,0 +1,25 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/DEV/pages/2153512965/Cr+er+une+migration
+
+// If your migrations target `answers` or `knowledge-elements`
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+const TABLE_NAME = 'flash-algorithm-configurations';
+const COLUMN_NAME = 'createdAt';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dateTime(COLUMN_NAME).notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { up, down };

--- a/api/server.js
+++ b/api/server.js
@@ -21,7 +21,7 @@ import {
   attachTargetProfileRoutes,
   complementaryCertificationRoutes,
 } from './src/certification/complementary-certification/routes.js';
-import { scenarioSimulatorRoutes } from './src/certification/flash-certification/routes.js';
+import { flashCertificationRoutes } from './src/certification/flash-certification/routes.js';
 import { certificationCourseRoutes } from './src/certification/course/routes.js';
 import { setupErrorHandling } from './config/server-setup-error-handling.js';
 
@@ -145,7 +145,7 @@ const setupRoutesAndPlugins = async function (server) {
     authenticationRoutes,
     sharedRoutes,
     evaluationRoutes,
-    scenarioSimulatorRoutes,
+    flashCertificationRoutes,
     devcompRoutes,
     schoolRoutes,
     ...certificationRoutes,

--- a/api/src/certification/flash-certification/application/flash-assessment-configuration-controller.js
+++ b/api/src/certification/flash-certification/application/flash-assessment-configuration-controller.js
@@ -5,6 +5,15 @@ const getActiveFlashAssessmentConfiguration = async (req, h) => {
   return h.response(flashAssessmentConfiguration);
 };
 
+const updateActiveFlashAssessmentConfiguration = async (req, h) => {
+  const { payload } = req;
+  await usecases.updateActiveFlashAssessmentConfiguration({
+    configuration: payload,
+  });
+  return h.response().code(204);
+};
+
 export const flashAssessmentConfigurationController = {
   getActiveFlashAssessmentConfiguration,
+  updateActiveFlashAssessmentConfiguration,
 };

--- a/api/src/certification/flash-certification/application/flash-assessment-configuration-controller.js
+++ b/api/src/certification/flash-certification/application/flash-assessment-configuration-controller.js
@@ -1,0 +1,10 @@
+import { usecases } from '../../shared/domain/usecases/index.js';
+
+const getActiveFlashAssessmentConfiguration = async (req, h) => {
+  const flashAssessmentConfiguration = await usecases.getActiveFlashAssessmentConfiguration();
+  return h.response(flashAssessmentConfiguration);
+};
+
+export const flashAssessmentConfigurationController = {
+  getActiveFlashAssessmentConfiguration,
+};

--- a/api/src/certification/flash-certification/application/flash-assessment-configuration-route.js
+++ b/api/src/certification/flash-certification/application/flash-assessment-configuration-route.js
@@ -1,5 +1,6 @@
 import { flashAssessmentConfigurationController } from './flash-assessment-configuration-controller.js';
 import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import Joi from 'joi';
 
 const register = async (server) => {
   server.route([
@@ -18,6 +19,37 @@ const register = async (server) => {
         notes: [
           '**Cette route est restreinte aux super-administrateurs** \n' +
             'Récupère la configuration active pour la certification v3',
+        ],
+      },
+    },
+    {
+      method: 'POST',
+      path: '/api/flash-assessment-configuration',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          payload: Joi.object({
+            warmUpLength: Joi.number().integer().min(0).optional(),
+            forcedCompetences: Joi.array().items(Joi.string()).optional(),
+            maximumAssessmentLength: Joi.number().integer().min(0).allow(null).optional(),
+            challengesBetweenSameCompetence: Joi.number().integer().min(0).allow(null).optional(),
+            limitToOneQuestionPerTube: Joi.boolean().optional(),
+            enablePassageByAllCompetences: Joi.boolean().optional(),
+            doubleMeasuresUntil: Joi.number().allow(null).optional(),
+            variationPercent: Joi.number().min(0).max(1).allow(null).optional(),
+            variationPercentUntil: Joi.number().allow(null).optional(),
+          }),
+        },
+        handler: flashAssessmentConfigurationController.updateActiveFlashAssessmentConfiguration,
+        tags: ['api', 'flash-assessment-configuration'],
+        notes: [
+          '**Cette route est restreinte aux super-administrateurs** \n' +
+            'Met à jour la configuration active pour la certification v3',
         ],
       },
     },

--- a/api/src/certification/flash-certification/application/flash-assessment-configuration-route.js
+++ b/api/src/certification/flash-certification/application/flash-assessment-configuration-route.js
@@ -1,0 +1,29 @@
+import { flashAssessmentConfigurationController } from './flash-assessment-configuration-controller.js';
+import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+
+const register = async (server) => {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/flash-assessment-configuration',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: flashAssessmentConfigurationController.getActiveFlashAssessmentConfiguration,
+        tags: ['api', 'flash-assessment-configuration'],
+        notes: [
+          '**Cette route est restreinte aux super-administrateurs** \n' +
+            'Récupère la configuration active pour la certification v3',
+        ],
+      },
+    },
+  ]);
+};
+
+const name = 'flash-assessment-configuration';
+
+export { register, name };

--- a/api/src/certification/flash-certification/domain/usecases/get-active-flash-assessment-configuration.js
+++ b/api/src/certification/flash-certification/domain/usecases/get-active-flash-assessment-configuration.js
@@ -1,0 +1,3 @@
+export const getActiveFlashAssessmentConfiguration = async ({ flashAlgorithmConfigurationRepository }) => {
+  return flashAlgorithmConfigurationRepository.get();
+};

--- a/api/src/certification/flash-certification/domain/usecases/update-active-flash-assessment-configuration.js
+++ b/api/src/certification/flash-certification/domain/usecases/update-active-flash-assessment-configuration.js
@@ -1,0 +1,14 @@
+import { FlashAssessmentAlgorithmConfiguration } from '../models/FlashAssessmentAlgorithmConfiguration.js';
+
+export const updateActiveFlashAssessmentConfiguration = async ({
+  flashAlgorithmConfigurationRepository,
+  configuration,
+}) => {
+  const previousConfiguration = await flashAlgorithmConfigurationRepository.get();
+  await flashAlgorithmConfigurationRepository.save(
+    new FlashAssessmentAlgorithmConfiguration({
+      ...previousConfiguration,
+      ...configuration,
+    }),
+  );
+};

--- a/api/src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js
+++ b/api/src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js
@@ -8,7 +8,7 @@ const save = async function (flashAlgorithmConfiguration) {
 };
 
 const get = async function () {
-  const flashAlgorithmConfiguration = await knex(TABLE_NAME).first();
+  const flashAlgorithmConfiguration = await knex(TABLE_NAME).orderBy('createdAt', 'desc').first();
 
   if (!flashAlgorithmConfiguration) {
     return new FlashAssessmentAlgorithmConfiguration();

--- a/api/src/certification/flash-certification/routes.js
+++ b/api/src/certification/flash-certification/routes.js
@@ -1,5 +1,6 @@
 import * as scenarioSimulator from './application/scenario-simulator-route.js';
+import * as flashAssessmentConfiguration from './application/flash-assessment-configuration-route.js';
 
-const scenarioSimulatorRoutes = [scenarioSimulator];
+const flashCertificationRoutes = [scenarioSimulator, flashAssessmentConfiguration];
 
-export { scenarioSimulatorRoutes };
+export { flashCertificationRoutes };

--- a/api/src/certification/shared/domain/usecases/index.js
+++ b/api/src/certification/shared/domain/usecases/index.js
@@ -23,6 +23,7 @@ import * as competenceMarkRepository from '../../../../../lib/infrastructure/rep
 import * as competenceRepository from '../../../../shared/infrastructure/repositories/competence-repository.js';
 import * as finalizedSessionRepository from '../../../session/infrastructure/repositories/finalized-session-repository.js';
 import * as flashAlgorithmService from '../../../flash-certification/domain/services/algorithm-methods/flash.js';
+import * as flashAlgorithmConfigurationRepository from '../../../flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js';
 import * as issueReportCategoryRepository from '../../../shared/infrastructure/repositories/issue-report-category-repository.js';
 import * as jurySessionRepository from '../../../session/infrastructure/repositories/jury-session-repository.js';
 import * as mailService from '../services/mail-service.js';
@@ -102,6 +103,7 @@ const dependencies = {
   complementaryCertificationRepository,
   finalizedSessionRepository,
   flashAlgorithmService,
+  flashAlgorithmConfigurationRepository,
   issueReportCategoryRepository,
   jurySessionRepository,
   mailService,

--- a/api/tests/certification/flash-certification/acceptance/application/flash-assessment-configuration-route_test.js
+++ b/api/tests/certification/flash-certification/acceptance/application/flash-assessment-configuration-route_test.js
@@ -1,5 +1,5 @@
 import { createServer } from '../../../../../server.js';
-import { databaseBuilder, expect, generateValidRequestAuthorizationHeader } from '../../../../test-helper.js';
+import { databaseBuilder, expect, generateValidRequestAuthorizationHeader, knex } from '../../../../test-helper.js';
 import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
 
 describe('Acceptance | Application | flash-assessment-configuration-route', function () {
@@ -7,6 +7,7 @@ describe('Acceptance | Application | flash-assessment-configuration-route', func
   beforeEach(async function () {
     server = await createServer();
   });
+
   describe('GET /api/flash-assessment-configuration', function () {
     describe('when called without being authenticated', function () {
       it('should return a 401', async function () {
@@ -77,6 +78,122 @@ describe('Acceptance | Application | flash-assessment-configuration-route', func
           // then
           expect(response.statusCode).to.equal(200);
           expect(JSON.parse(response.payload).warmUpLength).to.equal(warmUpLength);
+        });
+      });
+    });
+  });
+
+  describe('POST /api/flash-assessment-configuration', function () {
+    describe('when called without being authenticated', function () {
+      it('should return a 401', async function () {
+        // given
+        const options = {
+          method: 'POST',
+          url: '/api/flash-assessment-configuration',
+        };
+        // when
+        const response = await server.inject(options);
+        // then
+        expect(response.statusCode).to.equal(401);
+      });
+    });
+
+    describe('when called without a super admin role', function () {
+      it('should return a 403', async function () {
+        // given
+        const authorization = generateValidRequestAuthorizationHeader();
+
+        const options = {
+          method: 'POST',
+          url: '/api/flash-assessment-configuration',
+          headers: {
+            authorization,
+          },
+          payload: {},
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+
+    describe('when called with a super admin role', function () {
+      describe('when called with an invalid payload', function () {
+        it('should return a 400', async function () {
+          // given
+          const superAdmin = databaseBuilder.factory.buildUser.withRole({
+            role: PIX_ADMIN.ROLES.SUPER_ADMIN,
+          });
+
+          databaseBuilder.factory.buildFlashAlgorithmConfiguration({
+            variationPercent: 0.2,
+            createdAt: new Date('2020-01-01'),
+          });
+
+          await databaseBuilder.commit();
+
+          const authorization = generateValidRequestAuthorizationHeader(superAdmin.id);
+
+          const options = {
+            method: 'POST',
+            url: '/api/flash-assessment-configuration',
+            headers: {
+              authorization,
+            },
+            payload: {
+              lol: 0.5,
+            },
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+      });
+      describe('when called with a valid payload', function () {
+        it('should return a 204 and update the configuration', async function () {
+          // given
+          const superAdmin = databaseBuilder.factory.buildUser.withRole({
+            role: PIX_ADMIN.ROLES.SUPER_ADMIN,
+          });
+
+          databaseBuilder.factory.buildFlashAlgorithmConfiguration({
+            variationPercent: 0.2,
+            createdAt: new Date('2020-01-01'),
+          });
+
+          await databaseBuilder.commit();
+
+          const authorization = generateValidRequestAuthorizationHeader(superAdmin.id);
+
+          const options = {
+            method: 'POST',
+            url: '/api/flash-assessment-configuration',
+            headers: {
+              authorization,
+            },
+            payload: {
+              variationPercent: 0.5,
+            },
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(204);
+
+          const { count: configurationsCount } = await knex('flash-algorithm-configurations').count().first();
+
+          expect(configurationsCount).to.equal(2);
+
+          const configuration = await knex('flash-algorithm-configurations').orderBy('createdAt', 'desc').first();
+          expect(configuration.variationPercent).to.equal(0.5);
         });
       });
     });

--- a/api/tests/certification/flash-certification/acceptance/application/flash-assessment-configuration-route_test.js
+++ b/api/tests/certification/flash-certification/acceptance/application/flash-assessment-configuration-route_test.js
@@ -1,0 +1,84 @@
+import { createServer } from '../../../../../server.js';
+import { databaseBuilder, expect, generateValidRequestAuthorizationHeader } from '../../../../test-helper.js';
+import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
+
+describe('Acceptance | Application | flash-assessment-configuration-route', function () {
+  let server;
+  beforeEach(async function () {
+    server = await createServer();
+  });
+  describe('GET /api/flash-assessment-configuration', function () {
+    describe('when called without being authenticated', function () {
+      it('should return a 401', async function () {
+        // given
+        const options = {
+          method: 'GET',
+          url: '/api/flash-assessment-configuration',
+        };
+        // when
+        const response = await server.inject(options);
+        // then
+        expect(response.statusCode).to.equal(401);
+      });
+    });
+
+    describe('when called without a super admin role', function () {
+      it('should return a 403', async function () {
+        // given
+        const authorization = generateValidRequestAuthorizationHeader();
+
+        const options = {
+          method: 'GET',
+          url: '/api/flash-assessment-configuration',
+          headers: {
+            authorization,
+          },
+        };
+        // when
+        const response = await server.inject(options);
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+
+    describe('when called with a super admin role', function () {
+      describe('when there is an available configuration', function () {
+        it('should return a 200', async function () {
+          // given
+          const warmUpLength = 12;
+          const superAdmin = databaseBuilder.factory.buildUser.withRole({
+            role: PIX_ADMIN.ROLES.SUPER_ADMIN,
+          });
+
+          databaseBuilder.factory.buildFlashAlgorithmConfiguration({
+            createdAt: new Date('2020-01-01'),
+          });
+
+          databaseBuilder.factory.buildFlashAlgorithmConfiguration({
+            createdAt: new Date('2021-01-01'),
+            warmUpLength,
+          });
+
+          await databaseBuilder.commit();
+
+          const authorization = generateValidRequestAuthorizationHeader(superAdmin.id);
+
+          const options = {
+            method: 'GET',
+            url: '/api/flash-assessment-configuration',
+            headers: {
+              authorization,
+            },
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          expect(JSON.parse(response.payload).warmUpLength).to.equal(warmUpLength);
+        });
+      });
+    });
+  });
+});

--- a/api/tests/certification/flash-certification/integration/application/flash-assessment-configuration-controller_test.js
+++ b/api/tests/certification/flash-certification/integration/application/flash-assessment-configuration-controller_test.js
@@ -19,4 +19,24 @@ describe('Integration | Application | FlashAssessmentConfigurationController', f
       expect(response.source).to.deep.equal(expectedConfiguration);
     });
   });
+
+  describe('#updateActiveFlashAssessmentConfiguration', function () {
+    it('should update the active flash assessment configuration', async function () {
+      sinon.stub(usecases, 'updateActiveFlashAssessmentConfiguration');
+
+      const payload = {
+        warmUpLength: 12,
+      };
+
+      const response = await flashAssessmentConfigurationController.updateActiveFlashAssessmentConfiguration(
+        { payload },
+        hFake,
+      );
+
+      expect(response.statusCode).to.equal(204);
+      expect(usecases.updateActiveFlashAssessmentConfiguration).to.have.been.calledWith({
+        configuration: payload,
+      });
+    });
+  });
 });

--- a/api/tests/certification/flash-certification/integration/application/flash-assessment-configuration-controller_test.js
+++ b/api/tests/certification/flash-certification/integration/application/flash-assessment-configuration-controller_test.js
@@ -1,0 +1,22 @@
+import { flashAssessmentConfigurationController } from '../../../../../src/certification/flash-certification/application/flash-assessment-configuration-controller.js';
+import { domainBuilder, sinon, expect, hFake } from '../../../../test-helper.js';
+import { usecases } from '../../../../../src/certification/shared/domain/usecases/index.js';
+
+describe('Integration | Application | FlashAssessmentConfigurationController', function () {
+  describe('#getActiveFlashAssessmentConfiguration', function () {
+    it('should return the active flash assessment configuration', async function () {
+      sinon.stub(usecases, 'getActiveFlashAssessmentConfiguration');
+
+      const expectedConfiguration = domainBuilder.buildFlashAlgorithmConfiguration({
+        warmUpLength: 12,
+      });
+
+      usecases.getActiveFlashAssessmentConfiguration.resolves(expectedConfiguration);
+
+      const response = await flashAssessmentConfigurationController.getActiveFlashAssessmentConfiguration({}, hFake);
+
+      expect(response.statusCode).to.equal(200);
+      expect(response.source).to.deep.equal(expectedConfiguration);
+    });
+  });
+});

--- a/api/tests/certification/flash-certification/integration/infrastructure/repositories/flash-algorithm-configuration-repository_test.js
+++ b/api/tests/certification/flash-certification/integration/infrastructure/repositories/flash-algorithm-configuration-repository_test.js
@@ -148,6 +148,59 @@ describe('Integration | Infrastructure | Repository | FlashAlgorithmConfiguratio
       });
     });
 
+    describe('when there are multiple saved configurations', function () {
+      it('should return the latest', async function () {
+        // given
+        const latestFlashAlgorithmConfiguration = databaseBuilder.factory.buildFlashAlgorithmConfiguration({
+          warmUpLength: 1,
+          maximumAssessmentLength: 2,
+          challengesBetweenSameCompetence: 3,
+          variationPercent: 4,
+          variationPercentUntil: 3,
+          doubleMeasuresUntil: 5,
+          forcedCompetences: ['comp1', 'comp2'],
+          minimumEstimatedSuccessRateRanges: [
+            { type: 'fixed', startingChallengeIndex: 0, endingChallengeIndex: 7, value: 0.8 },
+          ],
+          limitToOneQuestionPerTube: true,
+          enablePassageByAllCompetences: false,
+          createdAt: new Date('2021-01-01'),
+        });
+
+        databaseBuilder.factory.buildFlashAlgorithmConfiguration({
+          warmUpLength: 1,
+          maximumAssessmentLength: 2,
+          challengesBetweenSameCompetence: 3,
+          variationPercent: 4,
+          variationPercentUntil: 3,
+          doubleMeasuresUntil: 5,
+          forcedCompetences: ['comp1', 'comp2'],
+          minimumEstimatedSuccessRateRanges: [
+            { type: 'fixed', startingChallengeIndex: 0, endingChallengeIndex: 7, value: 0.8 },
+          ],
+          limitToOneQuestionPerTube: true,
+          enablePassageByAllCompetences: false,
+          createdAt: new Date('2020-01-01'),
+        });
+
+        const expectedFlashAlgorithmConfiguration = domainBuilder.buildFlashAlgorithmConfiguration({
+          ...latestFlashAlgorithmConfiguration,
+          forcedCompetences: JSON.parse(latestFlashAlgorithmConfiguration.forcedCompetences),
+          minimumEstimatedSuccessRateRanges: JSON.parse(
+            latestFlashAlgorithmConfiguration.minimumEstimatedSuccessRateRanges,
+          ),
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const configResult = await flashAlgorithmConfigurationRepository.get();
+
+        // then
+        expect(configResult.toDTO()).to.deep.equal(expectedFlashAlgorithmConfiguration.toDTO());
+      });
+    });
+
     describe('when there is no saved configuration', function () {
       it('should return default configuration', async function () {
         // when

--- a/api/tests/certification/flash-certification/unit/domain/usecases/get-active-flash-assessment-configuration_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/usecases/get-active-flash-assessment-configuration_test.js
@@ -1,0 +1,21 @@
+import { getActiveFlashAssessmentConfiguration } from '../../../../../../src/certification/flash-certification/domain/usecases/get-active-flash-assessment-configuration.js';
+import { domainBuilder, sinon, expect } from '../../../../../test-helper.js';
+
+describe('#getActiveFlashAssessmentConfiguration', function () {
+  it('should return the last configuration', async function () {
+    // given
+    const flashAlgorithmConfigurationRepository = {
+      get: sinon.stub(),
+    };
+
+    const configuration = domainBuilder.buildFlashAlgorithmConfiguration();
+
+    flashAlgorithmConfigurationRepository.get.resolves(configuration);
+
+    // when
+    const activeConfiguration = await getActiveFlashAssessmentConfiguration({ flashAlgorithmConfigurationRepository });
+
+    // then
+    expect(activeConfiguration).to.deep.equal(configuration);
+  });
+});

--- a/api/tests/certification/flash-certification/unit/domain/usecases/update-active-flash-assessment-configuration_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/usecases/update-active-flash-assessment-configuration_test.js
@@ -1,0 +1,38 @@
+import { updateActiveFlashAssessmentConfiguration } from '../../../../../../src/certification/flash-certification/domain/usecases/update-active-flash-assessment-configuration.js';
+
+import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | Domain | UseCases | update-active-flash-assessment-configuration', function () {
+  it('should update the active flash assessment configuration', async function () {
+    // given
+    const flashAlgorithmConfigurationRepository = {
+      get: sinon.stub(),
+      save: sinon.stub(),
+    };
+
+    const configuration = {
+      warmUpLength: 12,
+    };
+
+    const previousConfiguration = domainBuilder.buildFlashAlgorithmConfiguration({
+      warmUpLength: 10,
+      variationPercent: 0.5,
+    });
+
+    flashAlgorithmConfigurationRepository.get.resolves(previousConfiguration);
+
+    // when
+    await updateActiveFlashAssessmentConfiguration({
+      flashAlgorithmConfigurationRepository,
+      configuration,
+    });
+
+    // then
+    const expectedConfiguration = domainBuilder.buildFlashAlgorithmConfiguration({
+      ...previousConfiguration,
+      ...configuration,
+    });
+
+    expect(flashAlgorithmConfigurationRepository.save).to.have.been.calledWith(expectedConfiguration);
+  });
+});

--- a/api/tests/integration/scripts/certification/next-gen/generate-flash-algorithm-configuration_test.js
+++ b/api/tests/integration/scripts/certification/next-gen/generate-flash-algorithm-configuration_test.js
@@ -23,6 +23,6 @@ describe('Integration | Scripts | Certification | generate-flash-algorithm-confi
       variationPercentUntil: null,
     };
     const flashAlgorithmConfiguration = await knex(TABLE_NAME).first();
-    expect(_.omit(flashAlgorithmConfiguration, 'id')).to.deep.equal(expectedFlashAlgorithmConfiguration);
+    expect(_.omit(flashAlgorithmConfiguration, ['id', 'createdAt'])).to.deep.equal(expectedFlashAlgorithmConfiguration);
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, la configuration de la certif v3 doit être faite directement en base de données, ce qui n’est pas du tout pratique pour connaître son état et la mettre à jour.


## :gift: Proposition
Créer un endpoint API GET pour récupérer l'état de la configuration actuelle et un endpoint API POST pour modifier la configuration.

Ce endpoint ne sera accessible que grâce à un token SuperAdmin.

## :socks: Remarques
La modification de la configuration est en réalité la création d’une nouvelle ligne en BDD, afin de conserver l’historique. La configuration active sera la dernière configuration insérée. D’autres tickets viendront ajouter le lien entre configuration et session de certification.

## :santa: Pour tester
Récupérer la config exisante :
```
TOKEN=$(curl 'https://api-pr7861.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr7861.review.pix.fr/api/flash-assessment-configuration \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X GET | jq .
```

Mettre à jour la configuration :
```
TOKEN=$(curl 'https://api-pr7861.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr7861.review.pix.fr/api/flash-assessment-configuration \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "variationPercent": 0.8 }'
```

Vérifier que le variationPercent a bien été mis à jour grâce à un nouveau GET.