### PR TITLE
[TECH] Retire les vérifications métier du campaign-creator-repository (PIX-10802)

### DIFF
--- a/api/src/prescription/campaign/domain/usecases/create-campaign.js
+++ b/api/src/prescription/campaign/domain/usecases/create-campaign.js
@@ -1,19 +1,36 @@
+import { UserNotAuthorizedToCreateCampaignError } from '../../../../../lib/domain/errors.js';
+
 const createCampaign = async function ({
   campaign,
+  userRepository,
   campaignAdministrationRepository,
   campaignCreatorRepository,
   codeGenerator,
 }) {
+  const userId = campaign.creatorId;
+  const ownerId = campaign.ownerId;
+  const organizationId = campaign.organizationId;
+
+  await _checkUserIsAMemberOfOrganization({ userRepository, organizationId, userId });
+  await _checkUserIsAMemberOfOrganization({ userRepository, organizationId, userId: ownerId });
+
   const generatedCampaignCode = await codeGenerator.generate(campaignAdministrationRepository);
-  const campaignCreator = await campaignCreatorRepository.get({
-    userId: campaign.creatorId,
-    organizationId: campaign.organizationId,
-    ownerId: campaign.ownerId,
-  });
+
+  const campaignCreator = await campaignCreatorRepository.get(organizationId);
 
   const campaignForCreation = campaignCreator.createCampaign({ ...campaign, code: generatedCampaignCode });
 
   return campaignAdministrationRepository.save(campaignForCreation);
 };
+
+async function _checkUserIsAMemberOfOrganization({ userRepository, organizationId, userId }) {
+  const userWithMemberships = await userRepository.getWithMemberships(userId);
+
+  if (!userWithMemberships.hasAccessToOrganization(organizationId)) {
+    throw new UserNotAuthorizedToCreateCampaignError(
+      `User does not have an access to the organization ${organizationId}`,
+    );
+  }
+}
 
 export { createCampaign };

--- a/api/src/prescription/campaign/domain/usecases/create-campaigns.js
+++ b/api/src/prescription/campaign/domain/usecases/create-campaigns.js
@@ -20,12 +20,7 @@ const createCampaigns = async function ({
       }
 
       const generatedCampaignCode = await codeGenerator.generate(campaignAdministrationRepository);
-      const campaignCreator = await campaignCreatorRepository.get({
-        userId: campaign.creatorId,
-        organizationId: campaign.organizationId,
-        shouldOwnerBeFromOrganization: false,
-        shouldCreatorBeFromOrganization: false,
-      });
+      const campaignCreator = await campaignCreatorRepository.get(campaign.organizationId);
 
       return campaignCreator.createCampaign({
         ...campaign,

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-creator-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-creator-repository.js
@@ -1,21 +1,7 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { CampaignCreator } from '../../domain/models/CampaignCreator.js';
-import { UserNotAuthorizedToCreateCampaignError } from '../../../../../lib/domain/errors.js';
 
-async function get({
-  userId,
-  organizationId,
-  ownerId,
-  shouldOwnerBeFromOrganization = true,
-  shouldCreatorBeFromOrganization = true,
-}) {
-  if (shouldCreatorBeFromOrganization) {
-    await _checkUserIsAMemberOfOrganization({ organizationId, userId });
-  }
-  if (shouldOwnerBeFromOrganization) {
-    await _checkOwnerIsAMemberOfOrganization({ organizationId, ownerId });
-  }
-
+async function get(organizationId) {
   const availableTargetProfileIds = await knex('target-profiles')
     .leftJoin('target-profile-shares', 'targetProfileId', 'target-profiles.id')
     .where({ outdated: false })
@@ -45,21 +31,3 @@ async function get({
 }
 
 export { get };
-
-async function _checkUserIsAMemberOfOrganization({ organizationId, userId }) {
-  const membership = await knex('memberships').where({ organizationId, userId }).first();
-  if (!membership) {
-    throw new UserNotAuthorizedToCreateCampaignError(
-      `User does not have an access to the organization ${organizationId}`,
-    );
-  }
-}
-
-async function _checkOwnerIsAMemberOfOrganization({ organizationId, ownerId }) {
-  const membership = await knex('memberships').where({ organizationId, userId: ownerId }).first();
-  if (!membership) {
-    throw new UserNotAuthorizedToCreateCampaignError(
-      `Owner does not have an access to the organization ${organizationId}`,
-    );
-  }
-}

--- a/api/tests/prescription/campaign/integration/domain/usecases/create-campaign_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/create-campaign_test.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 
 import * as campaignAdministrationRepository from '../../../../../../src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js';
 import * as campaignCreatorRepository from '../../../../../../src/prescription/campaign/infrastructure/repositories/campaign-creator-repository.js';
+import * as userRepository from '../../../../../../src/shared/infrastructure/repositories/user-repository.js';
 
 import { createCampaign } from '../../../../../../src/prescription/campaign/domain/usecases/create-campaign.js';
 import { Campaign } from '../../../../../../src/prescription/campaign/domain/read-models/Campaign.js';
@@ -54,6 +55,7 @@ describe('Integration | UseCases | create-campaign', function () {
     // when
     const result = await createCampaign({
       campaign,
+      userRepository,
       campaignAdministrationRepository,
       campaignCreatorRepository,
       codeGenerator,
@@ -82,6 +84,7 @@ describe('Integration | UseCases | create-campaign', function () {
     // when
     const result = await createCampaign({
       campaign,
+      userRepository,
       campaignAdministrationRepository,
       campaignCreatorRepository,
       codeGenerator,

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-creator-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-creator-repository_test.js
@@ -1,8 +1,6 @@
-import { expect, databaseBuilder, catchErr } from '../../../../../test-helper.js';
+import { expect, databaseBuilder } from '../../../../../test-helper.js';
 import * as campaignCreatorRepository from '../../../../../../src/prescription/campaign/infrastructure/repositories/campaign-creator-repository.js';
-import { UserNotAuthorizedToCreateCampaignError } from '../../../../../../lib/domain/errors.js';
 import * as apps from '../../../../../../lib/domain/constants.js';
-import { CampaignCreator } from '../../../../../../src/prescription/campaign/domain/models/CampaignCreator.js';
 
 describe('Integration | Repository | CampaignCreatorRepository', function () {
   describe('#get', function () {
@@ -17,7 +15,7 @@ describe('Integration | Repository | CampaignCreatorRepository', function () {
       });
       await databaseBuilder.commit();
 
-      const creator = await campaignCreatorRepository.get({ userId, organizationId, ownerId: userId });
+      const creator = await campaignCreatorRepository.get(organizationId);
 
       expect(creator.availableTargetProfileIds).to.deep.equal([targetProfileId]);
     });
@@ -33,7 +31,7 @@ describe('Integration | Repository | CampaignCreatorRepository', function () {
         databaseBuilder.factory.buildOrganizationFeature({ organizationId, featureId });
         await databaseBuilder.commit();
 
-        const creator = await campaignCreatorRepository.get({ userId, organizationId, ownerId: userId });
+        const creator = await campaignCreatorRepository.get(organizationId);
 
         expect(creator.isMultipleSendingsAssessmentEnable).to.be.true;
       });
@@ -53,7 +51,7 @@ describe('Integration | Repository | CampaignCreatorRepository', function () {
 
           await databaseBuilder.commit();
 
-          const creator = await campaignCreatorRepository.get({ userId, organizationId, ownerId: userId });
+          const creator = await campaignCreatorRepository.get(organizationId);
           expect(creator.availableTargetProfileIds).to.exactlyContain([targetProfilePublicId]);
         });
       });
@@ -76,7 +74,7 @@ describe('Integration | Repository | CampaignCreatorRepository', function () {
 
           await databaseBuilder.commit();
 
-          const creator = await campaignCreatorRepository.get({ userId, organizationId, ownerId: userId });
+          const creator = await campaignCreatorRepository.get(organizationId);
           expect(creator.availableTargetProfileIds).to.exactlyContain([targetProfileSharedId]);
         });
 
@@ -93,7 +91,7 @@ describe('Integration | Repository | CampaignCreatorRepository', function () {
 
           await databaseBuilder.commit();
 
-          const creator = await campaignCreatorRepository.get({ userId, organizationId, ownerId: userId });
+          const creator = await campaignCreatorRepository.get(organizationId);
           expect(creator.availableTargetProfileIds).to.exactlyContain([organizationTargetProfileId]);
         });
       });
@@ -121,93 +119,9 @@ describe('Integration | Repository | CampaignCreatorRepository', function () {
 
           await databaseBuilder.commit();
 
-          const creator = await campaignCreatorRepository.get({ userId, organizationId, ownerId: userId });
+          const creator = await campaignCreatorRepository.get(organizationId);
           expect(creator.availableTargetProfileIds).to.be.empty;
         });
-      });
-    });
-
-    context('when the user is not a member of the organization', function () {
-      it('throws an error', async function () {
-        const { id: userId } = databaseBuilder.factory.buildUser();
-        const { id: organizationMemberId } = databaseBuilder.factory.buildUser();
-        const { id: organizationId } = databaseBuilder.factory.buildOrganization();
-        databaseBuilder.factory.buildMembership({ organizationId, userId: organizationMemberId });
-
-        await databaseBuilder.commit();
-
-        const error = await catchErr(campaignCreatorRepository.get)({
-          userId,
-          organizationId,
-          ownerId: organizationMemberId,
-        });
-
-        expect(error).to.be.instanceOf(UserNotAuthorizedToCreateCampaignError);
-        expect(error.message).to.equal(`User does not have an access to the organization ${organizationId}`);
-      });
-
-      it('return the campaign creator', async function () {
-        // given
-        const userId = databaseBuilder.factory.buildUser().id;
-        const ownerId = databaseBuilder.factory.buildUser().id;
-
-        const organizationId = databaseBuilder.factory.buildOrganization().id;
-        databaseBuilder.factory.buildMembership({ organizationId, userId: ownerId });
-        const shouldCreatorBeFromOrganization = false;
-
-        await databaseBuilder.commit();
-
-        // when
-        const result = await campaignCreatorRepository.get({
-          userId,
-          organizationId,
-          ownerId,
-          shouldCreatorBeFromOrganization,
-        });
-
-        // then
-        expect(result).to.be.instanceOf(CampaignCreator);
-      });
-    });
-
-    context('when the owner is not a member of the organization', function () {
-      it('throws an error', async function () {
-        // given
-        const userId = databaseBuilder.factory.buildUser().id;
-        const ownerId = databaseBuilder.factory.buildUser().id;
-        const organizationId = databaseBuilder.factory.buildOrganization().id;
-        databaseBuilder.factory.buildMembership({ organizationId, userId });
-
-        await databaseBuilder.commit();
-
-        // when
-        const error = await catchErr(campaignCreatorRepository.get)({ userId, organizationId, ownerId });
-
-        // then
-        expect(error).to.be.instanceOf(UserNotAuthorizedToCreateCampaignError);
-        expect(error.message).to.equal(`Owner does not have an access to the organization ${organizationId}`);
-      });
-
-      it('return the campaign creator', async function () {
-        // given
-        const userId = databaseBuilder.factory.buildUser().id;
-        const ownerId = databaseBuilder.factory.buildUser().id;
-        const organizationId = databaseBuilder.factory.buildOrganization().id;
-        const shouldOwnerBeFromOrganization = false;
-        databaseBuilder.factory.buildMembership({ organizationId, userId });
-
-        await databaseBuilder.commit();
-
-        // when
-        const result = await campaignCreatorRepository.get({
-          userId,
-          organizationId,
-          ownerId,
-          shouldOwnerBeFromOrganization,
-        });
-
-        // then
-        expect(result).to.be.instanceOf(CampaignCreator);
       });
     });
   });

--- a/api/tests/prescription/campaign/unit/domain/usecases/create-campaign_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/create-campaign_test.js
@@ -1,16 +1,19 @@
-import { expect, sinon } from '../../../../../test-helper.js';
+import { catchErr, expect, sinon } from '../../../../../test-helper.js';
 import { createCampaign } from '../../../../../../src/prescription/campaign/domain/usecases/create-campaign.js';
 import { CampaignTypes } from '../../../../../../src/prescription/shared/domain/constants.js';
 import { CampaignCreator } from '../../../../../../src/prescription/campaign/domain/models/CampaignCreator.js';
+import { UserNotAuthorizedToCreateCampaignError } from '../../../../../../lib/domain/errors.js';
 
 describe('Unit | UseCase | create-campaign', function () {
   let campaignAdministrationRepository;
   let campaignCreatorRepository;
+  let userRepository;
   let codeGeneratorStub;
 
   beforeEach(function () {
     campaignAdministrationRepository = { save: sinon.stub() };
     campaignCreatorRepository = { get: sinon.stub() };
+    userRepository = { getWithMemberships: sinon.stub() };
     codeGeneratorStub = {
       generate: sinon.stub(),
     };
@@ -44,12 +47,15 @@ describe('Unit | UseCase | create-campaign', function () {
       .returns(campaignToCreate);
 
     codeGeneratorStub.generate.resolves(code);
-    campaignCreatorRepository.get.withArgs({ userId: creatorId, organizationId, ownerId }).resolves(campaignCreator);
+    campaignCreatorRepository.get.withArgs(organizationId).resolves(campaignCreator);
     campaignAdministrationRepository.save.withArgs(campaignToCreate).resolves(savedCampaign);
+    userRepository.getWithMemberships.withArgs(creatorId).resolves({ hasAccessToOrganization: () => true });
+    userRepository.getWithMemberships.withArgs(ownerId).resolves({ hasAccessToOrganization: () => true });
 
     // when
     const campaign = await createCampaign({
       campaign: campaignData,
+      userRepository,
       campaignAdministrationRepository,
       campaignCreatorRepository,
       codeGenerator: codeGeneratorStub,
@@ -59,5 +65,52 @@ describe('Unit | UseCase | create-campaign', function () {
     expect(campaignCreator.createCampaign).to.have.been.calledWithExactly({ ...campaignData, code });
     expect(campaignAdministrationRepository.save).to.have.been.calledWithExactly(campaignToCreate);
     expect(campaign).to.deep.equal(savedCampaign);
+  });
+
+  it('should throw an error if creator is not from organization', async function () {
+    // given
+    const creatorId = 13;
+    const ownerId = 13;
+    const organizationId = 14;
+    const campaignData = {
+      creatorId,
+      ownerId,
+      organizationId,
+    };
+
+    userRepository.getWithMemberships.withArgs(creatorId).resolves({ hasAccessToOrganization: () => false });
+
+    // when
+    const error = await catchErr(createCampaign)({
+      campaign: campaignData,
+      userRepository,
+    });
+
+    // then
+    expect(error).to.be.instanceOf(UserNotAuthorizedToCreateCampaignError);
+  });
+
+  it('should throw an error if owner is not from organization', async function () {
+    // given
+    const creatorId = 13;
+    const ownerId = 13;
+    const organizationId = 14;
+    const campaignData = {
+      creatorId,
+      ownerId,
+      organizationId,
+    };
+
+    userRepository.getWithMemberships.withArgs(creatorId).resolves({ hasAccessToOrganization: () => true });
+    userRepository.getWithMemberships.withArgs(creatorId).resolves({ hasAccessToOrganization: () => false });
+
+    // when
+    const error = await catchErr(createCampaign)({
+      campaign: campaignData,
+      userRepository,
+    });
+
+    // then
+    expect(error).to.be.instanceOf(UserNotAuthorizedToCreateCampaignError);
   });
 });

--- a/api/tests/prescription/campaign/unit/domain/usecases/create-campaigns_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/create-campaigns_test.js
@@ -74,22 +74,8 @@ describe('Unit | UseCase | campaign-administration | create-campaigns', function
       get: sinon.stub(),
     };
 
-    campaignCreatorRepositoryStub.get
-      .withArgs({
-        userId: campaignsToCreate[0].creatorId,
-        organizationId: campaignsToCreate[0].organizationId,
-        shouldOwnerBeFromOrganization: false,
-        shouldCreatorBeFromOrganization: false,
-      })
-      .resolves(campaignCreatorPOJO);
-    campaignCreatorRepositoryStub.get
-      .withArgs({
-        userId: campaignsToCreate[1].creatorId,
-        organizationId: campaignsToCreate[1].organizationId,
-        shouldOwnerBeFromOrganization: false,
-        shouldCreatorBeFromOrganization: false,
-      })
-      .resolves(campaignCreatorPOJO);
+    campaignCreatorRepositoryStub.get.withArgs(campaignsToCreate[0].organizationId).resolves(campaignCreatorPOJO);
+    campaignCreatorRepositoryStub.get.withArgs(campaignsToCreate[1].organizationId).resolves(campaignCreatorPOJO);
 
     const createdCampaignsSymbol = Symbol('');
     campaignAdministrationRepository.save.withArgs(campaignsWithAllData).resolves(createdCampaignsSymbol);


### PR DESCRIPTION
## :christmas_tree: Problème
Le campaign-creator-repository fait des vérifications métiers sur les données notamment si le creatorId et le ownerId sont bien ceux d'utilisateurs appartenant à l'organisation. Ces vérifications sont utiles uniquement dans la création de campagne via PixOrga. On ne veut pas que ces vérifications soient faite pour la création de campagnes en masse via PixAdmin.

## :gift: Proposition
On remonte ces vérifications au niveau de la couche domain. Cela permet de : 
- séparer les responsabilité
- simplifier le code du campaign-creator-repository
- simplifier le code du usecase create-campaigns

## :socks: Remarques
A l'avenir, on voudrait ne pas utiliser directement le userRepository dans les usecases de Prescription

## :santa: Pour tester
- Vérifier la création de campagne via PixOrga
- Vérifier la création de campagnes en masse via PixAdmin
