### PR TITLE
[BUGFIX] Corriger l'erreur 500 lors de la récupération d'un profil cible en JSON

### DIFF
--- a/api/src/prescription/target-profile/domain/usecases/get-target-profile-content-as-json.js
+++ b/api/src/prescription/target-profile/domain/usecases/get-target-profile-content-as-json.js
@@ -27,5 +27,8 @@ const getTargetProfileContentAsJson = async function ({
 export { getTargetProfileContentAsJson };
 
 function _hasAuthorizationToDownloadContent(adminMember) {
+  if (!adminMember) {
+    return false;
+  }
   return adminMember.isMetier || adminMember.isSupport || adminMember.isSuperAdmin;
 }

--- a/api/tests/prescription/target-profile/unit/domain/usecases/get-target-profile-content-as-json_test.js
+++ b/api/tests/prescription/target-profile/unit/domain/usecases/get-target-profile-content-as-json_test.js
@@ -15,6 +15,33 @@ describe('Unit | UseCase | get-target-profile-content-as-json', function () {
     MockDate.reset();
   });
 
+  context('when the user has not pix admin role', function () {
+    beforeEach(function () {
+      targetProfileForAdminRepository = { get: sinon.stub() };
+      targetProfileForAdminRepository.get.rejects(new Error('I should not be called'));
+      learningContentConversionService.findActiveSkillsForCappedTubes.rejects(new Error('I should not be called'));
+    });
+
+    it('should throw a ForbiddenAccess error', async function () {
+      // given
+      adminMemberRepository = { get: sinon.stub() };
+      adminMemberRepository.get.withArgs({ userId: 66 }).resolves(undefined);
+
+      // when
+      const error = await catchErr(getTargetProfileContentAsJson)({
+        userId: 66,
+        targetProfileId: 123,
+        adminMemberRepository,
+        targetProfileForAdminRepository,
+        learningContentConversionService,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(ForbiddenAccess);
+      expect(error.message).to.equal("L'utilisateur n'est pas autorisé à effectuer cette opération.");
+    });
+  });
+
   context('when the user does not have the authorization to get the content', function () {
     beforeEach(function () {
       targetProfileForAdminRepository = { get: sinon.stub() };


### PR DESCRIPTION
## :christmas_tree: Problème
Une erreur peut se produire lors de la récupération depuis Pix Admin d'un profil cible en JSON pour un utilisateur qui n'a pas de rôle dans Pix Admin (voir la stacktrace dans [datadog](https://app.datadoghq.eu/logs?query=status%3Aerror%20&cols=host%2Cservice&event=AgAAAY0SSNj-Z8QXKwAAAAAAAAAYAAAAAEFZMFNTTm1SQUFBTjF2NUUtQXFWSGdBSQAAACQAAAAAMDE4ZDEyNjMtNmYxOS00MjliLThlNTEtMTlhYTZkODBkNTYw&index=%2A&messageDisplay=inline&refresh_mode=paused&stream_sort=desc&viz=stream&from_ts=1705408780321&to_ts=1705408781131&live=false)).

## :gift: Proposition
Renvoyer une exception métier plutôt qu'une erreur 500.

## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
