### PR TITLE
[TECH] Ne pas permettre de créer de nouveau usecase dans `api/lib` (PIX-10667)

### DIFF
--- a/.github/workflows/lint-api-lib.yaml
+++ b/.github/workflows/lint-api-lib.yaml
@@ -1,0 +1,19 @@
+name: lint api/lib/domain/usecases new files
+on: push
+jobs:
+  lint-api-lib-staged:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: npm
+
+      - name: Lint api/lib/domain/usecases
+        working-directory: ./api
+        run: |
+          npm ci
+          npm run lint:staged:api-lib

--- a/api/.eslint-new-files-in-lib-config.cjs
+++ b/api/.eslint-new-files-in-lib-config.cjs
@@ -1,0 +1,20 @@
+'use strict';
+
+module.exports = {
+  parserOptions: {
+    ecmaVersion: 2020,
+    requireConfigFile: false,
+    babelOptions: {
+      parserOpts: {
+        plugins: ['importAssertions'],
+      },
+    },
+  },
+  parser: '@babel/eslint-parser',
+  globals: {
+    include: true,
+  },
+  rules: {
+    'max-lines': ['error', 0],
+  },
+};

--- a/api/lib/domain/usecases/fake-usecase.js
+++ b/api/lib/domain/usecases/fake-usecase.js
@@ -1,0 +1,3 @@
+const findAllTags = ({ tagRepository }) => tagRepository.findAll();
+
+export { findAllTags };

--- a/api/package.json
+++ b/api/package.json
@@ -144,6 +144,7 @@
     "lint:js": "eslint . --ext js --cache --cache-strategy content",
     "lint:js:fix": "npm run lint:js -- --fix",
     "lint:js:uncached": "eslint . --ext js",
+    "lint:staged:api-lib": "eslint --config .eslint-new-files-in-lib-config.cjs --no-eslintrc $(git log --name-only --format='' --diff-filter=A dev..HEAD | grep 'api/lib/domain/usecases/' | sed -e 's|api/||g')",
     "lint:translations": "eslint --ext .json  --format node_modules/eslint-plugin-i18n-json/formatter.js translations",
     "lint:translations:fix": "npm run lint:translations -- --fix",
     "postdeploy": "DEBUG=knex:* npm run db:migrate",


### PR DESCRIPTION
## :christmas_tree: Problème
Dans le cadre de la migration vers les Bounded Contexts, on a pour le moment pas d'outillage pour nous empêcher de créer des nouveaux usecases dans `api/lib/domain/usecases/`.

## :gift: Proposition
Pour éviter ça, la proposition est d'ajouter une nouvelle configuration ESLint spécifiquement pour les fichiers ajoutés dans l'historique et qui se trouvent dans le mauvais dossier. Pour assurer une erreur, on active une règle de lint : le nombre de lignes maximum de fichiers doit être inférieur à 0.

### Script `lint:staged`

Pour appliquer le lint sur les fichiers qui nous intéressent uniquement, on utilise : 
```shell
git log --name-only --format='' --diff-filter=A dev..HEAD | grep 'api/lib/domain/usecases/' | sed -e 's|api/||g'
```

1. on récupère les noms des fichiers ajoutés (et rien d'autres) entre la branche locale `dev` et l'état courant,
2. on filtre les noms qui contiennent `api/lib/domain/usecases/`,
3. on supprime `api/` du nom du fichier car on est déjà dans ce dossier lors du lint.

Cela donne une suite de noms de fichier du genre : `lib/domain/usecases/fake-usecase.js`.

Cette liste est envoyée à ESLint via : 

```shell
eslint --config .eslint-new-files-in-lib-config.cjs --no-eslintrc ${...}
```

Ou on applique notre configuration particulière.

### Fichier de config ESLint

On spécifie les mêmes paramètres de parsing que notre config de base (pour bien interpréter le JS), et on applique la fameuse règle : `'max-lines': ['error', 0],` 

## :socks: Remarques
C'est une proposition qui a ses limites :
- La commande ne renvoie pas d'erreur tant que le fichier n'a pas été commité,
- Elle ne traite que les créations de fichiers, pas les renommages ou déplacements,

## :santa: Pour tester
Un mauvais fichier a été ajouté en fin d'historique git, la CI doit être cassée sur celui ci à cause de notre nouvelle commande `lint:staged`.
