### PR TITLE
[TECH] :arrow_up: Mettre à jour notre fichier swagger en  v3.0

### DIFF
--- a/api/lib/swaggers.js
+++ b/api/lib/swaggers.js
@@ -32,6 +32,7 @@ const swaggerOptionsIn = {
   basePath: '/api',
   grouping: 'tags',
   routeTag: 'api',
+  OAS: 'v3.0',
   info: {
     title: 'Welcome to the Pix api catalog',
     version: packageJSON.version,


### PR DESCRIPTION
## :christmas_tree: Problème

Nous sommes en retard sur la version de la spec OpenAPI utilisée pour générer le fichier swagger.json

## :gift: Proposition

Le mettre à jour

## :santa: Pour tester

Importer le swagger.json généré sur la RA (`/api/swagger.json`) et vérifier que la version est bonne sur https://editor.swagger.io/
