### PR TITLE
[API] Déplacer la gestion des autorisations des endpoints de leurs usecases à des prehandlers (PIX-10798)

### DIFF
--- a/api/src/prescription/target-profile/application/admin-target-profile-route.js
+++ b/api/src/prescription/target-profile/application/admin-target-profile-route.js
@@ -41,7 +41,17 @@ const register = async function (server) {
       method: 'GET',
       path: '/api/admin/target-profiles/{id}/content-json',
       config: {
-        auth: false,
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
         validate: {
           params: Joi.object({
             id: identifiersType.targetProfileId,

--- a/api/src/prescription/target-profile/domain/usecases/get-target-profile-content-as-json.js
+++ b/api/src/prescription/target-profile/domain/usecases/get-target-profile-content-as-json.js
@@ -1,16 +1,10 @@
 import dayjs from 'dayjs';
-import { ForbiddenAccess } from '../../../../shared/domain/errors.js';
 
 const getTargetProfileContentAsJson = async function ({
-  userId,
   targetProfileId,
-  adminMemberRepository,
   targetProfileForAdminRepository,
   learningContentConversionService,
 }) {
-  const adminMember = await adminMemberRepository.get({ userId });
-  if (!_hasAuthorizationToDownloadContent(adminMember))
-    throw new ForbiddenAccess("L'utilisateur n'est pas autorisé à effectuer cette opération.");
   const targetProfileForAdmin = await targetProfileForAdminRepository.get({ id: targetProfileId });
   const skills = await learningContentConversionService.findActiveSkillsForCappedTubes(
     targetProfileForAdmin.cappedTubes,
@@ -25,7 +19,3 @@ const getTargetProfileContentAsJson = async function ({
 };
 
 export { getTargetProfileContentAsJson };
-
-function _hasAuthorizationToDownloadContent(adminMember) {
-  return adminMember.isMetier || adminMember.isSupport || adminMember.isSuperAdmin;
-}

--- a/api/tests/prescription/target-profile/integration/application/admin-target-profile-route_test.js
+++ b/api/tests/prescription/target-profile/integration/application/admin-target-profile-route_test.js
@@ -1,0 +1,65 @@
+import {
+  expect,
+  sinon,
+  HttpTestServer,
+  databaseBuilder,
+  generateValidRequestAuthorizationHeader,
+} from '../../../../test-helper.js';
+
+import { targetProfileController } from '../../../../../src/prescription/target-profile/application/admin-target-profile-controller.js';
+import * as adminModuleUnderTest from '../../../../../src/prescription/target-profile/application/admin-target-profile-route.js';
+import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
+
+const { ROLES } = PIX_ADMIN;
+
+describe('Integration | Application | admin-target-profile-route', function () {
+  describe('GET /api/admin/target-profiles/{id}/content-json', function () {
+    const method = 'GET';
+
+    let headers, httpTestServer, targetProfileId, url;
+
+    beforeEach(async function () {
+      sinon.stub(targetProfileController, 'getContentAsJsonFile').returns('ok');
+      httpTestServer = new HttpTestServer();
+      await httpTestServer.register(adminModuleUnderTest);
+      httpTestServer.setupAuthentication();
+      targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+    });
+
+    it('return a 403 status code does not have role superAdmin, Metier or Support', async function () {
+      const lambdaUser = databaseBuilder.factory.buildUser.withRole({ role: ROLES.CERTIF }).id;
+      url = `/api/admin/target-profiles/${targetProfileId}/content-json`;
+      // given
+      headers = {
+        authorization: generateValidRequestAuthorizationHeader(lambdaUser),
+      };
+
+      // when
+      const response = await httpTestServer.request(method, url, null, null, headers);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+
+    // Rule disabled to allow dynamic generated tests.
+    // See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    [ROLES.METIER, ROLES.SUPER_ADMIN, ROLES.SUPPORT].forEach(function (role) {
+      it(`return a 200 status code for role ${role}`, async function () {
+        const lambdaUser = databaseBuilder.factory.buildUser.withRole({ role });
+        await databaseBuilder.commit();
+        url = `/api/admin/target-profiles/${targetProfileId}/content-json`;
+        // given
+        headers = {
+          authorization: generateValidRequestAuthorizationHeader(lambdaUser.id),
+        };
+
+        // when
+        const response = await httpTestServer.request(method, url, null, null, headers);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+  });
+});

--- a/api/tests/prescription/target-profile/unit/domain/usecases/get-target-profile-content-as-json_test.js
+++ b/api/tests/prescription/target-profile/unit/domain/usecases/get-target-profile-content-as-json_test.js
@@ -1,6 +1,5 @@
-import { expect, sinon, catchErr, domainBuilder, MockDate } from '../../../../../test-helper.js';
+import { expect, sinon, domainBuilder, MockDate } from '../../../../../test-helper.js';
 import { getTargetProfileContentAsJson } from '../../../../../../src/prescription/target-profile/domain/usecases/get-target-profile-content-as-json.js';
-import { ForbiddenAccess } from '../../../../../../src/shared/domain/errors.js';
 
 describe('Unit | UseCase | get-target-profile-content-as-json', function () {
   let targetProfileForAdminRepository;
@@ -9,161 +8,82 @@ describe('Unit | UseCase | get-target-profile-content-as-json', function () {
 
   beforeEach(function () {
     learningContentConversionService = { findActiveSkillsForCappedTubes: sinon.stub() };
+    MockDate.set(new Date('2020-12-01'));
+    const area = domainBuilder.buildArea({ id: 'recArea', frameworkId: 'recFramework' });
+    const targetProfileForAdmin = domainBuilder.buildTargetProfileForAdmin({
+      name: 'Profil Rentrée scolaire',
+      areas: [area],
+      competences: [domainBuilder.buildCompetence({ id: 'recCompetence', area, areaId: area.id })],
+      thematics: [
+        domainBuilder.buildThematic({ id: 'recThematic1', competenceId: 'recCompetence' }),
+        domainBuilder.buildThematic({ id: 'recThematic2', competenceId: 'recCompetence' }),
+      ],
+      tubesWithLevelThematicMobileAndTablet: [
+        {
+          ...domainBuilder.buildTube({ id: 'recTube1' }),
+          thematicId: 'recThematic1',
+          level: 8,
+        },
+        {
+          ...domainBuilder.buildTube({ id: 'recTube3' }),
+          thematicId: 'recThematic2',
+          level: 1,
+        },
+        {
+          ...domainBuilder.buildTube({ id: 'recTube2' }),
+          thematicId: 'recThematic1',
+          level: 7,
+        },
+      ],
+    });
+    targetProfileForAdminRepository = { get: sinon.stub() };
+    targetProfileForAdminRepository.get.withArgs({ id: 123 }).resolves(targetProfileForAdmin);
+    const skillsForTube1 = [domainBuilder.buildSkill({ id: 'skill1Tube1', tubeId: 'recTube1' })];
+    const skillsForTube2 = [
+      domainBuilder.buildSkill({ id: 'skill1Tube2', tubeId: 'recTube2' }),
+      domainBuilder.buildSkill({ id: 'skill2Tube2', tubeId: 'recTube2' }),
+    ];
+    const skillsForTube3 = [];
+    learningContentConversionService.findActiveSkillsForCappedTubes
+      .withArgs([
+        {
+          id: 'recTube1',
+          level: 8,
+        },
+        {
+          id: 'recTube2',
+          level: 7,
+        },
+        {
+          id: 'recTube3',
+          level: 1,
+        },
+      ])
+      .resolves([...skillsForTube1, ...skillsForTube2, ...skillsForTube3]);
   });
 
   afterEach(function () {
     MockDate.reset();
   });
 
-  context('when the user does not have the authorization to get the content', function () {
-    beforeEach(function () {
-      targetProfileForAdminRepository = { get: sinon.stub() };
-      targetProfileForAdminRepository.get.rejects(new Error('I should not be called'));
-      learningContentConversionService.findActiveSkillsForCappedTubes.rejects(new Error('I should not be called'));
+  it('should return the json content and the filename for the target profile to export', async function () {
+    // given
+    const supportMember = domainBuilder.buildAdminMember.withRoleSupport({ userId: 66 });
+    adminMemberRepository = { get: sinon.stub().withArgs({ userId: 66 }).resolves(supportMember) };
+
+    // when
+    const { jsonContent, fileName } = await getTargetProfileContentAsJson({
+      userId: 66,
+      targetProfileId: 123,
+      adminMemberRepository,
+      targetProfileForAdminRepository,
+      learningContentConversionService,
     });
 
-    it('should throw a ForbiddenAccess error', async function () {
-      // given
-      const certifMember = domainBuilder.buildAdminMember.withRoleCertif({ userId: 66 });
-      adminMemberRepository = { get: sinon.stub().withArgs({ userId: 66 }).resolves(certifMember) };
-
-      // when
-      const error = await catchErr(getTargetProfileContentAsJson)({
-        userId: 66,
-        targetProfileId: 123,
-        adminMemberRepository,
-        targetProfileForAdminRepository,
-        learningContentConversionService,
-      });
-
-      // then
-      expect(error).to.be.instanceOf(ForbiddenAccess);
-      expect(error.message).to.equal("L'utilisateur n'est pas autorisé à effectuer cette opération.");
-    });
-  });
-  context('when the user has the authorization to get the content', function () {
-    beforeEach(function () {
-      MockDate.set(new Date('2020-12-01'));
-      const area = domainBuilder.buildArea({ id: 'recArea', frameworkId: 'recFramework' });
-      const targetProfileForAdmin = domainBuilder.buildTargetProfileForAdmin({
-        name: 'Profil Rentrée scolaire',
-        areas: [area],
-        competences: [domainBuilder.buildCompetence({ id: 'recCompetence', area, areaId: area.id })],
-        thematics: [
-          domainBuilder.buildThematic({ id: 'recThematic1', competenceId: 'recCompetence' }),
-          domainBuilder.buildThematic({ id: 'recThematic2', competenceId: 'recCompetence' }),
-        ],
-        tubesWithLevelThematicMobileAndTablet: [
-          {
-            ...domainBuilder.buildTube({ id: 'recTube1' }),
-            thematicId: 'recThematic1',
-            level: 8,
-          },
-          {
-            ...domainBuilder.buildTube({ id: 'recTube3' }),
-            thematicId: 'recThematic2',
-            level: 1,
-          },
-          {
-            ...domainBuilder.buildTube({ id: 'recTube2' }),
-            thematicId: 'recThematic1',
-            level: 7,
-          },
-        ],
-      });
-      targetProfileForAdminRepository = { get: sinon.stub() };
-      targetProfileForAdminRepository.get.withArgs({ id: 123 }).resolves(targetProfileForAdmin);
-      const skillsForTube1 = [domainBuilder.buildSkill({ id: 'skill1Tube1', tubeId: 'recTube1' })];
-      const skillsForTube2 = [
-        domainBuilder.buildSkill({ id: 'skill1Tube2', tubeId: 'recTube2' }),
-        domainBuilder.buildSkill({ id: 'skill2Tube2', tubeId: 'recTube2' }),
-      ];
-      const skillsForTube3 = [];
-      learningContentConversionService.findActiveSkillsForCappedTubes
-        .withArgs([
-          {
-            id: 'recTube1',
-            level: 8,
-          },
-          {
-            id: 'recTube2',
-            level: 7,
-          },
-          {
-            id: 'recTube3',
-            level: 1,
-          },
-        ])
-        .resolves([...skillsForTube1, ...skillsForTube2, ...skillsForTube3]);
-    });
-
-    context('when the user has role SUPPORT', function () {
-      it('should return the json content and the filename for the target profile to export', async function () {
-        // given
-        const supportMember = domainBuilder.buildAdminMember.withRoleSupport({ userId: 66 });
-        adminMemberRepository = { get: sinon.stub().withArgs({ userId: 66 }).resolves(supportMember) };
-
-        // when
-        const { jsonContent, fileName } = await getTargetProfileContentAsJson({
-          userId: 66,
-          targetProfileId: 123,
-          adminMemberRepository,
-          targetProfileForAdminRepository,
-          learningContentConversionService,
-        });
-
-        // then
-        expect(fileName).to.equal('20201201_profil_cible_Profil Rentrée scolaire.json');
-        expect(jsonContent).to.equal(
-          '[{"id":"recTube1","level":8,"frameworkId":"recFramework","skills":["skill1Tube1"]},{"id":"recTube2","level":7,"frameworkId":"recFramework","skills":["skill1Tube2","skill2Tube2"]},{"id":"recTube3","level":1,"frameworkId":"recFramework","skills":[]}]',
-        );
-      });
-    });
-
-    context('when the user has role METIER', function () {
-      it('should return the json content and the filename for the target profile to export', async function () {
-        // given
-        const metierMember = domainBuilder.buildAdminMember.withRoleMetier({ userId: 66 });
-        adminMemberRepository = { get: sinon.stub().withArgs({ userId: 66 }).resolves(metierMember) };
-
-        // when
-        const { jsonContent, fileName } = await getTargetProfileContentAsJson({
-          userId: 66,
-          targetProfileId: 123,
-          adminMemberRepository,
-          targetProfileForAdminRepository,
-          learningContentConversionService,
-        });
-
-        // then
-        expect(fileName).to.equal('20201201_profil_cible_Profil Rentrée scolaire.json');
-        expect(jsonContent).to.equal(
-          '[{"id":"recTube1","level":8,"frameworkId":"recFramework","skills":["skill1Tube1"]},{"id":"recTube2","level":7,"frameworkId":"recFramework","skills":["skill1Tube2","skill2Tube2"]},{"id":"recTube3","level":1,"frameworkId":"recFramework","skills":[]}]',
-        );
-      });
-    });
-
-    context('when the user has role SUPER_ADMIN', function () {
-      it('should return the json content and the filename for the target profile to export', async function () {
-        // given
-        const superAdminMember = domainBuilder.buildAdminMember.withRoleSuperAdmin({ userId: 66 });
-        adminMemberRepository = { get: sinon.stub().withArgs({ userId: 66 }).resolves(superAdminMember) };
-
-        // when
-        const { jsonContent, fileName } = await getTargetProfileContentAsJson({
-          userId: 66,
-          targetProfileId: 123,
-          adminMemberRepository,
-          targetProfileForAdminRepository,
-          learningContentConversionService,
-        });
-
-        // then
-        expect(fileName).to.equal('20201201_profil_cible_Profil Rentrée scolaire.json');
-        expect(jsonContent).to.equal(
-          '[{"id":"recTube1","level":8,"frameworkId":"recFramework","skills":["skill1Tube1"]},{"id":"recTube2","level":7,"frameworkId":"recFramework","skills":["skill1Tube2","skill2Tube2"]},{"id":"recTube3","level":1,"frameworkId":"recFramework","skills":[]}]',
-        );
-      });
-    });
+    // then
+    expect(fileName).to.equal('20201201_profil_cible_Profil Rentrée scolaire.json');
+    expect(jsonContent).to.equal(
+      '[{"id":"recTube1","level":8,"frameworkId":"recFramework","skills":["skill1Tube1"]},{"id":"recTube2","level":7,"frameworkId":"recFramework","skills":["skill1Tube2","skill2Tube2"]},{"id":"recTube3","level":1,"frameworkId":"recFramework","skills":[]}]',
+    );
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Pourquoi ré-inventer la roue dans les usecases alors que des prehandlers existent ?

## :gift: Proposition
Utiliser les pre-handlers au lieu de refaire la verification dans les usecases.

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Runner les tests et vérifier que tout passe
- Faire un tour sur PixOrga et PixAdmin pour vérifier