### PR TITLE
[BUGFIX] [Pix Admin] Corriger et uniformiser la traduction française pour l’action « Modifier » (PIX-10805)

### DIFF
--- a/admin/app/components/autonomous-courses/details.hbs
+++ b/admin/app/components/autonomous-courses/details.hbs
@@ -16,7 +16,7 @@
         @size="small"
         @triggerAction={{this.toggleEditMode}}
       >
-        Éditer
+        Modifier
       </PixButton>
     </div>
   {{/if}}

--- a/admin/app/components/badges/badge.hbs
+++ b/admin/app/components/badges/badge.hbs
@@ -116,7 +116,7 @@
             @isBorderVisible={{true}}
             @size="small"
             @triggerAction={{this.toggleEditMode}}
-          >Éditer</PixButton>
+          >Modifier</PixButton>
         </div>
       {{/if}}
     </div>

--- a/admin/app/components/campaigns/details.hbs
+++ b/admin/app/components/campaigns/details.hbs
@@ -67,7 +67,7 @@
       @backgroundColor="transparent-light"
       @isBorderVisible={{true}}
       @size="small"
-    >Éditer</PixButton>
+    >Modifier</PixButton>
   {{/if}}
 
 </section>

--- a/admin/app/components/certification-centers/information-view.hbs
+++ b/admin/app/components/certification-centers/information-view.hbs
@@ -47,7 +47,7 @@
     </ul>
     <div class="certification-center-information__button-section">
       <PixButton @size="small" @triggerAction={{@toggleEditMode}}>
-        Editer les informations
+        Modifier les informations
       </PixButton>
 
       <PixButtonLink

--- a/admin/app/components/certification-centers/information-view.hbs
+++ b/admin/app/components/certification-centers/information-view.hbs
@@ -47,7 +47,7 @@
     </ul>
     <div class="certification-center-information__button-section">
       <PixButton @size="small" @triggerAction={{@toggleEditMode}}>
-        Modifier les informations
+        Modifier
       </PixButton>
 
       <PixButtonLink

--- a/admin/app/components/certifications/candidate-edit-modal.hbs
+++ b/admin/app/components/certifications/candidate-edit-modal.hbs
@@ -1,5 +1,5 @@
 <PixModal
-  @title="Éditer les informations du candidat"
+  @title="Modifier les informations du candidat"
   @onCloseButtonClick={{this.onCancelButtonsClicked}}
   @showModal={{@isDisplayed}}
 >

--- a/admin/app/components/organizations/information-section-view.hbs
+++ b/admin/app/components/organizations/information-section-view.hbs
@@ -97,7 +97,7 @@
             @size="small"
             @triggerAction={{@toggleEditMode}}
           >
-            Éditer
+            Modifier
           </PixButton>
           {{#unless @organization.isArchived}}
             <PixButton @backgroundColor="red" @size="small" @triggerAction={{@toggleArchivingConfirmationModal}}>

--- a/admin/app/components/stages/view-stage.hbs
+++ b/admin/app/components/stages/view-stage.hbs
@@ -31,6 +31,6 @@
     @isBorderVisible={{true}}
     @triggerAction={{@toggleEditMode}}
   >
-    Éditer
+    Modifier
   </PixButton>
 </section>

--- a/admin/app/components/target-profiles/target-profile.hbs
+++ b/admin/app/components/target-profiles/target-profile.hbs
@@ -57,7 +57,7 @@
           @isBorderVisible={{true}}
           @triggerAction={{this.toggleEditMode}}
         >
-          Éditer
+          Modifier
         </PixButton>
         <div class="target-profile__actions-separator"></div>
         {{#unless @model.isSimplifiedAccess}}

--- a/admin/app/components/users/user-overview.hbs
+++ b/admin/app/components/users/user-overview.hbs
@@ -106,7 +106,7 @@
             @isBorderVisible={{true}}
             @triggerAction={{this.cancelEdit}}
           >Annuler</PixButton>
-          <PixButton @type="submit" @size="small" @backgroundColor="green">Editer</PixButton>
+          <PixButton @type="submit" @size="small" @backgroundColor="green">Modifier</PixButton>
         </div>
       </form>
     {{else}}

--- a/admin/app/templates/authenticated/trainings/training.hbs
+++ b/admin/app/templates/authenticated/trainings/training.hbs
@@ -40,7 +40,7 @@
           @backgroundColor="transparent-light"
           @isBorderVisible={{true}}
           @triggerAction={{this.toggleEditMode}}
-        >Editer
+        >Modifier
         </PixButton>
       {{/if}}
     {{/if}}

--- a/admin/tests/acceptance/authenticated/autonomous-courses/autonomous-courses-test.js
+++ b/admin/tests/acceptance/authenticated/autonomous-courses/autonomous-courses-test.js
@@ -125,7 +125,7 @@ module('Acceptance | Autonomous courses', function (hooks) {
         // when
         const screen = await visit('/autonomous-courses/1');
 
-        const button = screen.getByText('Éditer');
+        const button = screen.getByText('Modifier');
         await click(button);
 
         // then
@@ -139,7 +139,7 @@ module('Acceptance | Autonomous courses', function (hooks) {
         // when
         const screen = await visit('/autonomous-courses/1');
 
-        const editButton = screen.getByText('Éditer');
+        const editButton = screen.getByText('Modifier');
         await click(editButton);
 
         await fillByLabel(/Nom interne/, 'Une erreur de frappe');
@@ -154,7 +154,7 @@ module('Acceptance | Autonomous courses', function (hooks) {
         // when
         const screen = await visit('/autonomous-courses/1');
 
-        const button = screen.getByText('Éditer');
+        const button = screen.getByText('Modifier');
         await click(button);
 
         await fillByLabel(/Nom interne/, 'Parcours professionnalisant de Guillaume');

--- a/admin/tests/acceptance/authenticated/certification-centers/get_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get_test.js
@@ -101,7 +101,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
       const screen = await visit(`/certification-centers/${certificationCenter.id}`);
 
       // when
-      await clickByName('Modifier les informations');
+      await clickByName('Modifier');
 
       // then
       assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
@@ -117,7 +117,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
         type: 'SCO',
       });
       const screen = await visit(`/certification-centers/${certificationCenter.id}`);
-      await clickByName('Modifier les informations');
+      await clickByName('Modifier');
       this.server.patch(`/admin/certification-centers/${certificationCenter.id}`, () => new Response({}), 204);
 
       // when
@@ -155,7 +155,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
       server.create('complementary-certification', { key: 'A', label: 'Pix+Autre' });
 
       const screen = await visit(`/certification-centers/${certificationCenter.id}`);
-      await clickByName('Modifier les informations');
+      await clickByName('Modifier');
       this.server.patch(`/admin/certification-centers/${certificationCenter.id}`, () => new Response({}), 204);
 
       // when
@@ -181,7 +181,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
       });
       this.server.patch(`/admin/certification-centers/${certificationCenter.id}`, () => new Response({}), 422);
       const screen = await visit(`/certification-centers/${certificationCenter.id}`);
-      await clickByName('Modifier les informations');
+      await clickByName('Modifier');
 
       // when
       await clickByName('Enregistrer');

--- a/admin/tests/acceptance/authenticated/certification-centers/get_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get_test.js
@@ -90,7 +90,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
   });
 
   module('Update certification center', function () {
-    test('should display a form after clicking on "Editer"', async function (assert) {
+    test('should display a form after clicking on "Modifier"', async function (assert) {
       // given
       await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
       const certificationCenter = server.create('certification-center', {
@@ -101,7 +101,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
       const screen = await visit(`/certification-centers/${certificationCenter.id}`);
 
       // when
-      await clickByName('Editer les informations');
+      await clickByName('Modifier les informations');
 
       // then
       assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
@@ -117,7 +117,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
         type: 'SCO',
       });
       const screen = await visit(`/certification-centers/${certificationCenter.id}`);
-      await clickByName('Editer les informations');
+      await clickByName('Modifier les informations');
       this.server.patch(`/admin/certification-centers/${certificationCenter.id}`, () => new Response({}), 204);
 
       // when
@@ -155,7 +155,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
       server.create('complementary-certification', { key: 'A', label: 'Pix+Autre' });
 
       const screen = await visit(`/certification-centers/${certificationCenter.id}`);
-      await clickByName('Editer les informations');
+      await clickByName('Modifier les informations');
       this.server.patch(`/admin/certification-centers/${certificationCenter.id}`, () => new Response({}), 204);
 
       // when
@@ -181,7 +181,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
       });
       this.server.patch(`/admin/certification-centers/${certificationCenter.id}`, () => new Response({}), 422);
       const screen = await visit(`/certification-centers/${certificationCenter.id}`);
-      await clickByName('Editer les informations');
+      await clickByName('Modifier les informations');
 
       // when
       await clickByName('Enregistrer');

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -580,7 +580,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
             await clickByName('Enregistrer');
 
             // then
-            assert.dom(screen.queryByText('Éditer les informations du candidat')).doesNotExist();
+            assert.dom(screen.queryByText('Modifier les informations du candidat')).doesNotExist();
           });
         });
 
@@ -628,7 +628,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
             await clickByName('Enregistrer');
 
             // then
-            assert.dom(screen.getByRole('heading', { name: 'Éditer les informations du candidat' })).exists();
+            assert.dom(screen.getByRole('heading', { name: 'Modifier les informations du candidat' })).exists();
           });
 
           test('should leave candidate information untouched when aborting the edition', async function (assert) {

--- a/admin/tests/acceptance/authenticated/organizations/information-management_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management_test.js
@@ -18,7 +18,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
       // given
       const organization = this.server.create('organization', { name: 'oldOrganizationName' });
       const screen = await visit(`/organizations/${organization.id}`);
-      await clickByName('Éditer');
+      await clickByName('Modifier');
 
       // when
       await fillByLabel('* Nom', 'newOrganizationName');

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
@@ -184,7 +184,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         const screen = await visit('/target-profiles/1');
         await clickByName('Clés de lecture');
         await clickByName('Voir le détail du palier 100');
-        await clickByName('Éditer');
+        await clickByName('Modifier');
         await fillByLabel('Titre', 'titre modifié');
         await clickByName('Annuler');
 
@@ -287,7 +287,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
           const screen = await visit('/target-profiles/1');
           await clickByName('Clés de lecture');
           await clickByName('Voir le détail du palier 100');
-          await clickByName('Éditer');
+          await clickByName('Modifier');
           await click(screen.getByRole('button', { name: 'Niveau' }));
           await screen.findByRole('listbox');
           await click(screen.getByRole('option', { name: '1' }));
@@ -388,7 +388,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
           const screen = await visit('/target-profiles/1');
           await clickByName('Clés de lecture');
           await clickByName('Voir le détail du palier 100');
-          await clickByName('Éditer');
+          await clickByName('Modifier');
           await fillByLabel('Seuil', 20);
           await fillByLabel('Titre', 'nouveau titre');
           await fillByLabel('Message', 'nouveau message');
@@ -493,7 +493,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         const screen = await visit('/target-profiles/1');
         await clickByName('Clés de lecture');
         await clickByName('Détails du badge ancien titre');
-        await clickByName('Éditer');
+        await clickByName('Modifier');
         await fillByLabel('* Titre :', 'nouveau titre');
         await fillByLabel('* Clé :', 'NEW_KEY');
         await fillByLabel('Message :', 'nouveau message');
@@ -525,7 +525,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         const screen = await visit('/target-profiles/1');
         await clickByName('Clés de lecture');
         await clickByName('Détails du badge tagada');
-        await clickByName('Éditer');
+        await clickByName('Modifier');
         await fillByLabel('* Titre :', 'tsouintsouin');
         await clickByName('Annuler');
 

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/management_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/management_test.js
@@ -116,7 +116,7 @@ module('Acceptance | Target Profile Management', function (hooks) {
 
       // when
       const screen = await visit('/target-profiles/1');
-      await clickByName('Éditer');
+      await clickByName('Modifier');
       assert
         .dom(screen.getByRole('checkbox', { name: this.intl.t('pages.target-profiles.resettable-checkbox.label') }))
         .isChecked();
@@ -138,7 +138,7 @@ module('Acceptance | Target Profile Management', function (hooks) {
       assert
         .dom(_findByNestedText(screen, `${this.intl.t('pages.target-profiles.resettable-checkbox.label')} : Non`))
         .exists();
-      await clickByName('Éditer');
+      await clickByName('Modifier');
       assert.dom(screen.getByDisplayValue('description modifiée')).exists();
       assert.dom(screen.getByDisplayValue('commentaire modifié')).exists();
       assert.dom(screen.getByRole('button', { name: 'Catégorie :' })).containsText('Thématiques');
@@ -154,7 +154,7 @@ module('Acceptance | Target Profile Management', function (hooks) {
 
       // when
       const screen = await visit('/target-profiles/1');
-      await clickByName('Éditer');
+      await clickByName('Modifier');
       await fillByLabel('* Nom', 'nom modifié');
       await clickByName('Annuler');
 

--- a/admin/tests/acceptance/authenticated/trainings/training_test.js
+++ b/admin/tests/acceptance/authenticated/trainings/training_test.js
@@ -161,7 +161,7 @@ module('Acceptance | Trainings | Training', function (hooks) {
         await visit(`/trainings/${trainingId}`);
 
         // when
-        await click(screen.getByRole('button', { name: 'Editer' }));
+        await click(screen.getByRole('button', { name: 'Modifier' }));
         await fillByLabel('Titre', 'Nouveau contenu formatif modifié');
         await click(screen.getByRole('button', { name: 'Modifier le contenu formatif' }));
 
@@ -179,7 +179,7 @@ module('Acceptance | Trainings | Training', function (hooks) {
         await visit(`/trainings/${trainingId}`);
 
         // then
-        assert.notOk(screen.queryByRole('button', { name: 'Editer' }));
+        assert.notOk(screen.queryByRole('button', { name: 'Modifier' }));
       });
     });
   });

--- a/admin/tests/acceptance/authenticated/users/get_test.js
+++ b/admin/tests/acceptance/authenticated/users/get_test.js
@@ -113,7 +113,7 @@ module('Acceptance | authenticated/users/get', function (hooks) {
       await screen.findByRole('listbox');
       await click(screen.getByRole('option', { name: 'Anglais' }));
 
-      await clickByName('Editer');
+      await clickByName('Modifier');
 
       // then
       assert.dom(screen.getByText('Prénom : john')).exists();

--- a/admin/tests/integration/components/autonomous-courses/details_test.js
+++ b/admin/tests/integration/components/autonomous-courses/details_test.js
@@ -54,20 +54,20 @@ module('Integration | Component | AutonomousCourses::Details', function (hooks) 
 
   test('it should display update form when requested', async function (assert) {
     // when
-    const button = screen.getByText('Éditer');
+    const button = screen.getByText('Modifier');
     await click(button);
 
     // then
     assert.dom(screen.getByLabelText(/Nom interne/)).exists();
     assert.dom(screen.getByLabelText(/Nom public/)).exists();
     assert.dom(screen.getByLabelText(/Texte de la page d'accueil/)).exists();
-    assert.dom(screen.queryByText('Éditer')).doesNotExist();
+    assert.dom(screen.queryByText('Modifier')).doesNotExist();
     assert.dom(screen.getByText('Sauvegarder les modifications')).exists();
   });
 
   test('it should call reset argument function on reset', async function (assert) {
     // when
-    const editButton = screen.getByText('Éditer');
+    const editButton = screen.getByText('Modifier');
     await click(editButton);
 
     await fillByLabel(/Nom interne/, 'Une erreur de frappe');
@@ -81,7 +81,7 @@ module('Integration | Component | AutonomousCourses::Details', function (hooks) 
 
   test('it should call update argument function on update', async function (assert) {
     // when
-    const button = screen.getByText('Éditer');
+    const button = screen.getByText('Modifier');
     await click(button);
 
     await fillByLabel(/Nom interne/, 'Parcours professionnel');

--- a/admin/tests/integration/components/campaigns/details_test.js
+++ b/admin/tests/integration/components/campaigns/details_test.js
@@ -109,7 +109,7 @@ module('Integration | Component | Campaigns | details', function (hooks) {
 
     //when
     await render(hbs`<Campaigns::Details @campaign={{this.campaign}} @toggleEditMode={{this.toggleEditMode}} />`);
-    await clickByName('Éditer');
+    await clickByName('Modifier');
 
     //then
     assert.ok(this.toggleEditMode.called);
@@ -176,7 +176,7 @@ module('Integration | Component | Campaigns | details', function (hooks) {
       const screen = await render(hbs`<Campaigns::Details @campaign={{this.campaign}} />`);
 
       // expect
-      assert.dom(screen.queryByRole('button', { name: 'Éditer' })).doesNotExist();
+      assert.dom(screen.queryByRole('button', { name: 'Modifier' })).doesNotExist();
     });
   });
 });

--- a/admin/tests/integration/components/certifications/candidate-edit-modal_test.js
+++ b/admin/tests/integration/components/certifications/candidate-edit-modal_test.js
@@ -29,7 +29,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
       );
 
       // then
-      assert.dom(screen.getByRole('heading', { name: 'Éditer les informations du candidat' })).exists();
+      assert.dom(screen.getByRole('heading', { name: 'Modifier les informations du candidat' })).exists();
     });
   });
 

--- a/admin/tests/integration/components/organizations/information-section-view_test.js
+++ b/admin/tests/integration/components/organizations/information-section-view_test.js
@@ -154,7 +154,7 @@ module('Integration | Component | organizations/information-section-view', funct
       const screen = await render(hbs`<Organizations::InformationSectionView @organization={{this.organization}} />`);
 
       // then
-      assert.dom(screen.getByRole('button', { name: 'Éditer' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Modifier' })).exists();
       assert.dom(screen.getByRole('button', { name: "Archiver l'organisation" })).exists();
     });
 
@@ -283,7 +283,7 @@ module('Integration | Component | organizations/information-section-view', funct
       const screen = await render(hbs`<Organizations::InformationSectionView @organization={{this.organization}} />`);
 
       // then
-      assert.dom(screen.queryByRole('button', { name: 'Éditer' })).doesNotExist();
+      assert.dom(screen.queryByRole('button', { name: 'Modifier' })).doesNotExist();
       assert.dom(screen.queryByRole('button', { name: "Archiver l'organisation" })).doesNotExist();
     });
   });

--- a/admin/tests/integration/components/organizations/information-section_test.js
+++ b/admin/tests/integration/components/organizations/information-section_test.js
@@ -38,7 +38,7 @@ module('Integration | Component | organizations/information-section', function (
       const screen = await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
       // when
-      await clickByName('Éditer');
+      await clickByName('Modifier');
 
       // then
       assert.dom(screen.getByRole('textbox', { name: 'Nom' })).exists();
@@ -50,14 +50,14 @@ module('Integration | Component | organizations/information-section', function (
     test('it should toggle display mode on click to cancel button', async function (assert) {
       // given
       const screen = await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
-      await clickByName('Éditer');
+      await clickByName('Modifier');
 
       // when
       await clickByName('Annuler');
 
       // then
       assert.dom(screen.getByRole('heading', { name: 'Organization SCO' })).exists();
-      assert.dom(screen.getByRole('button', { name: 'Éditer' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Modifier' })).exists();
       assert.dom(screen.getByRole('button', { name: "Archiver l'organisation" })).exists();
     });
 
@@ -65,7 +65,7 @@ module('Integration | Component | organizations/information-section', function (
       // given
       const screen = await render(hbs`<Organizations::InformationSection @organization={{this.organization}} />`);
 
-      await clickByName('Éditer');
+      await clickByName('Modifier');
 
       await fillByLabel('* Nom', 'new name');
       await fillByLabel('Identifiant externe', 'new externalId');
@@ -112,7 +112,7 @@ module('Integration | Component | organizations/information-section', function (
       const screen = await render(
         hbs`<Organizations::InformationSection @organization={{this.organization}} @onSubmit={{this.onSubmit}} />`,
       );
-      await clickByName('Éditer');
+      await clickByName('Modifier');
 
       await fillByLabel('* Nom', 'new name');
       await fillByLabel('Identifiant externe', 'new externalId');

--- a/admin/tests/integration/components/stages/stage_test.js
+++ b/admin/tests/integration/components/stages/stage_test.js
@@ -40,7 +40,7 @@ module('Integration | Component | Stages::Stage', function (hooks) {
       );
 
       //then
-      assert.dom(screen.getByRole('button', { name: 'Éditer' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Modifier' })).exists();
       assert.dom(screen.getByText('ID : 34', { exact: false })).exists();
       assert.dom(screen.getByText('1er acquis', { exact: false })).exists();
       assert.dom(screen.getByText('Titre : palier premier acquis', { exact: false })).exists();
@@ -101,7 +101,7 @@ module('Integration | Component | Stages::Stage', function (hooks) {
       );
 
       //then
-      assert.dom(screen.getByRole('button', { name: 'Éditer' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Modifier' })).exists();
       assert.dom(screen.getByText('ID : 34', { exact: false })).exists();
       assert.dom(screen.getByText('Seuil : 60', { exact: false })).exists();
       assert.dom(screen.getByText('Titre : palier 3', { exact: false })).exists();
@@ -174,7 +174,7 @@ module('Integration | Component | Stages::Stage', function (hooks) {
         hbs`<Stages::Stage @stage={{this.stage}} @toggleEditMode={{this.toggleEditMode}} @isEditMode={{this.isEditMode}} />`,
       );
       // then
-      assert.dom(screen.queryByText('Éditer')).exists();
+      assert.dom(screen.queryByText('Modifier')).exists();
     });
   });
 

--- a/admin/tests/integration/components/users/user-overview_test.js
+++ b/admin/tests/integration/components/users/user-overview_test.js
@@ -269,7 +269,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
         await clickByName('Modifier');
 
         // then
-        assert.dom(screen.getByRole('button', { name: 'Editer' })).exists();
+        assert.dom(screen.getByRole('button', { name: 'Modifier' })).exists();
         assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
       });
 


### PR DESCRIPTION
## :christmas_tree: Problème

🔴 Les formulaires de Pix Admin utilisent le verbe d’action `Éditer` à tort, par anglicisme, alors qu’en français c’est le verbe d’action `Modifier` qui doit être utilisé.

🟢 On peut voir le bon usage du verbe `Modifier` notamment dans les traductions de Pix Orga : https://github.com/1024pix/pix/blob/dev/orga/translations/fr.json#L463-L465

Voir les détails sur cet anglicisme dans l’article https://fr.wiktionary.org/wiki/%C3%A9diter

## :gift: Proposition

1. Remplacer `Éditer` par `Modifier` 🇫🇷 sur les formulaires de modifications des différents contenus
2. Remplacer `Modifier les informations` par `Modifier` pour uniformiser le nom de l’action sur les formulaires

## :socks: Remarques

On pourra poursuivre cet effort d’uniformisation avec une autre PR sur l'utilisation des verbes d’action `Modifier` et `Enregistrer` dans le contexte de la validation des formulaires. Il y a en effet parfois l’un, parfois l'autre 🤡

Le travail sur l’uniformisation de `Modifier` et `Enregistrer` n’a pas été réalisé dans cette PR pour permettre à cette PR-ci d’être validée rapidement car ne comportant pas de choix à faire pour un terme plutôt qu’un autre.

## :santa: Pour tester

* La CI est OK
* Se connecter à Pix Admin, puis consulter et modifier les formulaires des différents types de contenu en s’assurant qu’il n’y a pas de régression et que les libellés corrigés sont bien en français correct et que l’ensemble est uniforme.
