### PR TITLE
[FEATURE] Brancher les passages dans Pix App pour enregistrer les réponses (PIX-10700)

### DIFF
--- a/mon-pix/app/adapters/element-answer.js
+++ b/mon-pix/app/adapters/element-answer.js
@@ -2,6 +2,22 @@ import ApplicationAdapter from './application';
 
 export default class ElementAnswer extends ApplicationAdapter {
   urlForCreateRecord(modelName, { adapterOptions }) {
-    return `${this.host}/${this.namespace}/modules/${adapterOptions.moduleSlug}/elements/${adapterOptions.elementId}/answers`;
+    return `${this.host}/${this.namespace}/passages/${adapterOptions.passageId}/answers`;
+  }
+
+  createRecord(store, type, snapshot) {
+    const url = this.urlForCreateRecord(type.modelName, snapshot);
+    const serializedSnapshot = this.serialize(snapshot);
+
+    return this.ajax(url, 'POST', {
+      data: {
+        data: {
+          attributes: {
+            'element-id': serializedSnapshot.data.relationships.element.data.id,
+            'user-response': serializedSnapshot.data.attributes['user-response'],
+          },
+        },
+      },
+    });
   }
 }

--- a/mon-pix/app/adapters/passage.js
+++ b/mon-pix/app/adapters/passage.js
@@ -1,0 +1,3 @@
+import ApplicationAdapter from './application';
+
+export default class Passage extends ApplicationAdapter {}

--- a/mon-pix/app/pods/module/get/controller.js
+++ b/mon-pix/app/pods/module/get/controller.js
@@ -14,13 +14,13 @@ export default class GetController extends Controller {
         element: answerData.element,
       })
       .save({
-        adapterOptions: { elementId: answerData.element.id, moduleSlug: this.model.id },
+        adapterOptions: { elementId: answerData.element.id, moduleSlug: this.model.module.id },
       });
 
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.model.id}`,
+      'pix-event-action': `Passage du module : ${this.model.module.id}`,
       'pix-event-name': `Click sur le bouton vérifier de l'élément : ${answerData.elementId}`,
     });
   }

--- a/mon-pix/app/pods/module/get/controller.js
+++ b/mon-pix/app/pods/module/get/controller.js
@@ -14,7 +14,7 @@ export default class GetController extends Controller {
         element: answerData.element,
       })
       .save({
-        adapterOptions: { elementId: answerData.element.id, moduleSlug: this.model.module.id },
+        adapterOptions: { passageId: this.model.passage.id },
       });
 
     this.metrics.add({

--- a/mon-pix/app/pods/module/get/route.js
+++ b/mon-pix/app/pods/module/get/route.js
@@ -5,6 +5,9 @@ export default class ModuleGetRoute extends Route {
   @service store;
 
   async model(params) {
-    return await this.store.findRecord('module', params.slug);
+    const module = await this.store.findRecord('module', params.slug);
+    const passage = await this.store.createRecord('passage', { moduleId: params.slug }).save();
+
+    return { module, passage };
   }
 }

--- a/mon-pix/app/pods/module/get/template.hbs
+++ b/mon-pix/app/pods/module/get/template.hbs
@@ -1,3 +1,3 @@
 <div class="modulix">
-  <Module::Details @module={{@model}} @submitAnswer={{this.submitAnswer}} />
+  <Module::Details @module={{@model.module}} @submitAnswer={{this.submitAnswer}} />
 </div>

--- a/mon-pix/app/pods/passage/model.js
+++ b/mon-pix/app/pods/passage/model.js
@@ -1,0 +1,5 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class Passage extends Model {
+  @attr('string') moduleId;
+}

--- a/mon-pix/mirage/routes/modules/create-passage.js
+++ b/mon-pix/mirage/routes/modules/create-passage.js
@@ -1,0 +1,6 @@
+export default function (schema, request) {
+  const params = JSON.parse(request.requestBody);
+  const moduleId = params.data.attributes['module-id'];
+
+  return schema.create('passage', { moduleId });
+}

--- a/mon-pix/mirage/routes/modules/index.js
+++ b/mon-pix/mirage/routes/modules/index.js
@@ -1,7 +1,9 @@
 import getModule from './get-module';
 import submitAnswer from './submit-answer';
+import createPassage from './create-passage';
 
 export default function index(config) {
   config.get('/modules/:slug', getModule);
   config.post('/modules/:slug/elements/:elementId/answers', submitAnswer);
+  config.post('/passages', createPassage);
 }

--- a/mon-pix/mirage/routes/modules/index.js
+++ b/mon-pix/mirage/routes/modules/index.js
@@ -4,6 +4,6 @@ import createPassage from './create-passage';
 
 export default function index(config) {
   config.get('/modules/:slug', getModule);
-  config.post('/modules/:slug/elements/:elementId/answers', submitAnswer);
+  config.post('/passages/:passageId/answers', submitAnswer);
   config.post('/passages', createPassage);
 }

--- a/mon-pix/mirage/routes/modules/submit-answer.js
+++ b/mon-pix/mirage/routes/modules/submit-answer.js
@@ -1,5 +1,7 @@
 export default function (schema, request) {
-  const elementId = request.params.elementId;
+  const params = JSON.parse(request.requestBody);
+  const elementId = params.data.attributes['element-id'];
+
   const correction = schema.correctionResponses.find(elementId);
   return schema.elementAnswers.create({ correction });
 }

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module_test.js
@@ -18,6 +18,10 @@ module('Acceptance | Module | Routes | navigateIntoTheModule', function (hooks) 
         grains,
       });
 
+      server.create('passage', {
+        moduleId: 'bien-ecrire-son-adresse-mail',
+      });
+
       // when
       const screen = await visit('/modules/bien-ecrire-son-adresse-mail');
 

--- a/mon-pix/tests/unit/adapters/element-answer_test.js
+++ b/mon-pix/tests/unit/adapters/element-answer_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
 
 module('Unit | Adapter | Module | ElementAnswer', function (hooks) {
   setupTest(hooks);
@@ -10,19 +11,64 @@ module('Unit | Adapter | Module | ElementAnswer', function (hooks) {
       const adapter = this.owner.lookup('adapter:element-answer');
       const option = {
         adapterOptions: {
-          moduleSlug: 'module-slug',
-          elementId: 'elementId',
+          passageId: '12',
         },
       };
       // when
       const url = adapter.urlForCreateRecord('element-answer', option);
 
       // then
-      assert.true(
-        url.endsWith(
-          `api/modules/${option.adapterOptions.moduleSlug}/elements/${option.adapterOptions.elementId}/answers`,
-        ),
-      );
+      assert.true(url.endsWith(`api/passages/${option.adapterOptions.passageId}/answers`));
+    });
+  });
+
+  module('#createRecord', function () {
+    test('should build the right payload', async function (assert) {
+      // given
+      const adapter = this.owner.lookup('adapter:element-answer');
+      adapter.ajax = sinon.stub().resolves();
+
+      const passageId = 12;
+      const userResponse = [];
+      const element = { id: 'element-id' };
+
+      const expectedUrl = `http://localhost:3000/api/passages/12/answers`;
+      const expectedMethod = 'POST';
+      const expectedData = {
+        data: {
+          data: {
+            attributes: {
+              'element-id': element.id,
+              'user-response': userResponse,
+            },
+          },
+        },
+      };
+      const snapshot = {
+        record: { element, userResponse },
+        adapterOptions: {
+          passageId,
+        },
+        serialize: function () {
+          return {
+            data: {
+              attributes: {
+                'user-response': userResponse,
+              },
+              relationships: {
+                element: { data: element },
+              },
+            },
+          };
+        },
+      };
+
+      // when
+      await adapter.createRecord(null, { modelName: 'passage' }, snapshot);
+
+      // then
+      sinon.assert.calledWith(adapter.ajax, expectedUrl, expectedMethod, expectedData);
+      assert.ok(true);
     });
   });
 });

--- a/mon-pix/tests/unit/controllers/modules/get_test.js
+++ b/mon-pix/tests/unit/controllers/modules/get_test.js
@@ -12,6 +12,7 @@ module('Unit | Module | Controller | get', function (hooks) {
       const expectedCorrection = 'correction';
       const userResponse = 'userResponse';
       const elementId = 'elementId';
+      const passageId = 'passageId';
       const element = 'element';
       const moduleSlug = 'moduleSlug';
 
@@ -36,6 +37,9 @@ module('Unit | Module | Controller | get', function (hooks) {
         module: {
           id: moduleSlug,
         },
+        passage: {
+          id: passageId,
+        },
       };
 
       controller.store = {
@@ -55,8 +59,7 @@ module('Unit | Module | Controller | get', function (hooks) {
       saveStub
         .withArgs({
           adapterOptions: {
-            elementId: answerData.elementId,
-            moduleSlug: moduleSlug,
+            passageId,
           },
         })
         .resolves({ correction: expectedCorrection });

--- a/mon-pix/tests/unit/controllers/modules/get_test.js
+++ b/mon-pix/tests/unit/controllers/modules/get_test.js
@@ -33,8 +33,11 @@ module('Unit | Module | Controller | get', function (hooks) {
 
       const controller = this.owner.lookup('controller:module/get');
       controller.model = {
-        id: moduleSlug,
+        module: {
+          id: moduleSlug,
+        },
       };
+
       controller.store = {
         createRecord: sinon.stub(),
       };

--- a/mon-pix/tests/unit/routes/module/get_test.js
+++ b/mon-pix/tests/unit/routes/module/get_test.js
@@ -13,7 +13,7 @@ module('Unit | Route | modules | get', function (hooks) {
     assert.ok(route);
   });
 
-  test('should load the corresponding model', async function (assert) {
+  test('should find the corresponding module', async function (assert) {
     // given
     const route = this.owner.lookup('route:module/get');
     const store = this.owner.lookup('service:store');
@@ -22,11 +22,34 @@ module('Unit | Route | modules | get', function (hooks) {
 
     store.findRecord = sinon.stub();
     store.findRecord.withArgs('module', 'the-module').resolves(module);
+    store.createRecord = sinon.stub();
+    store.createRecord.returns({ save: () => {} });
 
     // when
     const model = await route.model({ slug: 'the-module' });
 
     // then
-    assert.strictEqual(model, module);
+    assert.strictEqual(model.module, module);
+  });
+
+  test('should create and return a new passage', async function (assert) {
+    // given
+    const passage = Symbol('passage');
+
+    const route = this.owner.lookup('route:module/get');
+    const store = this.owner.lookup('service:store');
+
+    store.findRecord = sinon.stub();
+    store.createRecord = sinon.stub();
+    const save = sinon.stub();
+    save.resolves(passage);
+
+    store.createRecord.withArgs('passage', { moduleId: 'my-module' }).returns({ save: save });
+
+    // when
+    const model = await route.model({ slug: 'my-module' });
+
+    // then
+    assert.strictEqual(model.passage, passage);
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Nous possédons les routes pour créer un passage et mettre à jour les réponses de l'apprenant. Mais le front ne communique pas encore avec ces endpoints.

## :gift: Proposition

- Créer le passage via le model de la route front /modules/{module-id}.
- Créer les element-answers via la nouvelle route au lieu de l'ancienne.
- Supprimer côté front l'appel à l'ancienne route.

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester

### Tests fonctionnel:

1. Se rendre sur [la page du module](https://app-pr7872.review.pix.fr/modules/bien-ecrire-son-adresse-mail).
2. Parcourir le module en soumettant toutes les activités.
3. Vérifier que les feedbacks se chargent correctement.

### Test technique:

Checker en DB que les `passages` et les `element-answers` sont bien stockées.

Pour acceder le base de donnees pour ce PR dans scalingo 
`scalingo -a pix-api-review-pr7872 pgsql-console`