### PR TITLE
[FEATURE][ADMIN] Ajouter un label "organisation parente" sur la page d'une organisation parente (PIX-10049)

### DIFF
--- a/admin/app/components/organizations/information-section-view.hbs
+++ b/admin/app/components/organizations/information-section-view.hbs
@@ -1,6 +1,5 @@
 <div class="organization__data">
   <h2 class="organization__name">{{@organization.name}}</h2>
-
   {{#if @organization.tags}}
     <ul class="organization-tags-list">
       {{#each @organization.tags as |tag|}}
@@ -14,6 +13,11 @@
       n'a pas de tags.
     </PixMessage>
   {{/if}}
+  <div class="organization__network-label">
+    {{#if @organization.children}}
+      <PixTag @color="success">{{t "components.organizations.information-section-view.parent-organization"}}</PixTag>
+    {{/if}}
+  </div>
 
   {{#if @organization.isArchived}}
     <PixMessage class="organization-information-section__archived-message" @type="warning">

--- a/admin/app/styles/authenticated/organizations/get.scss
+++ b/admin/app/styles/authenticated/organizations/get.scss
@@ -1,5 +1,6 @@
 /* stylelint-disable selector-class-pattern */
 #organizations-get-page {
+
   .organization__information {
     display: flex;
 
@@ -36,6 +37,10 @@
       }
     }
 
+    .organization__network-label{
+      margin-bottom: var(--pix-spacing-6x);
+    }
+
     .organization__data {
       max-width: 100%;
       overflow: hidden;
@@ -49,7 +54,7 @@
       .organization-tags-list {
         display: flex;
         flex-wrap: wrap;
-        margin-bottom: $pix-spacing-m;
+        margin-bottom: var(--pix-spacing-6x);
         padding: 0;
         list-style: none;
 

--- a/admin/tests/acceptance/authenticated/organizations/information-management_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management_test.js
@@ -17,7 +17,10 @@ module('Acceptance | Organizations | Information management', function (hooks) {
     test('should be able to edit organization information', async function (assert) {
       // given
       const organization = this.server.create('organization', { name: 'oldOrganizationName' });
+      this.server.create('organization', { id: '1234' });
+
       const screen = await visit(`/organizations/${organization.id}`);
+
       await clickByName('Modifier');
 
       // when
@@ -25,6 +28,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
       await fillByLabel('Prénom du DPO', 'Bru');
       await fillByLabel('Nom du DPO', 'No');
       await fillByLabel('Adresse e-mail du DPO', 'bru.no@example.net');
+
       await clickByName('Enregistrer', { exact: true });
 
       // then

--- a/admin/tests/integration/components/organizations/information-section-view_test.js
+++ b/admin/tests/integration/components/organizations/information-section-view_test.js
@@ -1,12 +1,12 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | organizations/information-section-view', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   module('when user has access', function (hooks) {
     hooks.beforeEach(function () {
@@ -221,6 +221,45 @@ module('Integration | Component | organizations/information-section-view', funct
 
         // then
         assert.dom(screen.getByText('Archivée le 22/02/2022 par Rob Lochon.')).exists();
+      });
+    });
+
+    module('when organization is parent', function () {
+      test('it should display parent label', async function (assert) {
+        //given
+        const store = this.owner.lookup('service:store');
+        const child = store.createRecord('organization', { type: 'SCO', isManagingStudents: true });
+        const organization = store.createRecord('organization', {
+          type: 'SCO',
+          isManagingStudents: true,
+          children: [child],
+        });
+        this.set('organization', organization);
+
+        // when
+        const screen = await render(hbs`<Organizations::InformationSectionView @organization={{this.organization}} />`);
+
+        // then
+        assert.dom(screen.getByText('Organisation parente')).exists();
+      });
+    });
+
+    module('when organization is not parent', function () {
+      test('it should not display parent label', async function (assert) {
+        //given
+        const store = this.owner.lookup('service:store');
+        const organization = store.createRecord('organization', {
+          type: 'SCO',
+          name: 'notParent',
+          isManagingStudents: true,
+        });
+        this.set('organization', organization);
+
+        // when
+        const screen = await render(hbs`<Organizations::InformationSectionView @organization={{this.organization}} />`);
+
+        // then
+        assert.dom(screen.queryByText('Organisation parente')).doesNotExist();
       });
     });
 

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -108,6 +108,9 @@
           "name": "Name"
         },
         "table-name": "List of children organisations"
+      },
+      "information-section-view": {
+        "parent-organization": "Parent organization"
       }
     },
     "users": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -116,6 +116,9 @@
           "name": "Nom"
         },
         "table-name": "Liste des organisations enfants"
+      },
+      "information-section-view": {
+        "parent-organization": "Organisation parente"
       }
     },
     "users": {


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement nous ne pouvons pas visualiser rapidement sur la page d'informations d'une organisation, si celle-ci est une organisation parente. 
## :gift: Proposition
Ajouter un label "organisation parente"

## :socks: Remarques
RAS

## :santa: Pour tester
1. Cas passant
- Se connecter sur Pix Admin, en tant que Support, Métier ou SuperAdmin.
- Afficher la liste des organisations.
- Cliquer sur le lien de l'organisation 'Collège House of The Dragon' pour afficher sa page d'informations.
- Constater que le label 'organisation parente' apparaît.
2. Cas non passant
- Revenir sur la liste des organisations et cliquer sur le lien de l'organisation 'Child of "Collège House of the Dragon"'
- Constater que le label 'organisation parente' n'apparaît pas.

