### PR TITLE
[FEATURE] Rejeter une certif avec moins de V questions annulée pour problème technique (PIX-10752).

### DIFF
--- a/api/lib/domain/models/CertificationAssessmentScoreV3.js
+++ b/api/lib/domain/models/CertificationAssessmentScoreV3.js
@@ -165,7 +165,7 @@ const _shouldDowngradeScore = ({ maximumAssessmentLength, answers, abortReason }
 };
 
 const _isCertificationRejected = ({ answers, abortReason }) => {
-  return !_hasCandidateAnsweredEnoughQuestions({ answers }) && abortReason === ABORT_REASONS.CANDIDATE;
+  return !_hasCandidateAnsweredEnoughQuestions({ answers }) && abortReason;
 };
 
 const _hasCandidateCompletedTheCertification = ({ answers, maximumAssessmentLength }) => {

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -218,7 +218,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
               emitter: 'PIX-ALGO',
               pixScore: scoreForEstimatedLevel,
               reproducibilityRate: 100,
-              status: 'validated',
+              status: 'rejected',
               competenceMarks: [],
               assessmentId: 123,
               commentForCandidate:

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -398,7 +398,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
         });
 
         describe('when the candidate did not finish due to technical difficulties', function () {
-          it('should cancel the certification', async function () {
+          it('should cancel the certification and reject the assessment result', async function () {
             // given
             const abortReason = ABORT_REASONS.TECHNICAL;
             const expectedEstimatedLevel = 2;
@@ -450,12 +450,12 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
             // then
             const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScoreV3({
               nbPix: scoreForEstimatedLevel,
-              status: status.VALIDATED,
+              status: status.REJECTED,
             });
             const expectedAssessmentResult = new AssessmentResult({
               pixScore: scoreForEstimatedLevel,
               reproducibilityRate: certificationAssessmentScore.getPercentageCorrectAnswers(),
-              status: status.VALIDATED,
+              status: status.REJECTED,
               assessmentId: certificationAssessment.id,
               emitter: 'PIX-ALGO',
               commentForJury: 'Computed',


### PR DESCRIPTION
## :christmas_tree: Problème

Dans le cadre des nouvelles de règles de scoring métier pour la certif v3, un cas spécifique entraîne l’annulation automatique de la certification = une certif non terminée avec moins de V questions, et dont la raison de l’abandon est “Problème technique”.

Actuellement, si le certif-course est bien taggué “isCancelled” = true, l’assessment-result status est lui à “validated”. Donc en cas de désannulation, la certif passerait au statut “Validée” alors qu’elle ne respecte pas les critères qui permettent de délivrer un score.

## :gift: Proposition

Lorsqu’une certif a moins de V question, passer l’assessment-result à “Rejected” même si la raison de l’abandon est “Problème technique”.
Néanmoins, le certif-course lui doit bien rester “IsCancelled” = true en cas de pb technique

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester

• créer une session v3 et inscrire un candidat
• lancer le test avec le candidat, et répondre à moins de 20 questions
• dans Pix certif, cliquer sur “Finaliser la session” et sélectionner "problèmes techniques" en raison de l'abandon

• résultat : 
L'assessment result associé doit avoir le statut `rejected`
Le certification course doit avoir la propriété `isCancelled` à `true`

