### PR TITLE
[BUGFIX] Réactive le fonctionnement de l'aléatoire dans la certif v3 (PIX-10852)

### DIFF
--- a/api/lib/domain/usecases/get-next-challenge-for-certification.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-certification.js
@@ -65,7 +65,7 @@ const getNextChallengeForCertification = async function ({
       challenges: challengesWithoutSkillsWithAValidatedLiveAlert,
     });
 
-    const challenge = pickChallengeService.chooseNextChallenge(assessment.id)({ possibleChallenges });
+    const challenge = pickChallengeService.chooseNextChallenge()({ possibleChallenges });
 
     const certificationChallenge = new CertificationChallenge({
       associatedSkillName: challenge.skill.name,

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-certification_test.js
@@ -173,7 +173,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
               possibleChallenges: [nextChallengeToAnswer],
             })
             .returns(nextChallengeToAnswer);
-          pickChallengeService.chooseNextChallenge.withArgs(assessment.id).returns(chooseNextChallengeImpl);
+          pickChallengeService.chooseNextChallenge.withArgs().returns(chooseNextChallengeImpl);
 
           // when
           const challenge = await getNextChallengeForCertification({
@@ -321,7 +321,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
               possibleChallenges: [nextChallenge],
             })
             .returns(nextChallenge);
-          pickChallengeService.chooseNextChallenge.withArgs(assessment.id).returns(chooseNextChallengeImpl);
+          pickChallengeService.chooseNextChallenge.withArgs().returns(chooseNextChallengeImpl);
 
           // when
           const challenge = await getNextChallengeForCertification({
@@ -423,7 +423,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
               possibleChallenges: [challengeWithOtherSkill],
             })
             .returns(challengeWithOtherSkill);
-          pickChallengeService.chooseNextChallenge.withArgs(assessment.id).returns(chooseNextChallengeImpl);
+          pickChallengeService.chooseNextChallenge.withArgs().returns(chooseNextChallengeImpl);
 
           // when
           const challenge = await getNextChallengeForCertification({
@@ -619,7 +619,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
                   possibleChallenges: [nextChallengeToAnswer],
                 })
                 .returns(nextChallengeToAnswer);
-              pickChallengeService.chooseNextChallenge.withArgs(assessment.id).returns(chooseNextChallengeImpl);
+              pickChallengeService.chooseNextChallenge.withArgs().returns(chooseNextChallengeImpl);
 
               // when
               const challenge = await getNextChallengeForCertification({


### PR DESCRIPTION
## :christmas_tree: Problème
L'aléatoire ne fonctionnait pas correctement dans la certification v3 à cause d'un mauvais paramètre passé à la méthode `chooseNextChallenge`.

## :santa: Pour tester
- Créer une session de certification v3
- Ajouter 2 candidats
- Passer la certification avec ces 2 candidats et vérifier que les questions divergent