### PR TITLE
[FEATURE] Automatiquement scroller vers le grain suivant (PIX-10072)

### DIFF
--- a/mon-pix/app/pods/components/module/details/component.js
+++ b/mon-pix/app/pods/components/module/details/component.js
@@ -32,4 +32,13 @@ export default class ModuleDetails extends Component {
   grainTransition(grainId) {
     return this.args.module.transitionTexts.find((transition) => transition.grainId === grainId);
   }
+
+  @action
+  hasGrainJustAppeared(index) {
+    if (this.grainsToDisplay.length === 1) {
+      return false;
+    }
+
+    return this.grainsToDisplay.length - 1 === index;
+  }
 }

--- a/mon-pix/app/pods/components/module/details/component.js
+++ b/mon-pix/app/pods/components/module/details/component.js
@@ -5,6 +5,13 @@ import { tracked } from '@glimmer/tracking';
 export default class ModuleDetails extends Component {
   @tracked grainsToDisplay = [this.args.module.grains[0]];
 
+  static SCROLL_OFFSET_PX = 70;
+
+  @action
+  setGrainScrollOffsetCssProperty(element) {
+    element.style.setProperty('--grain-scroll-offset', `${ModuleDetails.SCROLL_OFFSET_PX}px`);
+  }
+
   get hasNextGrain() {
     return this.grainsToDisplay.length < this.args.module.grains.length;
   }

--- a/mon-pix/app/pods/components/module/details/template.hbs
+++ b/mon-pix/app/pods/components/module/details/template.hbs
@@ -14,6 +14,7 @@
         @canDisplayContinueButton={{this.grainCanDisplayContinueButton index}}
         @continueAction={{this.addNextGrainToDisplay}}
         @skipAction={{this.addNextGrainToDisplay}}
+        @hasJustAppeared={{this.hasGrainJustAppeared index}}
       />
     {{/each}}
   </div>

--- a/mon-pix/app/pods/components/module/details/template.hbs
+++ b/mon-pix/app/pods/components/module/details/template.hbs
@@ -5,7 +5,7 @@
     <h1>{{@module.title}}</h1>
   </div>
 
-  <div class="module__content">
+  <div class="module__content" {{did-insert this.setGrainScrollOffsetCssProperty}}>
     {{#each this.grainsToDisplay as |grain index|}}
       <Module::Grain
         @grain={{grain}}

--- a/mon-pix/app/pods/components/module/grain/component.js
+++ b/mon-pix/app/pods/components/module/grain/component.js
@@ -1,11 +1,10 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import ModuleDetails from '../details/component';
 
 export default class ModuleGrain extends Component {
   @service metrics;
-
-  static SCROLL_OFFSET_PX = 70;
 
   get shouldDisplayContinueButton() {
     return this.args.canDisplayContinueButton && this.allElementsAreAnswered;
@@ -33,7 +32,7 @@ export default class ModuleGrain extends Component {
 
     const newGrainY = element.getBoundingClientRect().top + window.scrollY;
     window.scroll({
-      top: newGrainY - ModuleGrain.SCROLL_OFFSET_PX,
+      top: newGrainY - ModuleDetails.SCROLL_OFFSET_PX,
       behavior: 'smooth',
     });
   }

--- a/mon-pix/app/pods/components/module/grain/component.js
+++ b/mon-pix/app/pods/components/module/grain/component.js
@@ -31,9 +31,10 @@ export default class ModuleGrain extends Component {
     element.focus({ preventScroll: true });
 
     const newGrainY = element.getBoundingClientRect().top + window.scrollY;
+    const userPrefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
     window.scroll({
       top: newGrainY - ModuleDetails.SCROLL_OFFSET_PX,
-      behavior: 'smooth',
+      behavior: userPrefersReducedMotion.matches ? 'instant' : 'smooth',
     });
   }
 

--- a/mon-pix/app/pods/components/module/grain/component.js
+++ b/mon-pix/app/pods/components/module/grain/component.js
@@ -17,6 +17,10 @@ export default class ModuleGrain extends Component {
     return this.args.grain.allElementsAreAnswered;
   }
 
+  get ariaLiveGrainValue() {
+    return this.args.hasJustAppeared ? 'assertive' : null;
+  }
+
   @action
   async continueAction() {
     await this.args.continueAction();

--- a/mon-pix/app/pods/components/module/grain/component.js
+++ b/mon-pix/app/pods/components/module/grain/component.js
@@ -5,6 +5,8 @@ import { inject as service } from '@ember/service';
 export default class ModuleGrain extends Component {
   @service metrics;
 
+  static SCROLL_OFFSET_PX = 70;
+
   get shouldDisplayContinueButton() {
     return this.args.canDisplayContinueButton && this.allElementsAreAnswered;
   }
@@ -19,6 +21,21 @@ export default class ModuleGrain extends Component {
 
   get ariaLiveGrainValue() {
     return this.args.hasJustAppeared ? 'assertive' : null;
+  }
+
+  @action
+  focusAndScroll(element) {
+    if (!this.args.hasJustAppeared) {
+      return;
+    }
+
+    element.focus({ preventScroll: true });
+
+    const newGrainY = element.getBoundingClientRect().top + window.scrollY;
+    window.scroll({
+      top: newGrainY - ModuleGrain.SCROLL_OFFSET_PX,
+      behavior: 'smooth',
+    });
   }
 
   @action

--- a/mon-pix/app/pods/components/module/grain/style.scss
+++ b/mon-pix/app/pods/components/module/grain/style.scss
@@ -1,6 +1,18 @@
 .grain {
   width: 100%;
 
+  &--active {
+    min-height: calc(100vh - var(--grain-scroll-offset));
+
+    @supports (min-height: 100dvh) {
+      min-height: calc(100dvh - var(--grain-scroll-offset));
+    }
+  }
+
+  &:last-child {
+    padding-bottom: var(--pix-spacing-12x);
+  }
+
   &__header {
     margin-bottom: var(--pix-spacing-6x);
     padding: 0 var(--pix-spacing-4x);

--- a/mon-pix/app/pods/components/module/grain/template.hbs
+++ b/mon-pix/app/pods/components/module/grain/template.hbs
@@ -1,4 +1,9 @@
-<article class="grain grain--lesson" aria-live={{this.ariaLiveGrainValue}}>
+<article
+  class="grain grain--lesson"
+  aria-live={{this.ariaLiveGrainValue}}
+  tabindex="-1"
+  {{did-insert this.focusAndScroll}}
+>
   <h2 class="screen-reader-only">{{@grain.title}}</h2>
 
   {{#if @transition}}

--- a/mon-pix/app/pods/components/module/grain/template.hbs
+++ b/mon-pix/app/pods/components/module/grain/template.hbs
@@ -1,4 +1,4 @@
-<article class="grain grain--lesson">
+<article class="grain grain--lesson" aria-live={{this.ariaLiveGrainValue}}>
   <h2 class="screen-reader-only">{{@grain.title}}</h2>
 
   {{#if @transition}}

--- a/mon-pix/app/pods/components/module/grain/template.hbs
+++ b/mon-pix/app/pods/components/module/grain/template.hbs
@@ -1,5 +1,5 @@
 <article
-  class="grain grain--lesson"
+  class="grain grain--lesson {{if @hasJustAppeared 'grain--active'}}"
   aria-live={{this.ariaLiveGrainValue}}
   tabindex="-1"
   {{did-insert this.focusAndScroll}}

--- a/mon-pix/tests/integration/components/module/details_test.js
+++ b/mon-pix/tests/integration/components/module/details_test.js
@@ -88,4 +88,76 @@ module('Integration | Component | Module | Details', function (hooks) {
       assert.strictEqual(findAll('.element-text').length, 1);
     });
   });
+
+  module('when user click on continue button', function (hooks) {
+    let continueButtonName;
+    hooks.beforeEach(function () {
+      continueButtonName = this.intl.t('pages.modulix.buttons.grain.continue');
+    });
+
+    test('should display next grain', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const text1Element = store.createRecord('text', { content: 'content', type: 'texts' });
+      const text2Element = store.createRecord('text', { content: 'content 2', type: 'texts' });
+      const grain1 = store.createRecord('grain', { elements: [text1Element] });
+      const grain2 = store.createRecord('grain', { elements: [text2Element] });
+
+      const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+      this.set('module', module);
+
+      const screen = await render(hbs`<Module::Details @module={{this.module}} />`);
+
+      const grainsBeforeAnyAction = screen.getAllByRole('article');
+      assert.strictEqual(grainsBeforeAnyAction.length, 1);
+
+      // when
+      await clickByName(continueButtonName);
+
+      // then
+      const grainsAfterContinueAction = screen.getAllByRole('article');
+      assert.strictEqual(grainsAfterContinueAction.length, 2);
+    });
+
+    test('should only set the aria-live="assertive" attribute on the last grain', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const text1Element = store.createRecord('text', { content: 'content', type: 'texts' });
+      const text2Element = store.createRecord('text', { content: 'content 2', type: 'texts' });
+      const text3Element = store.createRecord('text', { content: 'content 3', type: 'texts' });
+      const grain1 = store.createRecord('grain', { elements: [text1Element] });
+      const grain2 = store.createRecord('grain', { elements: [text2Element] });
+      const grain3 = store.createRecord('grain', { elements: [text3Element] });
+
+      const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2, grain3] });
+      this.set('module', module);
+
+      const screen = await render(hbs`<Module::Details @module={{this.module}} />`);
+
+      const grainsBeforeAnyAction = screen.getAllByRole('article');
+      assert.strictEqual(grainsBeforeAnyAction.length, 1);
+      const firstGrain = grainsBeforeAnyAction.at(-1);
+      assert.strictEqual(firstGrain.getAttribute('aria-live'), null);
+
+      // when
+      await clickByName(continueButtonName);
+
+      // then
+      const grainsAfterOneContinueActions = screen.getAllByRole('article');
+      assert.strictEqual(grainsAfterOneContinueActions.length, 2);
+      const secondGrain = grainsAfterOneContinueActions.at(-1);
+      assert.strictEqual(firstGrain.getAttribute('aria-live'), null);
+      assert.strictEqual(secondGrain.getAttribute('aria-live'), 'assertive');
+
+      // when
+      await clickByName(continueButtonName);
+
+      // then
+      const grainsAfterTwoContinueActions = screen.getAllByRole('article');
+      assert.strictEqual(grainsAfterTwoContinueActions.length, 3);
+      const thirdGrain = grainsAfterTwoContinueActions.at(-1);
+      assert.strictEqual(secondGrain.getAttribute('aria-live'), null);
+      assert.strictEqual(thirdGrain.getAttribute('aria-live'), 'assertive');
+    });
+  });
 });

--- a/mon-pix/tests/integration/components/module/details_test.js
+++ b/mon-pix/tests/integration/components/module/details_test.js
@@ -159,5 +159,43 @@ module('Integration | Component | Module | Details', function (hooks) {
       assert.strictEqual(secondGrain.getAttribute('aria-live'), null);
       assert.strictEqual(thirdGrain.getAttribute('aria-live'), 'assertive');
     });
+
+    test('should give focus on the last grain when appearing', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const text1Element = store.createRecord('text', { content: 'content', type: 'texts' });
+      const text2Element = store.createRecord('text', { content: 'content 2', type: 'texts' });
+      const text3Element = store.createRecord('text', { content: 'content 3', type: 'texts' });
+      const grain1 = store.createRecord('grain', { elements: [text1Element] });
+      const grain2 = store.createRecord('grain', { elements: [text2Element] });
+      const grain3 = store.createRecord('grain', { elements: [text3Element] });
+
+      const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2, grain3] });
+      this.set('module', module);
+
+      const screen = await render(hbs`<Module::Details @module={{this.module}} />`);
+
+      const grainsBeforeAnyAction = screen.getAllByRole('article');
+      assert.strictEqual(grainsBeforeAnyAction.length, 1);
+      assert.strictEqual(document.activeElement, document.body);
+
+      // when
+      await clickByName(continueButtonName);
+
+      // then
+      const grainsAfterOneContinueActions = screen.getAllByRole('article');
+      assert.strictEqual(grainsAfterOneContinueActions.length, 2);
+      const secondGrain = grainsAfterOneContinueActions.at(-1);
+      assert.strictEqual(document.activeElement, secondGrain);
+
+      // when
+      await clickByName(continueButtonName);
+
+      // then
+      const grainsAfterTwoContinueActions = screen.getAllByRole('article');
+      assert.strictEqual(grainsAfterTwoContinueActions.length, 3);
+      const thirdGrain = grainsAfterTwoContinueActions.at(-1);
+      assert.strictEqual(document.activeElement, thirdGrain);
+    });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Il n'est pas évident aujourd'hui pour l'utilisateur de comprendre que le contenu apparaît progressivement dans la page avec possibilité de revenir en arrière si souhaité.

## :gift: Proposition
Pour l'aider à comprendre cette fonctionnalité, scroller automatiquement vers le grain lors de son apparition. On a choisi avec Quentin de scroller `70px` au dessus du grain fraîchement apparu, pour que le grain précédant apparaisse tout juste en haut de l'écran. J'espère que de cette manière l'utilisateur pourra comprendre qu'il est possible de remonter.

J'en profite pour améliorer l'accessibilité en suivant les recommandations de Tanaguru : 
- Utiliser `aria-live="assertive"` pour énoncer le contenu du grain dès qu'il apparaît,
- Mettre également le focus sur le grain dessus, sans permettre la tabulation de grain à grain (`tabindex="-1"`)

## :socks: Remarques
Pour utiliser la même valeur `70px` dans le JS et dans le CSS, on a dynamiquement placé cette valeur dans une variable CSS via `element.style.setProperty('--grain-scroll-offset', '70px')`.

Le paramètre de préférence utilisateur "reduce motion" est respecté grâce à [`window.matchMedia`](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) qui est largement supporté.

## :santa: Pour tester
Sur [la RA](https://app-pr7889.review.pix.fr/modules/bien-ecrire-son-adresse-mail), constater le scroll auto quand on continue ou passe un grain.

Pour vérifier où est le focus sur la page, utiliser `document.activeElement` qui donne l'info (au hover sur l'élément qui ressort dans les devtools il sera mis en avant visuellement).

Pour l'`aria-live="assertive"`, utiliser VoiceOver et constater qu'après click sur "Continuer", le contenu du nouveau grain est vocalisé.