### PR TITLE
[FEATURE] Ajouter la page mission dans Pix Orga (Pix-10747)

### DIFF
--- a/orga/app/components/layout/sidebar.hbs
+++ b/orga/app/components/layout/sidebar.hbs
@@ -6,12 +6,15 @@
   </header>
 
   <nav class="sidebar-nav" aria-label={{t "navigation.main.aria-label"}}>
-    <LinkTo @route="authenticated.campaigns" class="sidebar-nav__item">
-      <span class="sidebar-nav__item-icon">
-        <img src="{{this.rootURL}}/icons/chevron-square-right.svg" alt="" role="none" />
-      </span>
-      {{t "navigation.main.campaigns"}}
-    </LinkTo>
+    {{#if this.shouldDisplayCampaignsEntry}}
+      <LinkTo @route="authenticated.campaigns" class="sidebar-nav__item">
+        <span class="sidebar-nav__item-icon">
+          <img src="{{this.rootURL}}/icons/chevron-square-right.svg" alt="" role="none" />
+        </span>
+        {{t "navigation.main.campaigns"}}
+      </LinkTo>
+    {{/if}}
+
     {{#if this.shouldDisplayCertificationsEntry}}
       <LinkTo @route="authenticated.certifications" class="sidebar-nav__item">
         <span class="sidebar-nav__item-icon">
@@ -20,12 +23,22 @@
         {{t "navigation.main.certifications"}}
       </LinkTo>
     {{/if}}
-    <LinkTo @route={{this.organizationLearnersList.route}} class="sidebar-nav__item">
-      <span class="sidebar-nav__item-icon">
-        <img src="{{this.rootURL}}/icons/address-book-light.svg" alt="" role="none" />
-      </span>
-      {{t this.organizationLearnersList.label}}
-    </LinkTo>
+    {{#if this.shouldDisplayParticipantsEntry}}
+      <LinkTo @route={{this.organizationLearnersList.route}} class="sidebar-nav__item">
+        <span class="sidebar-nav__item-icon">
+          <img src="{{this.rootURL}}/icons/address-book-light.svg" alt="" role="none" />
+        </span>
+        {{t this.organizationLearnersList.label}}
+      </LinkTo>
+    {{/if}}
+    {{#if this.shouldDisplayMissionsEntry}}
+      <LinkTo @route="authenticated.missions" class="sidebar-nav__item">
+        <span class="sidebar-nav__item-icon">
+          <img src="{{this.rootURL}}/icons/chevron-square-right.svg" alt="" role="none" />
+        </span>
+        {{t "navigation.main.missions"}}
+      </LinkTo>
+    {{/if}}
     <LinkTo @route="authenticated.team" class="sidebar-nav__item">
       <span class="sidebar-nav__item-icon">
         <img src="{{this.rootURL}}/icons/users-light.svg" alt="" role="none" />

--- a/orga/app/components/layout/sidebar.js
+++ b/orga/app/components/layout/sidebar.js
@@ -16,6 +16,15 @@ export default class SidebarMenu extends Component {
   get shouldDisplayPlacesEntry() {
     return this.currentUser.shouldAccessPlacesPage;
   }
+  get shouldDisplayMissionsEntry() {
+    return this.currentUser.shouldAccessMissionsPage;
+  }
+  get shouldDisplayCampaignsEntry() {
+    return this.currentUser.shouldAccessCampaignsPage;
+  }
+  get shouldDisplayParticipantsEntry() {
+    return this.currentUser.shouldAccessParticipantsPage;
+  }
 
   get organizationLearnersList() {
     if (this.currentUser.isSCOManagingStudents) {

--- a/orga/app/models/prescriber.js
+++ b/orga/app/models/prescriber.js
@@ -16,6 +16,7 @@ export default class Prescriber extends Model {
       MULTIPLE_SENDING_ASSESSMENT: 'MULTIPLE_SENDING_ASSESSMENT',
       COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY: 'COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY',
       PLACES_MANAGEMENT: 'PLACES_MANAGEMENT',
+      MISSIONS_MANAGEMENT: 'MISSIONS_MANAGEMENT',
     };
   }
   get fullName() {
@@ -36,6 +37,10 @@ export default class Prescriber extends Model {
 
   get placesManagement() {
     return this.features[Prescriber.featureList.PLACES_MANAGEMENT];
+  }
+
+  get missionsManagement() {
+    return this.features[Prescriber.featureList.MISSIONS_MANAGEMENT];
   }
 
   get isAdminOfTheCurrentOrganization() {

--- a/orga/app/router.js
+++ b/orga/app/router.js
@@ -78,6 +78,7 @@ Router.map(function () {
     this.route('certifications');
     this.route('preselect-target-profile', { path: '/selection-sujets' });
     this.route('places');
+    this.route('missions');
   });
 
   this.route('logout');

--- a/orga/app/routes/authenticated/index.js
+++ b/orga/app/routes/authenticated/index.js
@@ -3,8 +3,12 @@ import { service } from '@ember/service';
 
 export default class IndexRoute extends Route {
   @service router;
-
+  @service currentUser;
   beforeModel() {
-    return this.router.replaceWith('authenticated.campaigns');
+    if (this.currentUser.shouldAccessMissionsPage) {
+      return this.router.replaceWith('authenticated.missions');
+    } else {
+      return this.router.replaceWith('authenticated.campaigns');
+    }
   }
 }

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -60,4 +60,13 @@ export default class CurrentUserService extends Service {
   get shouldAccessPlacesPage() {
     return this.isAdminInOrganization && this.prescriber.placesManagement;
   }
+  get shouldAccessMissionsPage() {
+    return this.prescriber.missionsManagement;
+  }
+  get shouldAccessCampaignsPage() {
+    return !this.prescriber.missionsManagement;
+  }
+  get shouldAccessParticipantsPage() {
+    return !this.prescriber.missionsManagement;
+  }
 }

--- a/orga/app/templates/authenticated/missions.hbs
+++ b/orga/app/templates/authenticated/missions.hbs
@@ -1,0 +1,3 @@
+{{page-title (t "pages.missions.title")}}
+
+<h1 class="page-title">{{t "pages.missions.title"}}</h1>

--- a/orga/tests/acceptance/authentication_test.js
+++ b/orga/tests/acceptance/authentication_test.js
@@ -135,20 +135,32 @@ module('Acceptance | authentication', function (hooks) {
     });
 
     module('When prescriber has accepted terms of service', function (hooks) {
+      let prescriber;
       hooks.beforeEach(async () => {
         const user = createUserWithMembershipAndTermsOfServiceAccepted();
-        createPrescriberByUser(user);
+        prescriber = createPrescriberByUser(user);
 
         await authenticateSession(user.id);
       });
 
+      module('When the prescriber has the missions management feature', function () {
+        test('it should redirect prescriber to missions page', async function (assert) {
+          prescriber.features = { ...prescriber.features, MISSIONS_MANAGEMENT: true };
+          // when
+          await visit('/connexion');
+
+          // then
+          assert.strictEqual(currentURL(), '/missions');
+          assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
+        });
+      });
       test('it should redirect prescriber to campaign list page', async function (assert) {
         // when
         await visit('/connexion');
 
         // then
         assert.strictEqual(currentURL(), '/campagnes/les-miennes');
-        assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
+        assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
       });
 
       test('it should let prescriber access requested page', async function (assert) {

--- a/orga/tests/helpers/test-init.js
+++ b/orga/tests/helpers/test-init.js
@@ -50,6 +50,7 @@ export function createPrescriberWithPixOrgaTermsOfService({ pixOrgaTermsOfServic
     pixOrgaTermsOfServiceAccepted,
     memberships: [membership],
     userOrgaSettings: userOrgaSettings,
+    features: { MISSIONS_MANAGEMENT: false },
   });
 }
 
@@ -247,6 +248,7 @@ export function createMember() {
     pixOrgaTermsOfServiceAccepted: user.pixOrgaTermsOfServiceAccepted,
     memberships: user.memberships,
     userOrgaSettings: user.userOrgaSettings,
+    features: { MISSIONS_MANAGEMENT: false },
   });
 
   return { user, organization, membership, userOrgaSettings, prescriber };

--- a/orga/tests/integration/components/layout/sidebar_test.js
+++ b/orga/tests/integration/components/layout/sidebar_test.js
@@ -33,10 +33,12 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
     });
   });
 
-  module('Commun menu', function () {
+  module('Common menu', function () {
     test('should display Campagne and Équipe menu for all organisation members', async function (assert) {
       class CurrentUserStub extends Service {
         organization = Object.create({ id: 1 });
+        shouldAccessCampaignsPage = true;
+        shouldAccessParticipantsPage = true;
       }
       this.owner.register('service:current-user', CurrentUserStub);
       const intl = this.owner.lookup('service:intl');
@@ -91,6 +93,7 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
       // given
       class CurrentUserStub extends Service {
         organization = Object.create({ id: 1, type: 'PRO' });
+        shouldAccessParticipantsPage = true;
       }
 
       this.owner.register('service:current-user', CurrentUserStub);
@@ -111,6 +114,7 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
       class CurrentUserStub extends Service {
         organization = Object.create({ id: 1, type: 'SUP' });
         isSUPManagingStudents = true;
+        shouldAccessParticipantsPage = true;
       }
 
       this.owner.register('service:current-user', CurrentUserStub);
@@ -129,6 +133,7 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
       class CurrentUserStub extends Service {
         organization = Object.create({ id: 1, type: 'SUP' });
         isSUPManagingStudents = false;
+        shouldAccessParticipantsPage = true;
       }
 
       this.owner.register('service:current-user', CurrentUserStub);
@@ -149,6 +154,8 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
       class CurrentUserStub extends Service {
         organization = Object.create({ id: 1, type: 'SCO' });
         isSCOManagingStudents = true;
+        shouldAccessMissionsPage = false;
+        shouldAccessParticipantsPage = true;
       }
 
       this.owner.register('service:current-user', CurrentUserStub);
@@ -167,6 +174,7 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
       class CurrentUserStub extends Service {
         organization = Object.create({ id: 1, type: 'SCO' });
         isSCOManagingStudents = false;
+        shouldAccessParticipantsPage = true;
       }
 
       this.owner.register('service:current-user', CurrentUserStub);
@@ -216,6 +224,39 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
 
       // then
       assert.dom(screen.queryByLabelText('Certifications')).isNotVisible();
+    });
+  });
+
+  module('When the user has the mission-management feature', function () {
+    test('should display Mission menu', async function (assert) {
+      class CurrentUserStub extends Service {
+        organization = Object.create({ id: 5 });
+        shouldAccessMissionsPage = true;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+      const intl = this.owner.lookup('service:intl');
+      intl.setLocale(['fr', 'fr']);
+
+      const screen = await render(hbs`<Layout::Sidebar />`);
+
+      assert.dom(screen.getByText('Missions')).exists();
+    });
+
+    test('should not display Campagne and Participants menus', async function (assert) {
+      class CurrentUserStub extends Service {
+        organization = Object.create({ id: 5 });
+        shouldAccessMissionsPage = true;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+      const intl = this.owner.lookup('service:intl');
+      intl.setLocale(['fr', 'fr']);
+
+      const screen = await render(hbs`<Layout::Sidebar />`);
+
+      assert.dom(screen.queryByText('Campagnes')).doesNotExist();
+      assert.dom(screen.queryByText('Participants')).doesNotExist();
+      assert.dom(screen.queryByText('Étudiants')).doesNotExist();
+      assert.dom(screen.queryByText('Élèves')).doesNotExist();
     });
   });
 

--- a/orga/tests/unit/models/prescriber_test.js
+++ b/orga/tests/unit/models/prescriber_test.js
@@ -161,4 +161,32 @@ module('Unit | Model | prescriber', function (hooks) {
       assert.false(placesManagement);
     });
   });
+
+  module('#missionsManagement', function () {
+    test('it returns true when feature is enabled', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const model = store.createRecord('prescriber', {
+        features: { ['MISSIONS_MANAGEMENT']: true },
+      });
+      // when
+      const missionsManagement = model.missionsManagement;
+
+      // then
+      assert.true(missionsManagement);
+    });
+
+    test('it returns false when feature is disabled', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const model = store.createRecord('prescriber', {
+        features: { ['MISSIONS_MANAGEMENT']: false },
+      });
+      // when
+      const missionsManagement = model.missionsManagement;
+
+      // then
+      assert.false(missionsManagement);
+    });
+  });
 });

--- a/orga/tests/unit/services/current-user_test.js
+++ b/orga/tests/unit/services/current-user_test.js
@@ -279,6 +279,59 @@ module('Unit | Service | current-user', function (hooks) {
         assert.false(currentUserService.shouldAccessPlacesPage);
       });
     });
+
+    module('#shouldAccessMissionsPage', function () {
+      test('should return true if user has feature activated', function (assert) {
+        currentUserService.prescriber = {
+          missionsManagement: true,
+        };
+
+        assert.true(currentUserService.shouldAccessMissionsPage);
+      });
+
+      test('should return false if user does not have feature activated', function (assert) {
+        currentUserService.prescriber = {
+          missionsManagement: false,
+        };
+
+        assert.false(currentUserService.shouldAccessMissionsPage);
+      });
+    });
+
+    module('#shouldAccessCampaignsPage', function () {
+      test('should return false if user has mission feature activated', function (assert) {
+        currentUserService.prescriber = {
+          missionsManagement: true,
+        };
+
+        assert.false(currentUserService.shouldAccessCampaignsPage);
+      });
+
+      test('should return true if user does not have missions feature activated', function (assert) {
+        currentUserService.prescriber = {
+          missionsManagement: false,
+        };
+
+        assert.true(currentUserService.shouldAccessCampaignsPage);
+      });
+    });
+    module('#shouldAccessParticipantsPage', function () {
+      test('should return false if user has mission feature activated', function (assert) {
+        currentUserService.prescriber = {
+          missionsManagement: true,
+        };
+
+        assert.false(currentUserService.shouldAccessParticipantsPage);
+      });
+
+      test('should return true if user does not have missions feature activated', function (assert) {
+        currentUserService.prescriber = {
+          missionsManagement: false,
+        };
+
+        assert.true(currentUserService.shouldAccessParticipantsPage);
+      });
+    });
   });
 
   module('user is not authenticated', function () {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -267,6 +267,7 @@
       "campaigns": "Campaigns",
       "certifications": "Certifications",
       "documentation": "Documentation",
+      "missions": "Missions",
       "organization-participants": "Participants",
       "places": "Seats",
       "sco-organization-participants": "Students",
@@ -750,6 +751,9 @@
           }
         }
       }
+    },
+    "missions": {
+      "title": "Missions"
     },
     "organization-learner": {
       "activity": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -270,6 +270,7 @@
       "campaigns": "Campagnes",
       "certifications": "Certifications",
       "documentation": "Documentation",
+      "missions": "Missions",
       "organization-participants": "Participants",
       "places": "Places",
       "sco-organization-participants": "Élèves",
@@ -753,6 +754,9 @@
           }
         }
       }
+    },
+    "missions": {
+      "title": "Missions"
     },
     "organization-learner": {
       "activity": {


### PR DESCRIPTION
## :christmas_tree: Problème
On souhaite permettre aux enseignants du premier degré d'accéder aux résultats des élèves qui ont passé des missions.
À l'heure actuelle, il n'existe pas de page qui permette cette consultation.

## :gift: Proposition
Première étape est de faire une entrée et une page Mission

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Se connecter à pix orga avec un compte rattaché à une orga de type SCO-1D et voir qu'on a l'entré mission et qu'on arrive directement sur la page mission et qu'il n'y a pas les entrées `campagnes`, `Participants | Élèves | Étudiants`  
**Tests de NON RÉGRESSION**
- Se connecter avec des comptes SCO, SUP ET PRO et vérifier qu'aucun n'a l'entrée `Mission` et qu'ils ont les entrées `campagnes`, `Participants | Élèves | Étudiants`  