### PR TITLE
[FEATURE] Renommer le commentForJury d'une certification sur  Pix Admin (PIX-10827).

### DIFF
--- a/admin/app/components/certifications/certification/comments.hbs
+++ b/admin/app/components/certifications/certification/comments.hbs
@@ -18,7 +18,7 @@
     <Certifications::InfoField
       @value={{@certification.commentForJury}}
       @edition={{this.editingComments}}
-      @label="Pour le jury :"
+      @label="Notes internes Jury Pix :"
       @fieldId="certification-commentForJury"
       @isTextarea={{true}}
     />

--- a/admin/app/components/certifications/certification/comments.hbs
+++ b/admin/app/components/certifications/certification/comments.hbs
@@ -16,10 +16,10 @@
       @isTextarea={{true}}
     />
     <Certifications::InfoField
-      @value={{@certification.commentForJury}}
+      @value={{@certification.commentByJury}}
       @edition={{this.editingComments}}
       @label="Notes internes Jury Pix :"
-      @fieldId="certification-commentForJury"
+      @fieldId="certification-commentByJury"
       @isTextarea={{true}}
     />
     <Certifications::InfoField

--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -40,7 +40,7 @@ export default class Certification extends Model {
   @attr() juryId;
   @attr('string') commentForCandidate;
   @attr('string') commentForOrganization;
-  @attr('string') commentForJury;
+  @attr('string') commentByJury;
   @attr() pixScore;
   @attr() competencesWithMark;
   @attr('boolean', { defaultValue: false }) isPublished;

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -1098,7 +1098,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
           // then
           assert.dom(screen.getByRole('textbox', { name: 'Pour le candidat :' })).exists();
           assert.dom(screen.getByRole('textbox', { name: "Pour l'organisation :" })).exists();
-          assert.dom(screen.getByRole('textbox', { name: 'Pour le jury :' })).exists();
+          assert.dom(screen.getByRole('textbox', { name: 'Notes internes Jury Pix :' })).exists();
           assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
           assert.dom(screen.getByRole('button', { name: 'Enregistrer' })).exists();
         });

--- a/admin/tests/integration/components/certifications/certification/comments_test.js
+++ b/admin/tests/integration/components/certifications/certification/comments_test.js
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Certifications | certification | Comments ', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('should display certification comments', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    this.certification = store.createRecord('certification', {
+      firstName: 'Fabrice',
+      lastName: 'Gadjo',
+      birthdate: '2000-12-15',
+      sex: 'F',
+      birthInseeCode: '99101',
+      birthplace: 'Copenhague',
+      birthCountry: 'DANEMARK',
+      commentByJury: "C'était super, le jury est content",
+      commentForOrganization: "C'était super, bravo à l'organisation",
+      commentForCandidate: "C'était super, bravo au candidat",
+    });
+
+    // when
+    const screen = await render(hbs`<Certifications::Certification::Comments @certification={{this.certification}} />`);
+
+    // then
+    assert.dom(screen.getByText('Pour le candidat :')).exists();
+    assert.dom(screen.getByText("C'était super, bravo au candidat")).exists();
+    assert.dom(screen.getByText("Pour l'organisation :")).exists();
+    assert.dom(screen.getByText("C'était super, bravo à l'organisation")).exists();
+    assert.dom(screen.getByText('Notes internes Jury Pix :')).exists();
+    assert.dom(screen.getByText("C'était super, le jury est content")).exists();
+  });
+});

--- a/api/lib/infrastructure/serializers/jsonapi/jury-certification-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/jury-certification-serializer.js
@@ -8,7 +8,6 @@ const serialize = function (juryCertification) {
       return {
         id: juryCertification.certificationCourseId,
         ...juryCertification,
-        commentForJury: juryCertification.commentByJury,
         competencesWithMark: juryCertification.competenceMarks,
       };
     },
@@ -35,7 +34,7 @@ const serialize = function (juryCertification) {
       'competencesWithMark',
       'commentForCandidate',
       'commentForOrganization',
-      'commentForJury',
+      'commentByJury',
       'commonComplementaryCertificationCourseResult',
       'complementaryCertificationCourseResultWithExternal',
       'certificationIssueReports',

--- a/api/src/certification/course/infrastructure/serializers/jsonapi/assessment-result-serializer.js
+++ b/api/src/certification/course/infrastructure/serializers/jsonapi/assessment-result-serializer.js
@@ -10,7 +10,7 @@ const deserialize = async function (payload) {
   return new AssessmentResult({
     assessmentId: assessmentResult.assessmentId,
     emitter: assessmentResult.emitter,
-    commentByJury: assessmentResult.commentForJury,
+    commentByJury: assessmentResult.commentByJury,
     commentForCandidate: assessmentResult.commentForCandidate,
     commentForOrganization: assessmentResult.commentForOrganization,
     pixScore: assessmentResult.pixScore,

--- a/api/tests/acceptance/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-courses/certification-course-controller_test.js
@@ -318,7 +318,7 @@ describe('Acceptance | API | Certification Course', function () {
           'pix-score': 55,
           'jury-id': 66,
           'comment-for-candidate': 'comment candidate',
-          'comment-for-jury': 'comment jury',
+          'comment-by-jury': 'comment jury',
           'comment-for-organization': 'comment organization',
           version: 2,
           'competences-with-mark': [

--- a/api/tests/certification/course/acceptance/application/certification-course-route_test.js
+++ b/api/tests/certification/course/acceptance/application/certification-course-route_test.js
@@ -143,7 +143,7 @@ describe('Acceptance | Route | certification-course', function () {
               'pix-score': 27,
               status: 'validated',
               emitter: 'Jury',
-              'comment-for-jury': 'Parce que',
+              'comment-by-jury': 'Parce que',
               'comment-for-candidate': 'Voilà',
               'comment-for-organization': 'Je suis sûr que vous etes ok avec nous',
             },

--- a/api/tests/certification/course/unit/application/certification-course-controller_test.js
+++ b/api/tests/certification/course/unit/application/certification-course-controller_test.js
@@ -85,7 +85,7 @@ describe('Unit | Controller | certification-course-controller', function () {
               'pix-score': 300,
               status: 'validated',
               emitter: 'Jury Pix',
-              'comment-for-jury': 'Tell',
+              'comment-by-jury': 'Tell',
               'comment-for-candidate': 'Me',
               'comment-for-organization': 'Why',
             },

--- a/api/tests/certification/course/unit/infrasctructure/serializers/jsonapi/assessment-result-serializer_test.js
+++ b/api/tests/certification/course/unit/infrasctructure/serializers/jsonapi/assessment-result-serializer_test.js
@@ -9,7 +9,7 @@ describe('Unit | Serializer | JSONAPI | assessment-result-serializer', function 
         data: {
           attributes: {
             'assessment-id': 1,
-            'comment-for-jury': 'comment',
+            'comment-by-jury': 'comment',
             'comment-for-candidate': null,
             'comment-for-organization': 'another comment',
             emitter: 'Jury Pix',

--- a/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-serializer_test.js
@@ -101,7 +101,7 @@ describe('Unit | Serializer | JSONAPI | jury-certification-serializer', function
             'pix-score': 555,
             'competences-with-mark': juryCertification.competenceMarks,
             'comment-for-candidate': 'coucou',
-            'comment-for-jury': 'ça va',
+            'comment-by-jury': 'ça va',
             'comment-for-organization': 'comment',
             version: 2,
           },


### PR DESCRIPTION
## :christmas_tree: Problème
Dans le cadre de l'automatisation des commentaires jury, nous souhaitons repenser l'existant notamment le `commentForJury` pour le renommer en `commentByJury`. 
Le renommage a déjà été fait coté API dans cette PR https://github.com/1024pix/pix/pull/7885
Mais les front et les serializers n'ont pas été changés.

## :gift: Proposition
Renommer commentForJury et changer le wording du champ en "Notes internes Jury Pix"

## :santa: Pour tester

- Aller sur Pix Admin
- Choisir une certification V 2
-  Sélectionner une certification et vérifier qu'il n'y a pas 'Computed'  dans la ligne "Notes internes Jury Pix :"
- Changer le commentaire "Notes internes Jury Pix :", sauvegardez, rechargez, vérifier que votre commentaire est bien pris en compte
- Faire de même avec une certification V3