### PR TITLE
[BUGFIX] Adapter les couleurs du graphique des status par jour à celui des status par type (PIX-10864)

### DIFF
--- a/orga/app/components/campaign/charts/participants-by-day.js
+++ b/orga/app/components/campaign/charts/participants-by-day.js
@@ -60,8 +60,8 @@ export default class ParticipantsByDay extends Component {
         {
           label: this.intl.t(this.labels.started.legend),
           data: this.startedDatasets,
-          borderColor: '#3d68ff',
-          backgroundColor: '#3d68ff',
+          borderColor: '#613fdd',
+          backgroundColor: '#613fdd',
           tension: 0.2,
           pointStyle: 'circle',
           order: 2,
@@ -69,8 +69,8 @@ export default class ParticipantsByDay extends Component {
         {
           label: this.intl.t(this.labels.shared.legend),
           data: this.sharedDatasets,
-          borderColor: '#613fdd',
-          backgroundColor: '#613fdd',
+          borderColor: '#038a25',
+          backgroundColor: '#038a25',
           tension: 0.2,
           pointStyle: 'rect',
           order: 1,


### PR DESCRIPTION
## :christmas_tree: Problème
Dans le ticket précédent je n'ai pas changé la bonne couleur

## :gift: Proposition
Changer la bonne couleur et remettre la précédente comme avant

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- se connecter à PixOrga, aller sur une campagne avec des graphiques, vérifier la cohérence des légendes