### PR TITLE
[FEATURE] Utiliser les certification-challenges plutôt que les challenges pour le rescoring (PIX-10751).

### DIFF
--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -17,6 +17,7 @@ import * as campaignParticipationRepository from '../../infrastructure/repositor
 import * as campaignParticipationResultRepository from '../../infrastructure/repositories/campaign-participation-result-repository.js';
 import * as certificationAssessmentRepository from '../../infrastructure/repositories/certification-assessment-repository.js';
 import * as certificationCenterRepository from '../../../src/certification/shared/infrastructure/repositories/certification-center-repository.js';
+import * as certificationChallengeForScoringRepository from '../../../src/certification/scoring/infrastructure/repositories/certification-challenge-for-scoring-repository.js';
 import * as certificationCourseRepository from '../../../src/certification/shared/infrastructure/repositories/certification-course-repository.js';
 import * as certificationIssueReportRepository from '../../../src/certification/shared/infrastructure/repositories/certification-issue-report-repository.js';
 import * as challengeRepository from '../../../src/shared/infrastructure/repositories/challenge-repository.js';
@@ -68,6 +69,7 @@ const dependencies = {
   campaignParticipationResultRepository,
   certificationAssessmentRepository,
   certificationCenterRepository,
+  certificationChallengeForScoringRepository,
   certificationCourseRepository,
   certificationIssueReportRepository,
   challengeRepository,

--- a/api/src/certification/scoring/domain/models/CertificationChallengeForScoring.js
+++ b/api/src/certification/scoring/domain/models/CertificationChallengeForScoring.js
@@ -1,0 +1,7 @@
+export class CertificationChallengeForScoring {
+  constructor({ id, discriminant, difficulty }) {
+    this.id = id;
+    this.discriminant = discriminant;
+    this.difficulty = difficulty;
+  }
+}

--- a/api/src/certification/scoring/infrastructure/repositories/certification-challenge-for-scoring-repository.js
+++ b/api/src/certification/scoring/infrastructure/repositories/certification-challenge-for-scoring-repository.js
@@ -1,0 +1,19 @@
+import { knex } from '../../../../../db/knex-database-connection.js';
+import { CertificationChallengeForScoring } from '../../domain/models/CertificationChallengeForScoring.js';
+
+export const getByCertificationCourseId = async ({ certificationCourseId }) => {
+  const certificationChallengesForScoringDTO = await knex('certification-challenges')
+    .select('challengeId', 'discriminant', 'difficulty')
+    .where({ courseId: certificationCourseId });
+
+  return _toDomain(certificationChallengesForScoringDTO);
+};
+
+function _toDomain(certificationChallengesForScoringDTO) {
+  return certificationChallengesForScoringDTO.map((certificationChallengeForScoring) => {
+    return new CertificationChallengeForScoring({
+      ...certificationChallengeForScoring,
+      id: certificationChallengeForScoring.challengeId,
+    });
+  });
+}

--- a/api/src/shared/infrastructure/repositories/challenge-repository.js
+++ b/api/src/shared/infrastructure/repositories/challenge-repository.js
@@ -112,15 +112,6 @@ export async function getManyTypes(ids) {
   return Object.fromEntries(challenges.map(({ id, type }) => [id, type]));
 }
 
-export async function getManyFlashParameters(ids) {
-  const challenges = await challengeDatasource.getMany(ids);
-  return challenges.map(({ id, alpha, delta }) => ({
-    id,
-    discriminant: alpha,
-    difficulty: delta,
-  }));
-}
-
 export {
   get,
   getMany,

--- a/api/tests/certification/course/acceptance/application/certification-course-route_test.js
+++ b/api/tests/certification/course/acceptance/application/certification-course-route_test.js
@@ -11,52 +11,107 @@ import { Assessment } from '../../../../../src/shared/domain/models/Assessment.j
 
 describe('Acceptance | Route | certification-course', function () {
   describe('POST /api/admin/certification-courses/{id}/reject', function () {
-    it('should create a new rejected AssessmentResult', async function () {
-      // given
-      const userId = (await insertUserWithRoleSuperAdmin()).id;
+    describe('when certification is V2', function () {
+      it('should create a new rejected AssessmentResult', async function () {
+        // given
+        const userId = (await insertUserWithRoleSuperAdmin()).id;
 
-      const session = databaseBuilder.factory.buildSession({
-        publishedAt: new Date('2018-12-01T01:02:03Z'),
+        const session = databaseBuilder.factory.buildSession({
+          publishedAt: new Date('2018-12-01T01:02:03Z'),
+        });
+
+        const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+          sessionId: session.id,
+          userId,
+        });
+
+        const { assessment, assessmentResult } = await createSuccessfulCertificationCourse({
+          userId,
+          certificationCourse,
+        });
+
+        const server = await createServer();
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: `/api/admin/certification-courses/${certificationCourse.id}/reject`,
+          headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        });
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        const rejectedCertificationCourse = await knex('certification-courses').first();
+        const assessmentResults = await knex('assessment-results')
+          .where({
+            assessmentId: assessment.id,
+          })
+          .orderBy('createdAt');
+
+        expect(rejectedCertificationCourse.isRejectedForFraud).to.equal(true);
+        expect(assessmentResults).to.have.length(2);
+        expect(assessmentResults[0]).to.deep.equal(assessmentResult);
+        expect(assessmentResults[1].status).to.equal('rejected');
+
+        const lastAssessmentResult = await knex('certification-courses-last-assessment-results').first();
+
+        expect(lastAssessmentResult).to.deep.equal({
+          certificationCourseId: certificationCourse.id,
+          lastAssessmentResultId: assessmentResults[1].id,
+        });
       });
+    });
 
-      const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
-        sessionId: session.id,
-        userId,
-      });
+    describe('when certification is V3', function () {
+      it('should create a new rejected AssessmentResult', async function () {
+        // given
+        const userId = (await insertUserWithRoleSuperAdmin()).id;
 
-      const { assessment, assessmentResult } = await createSuccessfulCertificationCourse({
-        userId,
-        certificationCourse,
-      });
+        const session = databaseBuilder.factory.buildSession({
+          publishedAt: new Date('2018-12-01T01:02:03Z'),
+          version: 3,
+        });
 
-      const server = await createServer();
+        const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+          sessionId: session.id,
+          userId,
+          version: 3,
+        });
 
-      // when
-      const response = await server.inject({
-        method: 'POST',
-        url: `/api/admin/certification-courses/${certificationCourse.id}/reject`,
-        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
-      });
+        const { assessment, assessmentResult } = await createSuccessfulCertificationCourse({
+          userId,
+          certificationCourse,
+        });
 
-      // then
-      expect(response.statusCode).to.equal(200);
-      const rejectedCertificationCourse = await knex('certification-courses').first();
-      const assessmentResults = await knex('assessment-results')
-        .where({
-          assessmentId: assessment.id,
-        })
-        .orderBy('createdAt');
+        const server = await createServer();
 
-      expect(rejectedCertificationCourse.isRejectedForFraud).to.equal(true);
-      expect(assessmentResults).to.have.length(2);
-      expect(assessmentResults[0]).to.deep.equal(assessmentResult);
-      expect(assessmentResults[1].status).to.equal('rejected');
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: `/api/admin/certification-courses/${certificationCourse.id}/reject`,
+          headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        });
 
-      const lastAssessmentResult = await knex('certification-courses-last-assessment-results').first();
+        // then
+        expect(response.statusCode).to.equal(200);
+        const rejectedCertificationCourse = await knex('certification-courses').first();
+        const assessmentResults = await knex('assessment-results')
+          .where({
+            assessmentId: assessment.id,
+          })
+          .orderBy('createdAt');
 
-      expect(lastAssessmentResult).to.deep.equal({
-        certificationCourseId: certificationCourse.id,
-        lastAssessmentResultId: assessmentResults[1].id,
+        expect(rejectedCertificationCourse.isRejectedForFraud).to.equal(true);
+        expect(assessmentResults).to.have.length(2);
+        expect(assessmentResults[0]).to.deep.equal(assessmentResult);
+        expect(assessmentResults[1].status).to.equal('rejected');
+
+        const lastAssessmentResult = await knex('certification-courses-last-assessment-results').first();
+
+        expect(lastAssessmentResult).to.deep.equal({
+          certificationCourseId: certificationCourse.id,
+          lastAssessmentResultId: assessmentResults[1].id,
+        });
       });
     });
   });

--- a/api/tests/certification/scoring/integration/infrastructure/repositories/certification-challenge-for-scoring-repository_test.js
+++ b/api/tests/certification/scoring/integration/infrastructure/repositories/certification-challenge-for-scoring-repository_test.js
@@ -1,0 +1,55 @@
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+import { getByCertificationCourseId } from '../../../../../../src/certification/scoring/infrastructure/repositories/certification-challenge-for-scoring-repository.js';
+import { CertificationChallengeForScoring } from '../../../../../../src/certification/scoring/domain/models/CertificationChallengeForScoring.js';
+
+describe('Integration | Infrastructure | Repository | CertificationChallengeForScoringRepository', function () {
+  describe('#getByCertificationCourseId', function () {
+    let certificationCourseId;
+
+    beforeEach(async function () {
+      const userId = databaseBuilder.factory.buildUser().id;
+      const sessionId = databaseBuilder.factory.buildSession().id;
+
+      certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+        userId,
+        sessionId,
+      }).id;
+
+      await databaseBuilder.commit();
+    });
+    describe('when there is no challenge', function () {
+      it('should return an empty array', async function () {
+        const challenges = await getByCertificationCourseId({ certificationCourseId });
+
+        expect(challenges.length).to.equal(0);
+      });
+    });
+
+    describe('when there are 2 challenges', function () {
+      it('should return all certification challenges for scoring for the certification course', async function () {
+        databaseBuilder.factory.buildCertificationChallenge({
+          id: 1,
+          challengeId: 'challenge_id_1',
+          courseId: certificationCourseId,
+          discriminant: 1.1,
+          difficulty: 1,
+        });
+
+        databaseBuilder.factory.buildCertificationChallenge({
+          id: 2,
+          challengeId: 'challenge_id_2',
+          courseId: certificationCourseId,
+          discriminant: 1.2,
+          difficulty: 1,
+        });
+
+        await databaseBuilder.commit();
+
+        const challenges = await getByCertificationCourseId({ certificationCourseId });
+
+        expect(challenges.length).to.equal(2);
+        expect(challenges[0]).to.be.instanceOf(CertificationChallengeForScoring);
+      });
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
@@ -719,36 +719,6 @@ describe('Integration | Repository | challenge-repository', function () {
       });
     });
   });
-
-  describe('#getManyFlashParameters', function () {
-    it('should return an object associating ids to discriminant and difficulty', async function () {
-      // given
-      const skill = _buildSkill({ id: 'recSkill1' });
-
-      const challenge1 = _buildChallenge({ id: 'recChallenge1', skill, locales: ['fr'], alpha: 0.567, delta: 0.123 });
-      const challenge2 = _buildChallenge({ id: 'recChallenge2', skill, locales: ['fr-fr'], alpha: 0.56, delta: 0.12 });
-      const challenge3 = _buildChallenge({ id: 'recChallenge3', skill, locales: ['en'], alpha: 0.5, delta: 0.1 });
-
-      mockLearningContent({
-        skills: [skill],
-        challenges: [challenge1, challenge2, challenge3],
-      });
-
-      // when
-      const challengesFlashParameters = await challengeRepository.getManyFlashParameters([
-        'recChallenge1',
-        'recChallenge2',
-        'recChallenge3',
-      ]);
-
-      // then
-      expect(challengesFlashParameters).to.deep.equal([
-        { id: 'recChallenge1', discriminant: 0.567, difficulty: 0.123 },
-        { id: 'recChallenge2', discriminant: 0.56, difficulty: 0.12 },
-        { id: 'recChallenge3', discriminant: 0.5, difficulty: 0.1 },
-      ]);
-    });
-  });
 });
 
 function _buildSkill({ id, name = '@sau6', tubeId = 'recTUB123' }) {

--- a/api/tests/tooling/domain-builder/factory/certification/scoring/build-certification-challenge-for-scoring.js
+++ b/api/tests/tooling/domain-builder/factory/certification/scoring/build-certification-challenge-for-scoring.js
@@ -1,0 +1,11 @@
+import { CertificationChallengeForScoring } from '../../../../../../src/certification/scoring/domain/models/CertificationChallengeForScoring.js';
+
+const buildCertificationChallengeForScoring = function ({ id = 123, discriminant = 0.5, difficulty = 2.1 } = {}) {
+  return new CertificationChallengeForScoring({
+    id,
+    discriminant,
+    difficulty,
+  });
+};
+
+export { buildCertificationChallengeForScoring };

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -32,6 +32,7 @@ import { buildCertificationCandidate } from './build-certification-candidate.js'
 import { buildCertificationCandidateForAttendanceSheet } from './build-certification-candidate-for-attendance-sheet.js';
 import { buildCertificationCandidateForSupervising } from './build-certification-candidate-for-supervising.js';
 import { buildCertificationCandidateSubscription } from './build-certification-candidate-subscription.js';
+import { buildCertificationChallengeForScoring } from './certification/scoring/build-certification-challenge-for-scoring.js';
 import { buildCertificationEligibility } from './build-certification-eligibility.js';
 import { buildCertificationIssueReport } from './build-certification-issue-report.js';
 import { buildCertificationOfficer } from './build-certification-officer.js';
@@ -212,6 +213,7 @@ export {
   buildCertificationCandidateForAttendanceSheet,
   buildCertificationCandidateForSupervising,
   buildCertificationCandidateSubscription,
+  buildCertificationChallengeForScoring,
   buildCertificationEligibility,
   buildCertificationIssueReport,
   buildCertificationOfficer,

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -27,8 +27,8 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
   describe('when handling a v3 certification', function () {
     let assessmentResultRepository,
       certificationAssessmentRepository,
+      certificationChallengeForScoringRepository,
       answerRepository,
-      challengeRepository,
       certificationCourseRepository,
       flashAlgorithmConfigurationRepository,
       flashAlgorithmService;
@@ -44,30 +44,27 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
       certificationAssessmentRepository = {
         getByCertificationCourseId: sinon.stub(),
       };
+      certificationChallengeForScoringRepository = {
+        getByCertificationCourseId: sinon.stub(),
+      };
       answerRepository = {
         findByAssessment: sinon.stub(),
       };
-      challengeRepository = {
-        getManyFlashParameters: sinon.stub(),
-      };
-
       certificationCourseRepository = {
         get: sinon.stub(),
         update: sinon.stub().resolves(),
       };
-
       flashAlgorithmConfigurationRepository = {
         get: sinon.stub(),
       };
-
       flashAlgorithmService = {
         getEstimatedLevelAndErrorRate: sinon.stub(),
       };
 
       dependencies = {
         certificationAssessmentRepository,
+        certificationChallengeForScoringRepository,
         answerRepository,
-        challengeRepository,
         assessmentResultRepository,
         certificationCourseRepository,
         flashAlgorithmConfigurationRepository,
@@ -91,13 +88,18 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           });
 
           const challenges = generateChallengeList({ length: minimumAnswersRequiredToValidateACertification - 1 });
-          const challengeIds = challenges.map(({ id }) => id);
-
+          const certificationChallengesForScoring = challenges.map((challenge) =>
+            domainBuilder.buildCertificationChallengeForScoring(challenge),
+          );
           const answers = generateAnswersForChallenges({ challenges });
 
           const expectedEstimatedLevel = 2;
           const scoreForEstimatedLevel = 592;
           const { certificationCourseId } = certificationAssessment;
+
+          certificationChallengeForScoringRepository.getByCertificationCourseId
+            .withArgs({ certificationCourseId })
+            .resolves(certificationChallengesForScoring);
 
           certificationAssessmentRepository.getByCertificationCourseId
             .withArgs({ certificationCourseId })
@@ -105,15 +107,13 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
 
           answerRepository.findByAssessment.withArgs(certificationAssessment.id).resolves(answers);
 
-          challengeRepository.getManyFlashParameters.withArgs(challengeIds).resolves(challenges);
-
           certificationCourseRepository.get
             .withArgs(certificationAssessment.certificationCourseId)
             .resolves(abortedCertificationCourse);
 
           flashAlgorithmService.getEstimatedLevelAndErrorRate
             .withArgs({
-              challenges,
+              challenges: certificationChallengesForScoring,
               allAnswers: answers,
               estimatedLevel: sinon.match.number,
               variationPercent: undefined,
@@ -169,13 +169,18 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           });
 
           const challenges = generateChallengeList({ length: minimumAnswersRequiredToValidateACertification - 1 });
-          const challengeIds = challenges.map(({ id }) => id);
-
+          const certificationChallengesForScoring = challenges.map((challenge) =>
+            domainBuilder.buildCertificationChallengeForScoring(challenge),
+          );
           const answers = generateAnswersForChallenges({ challenges });
 
           const expectedEstimatedLevel = 2;
           const scoreForEstimatedLevel = 592;
           const { certificationCourseId } = certificationAssessment;
+
+          certificationChallengeForScoringRepository.getByCertificationCourseId
+            .withArgs({ certificationCourseId })
+            .resolves(certificationChallengesForScoring);
 
           certificationAssessmentRepository.getByCertificationCourseId
             .withArgs({ certificationCourseId })
@@ -183,15 +188,13 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
 
           answerRepository.findByAssessment.withArgs(certificationAssessment.id).resolves(answers);
 
-          challengeRepository.getManyFlashParameters.withArgs(challengeIds).resolves(challenges);
-
           certificationCourseRepository.get
             .withArgs(certificationAssessment.certificationCourseId)
             .resolves(abortedCertificationCourse);
 
           flashAlgorithmService.getEstimatedLevelAndErrorRate
             .withArgs({
-              challenges,
+              challenges: certificationChallengesForScoring,
               allAnswers: answers,
               estimatedLevel: sinon.match.number,
               variationPercent: undefined,
@@ -261,21 +264,24 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           });
 
           const challenges = generateChallengeList({ length: minimumAnswersRequiredToValidateACertification });
-          const challengeIds = challenges.map(({ id }) => id);
-
+          const certificationChallengesForScoring = challenges.map((challenge) =>
+            domainBuilder.buildCertificationChallengeForScoring(challenge),
+          );
           const answers = generateAnswersForChallenges({ challenges });
 
           const expectedEstimatedLevel = 2;
           const rawScore = 592;
           const { certificationCourseId } = certificationAssessment;
 
+          certificationChallengeForScoringRepository.getByCertificationCourseId
+            .withArgs({ certificationCourseId })
+            .resolves(certificationChallengesForScoring);
+
           certificationAssessmentRepository.getByCertificationCourseId
             .withArgs({ certificationCourseId })
             .resolves(certificationAssessment);
 
           answerRepository.findByAssessment.withArgs(certificationAssessment.id).resolves(answers);
-
-          challengeRepository.getManyFlashParameters.withArgs(challengeIds).resolves(challenges);
 
           certificationCourseRepository.get
             .withArgs(certificationAssessment.certificationCourseId)
@@ -285,7 +291,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
 
           flashAlgorithmService.getEstimatedLevelAndErrorRate
             .withArgs({
-              challenges,
+              challenges: certificationChallengesForScoring,
               allAnswers: answers,
               estimatedLevel: sinon.match.number,
               variationPercent: undefined,
@@ -341,21 +347,24 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           });
 
           const challenges = generateChallengeList({ length: minimumAnswersRequiredToValidateACertification });
-          const challengeIds = challenges.map(({ id }) => id);
-
+          const certificationChallengesForScoring = challenges.map((challenge) =>
+            domainBuilder.buildCertificationChallengeForScoring(challenge),
+          );
           const answers = generateAnswersForChallenges({ challenges });
 
           const expectedEstimatedLevel = 2;
           const degradedScore = 474;
           const { certificationCourseId } = certificationAssessment;
 
+          certificationChallengeForScoringRepository.getByCertificationCourseId
+            .withArgs({ certificationCourseId })
+            .resolves(certificationChallengesForScoring);
+
           certificationAssessmentRepository.getByCertificationCourseId
             .withArgs({ certificationCourseId })
             .resolves(certificationAssessment);
 
           answerRepository.findByAssessment.withArgs(certificationAssessment.id).resolves(answers);
-
-          challengeRepository.getManyFlashParameters.withArgs(challengeIds).resolves(challenges);
 
           certificationCourseRepository.get
             .withArgs(certificationAssessment.certificationCourseId)
@@ -365,7 +374,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
 
           flashAlgorithmService.getEstimatedLevelAndErrorRate
             .withArgs({
-              challenges,
+              challenges: certificationChallengesForScoring,
               allAnswers: answers,
               estimatedLevel: sinon.match.number,
               variationPercent: undefined,
@@ -422,13 +431,18 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         });
 
         const challenges = generateChallengeList({ length: maximumAssessmentLength });
-        const challengeIds = challenges.map(({ id }) => id);
-
+        const certificationChallengesForScoring = challenges.map((challenge) =>
+          domainBuilder.buildCertificationChallengeForScoring(challenge),
+        );
         const answers = generateAnswersForChallenges({ challenges });
 
         const expectedEstimatedLevel = 2;
         const scoreForEstimatedLevel = 592;
         const { certificationCourseId } = certificationAssessment;
+
+        certificationChallengeForScoringRepository.getByCertificationCourseId
+          .withArgs({ certificationCourseId })
+          .resolves(certificationChallengesForScoring);
 
         certificationAssessmentRepository.getByCertificationCourseId
           .withArgs({ certificationCourseId })
@@ -438,15 +452,13 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
 
         answerRepository.findByAssessment.withArgs(certificationAssessment.id).resolves(answers);
 
-        challengeRepository.getManyFlashParameters.withArgs(challengeIds).resolves(challenges);
-
         certificationCourseRepository.get
           .withArgs(certificationAssessment.certificationCourseId)
           .resolves(abortedCertificationCourse);
 
         flashAlgorithmService.getEstimatedLevelAndErrorRate
           .withArgs({
-            challenges,
+            challenges: certificationChallengesForScoring,
             allAnswers: answers,
             estimatedLevel: sinon.match.number,
             variationPercent: undefined,
@@ -489,6 +501,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
 
         expect(result).to.deep.equal(expectedEvent);
       });
+
       describe('when certification is rejected for fraud', function () {
         it('should save the score with rejected status', async function () {
           const certificationAssessment = domainBuilder.buildCertificationAssessment({
@@ -500,13 +513,18 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           });
 
           const challenges = generateChallengeList({ length: maximumAssessmentLength });
-          const challengeIds = challenges.map(({ id }) => id);
-
+          const certificationChallengesForScoring = challenges.map((challenge) =>
+            domainBuilder.buildCertificationChallengeForScoring(challenge),
+          );
           const answers = generateAnswersForChallenges({ challenges });
 
           const expectedEstimatedLevel = 2;
           const scoreForEstimatedLevel = 592;
           const { certificationCourseId } = certificationAssessment;
+
+          certificationChallengeForScoringRepository.getByCertificationCourseId
+            .withArgs({ certificationCourseId })
+            .resolves(certificationChallengesForScoring);
 
           certificationAssessmentRepository.getByCertificationCourseId
             .withArgs({ certificationCourseId })
@@ -516,15 +534,13 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
 
           answerRepository.findByAssessment.withArgs(certificationAssessment.id).resolves(answers);
 
-          challengeRepository.getManyFlashParameters.withArgs(challengeIds).resolves(challenges);
-
           certificationCourseRepository.get
             .withArgs(certificationAssessment.certificationCourseId)
             .resolves(abortedCertificationCourse);
 
           flashAlgorithmService.getEstimatedLevelAndErrorRate
             .withArgs({
-              challenges,
+              challenges: certificationChallengesForScoring,
               allAnswers: answers,
               estimatedLevel: sinon.match.number,
               variationPercent: undefined,
@@ -578,13 +594,19 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           const abortedCertificationCourse = domainBuilder.buildCertificationCourse({});
 
           const challenges = generateChallengeList({ length: maximumAssessmentLength });
-          const challengeIds = challenges.map(({ id }) => id);
+          const certificationChallengesForScoring = challenges.map((challenge) =>
+            domainBuilder.buildCertificationChallengeForScoring(challenge),
+          );
 
           const answers = generateAnswersForChallenges({ challenges });
 
           const expectedEstimatedLevel = 8;
           const cappedScoreForEstimatedLevel = 896;
           const { certificationCourseId } = certificationAssessment;
+
+          certificationChallengeForScoringRepository.getByCertificationCourseId
+            .withArgs({ certificationCourseId })
+            .resolves(certificationChallengesForScoring);
 
           certificationAssessmentRepository.getByCertificationCourseId
             .withArgs({ certificationCourseId })
@@ -594,15 +616,13 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
 
           answerRepository.findByAssessment.withArgs(certificationAssessment.id).resolves(answers);
 
-          challengeRepository.getManyFlashParameters.withArgs(challengeIds).resolves(challenges);
-
           certificationCourseRepository.get
             .withArgs(certificationAssessment.certificationCourseId)
             .resolves(abortedCertificationCourse);
 
           flashAlgorithmService.getEstimatedLevelAndErrorRate
             .withArgs({
-              challenges,
+              challenges: certificationChallengesForScoring,
               allAnswers: answers,
               estimatedLevel: sinon.match.number,
               variationPercent: undefined,


### PR DESCRIPTION
## :christmas_tree: Problème

Une certif peut avoir besoin d’un rescoring.
Aujourd’hui, on se base sur les infos du challenge pour procéder à ce rescoring, ce qui veut dire qu’en cas de mise à jour de la calibration, le candidat ne sera pas scoré sur les mêmes règles qu’au moment de sa certification.

## :gift: Proposition

En cas de rescoring, prendre en compte les certif-challenge qui portent l’info de la calibration au moment de la certif.

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester

• créer une session v3 et inscrire un candidat
• lancer le test avec le candidat, et terminer la session (qu'importe le résultat ou le nombre de questions passées)
• Dans Pix-Admin, rejeter la certification
• Constater que ça fonctionne toujours
