### PR TITLE
[FEATURE] Accepte externalId comme alias pour participantExternalId (PIX-10819).

### DIFF
--- a/mon-pix/app/routes/campaigns/entry-point.js
+++ b/mon-pix/app/routes/campaigns/entry-point.js
@@ -24,8 +24,9 @@ export default class EntryPoint extends Route {
     this.campaignStorage.clear(campaign.code);
 
     const queryParams = transition.to.queryParams;
-    if (queryParams.participantExternalId) {
-      this.campaignStorage.set(campaign.code, 'participantExternalId', transition.to.queryParams.participantExternalId);
+    if (queryParams.participantExternalId || queryParams.externalId) {
+      const participantExternalId = queryParams.participantExternalId || queryParams.externalId;
+      this.campaignStorage.set(campaign.code, 'participantExternalId', participantExternalId);
     }
     if (queryParams.retry) {
       this.metrics.add({

--- a/mon-pix/tests/unit/routes/campaigns/entry-point_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/entry-point_test.js
@@ -247,6 +247,23 @@ module('Unit | Route | Entry Point', function (hooks) {
           sinon.assert.calledWith(route.campaignStorage.set, campaign.code, 'participantExternalId', 'externalId');
           assert.ok(true);
         });
+
+        test('allow externalId as alias', async function (assert) {
+          //given
+          transition = { to: { queryParams: { externalId: 'externalId' } } };
+          route.currentUser = {
+            user: {
+              id: 12,
+            },
+          };
+
+          //when
+          await route.afterModel(campaign, transition);
+
+          //then
+          sinon.assert.calledWith(route.campaignStorage.set, campaign.code, 'participantExternalId', 'externalId');
+          assert.ok(true);
+        });
       });
 
       module('when there is no participantExternalId', function () {


### PR DESCRIPTION
## :christmas_tree: Problème
Dans le cadre de l’observatoire des compétences, le partenaire Bilendi a fait un développement spécifique pour être en mesure de nous envoyer et récupérer l’identifiant de chaque personne interrogée via la variable externalId.

## :gift: Proposition
On ajoute externalId comme alias de participantExternalId en query param.

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Se connecter à PixApp
- Participer à la campagne PROASSIMP en mettant l'externalId en query param : http://localhost:4200/campagnes/PROASSIMP?externalId=Toto
- Constater qu'on ne voit pas la page qui demande la saisie du participant external id
- Aller sur Orga et vérifier dans la page d'activité de la campagne qu'on retrouve bien le participantExternalId