### PR TITLE
[BUGFIX] Corrige le crash de l'affichage des détails d'une certif v3 lorsqu'une réponse est dans certains status (PIX-10876)

### DIFF
--- a/admin/app/components/certifications/certification/details-v3.js
+++ b/admin/app/components/certifications/certification/details-v3.js
@@ -3,6 +3,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { subcategoryToCode, subcategoryToLabel } from '../../../models/certification-issue-report';
 import { abortReasons, assessmentStates } from '../../../models/v3-certification-course-details-for-administration';
+import { AnswerStatus } from '../../../models/certification-challenges-for-administration';
 
 const successColor = 'success';
 const errorColor = 'error';
@@ -16,14 +17,46 @@ const abortReasonMap = {
 };
 
 const answerStatusMap = [
-  { value: 'ok', label: 'pages.certifications.certification.details.v3.answer-status.ok', color: successColor },
-  { value: 'ko', label: 'pages.certifications.certification.details.v3.answer-status.ko', color: neutralColor },
+  {
+    value: AnswerStatus.OK,
+    label: 'pages.certifications.certification.details.v3.answer-status.ok',
+    color: successColor,
+  },
+  {
+    value: AnswerStatus.KO,
+    label: 'pages.certifications.certification.details.v3.answer-status.ko',
+    color: neutralColor,
+  },
   {
     value: null,
     label: 'pages.certifications.certification.details.v3.answer-status.validated-live-alert',
     color: errorColor,
   },
-  { value: 'aband', label: 'pages.certifications.certification.details.v3.answer-status.aband', color: tertiaryColor },
+  {
+    value: AnswerStatus.ABAND,
+    label: 'pages.certifications.certification.details.v3.answer-status.aband',
+    color: tertiaryColor,
+  },
+  {
+    value: AnswerStatus.TIMEDOUT,
+    label: 'pages.certifications.certification.details.v3.answer-status.timedout',
+    color: secondaryColor,
+  },
+  {
+    value: AnswerStatus.FOCUSEDOUT,
+    label: 'pages.certifications.certification.details.v3.answer-status.focused-out',
+    color: secondaryColor,
+  },
+  {
+    value: AnswerStatus.PARTIALLY,
+    label: 'pages.certifications.certification.details.v3.answer-status.partially-ok',
+    color: secondaryColor,
+  },
+  {
+    value: AnswerStatus.UNIMPLEMENTED,
+    label: 'pages.certifications.certification.details.v3.answer-status.unimplemented',
+    color: secondaryColor,
+  },
 ];
 
 const assessmentResultStatusLabelAndColor = (status) => ({

--- a/admin/app/models/certification-challenges-for-administration.js
+++ b/admin/app/models/certification-challenges-for-administration.js
@@ -1,4 +1,14 @@
 import Model, { attr } from '@ember-data/model';
+
+export const AnswerStatus = {
+  OK: 'ok',
+  KO: 'ko',
+  ABAND: 'aband',
+  TIMEDOUT: 'timedout',
+  FOCUSEDOUT: 'focusedOut',
+  PARTIALLY: 'partially',
+  UNIMPLEMENTED: 'unimplemented',
+};
 export default class CertificationChallengesForAdministration extends Model {
   @attr() answerStatus;
   @attr() answeredAt;

--- a/admin/tests/integration/components/certifications/certification/details-v3_test.js
+++ b/admin/tests/integration/components/certifications/certification/details-v3_test.js
@@ -49,6 +49,50 @@ const answers = [
     competenceIndex: '1.3',
     skillName: '@rec124',
   },
+  {
+    id: 5,
+    questionNumber: '4',
+    answerStatus: 'timedout',
+    answerStatusName: 'Temps écoulé',
+    validatedLiveAlert: false,
+    answeredAt: new Date('2020-01-01T17:13:00Z'),
+    competenceName: 'Réparer les couteaux',
+    competenceIndex: '1.3',
+    skillName: '@rec124',
+  },
+  {
+    id: 6,
+    questionNumber: '5',
+    answerStatus: 'focusedOut',
+    answerStatusName: 'Focus out',
+    validatedLiveAlert: false,
+    answeredAt: new Date('2020-01-01T17:13:00Z'),
+    competenceName: 'Concevoir les couteaux',
+    competenceIndex: '1.3',
+    skillName: '@rec124',
+  },
+  {
+    id: 7,
+    questionNumber: '6',
+    answerStatus: 'partially',
+    answerStatusName: 'Partiellement OK',
+    validatedLiveAlert: false,
+    answeredAt: new Date('2020-01-01T17:13:00Z'),
+    competenceName: 'Aiguiser les couteaux',
+    competenceIndex: '1.3',
+    skillName: '@rec124',
+  },
+  {
+    id: 8,
+    questionNumber: '7',
+    answerStatus: 'unimplemented',
+    answerStatusName: 'Non implémentée',
+    validatedLiveAlert: false,
+    answeredAt: new Date('2020-01-01T17:13:00Z'),
+    competenceName: 'Aiguiser les couteaux',
+    competenceIndex: '1.3',
+    skillName: '@rec124',
+  },
 ];
 
 module('Integration | Component | Certifications | certification > details v3', function (hooks) {
@@ -312,7 +356,7 @@ module('Integration | Component | Certifications | certification > details v3', 
         assert.dom(screen.getByRole('heading', { name: 'Liste des questions' })).exists();
 
         const linesWithResults = screen.getAllByRole('row').slice(1);
-        assert.strictEqual(linesWithResults.length, 4);
+        assert.strictEqual(linesWithResults.length, answers.length);
 
         const result = [];
 

--- a/admin/tests/unit/components/certifications/certification/details-v3_test.js
+++ b/admin/tests/unit/components/certifications/certification/details-v3_test.js
@@ -20,6 +20,26 @@ module('Unit | Component | certifications/certification/details-v3', function (h
       color: 'error',
     },
     { value: 'aband', label: 'pages.certifications.certification.details.v3.answer-status.aband', color: 'tertiary' },
+    {
+      value: 'timedout',
+      label: 'pages.certifications.certification.details.v3.answer-status.timedout',
+      color: 'secondary',
+    },
+    {
+      value: 'focusedOut',
+      label: 'pages.certifications.certification.details.v3.answer-status.focused-out',
+      color: 'secondary',
+    },
+    {
+      value: 'partially',
+      label: 'pages.certifications.certification.details.v3.answer-status.partially-ok',
+      color: 'secondary',
+    },
+    {
+      value: 'unimplemented',
+      label: 'pages.certifications.certification.details.v3.answer-status.unimplemented',
+      color: 'secondary',
+    },
   ];
 
   module('answerStatusLabel', function () {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -175,8 +175,12 @@
             },
             "answer-status": {
               "aband": "Abandonnée",
+              "focused-out": "Focus out",
               "ko": "KO",
               "ok": "OK",
+              "partially-ok": "Partiellement OK",
+              "timedout": "Temps écoulé",
+              "unimplemented": "Non implémentée",
               "validated-live-alert": "Signalement validé"
             },
             "assessment-result-status": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -185,8 +185,12 @@
             },
             "answer-status": {
               "aband": "Abandonnée",
+              "focused-out": "Focus out",
               "ko": "KO",
               "ok": "OK",
+              "partially-ok": "Partiellement OK",
+              "timedout": "Temps écoulé",
+              "unimplemented": "Non implémentée",
               "validated-live-alert": "Signalement validé"
             },
             "assessment-result-status": {

--- a/api/db/seeds/data/team-certification/data-builder.js
+++ b/api/db/seeds/data/team-certification/data-builder.js
@@ -638,8 +638,8 @@ async function _createIssueReportCategories({ databaseBuilder }) {
 }
 
 async function _createAPublishedV3CertificationSession({ databaseBuilder }) {
-  const answers = ['ok', 'ko'];
-  const scores = [640, 29];
+  const answers = ['ok', 'ko', 'focusedOut'];
+  const scores = [640, 29, 0];
   const numberOfChallengesPerCourse = 32;
 
   const { certificationCandidates } = await _createPublishedV3Session({


### PR DESCRIPTION
## :christmas_tree: Problème
Lorsqu'une réponse est dans un des status suivant, l'affichage des détails d'une certif v3 crash : 
'timedout', 'focusedOut', 'partially', 'unimplemented'

## :gift: Proposition
Supporter l'affichage de ces status.


## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
