### PR TITLE
[BUGFIX] La dernière participation partagée affichée devrait être celle de la campagne en question (PIX-10880)

### DIFF
--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-participant-activity-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-participant-activity-repository.js
@@ -42,6 +42,7 @@ function _buildCampaignParticipationByParticipant(queryBuilder, campaignId, filt
         .whereRaw('"organizationLearnerId" = "view-active-organization-learners"."id"')
         .and.where('status', CampaignParticipationStatuses.SHARED)
         .and.whereNull('campaign-participations.deletedAt')
+        .and.where('campaignId', campaignId)
         .orderBy('sharedAt', 'desc')
         .limit(1)
         .as('lastSharedCampaignParticipationId'),


### PR DESCRIPTION
## :christmas_tree: Problème
Nous avons introduit un bug dans le [ticket](https://1024pix.atlassian.net/jira/software/c/projects/PIX/boards/93?selectedIssue=PIX-10449) 

Le code du repository `campaign-participant-activity` pour l’attribut `lastSharedCampaignParticipationId` ne fait de ségrégation sur la campagne. On retourne donc l’id de la dernière participation partagée par le prescrit toutes campagnes de l’organisation confondu.

## :gift: Proposition
Réparer ça

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester

- Se connecter avec le compte PRO à PixOrga
- Créer une deuxième campagne d'évaluation avec participantExternalId
- Se connecter avec un compte utilisateur à PixApp
- Participer à la campagne PROASSIMP et partager ses résultats
- Participer à la deuxième campagne que vous avez créée
- Sur Orga se rendre sur la page d’activite de la campagne PROASSIMP
- Cliquer sur la participation du compte PixApp avec lequel vous vous êtes connecté
- Constater que le participantExternalId et les compétences testées sont bien celles de de PROASSIMP