### PR TITLE
[TECH] Renommage de l'utilitaire de combinaison des security prehandlers (PIX-10967)

### DIFF
--- a/api/lib/application/campaign-participations/index.js
+++ b/api/lib/application/campaign-participations/index.js
@@ -168,7 +168,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
@@ -196,7 +196,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
               ])(request, h),

--- a/api/lib/application/campaigns-administration/index.js
+++ b/api/lib/application/campaigns-administration/index.js
@@ -16,11 +16,11 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
               ])(request, h),
-            assign: 'adminMemberHasAtLeastOneAccessOf',
+            assign: 'hasAtLeastOneAccessOf',
           },
         ],
         payload: {

--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -24,7 +24,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -53,7 +53,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,

--- a/api/lib/application/certification-center-invitations/index.js
+++ b/api/lib/application/certification-center-invitations/index.js
@@ -13,7 +13,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,

--- a/api/lib/application/certification-center-memberships/index.js
+++ b/api/lib/application/certification-center-memberships/index.js
@@ -62,7 +62,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -87,7 +87,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -13,7 +13,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -37,7 +37,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -60,7 +60,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -89,7 +89,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -118,7 +118,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -152,7 +152,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -175,7 +175,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -216,7 +216,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,

--- a/api/lib/application/certification-courses/index.js
+++ b/api/lib/application/certification-courses/index.js
@@ -13,7 +13,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -43,7 +43,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -77,7 +77,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -104,7 +104,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -174,7 +174,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -198,7 +198,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,

--- a/api/lib/application/certification-issue-reports/index.js
+++ b/api/lib/application/certification-issue-reports/index.js
@@ -45,7 +45,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,

--- a/api/lib/application/certifications/index.js
+++ b/api/lib/application/certifications/index.js
@@ -72,7 +72,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -101,7 +101,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,

--- a/api/lib/application/complementary-certification-course-results/index.js
+++ b/api/lib/application/complementary-certification-course-results/index.js
@@ -28,7 +28,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,

--- a/api/lib/application/complementary-certifications/index.js
+++ b/api/lib/application/complementary-certifications/index.js
@@ -11,7 +11,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
@@ -40,7 +40,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,

--- a/api/lib/application/frameworks/index.js
+++ b/api/lib/application/frameworks/index.js
@@ -13,7 +13,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
@@ -35,7 +35,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,

--- a/api/lib/application/memberships/index.js
+++ b/api/lib/application/memberships/index.js
@@ -13,7 +13,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
@@ -42,7 +42,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
@@ -77,7 +77,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,

--- a/api/lib/application/organization-learners/index.js
+++ b/api/lib/application/organization-learners/index.js
@@ -15,7 +15,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
               ])(request, h),

--- a/api/lib/application/organizations-administration/index.js
+++ b/api/lib/application/organizations-administration/index.js
@@ -19,7 +19,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -48,7 +48,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -21,7 +21,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
@@ -45,9 +45,10 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
-                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-              ])(request, h),
+              securityPreHandlers.hasAtLeastOneAccessOf([securityPreHandlers.checkAdminMemberHasRoleSuperAdmin])(
+                request,
+                h,
+              ),
             assign: 'hasAuthorizationToAccessAdminScope',
           },
         ],
@@ -78,7 +79,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -118,7 +119,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
@@ -146,7 +147,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -175,7 +176,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -204,7 +205,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
@@ -233,7 +234,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
@@ -273,7 +274,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
@@ -310,7 +311,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -338,7 +339,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -367,7 +368,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -21,7 +21,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -50,7 +50,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -94,7 +94,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -119,7 +119,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -194,7 +194,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -226,7 +226,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -353,7 +353,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -385,7 +385,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -413,7 +413,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -441,7 +441,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -472,7 +472,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -500,7 +500,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,

--- a/api/lib/application/tags/index.js
+++ b/api/lib/application/tags/index.js
@@ -43,7 +43,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -67,7 +67,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,

--- a/api/lib/application/target-profiles-management/index.js
+++ b/api/lib/application/target-profiles-management/index.js
@@ -12,7 +12,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
               ])(request, h),

--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -14,7 +14,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
@@ -52,7 +52,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
@@ -80,7 +80,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
@@ -116,7 +116,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
@@ -144,7 +144,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
@@ -195,7 +195,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
@@ -226,7 +226,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
@@ -257,7 +257,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
@@ -302,7 +302,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
@@ -330,7 +330,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
@@ -359,7 +359,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -40,7 +40,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -86,7 +86,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -109,7 +109,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -136,7 +136,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -161,7 +161,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -189,7 +189,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -217,7 +217,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
               ])(request, h),
@@ -267,7 +267,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
               ])(request, h),
@@ -290,7 +290,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
               ])(request, h),
@@ -308,7 +308,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
               ])(request, h),
@@ -351,7 +351,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
               ])(request, h),
@@ -369,7 +369,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
               ])(request, h),

--- a/api/src/certification/complementary-certification/application/complementary-certification-route.js
+++ b/api/src/certification/complementary-certification/application/complementary-certification-route.js
@@ -10,7 +10,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,

--- a/api/src/certification/course/application/certification-attestation-route.js
+++ b/api/src/certification/course/application/certification-attestation-route.js
@@ -19,7 +19,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,

--- a/api/src/certification/course/application/certification-course-route.js
+++ b/api/src/certification/course/application/certification-course-route.js
@@ -17,7 +17,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -41,7 +41,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -60,7 +60,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -84,7 +84,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,

--- a/api/src/certification/session/application/certification-officer-route.js
+++ b/api/src/certification/session/application/certification-officer-route.js
@@ -19,7 +19,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,

--- a/api/src/certification/session/application/unfinalize-route.js
+++ b/api/src/certification/session/application/unfinalize-route.js
@@ -12,7 +12,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,

--- a/api/src/devcomp/application/trainings/index.js
+++ b/api/src/devcomp/application/trainings/index.js
@@ -14,7 +14,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
@@ -51,7 +51,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
@@ -79,7 +79,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -107,7 +107,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
               ])(request, h),
@@ -150,7 +150,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
               ])(request, h),
@@ -198,7 +198,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
               ])(request, h),
@@ -241,7 +241,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
               ])(request, h),

--- a/api/src/evaluation/application/autonomous-courses/index.js
+++ b/api/src/evaluation/application/autonomous-courses/index.js
@@ -14,7 +14,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
@@ -49,7 +49,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
@@ -84,7 +84,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
@@ -116,7 +116,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
@@ -144,7 +144,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,

--- a/api/src/evaluation/application/stage-collections/index.js
+++ b/api/src/evaluation/application/stage-collections/index.js
@@ -12,7 +12,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,

--- a/api/src/evaluation/application/stages/index.js
+++ b/api/src/evaluation/application/stages/index.js
@@ -12,7 +12,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,

--- a/api/src/prescription/campaign/application/campaign-administration-route.js
+++ b/api/src/prescription/campaign/application/campaign-administration-route.js
@@ -101,7 +101,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,

--- a/api/src/prescription/organization-place/application/organization-place-route.js
+++ b/api/src/prescription/organization-place/application/organization-place-route.js
@@ -13,7 +13,7 @@ const register = async (server) => {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -42,7 +42,7 @@ const register = async (server) => {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
               ])(request, h),
@@ -70,7 +70,7 @@ const register = async (server) => {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -98,7 +98,7 @@ const register = async (server) => {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
               ])(request, h),

--- a/api/src/prescription/target-profile/application/admin-target-profile-route.js
+++ b/api/src/prescription/target-profile/application/admin-target-profile-route.js
@@ -13,7 +13,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,

--- a/api/src/shared/application/assessments/index.js
+++ b/api/src/shared/application/assessments/index.js
@@ -86,7 +86,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -212,7 +212,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleCertif,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,

--- a/api/src/shared/application/badges/index.js
+++ b/api/src/shared/application/badges/index.js
@@ -12,7 +12,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,
@@ -55,7 +55,7 @@ const register = async function (server) {
         pre: [
           {
             method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+              securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                 securityPreHandlers.checkAdminMemberHasRoleSupport,
                 securityPreHandlers.checkAdminMemberHasRoleMetier,

--- a/api/src/shared/application/security-pre-handlers.js
+++ b/api/src/shared/application/security-pre-handlers.js
@@ -617,7 +617,7 @@ async function checkAuthorizationToAccessCampaign(
   return _replyForbiddenError(h);
 }
 
-function adminMemberHasAtLeastOneAccessOf(securityChecks) {
+function hasAtLeastOneAccessOf(securityChecks) {
   return async (request, h) => {
     const responses = await bluebird.map(securityChecks, (securityCheck) => securityCheck(request, h));
     const hasAccess = responses.some((response) => !response.source?.errors);
@@ -704,7 +704,7 @@ function _noOrganizationFound(error) {
 }
 
 const securityPreHandlers = {
-  adminMemberHasAtLeastOneAccessOf,
+  hasAtLeastOneAccessOf,
   checkAdminMemberHasRoleCertif,
   checkAdminMemberHasRoleMetier,
   checkAdminMemberHasRoleSuperAdmin,

--- a/api/tests/acceptance/application/security-pre-handlers_test.js
+++ b/api/tests/acceptance/application/security-pre-handlers_test.js
@@ -293,7 +293,7 @@ describe('Acceptance | Application | SecurityPreHandlers', function () {
     });
   });
 
-  describe('#adminMemberHasAtLeastOneAccessOf', function () {
+  describe('#hasAtLeastOneAccessOf', function () {
     let userId;
     let organizationId;
     let options;

--- a/api/tests/certification/complementary-certification/unit/application/complementary-certification-route_test.js
+++ b/api/tests/certification/complementary-certification/unit/application/complementary-certification-route_test.js
@@ -11,7 +11,7 @@ describe('Unit | Application | Certification | ComplementaryCertification | comp
         sinon
           .stub(complementaryCertificationController, 'getComplementaryCertificationTargetProfileHistory')
           .returns('ok');
-        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
 
@@ -32,7 +32,7 @@ describe('Unit | Application | Certification | ComplementaryCertification | comp
         sinon
           .stub(complementaryCertificationController, 'getComplementaryCertificationTargetProfileHistory')
           .returns('ok');
-        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns((request, h) =>
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns((request, h) =>
           h
             .response({ errors: new Error('') })
             .code(403)

--- a/api/tests/certification/course/unit/application/certification-attestation-route_test.js
+++ b/api/tests/certification/course/unit/application/certification-attestation-route_test.js
@@ -6,7 +6,7 @@ describe('Unit | Route | certification-attestation-route', function () {
     it('return forbidden access if user has METIER role', async function () {
       // given
       sinon
-        .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+        .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
         .withArgs([
           securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
           securityPreHandlers.checkAdminMemberHasRoleCertif,

--- a/api/tests/certification/course/unit/application/certification-course-route_test.js
+++ b/api/tests/certification/course/unit/application/certification-course-route_test.js
@@ -6,7 +6,7 @@ describe('Unit | Route | certification-course-route', function () {
     it('return forbidden access if user has METIER role', async function () {
       // given
       sinon
-        .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+        .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
         .withArgs([
           securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
           securityPreHandlers.checkAdminMemberHasRoleCertif,
@@ -34,7 +34,7 @@ describe('Unit | Route | certification-course-route', function () {
     it('return forbidden access if user has METIER role', async function () {
       // given
       sinon
-        .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+        .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
         .withArgs([
           securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
           securityPreHandlers.checkAdminMemberHasRoleCertif,
@@ -62,7 +62,7 @@ describe('Unit | Route | certification-course-route', function () {
     it('returns a 200', async function () {
       // given
       sinon
-        .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+        .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
         .withArgs([
           securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
           securityPreHandlers.checkAdminMemberHasRoleCertif,

--- a/api/tests/certification/session/unit/application/certification-officer-route_test.js
+++ b/api/tests/certification/session/unit/application/certification-officer-route_test.js
@@ -7,7 +7,7 @@ describe('Unit | Router | certification-officer-route', function () {
   describe('PATCH /api/admin/sessions/{id}/certification-officer-assignment', function () {
     it('should exist', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       sinon.stub(certificationOfficerController, 'assignCertificationOfficer').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
@@ -22,7 +22,7 @@ describe('Unit | Router | certification-officer-route', function () {
     it('return forbidden access if user has METIER role', async function () {
       // given
       sinon
-        .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+        .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
         .withArgs([
           securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
           securityPreHandlers.checkAdminMemberHasRoleCertif,

--- a/api/tests/devcomp/unit/application/trainings/index_test.js
+++ b/api/tests/devcomp/unit/application/trainings/index_test.js
@@ -868,7 +868,7 @@ describe('Unit | Devcomp | Application | Trainings | Router | training-router', 
       it('should return a response with an HTTP status code 403', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -895,7 +895,7 @@ describe('Unit | Devcomp | Application | Trainings | Router | training-router', 
     context('when there is no pagination', function () {
       it('should resolve with HTTP code 200', async function () {
         // given
-        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
         sinon
           .stub(trainingController, 'findPaginatedTrainingSummaries')
           .callsFake((request, h) => h.response('ok').code(200));
@@ -913,7 +913,7 @@ describe('Unit | Devcomp | Application | Trainings | Router | training-router', 
     context('when there are pagination', function () {
       it('should resolve with HTTP code 200', async function () {
         // given
-        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
         sinon
           .stub(trainingController, 'findPaginatedTrainingSummaries')
           .callsFake((request, h) => h.response('ok').code(200));

--- a/api/tests/evaluation/unit/application/autonomous-courses/index_test.js
+++ b/api/tests/evaluation/unit/application/autonomous-courses/index_test.js
@@ -9,7 +9,7 @@ describe('Unit | Application | Badges | Routes', function () {
       it('should return an HTTP status code 200', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -31,7 +31,7 @@ describe('Unit | Application | Badges | Routes', function () {
         it('should return a response with an HTTP status code 403', async function () {
           // given
           sinon
-            .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+            .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
             .withArgs([
               securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
               securityPreHandlers.checkAdminMemberHasRoleSupport,

--- a/api/tests/integration/application/certifications/index_test.js
+++ b/api/tests/integration/application/certifications/index_test.js
@@ -9,7 +9,7 @@ describe('Integration | Application | Route | Certifications', function () {
   beforeEach(async function () {
     sinon.stub(certificationController, 'findUserCertifications').returns('ok');
     sinon.stub(certificationController, 'getCertification').callsFake((request, h) => h.response('ok').code(200));
-    sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+    sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
 
     httpTestServer = new HttpTestServer();
     await httpTestServer.register(moduleUnderTest);

--- a/api/tests/integration/application/memberships/membership-controller_test.js
+++ b/api/tests/integration/application/memberships/membership-controller_test.js
@@ -13,7 +13,7 @@ describe('Integration | Application | Memberships | membership-controller', func
     sinon.stub(usecases, 'updateMembership');
     sinon.stub(usecases, 'createCertificationCenterMembershipForScoOrganizationAdminMember');
     sinon.stub(usecases, 'disableMembership');
-    sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf');
+    sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf');
     sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization');
     httpTestServer = new HttpTestServer();
     await httpTestServer.register(moduleUnderTest);
@@ -42,7 +42,7 @@ describe('Integration | Application | Memberships | membership-controller', func
             .withArgs({ membership })
             .resolves(certificationCenterMembership);
 
-          securityPreHandlers.adminMemberHasAtLeastOneAccessOf.returns(() => true);
+          securityPreHandlers.hasAtLeastOneAccessOf.returns(() => true);
 
           // when
           const response = await httpTestServer.request('POST', '/api/admin/memberships', payload);
@@ -62,7 +62,7 @@ describe('Integration | Application | Memberships | membership-controller', func
             .withArgs({ membership })
             .resolves(undefined);
 
-          securityPreHandlers.adminMemberHasAtLeastOneAccessOf.returns(() => true);
+          securityPreHandlers.hasAtLeastOneAccessOf.returns(() => true);
 
           // when
           const response = await httpTestServer.request('POST', '/api/admin/memberships', payload);
@@ -77,7 +77,7 @@ describe('Integration | Application | Memberships | membership-controller', func
         const membership = domainBuilder.buildMembership();
         usecases.createMembership.resolves(membership);
 
-        securityPreHandlers.adminMemberHasAtLeastOneAccessOf.returns(() => true);
+        securityPreHandlers.hasAtLeastOneAccessOf.returns(() => true);
 
         // when
         const response = await httpTestServer.request('POST', '/api/admin/memberships', payload);
@@ -91,9 +91,7 @@ describe('Integration | Application | Memberships | membership-controller', func
       context('when user is not allowed to access resource', function () {
         it('should resolve a 403 HTTP response', async function () {
           // given
-          securityPreHandlers.adminMemberHasAtLeastOneAccessOf.returns((request, h) =>
-            h.response().code(403).takeover(),
-          );
+          securityPreHandlers.hasAtLeastOneAccessOf.returns((request, h) => h.response().code(403).takeover());
 
           // when
           const response = await httpTestServer.request('POST', '/api/admin/memberships', payload);

--- a/api/tests/integration/application/organizations/index_test.js
+++ b/api/tests/integration/application/organizations/index_test.js
@@ -10,7 +10,7 @@ describe('Integration | Application | Organizations | Routes', function () {
       const method = 'POST';
       const url = '/api/admin/organizations';
 
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       sinon.stub(organizationController, 'create').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
@@ -29,7 +29,7 @@ describe('Integration | Application | Organizations | Routes', function () {
       const method = 'GET';
       const url = '/api/admin/organizations';
 
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       sinon.stub(organizationController, 'findPaginatedFilteredOrganizations').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
@@ -49,7 +49,7 @@ describe('Integration | Application | Organizations | Routes', function () {
           const url = '/api/admin/organizations';
 
           sinon
-            .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+            .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
             .returns((request, h) => h.response().code(403).takeover());
           sinon.stub(organizationController, 'findPaginatedFilteredOrganizations').returns('ok');
           const httpTestServer = new HttpTestServer();
@@ -71,7 +71,7 @@ describe('Integration | Application | Organizations | Routes', function () {
       const method = 'POST';
       const url = '/api/admin/organizations/1/archive';
 
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       sinon.stub(organizationController, 'archiveOrganization').callsFake((request, h) => h.response('ok').code(204));
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
@@ -91,7 +91,7 @@ describe('Integration | Application | Organizations | Routes', function () {
       const method = 'GET';
       const url = '/api/admin/organizations/1/invitations';
 
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       sinon.stub(organizationController, 'findPendingInvitations').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
@@ -111,7 +111,7 @@ describe('Integration | Application | Organizations | Routes', function () {
       const method = 'DELETE';
       const url = '/api/admin/organizations/1/invitations/1';
 
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       sinon
         .stub(organizationController, 'cancelOrganizationInvitation')
         .returns((request, h) => h.response().code(204));

--- a/api/tests/integration/application/organizations/organization-controller_test.js
+++ b/api/tests/integration/application/organizations/organization-controller_test.js
@@ -24,7 +24,7 @@ describe('Integration | Application | Organizations | organization-controller', 
     sandbox.stub(securityPreHandlers, 'checkUserBelongsToScoOrganizationAndManagesStudents');
     sandbox.stub(securityPreHandlers, 'checkUserBelongsToSupOrganizationAndManagesStudents');
     sandbox.stub(securityPreHandlers, 'checkUserIsAdminInSCOOrganizationManagingStudents');
-    sandbox.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf');
+    sandbox.stub(securityPreHandlers, 'hasAtLeastOneAccessOf');
     sandbox.stub(securityPreHandlers, 'checkUserBelongsToOrganization');
     httpTestServer = new HttpTestServer();
     await httpTestServer.register(moduleUnderTest);
@@ -37,7 +37,7 @@ describe('Integration | Application | Organizations | organization-controller', 
   describe('#findPaginatedFilteredOrganizationMembershipsForAdmin', function () {
     context('Success cases', function () {
       beforeEach(function () {
-        securityPreHandlers.adminMemberHasAtLeastOneAccessOf.returns(() => true);
+        securityPreHandlers.hasAtLeastOneAccessOf.returns(() => true);
       });
 
       it('should return an HTTP response with status code 200', async function () {

--- a/api/tests/integration/application/security-pre-handlers_test.js
+++ b/api/tests/integration/application/security-pre-handlers_test.js
@@ -29,7 +29,7 @@ describe('Integration | Application | SecurityPreHandlers', function () {
                 pre: [
                   {
                     method: (request, h) =>
-                      securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                      securityPreHandlers.hasAtLeastOneAccessOf([
                         securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
                         securityPreHandlers.checkAdminMemberHasRoleCertif,
                       ])(request, h),

--- a/api/tests/integration/application/users/index_test.js
+++ b/api/tests/integration/application/users/index_test.js
@@ -10,7 +10,7 @@ describe('Integration | Application | Users | Routes', function () {
   let httpTestServer;
 
   beforeEach(async function () {
-    sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf');
+    sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf');
     sinon
       .stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser')
       .callsFake((request, h) => h.response(true));
@@ -124,7 +124,7 @@ describe('Integration | Application | Users | Routes', function () {
     describe('GET /api/admin/users/{id}', function () {
       it('should exist', async function () {
         // given
-        securityPreHandlers.adminMemberHasAtLeastOneAccessOf.returns(() => true);
+        securityPreHandlers.hasAtLeastOneAccessOf.returns(() => true);
         const url = '/api/admin/users/123';
 
         // when
@@ -160,7 +160,7 @@ describe('Integration | Application | Users | Routes', function () {
     describe('PATCH /api/admin/users/{id}', function () {
       it('should update user when payload is valid', async function () {
         // given
-        securityPreHandlers.adminMemberHasAtLeastOneAccessOf.returns(() => true);
+        securityPreHandlers.hasAtLeastOneAccessOf.returns(() => true);
         const url = '/api/admin/users/123';
 
         const payload = {
@@ -183,7 +183,7 @@ describe('Integration | Application | Users | Routes', function () {
 
       it('should return bad request when firstName is missing', async function () {
         // given
-        securityPreHandlers.adminMemberHasAtLeastOneAccessOf.returns(() => true);
+        securityPreHandlers.hasAtLeastOneAccessOf.returns(() => true);
         const url = '/api/admin/users/123';
 
         const payload = {
@@ -207,7 +207,7 @@ describe('Integration | Application | Users | Routes', function () {
 
       it('should return bad request when lastName is missing', async function () {
         // given
-        securityPreHandlers.adminMemberHasAtLeastOneAccessOf.returns((request, h) => h.response().code(403).takeover());
+        securityPreHandlers.hasAtLeastOneAccessOf.returns((request, h) => h.response().code(403).takeover());
         const url = '/api/admin/users/123';
         const payload = {
           data: {

--- a/api/tests/integration/application/users/user-controller_test.js
+++ b/api/tests/integration/application/users/user-controller_test.js
@@ -12,7 +12,7 @@ describe('Integration | Application | Users | user-controller', function () {
   beforeEach(async function () {
     sandbox = sinon.createSandbox();
     sandbox.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser');
-    sandbox.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf');
+    sandbox.stub(securityPreHandlers, 'hasAtLeastOneAccessOf');
 
     sandbox.stub(usecases, 'getUserCampaignParticipationToCampaign');
     sandbox.stub(usecases, 'getUserProfileSharedForCampaign');
@@ -181,7 +181,7 @@ describe('Integration | Application | Users | user-controller', function () {
     };
 
     beforeEach(function () {
-      securityPreHandlers.adminMemberHasAtLeastOneAccessOf.returns(() => true);
+      securityPreHandlers.hasAtLeastOneAccessOf.returns(() => true);
     });
 
     context('Success cases', function () {
@@ -200,7 +200,7 @@ describe('Integration | Application | Users | user-controller', function () {
     context('Error cases', function () {
       it('should return a 403 HTTP response when when user is not allowed to access resource', async function () {
         // given
-        securityPreHandlers.adminMemberHasAtLeastOneAccessOf.returns((request, h) => h.response().code(403).takeover());
+        securityPreHandlers.hasAtLeastOneAccessOf.returns((request, h) => h.response().code(403).takeover());
 
         // when
         const response = await httpTestServer.request(method, url, payload);

--- a/api/tests/prescription/organization-place/integration/application/organization-place-controller_test.js
+++ b/api/tests/prescription/organization-place/integration/application/organization-place-controller_test.js
@@ -18,7 +18,7 @@ describe('Integration | Application | organization-place-controller', function (
     sandbox.stub(securityPreHandlers, 'checkUserBelongsToScoOrganizationAndManagesStudents');
     sandbox.stub(securityPreHandlers, 'checkUserBelongsToSupOrganizationAndManagesStudents');
     sandbox.stub(securityPreHandlers, 'checkUserIsAdminInSCOOrganizationManagingStudents');
-    sandbox.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf');
+    sandbox.stub(securityPreHandlers, 'hasAtLeastOneAccessOf');
     sandbox.stub(securityPreHandlers, 'checkUserBelongsToOrganization');
     httpTestServer = new HttpTestServer();
     await httpTestServer.register(moduleUnderTest);
@@ -42,7 +42,7 @@ describe('Integration | Application | organization-place-controller', function (
           category: 'T2',
         });
         usecases.findOrganizationPlacesLot.resolves([place]);
-        securityPreHandlers.adminMemberHasAtLeastOneAccessOf.returns(() => true);
+        securityPreHandlers.hasAtLeastOneAccessOf.returns(() => true);
 
         // when
         const response = await httpTestServer.request('GET', `/api/admin/organizations/${organizationId}/places`);

--- a/api/tests/prescription/organization-place/unit/application/organization-place-route_test.js
+++ b/api/tests/prescription/organization-place/unit/application/organization-place-route_test.js
@@ -26,7 +26,7 @@ describe('Unit | Router | organization-place-route', function () {
 
     it('should return an empty list when no places is found', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       sinon.stub(usecases, 'findOrganizationPlacesLot').returns([]);
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);

--- a/api/tests/shared/unit/application/assessments/index_test.js
+++ b/api/tests/shared/unit/application/assessments/index_test.js
@@ -127,7 +127,7 @@ describe('Unit | Application | Router | assessment-router', function () {
 
     it('should return a response with an HTTP status code 403 if user does not have the rights', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns((request, h) =>
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns((request, h) =>
         h
           .response({ errors: new Error('Unauthorized') })
           .code(403)
@@ -144,7 +144,7 @@ describe('Unit | Application | Router | assessment-router', function () {
       );
 
       // then
-      expect(securityPreHandlers.adminMemberHasAtLeastOneAccessOf).to.have.be.called;
+      expect(securityPreHandlers.hasAtLeastOneAccessOf).to.have.be.called;
       expect(statusCode).to.equal(403);
     });
   });

--- a/api/tests/shared/unit/application/badges/index_test.js
+++ b/api/tests/shared/unit/application/badges/index_test.js
@@ -26,7 +26,7 @@ describe('Unit | Application | Badges | Routes', function () {
       it('should return an HTTP status code 204', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -48,7 +48,7 @@ describe('Unit | Application | Badges | Routes', function () {
         it('should return a response with an HTTP status code 403', async function () {
           // given
           sinon
-            .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+            .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
             .withArgs([
               securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
               securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -93,7 +93,7 @@ describe('Unit | Application | Badges | Routes', function () {
       it('should return an HTTP status code 204', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -130,7 +130,7 @@ describe('Unit | Application | Badges | Routes', function () {
       it('should return a response with an HTTP status code 403', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleSupport,

--- a/api/tests/unit/application/campaign-participations/index_test.js
+++ b/api/tests/unit/application/campaign-participations/index_test.js
@@ -190,7 +190,7 @@ describe('Unit | Application | Router | campaign-participation-router ', functio
   describe('DELETE /api/admin/campaign-participations/{id}', function () {
     it('should return an HTTP status code 200', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       sinon.stub(campaignParticipationController, 'deleteCampaignParticipationForAdmin').resolves('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
@@ -199,14 +199,14 @@ describe('Unit | Application | Router | campaign-participation-router ', functio
       const response = await httpTestServer.request('DELETE', '/api/admin/campaign-participations/2');
 
       // then
-      sinon.assert.calledOnce(securityPreHandlers.adminMemberHasAtLeastOneAccessOf);
+      sinon.assert.calledOnce(securityPreHandlers.hasAtLeastOneAccessOf);
       sinon.assert.calledOnce(campaignParticipationController.deleteCampaignParticipationForAdmin);
       expect(response.statusCode).to.equal(200);
     });
 
     it('should return an HTTP status code 403', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns((request, h) =>
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns((request, h) =>
         h
           .response({ errors: new Error('') })
           .code(403)
@@ -219,7 +219,7 @@ describe('Unit | Application | Router | campaign-participation-router ', functio
       const response = await httpTestServer.request('DELETE', '/api/admin/campaign-participations/2');
 
       // then
-      sinon.assert.calledOnce(securityPreHandlers.adminMemberHasAtLeastOneAccessOf);
+      sinon.assert.calledOnce(securityPreHandlers.hasAtLeastOneAccessOf);
       expect(response.statusCode).to.equal(403);
     });
   });

--- a/api/tests/unit/application/campaign/index_test.js
+++ b/api/tests/unit/application/campaign/index_test.js
@@ -41,7 +41,7 @@ describe('Unit | Application | Router | campaign-router ', function () {
   describe('GET /api/admin/campaigns/{id}', function () {
     it('should return 200', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       sinon
         .stub(campaignManagementController, 'getCampaignDetails')
         .callsFake((request, h) => h.response('ok').code(200));
@@ -70,7 +70,7 @@ describe('Unit | Application | Router | campaign-router ', function () {
     it('should return 403 when unauthorized', async function () {
       // given
       sinon
-        .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+        .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
         .returns((request, h) => h.response().code(403).takeover());
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
@@ -86,7 +86,7 @@ describe('Unit | Application | Router | campaign-router ', function () {
   describe('GET /api/admin/campaigns/{id}/participations', function () {
     it('should return 200', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       sinon
         .stub(campaignManagementController, 'findPaginatedParticipationsForCampaignManagement')
         .callsFake((request, h) => h.response('ok').code(200));
@@ -115,7 +115,7 @@ describe('Unit | Application | Router | campaign-router ', function () {
     it('should return 403 when unauthorized', async function () {
       // given
       sinon
-        .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+        .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
         .returns((request, h) => h.response().code(403).takeover());
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);

--- a/api/tests/unit/application/campaigns-administration/index_test.js
+++ b/api/tests/unit/application/campaigns-administration/index_test.js
@@ -8,7 +8,7 @@ describe('Unit | Application | Router | campaign-participation-router ', functio
     it('returns 200 when admin member has rights', async function () {
       // given
       sinon.stub(campaignController, 'archiveCampaigns').returns(null);
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 
@@ -16,7 +16,7 @@ describe('Unit | Application | Router | campaign-participation-router ', functio
       await httpTestServer.request('POST', '/api/admin/campaigns/archive-campaigns', {});
 
       // then
-      expect(securityPreHandlers.adminMemberHasAtLeastOneAccessOf).to.have.been.calledWithExactly([
+      expect(securityPreHandlers.hasAtLeastOneAccessOf).to.have.been.calledWithExactly([
         securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
         securityPreHandlers.checkAdminMemberHasRoleMetier,
       ]);

--- a/api/tests/unit/application/certification-centers/index_test.js
+++ b/api/tests/unit/application/certification-centers/index_test.js
@@ -195,7 +195,7 @@ describe('Unit | Router | certification-center-router', function () {
 
     it('should exist', async function () {
       //given
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       sinon
         .stub(certificationCenterController, 'findCertificationCenterMembershipsByCertificationCenter')
         .returns('ok');
@@ -232,7 +232,7 @@ describe('Unit | Router | certification-center-router', function () {
 
     it('should return CREATED (200) when everything does as expected', async function () {
       //given
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       sinon.stub(certificationCenterController, 'createCertificationCenterMembershipByEmail').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);

--- a/api/tests/unit/application/certification-courses/index_test.js
+++ b/api/tests/unit/application/certification-courses/index_test.js
@@ -7,7 +7,7 @@ describe('Unit | Application | Certifications Course | Route', function () {
   describe('GET /api/admin/certifications/{id}/details', function () {
     it('should exist', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       sinon.stub(certificationCoursesController, 'getCertificationDetails').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
@@ -23,7 +23,7 @@ describe('Unit | Application | Certifications Course | Route', function () {
   describe('GET /api/admin/certifications/{id}/certified-profile', function () {
     it('should exist', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       sinon.stub(certificationCoursesController, 'getCertifiedProfile').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
@@ -40,7 +40,7 @@ describe('Unit | Application | Certifications Course | Route', function () {
     it('should reject with 403 code when user is not Super Admin', async function () {
       // given
       sinon
-        .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+        .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
         .returns((request, h) => h.response().code(403).takeover());
       sinon.stub(certificationCoursesController, 'getJuryCertification').throws(new Error('I should not be here'));
       const httpTestServer = new HttpTestServer();
@@ -56,7 +56,7 @@ describe('Unit | Application | Certifications Course | Route', function () {
 
     it('should call handler when user is ', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       sinon.stub(certificationCoursesController, 'getJuryCertification').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
@@ -100,7 +100,7 @@ describe('Unit | Application | Certifications Course | Route', function () {
   describe('PATCH /api/certification-courses/id', function () {
     it('should exist', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       sinon.stub(certificationCoursesController, 'update').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
@@ -115,7 +115,7 @@ describe('Unit | Application | Certifications Course | Route', function () {
     it('should return a forbidden access if user has METIER role', async function () {
       // given
       sinon
-        .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+        .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
         .withArgs([
           securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
           securityPreHandlers.checkAdminMemberHasRoleCertif,
@@ -184,7 +184,7 @@ describe('Unit | Application | Certifications Course | Route', function () {
     it('return forbidden access if user has METIER role', async function () {
       // given
       sinon
-        .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+        .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
         .withArgs([
           securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
           securityPreHandlers.checkAdminMemberHasRoleCertif,
@@ -209,7 +209,7 @@ describe('Unit | Application | Certifications Course | Route', function () {
 
     it('should call handler when user is ', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       sinon.stub(certificationCoursesController, 'cancel').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
@@ -226,7 +226,7 @@ describe('Unit | Application | Certifications Course | Route', function () {
     it('return forbidden access if user has METIER role', async function () {
       // given
       sinon
-        .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+        .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
         .withArgs([
           securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
           securityPreHandlers.checkAdminMemberHasRoleCertif,
@@ -252,7 +252,7 @@ describe('Unit | Application | Certifications Course | Route', function () {
 
     it('should call handler when user is ', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       sinon.stub(certificationCoursesController, 'uncancel').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);

--- a/api/tests/unit/application/certification-issue-reports/index_test.js
+++ b/api/tests/unit/application/certification-issue-reports/index_test.js
@@ -54,7 +54,7 @@ describe('Unit | Application | Certifications Issue Report | Route', function ()
       it('should return 204', async function () {
         // given
         sinon.stub(certificationIssueReportController, 'manuallyResolve').callsFake((_, h) => h.response().code(204));
-        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
 
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
@@ -74,7 +74,7 @@ describe('Unit | Application | Certifications Issue Report | Route', function ()
     it('return forbidden access if user has METIER role', async function () {
       // given
       sinon
-        .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+        .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
         .withArgs([
           securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
           securityPreHandlers.checkAdminMemberHasRoleCertif,

--- a/api/tests/unit/application/certifications/index_test.js
+++ b/api/tests/unit/application/certifications/index_test.js
@@ -8,7 +8,7 @@ describe('Unit | Application | Certification | Routes', function () {
     it('return forbidden access if user has METIER role', async function () {
       // given
       sinon
-        .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+        .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
         .withArgs([
           securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
           securityPreHandlers.checkAdminMemberHasRoleCertif,
@@ -42,7 +42,7 @@ describe('Unit | Application | Certification | Routes', function () {
     it('checks that a valid certification-course id is given', async function () {
       // given
       sinon.stub(certificationController, 'neutralizeChallenge').returns('ok');
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
       const payload = {
@@ -64,7 +64,7 @@ describe('Unit | Application | Certification | Routes', function () {
     it('checks that a challenge recId is given', async function () {
       // given
       sinon.stub(certificationController, 'neutralizeChallenge').returns('ok');
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
       const payload = {
@@ -88,7 +88,7 @@ describe('Unit | Application | Certification | Routes', function () {
     it('return forbidden access if user has METIER role', async function () {
       // given
       sinon
-        .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+        .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
         .withArgs([
           securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
           securityPreHandlers.checkAdminMemberHasRoleCertif,
@@ -122,7 +122,7 @@ describe('Unit | Application | Certification | Routes', function () {
     it('checks that a valid certification-course id is given', async function () {
       // given
       sinon.stub(certificationController, 'deneutralizeChallenge').returns('ok');
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
       const payload = {
@@ -144,7 +144,7 @@ describe('Unit | Application | Certification | Routes', function () {
     it('checks that a challenge recId is given', async function () {
       // given
       sinon.stub(certificationController, 'deneutralizeChallenge').returns('ok');
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
       const payload = {

--- a/api/tests/unit/application/complementary-certification-course-results/index_test.js
+++ b/api/tests/unit/application/complementary-certification-course-results/index_test.js
@@ -8,8 +8,8 @@ describe('Unit | Application | Complementary Certification Course Results | Rout
   describe('POST /api/admin/complementary-certification-course-results', function () {
     it('return forbidden access if user has METIER role', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf');
-      securityPreHandlers.adminMemberHasAtLeastOneAccessOf
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf');
+      securityPreHandlers.hasAtLeastOneAccessOf
         .withArgs([
           securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
           securityPreHandlers.checkAdminMemberHasRoleCertif,
@@ -46,8 +46,8 @@ describe('Unit | Application | Complementary Certification Course Results | Rout
         // given
         sinon.stub(complementaryCertificationCourseResultsController, 'saveJuryComplementaryCertificationCourseResult');
         complementaryCertificationCourseResultsController.saveJuryComplementaryCertificationCourseResult.resolves();
-        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf');
-        securityPreHandlers.adminMemberHasAtLeastOneAccessOf
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf');
+        securityPreHandlers.hasAtLeastOneAccessOf
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleCertif,
@@ -85,8 +85,8 @@ describe('Unit | Application | Complementary Certification Course Results | Rout
         // given
         sinon.stub(complementaryCertificationCourseResultsController, 'saveJuryComplementaryCertificationCourseResult');
         complementaryCertificationCourseResultsController.saveJuryComplementaryCertificationCourseResult.resolves();
-        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf');
-        securityPreHandlers.adminMemberHasAtLeastOneAccessOf
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf');
+        securityPreHandlers.hasAtLeastOneAccessOf
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleCertif,

--- a/api/tests/unit/application/complementary-certifications/index_test.js
+++ b/api/tests/unit/application/complementary-certifications/index_test.js
@@ -9,7 +9,7 @@ describe('Unit | Application | Router | complementary-certifications-router', fu
       it('should return 403 HTTP status code', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .returns((request, h) => h.response().code(403).takeover());
         sinon.stub(complementaryCertificationController, 'findComplementaryCertifications').returns('ok');
         const httpTestServer = new HttpTestServer();
@@ -54,7 +54,7 @@ describe('Unit | Application | Router | complementary-certifications-router', fu
       it('should return 403 HTTP status code', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .returns((request, h) => h.response().code(403).takeover());
         sinon
           .stub(complementaryCertificationController, 'searchAttachableTargetProfilesForComplementaryCertifications')

--- a/api/tests/unit/application/frameworks/index_test.js
+++ b/api/tests/unit/application/frameworks/index_test.js
@@ -11,7 +11,7 @@ describe('Unit | Application | Frameworks | Routes', function () {
     it('should return a response with an HTTP status code 200 when user has role "SUPER_ADMIN", "SUPPORT" or "METIER"', async function () {
       // given
       sinon
-        .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+        .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
         .withArgs([
           securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
           securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -32,7 +32,7 @@ describe('Unit | Application | Frameworks | Routes', function () {
     it('should return a response with an HTTP status code 403 when user has role "CERTIF"', async function () {
       // given
       sinon
-        .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+        .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
         .withArgs([
           securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
           securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -63,7 +63,7 @@ describe('Unit | Application | Frameworks | Routes', function () {
     it('should return a response with an HTTP status code 200 when user has role "SUPER_ADMIN", "SUPPORT" or "METIER"', async function () {
       // given
       sinon
-        .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+        .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
         .withArgs([
           securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
           securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -84,7 +84,7 @@ describe('Unit | Application | Frameworks | Routes', function () {
     it('should return a response with an HTTP status code 403 when user has role "CERTIF"', async function () {
       // given
       sinon
-        .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+        .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
         .withArgs([
           securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
           securityPreHandlers.checkAdminMemberHasRoleSupport,

--- a/api/tests/unit/application/memberships/index_test.js
+++ b/api/tests/unit/application/memberships/index_test.js
@@ -7,7 +7,7 @@ describe('Unit | Router | membership-router', function () {
   describe('PATCH /api/admin/memberships/{id}', function () {
     it('should return 200 if user is Pix Admin', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       sinon.stub(membershipController, 'update').callsFake((request, h) => h.response().code(200));
 
       const httpTestServer = new HttpTestServer();
@@ -112,7 +112,7 @@ describe('Unit | Router | membership-router', function () {
   describe('POST /api/admin/memberships/{id}/disable', function () {
     it('should return 204 if user is Pix Admin', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       sinon.stub(membershipController, 'disable').callsFake((request, h) => h.response().code(204));
 
       const httpTestServer = new HttpTestServer();

--- a/api/tests/unit/application/organizations/index_test.js
+++ b/api/tests/unit/application/organizations/index_test.js
@@ -11,7 +11,7 @@ describe('Unit | Router | organization-router', function () {
 
     it('should return OK (200) when request is valid', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       sinon.stub(organizationController, 'findPaginatedFilteredOrganizations').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
@@ -529,7 +529,7 @@ describe('Unit | Router | organization-router', function () {
 
     it('should return HTTP code 201', async function () {
       // given
-      sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
       sinon
         .stub(organizationController, 'sendInvitationByLangAndRole')
         .callsFake((request, h) => h.response().created());

--- a/api/tests/unit/application/security-pre-handlers_test.js
+++ b/api/tests/unit/application/security-pre-handlers_test.js
@@ -877,7 +877,7 @@ describe('Unit | Application | SecurityPreHandlers', function () {
     });
   });
 
-  describe('#adminMemberHasAtLeastOneAccessOf', function () {
+  describe('#hasAtLeastOneAccessOf', function () {
     let belongsToOrganizationStub;
     let hasRoleSuperAdminStub;
     let request;
@@ -903,7 +903,7 @@ describe('Unit | Application | SecurityPreHandlers', function () {
         hasRoleSuperAdminStub.callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
 
         // when
-        const response = await securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+        const response = await securityPreHandlers.hasAtLeastOneAccessOf([
           belongsToOrganizationStub,
           hasRoleSuperAdminStub,
         ])(request, hFake);
@@ -918,7 +918,7 @@ describe('Unit | Application | SecurityPreHandlers', function () {
         hasRoleSuperAdminStub.callsFake((request, h) => h.response(true));
 
         // when
-        const response = await securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+        const response = await securityPreHandlers.hasAtLeastOneAccessOf([
           belongsToOrganizationStub,
           hasRoleSuperAdminStub,
         ])(request, hFake);
@@ -933,7 +933,7 @@ describe('Unit | Application | SecurityPreHandlers', function () {
         hasRoleSuperAdminStub.callsFake((request, h) => h.response(true));
 
         // when
-        const response = await securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+        const response = await securityPreHandlers.hasAtLeastOneAccessOf([
           belongsToOrganizationStub,
           hasRoleSuperAdminStub,
         ])(request, hFake);
@@ -950,7 +950,7 @@ describe('Unit | Application | SecurityPreHandlers', function () {
         hasRoleSuperAdminStub.callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
 
         // when
-        const response = await securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+        const response = await securityPreHandlers.hasAtLeastOneAccessOf([
           belongsToOrganizationStub,
           hasRoleSuperAdminStub,
         ])(request, hFake);

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -280,7 +280,7 @@ describe('Unit | Application | Sessions | Routes', function () {
     describe('GET /api/admin/sessions/{id}', function () {
       it('should exist', async function () {
         // given
-        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
         sinon.stub(sessionController, 'getJurySession').returns('ok');
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
@@ -296,7 +296,7 @@ describe('Unit | Application | Sessions | Routes', function () {
     describe('GET /api/admin/sessions', function () {
       it('should exist', async function () {
         // given
-        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
         sinon.stub(sessionController, 'findPaginatedFilteredJurySessions').returns('ok');
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
@@ -311,7 +311,7 @@ describe('Unit | Application | Sessions | Routes', function () {
     describe('GET /api/admin/sessions/{id}/jury-certification-summaries', function () {
       it('should exist', async function () {
         // given
-        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
         sinon.stub(sessionController, 'getJuryCertificationSummaries').returns('ok');
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
@@ -348,7 +348,7 @@ describe('Unit | Application | Sessions | Routes', function () {
       it('return forbidden access if user has METIER role', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleCertif,
@@ -382,7 +382,7 @@ describe('Unit | Application | Sessions | Routes', function () {
     describe('PATCH /api/admin/sessions/{id}/unpublish', function () {
       it('should exist', async function () {
         // given
-        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
         sinon.stub(sessionController, 'unpublish').returns('ok');
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
@@ -397,7 +397,7 @@ describe('Unit | Application | Sessions | Routes', function () {
       it('return forbidden access if user has METIER role', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleCertif,
@@ -425,7 +425,7 @@ describe('Unit | Application | Sessions | Routes', function () {
       it('is protected by a pre-handler checking authorization to access Pix Admin', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .returns((request, h) => h.response().code(403).takeover());
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
@@ -448,7 +448,7 @@ describe('Unit | Application | Sessions | Routes', function () {
       it('return forbidden access if user has METIER role', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleCertif,
@@ -479,7 +479,7 @@ describe('Unit | Application | Sessions | Routes', function () {
 
       it('should succeed with valid session ids', async function () {
         // given
-        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
         sinon.stub(sessionController, 'publishInBatch').returns('ok');
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
@@ -523,7 +523,7 @@ describe('Unit | Application | Sessions | Routes', function () {
     describe('PUT /api/admin/sessions/{id}/results-sent-to-prescriber', function () {
       it('should exist', async function () {
         // when
-        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
         sinon.stub(sessionController, 'flagResultsAsSentToPrescriber').returns('ok');
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
@@ -537,7 +537,7 @@ describe('Unit | Application | Sessions | Routes', function () {
       it('return forbidden access if user has METIER role', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleCertif,
@@ -564,7 +564,7 @@ describe('Unit | Application | Sessions | Routes', function () {
     describe('GET /api/admin/sessions/to-publish', function () {
       it('exists', async function () {
         // given
-        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
         sinon.stub(finalizedSessionController, 'findFinalizedSessionsToPublish').returns('ok');
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
@@ -578,7 +578,7 @@ describe('Unit | Application | Sessions | Routes', function () {
       it('is protected by a prehandler checking the SUPER_ADMIN role', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .returns((request, h) => h.response().code(403).takeover());
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
@@ -594,7 +594,7 @@ describe('Unit | Application | Sessions | Routes', function () {
     describe('GET /api/admin/sessions/with-required-action', function () {
       it('exists', async function () {
         // given
-        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
         sinon.stub(finalizedSessionController, 'findFinalizedSessionsWithRequiredAction').returns('ok');
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
@@ -609,7 +609,7 @@ describe('Unit | Application | Sessions | Routes', function () {
       it('is protected by a prehandler checking the SUPER_ADMIN role', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .returns((request, h) => h.response().code(403).takeover());
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
@@ -625,7 +625,7 @@ describe('Unit | Application | Sessions | Routes', function () {
     describe('PUT /api/admin/sessions/{id}/comment', function () {
       it('should exist', async function () {
         // given
-        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
         sinon.stub(sessionController, 'commentAsJury').returns('ok');
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
@@ -640,7 +640,7 @@ describe('Unit | Application | Sessions | Routes', function () {
       it('is protected by a prehandler checking the SUPER_ADMIN role', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .returns((request, h) => h.response().code(403).takeover());
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
@@ -655,7 +655,7 @@ describe('Unit | Application | Sessions | Routes', function () {
       it('return forbidden access if user has METIER role', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleCertif,
@@ -682,7 +682,7 @@ describe('Unit | Application | Sessions | Routes', function () {
     describe('DELETE /api/admin/sessions/{id}/comment', function () {
       it('should call appropriate use case and ensure user has access to Pix Admin', async function () {
         // given
-        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
         sinon.stub(sessionController, 'deleteJuryComment').returns('ok');
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
@@ -691,14 +691,14 @@ describe('Unit | Application | Sessions | Routes', function () {
         await httpTestServer.request('DELETE', '/api/admin/sessions/1/comment');
 
         // then
-        expect(securityPreHandlers.adminMemberHasAtLeastOneAccessOf).to.be.calledOnce;
+        expect(securityPreHandlers.hasAtLeastOneAccessOf).to.be.calledOnce;
         expect(sessionController.deleteJuryComment).to.be.calledOnce;
       });
 
       it('return forbidden access if user has METIER role', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleCertif,
@@ -726,7 +726,7 @@ describe('Unit | Application | Sessions | Routes', function () {
       it('return forbidden access if user has METIER role', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleCertif,

--- a/api/tests/unit/application/target-profiles/index_test.js
+++ b/api/tests/unit/application/target-profiles/index_test.js
@@ -12,7 +12,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
       it('should return a response with an HTTP status code 200', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -37,7 +37,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
       it('should return a response with an HTTP status code 403', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -64,7 +64,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
     context('when there is no filter nor pagination', function () {
       it('should resolve with HTTP code 200', async function () {
         // given
-        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
         sinon
           .stub(targetProfileController, 'findPaginatedFilteredTargetProfileSummariesForAdmin')
           .callsFake((request, h) => h.response('ok').code(200));
@@ -82,7 +82,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
     context('when there are filters and pagination', function () {
       it('should resolve with HTTP code 200', async function () {
         // given
-        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
         sinon
           .stub(targetProfileController, 'findPaginatedFilteredTargetProfileSummariesForAdmin')
           .callsFake((request, h) => h.response('ok').code(200));
@@ -151,7 +151,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
       it('should return a response with an HTTP status code 200', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -190,7 +190,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
       it('should return a response with an HTTP status code 403', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -223,7 +223,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
       it('should return a response with an HTTP status code 200', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -246,7 +246,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
       context('when there is no filter nor pagination', function () {
         it('should resolve with an HTTP status code 200', async function () {
           // given
-          sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+          sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
           sinon
             .stub(targetProfileController, 'findPaginatedFilteredTargetProfileOrganizations')
             .callsFake((request, h) => h.response('ok').code(200));
@@ -264,7 +264,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
       context('when there are filters and pagination', function () {
         it('should resolve with an HTTP status code 200', async function () {
           // given
-          sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+          sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
           sinon
             .stub(targetProfileController, 'findPaginatedFilteredTargetProfileOrganizations')
             .callsFake((request, h) => h.response('ok').code(200));
@@ -332,7 +332,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
       it('should return a response with an HTTP status code 403', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -366,7 +366,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
       it('should return a response with an HTTP status code 204', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -437,7 +437,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
       it('should return a response with an HTTP status code 403', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -471,7 +471,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
       it('should return a response with an HTTP status code 204', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -529,7 +529,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
       it('should return a response with an HTTP status code 403', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -576,7 +576,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
       it('should return a response with an HTTP status code 201', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -613,7 +613,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
       it('should return a response with an HTTP status code 403', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -658,7 +658,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
       it('should return a response with an HTTP status code 204', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -743,7 +743,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
       it('should return a response with an HTTP status code 403', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -777,7 +777,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
       it('should return a response with an HTTP status code 204', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -816,7 +816,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
       it('should return a response with an HTTP status code 403', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -850,7 +850,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
       it('should return a response with an HTTP status code 200', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -892,7 +892,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
       it('should return a response with an HTTP status code 403', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -1214,7 +1214,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
       it('should return a response with an HTTP status code 200', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleSupport,
@@ -1256,7 +1256,7 @@ describe('Unit | Application | Target Profiles | Routes', function () {
       it('should return a response with an HTTP status code 403', async function () {
         // given
         sinon
-          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
           .withArgs([
             securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             securityPreHandlers.checkAdminMemberHasRoleSupport,

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -574,7 +574,7 @@ describe('Unit | Router | user-router', function () {
     describe('GET /api/admin/users', function () {
       it('should return an HTTP status code 200', async function () {
         // given
-        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
         sinon.stub(userController, 'findPaginatedFilteredUsers').returns('ok');
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
@@ -586,14 +586,14 @@ describe('Unit | Router | user-router', function () {
         );
 
         // then
-        sinon.assert.calledOnce(securityPreHandlers.adminMemberHasAtLeastOneAccessOf);
+        sinon.assert.calledOnce(securityPreHandlers.hasAtLeastOneAccessOf);
         sinon.assert.calledOnce(userController.findPaginatedFilteredUsers);
         expect(response.statusCode).to.equal(200);
       });
 
       it('should return an HTTP status code 403', async function () {
         // given
-        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns((request, h) =>
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns((request, h) =>
           h
             .response({ errors: new Error('') })
             .code(403)
@@ -609,14 +609,14 @@ describe('Unit | Router | user-router', function () {
         );
 
         // then
-        sinon.assert.calledOnce(securityPreHandlers.adminMemberHasAtLeastOneAccessOf);
+        sinon.assert.calledOnce(securityPreHandlers.hasAtLeastOneAccessOf);
         expect(response.statusCode).to.equal(403);
       });
 
       describe('when the search value in the search email field in users filter is a string and not a full email', function () {
         it('is accepted and the search is performed', async function () {
           // given
-          sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+          sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
           sinon.stub(userController, 'findPaginatedFilteredUsers').returns('ok');
           const httpTestServer = new HttpTestServer();
           await httpTestServer.register(moduleUnderTest);
@@ -647,7 +647,7 @@ describe('Unit | Router | user-router', function () {
     describe('GET /api/admin/users/{id}', function () {
       it('should return an HTTP status code 200', async function () {
         // given
-        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
         sinon.stub(userController, 'getUserDetailsForAdmin').resolves('ok');
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
@@ -656,14 +656,14 @@ describe('Unit | Router | user-router', function () {
         const response = await httpTestServer.request('GET', '/api/admin/users/8');
 
         // then
-        sinon.assert.calledOnce(securityPreHandlers.adminMemberHasAtLeastOneAccessOf);
+        sinon.assert.calledOnce(securityPreHandlers.hasAtLeastOneAccessOf);
         sinon.assert.calledOnce(userController.getUserDetailsForAdmin);
         expect(response.statusCode).to.equal(200);
       });
 
       it('should return an HTTP status code 403', async function () {
         // given
-        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns((request, h) =>
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns((request, h) =>
           h
             .response({ errors: new Error('') })
             .code(403)
@@ -676,7 +676,7 @@ describe('Unit | Router | user-router', function () {
         const response = await httpTestServer.request('GET', '/api/admin/users/8');
 
         // then
-        sinon.assert.calledOnce(securityPreHandlers.adminMemberHasAtLeastOneAccessOf);
+        sinon.assert.calledOnce(securityPreHandlers.hasAtLeastOneAccessOf);
         expect(response.statusCode).to.equal(403);
       });
     });
@@ -1289,7 +1289,7 @@ describe('Unit | Router | user-router', function () {
     describe('GET /api/admin/users/{id}/participations', function () {
       it('should return an HTTP status code 200', async function () {
         // given
-        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
         sinon.stub(userController, 'findCampaignParticipationsForUserManagement').resolves('ok');
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
@@ -1298,14 +1298,14 @@ describe('Unit | Router | user-router', function () {
         const response = await httpTestServer.request('GET', '/api/admin/users/8/participations');
 
         // then
-        sinon.assert.calledOnce(securityPreHandlers.adminMemberHasAtLeastOneAccessOf);
+        sinon.assert.calledOnce(securityPreHandlers.hasAtLeastOneAccessOf);
         sinon.assert.calledOnce(userController.findCampaignParticipationsForUserManagement);
         expect(response.statusCode).to.equal(200);
       });
 
       it('should return an HTTP status code 403', async function () {
         // given
-        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns((request, h) =>
+        sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns((request, h) =>
           h
             .response({ errors: new Error('') })
             .code(403)
@@ -1318,7 +1318,7 @@ describe('Unit | Router | user-router', function () {
         const response = await httpTestServer.request('GET', '/api/admin/users/8/participations');
 
         // then
-        sinon.assert.calledOnce(securityPreHandlers.adminMemberHasAtLeastOneAccessOf);
+        sinon.assert.calledOnce(securityPreHandlers.hasAtLeastOneAccessOf);
         expect(response.statusCode).to.equal(403);
       });
     });


### PR DESCRIPTION
## :christmas_tree: Problème
La méthode utilitaire `adminMemberHasAtLeastOneAccessOf` pour combiner les pre-handlers n'est pas spécifique au scope d'admin dans son implémentation. Or son nom laisse penser qu'elle ne peut être utilisée que pour des vérifications de rôles admins.

## :gift: Proposition

Afin de ne pas porter à confusion à la lecture, renommons cette méthode `adminMemberHasAtLeastOneAccessOf` en `hasAtLeastOneAccessOf` pour que son action soit claire et qu'elle puisse être utilisée ailleurs si besoin.

## :socks: Remarques
nope

## :santa: Pour tester

Pas de nouveauté à tester.
Potentiellement de la non-régression sur tout le scope admin mais avec un faible risque.
Pour tester une route d'admin:
- se connecter sur admin `superadmin@example.net` / `pix123`
- lister les organisations sur [cette page](https://admin-pr7899.review.pix.fr/organizations/list)
(appel GET sur `/api/admin/organizations` qui est protégé par des préhandlers combinés par cette méthode) 