### PR TITLE
[FEATURE][CERTIF | ORGA] Utiliser un fichier de langues pour lister les langues disponibles (PIX-10686)

### DIFF
--- a/certif/app/components/language-switcher.js
+++ b/certif/app/components/language-switcher.js
@@ -2,17 +2,35 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
+import languages from 'pix-certif/languages';
+
+const FRENCH_LANGUAGE = 'fr';
+
 export default class LanguageSwitcher extends Component {
   @tracked selectedLanguage = this.args.selectedLanguage;
 
-  availableLanguages = [
-    { label: 'Français', value: 'fr' },
-    { label: 'English', value: 'en' },
-  ];
+  availableLanguages = this.mapToOptions(languages);
 
   @action
   onChange(value) {
     this.selectedLanguage = value;
     this.args.onLanguageChange(value);
+  }
+
+  mapToOptions(languages) {
+    const options = Object.entries(languages)
+      .filter(([_, config]) => config.languageSwitcherDisplayed)
+      .map(([key, config]) => ({
+        label: config.value,
+        value: key,
+      }));
+
+    const optionsWithoutFrSortedByLabel = options
+      .filter((option) => option.value !== FRENCH_LANGUAGE)
+      .sort((option) => option.label);
+
+    const frenchLanguageOption = options.find((option) => option.value === FRENCH_LANGUAGE);
+
+    return [frenchLanguageOption, ...optionsWithoutFrSortedByLabel];
   }
 }

--- a/certif/app/languages.js
+++ b/certif/app/languages.js
@@ -1,0 +1,11 @@
+export default {
+  en: {
+    value: 'English',
+    languageSwitcherDisplayed: true,
+  },
+
+  fr: {
+    value: 'Français',
+    languageSwitcherDisplayed: true,
+  },
+};

--- a/certif/app/services/locale.js
+++ b/certif/app/services/locale.js
@@ -1,12 +1,13 @@
 import Service, { inject as service } from '@ember/service';
 import config from 'pix-certif/config/environment';
+import languages from 'pix-certif/languages';
 
 export const FRENCH_INTERNATIONAL_LOCALE = 'fr';
 export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 export const FRENCH_FRANCE_LOCALE = 'fr-FR';
 export const DEFAULT_LOCALE = FRENCH_INTERNATIONAL_LOCALE;
 
-const SUPPORTED_LANGUAGES = [FRENCH_INTERNATIONAL_LOCALE, ENGLISH_INTERNATIONAL_LOCALE];
+const SUPPORTED_LANGUAGES = Object.keys(languages);
 const { COOKIE_LOCALE_LIFESPAN_IN_SECONDS } = config.APP;
 
 export default class LocaleService extends Service {

--- a/certif/tests/integration/components/language-switcher_test.js
+++ b/certif/tests/integration/components/language-switcher_test.js
@@ -19,7 +19,7 @@ module('Integration | Component | Language Switcher', function (hooks) {
   });
 
   module('when component is clicked', function () {
-    test('displays a list of available languages', async function (assert) {
+    test('displays a list of available languages with french language first', async function (assert) {
       // given
       const screen = await render(hbs`<LanguageSwitcher @selectedLanguage='en' />`);
 
@@ -28,8 +28,13 @@ module('Integration | Component | Language Switcher', function (hooks) {
       await screen.findByRole('listbox');
 
       // then
-      assert.dom(screen.getByRole('option', { name: 'Français' })).exists();
+      const options = await screen.findAllByRole('option');
       assert.dom(screen.getByRole('option', { name: 'English' })).exists();
+      const optionsInnerText = options.map((option) => {
+        return option.innerText;
+      });
+
+      assert.deepEqual(optionsInnerText, ['Français', 'English']);
     });
   });
 

--- a/certif/tests/unit/components/language-switcher_test.js
+++ b/certif/tests/unit/components/language-switcher_test.js
@@ -1,0 +1,110 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
+
+module('Unit | Component | language-switcher', function (hooks) {
+  setupTest(hooks);
+
+  let component;
+
+  hooks.beforeEach(function () {
+    component = createGlimmerComponent('component:language-switcher');
+  });
+
+  module('#mapToOptions', function () {
+    test('sorts languages with french international language first', function (assert) {
+      // given
+      const languages = {
+        en: {
+          value: 'English',
+          languageSwitcherDisplayed: true,
+        },
+        fr: {
+          value: 'Français',
+          languageSwitcherDisplayed: true,
+        },
+      };
+
+      // when
+      const result = component.mapToOptions(languages);
+
+      // then
+      const expectedResult = {
+        label: 'Français',
+        value: 'fr',
+      };
+
+      assert.deepEqual(result[0], expectedResult);
+    });
+
+    test('sorts other languages by "value"', function (assert) {
+      // given
+      const languages = {
+        en: {
+          value: 'English',
+          languageSwitcherDisplayed: true,
+        },
+        es: {
+          value: 'Spanish',
+          languageSwitcherDisplayed: true,
+        },
+        fr: {
+          value: 'Français',
+          languageSwitcherDisplayed: true,
+        },
+      };
+
+      // when
+      const result = component.mapToOptions(languages);
+
+      // then
+      const expectedResult = [
+        {
+          label: 'Français',
+          value: 'fr',
+        },
+        {
+          label: 'English',
+          value: 'en',
+        },
+        {
+          label: 'Spanish',
+          value: 'es',
+        },
+      ];
+      assert.deepEqual(result, expectedResult);
+    });
+
+    module('when languages have attribute "languageSwitcherDisplayed" at "false"', function () {
+      test(`does not map these languages`, function (assert) {
+        // given
+        const languages = {
+          fr: {
+            value: 'Français',
+            languageSwitcherDisplayed: true,
+          },
+          en: {
+            value: 'English',
+            languageSwitcherDisplayed: false,
+          },
+          es: {
+            value: 'Spanish',
+            languageSwitcherDisplayed: false,
+          },
+        };
+
+        // when
+        const result = component.mapToOptions(languages);
+
+        // then
+        const expectedResult = [
+          {
+            label: 'Français',
+            value: 'fr',
+          },
+        ];
+        assert.deepEqual(result, expectedResult);
+      });
+    });
+  });
+});

--- a/orga/app/components/language-switcher.js
+++ b/orga/app/components/language-switcher.js
@@ -2,17 +2,35 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
+import languages from 'pix-orga/languages';
+
+const FRENCH_LANGUAGE = 'fr';
+
 export default class LanguageSwitcher extends Component {
   @tracked selectedLanguage = this.args.selectedLanguage;
 
-  availableLanguages = [
-    { label: 'Français', value: 'fr' },
-    { label: 'English', value: 'en' },
-  ];
+  availableLanguages = this.mapToOptions(languages);
 
   @action
   onChange(value) {
     this.selectedLanguage = value;
     this.args.onLanguageChange(value);
+  }
+
+  mapToOptions(languages) {
+    const options = Object.entries(languages)
+      .filter(([_, config]) => config.languageSwitcherDisplayed)
+      .map(([key, config]) => ({
+        label: config.value,
+        value: key,
+      }));
+
+    const optionsWithoutFrSortedByLabel = options
+      .filter((option) => option.value !== FRENCH_LANGUAGE)
+      .sort((option) => option.label);
+
+    const frenchLanguageOption = options.find((option) => option.value === FRENCH_LANGUAGE);
+
+    return [frenchLanguageOption, ...optionsWithoutFrSortedByLabel];
   }
 }

--- a/orga/app/languages.js
+++ b/orga/app/languages.js
@@ -1,0 +1,11 @@
+export default {
+  en: {
+    value: 'English',
+    languageSwitcherDisplayed: true,
+  },
+
+  fr: {
+    value: 'Français',
+    languageSwitcherDisplayed: true,
+  },
+};

--- a/orga/app/services/locale.js
+++ b/orga/app/services/locale.js
@@ -1,11 +1,12 @@
 import Service, { inject as service } from '@ember/service';
 import config from 'pix-orga/config/environment';
+import languages from 'pix-orga/languages';
 
 export const FRENCH_INTERNATIONAL_LOCALE = 'fr';
 export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 export const FRENCH_FRANCE_LOCALE = 'fr-FR';
 export const DEFAULT_LOCALE = FRENCH_INTERNATIONAL_LOCALE;
-const SUPPORTED_LANGUAGES = [FRENCH_INTERNATIONAL_LOCALE, ENGLISH_INTERNATIONAL_LOCALE];
+const SUPPORTED_LANGUAGES = Object.keys(languages);
 
 const { COOKIE_LOCALE_LIFESPAN_IN_SECONDS } = config.APP;
 

--- a/orga/tests/integration/language-switcher_test.js
+++ b/orga/tests/integration/language-switcher_test.js
@@ -19,7 +19,7 @@ module('Integration | Component | Language Switcher', function (hooks) {
   });
 
   module('when component is clicked', function () {
-    test('displays a list of available languages', async function (assert) {
+    test('displays a list of available languages with french language first', async function (assert) {
       // given
       const screen = await render(hbs`<LanguageSwitcher @selectedLanguage='en' />`);
 
@@ -28,8 +28,13 @@ module('Integration | Component | Language Switcher', function (hooks) {
       await screen.findByRole('listbox');
 
       // then
-      assert.dom(screen.getByRole('option', { name: 'Français' })).exists();
+      const options = await screen.findAllByRole('option');
       assert.dom(screen.getByRole('option', { name: 'English' })).exists();
+      const optionsInnerText = options.map((option) => {
+        return option.innerText;
+      });
+
+      assert.deepEqual(optionsInnerText, ['Français', 'English']);
     });
   });
 

--- a/orga/tests/unit/components/language-switcher_test.js
+++ b/orga/tests/unit/components/language-switcher_test.js
@@ -1,0 +1,110 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
+
+module('Unit | Component | language-switcher', function (hooks) {
+  setupTest(hooks);
+
+  let component;
+
+  hooks.beforeEach(function () {
+    component = createGlimmerComponent('component:language-switcher');
+  });
+
+  module('#mapToOptions', function () {
+    test('sorts languages with french international language first', function (assert) {
+      // given
+      const languages = {
+        en: {
+          value: 'English',
+          languageSwitcherDisplayed: true,
+        },
+        fr: {
+          value: 'Français',
+          languageSwitcherDisplayed: true,
+        },
+      };
+
+      // when
+      const result = component.mapToOptions(languages);
+
+      // then
+      const expectedResult = {
+        label: 'Français',
+        value: 'fr',
+      };
+
+      assert.deepEqual(result[0], expectedResult);
+    });
+
+    test('sorts other languages by "value"', function (assert) {
+      // given
+      const languages = {
+        en: {
+          value: 'English',
+          languageSwitcherDisplayed: true,
+        },
+        es: {
+          value: 'Spanish',
+          languageSwitcherDisplayed: true,
+        },
+        fr: {
+          value: 'Français',
+          languageSwitcherDisplayed: true,
+        },
+      };
+
+      // when
+      const result = component.mapToOptions(languages);
+
+      // then
+      const expectedResult = [
+        {
+          label: 'Français',
+          value: 'fr',
+        },
+        {
+          label: 'English',
+          value: 'en',
+        },
+        {
+          label: 'Spanish',
+          value: 'es',
+        },
+      ];
+      assert.deepEqual(result, expectedResult);
+    });
+
+    module('when languages have attribute "languageSwitcherDisplayed" at "false"', function () {
+      test(`does not map these languages`, function (assert) {
+        // given
+        const languages = {
+          fr: {
+            value: 'Français',
+            languageSwitcherDisplayed: true,
+          },
+          en: {
+            value: 'English',
+            languageSwitcherDisplayed: false,
+          },
+          es: {
+            value: 'Spanish',
+            languageSwitcherDisplayed: false,
+          },
+        };
+
+        // when
+        const result = component.mapToOptions(languages);
+
+        // then
+        const expectedResult = [
+          {
+            label: 'Français',
+            value: 'fr',
+          },
+        ];
+        assert.deepEqual(result, expectedResult);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, la gestion des langues sur Pix Certif et Pix Orga est décentralisée.
Il faut pour ajouter une nouvelle langue :
- Ajouter l'entrée dans le composant `<LanguageSwitcher/>` pour qu'il apparaisse sur les mires de connexions
- Ajouter la langue dans le service `locale.js` pour qu'il puisse gérer le cas où on met `?lang={newLang}`

## :gift: Proposition
Centraliser cette gestion dans un fichier de config `languages.js`

## :socks: Remarques
Un champ `languageSwitcherDisplayed` a été ajouté dans le cas où, lors de l'ajout d'une nouvelle langue, on veut qu'il puisse être disponible avec le paramètre `?lang=` mais non affiché sur les sélecteurs de langues du site.

## :santa: Pour tester
### 🟢 Tests de non régression sur Pix Certif

**Connexion - Sélecteur de langues**
- Aller sur la RA de Pix Certif .org https://certif-pr7902.review.pix.org/
- Vérifier que Français est bien affiché lorsqu'on arrive sur cette page
- Sélectionner l'option English dans le sélecteur de langues
- Vérifier que la page de connexion se met bien en anglais

**Connexion - ?lang=en**
- Aller sur la RA de Pix Certif https://certif-pr7902.review.pix.org/connexion?lang=en
- Vérifier que la page est en anglais.
- Vérifier que le sélecteur de langues affiche bien l'option English.
- Sélectionner l'option Français dans le sélecteur de langues.
- Vérifier que le contenu de la page passe en français.

**Double mire invitation à rejoindre un Centre de Certification - Sélecteurs de langues**
- Aller sur la RA de Pix Certif .org https://certif-pr7902.review.pix.org/rejoindre?invitationId=106930&code=Z594GPPZPA
- Vérifier que Français est bien affiché lorsqu'on arrive sur cette page
- Sélectionner l'option English dans le sélecteur de langues
- Vérifier que la page de connexion se met bien en anglais

**Double mire invitation à rejoindre un Centre de Certification - &lang=en**
- Aller sur la RA de Pix Certif https://certif-pr7902.review.pix.org/rejoindre?invitationId=106930&code=Z594GPPZPA&lang=en
- Vérifier que la page est en anglais.
- Vérifier que le sélecteur de langues affiche bien l'option English.
- Sélectionner l'option Français dans le sélecteur de langues
- Vérifier que le contenu de la page passe en français.

**Test après connexion (?lang=en)**
- Aller sur la RA de Pix Certif .org https://certif-pr7902.review.pix.org/
- Se connecter avec un compte utilisateur (ex: [james-paledroits@example.net](mailto:james-paledroits@example.net))
- Ajouter ?lang=en à l'url (https://certif-pr7902.review.pix.org/sessions/liste?lang=en)
- Vérifier que le contenu de la page passe bien en anglais.

### 🔵 Tests de non régression sur Pix Orga

**Connexion - Sélecteur de langues**
- Aller sur la RA de Pix Orga .org https://orga-pr7902.review.pix.org/
- Vérifier que Français est bien affiché lorsqu'on arrive sur cette page
- Sélectionner l'option English dans le sélecteur de langues
- Vérifier que la page de connexion se met bien en anglais

**Connexion - ?lang=en**
- Aller sur la RA de Pix Orga https://orga-pr7902.review.pix.org/connexion?lang=en
- Vérifier que la page est en anglais.
- Vérifier que le sélecteur de langues affiche bien l'option English.
- Sélectionner l'option Français dans le sélecteur de langues.
- Vérifier que le contenu de la page passe en français.

**Double mire invitation à rejoindre une Organisation - Sélecteurs de langues**
- Aller sur la RA de Pix Orga .org https://orga-pr7902.review.pix.org/rejoindre?invitationId=2&code=MENZD40L09
- Vérifier que Français est bien affiché lorsqu'on arrive sur cette page
- Sélectionner l'option English dans le sélecteur de langues
- Vérifier que la page de connexion se met bien en anglais

**Double mire invitation à rejoindre une Organisation - &lang=en**
- Aller sur la RA de  Pix Orga .org https://orga-pr7902.review.pix.org/rejoindre?invitationId=2&code=MENZD40L09&lang=en
- Vérifier que la page est en anglais.
- Vérifier que le sélecteur de langues affiche bien l'option English.
- Sélectionner l'option Français dans le sélecteur de langues
- Vérifier que le contenu de la page passe en français.

**Test après connexion (?lang=en)**
- Aller sur la RA de Pix Orga .org https://orga-pr7902.review.pix.org/
- Se connecter avec un compte utilisateur (ex: [allorga@example.net](mailto:allorga@example.net))
- Ajouter ?lang=en à l'url (https://orga-pr7902.review.pix.org/campagnes/les-miennes?lang=en)
- Vérifier que le contenu de la page passe bien en anglais.
