### PR TITLE
[TECH] Améliore la configuration Phrase.

### DIFF
--- a/.phrase.yml
+++ b/.phrase.yml
@@ -2,40 +2,106 @@ phrase:
   file_format: nested_json
   push:
     sources:
-    - file: ./mon-pix/translations/<locale_name>.json
+    - file: ./mon-pix/translations/fr.json
       project_id: "9ca9a54c81b5a85168c8df3d6953a49e"
+      params:
+        update_translations: true
+        locale_id: 'fr'
 
-    - file: ./orga/translations/<locale_name>.json
+    - file: ./mon-pix/translations/en.json
+      project_id: "9ca9a54c81b5a85168c8df3d6953a49e"
+      params:
+        update_translations: true
+        locale_id: 'en'
+
+    - file: ./orga/translations/fr.json
       project_id: "93a23f4b74a86dbb53244134fb21ef43"
+      params:
+        update_translations: true
+        locale_id: 'fr'
 
-    - file: ./certif/translations/<locale_name>.json
+    - file: ./orga/translations/en.json
+      project_id: "93a23f4b74a86dbb53244134fb21ef43"
+      params:
+        update_translations: true
+        locale_id: 'en'
+
+    - file: ./certif/translations/fr.json
       project_id: "3371843f0a06e47d0fba1374b19b439c"
+      params:
+        update_translations: true
+        locale_id: 'fr'
 
-    - file: ./admin/translations/<locale_name>.json
+    - file: ./certif/translations/en.json
+      project_id: "3371843f0a06e47d0fba1374b19b439c"
+      params:
+        update_translations: true
+        locale_id: 'en'
+
+    - file: ./admin/translations/fr.json
       project_id: "0e242bea62d0ac0d989d082b8d1d96d7"
+      params:
+        update_translations: true
+        locale_id: 'fr'
 
-    - file: ./1d/translations/<locale_name>.json
+    - file: ./admin/translations/en.json
+      project_id: "0e242bea62d0ac0d989d082b8d1d96d7"
+      params:
+        update_translations: true
+        locale_id: 'en'
+
+    - file: ./1d/translations/fr.json
       project_id: "dd99bbfc9e880398e292a808e7013896"
+      params:
+        update_translations: true
+        locale_id: 'fr'
 
-    - file: ./api/translations/<locale_name>.json
+    - file: ./1d/translations/en.json
+      project_id: "dd99bbfc9e880398e292a808e7013896"
+      params:
+        update_translations: true
+        locale_id: 'en'
+
+    - file: ./api/translations/fr.json
       project_id: "88f30f82bdab4e25ac5e57b6663a941a"
+      params:
+        update_translations: true
+        locale_id: 'fr'
+
+    - file: ./api/translations/en.json
+      project_id: "88f30f82bdab4e25ac5e57b6663a941a"
+      params:
+        update_translations: true
+        locale_id: 'en'
 
   pull:
     targets:
-     - file: ./mon-pix/translations/<locale_name>.json
+     - file: ./mon-pix/translations/nl.json
        project_id: "9ca9a54c81b5a85168c8df3d6953a49e"
+       params:
+         locale_id: 'nl'
 
-     - file: ./orga/translations/<locale_name>.json
+     - file: ./orga/translations/nl.json
        project_id: "93a23f4b74a86dbb53244134fb21ef43"
+       params:
+         locale_id: 'nl'
 
-     - file: ./certif/translations/<locale_name>.json
+     - file: ./certif/translations/nl.json
        project_id: "3371843f0a06e47d0fba1374b19b439c"
+       params:
+         locale_id: 'nl'
 
-     - file: ./admin/translations/<locale_name>.json
+     - file: ./admin/translations/nl.json
        project_id: "0e242bea62d0ac0d989d082b8d1d96d7"
+       params:
+         locale_id: 'nl'
 
-     - file: ./1d/translations/<locale_name>.json
+     - file: ./1d/translations/nl.json
        project_id: "dd99bbfc9e880398e292a808e7013896"
+       params:
+         locale_id: 'nl'
 
-     - file: ./api/translations/<locale_name>.json
+     - file: ./api/translations/nl.json
        project_id: "88f30f82bdab4e25ac5e57b6663a941a"
+       params:
+         locale_id: 'nl'


### PR DESCRIPTION
## :christmas_tree: Problème

Toutes les locales sont systématiquements synchronisés depuis et vers Phrase.
Cela entraine des conflits et peut avoir des régressions sur les traductions de référence (`fr`).

## :gift: Proposition

Expliciter les locales à synchroniser :
- `fr` et `en` depuis GitHub vers Phrase uniquement ;
- `nl` depuis Phrase vers GitHub uniquement.

## :socks: Remarques

Pour le moment, on prend en référence également la locale `en`.
A terme, il faudra surement passer par Phrase pour traduire en anglais et donc adapter la configuration en fonction.

## :santa: Pour tester

Après avoir mergé (sic), lancer une synchronisation GitHub vers Phrase.
Vérifier que seules les clés fr et en sont mises à jour dans Phrase.

Lancer une synchronisation GitHub depuis Phrase.
Vérifier que la PR créé par Phrase ne met à jour que le fichier `nl.json`.
