### PR TITLE
[FEATURE] Affiche le nombre de participation à une campagne (PIX-10446)

### DIFF
--- a/api/src/prescription/campaign/domain/read-models/CampaignParticipantActivity.js
+++ b/api/src/prescription/campaign/domain/read-models/CampaignParticipantActivity.js
@@ -8,6 +8,7 @@ class CampaignParticipantActivity {
     sharedAt,
     status,
     lastSharedCampaignParticipationId,
+    participationCount,
   } = {}) {
     this.campaignParticipationId = campaignParticipationId;
     this.userId = userId;
@@ -17,6 +18,7 @@ class CampaignParticipantActivity {
     this.sharedAt = sharedAt;
     this.status = status;
     this.lastSharedOrCurrentCampaignParticipationId = lastSharedCampaignParticipationId || campaignParticipationId;
+    this.participationCount = participationCount || 0;
   }
 }
 

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-participant-activity-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-participant-activity-repository.js
@@ -46,6 +46,12 @@ function _buildCampaignParticipationByParticipant(queryBuilder, campaignId, filt
         .orderBy('sharedAt', 'desc')
         .limit(1)
         .as('lastSharedCampaignParticipationId'),
+      knex('campaign-participations')
+        .whereRaw('"organizationLearnerId" = "view-active-organization-learners"."id"')
+        .and.whereNull('campaign-participations.deletedAt')
+        .and.where('campaignId', campaignId)
+        .count('id')
+        .as('participationCount'),
     )
     .from('campaign-participations')
     .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-participant-activity-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-participant-activity-serializer.js
@@ -12,6 +12,7 @@ const serialize = function ({ campaignParticipantsActivities, pagination }) {
       'status',
       'progression',
       'lastSharedOrCurrentCampaignParticipationId',
+      'participationCount',
     ],
     meta: pagination,
   }).serialize(campaignParticipantsActivities);

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participant-activity-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participant-activity-repository_test.js
@@ -45,11 +45,16 @@ describe('Integration | Repository | Campaign Participant activity', function ()
         // given
         const campaign = databaseBuilder.factory.buildCampaign();
         const user = databaseBuilder.factory.buildUser();
+        const learner = databaseBuilder.factory.buildOrganizationLearner({
+          userId: user.id,
+          organizationId: campaign.organizationId,
+        });
 
         databaseBuilder.factory.buildCampaignParticipation({
           participantExternalId: 'The bad',
+          organizationLearnerId: learner.id,
           campaignId: campaign.id,
-          status: STARTED,
+          status: SHARED,
           userId: user.id,
           isImproved: true,
         });
@@ -59,6 +64,7 @@ describe('Integration | Repository | Campaign Participant activity', function ()
           campaignId: campaign.id,
           status: STARTED,
           userId: user.id,
+          organizationLearnerId: learner.id,
           isImproved: false,
         });
 
@@ -71,6 +77,7 @@ describe('Integration | Repository | Campaign Participant activity', function ()
         //then
         expect(campaignParticipantsActivities).to.have.lengthOf(1);
         expect(campaignParticipantsActivities[0].participantExternalId).to.equal('The good');
+        expect(campaignParticipantsActivities[0].participationCount).to.equal(2);
       });
 
       it('Returns the most recent participation with the shared participation Id', async function () {

--- a/api/tests/prescription/campaign/unit/domain/read-models/CampaignParticipantActivity_test.js
+++ b/api/tests/prescription/campaign/unit/domain/read-models/CampaignParticipantActivity_test.js
@@ -16,6 +16,7 @@ describe('Unit | Domain | Read-Models | CampaignResults | CampaignParticipantAct
         sharedAt,
         status: CampaignParticipationStatuses.SHARED,
         lastSharedCampaignParticipationId: null,
+        participationCount: null,
       });
 
       expect(campaignParticipantActivity).to.deep.equal({
@@ -27,9 +28,10 @@ describe('Unit | Domain | Read-Models | CampaignResults | CampaignParticipantAct
         sharedAt,
         status: CampaignParticipationStatuses.SHARED,
         lastSharedOrCurrentCampaignParticipationId: 45,
+        participationCount: 0,
       });
     });
-    it('should lastSharedCampaignParticipationId if provided', function () {
+    it('should use lastSharedCampaignParticipationId if provided', function () {
       const lastSharedCampaignParticipationId = 42;
 
       const campaignParticipantActivity = new CampaignParticipantActivity({

--- a/api/tests/prescription/campaign/unit/infrastrucutre/serializers/jsonapi/campaign-participant-activity-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastrucutre/serializers/jsonapi/campaign-participant-activity-serializer_test.js
@@ -17,6 +17,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participant-activity-serializer
           lastName: 'Habibi',
           participantExternalId: 'Dev',
           status: SHARED,
+          participationCount: 1,
         }),
         new CampaignParticipantActivity({
           userId: 2,
@@ -48,6 +49,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participant-activity-serializer
               'participant-external-id': 'Dev',
               status: SHARED,
               'last-shared-or-current-campaign-participation-id': '1',
+              'participation-count': 1,
             },
           },
           {
@@ -59,6 +61,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participant-activity-serializer
               'participant-external-id': 'Footballer',
               status: STARTED,
               'last-shared-or-current-campaign-participation-id': '2',
+              'participation-count': 0,
             },
           },
         ],

--- a/orga/app/components/campaign/activity/participants-list.hbs
+++ b/orga/app/components/campaign/activity/participants-list.hbs
@@ -22,6 +22,9 @@
           <col class="table__column--wide" />
         {{/if}}
         <col class="table__column--wide" />
+        {{#if @showParticipationCount}}
+          <col class="table__column--wide" />
+        {{/if}}
         {{#if this.canDeleteParticipation}}
           <col class="table__column--small table__column--right hide-on-mobile" />
         {{/if}}
@@ -34,6 +37,11 @@
             <Table::Header>{{@campaign.idPixLabel}}</Table::Header>
           {{/if}}
           <Table::Header>{{t "pages.campaign-activity.table.column.status"}}</Table::Header>
+          {{#if @showParticipationCount}}
+            <Table::Header @size="wide">
+              {{t "pages.campaign-activity.table.column.participationCount"}}
+            </Table::Header>
+          {{/if}}
           {{#if this.canDeleteParticipation}}
             <Table::Header class="hide-on-mobile">
               <span class="screen-reader-only">
@@ -81,6 +89,11 @@
               <td>
                 <Ui::ParticipationStatus @status={{participation.status}} @campaignType={{@campaign.type}} />
               </td>
+              {{#if @showParticipationCount}}
+                <td>
+                  {{participation.participationCount}}
+                </td>
+              {{/if}}
               {{#if this.canDeleteParticipation}}
                 <td class="hide-on-mobile">
                   <PixIconButton

--- a/orga/app/models/campaign-participant-activity.js
+++ b/orga/app/models/campaign-participant-activity.js
@@ -6,4 +6,5 @@ export default class CampaignParticipantActivity extends Model {
   @attr('string') participantExternalId;
   @attr('string') status;
   @attr('string') lastSharedOrCurrentCampaignParticipationId;
+  @attr('number') participationCount;
 }

--- a/orga/app/templates/authenticated/campaigns/campaign/activity.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/activity.hbs
@@ -22,6 +22,7 @@
     @onFilter={{this.triggerFiltering}}
     @onResetFilter={{this.resetFiltering}}
     @deleteCampaignParticipation={{this.deleteCampaignParticipation}}
+    @showParticipationCount={{@model.campaign.multipleSendings}}
     class="activity__participants-list"
   />
 {{else}}

--- a/orga/tests/integration/components/campaign/activity/participants-list_test.js
+++ b/orga/tests/integration/components/campaign/activity/participants-list_test.js
@@ -81,6 +81,68 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
     assert.dom(screen.getByRole('link', /la frite/i)).hasAttribute('href', '/campagnes/100/profils/456');
   });
 
+  test('it should display participation column when showParticipationCount is true', async function (assert) {
+    class CurrentUserStub extends Service {
+      isAdminInOrganization = true;
+    }
+    this.owner.register('service:current-user', CurrentUserStub);
+    this.set('campaign', { id: '100', idPixLabel: 'id', type: 'ASSESSMENT' });
+
+    this.set('participations', [
+      {
+        id: '123',
+        firstName: 'Joe',
+        lastName: 'La frite',
+        status: 'TO_SHARE',
+        participantExternalId: 'patate',
+        lastSharedOrCurrentCampaignParticipationId: '456',
+        participationCount: 2,
+      },
+    ]);
+    const screen = await render(
+      hbs`<Campaign::Activity::ParticipantsList
+  @campaign={{this.campaign}}
+  @participations={{this.participations}}
+  @onClickParticipant={{this.clickSpy}}
+  @onFilter={{this.noop}}
+  @showParticipationCount={{true}}
+/>`,
+    );
+
+    assert.dom(screen.getByText(this.intl.t('pages.campaign-activity.table.column.participationCount'))).exists();
+    assert.dom(screen.getByText('2')).exists();
+  });
+
+  test('it should hide participation column when showParticipationCount is false', async function (assert) {
+    class CurrentUserStub extends Service {
+      isAdminInOrganization = true;
+    }
+    this.owner.register('service:current-user', CurrentUserStub);
+    this.set('campaign', { id: '100', idPixLabel: 'id', type: 'ASSESSMENT' });
+
+    this.set('participations', [
+      {
+        id: '123',
+        firstName: 'Joe',
+        lastName: 'La frite',
+        status: 'TO_SHARE',
+        participantExternalId: 'patate',
+        lastSharedOrCurrentCampaignParticipationId: '456',
+        participationCount: 1,
+      },
+    ]);
+    const screen = await render(
+      hbs`<Campaign::Activity::ParticipantsList
+  @campaign={{this.campaign}}
+  @participations={{this.participations}}
+  @onClickParticipant={{this.clickSpy}}
+  @onFilter={{this.noop}}
+/>`,
+    );
+
+    assert.notOk(screen.queryByText('Participations'));
+  });
+
   test('[A11Y] it should have an aria label', async function (assert) {
     this.set('campaign', { idPixLabel: 'id', type: 'ASSESSMENT' });
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -374,6 +374,7 @@
           "delete": "Delete participation",
           "first-name": "First name",
           "last-name": "Last name",
+          "participationCount": "Number of participations",
           "status": "Status"
         },
         "delete-button-label": "Delete participation",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -377,6 +377,7 @@
           "delete": "Supprimer la participation",
           "first-name": "Prénom",
           "last-name": "Nom",
+          "participationCount": "Nombre de participations",
           "status": "Statut"
         },
         "delete-button-label": "Supprimer la participation",


### PR DESCRIPTION
## :christmas_tree: Problème
Le prescripteur ne peut pas voir le nombre de participations effectuées par un prescrit à une campagne à envoi multiple.  On veut lui donner cette information pour qu’il puisse suivre l’activité de ses prescrits. 

## :gift: Proposition
Uniquement dans le cas d’une campagne à envoi multiple, ajouter une colonne avec le nombre de participations du prescrit dans le tableau sur la page activité de la campagne : 

## :socks: Remarques
J'ai fait le choix de modifier l'api pour que le endpoint renvoi toujours l'info du nombre de participant et que la colonne soit affichée ou non par le front.

## :santa: Pour tester
- se connecter sur orga avec le compte sco
- choisir l'orga not managing student
- allez sur la campagne envoi simple PIX+ EDU - SCO - envoi simple
- ne pas voir la colonne participation

- allez sur la campagne envoi simple PIX+ EDU - SCO - envoi multiple
- voir la colonne participation

sur mon-pix 
- passer la campagne EDUMULTIP
- se connecter avec  `learneremail1003_30@example.net`
- passer la campagne / envoyer ses resultats

sur orga
- allez sur la campagne envoi simple PIX+ EDU - SCO - envoi multiple
- voir que la colonne participation a augmenté pour le prescrit 30 
