### PR TITLE
[TECH] Déplacement du fichier des sécurity pre handlers (PIX-10890)

### DIFF
--- a/api/lib/application/activity-answers/index.js
+++ b/api/lib/application/activity-answers/index.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 import { activityAnswerController } from './activity-answer-controller.js';
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 
 const register = async function (server) {
   server.route([

--- a/api/lib/application/admin-members/index.js
+++ b/api/lib/application/admin-members/index.js
@@ -1,5 +1,5 @@
 import { adminMemberController } from './admin-member-controller.js';
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
 import Joi from 'joi';
 

--- a/api/lib/application/cache/index.js
+++ b/api/lib/application/cache/index.js
@@ -1,4 +1,4 @@
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { cacheController } from './cache-controller.js';
 
 const register = async function (server) {

--- a/api/lib/application/campaign-participations/index.js
+++ b/api/lib/application/campaign-participations/index.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 import { campaignParticipationController } from './campaign-participation-controller.js';
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
 
 const register = async function (server) {

--- a/api/lib/application/campaigns-administration/index.js
+++ b/api/lib/application/campaigns-administration/index.js
@@ -1,6 +1,6 @@
 import { sendJsonApiError, PayloadTooLargeError } from '../http-errors.js';
 import { campaignController } from './campaign-controller.js';
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 const TWENTY_MEGABYTES = 1048576 * 20;
 
 const ERRORS = {

--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -2,7 +2,7 @@ import Joi from 'joi';
 import { campaignController } from './campaign-controller.js';
 import { campaignManagementController } from './campaign-management-controller.js';
 import { campaignStatsController } from './campaign-stats-controller.js';
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
 
 const register = async function (server) {

--- a/api/lib/application/certification-center-invitations/index.js
+++ b/api/lib/application/certification-center-invitations/index.js
@@ -2,7 +2,7 @@ import Joi from 'joi';
 
 import { certificationCenterInvitationController } from './certification-center-invitation-controller.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 
 const register = async function (server) {
   const adminRoutes = [

--- a/api/lib/application/certification-center-memberships/index.js
+++ b/api/lib/application/certification-center-memberships/index.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
 import { certificationCenterMembershipController } from './certification-center-membership-controller.js';
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
 
 const register = async function (server) {

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -1,5 +1,5 @@
 import { certificationCenterController } from './certification-center-controller.js';
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import Joi from 'joi';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
 

--- a/api/lib/application/certification-courses/index.js
+++ b/api/lib/application/certification-courses/index.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { certificationCourseController } from './certification-course-controller.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
 

--- a/api/lib/application/certification-issue-reports/index.js
+++ b/api/lib/application/certification-issue-reports/index.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 import { certificationIssueReportController } from './certification-issue-report-controller.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 
 const register = async function (server) {
   server.route([

--- a/api/lib/application/certification-reports/index.js
+++ b/api/lib/application/certification-reports/index.js
@@ -2,7 +2,7 @@ import Joi from 'joi';
 import { certificationReportController } from './certification-report-controller.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
 import { authorization } from '../preHandlers/authorization.js';
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 
 const register = async function (server) {
   server.route([

--- a/api/lib/application/certifications/index.js
+++ b/api/lib/application/certifications/index.js
@@ -2,7 +2,7 @@ import Joi from 'joi';
 
 import { certificationController } from './certification-controller.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 
 const register = async function (server) {
   server.route([

--- a/api/lib/application/complementary-certification-course-results/index.js
+++ b/api/lib/application/complementary-certification-course-results/index.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { complementaryCertificationCourseResultsController } from './complementary-certification-course-results-controller.js';
 import { juryOptions } from '../../domain/models/ComplementaryCertificationCourseResult.js';
 

--- a/api/lib/application/complementary-certifications/index.js
+++ b/api/lib/application/complementary-certifications/index.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 import { complementaryCertificationController } from './complementary-certification-controller.js';
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 
 const register = async function (server) {
   server.route([

--- a/api/lib/application/frameworks/index.js
+++ b/api/lib/application/frameworks/index.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 import { frameworksController as frameworkController } from './frameworks-controller.js';
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
 
 const register = async function (server) {

--- a/api/lib/application/lcms/index.js
+++ b/api/lib/application/lcms/index.js
@@ -1,4 +1,4 @@
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { lcmsController } from './lcms-controller.js';
 
 const register = async function (server) {

--- a/api/lib/application/memberships/index.js
+++ b/api/lib/application/memberships/index.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { membershipController } from './membership-controller.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
 

--- a/api/lib/application/organization-learners/index.js
+++ b/api/lib/application/organization-learners/index.js
@@ -2,7 +2,7 @@ import BaseJoi from 'joi';
 import JoiDate from '@joi/date';
 const Joi = BaseJoi.extend(JoiDate);
 
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { organizationLearnerController } from './organization-learner-controller.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
 

--- a/api/lib/application/organizations-administration/index.js
+++ b/api/lib/application/organizations-administration/index.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
 import { sendJsonApiError, PayloadTooLargeError } from '../http-errors.js';
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { organizationAdministrationController as organizationController } from './organization-administration-controller.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
 

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -3,7 +3,7 @@ import JoiDate from '@joi/date';
 const Joi = BaseJoi.extend(JoiDate);
 
 import { sendJsonApiError, PayloadTooLargeError, NotFoundError, BadRequestError } from '../http-errors.js';
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { organizationController } from './organization-controller.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
 

--- a/api/lib/application/sco-organization-learners/index.js
+++ b/api/lib/application/sco-organization-learners/index.js
@@ -5,7 +5,7 @@ const Joi = BaseJoi.extend(JoiDate);
 import { sendJsonApiError, UnprocessableEntityError, BadRequestError } from '../http-errors.js';
 import { scoOrganizationLearnerController } from './sco-organization-learner-controller.js';
 import XRegExp from 'xregexp';
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
 import { config } from '../../config.js';
 

--- a/api/lib/application/scoring-simulator/index.js
+++ b/api/lib/application/scoring-simulator/index.js
@@ -1,5 +1,5 @@
 import Joi from 'joi';
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { scoringSimulatorController } from './scoring-simulator-controller.js';
 
 const register = async function (server) {

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -2,7 +2,7 @@ import BaseJoi from 'joi';
 import JoiDate from '@joi/date';
 const Joi = BaseJoi.extend(JoiDate);
 
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { sessionController } from './session-controller.js';
 import { sessionForSupervisingController } from './session-for-supervising-controller.js';
 import { sessionWithCleaCertifiedCandidateController } from './session-with-clea-certified-candidate-controller.js';

--- a/api/lib/application/sup-organization-learners/index.js
+++ b/api/lib/application/sup-organization-learners/index.js
@@ -4,7 +4,7 @@ const Joi = BaseJoi.extend(JoiDate);
 
 import { sendJsonApiError, UnprocessableEntityError, NotFoundError } from '../http-errors.js';
 import { supOrganizationLearnerController } from './sup-organization-learner-controller.js';
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
 
 const register = async function (server) {

--- a/api/lib/application/tags/index.js
+++ b/api/lib/application/tags/index.js
@@ -1,4 +1,4 @@
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { tagController } from './tag-controller.js';
 import Joi from 'joi';
 import { identifiersType } from '../../domain/types/identifiers-type.js';

--- a/api/lib/application/target-profiles-management/index.js
+++ b/api/lib/application/target-profiles-management/index.js
@@ -1,5 +1,5 @@
 import Joi from 'joi';
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { targetProfilesManagementController } from './target-profile-management-controller.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
 

--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
 import { BadRequestError, sendJsonApiError } from '../http-errors.js';
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { targetProfileController } from './target-profile-controller.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
 

--- a/api/lib/application/user-orga-settings/index.js
+++ b/api/lib/application/user-orga-settings/index.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { userOrgaSettingsController } from './user-orga-settings-controller.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
 

--- a/api/lib/application/user-tutorials/index.js
+++ b/api/lib/application/user-tutorials/index.js
@@ -2,7 +2,7 @@ import Joi from 'joi';
 
 import { userTutorialsController } from './user-tutorials-controller.js';
 import { identifiersType } from '../../domain/types/identifiers-type.js';
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 
 const register = async function (server) {
   server.route([

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 import XRegExp from 'xregexp';
 
-import { securityPreHandlers } from '../security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { userController } from './user-controller.js';
 import { sendJsonApiError, BadRequestError } from '../http-errors.js';
 import { userVerification } from '../preHandlers/user-existence-verification.js';

--- a/api/src/authentication/application/routes.js
+++ b/api/src/authentication/application/routes.js
@@ -1,5 +1,5 @@
 import Joi from 'joi';
-import { securityPreHandlers } from '../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../shared/application/security-pre-handlers.js';
 import { authenticationController as AuthenticationController } from './authentication-controller.js';
 
 const register = async function (server) {

--- a/api/src/certification/complementary-certification/application/attach-target-profile-route.js
+++ b/api/src/certification/complementary-certification/application/attach-target-profile-route.js
@@ -1,5 +1,5 @@
 import { attachTargetProfileController } from './attach-target-profile-controller.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import Joi from 'joi';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
 import { erreurDoc } from '../../../../lib/infrastructure/open-api-doc/pole-emploi/erreur-doc.js';

--- a/api/src/certification/complementary-certification/application/complementary-certification-route.js
+++ b/api/src/certification/complementary-certification/application/complementary-certification-route.js
@@ -1,5 +1,5 @@
 import { complementaryCertificationController } from './complementary-certification-controller.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 
 const register = async function (server) {
   server.route([

--- a/api/src/certification/course/application/certification-attestation-route.js
+++ b/api/src/certification/course/application/certification-attestation-route.js
@@ -2,7 +2,7 @@ import Joi from 'joi';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
 import { certificationAttestationController } from './certification-attestation-controller.js';
 import { LOCALE } from '../../../shared/domain/constants.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 const { FRENCH_SPOKEN, ENGLISH_SPOKEN } = LOCALE;
 
 const register = async function (server) {

--- a/api/src/certification/course/application/certification-course-route.js
+++ b/api/src/certification/course/application/certification-course-route.js
@@ -1,5 +1,5 @@
 import Joi from 'joi';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
 import { certificationCourseController } from './certification-course-controller.js';
 

--- a/api/src/certification/flash-certification/application/flash-assessment-configuration-route.js
+++ b/api/src/certification/flash-certification/application/flash-assessment-configuration-route.js
@@ -1,5 +1,5 @@
 import { flashAssessmentConfigurationController } from './flash-assessment-configuration-controller.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import Joi from 'joi';
 
 const register = async (server) => {

--- a/api/src/certification/flash-certification/application/scenario-simulator-route.js
+++ b/api/src/certification/flash-certification/application/scenario-simulator-route.js
@@ -1,5 +1,5 @@
 import Joi from 'joi';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { scenarioSimulatorController } from './scenario-simulator-controller.js';
 
 const _successRatesConfigurationValidator = Joi.alternatives(

--- a/api/src/certification/session/application/certification-officer-route.js
+++ b/api/src/certification/session/application/certification-officer-route.js
@@ -1,5 +1,5 @@
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import BaseJoi from 'joi';
 import JoiDate from '@joi/date';
 import { certificationOfficerController } from './certification-officer-controller.js';

--- a/api/src/certification/session/application/session-mass-import-route.js
+++ b/api/src/certification/session/application/session-mass-import-route.js
@@ -1,5 +1,5 @@
 import { sessionMassImportController } from './session-mass-import-controller.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import Joi from 'joi';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
 

--- a/api/src/certification/session/application/session-route.js
+++ b/api/src/certification/session/application/session-route.js
@@ -1,4 +1,4 @@
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import Joi from 'joi';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
 import { sessionController } from './session-controller.js';

--- a/api/src/certification/session/application/unfinalize-route.js
+++ b/api/src/certification/session/application/unfinalize-route.js
@@ -1,5 +1,5 @@
 import { unfinalizeController } from './unfinalize-controller.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import Joi from 'joi';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
 

--- a/api/src/certification/session/application/update-cpf-import-status-route.js
+++ b/api/src/certification/session/application/update-cpf-import-status-route.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 import { udpdateCpfImportStatusController } from './update-cpf-import-status-controller.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 
 const register = async function (server) {
   server.route([

--- a/api/src/devcomp/application/trainings/index.js
+++ b/api/src/devcomp/application/trainings/index.js
@@ -2,7 +2,7 @@ import Joi from 'joi';
 
 import { trainingController as trainingsController } from './training-controller.js';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { sendJsonApiError, NotFoundError, BadRequestError } from '../../../../lib/application/http-errors.js';
 
 const register = async function (server) {

--- a/api/src/evaluation/application/autonomous-courses/index.js
+++ b/api/src/evaluation/application/autonomous-courses/index.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 import { autonomousCourseController } from './autonomous-course-controller.js';
 import { autonomousCourseTargetProfileController } from './autonomous-course-target-profile-controller.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { sendJsonApiError, BadRequestError } from '../../../../lib/application/http-errors.js';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
 

--- a/api/src/evaluation/application/stage-collections/index.js
+++ b/api/src/evaluation/application/stage-collections/index.js
@@ -1,5 +1,5 @@
 import Joi from 'joi';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { stageCollectionController } from './stage-collection-controller.js';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
 

--- a/api/src/evaluation/application/stages/index.js
+++ b/api/src/evaluation/application/stages/index.js
@@ -1,5 +1,5 @@
 import Joi from 'joi';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { stageController } from './stage-controller.js';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
 

--- a/api/src/prescription/campaign/application/campaign-administration-route.js
+++ b/api/src/prescription/campaign/application/campaign-administration-route.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 import { campaignAdministrationController } from './campaign-adminstration-controller.js';
 import { sendJsonApiError, PayloadTooLargeError } from '../../../../lib/application/http-errors.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
 const TWENTY_MEGABYTES = 1048576 * 20;
 

--- a/api/src/prescription/campaign/application/campaign-detail-route.js
+++ b/api/src/prescription/campaign/application/campaign-detail-route.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 import { campaignDetailController } from './campaign-detail-controller.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
 
 import { CampaignParticipationStatuses } from '../../shared/domain/constants.js';

--- a/api/src/prescription/campaign/application/campaign-results-route.js
+++ b/api/src/prescription/campaign/application/campaign-results-route.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 import { campaignResultsController } from './campaign-results-controller.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
 
 const register = async function (server) {

--- a/api/src/prescription/learner-management/application/organization-learners-route.js
+++ b/api/src/prescription/learner-management/application/organization-learners-route.js
@@ -1,4 +1,4 @@
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import Joi from 'joi';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
 import { organizationLearnersController } from './organization-learners-controller.js';

--- a/api/src/prescription/learner-management/application/sco-organization-management-route.js
+++ b/api/src/prescription/learner-management/application/sco-organization-management-route.js
@@ -3,7 +3,7 @@ import JoiDate from '@joi/date';
 const Joi = BaseJoi.extend(JoiDate);
 
 import { sendJsonApiError, PayloadTooLargeError } from '../../../../lib/application/http-errors.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
 import { scoOrganizationManagementController } from './sco-organization-management-controller.js';
 

--- a/api/src/prescription/learner-management/application/sup-organization-management-route.js
+++ b/api/src/prescription/learner-management/application/sup-organization-management-route.js
@@ -3,7 +3,7 @@ import JoiDate from '@joi/date';
 const Joi = BaseJoi.extend(JoiDate);
 
 import { sendJsonApiError, PayloadTooLargeError } from '../../../../lib/application/http-errors.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { supOrganizationManagementController } from './sup-organization-management-controller.js';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
 

--- a/api/src/prescription/organization-learner/application/learner-list-route.js
+++ b/api/src/prescription/organization-learner/application/learner-list-route.js
@@ -1,7 +1,7 @@
 import BaseJoi from 'joi';
 import JoiDate from '@joi/date';
 const Joi = BaseJoi.extend(JoiDate);
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { learnerListController } from './learner-list-controller.js';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
 

--- a/api/src/prescription/organization-learner/application/sco-learner-list-route.js
+++ b/api/src/prescription/organization-learner/application/sco-learner-list-route.js
@@ -1,7 +1,7 @@
 import BaseJoi from 'joi';
 import JoiDate from '@joi/date';
 const Joi = BaseJoi.extend(JoiDate);
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { scoLearnerListController } from './sco-learner-list-controller.js';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
 

--- a/api/src/prescription/organization-learner/application/sup-learner-list-route.js
+++ b/api/src/prescription/organization-learner/application/sup-learner-list-route.js
@@ -1,7 +1,7 @@
 import BaseJoi from 'joi';
 import JoiDate from '@joi/date';
 const Joi = BaseJoi.extend(JoiDate);
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { supLearnerListController } from './sup-learner-list-controller.js';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
 

--- a/api/src/prescription/organization-place/application/organization-place-route.js
+++ b/api/src/prescription/organization-place/application/organization-place-route.js
@@ -1,4 +1,4 @@
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
 import { organizationPlaceController } from './organization-place-controller.js';
 import Joi from 'joi';

--- a/api/src/prescription/target-profile/application/admin-target-profile-route.js
+++ b/api/src/prescription/target-profile/application/admin-target-profile-route.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { targetProfileController } from './admin-target-profile-controller.js';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
 

--- a/api/src/prescription/target-profile/application/target-profile-route.js
+++ b/api/src/prescription/target-profile/application/target-profile-route.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { targetProfileController } from './target-profile-controller.js';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
 

--- a/api/src/school/application/assessment-route.js
+++ b/api/src/school/application/assessment-route.js
@@ -1,4 +1,4 @@
-import { securityPreHandlers } from '../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../shared/application/security-pre-handlers.js';
 import Joi from 'joi';
 import { identifiersType } from '../../../lib/domain/types/identifiers-type.js';
 import { assessmentController } from './assessment-controller.js';

--- a/api/src/school/application/mission-route.js
+++ b/api/src/school/application/mission-route.js
@@ -2,7 +2,7 @@ import Joi from 'joi';
 
 import { missionController } from './mission-controller.js';
 import { identifiersType } from '../../../lib/domain/types/identifiers-type.js';
-import { securityPreHandlers } from '../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../shared/application/security-pre-handlers.js';
 
 const register = async function (server) {
   server.route([

--- a/api/src/school/application/organization-learner-route.js
+++ b/api/src/school/application/organization-learner-route.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 import { organizationLearnerController } from './organization-learner-controller.js';
-import { securityPreHandlers } from '../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../lib/domain/types/identifiers-type.js';
 
 const register = async function (server) {

--- a/api/src/school/application/school-route.js
+++ b/api/src/school/application/school-route.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 import { schoolController } from './school-controller.js';
-import { securityPreHandlers } from '../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../lib/domain/types/identifiers-type.js';
 
 const register = async function (server) {

--- a/api/src/shared/application/assessments/index.js
+++ b/api/src/shared/application/assessments/index.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 import { config } from '../../../../lib/config.js';
 import { assessmentController } from './assessment-controller.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../application/security-pre-handlers.js';
 import { assessmentAuthorization } from '../../../../lib/application/preHandlers/assessment-authorization.js';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
 

--- a/api/src/shared/application/badges/index.js
+++ b/api/src/shared/application/badges/index.js
@@ -1,5 +1,5 @@
 import Joi from 'joi';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../application/security-pre-handlers.js';
 import { badgesController } from './badges-controller.js';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
 

--- a/api/src/shared/application/challenges/index.js
+++ b/api/src/shared/application/challenges/index.js
@@ -2,7 +2,7 @@ import Joi from 'joi';
 
 import { challengeController } from './challenge-controller.js';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../application/security-pre-handlers.js';
 
 const register = async function (server) {
   server.route([

--- a/api/src/shared/application/security-pre-handlers.js
+++ b/api/src/shared/application/security-pre-handlers.js
@@ -2,39 +2,39 @@ import bluebird from 'bluebird';
 import jsonapiSerializer from 'jsonapi-serializer';
 import lodash from 'lodash';
 
-import * as checkIfUserIsBlockedUseCase from './usecases/checkIfUserIsBlocked.js';
-import * as checkAdminMemberHasRoleSuperAdminUseCase from './usecases/checkAdminMemberHasRoleSuperAdmin.js';
-import * as checkAdminMemberHasRoleCertifUseCase from './usecases/checkAdminMemberHasRoleCertif.js';
-import * as checkAdminMemberHasRoleSupportUseCase from './usecases/checkAdminMemberHasRoleSupport.js';
-import * as checkAdminMemberHasRoleMetierUseCase from './usecases/checkAdminMemberHasRoleMetier.js';
-import * as checkUserIsAdminInOrganizationUseCase from './usecases/checkUserIsAdminInOrganization.js';
-import * as checkUserBelongsToOrganizationManagingStudentsUseCase from './usecases/checkUserBelongsToOrganizationManagingStudents.js';
-import * as checkUserBelongsToLearnersOrganizationUseCase from './usecases/checkUserBelongsToLearnersOrganization.js';
-import * as checkUserBelongsToScoOrganizationAndManagesStudentsUseCase from './usecases/checkUserBelongsToScoOrganizationAndManagesStudents.js';
-import * as checkUserBelongsToSupOrganizationAndManagesStudentsUseCase from './usecases/checkUserBelongsToSupOrganizationAndManagesStudents.js';
-import * as checkUserOwnsCertificationCourseUseCase from './usecases/checkUserOwnsCertificationCourse.js';
-import * as checkUserBelongsToOrganizationUseCase from './usecases/checkUserBelongsToOrganization.js';
-import * as checkUserCanDisableHisOrganizationMembershipUseCase from './usecases/checkUserCanDisableHisOrganizationMembership.js';
-import * as checkUserIsAdminAndManagingStudentsForOrganization from './usecases/checkUserIsAdminAndManagingStudentsForOrganization.js';
-import * as checkUserIsAdminOfCertificationCenterUsecase from './usecases/checkUserIsAdminOfCertificationCenter.js';
-import * as checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationIdUseCase from './usecases/check-user-is-admin-of-certification-center-with-certification-center-invitation-id.js';
-import * as checkUserIsAdminOfCertificationCenterWithCertificationCenterMembershipIdUseCase from './usecases/check-user-is-admin-of-certification-center-with-certification-center-membership-id.js';
-import * as checkUserIsMemberOfCertificationCenterUsecase from './usecases/checkUserIsMemberOfCertificationCenter.js';
-import * as checkUserIsMemberOfCertificationCenterSessionUsecase from './usecases/checkUserIsMemberOfCertificationCenterSession.js';
-import * as checkAuthorizationToManageCampaignUsecase from './usecases/checkAuthorizationToManageCampaign.js';
-import * as checkAuthorizationToAccessCampaignUsecase from './usecases/checkAuthorizationToAccessCampaign.js';
-import * as checkOrganizationIsScoAndManagingStudentUsecase from './usecases/checkOrganizationIsScoAndManagingStudent.js';
-import * as checkPix1dEnabled from './usecases/checkPix1dEnabled.js';
-import * as certificationIssueReportRepository from '../../src/certification/shared/infrastructure/repositories/certification-issue-report-repository.js';
-import * as organizationRepository from '../infrastructure/repositories/organization-repository.js';
+import * as checkIfUserIsBlockedUseCase from '../../../lib/application/usecases/checkIfUserIsBlocked.js';
+import * as checkAdminMemberHasRoleSuperAdminUseCase from '../../../lib/application/usecases/checkAdminMemberHasRoleSuperAdmin.js';
+import * as checkAdminMemberHasRoleCertifUseCase from '../../../lib/application/usecases/checkAdminMemberHasRoleCertif.js';
+import * as checkAdminMemberHasRoleSupportUseCase from '../../../lib/application/usecases/checkAdminMemberHasRoleSupport.js';
+import * as checkAdminMemberHasRoleMetierUseCase from '../../../lib/application/usecases/checkAdminMemberHasRoleMetier.js';
+import * as checkUserIsAdminInOrganizationUseCase from '../../../lib/application/usecases/checkUserIsAdminInOrganization.js';
+import * as checkUserBelongsToOrganizationManagingStudentsUseCase from '../../../lib/application/usecases/checkUserBelongsToOrganizationManagingStudents.js';
+import * as checkUserBelongsToLearnersOrganizationUseCase from '../../../lib/application/usecases/checkUserBelongsToLearnersOrganization.js';
+import * as checkUserBelongsToScoOrganizationAndManagesStudentsUseCase from '../../../lib/application/usecases/checkUserBelongsToScoOrganizationAndManagesStudents.js';
+import * as checkUserBelongsToSupOrganizationAndManagesStudentsUseCase from '../../../lib/application/usecases/checkUserBelongsToSupOrganizationAndManagesStudents.js';
+import * as checkUserOwnsCertificationCourseUseCase from '../../../lib/application/usecases/checkUserOwnsCertificationCourse.js';
+import * as checkUserBelongsToOrganizationUseCase from '../../../lib/application/usecases/checkUserBelongsToOrganization.js';
+import * as checkUserCanDisableHisOrganizationMembershipUseCase from '../../../lib/application/usecases/checkUserCanDisableHisOrganizationMembership.js';
+import * as checkUserIsAdminAndManagingStudentsForOrganization from '../../../lib/application/usecases/checkUserIsAdminAndManagingStudentsForOrganization.js';
+import * as checkUserIsAdminOfCertificationCenterUsecase from '../../../lib/application/usecases/checkUserIsAdminOfCertificationCenter.js';
+import * as checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationIdUseCase from '../../../lib/application/usecases/check-user-is-admin-of-certification-center-with-certification-center-invitation-id.js';
+import * as checkUserIsAdminOfCertificationCenterWithCertificationCenterMembershipIdUseCase from '../../../lib/application/usecases/check-user-is-admin-of-certification-center-with-certification-center-membership-id.js';
+import * as checkUserIsMemberOfCertificationCenterUsecase from '../../../lib/application/usecases/checkUserIsMemberOfCertificationCenter.js';
+import * as checkUserIsMemberOfCertificationCenterSessionUsecase from '../../../lib/application/usecases/checkUserIsMemberOfCertificationCenterSession.js';
+import * as checkAuthorizationToManageCampaignUsecase from '../../../lib/application/usecases/checkAuthorizationToManageCampaign.js';
+import * as checkAuthorizationToAccessCampaignUsecase from '../../../lib/application/usecases/checkAuthorizationToAccessCampaign.js';
+import * as checkOrganizationIsScoAndManagingStudentUsecase from '../../../lib/application/usecases/checkOrganizationIsScoAndManagingStudent.js';
+import * as checkPix1dEnabled from '../../../lib/application/usecases/checkPix1dEnabled.js';
+import * as certificationIssueReportRepository from '../../certification/shared/infrastructure/repositories/certification-issue-report-repository.js';
+import * as organizationRepository from '../../../lib/infrastructure/repositories/organization-repository.js';
 
-import * as checkUserIsMemberOfAnOrganizationUseCase from '../../src/shared/application/validator/checkUserIsMemberOfAnOrganization.js';
-import * as checkOrganizationHasFeatureUseCase from '../../src/shared/application/usecases/checkOrganizationHasFeature.js';
+import * as checkUserIsMemberOfAnOrganizationUseCase from './validator/checkUserIsMemberOfAnOrganization.js';
+import * as checkOrganizationHasFeatureUseCase from './usecases/checkOrganizationHasFeature.js';
 
-import { Organization } from '../domain/models/index.js';
-import { NotFoundError } from '../domain/errors.js';
-import { ForbiddenAccess } from '../../src/shared/domain/errors.js';
-import { PIX_ADMIN } from '../../src/authorization/domain/constants.js';
+import { Organization } from '../../../lib/domain/models/index.js';
+import { NotFoundError } from '../../../lib/domain/errors.js';
+import { ForbiddenAccess } from '../domain/errors.js';
+import { PIX_ADMIN } from '../../authorization/domain/constants.js';
 
 const { Error: JSONAPIError } = jsonapiSerializer;
 const { has } = lodash;
@@ -153,7 +153,7 @@ function checkRequestedUserIsAuthenticatedUser(request, h) {
   const authenticatedUserId = request.auth.credentials.userId;
 
   // We cannot guarantee that callers will enforce the type to be an integer upstream
-  // eslint-disable-next-line no-restricted-syntax
+
   const requestedUserId = request.params.userId || parseInt(request.params.id);
 
   return authenticatedUserId === requestedUserId ? h.response(true) : _replyForbiddenError(h);

--- a/api/src/shared/prescriber-management/application/prescriber-informations-route.js
+++ b/api/src/shared/prescriber-management/application/prescriber-informations-route.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../application/security-pre-handlers.js';
 import { prescriberController } from './prescriber-informations-controller.js';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';
 

--- a/api/tests/acceptance/application/security-pre-handlers_test.js
+++ b/api/tests/acceptance/application/security-pre-handlers_test.js
@@ -1,7 +1,7 @@
 import { expect, generateValidRequestAuthorizationHeader, databaseBuilder } from '../../test-helper.js';
 import { createServer } from '../../../server.js';
 import { Membership } from '../../../lib/domain/models/Membership.js';
-import { securityPreHandlers } from '../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { ORGANIZATION_FEATURE } from '../../../lib/domain/constants.js';
 
 describe('Acceptance | Application | SecurityPreHandlers', function () {

--- a/api/tests/certification/complementary-certification/unit/application/attach-target-profile-route_test.js
+++ b/api/tests/certification/complementary-certification/unit/application/attach-target-profile-route_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import * as moduleUnderTest from '../../../../../src/certification/complementary-certification/application/attach-target-profile-route.js';
 import { attachTargetProfileController } from '../../../../../src/certification/complementary-certification/application/attach-target-profile-controller.js';
 

--- a/api/tests/certification/complementary-certification/unit/application/complementary-certification-route_test.js
+++ b/api/tests/certification/complementary-certification/unit/application/complementary-certification-route_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import * as moduleUnderTest from '../../../../../src/certification/complementary-certification/application/complementary-certification-route.js';
 import { complementaryCertificationController } from '../../../../../src/certification/complementary-certification/application/complementary-certification-controller.js';
 

--- a/api/tests/certification/course/unit/application/certification-attestation-route_test.js
+++ b/api/tests/certification/course/unit/application/certification-attestation-route_test.js
@@ -1,5 +1,5 @@
 import { expect, sinon, HttpTestServer } from '../../../../test-helper.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import * as moduleUnderTest from '../../../../../src/certification/course/application/certification-attestation-route.js';
 describe('Unit | Route | certification-attestation-route', function () {
   describe('GET /api/admin/sessions/{id}/attestations', function () {

--- a/api/tests/certification/course/unit/application/certification-course-route_test.js
+++ b/api/tests/certification/course/unit/application/certification-course-route_test.js
@@ -1,5 +1,5 @@
 import { expect, sinon, HttpTestServer } from '../../../../test-helper.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import * as moduleUnderTest from '../../../../../src/certification/course/application/certification-course-route.js';
 describe('Unit | Route | certification-course-route', function () {
   describe('POST /api/admin/certification-courses/{id}/reject', function () {

--- a/api/tests/certification/flash-certification/integration/application/scenario-simulator-controller_test.js
+++ b/api/tests/certification/flash-certification/integration/application/scenario-simulator-controller_test.js
@@ -2,7 +2,7 @@ import { expect, sinon, HttpTestServer, domainBuilder, parseJsonStream } from '.
 import { usecases } from '../../../../../src/certification/shared/domain/usecases/index.js';
 import * as moduleUnderTest from '../../../../../src/certification/flash-certification/application/scenario-simulator-route.js';
 import { random } from '../../../../../lib/infrastructure/utils/random.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { pickAnswerStatusService } from '../../../../../lib/domain/services/pick-answer-status-service.js';
 import { pickChallengeService } from '../../../../../lib/domain/services/pick-challenge-service.js';
 

--- a/api/tests/certification/session/unit/application/certification-officer-route_test.js
+++ b/api/tests/certification/session/unit/application/certification-officer-route_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { certificationOfficerController } from '../../../../../src/certification/session/application/certification-officer-controller.js';
 import * as moduleUnderTest from '../../../../../src/certification/session/application/certification-officer-route.js';
 

--- a/api/tests/certification/session/unit/application/session-mass-import-route_test.js
+++ b/api/tests/certification/session/unit/application/session-mass-import-route_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 
 import * as moduleUnderTest from '../../../../../src/certification/session/application/session-mass-import-route.js';
 import { sessionMassImportController } from '../../../../../src/certification/session/application/session-mass-import-controller.js';

--- a/api/tests/certification/session/unit/application/session-route_test.js
+++ b/api/tests/certification/session/unit/application/session-route_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 
 import * as moduleUnderTest from '../../../../../src/certification/session/application/session-route.js';
 import { sessionController } from '../../../../../src/certification/session/application/session-controller.js';

--- a/api/tests/certification/session/unit/application/unfinalize-route_test.js
+++ b/api/tests/certification/session/unit/application/unfinalize-route_test.js
@@ -2,7 +2,7 @@ import { HttpTestServer } from '../../../../tooling/server/http-test-server.js';
 import * as moduleUnderTest from '../../../../../src/certification/session/application/unfinalize-route.js';
 import { expect, sinon } from '../../../../test-helper.js';
 import { unfinalizeController } from '../../../../../src/certification/session/application/unfinalize-controller.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 
 describe('Unit | Router | session-unfinalize', function () {
   describe('PATCH /api/admin/sessions/{id}/unfinalize', function () {

--- a/api/tests/devcomp/unit/application/trainings/index_test.js
+++ b/api/tests/devcomp/unit/application/trainings/index_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { trainingController } from '../../../../../src/devcomp/application/trainings/training-controller.js';
 import * as moduleUnderTest from '../../../../../src/devcomp/application/trainings/index.js';
 

--- a/api/tests/evaluation/unit/application/autonomous-courses/index_test.js
+++ b/api/tests/evaluation/unit/application/autonomous-courses/index_test.js
@@ -1,6 +1,6 @@
 import { expect, sinon, HttpTestServer } from '../../../../test-helper.js';
 import { autonomousCourseController } from '../../../../../src/evaluation/application/autonomous-courses/autonomous-course-controller.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import * as autonomousCoursesRouter from '../../../../../src/evaluation/application/autonomous-courses/index.js';
 
 describe('Unit | Application | Badges | Routes', function () {

--- a/api/tests/integration/application/certification-center-memberships/certification-center-membership-controller_test.js
+++ b/api/tests/integration/application/certification-center-memberships/certification-center-membership-controller_test.js
@@ -1,5 +1,5 @@
 import { expect, sinon, HttpTestServer } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { certificationCenterMembershipController } from '../../../../lib/application/certification-center-memberships/certification-center-membership-controller.js';
 import * as moduleUnderTest from '../../../../lib/application/certification-center-memberships/index.js';
 

--- a/api/tests/integration/application/certifications/index_test.js
+++ b/api/tests/integration/application/certifications/index_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { certificationController } from '../../../../lib/application/certifications/certification-controller.js';
 import * as moduleUnderTest from '../../../../lib/application/certifications/index.js';
 

--- a/api/tests/integration/application/complementary-certification-course-results/complementary-certification-course-results-controller_test.js
+++ b/api/tests/integration/application/complementary-certification-course-results/complementary-certification-course-results-controller_test.js
@@ -1,5 +1,5 @@
 import { expect, sinon, HttpTestServer } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
 import { InvalidJuryLevelError } from '../../../../lib/domain/errors.js';
 import * as moduleUnderTest from '../../../../lib/application/complementary-certification-course-results/index.js';

--- a/api/tests/integration/application/complementary-certification-course-results/index_test.js
+++ b/api/tests/integration/application/complementary-certification-course-results/index_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import * as moduleUnderTest from '../../../../lib/application/complementary-certification-course-results/index.js';
 import { complementaryCertificationCourseResultsController } from '../../../../lib/application/complementary-certification-course-results/complementary-certification-course-results-controller.js';
 

--- a/api/tests/integration/application/memberships/membership-controller_test.js
+++ b/api/tests/integration/application/memberships/membership-controller_test.js
@@ -1,7 +1,7 @@
 import { expect, sinon, domainBuilder, HttpTestServer } from '../../../test-helper.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
 import { Membership } from '../../../../lib/domain/models/Membership.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import * as moduleUnderTest from '../../../../lib/application/memberships/index.js';
 import { InvalidMembershipOrganizationRoleError } from '../../../../lib/domain/errors.js';
 

--- a/api/tests/integration/application/organizations/index_test.js
+++ b/api/tests/integration/application/organizations/index_test.js
@@ -1,5 +1,5 @@
 import { expect, sinon, HttpTestServer } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { organizationController } from '../../../../lib/application/organizations/organization-controller.js';
 import * as moduleUnderTest from '../../../../lib/application/organizations/index.js';
 

--- a/api/tests/integration/application/organizations/organization-controller_test.js
+++ b/api/tests/integration/application/organizations/organization-controller_test.js
@@ -1,5 +1,5 @@
 import { expect, sinon, domainBuilder, HttpTestServer } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
 
 import { OrganizationInvitation } from '../../../../lib/domain/models/OrganizationInvitation.js';

--- a/api/tests/integration/application/sco-organization-learners/index_test.js
+++ b/api/tests/integration/application/sco-organization-learners/index_test.js
@@ -1,6 +1,6 @@
 import { expect, sinon, HttpTestServer } from '../../../test-helper.js';
 import { scoOrganizationLearnerController } from '../../../../lib/application/sco-organization-learners/sco-organization-learner-controller.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import * as moduleUnderTest from '../../../../lib/application/sco-organization-learners/index.js';
 
 describe('Integration | Application | Route | sco-organization-learners', function () {

--- a/api/tests/integration/application/sco-organization-learners/sco-organization-learner-controller_test.js
+++ b/api/tests/integration/application/sco-organization-learners/sco-organization-learner-controller_test.js
@@ -1,7 +1,7 @@
 import { expect, sinon, domainBuilder, HttpTestServer } from '../../../test-helper.js';
 import * as moduleUnderTest from '../../../../lib/application/sco-organization-learners/index.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 
 import {
   NotFoundError,

--- a/api/tests/integration/application/scoring-simulator/scoring-simulator-controller_test.js
+++ b/api/tests/integration/application/scoring-simulator/scoring-simulator-controller_test.js
@@ -4,7 +4,7 @@ import { ScoringSimulation } from '../../../../lib/domain/models/ScoringSimulati
 import { Answer } from '../../../../src/evaluation/domain/models/Answer.js';
 import { ScoringSimulationContext } from '../../../../lib/domain/models/ScoringSimulationContext.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import * as moduleUnderTest from '../../../../lib/application/scoring-simulator/index.js';
 
 describe('Integration | Application | Scoring-simulator | scoring-simulator-controller', function () {

--- a/api/tests/integration/application/security-pre-handlers_test.js
+++ b/api/tests/integration/application/security-pre-handlers_test.js
@@ -6,7 +6,7 @@ import {
   sinon,
 } from '../../test-helper.js';
 
-import { securityPreHandlers } from '../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { config as settings } from '../../../lib/config.js';
 import { PIX_ADMIN } from '../../../src/authorization/domain/constants.js';
 

--- a/api/tests/integration/application/sup-organization-learners/index_test.js
+++ b/api/tests/integration/application/sup-organization-learners/index_test.js
@@ -1,6 +1,6 @@
 import { expect, sinon, HttpTestServer, generateValidRequestAuthorizationHeader } from '../../../test-helper.js';
 import { supOrganizationLearnerController } from '../../../../lib/application/sup-organization-learners/sup-organization-learner-controller.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared//application/security-pre-handlers.js';
 import * as moduleUnderTest from '../../../../lib/application/sup-organization-learners/index.js';
 
 describe('Integration | Application | Route | sup-organization-learners', function () {

--- a/api/tests/integration/application/users/index_test.js
+++ b/api/tests/integration/application/users/index_test.js
@@ -1,5 +1,5 @@
 import { expect, sinon, HttpTestServer } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { userController } from '../../../../lib/application/users/user-controller.js';
 import * as moduleUnderTest from '../../../../lib/application/users/index.js';
 

--- a/api/tests/integration/application/users/user-controller_test.js
+++ b/api/tests/integration/application/users/user-controller_test.js
@@ -1,5 +1,5 @@
 import { expect, sinon, domainBuilder, HttpTestServer } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
 import { UserNotAuthorizedToRemoveAuthenticationMethod } from '../../../../lib/domain/errors.js';
 import { AssessmentResult } from '../../../../lib/domain/read-models/participant-results/AssessmentResult.js';

--- a/api/tests/prescription/campaign/integration/application/campaign-detail-route_test.js
+++ b/api/tests/prescription/campaign/integration/application/campaign-detail-route_test.js
@@ -1,6 +1,6 @@
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 import { campaignDetailController } from '../../../../../src/prescription/campaign/application/campaign-detail-controller.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import * as moduleUnderTest from '../../../../../src/prescription/campaign/application/campaign-detail-route.js';
 
 describe('Integration | Application | Route | campaign detail router', function () {

--- a/api/tests/prescription/campaign/unit/application/campaign-administration-route_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-administration-route_test.js
@@ -1,7 +1,7 @@
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 import { campaignAdministrationController } from '../../../../../src/prescription/campaign/application/campaign-adminstration-controller.js';
 import * as moduleUnderTest from '../../../../../src/prescription/campaign/application/campaign-administration-route.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import {
   SwapCampaignMismatchOrganizationError,
   UnknownCampaignId,

--- a/api/tests/prescription/campaign/unit/application/campaign-detail-route_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-detail-route_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { campaignDetailController } from '../../../../../src/prescription/campaign/application/campaign-detail-controller.js';
 import * as moduleUnderTest from '../../../../../src/prescription/campaign/application/campaign-detail-route.js';
 

--- a/api/tests/prescription/campaign/unit/application/campaign-results-route_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-results-route_test.js
@@ -1,6 +1,6 @@
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 import { campaignResultsController } from '../../../../../src/prescription/campaign/application/campaign-results-controller.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 
 import * as moduleUnderTest from '../../../../../src/prescription/campaign/application/campaign-results-route.js';
 

--- a/api/tests/prescription/learner-management/unit/application/sco-organization-management-route_test.js
+++ b/api/tests/prescription/learner-management/unit/application/sco-organization-management-route_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { scoOrganizationManagementController } from '../../../../../src/prescription/learner-management/application/sco-organization-management-controller.js';
 import * as moduleUnderTest from '../../../../../src/prescription/learner-management/application/sco-organization-management-route.js';
 

--- a/api/tests/prescription/learner-management/unit/application/sup-organization-management-route_test.js
+++ b/api/tests/prescription/learner-management/unit/application/sup-organization-management-route_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { supOrganizationManagementController } from '../../../../../src/prescription/learner-management/application/sup-organization-management-controller.js';
 import * as moduleUnderTest from '../../../../../src/prescription/learner-management/application/sup-organization-management-route.js';
 

--- a/api/tests/prescription/organization-learner/integration/application/learner-list-controller_test.js
+++ b/api/tests/prescription/organization-learner/integration/application/learner-list-controller_test.js
@@ -1,5 +1,5 @@
 import { expect, sinon, HttpTestServer } from '../../../../test-helper.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { usecases } from '../../../../../src/prescription/organization-learner/domain/usecases/index.js';
 
 import * as moduleUnderTest from '../../../../../src/prescription/organization-learner/application/learner-list-route.js';

--- a/api/tests/prescription/organization-learner/integration/application/learner-list-route_test.js
+++ b/api/tests/prescription/organization-learner/integration/application/learner-list-route_test.js
@@ -1,5 +1,5 @@
 import { expect, sinon, HttpTestServer } from '../../../../test-helper.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { learnerListController } from '../../../../../src/prescription/organization-learner/application/learner-list-controller.js';
 import * as moduleUnderTest from '../../../../../src/prescription/organization-learner/application/learner-list-route.js';
 

--- a/api/tests/prescription/organization-learner/integration/application/sco-learner-list-controller_test.js
+++ b/api/tests/prescription/organization-learner/integration/application/sco-learner-list-controller_test.js
@@ -1,5 +1,5 @@
 import { expect, sinon, HttpTestServer } from '../../../../test-helper.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { usecases } from '../../../../../src/prescription/organization-learner/domain/usecases/index.js';
 
 import { ScoOrganizationParticipant } from '../../../../../src/prescription/organization-learner/domain/read-models/ScoOrganizationParticipant.js';

--- a/api/tests/prescription/organization-learner/integration/application/sco-learner-list-route_test.js
+++ b/api/tests/prescription/organization-learner/integration/application/sco-learner-list-route_test.js
@@ -1,5 +1,5 @@
 import { expect, sinon, HttpTestServer } from '../../../../test-helper.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { scoLearnerListController } from '../../../../../src/prescription/organization-learner/application/sco-learner-list-controller.js';
 import * as moduleUnderTest from '../../../../../src/prescription/organization-learner/application/sco-learner-list-route.js';
 

--- a/api/tests/prescription/organization-learner/integration/application/sup-learner-list-controller_test.js
+++ b/api/tests/prescription/organization-learner/integration/application/sup-learner-list-controller_test.js
@@ -1,5 +1,5 @@
 import { expect, sinon, HttpTestServer } from '../../../../test-helper.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { usecases } from '../../../../../src/prescription/organization-learner/domain/usecases/index.js';
 
 import { SupOrganizationParticipant } from '../../../../../src/prescription/organization-learner/domain/read-models/SupOrganizationParticipant.js';

--- a/api/tests/prescription/organization-learner/integration/application/sup-learner-list-route_test.js
+++ b/api/tests/prescription/organization-learner/integration/application/sup-learner-list-route_test.js
@@ -1,5 +1,5 @@
 import { expect, sinon, HttpTestServer } from '../../../../test-helper.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { supLearnerListController } from '../../../../../src/prescription/organization-learner/application/sup-learner-list-controller.js';
 import * as moduleUnderTest from '../../../../../src/prescription/organization-learner/application/sup-learner-list-route.js';
 

--- a/api/tests/prescription/organization-place/integration/application/organization-place-controller_test.js
+++ b/api/tests/prescription/organization-place/integration/application/organization-place-controller_test.js
@@ -1,6 +1,6 @@
 import { domainBuilder, expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 import { usecases } from '../../../../../src/prescription/organization-place/domain/usecases/index.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import * as moduleUnderTest from '../../../../../src/prescription/organization-place/application/organization-place-route.js';
 
 describe('Integration | Application | organization-place-controller', function () {

--- a/api/tests/prescription/organization-place/integration/application/organization-place-route_test.js
+++ b/api/tests/prescription/organization-place/integration/application/organization-place-route_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import * as moduleUnderTest from '../../../../../src/prescription/organization-place/application/organization-place-route.js';
 import { organizationPlaceController } from '../../../../../src/prescription/organization-place/application/organization-place-controller.js';
 

--- a/api/tests/prescription/organization-place/unit/application/organization-place-route_test.js
+++ b/api/tests/prescription/organization-place/unit/application/organization-place-route_test.js
@@ -1,7 +1,7 @@
 import { HttpTestServer } from '../../../../tooling/server/http-test-server.js';
 import * as moduleUnderTest from '../../../../../src/prescription/organization-place/application/organization-place-route.js';
 import { expect, sinon } from '../../../../test-helper.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { usecases } from '../../../../../src/prescription/organization-place/domain/usecases/index.js';
 import { organizationPlaceController } from '../../../../../src/prescription/organization-place/application/organization-place-controller.js';
 import * as organizationPlacesCategories from '../../../../../src/prescription/organization-place/domain/constants/organization-places-categories.js';

--- a/api/tests/prescription/target-profile/unit/application/admin-target-profiles-route_test.js
+++ b/api/tests/prescription/target-profile/unit/application/admin-target-profiles-route_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { targetProfileController } from '../../../../../src/prescription/target-profile/application/admin-target-profile-controller.js';
 import * as moduleUnderTest from '../../../../../src/prescription/target-profile/application/admin-target-profile-route.js';
 

--- a/api/tests/school/unit/application/mission-route_test.js
+++ b/api/tests/school/unit/application/mission-route_test.js
@@ -1,6 +1,6 @@
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
 
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { missionController } from '../../../../src/school/application/mission-controller.js';
 import * as moduleUnderTest from '../../../../src/school/application/mission-route.js';
 

--- a/api/tests/school/unit/application/organization-learner-route_test.js
+++ b/api/tests/school/unit/application/organization-learner-route_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { organizationLearnerController } from '../../../../src/school/application/organization-learner-controller.js';
 import * as moduleUnderTest from '../../../../src/school/application/organization-learner-route.js';
 

--- a/api/tests/school/unit/application/school-route_test.js
+++ b/api/tests/school/unit/application/school-route_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { schoolController } from '../../../../src/school/application/school-controller.js';
 import * as moduleUnderTest from '../../../../src/school/application/school-route.js';
 

--- a/api/tests/shared/prescriber-management/integration/application/prescriber-informations-controller_test.js
+++ b/api/tests/shared/prescriber-management/integration/application/prescriber-informations-controller_test.js
@@ -1,5 +1,5 @@
 import { expect, sinon, domainBuilder, HttpTestServer } from '../../../../test-helper.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { usecases } from '../../../../../src/shared/prescriber-management/domain/usecases/index.js';
 import * as moduleUnderTest from '../../../../../src/shared/prescriber-management/application/prescriber-informations-route.js';
 

--- a/api/tests/shared/prescriber-management/integration/application/prescriber-informations-route_test.js
+++ b/api/tests/shared/prescriber-management/integration/application/prescriber-informations-route_test.js
@@ -1,5 +1,5 @@
 import { expect, sinon, HttpTestServer } from '../../../../test-helper.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { prescriberController } from '../../../../../src/shared/prescriber-management/application/prescriber-informations-controller.js';
 import * as moduleUnderTest from '../../../../../src/shared/prescriber-management/application/prescriber-informations-route.js';
 

--- a/api/tests/shared/prescriber-management/unit/application/prescriber-informations-route_test.js
+++ b/api/tests/shared/prescriber-management/unit/application/prescriber-informations-route_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { prescriberController } from '../../../../../src/shared/prescriber-management/application/prescriber-informations-controller.js';
 import * as moduleUnderTest from '../../../../../src/shared/prescriber-management/application/prescriber-informations-route.js';
 

--- a/api/tests/shared/unit/application/assessments/index_test.js
+++ b/api/tests/shared/unit/application/assessments/index_test.js
@@ -2,7 +2,7 @@ import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 import { config as settings } from '../../../../../lib/config.js';
 import { assessmentAuthorization } from '../../../../../lib/application/preHandlers/assessment-authorization.js';
 import { assessmentController } from '../../../../../src/shared/application/assessments/assessment-controller.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import * as moduleUnderTest from '../../../../../src/shared/application/assessments/index.js';
 
 describe('Unit | Application | Router | assessment-router', function () {

--- a/api/tests/shared/unit/application/badges/index_test.js
+++ b/api/tests/shared/unit/application/badges/index_test.js
@@ -1,6 +1,6 @@
 import { expect, sinon, HttpTestServer } from '../../../../test-helper.js';
 import { badgesController } from '../../../../../src/shared/application/badges/badges-controller.js';
-import { securityPreHandlers } from '../../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import * as badgesRouter from '../../../../../src/shared/application/badges/index.js';
 
 describe('Unit | Application | Badges | Routes', function () {

--- a/api/tests/unit/application/admin-members/index_test.js
+++ b/api/tests/unit/application/admin-members/index_test.js
@@ -4,7 +4,7 @@ import { PIX_ADMIN } from '../../../../src/authorization/domain/constants.js';
 const { ROLES } = PIX_ADMIN;
 
 import { adminMemberController } from '../../../../lib/application/admin-members/admin-member-controller.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import * as adminMembersRouter from '../../../../lib/application/admin-members/index.js';
 
 describe('Unit | Application | Router | admin-members-router', function () {

--- a/api/tests/unit/application/cache/index_test.js
+++ b/api/tests/unit/application/cache/index_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { cacheController } from '../../../../lib/application/cache/cache-controller.js';
 import * as moduleUnderTest from '../../../../lib/application/cache/index.js';
 

--- a/api/tests/unit/application/campaign-participations/index_test.js
+++ b/api/tests/unit/application/campaign-participations/index_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { campaignParticipationController } from '../../../../lib/application/campaign-participations/campaign-participation-controller.js';
 import * as moduleUnderTest from '../../../../lib/application/campaign-participations/index.js';
 

--- a/api/tests/unit/application/campaign/index_test.js
+++ b/api/tests/unit/application/campaign/index_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
 import { campaignController } from '../../../../lib/application/campaigns/campaign-controller.js';
 import { campaignStatsController } from '../../../../lib/application/campaigns/campaign-stats-controller.js';

--- a/api/tests/unit/application/campaigns-administration/index_test.js
+++ b/api/tests/unit/application/campaigns-administration/index_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { campaignController } from '../../../../lib/application/campaigns-administration/campaign-controller.js';
 import * as moduleUnderTest from '../../../../lib/application/campaigns-administration/index.js';
 

--- a/api/tests/unit/application/certification-centers/index_test.js
+++ b/api/tests/unit/application/certification-centers/index_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { certificationCenterController } from '../../../../lib/application/certification-centers/certification-center-controller.js';
 
 import * as moduleUnderTest from '../../../../lib/application/certification-centers/index.js';

--- a/api/tests/unit/application/certification-courses/index_test.js
+++ b/api/tests/unit/application/certification-courses/index_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { certificationCourseController as certificationCoursesController } from '../../../../lib/application/certification-courses/certification-course-controller.js';
 import * as moduleUnderTest from '../../../../lib/application/certification-courses/index.js';
 

--- a/api/tests/unit/application/certification-issue-reports/index_test.js
+++ b/api/tests/unit/application/certification-issue-reports/index_test.js
@@ -1,6 +1,6 @@
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
 import { certificationIssueReportController } from '../../../../lib/application/certification-issue-reports/certification-issue-report-controller.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import * as moduleUnderTest from '../../../../lib/application/certification-issue-reports/index.js';
 
 describe('Unit | Application | Certifications Issue Report | Route', function () {

--- a/api/tests/unit/application/certification-report/index_test.js
+++ b/api/tests/unit/application/certification-report/index_test.js
@@ -2,7 +2,7 @@ import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
 import { certificationReportController } from '../../../../lib/application/certification-reports/certification-report-controller.js';
 import { NotFoundError } from '../../../../lib/application/http-errors.js';
 import { authorization } from '../../../../lib/application/preHandlers/authorization.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import * as moduleUnderTest from '../../../../lib/application/certification-reports/index.js';
 
 describe('Unit | Application | Certifications Report | Route', function () {

--- a/api/tests/unit/application/certifications/index_test.js
+++ b/api/tests/unit/application/certifications/index_test.js
@@ -1,5 +1,5 @@
 import { sinon, expect, HttpTestServer } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { certificationController } from '../../../../lib/application/certifications/certification-controller.js';
 import * as moduleUnderTest from '../../../../lib/application/certifications/index.js';
 

--- a/api/tests/unit/application/complementary-certification-course-results/index_test.js
+++ b/api/tests/unit/application/complementary-certification-course-results/index_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import * as moduleUnderTest from '../../../../lib/application/complementary-certification-course-results/index.js';
 import { juryOptions } from '../../../../lib/domain/models/ComplementaryCertificationCourseResult.js';
 import { complementaryCertificationCourseResultsController } from '../../../../lib/application/complementary-certification-course-results/complementary-certification-course-results-controller.js';

--- a/api/tests/unit/application/complementary-certifications/index_test.js
+++ b/api/tests/unit/application/complementary-certifications/index_test.js
@@ -1,6 +1,6 @@
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
 import { complementaryCertificationController } from '../../../../lib/application/complementary-certifications/complementary-certification-controller.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import * as moduleUnderTest from '../../../../lib/application/complementary-certifications/index.js';
 
 describe('Unit | Application | Router | complementary-certifications-router', function () {

--- a/api/tests/unit/application/frameworks/index_test.js
+++ b/api/tests/unit/application/frameworks/index_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon, generateValidRequestAuthorizationHeader } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { frameworksController } from '../../../../lib/application/frameworks/frameworks-controller.js';
 import * as moduleUnderTest from '../../../../lib/application/frameworks/index.js';
 

--- a/api/tests/unit/application/lcms/index_test.js
+++ b/api/tests/unit/application/lcms/index_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { lcmsController } from '../../../../lib/application/lcms/lcms-controller.js';
 import * as moduleUnderTest from '../../../../lib/application/lcms/index.js';
 

--- a/api/tests/unit/application/memberships/index_test.js
+++ b/api/tests/unit/application/memberships/index_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { membershipController } from '../../../../lib/application/memberships/membership-controller.js';
 import * as moduleUnderTest from '../../../../lib/application/memberships/index.js';
 

--- a/api/tests/unit/application/organization-learners/index_test.js
+++ b/api/tests/unit/application/organization-learners/index_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { organizationLearnerController } from '../../../../lib/application/organization-learners/organization-learner-controller.js';
 import * as moduleUnderTest from '../../../../lib/application/organization-learners/index.js';
 

--- a/api/tests/unit/application/organizations-administration/index_test.js
+++ b/api/tests/unit/application/organizations-administration/index_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import * as moduleUnderTest from '../../../../lib/application/organizations-administration/index.js';
 
 describe('Unit | Router | organization-administration-router', function () {

--- a/api/tests/unit/application/organizations/index_test.js
+++ b/api/tests/unit/application/organizations/index_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { organizationController } from '../../../../lib/application/organizations/organization-controller.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
 import { identifiersType } from '../../../../lib/domain/types/identifiers-type.js';

--- a/api/tests/unit/application/security-pre-handlers_test.js
+++ b/api/tests/unit/application/security-pre-handlers_test.js
@@ -1,5 +1,5 @@
 import { expect, sinon, hFake, domainBuilder } from '../../test-helper.js';
-import { securityPreHandlers } from '../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { tokenService } from '../../../src/shared/domain/services/token-service.js';
 import { NotFoundError } from '../../../lib/domain/errors.js';
 

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -5,7 +5,7 @@ import FormData from 'form-data';
 import streamToPromise from 'stream-to-promise';
 import { NotFoundError } from '../../../../lib/application/http-errors.js';
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { sessionController } from '../../../../lib/application/sessions/session-controller.js';
 import { sessionForSupervisingController } from '../../../../lib/application/sessions/session-for-supervising-controller.js';
 import { sessionWithCleaCertifiedCandidateController } from '../../../../lib/application/sessions/session-with-clea-certified-candidate-controller.js';

--- a/api/tests/unit/application/tags/index_test.js
+++ b/api/tests/unit/application/tags/index_test.js
@@ -1,5 +1,5 @@
 import { domainBuilder, expect, sinon, HttpTestServer } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { tagController } from '../../../../lib/application/tags/tag-controller.js';
 import * as moduleUnderTest from '../../../../lib/application/tags/index.js';
 

--- a/api/tests/unit/application/target-profiles/index_test.js
+++ b/api/tests/unit/application/target-profiles/index_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { targetProfileController } from '../../../../lib/application/target-profiles/target-profile-controller.js';
 import * as moduleUnderTest from '../../../../lib/application/target-profiles/index.js';
 

--- a/api/tests/unit/application/user-tutorials/index_test.js
+++ b/api/tests/unit/application/user-tutorials/index_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { userTutorialsController } from '../../../../lib/application/user-tutorials/user-tutorials-controller.js';
 import * as moduleUnderTest from '../../../../lib/application/user-tutorials/index.js';
 

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -1,5 +1,5 @@
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
-import { securityPreHandlers } from '../../../../lib/application/security-pre-handlers.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { userVerification } from '../../../../lib/application/preHandlers/user-existence-verification.js';
 import { userController } from '../../../../lib/application/users/user-controller.js';
 import * as OidcIdentityProviders from '../../../../lib/domain/constants/oidc-identity-providers.js';


### PR DESCRIPTION
## :christmas_tree: Problème

cf https://github.com/1024pix/pix/blob/dev/docs/adr/0051-nouvelle-arborescence-api.md

## :gift: Proposition

Déplacement du fichier de Security Pre Handlers dans le repertoire `src/shared`

## :socks: Remarques


## :santa: Pour tester

Tests vert et rien de changer dans les diverses applications.
