### PR TITLE
[BUGFIX] Bloquer le bouton de vérification d'un élément après soumission (PIX-10869)

### DIFF
--- a/mon-pix/app/pods/components/module/qcu/template.hbs
+++ b/mon-pix/app/pods/components/module/qcu/template.hbs
@@ -1,4 +1,4 @@
-<form class="element-qcu" {{on "submit" this.submitAnswer}}>
+<form class="element-qcu">
   <fieldset disabled={{this.disableInput}}>
     <div class="element-qcu__header">
       <div class="element-qcu-header__instruction">
@@ -30,7 +30,13 @@
   {{/if}}
 
   {{#unless this.qcu.lastCorrection}}
-    <PixButton @backgroundColor="green" @shape="rounded" @type="submit" class="element-qcu__verify_button">
+    <PixButton
+      @backgroundColor="green"
+      @shape="rounded"
+      @type="submit"
+      class="element-qcu__verify_button"
+      @triggerAction={{this.submitAnswer}}
+    >
       {{t "pages.modulix.buttons.activity.verify"}}
     </PixButton>
   {{/unless}}

--- a/mon-pix/app/pods/components/module/qrocm/template.hbs
+++ b/mon-pix/app/pods/components/module/qrocm/template.hbs
@@ -1,11 +1,4 @@
-<form
-  class="element-qrocm"
-  autocapitalize="off"
-  autocomplete="nope"
-  autocorrect="off"
-  spellcheck="false"
-  {{on "submit" this.submitAnswer}}
->
+<form class="element-qrocm" autocapitalize="off" autocomplete="nope" autocorrect="off" spellcheck="false">
   <fieldset disabled={{this.disableInput}}>
     <div class="element-qrocm__header">
       <div class="element-qrocm-header__instruction">
@@ -60,7 +53,13 @@
   {{/if}}
 
   {{#unless this.qrocm.lastCorrection}}
-    <PixButton @backgroundColor="green" @shape="rounded" @type="submit" class="element-qrocm__verify_button">
+    <PixButton
+      @backgroundColor="green"
+      @shape="rounded"
+      @type="submit"
+      class="element-qrocm__verify_button"
+      @triggerAction={{this.submitAnswer}}
+    >
       {{t "pages.modulix.buttons.activity.verify"}}
     </PixButton>
   {{/unless}}


### PR DESCRIPTION
## :christmas_tree: Problème
Lorsque l’on vérifie sa réponse, le bouton peut pour le moment être spammé notamment en cas de réseau moyen.

## :gift: Proposition
Bloquer l’utilisation du bouton dès qu’il a été cliqué une fois pour attendre le retour du serveur. Utiliser le paramètre `triggerAction` sur le `PixButton` qui bloque le bouton et change son visuel le temps de chargement.

## :socks: Remarques
Je ne pense pas que ce soit testable automatiquement.

## :santa: Pour tester
Vérifier avec un mauvais réseau que le bouton n'est pas reclickable après soumission.

https://app-pr7908.review.pix.fr/modules/bien-ecrire-son-adresse-mail
