### PR TITLE
[FEATURE] Cacher le bouton "Passer" une fois cliqué (PIX-10891)

### DIFF
--- a/mon-pix/app/pods/components/module/details/component.js
+++ b/mon-pix/app/pods/components/module/details/component.js
@@ -31,7 +31,7 @@ export default class ModuleDetails extends Component {
   }
 
   @action
-  grainCanDisplayContinueButton(index) {
+  grainCanDisplayActionsButton(index) {
     return this.lastIndex === index && this.hasNextGrain;
   }
 

--- a/mon-pix/app/pods/components/module/details/template.hbs
+++ b/mon-pix/app/pods/components/module/details/template.hbs
@@ -11,7 +11,7 @@
         @grain={{grain}}
         @transition={{this.grainTransition grain.id}}
         @submitAnswer={{@submitAnswer}}
-        @canDisplayContinueButton={{this.grainCanDisplayContinueButton index}}
+        @canDisplayActionsButton={{this.grainCanDisplayActionsButton index}}
         @continueAction={{this.addNextGrainToDisplay}}
         @skipAction={{this.addNextGrainToDisplay}}
         @hasJustAppeared={{this.hasGrainJustAppeared index}}

--- a/mon-pix/app/pods/components/module/grain/component.js
+++ b/mon-pix/app/pods/components/module/grain/component.js
@@ -11,7 +11,7 @@ export default class ModuleGrain extends Component {
   }
 
   get shouldDisplaySkipButton() {
-    return this.args.grain.hasAnswerableElements && !this.allElementsAreAnswered;
+    return this.args.canDisplayActionsButton && this.args.grain.hasAnswerableElements && !this.allElementsAreAnswered;
   }
 
   get allElementsAreAnswered() {

--- a/mon-pix/app/pods/components/module/grain/component.js
+++ b/mon-pix/app/pods/components/module/grain/component.js
@@ -7,7 +7,7 @@ export default class ModuleGrain extends Component {
   @service metrics;
 
   get shouldDisplayContinueButton() {
-    return this.args.canDisplayContinueButton && this.allElementsAreAnswered;
+    return this.args.canDisplayActionsButton && this.allElementsAreAnswered;
   }
 
   get shouldDisplaySkipButton() {

--- a/mon-pix/tests/integration/components/module/grain_test.js
+++ b/mon-pix/tests/integration/components/module/grain_test.js
@@ -189,7 +189,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // when
       const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canDisplayContinueButton={{true}} />`);
+            <Module::Grain @grain={{this.grain}} @canDisplayActionsButton={{true}} />`);
 
       // then
       assert
@@ -197,7 +197,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
         .doesNotExist();
     });
 
-    module('when canDisplayContinueButton is true', function () {
+    module('when canDisplayActionsButton is true', function () {
       test('should display continue button', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
@@ -211,13 +211,13 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
         // when
         const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canDisplayContinueButton={{true}} />`);
+            <Module::Grain @grain={{this.grain}} @canDisplayActionsButton={{true}} />`);
 
         // then
         assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists();
       });
     });
-    module('when canDisplayContinueButton is false', function () {
+    module('when canDisplayActionsButton is false', function () {
       test('should not display continue button', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
@@ -229,7 +229,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
         // when
         const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canDisplayContinueButton={{false}} />`);
+            <Module::Grain @grain={{this.grain}} @canDisplayActionsButton={{false}} />`);
 
         // then
         assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
@@ -237,7 +237,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
     });
   });
 
-  module('when not any element are answered', function () {
+  module('when at least one element has not been answered', function () {
     test('should display skip button', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
@@ -249,13 +249,13 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // when
       const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canDisplayContinueButton={{true}} />`);
+            <Module::Grain @grain={{this.grain}} @canDisplayActionsButton={{true}} />`);
 
       // then
       assert.dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') })).exists();
     });
 
-    module('when canDisplayContinueButton is true', function () {
+    module('when canDisplayActionsButton is true', function () {
       test('should not display continue button', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
@@ -267,13 +267,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
         // when
         const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canDisplayContinueButton={{true}} />`);
+            <Module::Grain @grain={{this.grain}} @canDisplayActionsButton={{true}} />`);
 
         // then
         assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
       });
     });
-    module('when canDisplayContinueButton is false', function () {
+
+    module('when canDisplayActionsButton is false', function () {
       test('should not display continue button', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
@@ -285,7 +286,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
         // when
         const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canDisplayContinueButton={{false}} />`);
+            <Module::Grain @grain={{this.grain}} @canDisplayActionsButton={{false}} />`);
 
         // then
         assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
@@ -309,7 +310,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // when
       await render(
-        hbs`<Module::Grain @grain={{this.grain}} @canDisplayContinueButton={{true}} @continueAction={{this.continueAction}} />`,
+        hbs`<Module::Grain @grain={{this.grain}} @canDisplayActionsButton={{true}} @continueAction={{this.continueAction}} />`,
       );
       await clickByName('Continuer');
 
@@ -343,7 +344,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // when
       await render(
-        hbs`<Module::Grain @grain={{this.grain}} @canDisplayContinueButton={{true}} @continueAction={{this.continueAction}} @skipAction={{this.skipAction}} />`,
+        hbs`<Module::Grain @grain={{this.grain}} @canDisplayActionsButton={{true}} @continueAction={{this.continueAction}} @skipAction={{this.skipAction}} />`,
       );
       await clickByName(this.intl.t('pages.modulix.buttons.grain.skip'));
 

--- a/mon-pix/tests/integration/components/module/grain_test.js
+++ b/mon-pix/tests/integration/components/module/grain_test.js
@@ -238,23 +238,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
   });
 
   module('when at least one element has not been answered', function () {
-    test('should display skip button', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const element = store.createRecord('element', { type: 'qcus', isAnswerable: true });
-      const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
-      this.set('grain', grain);
-
-      assert.false(grain.allElementsAreAnswered);
-
-      // when
-      const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canDisplayActionsButton={{true}} />`);
-
-      // then
-      assert.dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') })).exists();
-    });
-
     module('when canDisplayActionsButton is true', function () {
       test('should not display continue button', async function (assert) {
         // given
@@ -271,6 +254,23 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
         // then
         assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+      });
+
+      test('should display skip button', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = store.createRecord('element', { type: 'qcus', isAnswerable: true });
+        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+        this.set('grain', grain);
+
+        assert.false(grain.allElementsAreAnswered);
+
+        // when
+        const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} @canDisplayActionsButton={{true}} />`);
+
+        // then
+        assert.dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') })).exists();
       });
     });
 
@@ -290,6 +290,25 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
         // then
         assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+      });
+
+      test('should not display skip button', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = store.createRecord('element', { type: 'qcus', isAnswerable: true });
+        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+        this.set('grain', grain);
+
+        assert.false(grain.allElementsAreAnswered);
+
+        // when
+        const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} @canDisplayActionsButton={{false}} />`);
+
+        // then
+        assert
+          .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') }))
+          .doesNotExist();
       });
     });
   });


### PR DESCRIPTION
## :christmas_tree: Problème
Quand on clique sur le bouton "Passer" d'un grain activité, on passe au grain suivant. Il est possible de remonter et le bouton "Passer" reste affiché, on peut toujours appuyer dessus et cela permet de "sauter" des grains.

## :gift: Proposition
Ne permettre de passer le grain que si il est encore actif.

## :socks: Remarques
RAS

## :santa: Pour tester
Sur la RA :
- Arriver jusqu'à un grain activité,
- Passer
- Constater en remontant que le bouton a disparu
- Répondre à l'activité toujours active
- Constater que cela fonctionne
- Continuer le module jusqu'à la fin
