### PR TITLE
:bug: api: Set today's date for KE's reset

### DIFF
--- a/api/lib/domain/models/KnowledgeElement.js
+++ b/api/lib/domain/models/KnowledgeElement.js
@@ -60,6 +60,7 @@ class KnowledgeElement {
       status: statuses.RESET,
       earnedPix: 0,
       id: undefined,
+      createdAt: undefined,
     });
   }
 

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -69,15 +69,13 @@ async function _countValidatedByCompetencesForUsersWithinCampaign(userIdsAndDate
 }
 
 const save = async function (knowledgeElement) {
-  const knowledgeElementToSave = _.omit(knowledgeElement, ['id', 'createdAt']);
-  const [savedKnowledgeElement] = await knex(tableName).insert(knowledgeElementToSave).returning('*');
+  const [savedKnowledgeElement] = await knex(tableName).insert(knowledgeElement).returning('*');
   return new KnowledgeElement(savedKnowledgeElement);
 };
 
 const batchSave = async function ({ knowledgeElements, domainTransaction = DomainTransaction.emptyTransaction() }) {
   const knexConn = domainTransaction.knexTransaction || knex;
-  const knowledgeElementsToSave = knowledgeElements.map((ke) => _.omit(ke, ['id', 'createdAt']));
-  await knexConn.batchInsert(tableName, knowledgeElementsToSave);
+  await knexConn.batchInsert(tableName, knowledgeElements);
 };
 
 const findUniqByUserId = function ({ userId, limitDate, domainTransaction }) {

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -8,7 +8,11 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
   describe('#save', function () {
     let knowledgeElementToSave;
 
-    beforeEach(function () {
+    afterEach(function () {
+      return knex('knowledge-elements').del();
+    });
+
+    it('should save the knowledgeElement in db', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser({}).id;
       const assessmentId = databaseBuilder.factory.buildAssessment({ userId }).id;
@@ -21,10 +25,8 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       });
       knowledgeElementToSave.id = undefined;
 
-      return databaseBuilder.commit();
-    });
+      await databaseBuilder.commit();
 
-    it('should save the knowledgeElement in db', async function () {
       // when
       await knowledgeElementRepository.save(knowledgeElementToSave);
 
@@ -39,7 +41,11 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
   describe('#batchSave', function () {
     let knowledgeElementsToSave;
 
-    beforeEach(function () {
+    afterEach(function () {
+      return knex('knowledge-elements').del();
+    });
+
+    it('should save all the knowledgeElements in db', async function () {
       // given
       knowledgeElementsToSave = [];
       const userId = databaseBuilder.factory.buildUser({}).id;
@@ -48,6 +54,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       const answerId2 = databaseBuilder.factory.buildAnswer({ assessmentId }).id;
       knowledgeElementsToSave.push(
         domainBuilder.buildKnowledgeElement({
+          id: null,
           userId,
           assessmentId,
           answerId: answerId1,
@@ -56,17 +63,17 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       );
       knowledgeElementsToSave.push(
         domainBuilder.buildKnowledgeElement({
+          id: null,
           userId,
           assessmentId,
           answerId: answerId2,
           competenceId: 'recABC',
         }),
       );
+      knowledgeElementsToSave.forEach((ke) => (ke.id = undefined));
 
-      return databaseBuilder.commit();
-    });
+      await databaseBuilder.commit();
 
-    it('should save all the knowledgeElements in db', async function () {
       // when
       await knowledgeElementRepository.batchSave({ knowledgeElements: knowledgeElementsToSave });
 

--- a/api/tests/unit/domain/models/KnowledgeElement_test.js
+++ b/api/tests/unit/domain/models/KnowledgeElement_test.js
@@ -367,15 +367,26 @@ describe('Unit | Domain | Models | KnowledgeElement', function () {
   describe('#reset', function () {
     it('should set status to RESET', function () {
       // given
+      const now = new Date('2024-06-01');
       const knowledgeElement = domainBuilder.buildKnowledgeElement({
+        id: 1,
         status: KnowledgeElement.StatusType.VALIDATED,
+        createdAt: new Date('2023-12-01'),
       });
 
       // when
       const resetKe = KnowledgeElement.reset(knowledgeElement);
 
       // then
-      expect(resetKe.status).to.be.equal(KnowledgeElement.StatusType.RESET);
+      expect(resetKe).to.deepEqualInstance(
+        new KnowledgeElement({
+          ...knowledgeElement,
+          id: undefined,
+          createdAt: undefined,
+          status: KnowledgeElement.StatusType.RESET,
+          earnedPix: 0,
+        }),
+      );
     });
 
     it('should set earnedPix to 0', function () {


### PR DESCRIPTION
## :christmas_tree: Problème
Lors d'un reset, on cree un nouveau KE qui reprends les infos du KE qu'il "reset". On enregistre donc la date du passage de l'acquis et non pas la date du reset.

Lors d'une investigation, la date du reset est donc faussé

## :gift: Proposition
Mettre la date de l'action reset sur les KE reset

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
