### PR TITLE
[FEATURE] Ajouter un label "organisation enfant" sur la page d'une organisation enfant (PIX-10050)

### DIFF
--- a/admin/app/components/organizations/information-section-view.hbs
+++ b/admin/app/components/organizations/information-section-view.hbs
@@ -1,5 +1,6 @@
 <div class="organization__data">
   <h2 class="organization__name">{{@organization.name}}</h2>
+
   {{#if @organization.tags}}
     <ul class="organization-tags-list">
       {{#each @organization.tags as |tag|}}
@@ -17,8 +18,23 @@
     {{#if @organization.children}}
       <PixTag @color="success">{{t "components.organizations.information-section-view.parent-organization"}}</PixTag>
     {{/if}}
+    {{#if @organization.parentOrganizationId}}
+      <ul>
+        <li>
+          <PixTag class="organization__child-tag" @color="success">{{t
+              "components.organizations.information-section-view.child-organization"
+            }}</PixTag>
+        </li>
+        <li>
+          {{t "components.organizations.information-section-view.parent-organization"}}
+          :
+          <LinkTo @route="authenticated.organizations.get" @model={{@organization.parentOrganizationId}}>
+            {{@organization.parentOrganizationName}}
+          </LinkTo>
+        </li>
+      </ul>
+    {{/if}}
   </div>
-
   {{#if @organization.isArchived}}
     <PixMessage class="organization-information-section__archived-message" @type="warning">
       Archivée le

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -28,7 +28,8 @@ export default class Organization extends Model {
   @attr() dataProtectionOfficerEmail;
   @attr() features;
   @attr('nullable-string') code;
-
+  @attr() parentOrganizationId;
+  @attr('nullable-string') parentOrganizationName;
   @equal('type', 'SCO') isOrganizationSCO;
   @equal('type', 'SUP') isOrganizationSUP;
 

--- a/admin/app/styles/authenticated/organizations/get.scss
+++ b/admin/app/styles/authenticated/organizations/get.scss
@@ -41,6 +41,10 @@
       margin-bottom: var(--pix-spacing-6x);
     }
 
+    .organization__child-tag{
+      margin-bottom: var(--pix-spacing-2x);
+    }
+
     .organization__data {
       max-width: 100%;
       overflow: hidden;

--- a/admin/tests/integration/components/organizations/information-section-view_test.js
+++ b/admin/tests/integration/components/organizations/information-section-view_test.js
@@ -244,8 +244,30 @@ module('Integration | Component | organizations/information-section-view', funct
       });
     });
 
-    module('when organization is not parent', function () {
-      test('it should not display parent label', async function (assert) {
+    module('when organization is child', function () {
+      test('it displays child label and parent organization name', async function (assert) {
+        //given
+        const store = this.owner.lookup('service:store');
+        const parentOrganization = store.createRecord('organization', { id: 5, type: 'SCO', isManagingStudents: true });
+        const organization = store.createRecord('organization', {
+          type: 'SCO',
+          isManagingStudents: true,
+          parentOrganizationId: parentOrganization.id,
+          parentOrganizationName: 'Shibusen',
+        });
+        this.set('organization', organization);
+
+        // when
+        const screen = await render(hbs`<Organizations::InformationSectionView @organization={{this.organization}} />`);
+
+        // then
+        assert.dom(screen.getByText('Organisation enfant')).exists();
+        assert.dom(screen.getByText('Shibusen')).exists();
+      });
+    });
+
+    module('when organization is neither parent nor children', function () {
+      test('it displays no organization network label', async function (assert) {
         //given
         const store = this.owner.lookup('service:store');
         const organization = store.createRecord('organization', {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -110,6 +110,7 @@
         "table-name": "List of children organisations"
       },
       "information-section-view": {
+        "child-organization": "Child organization",
         "parent-organization": "Parent organization"
       }
     },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -118,6 +118,7 @@
         "table-name": "Liste des organisations enfants"
       },
       "information-section-view": {
+        "child-organization": "Organisation enfant",
         "parent-organization": "Organisation parente"
       }
     },

--- a/api/lib/domain/models/organizations-administration/OrganizationForAdmin.js
+++ b/api/lib/domain/models/organizations-administration/OrganizationForAdmin.js
@@ -35,6 +35,7 @@ class OrganizationForAdmin {
     features = {},
     code,
     parentOrganizationId,
+    parentOrganizationName,
   } = {}) {
     this.id = id;
     this.name = name;
@@ -54,6 +55,8 @@ class OrganizationForAdmin {
     this.archivedAt = archivedAt;
     this.archivistFirstName = archivistFirstName;
     this.archivistLastName = archivistLastName;
+    this.parentOrganizationId = parentOrganizationId;
+    this.parentOrganizationName = parentOrganizationName;
     this.dataProtectionOfficer = new DataProtectionOfficer({
       organizationId: id,
       firstName: dataProtectionOfficerFirstName,
@@ -75,7 +78,6 @@ class OrganizationForAdmin {
     this.tagsToAdd = [];
     this.tagsToRemove = [];
     this.code = code;
-    this.parentOrganizationId = parentOrganizationId;
   }
 
   get archivistFullName() {

--- a/api/lib/infrastructure/repositories/organization-for-admin-repository.js
+++ b/api/lib/infrastructure/repositories/organization-for-admin-repository.js
@@ -68,6 +68,7 @@ const get = async function (id, domainTransaction = DomainTransaction.emptyTrans
       creatorLastName: 'creators.lastName',
       identityProviderForCampaigns: 'organizations.identityProviderForCampaigns',
       parentOrganizationId: 'organizations.parentOrganizationId',
+      parentOrganizationName: 'parentOrganizations.name',
     })
     .leftJoin('users AS archivists', 'archivists.id', 'organizations.archivedBy')
     .leftJoin('users AS creators', 'creators.id', 'organizations.createdBy')
@@ -76,6 +77,7 @@ const get = async function (id, domainTransaction = DomainTransaction.emptyTrans
       'dataProtectionOfficers.organizationId',
       'organizations.id',
     )
+    .leftJoin('organizations AS parentOrganizations', 'parentOrganizations.id', 'organizations.parentOrganizationId')
     .where('organizations.id', id)
     .first();
 
@@ -222,6 +224,7 @@ function _toDomain(rawOrganization) {
     features: rawOrganization.features,
     tags: rawOrganization.tags || [],
     parentOrganizationId: rawOrganization.parentOrganizationId,
+    parentOrganizationName: rawOrganization.parentOrganizationName,
   });
 
   return organization;

--- a/api/lib/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin-serializer.js
@@ -42,6 +42,8 @@ const serialize = function (organizations, meta) {
       'children',
       'identityProviderForCampaigns',
       'features',
+      'parentOrganizationId',
+      'parentOrganizationName',
     ],
     organizationMemberships: {
       ref: 'id',

--- a/api/tests/acceptance/application/organizations-administration/organization-administration-get_test.js
+++ b/api/tests/acceptance/application/organizations-administration/organization-administration-get_test.js
@@ -74,6 +74,8 @@ describe('Acceptance | Routes | organization-administration-controller', functio
               type: organization.type,
               'logo-url': organization.logoUrl,
               'external-id': organization.externalId,
+              'parent-organization-id': organization.parentOrganizationId,
+              'parent-organization-name': null,
               'province-code': organization.provinceCode,
               'is-managing-students': organization.isManagingStudents,
               credit: organization.credit,

--- a/api/tests/tooling/domain-builder/factory/build-organization-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-organization-for-admin.js
@@ -28,6 +28,7 @@ function buildOrganizationForAdmin({
   identityProviderForCampaigns = null,
   features = {},
   parentOrganizationId = null,
+  parentOrganizationName = null,
 } = {}) {
   return new OrganizationForAdmin({
     id,
@@ -57,6 +58,7 @@ function buildOrganizationForAdmin({
     identityProviderForCampaigns,
     features,
     parentOrganizationId,
+    parentOrganizationName,
   });
 }
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-for-admin-serializer_test.js
@@ -12,6 +12,23 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         domainBuilder.buildTag({ id: 7, name: 'AEFE' }),
         domainBuilder.buildTag({ id: 44, name: 'PUBLIC' }),
       ];
+      const parentOrganization = domainBuilder.buildOrganizationForAdmin({
+        email: 'motherSco.generic.account@example.net',
+        tags,
+        code: null,
+        createdBy: 10,
+        documentationUrl: 'https://pix.fr/',
+        archivistFirstName: 'John',
+        archivistLastName: 'Doe',
+        dataProtectionOfficerFirstName: 'Justin',
+        dataProtectionOfficerLastName: 'Ptipeu',
+        dataProtectionOfficerEmail: 'justin.ptipeu@example.net',
+        identityProviderForCampaigns: NON_OIDC_IDENTITY_PROVIDERS.GAR.code,
+        features: {
+          [apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: true,
+        },
+        name: 'motherSco',
+      });
       const organization = domainBuilder.buildOrganizationForAdmin({
         email: 'sco.generic.account@example.net',
         tags,
@@ -27,6 +44,8 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         features: {
           [apps.ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: true,
         },
+        parentOrganizationId: parentOrganization.id,
+        parentOrganizationName: parentOrganization.name,
       });
       const meta = { some: 'meta' };
 
@@ -43,6 +62,8 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
             type: organization.type,
             'logo-url': organization.logoUrl,
             'external-id': organization.externalId,
+            'parent-organization-id': organization.parentOrganizationId,
+            'parent-organization-name': organization.parentOrganizationName,
             'province-code': organization.provinceCode,
             'is-managing-students': organization.isManagingStudents,
             code: organization.code,


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement nous ne pouvons pas visualiser rapidement sur la page d'informations d'une organisation, si celle-ci est une organisation enfant. 

## :gift: Proposition
Ajouter un label "organisation enfant" et un lien vers son parent : 

![Capture d’écran du 2024-02-08 09-44-14](https://github.com/1024pix/pix/assets/143821056/13971816-660b-49ce-9bb1-0ca1c6d02b1d)


## :socks: Remarques
 1. Dans une prochaine PR les noms 'Organisation enfant' et 'Organisation parent' seront changés en 'Organisation mère' et 'Organisation fille'.
 2. Vous constaterez que les dimensions des labels 'enfant/parent' et des tags (ex 'CFA') éventuellement présents au dessus des labels ne sont pas les mêmes. La dimension actuelle du label 'organisation enfant'/'organisation parent' a été validée à nouveau par l'équipe Design (et celle des tags changera prochainement).

## :santa: Pour tester
### 1. Cas d'une organisation enfant
- Se connecter sur Pix Admin, en tant que SuperAdmin.
- Afficher la liste des organisations.
- Cliquer sur le lien de l'organisation 'Child of Collège House of The Dragon' pour afficher sa page d'informations.
- Constater que le label 'organisation enfant' apparaît.
- Constater aussi que qu'un lien vers l'organisation parente est affiché sous le label, vérifier que le lien nous redirige bien vers cette organisation.
- Afficher un tag (onglets 'Tags' pour vérifier que l'affichage des labels n'empêche pas celui des tags.
- Refaire la même opération (points 2 à 5) avec un compte Métier, Support ou Certif et vérifier que le label apparaît également.
### 2. Cas d'une organisation sans enfant ni parent
- Revenir sur la liste des organisations et cliquer sur le lien de l'organisation 'Lycée Joséphine Baker'
- Constater que les labels 'organisation enfant' et 'organisation parente' n'apparaissent pas.
### 3. Cas d'une organisation parente : test de non régression
- Revenir sur la liste des organisations et cliquer sur le lien de l'organisation 'Collège House of the Dragon'
- Constater que le label 'organisation enfant' n'apparaît pas et que le label 'organisation parente' apparaît.


