### PR TITLE
[FEATURE] Renvoyer une 422 si le curseur du pole emploi sendings n'est pas dans un format JSON valide (PIX-10867)

### DIFF
--- a/api/lib/application/pole-emploi/pole-emploi-controller.js
+++ b/api/lib/application/pole-emploi/pole-emploi-controller.js
@@ -1,13 +1,20 @@
 import { usecases } from '../../domain/usecases/index.js';
 import * as poleEmploiService from '../../domain/services/pole-emploi-service.js';
+import { UnprocessableEntityError } from '../http-errors.js';
 
-const getSendings = async function (request, h) {
+const getSendings = async function (request, h, dependencies = { poleEmploiService }) {
+  let cursorData;
   const cursor = request.query.curseur;
 
-  const cursorData = await poleEmploiService.decodeCursor(cursor);
-  const filters = _extractFilters(request);
-  const { sendings, link } = await usecases.getPoleEmploiSendings({ cursorData, filters });
-  return h.response(sendings).header('link', link).code(200);
+  try {
+    cursorData = await dependencies.poleEmploiService.decodeCursor(cursor);
+    const filters = _extractFilters(request);
+    const { sendings, link } = await usecases.getPoleEmploiSendings({ cursorData, filters });
+    return h.response(sendings).header('link', link).code(200);
+  } catch (error) {
+    if (error instanceof SyntaxError) throw new UnprocessableEntityError('The provided cursor is unreadable');
+    throw error;
+  }
 };
 
 const poleEmploiController = { getSendings };

--- a/api/lib/application/pole-emploi/pole-emploi-controller.js
+++ b/api/lib/application/pole-emploi/pole-emploi-controller.js
@@ -1,9 +1,12 @@
 import { usecases } from '../../domain/usecases/index.js';
+import * as poleEmploiService from '../../domain/services/pole-emploi-service.js';
 
 const getSendings = async function (request, h) {
   const cursor = request.query.curseur;
+
+  const cursorData = await poleEmploiService.decodeCursor(cursor);
   const filters = _extractFilters(request);
-  const { sendings, link } = await usecases.getPoleEmploiSendings({ cursor, filters });
+  const { sendings, link } = await usecases.getPoleEmploiSendings({ cursorData, filters });
   return h.response(sendings).header('link', link).code(200);
 };
 

--- a/api/lib/domain/usecases/get-pole-emploi-sendings.js
+++ b/api/lib/domain/usecases/get-pole-emploi-sendings.js
@@ -1,7 +1,6 @@
 import * as poleEmploiService from '../services/pole-emploi-service.js';
 
-const getPoleEmploiSendings = async function ({ cursor, poleEmploiSendingRepository, filters }) {
-  const cursorData = await poleEmploiService.decodeCursor(cursor);
+const getPoleEmploiSendings = async function ({ cursorData, poleEmploiSendingRepository, filters }) {
   const sendings = await poleEmploiSendingRepository.find(cursorData, filters);
   const link = _generateLink(sendings, filters);
   return { sendings, link };

--- a/api/tests/acceptance/application/pole-emploi/pole-emploi-controller_test.js
+++ b/api/tests/acceptance/application/pole-emploi/pole-emploi-controller_test.js
@@ -1,0 +1,44 @@
+import { expect, generateValidRequestAuthorizationHeaderForApplication } from '../../../test-helper.js';
+
+import { createServer } from '../../../../server.js';
+import { generateCursor } from '../../../../lib/domain/services/pole-emploi-service.js';
+
+describe('Acceptance | Application | Pole Emploi Controller', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('GET /api/pole-emploi/envois', function () {
+    context('Sucess case', function () {
+      it('returns a 200 HTTP status code', async function () {
+        // given
+        const POLE_EMPLOI_CLIENT_ID = 'poleEmploiClientId';
+        const POLE_EMPLOI_SCOPE = 'pole-emploi-participants-result';
+        const POLE_EMPLOI_SOURCE = 'poleEmploi';
+        const curseur = await generateCursor({
+          idEnvoi: 1,
+          dateEnvoi: new Date(),
+        });
+        const request = {
+          method: 'GET',
+          url: `/api/pole-emploi/envois?curseur=${curseur}`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeaderForApplication(
+              POLE_EMPLOI_CLIENT_ID,
+              POLE_EMPLOI_SOURCE,
+              POLE_EMPLOI_SCOPE,
+            ),
+          },
+        };
+
+        // when
+        const { statusCode } = await server.inject(request);
+
+        // then
+        expect(statusCode).to.equal(200);
+      });
+    });
+  });
+});

--- a/api/tests/integration/domain/usecases/get-pole-emploi-sendings_test.js
+++ b/api/tests/integration/domain/usecases/get-pole-emploi-sendings_test.js
@@ -47,10 +47,10 @@ describe('Integration | UseCase | get-campaign-participations-counts-by-stage', 
         dateEnvoi: sending2.createdAt,
       });
       const expectedLink = poleEmploiService.generateLink({ idEnvoi: sending1.id, dateEnvoi: sending1.createdAt });
-
+      const cursorData = poleEmploiService.decodeCursor(cursorCorrespondingToSending2);
       //when
       const response = await usecases.getPoleEmploiSendings({
-        cursor: cursorCorrespondingToSending2,
+        cursorData,
         poleEmploiSendingRepository,
       });
       //then
@@ -89,10 +89,11 @@ describe('Integration | UseCase | get-campaign-participations-counts-by-stage', 
         idEnvoi: sending1.id,
         dateEnvoi: sending1.createdAt,
       });
+      const cursorData = poleEmploiService.decodeCursor(cursorCorrespondingToSending1);
 
       //when
       const response = await usecases.getPoleEmploiSendings({
-        cursor: cursorCorrespondingToSending1,
+        cursorData,
         poleEmploiSendingRepository,
       });
 

--- a/api/tests/unit/application/pole-emploi/pole-emploi-controller_test.js
+++ b/api/tests/unit/application/pole-emploi/pole-emploi-controller_test.js
@@ -4,19 +4,28 @@ import { usecases } from '../../../../lib/domain/usecases/index.js';
 
 describe('Unit | Controller | pole-emploi-controller', function () {
   describe('#getSendings', function () {
+    let curseur, decodedCurseur, sending, poleEmploiService;
+    beforeEach(function () {
+      curseur = Symbol('curseur');
+      decodedCurseur = Symbol('decoded curseur');
+      sending = [{ idEnvoi: 1 }];
+      poleEmploiService = { decodeCursor: sinon.stub() };
+    });
     context('when there is a cursor in the url', function () {
       it('should return the pole emploi sending', async function () {
         // given
-        const request = { query: { curseur: 'azefvbjljhgrEDJNH' } };
-        const sending = [{ idEnvoi: 456 }];
+        const curseur = Symbol('curseur');
+        const decodedCurseur = Symbol('decoded curseur');
+        const request = { query: { curseur } };
         sinon.stub(usecases, 'getPoleEmploiSendings').resolves(sending);
+        poleEmploiService.decodeCursor.withArgs(curseur).resolves(decodedCurseur);
 
         // when
-        await poleEmploiController.getSendings(request, hFake);
+        await poleEmploiController.getSendings(request, hFake, { poleEmploiService });
 
         //then
         expect(usecases.getPoleEmploiSendings).have.been.calledWithExactly({
-          cursor: 'azefvbjljhgrEDJNH',
+          cursorData: decodedCurseur,
           filters: {},
         });
       });
@@ -25,16 +34,17 @@ describe('Unit | Controller | pole-emploi-controller', function () {
       context("when enErreur is 'false'", function () {
         it('should return the pole emploi sending', async function () {
           // given
-          const request = { query: { curseur: 'azefvbjljhgrEDJNH', enErreur: false } };
+          const request = { query: { curseur, enErreur: false } };
           const sending = [{ idEnvoi: 456 }];
+          poleEmploiService.decodeCursor.withArgs(curseur).resolves(decodedCurseur);
           sinon.stub(usecases, 'getPoleEmploiSendings').resolves(sending);
 
           // when
-          await poleEmploiController.getSendings(request, hFake);
+          await poleEmploiController.getSendings(request, hFake, { poleEmploiService });
 
           //then
           expect(usecases.getPoleEmploiSendings).have.been.calledWithExactly({
-            cursor: 'azefvbjljhgrEDJNH',
+            cursorData: decodedCurseur,
             filters: { isSuccessful: true },
           });
         });
@@ -42,16 +52,17 @@ describe('Unit | Controller | pole-emploi-controller', function () {
       context("when enErreur is 'true'", function () {
         it('should return the pole emploi sending', async function () {
           // given
-          const request = { query: { curseur: 'azefvbjljhgrEDJNH', enErreur: true } };
+          const request = { query: { curseur, enErreur: true } };
           const sending = [{ idEnvoi: 456 }];
+          poleEmploiService.decodeCursor.withArgs(curseur).resolves(decodedCurseur);
           sinon.stub(usecases, 'getPoleEmploiSendings').resolves(sending);
 
           // when
-          await poleEmploiController.getSendings(request, hFake);
+          await poleEmploiController.getSendings(request, hFake, { poleEmploiService });
 
           //then
           expect(usecases.getPoleEmploiSendings).have.been.calledWithExactly({
-            cursor: 'azefvbjljhgrEDJNH',
+            cursorData: decodedCurseur,
             filters: { isSuccessful: false },
           });
         });


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement si pôle emploi utilise "mal" le endpoint leurs étant dédié en envoyant une info dans le paramètre "curseur" qui n'est pas dans un format JSON valide, notre API leurs renvoi une 500.

## :gift: Proposition
Il faudrait gérer ce cas d'erreur, et leurs renvoyer une 422 à la place

## :socks: Remarques
J'ai déplacé la partie "decode" du curseur, car cette partie est similaire à un deserialize, qui doit être fait dans la couche application et non dans un usecase

## :santa: Pour tester
A faire en local (pour bypass le token du pull pole emploi)
- Dans le fichier `api/lib/application/pole-emploi/index.js`, ligne 12, écrire : `auth:  false`
- Lancer l'api
- Faire un curl sur : `'http://localhost:3000/api/pole-emploi/envois?curseur=https://allez.lom'`
- Vérifier que l'erreur retournée est avec un status code 422 'Unauthorize'
- 🐈‍⬛ 
