### PR TITLE
[FEATURE] Changer Pôle Emploi en France Travail sur les différents écrans du parcours PE (PIX-10516)

### DIFF
--- a/admin/app/components/users/user-detail-personal-information.js
+++ b/admin/app/components/users/user-detail-personal-information.js
@@ -9,7 +9,7 @@ const DISSOCIATE_SUCCESS_NOTIFICATION_MESSAGE = 'La dissociation a bien été ef
 const typesLabel = {
   EMAIL: 'Adresse e-mail',
   USERNAME: 'Identifiant',
-  POLE_EMPLOI: 'Pôle Emploi',
+  POLE_EMPLOI: 'France Travail',
   GAR: 'Médiacentre',
   CNAV: 'CNAV',
   FWB: 'Fédération Wallonie-Bruxelles',

--- a/admin/app/controllers/authenticated/users/get/information.js
+++ b/admin/app/controllers/authenticated/users/get/information.js
@@ -9,7 +9,7 @@ export default class UserInformationController extends Controller {
   ERROR_MESSAGES = {
     DEFAULT: 'Une erreur est survenue.',
     STATUS_422: {
-      POLE_EMPLOI: "L'utilisateur a déjà une méthode de connexion Pôle Emploi.",
+      POLE_EMPLOI: "L'utilisateur a déjà une méthode de connexion France Travail.",
       GAR: "L'utilisateur a déjà une méthode de connexion Médiacentre.",
       CNAV: "L'utilisateur a déjà une méthode de connexion CNAV.",
       FWB: "L'utilisateur a déjà une méthode de connexion Fédération Wallonie-Bruxelles.",

--- a/admin/tests/unit/components/users/user-detail-personal-information_test.js
+++ b/admin/tests/unit/components/users/user-detail-personal-information_test.js
@@ -87,7 +87,7 @@ module('Unit | Component | users | user-detail-personal-information', function (
         component.authenticationMethodType = 'POLE_EMPLOI';
 
         // when & then
-        assert.strictEqual(component.translatedType, 'Pôle Emploi');
+        assert.strictEqual(component.translatedType, 'France Travail');
       });
     });
 

--- a/api/db/seeds/data/team-acces/build-users.js
+++ b/api/db/seeds/data/team-acces/build-users.js
@@ -25,9 +25,10 @@ function _buildUserWithFwbAuthenticationMethod(databaseBuilder) {
 }
 
 function _buildUserWithPoleEmploiAuthenticationMethod(databaseBuilder) {
-  const user = databaseBuilder.factory.buildUser.withoutPixAuthenticationMethod({
+  const user = databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'Paul',
     lastName: 'Emploi',
+    email: 'paul-emploi@example.net',
   });
 
   databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({

--- a/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
@@ -27,7 +27,7 @@ class PoleEmploiOidcAuthenticationService extends OidcAuthenticationService {
       configKey,
       source: 'pole_emploi_connect',
       slug: 'pole-emploi',
-      organizationName: 'Pôle Emploi',
+      organizationName: 'France Travail',
       additionalRequiredProperties: ['logoutUrl', 'afterLogoutUrl', 'sendingUrl'],
       hasLogoutUrl: true,
       jwtOptions: { expiresIn: config[configKey].accessTokenLifespanMs / 1000 },

--- a/api/tests/integration/domain/services/authentication/pole-emploi-oidc-authentication-service_test.js
+++ b/api/tests/integration/domain/services/authentication/pole-emploi-oidc-authentication-service_test.js
@@ -12,14 +12,14 @@ describe('Integration | Domain | Services | pole-emploi-oidc-authentication-serv
   describe('instanciate', function () {
     it('has speficic properties related to this identity provider', async function () {
       // when
-      const fwbOidcAuthenticationService = new PoleEmploiOidcAuthenticationService();
+      const oidcAuthenticationService = new PoleEmploiOidcAuthenticationService();
 
       // then
-      expect(fwbOidcAuthenticationService.source).to.equal('pole_emploi_connect');
-      expect(fwbOidcAuthenticationService.identityProvider).to.equal('POLE_EMPLOI');
-      expect(fwbOidcAuthenticationService.slug).to.equal('pole-emploi');
-      expect(fwbOidcAuthenticationService.organizationName).to.equal('Pôle Emploi');
-      expect(fwbOidcAuthenticationService.hasLogoutUrl).to.be.true;
+      expect(oidcAuthenticationService.source).to.equal('pole_emploi_connect');
+      expect(oidcAuthenticationService.identityProvider).to.equal('POLE_EMPLOI');
+      expect(oidcAuthenticationService.slug).to.equal('pole-emploi');
+      expect(oidcAuthenticationService.organizationName).to.equal('France Travail');
+      expect(oidcAuthenticationService.hasLogoutUrl).to.be.true;
     });
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème
Suite au changement de nom de Pôle Emploi pour France Travail, nous devons mettre à jour certains écrans.

## :gift: Proposition
Faire les modifications sur les écrans du scope Accès qui sont prioritaires pour la mise en production.

## :socks: Remarques

✨ L'environnement de recette de Pôle emploi a été configuré pour autorisé le `redirect_uri` de la RA de Pix App.
✨ La RA de Pix API a été configurée pour avoir `POLE_EMPLOI_ENABLED`.

Il ne faudra pas oublier de faire des changements côté API (nom de code, nom de clés, etc.).
Cela pourra se faire plus tard dans le cadre l'industrialisation des SSO.

## :santa: Pour tester
### 🟣 Sur Pix App

- Se connecter avec l'utilisateur `paul-emploi@example.net`
- Se rendre dans l'espace `Mon Compte`, puis dans `Mes méthodes de connexion`
- Vérifier que dans `Connexion externe` il y a bien écrit **via France Travail**