### PR TITLE
[BUGFIX] Ne pas formater la réponse des QROCM-ind (PIX-10924)

### DIFF
--- a/mon-pix/app/pods/components/module/qrocm/template.hbs
+++ b/mon-pix/app/pods/components/module/qrocm/template.hbs
@@ -1,4 +1,11 @@
-<form class="element-qrocm" {{on "submit" this.submitAnswer}}>
+<form
+  class="element-qrocm"
+  autocapitalize="off"
+  autocomplete="nope"
+  autocorrect="off"
+  spellcheck="false"
+  {{on "submit" this.submitAnswer}}
+>
   <fieldset disabled={{this.disableInput}}>
     <div class="element-qrocm__header">
       <div class="element-qrocm-header__instruction">
@@ -22,7 +29,6 @@
                 @type="text"
                 @value={{get this.selectedValues block.input}}
                 @id={{block.input}}
-                autocomplete="nope"
                 placeholder={{block.placeholder}}
                 @ariaLabel={{block.ariaLabel}}
                 {{on "change" (fn this.onInputChanged block)}}


### PR DESCRIPTION
## :christmas_tree: Problème
Les réponses aux QROC peuvent être formatées par les téléphones intelligents. Pour le dernier élément du module Bien écrire son adresse mail, on peut se retrouver ainsi avec une adresse mail qui démarre par une majuscule, de la correction orthographique et de la sélection d'adresse mail qu'on ne souhaite pas.

## :gift: Proposition
Sur le formulaire de la modalité QROCM-ind :
- Ajouter l'attribut [`autocapitalize`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize) avec la valeur `"off"` pour ne pas démarrer avec une majuscule par défaut,
- Ajouter l'attribut [`spellcheck`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/spellcheck) avec la valeur `"false"` pour ne pas encourager les corrections de langue,
- Ajouter l'attribut [`autocorrect`](https://developer.mozilla.org/fr/docs/Web/HTML/Element/input#autocorrect) avec la valeur `"off"` pour ne pas faire de correction automatique sur Safari,
- Ajouter l'attribut [`autocomplete`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#values) avec la valeur `"nope"` pour ne pas permettre la sélection de préférences utilisateurs.

Pour le dernier point, c'est un simple déplacement de l'attribut du champ `input` au champ `form`.

## :socks: Remarques
Ce sujet fait suite à #2442, les constats de l'époque sont toujours (malheureusement) valides. S'y référer pour plus de détails sur le fonctionnement de l'attribut `autocomplete`.

## :santa: Pour tester
Sur mobile, accéder au dernier élément et constater que son utilisation est meilleure.