### PR TITLE
[FEATURE] Création en masse d'organisations PIX 1D (PIX-10889)

### DIFF
--- a/api/src/school/infrastructure/repositories/school-repository.js
+++ b/api/src/school/infrastructure/repositories/school-repository.js
@@ -1,10 +1,11 @@
 import { knex } from '../../../../db/knex-database-connection.js';
 import { School } from '../../domain/models/School.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 
-const save = async function ({ organizationId, code }) {
-  const [organizationCreated] = await knex('schools').insert({ organizationId, code }).returning('*');
-  return organizationCreated.code;
+const save = async function ({ organizationId, code, domainTransaction = DomainTransaction.emptyTransaction() }) {
+  const knexConn = domainTransaction.knexTransaction ?? knex;
+  await knexConn('schools').insert({ organizationId, code }).returning('*');
 };
 
 const isCodeAvailable = async function (code) {

--- a/api/tests/school/integration/infrastructure/repositories/school-repository_test.js
+++ b/api/tests/school/integration/infrastructure/repositories/school-repository_test.js
@@ -1,4 +1,4 @@
-import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, knex } from '../../../../test-helper.js';
 import * as schoolRepository from '../../../../../src/school/infrastructure/repositories/school-repository.js';
 import { School } from '../../../../../src/school/domain/models/School.js';
 import { NotFoundError } from '../../../../../lib/domain/errors.js';
@@ -12,10 +12,12 @@ describe('Integration | Repository | School', function () {
       await databaseBuilder.commit();
 
       // when
-      const result = await schoolRepository.save({ organizationId: organization.id, code: 'HAPPYY123' });
+      await schoolRepository.save({ organizationId: organization.id, code: 'HAPPYY123' });
 
       // then
-      expect(result).to.equal('HAPPYY123');
+      const savedSchool = await knex('schools').first();
+      expect(savedSchool.organizationId).to.equal(organization.id);
+      expect(savedSchool.code).to.equal('HAPPYY123');
     });
   });
   describe('#getByCode', function () {


### PR DESCRIPTION
## :christmas_tree: Problème

Afin de pouvoir être prêt pour septembre 2024, nous avons besoin de créer tous les établissements de premiers degrés (car nous ne connaissons pas les organisations volontaires)

## :gift: Proposition
Modifier le script de création en masse créé par l'équipe Accés afin de pouvoir : 

- Créer des orgas de type SCO1D
- En ajoutant la feature mission à ses orgas
- En créant un code établissement pour chacune d’entre elle

## :santa: Pour tester
Générer un fichier d'import à partir de l'[opendata](https://data.education.gouv.fr/explore/?sort=modified&exclude.keyword=hors%20catalogue).
Les tags "PUBLIC" et "ECOLE" doivent être positionnés dans le fichier.

edit : 
- Pour faire un test simple avec un fichier d'import que nous avons fait nous même : [test-import-simple-ecole.csv](https://github.com/1024pix/pix/files/14108769/test-import-simple-ecole.csv)
- Pour faire un test « taille réelle » avec un fichier extrait et préparer le 29 janvier 2024 à partir des données ouvertes de l'éducation nationale : [20240129-liste-ecole-pour-import-pixorga.csv](https://github.com/1024pix/pix/files/14108768/20240129-liste-ecole-pour-import-pixorga.csv)
