### PR TITLE
[BUGFIX] Corriger le tracking du bouton "Vérifier" sur Modulix (PIX-10938)

### DIFF
--- a/mon-pix/app/pods/module/get/controller.js
+++ b/mon-pix/app/pods/module/get/controller.js
@@ -21,7 +21,7 @@ export default class GetController extends Controller {
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.model.module.id}`,
-      'pix-event-name': `Click sur le bouton vérifier de l'élément : ${answerData.elementId}`,
+      'pix-event-name': `Click sur le bouton vérifier de l'élément : ${answerData.element.id}`,
     });
   }
 }

--- a/mon-pix/tests/unit/controllers/modules/get_test.js
+++ b/mon-pix/tests/unit/controllers/modules/get_test.js
@@ -13,13 +13,11 @@ module('Unit | Module | Controller | get', function (hooks) {
       const userResponse = 'userResponse';
       const elementId = 'elementId';
       const passageId = 'passageId';
-      const element = 'element';
+      const element = { id: elementId };
       const moduleSlug = 'moduleSlug';
 
       const answerData = {
         userResponse,
-        elementId,
-        moduleSlug,
         element,
       };
 


### PR DESCRIPTION
## :unicorn: Problème
L'identifiant de l'élément "vérifié" lors d'un passage de Modulix est toujours `undefined`.

## :robot: Proposition
Utiliser le bon identifiant pour correctement tracker.

## :rainbow: Remarques
RAS

## :100: Pour tester
- Aller sur [un module sur Pix App](https://app-pr7923.review.pix.fr/modules/bien-ecrire-son-adresse-mail)
- Passer les grains jusqu'à une activité
- Cliquer sur le bouton "Vérifier"
- Constater qu'une requête est faite à Matomo avec le bon identifiant d'élément
