### PR TITLE
[BUGFIX] Permettre la remise à zero d'une compétence (PIX-10892)

### DIFF
--- a/api/src/evaluation/domain/services/scorecard-service.js
+++ b/api/src/evaluation/domain/services/scorecard-service.js
@@ -130,6 +130,12 @@ async function _resetCampaignAssessment({
   campaignParticipationRepository,
   campaignRepository,
 }) {
+  // assessment.campaignParticipation can be null for organization that ask for
+  // remove its data and users participations
+  // @see pr 7853
+  if (!assessment.campaignParticipationId) {
+    return null;
+  }
   const campaignParticipation = await campaignParticipationRepository.get(assessment.campaignParticipationId);
   const skillIds = await campaignRepository.findSkillIdsByCampaignParticipationId({
     campaignParticipationId: assessment.campaignParticipationId,

--- a/api/tests/evaluation/unit/domain/services/scorecard-service_test.js
+++ b/api/tests/evaluation/unit/domain/services/scorecard-service_test.js
@@ -316,6 +316,33 @@ describe('Unit | Service | ScorecardService', function () {
           .withArgs({ userId, competenceId })
           .resolves(knowledgeElements);
       });
+      it('should not throws when a campaign assessment has been unlink with its participation', async function () {
+        const anonymizedAssessment = domainBuilder.buildAssessment.ofTypeCampaign({
+          id: 98765,
+          state: 'started',
+          userId,
+        });
+        anonymizedAssessment.campaignParticipationId = null;
+
+        assessmentRepository.findNotAbortedCampaignAssessmentsByUserId
+          .withArgs(userId)
+          .resolves([anonymizedAssessment]);
+
+        // when
+        const call = async () => {
+          await scorecardService.resetScorecard({
+            userId,
+            competenceId,
+            shouldResetCompetenceEvaluation,
+            assessmentRepository,
+            knowledgeElementRepository,
+            campaignParticipationRepository,
+            competenceEvaluationRepository,
+            campaignRepository,
+          });
+        };
+        expect(await call()).not.to.throw;
+      });
 
       // then
       it('should reset each knowledge Element', async function () {


### PR DESCRIPTION
## :egg: Problème
Je veux pouvoir reset mes compétences même si certaines de mes participations ont été supprimées. Or actuellement cela génère une 500

## :bowl_with_spoon: Proposition
Eviter d'appeler `campaignParticipation.get()`  si la participation a été anonymisée.

## :milk_glass: Remarques
Ceci est un :adhesive_bandage: 
La méthode `get` du `CampaignParticipationRepository` pourrait aussi prévoir de renvoyer `null` dans le cas ou il ne trouve pas la campagne participation.

Suite à une séance d'archéologie, on se pose la question de l'utilité / impact du code qui crée un nouvel assessment pour les participations touchés par la remise à zero

## :butter: Pour tester
- créer une campagne avec profil cible qui embarque des skill de la compétence a remettre à zéro
- Sur mon pix, on participe à cette campagne
- on va délier l'assessment de la participation (script de suppression des données de l'orga)
- Faire un reset de la compétence 
- ne pas observer d'erreur 