### PR TITLE
[FEATURE] Afficher le score par compétence sur la page de certificat pour la v3 (PIX-10689)

### DIFF
--- a/admin/app/components/certifications/competence-list.hbs
+++ b/admin/app/components/certifications/competence-list.hbs
@@ -24,7 +24,9 @@
     {{#each @competences as |competence|}}
       <li class="competence-list-details__item" aria-label="Informations de la compétence {{competence.index}}">
         <span aria-hidden="true">{{competence.index}}</span>
-        <span>{{competence.score}} Pix</span>
+        {{#if @shouldDisplayPixScore}}
+          <span>{{competence.score}} Pix</span>
+        {{/if}}
         <span>Niveau: {{competence.level}}</span>
       </li>
     {{/each}}

--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -77,6 +77,10 @@ export default class CertificationInformationsController extends Controller {
     ];
   }
 
+  get shouldDisplayPixScore() {
+    return this.certification.version === 2;
+  }
+
   @action
   async resolveIssueReport(issueReport, resolutionLabel) {
     try {

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -251,6 +251,7 @@
 
       <Certifications::CompetenceList
         @competences={{this.certification.competences}}
+        @shouldDisplayPixScore={{this.shouldDisplayPixScore}}
         @edition={{false}}
         @onUpdateScore={{this.onUpdateScore}}
         @onUpdateLevel={{this.onUpdateLevel}}

--- a/admin/tests/integration/components/certifications/info-competences_test.js
+++ b/admin/tests/integration/components/certifications/info-competences_test.js
@@ -28,7 +28,9 @@ module('Integration | Component | certifications/competence-list', function (hoo
     this.set('competences', [{ index: '1.1', score: '30', level: '3' }]);
 
     // when
-    const screen = await render(hbs`<Certifications::CompetenceList @competences={{this.competences}} />`);
+    const screen = await render(
+      hbs`<Certifications::CompetenceList @competences={{this.competences}}  @shouldDisplayPixScore={{true}}/>`,
+    );
 
     // then
     assert.dom(screen.getByLabelText('Informations de la compétence 1.1')).containsText('30 Pix');
@@ -52,27 +54,51 @@ module('Integration | Component | certifications/competence-list', function (hoo
     assert.strictEqual(screen.getAllByLabelText('Informations de la compétence', { exact: false }).length, 16);
   });
 
-  test('it should display competence levels and scores at the right places in edition mode', async function (assert) {
-    // given
-    this.set('competences', [
-      { index: '1.1', score: '30', level: '3' },
-      { index: '2.1', score: '16', level: '2' },
-      { index: '2.2', score: '42', level: '5' },
-    ]);
+  module('when certification is V2', function () {
+    test('it should display competence levels and scores at the right places in edition mode', async function (assert) {
+      // given
+      this.set('competences', [
+        { index: '1.1', score: '30', level: '3' },
+        { index: '2.1', score: '16', level: '2' },
+        { index: '2.2', score: '42', level: '5' },
+      ]);
 
-    // when
-    const screen = await render(
-      hbs`<Certifications::CompetenceList @competences={{this.competences}} @edition='true' />`,
-    );
+      // when
+      const screen = await render(
+        hbs`<Certifications::CompetenceList @competences={{this.competences}} @edition='true' />`,
+      );
 
-    // then
-    assert.dom(screen.getByRole('textbox', { name: '1.1' })).hasValue('30');
-    assert.dom(screen.getByRole('textbox', { name: '2.1' })).hasValue('16');
-    assert.dom(screen.getByRole('textbox', { name: '2.2' })).hasValue('42');
+      // then
+      assert.dom(screen.getByRole('textbox', { name: '1.1' })).hasValue('30');
+      assert.dom(screen.getByRole('textbox', { name: '2.1' })).hasValue('16');
+      assert.dom(screen.getByRole('textbox', { name: '2.2' })).hasValue('42');
 
-    const certificationInfoLevelInputs = screen.getAllByRole('textbox', { name: 'Niveau:' });
-    assert.dom(certificationInfoLevelInputs[0]).hasValue('3');
-    assert.dom(certificationInfoLevelInputs[3]).hasValue('2');
-    assert.dom(certificationInfoLevelInputs[4]).hasValue('5');
+      const certificationInfoLevelInputs = screen.getAllByRole('textbox', { name: 'Niveau:' });
+      assert.dom(certificationInfoLevelInputs[0]).hasValue('3');
+      assert.dom(certificationInfoLevelInputs[3]).hasValue('2');
+      assert.dom(certificationInfoLevelInputs[4]).hasValue('5');
+    });
+  });
+
+  module('when certification is V3', function () {
+    test('it should not display competence scores', async function (assert) {
+      // given
+      this.set('competences', [
+        { index: '1.1', score: '0', level: '3' },
+        { index: '2.1', score: '0', level: '2' },
+        { index: '2.2', score: '0', level: '5' },
+      ]);
+
+      // when
+      const screen = await render(
+        hbs`<Certifications::CompetenceList @competences={{this.competences}}  @shouldDisplayPixScore={{false}}/>`,
+      );
+
+      // then
+      assert.dom(screen.queryByText('0 Pix')).doesNotExist();
+      assert.dom(screen.getByText('Niveau: 3')).exists();
+      assert.dom(screen.getByText('Niveau: 2')).exists();
+      assert.dom(screen.getByText('Niveau: 5')).exists();
+    });
   });
 });

--- a/api/lib/domain/events/handle-certification-scoring.js
+++ b/api/lib/domain/events/handle-certification-scoring.js
@@ -21,6 +21,7 @@ async function handleCertificationScoring({
   certificationAssessmentRepository,
   certificationCourseRepository,
   competenceMarkRepository,
+  competenceForScoringRepository,
   scoringCertificationService,
   answerRepository,
   challengeRepository,
@@ -40,6 +41,7 @@ async function handleCertificationScoring({
         certificationAssessment,
         assessmentResultRepository,
         certificationCourseRepository,
+        competenceForScoringRepository,
         competenceMarkRepository,
         flashAlgorithmConfigurationRepository,
         flashAlgorithmService,
@@ -108,6 +110,7 @@ async function _handleV3CertificationScoring({
   assessmentResultRepository,
   certificationCourseRepository,
   competenceMarkRepository,
+  competenceForScoringRepository,
   flashAlgorithmConfigurationRepository,
   flashAlgorithmService,
   locale,
@@ -129,12 +132,15 @@ async function _handleV3CertificationScoring({
     configuration,
   });
 
+  const competencesForScoring = await competenceForScoringRepository.listByLocale({ locale });
+
   const certificationAssessmentScore = CertificationAssessmentScoreV3.fromChallengesAndAnswers({
     algorithm,
     challenges,
     allAnswers,
     abortReason,
     maxReachableLevelOnCertificationDate: certificationCourse.getMaxReachableLevelOnCertificationDate(),
+    competencesForScoring,
   });
 
   if (_shouldCancelV3Certification({ allAnswers, certificationCourse })) {
@@ -183,7 +189,7 @@ async function _saveResult({
   await bluebird.mapSeries(certificationAssessmentScore.competenceMarks, (competenceMark) => {
     const competenceMarkDomain = new CompetenceMark({
       ...competenceMark,
-      ...{ assessmentResultId: assessmentResult.id },
+      assessmentResultId: assessmentResult.id,
     });
     return competenceMarkRepository.save(competenceMarkDomain);
   });

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -22,6 +22,7 @@ import * as certificationCourseRepository from '../../../src/certification/share
 import * as certificationIssueReportRepository from '../../../src/certification/shared/infrastructure/repositories/certification-issue-report-repository.js';
 import * as challengeRepository from '../../../src/shared/infrastructure/repositories/challenge-repository.js';
 import * as competenceMarkRepository from '../../infrastructure/repositories/competence-mark-repository.js';
+import * as competenceForScoringRepository from '../../../src/certification/scoring/infrastructure/repositories/competence-for-scoring-repository.js';
 import * as competenceRepository from '../../../src/shared/infrastructure/repositories/competence-repository.js';
 import * as complementaryCertificationCourseResultRepository from '../../infrastructure/repositories/complementary-certification-course-result-repository.js';
 import * as complementaryCertificationScoringCriteriaRepository from '../../infrastructure/repositories/complementary-certification-scoring-criteria-repository.js';
@@ -74,6 +75,7 @@ const dependencies = {
   certificationIssueReportRepository,
   challengeRepository,
   competenceMarkRepository,
+  competenceForScoringRepository,
   competenceRepository,
   complementaryCertificationCourseResultRepository,
   complementaryCertificationScoringCriteriaRepository,

--- a/api/src/certification/scoring/domain/models/CompetenceForScoring.js
+++ b/api/src/certification/scoring/domain/models/CompetenceForScoring.js
@@ -1,0 +1,46 @@
+import { CompetenceMark } from '../../../../../lib/domain/models/index.js';
+
+/**
+ * @typedef Interval
+ * @type {object}
+ * @property competenceLevel {number} - the level of the competence
+ * @property bounds {Bounds} - the boundaries of the interval
+ */
+
+/**
+ * @typedef Bounds
+ * @type {object}
+ * @property min {number} - the minimum value of the interval
+ * @property max {number} - the maximum value of the interval
+ */
+
+export class CompetenceForScoring {
+  /**
+   * @param competenceId {string}
+   * @param areaCode {string}
+   * @param competenceCode {string}
+   * @param intervals {Interval[]} - the capacity boundaries for each level
+   */
+  constructor({ competenceId, areaCode, competenceCode, intervals }) {
+    this.competenceId = competenceId;
+    this.areaCode = areaCode;
+    this.competenceCode = competenceCode;
+    this.intervals = intervals;
+  }
+
+  getCompetenceMark(estimatedLevel) {
+    const level = this._findInterval(estimatedLevel)?.competenceLevel;
+
+    return new CompetenceMark({
+      competenceId: this.competenceId,
+      area_code: this.areaCode,
+      competence_code: this.competenceCode,
+      level,
+      score: 0,
+    });
+  }
+
+  _findInterval(estimatedLevel) {
+    return this.intervals.find(({ bounds }) => bounds.min <= estimatedLevel && estimatedLevel < bounds.max);
+  }
+}

--- a/api/src/certification/scoring/infrastructure/repositories/competence-for-scoring-repository.js
+++ b/api/src/certification/scoring/infrastructure/repositories/competence-for-scoring-repository.js
@@ -1,0 +1,20 @@
+import * as competenceRepository from '../../../../shared/infrastructure/repositories/competence-repository.js';
+import * as areaRepository from '../../../../../lib/infrastructure/repositories/area-repository.js';
+import { competenceLevelIntervals } from '../../../flash-certification/domain/constants/competence-level-intervals.js';
+import { CompetenceForScoring } from '../../domain/models/CompetenceForScoring.js';
+
+export const listByLocale = async ({ locale }) => {
+  const allAreas = await areaRepository.list();
+  const competenceList = await competenceRepository.list({ locale });
+
+  return competenceLevelIntervals.map(({ competence: competenceCode, values }) => {
+    const competence = competenceList.find(({ index: code }) => code === competenceCode);
+    const area = allAreas.find((area) => area.id === competence.areaId);
+    return new CompetenceForScoring({
+      competenceId: competence.id,
+      areaCode: area.code,
+      competenceCode,
+      intervals: values,
+    });
+  });
+};

--- a/api/src/certification/shared/domain/usecases/index.js
+++ b/api/src/certification/shared/domain/usecases/index.js
@@ -13,6 +13,7 @@ import * as certificationChallengeLiveAlertRepository from '../../../session/inf
 import * as certificationCourseRepository from '../../infrastructure/repositories/certification-course-repository.js';
 import * as certificationIssueReportRepository from '../../../shared/infrastructure/repositories/certification-issue-report-repository.js';
 import * as certificationReportRepository from '../../../shared/infrastructure/repositories/certification-report-repository.js';
+import * as competenceForScoringRepository from '../../../../../src/certification/scoring/infrastructure/repositories/competence-for-scoring-repository.js';
 import * as complementaryCertificationRepository from '../../../../../lib/infrastructure/repositories/complementary-certification-repository.js';
 import * as certificateRepository from '../../../course/infrastructure/repositories/certificate-repository.js';
 import * as challengeRepository from '../../../../shared/infrastructure/repositories/challenge-repository.js';
@@ -63,6 +64,7 @@ import { injectDependencies } from '../../../../shared/infrastructure/utils/depe
  * @typedef {certificationOfficerRepository} CertificationOfficerRepository
  * @typedef {competenceMarkRepository} CompetenceMarkRepository
  * @typedef {competenceRepository} CompetenceRepository
+ * @typedef {competenceForScoringRepository} CompetenceForScoringRepository
  * @typedef {complementaryCertificationRepository} ComplementaryCertificationRepository
  * @typedef {cpfExportRepository} CpfExportRepository
  * @typedef {finalizedSessionRepository} FinalizedSessionRepository
@@ -91,6 +93,7 @@ const dependencies = {
   certificationChallengeLiveAlertRepository,
   certificationCourseRepository,
   certificationCpfService,
+  competenceForScoringRepository,
   certificationIssueReportRepository,
   certificationOfficerRepository,
   certificationReportRepository,

--- a/api/tests/certification/scoring/integration/infrastructure/repositories/competence-for-scoring-repository_test.js
+++ b/api/tests/certification/scoring/integration/infrastructure/repositories/competence-for-scoring-repository_test.js
@@ -1,0 +1,53 @@
+import { expect, mockLearningContent } from '../../../../../test-helper.js';
+import { buildArea, buildCompetence, buildFramework } from '../../../../../tooling/domain-builder/factory/index.js';
+import { buildLearningContent } from '../../../../../tooling/learning-content-builder/index.js';
+import { competenceLevelIntervals } from '../../../../../../src/certification/flash-certification/domain/constants/competence-level-intervals.js';
+import _ from 'lodash';
+import { listByLocale } from '../../../../../../src/certification/scoring/infrastructure/repositories/competence-for-scoring-repository.js';
+import { CompetenceForScoring } from '../../../../../../src/certification/scoring/domain/models/CompetenceForScoring.js';
+
+describe('Unit | Repository | competence-for-scoring-repository', function () {
+  beforeEach(function () {
+    const frameworkId = 'frameworkId';
+
+    const getAreaCode = (competenceCode) => competenceCode.split('.').shift();
+    const competenceLevelIntervalsWithAreaCode = competenceLevelIntervals.map((competenceLevelInterval) => ({
+      ...competenceLevelInterval,
+      areaCode: getAreaCode(competenceLevelInterval.competence),
+    }));
+
+    const competenceLevelIntervalsByArea = _.groupBy(competenceLevelIntervalsWithAreaCode, 'areaCode');
+
+    const areas = Object.entries(competenceLevelIntervalsByArea).map(([areaCode, competenceLevelIntervals]) => {
+      const areaId = `recArea${areaCode}`;
+
+      const competences = competenceLevelIntervals.map((competenceLevelInterval) => {
+        const competenceIndex = competenceLevelInterval.competence;
+        const competenceId = `recCompetence${competenceIndex}`;
+
+        return buildCompetence({ id: competenceId, areaId, index: competenceIndex });
+      });
+
+      return buildArea({ id: areaId, frameworkId, code: areaCode, competences });
+    });
+
+    const framework = buildFramework({ id: frameworkId, name: 'someFramework', areas });
+
+    const learningContent = buildLearningContent([framework]);
+
+    mockLearningContent(learningContent);
+  });
+
+  describe('#listByLocale', function () {
+    it('should return a list of competences for scoring', async function () {
+      // when
+      const resultList = await listByLocale({ locale: 'fr-fr' });
+
+      // then
+      resultList.map((result) => {
+        expect(result).to.be.instanceOf(CompetenceForScoring);
+      });
+      expect(resultList.length).to.equal(16);
+    });
+  });
+});

--- a/api/tests/certification/scoring/unit/domain/models/CompetenceForScoring_test.js
+++ b/api/tests/certification/scoring/unit/domain/models/CompetenceForScoring_test.js
@@ -1,0 +1,113 @@
+import { domainBuilder, expect } from '../../../../../test-helper.js';
+import { CompetenceForScoring } from '../../../../../../src/certification/scoring/domain/models/CompetenceForScoring.js';
+
+describe('Unit | Certification | CompetenceForScoring', function () {
+  describe('#getCompetenceMark', function () {
+    let intervals;
+
+    const competenceId = 'recCompetenceId';
+    const areaCode = '1';
+    const competenceCode = '1.1';
+
+    beforeEach(function () {
+      intervals = [
+        {
+          bounds: {
+            max: -1,
+            min: Number.MIN_SAFE_INTEGER,
+          },
+          competenceLevel: 0,
+        },
+        {
+          bounds: {
+            max: 1,
+            min: -1,
+          },
+          competenceLevel: 1,
+        },
+        {
+          bounds: {
+            max: Number.MAX_SAFE_INTEGER,
+            min: -1,
+          },
+          competenceLevel: 2,
+        },
+      ];
+    });
+
+    describe('when the capacity is inside the lowest interval', function () {
+      it('should return the CompetenceMark with a level of 0', function () {
+        const estimatedLevel = -4;
+
+        const competenceForScoring = new CompetenceForScoring({
+          competenceId,
+          areaCode,
+          competenceCode,
+          intervals,
+        });
+
+        const competenceMark = competenceForScoring.getCompetenceMark(estimatedLevel);
+
+        const expectedCompetenceMark = domainBuilder.buildCompetenceMark({
+          competenceId,
+          area_code: areaCode,
+          competence_code: competenceCode,
+          level: 0,
+          score: 0,
+        });
+
+        expect(competenceMark).to.deep.equal(expectedCompetenceMark);
+      });
+    });
+
+    describe('when the capacity is inside the level 1 interval', function () {
+      it('should return the CompetenceMark with a level of 1', function () {
+        const estimatedLevel = 0;
+
+        const competenceForScoring = new CompetenceForScoring({
+          competenceId,
+          areaCode,
+          competenceCode,
+          intervals,
+        });
+
+        const competenceMark = competenceForScoring.getCompetenceMark(estimatedLevel);
+
+        const expectedCompetenceMark = domainBuilder.buildCompetenceMark({
+          competenceId,
+          area_code: areaCode,
+          competence_code: competenceCode,
+          level: 1,
+          score: 0,
+        });
+
+        expect(competenceMark).to.deep.equal(expectedCompetenceMark);
+      });
+    });
+
+    describe('when the capacity is above the highest interval', function () {
+      it('should return the CompetenceMark with a level of the highest interval', function () {
+        const estimatedLevel = 3;
+
+        const competenceForScoring = new CompetenceForScoring({
+          competenceId,
+          areaCode,
+          competenceCode,
+          intervals,
+        });
+
+        const competenceMark = competenceForScoring.getCompetenceMark(estimatedLevel);
+
+        const expectedCompetenceMark = domainBuilder.buildCompetenceMark({
+          competenceId,
+          area_code: areaCode,
+          competence_code: competenceCode,
+          level: 2,
+          score: 0,
+        });
+
+        expect(competenceMark).to.deep.equal(expectedCompetenceMark);
+      });
+    });
+  });
+});

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
@@ -33,7 +33,7 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
       competences: [
         {
           id: 'recCompetence0',
-          index: 'competence0',
+          index: '1.1',
           tubes: [
             {
               id: 'recTube0_0',
@@ -60,7 +60,7 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
         },
         {
           id: 'recCompetence1',
-          index: 'competence1',
+          index: '1.2',
           tubes: [
             {
               id: 'recTube1_0',
@@ -86,7 +86,7 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
         },
         {
           id: 'recCompetence2',
-          index: 'competence2',
+          index: '1.3',
           tubes: [
             {
               id: 'recTube2_0',
@@ -112,7 +112,7 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
         },
         {
           id: 'recCompetence3',
-          index: 'competence3',
+          index: '1.4',
           tubes: [
             {
               id: 'recTube3_0',
@@ -136,9 +136,15 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
             },
           ],
         },
+      ],
+    },
+    {
+      id: 'recArea1',
+      code: 'area1',
+      competences: [
         {
           id: 'recCompetence4',
-          index: 'competence4',
+          index: '2.1',
           tubes: [
             {
               id: 'recTube4_0',
@@ -157,6 +163,216 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
                   id: 'recSkill4_2',
                   nom: '@recSkill4_2',
                   challenges: [{ id: 'recChallenge4_2_0', ...hardChallengeParams }],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'recCompetence5',
+          index: '2.2',
+          tubes: [
+            {
+              id: 'recTube4_0',
+              skills: [
+                {
+                  id: 'recSkill5_0',
+                  nom: '@recSkill5_0',
+                  challenges: [{ id: 'recChallenge5_0_0', ...easyChallengeParams }],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'recCompetence6',
+          index: '2.3',
+          tubes: [
+            {
+              id: 'recTube4_0',
+              skills: [
+                {
+                  id: 'recSkill6_0',
+                  nom: '@recSkill6_0',
+                  challenges: [{ id: 'recChallenge6_0_0', ...easyChallengeParams }],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'recCompetence7',
+          index: '2.4',
+          tubes: [
+            {
+              id: 'recTube7_0',
+              skills: [
+                {
+                  id: 'recSkill7_0',
+                  nom: '@recSkill7_0',
+                  challenges: [{ id: 'recChallenge7_0_0', ...easyChallengeParams }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'recArea2',
+      code: 'area2',
+      competences: [
+        {
+          id: 'recCompetence8',
+          index: '3.1',
+          tubes: [
+            {
+              id: 'recTube8_0',
+              skills: [
+                {
+                  id: 'recSkill8_0',
+                  nom: '@recSkill8_0',
+                  challenges: [{ id: 'recChallenge8_0_0', ...easyChallengeParams }],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'recCompetence9',
+          index: '3.2',
+          tubes: [
+            {
+              id: 'recTube9_0',
+              skills: [
+                {
+                  id: 'recSkill9_0',
+                  nom: '@recSkill9_0',
+                  challenges: [{ id: 'recChallenge9_0_0', ...easyChallengeParams }],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'recCompetence10',
+          index: '3.3',
+          tubes: [
+            {
+              id: 'recTube10_0',
+              skills: [
+                {
+                  id: 'recSkill10_0',
+                  nom: '@recSkill10_0',
+                  challenges: [{ id: 'recChallenge10_0_0', ...easyChallengeParams }],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'recCompetence11',
+          index: '3.4',
+          tubes: [
+            {
+              id: 'recTube11_0',
+              skills: [
+                {
+                  id: 'recSkill11_0',
+                  nom: '@recSkill11_0',
+                  challenges: [{ id: 'recChallenge11_0_0', ...easyChallengeParams }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'recArea3',
+      code: 'area3',
+      competences: [
+        {
+          id: 'recCompetence12',
+          index: '4.1',
+          tubes: [
+            {
+              id: 'recTube4_0',
+              skills: [
+                {
+                  id: 'recSkill12_0',
+                  nom: '@recSkill12_0',
+                  challenges: [{ id: 'recChallenge12_0_0', ...easyChallengeParams }],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'recCompetence13',
+          index: '4.2',
+          tubes: [
+            {
+              id: 'recTube13_0',
+              skills: [
+                {
+                  id: 'recSkill13_0',
+                  nom: '@recSkill13_0',
+                  challenges: [{ id: 'recChallenge13_0_0', ...easyChallengeParams }],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'recCompetence14',
+          index: '4.3',
+          tubes: [
+            {
+              id: 'recTube14_0',
+              skills: [
+                {
+                  id: 'recSkill14_0',
+                  nom: '@recSkill14_0',
+                  challenges: [{ id: 'recChallenge14_0_0', ...easyChallengeParams }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'recArea4',
+      code: 'area4',
+      competences: [
+        {
+          id: 'recCompetence15',
+          index: '5.1',
+          tubes: [
+            {
+              id: 'recTube15_0',
+              skills: [
+                {
+                  id: 'recSkill15_0',
+                  nom: '@recSkill15_0',
+                  challenges: [{ id: 'recChallenge15_0_0', ...easyChallengeParams }],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'recCompetence16',
+          index: '5.2',
+          tubes: [
+            {
+              id: 'recTube16_0',
+              skills: [
+                {
+                  id: 'recSkill16_0',
+                  nom: '@recSkill16_0',
+                  challenges: [{ id: 'recChallenge16_0_0', ...easyChallengeParams }],
                 },
               ],
             },

--- a/api/tests/tooling/domain-builder/factory/certification/scoring/build-competence-for-scoring.js
+++ b/api/tests/tooling/domain-builder/factory/certification/scoring/build-competence-for-scoring.js
@@ -22,7 +22,7 @@ export const buildCompetenceForScoring = ({
     {
       bounds: {
         max: Number.MAX_SAFE_INTEGER,
-        min: -1,
+        min: 1,
       },
       competenceLevel: 2,
     },

--- a/api/tests/tooling/domain-builder/factory/certification/scoring/build-competence-for-scoring.js
+++ b/api/tests/tooling/domain-builder/factory/certification/scoring/build-competence-for-scoring.js
@@ -1,0 +1,37 @@
+import { CompetenceForScoring } from '../../../../../../src/certification/scoring/domain/models/CompetenceForScoring.js';
+
+export const buildCompetenceForScoring = ({
+  competenceId = 'recCompetenceId',
+  areaCode = '1',
+  competenceCode = '1.1',
+  intervals = [
+    {
+      bounds: {
+        max: -1,
+        min: Number.MIN_SAFE_INTEGER,
+      },
+      competenceLevel: 0,
+    },
+    {
+      bounds: {
+        max: 1,
+        min: -1,
+      },
+      competenceLevel: 1,
+    },
+    {
+      bounds: {
+        max: Number.MAX_SAFE_INTEGER,
+        min: -1,
+      },
+      competenceLevel: 2,
+    },
+  ],
+} = {}) => {
+  return new CompetenceForScoring({
+    competenceId,
+    areaCode,
+    competenceCode,
+    intervals,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -34,6 +34,7 @@ import { buildCertificationCandidateForAttendanceSheet } from './build-certifica
 import { buildCertificationCandidateForSupervising } from './build-certification-candidate-for-supervising.js';
 import { buildCertificationCandidateSubscription } from './build-certification-candidate-subscription.js';
 import { buildCertificationChallengeForScoring } from './certification/scoring/build-certification-challenge-for-scoring.js';
+import { buildCompetenceForScoring } from './certification/scoring/build-competence-for-scoring.js';
 import { buildCertificationEligibility } from './build-certification-eligibility.js';
 import { buildCertificationIssueReport } from './build-certification-issue-report.js';
 import { buildCertificationOfficer } from './build-certification-officer.js';
@@ -258,6 +259,7 @@ export {
   buildCleaCertifiedCandidate,
   buildCompetence,
   buildCompetenceEvaluation,
+  buildCompetenceForScoring,
   buildCompetenceMark,
   buildCompetenceResult,
   buildCompetenceTree,

--- a/mon-pix/app/components/user-certifications-detail-competence.hbs
+++ b/mon-pix/app/components/user-certifications-detail-competence.hbs
@@ -9,14 +9,14 @@
     <tbody>
       {{#each this.sortedCompetences as |competence|}}
         <tr
-          class="user-certifications-detail-competence-list__row user-certifications-detail-competence-list-row
-            {{if (lt competence.level 0) 'user-certifications-detail-competence-list-row--disabled'}}"
+          class="user-certifications-detail-competence-list__row user-certifications-detail-competence-list-row"
+          aria-disabled={{this.isCompetenceDisabled competence}}
         >
           <td class="user-certifications-detail-competence-list-row__name">
             {{competence.name}}
           </td>
           <td class="user-certifications-detail-competence-list-row__level">
-            {{if (lt competence.level 1) "" competence.level}}
+            {{if (gt 1 competence.level) "" competence.level}}
           </td>
         </tr>
       {{/each}}

--- a/mon-pix/app/components/user-certifications-detail-competence.js
+++ b/mon-pix/app/components/user-certifications-detail-competence.js
@@ -5,4 +5,8 @@ export default class UserCertificationsDetailCompetence extends Component {
   get sortedCompetences() {
     return sortBy(this.args.area?.resultCompetences, 'index');
   }
+
+  isCompetenceDisabled(competence) {
+    return competence.level < 1 ? 'true' : 'false';
+  }
 }

--- a/mon-pix/app/styles/components/_user-certifications-detail-competence.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-competence.scss
@@ -116,7 +116,7 @@
     text-align: center;
   }
 
-  &--disabled {
+  &[aria-disabled='true'] {
     opacity: 0.4;
   }
 }

--- a/mon-pix/tests/integration/components/user-certifications-detail-competence_test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-competence_test.js
@@ -89,4 +89,20 @@ module('Integration | Component | user-certifications-detail-competence', functi
       },
     ]);
   });
+
+  module('if certification is v3', function () {
+    test('render all failed competences properly', async function (assert) {
+      const expectedDisabledCompetenceList = ['Adapter les docs à leur finalité', 'Développer des docs multimédia'];
+
+      const failedCompetenceElements = Array.from(
+        document.getElementsByClassName('user-certifications-detail-competence-list-row'),
+      );
+
+      const disabledRowCompetenceName = failedCompetenceElements
+        .filter((element) => element.attributes['aria-disabled'].value === 'true')
+        .map((element) => element.innerText);
+
+      assert.deepEqual(disabledRowCompetenceName, expectedDisabledCompetenceList);
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème

Une nouvelle formule de scoring va être implémentée pour estimer le niveau par compétence d’un candidat.
Les niveaux estimés par compétence d’une certif sont affichés à plusieurs endroits sur les plateformes, et ces affichages sont aujourd’hui KO

## :robot: Proposition

Corriger l’affichage des niveaux estimés par compétence d’une certif v3 sur la page de détails d’une certification dans Dans Pix Admin, cacher uniquement pour les certif v3 la colonne du milieu qui donne le score en Pix par compétence (non pertinent pour la certif v3 qui ne propose pas un score en Pix par compétence)

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

- Créer une session de certification avec `certifv3@example.net`
- Ajouter un candidat
- Passer la session avec ce candidat sous le compte `certifiable-contenu-user@example.net`
- Dans Pix-Admin, vérifier que la colonne du score n'est pas visible dans la page de la certification passée

Idem en V2, sauf que le score par compétence s'affiche. (non régression)
