### PR TITLE
[TECH] Montée de version de Pix UI en v42.0.4 sur PixApp (PIX-10947)

### DIFF
--- a/mon-pix/app/components/certifications/certification-ender.hbs
+++ b/mon-pix/app/components/certifications/certification-ender.hbs
@@ -20,7 +20,11 @@
           {{t "pages.certification-ender.candidate.ended-due-to-finalization"}}
         </div>
       {{/if}}
-      <PixButtonLink @route="logout" @backgroundColor="blue" class="certification-ender__candidate-action-disconnect">
+      <PixButtonLink
+        @route="logout"
+        @backgroundColor="primary"
+        class="certification-ender__candidate-action-disconnect"
+      >
         {{t "pages.certification-ender.candidate.disconnect"}}
       </PixButtonLink>
       <div class="certification-ender__candidate-disconnect-tip">

--- a/mon-pix/app/components/scorecard-details.hbs
+++ b/mon-pix/app/components/scorecard-details.hbs
@@ -240,7 +240,7 @@
         </PixButton>
       </li>
       <li>
-        <PixButton id="pix-modal-footer__button-reset" @backgroundColor="red" @triggerAction={{this.reset}}>
+        <PixButton id="pix-modal-footer__button-reset" @backgroundColor="error" @triggerAction={{this.reset}}>
           {{t "pages.competence-details.actions.reset.label"}}
         </PixButton>
       </li>

--- a/mon-pix/app/components/skill-review-improve.hbs
+++ b/mon-pix/app/components/skill-review-improve.hbs
@@ -7,7 +7,7 @@
       {{t "pages.skill-review.improve.description"}}
     </p>
   </div>
-  <PixButton @backgroundColor="grey" @triggerAction={{@improve}}>
+  <PixButton @backgroundColor="neutral" @triggerAction={{@improve}}>
     {{t "pages.skill-review.actions.improve"}}
   </PixButton>
 </div>

--- a/mon-pix/app/pods/components/module/grain/template.hbs
+++ b/mon-pix/app/pods/components/module/grain/template.hbs
@@ -45,7 +45,7 @@
 
   {{#if this.shouldDisplayContinueButton}}
     <footer class="grain__footer">
-      <PixButton @backgroundColor="blue" @shape="rounded" @triggerAction={{this.continueAction}}>
+      <PixButton @backgroundColor="primary" @shape="rounded" @triggerAction={{this.continueAction}}>
         {{t "pages.modulix.buttons.grain.continue"}}
       </PixButton>
     </footer>

--- a/mon-pix/app/pods/components/module/qcu/template.hbs
+++ b/mon-pix/app/pods/components/module/qcu/template.hbs
@@ -31,7 +31,7 @@
 
   {{#unless this.qcu.lastCorrection}}
     <PixButton
-      @backgroundColor="green"
+      @backgroundColor="success"
       @shape="rounded"
       @type="submit"
       class="element-qcu__verify_button"

--- a/mon-pix/app/pods/components/module/qrocm/template.hbs
+++ b/mon-pix/app/pods/components/module/qrocm/template.hbs
@@ -54,7 +54,7 @@
 
   {{#unless this.qrocm.lastCorrection}}
     <PixButton
-      @backgroundColor="green"
+      @backgroundColor="success"
       @shape="rounded"
       @type="submit"
       class="element-qrocm__verify_button"

--- a/mon-pix/app/templates/terms-of-service.hbs
+++ b/mon-pix/app/templates/terms-of-service.hbs
@@ -25,7 +25,7 @@
     {{/if}}
 
     <div class="terms-of-service-form__actions">
-      <PixButtonLink @route="logout" @backgroundColor="grey">{{t "common.actions.back"}}</PixButtonLink>
+      <PixButtonLink @route="logout" @backgroundColor="neutral">{{t "common.actions.back"}}</PixButtonLink>
 
       <PixButton @type="submit" @triggerAction={{this.submit}} class="terms-of-service-form-actions__submit">
         {{t "pages.terms-of-service.form.button"}}

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -13,7 +13,7 @@
         "@1024pix/ember-matomo-tag-manager": "^2.4.3",
         "@1024pix/ember-testing-library": "^1.0.0",
         "@1024pix/eslint-config": "^1.1.1",
-        "@1024pix/pix-ui": "^41.2.0",
+        "@1024pix/pix-ui": "^42.0.4",
         "@1024pix/stylelint-config": "^5.0.2",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.2",
@@ -149,9 +149,9 @@
       "dev": true
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "41.2.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-41.2.0.tgz",
-      "integrity": "sha512-1bIPJ4UtL5DMYe8M4ehPXSFjfmgguJ1lN9Meq+V2+5kBsFSwBWmbf9hjKdFcSizMuyFVM/iygiZohjDk6Li9gg==",
+      "version": "42.0.4",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-42.0.4.tgz",
+      "integrity": "sha512-Qjz0ahnlqGS6My/+uk0b+OnOT2cAPnF2HTTnuVbLcxPA97+K+7NEaySGgPlFPUfZxU3YqlFT4VrlN7mkD/vrNA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -44,7 +44,7 @@
     "@1024pix/ember-matomo-tag-manager": "^2.4.3",
     "@1024pix/ember-testing-library": "^1.0.0",
     "@1024pix/eslint-config": "^1.1.1",
-    "@1024pix/pix-ui": "^41.2.0",
+    "@1024pix/pix-ui": "^42.0.4",
     "@1024pix/stylelint-config": "^5.0.2",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.2",


### PR DESCRIPTION
## :unicorn: Problème
PixApp n'a pas la dernière version disponible de Pix UI.

## :robot: Proposition
Monter de version. Constater que [le breaking change](https://github.com/1024pix/pix-ui/pull/515) n'impacte pas PixApp, par exemple en vérifiant avec les regex suivantes que les paramètes `model` et `route` ne sont pas utilisés sur le composant `PixButton` :

```
LinkTo\s+(.+)?@(model|route)=
PixButtonLink\s+(.+)?@(model|route)=
PixButton\s+(.+)?@(model|route)=
```

## :rainbow: Remarques
J'ai migré les attributs `backgroundColor` des `PixButton` et `PixButtonLink`, il n'y est pas sensé avoir d'impact visuel.

J'ai utilisé ce genre de regex : 
```
PixButtonLink(\s+(.+)?)@backgroundColor="blue"
```
Puis remplacé par 
```
PixButtonLink$1@backgroundColor="primary"
```

## :100: Pour tester
CI verte.
