### PR TITLE
[BUGFIX] Ajouter une migration pour remplacer les participantExternalId empty par null (PIX-10897)

### DIFF
--- a/api/db/migrations/20240129134258_replace-empty-participantExternalId-by-null-on-campaign-participations.js
+++ b/api/db/migrations/20240129134258_replace-empty-participantExternalId-by-null-on-campaign-participations.js
@@ -1,0 +1,21 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/DEV/pages/2153512965/Cr+er+une+migration
+
+// If your migrations target `answers` or `knowledge-elements`
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+const TABLE_NAME = 'campaign-participations';
+const COLUMN_NAME = 'participantExternalId';
+
+const up = async function (knex) {
+  await knex(TABLE_NAME).where(COLUMN_NAME, '').update(COLUMN_NAME, null);
+};
+
+const down = async function () {
+  // Do nothing because it's a bugfix, so we don't want this to be rollbacked
+};
+
+export { up, down };

--- a/api/scripts/prod/delete-organization-learners-from-organization.js
+++ b/api/scripts/prod/delete-organization-learners-from-organization.js
@@ -81,7 +81,7 @@ async function _anonymizeOrganizationLearners({ knexConn, organizationId }) {
 
 function _anonymizeCampaignParticipations({ knexConn, organizationId }) {
   return knexConn('campaign-participations')
-    .update({ participantExternalId: '', userId: null })
+    .update({ participantExternalId: null, userId: null })
     .whereRaw('id IN (?)', [
       knexConn('campaign-participations')
         .join('organization-learners', 'organization-learners.id', 'campaign-participations.organizationLearnerId')

--- a/api/tests/integration/migration/20240129134258_replace-empty-participantExternalId-by-null-on-campaign-participations_test.js
+++ b/api/tests/integration/migration/20240129134258_replace-empty-participantExternalId-by-null-on-campaign-participations_test.js
@@ -1,0 +1,42 @@
+import { expect, databaseBuilder, knex } from '../../test-helper.js';
+import { up as migrationToTest } from '../../../db/migrations/20240129134258_replace-empty-participantExternalId-by-null-on-campaign-participations.js';
+
+describe('Integration | Migration | replace-empty-participantExternalId-by-null-on-campaign-participations', function () {
+  it('should set to null participantExternalId when it is empty', async function () {
+    // given
+    const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+      participantExternalId: '',
+    }).id;
+
+    await databaseBuilder.commit();
+
+    // when
+    await migrationToTest(knex);
+
+    // then
+    const campaignParticipationUpdated = await knex('campaign-participations')
+      .where('id', campaignParticipationId)
+      .first();
+
+    expect(campaignParticipationUpdated.participantExternalId).to.be.null;
+  });
+
+  it('should not update participantExternalId when it is not empty', async function () {
+    // given
+    const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+      participantExternalId: "Allez l'om",
+    }).id;
+
+    await databaseBuilder.commit();
+
+    // when
+    await migrationToTest(knex);
+
+    // then
+    const campaignParticipationNotUpdated = await knex('campaign-participations')
+      .where('id', campaignParticipationId)
+      .first();
+
+    expect(campaignParticipationNotUpdated.participantExternalId).to.equal("Allez l'om");
+  });
+});

--- a/api/tests/integration/scripts/prod/delete-organization-learners-from-organization_test.js
+++ b/api/tests/integration/scripts/prod/delete-organization-learners-from-organization_test.js
@@ -167,6 +167,7 @@ describe('Script | Prod | Delete Organization Learners From Organization', funct
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
         organizationLearnerId,
+        participantExternalId: 'coucou',
       });
       await databaseBuilder.commit();
 
@@ -175,7 +176,7 @@ describe('Script | Prod | Delete Organization Learners From Organization', funct
       const participationResult = await knex('campaign-participations').where({ organizationLearnerId }).first();
       expect(organizationLearnerResult.firstName).to.equal('');
       expect(organizationLearnerResult.lastName).to.equal('');
-      expect(participationResult.participantExternalId).to.equal('');
+      expect(participationResult.participantExternalId).to.be.null;
     });
 
     it('anonymize organization learners personal info even if learner is already deleted', async function () {
@@ -384,7 +385,7 @@ describe('Script | Prod | Delete Organization Learners From Organization', funct
 
         expect(campaignParticipationToKeep.deletedAt).to.be.null;
         expect(campaignParticipationToDelete.deletedAt).not.to.be.null;
-        expect(campaignParticipationToDelete.participantExternalId).to.equal('');
+        expect(campaignParticipationToDelete.participantExternalId).to.be.null;
         expect(campaignParticipationToKeep.participantExternalId).to.equal('Ninja');
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Suite à l'investigation d'une erreur 422 pendant l'export des résultats d'une campagne, nous nous sommes rendus compte que environ 2800 participations ont un `participantExternalId` qui est vide.
C'est ce champ qui provoque une 422 si il est vide lors de l'export des résultats. On autorise le `null` sur cette colonne, mais pas d'empty string. Car cette valeur n'est pas possible via les fronts et est convertie à `null` dans tous les cas avant d'être inserée en base.

## :robot: Proposition
Faire une migration qui mets à jour toutes les lignes ayant un `participantExternalId` empty à `null`
Actuellement en production -> 2863 lignes sont concernées.

## :rainbow: Remarques
On modifie également le script de suppression de données afin qu'il mette à jour à `null` également lors d'une suppression

## :100: Pour tester
- Les tests sont verts

Pas évident à tester fonctionnellement 😄 
- Remplacer un ou deux `participantExternalId` à `''` directement en sql sur la table `campaign-participations`
- Supprimer la ligne de la migration de cette PR dans la table `knex_migrations` 
- Faire un `npm run db:migrate`
- Vérifier que les `participantExternalId` précedemment mis à `empty` sont maintenant `null`
- 🐈‍⬛ 
