### PR TITLE
[BUGFIX] Ne plus appeler la route API pour récupérer tous les oidc providers juste après la connexion sur Pix Admin (PIX-10964).

### DIFF
--- a/admin/app/routes/application.js
+++ b/admin/app/routes/application.js
@@ -8,15 +8,12 @@ export default class ApplicationRoute extends Route {
   @service intl;
   @service currentUser;
   @service featureToggles;
-  @service oidcIdentityProviders;
 
   async beforeModel() {
     await this.session.setup();
     this.intl.setLocale([defaultLocale]);
 
     await this.featureToggles.load();
-
-    await this.oidcIdentityProviders.loadReadyIdentityProviders();
 
     return this._loadCurrentUser();
   }

--- a/admin/app/routes/authenticated.js
+++ b/admin/app/routes/authenticated.js
@@ -3,13 +3,8 @@ import { service } from '@ember/service';
 
 export default class AuthenticatedRoute extends Route {
   @service session;
-  @service oidcIdentityProviders;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-  }
-
-  async model() {
-    await this.oidcIdentityProviders.loadAllAvailableIdentityProviders();
   }
 }

--- a/admin/app/routes/authenticated/users/get.js
+++ b/admin/app/routes/authenticated/users/get.js
@@ -4,6 +4,11 @@ import { service } from '@ember/service';
 
 export default class AuthenticatedUsersGetRoute extends Route {
   @service store;
+  @service oidcIdentityProviders;
+
+  async beforeModel() {
+    await this.oidcIdentityProviders.loadAllAvailableIdentityProviders();
+  }
 
   model(params) {
     return this.store.findRecord('user', params.user_id);

--- a/admin/app/routes/login.js
+++ b/admin/app/routes/login.js
@@ -3,8 +3,13 @@ import { service } from '@ember/service';
 
 export default class LoginRoute extends Route {
   @service session;
+  @service oidcIdentityProviders;
 
   beforeModel() {
     this.session.prohibitAuthentication('authenticated');
+  }
+
+  async model() {
+    await this.oidcIdentityProviders.loadReadyIdentityProviders();
   }
 }

--- a/admin/app/services/oidc-identity-providers.js
+++ b/admin/app/services/oidc-identity-providers.js
@@ -8,15 +8,13 @@ export default class OidcIdentityProviders extends Service {
   }
 
   async loadAllAvailableIdentityProviders() {
-    const oidcIdentityProviders = await this.store.findAll('oidc-identity-provider');
-    oidcIdentityProviders.map((oidcIdentityProvider) => (this[oidcIdentityProvider.id] = oidcIdentityProvider));
+    await this.store.findAll('oidc-identity-provider');
   }
 
   async loadReadyIdentityProviders() {
-    const oidcIdentityProviders = await this.store.findAll('oidc-identity-provider', {
+    await this.store.findAll('oidc-identity-provider', {
       adapterOptions: { readyIdentityProviders: true },
     });
-    oidcIdentityProviders.map((oidcIdentityProvider) => (this[oidcIdentityProvider.id] = oidcIdentityProvider));
   }
 
   isProviderEnabled(identityProviderSlug) {

--- a/admin/tests/unit/routes/authenticated/users/get_test.js
+++ b/admin/tests/unit/routes/authenticated/users/get_test.js
@@ -1,0 +1,27 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/users/get', function (hooks) {
+  setupTest(hooks);
+
+  module('beforeModel', function (hooks) {
+    hooks.afterEach(function () {
+      sinon.restore();
+    });
+
+    test('loads all available identity providers', async function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/users/get');
+
+      sinon.stub(route.oidcIdentityProviders, 'loadAllAvailableIdentityProviders');
+      route.oidcIdentityProviders.loadAllAvailableIdentityProviders.resolves();
+
+      // when
+      await route.beforeModel();
+
+      // then
+      assert.ok(route.oidcIdentityProviders.loadAllAvailableIdentityProviders.called);
+    });
+  });
+});

--- a/admin/tests/unit/routes/authenticated_test.js
+++ b/admin/tests/unit/routes/authenticated_test.js
@@ -1,28 +1,10 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import sinon from 'sinon';
-
 module('Unit | Route | authenticated', function (hooks) {
   setupTest(hooks);
 
   test('it exists', function (assert) {
     const route = this.owner.lookup('route:authenticated');
     assert.ok(route);
-  });
-
-  module('model', function () {
-    test('loads all available identity providers', async function (assert) {
-      // given
-      const route = this.owner.lookup('route:authenticated');
-
-      sinon.stub(route.oidcIdentityProviders, 'loadAllAvailableIdentityProviders');
-      route.oidcIdentityProviders.loadAllAvailableIdentityProviders.resolves();
-
-      // when
-      await route.model();
-
-      // then
-      assert.ok(route.oidcIdentityProviders.loadAllAvailableIdentityProviders.called);
-    });
   });
 });

--- a/admin/tests/unit/routes/login_test.js
+++ b/admin/tests/unit/routes/login_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
 
 module('Unit | Route | login', function (hooks) {
   setupTest(hooks);
@@ -7,5 +8,25 @@ module('Unit | Route | login', function (hooks) {
   test('it exists', function (assert) {
     const route = this.owner.lookup('route:login');
     assert.ok(route);
+  });
+
+  module('model', function (hooks) {
+    hooks.afterEach(function () {
+      sinon.restore();
+    });
+
+    test('loads ready identity providers', async function (assert) {
+      // given
+      const route = this.owner.lookup('route:login');
+
+      sinon.stub(route.oidcIdentityProviders, 'loadReadyIdentityProviders');
+      route.oidcIdentityProviders.loadReadyIdentityProviders.resolves();
+
+      // when
+      await route.model();
+
+      // then
+      assert.ok(route.oidcIdentityProviders.loadReadyIdentityProviders.called);
+    });
   });
 });

--- a/admin/tests/unit/services/oidc-identity-providers_test.js
+++ b/admin/tests/unit/services/oidc-identity-providers_test.js
@@ -8,6 +8,7 @@ import Service from '@ember/service';
 module('Unit | Service | oidc-identity-providers', function (hooks) {
   setupTest(hooks);
   let oidcIdentityProvidersService, oidcPartner;
+  let storeStub;
 
   hooks.beforeEach(function () {
     // given
@@ -19,7 +20,7 @@ module('Unit | Service | oidc-identity-providers', function (hooks) {
       source: 'oidc-externe',
     };
     const oidcPartnerObject = Object.create(oidcPartner);
-    const storeStub = Service.create({
+    storeStub = Service.create({
       findAll: sinon.stub().resolves([oidcPartnerObject]),
       peekAll: sinon.stub().returns([oidcPartnerObject]),
     });
@@ -33,6 +34,7 @@ module('Unit | Service | oidc-identity-providers', function (hooks) {
       await oidcIdentityProvidersService.loadAllAvailableIdentityProviders();
 
       // then
+      assert.ok(storeStub.findAll.calledWith('oidc-identity-provider'));
       assert.strictEqual(oidcIdentityProvidersService.list[0].code, oidcPartner.code);
       assert.strictEqual(oidcIdentityProvidersService.list[0].organizationName, oidcPartner.organizationName);
       assert.strictEqual(oidcIdentityProvidersService.list[0].hasLogoutUrl, oidcPartner.hasLogoutUrl);
@@ -46,6 +48,11 @@ module('Unit | Service | oidc-identity-providers', function (hooks) {
       await oidcIdentityProvidersService.loadReadyIdentityProviders();
 
       // then
+      assert.ok(
+        storeStub.findAll.calledWith('oidc-identity-provider', {
+          adapterOptions: { readyIdentityProviders: true },
+        }),
+      );
       assert.strictEqual(oidcIdentityProvidersService.list[0].code, oidcPartner.code);
       assert.strictEqual(oidcIdentityProvidersService.list[0].organizationName, oidcPartner.organizationName);
       assert.strictEqual(oidcIdentityProvidersService.list[0].hasLogoutUrl, oidcPartner.hasLogoutUrl);

--- a/admin/tests/unit/services/oidc-identity-providers_test.js
+++ b/admin/tests/unit/services/oidc-identity-providers_test.js
@@ -33,10 +33,6 @@ module('Unit | Service | oidc-identity-providers', function (hooks) {
       await oidcIdentityProvidersService.loadAllAvailableIdentityProviders();
 
       // then
-      assert.strictEqual(oidcIdentityProvidersService['oidc-partner'].code, oidcPartner.code);
-      assert.strictEqual(oidcIdentityProvidersService['oidc-partner'].organizationName, oidcPartner.organizationName);
-      assert.strictEqual(oidcIdentityProvidersService['oidc-partner'].hasLogoutUrl, oidcPartner.hasLogoutUrl);
-      assert.strictEqual(oidcIdentityProvidersService['oidc-partner'].source, oidcPartner.source);
       assert.strictEqual(oidcIdentityProvidersService.list[0].code, oidcPartner.code);
       assert.strictEqual(oidcIdentityProvidersService.list[0].organizationName, oidcPartner.organizationName);
       assert.strictEqual(oidcIdentityProvidersService.list[0].hasLogoutUrl, oidcPartner.hasLogoutUrl);
@@ -50,10 +46,6 @@ module('Unit | Service | oidc-identity-providers', function (hooks) {
       await oidcIdentityProvidersService.loadReadyIdentityProviders();
 
       // then
-      assert.strictEqual(oidcIdentityProvidersService['oidc-partner'].code, oidcPartner.code);
-      assert.strictEqual(oidcIdentityProvidersService['oidc-partner'].organizationName, oidcPartner.organizationName);
-      assert.strictEqual(oidcIdentityProvidersService['oidc-partner'].hasLogoutUrl, oidcPartner.hasLogoutUrl);
-      assert.strictEqual(oidcIdentityProvidersService['oidc-partner'].source, oidcPartner.source);
       assert.strictEqual(oidcIdentityProvidersService.list[0].code, oidcPartner.code);
       assert.strictEqual(oidcIdentityProvidersService.list[0].organizationName, oidcPartner.organizationName);
       assert.strictEqual(oidcIdentityProvidersService.list[0].hasLogoutUrl, oidcPartner.hasLogoutUrl);


### PR DESCRIPTION
## :unicorn: Problème

Lorsqu'on se connecte sur Pix Admin avec la mire classique, on peut voir le bouton Google apparaître une demi-seconde avant d'accéder à l'application.

https://github.com/1024pix/pix/assets/58915422/cfc186aa-fa72-4f4f-aea2-c26eeb82177f

Une première route API est appelée coté application pour retourner les fournisseurs d'identité activé ("ready") pour Pix Admin. C'est elle qui détermine l'affichage ou non le bouton Google.
Lorsque l'utilisateur se connecte, une seconde route API est immédiatement appelée (car positionnée sur la partie `authenticated` de l'application), qui elle va récupérer tous les fournisseurs d'identité (activés ou non) pour les afficher sur la page Utilisateur de Pix Admin.

On se retrouve avec une réponse API plus rapide que la transition front, raison pour laquelle le bouton apparaît une demi-seconde.

## :robot: Proposition
Appeler les deux routes API sur les oidc providers aux endroits les plus pertinents par rapport à nos besoins.
- La route pour les ready providers => déplacement de l'appel (from `application` to `login-form`)
- La route pour les all providers => déplacement de l'appel (from `authenticated` to `users`)

## :rainbow: Remarques
En effet le besoin d'avoir tous les providers concerne la page utilisateur uniquement.
On déplace les "ready" providers coté login-form car en cas de rechargement de l'application, l'appel API était réalisé alors qu'on en a uniquement besoin dans le contexte de la connexion.
Une conséquence est que l'appel est fait désormais à chaque chargement de la page utilisateur et plus une seule fois au chargement de l'application. Mais étant donné le faible nombre d'utilisateurs de Pix Admin, nous considérons que l'impact sur les performance est anecdotique.

## :100: Pour tester
1. Aller sur Pix Admin, constater que l'appel API est fait et retourne un tableau vide (aucun providers ready)
2. Se connecter via la mire classique et constater que le bouton Google n'apparaît plus
3. Se rendre sur la page de détails d'un utilisateur et constater que l'appel API est fait et retourne tous les providers.

