### PR TITLE
[POC] Met en place un POC de l'import SIECLE via un bucket S3 chez OVH (PIX-10927)

### DIFF
--- a/api/lib/domain/services/organization-learners-xml-service.js
+++ b/api/lib/domain/services/organization-learners-xml-service.js
@@ -2,8 +2,8 @@ import { SiecleParser } from '../../infrastructure/serializers/xml/siecle-parser
 
 export { extractOrganizationLearnersInformationFromSIECLE };
 
-async function extractOrganizationLearnersInformationFromSIECLE(path, organization) {
-  const parser = new SiecleParser(organization, path);
+async function extractOrganizationLearnersInformationFromSIECLE(path, organization, importStorage) {
+  const parser = new SiecleParser(organization, path, importStorage);
 
   return parser.parse();
 }

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -1,6 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
-/* eslint-disable import/no-restricted-paths */
-
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
@@ -178,6 +175,7 @@ import { getCompetenceLevel } from '../../../src/evaluation/domain/services/get-
 import { participantResultsSharedRepository } from '../../infrastructure/repositories/participant-results-shared-repository.js';
 import { pickChallengeService } from '../services/pick-challenge-service.js';
 import { tokenService } from '../../../src/shared/domain/services/token-service.js';
+import { importStorage } from '../../infrastructure/storage/import-storage.js';
 
 import * as dateUtils from '../../../src/shared/infrastructure/utils/date-utils.js';
 
@@ -206,6 +204,7 @@ function requirePoleEmploiNotifier() {
  */
 
 const dependencies = {
+  importStorage,
   accountRecoveryDemandRepository,
   activityAnswerRepository,
   activityRepository,

--- a/api/lib/infrastructure/serializers/xml/siecle-parser.js
+++ b/api/lib/infrastructure/serializers/xml/siecle-parser.js
@@ -18,14 +18,15 @@ const ELEVE_ELEMENT = '<ELEVE';
 const STRUCTURE_ELEVE_ELEMENT = '<STRUCTURES_ELEVE';
 
 class SiecleParser {
-  constructor(organization, path) {
+  constructor(organization, path, importStorage) {
     this.organization = organization;
     this.path = path;
+    this.importStorage = importStorage;
     this.organizationLearnersSet = new XMLOrganizationLearnersSet();
   }
 
   async parse() {
-    this.siecleFileStreamer = await SiecleFileStreamer.create(this.path);
+    this.siecleFileStreamer = await SiecleFileStreamer.create(this.path, this.importStorage);
 
     await this._parseUAI();
 

--- a/api/lib/infrastructure/storage/import-storage.js
+++ b/api/lib/infrastructure/storage/import-storage.js
@@ -1,0 +1,23 @@
+import { S3ObjectStorageProvider } from '../../../src/shared/storage/infrastructure/providers/S3ObjectStorageProvider.js';
+import { config } from '../../../src/shared/config.js';
+
+class ImportStorage {
+  #client;
+
+  constructor() {
+    this.#client = S3ObjectStorageProvider.createClient(config.import.storage.client);
+  }
+
+  sendFile({ filename, readableStream }) {
+    return this.#client.startUpload({ filename, readableStream });
+  }
+
+  async getFileReadableStream({ filename }) {
+    const data = await this.#client.readFile({ key: filename });
+
+    return data.Body;
+  }
+}
+
+const importStorage = new ImportStorage();
+export { importStorage, ImportStorage };

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -55,6 +55,17 @@ function _getLogForHumans() {
 
 const configuration = (function () {
   const config = {
+    import: {
+      storage: {
+        client: {
+          accessKeyId: process.env.IMPORT_STORAGE_ACCESS_KEY_ID,
+          secretAccessKey: process.env.IMPORT_STORAGE_SECRET_ACCESS_KEY,
+          endpoint: process.env.IMPORT_STORAGE_ENDPOINT,
+          region: process.env.IMPORT_STORAGE_REGION,
+          bucket: process.env.IMPORT_STORAGE_BUCKET_NAME,
+        },
+      },
+    },
     account: {
       passwordValidationPattern: '^(?=.*\\p{Lu})(?=.*\\p{Ll})(?=.*\\d).{8,}$',
     },


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la refonte de l'import pour donner la main aux captains et ne plus bloquer l'utilisateur pendant la durée de l'import, une étape consiste à ne plus streamer le fichier directement mais le stocker d'abord dans un bucket S3 chez OVH. Cette PR est une POC qui vise à essayer le fonctionnement des buckets S3 tel que c'est déjà fait pour le CPF.

## :robot: Proposition

Configuration OVH :

1/ Se connecter sur OVH
2/ Dans "Public Cloud" puis "Object storage" et "Utilisateurs S3", Créer un nouvel utilisateur (ici pix-import-dev)
3/ Dans "Mes conteneurs", Créer un conteur **Standard** dans la région **Gravelines** (ici pix-import-dev)
4/ Dans "Utilisateurs S3" sur l'utilisateur pix-cpf-dev faites "Télécharger S3 Policy (JSON)"
5/ Ouvrir le fichier et changer pix-cpf-dev en pix-import-dev
6/ Sur l'utilisateur pix-import-dev faire "Importer S3 Policy (JSON)" avec le fichier modifié (il faudra sûrement affiner les droits dont on a besoin)

Voici les variables d'environnements néccessaires au bon fonctionnement dont les valeurs sont à récupérer depuis OVH : 

```
IMPORT_STORAGE_ACCESS_KEY_ID=XXX
IMPORT_STORAGE_SECRET_ACCESS_KEY=XXX
IMPORT_STORAGE_ENDPOINT=XXX
IMPORT_STORAGE_REGION=XXX
IMPORT_STORAGE_BUCKET_NAME=XXX
```

## :rainbow: Remarques

Ce POC vérifie deux choses : 

- Upload vers un bucket S3
- Lecture depuis un bucket S3

Ce qu'il manque : 

- Supprimer le fichier une fois qu'on en a plus besoin
- Les tests sont cassants, je ne m'en suis pas soucié

## :100: Pour tester
- En local, après avoir bien configurer l'environnement
- Se connecter à Orga avec le compte SCO
- Essayer d'importer un fichier SIECLE valide
- Constater que ça fonctionne correctement
