### PR TITLE
[BUGFIX] Prendre en compte le mot remplacé par le dictionnaire d'une tablette/téléphone (Pix-10968)

### DIFF
--- a/1d/app/pods/components/challenge/challenge-item-qroc/template.hbs
+++ b/1d/app/pods/components/challenge/challenge-item-qroc/template.hbs
@@ -31,7 +31,10 @@
           name={{block.randomName}}
           autocomplete="nope"
           data-uid="qroc-proposal-uid"
+          {{! To activate validation button as soon as possible }}
           {{on "keyup" this.updateUserAnswerValue}}
+          {{! To also deal with browser dictionary auto complete }}
+          {{on "change" this.updateUserAnswerValue}}
         />
       {{else if (eq @challenge.format "phrase")}}
         <PixInput
@@ -42,7 +45,10 @@
           placeholder={{block.placeholder}}
           autocomplete="nope"
           data-uid="qroc-proposal-uid"
+          {{! To activate validation button as soon as possible }}
           {{on "keyup" this.updateUserAnswerValue}}
+          {{! To also deal with browser dictionary auto complete }}
+          {{on "change" this.updateUserAnswerValue}}
         />
       {{else if (eq @challenge.format "nombre")}}
         <PixInput
@@ -64,7 +70,10 @@
           type="text"
           autocomplete="nope"
           data-uid="qroc-proposal-uid"
+          {{! To activate validation button as soon as possible }}
           {{on "keyup" this.updateUserAnswerValue}}
+          {{! To also deal with browser dictionary auto complete }}
+          {{on "change" this.updateUserAnswerValue}}
         />
       {{/if}}
     {{/if}}

--- a/1d/app/pods/components/challenge/challenge-item-qrocm/template.hbs
+++ b/1d/app/pods/components/challenge/challenge-item-qrocm/template.hbs
@@ -41,7 +41,10 @@
               placeholder={{block.placeholder}}
               name={{block.randomName}}
               autocomplete="nope"
+              {{! To activate validation button as soon as possible }}
               {{on "keyup" (fn this.onInputChange block.input)}}
+              {{! To also deal with browser dictionary auto complete }}
+              {{on "change" (fn this.onInputChange block.input)}}
             />
           {{else if (eq @challenge.format "phrase")}}
             <PixInput
@@ -52,7 +55,10 @@
               autocomplete="nope"
               placeholder={{block.placeholder}}
               @ariaLabel={{block.ariaLabel}}
+              {{! To activate validation button as soon as possible }}
               {{on "keyup" (fn this.onInputChange block.input)}}
+              {{! To also deal with browser dictionary auto complete }}
+              {{on "change" (fn this.onInputChange block.input)}}
             />
           {{else}}
             <PixInput
@@ -64,7 +70,10 @@
               placeholder={{block.placeholder}}
               @value={{get @answersValue block.input}}
               @ariaLabel={{block.ariaLabel}}
+              {{! To activate validation button as soon as possible }}
               {{on "keyup" (fn this.onInputChange block.input)}}
+              {{! To also deal with browser dictionary auto complete }}
+              {{on "change" (fn this.onInputChange block.input)}}
             />
           {{/if}}
         </div>


### PR DESCRIPTION
## :unicorn: Problème
Lors de nos panels, on s'est rendu compte que lorsqu'un élève commençait à saisir une réponse dans un champs et qu'il sélectionnait le mot suggéré par le dico de la tablette (apple), la réponse envoyée était correspondait à ce que l'élève avait écrit.

## :robot: Proposition
Faire en sorte de prendre en compte toutes les réponses, peu importe comment ont été saisies les réponses

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- Sur téléphone/tablette Apple: arrivé au niveau défi et remplir les champs avec les suggestions de l'appareil
- sur ordi: passer par l'outil lambdaTest (mdp dans lockself) pour simuler tablette ou téléphone Apple, récupérer l'url de la RA, commencer pix1d pour arriver au niveau défi et remplir les champs avec les suggestions de l'appareil
