### PR TITLE
[BUGFIX] Le logo Pix Orga doit rediriger vers la page des missions si l'orga est de type Sco-1D (Pix-10939)

### DIFF
--- a/orga/app/components/layout/sidebar.hbs
+++ b/orga/app/components/layout/sidebar.hbs
@@ -1,6 +1,6 @@
 <aside class="sidebar">
   <header class="sidebar__logo hide-on-mobile">
-    <LinkTo @route="authenticated.campaigns">
+    <LinkTo @route={{this.redirectionRoute}}>
       <img src="{{this.rootUrl}}/pix-orga.svg" alt="{{t 'common.home-page'}}" />
     </LinkTo>
   </header>

--- a/orga/app/components/layout/sidebar.js
+++ b/orga/app/components/layout/sidebar.js
@@ -5,6 +5,14 @@ export default class SidebarMenu extends Component {
   @service currentUser;
   @service url;
 
+  get redirectionRoute() {
+    if (this.shouldDisplayMissionsEntry) {
+      return 'authenticated.missions';
+    } else {
+      return 'authenticated.campaigns';
+    }
+  }
+
   get documentationUrl() {
     return this.currentUser.organization.documentationUrl;
   }

--- a/orga/tests/integration/components/layout/sidebar_test.js
+++ b/orga/tests/integration/components/layout/sidebar_test.js
@@ -34,6 +34,22 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
   });
 
   module('Common menu', function () {
+    test('the logo should redirect to campaigns page', async function (assert) {
+      class CurrentUserStub extends Service {
+        organization = Object.create({ id: 5 });
+        shouldAccessCampaignsPage = true;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+      const intl = this.owner.lookup('service:intl');
+      intl.setLocale(['fr', 'fr']);
+
+      const screen = await render(hbs`<Layout::Sidebar />`);
+
+      const logoLink = screen.getByRole('link', { name: this.intl.t('common.home-page') });
+
+      assert.dom(logoLink).hasAttribute('href', '/campagnes');
+    });
+
     test('should display Campagne and Équipe menu for all organisation members', async function (assert) {
       class CurrentUserStub extends Service {
         organization = Object.create({ id: 1 });
@@ -228,6 +244,21 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
   });
 
   module('When the user has the mission-management feature', function () {
+    test('the logo should redirect to mission page', async function (assert) {
+      class CurrentUserStub extends Service {
+        organization = Object.create({ id: 5 });
+        shouldAccessMissionsPage = true;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+      const intl = this.owner.lookup('service:intl');
+      intl.setLocale(['fr', 'fr']);
+
+      const screen = await render(hbs`<Layout::Sidebar />`);
+
+      const logoLink = screen.getByRole('link', { name: this.intl.t('common.home-page') });
+      assert.dom(logoLink).hasAttribute('href', '/missions');
+    });
+
     test('should display Mission menu', async function (assert) {
       class CurrentUserStub extends Service {
         organization = Object.create({ id: 5 });


### PR DESCRIPTION
## :unicorn: Problème
En ajoutant la page des missions dans pix orga, nous avons oublié de changer la redirection du logo, donc on arrivait sur la page 'Mes campagnes'

## :robot: Proposition
Mettre à jour la redirection en fonction de si l'orga est de type sco-1d ou pas 

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- se connecter avec un compte pix1d et voir que lorsqu'on clique sur le logo on est rediriger vers la page `Missions`
-  se connecter avec un compte qui n'est pas pix1d et voir que lorsqu'on clique sur le logo on est rediriger vers la page `mes campagne`