### PR TITLE
[FEATURE] Migrer les variables CSS dans le bon format (PIX-10668)

### DIFF
--- a/mon-pix/app/styles/components/_action-chip.scss
+++ b/mon-pix/app/styles/components/_action-chip.scss
@@ -2,21 +2,21 @@
   width: 36px;
   height: 36px;
   text-align: center;
-  background: $pix-neutral-0;
-  border: 1px solid $pix-neutral-10;
+  background: var(--pix-neutral-0);
+  border: 1px solid var(--pix-neutral-20);
   border-radius: 50%;
 
   &__icon {
     top: 0%;
     bottom: 0%;
     left: calc(50% - 20px / 2);
-    color: $pix-neutral-50;
+    color: var(--pix-neutral-100);
     font-size: 18px;
   }
 
   &:hover {
-    background: $pix-neutral-10;
-    border: 1.4px solid $pix-neutral-50;
+    background: var(--pix-neutral-20);
+    border: 1.4px solid var(--pix-neutral-100);
     cursor: pointer;
   }
 
@@ -26,39 +26,39 @@
   }
 
   &--selected {
-    border-color: $pix-primary;
+    border-color: var(--pix-primary-500);
 
     .action-chip__icon {
-      color: $pix-primary;
+      color: var(--pix-primary-500);
     }
 
     &:hover {
-      border-color: $pix-primary-60;
+      border-color: var(--pix-primary-700);
 
       .action-chip__icon {
-        color: $pix-primary-60;
+        color: var(--pix-primary-700);
       }
     }
 
     &:focus-visible {
-      background-color: $pix-primary;
-      border-color: $pix-neutral-0;
-      box-shadow: 0 0 0 3px $pix-primary;
+      background-color: var(--pix-primary-500);
+      border-color: var(--pix-neutral-0);
+      box-shadow: 0 0 0 3px var(--pix-primary-500);
 
       .action-chip__icon {
-        color: $pix-neutral-0;
+        color: var(--pix-neutral-0);
       }
     }
   }
 
   &:not(.action-chip--selected):focus-visible {
-    background-color: $pix-neutral-60;
-    border-color: $pix-neutral-0;
+    background-color: var(--pix-neutral-500);
+    border-color: var(--pix-neutral-0);
     outline: none;
-    box-shadow: 0 0 0 3px $pix-neutral-60;
+    box-shadow: 0 0 0 3px var(--pix-neutral-500);
 
     .action-chip__icon {
-      color: $pix-neutral-0;
+      color: var(--pix-neutral-0);
     }
   }
 }

--- a/mon-pix/app/styles/components/_assessment-banner.scss
+++ b/mon-pix/app/styles/components/_assessment-banner.scss
@@ -4,7 +4,7 @@
   justify-content: space-around;
   width: 100%;
   min-height: 180px;
-  color: $pix-neutral-0;
+  color: var(--pix-neutral-0);
   background: $pix-primary-app-gradient;
   box-shadow: 0 2px 8px 0 rgb(0 0 0 / 10%);
 }
@@ -52,7 +52,7 @@
   width: 1px;
   height: 16px;
   margin: 0 10px;
-  background: $pix-neutral-15;
+  background: var(--pix-neutral-20);
 
   @include device-is('desktop') {
     margin: 0 12px;
@@ -65,11 +65,11 @@
   z-index: 1;
   height: 1.5rem;
   margin-left: auto;
-  color: $pix-neutral-0;
+  color: var(--pix-neutral-0);
   text-align: right;
 
   &:hover {
-    color: rgb($pix-neutral-0, 0.8);
+    color: rgb(var(--pix-neutral-0), 0.8);
   }
 }
 

--- a/mon-pix/app/styles/components/_assessment-banner.scss
+++ b/mon-pix/app/styles/components/_assessment-banner.scss
@@ -14,7 +14,7 @@
   align-items: center;
   width: 100%;
   max-width: 990px;
-  margin-top: $pix-spacing-m;
+  margin-top: var(--pix-spacing-6x);
   padding: 0 10px;
 
   @include device-is('desktop') {
@@ -78,6 +78,6 @@
   justify-content: flex-end;
 
   & > * + * {
-    margin-left: $pix-spacing-xs;
+    margin-left: var(--pix-spacing-2x);
   }
 }

--- a/mon-pix/app/styles/components/_background-banner.scss
+++ b/mon-pix/app/styles/components/_background-banner.scss
@@ -1,15 +1,15 @@
 .background-banner {
   width: 100%;
   min-height: 270px;
-  color: $pix-neutral-0;
+  color: var(--pix-neutral-0);
   background: $pix-primary-app-gradient;
   box-shadow: 0 2px 8px 0 rgb(0 0 0 / 10%);
 }
 
 .background-banner-v2 {
   width: 100%;
-  background: $pix-neutral-0;
-  box-shadow: 0 2px 5px 0 rgba($pix-neutral-90, 0.06);
+  background: var(--pix-neutral-0);
+  box-shadow: 0 2px 5px 0 rgba(var(--pix-neutral-900), 0.06);
 }
 
 .background-banner-wrapper {

--- a/mon-pix/app/styles/components/_badge-card-certifiable.scss
+++ b/mon-pix/app/styles/components/_badge-card-certifiable.scss
@@ -13,7 +13,7 @@
   justify-content: center;
   margin-bottom: 20px;
   padding: $pix-spacing-m;
-  background-color: $pix-success-5;
+  background-color: var(--pix-success-50);
   border-radius: 16px;
 
   &__header {
@@ -23,7 +23,7 @@
   }
 
   &--not-acquired {
-    background-color: $pix-neutral-10;
+    background-color: var(--pix-neutral-20);
   }
 
   @include device-is('tablet') {
@@ -71,7 +71,7 @@
     width: fit-content;
     padding: $pix-spacing-xxs $pix-spacing-xs;
     white-space: nowrap;
-    background-color: $pix-neutral-0;
+    background-color: var(--pix-neutral-0);
     border-radius: 8px;
   }
 

--- a/mon-pix/app/styles/components/_badge-card-certifiable.scss
+++ b/mon-pix/app/styles/components/_badge-card-certifiable.scss
@@ -12,7 +12,7 @@
   align-items: center;
   justify-content: center;
   margin-bottom: 20px;
-  padding: $pix-spacing-m;
+  padding: var(--pix-spacing-6x);
   background-color: var(--pix-success-50);
   border-radius: 16px;
 
@@ -52,7 +52,7 @@
   &__content {
     display: flex;
     flex-wrap: wrap;
-    gap: $pix-spacing-s;
+    gap: var(--pix-spacing-4x);
     align-items: center;
     justify-content: center;
   }
@@ -60,7 +60,7 @@
   &__title {
     @extend %pix-title-xs;
 
-    margin: $pix-spacing-xs 0 $pix-spacing-s;
+    margin: var(--pix-spacing-2x) 0 var(--pix-spacing-4x);
   }
 }
 
@@ -69,7 +69,7 @@
     @extend %pix-body-s;
 
     width: fit-content;
-    padding: $pix-spacing-xxs $pix-spacing-xs;
+    padding: var(--pix-spacing-1x) var(--pix-spacing-2x);
     white-space: nowrap;
     background-color: var(--pix-neutral-0);
     border-radius: 8px;

--- a/mon-pix/app/styles/components/_badge-card.scss
+++ b/mon-pix/app/styles/components/_badge-card.scss
@@ -27,7 +27,7 @@
     display: flex;
     flex-direction: column;
     max-width: 70%;
-    padding: $pix-spacing-m $pix-spacing-s $pix-spacing-m $pix-spacing-m;
+    padding: var(--pix-spacing-6x) var(--pix-spacing-4x) var(--pix-spacing-6x) var(--pix-spacing-6x);
 
     @include device-is('desktop') {
       flex: 1 1 40%;
@@ -42,7 +42,7 @@
     justify-content: center;
     min-width: 120px;
     max-width: 120px;
-    padding: $pix-spacing-s;
+    padding: var(--pix-spacing-4x);
     background-color: var(--pix-neutral-20);
 
     img {
@@ -58,14 +58,14 @@
 .badge-card-content {
   &__header {
     display: flex;
-    gap: $pix-spacing-s;
+    gap: var(--pix-spacing-4x);
     align-items: center;
   }
 
   &__title {
     @extend %pix-title-xs;
 
-    margin: 12px 0 $pix-spacing-xs;
+    margin: 12px 0 var(--pix-spacing-2x);
     color: var(--pix-neutral-900);
   }
 
@@ -81,7 +81,7 @@
   &__status {
     @extend %pix-body-s;
 
-    padding: $pix-spacing-xxs $pix-spacing-xs;
+    padding: var(--pix-spacing-1x) var(--pix-spacing-2x);
     white-space: nowrap;
     background-color: var(--pix-neutral-20);
     border-radius: 8px;
@@ -90,12 +90,12 @@
 
 .badge-card-content-header-status {
   &__acquired-icon {
-    margin-right: $pix-spacing-xxs;
+    margin-right: var(--pix-spacing-1x);
     color: var(--pix-success-500);
   }
 
   &__not-acquired-icon {
-    margin-right: $pix-spacing-xxs;
+    margin-right: var(--pix-spacing-1x);
     color: var(--pix-neutral-100);
   }
 }

--- a/mon-pix/app/styles/components/_badge-card.scss
+++ b/mon-pix/app/styles/components/_badge-card.scss
@@ -14,7 +14,7 @@
   overflow: hidden;
   word-break: break-word;
   border-radius: 10px;
-  box-shadow: 0 3px 4px 0 rgb(12 22 58 / 10%), 0 1px 3px 0 rgba($pix-neutral-110, 0.1);
+  box-shadow: 0 3px 4px 0 rgb(12 22 58 / 10%), 0 1px 3px 0 rgba(var(--pix-neutral-900), 0.1);
 
   @include device-is('desktop') {
     flex: 1 1 40%;
@@ -43,7 +43,7 @@
     min-width: 120px;
     max-width: 120px;
     padding: $pix-spacing-s;
-    background-color: $pix-neutral-10;
+    background-color: var(--pix-neutral-20);
 
     img {
       width: 90px;
@@ -66,14 +66,14 @@
     @extend %pix-title-xs;
 
     margin: 12px 0 $pix-spacing-xs;
-    color: $pix-neutral-100;
+    color: var(--pix-neutral-900);
   }
 
   &__message {
     @extend %pix-body-s;
 
     margin-bottom: 0;
-    color: $pix-neutral-45;
+    color: var(--pix-neutral-500);
   }
 }
 
@@ -83,7 +83,7 @@
 
     padding: $pix-spacing-xxs $pix-spacing-xs;
     white-space: nowrap;
-    background-color: $pix-neutral-10;
+    background-color: var(--pix-neutral-20);
     border-radius: 8px;
   }
 }
@@ -91,11 +91,11 @@
 .badge-card-content-header-status {
   &__acquired-icon {
     margin-right: $pix-spacing-xxs;
-    color: $pix-success-50;
+    color: var(--pix-success-500);
   }
 
   &__not-acquired-icon {
     margin-right: $pix-spacing-xxs;
-    color: $pix-neutral-50;
+    color: var(--pix-neutral-100);
   }
 }

--- a/mon-pix/app/styles/components/_certification-banner.scss
+++ b/mon-pix/app/styles/components/_certification-banner.scss
@@ -9,8 +9,8 @@
     justify-content: space-around;
     width: 100%;
     height: 270px;
-    color: $pix-neutral-0;
-    background: $pix-primary-certif-gradient;
+    color: var(--pix-neutral-0);
+    background: var(--pix-primary-500)-certif-gradient;
     box-shadow: 0 2px 8px 0 rgb(0 0 0 / 10%);
   }
 }
@@ -29,7 +29,7 @@
 .certification-number {
   width: 170px;
   margin-left: auto;
-  color: $pix-neutral-0;
+  color: var(--pix-neutral-0);
   text-align: right;
 
   &__label {

--- a/mon-pix/app/styles/components/_certification-joiner.scss
+++ b/mon-pix/app/styles/components/_certification-joiner.scss
@@ -4,7 +4,7 @@
 
   &__title {
     margin-bottom: 32px;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-size: 2rem;
     font-family: $font-open-sans;
     text-align: center;
@@ -29,32 +29,32 @@
     min-width: 0;
     height: 50px;
     padding-left: 10px;
-    border: 2px solid $pix-neutral-20;
+    border: 2px solid var(--pix-neutral-20);
     border-radius: 4px;
     outline-width: 1px;
 
     &:hover {
-      box-shadow: 0 0 0 2px $pix-primary-40;
+      box-shadow: 0 0 0 2px var(--pix-primary-500);
     }
 
     &:focus {
-      outline: 1px solid $pix-primary-40;
-      box-shadow: 0 0 0 2px $pix-primary-40;
+      outline: 1px solid var(--pix-primary-500);
+      box-shadow: 0 0 0 2px var(--pix-primary-500);
     }
 
     &:focus-within {
-      outline: 1px solid $pix-primary-40;
-      box-shadow: 0 0 0 2px $pix-primary-40;
+      outline: 1px solid var(--pix-primary-500);
+      box-shadow: 0 0 0 2px var(--pix-primary-500);
     }
 
     &.certification-joiner__input--invalid:not(:hover) {
-      outline: 1px solid $pix-error-50;
-      box-shadow: 0 0 0 2px $pix-error-50;
+      outline: 1px solid var(--pix-error-500);
+      box-shadow: 0 0 0 2px var(--pix-error-500);
     }
 
     &.certification-joiner__input--invalid:focus {
-      outline: 1px solid $pix-error-50;
-      box-shadow: 0 0 0 2px $pix-error-50;
+      outline: 1px solid var(--pix-error-500);
+      box-shadow: 0 0 0 2px var(--pix-error-500);
     }
   }
 
@@ -66,26 +66,26 @@
     width: 100%;
     margin-top: 8px;
     margin-bottom: 34px;
-    border: 2px solid $pix-neutral-0;
+    border: 2px solid var(--pix-neutral-0);
 
     &:focus-within {
-      border: 2px solid $pix-neutral-0;
-      box-shadow: 0 0 0 2px $pix-primary;
+      border: 2px solid var(--pix-neutral-0);
+      box-shadow: 0 0 0 2px var(--pix-primary-500);
     }
   }
 
   ::placeholder {
-    color: $pix-neutral-30;
+    color: var(--pix-neutral-100);
   }
 
   :input-placeholder {
-    color: $pix-neutral-30;
+    color: var(--pix-neutral-100);
   }
 
   p.certification-joiner__validation-error {
     margin-top: 6px;
     margin-bottom: 0;
-    color: $pix-warning-60;
+    color: var(--pix-warning-700);
     font-size: 0.875rem;
   }
 
@@ -106,14 +106,14 @@
 
   &__label {
     margin-bottom: 4px;
-    color: $pix-neutral-70;
+    color: var(--pix-neutral-800);
     font-size: 0.875rem;
   }
 
   .certification-course-page {
     &__errors {
       margin: 5px;
-      color: $pix-warning-60;
+      color: var(--pix-warning-700);
       font-size: 0.875rem;
       text-align: start;
 
@@ -127,7 +127,7 @@
 
       a,
       a:visited {
-        color: $pix-warning-60;
+        color: var(--pix-warning-700);
         text-decoration: underline;
       }
     }

--- a/mon-pix/app/styles/components/_certification-result.scss
+++ b/mon-pix/app/styles/components/_certification-result.scss
@@ -8,7 +8,7 @@
   margin: -150px auto;
   padding-top: 10px;
   line-height: 1.875rem;
-  background-color: $pix-neutral-0;
+  background-color: var(--pix-neutral-0);
 
   @include device-is('tablet') {
     padding: 41px 0;
@@ -17,7 +17,7 @@
 
 .result-content__panel-title {
   margin-top: 11px;
-  color: $pix-neutral-80;
+  color: var(--pix-neutral-800);
   font-weight: $font-bold;
   font-size: 1.563rem;
   font-family: $font-open-sans;
@@ -32,7 +32,7 @@
 .result-content__panel-description {
   margin-top: 21px;
   padding: 0 3px;
-  color: $pix-neutral-80;
+  color: var(--pix-neutral-800);
   font-size: 1.25rem;
   font-family: $font-open-sans;
   line-height: 1.875rem;
@@ -42,7 +42,7 @@
 .result-content__panel-description-supervisor {
   margin-top: 21px;
   padding: 0 3px;
-  color: $pix-warning-60;
+  color: var(--pix-warning-700);
   font-weight: bold;
   font-size: 1.25rem;
   line-height: 1.875rem;
@@ -57,7 +57,7 @@
 .result-content__warning-text {
   padding-bottom: 30px;
   padding-left: 0.625rem;
-  color: $pix-neutral-80;
+  color: var(--pix-neutral-800);
   font-size: 0.938rem;
   line-height: normal;
   text-align: center;
@@ -87,5 +87,5 @@
 
 .result-content__logout-button,
 .result-content__logout-button:hover {
-  color: $pix-neutral-0;
+  color: var(--pix-neutral-0);
 }

--- a/mon-pix/app/styles/components/_certification-starter.scss
+++ b/mon-pix/app/styles/components/_certification-starter.scss
@@ -21,7 +21,7 @@
 
   &__errors {
     margin: 5px;
-    color: $pix-warning-60;
+    color: var(--pix-warning-700);
     font-size: 0.875rem;
     text-align: start;
 
@@ -35,7 +35,7 @@
 
     a,
     a:visited {
-      color: $pix-warning-60;
+      color: var(--pix-warning-700);
       text-decoration: underline;
     }
   }
@@ -46,20 +46,20 @@
     justify-content: center;
     margin-top: 16px;
     padding: 16px;
-    color: $pix-neutral-70;
-    background-color: $pix-neutral-10;
+    color: var(--pix-neutral-800);
+    background-color: var(--pix-neutral-20);
     border-radius: 8px;
 
     a,
     a:visited {
-      color: $pix-neutral-70;
+      color: var(--pix-neutral-800);
       text-decoration-line: underline;
     }
   }
 
   &__title {
     margin-bottom: 20px;
-    color: $pix-neutral-100;
+    color: var(--pix-neutral-900);
     font-size: 2.625rem;
     font-family: $font-open-sans;
     text-align: center;
@@ -68,13 +68,13 @@
 
 .certification-starter-subscriptions {
   margin-bottom: 32px;
-  color: $pix-neutral-90;
+  color: var(--pix-neutral-900);
   font-size: 0.875rem;
 
   &-container {
     padding: 16px 0;
     text-align: center;
-    background-color: $pix-neutral-10;
+    background-color: var(--pix-neutral-20);
 
     &-title {
       font-size: 1rem;
@@ -91,12 +91,12 @@
       }
 
       &__eligible-icon {
-        color: $pix-success-70;
+        color: var(--pix-success-700);
       }
 
       &__non-eligible-item,
       &__non-eligible-icon {
-        color: $pix-neutral-50;
+        color: var(--pix-neutral-100);
       }
     }
 
@@ -104,8 +104,8 @@
       display: flex;
       align-items: center;
       padding: 10px 16px;
-      color: $pix-warning-70;
-      background-color: $pix-warning-5;
+      color: var(--pix-warning-700);
+      background-color: var(--pix-warning-50);
     }
 
     &__info-icon {
@@ -118,7 +118,7 @@
   display: block;
   margin-top: 5px;
   margin-bottom: 5px;
-  color: $pix-neutral-80;
+  color: var(--pix-neutral-800);
   font-size: 1.25rem;
   font-family: $font-open-sans;
   line-height: 28px;
@@ -127,7 +127,7 @@
 
 .certification-start-page__cgu {
   margin: 5px 30px;
-  color: $pix-neutral-80;
+  color: var(--pix-neutral-800);
   font-size: 0.75rem;
   line-height: 18px;
   text-align: justify;
@@ -158,15 +158,15 @@
   text-transform: uppercase;
   background: repeating-linear-gradient(
       90deg,
-      $pix-neutral-22 0,
-      $pix-neutral-22 1ch,
+      var(--pix-neutral-100) 0,
+      var(--pix-neutral-100) 1ch,
       transparent 0,
       transparent 1ch + $space-between-dashes
     )
     0 100% / #{$total-width - $space-between-dashes} 2px no-repeat;
   background-position-x: 0.5ch;
   background-position-y: 2.5ch;
-  border: solid 2px $pix-neutral-20;
+  border: solid 2px var(--pix-neutral-20);
   border-radius: 3px;
   outline: none;
 
@@ -183,8 +183,8 @@
     letter-spacing: $space-between-dashes;
     background: repeating-linear-gradient(
         90deg,
-        $pix-neutral-22 0,
-        $pix-neutral-22 1.3ch,
+        var(--pix-neutral-100) 0,
+        var(--pix-neutral-100) 1.3ch,
         transparent 0,
         transparent 1.3ch + $space-between-dashes
       )
@@ -195,7 +195,7 @@
   }
 
   &:focus {
-    color: $pix-neutral-70;
+    color: var(--pix-neutral-800);
     outline: none;
   }
 }

--- a/mon-pix/app/styles/components/_certifications-list-item.scss
+++ b/mon-pix/app/styles/components/_certifications-list-item.scss
@@ -3,7 +3,7 @@
 .certifications-list-item {
   padding: 5px;
   text-align: center;
-  border-bottom: 1px solid $pix-neutral-20;
+  border-bottom: 1px solid var(--pix-neutral-20);
 }
 
 .certifications-list-item img {
@@ -26,7 +26,7 @@
 
 .certifications-list-item__clickable:hover {
   color: inherit;
-  background-color: $pix-neutral-10;
+  background-color: var(--pix-neutral-20);
 }
 
 .certifications-list-item__not-clickable a {
@@ -72,10 +72,10 @@
   @extend .certifications-list-item__cell;
 
   padding: 10px 0;
-  color: $pix-neutral-60;
+  color: var(--pix-neutral-500);
   font-size: 1rem;
   text-align: left;
-  border-top: 1px solid $pix-neutral-20;
+  border-top: 1px solid var(--pix-neutral-20);
 }
 
 .certifications-list-item__cell {
@@ -89,11 +89,11 @@
 }
 
 .certifications-list-item__unpublished-item {
-  color: $pix-neutral-35;
+  color: var(--pix-neutral-100);
 }
 
 .certifications-list-item__published-item {
-  color: $pix-neutral-80;
+  color: var(--pix-neutral-800);
 }
 
 .certifications-list-item__cell-pix-score {
@@ -116,7 +116,7 @@
 
   span {
     display: table-cell;
-    color: $pix-neutral-70;
+    color: var(--pix-neutral-800);
     font-weight: 300;
     font-size: 0.5rem;
     line-height: normal;
@@ -143,7 +143,7 @@
   justify-content: left;
 
   & :first-child {
-    color: $pix-primary;
+    color: var(--pix-primary-500);
     font-size: 0.813rem;
     text-transform: uppercase;
     background: none;

--- a/mon-pix/app/styles/components/_certifications-list.scss
+++ b/mon-pix/app/styles/components/_certifications-list.scss
@@ -1,6 +1,6 @@
 .certifications-list {
   justify-content: space-around;
-  color: $pix-neutral-80;
+  color: var(--pix-neutral-800);
   font-size: 0.625rem;
   font-family: $font-open-sans;
   background-color: transparent;

--- a/mon-pix/app/styles/components/_challenge-actions.scss
+++ b/mon-pix/app/styles/components/_challenge-actions.scss
@@ -28,7 +28,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  margin: $pix-spacing-xxs;
+  margin: var(--pix-spacing-1x);
   background-color: var(--pix-neutral-20);
 
   &__group > p {
@@ -42,7 +42,7 @@
     &__buttons {
       display: flex;
       flex-direction: column;
-      padding: 0 $pix-spacing-m;
+      padding: 0 var(--pix-spacing-6x);
     }
 
     &__action-validate {
@@ -62,7 +62,7 @@
 
     &__action-validate {
       min-width: 12.5em;
-      margin-left: $pix-spacing-s;
+      margin-left: var(--pix-spacing-4x);
     }
   }
 

--- a/mon-pix/app/styles/components/_challenge-actions.scss
+++ b/mon-pix/app/styles/components/_challenge-actions.scss
@@ -29,11 +29,11 @@
   flex-direction: column;
   justify-content: center;
   margin: $pix-spacing-xxs;
-  background-color: $pix-neutral-10;
+  background-color: var(--pix-neutral-20);
 
   &__group > p {
     margin-top: 8px;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-size: 0.75rem;
     line-height: 17px;
   }
@@ -68,7 +68,7 @@
 
   &__already-answered {
     margin-right: 20px;
-    color: $pix-neutral-70;
+    color: var(--pix-neutral-800);
     font-weight: $font-medium;
     font-size: 1rem;
     font-family: $font-roboto;
@@ -80,7 +80,7 @@
     align-items: center;
     max-width: 600px;
     margin: 0 auto 24px 12px;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-weight: $font-normal;
     font-size: 0.875rem;
     font-family: $font-roboto;
@@ -97,7 +97,7 @@
   &__icon {
     margin-right: 20px;
     margin-left: 0;
-    color: $pix-neutral-45;
+    color: var(--pix-neutral-500);
     font-size: 1rem;
   }
 }

--- a/mon-pix/app/styles/components/_challenge-embed-simulator.scss
+++ b/mon-pix/app/styles/components/_challenge-embed-simulator.scss
@@ -18,9 +18,9 @@
     align-items: center;
     justify-content: center;
     width: 100%;
-    color: $pix-neutral-40;
+    color: var(--pix-neutral-500);
     font-size: 4.375rem;
-    background-color: $pix-neutral-15;
+    background-color: var(--pix-neutral-20);
   }
 
   .rounded-panel {

--- a/mon-pix/app/styles/components/_challenge-embed-simulator.scss
+++ b/mon-pix/app/styles/components/_challenge-embed-simulator.scss
@@ -64,8 +64,8 @@
 .embed__reboot {
   display: flex;
   justify-content: flex-end;
-  margin-top: $pix-spacing-xxs;
-  padding-right: $pix-spacing-xs;
+  margin-top: var(--pix-spacing-1x);
+  padding-right: var(--pix-spacing-2x);
 }
 
 .embed-reboot__content {

--- a/mon-pix/app/styles/components/_challenge-illustration.scss
+++ b/mon-pix/app/styles/components/_challenge-illustration.scss
@@ -6,9 +6,9 @@
     justify-content: center;
     width: 100%;
     height: 300px;
-    color: $pix-neutral-40;
+    color: var(--pix-neutral-500);
     font-size: 4.375rem;
-    background-color: $pix-neutral-15;
+    background-color: var(--pix-neutral-20);
   }
 
   &__loaded-image {

--- a/mon-pix/app/styles/components/_challenge-item.scss
+++ b/mon-pix/app/styles/components/_challenge-item.scss
@@ -4,7 +4,7 @@
   &--focused {
     z-index: 1;
     border-radius: 10px;
-    outline: 3px dashed $pix-neutral-70;
+    outline: 3px dashed var(--pix-neutral-800);
     outline-offset: -3px;
   }
 }
@@ -15,14 +15,14 @@
   display: flex;
   flex-direction: column;
   margin: 4px;
-  background-color: $pix-neutral-10;
+  background-color: var(--pix-neutral-20);
 
   label {
     font-weight: $font-normal;
   }
 
   a {
-    color: $pix-primary;
+    color: var(--pix-primary-500);
     text-decoration: underline;
 
     @include device-is('tablet') {
@@ -32,7 +32,7 @@
     &:active,
     &:focus,
     &:hover {
-      color: $pix-primary-60;
+      color: var(--pix-primary-700);
     }
 
     &::after {
@@ -116,7 +116,7 @@ form .challenge-response {
 
     float: left;
     margin-top: 0;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
 
     &:not(:last-child) {
       margin-bottom: 1rem;

--- a/mon-pix/app/styles/components/_challenge-item.scss
+++ b/mon-pix/app/styles/components/_challenge-item.scss
@@ -1,5 +1,5 @@
 .challenge-item {
-  padding: $pix-spacing-xxs;
+  padding: var(--pix-spacing-1x);
 
   &--focused {
     z-index: 1;
@@ -72,7 +72,7 @@
     }
 
     &--input {
-      margin: $pix-spacing-xs;
+      margin: var(--pix-spacing-2x);
     }
   }
 
@@ -126,7 +126,7 @@ form .challenge-response {
   .qroc-proposal {
     display: flex;
     flex-wrap: wrap;
-    gap: $pix-spacing-xs;
+    gap: var(--pix-spacing-2x);
     align-items: center;
 
     .qroc_input-label {

--- a/mon-pix/app/styles/components/_challenge-statement.scss
+++ b/mon-pix/app/styles/components/_challenge-statement.scss
@@ -13,7 +13,7 @@
   font-family: $font-open-sans;
 
   hr {
-    border-top: 1px solid $pix-neutral-15;
+    border-top: 1px solid var(--pix-neutral-20);
     border-bottom: none;
   }
 
@@ -33,7 +33,7 @@
     display: block;
     width: 4px;
     height: 100%;
-    background-color: $pix-neutral-20;
+    background-color: var(--pix-neutral-20);
     border-radius: 2px;
     content: '';
   }
@@ -44,7 +44,7 @@
     @extend %pix-body-l;
 
     width: 100%;
-    color: $pix-neutral-80;
+    color: var(--pix-neutral-800);
 
     p {
       overflow-wrap: break-word;
@@ -55,7 +55,7 @@
     }
 
     a {
-      color: $pix-primary;
+      color: var(--pix-primary-500);
       text-decoration: underline;
 
       @include device-is('tablet') {
@@ -65,7 +65,7 @@
       &:active,
       &:focus,
       &:hover {
-        color: $pix-primary-60;
+        color: var(--pix-primary-700);
       }
     }
 
@@ -80,13 +80,13 @@
   box-sizing: content-box;
   padding: 10px 0;
   text-align: center;
-  border-top: 1px solid $pix-neutral-20;
+  border-top: 1px solid var(--pix-neutral-20);
 }
 
 .challenge-statement__attachments-section {
   padding: 20px;
   text-align: center;
-  background-color: $pix-neutral-15;
+  background-color: var(--pix-neutral-20);
 }
 
 .challenge-statement__text {
@@ -97,7 +97,7 @@
   position: relative;
   display: inline-block;
   margin: 0 5px;
-  color: $pix-primary;
+  color: var(--pix-primary-500);
   cursor: pointer;
 }
 
@@ -110,10 +110,10 @@
   height: auto;
   margin-left: -400px;
   padding: 15px;
-  color: $pix-neutral-22;
+  color: var(--pix-neutral-100);
   text-align: justify;
-  background-color: $pix-neutral-0;
-  border: solid 1px $pix-neutral-20;
+  background-color: var(--pix-neutral-0);
+  border: solid 1px var(--pix-neutral-20);
   border-radius: 6px;
   box-shadow: 1px 1px 1px 0 rgb(0 0 0 / 10%);
   visibility: hidden;
@@ -127,7 +127,7 @@
   width: 0;
   height: 0;
   margin-left: -10px;
-  border-top: 10px solid $pix-neutral-20;
+  border-top: 10px solid var(--pix-neutral-20);
   border-right: 10px solid transparent;
   border-left: 10px solid transparent;
   content: '';
@@ -152,7 +152,7 @@
 }
 
 .challenge-statement__help-text {
-  color: $pix-neutral-80;
+  color: var(--pix-neutral-800);
   font-size: 0.875rem;
 }
 
@@ -192,33 +192,33 @@
   width: 156px;
   height: 46px;
   margin-bottom: $pix-spacing-m;
-  color: $pix-neutral-0;
+  color: var(--pix-neutral-0);
   text-align: center;
-  background-color: $pix-primary;
+  background-color: var(--pix-primary-500);
   border-radius: 23px;
   cursor: pointer;
 }
 
 .challenge-statement__action-link:hover,
 .challenge-statement__action-link:focus {
-  color: $pix-neutral-0;
+  color: var(--pix-neutral-0);
 }
 
 .challenge-statement__action-help {
   font-size: 0.825rem;
 
   &--link {
-    color: $pix-primary-60;
+    color: var(--pix-primary-700);
     text-decoration: underline;
 
     &:active,
     &:focus,
     &:hover {
-      color: $pix-primary-60;
+      color: var(--pix-primary-700);
     }
 
     &:visited {
-      color: $pix-primary;
+      color: var(--pix-primary-500);
     }
 
     &::after {
@@ -244,7 +244,7 @@
 
   button {
     padding: 0;
-    color: $pix-primary;
+    color: var(--pix-primary-500);
     font-weight: 500;
     font-size: 1rem;
     background-color: transparent;
@@ -254,7 +254,7 @@
     &:hover,
     &:focus,
     &:active {
-      color: $pix-neutral-0;
+      color: var(--pix-neutral-0);
     }
   }
 

--- a/mon-pix/app/styles/components/_challenge-statement.scss
+++ b/mon-pix/app/styles/components/_challenge-statement.scss
@@ -191,7 +191,7 @@
 .challenge-statement__action-link {
   width: 156px;
   height: 46px;
-  margin-bottom: $pix-spacing-m;
+  margin-bottom: var(--pix-spacing-6x);
   color: var(--pix-neutral-0);
   text-align: center;
   background-color: var(--pix-primary-500);

--- a/mon-pix/app/styles/components/_checkpoint.scss
+++ b/mon-pix/app/styles/components/_checkpoint.scss
@@ -7,16 +7,16 @@
 
 .checkpoint__header {
   width: 100%;
-  margin: $pix-spacing-m 0 $pix-spacing-s;
-  padding-inline: $pix-spacing-xs;
+  margin: var(--pix-spacing-6x) 0 var(--pix-spacing-4x);
+  padding-inline: var(--pix-spacing-2x);
 
   @include device-is('tablet') {
     display: flex;
     align-items: baseline;
     justify-content: space-between;
     max-width: 832px;
-    margin: $pix-spacing-l 0 $pix-spacing-xs;
-    padding: 0 $pix-spacing-s;
+    margin: var(--pix-spacing-8x) 0 var(--pix-spacing-2x);
+    padding: 0 var(--pix-spacing-4x);
   }
 }
 

--- a/mon-pix/app/styles/components/_checkpoint.scss
+++ b/mon-pix/app/styles/components/_checkpoint.scss
@@ -98,7 +98,7 @@
     max-width: 100%;
     margin-top: 0;
     margin-bottom: 40px;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-size: 1.5rem;
     line-height: 2.063rem;
     white-space: pre-line;

--- a/mon-pix/app/styles/components/_choice-chip.scss
+++ b/mon-pix/app/styles/components/_choice-chip.scss
@@ -3,33 +3,33 @@
   align-items: center;
   justify-content: center;
   padding: 6px 16px;
-  color: $pix-neutral-50;
+  color: var(--pix-neutral-100);
   font-weight: $font-medium;
   font-size: 0.875rem;
   line-height: 1.25rem;
   letter-spacing: 0.028rem;
   white-space: nowrap;
   text-decoration: none;
-  background: $pix-neutral-10;
+  background: var(--pix-neutral-20);
   border: 2px solid transparent;
   border-radius: 50px;
   cursor: pointer;
 
   &--active {
-    color: $pix-primary-70;
-    background: $pix-primary-10;
+    color: var(--pix-primary-700);
+    background: var(--pix-primary-100);
   }
 
   &:hover {
-    color: $pix-neutral-90;
-    background: $pix-neutral-20;
+    color: var(--pix-neutral-900);
+    background: var(--pix-neutral-20);
   }
 
   &:focus-visible {
-    color: $pix-neutral-0;
-    background-color: $pix-neutral-60;
-    border-color: $pix-neutral-0;
+    color: var(--pix-neutral-0);
+    background-color: var(--pix-neutral-500);
+    border-color: var(--pix-neutral-0);
     outline: none;
-    box-shadow: 0 0 0 2px $pix-neutral-60;
+    box-shadow: 0 0 0 2px var(--pix-neutral-500);
   }
 }

--- a/mon-pix/app/styles/components/_circle-chart.scss
+++ b/mon-pix/app/styles/components/_circle-chart.scss
@@ -29,7 +29,7 @@
 .circle {
   fill: none;
   stroke-width: 1.1;
-  stroke: $pix-neutral-20;
+  stroke: var(--pix-neutral-20);
   stroke-linecap: round;
 
   &--thick {
@@ -38,27 +38,27 @@
 
   &--slice {
     animation: progress 1s ease-out forwards;
-    stroke: $pix-information-light;
+    stroke: var(--pix-information-light);
   }
 
   &--jaffa {
-    stroke: $pix-information-light;
+    stroke: var(--pix-information-light);
   }
 
   &--emerald {
-    stroke: $pix-content-light;
+    stroke: var(--pix-content-light);
   }
 
   &--cerulean {
-    stroke: $pix-communication-light;
+    stroke: var(--pix-communication-light);
   }
 
   &--wild-strawberry {
-    stroke: $pix-security-light;
+    stroke: var(--pix-security-light);
   }
 
   &--butterfly-bush {
-    stroke: $pix-environment-light;
+    stroke: var(--pix-environment-light);
   }
 }
 

--- a/mon-pix/app/styles/components/_communication-banner.scss
+++ b/mon-pix/app/styles/components/_communication-banner.scss
@@ -4,7 +4,7 @@
   justify-content: center;
   height: 56px;
   padding: 10px 0;
-  color: $pix-neutral-0;
+  color: var(--pix-neutral-0);
   font-weight: 400;
   font-size: 0.625rem;
   font-family: $font-open-sans;
@@ -21,19 +21,19 @@
   }
 
   a {
-    color: $pix-neutral-0;
+    color: var(--pix-neutral-0);
     text-decoration: underline;
   }
 
   &--info {
-    background-color: darken($pix-primary, 5%);
+    background-color: darken(var(--pix-primary-500), 5%);
   }
 
   &--warning {
-    background-color: $pix-information-light;
+    background-color: var(--pix-information-light);
   }
 
   &--error {
-    background-color: darken($pix-error-60, 10%);
+    background-color: darken(var(--pix-error-700), 10%);
   }
 }

--- a/mon-pix/app/styles/components/_comparison-window.scss
+++ b/mon-pix/app/styles/components/_comparison-window.scss
@@ -34,7 +34,7 @@
     max-width: 991px;
     margin: 0 15px 15px;
     padding: 36px 0 28px;
-    border: 1.3px dashed $pix-neutral-40;
+    border: 1.3px dashed var(--pix-neutral-500);
     border-radius: 5px;
 
     @include device-is('desktop') {
@@ -46,7 +46,7 @@
 .comparison-windows-content-body-default-message-container {
   &__default-message-title {
     margin: 10px 25px 40px;
-    color: $pix-neutral-110;
+    color: var(--pix-neutral-900);
     font-weight: $font-medium;
     font-size: 1.063rem;
     font-family: $font-open-sans;
@@ -66,7 +66,7 @@
   &__text {
     @extend %pix-body-m;
 
-    color: $pix-success-70;
+    color: var(--pix-success-700);
     font-weight: $font-bold;
   }
 

--- a/mon-pix/app/styles/components/_comparison-window.scss
+++ b/mon-pix/app/styles/components/_comparison-window.scss
@@ -61,7 +61,7 @@
 .comparison-window-solution {
   display: flex;
   align-items: stretch;
-  margin-top: $pix-spacing-xs;
+  margin-top: var(--pix-spacing-2x);
 
   &__text {
     @extend %pix-body-m;
@@ -81,5 +81,5 @@
 }
 
 .comparison-window .feedback-panel {
-  margin-bottom: $pix-spacing-xs;
+  margin-bottom: var(--pix-spacing-2x);
 }

--- a/mon-pix/app/styles/components/_competence-card-default.scss
+++ b/mon-pix/app/styles/components/_competence-card-default.scss
@@ -25,32 +25,32 @@
 
     &--jaffa,
     &--jaffa::after {
-      background: radial-gradient($pix-information-dark 25%, $pix-information-light 100%);
-      background-color: $pix-information-dark;
+      background: radial-gradient(var(--pix-information-dark) 25%, var(--pix-information-light) 100%);
+      background-color: var(--pix-information-dark);
     }
 
     &--emerald,
     &--emerald::after {
-      background: radial-gradient($pix-content-dark 25%, $pix-content-light 100%);
-      background-color: $pix-content-dark;
+      background: radial-gradient(var(--pix-content-dark) 25%, var(--pix-content-light) 100%);
+      background-color: var(--pix-content-dark);
     }
 
     &--cerulean,
     &--cerulean::after {
-      background: radial-gradient($pix-communication-dark 25%, $pix-communication-light 100%);
-      background-color: $pix-communication-dark;
+      background: radial-gradient(var(--pix-communication-dark) 25%, var(--pix-communication-light) 100%);
+      background-color: var(--pix-communication-dark);
     }
 
     &--wild-strawberry,
     &--wild-strawberry::after {
-      background: radial-gradient($pix-security-dark 25%, $pix-security-light 100%);
-      background-color: $pix-security-dark;
+      background: radial-gradient(var(--pix-security-dark) 25%, var(--pix-security-light) 100%);
+      background-color: var(--pix-security-dark);
     }
 
     &--butterfly-bush,
     &--butterfly-bush::after {
-      background: radial-gradient($pix-environment-dark 25%, $pix-environment-light 100%);
-      background-color: $pix-environment-dark;
+      background: radial-gradient(var(--pix-environment-dark) 25%, var(--pix-environment-light) 100%);
+      background-color: var(--pix-environment-dark);
     }
   }
 
@@ -89,7 +89,7 @@
   }
 
   .competence-card__link:hover {
-    border: 12px solid rgba($pix-neutral-0, 0.4);
+    border: 12px solid rgba(var(--pix-neutral-0), 0.4);
   }
 
   .competence-card__link:hover .competence-card__score-details {
@@ -116,7 +116,7 @@
   }
 
   .competence-card:hover {
-    box-shadow: 0 7px 14px 0 rgb(12 22 58 / 20%), 0 3px 6px 0 rgba($pix-neutral-110, 0.2);
+    box-shadow: 0 7px 14px 0 rgb(12 22 58 / 20%), 0 3px 6px 0 rgba(var(--pix-neutral-900), 0.2);
   }
 
   .competence-card:hover .competence-card__title {
@@ -154,11 +154,11 @@
   }
 
   .competence-card__score-label--congrats {
-    color: $pix-neutral-0;
+    color: var(--pix-neutral-0);
   }
 
   .competence-card__score-value--congrats {
-    color: $pix-neutral-0;
+    color: var(--pix-neutral-0);
     font-weight: $font-bold;
     font-size: 2.813rem;
   }
@@ -171,7 +171,7 @@
     justify-content: center;
     width: 100%;
     height: 34px;
-    color: $pix-neutral-70;
+    color: var(--pix-neutral-800);
     font-weight: $font-bold;
     font-size: 0.938rem;
     font-family: $font-open-sans;
@@ -183,7 +183,7 @@
     display: block;
     margin-top: 3px;
     margin-bottom: -4px;
-    color: $pix-neutral-30;
+    color: var(--pix-neutral-100);
     font-size: 0.625rem;
     letter-spacing: 0.5px;
     text-transform: uppercase;
@@ -247,14 +247,14 @@
 
   .competence-card-improvement-countdown {
     &__label {
-      color: $pix-neutral-60;
+      color: var(--pix-neutral-500);
       font-size: 0.6875rem;
       letter-spacing: 0.0075rem;
     }
 
     &__count {
       margin-top: 6px;
-      color: $pix-neutral-90;
+      color: var(--pix-neutral-900);
       font-size: 1rem;
       letter-spacing: 0.01rem;
     }

--- a/mon-pix/app/styles/components/_competence-card-mobile.scss
+++ b/mon-pix/app/styles/components/_competence-card-mobile.scss
@@ -4,19 +4,19 @@
   overflow: hidden;
   font-family: $font-roboto;
   background-color: white;
-  border: 1px solid $pix-neutral-20;
+  border: 1px solid var(--pix-neutral-20);
   border-radius: 11px;
-  box-shadow: 0 3px 4px 0 rgb(12 22 58 / 10%), 0 1px 3px 0 rgba($pix-neutral-110, 0.1);
+  box-shadow: 0 3px 4px 0 rgb(12 22 58 / 10%), 0 1px 3px 0 rgba(var(--pix-neutral-900), 0.1);
   transition: all 0.1s linear;
   pointer-events: none;
-  -webkit-tap-highlight-color: rgba($pix-neutral-60, 0.3);
+  -webkit-tap-highlight-color: rgba(var(--pix-neutral-500), 0.3);
 
   &--interactive {
     pointer-events: auto;
   }
 
   & a {
-    color: $pix-neutral-0;
+    color: var(--pix-neutral-0);
     text-decoration: none;
   }
 }
@@ -29,7 +29,7 @@
   height: 100%;
   padding: 16px 12px;
   overflow: visible;
-  color: $pix-neutral-0;
+  color: var(--pix-neutral-0);
   transition: height 0.2s cubic-bezier(0.265, 0.075, 0.025, 0.99);
 }
 
@@ -46,23 +46,23 @@
   }
 
   &--jaffa::after {
-    background: linear-gradient(90deg, $pix-information-dark 45%, $pix-information-light 100%);
+    background: linear-gradient(90deg, var(--pix-information-dark) 45%, var(--pix-information-light) 100%);
   }
 
   &--emerald::after {
-    background: linear-gradient(90deg, $pix-content-dark 45%, $pix-content-light 100%);
+    background: linear-gradient(90deg, var(--pix-content-dark) 45%, var(--pix-content-light) 100%);
   }
 
   &--cerulean::after {
-    background: linear-gradient(90deg, $pix-primary 45%, $pix-communication-light 100%);
+    background: linear-gradient(90deg, var(--pix-primary-500) 45%, var(--pix-communication-light) 100%);
   }
 
   &--wild-strawberry::after {
-    background: linear-gradient(90deg, $pix-security-dark 45%, $pix-security-light 100%);
+    background: linear-gradient(90deg, var(--pix-security-dark) 45%, var(--pix-security-light) 100%);
   }
 
   &--butterfly-bush::after {
-    background: linear-gradient(90deg, $pix-environment-dark 45%, $pix-environment-light 100%);
+    background: linear-gradient(90deg, var(--pix-environment-dark) 45%, var(--pix-environment-light) 100%);
   }
 }
 
@@ -94,7 +94,7 @@
   justify-content: center;
   height: 80px;
   margin: 10px;
-  border: 0 solid rgba($pix-neutral-0, 0.4);
+  border: 0 solid rgba(var(--pix-neutral-0), 0.4);
   transition: border 0.1s ease-in;
 
   &--white-background {
@@ -110,9 +110,9 @@
   display: flex;
   align-items: center;
   padding: 5px;
-  background-color: $pix-neutral-0;
+  background-color: var(--pix-neutral-0);
   background-clip: padding-box;
-  border: 0 solid rgba($pix-neutral-0, 0.4);
+  border: 0 solid rgba(var(--pix-neutral-0), 0.4);
   border-radius: 50%;
   transition: border 0.1s ease-in;
 }
@@ -128,7 +128,7 @@
   font-size: 2.188rem;
 
   &--congrats {
-    color: $pix-neutral-0;
+    color: var(--pix-neutral-0);
     font-weight: $font-bold;
   }
 }
@@ -150,5 +150,5 @@
 }
 
 .competence-card__score-label--congrats {
-  color: $pix-neutral-0;
+  color: var(--pix-neutral-0);
 }

--- a/mon-pix/app/styles/components/_congratulations-certification-banner.scss
+++ b/mon-pix/app/styles/components/_congratulations-certification-banner.scss
@@ -147,11 +147,11 @@
 }
 
 .oudated-complementary-certification-banner {
-  margin-top: $pix-spacing-s;
+  margin-top: var(--pix-spacing-4x);
 
   &__row {
     display: flex;
-    padding: $pix-spacing-s;
+    padding: var(--pix-spacing-4x);
     background-color: var(--pix-primary-100);
     border-radius: 16px;
   }
@@ -159,6 +159,6 @@
   &__icon {
     max-width: 64px;
     max-height: 64px;
-    margin-right: $pix-spacing-s;
+    margin-right: var(--pix-spacing-4x);
   }
 }

--- a/mon-pix/app/styles/components/_congratulations-certification-banner.scss
+++ b/mon-pix/app/styles/components/_congratulations-certification-banner.scss
@@ -7,8 +7,8 @@
   box-sizing: border-box;
   height: fit-content;
   padding: 24px 16px;
-  color: $pix-neutral-10;
-  background: $pix-content-dark;
+  color: var(--pix-neutral-20);
+  background: var(--pix-content-dark);
   border-radius: 6px;
   text-rendering: optimizelegibility;
 
@@ -28,19 +28,19 @@
   bottom: auto;
   left: auto;
   display: flex;
-  color: $pix-neutral-0;
+  color: var(--pix-neutral-0);
   font-size: 1.25rem;
   cursor: pointer;
   opacity: 0.5;
 
   &:hover,
   &:active {
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
   }
 }
 
 @mixin textBannerStyle {
-  color: $pix-neutral-10;
+  color: var(--pix-neutral-20);
   font-weight: $font-normal;
   font-family: $font-open-sans;
   line-height: 2rem;
@@ -60,7 +60,7 @@
   flex-direction: column;
   margin: 0 auto;
   padding: 16px 32px;
-  background-color: $pix-success-5;
+  background-color: var(--pix-success-50);
   border-radius: 16px;
 }
 
@@ -84,7 +84,7 @@
   flex-direction: column;
   align-items: flex-start;
   margin-top: 16px;
-  color: $pix-neutral-90;
+  color: var(--pix-neutral-900);
   text-align: center;
 
   @include device-is('tablet') {
@@ -129,7 +129,7 @@
   font-weight: 500;
   font-size: 0.875rem;
   font-family: $font-roboto;
-  border: 1px solid $pix-neutral-10;
+  border: 1px solid var(--pix-neutral-20);
   border-radius: 4px;
 
   &:last-child {
@@ -152,7 +152,7 @@
   &__row {
     display: flex;
     padding: $pix-spacing-s;
-    background-color: $pix-primary-10;
+    background-color: var(--pix-primary-100);
     border-radius: 16px;
   }
 

--- a/mon-pix/app/styles/components/_feedback-panel-v3.scss
+++ b/mon-pix/app/styles/components/_feedback-panel-v3.scss
@@ -1,6 +1,6 @@
 .feedback-panel-v3 {
   margin-bottom: $pix-spacing-xl;
-  color: $pix-neutral-70;
+  color: var(--pix-neutral-800);
   font-size: 0.875rem;
   font-family: $font-roboto;
 
@@ -20,7 +20,7 @@
       align-items: center;
       margin: 0;
       padding: 0;
-      color: $pix-primary-70;
+      color: var(--pix-primary-700);
       font-weight: $font-bold;
     }
   }
@@ -45,7 +45,7 @@
   }
 
   &[aria-expanded='true'] {
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
   }
 
   &--hidden {
@@ -55,7 +55,7 @@
   &:hover,
   &:focus-visible,
   &:active {
-    color: $pix-primary;
+    color: var(--pix-primary-500);
   }
 }
 
@@ -73,9 +73,9 @@
     text-decoration: underline;
 
     &:first-of-type {
-      color: $pix-error-70;
+      color: var(--pix-error-700);
       font-weight: $font-bold;
-      text-decoration-color: $pix-error-70;
+      text-decoration-color: var(--pix-error-700);
     }
   }
 }

--- a/mon-pix/app/styles/components/_feedback-panel-v3.scss
+++ b/mon-pix/app/styles/components/_feedback-panel-v3.scss
@@ -1,5 +1,5 @@
 .feedback-panel-v3 {
-  margin-bottom: $pix-spacing-xl;
+  margin-bottom: var(--pix-spacing-10x);
   color: var(--pix-neutral-800);
   font-size: 0.875rem;
   font-family: $font-roboto;
@@ -16,7 +16,7 @@
 
     button {
       display: flex;
-      gap: $pix-spacing-xxs;
+      gap: var(--pix-spacing-1x);
       align-items: center;
       margin: 0;
       padding: 0;
@@ -31,17 +31,17 @@
 
 .feedback-panel-v3__open-button {
   display: flex;
-  gap: $pix-spacing-xxs;
+  gap: var(--pix-spacing-1x);
   align-items: center;
   width: 100%;
-  margin-top: $pix-spacing-s;
+  margin-top: var(--pix-spacing-4x);
   padding: 0.75rem 0;
   line-height: 20px;
   text-align: left;
   text-decoration: underline;
 
   svg {
-    margin-right: $pix-spacing-xxs;
+    margin-right: var(--pix-spacing-1x);
   }
 
   &[aria-expanded='true'] {
@@ -81,5 +81,5 @@
 }
 
 .feedback-panel-v3__information {
-  margin-top: $pix-spacing-s;
+  margin-top: var(--pix-spacing-4x);
 }

--- a/mon-pix/app/styles/components/_feedback-panel.scss
+++ b/mon-pix/app/styles/components/_feedback-panel.scss
@@ -1,7 +1,7 @@
 .feedback-panel {
   z-index: 1;
   padding: 0 $pix-spacing-s;
-  color: $pix-neutral-60;
+  color: var(--pix-neutral-500);
   font-size: 0.938rem;
 }
 
@@ -12,7 +12,7 @@
   gap: $pix-spacing-xxs;
   width: 100%;
   padding: 0.75rem 0;
-  color: $pix-neutral-70;
+  color: var(--pix-neutral-800);
   font-weight: $font-normal;
   font-size: 0.875rem;
   font-family: $font-roboto;
@@ -28,14 +28,14 @@
   }
 
   &[aria-expanded='true'] {
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
   }
 }
 
 .feedback-panel__open-button:hover,
 .feedback-panel__open-button:focus-visible,
 .feedback-panel__open-button:active {
-  color: $pix-primary;
+  color: var(--pix-primary-500);
 }
 
 /* "Form" view
@@ -53,10 +53,10 @@
   font-size: 1.25rem;
 
   & .link {
-    color: $pix-primary-60;
+    color: var(--pix-primary-700);
 
     &:hover {
-      color: $pix-primary-60;
+      color: var(--pix-primary-700);
     }
   }
 }
@@ -76,7 +76,7 @@
   display: flex;
   align-items: center;
   margin: $pix-spacing-s 0;
-  color: $pix-neutral-70;
+  color: var(--pix-neutral-800);
   font-weight: 500;
   text-decoration: underline;
 }
@@ -117,8 +117,8 @@
   font-weight: bold;
   font-size: 0.938rem;
   word-break: break-word;
-  background-color: $pix-neutral-0;
-  border: dashed $pix-neutral-70;
+  background-color: var(--pix-neutral-0);
+  border: dashed var(--pix-neutral-800);
 
   & .tuto-icon {
     width: 15px;
@@ -127,7 +127,7 @@
       float: left;
       width: 20px;
       height: 20px;
-      color: $pix-warning-60;
+      color: var(--pix-warning-700);
     }
   }
 
@@ -140,8 +140,8 @@
   box-sizing: border-box;
   margin: 0 10px 20px 0;
   padding: 10px 20px;
-  background-color: $pix-neutral-20;
-  border: 1px solid $pix-neutral-40;
+  background-color: var(--pix-neutral-20);
+  border: 1px solid var(--pix-neutral-500);
   border-radius: 3px;
 
   &[disabled] {
@@ -151,24 +151,24 @@
 
 .feedback-panel__button--send {
   color: white;
-  background-color: $pix-neutral-50;
+  background-color: var(--pix-neutral-100);
 
   &:hover,
   &:focus {
-    background-color: $pix-neutral-70;
+    background-color: var(--pix-neutral-800);
   }
 }
 
 .feedback-panel__form-legal-notice {
   margin-top: $pix-spacing-s;
   padding-top: $pix-spacing-s;
-  color: $pix-neutral-50;
+  color: var(--pix-neutral-100);
   font-size: 0.75rem;
   line-height: 1.5;
-  border-top: 1px solid $pix-neutral-20;
+  border-top: 1px solid var(--pix-neutral-20);
 
   & a {
-    color: $pix-primary-60;
+    color: var(--pix-primary-700);
   }
 }
 

--- a/mon-pix/app/styles/components/_feedback-panel.scss
+++ b/mon-pix/app/styles/components/_feedback-panel.scss
@@ -1,6 +1,6 @@
 .feedback-panel {
   z-index: 1;
-  padding: 0 $pix-spacing-s;
+  padding: 0 var(--pix-spacing-4x);
   color: var(--pix-neutral-500);
   font-size: 0.938rem;
 }
@@ -9,7 +9,7 @@
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 
 .feedback-panel__open-button {
-  gap: $pix-spacing-xxs;
+  gap: var(--pix-spacing-1x);
   width: 100%;
   padding: 0.75rem 0;
   color: var(--pix-neutral-800);
@@ -24,7 +24,7 @@
   cursor: pointer;
 
   svg {
-    margin-right: $pix-spacing-xxs;
+    margin-right: var(--pix-spacing-1x);
   }
 
   &[aria-expanded='true'] {
@@ -46,7 +46,7 @@
 }
 
 .feedback-panel__view--form {
-  padding: $pix-spacing-xs 0;
+  padding: var(--pix-spacing-2x) 0;
 }
 
 .feedback-panel__form-description {
@@ -63,7 +63,7 @@
 
 .feedback-panel__form-wrapper {
   display: flex;
-  margin-top: $pix-spacing-s;
+  margin-top: var(--pix-spacing-4x);
 }
 
 .feedback-panel__form {
@@ -75,7 +75,7 @@
 
   display: flex;
   align-items: center;
-  margin: $pix-spacing-s 0;
+  margin: var(--pix-spacing-4x) 0;
   color: var(--pix-neutral-800);
   font-weight: 500;
   text-decoration: underline;
@@ -83,20 +83,20 @@
 
 .feedback-panel-comment {
   &__icon {
-    margin-right: $pix-spacing-xxs;
-    padding: $pix-spacing-xxs;
+    margin-right: var(--pix-spacing-1x);
+    padding: var(--pix-spacing-1x);
   }
 }
 
 .feedback-panel__field-notice {
-  margin: $pix-spacing-s 0 $pix-spacing-xxs;
+  margin: var(--pix-spacing-4x) 0 var(--pix-spacing-1x);
   font-size: 0.75rem;
 }
 
 .feedback-panel__category-selection {
   display: flex;
   flex-direction: column;
-  gap: $pix-spacing-s;
+  gap: var(--pix-spacing-4x);
 
   > div {
     max-width: 100%;
@@ -160,8 +160,8 @@
 }
 
 .feedback-panel__form-legal-notice {
-  margin-top: $pix-spacing-s;
-  padding-top: $pix-spacing-s;
+  margin-top: var(--pix-spacing-4x);
+  padding-top: var(--pix-spacing-4x);
   color: var(--pix-neutral-100);
   font-size: 0.75rem;
   line-height: 1.5;
@@ -176,12 +176,12 @@
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 
 .feedback-panel__view--mercix {
-  padding: $pix-spacing-s 0 $pix-spacing-m;
+  padding: var(--pix-spacing-4x) 0 var(--pix-spacing-6x);
   font-size: 1rem;
   text-align: center;
 
   p + p {
-    margin-top: $pix-spacing-xs;
+    margin-top: var(--pix-spacing-2x);
   }
 }
 
@@ -195,9 +195,9 @@
 .feedback-panel__submit-modal > [class$='__footer'] {
   display: flex;
   justify-content: flex-end;
-  padding-bottom: $pix-spacing-s;
+  padding-bottom: var(--pix-spacing-4x);
 
   & > :not(:first-child) {
-    margin-left: $pix-spacing-xs;
+    margin-left: var(--pix-spacing-2x);
   }
 }

--- a/mon-pix/app/styles/components/_focused-certification-challenge-instructions.scss
+++ b/mon-pix/app/styles/components/_focused-certification-challenge-instructions.scss
@@ -18,7 +18,7 @@
 
   &__title {
     margin-top: 22px;
-    color: $pix-neutral-80;
+    color: var(--pix-neutral-800);
     font-size: 3rem;
     font-family: $font-open-sans;
     font-style: normal;
@@ -30,7 +30,7 @@
     max-width: 450px;
     margin-top: 24px;
     margin-bottom: 50px;
-    color: $pix-neutral-80;
+    color: var(--pix-neutral-800);
     font-weight: 500;
     font-size: 1.25rem;
     font-family: $font-roboto;

--- a/mon-pix/app/styles/components/_footer.scss
+++ b/mon-pix/app/styles/components/_footer.scss
@@ -81,7 +81,7 @@
 
   &__copyrights {
     padding-top: 16px;
-    color: $pix-neutral-50;
+    color: var(--pix-neutral-100);
     font-size: 0.75rem;
     font-family: $font-roboto;
     letter-spacing: 0.008rem;
@@ -97,7 +97,7 @@
   &__item {
     display: inline-block;
     padding: 0 12px 6px 0;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-size: 0.8125rem;
     font-family: $font-roboto;
     line-height: 1.375rem;
@@ -105,7 +105,7 @@
 
     &--internal-link {
       &:visited {
-        color: $pix-neutral-60;
+        color: var(--pix-neutral-500);
       }
     }
 
@@ -115,17 +115,17 @@
     }
 
     &.active {
-      color: $pix-primary-70;
+      color: var(--pix-primary-700);
       text-decoration: none;
     }
 
     &:focus {
-      color: $pix-neutral-50;
+      color: var(--pix-neutral-100);
       text-decoration: none;
     }
 
     &:hover {
-      color: $pix-primary-70;
+      color: var(--pix-primary-700);
       text-decoration: none;
       cursor: pointer;
     }

--- a/mon-pix/app/styles/components/_footer.scss
+++ b/mon-pix/app/styles/components/_footer.scss
@@ -6,7 +6,7 @@
   display: flex;
   flex-direction: column;
   max-width: 1280px;
-  padding: $pix-spacing-m 20px;
+  padding: var(--pix-spacing-6x) 20px;
 
   @include device-is('desktop') {
     flex-direction: row;

--- a/mon-pix/app/styles/components/_form-textfield.scss
+++ b/mon-pix/app/styles/components/_form-textfield.scss
@@ -6,7 +6,7 @@
 }
 
 .form-textfield__label {
-  color: $pix-neutral-80;
+  color: var(--pix-neutral-800);
   font-weight: $font-medium;
   font-size: 0.938rem;
   letter-spacing: 0.031rem;
@@ -36,14 +36,14 @@
   align-items: center;
   width: 100%;
   height: 46px;
-  background-color: $pix-neutral-0;
-  border: 2px solid $pix-neutral-20;
+  background-color: var(--pix-neutral-0);
+  border: 2px solid var(--pix-neutral-20);
   border-radius: 3px;
 
   &:hover,
   &:focus,
   &:focus-within {
-    border: 2px solid $pix-primary-40;
+    border: 2px solid var(--pix-primary-500);
   }
 
   @include device-is('desktop') {
@@ -52,19 +52,19 @@
 }
 
 .form-textfield__input-container--default {
-  border: 2px solid $pix-neutral-20;
+  border: 2px solid var(--pix-neutral-20);
 }
 
 .form-textfield__input-container--error {
-  border: 2px solid $pix-error-70;
+  border: 2px solid var(--pix-error-700);
 }
 
 .form-textfield__input-container--success {
-  border: 2px solid $pix-success-70;
+  border: 2px solid var(--pix-success-700);
 }
 
 .form-textfield__input-container--disabled {
-  background-color: $pix-neutral-20;
+  background-color: var(--pix-neutral-20);
 }
 
 .form-textfield__input-container--password {
@@ -77,7 +77,7 @@
   flex-grow: 1;
   height: 40px;
   padding: 0 10px;
-  color: $pix-neutral-50;
+  color: var(--pix-neutral-100);
   font-size: 0.875rem;
   border: none;
   border-radius: 3px;
@@ -93,7 +93,7 @@
   }
 
   &[disabled] {
-    background-color: $pix-neutral-20;
+    background-color: var(--pix-neutral-20);
   }
 }
 
@@ -103,11 +103,11 @@
 }
 
 .form-textfield__message--error {
-  color: $pix-error-70;
+  color: var(--pix-error-700);
 }
 
 .form-textfield__message--success {
-  color: $pix-success-70;
+  color: var(--pix-success-700);
 }
 
 .form-textfield__message--error.form-textfield__message-password,
@@ -132,7 +132,7 @@
   border: none;
 
   &:focus {
-    outline: 1px solid $pix-primary;
+    outline: 1px solid var(--pix-primary-500);
     box-shadow: 0 0 5px 0 rgb(61 104 255 / 50%);
   }
 }
@@ -146,7 +146,7 @@
     border: none;
 
     &:focus {
-      outline: 1px solid $pix-primary;
+      outline: 1px solid var(--pix-primary-500);
       box-shadow: 0 0 5px 0 rgb(61 104 255 / 50%);
     }
   }
@@ -159,12 +159,12 @@
 .form-textfield-icon-button {
   &__eye {
     margin-top: 1px;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-size: 1.125rem;
     transition: 0.5s;
 
     &:hover {
-      color: $pix-neutral-100;
+      color: var(--pix-neutral-900);
       cursor: pointer;
     }
   }

--- a/mon-pix/app/styles/components/_hexagon-score.scss
+++ b/mon-pix/app/styles/components/_hexagon-score.scss
@@ -11,23 +11,23 @@
 }
 
 @mixin hexagon-score-title {
-  color: $pix-neutral-100;
+  color: var(--pix-neutral-900);
   font-size: 0.875rem;
   font-family: $font-roboto;
   letter-spacing: 0.219rem;
 }
 
 @mixin hexagon-score-pix-score {
-  color: $pix-neutral-110;
+  color: var(--pix-neutral-900);
   font-size: 2.875rem;
   font-family: $font-open-sans;
 }
 
 @mixin hexagon-score-pix-total {
-  color: $pix-neutral-60;
+  color: var(--pix-neutral-500);
   font-size: 0.813rem;
   font-family: $font-roboto;
-  border-top: 1px solid $pix-neutral-30;
+  border-top: 1px solid var(--pix-neutral-100);
 }
 
 .hexagon-score-content {
@@ -116,6 +116,6 @@
 
   &:hover,
   &:focus {
-    color: $pix-neutral-80;
+    color: var(--pix-neutral-800);
   }
 }

--- a/mon-pix/app/styles/components/_learning-more-tutorial-panel.scss
+++ b/mon-pix/app/styles/components/_learning-more-tutorial-panel.scss
@@ -12,12 +12,12 @@
 }
 
 .learning-more-panel__hint-title {
-  @include tutorial-panel-title($pix-neutral-10);
+  @include tutorial-panel-title(var(--pix-neutral-20));
 }
 
 .learning-more-panel__tutorial-info {
   margin: 5px;
-  color: $pix-neutral-50;
+  color: var(--pix-neutral-100);
   font-size: 0.813rem;
   line-height: 1.25rem;
 }

--- a/mon-pix/app/styles/components/_levelup-notif.scss
+++ b/mon-pix/app/styles/components/_levelup-notif.scss
@@ -8,10 +8,10 @@
   justify-content: center;
   width: 300px;
   height: 80px;
-  color: $pix-neutral-70;
+  color: var(--pix-neutral-800);
   background-color: rgb(255 255 255 / 92%);
   border-radius: 5px;
-  box-shadow: 0 0 10px $pix-neutral-80;
+  box-shadow: 0 0 10px var(--pix-neutral-800);
   animation-name: slidein;
   animation-duration: 1s;
   user-select: none;
@@ -46,18 +46,18 @@
     justify-content: center;
     width: 70px;
     padding: 0;
-    color: $pix-neutral-50;
+    color: var(--pix-neutral-100);
     font-size: 1.5rem;
     background-color: transparent;
     border: none;
-    border-left: 1px solid $pix-neutral-20;
+    border-left: 1px solid var(--pix-neutral-20);
     cursor: pointer;
 
     &:hover,
     &:focus,
     &:active {
-      color: $pix-neutral-70;
-      background-color: $pix-neutral-15;
+      color: var(--pix-neutral-800);
+      background-color: var(--pix-neutral-20);
       border-top-right-radius: 5px;
       border-bottom-right-radius: 5px;
     }

--- a/mon-pix/app/styles/components/_login-form.scss
+++ b/mon-pix/app/styles/components/_login-form.scss
@@ -17,7 +17,7 @@
 
   &__forgotten-password {
     margin: 16px 0;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-size: 0.75rem;
     line-height: 1.1875rem;
     letter-spacing: 0.009rem;
@@ -25,7 +25,7 @@
   }
 
   &__forgotten-password span {
-    color: $pix-neutral-80;
+    color: var(--pix-neutral-800);
     font-size: 0.875rem;
   }
 

--- a/mon-pix/app/styles/components/_login-or-register.scss
+++ b/mon-pix/app/styles/components/_login-or-register.scss
@@ -38,7 +38,7 @@
 
   &__invitation {
     margin-top: 24px;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-weight: 500;
     font-size: 1.25rem;
     font-family: $font-roboto;
@@ -74,7 +74,7 @@
 
   &__divider {
     margin-top: 30px;
-    border-left: 1px solid $pix-neutral-30;
+    border-left: 1px solid var(--pix-neutral-100);
   }
 }
 
@@ -94,7 +94,7 @@
 
 .form-title {
   margin-bottom: 20px;
-  color: $pix-neutral-100;
+  color: var(--pix-neutral-900);
   font-size: 1.875rem;
   font-family: $font-open-sans;
 }

--- a/mon-pix/app/styles/components/_navbar-burger-menu.scss
+++ b/mon-pix/app/styles/components/_navbar-burger-menu.scss
@@ -91,7 +91,7 @@
     }
 
     &--logout {
-      margin-top: $pix-spacing-xs;
+      margin-top: var(--pix-spacing-2x);
     }
   }
 }

--- a/mon-pix/app/styles/components/_navbar-burger-menu.scss
+++ b/mon-pix/app/styles/components/_navbar-burger-menu.scss
@@ -30,7 +30,7 @@
 
   &__footer {
     padding: 20px 0;
-    background-color: $pix-primary;
+    background-color: var(--pix-primary-500);
   }
 }
 
@@ -39,24 +39,24 @@
     display: inline-block;
     width: 100%;
     padding: 12px 32px;
-    color: $pix-neutral-70;
+    color: var(--pix-neutral-800);
     font-size: 1.125rem;
     font-family: $font-roboto;
 
     &.active {
       padding-left: calc(32px - 5px);
-      color: $pix-primary;
-      border-left: 5px solid $pix-primary;
+      color: var(--pix-primary-500);
+      border-left: 5px solid var(--pix-primary-500);
     }
 
     &:hover {
-      color: $pix-primary-60;
-      background-color: $pix-neutral-10;
+      color: var(--pix-primary-700);
+      background-color: var(--pix-neutral-20);
     }
 
     &:active {
-      color: $pix-primary-70;
-      background-color: $pix-neutral-15;
+      color: var(--pix-primary-700);
+      background-color: var(--pix-neutral-20);
     }
   }
 }
@@ -73,21 +73,21 @@
     display: inline-block;
     width: 100%;
     padding: 10px 32px;
-    color: $pix-neutral-0;
+    color: var(--pix-neutral-0);
     font-size: 1rem;
     font-family: $font-open-sans;
 
     &.active {
       padding-left: calc(32px - 5px);
-      border-left: 5px solid $pix-neutral-0;
+      border-left: 5px solid var(--pix-neutral-0);
     }
 
     &:hover {
-      background-color: $pix-primary-60;
+      background-color: var(--pix-primary-700);
     }
 
     &:active {
-      background-color: $pix-primary-70;
+      background-color: var(--pix-primary-700);
     }
 
     &--logout {

--- a/mon-pix/app/styles/components/_navbar-desktop-header.scss
+++ b/mon-pix/app/styles/components/_navbar-desktop-header.scss
@@ -30,7 +30,7 @@
     position: relative;
     display: block;
     margin-top: 2px;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-weight: var(--pix-font-medium);
 
     &::after {
@@ -52,7 +52,7 @@
     }
 
     &:focus {
-      color: $pix-neutral-60;
+      color: var(--pix-neutral-500);
     }
 
     &:hover {

--- a/mon-pix/app/styles/components/_navbar-desktop-menu.scss
+++ b/mon-pix/app/styles/components/_navbar-desktop-menu.scss
@@ -19,13 +19,13 @@
   justify-content: center;
   height: 40px;
   margin-left: 20px;
-  color: $pix-neutral-45;
+  color: var(--pix-neutral-500);
   text-transform: uppercase;
   border: none;
 }
 
 .navbar-header--white .navbar-desktop-menu-links__item {
-  color: $pix-neutral-50;
+  color: var(--pix-neutral-100);
 }
 
 .navbar-desktop-menu-links__item:first-child {
@@ -46,7 +46,7 @@
   &:hover,
   &:focus,
   &:active {
-    color: $pix-warning-60;
+    color: var(--pix-warning-700);
     text-decoration: none;
   }
 }
@@ -54,30 +54,30 @@
 .navbar-menu-signup-link {
   width: 140px;
   padding: 10px;
-  color: $pix-primary;
+  color: var(--pix-primary-500);
   font-size: 0.813rem;
   text-align: center;
   background-color: transparent;
-  border: 2px solid $pix-primary;
+  border: 2px solid var(--pix-primary-500);
   border-radius: 20px;
 
   &:hover,
   &:focus,
   &:active {
-    color: $pix-neutral-0;
+    color: var(--pix-neutral-0);
     text-decoration: none;
-    background-color: $pix-primary;
+    background-color: var(--pix-primary-500);
   }
 }
 
 .navbar-header--white .navbar-menu-signup-link {
-  color: $pix-primary;
-  border: 2px solid $pix-primary;
+  color: var(--pix-primary-500);
+  border: 2px solid var(--pix-primary-500);
 
   &:hover,
   &:focus,
   &:active {
-    color: $pix-neutral-0;
-    background-color: $pix-primary;
+    color: var(--pix-neutral-0);
+    background-color: var(--pix-primary-500);
   }
 }

--- a/mon-pix/app/styles/components/_navbar-header.scss
+++ b/mon-pix/app/styles/components/_navbar-header.scss
@@ -1,8 +1,8 @@
 .navbar-header {
   float: none;
   width: 100%;
-  color: $pix-neutral-50;
-  background-color: $pix-neutral-0;
+  color: var(--pix-neutral-100);
+  background-color: var(--pix-neutral-0);
 
   .pix-sidebar__footer {
     padding: 0;

--- a/mon-pix/app/styles/components/_navbar-mobile-header.scss
+++ b/mon-pix/app/styles/components/_navbar-mobile-header.scss
@@ -11,7 +11,7 @@
   &__burger-icon {
     display: inline-flex;
     padding: 0;
-    color: $pix-neutral-70;
+    color: var(--pix-neutral-800);
     font-size: 1.625rem;
     background: none;
     border: none;

--- a/mon-pix/app/styles/components/_new-information.scss
+++ b/mon-pix/app/styles/components/_new-information.scss
@@ -55,11 +55,11 @@
   }
 
   &--white-text {
-    color: $pix-neutral-0;
+    color: var(--pix-neutral-0);
   }
 
   &--black-text {
-    color: $pix-neutral-80;
+    color: var(--pix-neutral-800);
   }
 
   &--align-text-center {
@@ -144,7 +144,7 @@
 
     &:focus span,
     &:hover span {
-      border-bottom: 1px solid $pix-neutral-0;
+      border-bottom: 1px solid var(--pix-neutral-0);
     }
   }
 }

--- a/mon-pix/app/styles/components/_no-certification-panel.scss
+++ b/mon-pix/app/styles/components/_no-certification-panel.scss
@@ -3,7 +3,7 @@
   align-items: center;
   justify-content: center;
   height: 200px;
-  color: $pix-neutral-80;
+  color: var(--pix-neutral-800);
   font-size: 1.063rem;
   font-family: $font-open-sans;
   background-color: white;

--- a/mon-pix/app/styles/components/_panel.scss
+++ b/mon-pix/app/styles/components/_panel.scss
@@ -9,7 +9,7 @@
   }
 
   &--link {
-    color: $pix-neutral-100;
+    color: var(--pix-neutral-900);
     text-decoration: none;
     border: solid 2px white;
     outline: none;
@@ -18,7 +18,7 @@
     &:hover,
     &:active,
     &:focus {
-      border-color: $pix-primary-40;
+      border-color: var(--pix-primary-500);
       box-shadow: 0 2px 5px 0 rgb(0 0 0 / 5%);
       transition: border-color 1s ease;
     }

--- a/mon-pix/app/styles/components/_password-reset-demand-form.scss
+++ b/mon-pix/app/styles/components/_password-reset-demand-form.scss
@@ -9,7 +9,7 @@
     margin: 0 auto;
     padding: 20px 10px;
     font-family: $font-open-sans;
-    background-color: $pix-neutral-0;
+    background-color: var(--pix-neutral-0);
     border-radius: 10px;
 
     @include device-is('tablet') {
@@ -46,7 +46,7 @@
     font-size: 1.375rem;
 
     &--forgotten-password {
-      color: $pix-neutral-80;
+      color: var(--pix-neutral-800);
       font-size: 1.563rem;
 
       @include device-is('desktop') {
@@ -70,7 +70,7 @@
 
   &__notification-message--error {
     margin: 0;
-    color: $pix-error-70;
+    color: var(--pix-error-700);
     font-weight: 400;
     font-size: 1rem;
     line-height: 1.625rem;
@@ -93,7 +93,7 @@
 
 .password-reset-demand-body__text {
   margin-bottom: 15px;
-  color: $pix-neutral-80;
+  color: var(--pix-neutral-800);
   font-size: 0.8rem;
   font-family: $font-open-sans;
 

--- a/mon-pix/app/styles/components/_pix-toggle.scss
+++ b/mon-pix/app/styles/components/_pix-toggle.scss
@@ -1,13 +1,13 @@
 .pix-toggle-deprecated {
   display: flex;
   height: 44px;
-  color: $pix-neutral-60;
+  color: var(--pix-neutral-500);
   font-weight: $font-medium;
   font-size: 1rem;
   font-family: $font-roboto;
   letter-spacing: 0.45px;
   text-align: center;
-  border: 2px solid $pix-neutral-20;
+  border: 2px solid var(--pix-neutral-20);
   border-radius: 12px;
   cursor: pointer;
 
@@ -20,13 +20,13 @@
 
   &__on {
     color: white;
-    background-color: $pix-neutral-60;
+    background-color: var(--pix-neutral-500);
   }
 
   &__off {
 
     &:hover {
-      color: $pix-neutral-70;
+      color: var(--pix-neutral-800);
     }
   }
 }

--- a/mon-pix/app/styles/components/_progress-bar.scss
+++ b/mon-pix/app/styles/components/_progress-bar.scss
@@ -18,11 +18,11 @@
 }
 
 .progress-bar-stepnum {
-  color: $pix-neutral-110;
+  color: var(--pix-neutral-900);
   opacity: 0.3;
 
   &.active {
-    color: $pix-neutral-0;
+    color: var(--pix-neutral-0);
     opacity: 1;
   }
 }
@@ -63,7 +63,7 @@
 
 .assessment-progress {
   margin: 12px 0 10px;
-  color: $pix-neutral-0;
+  color: var(--pix-neutral-0);
   text-align: right;
 
   &__label {

--- a/mon-pix/app/styles/components/_qcm-proposals.scss
+++ b/mon-pix/app/styles/components/_qcm-proposals.scss
@@ -3,9 +3,9 @@
   flex-direction: row;
   align-items: center;
   justify-content: flex-start;
-  margin-left: $pix-spacing-xs;
+  margin-left: var(--pix-spacing-2x);
 
   & + .proposal-paragraph {
-    margin-top: $pix-spacing-s;
+    margin-top: var(--pix-spacing-4x);
   }
 }

--- a/mon-pix/app/styles/components/_qcm-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qcm-solution-panel.scss
@@ -34,7 +34,7 @@
 
   &__answer-details[data-goodness='good'] {
     display: inline;
-    color: $pix-success-70;
+    color: var(--pix-success-700);
     font-weight: $font-bold;
   }
 
@@ -57,7 +57,7 @@
     min-width: 18px;
     min-height: 18px;
     margin: 4px 10px;
-    border: 1.2px solid $pix-neutral-90;
+    border: 1.2px solid var(--pix-neutral-900);
     border-radius: 2px;
   }
 }

--- a/mon-pix/app/styles/components/_qcu-panel.scss
+++ b/mon-pix/app/styles/components/_qcu-panel.scss
@@ -1,6 +1,6 @@
 .qcu-panel {
   a {
-    color: $pix-primary;
+    color: var(--pix-primary-500);
     text-decoration: underline;
 
     @include device-is('tablet') {
@@ -10,7 +10,7 @@
     &:active,
     &:focus,
     &:hover {
-      color: $pix-primary-60;
+      color: var(--pix-primary-700);
     }
 
     &::after {
@@ -46,7 +46,7 @@
       display: inline-block;
 
       &[data-goodness='good'] {
-        color: $pix-success-70;
+        color: var(--pix-success-700);
         font-weight: $font-bold;
       }
 

--- a/mon-pix/app/styles/components/_qcu-proposals.scss
+++ b/mon-pix/app/styles/components/_qcu-proposals.scss
@@ -1,6 +1,6 @@
 .qcu-proposals {
   a {
-    color: $pix-primary;
+    color: var(--pix-primary-500);
     text-decoration: underline;
 
     @include device-is('tablet') {
@@ -10,7 +10,7 @@
     &:active,
     &:focus,
     &:hover {
-      color: $pix-primary-60;
+      color: var(--pix-primary-700);
     }
 
     &::after {

--- a/mon-pix/app/styles/components/_qcu-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qcu-solution-panel.scss
@@ -6,7 +6,7 @@
 
 .qcu-solution-panel {
   a {
-    color: $pix-primary;
+    color: var(--pix-primary-500);
     text-decoration: underline;
 
     @include device-is('tablet') {
@@ -14,7 +14,7 @@
     }
 
     &:focus {
-      color: $pix-primary-60;
+      color: var(--pix-primary-700);
     }
 
     &::after {
@@ -44,7 +44,7 @@
     }
 
     &[data-goodness='good'] {
-      color: $pix-success-70;
+      color: var(--pix-success-700);
       font-weight: $font-bold;
     }
 

--- a/mon-pix/app/styles/components/_qroc-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qroc-solution-panel.scss
@@ -24,7 +24,7 @@
     textarea,
     input,
     [disabled] {
-      color: $pix-success-70;
+      color: var(--pix-success-700);
       font-weight: $font-bold;
     }
   }
@@ -39,7 +39,7 @@
   &--aband {
     textarea,
     input {
-      color: $pix-neutral-80;
+      color: var(--pix-neutral-800);
       font-style: italic;
     }
   }

--- a/mon-pix/app/styles/components/_qrocm-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qrocm-solution-panel.scss
@@ -11,7 +11,7 @@
 
   &--input {
     display: inline-block;
-    padding: $pix-spacing-xxs $pix-spacing-xxs $pix-spacing-xxs 0;
+    padding: var(--pix-spacing-1x) var(--pix-spacing-1x) var(--pix-spacing-1x) 0;
     vertical-align: 0;
 
     &:not(:last-child) {
@@ -50,7 +50,7 @@
 .correction-qrocm-text {
   &__label {
     display: inline;
-    padding: $pix-spacing-xxs $pix-spacing-xxs $pix-spacing-xxs 0;
+    padding: var(--pix-spacing-1x) var(--pix-spacing-1x) var(--pix-spacing-1x) 0;
 
     &:not(:last-child) {
       padding-left: 0;
@@ -65,7 +65,7 @@
   &-text {
     @extend %pix-body-m;
 
-    margin: $pix-spacing-xxs 0 $pix-spacing-xs;
+    margin: var(--pix-spacing-1x) 0 var(--pix-spacing-2x);
     color: var(--pix-success-700);
     font-weight: $font-bold;
   }

--- a/mon-pix/app/styles/components/_qrocm-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qrocm-solution-panel.scss
@@ -66,7 +66,7 @@
     @extend %pix-body-m;
 
     margin: $pix-spacing-xxs 0 $pix-spacing-xs;
-    color: $pix-success-70;
+    color: var(--pix-success-700);
     font-weight: $font-bold;
   }
 }

--- a/mon-pix/app/styles/components/_reached-stage.scss
+++ b/mon-pix/app/styles/components/_reached-stage.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   margin: 20px auto 0;
-  background: $pix-neutral-0;
+  background: var(--pix-neutral-0);
   border: 1px solid rgb(231 231 231);
   border-radius: 16px;
 
@@ -27,7 +27,7 @@
   }
 
   &__percentage-text {
-    color: $pix-neutral-50;
+    color: var(--pix-neutral-100);
     font-weight: $font-medium;
     font-size: 0.875rem;
     font-family: $font-roboto;

--- a/mon-pix/app/styles/components/_reached-stage.scss
+++ b/mon-pix/app/styles/components/_reached-stage.scss
@@ -23,7 +23,7 @@
     justify-content: center;
     min-width: 200px;
     max-width: 250px;
-    margin-bottom: $pix-spacing-m;
+    margin-bottom: var(--pix-spacing-6x);
   }
 
   &__percentage-text {

--- a/mon-pix/app/styles/components/_register-form.scss
+++ b/mon-pix/app/styles/components/_register-form.scss
@@ -8,14 +8,14 @@
   &__login-options {
     display: inline-block;
     margin-bottom: 5px;
-    color: $pix-neutral-80;
+    color: var(--pix-neutral-800);
     font-weight: $font-bold;
     font-size: 0.875rem;
     font-family: $font-roboto;
   }
 
   &__required-inputs {
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-weight: $font-normal;
     font-size: 1rem;
     font-family: $font-roboto;
@@ -38,7 +38,7 @@
   }
 
   &__validation-error {
-    color: $pix-error-70;
+    color: var(--pix-error-700);
     font-weight: normal;
   }
 
@@ -54,8 +54,8 @@
   hr {
     height: 2px;
     margin: 20px 0;
-    color: $pix-neutral-20;
-    background-color: $pix-neutral-20;
+    color: var(--pix-neutral-20);
+    background-color: var(--pix-neutral-20);
     border: none;
   }
 
@@ -68,7 +68,7 @@
 
   &__error {
     padding: 4px 10px;
-    color: $pix-warning-60;
+    color: var(--pix-warning-700);
     font-size: 0.938rem;
     text-align: center;
 
@@ -83,7 +83,7 @@
     margin-top: 20px;
 
     &__label {
-      color: $pix-neutral-80;
+      color: var(--pix-neutral-800);
       font-weight: $font-medium;
       font-size: 0.938rem;
       letter-spacing: 0.031rem;
@@ -91,10 +91,10 @@
 
     &__span {
       padding: 15px 10px;
-      color: $pix-neutral-50;
+      color: var(--pix-neutral-100);
       font-size: 0.875rem;
       font-family: $font-roboto;
-      background-color: $pix-neutral-20;
+      background-color: var(--pix-neutral-20);
       border-radius: 3px;
     }
   }

--- a/mon-pix/app/styles/components/_reset-campaign-participation-modal.scss
+++ b/mon-pix/app/styles/components/_reset-campaign-participation-modal.scss
@@ -1,11 +1,11 @@
 .reset-campaign-participation-modal {
   &__text {
-    margin: $pix-spacing-m;
+    margin: var(--pix-spacing-6x);
   }
 
   &__footer {
     display: flex;
-    gap: $pix-spacing-s;
+    gap: var(--pix-spacing-4x);
     align-items: center;
     justify-content: end;
   }

--- a/mon-pix/app/styles/components/_reset-password-form.scss
+++ b/mon-pix/app/styles/components/_reset-password-form.scss
@@ -7,7 +7,7 @@
     width: 95%;
     max-width: 609px;
     padding: 30px 10px;
-    background-color: $pix-neutral-0;
+    background-color: var(--pix-neutral-0);
     border-radius: 10px;
 
     @include device-is('tablet') {
@@ -40,7 +40,7 @@
 }
 
 .reset-password-form-title {
-  color: $pix-neutral-80;
+  color: var(--pix-neutral-800);
   font-size: 1.563rem;
   font-family: $font-open-sans;
 
@@ -52,7 +52,7 @@
 .reset-password-form-subtitle {
   width: 100%;
   margin-top: 10px;
-  color: $pix-neutral-80;
+  color: var(--pix-neutral-800);
   font-size: 0.938rem;
   font-family: $font-open-sans;
   line-height: 28px;
@@ -66,7 +66,7 @@
 
 .reset-password-form-text {
   padding: 20px 0;
-  color: $pix-neutral-80;
+  color: var(--pix-neutral-800);
   font-size: 0.938rem;
   font-family: $font-open-sans;
 }

--- a/mon-pix/app/styles/components/_result-item.scss
+++ b/mon-pix/app/styles/components/_result-item.scss
@@ -5,13 +5,13 @@
   width: auto;
   height: 110px;
   padding: 8px 0;
-  background-color: $pix-neutral-0;
+  background-color: var(--pix-neutral-0);
   border: none;
   border-radius: 4px;
   outline: none;
 
   &:nth-child(odd) {
-    background: $pix-neutral-10;
+    background: var(--pix-neutral-20);
   }
 
   @include device-is('tablet') {
@@ -43,7 +43,7 @@
 }
 
 .result-item__correction-button {
-  color: $pix-primary-60;
+  color: var(--pix-primary-700);
   font-weight: $font-normal;
   font-size: 0.875rem;
   background-color: transparent;
@@ -53,7 +53,7 @@
   &:hover,
   &:focus,
   &:active {
-    color: $pix-primary-60;
+    color: var(--pix-primary-700);
     text-decoration: underline;
     cursor: pointer;
   }
@@ -68,18 +68,18 @@
   }
 
   &--green {
-    color: $pix-success-70;
+    color: var(--pix-success-700);
   }
 
   &--orange {
-    color: $pix-information-light;
+    color: var(--pix-information-light);
   }
 
   &--red {
-    color: $pix-error-50;
+    color: var(--pix-error-500);
   }
 
   &--grey {
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
   }
 }

--- a/mon-pix/app/styles/components/_rounded-panel.scss
+++ b/mon-pix/app/styles/components/_rounded-panel.scss
@@ -1,6 +1,6 @@
 .rounded-panel {
   margin-bottom: 30px;
-  background-color: $pix-neutral-0;
+  background-color: var(--pix-neutral-0);
   border-radius: 10px;
   box-shadow: 0 2px 5px 0 rgb(0 0 0 / 5%);
 
@@ -60,7 +60,7 @@
   @include device-is('tablet') {
     flex-direction: row;
     height: 205px;
-    border-bottom: 1px dashed $pix-neutral-22;
+    border-bottom: 1px dashed var(--pix-neutral-100);
   }
 }
 
@@ -122,7 +122,7 @@
   }
 
   &__content--first-title {
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-size: 1.625rem;
     font-family: $font-open-sans;
     line-height: 2.75rem;

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -9,7 +9,7 @@
 
 .tutorials-header {
   &__title {
-    margin-bottom: $pix-spacing-s;
+    margin-bottom: var(--pix-spacing-4x);
     font-size: 2rem;
     font-family: $font-open-sans;
   }
@@ -70,12 +70,12 @@
 
   &__resume-or-start-button,
   &__improve-button {
-    margin-top: $pix-spacing-m;
+    margin-top: var(--pix-spacing-6x);
   }
 
   &__reset-button {
     width: 180px;
-    margin-top: $pix-spacing-m;
+    margin-top: var(--pix-spacing-6x);
   }
 
   &__reset-modal {
@@ -210,7 +210,7 @@
 
 .scorecard-details-reset-modal {
   &__important-message {
-    margin-bottom: $pix-spacing-s;
+    margin-bottom: var(--pix-spacing-4x);
     color: var(--pix-neutral-900);
     font-weight: $font-medium;
     font-size: 1.375rem;
@@ -228,7 +228,7 @@
     }
 
     .scorecard-details-reset-modal__list {
-      padding-left: $pix-spacing-l;
+      padding-left: var(--pix-spacing-8x);
     }
 
     .scorecard-details-reset-modal-list__item {

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -16,7 +16,7 @@
 
   &__description {
     margin: 0 0 10px;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-weight: $font-normal;
     font-size: 1rem;
     font-family: $font-roboto;
@@ -29,7 +29,7 @@
 
   &__title {
     margin-bottom: 24px;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-weight: $font-normal;
     font-size: 1.25rem;
     font-family: $font-open-sans;
@@ -56,7 +56,7 @@
     margin: 14px;
     padding: 40px 0;
     font-family: $font-roboto;
-    background-color: $pix-neutral-5;
+    background-color: var(--pix-neutral-20);
     border-radius: 6.75px;
 
     @include device-is('desktop') {
@@ -86,7 +86,7 @@
 
   &__improving-text {
     margin-top: 4px;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-size: 0.8rem;
     font-family: $font-roboto;
     letter-spacing: 0.0075rem;
@@ -113,7 +113,7 @@
     @include device-is('desktop') {
       max-width: 68%;
       padding: 0 30px;
-      border-right: 2px dashed $pix-neutral-22;
+      border-right: 2px dashed var(--pix-neutral-100);
     }
   }
 
@@ -139,23 +139,23 @@
     text-transform: uppercase;
 
     &--jaffa {
-      color: darken($pix-information-dark, 15%);
+      color: darken(var(--pix-information-dark), 15%);
     }
 
     &--emerald {
-      color: darken($pix-content-dark, 10%);
+      color: darken(var(--pix-content-dark), 10%);
     }
 
     &--cerulean {
-      color: darken($pix-communication-dark, 10%);
+      color: darken(var(--pix-communication-dark), 10%);
     }
 
     &--wild-strawberry {
-      color: $pix-security-dark;
+      color: var(--pix-security-dark);
     }
 
     &--butterfly-bush {
-      color: $pix-environment-light;
+      color: var(--pix-environment-light);
     }
   }
 
@@ -166,7 +166,7 @@
   }
 
   &__description {
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-size: 1rem;
     font-family: $font-open-sans;
     line-height: 1.625rem;
@@ -183,7 +183,7 @@
 
   &__level-info {
     margin-top: 20px;
-    color: $pix-neutral-80;
+    color: var(--pix-neutral-800);
     letter-spacing: 0.019rem;
     white-space: nowrap;
     text-transform: uppercase;
@@ -191,7 +191,7 @@
 
   &__reset-message {
     padding-top: 50px;
-    color: $pix-neutral-30;
+    color: var(--pix-neutral-100);
     font-size: 0.813rem;
     font-family: $font-roboto;
   }
@@ -203,7 +203,7 @@
     flex-direction: column;
     align-items: center;
     margin-left: 60px;
-    color: $pix-neutral-80;
+    color: var(--pix-neutral-800);
     text-transform: uppercase;
   }
 }
@@ -211,7 +211,7 @@
 .scorecard-details-reset-modal {
   &__important-message {
     margin-bottom: $pix-spacing-s;
-    color: $pix-neutral-110;
+    color: var(--pix-neutral-900);
     font-weight: $font-medium;
     font-size: 1.375rem;
     font-family: $font-roboto;
@@ -219,7 +219,7 @@
 
   &__warning {
     padding-bottom: 10px;
-    color: $pix-neutral-80;
+    color: var(--pix-neutral-800);
     font-size: 1rem;
     font-family: $font-roboto;
 
@@ -249,14 +249,14 @@
 
 .scorecard-details-improvement-countdown {
   &__label {
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-size: 0.6875rem;
     letter-spacing: 0.0075rem;
   }
 
   &__count {
     margin-top: 6px;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-size: 1rem;
     letter-spacing: 0.01rem;
   }

--- a/mon-pix/app/styles/components/_skip-link.scss
+++ b/mon-pix/app/styles/components/_skip-link.scss
@@ -3,8 +3,8 @@
   z-index: 1;
   margin: 8px;
   padding: 0.5em;
-  color: $pix-neutral-0;
-  background-color: $pix-primary;
+  color: var(--pix-neutral-0);
+  background-color: var(--pix-primary-500);
   transform: translateY(calc(-100% - 16px));
   transition: transform 0.3s;
 

--- a/mon-pix/app/styles/components/_timed-challenge-instructions.scss
+++ b/mon-pix/app/styles/components/_timed-challenge-instructions.scss
@@ -8,7 +8,7 @@
 
   &__primary {
     margin-top: 22px;
-    color: $pix-neutral-80;
+    color: var(--pix-neutral-800);
     font-weight: $font-bold;
     font-size: 1.5rem;
     font-style: normal;
@@ -18,18 +18,18 @@
   &__secondary {
     margin-top: 9px;
     margin-bottom: 50px;
-    color: $pix-neutral-80;
+    color: var(--pix-neutral-800);
     font-size: 1.125rem;
     font-style: normal;
     font-stretch: normal;
   }
 
   &__time {
-    color: $pix-primary;
+    color: var(--pix-primary-500);
   }
 
   &__allocated-time {
-    color: $pix-neutral-80;
+    color: var(--pix-neutral-800);
     font-size: 1.7375rem;
   }
 
@@ -51,7 +51,7 @@
     margin: 0 auto;
     padding: 4px 12px;
     line-height: 3.125rem;
-    background-color: $pix-neutral-20;
+    background-color: var(--pix-neutral-20);
     border-radius: 7px;
   }
 }

--- a/mon-pix/app/styles/components/_timeout-gauge.scss
+++ b/mon-pix/app/styles/components/_timeout-gauge.scss
@@ -18,7 +18,7 @@
   width: 100px;
   height: 36px;
   overflow: hidden;
-  background-color: $pix-neutral-20;
+  background-color: var(--pix-neutral-20);
   border-radius: 5px;
 }
 
@@ -28,7 +28,7 @@
   left: 0;
   z-index: 1;
   height: 100%;
-  background-color: $pix-neutral-10;
+  background-color: var(--pix-neutral-20);
   border-top-left-radius: 5px;
   border-bottom-left-radius: 5px;
 }

--- a/mon-pix/app/styles/components/_tooltip.scss
+++ b/mon-pix/app/styles/components/_tooltip.scss
@@ -47,7 +47,7 @@
     min-width: 220px;
     max-width: 300px;
     padding: 24px;
-    background-color: $pix-neutral-0;
+    background-color: var(--pix-neutral-0);
     border-radius: 15px;
     box-shadow: 0 0 20px 0 rgb(0 0 0 / 20%);
 

--- a/mon-pix/app/styles/components/_training-card.scss
+++ b/mon-pix/app/styles/components/_training-card.scss
@@ -16,7 +16,7 @@
   height: 54px;
   margin: 16px 16px 8px;
   overflow: hidden;
-  color: $pix-neutral-90;
+  color: var(--pix-neutral-900);
   font-weight: $font-medium;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -60,7 +60,7 @@
       z-index: 1;
       width: 64px;
       padding: $pix-spacing-xxs;
-      background-color: $pix-neutral-0;
+      background-color: var(--pix-neutral-0);
       border-radius: 0 0 4px 4px;
     }
 

--- a/mon-pix/app/styles/components/_training-card.scss
+++ b/mon-pix/app/styles/components/_training-card.scss
@@ -23,7 +23,7 @@
 }
 
 .training-card-content__infos {
-  padding: 0 $pix-spacing-s;
+  padding: 0 var(--pix-spacing-4x);
 }
 
 .training-card-content-infos__tag {
@@ -51,15 +51,15 @@
 .training-card-content__illustration {
   position: relative;
   height: 155px;
-  margin-top: $pix-spacing-m;
+  margin-top: var(--pix-spacing-6x);
 
   .training-card-content-illustration {
     &__logo {
       position: absolute;
-      left: $pix-spacing-s;
+      left: var(--pix-spacing-4x);
       z-index: 1;
       width: 64px;
-      padding: $pix-spacing-xxs;
+      padding: var(--pix-spacing-1x);
       background-color: var(--pix-neutral-0);
       border-radius: 0 0 4px 4px;
     }

--- a/mon-pix/app/styles/components/_tutorial-card.scss
+++ b/mon-pix/app/styles/components/_tutorial-card.scss
@@ -3,9 +3,9 @@
   gap: 12px;
   min-height: 170px;
   padding: 16px;
-  background: $pix-neutral-0;
+  background: var(--pix-neutral-0);
   border-radius: 8px;
-  box-shadow: 0 2px 5px 0 rgba($pix-neutral-90, 0.06);
+  box-shadow: 0 2px 5px 0 rgba(var(--pix-neutral-900), 0.06);
 
   &__content {
     display: flex;
@@ -28,11 +28,11 @@
     -webkit-box-orient: vertical;
 
     a {
-      color: $pix-neutral-90;
+      color: var(--pix-neutral-900);
 
       &:hover,
       &:focus {
-        color: $pix-primary;
+        color: var(--pix-primary-500);
       }
     }
   }
@@ -40,7 +40,7 @@
   &__details {
     height: 24px;
     margin: 0;
-    color: $pix-neutral-50;
+    color: var(--pix-neutral-100);
     font-weight: $font-normal;
     font-size: 0.813rem;
     font-family: $font-roboto;

--- a/mon-pix/app/styles/components/_tutorial-item.scss
+++ b/mon-pix/app/styles/components/_tutorial-item.scss
@@ -1,6 +1,6 @@
 .tutorial-item {
   margin-bottom: 24px;
-  border-bottom: 1px solid $pix-neutral-20;
+  border-bottom: 1px solid var(--pix-neutral-20);
 }
 
 .tutorial__content {
@@ -14,7 +14,7 @@
     display: block;
     width: 4px;
     height: calc(100% - 6px);
-    background: $pix-neutral-50;
+    background: var(--pix-neutral-100);
     border-radius: 50px;
     content: ' ';
   }
@@ -25,7 +25,7 @@
   &__title {
     display: inline-block;
     margin-bottom: 4px;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-weight: $font-normal;
     font-size: 1.125rem;
     line-height: 1.875rem;
@@ -42,7 +42,7 @@
 
   &__description {
     margin: 0 0 14px;
-    color: $pix-neutral-50;
+    color: var(--pix-neutral-100);
     font-weight: $font-normal;
     font-size: 0.875rem;
     font-family: $font-roboto;
@@ -66,7 +66,7 @@
     display: block;
     margin: 0 0 16px;
     padding: 0;
-    color: $pix-neutral-50;
+    color: var(--pix-neutral-100);
     font-weight: $font-medium;
     font-size: 0.813rem;
     letter-spacing: 0.028rem;
@@ -83,7 +83,7 @@
     }
 
     &:disabled {
-      color: $pix-neutral-30;
+      color: var(--pix-neutral-100);
       cursor: auto;
       filter: brightness(90%);
     }
@@ -93,7 +93,7 @@
     display: block;
     margin: 0 0 16px;
     padding: 0;
-    color: $pix-neutral-50;
+    color: var(--pix-neutral-100);
     font-weight: $font-medium;
     font-size: 0.813rem;
     letter-spacing: 0.028rem;
@@ -110,7 +110,7 @@
     }
 
     &:disabled {
-      color: $pix-neutral-30;
+      color: var(--pix-neutral-100);
       cursor: auto;
       filter: brightness(90%);
     }

--- a/mon-pix/app/styles/components/_tutorial-panel.scss
+++ b/mon-pix/app/styles/components/_tutorial-panel.scss
@@ -37,13 +37,13 @@
 
 .tutorial-panel__tutorial-info {
   margin: -5px 5px 0;
-  color: $pix-neutral-50;
+  color: var(--pix-neutral-100);
   font-size: 0.813rem;
   line-height: 1.25rem;
 }
 
 .tutorial-panel__hint-title {
-  @include tutorial-panel-title($pix-neutral-10);
+  @include tutorial-panel-title(var(--pix-neutral-20));
 }
 
 .tutorial-panel__hint-content {

--- a/mon-pix/app/styles/components/_user-account-update-email.scss
+++ b/mon-pix/app/styles/components/_user-account-update-email.scss
@@ -13,7 +13,7 @@
 
   &__informations {
     padding-top: 12px;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-family: $font-open-sans;
     line-height: 1.75rem;
     text-align: center;
@@ -37,7 +37,7 @@
 
   &__error {
     padding-top: 30px;
-    color: $pix-error-60;
+    color: var(--pix-error-700);
   }
 }
 

--- a/mon-pix/app/styles/components/_user-account.scss
+++ b/mon-pix/app/styles/components/_user-account.scss
@@ -5,7 +5,7 @@
     right: 0;
     margin: 0 0 8px;
     padding-bottom: 26px;
-    color: $pix-neutral-0;
+    color: var(--pix-neutral-0);
     font-weight: 300;
     font-size: 3rem;
     font-family: $font-open-sans;
@@ -14,7 +14,7 @@
 
   &__validation-title {
     padding-bottom: 16px;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-weight: 400;
     font-size: 1.5rem;
     font-family: $font-open-sans;
@@ -48,7 +48,7 @@
       }
 
       ul li {
-        border-bottom: 1.5px solid $pix-neutral-10;
+        border-bottom: 1.5px solid var(--pix-neutral-20);
         border-radius: 4px;
 
         &:first-child a {
@@ -64,22 +64,22 @@
       &__link {
         display: block;
         padding: 16px 60px 16px 20px;
-        color: $pix-neutral-60;
+        color: var(--pix-neutral-500);
 
         svg {
           margin-right: 8px;
         }
 
         &:hover {
-          background-color: $pix-neutral-15;
+          background-color: var(--pix-neutral-20);
         }
 
         &:focus-within {
-          background-color: $pix-neutral-15;
+          background-color: var(--pix-neutral-20);
         }
 
         &.active {
-          background-color: $pix-neutral-15;
+          background-color: var(--pix-neutral-20);
         }
       }
     }

--- a/mon-pix/app/styles/components/_user-certification-hexagon-score.scss
+++ b/mon-pix/app/styles/components/_user-certification-hexagon-score.scss
@@ -18,7 +18,7 @@
     text-align: center;
 
     &-title {
-      color: $pix-neutral-60;
+      color: var(--pix-neutral-500);
       font-weight: lighter;
       font-size: 0.8rem;
       font-family: $font-roboto;
@@ -27,7 +27,7 @@
     }
 
     &-pix-score {
-      color: $pix-neutral-70;
+      color: var(--pix-neutral-800);
       font-weight: $font-medium;
       font-size: 2.3rem;
       font-family: $font-open-sans;
@@ -35,7 +35,7 @@
 
     &-certified {
       width: 70px;
-      color: $pix-neutral-60;
+      color: var(--pix-neutral-500);
       font-weight: $font-medium;
       font-size: 0.7rem;
       font-family: $font-roboto;

--- a/mon-pix/app/styles/components/_user-certifications-detail-competence.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-competence.scss
@@ -66,7 +66,7 @@
     align-items: center;
     justify-content: space-between;
     height: inherit;
-    padding: $pix-spacing-m 0 $pix-spacing-m $pix-spacing-s;
+    padding: var(--pix-spacing-6x) 0 var(--pix-spacing-6x) var(--pix-spacing-4x);
     font-weight: normal;
     text-transform: uppercase;
 
@@ -77,7 +77,7 @@
 
       &:last-child {
         min-width: 90px;
-        padding-right: $pix-spacing-l;
+        padding-right: var(--pix-spacing-8x);
         color: var(--pix-neutral-500);
       }
     }
@@ -110,7 +110,7 @@
 
   &__level {
     min-width: 90px;
-    padding-right: $pix-spacing-l;
+    padding-right: var(--pix-spacing-8x);
     font-weight: bold;
     font-size: 1.5rem;
     text-align: center;

--- a/mon-pix/app/styles/components/_user-certifications-detail-competence.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-competence.scss
@@ -40,23 +40,23 @@
   }
 
   &--jaffa {
-    @include coloriseElements($pix-information-light);
+    @include coloriseElements(var(--pix-information-light));
   }
 
   &--emerald {
-    @include coloriseElements($pix-content-light);
+    @include coloriseElements(var(--pix-content-light));
   }
 
   &--cerulean {
-    @include coloriseElements($pix-communication-light);
+    @include coloriseElements(var(--pix-communication-light));
   }
 
   &--wild-strawberry {
-    @include coloriseElements($pix-security-light);
+    @include coloriseElements(var(--pix-security-light));
   }
 
   &--butterfly-bush {
-    @include coloriseElements($pix-environment-light);
+    @include coloriseElements(var(--pix-environment-light));
   }
 }
 
@@ -78,7 +78,7 @@
       &:last-child {
         min-width: 90px;
         padding-right: $pix-spacing-l;
-        color: $pix-neutral-60;
+        color: var(--pix-neutral-500);
       }
     }
   }
@@ -104,7 +104,7 @@
 .user-certifications-detail-competence-list-row {
   &__name {
     padding: 20px 0 20px 36px;
-    color: $pix-neutral-80;
+    color: var(--pix-neutral-800);
     font-family: $font-open-sans;
   }
 

--- a/mon-pix/app/styles/components/_user-certifications-detail-header.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-header.scss
@@ -18,7 +18,7 @@
 
   &__info-certificate {
     align-self: center;
-    color: $pix-neutral-80;
+    color: var(--pix-neutral-800);
 
     & > * {
       margin: 0;
@@ -35,7 +35,7 @@
     }
 
     &--grey {
-      color: $pix-neutral-45;
+      color: var(--pix-neutral-500);
       font-size: 0.875rem;
       line-height: 23px;
 
@@ -50,7 +50,7 @@
 
     &--professionalizing-warning {
       padding-top: 12px;
-      color: $pix-neutral-45;
+      color: var(--pix-neutral-500);
       font-size: 0.875rem;
       line-height: 23px;
     }
@@ -73,7 +73,7 @@
 
 .attestation-and-verification-code {
   padding: 16px 20px;
-  background-color: $pix-neutral-10;
+  background-color: var(--pix-neutral-20);
   border-radius: 8px;
 
   .attestation {
@@ -89,19 +89,19 @@
     &__error-message {
       max-width: 250px;
       margin-top: 15px;
-      color: $pix-error-50;
+      color: var(--pix-error-500);
     }
   }
 
   hr {
     margin: 24px 0;
-    border: 1px solid $pix-neutral-15;
+    border: 1px solid var(--pix-neutral-20);
   }
 
   .verification-code {
     max-width: 250px;
     margin: auto;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-family: $font-open-sans;
     letter-spacing: 0;
 
@@ -118,8 +118,8 @@
       align-items: baseline;
       justify-content: center;
       padding: 10px 20px;
-      background-color: $pix-neutral-5;
-      border: 1.5px $pix-neutral-22 dashed;
+      background-color: var(--pix-neutral-20);
+      border: 1.5px var(--pix-neutral-100) dashed;
       border-radius: 4px;
 
       .verification-code__code {
@@ -133,14 +133,14 @@
 
       .verification-code__copy-button {
         padding: 0;
-        color: $pix-primary;
+        color: var(--pix-primary-500);
         font-size: 1.25rem;
         background: none;
         border: none;
         cursor: pointer;
 
         &:hover {
-          color: darken($pix-primary, 20%);
+          color: darken(var(--pix-primary-500), 20%);
         }
       }
     }

--- a/mon-pix/app/styles/components/_user-certifications-detail-result.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-result.scss
@@ -5,7 +5,7 @@
   justify-content: flex-start;
   max-width: 370px;
   height: 100%;
-  color: $pix-neutral-80;
+  color: var(--pix-neutral-800);
   font-size: 1.125rem;
 
   div {

--- a/mon-pix/app/styles/components/_user-logged-menu.scss
+++ b/mon-pix/app/styles/components/_user-logged-menu.scss
@@ -8,13 +8,13 @@
   width: 0;
   height: 0;
   margin: auto 0 auto 2px;
-  border-color: $pix-neutral-60 transparent transparent transparent;
+  border-color: var(--pix-neutral-500) transparent transparent transparent;
   border-style: solid;
   border-width: 4px 4px 0;
 }
 
 .logged-user-name__link {
-  color: $pix-neutral-60;
+  color: var(--pix-neutral-500);
   font-size: 1rem;
   text-decoration: none;
   cursor: pointer;
@@ -22,16 +22,16 @@
   &:visited,
   &:focus,
   &:active {
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     text-decoration: none;
   }
 
   &:hover {
-    color: $pix-primary-60;
+    color: var(--pix-primary-700);
     text-decoration: none;
 
     > .caret {
-      border-color: $pix-primary-60 transparent transparent transparent;
+      border-color: var(--pix-primary-700) transparent transparent transparent;
     }
   }
 }
@@ -42,7 +42,7 @@
   max-width: 150px;
   padding: 0;
   overflow: hidden;
-  color: $pix-neutral-60;
+  color: var(--pix-neutral-500);
   font-family: $font-roboto;
   letter-spacing: 0.031rem;
   white-space: nowrap;
@@ -66,14 +66,14 @@
   min-width: 240px;
   max-width: 380px;
   overflow: hidden;
-  background-color: $pix-neutral-0;
+  background-color: var(--pix-neutral-0);
   border-radius: 4px;
   box-shadow: 0 1px 1px 0 rgb(60 64 67 / 8%), 0 1px 3px 1px rgb(60 64 67 / 16%);
 
   &__details {
     padding: 12px 16px;
-    color: $pix-neutral-80;
-    background-color: $pix-neutral-10;
+    color: var(--pix-neutral-800);
+    background-color: var(--pix-neutral-20);
   }
 
   &__actions {
@@ -99,15 +99,15 @@
   display: flex;
   align-items: center;
   padding: 12px 16px;
-  color: $pix-neutral-80;
+  color: var(--pix-neutral-800);
   font-size: 0.938rem;
-  border-top: 1px solid $pix-neutral-15;
+  border-top: 1px solid var(--pix-neutral-20);
   transition: background-color 0.1s linear;
 
   &:hover {
-    color: $pix-neutral-80;
+    color: var(--pix-neutral-800);
     text-decoration: none;
-    background-color: $pix-neutral-10;
+    background-color: var(--pix-neutral-20);
   }
 
   & > svg {

--- a/mon-pix/app/styles/components/account-recovery/_confirmation-step.scss
+++ b/mon-pix/app/styles/components/account-recovery/_confirmation-step.scss
@@ -8,14 +8,14 @@
   height: 65px;
   margin-bottom: 8px;
   padding: 12px 20px;
-  color: $pix-neutral-70;
+  color: var(--pix-neutral-800);
   font-weight: 500;
-  background: $pix-neutral-10;
+  background: var(--pix-neutral-20);
   border-radius: 8px;
 
   & > div:first-of-type {
     margin-bottom: 6px;
-    color: $pix-neutral-70;
+    color: var(--pix-neutral-800);
     font-weight: normal;
     font-size: 0.875rem;
     font-family: $font-roboto;

--- a/mon-pix/app/styles/components/account-recovery/_student-information-form.scss
+++ b/mon-pix/app/styles/components/account-recovery/_student-information-form.scss
@@ -5,7 +5,7 @@
     right: 0;
     z-index: 100;
     display: block;
-    color: $pix-communication-dark;
+    color: var(--pix-communication-dark);
 
     strong {
       font-weight: bold;

--- a/mon-pix/app/styles/components/authentication/_login-or-register-oidc.scss
+++ b/mon-pix/app/styles/components/authentication/_login-or-register-oidc.scss
@@ -19,7 +19,7 @@
 
   &__title {
     padding: 22px 0 38px;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-weight: 300;
     font-size: 36px;
     font-family: $font-open-sans;
@@ -47,7 +47,7 @@
 
   &__subtitle {
     padding-bottom: 24px;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-weight: 500;
     font-size: 22px;
     font-family: $font-open-sans;
@@ -61,7 +61,7 @@
   &__description {
     margin: 0;
     padding-bottom: 24px;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-weight: 500;
     font-size: 16px;
     font-family: $font-roboto;
@@ -71,13 +71,13 @@
   &__description em {
     padding-right: 0.2rem;
     padding-left: 0.2rem;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-style: normal;
   }
 
   &__information {
     margin-bottom: 2rem;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-weight: 500;
     font-size: 16px;
     font-family: $font-roboto;
@@ -115,13 +115,13 @@
   &__divider {
     width: 100%;
     margin: 50px 0 30px;
-    border-bottom: 1px solid $pix-neutral-30;
+    border-bottom: 1px solid var(--pix-neutral-100);
 
     @include device-is('desktop') {
       width: 0;
       margin: 0;
       border-bottom-style: none;
-      border-left: 1px solid $pix-neutral-30;
+      border-left: 1px solid var(--pix-neutral-100);
     }
   }
 
@@ -141,7 +141,7 @@
 
   &__mandatory-description {
     padding-bottom: 10px;
-    color: $pix-neutral-70;
+    color: var(--pix-neutral-800);
     font-size: 14px;
     text-align: center;
   }
@@ -155,7 +155,7 @@
   &__forgotten-password-link {
     align-self: flex-end;
     margin-top: 5px;
-    color: $pix-neutral-70;
+    color: var(--pix-neutral-800);
     font-size: 14px;
   }
 

--- a/mon-pix/app/styles/components/authentication/_oidc-reconciliation.scss
+++ b/mon-pix/app/styles/components/authentication/_oidc-reconciliation.scss
@@ -2,7 +2,7 @@
   &__title,
   &__subtitle,
   &__information {
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     text-align: center;
   }
 
@@ -41,13 +41,13 @@
     align-items: center;
     width: 570px;
     padding-top: $pix-spacing-l;
-    background-color: $pix-neutral-10;
+    background-color: var(--pix-neutral-20);
     border-radius: $pix-spacing-xs;
 
     svg {
       min-width: 120px;
       height: 120px;
-      color: $pix-neutral-50;
+      color: var(--pix-neutral-100);
     }
 
     p {
@@ -55,7 +55,7 @@
 
       margin: 0;
       padding-top: $pix-spacing-xs;
-      color: $pix-neutral-90;
+      color: var(--pix-neutral-900);
     }
   }
 
@@ -77,20 +77,20 @@
     p {
       @extend %pix-title-xs;
 
-      color: $pix-neutral-90;
+      color: var(--pix-neutral-900);
       font-weight: 400;
     }
   }
 
   &__user-authentication-methods-list {
     padding: $pix-spacing-l $pix-spacing-xl;
-    background-color: $pix-neutral-0;
+    background-color: var(--pix-neutral-0);
     border-radius: $pix-spacing-xs;
 
     dd,
     dt {
       display: inline;
-      color: $pix-neutral-90;
+      color: var(--pix-neutral-900);
 
       @extend %pix-body-l;
     }
@@ -113,7 +113,7 @@
   &__arrow {
     min-width: 50px;
     height: 70px;
-    color: $pix-neutral-15;
+    color: var(--pix-neutral-20);
   }
 
   &__authentication-method-to-add {
@@ -126,7 +126,7 @@
 
       @extend %pix-body-l;
 
-      color: $pix-neutral-90;
+      color: var(--pix-neutral-900);
     }
 
     dd,

--- a/mon-pix/app/styles/components/authentication/_oidc-reconciliation.scss
+++ b/mon-pix/app/styles/components/authentication/_oidc-reconciliation.scss
@@ -9,7 +9,7 @@
   &__title {
     @extend %pix-title-m;
 
-    padding-top: $pix-spacing-l;
+    padding-top: var(--pix-spacing-8x);
     text-align: center;
   }
 
@@ -18,13 +18,13 @@
 
     display: block;
     margin: 0;
-    padding: $pix-spacing-s 0 $pix-spacing-xxs 0;
+    padding: var(--pix-spacing-4x) 0 var(--pix-spacing-1x) 0;
   }
 
   &__information {
     @extend %pix-title-xs;
 
-    margin-bottom: $pix-spacing-xxl;
+    margin-bottom: var(--pix-spacing-12x);
     font-weight: 400;
   }
 
@@ -40,9 +40,9 @@
     flex-direction: column;
     align-items: center;
     width: 570px;
-    padding-top: $pix-spacing-l;
+    padding-top: var(--pix-spacing-8x);
     background-color: var(--pix-neutral-20);
-    border-radius: $pix-spacing-xs;
+    border-radius: var(--pix-spacing-2x);
 
     svg {
       min-width: 120px;
@@ -54,14 +54,14 @@
       @extend %pix-title-xs;
 
       margin: 0;
-      padding-top: $pix-spacing-xs;
+      padding-top: var(--pix-spacing-2x);
       color: var(--pix-neutral-900);
     }
   }
 
   &__user-authentication-methods {
     width: 100%;
-    padding: $pix-spacing-l;
+    padding: var(--pix-spacing-8x);
 
     p {
       @extend %pix-title-xs;
@@ -72,7 +72,7 @@
 
   &__new-authentication-method {
     width: 506px;
-    padding-top: $pix-spacing-s;
+    padding-top: var(--pix-spacing-4x);
 
     p {
       @extend %pix-title-xs;
@@ -83,9 +83,9 @@
   }
 
   &__user-authentication-methods-list {
-    padding: $pix-spacing-l $pix-spacing-xl;
+    padding: var(--pix-spacing-8x) var(--pix-spacing-10x);
     background-color: var(--pix-neutral-0);
-    border-radius: $pix-spacing-xs;
+    border-radius: var(--pix-spacing-2x);
 
     dd,
     dt {
@@ -98,7 +98,7 @@
     dt {
       display: inline-block;
       width: 38%;
-      padding: $pix-spacing-xxs 0;
+      padding: var(--pix-spacing-1x) 0;
       font-weight: 500;
     }
   }
@@ -107,7 +107,7 @@
     display: flex;
     justify-content: right;
     width: 570px;
-    margin-top: $pix-spacing-xs;
+    margin-top: var(--pix-spacing-2x);
   }
 
   &__arrow {
@@ -122,7 +122,7 @@
 
     dl {
       margin: 0;
-      padding: $pix-spacing-l $pix-spacing-xl;
+      padding: var(--pix-spacing-8x) var(--pix-spacing-10x);
 
       @extend %pix-body-l;
 
@@ -141,9 +141,9 @@
 
   &__action-buttons {
     display: flex;
-    gap: $pix-spacing-m;
+    gap: var(--pix-spacing-6x);
     justify-content: center;
     width: 100%;
-    padding-top: $pix-spacing-l;
+    padding-top: var(--pix-spacing-8x);
   }
 }

--- a/mon-pix/app/styles/components/autonomous-course/_landing-page-start-block.scss
+++ b/mon-pix/app/styles/components/autonomous-course/_landing-page-start-block.scss
@@ -23,14 +23,14 @@
   @extend %pix-body-l;
 
   margin-top: 1rem;
-  color: $pix-neutral-50;
+  color: var(--pix-neutral-100);
 }
 
 .autonomous-course-landing-page-start-block__launcher {
   display: inline-block;
   margin: 1.5rem 0 2rem;
   padding: 1.5rem 2rem;
-  background-color: $pix-neutral-10;
+  background-color: var(--pix-neutral-20);
   border-radius: 0.5rem;
 
   p {
@@ -43,7 +43,7 @@
 
   .sign-in-button {
     margin-top: 0.5rem;
-    color: $pix-primary;
+    color: var(--pix-primary-500);
     font-size: 0.875rem;
     text-decoration: underline;
   }

--- a/mon-pix/app/styles/components/campaign-participation-overview/_card.scss
+++ b/mon-pix/app/styles/components/campaign-participation-overview/_card.scss
@@ -7,7 +7,7 @@
   height: 273px;
   padding: 16px 24px 32px;
   font-family: $font-roboto;
-  background: $pix-neutral-0;
+  background: var(--pix-neutral-0);
   border-radius: 8px;
   box-shadow: 0 2px 0 0 rgb(23 43 77 / 6%);
 
@@ -28,10 +28,10 @@
     min-height: 50px;
     max-height: 50px;
     margin-bottom: 12px;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-weight: $font-medium;
     font-size: 1.125rem;
-    background-color: $pix-neutral-10;
+    background-color: var(--pix-neutral-20);
     border-radius: 4px;
   }
 
@@ -69,7 +69,7 @@
 
   &__title {
     overflow: hidden;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-weight: $font-medium;
     font-size: 1.125rem;
     line-height: normal;
@@ -80,13 +80,13 @@
   &__subtitle {
     display: block;
     margin-top: 8px;
-    color: $pix-neutral-50;
+    color: var(--pix-neutral-100);
     font-weight: $font-medium;
     font-size: 0.875rem;
   }
 
   &__date {
-    color: $pix-neutral-50;
+    color: var(--pix-neutral-100);
     font-size: 0.8125rem;
   }
 }

--- a/mon-pix/app/styles/components/campaigns/assessment/skill-review/share-badge-icons.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/skill-review/share-badge-icons.scss
@@ -28,19 +28,19 @@
 
 // Certifiable badge item
 .skill-review-share-badge-icons__item--certifiable {
-  background-color: $pix-success-5;
+  background-color: var(--pix-success-50);
 
   & + .skill-review-share-badge-icons__item--certifiable::before {
-    background-color: $pix-success-5;
+    background-color: var(--pix-success-50);
   }
 }
 
 // Not certifiable badge item
 .skill-review-share-badge-icons__item--not-certifiable {
-  background-color: $pix-neutral-10;
+  background-color: var(--pix-neutral-20);
 
   & + .skill-review-share-badge-icons__item--not-certifiable::before {
-    background-color: $pix-neutral-10;
+    background-color: var(--pix-neutral-20);
   }
 }
 

--- a/mon-pix/app/styles/components/campaigns/assessment/skill-review/share-badge-icons.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/skill-review/share-badge-icons.scss
@@ -1,6 +1,6 @@
 .skill-review-share__badge-icons {
   display: flex;
-  margin-top: $pix-spacing-s;
+  margin-top: var(--pix-spacing-4x);
 }
 
 /*
@@ -8,7 +8,7 @@
  */
 [class*='skill-review-share-badge-icons__item'] {
   position: relative;
-  padding: $pix-spacing-xs;
+  padding: var(--pix-spacing-2x);
   border-radius: 1rem;
 
   & > * {
@@ -45,7 +45,7 @@
 }
 
 .skill-review-share-badge-icons__item--certifiable + .skill-review-share-badge-icons__item--not-certifiable {
-  margin-left: $pix-spacing-xs;
+  margin-left: var(--pix-spacing-2x);
 }
 
 /*

--- a/mon-pix/app/styles/components/certifications/certification-ender.scss
+++ b/mon-pix/app/styles/components/certifications/certification-ender.scss
@@ -5,7 +5,7 @@
   padding-top: 10px;
   overflow: hidden;
   line-height: 1.875rem;
-  background-color: $pix-neutral-0;
+  background-color: var(--pix-neutral-0);
 
   &__image {
     display: block;
@@ -24,7 +24,7 @@
 
   &__candidate-name {
     display: block;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-weight: normal;
     font-size: 1.25rem;
     font-family: $font-open-sans;
@@ -33,7 +33,7 @@
 
   &__candidate-title {
     display: block;
-    color: $pix-success-70;
+    color: var(--pix-success-700);
     font-size: 2rem;
     font-family: $font-open-sans;
     line-height: 64px;
@@ -43,7 +43,7 @@
     display: block;
     width: 272px;
     margin: 16px auto auto;
-    color: $pix-neutral-50;
+    color: var(--pix-neutral-100);
     font-size: 1rem;
     font-family: $font-roboto;
     line-height: 22px;
@@ -56,7 +56,7 @@
 
       &__content {
         margin-left: 16px;
-        color: $pix-neutral-50;
+        color: var(--pix-neutral-100);
         font-size: 14px;
         line-height: 20px;
       }
@@ -75,7 +75,7 @@
     display: block;
     width: 272px;
     margin: auto;
-    color: $pix-neutral-50;
+    color: var(--pix-neutral-100);
     font-size: 0.875rem;
     font-family: $font-roboto;
     line-height: 22px;
@@ -84,14 +84,14 @@
   &__results {
     margin: 8px;
     padding: 16px 24px;
-    background-color: $pix-neutral-10;
+    background-color: var(--pix-neutral-20);
     border-radius: 10px;
     box-shadow: 0 2px 5px 0 rgb(0 0 0 / 5%);
   }
 
   &__results-disclaimer {
     margin-bottom: 8px;
-    color: $pix-success-70;
+    color: var(--pix-success-700);
     font-weight: 600;
     font-size: 0.875rem;
     font-family: $font-open-sans;
@@ -102,14 +102,14 @@
   &__results-title {
     display: block;
     margin-bottom: 6px;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-size: 1.25rem;
     font-family: $font-open-sans;
   }
 
   &__results-steps {
     display: block;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-size: 0.875rem;
     font-family: $font-roboto;
     line-height: 22px;

--- a/mon-pix/app/styles/components/dashboard/_content.scss
+++ b/mon-pix/app/styles/components/dashboard/_content.scss
@@ -1,6 +1,6 @@
 @mixin add-dashboard-content-separator() {
   padding: 24px 0;
-  border-bottom: 1px solid $pix-neutral-20;
+  border-bottom: 1px solid var(--pix-neutral-20);
 }
 
 .dashboard-content {
@@ -127,7 +127,7 @@
     flex-direction: column;
     align-items: center;
     padding: 19px 0;
-    background-color: $pix-neutral-0;
+    background-color: var(--pix-neutral-0);
     border-radius: 10px;
     box-shadow: 0 1px 0 0 rgb(23 43 77 / 12%);
 
@@ -141,23 +141,23 @@
 .dashboard-content-score-wrapper {
   &__button {
     padding-top: 10px;
-    color: $pix-primary;
+    color: var(--pix-primary-500);
 
     &:hover,
     &:focus {
-      color: $pix-primary-70;
+      color: var(--pix-primary-700);
       text-decoration: underline;
     }
 
     &:visited {
-      color: $pix-tertiary-70;
+      color: var(--pix-tertiary-900);
     }
   }
 }
 
 .dashboard-section {
   &__title {
-    color: $pix-neutral-80;
+    color: var(--pix-neutral-800);
     font-weight: $font-medium;
     font-size: 1.125rem;
     font-family: $font-open-sans;
@@ -167,7 +167,7 @@
 
   &__subtitle {
     margin: 4px 0 24px;
-    color: $pix-neutral-50;
+    color: var(--pix-neutral-100);
     font-size: 0.8125rem;
     font-family: $font-roboto;
     letter-spacing: 0.009rem;
@@ -184,13 +184,13 @@
   &__button {
     display: none;
     padding: 10px 16px;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-size: 0.875rem;
-    border: 1px solid $pix-neutral-50;
+    border: 1px solid var(--pix-neutral-100);
     border-radius: 4px;
 
     &:hover {
-      background-color: darken($pix-neutral-10, 5%);
+      background-color: darken(var(--pix-neutral-20), 5%);
     }
 
     @include device-is('tablet') {

--- a/mon-pix/app/styles/components/sitemap/_content.scss
+++ b/mon-pix/app/styles/components/sitemap/_content.scss
@@ -9,7 +9,7 @@
     list-style: none;
 
     a {
-      color: $pix-primary-60;
+      color: var(--pix-primary-700);
     }
   }
 
@@ -30,7 +30,7 @@
 
   &__title {
     margin-top: 48px;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-weight: $font-normal;
     font-size: 3rem;
     line-height: 4.125rem;
@@ -46,7 +46,7 @@
     }
 
     a:visited {
-      color: $pix-primary_80;
+      color: var(--pix-primary-500)_80;
       text-decoration: none;
     }
   }
@@ -60,7 +60,7 @@
     font-size: 2rem;
 
     &--title {
-      color: $pix-neutral-60;
+      color: var(--pix-neutral-500);
     }
   }
 }
@@ -70,7 +70,7 @@
   &__resources {
 
     li::before {
-      color: $pix-neutral-45;
+      color: var(--pix-neutral-500);
       content: '•';
     }
   }
@@ -79,7 +79,7 @@
 .sitemap-content-items-link-skills {
 
   li::before {
-    color: $pix-neutral-45;
+    color: var(--pix-neutral-500);
     content: '•';
   }
 

--- a/mon-pix/app/styles/components/user-account/_email-verification-code.scss
+++ b/mon-pix/app/styles/components/user-account/_email-verification-code.scss
@@ -1,5 +1,5 @@
 .email-verification-code {
-  color: $pix-neutral-70;
+  color: var(--pix-neutral-800);
 
   &__description {
     font-size: 0.875rem;
@@ -36,7 +36,7 @@
     button {
       margin-left: 2px;
       padding: 0;
-      color: $pix-primary;
+      color: var(--pix-primary-500);
       font-size: 1rem;
       font-family: $font-roboto;
       background-color: transparent;

--- a/mon-pix/app/styles/components/user-account/_update-email-with-validation.scss
+++ b/mon-pix/app/styles/components/user-account/_update-email-with-validation.scss
@@ -25,11 +25,11 @@
 
   &__informations {
     padding: 32px 0 16px;
-    color: $pix-neutral-70;
+    color: var(--pix-neutral-800);
     font-size: 0.875rem;
     font-family: $font-roboto;
     line-height: 1.5rem;
-    border-top: 1px solid $pix-neutral-20;
+    border-top: 1px solid var(--pix-neutral-20);
 
     @include device-is('tablet') {
       margin-right: 8px;

--- a/mon-pix/app/styles/components/user-tutorials/_sidebar.scss
+++ b/mon-pix/app/styles/components/user-tutorials/_sidebar.scss
@@ -6,7 +6,7 @@
       position: relative;
       align-items: center;
       padding-left: 2rem;
-      color: $pix-neutral-70;
+      color: var(--pix-neutral-800);
       font-weight: 500;
       font-size: 0.875rem;
       font-family: $font-open-sans;
@@ -24,23 +24,23 @@
       }
 
       &.jaffa::before {
-        border-color: $pix-information-light;
+        border-color: var(--pix-information-light);
       }
 
       &.emerald::before {
-        border-color: $pix-content-light;
+        border-color: var(--pix-content-light);
       }
 
       &.cerulean::before {
-        border-color: $pix-communication-light;
+        border-color: var(--pix-communication-light);
       }
 
       &.wild-strawberry::before {
-        border-color: $pix-security-light;
+        border-color: var(--pix-security-light);
       }
 
       &.butterfly-bush::before {
-        border-color: $pix-environment-light;
+        border-color: var(--pix-environment-light);
       }
     }
   }

--- a/mon-pix/app/styles/globals/_alert.scss
+++ b/mon-pix/app/styles/globals/_alert.scss
@@ -1,4 +1,4 @@
 abbr.mandatory-mark {
-  color: $pix-error-70;
+  color: var(--pix-error-700);
   cursor: help;
 }

--- a/mon-pix/app/styles/globals/_buttons.scss
+++ b/mon-pix/app/styles/globals/_buttons.scss
@@ -1,12 +1,12 @@
 .button {
   padding: 5px;
-  color: $pix-neutral-0;
+  color: var(--pix-neutral-0);
   font-weight: 500;
   font-size: 1rem;
   font-family: $font-roboto;
   letter-spacing: 0.012rem;
   text-align: center;
-  background-color: $pix-primary;
+  background-color: var(--pix-primary-500);
   border: none;
   border-radius: 5px;
   outline: none;
@@ -16,7 +16,7 @@
   &:hover,
   &:active,
   &:focus {
-    background-color: $pix-primary-60;
+    background-color: var(--pix-primary-700);
   }
 
   &--link {
@@ -25,7 +25,7 @@
     &:hover,
     &:active,
     &:focus {
-      color: $pix-neutral-0;
+      color: var(--pix-neutral-0);
       text-decoration: none;
     }
   }
@@ -65,88 +65,88 @@
   }
 
   &--grey {
-    color: $pix-neutral-80;
-    background: $pix-neutral-15;
-    border: 2px solid $pix-neutral-40;
+    color: var(--pix-neutral-800);
+    background: var(--pix-neutral-20);
+    border: 2px solid var(--pix-neutral-500);
 
     &:hover,
     &:active,
     &:focus {
-      background-color: $pix-neutral-20;
-      border: 2px solid $pix-neutral-80;
+      background-color: var(--pix-neutral-20);
+      border: 2px solid var(--pix-neutral-800);
     }
   }
 
   &--green {
     color: white;
-    background: $pix-success-60;
+    background: var(--pix-success-700);
 
     &:hover,
     &:active,
     &:focus {
-      background-color: $pix-success-70;
+      background-color: var(--pix-success-700);
     }
   }
 
   &--red {
-    color: $pix-neutral-0;
-    background: $pix-error-60;
+    color: var(--pix-neutral-0);
+    background: var(--pix-error-700);
 
     &:hover,
     &:active,
     &:focus {
-      background-color: $pix-error-70;
-      border: 2px solid $pix-warning-40;
+      background-color: var(--pix-error-700);
+      border: 2px solid var(--pix-warning-500);
     }
   }
 
   &--yellow {
-    color: $pix-neutral-100;
+    color: var(--pix-neutral-900);
     font-weight: $font-bold;
     font-size: 0.906rem;
-    background: $pix-warning-10;
+    background: var(--pix-warning-100);
     box-shadow: 0 2px 6px 0 rgb(12 22 58 / 11%), 0 1px 3px 0 rgb(0 0 0 / 8%);
 
     &:hover,
     &:active,
     &:focus {
-      color: $pix-neutral-100;
-      background-color: $pix-warning-10;
+      color: var(--pix-neutral-900);
+      background-color: var(--pix-warning-100);
     }
   }
 
   &--dark-grey {
-    color: $pix-neutral-0;
+    color: var(--pix-neutral-0);
     font-weight: $font-bold;
     font-size: 0.938rem;
-    background-color: $pix-neutral-60;
+    background-color: var(--pix-neutral-500);
 
     &:hover,
     &:active,
     &:focus {
-      background-color: $pix-neutral-80;
+      background-color: var(--pix-neutral-800);
     }
   }
 
   &--white {
-    color: $pix-neutral-110;
-    background-color: $pix-neutral-0;
+    color: var(--pix-neutral-900);
+    background-color: var(--pix-neutral-0);
 
     &:hover,
     &:active,
     &:focus {
-      background-color: $pix-neutral-20;
+      background-color: var(--pix-neutral-20);
     }
   }
 
   &--no-color {
-    color: $pix-neutral-100;
+    color: var(--pix-neutral-900);
     background-color: transparent;
 
     &:hover,
     &:active,
     &:focus {
-      background-color: $pix-neutral-20;
+      background-color: var(--pix-neutral-20);
     }
   }
 
@@ -157,7 +157,7 @@
     &:hover,
     &:focus-within {
       border: 2px solid white;
-      box-shadow: 0 0 0 2px $pix-primary;
+      box-shadow: 0 0 0 2px var(--pix-primary-500);
     }
   }
 
@@ -168,7 +168,7 @@
 
 .icon-button {
   padding: 4px 8px;
-  color: $pix-neutral-60;
+  color: var(--pix-neutral-500);
   font-size: 1rem;
   background-color: transparent;
   border: none;
@@ -179,7 +179,7 @@
 
   &:hover,
   &:active {
-    background-color: $pix-neutral-20;
+    background-color: var(--pix-neutral-20);
   }
 }
 
@@ -190,7 +190,7 @@
 }
 
 .link {
-  color: $pix-primary;
+  color: var(--pix-primary-500);
   text-decoration: none;
   background-color: inherit;
   border: none;
@@ -199,14 +199,14 @@
   &:hover,
   &:focus,
   &:active {
-    color: $pix-primary-60;
+    color: var(--pix-primary-700);
     text-decoration: underline;
     cursor: pointer;
   }
 
   &:focus-visible {
     border-radius: 2px;
-    outline: 1.5px solid $pix-primary;
+    outline: 1.5px solid var(--pix-primary-500);
     outline-offset: 1px;
   }
 
@@ -215,6 +215,6 @@
   }
 
   &--grey {
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
   }
 }

--- a/mon-pix/app/styles/globals/_inputs.scss
+++ b/mon-pix/app/styles/globals/_inputs.scss
@@ -2,7 +2,7 @@ input.input-code {
   box-sizing: content-box;
   min-height: 50px;
   padding: 0 1px 1px 0.5ch;
-  color: $pix-neutral-70;
+  color: var(--pix-neutral-800);
   font-size: 1.875rem;
   font-family: $font-roboto-mono;
   letter-spacing: 0.5ch;
@@ -10,13 +10,13 @@ input.input-code {
   background:
     repeating-linear-gradient(
         90deg,
-        $pix-neutral-22 0,
-        $pix-neutral-22 1ch,
+        var(--pix-neutral-100) 0,
+        var(--pix-neutral-100) 1ch,
         transparent 0,
         transparent 1.5ch
       ) 0 96% / 98% 2px no-repeat;
   background-origin: content-box;
-  border: solid 2px $pix-neutral-20;
+  border: solid 2px var(--pix-neutral-20);
   border-radius: 3px;
 
   @media all and (-ms-high-contrast: none) {
@@ -26,8 +26,8 @@ input.input-code {
     background:
       repeating-linear-gradient(
           90deg,
-          $pix-neutral-22 0,
-          $pix-neutral-22 1.33ch,
+          var(--pix-neutral-100) 0,
+          var(--pix-neutral-100) 1.33ch,
           transparent 0,
           transparent 1.733ch
         ) 0 96% / 98% 2px no-repeat;

--- a/mon-pix/app/styles/globals/_layout.scss
+++ b/mon-pix/app/styles/globals/_layout.scss
@@ -1,6 +1,6 @@
 body {
-  color: $pix-neutral-70;
-  background-color: $pix-neutral-10;
+  color: var(--pix-neutral-800);
+  background-color: var(--pix-neutral-20);
 }
 
 .body {

--- a/mon-pix/app/styles/globals/_loading.scss
+++ b/mon-pix/app/styles/globals/_loading.scss
@@ -9,7 +9,7 @@
   justify-content: center;
   width: 100%;
   height: 100%;
-  background-color: $pix-neutral-10;
+  background-color: var(--pix-neutral-20);
 }
 
 .app-loader__text {

--- a/mon-pix/app/styles/globals/_tables.scss
+++ b/mon-pix/app/styles/globals/_tables.scss
@@ -9,7 +9,7 @@
   thead {
     display: none;
     width: 100%;
-    color: $pix-neutral-80;
+    color: var(--pix-neutral-800);
 
     @include device-is('tablet') {
       display: table-header-group;
@@ -17,14 +17,14 @@
   }
 
   tbody {
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
   }
 
   tr {
     display: flex;
     flex-direction: column;
     width: 100%;
-    border-bottom: 1px solid $pix-neutral-10;
+    border-bottom: 1px solid var(--pix-neutral-20);
 
     @include device-is('tablet') {
       display: table-row;
@@ -33,7 +33,7 @@
   }
 
   th {
-    border-top: 1px solid $pix-neutral-10;
+    border-top: 1px solid var(--pix-neutral-20);
   }
 
   td,

--- a/mon-pix/app/styles/globals/_text.scss
+++ b/mon-pix/app/styles/globals/_text.scss
@@ -1,12 +1,12 @@
 .score-label {
-  color: $pix-neutral-100;
+  color: var(--pix-neutral-900);
   font-size: 0.625rem;
   letter-spacing: 0.156rem;
   text-transform: uppercase;
 }
 
 .score-value {
-  color: $pix-neutral-110;
+  color: var(--pix-neutral-900);
   font-size: 2.875rem;
   font-family: $font-open-sans;
   line-height: 2.875rem;
@@ -16,7 +16,7 @@
   position: relative;
   z-index: 1;
   margin-bottom: 20px;
-  color: $pix-neutral-80;
+  color: var(--pix-neutral-800);
   font-weight: $font-medium;
   font-size: 1.375rem;
 

--- a/mon-pix/app/styles/pages/_account-recovery.scss
+++ b/mon-pix/app/styles/pages/_account-recovery.scss
@@ -2,7 +2,7 @@
   display: flex;
   min-height: 100vh;
   padding: 30px;
-  background-color: $pix-neutral-0;
+  background-color: var(--pix-neutral-0);
 
   @include device-is('tablet') {
     padding: 56px 60px;
@@ -12,7 +12,7 @@
     position: relative;
     display: flex;
     flex-direction: column;
-    background-color: $pix-neutral-0;
+    background-color: var(--pix-neutral-0);
 
     @include device-is('desktop') {
       flex: 1 1 0;
@@ -69,7 +69,7 @@
 
     &--title {
       margin-bottom: 16px;
-      color: $pix-neutral-90;
+      color: var(--pix-neutral-900);
       font-weight: 400;
       font-size: 1.5rem;
       font-family: $font-open-sans;
@@ -78,22 +78,22 @@
 
     &--information-text {
       margin: 0;
-      color: $pix-neutral-90;
+      color: var(--pix-neutral-900);
       font-family: $font-roboto;
 
       a {
-        color: $pix-communication-dark;
+        color: var(--pix-communication-dark);
       }
 
       &--details {
         margin-top: 16px;
         margin-bottom: 24px;
-        color: $pix-neutral-90;
+        color: var(--pix-neutral-900);
         font-size: 0.875rem;
         font-family: $font-roboto;
 
         a {
-          color: $pix-communication-dark;
+          color: var(--pix-communication-dark);
         }
 
         &.checkbox-with-label {
@@ -120,7 +120,7 @@
       margin-top: 20px;
 
       a {
-        color: $pix-communication-dark;
+        color: var(--pix-communication-dark);
       }
     }
 

--- a/mon-pix/app/styles/pages/_assessment-results.scss
+++ b/mon-pix/app/styles/pages/_assessment-results.scss
@@ -14,7 +14,7 @@
   max-width: 800px;
   margin-top: -60px;
   padding: 30px;
-  background: $pix-neutral-0;
+  background: var(--pix-neutral-0);
   border-radius: 10px;
   box-shadow: 0 7px 14px 0 rgb(12 22 58 / 10%), 0 3px 6px 0 rgb(0 0 0 / 10%);
 }
@@ -54,7 +54,7 @@
 }
 
 .assessment-results__link-back {
-  color: $pix-neutral-0;
+  color: var(--pix-neutral-0);
   font-weight: $font-medium;
   font-size: 1rem;
   font-family: $font-open-sans;

--- a/mon-pix/app/styles/pages/_campaign-landing-page.scss
+++ b/mon-pix/app/styles/pages/_campaign-landing-page.scss
@@ -1,6 +1,6 @@
 /* ------------------------ START ------------------------ */
 .campaign-landing-page__container {
-  margin-bottom: $pix-spacing-xxl;
+  margin-bottom: var(--pix-spacing-12x);
 }
 
 .campaign-landing-page__container__start {
@@ -8,7 +8,7 @@
   flex-direction: column;
   align-items: center;
   margin-bottom: 25px;
-  padding-bottom: $pix-spacing-xl;
+  padding-bottom: var(--pix-spacing-10x);
 }
 
 .campaign-landing-page__start__image__container {
@@ -59,7 +59,7 @@
   }
 
   &__announcement {
-    margin-top: $pix-spacing-s;
+    margin-top: var(--pix-spacing-4x);
     font-size: 1.125rem;
   }
 
@@ -105,7 +105,7 @@
 }
 
 .campaign-landing-page__start__warning {
-  margin-top: $pix-spacing-xl;
+  margin-top: var(--pix-spacing-10x);
   color: var(--pix-neutral-900);
   font-size: 0.875rem;
   text-align: center;

--- a/mon-pix/app/styles/pages/_campaign-landing-page.scss
+++ b/mon-pix/app/styles/pages/_campaign-landing-page.scss
@@ -64,7 +64,7 @@
   }
 
   &__legal {
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-size: 0.75rem;
   }
 }
@@ -76,7 +76,7 @@
   font-size: 1rem;
   font-family: $font-open-sans;
   text-align: left;
-  border-top: 1px dashed $pix-neutral-22;
+  border-top: 1px dashed var(--pix-neutral-100);
 
   strong {
     font-weight: $font-medium;
@@ -106,7 +106,7 @@
 
 .campaign-landing-page__start__warning {
   margin-top: $pix-spacing-xl;
-  color: $pix-neutral-90;
+  color: var(--pix-neutral-900);
   font-size: 0.875rem;
   text-align: center;
 }

--- a/mon-pix/app/styles/pages/_campaign-tutorial.scss
+++ b/mon-pix/app/styles/pages/_campaign-tutorial.scss
@@ -2,7 +2,7 @@
   display: flex;
   width: 100%;
   height: 100vh;
-  background: $pix-secondary-app-gradient;
+  background: $pix-primary-app-gradient;
 
   &__container {
     max-width: 800px;
@@ -19,7 +19,7 @@
   }
 
   &__title {
-    color: $pix-primary;
+    color: var(--pix-primary-500);
     font-weight: 600;
     font-size: 1.25rem;
     font-family: $font-open-sans;
@@ -42,7 +42,7 @@
   }
 
   &__explanation-text {
-    color: $pix-neutral-100;
+    color: var(--pix-neutral-900);
     font-size: 1.125rem;
     font-family: $font-open-sans;
     white-space: pre-line;
@@ -69,11 +69,11 @@
       width: 10px;
       height: 10px;
       margin: 2px;
-      background-color: $pix-neutral-22;
+      background-color: var(--pix-neutral-100);
       border-radius: 50%;
 
       &__active {
-        background-color: $pix-primary;
+        background-color: var(--pix-primary-500);
       }
     }
   }

--- a/mon-pix/app/styles/pages/_challenge.scss
+++ b/mon-pix/app/styles/pages/_challenge.scss
@@ -12,7 +12,7 @@
   /* CSS patch to delete when screen improved */
   &-statement {
     p + p {
-      margin-top: $pix-spacing-xxs;
+      margin-top: var(--pix-spacing-1x);
     }
 
     h2 {
@@ -55,7 +55,7 @@
     z-index: 1;
     width: 100%;
     max-width: 990px;
-    margin: $pix-spacing-s 0;
+    margin: var(--pix-spacing-4x) 0;
     padding: 0 20px;
     text-align: left;
 

--- a/mon-pix/app/styles/pages/_challenge.scss
+++ b/mon-pix/app/styles/pages/_challenge.scss
@@ -69,10 +69,10 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    color: $pix-primary-70;
-    background-color: rgba($pix-primary-20, 0.9);
+    color: var(--pix-primary-700);
+    background-color: rgba(var(--pix-primary-100), 0.9);
     border-radius: 51px;
-    box-shadow: 0 10px 20px 0 rgba($pix-content-dark, 0.06);
+    box-shadow: 0 10px 20px 0 rgba(var(--pix-content-dark), 0.06);
 
     &.challenge__info-alert--hide {
       height: 0;

--- a/mon-pix/app/styles/pages/_competence-results.scss
+++ b/mon-pix/app/styles/pages/_competence-results.scss
@@ -10,7 +10,7 @@
 
     &-result-comment {
       margin: 0;
-      color: $pix-neutral-0;
+      color: var(--pix-neutral-0);
       font-weight: $font-bold;
       font-size: 3rem;
       font-family: $font-open-sans;
@@ -90,7 +90,7 @@
 
   &__subtitle {
     margin-top: 14px;
-    color: $pix-neutral-0;
+    color: var(--pix-neutral-0);
     font-size: 1.125rem;
     font-family: $font-open-sans;
     text-align: center;
@@ -158,14 +158,14 @@
 .competence-results-banner-text-results {
 
   &__label {
-    color: $pix-neutral-0;
+    color: var(--pix-neutral-0);
     font-size: 0.875rem;
     font-family: $font-open-sans;
   }
 
   &__value {
     padding: 0 10px;
-    color: $pix-neutral-0;
+    color: var(--pix-neutral-0);
     font-size: 1.5rem;
     font-family: $font-open-sans;
     text-transform: capitalize;

--- a/mon-pix/app/styles/pages/_connection-methods.scss
+++ b/mon-pix/app/styles/pages/_connection-methods.scss
@@ -1,7 +1,7 @@
 .user-account-panel__item {
   display: flex;
   flex-wrap: wrap;
-  gap: $pix-spacing-m;
+  gap: var(--pix-spacing-6x);
   justify-content: space-between;
   padding-top: 16px;
   padding-bottom: 16px;
@@ -28,7 +28,7 @@
 .user-account-panel-item__text {
   display: flex;
   flex-wrap: wrap;
-  gap: $pix-spacing-xs;
+  gap: var(--pix-spacing-2x);
 }
 
 .user-account-panel-item__label {

--- a/mon-pix/app/styles/pages/_connection-methods.scss
+++ b/mon-pix/app/styles/pages/_connection-methods.scss
@@ -5,7 +5,7 @@
   justify-content: space-between;
   padding-top: 16px;
   padding-bottom: 16px;
-  border-top: $pix-neutral-15 1px solid;
+  border-top: var(--pix-neutral-20) 1px solid;
 
   &--with-success-message {
     margin: 20px 0 0;
@@ -42,7 +42,7 @@
   display: flex;
   align-items: center;
   margin: 0;
-  color: $pix-neutral-50;
+  color: var(--pix-neutral-100);
 }
 
 .user-account-panel-item__edit-button {

--- a/mon-pix/app/styles/pages/_course-preview.scss
+++ b/mon-pix/app/styles/pages/_course-preview.scss
@@ -1,4 +1,4 @@
 #course-preview strong {
-  color: $pix-primary;
+  color: var(--pix-primary-500);
   font-weight: $font-medium;
 }

--- a/mon-pix/app/styles/pages/_error.scss
+++ b/mon-pix/app/styles/pages/_error.scss
@@ -7,8 +7,8 @@
   &__error {
     margin: 20px;
     padding: 20px;
-    color: $pix-neutral-45;
-    background: $pix-neutral-15;
+    color: var(--pix-neutral-500);
+    background: var(--pix-neutral-20);
   }
 
   &__error-title {
@@ -31,7 +31,7 @@
   align-items: center;
   margin: 0 20px;
   padding: 40px;
-  border-bottom: 1px dashed $pix-neutral-50;
+  border-bottom: 1px dashed var(--pix-neutral-100);
 
   @include device-is('desktop') {
     padding: 80px 0;

--- a/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
@@ -21,7 +21,7 @@
   &__instruction {
     max-width: 600px;
     margin-bottom: $pix-spacing-s;
-    color: $pix-neutral-100;
+    color: var(--pix-neutral-900);
     font-size: 1.219rem;
     font-family: $font-open-sans;
     text-align: center;
@@ -61,7 +61,7 @@
 
   &__error {
     margin-bottom: $pix-spacing-s;
-    color: $pix-warning-60;
+    color: var(--pix-warning-700);
     font-size: 0.875rem;
     text-align: center;
   }
@@ -69,7 +69,7 @@
   &__warning {
     margin-top: $pix-spacing-s;
     margin-bottom: $pix-spacing-s;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-size: 0.875rem;
     text-align: center;
   }
@@ -78,7 +78,7 @@
     max-width: 600px;
     padding-top: 25px;
     text-align: center;
-    border-top: 1px solid $pix-neutral-15;
+    border-top: 1px solid var(--pix-neutral-20);
 
     @include device-is('tablet') {
       width: 75vw;
@@ -100,5 +100,5 @@
 .mediacentre-start-campaign-modal-action-buttons__continue-action {
   @extend %pix-body-s;
 
-  color: $pix-primary;
+  color: var(--pix-primary-500);
 }

--- a/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
@@ -5,22 +5,22 @@
     align-items: center;
     width: 100%;
     margin-bottom: 32px;
-    padding: 16px 16px $pix-spacing-s;
+    padding: 16px 16px var(--pix-spacing-4x);
 
     @include device-is('tablet') {
-      padding: $pix-spacing-xl;
+      padding: var(--pix-spacing-10x);
     }
   }
 
   &__title {
-    margin-bottom: $pix-spacing-l;
+    margin-bottom: var(--pix-spacing-8x);
     font-size: 2rem;
     text-align: center;
   }
 
   &__instruction {
     max-width: 600px;
-    margin-bottom: $pix-spacing-s;
+    margin-bottom: var(--pix-spacing-4x);
     color: var(--pix-neutral-900);
     font-size: 1.219rem;
     font-family: $font-open-sans;
@@ -37,7 +37,7 @@
 
   &__form-field {
     display: inline-block;
-    margin-bottom: $pix-spacing-s;
+    margin-bottom: var(--pix-spacing-4x);
     text-align: left;
 
     input {
@@ -56,19 +56,19 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin-bottom: $pix-spacing-s;
+    margin-bottom: var(--pix-spacing-4x);
   }
 
   &__error {
-    margin-bottom: $pix-spacing-s;
+    margin-bottom: var(--pix-spacing-4x);
     color: var(--pix-warning-700);
     font-size: 0.875rem;
     text-align: center;
   }
 
   &__warning {
-    margin-top: $pix-spacing-s;
-    margin-bottom: $pix-spacing-s;
+    margin-top: var(--pix-spacing-4x);
+    margin-bottom: var(--pix-spacing-4x);
     color: var(--pix-neutral-900);
     font-size: 0.875rem;
     text-align: center;

--- a/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
@@ -16,7 +16,7 @@
 
     .form__title {
       margin-bottom: 16px;
-      color: $pix-neutral-80;
+      color: var(--pix-neutral-800);
       font-size: 2rem;
       font-family: $font-open-sans;
     }
@@ -24,7 +24,7 @@
     .form__description {
       max-width: 500px;
       margin-bottom: 32px;
-      color: $pix-neutral-60;
+      color: var(--pix-neutral-500);
       line-height: 22px;
     }
 
@@ -34,7 +34,7 @@
 
       label {
         margin-bottom: 6px;
-        color: $pix-neutral-100;
+        color: var(--pix-neutral-900);
         font-weight: $font-normal;
         font-size: 0.875rem;
         line-height: 22px;
@@ -61,7 +61,7 @@
 
     .form__error--validation {
       margin: 16px 10px 0;
-      color: $pix-error-60;
+      color: var(--pix-error-700);
       font-size: 0.875rem;
     }
 

--- a/mon-pix/app/styles/pages/_fill-in-participant-external-id.scss
+++ b/mon-pix/app/styles/pages/_fill-in-participant-external-id.scss
@@ -59,7 +59,7 @@
 .fill-in-participant-external-id__form-field input {
   width: 232px;
   height: 43px;
-  margin-right: $pix-spacing-xs;
+  margin-right: var(--pix-spacing-2x);
   padding: 4px 8px;
   border: solid 2px var(--pix-neutral-20);
   border-radius: 3px;

--- a/mon-pix/app/styles/pages/_fill-in-participant-external-id.scss
+++ b/mon-pix/app/styles/pages/_fill-in-participant-external-id.scss
@@ -61,7 +61,7 @@
   height: 43px;
   margin-right: $pix-spacing-xs;
   padding: 4px 8px;
-  border: solid 2px $pix-neutral-20;
+  border: solid 2px var(--pix-neutral-20);
   border-radius: 3px;
   outline: none;
 }

--- a/mon-pix/app/styles/pages/_inscription.scss
+++ b/mon-pix/app/styles/pages/_inscription.scss
@@ -1,3 +1,3 @@
 .sign-form-page__container {
-  margin: $pix-spacing-s;
+  margin: var(--pix-spacing-4x);
 }

--- a/mon-pix/app/styles/pages/_join-restricted-campaign.scss
+++ b/mon-pix/app/styles/pages/_join-restricted-campaign.scss
@@ -10,15 +10,15 @@
     width: 100%;
     height: 50px;
     padding-left: 10px;
-    border: 2px solid $pix-neutral-20;
+    border: 2px solid var(--pix-neutral-20);
     border-radius: 4px;
 
     &[disabled] {
-      background-color: $pix-neutral-20;
+      background-color: var(--pix-neutral-20);
     }
 
     &.input--error {
-      border-color: $pix-warning-60;
+      border-color: var(--pix-warning-700);
     }
   }
 
@@ -32,7 +32,7 @@
 
   &__title,
   &__sco-title {
-    color: $pix-neutral-100;
+    color: var(--pix-neutral-900);
     font-family: $font-open-sans;
     text-align: center;
   }
@@ -54,7 +54,7 @@
 
   &__subtitle {
     margin-bottom: 30px;
-    color: $pix-neutral-100;
+    color: var(--pix-neutral-900);
     font-size: 1.125rem;
     font-family: $font-open-sans;
     text-align: center;
@@ -68,14 +68,14 @@
   }
 
   &__field-error {
-    color: $pix-error-60;
+    color: var(--pix-error-700);
     font-size: 0.875rem;
   }
 
   &__error {
     margin: 8px 0;
     padding: 4px 10px;
-    color: $pix-error-60;
+    color: var(--pix-error-700);
     font-size: 0.938rem;
     text-align: center;
 
@@ -121,7 +121,7 @@
 }
 
 .ember-modal-overlay.translucent {
-  background-color: rgba(red($pix-neutral-110), green($pix-neutral-110), blue($pix-neutral-110), 40%);
+  background-color: rgba(red(var(--pix-neutral-900)), green($pix-neutral-110), blue($pix-neutral-110), 40%);
 }
 
 .join-error-modal {
@@ -134,20 +134,20 @@
     justify-content: space-between;
     height: 78px;
     padding: 20px;
-    background-color: $pix-neutral-0;
+    background-color: var(--pix-neutral-0);
   }
 
   &__body {
     display: flex;
     flex-direction: column;
     justify-content: center;
-    background-color: $pix-neutral-10;
+    background-color: var(--pix-neutral-20);
   }
 
   &__footer {
     display: flex;
     justify-content: center;
-    background-color: $pix-neutral-10;
+    background-color: var(--pix-neutral-20);
 
     > button {
       margin: 0 8px;
@@ -165,7 +165,7 @@
 .join-error-modal-header-title {
   &__text {
     margin-left: 8px;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-weight: $font-normal;
     font-size: 1.25rem;
     font-family: $font-open-sans;
@@ -178,15 +178,15 @@
     width: 32px;
     height: 32px;
     padding: 8px;
-    color: $pix-neutral-45;
-    background-color: $pix-neutral-15;
+    color: var(--pix-neutral-500);
+    background-color: var(--pix-neutral-20);
     border-radius: 50px;
   }
 }
 
 .join-error-modal-body {
   &__message {
-    color: $pix-neutral-110;
+    color: var(--pix-neutral-900);
     font-weight: $font-normal;
     font-size: 0.875rem;
     font-family: $font-roboto;

--- a/mon-pix/app/styles/pages/_language.scss
+++ b/mon-pix/app/styles/pages/_language.scss
@@ -1,7 +1,7 @@
 .language {
-  padding: $pix-spacing-xs 0;
+  padding: var(--pix-spacing-2x) 0;
 
   &__notification {
-    margin-top: $pix-spacing-s;
+    margin-top: var(--pix-spacing-4x);
   }
 }

--- a/mon-pix/app/styles/pages/_not-connected.scss
+++ b/mon-pix/app/styles/pages/_not-connected.scss
@@ -20,7 +20,7 @@
 
   &__text-block {
     padding-top: 30px;
-    color: $pix-neutral-80;
+    color: var(--pix-neutral-800);
     font-size: 1.875rem;
     line-height: 46px;
     text-align: center;

--- a/mon-pix/app/styles/pages/_personal-information.scss
+++ b/mon-pix/app/styles/pages/_personal-information.scss
@@ -9,7 +9,7 @@
   align-content: flex-start;
   margin: 20px 0;
   padding-bottom: 1rem;
-  border-bottom: $pix-neutral-15 1px solid;
+  border-bottom: var(--pix-neutral-20) 1px solid;
 
   &:last-child {
     padding-bottom: 0;
@@ -25,13 +25,13 @@
 
   &__value {
     margin: 0;
-    color: $pix-neutral-50;
+    color: var(--pix-neutral-100);
   }
 
   &__select {
     width: 165px;
     margin: 0;
-    color: $pix-neutral-50;
+    color: var(--pix-neutral-100);
   }
 }
 

--- a/mon-pix/app/styles/pages/_profile-already-shared.scss
+++ b/mon-pix/app/styles/pages/_profile-already-shared.scss
@@ -5,7 +5,7 @@
   margin-top: 40px;
   padding-top: 20px;
   padding-bottom: 20px;
-  border-top: 1px dashed $pix-neutral-22;
+  border-top: 1px dashed var(--pix-neutral-100);
 
   &__message {
     font-size: 1.5rem;

--- a/mon-pix/app/styles/pages/_send-profile.scss
+++ b/mon-pix/app/styles/pages/_send-profile.scss
@@ -19,7 +19,7 @@
   }
 
   &__title {
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-size: 2rem;
     font-family: $font-open-sans;
     text-align: center;
@@ -27,7 +27,7 @@
 
   &__instruction {
     margin: 30px;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-size: 1.25rem;
     font-family: $font-open-sans;
     line-height: 2.5rem;
@@ -39,7 +39,7 @@
     flex-flow: column;
     align-items: center;
     padding: 20px;
-    background-color: $pix-neutral-10;
+    background-color: var(--pix-neutral-20);
     border-radius: 6px;
   }
 
@@ -51,10 +51,10 @@
     margin-bottom: 39px;
     padding-top: 36px;
     padding-bottom: 22px;
-    border-top: 1px dashed $pix-neutral-22;
+    border-top: 1px dashed var(--pix-neutral-100);
 
     &--with-border-bottom {
-      border-bottom: 1px dashed $pix-neutral-22;
+      border-bottom: 1px dashed var(--pix-neutral-100);
     }
 
     &__cards {
@@ -65,7 +65,7 @@
 
   &__recipient {
     margin-bottom: 1em;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-weight: $font-medium;
     font-size: 1.25rem;
     font-family: $font-open-sans;
@@ -76,7 +76,7 @@
   &__text {
     max-width: 640px;
     margin: 30px auto 60px;
-    color: $pix-neutral-35;
+    color: var(--pix-neutral-100);
     font-size: 1.375rem;
     font-family: $font-open-sans;
     text-align: center;

--- a/mon-pix/app/styles/pages/_sign-form.scss
+++ b/mon-pix/app/styles/pages/_sign-form.scss
@@ -23,7 +23,7 @@
     flex-direction: column;
     align-items: center;
     max-width: 609px;
-    margin-bottom: $pix-spacing-s;
+    margin-bottom: var(--pix-spacing-4x);
     padding: 20px 10px;
     background-color: var(--pix-neutral-0);
     border-radius: 10px;
@@ -103,7 +103,7 @@
   &__inputs {
     display: flex;
     flex-direction: column;
-    gap: $pix-spacing-s;
+    gap: var(--pix-spacing-4x);
     align-items: center;
   }
 
@@ -202,8 +202,8 @@
     }
 
     &__logo {
-      width: $pix-spacing-m;
-      margin: 6px $pix-spacing-xs 6px $pix-spacing-s;
+      width: var(--pix-spacing-6x);
+      margin: 6px var(--pix-spacing-2x) 6px var(--pix-spacing-4x);
 
       &:focus,
       &:hover,
@@ -222,7 +222,7 @@
 }
 
 .oidc-provider-fwb {
-  padding: $pix-spacing-xs $pix-spacing-s $pix-spacing-xs $pix-spacing-xs;
+  padding: var(--pix-spacing-2x) var(--pix-spacing-4x) var(--pix-spacing-2x) var(--pix-spacing-2x);
   color: var(--pix-neutral-900);
   
   &:focus,

--- a/mon-pix/app/styles/pages/_sign-form.scss
+++ b/mon-pix/app/styles/pages/_sign-form.scss
@@ -25,7 +25,7 @@
     max-width: 609px;
     margin-bottom: $pix-spacing-s;
     padding: 20px 10px;
-    background-color: $pix-neutral-0;
+    background-color: var(--pix-neutral-0);
     border-radius: 10px;
 
     @include device-is('tablet') {
@@ -49,7 +49,7 @@
 
   &__notification-message--error {
     margin: 0 0 10px;
-    color: $pix-error-70;
+    color: var(--pix-error-700);
     font-weight: 400;
     font-size: 1rem;
     line-height: 1.625rem;
@@ -63,7 +63,7 @@
   &__validation-error {
     margin: 0;
     padding-bottom: 10px;
-    color: $pix-error-70;
+    color: var(--pix-error-700);
     font-weight: normal;
     font-size: 0.875rem;
   }
@@ -75,7 +75,7 @@
 
     margin-top: var(--pix-spacing-8x);
     margin-bottom: var(--pix-spacing-4x);
-    color: $pix-neutral-80;
+    color: var(--pix-neutral-800);
   }
 
   &__subtitle {
@@ -96,7 +96,7 @@
     @extend %pix-body-s;
 
     margin-top: var(--pix-spacing-4x);
-    color: $pix-neutral-80;
+    color: var(--pix-neutral-800);
     text-align: center;
   }
 
@@ -136,7 +136,7 @@
     margin: var(--pix-spacing-4x) 0;
     line-height: 0.1rem;
     text-align: center;
-    border-bottom: 1.5px solid $pix-neutral-20;
+    border-bottom: 1.5px solid var(--pix-neutral-20);
 
     @include device-is('mobile') {
       width: 100%;
@@ -144,9 +144,9 @@
 
     span {
       padding: 0 10px;
-      color: $pix-neutral-80;
+      color: var(--pix-neutral-800);
       font-size: 16px;
-      background: $pix-neutral-0;
+      background: var(--pix-neutral-0);
     }
   }
 
@@ -163,8 +163,8 @@
     &:focus,
     &:hover,
     &:focus-within {
-      border: 2px solid $pix-neutral-0;
-      box-shadow: 0 0 0 2px $pix-neutral-70;
+      border: 2px solid var(--pix-neutral-0);
+      box-shadow: 0 0 0 2px var(--pix-neutral-800);
     }
 
     img {
@@ -190,15 +190,15 @@
     align-items: center;
     font-weight: $font-medium;
     text-decoration: none;
-    background-color: $pix-neutral-0;
-    border: 1px solid $pix-neutral-50;
+    background-color: var(--pix-neutral-0);
+    border: 1px solid var(--pix-neutral-100);
     border-radius: 100px;
 
     &:focus,
     &:hover,
     &:focus-within {
-      color: $pix-neutral-0;
-      border: 1px solid $pix-neutral-50;
+      color: var(--pix-neutral-0);
+      border: 1px solid var(--pix-neutral-100);
     }
 
     &__logo {
@@ -208,28 +208,28 @@
       &:focus,
       &:hover,
       &:focus-within {
-        color: $pix-neutral-0;
-        background-color: $pix-neutral-0;
+        color: var(--pix-neutral-0);
+        background-color: var(--pix-neutral-0);
       }
     }
   }
 }
 
 .oidc-provider-pole-emploi {
-  color: $pix-neutral-0;
+  color: var(--pix-neutral-0);
   background-color: #1B2E57;
-  border-style : 1px solid $pix-neutral-50;
+  border-style : 1px solid var(--pix-neutral-100);
 }
 
 .oidc-provider-fwb {
   padding: $pix-spacing-xs $pix-spacing-s $pix-spacing-xs $pix-spacing-xs;
-  color: $pix-neutral-90;
+  color: var(--pix-neutral-900);
   
   &:focus,
   &:hover,
   &:focus-within {
-    color: $pix-neutral-0;
-    background-color: $pix-neutral-60;
+    color: var(--pix-neutral-0);
+    background-color: var(--pix-neutral-500);
     border-radius: 0 100px 100px 0;
   }
 }

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -42,18 +42,18 @@
       margin: 0 auto ;
 
       &:first-child {
-        margin-bottom: $pix-spacing-xs;
+        margin-bottom: var(--pix-spacing-2x);
       }
     }
   }
 
   &__action-banner {
-    margin-top: $pix-spacing-s;
+    margin-top: var(--pix-spacing-4x);
   }
 
   &__trainings {
-    margin-top: $pix-spacing-xl;
-    padding: $pix-spacing-l 0;
+    margin-top: var(--pix-spacing-10x);
+    padding: var(--pix-spacing-8x) 0;
     border-top: 2px solid var(--pix-neutral-20);
   }
 
@@ -161,7 +161,7 @@
   &__description {
     @extend %pix-body-s;
 
-    margin-top: $pix-spacing-xs;
+    margin-top: var(--pix-spacing-2x);
     color: var(--pix-neutral-500);
   }
 
@@ -169,7 +169,7 @@
     display: grid;
     grid-template-columns: 1fr;
     align-items: center;
-    margin-top: $pix-spacing-m;
+    margin-top: var(--pix-spacing-6x);
     padding: 0;
     column-gap: 24px;
     row-gap: 24px;
@@ -222,7 +222,7 @@
   }
 
   &__column-header {
-    padding-bottom: $pix-spacing-xs;
+    padding-bottom: var(--pix-spacing-2x);
     text-align: left;
   }
 
@@ -230,16 +230,16 @@
     display: flex;
     align-items: center;
     height: 100%;
-    padding: $pix-spacing-s $pix-spacing-s $pix-spacing-s 0;
+    padding: var(--pix-spacing-4x) var(--pix-spacing-4x) var(--pix-spacing-4x) 0;
   }
 
   &__name {
-    margin-left: $pix-spacing-s;
+    margin-left: var(--pix-spacing-4x);
     text-align: left;
   }
 
   &__border {
-    padding: $pix-spacing-s 0;
+    padding: var(--pix-spacing-4x) 0;
     border-style: solid;
     border-width: 1.5px;
     border-radius: 1.5px;
@@ -275,12 +275,12 @@
   &__title {
     @extend %pix-title-s;
 
-    padding-bottom: $pix-spacing-m;
+    padding-bottom: var(--pix-spacing-6x);
     color: var(--pix-neutral-900);
   }
 
   &__content {
-    padding-top: $pix-spacing-m;
+    padding-top: var(--pix-spacing-6x);
 
     &:nth-child(2) {
       padding-top: 0;
@@ -290,7 +290,7 @@
   &__area {
     display: flex;
     align-items: center;
-    padding-bottom: $pix-spacing-xs;
+    padding-bottom: var(--pix-spacing-2x);
   }
 
   &__subtitle {
@@ -301,7 +301,7 @@
   }
 
   &__border {
-    margin-right: $pix-spacing-xs;
+    margin-right: var(--pix-spacing-2x);
     padding: 0.7rem 0;
     border-style: solid;
     border-width: 2.5px;
@@ -317,14 +317,14 @@
       background-color: var(--pix-neutral-20);
 
       & + tr {
-        border-top: $pix-spacing-xs solid var(--pix-neutral-0);
+        border-top: var(--pix-spacing-2x) solid var(--pix-neutral-0);
       }
     }
 
     th {
       @extend %pix-body-m;
 
-      padding: $pix-spacing-xs $pix-spacing-s;
+      padding: var(--pix-spacing-2x) var(--pix-spacing-4x);
       color: var(--pix-neutral-900);
       font-weight: $font-normal;
       text-align: left;
@@ -335,13 +335,13 @@
     display: flex;
     align-items: center;
     justify-content: flex-end;
-    padding: $pix-spacing-xs $pix-spacing-s;
+    padding: var(--pix-spacing-2x) var(--pix-spacing-4x);
   }
 
   &__reached-stage-percentage {
     @extend %pix-body-xs;
 
-    margin-right: $pix-spacing-s;
+    margin-right: var(--pix-spacing-4x);
   }
 
   &__reached-stage-stars {
@@ -503,12 +503,12 @@
     flex-direction: column;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: $pix-spacing-l;
+    margin-bottom: var(--pix-spacing-8x);
     text-align: center;
 
     @include device-is('tablet') {
       flex-direction: row;
-      margin-bottom: $pix-spacing-s;
+      margin-bottom: var(--pix-spacing-4x);
     }
   }
 

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -21,11 +21,11 @@
   }
 
   &__retry {
-    color: $pix-neutral-100;
+    color: var(--pix-neutral-900);
     font-size: 1.125rem;
     font-family: $font-open-sans;
     text-align: center;
-    border-top: 1px dashed $pix-neutral-22;
+    border-top: 1px dashed var(--pix-neutral-100);
 
     @include device-is('tablet') {
       margin-top: 32px;
@@ -54,7 +54,7 @@
   &__trainings {
     margin-top: $pix-spacing-xl;
     padding: $pix-spacing-l 0;
-    border-top: 2px solid $pix-neutral-20;
+    border-top: 2px solid var(--pix-neutral-20);
   }
 
   &__share {
@@ -99,11 +99,11 @@
     justify-content: space-between;
     margin-bottom: 30px;
     padding: 30px;
-    border-bottom: 1px dashed $pix-neutral-22;
+    border-bottom: 1px dashed var(--pix-neutral-100);
   }
 
   &__explain-text {
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-size: 1.5rem;
     line-height: 33px;
   }
@@ -134,7 +134,7 @@
     align-items: flex-start;
 
     > h2 {
-      color: $pix-neutral-60;
+      color: var(--pix-neutral-500);
       font-size: 16px;
     }
 
@@ -155,14 +155,14 @@
   &__title {
     @extend %pix-title-s;
 
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
   }
 
   &__description {
     @extend %pix-body-s;
 
     margin-top: $pix-spacing-xs;
-    color: $pix-neutral-45;
+    color: var(--pix-neutral-500);
   }
 
   &__list {
@@ -188,14 +188,14 @@
     width: 100%;
     padding: 0;
     overflow: hidden;
-    border: 1px solid $pix-neutral-15;
+    border: 1px solid var(--pix-neutral-20);
     border-radius: 8px;
     transition: all 0.2s ease-in-out;
 
     &:hover {
       box-shadow:
         0 7px 14px 0 rgb(12 22 58 / 20%),
-        0 3px 6px 0 rgba($pix-neutral-110, 0.2);
+        0 3px 6px 0 rgba(var(--pix-neutral-900), 0.2);
     }
   }
 }
@@ -203,14 +203,14 @@
 .skill-review-information {
   &__info-icon {
     float: left;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-size: 0.938em;
   }
 
   &__text {
     margin-top: 14px;
     padding-left: 14px;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-size: 0.875rem;
     font-family: $font-open-sans;
   }
@@ -245,28 +245,28 @@
     border-radius: 1.5px;
 
     &--jaffa {
-      color: $pix-information-light;
-      background: $pix-information-light;
+      color: var(--pix-information-light);
+      background: var(--pix-information-light);
     }
 
     &--emerald {
-      color: $pix-content-light;
-      background: $pix-content-light;
+      color: var(--pix-content-light);
+      background: var(--pix-content-light);
     }
 
     &--cerulean {
-      color: $pix-communication-light;
-      background: $pix-communication-light;
+      color: var(--pix-communication-light);
+      background: var(--pix-communication-light);
     }
 
     &--wild-strawberry {
-      color: $pix-security-light;
-      background: $pix-security-light;
+      color: var(--pix-security-light);
+      background: var(--pix-security-light);
     }
 
     &--butterfly-bush {
-      color: $pix-environment-light;
-      background: $pix-environment-light;
+      color: var(--pix-environment-light);
+      background: var(--pix-environment-light);
     }
   }
 }
@@ -276,7 +276,7 @@
     @extend %pix-title-s;
 
     padding-bottom: $pix-spacing-m;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
   }
 
   &__content {
@@ -296,7 +296,7 @@
   &__subtitle {
     @extend %pix-body-l;
 
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-weight: $font-medium;
   }
 
@@ -314,10 +314,10 @@
 
     tr {
       height: 3rem;
-      background-color: $pix-neutral-5;
+      background-color: var(--pix-neutral-20);
 
       & + tr {
-        border-top: $pix-spacing-xs solid $pix-neutral-0;
+        border-top: $pix-spacing-xs solid var(--pix-neutral-0);
       }
     }
 
@@ -325,7 +325,7 @@
       @extend %pix-body-m;
 
       padding: $pix-spacing-xs $pix-spacing-s;
-      color: $pix-neutral-90;
+      color: var(--pix-neutral-900);
       font-weight: $font-normal;
       text-align: left;
     }
@@ -351,7 +351,7 @@
 
 .skill-review-table-header {
   &__circle-chart-value {
-    color: $pix-neutral-100;
+    color: var(--pix-neutral-900);
     font-size: 1.938rem;
     font-family: $font-roboto;
   }
@@ -375,7 +375,7 @@
 
   &__title {
     margin: 0;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-weight: $font-bold;
     font-size: 1rem;
     font-family: $font-open-sans;
@@ -383,14 +383,14 @@
 
   &__organization-name {
     margin: 8px 0;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-weight: $font-normal;
     font-size: 1.5rem;
     font-family: $font-open-sans;
   }
 
   &__text {
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-size: 1rem;
     font-family: $font-roboto;
     line-height: 1.625rem;
@@ -404,10 +404,10 @@
     display: inline-block;
     margin-top: 12px;
     padding: 8px 12px;
-    color: $pix-neutral-0;
+    color: var(--pix-neutral-0);
     font-size: 0.875rem;
     text-decoration: none;
-    background-color: $pix-primary;
+    background-color: var(--pix-primary-500);
     border-radius: 4px;
     cursor: pointer;
 
@@ -420,7 +420,7 @@
 .skill-review-result-abstract {
   &__text {
     margin: 16px 0;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-size: 1.625rem;
     font-family: $font-open-sans;
     line-height: 2.75rem;
@@ -435,14 +435,14 @@
 
     > strong {
       display: inline-block;
-      color: $pix-primary;
+      color: var(--pix-primary-500);
       font-weight: 300;
     }
   }
 
   &__subtext {
     margin: 40px 0;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-weight: $font-bold;
     text-align: center;
   }
@@ -469,13 +469,13 @@
 .badge-container {
   margin-bottom: 24px;
   padding-bottom: 24px;
-  border-bottom: 1px dashed $pix-neutral-22;
+  border-bottom: 1px dashed var(--pix-neutral-100);
 }
 
 .skill-review-result-detail {
   &__badge-subtitle {
     margin: 0 0 24px;
-    color: $pix-neutral-100;
+    color: var(--pix-neutral-900);
     font-weight: $font-normal;
     font-size: 1.5rem;
     font-family: $font-open-sans;
@@ -514,7 +514,7 @@
 
   &__subtitle {
     margin-bottom: 32px;
-    color: $pix-neutral-100;
+    color: var(--pix-neutral-900);
     font-weight: $font-normal;
     font-size: 1.5rem;
     font-family: $font-open-sans;
@@ -533,7 +533,7 @@
 
   &__legal {
     margin: 4px 0;
-    color: $pix-neutral-45;
+    color: var(--pix-neutral-500);
     font-weight: $font-normal;
     font-size: 0.85rem;
     font-family: $font-roboto;
@@ -543,18 +543,18 @@
   &__thanks {
     margin-bottom: 16px;
     padding: 16px;
-    color: $pix-success-70;
+    color: var(--pix-success-700);
     font-weight: $font-medium;
     font-size: 1rem;
     font-family: $font-open-sans;
     line-height: 2rem;
-    background-color: $pix-success-5;
+    background-color: var(--pix-success-50);
     border-radius: 4px;
   }
 
   &__error {
     padding-bottom: 10px;
-    color: $pix-warning-60;
+    color: var(--pix-warning-700);
     font-size: 0.938rem;
   }
 
@@ -603,7 +603,7 @@
   &__text {
     max-width: 640px;
     margin: 30px auto 60px;
-    color: $pix-neutral-35;
+    color: var(--pix-neutral-100);
     font-size: 1.375rem;
     font-family: $font-open-sans;
     line-height: 30px;
@@ -613,14 +613,14 @@
 .stage-congrats {
   &__title {
     padding-bottom: 10px;
-    color: $pix-neutral-100;
+    color: var(--pix-neutral-900);
     font-weight: $font-bold;
     font-size: 1.875rem;
     font-family: $font-open-sans;
   }
 
   &__message {
-    color: $pix-neutral-45;
+    color: var(--pix-neutral-500);
     font-weight: $font-normal;
     font-size: 1.125rem;
     font-family: $font-open-sans;
@@ -638,11 +638,11 @@
   }
 
   .progression-gauge {
-    border-bottom: 4px solid $pix-neutral-20;
+    border-bottom: 4px solid var(--pix-neutral-20);
   }
 
   .progression-gauge__marker {
-    border-bottom: 4px solid $pix-information-light;
+    border-bottom: 4px solid var(--pix-information-light);
   }
 
   .default-table thead {

--- a/mon-pix/app/styles/pages/_terms-of-service.scss
+++ b/mon-pix/app/styles/pages/_terms-of-service.scss
@@ -27,7 +27,7 @@
 
   &__title,
   &__description {
-    color: $pix-neutral-80;
+    color: var(--pix-neutral-800);
     font-family: $font-roboto;
     text-align: center;
   }
@@ -54,7 +54,7 @@
 .terms-of-service-form-conditions {
   &__validation-error {
     margin-top: 16px;
-    color: $pix-error-50;
+    color: var(--pix-error-500);
     font-weight: normal;
   }
 }

--- a/mon-pix/app/styles/pages/_update-expired-password-form.scss
+++ b/mon-pix/app/styles/pages/_update-expired-password-form.scss
@@ -24,7 +24,7 @@
     max-width: 609px;
     margin: 10px auto;
     padding-top: 10px;
-    background-color: $pix-neutral-0;
+    background-color: var(--pix-neutral-0);
     border-radius: 10px;
 
     @include device-is('tablet') {
@@ -59,7 +59,7 @@
 
   &__error-notification-message {
     max-width: 426px;
-    color: $pix-error-70;
+    color: var(--pix-error-700);
     font-size: 0.875rem;
     text-align: center;
   }
@@ -89,7 +89,7 @@
 
 .update-expired-password-form-title {
   margin: 0;
-  color: $pix-neutral-80;
+  color: var(--pix-neutral-800);
   font-size: 1.563rem;
   font-family: $font-open-sans;
   text-align: center;
@@ -102,7 +102,7 @@
 .update-expired-password-form-subtitle {
   width: 100%;
   margin: 10px 0 0;
-  color: $pix-neutral-80;
+  color: var(--pix-neutral-800);
   font-size: 1rem;
   font-family: $font-roboto;
   line-height: 22px;
@@ -110,7 +110,7 @@
 }
 
 .update-expired-password-form-text {
-  color: $pix-neutral-80;
+  color: var(--pix-neutral-800);
   font-size: 0.838rem;
   font-family: $font-open-sans;
   text-align: center;

--- a/mon-pix/app/styles/pages/_user-certifications-get.scss
+++ b/mon-pix/app/styles/pages/_user-certifications-get.scss
@@ -16,12 +16,12 @@
   }
 
   h2 {
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
   }
 
   &__note {
     max-width: 980px;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-size: 0.875rem;
     line-height: 22px;
     letter-spacing: 0.15px;

--- a/mon-pix/app/styles/pages/_user-certifications.scss
+++ b/mon-pix/app/styles/pages/_user-certifications.scss
@@ -13,7 +13,7 @@
   margin: 0;
   padding-top: 60px;
   padding-bottom: 40px;
-  color: $pix-neutral-80;
+  color: var(--pix-neutral-800);
   font-weight: $font-medium;
   font-size: 1.75rem;
   font-family: $font-open-sans;

--- a/mon-pix/app/styles/pages/_user-tests.scss
+++ b/mon-pix/app/styles/pages/_user-tests.scss
@@ -42,7 +42,7 @@
   &__title {
     width: 100%;
     margin: 0 0 8px;
-    color: $pix-neutral-0;
+    color: var(--pix-neutral-0);
     font-weight: 300;
     font-size: 3rem;
   }

--- a/mon-pix/app/styles/pages/_user-trainings.scss
+++ b/mon-pix/app/styles/pages/_user-trainings.scss
@@ -35,7 +35,7 @@
   flex-direction: column;
   width: 100%;
   min-height: inherit;
-  margin: $pix-spacing-m auto 0;
+  margin: var(--pix-spacing-6x) auto 0;
   padding: 20px 32px 0;
   color: var(--pix-neutral-900);
 
@@ -61,7 +61,7 @@
     display: grid;
     grid-template-columns: 1fr;
     gap: 24px;
-    margin-bottom: $pix-spacing-l;
+    margin-bottom: var(--pix-spacing-8x);
     padding: 0;
     list-style: none;
 

--- a/mon-pix/app/styles/pages/_user-trainings.scss
+++ b/mon-pix/app/styles/pages/_user-trainings.scss
@@ -10,7 +10,7 @@
   }
 
   &__title {
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
     font-weight: $font-normal;
     font-size: 2rem;
     font-family: $font-open-sans;
@@ -21,7 +21,7 @@
   &__description {
     margin: 0;
     padding: 8px 0 32px;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
     font-weight: $font-normal;
     font-size: 1rem;
     font-family: $font-roboto;
@@ -37,7 +37,7 @@
   min-height: inherit;
   margin: $pix-spacing-m auto 0;
   padding: 20px 32px 0;
-  color: $pix-neutral-90;
+  color: var(--pix-neutral-900);
 
   @include device-is('tablet') {
     padding: 40px 0 0;
@@ -78,7 +78,7 @@
 .user-trainings-content-list {
   &__item {
     &:hover {
-      box-shadow: 0 7px 14px 0 rgb(12 22 58 / 20%), 0 3px 6px 0 rgba($pix-neutral-110, 0.2);
+      box-shadow: 0 7px 14px 0 rgb(12 22 58 / 20%), 0 3px 6px 0 rgba(var(--pix-neutral-900), 0.2);
     }
   }
 }

--- a/mon-pix/app/styles/pages/_user-tutorials.scss
+++ b/mon-pix/app/styles/pages/_user-tutorials.scss
@@ -11,14 +11,14 @@
   &__title {
     @extend %pix-title-m;
 
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
   }
 
   &__description {
     @extend %pix-body-m;
 
     padding: $pix-spacing-xs 0 $pix-spacing-l;
-    color: $pix-neutral-60;
+    color: var(--pix-neutral-500);
   }
 
   &__filters {
@@ -73,7 +73,7 @@
     @extend %pix-title-s;
 
     margin-top: $pix-spacing-m;
-    color: $pix-neutral-90;
+    color: var(--pix-neutral-900);
 
     @include device-is('desktop') {
       margin-top: 0;

--- a/mon-pix/app/styles/pages/_user-tutorials.scss
+++ b/mon-pix/app/styles/pages/_user-tutorials.scss
@@ -1,11 +1,11 @@
 .user-tutorials-banner {
-  margin: 0 $pix-spacing-m;
-  padding-bottom: $pix-spacing-s;
+  margin: 0 var(--pix-spacing-6x);
+  padding-bottom: var(--pix-spacing-4x);
 
   @include device-is('desktop') {
     max-width: 1280px;
     margin: 0 auto;
-    padding: $pix-spacing-s 20px;
+    padding: var(--pix-spacing-4x) 20px;
   }
 
   &__title {
@@ -17,14 +17,14 @@
   &__description {
     @extend %pix-body-m;
 
-    padding: $pix-spacing-xs 0 $pix-spacing-l;
+    padding: var(--pix-spacing-2x) 0 var(--pix-spacing-8x);
     color: var(--pix-neutral-500);
   }
 
   &__filters {
     display: flex;
     flex-wrap: wrap;
-    gap: $pix-spacing-s;
+    gap: var(--pix-spacing-4x);
     align-items: center;
     min-height: 2.8125rem;
   }
@@ -32,7 +32,7 @@
 
 .user-tutorials-content {
   margin: 0 auto;
-  padding: $pix-spacing-m 20px 0;
+  padding: var(--pix-spacing-6x) 20px 0;
 
   @include device-is('desktop') {
     max-width: 1280px;
@@ -41,12 +41,12 @@
   &__cards {
     display: grid;
     grid-template-columns: 1fr;
-    margin-bottom: $pix-spacing-l;
-    row-gap: $pix-spacing-s;
+    margin-bottom: var(--pix-spacing-8x);
+    row-gap: var(--pix-spacing-4x);
 
     @include device-is('desktop') {
       grid-template-columns: 1fr 1fr;
-      column-gap: $pix-spacing-m;
+      column-gap: var(--pix-spacing-6x);
     }
   }
 
@@ -72,7 +72,7 @@
   &__title {
     @extend %pix-title-s;
 
-    margin-top: $pix-spacing-m;
+    margin-top: var(--pix-spacing-6x);
     color: var(--pix-neutral-900);
 
     @include device-is('desktop') {


### PR DESCRIPTION
## :unicorn: Problème
Nous n'utilisons plus les bons Design Tokens de couleurs depuis la montée de version en [v41.2.0 de Pix UI](https://github.com/1024pix/pix-ui/blob/dev/CHANGELOG.md#v4120-08122023).

## :robot: Proposition
Les migrer via le script mis à disposition via :

```bash
./node_modules/@1024pix/pix-ui/scripts/migrate-colors-scss-vars-to-css-vars.sh
./node_modules/@1024pix/pix-ui/scripts/migrate-spacing-scss-vars-to-css-vars.sh
```

Quelques petits ajustements sont nécessaires :

Il est nécessaire de supprimer les usages de rgba (pas d'usage de darken lighten ou autre)

## :rainbow: Remarques
Quelques usages de variables ont posé problèmes dans le script, j'ai executé ceci pour corriger les petites pétouilles :

```bash
#!/bin/bash -e

for f in $(find . -name '*.scss' -not -path './node_modules/*' -not -name '_colors.scss')
do
  echo "parsing file" $f
  sed -i '' -e 's/var(--pix-primary-500)-app-gradient/$pix-primary-app-gradient/' "$f"
  sed -i '' -e 's/var(--pix-secondary-500)-app-gradient/$pix-primary-app-gradient/' "$f"
  sed -i '' -e 's/var(--pix-neutral-20)0/var(--pix-neutral-100)/' "$f"
  sed -i '' -e 's/var(--pix-secondary-500)-70/var(--pix-secondary-700)/' "$f"
done
```


## :100: Pour tester
Faire un tour sur Pix App et vérifier la cohérence et les contrastes des couleurs des pages.
