### PR TITLE
[FEATURE] Ajout d'une modale sur la définalisation de session (PIX-10898)

### DIFF
--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -24,7 +24,7 @@ export default class CertificationInformationsController extends Controller {
   @tracked modalTitle = null;
   @tracked confirmMessage = '';
   @tracked confirmErrorMessage = '';
-  @tracked confirmAction = 'onCancelCertificationConfirmation';
+  @tracked confirmAction = this.onCancelCertificationConfirmation;
   @tracked isCandidateEditModalOpen = false;
   @tracked displayJuryLevelSelect = false;
 
@@ -119,7 +119,7 @@ export default class CertificationInformationsController extends Controller {
   onCancelCertificationButtonClick() {
     const confirmMessage =
       'Êtes-vous sûr·e de vouloir annuler cette certification ? Cliquez sur confirmer pour poursuivre.';
-    this.confirmAction = 'onCancelCertificationConfirmation';
+    this.confirmAction = this.onCancelCertificationConfirmation;
     this.confirmMessage = confirmMessage;
     this.displayConfirm = true;
   }
@@ -128,7 +128,7 @@ export default class CertificationInformationsController extends Controller {
   onUncancelCertificationButtonClick() {
     const confirmMessage =
       'Êtes-vous sûr·e de vouloir désannuler cette certification ? Cliquez sur confirmer pour poursuivre.';
-    this.confirmAction = 'onUncancelCertificationConfirmation';
+    this.confirmAction = this.onUncancelCertificationConfirmation;
     this.confirmMessage = confirmMessage;
     this.displayConfirm = true;
   }
@@ -138,7 +138,7 @@ export default class CertificationInformationsController extends Controller {
     const confirmMessage =
       'Êtes-vous sûr·e de vouloir rejeter cette certification ? Cliquez sur confirmer pour poursuivre.';
     this.modalTitle = 'Confirmer le rejet de la certification';
-    this.confirmAction = 'onRejectCertificationConfirmation';
+    this.confirmAction = this.onRejectCertificationConfirmation;
     this.confirmMessage = confirmMessage;
     this.displayConfirm = true;
   }
@@ -156,7 +156,7 @@ export default class CertificationInformationsController extends Controller {
     const confirmMessage =
       'Êtes-vous sûr·e de vouloir annuler le rejet de cette certification ? Cliquez sur confirmer pour poursuivre.';
     this.modalTitle = "Confirmer l'annulation du rejet de la certification";
-    this.confirmAction = 'onUnrejectCertificationConfirmation';
+    this.confirmAction = this.onUnrejectCertificationConfirmation;
     this.confirmMessage = confirmMessage;
     this.displayConfirm = true;
   }

--- a/admin/app/controllers/authenticated/sessions/session/informations.js
+++ b/admin/app/controllers/authenticated/sessions/session/informations.js
@@ -16,7 +16,10 @@ export default class IndexController extends Controller {
 
   @alias('model') sessionModel;
 
-  @tracked isShowingAssignmentModal = false;
+  @tracked modalTitle = '';
+  @tracked modalMessage = '';
+  @tracked modalConfirmAction = this.cancelModal;
+  @tracked isShowingModal = false;
 
   @tracked isCopyButtonClicked = false;
   @tracked copyButtonText = 'Copié';
@@ -54,20 +57,28 @@ export default class IndexController extends Controller {
   @action
   async checkForAssignment() {
     if (this.isAssigned) {
-      this.isShowingAssignmentModal = true;
+      this.modalTitle = 'Assignation de la session';
+      this.modalMessage = this.intl.t('pages.sessions.informations.assignment-confirmation-modal', {
+        fullName: this.sessionModel.assignedCertificationOfficer.get('fullName'),
+        htmlSafe: true,
+      });
+      this.modalConfirmAction = this.confirmAssignment;
+      this.isShowingModal = true;
       return;
     }
     await this._assignSessionToCurrentUser();
   }
 
   @action
-  cancelAssignment() {
-    this.isShowingAssignmentModal = false;
+  cancelModal() {
+    this.isShowingModal = false;
+    this.modalConfirmAction = this.cancelModal;
   }
 
   @action
   async confirmAssignment() {
     await this._assignSessionToCurrentUser();
+    this.cancelModal();
   }
 
   @action
@@ -135,6 +146,5 @@ export default class IndexController extends Controller {
     } catch (err) {
       this.notifications.error("Erreur lors de l'assignation à la session");
     }
-    this.isShowingAssignmentModal = false;
   }
 }

--- a/admin/app/controllers/authenticated/sessions/session/informations.js
+++ b/admin/app/controllers/authenticated/sessions/session/informations.js
@@ -52,6 +52,15 @@ export default class IndexController extends Controller {
     } catch (err) {
       this.notifications.error('Erreur lors de la définalisation de la session');
     }
+    this.cancelModal();
+  }
+
+  @action
+  async onUnfinalizeSessionButtonClick() {
+    this.modalTitle = '';
+    this.modalMessage = this.intl.t('pages.sessions.informations.unfinalization-confirmation-modal');
+    this.modalConfirmAction = this.unfinalizeSession;
+    this.isShowingModal = true;
   }
 
   @action

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -1,4 +1,3 @@
-{{! template-lint-disable no-action }}
 <div class="certification-informations">
   <div class="certification-informations__row">
     <PixButton @route="authenticated.users.get" @size="small" @model={{this.certification.userId}}>
@@ -264,9 +263,9 @@
   @title={{this.modalTitle}}
   @message={{this.confirmMessage}}
   @error={{this.confirmErrorMessage}}
-  @confirm={{action this.confirmAction}}
+  @confirm={{this.confirmAction}}
   @show={{this.displayConfirm}}
-  @cancel={{action this.onCancelConfirm}}
+  @cancel={{this.onCancelConfirm}}
 />
 
 {{#if this.isCandidateEditModalOpen}}

--- a/admin/app/templates/authenticated/sessions/session/informations.hbs
+++ b/admin/app/templates/authenticated/sessions/session/informations.hbs
@@ -203,31 +203,10 @@
   @onDeleteButtonClicked={{this.deleteComment}}
 />
 
-<PixModal
-  @title="Assignation de la session"
-  @onCloseButtonClick={{this.cancelAssignment}}
-  @showModal={{this.isShowingAssignmentModal}}
->
-  <:content>
-    <p>
-      L'utilisateur
-      {{this.sessionModel.assignedCertificationOfficer.fullName}}
-      s'est déjà assigné cette session.
-      <br />
-      Voulez-vous vous quand même vous assigner cette session ?
-    </p>
-  </:content>
-  <:footer>
-    <PixButton
-      @backgroundColor="transparent-light"
-      @isBorderVisible={{true}}
-      @size="small"
-      @triggerAction={{this.cancelAssignment}}
-    >
-      Annuler
-    </PixButton>
-    <PixButton @size="small" @triggerAction={{this.confirmAssignment}}>
-      Confirmer
-    </PixButton>
-  </:footer>
-</PixModal>
+<ConfirmPopup
+  @title={{this.modalTitle}}
+  @message={{this.modalMessage}}
+  @confirm={{this.modalConfirmAction}}
+  @cancel={{this.cancelModal}}
+  @show={{this.isShowingModal}}
+/>

--- a/admin/app/templates/authenticated/sessions/session/informations.hbs
+++ b/admin/app/templates/authenticated/sessions/session/informations.hbs
@@ -133,7 +133,7 @@
                 <PixButton
                   @size="big"
                   @isDisabled={{true}}
-                  @triggerAction={{this.unfinalizeSession}}
+                  @triggerAction={{this.onUnfinalizeSessionButtonClick}}
                   @backgroundColor="error"
                 >Définaliser la session
                 </PixButton>
@@ -144,8 +144,11 @@
               </:tooltip>
             </PixTooltip>
           {{else}}
-            <PixButton @size="big" @triggerAction={{this.unfinalizeSession}} @backgroundColor="error">Définaliser la
-              session
+            <PixButton
+              @size="big"
+              @triggerAction={{this.onUnfinalizeSessionButtonClick}}
+              @backgroundColor="error"
+            >Définaliser la session
             </PixButton>
           {{/if}}
         {{/if}}

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -84,8 +84,7 @@ function routes() {
   });
   this.post('/admin/admin-members', createAdminMember);
   this.get('/admin/admin-members/me', (schema, request) => {
-    const userToken = request.requestHeaders.Authorization.replace('Bearer ', '');
-    const userId = JSON.parse(atob(userToken.split('.')[1])).user_id;
+    const userId = _parseUserIdFromJWT(request);
     return schema.adminMembers.findBy({ userId });
   });
   this.patch('/admin/admin-members/:id', (schema, request) => {
@@ -122,6 +121,12 @@ function routes() {
   });
   this.get('/admin/sessions/:id/generate-results-download-link', {
     sessionResultsLink: 'http://link-to-results.fr?lang=fr',
+  });
+  this.patch('/admin/sessions/:id/certification-officer-assignment', (schema, request) => {
+    const userId = _parseUserIdFromJWT(request);
+    const sessionId = request.params.id;
+    const session = schema.sessions.findBy({ id: sessionId });
+    return session.update({ assignedCertificationOfficerId: userId });
   });
 
   this.get('/admin/users');
@@ -610,4 +615,9 @@ function _configureOrganizationsRoutes(context) {
       ],
     };
   });
+}
+
+function _parseUserIdFromJWT(request) {
+  const userToken = request.requestHeaders.Authorization.replace('Bearer ', '');
+  return JSON.parse(atob(userToken.split('.')[1])).user_id;
 }

--- a/admin/mirage/serializers/session.js
+++ b/admin/mirage/serializers/session.js
@@ -1,6 +1,9 @@
 import ApplicationSerializer from './application';
 
+const _includes = ['assignedCertificationOfficer'];
+
 export default ApplicationSerializer.extend({
+  include: _includes,
   links(session) {
     const links = {
       juryCertificationSummaries: {

--- a/admin/tests/acceptance/authenticated/sessions/session/informations_test.js
+++ b/admin/tests/acceptance/authenticated/sessions/session/informations_test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import { currentURL } from '@ember/test-helpers';
-import { fillByLabel, clickByName, visit } from '@1024pix/ember-testing-library';
+import { fillByLabel, clickByName, visit, within } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
+import { waitForDialogClose } from '../../../../helpers/wait-for';
 
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateAdminMemberWithRole } from '../../../../helpers/test-init';
@@ -49,6 +50,9 @@ module('Acceptance | authenticated/sessions/session/informations', function (hoo
 
           // when
           await clickByName('Définaliser la session');
+          const modal = await screen.findByRole('dialog');
+          await within(modal).queryByRole('button', { name: 'Confirmer' }).click();
+          await waitForDialogClose();
 
           // then
           assert.dom(screen.queryByText('Date de finalisation :')).doesNotExist();

--- a/admin/tests/helpers/wait-for.js
+++ b/admin/tests/helpers/wait-for.js
@@ -1,0 +1,15 @@
+import { getScreen } from '@1024pix/ember-testing-library';
+import { waitUntil } from '@ember/test-helpers';
+
+export async function waitForDialogClose() {
+  const screen = await getScreen();
+
+  await waitUntil(() => {
+    try {
+      screen.getByRole('dialog');
+      return false;
+    } catch {
+      return true;
+    }
+  });
+}

--- a/admin/tests/unit/controllers/authenticated/sessions/session/informations_test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/session/informations_test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 import Service from '@ember/service';
+import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
 
 module('Unit | Controller | authenticated/sessions/session/informations', function (hooks) {
-  setupTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   let controller;
 
@@ -57,14 +57,21 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
     module('when a user is already assigned to session', function () {
       test('it should show the modal', async function (assert) {
         //given
-        const getId = sinon.stub().returns(true);
-        controller.model.assignedCertificationOfficer = { get: getId };
+        const fullName = 'Helmut Fritz';
+        const getFullName = sinon.stub().returns(fullName);
+        controller.model.assignedCertificationOfficer = { get: getFullName };
 
         // when
         await controller.actions.checkForAssignment.call(controller);
 
         // then
-        assert.true(controller.isShowingAssignmentModal);
+        assert.true(controller.isShowingModal);
+        assert.strictEqual(controller.modalConfirmAction, controller.confirmAssignment);
+        assert.deepEqual(
+          controller.modalMessage,
+          this.intl.t('pages.sessions.informations.assignment-confirmation-modal', { fullName, htmlSafe: true }),
+        );
+        assert.strictEqual(controller.modalTitle, 'Assignation de la session');
         assert.true(controller.model.save.notCalled);
       });
     });
@@ -84,7 +91,7 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
           controller.model.save.calledWithExactly({ adapterOptions: { certificationOfficerAssignment: true } }),
         );
         assert.ok(controller.notifications.success.calledWithExactly('La session vous a correctement été assignée'));
-        assert.false(controller.isShowingAssignmentModal);
+        assert.false(controller.isShowingModal);
       });
 
       test('it should show a notification error when save failed', async function (assert) {
@@ -99,7 +106,7 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
         // then
         assert.ok(controller.model.save.calledOnce);
         assert.ok(controller.notifications.error.calledWithExactly("Erreur lors de l'assignation à la session"));
-        assert.false(controller.isShowingAssignmentModal);
+        assert.false(controller.isShowingModal);
       });
     });
   });
@@ -107,10 +114,10 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
   module('#cancelAssignment', function () {
     test('it should close the modal', async function (assert) {
       // when
-      await controller.actions.cancelAssignment.call(controller);
+      await controller.actions.cancelModal.call(controller);
 
       // then
-      assert.false(controller.isShowingAssignmentModal);
+      assert.false(controller.isShowingModal);
     });
   });
 
@@ -131,7 +138,7 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
       // then
       assert.ok(controller.model.save.calledWithExactly({ adapterOptions: { certificationOfficerAssignment: true } }));
       assert.ok(controller.notifications.success.calledWithExactly('La session vous a correctement été assignée'));
-      assert.false(controller.isShowingAssignmentModal);
+      assert.false(controller.isShowingModal);
     });
 
     test('it should show a notification error when save failed too', async function (assert) {
@@ -146,7 +153,7 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
       // then
       assert.ok(controller.model.save.calledOnce);
       assert.ok(controller.notifications.error.calledWithExactly("Erreur lors de l'assignation à la session"));
-      assert.false(controller.isShowingAssignmentModal);
+      assert.false(controller.isShowingModal);
     });
   });
 

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -281,6 +281,11 @@
       "title": "Children organisations",
       "empty-table": "No child organisation"
     },
+    "sessions": {
+      "informations": {
+        "assignment-confirmation-modal": "This session is already assigned to the user {fullName}.'<br/>'Do you still want to assign it to yourself?",
+      }
+    },
     "target-profiles": {
       "resettable-checkbox": {
         "label": "Allow resetting for evaluation-type campaigns when multiple submissions are enabled for the organisation"

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -284,6 +284,7 @@
     "sessions": {
       "informations": {
         "assignment-confirmation-modal": "This session is already assigned to the user {fullName}.'<br/>'Do you still want to assign it to yourself?",
+        "unfinalization-confirmation-modal": "Are you sure you want to unfinalize this session ? Click on confirm to process."
       }
     },
     "target-profiles": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -301,6 +301,7 @@
     "sessions": {
       "informations": {
         "assignment-confirmation-modal": "L'utilisateur {fullName} s'est déjà assigné cette session.'<br/>'Voulez-vous vous quand même vous assigner cette session ?",
+        "unfinalization-confirmation-modal": "Êtes-vous sûr.e de vouloir définaliser cette session ? Cliquez sur confirmer pour poursuivre."
       }
     },
     "target-profiles": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -298,6 +298,11 @@
         }
       }
     },
+    "sessions": {
+      "informations": {
+        "assignment-confirmation-modal": "L'utilisateur {fullName} s'est déjà assigné cette session.'<br/>'Voulez-vous vous quand même vous assigner cette session ?",
+      }
+    },
     "target-profiles": {
       "resettable-checkbox": {
         "label": "Permettre la remise à zéro des acquis du profil cible"


### PR DESCRIPTION
## :unicorn: Problème
La dé-finalisation de session est une action assez lourde qui ne doit pas être réalisée par mégarde.
## :robot: Proposition
On souhaite mettre en place une modale de confirmation avant de définaliser une session.

## :100: Pour tester
- Se connecter à la [session 7005 sur admin](https://admin-pr7939.review.pix.fr/sessions/7005) (superadmin@example.net/pix123)
- Cliquer sur le bouton pour définaliser la session:
<img width="211" alt="image" src="https://github.com/1024pix/pix/assets/3033624/b81f1af4-4508-40fd-842f-8eccf6bcb3b8">  

- Constater la présence de la modale: 
<img width="526" alt="image" src="https://github.com/1024pix/pix/assets/3033624/675c220b-8582-4172-9c7e-fa52ecbdec43">

💡 Si vous définalisez la session dans le cadre de vos tests, vous pouvez la [refinaliser sur certif](https://certif-pr7939.review.pix.fr/sessions/7005) (certif-pro@example.net/pix123)

Non régression assignation de session:
- Se connecter à la [session 7005 sur admin](https://admin-pr7939.review.pix.fr/sessions/7005) (superadmin@example.net/pix123) 
- Cliquer sur le bouton pour s'assigner la session:
<img width="208" alt="image" src="https://github.com/1024pix/pix/assets/3033624/f5ed74ca-4396-45a6-8a93-ce332236eada">

- Constater la présence de la modale (avec le saut de ligne 💅) (PI, j'ai assigné la session à l'utilisateur `pixcertif@example.net`) 

Non régression page de certification:
- Se connecter à la [session 7005 sur admin](https://admin-pr7939.review.pix.fr/certifications/144462) (superadmin@example.net/pix123) 
- Cliquer sur le bouton pour (dé)rejeter la session par exemple (possible d'annuler/désannuler etc)
- Constater la présence de la modale