### PR TITLE
[FEATURE] Ouvrir le portail surveillant dans un nouvel onglet (PIX-10973).

### DIFF
--- a/certif/app/templates/authenticated.hbs
+++ b/certif/app/templates/authenticated.hbs
@@ -28,7 +28,13 @@
             </LinkTo>
           </li>
           <li>
-            <LinkTo @route="login-session-supervisor" class="sidebar-menu__item" type="button">
+            <LinkTo
+              @route="login-session-supervisor"
+              class="sidebar-menu__item"
+              type="button"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               <FaIcon @icon="eye" class="sidebar-menu__item-icon" />
               {{t "navigation.main.supervisor"}}
             </LinkTo>

--- a/certif/tests/acceptance/authenticated_test.js
+++ b/certif/tests/acceptance/authenticated_test.js
@@ -69,7 +69,7 @@ module('Acceptance | authenticated', function (hooks) {
       assert.dom(screen.getByRole('link', { name: 'Espace surveillant' })).exists();
     });
 
-    test('it should redirect to the login session supervisor', async function (assert) {
+    test('it should open the login session supervisor in a new tab', async function (assert) {
       // given
       const currentAllowedCertificationCenterAccess = server.create('allowed-certification-center-access', {
         name: 'Bibiche',
@@ -85,10 +85,11 @@ module('Acceptance | authenticated', function (hooks) {
 
       // when
       const screen = await visitScreen('/sessions/liste');
-      await click(screen.getByRole('link', { name: 'Espace surveillant' }));
+      const invigilatorSpaceLink = screen.getByRole('link', { name: 'Espace surveillant' });
+      await click(invigilatorSpaceLink);
 
       // then
-      assert.strictEqual(currentURL(), '/connexion-espace-surveillant');
+      assert.dom(invigilatorSpaceLink).hasAttribute('target', '_blank');
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème

L’espace surveillant est accessible depuis Pix certif pour les membres d’un espace.
Lorsqu’on clique sur le menu “Espace surveillant”, on est redirigé sur l’espace surveillant alors qu’on souhaite garder Pix certif ouvert également

## :robot: Proposition

Dans Pix Certif pour un CDC v2 ou v3 > menu “Espace surveillant” : ouvrir l’ES dans un nouvel onglet

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

Se connecter à pix-certif avec `certifv3@example.net` et `certif-pro@example.net` et vérifier que l'ouverture de l'espace surveillant se fait dans un nouvel onglet.
