### PR TITLE
[FEATURE] Ajouter toutes les participations dans l'export des collecte de profils (Pix-10454)

### DIFF
--- a/api/scripts/prod/compute-participation-results.js
+++ b/api/scripts/prod/compute-participation-results.js
@@ -103,8 +103,9 @@ async function _getCampaignParticipationChunks(campaign) {
 async function _computeResults(skillIds, competences, campaignParticipations) {
   const knowledgeElementByUser = await _getKnowledgeElementsByUser(campaignParticipations);
 
-  const userIdsAndDates = {};
-  campaignParticipations.forEach(({ userId, sharedAt }) => (userIdsAndDates[userId] = sharedAt));
+  const userIdsAndDates = campaignParticipations.map(({ userId, sharedAt }) => {
+    return { userId, sharedAt };
+  });
   const placementProfiles = await placementProfileService.getPlacementProfilesWithSnapshotting({
     userIdsAndDates,
     competences,

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-participation-repository.js
@@ -16,7 +16,10 @@ const findProfilesCollectionResultDataByCampaignId = async function (campaignId)
       'view-active-organization-learners.id',
       'campaign-participations.organizationLearnerId',
     )
-    .where({ campaignId, isImproved: false, 'campaign-participations.deletedAt': null });
+    .where({ campaignId, 'campaign-participations.deletedAt': null })
+    .orderBy('lastName', 'ASC')
+    .orderBy('firstName', 'ASC')
+    .orderBy('createdAt', 'DESC');
 
   return results.map(_rowToResult);
 };

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository.js
@@ -65,11 +65,12 @@ async function _makeMemoizedGetPlacementProfileForUser(results) {
   const sharedResultsChunks = await bluebird.mapSeries(
     chunk(sharedResults, constants.CHUNK_SIZE_CAMPAIGN_RESULT_PROCESSING),
     (sharedResultsChunk) => {
-      const sharedAtDatesByUsers = Object.fromEntries(
-        sharedResultsChunk.map(({ userId, sharedAt }) => [userId, sharedAt]),
-      );
+      const userIdsAndDates = sharedResultsChunk.map(({ userId, sharedAt }) => {
+        return { userId, sharedAt };
+      });
+
       return placementProfileService.getPlacementProfilesWithSnapshotting({
-        userIdsAndDates: sharedAtDatesByUsers,
+        userIdsAndDates,
         allowExcessPixAndLevels: false,
         competences,
       });

--- a/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -17,7 +17,6 @@ import { MAX_REACHABLE_LEVEL, MAX_REACHABLE_PIX_BY_COMPETENCE } from '../../../.
 describe('Integration | Domain | Use Cases | start-writing-profiles-collection-campaign-results-to-stream', function () {
   describe('#startWritingCampaignProfilesCollectionResultsToStream', function () {
     let organization;
-    let user;
     let participant;
     let organizationLearner;
     let campaign;
@@ -27,10 +26,10 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
     let i18n;
 
     const createdAt = new Date('2019-02-25T10:00:00Z');
+    const sharedAt = new Date('2019-03-01T23:04:05Z');
 
     beforeEach(async function () {
       i18n = getI18n();
-      user = databaseBuilder.factory.buildUser();
       organization = databaseBuilder.factory.buildOrganization();
       const skillWeb1 = { id: 'recSkillWeb1', name: '@web1', competenceIds: ['recCompetence1'] };
       const skillWeb2 = { id: 'recSkillWeb2', name: '@web2', competenceIds: ['recCompetence1'] };
@@ -41,7 +40,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
 
       participant = databaseBuilder.factory.buildUser();
 
-      databaseBuilder.factory.buildKnowledgeElement({
+      const ke1 = databaseBuilder.factory.buildKnowledgeElement({
         status: 'validated',
         pixScore: 2,
         skillId: skillWeb1.id,
@@ -50,7 +49,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
         userId: participant.id,
         createdAt,
       });
-      databaseBuilder.factory.buildKnowledgeElement({
+      const ke2 = databaseBuilder.factory.buildKnowledgeElement({
         status: 'validated',
         pixScore: 2,
         skillId: skillWeb2.id,
@@ -59,7 +58,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
         userId: participant.id,
         createdAt,
       });
-      databaseBuilder.factory.buildKnowledgeElement({
+      const ke3 = databaseBuilder.factory.buildKnowledgeElement({
         status: 'invalidated',
         pixScore: 2,
         skillId: skillWeb3.id,
@@ -68,16 +67,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
         userId: participant.id,
         createdAt,
       });
-      databaseBuilder.factory.buildKnowledgeElement({
-        status: 'validated',
-        pixScore: 2,
-        skillId: skillWeb3.id,
-        earnedPix: 6,
-        competenceId: 'recCompetence1',
-        userId: participant.id,
-        createdAt: new Date('2019-03-25T10:00:00Z'),
-      });
-      databaseBuilder.factory.buildKnowledgeElement({
+      const ke4 = databaseBuilder.factory.buildKnowledgeElement({
         status: 'validated',
         skillId: skillUrl1.id,
         earnedPix: 2,
@@ -85,13 +75,19 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
         userId: participant.id,
         createdAt,
       });
-      databaseBuilder.factory.buildKnowledgeElement({
+      const ke5 = databaseBuilder.factory.buildKnowledgeElement({
         status: 'validated',
         skillId: skillUrl8.id,
         earnedPix: 64,
         competenceId: 'recCompetence2',
         userId: participant.id,
         createdAt,
+      });
+
+      databaseBuilder.factory.buildKnowledgeElementSnapshot({
+        userId: participant.id,
+        snappedAt: sharedAt,
+        snapshot: JSON.stringify([ke1, ke2, ke3, ke4, ke5]),
       });
 
       await databaseBuilder.commit();
@@ -123,7 +119,6 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
     context('When the organization is PRO', function () {
       beforeEach(async function () {
         organization = databaseBuilder.factory.buildOrganization({ type: 'PRO' });
-        databaseBuilder.factory.buildMembership({ userId: user.id, organizationId: organization.id });
 
         campaign = databaseBuilder.factory.buildCampaign({
           name: '@Campagne de Test N°2',
@@ -140,7 +135,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           organizationLearner,
           {
             createdAt,
-            sharedAt: new Date('2019-03-01T23:04:05Z'),
+            sharedAt,
             participantExternalId: '+Mon mail pro',
             campaignId: campaign.id,
             userId: participant.id,
@@ -174,7 +169,6 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
 
         // when
         startWritingCampaignProfilesCollectionResultsToStream({
-          userId: user.id,
           campaignId: campaign.id,
           writableStream,
           i18n,
@@ -199,7 +193,6 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
     context('When the organization is SCO and managing student', function () {
       beforeEach(async function () {
         organization = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
-        databaseBuilder.factory.buildMembership({ userId: user.id, organizationId: organization.id });
 
         organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
           userId: participant.id,
@@ -221,7 +214,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
 
         campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           createdAt,
-          sharedAt: new Date('2019-03-01T23:04:05Z'),
+          sharedAt,
           participantExternalId: '+Mon mail pro',
           campaignId: campaign.id,
           userId: participant.id,
@@ -256,7 +249,6 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
 
         // when
         startWritingCampaignProfilesCollectionResultsToStream({
-          userId: user.id,
           campaignId: campaign.id,
           writableStream,
           i18n,
@@ -281,7 +273,6 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
     context('When the organization is SUP and isManagingStudent', function () {
       beforeEach(async function () {
         organization = databaseBuilder.factory.buildOrganization({ type: 'SUP', isManagingStudents: true });
-        databaseBuilder.factory.buildMembership({ userId: user.id, organizationId: organization.id });
 
         organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
           userId: participant.id,
@@ -304,7 +295,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
 
         campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           createdAt,
-          sharedAt: new Date('2019-03-01T23:04:05Z'),
+          sharedAt,
           participantExternalId: '+Mon mail pro',
           campaignId: campaign.id,
           userId: participant.id,
@@ -340,7 +331,6 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
 
         // when
         startWritingCampaignProfilesCollectionResultsToStream({
-          userId: user.id,
           campaignId: campaign.id,
           writableStream,
           i18n,

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -148,33 +148,33 @@ describe('Integration | Repository | Campaign Participation', function () {
     });
 
     context('When the participant has improved its participation', function () {
-      let campaignId, improvedCampaignParticipation;
-
-      beforeEach(async function () {
-        campaignId = databaseBuilder.factory.buildCampaign({
+      it('should return all campaign-participation', async function () {
+        // given
+        const campaignId = databaseBuilder.factory.buildCampaign({
           type: CampaignTypes.PROFILES_COLLECTION,
           multipleSendings: true,
         }).id;
 
-        databaseBuilder.factory.buildCampaignParticipation({
+        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaignId,
-          createdAt: new Date('2016-01-15T14:59:35Z'),
+          createdAt: new Date('2016-01-15T14:50:35Z'),
           isImproved: true,
         });
-        improvedCampaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+        const improvedCampaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaignId,
           createdAt: new Date('2016-07-15T14:59:35Z'),
           isImproved: false,
         });
         await databaseBuilder.commit();
-      });
 
-      it('should return the non improved campaign-participation', async function () {
+        // when
         const participationResultDatas =
           await campaignParticipationRepository.findProfilesCollectionResultDataByCampaignId(campaignId);
 
-        expect(participationResultDatas.length).to.eq(1);
+        // then
+        expect(participationResultDatas).to.lengthOf(2);
         expect(participationResultDatas[0].id).to.eq(improvedCampaignParticipation.id);
+        expect(participationResultDatas[1].id).to.eq(campaignParticipation.id);
       });
     });
 

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
@@ -140,7 +140,7 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
           false,
         );
 
-        databaseBuilder.factory.buildKnowledgeElement({
+        const ke1 = databaseBuilder.factory.buildKnowledgeElement({
           status: 'validated',
           competenceId: competences[0].id,
           skillId: skills[0].id,
@@ -149,13 +149,19 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
           createdAt,
         });
 
-        databaseBuilder.factory.buildKnowledgeElement({
+        const ke2 = databaseBuilder.factory.buildKnowledgeElement({
           status: 'validated',
           competenceId: competences[1].id,
           skillId: skills[2].id,
           earnedPix: 6,
           userId: campaignParticipation.userId,
           createdAt,
+        });
+
+        databaseBuilder.factory.buildKnowledgeElementSnapshot({
+          userId: campaignParticipation.userId,
+          snappedAt: campaignParticipation.sharedAt,
+          snapshot: JSON.stringify([ke1, ke2]),
         });
 
         await databaseBuilder.commit();


### PR DESCRIPTION
## :unicorn: Problème
Afin de voir la progression des apprenants. nous avons besoin que les membres de l'organisation puissent voir toutes les participations de leurs apprenants

## :robot: Proposition
Ajouter lors de l'export des résultats d'une collecte de profil toutes les participations que les apprenants ont pu effectuer

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter sur PixOrga  `pro-orga@example.net`.
Aller sur PROCOLMUL
Effectuer un export
Utiliser learneremail1005_0@example.net sur PixAPP
Passer quelques questions en parcours libre
Utiliser j'ai un code PROCOLMUL
Partager le nouveau résultat
Retourner sur la campagne PROCOLMUL sur PixOrga 
Télécharger à nouveau l'export et vérifier qu'il y a une nouvelle ligne pour learner0