### PR TITLE
[FEATURE] Changer la position de la gestion de l'alert dans l'espace surveillant (PIX-10942).

### DIFF
--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -101,14 +101,15 @@
         @close={{this.closeMenu}}
         aria-label={{t "pages.session-supervising.candidate-in-list.candidate-options"}}
       >
-        <Dropdown::Item @onClick={{this.askUserToConfirmTestResume}}>
-          {{t "pages.session-supervising.candidate-in-list.resume-test-modal.allow-test-resume"}}
-        </Dropdown::Item>
         {{#if @candidate.liveAlert}}
           <Dropdown::Item @onClick={{this.askUserToHandleLiveAlert}}>
             {{t "pages.session-supervising.candidate-in-list.resume-test-modal.handle-live-alert"}}
           </Dropdown::Item>
         {{/if}}
+
+        <Dropdown::Item @onClick={{this.askUserToConfirmTestResume}}>
+          {{t "pages.session-supervising.candidate-in-list.resume-test-modal.allow-test-resume"}}
+        </Dropdown::Item>
 
         <Dropdown::Item @onClick={{this.askUserToConfirmTestEnd}}>
           {{t "pages.session-supervising.candidate-in-list.test-end-modal.end-assessment"}}

--- a/certif/tests/acceptance/session-supervising_test.js
+++ b/certif/tests/acceptance/session-supervising_test.js
@@ -263,7 +263,7 @@ module('Acceptance | Session supervising', function (hooks) {
       await click(firstVisit.getByRole('button', { name: 'Afficher les options du candidat' }));
 
       // then
-      assert.dom('button[name="Gérer un signalement"]').doesNotExist();
+      assert.dom('button[name="Gérer le signalement"]').doesNotExist();
     });
   });
 
@@ -302,7 +302,7 @@ module('Acceptance | Session supervising', function (hooks) {
 
           // when
           await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
-          await click(screen.getByRole('button', { name: 'Gérer un signalement' }));
+          await click(screen.getByRole('button', { name: 'Gérer le signalement' }));
           await click(screen.getByText('Refuser le signalement'));
 
           // then
@@ -341,7 +341,7 @@ module('Acceptance | Session supervising', function (hooks) {
 
           // when
           await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
-          await click(screen.getByRole('button', { name: 'Gérer un signalement' }));
+          await click(screen.getByRole('button', { name: 'Gérer le signalement' }));
           await click(screen.getByText('Refuser le signalement'));
           await settled();
 
@@ -395,7 +395,7 @@ module('Acceptance | Session supervising', function (hooks) {
 
           // when
           await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
-          await click(screen.getByRole('button', { name: 'Gérer un signalement' }));
+          await click(screen.getByRole('button', { name: 'Gérer le signalement' }));
 
           await click(
             screen.getByLabelText(
@@ -450,7 +450,7 @@ module('Acceptance | Session supervising', function (hooks) {
 
           // when
           await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
-          await click(screen.getByRole('button', { name: 'Gérer un signalement' }));
+          await click(screen.getByRole('button', { name: 'Gérer le signalement' }));
           await click(
             screen.getByLabelText(
               "E5 Le site est bloqué par les restrictions réseau de l'établissement (réseaux sociaux par ex.)",
@@ -500,7 +500,7 @@ module('Acceptance | Session supervising', function (hooks) {
 
           // when
           await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
-          await click(screen.getByRole('button', { name: 'Gérer un signalement' }));
+          await click(screen.getByRole('button', { name: 'Gérer le signalement' }));
           await click(screen.getByLabelText('E4 Le site à visiter est indisponible/en maintenance/inaccessible'));
           await click(screen.getByText('Refuser le signalement'));
 
@@ -510,7 +510,7 @@ module('Acceptance | Session supervising', function (hooks) {
           const visibleCloseButton = closeButtons.filter((element) => isVisible(element))[0];
           await click(visibleCloseButton);
           await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
-          await click(screen.getByRole('button', { name: 'Gérer un signalement' }));
+          await click(screen.getByRole('button', { name: 'Gérer le signalement' }));
           // then
           const checkedRadioButtons = screen.queryAllByRole('radio', { checked: true });
           assert.strictEqual(checkedRadioButtons.length, 0);
@@ -549,7 +549,7 @@ module('Acceptance | Session supervising', function (hooks) {
 
           // when
           await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
-          await click(screen.getByRole('button', { name: 'Gérer un signalement' }));
+          await click(screen.getByRole('button', { name: 'Gérer le signalement' }));
           await click(screen.getByLabelText('E4 Le site à visiter est indisponible/en maintenance/inaccessible'));
 
           const modal = await screen.findByRole('dialog');

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -339,7 +339,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
         // then
         assert.dom(screen.getByText('Autoriser la reprise du test')).exists();
         assert.dom(screen.getByText('Terminer le test')).exists();
-        assert.dom(screen.queryByText('Gérer un signalement')).doesNotExist();
+        assert.dom(screen.queryByText('Gérer le signalement')).doesNotExist();
       });
     });
 
@@ -366,7 +366,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
 
         // then
         assert.dom(screen.getByText('Autoriser la reprise du test')).exists();
-        assert.dom(screen.getByText('Gérer un signalement')).exists();
+        assert.dom(screen.getByText('Gérer le signalement')).exists();
         assert.dom(screen.getByText('Terminer le test')).exists();
       });
     });
@@ -474,7 +474,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
               <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
             `);
       await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
-      await click(screen.getByRole('button', { name: 'Gérer un signalement' }));
+      await click(screen.getByRole('button', { name: 'Gérer le signalement' }));
 
       // then
       assert

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -463,7 +463,7 @@
           "cancel-label": "Cancel and close the confirmation window",
           "description": "If the candidate has closed their Pix Certification exam window (by mistake, or because of a technical problem) and is still present in the exam room, you can allow them to resume their test where they left it.",
           "error": " An error has occurred, {firstName} {lastName} couldn't be allowed to resume his/her Pix certification exam.",
-          "handle-live-alert": "Gérer un signalement",
+          "handle-live-alert": "Gérer le signalement",
           "instruction-with-name": "Allow {firstName} {lastName} to resume their test ?",
           "success": "Success ! {firstName} {lastName} can resume his/her Pix certification exam."
         },

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -463,7 +463,7 @@
           "cancel-label": "Annuler et fermer la fenêtre de confirmation",
           "description": "Si le candidat a fermé la fenêtre de son test de certification (par erreur, ou à cause d'un problème technique) et est toujours présent dans la salle de test, vous pouvez lui permettre de reprendre son test à l'endroit où il l'avait quitté.",
           "error": "Une erreur est survenue, {firstName} {lastName} n'a a pu être autorisé à reprendre son test.",
-          "handle-live-alert": "Gérer un signalement",
+          "handle-live-alert": "Gérer le signalement",
           "instruction-with-name": "Autoriser {firstName} {lastName} à reprendre son test ?",
           "success": "Succès ! {firstName} {lastName} peut reprendre son test de certification."
         },


### PR DESCRIPTION
## :unicorn: Problème

Lorsqu’un candidat fait un signalement pendant son test de certification, une nouvelle action “Gérer un signalement” devient disponible depuis l’espace surveillant.
Actuellement, cette nouvelle action s’affiche en 2ème position après “Autoriser la reprise du test”. Il y a donc un risque que le surveillant clique par mégarde sur cette option, et donne un jeton au candidat pour relancer son test en toute autonomie.

## :robot: Proposition

Modifier l’ordre des actions possibles depuis l’ES quand un signalement est en cours. 
A afficher dans l’ordre suivant : 
• Gérer un signalement : si possible de changer de le wording en “Gérer le signalement” ça serait topissime :pray: 
• Autoriser la reprise du test
• Terminer le test

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

Créer une session de certification dans un CDC taggué “Pilote certif v3” et y inscrire un candidat
Lancer le test du candidat et “Signaler un problème avec la question” > “Oui, je suis sur”
Ouvrir l’ES et cliquer sur l’icône pour afficher les options 
-> L’option “Gérer le signalement” apparait en 1er dans la liste
