### PR TITLE
[FEATURE] Retirer les validations et contraintes sur le code d'un fournisseur d'identité (PIX-10980)

### DIFF
--- a/api/db/migrations/20240131091457_remove-identity-provider-constraint-from-authentication-methods-table.js
+++ b/api/db/migrations/20240131091457_remove-identity-provider-constraint-from-authentication-methods-table.js
@@ -1,0 +1,17 @@
+const TABLE_NAME = 'authentication-methods';
+const COLUMN_NAME = 'identityProvider';
+const CONSTRAINT_NAME = 'authentication_methods_identityProvider_check';
+
+const up = async function (knex) {
+  // eslint-disable-next-line knex/avoid-injections
+  return knex.raw(`ALTER TABLE "${TABLE_NAME}" DROP CONSTRAINT "${CONSTRAINT_NAME}"`);
+};
+
+const down = async function (knex) {
+  // eslint-disable-next-line knex/avoid-injections
+  return knex.raw(
+    `ALTER TABLE "${TABLE_NAME}" ADD CONSTRAINT "${CONSTRAINT_NAME}" CHECK ( "${COLUMN_NAME}" IN ('PIX', 'GAR', 'POLE_EMPLOI', 'CNAV', 'FWB', 'PAYSDELALOIRE') )`,
+  );
+};
+
+export { up, down };

--- a/api/db/migrations/20240201102606_remove-identity-provider-for-campaigns-constraint-from-organization-table.js
+++ b/api/db/migrations/20240201102606_remove-identity-provider-for-campaigns-constraint-from-organization-table.js
@@ -1,0 +1,17 @@
+const TABLE_NAME = 'organizations';
+const COLUMN_NAME = 'identityProviderForCampaigns';
+const CONSTRAINT_NAME = 'organizations_identityProviderForCampaigns_check';
+
+const up = async function (knex) {
+  // eslint-disable-next-line knex/avoid-injections
+  return knex.raw(`ALTER TABLE "${TABLE_NAME}" DROP CONSTRAINT "${CONSTRAINT_NAME}"`);
+};
+
+const down = async function (knex) {
+  // eslint-disable-next-line knex/avoid-injections
+  return knex.raw(
+    `ALTER TABLE "${TABLE_NAME}" ADD CONSTRAINT "${CONSTRAINT_NAME}" CHECK ( "${COLUMN_NAME}" IN ('PIX', 'GAR', 'POLE_EMPLOI', 'CNAV', 'FWB', 'PAYSDELALOIRE') )`,
+  );
+};
+
+export { up, down };

--- a/api/lib/application/authentication/oidc/index.js
+++ b/api/lib/application/authentication/oidc/index.js
@@ -1,8 +1,6 @@
 import Joi from 'joi';
-import * as OidcIdentityProviders from '../../../domain/constants/oidc-identity-providers.js';
-import { oidcController } from './oidc-controller.js';
 
-const validOidcProviderCodes = OidcIdentityProviders.getValidOidcProviderCodes();
+import { oidcController } from './oidc-controller.js';
 
 const register = async function (server) {
   const adminRoutes = [
@@ -45,13 +43,7 @@ const register = async function (server) {
       config: {
         validate: {
           query: Joi.object({
-            identity_provider: Joi.string()
-              .required()
-              .valid(
-                OidcIdentityProviders.POLE_EMPLOI.code,
-                OidcIdentityProviders.FWB.code,
-                OidcIdentityProviders.PAYSDELALOIRE.code,
-              ),
+            identity_provider: Joi.string().required(),
             logout_url_uuid: Joi.string()
               .regex(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i)
               .required(),
@@ -72,9 +64,7 @@ const register = async function (server) {
         auth: false,
         validate: {
           query: Joi.object({
-            identity_provider: Joi.string()
-              .required()
-              .valid(...validOidcProviderCodes),
+            identity_provider: Joi.string().required(),
             redirect_uri: Joi.string().required(),
           }),
         },
@@ -95,9 +85,7 @@ const register = async function (server) {
           payload: Joi.object({
             data: {
               attributes: {
-                identity_provider: Joi.string()
-                  .required()
-                  .valid(...validOidcProviderCodes),
+                identity_provider: Joi.string().required(),
                 code: Joi.string().required(),
                 redirect_uri: Joi.string().required(),
                 state_sent: Joi.string().required(),
@@ -123,9 +111,7 @@ const register = async function (server) {
           payload: Joi.object({
             data: {
               attributes: {
-                identity_provider: Joi.string()
-                  .required()
-                  .valid(...validOidcProviderCodes),
+                identity_provider: Joi.string().required(),
                 authentication_key: Joi.string().required(),
               },
             },
@@ -150,9 +136,7 @@ const register = async function (server) {
               attributes: Joi.object({
                 email: Joi.string().email().required(),
                 password: Joi.string().required(),
-                'identity-provider': Joi.string()
-                  .required()
-                  .valid(...validOidcProviderCodes),
+                'identity-provider': Joi.string().required(),
                 'authentication-key': Joi.string().required(),
               }),
               type: Joi.string(),
@@ -176,9 +160,7 @@ const register = async function (server) {
           payload: Joi.object({
             data: Joi.object({
               attributes: Joi.object({
-                identity_provider: Joi.string()
-                  .required()
-                  .valid(...validOidcProviderCodes),
+                identity_provider: Joi.string().required(),
                 authentication_key: Joi.string().required(),
               }),
               type: Joi.string(),

--- a/api/lib/domain/models/AuthenticationMethod.js
+++ b/api/lib/domain/models/AuthenticationMethod.js
@@ -3,13 +3,7 @@ import JoiDate from '@joi/date';
 const Joi = BaseJoi.extend(JoiDate);
 import { validateEntity } from '../validators/entity-validator.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
-import {
-  getValidOidcProviderCodes,
-  POLE_EMPLOI,
-  CNAV,
-  FWB,
-  PAYSDELALOIRE,
-} from '../constants/oidc-identity-providers.js';
+import { POLE_EMPLOI, CNAV, FWB, PAYSDELALOIRE } from '../constants/oidc-identity-providers.js';
 
 class PixAuthenticationComplement {
   constructor({ password, shouldChangePassword } = {}) {
@@ -68,9 +62,7 @@ class GARAuthenticationComplement {
 
 const validationSchema = Joi.object({
   id: Joi.number().optional(),
-  identityProvider: Joi.string()
-    .valid(NON_OIDC_IDENTITY_PROVIDERS.PIX.code, NON_OIDC_IDENTITY_PROVIDERS.GAR.code, ...getValidOidcProviderCodes())
-    .required(),
+  identityProvider: Joi.string().required(),
   authenticationComplement: Joi.when('identityProvider', [
     { is: NON_OIDC_IDENTITY_PROVIDERS.PIX.code, then: Joi.object().instance(PixAuthenticationComplement).required() },
     { is: POLE_EMPLOI.code, then: Joi.object().instance(PoleEmploiOidcAuthenticationComplement).required() },
@@ -131,4 +123,5 @@ AuthenticationMethod.PixAuthenticationComplement = PixAuthenticationComplement;
 AuthenticationMethod.OidcAuthenticationComplement = OidcAuthenticationComplement;
 AuthenticationMethod.PoleEmploiOidcAuthenticationComplement = PoleEmploiOidcAuthenticationComplement;
 AuthenticationMethod.GARAuthenticationComplement = GARAuthenticationComplement;
+
 export { AuthenticationMethod };

--- a/api/lib/domain/validators/organization-with-tags-and-target-profiles-script.js
+++ b/api/lib/domain/validators/organization-with-tags-and-target-profiles-script.js
@@ -2,8 +2,6 @@ import Joi from 'joi';
 import { EntityValidationError } from '../../../src/shared/domain/errors.js';
 import { Organization } from '../models/Organization.js';
 import { Membership } from '../models/Membership.js';
-import { getValidOidcProviderCodes } from '../constants/oidc-identity-providers.js';
-import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 
 const schema = Joi.object({
   type: Joi.string()
@@ -26,12 +24,7 @@ const schema = Joi.object({
     'string.empty': "La locale n'est pas renseignée.",
     'any.only': "La locale doit avoir l'une des valeurs suivantes : fr-fr, fr ou en",
   }),
-  identityProviderForCampaigns: Joi.string()
-    .allow(null)
-    .valid(NON_OIDC_IDENTITY_PROVIDERS.GAR.code, ...getValidOidcProviderCodes())
-    .messages({
-      'any.only': `L'organisme fourni doit avoir l'une des valeurs suivantes : GAR,${getValidOidcProviderCodes()}`,
-    }),
+  identityProviderForCampaigns: Joi.string().allow(null),
   provinceCode: Joi.string().required().allow('', null),
   credit: Joi.number().required().messages({
     'number.base': 'Le crédit doit être un entier.',

--- a/api/tests/integration/application/authentication/oidc/index_test.js
+++ b/api/tests/integration/application/authentication/oidc/index_test.js
@@ -74,20 +74,6 @@ describe('Integration | Application | Route | OidcRouter', function () {
         });
       });
     });
-
-    context('when identity_provider parameter is not POLE_EMPLOI', function () {
-      it('should return a response with HTTP status code 400', async function () {
-        // given & when
-        const { statusCode } = await server.requestObject({
-          method: 'GET',
-          url: '/api/oidc/redirect-logout-url?identity_provider=MY_IDP&logout_url_uuid=b45cb781-4e9a-49b6-8c7e-ff5f02e07720',
-          headers: { authorization: generateValidRequestAuthorizationHeader() },
-        });
-
-        // then
-        expect(statusCode).to.equal(400);
-      });
-    });
   });
 
   describe('POST /api/oidc/user/check-reconciliation', function () {

--- a/api/tests/unit/domain/models/AuthenticationMethod_test.js
+++ b/api/tests/unit/domain/models/AuthenticationMethod_test.js
@@ -93,7 +93,7 @@ describe('Unit | Domain | Models | AuthenticationMethod', function () {
       expect(
         () =>
           new AuthenticationMethod({
-            identityProvider: 'not_valid',
+            identityProvider: 15,
             externalIdentifier: 'externalIdentifier',
             userId: 1,
           }),


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, il y a une suite de validations et de contraintes qui évite de manipulé des codes de fournisseurs d’identité n'étant pas repris dans notre liste. Ceci est un frein à l’industrialisation que nous souhaitons mettre en place.

## :robot: Proposition

Retirer toute les validations et contraintes lié au code d’un fournisseur d’identité au niveau de l’API.

## :rainbow: Remarques

RAS

## :100: Pour tester

À tester en local

1. En préalable exécuter la commande `npm run db:reset`
2. Constater en base de données que le schéma des tables `authentication-methods` et `organizations` ont bien été modifiés avec, respectivement, la disparition des contraintes `authentication_methods_identityProvider_check` et `organizations_identityProviderForCampaigns_check`.
3. Exécuter la commande de rollback `npm run db:rollback:latest`
4. Constater en base de données que le schéma des tables `authentication-methods` et `organizations` a bien retrouvé son état initial avec, respectivement, la présences des contraintes `authentication_methods_identityProvider_check` et `organizations_identityProviderForCampaigns_check`.
5. Réaliser une connexion puis déconnexion avec un SSO OIDC pour vérifier qu'il n'y a pas de régression