### PR TITLE
[TECH] Faire retourner uniquement la correction par la méthode `assess` (PIX-10875) (PIX-10298)

### DIFF
--- a/api/src/devcomp/domain/usecases/verify-and-save-answer.js
+++ b/api/src/devcomp/domain/usecases/verify-and-save-answer.js
@@ -11,16 +11,19 @@ async function verifyAndSaveAnswer({
 }) {
   const passage = await _getPassage({ passageId, passageRepository });
   const module = await moduleRepository.getBySlugForVerification({ slug: passage.moduleId });
+
   const grain = module.getGrainByElementId(elementId);
   const element = grain.getElementById(elementId);
-  element.validateUserResponseFormat(userResponse);
 
-  const { correction, userResponseValue } = element.assess(userResponse);
+  element.setUserResponse(userResponse);
+
+  const correction = element.assess();
+
   return await elementAnswerRepository.save({
     passageId,
     elementId,
     grainId: grain.id,
-    value: userResponseValue,
+    value: element.userResponse,
     correction,
   });
 }

--- a/api/tests/devcomp/unit/domain/models/element/QCU-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCU-for-answer-verification_test.js
@@ -47,23 +47,16 @@ describe('Unit | Devcomp | Domain | Models | Element | QcuForAnswerVerification'
   });
 
   describe('#assess', function () {
-    it('should return a QcuCorrectionResponse and the user response for a valid answer', function () {
+    it('should return a QcuCorrectionResponse for a valid answer', function () {
       // given
       const stubedIsOk = sinon.stub().returns(true);
       const assessResult = { result: { isOK: stubedIsOk } };
       const qcuSolution = Symbol('correctSolution');
-      const userResponse = [qcuSolution];
+      const userResponse = qcuSolution;
 
       const validator = {
         assess: sinon.stub(),
       };
-      validator.assess
-        .withArgs({
-          answer: {
-            value: userResponse[0],
-          },
-        })
-        .returns(assessResult);
       const qcu = new QCUForAnswerVerification({
         id: 'qcu-id',
         instruction: '',
@@ -72,41 +65,40 @@ describe('Unit | Devcomp | Domain | Models | Element | QcuForAnswerVerification'
         solution: qcuSolution,
         validator,
       });
+      qcu.userResponse = userResponse;
 
-      const expectedResult = {
-        userResponseValue: userResponse[0],
-        correction: {
-          status: assessResult.result,
-          feedback: qcu.feedbacks.valid,
-          solution: qcuSolution,
-        },
+      validator.assess
+        .withArgs({
+          answer: {
+            value: userResponse,
+          },
+        })
+        .returns(assessResult);
+
+      const expectedCorrection = {
+        status: assessResult.result,
+        feedback: qcu.feedbacks.valid,
+        solution: qcuSolution,
       };
 
       // when
-      const result = qcu.assess(userResponse);
+      const correction = qcu.assess();
 
       // then
-      expect(result).to.deep.equal(expectedResult);
-      expect(result.correction).to.deepEqualInstance(new QcuCorrectionResponse(expectedResult.correction));
+      expect(correction).to.deep.equal(expectedCorrection);
+      expect(correction).to.deepEqualInstance(new QcuCorrectionResponse(expectedCorrection));
     });
 
-    it('should return a QcuCorrectionResponse and the user response for a invalid answer', function () {
+    it('should return a QcuCorrectionResponse for a invalid answer', function () {
       // given
       const stubedIsOk = sinon.stub().returns(false);
       const assessResult = { result: { isOK: stubedIsOk } };
       const qcuSolution = Symbol('correctSolution');
-      const userResponse = ['wrongAnswer'];
+      const userResponse = 'wrongAnswer';
 
       const validator = {
         assess: sinon.stub(),
       };
-      validator.assess
-        .withArgs({
-          answer: {
-            value: userResponse[0],
-          },
-        })
-        .returns(assessResult);
       const qcu = new QCUForAnswerVerification({
         id: 'qcu-id',
         instruction: '',
@@ -115,31 +107,38 @@ describe('Unit | Devcomp | Domain | Models | Element | QcuForAnswerVerification'
         solution: qcuSolution,
         validator,
       });
+      qcu.userResponse = userResponse;
 
-      const expectedResult = {
-        userResponseValue: userResponse[0],
-        correction: {
-          status: assessResult.result,
-          feedback: qcu.feedbacks.invalid,
-          solution: qcuSolution,
-        },
+      validator.assess
+        .withArgs({
+          answer: {
+            value: userResponse,
+          },
+        })
+        .returns(assessResult);
+
+      const expectedCorrection = {
+        status: assessResult.result,
+        feedback: qcu.feedbacks.invalid,
+        solution: qcuSolution,
       };
 
       // when
-      const result = qcu.assess(userResponse);
+      const correction = qcu.assess();
 
       // then
-      expect(result).to.deep.equal(expectedResult);
-      expect(result.correction).to.deepEqualInstance(new QcuCorrectionResponse(expectedResult.correction));
+      expect(correction).to.deep.equal(expectedCorrection);
+      expect(correction).to.deepEqualInstance(new QcuCorrectionResponse(expectedCorrection));
     });
   });
 
-  describe('#validateUserResponseFormat', function () {
+  describe('#setUserResponse', function () {
     describe('if userResponse is valid', function () {
-      it('should not throw error', function () {
+      it('should return the user response value', function () {
         // given
         const qcuSolution = '12';
         const userResponse = [qcuSolution];
+        const expectedUserResponse = userResponse[0];
 
         const qcu = new QCUForAnswerVerification({
           id: 'qcu-id',
@@ -149,8 +148,11 @@ describe('Unit | Devcomp | Domain | Models | Element | QcuForAnswerVerification'
           solution: qcuSolution,
         });
 
-        // when/then
-        expect(() => qcu.validateUserResponseFormat(userResponse)).not.to.throw();
+        // when
+        qcu.setUserResponse(userResponse);
+
+        // then
+        expect(qcu.userResponse).to.deep.equal(expectedUserResponse);
       });
     });
 
@@ -199,7 +201,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QcuForAnswerVerification'
           });
 
           // when/then
-          expect(() => qcu.validateUserResponseFormat(userResponse)).to.throw(EntityValidationError);
+          expect(() => qcu.setUserResponse(userResponse)).to.throw(EntityValidationError);
         });
       });
     });

--- a/api/tests/devcomp/unit/domain/usecases/verify-and-save-answer_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/verify-and-save-answer_test.js
@@ -28,10 +28,7 @@ describe('Unit | Devcomp | Domain | UseCases | verify-and-save-answer', function
         const elementId = Symbol('elementId');
         const passageId = Symbol('passageId');
         const userResponse = Symbol('userResponse');
-        const elementAnswer = {
-          userResponseValue: userResponse,
-          correction: { status: { status: Symbol('status') } },
-        };
+        const correction = { status: { status: Symbol('status') } };
         const persistedElementAnswer = Symbol('persistedElementAnswer');
 
         const passageRepository = {
@@ -46,9 +43,14 @@ describe('Unit | Devcomp | Domain | UseCases | verify-and-save-answer', function
 
         const module = { getGrainByElementId: sinon.stub() };
 
-        const element = { assess: sinon.stub(), validateUserResponseFormat: sinon.stub() };
-        element.assess.withArgs(userResponse).returns(elementAnswer);
-        element.validateUserResponseFormat.withArgs(userResponse).returns();
+        const element = {
+          userResponse: Symbol('UserResponse'),
+          assess: sinon.stub(),
+          validateUserResponseFormat: sinon.stub(),
+          setUserResponse: sinon.stub(),
+        };
+        element.setUserResponse.withArgs(userResponse).returns();
+        element.assess.withArgs().returns(correction);
 
         const grain = { id: 'grain-id', getElementById: sinon.stub() };
         grain.getElementById.withArgs(elementId).returns(element);
@@ -64,8 +66,8 @@ describe('Unit | Devcomp | Domain | UseCases | verify-and-save-answer', function
             passageId,
             elementId,
             grainId: grain.id,
-            value: userResponse,
-            correction: elementAnswer.correction,
+            value: element.userResponse,
+            correction: correction,
           })
           .resolves(persistedElementAnswer);
 
@@ -81,7 +83,7 @@ describe('Unit | Devcomp | Domain | UseCases | verify-and-save-answer', function
 
         // then
         expect(result).to.equal(persistedElementAnswer);
-        expect(element.validateUserResponseFormat).to.have.been.calledOnce;
+        expect(element.setUserResponse).to.have.been.calledOnce;
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
À l'issue du décommissionnement, la méthode `assess` de `QROCMForAnswerVerification` et `QCUForAnswerVerification` renvoit un objet `{ userResponseValue, correction }` ce qui est un peu léger d'un point de vue DDD.

## :robot: Proposition
Nous privilégions l’hypothèse que la méthode `assess` renvoi de la donnée qui ne la concerne pas (la `userResponseValue` formattée).

Nous proposons donc que dans le usecase `verifyAndSaveAnswer`, on implémente une nouvelle méthode `setUserResponse` pour les `QCUForAnswerVerification` et `QROCMForAnswerVerification` qui permet de setter la réponse formatée comme souhaité selon la modalité tout en validant son format.

Ainsi, la méthode `assess` ne renverrait plus que la `Correction`.

## :rainbow: Remarques

## :100: Pour tester
La CI passe.
