### PR TITLE
[TECH] Améliore la robustesse du groupBy dans certification-point-of-contact-repository

### DIFF
--- a/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
+++ b/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
@@ -23,14 +23,7 @@ const get = async function (userId) {
     .from('users')
     .leftJoin('certification-center-memberships', 'certification-center-memberships.userId', 'users.id')
     .where('users.id', userId)
-    .groupBy(
-      'users.id',
-      'users.firstName',
-      'users.lastName',
-      'users.email',
-      'users.lang',
-      'users.pixCertifTermsOfServiceAccepted',
-    )
+    .groupBy('users.id')
     .first();
 
   if (!certificationPointOfContactDTO) {
@@ -107,13 +100,7 @@ async function _findAllowedCertificationCenterAccesses(certificationCenterIds) {
     )
     .whereIn('certification-centers.id', certificationCenterIds)
     .orderBy('certification-centers.id')
-    .groupBy(
-      'certification-centers.id',
-      'certification-centers.name',
-      'certification-centers.externalId',
-      'certification-centers.type',
-      'organizations.isManagingStudents',
-    );
+    .groupBy('certification-centers.id', 'organizations.isManagingStudents');
 
   return _.map(allowedCertificationCenterAccessDTOs, (allowedCertificationCenterAccessDTO) => {
     return new AllowedCertificationCenterAccess({

--- a/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
+++ b/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
@@ -23,7 +23,14 @@ const get = async function (userId) {
     .from('users')
     .leftJoin('certification-center-memberships', 'certification-center-memberships.userId', 'users.id')
     .where('users.id', userId)
-    .groupByRaw('1, 2, 3, 4, 5')
+    .groupBy(
+      'users.id',
+      'users.firstName',
+      'users.lastName',
+      'users.email',
+      'users.lang',
+      'users.pixCertifTermsOfServiceAccepted',
+    )
     .first();
 
   if (!certificationPointOfContactDTO) {
@@ -100,7 +107,13 @@ async function _findAllowedCertificationCenterAccesses(certificationCenterIds) {
     )
     .whereIn('certification-centers.id', certificationCenterIds)
     .orderBy('certification-centers.id')
-    .groupByRaw('1, 2, 3, 4, 5');
+    .groupBy(
+      'certification-centers.id',
+      'certification-centers.name',
+      'certification-centers.externalId',
+      'certification-centers.type',
+      'organizations.isManagingStudents',
+    );
 
   return _.map(allowedCertificationCenterAccessDTOs, (allowedCertificationCenterAccessDTO) => {
     return new AllowedCertificationCenterAccess({


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le groupBy est fait en se basant sur l'ordre des colonnes dans le select `groupByRaw('1, 2, 3, 4, 5')`. C'est une mauvaise pratique qui conduit à des bugs, notamment lors de l'ajout de colonnes dans le select.

De plus, le groupBy se fait sur de nombreux champs inutiles, puisqu'ils sont nécessairement unique pour un id unique.

## :robot: Proposition
Remplacer ce `groupByRaw` par un `groupBy` ayant comme paramètres uniquement les colonnes nécessaire.

## :100: Pour tester
- Aller sur pix admin (superadmin@example.net // pix123)
- Dans centre de certification, sélectionner un centre et lui ajouter l'utilisateur certif-pro@example.net
- Se rendre sur pix certif (certif-pro@example.net // pix123
- Tester le changement de centre en haut à droite