### PR TITLE
[FEATURE] Accès à la documentation V3 pour les centres de certifications pilotes (PIX-10839).

### DIFF
--- a/api/lib/domain/read-models/AllowedCertificationCenterAccess.js
+++ b/api/lib/domain/read-models/AllowedCertificationCenterAccess.js
@@ -9,6 +9,7 @@ class AllowedCertificationCenterAccess {
     isRelatedToManagingStudentsOrganization,
     relatedOrganizationTags,
     habilitations,
+    isV3Pilot,
   }) {
     this.id = id;
     this.name = name;
@@ -17,6 +18,7 @@ class AllowedCertificationCenterAccess {
     this.isRelatedToManagingStudentsOrganization = isRelatedToManagingStudentsOrganization;
     this.relatedOrganizationTags = relatedOrganizationTags;
     this.habilitations = habilitations;
+    this.isV3Pilot = isV3Pilot;
   }
 
   isAccessBlockedCollege() {

--- a/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
+++ b/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
@@ -78,6 +78,7 @@ async function _findAllowedCertificationCenterAccesses(certificationCenterIds) {
       habilitations: knex.raw(
         `array_agg(json_build_object('id', "complementary-certifications".id, 'label', "complementary-certifications".label, 'key', "complementary-certifications".key) order by "complementary-certifications".id)`,
       ),
+      isV3Pilot: 'certification-centers.isV3Pilot',
     })
     .from('certification-centers')
     .leftJoin('organizations', function () {

--- a/api/lib/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer.js
@@ -34,6 +34,7 @@ const serialize = function (certificationPointOfContact) {
         'isAccessBlockedAgri',
         'relatedOrganizationTags',
         'habilitations',
+        'isV3Pilot',
         'pixCertifScoBlockedAccessDateLycee',
         'pixCertifScoBlockedAccessDateCollege',
       ],

--- a/api/tests/integration/infrastructure/repositories/certification-point-of-contact-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-point-of-contact-repository_test.js
@@ -279,6 +279,7 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
         name: 'Centre de certif sans orga reliée',
         type: CertificationCenter.types.PRO,
         externalId: 'Centre1',
+        isV3Pilot: true,
       });
       databaseBuilder.factory.buildComplementaryCertificationHabilitation({
         certificationCenterId: 1,
@@ -293,6 +294,7 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
         name: 'Centre de certif reliée à une orga sans tags',
         type: CertificationCenter.types.PRO,
         externalId: 'Centre2',
+        isV3Pilot: true,
       });
       databaseBuilder.factory.buildComplementaryCertificationHabilitation({
         certificationCenterId: 2,
@@ -344,6 +346,7 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
         externalId: 'Centre1',
         type: CertificationCenter.types.PRO,
         isRelatedToManagingStudentsOrganization: false,
+        isV3Pilot: true,
         relatedOrganizationTags: [],
         habilitations: [
           { id: 1, label: 'Certif comp 1', key: 'COMP_1' },
@@ -356,6 +359,7 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
         externalId: 'Centre2',
         type: CertificationCenter.types.PRO,
         isRelatedToManagingStudentsOrganization: false,
+        isV3Pilot: true,
         relatedOrganizationTags: [],
         habilitations: [{ id: 3, label: 'Certif comp 3', key: 'COMP_3' }],
       });

--- a/api/tests/tooling/domain-builder/factory/build-allowed-certification-center-access.js
+++ b/api/tests/tooling/domain-builder/factory/build-allowed-certification-center-access.js
@@ -10,6 +10,7 @@ function buildAllowedCertificationCenterAccess({
   isRelatedToManagingStudentsOrganization = false,
   relatedOrganizationTags = [],
   habilitations = [],
+  isV3Pilot = false,
 } = {}) {
   return new AllowedCertificationCenterAccess({
     id,
@@ -19,6 +20,7 @@ function buildAllowedCertificationCenterAccess({
     isRelatedToManagingStudentsOrganization,
     relatedOrganizationTags,
     habilitations,
+    isV3Pilot,
   });
 }
 

--- a/api/tests/unit/application/certification-point-of-contacts/certification-point-of-contact-controller_test.js
+++ b/api/tests/unit/application/certification-point-of-contacts/certification-point-of-contact-controller_test.js
@@ -92,6 +92,7 @@ describe('Unit | Controller | certifications-point-of-contact-controller', funct
               'is-access-blocked-lycee': false,
               'is-access-blocked-aefe': false,
               'is-access-blocked-agri': false,
+              'is-v3-pilot': false,
               'is-related-to-managing-students-organization': false,
               'pix-certif-sco-blocked-access-date-college': null,
               'pix-certif-sco-blocked-access-date-lycee': null,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer_test.js
@@ -17,6 +17,7 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
         externalId: 'BUFFY_SLAYER',
         type: 'PRO',
         isRelatedToManagingStudentsOrganization: false,
+        isV3Pilot: false,
         relatedOrganizationTags: [],
         habilitations: [
           { id: 1, name: 'Certif comp 1' },
@@ -30,6 +31,7 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
         externalId: 'SPIKE',
         type: 'SCO',
         isRelatedToManagingStudentsOrganization: true,
+        isV3Pilot: false,
         relatedOrganizationTags: ['tag1'],
         habilitations: [],
       });
@@ -114,6 +116,7 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
               'is-access-blocked-lycee': false,
               'is-access-blocked-aefe': false,
               'is-access-blocked-agri': false,
+              'is-v3-pilot': false,
               'pix-certif-sco-blocked-access-date-college': '2022-06-01',
               'pix-certif-sco-blocked-access-date-lycee': '2022-08-01',
               'related-organization-tags': [],
@@ -135,6 +138,7 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
               'is-access-blocked-lycee': false,
               'is-access-blocked-aefe': false,
               'is-access-blocked-agri': false,
+              'is-v3-pilot': false,
               'pix-certif-sco-blocked-access-date-college': '2022-06-01',
               'pix-certif-sco-blocked-access-date-lycee': '2022-08-01',
               'related-organization-tags': ['tag1'],

--- a/certif/app/controllers/authenticated.js
+++ b/certif/app/controllers/authenticated.js
@@ -5,6 +5,7 @@ import { tracked } from '@glimmer/tracking';
 
 const LINK_SCO = 'http://cloud.pix.fr/s/GqwW6dFDDrHezfS';
 const LINK_OTHER = 'http://cloud.pix.fr/s/fLSG4mYCcX7GDRF';
+const LINK_V3_PILOT = 'https://cloud.pix.fr/s/f2PNGLajBypbaiJ';
 
 export default class AuthenticatedController extends Controller {
   @tracked isBannerVisible = true;
@@ -29,6 +30,9 @@ export default class AuthenticatedController extends Controller {
   }
 
   get documentationLink() {
+    if (this.currentUser.currentAllowedCertificationCenterAccess.isV3Pilot) {
+      return LINK_V3_PILOT;
+    }
     if (this.currentUser.currentAllowedCertificationCenterAccess.isScoManagingStudents) {
       return LINK_SCO;
     }

--- a/certif/app/models/allowed-certification-center-access.js
+++ b/certif/app/models/allowed-certification-center-access.js
@@ -19,6 +19,7 @@ export default class AllowedCertificationCenterAccess extends Model {
   @attr() habilitations;
   @attr() pixCertifScoBlockedAccessDateLycee;
   @attr() pixCertifScoBlockedAccessDateCollege;
+  @attr() isV3Pilot;
 
   get isSco() {
     return this.type === CERTIFICATION_CENTER_TYPES.SCO;

--- a/certif/tests/unit/controllers/authenticated_test.js
+++ b/certif/tests/unit/controllers/authenticated_test.js
@@ -7,6 +7,31 @@ module('Unit | Controller | authenticated', function (hooks) {
   setupTest(hooks);
 
   module('#get documentationLink', function () {
+    test('should return the dedicated link for V3 pilot certification center', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const currentAllowedCertificationCenterAccess = run(() =>
+        store.createRecord('allowed-certification-center-access', {
+          id: 123,
+          name: 'Sunnydale',
+          type: 'SCO',
+          isRelatedToManagingStudentsOrganization: true,
+          isV3Pilot: true,
+        }),
+      );
+      class CurrentUserStub extends Service {
+        currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+      const controller = this.owner.lookup('controller:authenticated');
+
+      // when
+      const documentationLink = controller.documentationLink;
+
+      // then
+      assert.strictEqual(documentationLink, 'https://cloud.pix.fr/s/f2PNGLajBypbaiJ');
+    });
+
     test('should return the dedicated link for non SCO isManagingStudents certification center', function (assert) {
       // given
       const store = this.owner.lookup('service:store');


### PR DESCRIPTION
## :unicorn: Problème

De la documentation (= kit de certification) est mise à disposition des membres des centres de certification depuis l’outil Pix Admin. 
Actuellement, le lien “Documentation” renvoie vers le kit de certification propre à la certification actuelle, même pour les CDC taggués “pilote certification v3”, ce qui n’est pas pertinent. 

## :robot: Proposition

Dans Pix Certif > menu “Documentation” : rediriger les membres d’un CDC pilote vers un dossier cloud particulier qui s’ouvre dans un nouvel onglet

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

Ouvrir Pix certif pour un CDC isV3Pilot
Cliquer sur le menu “Documentation”
L’utilisateur est redirigé vers le cloud avec la documentation spécifique certif v3

Ouvrir Pix certif pour un CDC qui n’est PAS isV3Pilot
Cliquer sur le menu “Documentation”
L’utilisateur est redirigé vers le cloud avec la documentation actuelle certif v2
