### PR TITLE
[BUGFIX] Stopper le polling dans l'espace surveillant si le surveillant n'est plus connecté (PIX-10996).

### DIFF
--- a/certif/app/routes/session-supervising.js
+++ b/certif/app/routes/session-supervising.js
@@ -14,21 +14,28 @@ export default class SessionSupervisingRoute extends Route {
 
   afterModel(model) {
     this.poller = setInterval(async () => {
-      await this.store.queryRecord('session-for-supervising', { sessionId: model.id });
+      try {
+        await this.store.queryRecord('session-for-supervising', { sessionId: model.id });
+      } catch (_) {
+        this.#stopPolling();
+      }
     }, ENV.APP.sessionSupervisingPollingRate);
   }
 
   deactivate() {
-    if (this.poller) {
-      clearInterval(this.poller);
-    }
+    this.#stopPolling();
   }
 
   @action
   error() {
+    this.#stopPolling();
+    return true;
+  }
+
+  #stopPolling() {
     if (this.poller) {
       clearInterval(this.poller);
+      this.poller = null;
     }
-    return true;
   }
 }

--- a/certif/tests/unit/routes/session-supervising_test.js
+++ b/certif/tests/unit/routes/session-supervising_test.js
@@ -1,0 +1,48 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+import ENV from '../../../config/environment';
+
+module('Unit | Route | login', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:session-supervising');
+    assert.ok(route);
+  });
+
+  module('#afterModel', function (hooks) {
+    let sessionSupervisingPollingRate;
+
+    hooks.beforeEach(function () {
+      sessionSupervisingPollingRate = ENV.APP.sessionSupervisingPollingRate;
+    });
+
+    hooks.afterEach(function () {
+      ENV.APP.sessionSupervisingPollingRate = sessionSupervisingPollingRate;
+    });
+
+    test('it should stop polling when an error occurs in session supervising fetch', function (assert) {
+      const done = assert.async();
+      assert.expect(2);
+
+      ENV.APP.sessionSupervisingPollingRate = 100;
+
+      const route = this.owner.lookup('route:session-supervising');
+      const session = { id: 123 };
+      route.store = { queryRecord: sinon.stub() };
+
+      route.store.queryRecord.onCall(0).returns(Promise.resolve());
+      route.store.queryRecord.onCall(1).throws(new Error());
+
+      route.afterModel(session);
+
+      setTimeout(function () {
+        assert.strictEqual(route.poller, null);
+        assert.strictEqual(route.store.queryRecord.callCount, 2);
+
+        done();
+      }, 250);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Dans l'espace surveillant de Pix Certif, un polling est effectué afin d'afficher au surveillant des données les plus à jour possible. Néanmoins, lorsque le surveillant n'est plus connecté car son token a expiré (l'API renvoie une erreur 401), le polling ne s'arrête pas. Voir le problème sur [Datadog](https://app.datadoghq.eu/logs?query=service%3A%22pix-api-recette%22%20%40http.url_details.path%3A%5C%2Fapi%5C%2Fsessions%5C%2F%2A%5C%2Fsupervising%20host%3Arouter%20&cols=host%2Cservice%2C%40http.url&index=%2A&messageDisplay=inline&refresh_mode=paused&source=monitor_notif&storage=hot&stream_sort=time%2Cdesc&view=spans&viz=stream&from_ts=1706707221250&to_ts=1706710750824&live=false)  

## :robot: Proposition
Stopper le polling dés que l'API renvoie une erreur.

## :rainbow: Remarques
Vu avec Antoine, il y a peut-être un problème plus global de non redirection vers la page de login lorsqu'une requête à l'API renvoie une 401 (ce qui, je crois existait à un moment). Dans ce cas, cette PR ne sera peut-être pas utile

## :100: Pour tester
- Se connecter à Pix Certif avec le compte `certif-pro@example.net`
- Aller sur l'espace surveillant pour la session `7002`
- Ouvrir la console navigateur et surveiller les appels réseaux 
- Se connecter au redis `scalingo -a pix-api-review-pr7950 redis-console`
- Lister les clés `KEYS *`
- Supprimer les deux clés `temporary-storage:refresh-tokens:...` (ex  `DEL temporary-storage:refresh-tokens:7002:8abc144e-5ee1-448e-9d6a-18d7878cf413 temporary-storage:user-refresh-tokens:7002`)
- Retourner sur l'onglet de l'espace surveillant et vérifier qu'à la première 401, le polling s'arrête
