### PR TITLE
[FEATURE] Retirer l'icône de suppression d'issue-report pour les live-alerts en certif V3 (PIX-10941).

### DIFF
--- a/certif/app/components/issue-report-modal/issue-reports-modal.hbs
+++ b/certif/app/components/issue-report-modal/issue-reports-modal.hbs
@@ -13,11 +13,21 @@
           <li class="issue-report-modal__report">
             <p class="issue-report-modal__category-label">
               {{issueReport.categoryCode}}&nbsp;{{t issueReport.categoryLabel}}
-              <PixIconButton
-                @icon="trash"
-                aria-label={{t "pages.session-finalization.issue-reports-modal.actions.delete-reporting"}}
-                @triggerAction={{fn this.handleClickOnDeleteButton issueReport}}
-              />
+              {{#if (eq @version 3)}}
+                {{#unless issueReport.isInChallengeIssue}}
+                  <PixIconButton
+                    @icon="trash"
+                    aria-label={{t "pages.session-finalization.issue-reports-modal.actions.delete-reporting"}}
+                    @triggerAction={{fn this.handleClickOnDeleteButton issueReport}}
+                  />
+                {{/unless}}
+              {{else}}
+                <PixIconButton
+                  @icon="trash"
+                  aria-label={{t "pages.session-finalization.issue-reports-modal.actions.delete-reporting"}}
+                  @triggerAction={{fn this.handleClickOnDeleteButton issueReport}}
+                />
+              {{/if}}
             </p>
             {{#if issueReport.subcategoryLabel}}
               <p class="issue-report-modal__subcategory-label">{{issueReport.subcategoryCode}}&nbsp;{{t

--- a/certif/app/components/session-finalization/completed-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/completed-reports-information-step.hbs
@@ -109,6 +109,7 @@
       @onClickIssueReport={{this.openAddIssueReportModal}}
       @onClickDeleteIssueReport={{@onIssueReportDeleteButtonClicked}}
       @report={{this.reportToEdit}}
+      @version={{@session.version}}
     />
   {{/if}}
 </div>

--- a/certif/app/models/certification-issue-report.js
+++ b/certif/app/models/certification-issue-report.js
@@ -136,4 +136,8 @@ export default class CertificationIssueReport extends Model {
   get subcategoryCode() {
     return subcategoryToCode[this.subcategory];
   }
+
+  get isInChallengeIssue() {
+    return categoryToCode[this.category] === categoryToCode[certificationIssueReportCategories.IN_CHALLENGE];
+  }
 }

--- a/certif/tests/integration/components/issue-reports-modal_test.js
+++ b/certif/tests/integration/components/issue-reports-modal_test.js
@@ -154,4 +154,119 @@ module('Integration | Component | issue-reports-modal', function (hooks) {
     assert.contains(this.intl.t(subcategoryToLabel[certificationIssueReportSubcategories.NAME_OR_BIRTHDATE]));
     assert.dom('li').exists({ count: 2 });
   });
+
+  module('when certification is V3', function () {
+    module('when issue report contains IN_CHALLENGE (E1-E12) issues', function () {
+      test('it should not display the delete button for these issues', async function (assert) {
+        // given
+        const version = 3;
+        const store = this.owner.lookup('service:store');
+        const issue1 = store.createRecord('certification-issue-report', {
+          category: certificationIssueReportCategories.IN_CHALLENGE,
+        });
+
+        const report = store.createRecord('certification-report', {
+          certificationIssueReports: [issue1],
+        });
+
+        const onClickIssueReportStub = sinon.stub();
+        const closeIssueReportsModalStub = sinon.stub();
+        this.set('report', report);
+        this.set('onClickIssueReport', onClickIssueReportStub);
+        this.set('closeIssueReportsModal', closeIssueReportsModalStub);
+        this.set('version', version);
+
+        // when
+        const screen = await render(hbs`
+      <IssueReportModal::IssueReportsModal
+        @showModal={{true}}
+        @report={{this.report}}
+        @closeModal={{this.closeIssueReportsModal}}
+        @onClickIssueReport={{this.onClickIssueReport}}
+        @version={{this.version}}
+      />
+    `);
+
+        // then
+        assert.dom(screen.queryByRole('button', { name: 'Supprimer le signalement' })).doesNotExist();
+      });
+    });
+
+    module('when issue report does not contain IN_CHALLENGE (E1-E12) issues', function () {
+      test('it should display the delete button for these issues', async function (assert) {
+        // given
+        const version = 3;
+        const store = this.owner.lookup('service:store');
+        const issue1 = store.createRecord('certification-issue-report', {
+          category: certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES,
+        });
+
+        const report = store.createRecord('certification-report', {
+          certificationIssueReports: [issue1],
+        });
+        const onClickIssueReportStub = sinon.stub();
+        const closeIssueReportsModalStub = sinon.stub();
+        this.set('report', report);
+        this.set('onClickIssueReport', onClickIssueReportStub);
+        this.set('closeIssueReportsModal', closeIssueReportsModalStub);
+        this.set('version', version);
+
+        // when
+        const screen = await render(hbs`
+      <IssueReportModal::IssueReportsModal
+        @showModal={{true}}
+        @report={{this.report}}
+        @closeModal={{this.closeIssueReportsModal}}
+        @onClickIssueReport={{this.onClickIssueReport}}
+        @version={{this.version}}
+      />
+    `);
+
+        // then
+        assert.dom(screen.queryByRole('button', { name: 'Supprimer le signalement' })).exists();
+      });
+    });
+  });
+
+  module('when certification is V2', function () {
+    module('when issue report contains IN_CHALLENGE (E1-E12) issues', function () {
+      test('it should display the delete button for these issues', async function (assert) {
+        // given
+        const version = 2;
+        const store = this.owner.lookup('service:store');
+        const issue1 = store.createRecord('certification-issue-report', {
+          category: certificationIssueReportCategories.IN_CHALLENGE,
+        });
+
+        const issue2 = store.createRecord('certification-issue-report', {
+          category: certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES,
+        });
+
+        const report = store.createRecord('certification-report', {
+          certificationIssueReports: [issue1, issue2],
+        });
+
+        const onClickIssueReportStub = sinon.stub();
+        const closeIssueReportsModalStub = sinon.stub();
+        this.set('report', report);
+        this.set('onClickIssueReport', onClickIssueReportStub);
+        this.set('closeIssueReportsModal', closeIssueReportsModalStub);
+        this.set('version', version);
+
+        // when
+        const screen = await render(hbs`
+      <IssueReportModal::IssueReportsModal
+        @showModal={{true}}
+        @report={{this.report}}
+        @closeModal={{this.closeIssueReportsModal}}
+        @onClickIssueReport={{this.onClickIssueReport}}
+        @version={{this.version}}
+      />
+    `);
+
+        // then
+        assert.strictEqual(screen.queryAllByRole('button', { name: 'Supprimer le signalement' }).length, 2);
+      });
+    });
+  });
 });

--- a/certif/tests/integration/components/issue-reports-modal_test.js
+++ b/certif/tests/integration/components/issue-reports-modal_test.js
@@ -3,7 +3,6 @@ import { click } from '@ember/test-helpers';
 import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
-import EmberObject from '@ember/object';
 import {
   certificationIssueReportCategories,
   certificationIssueReportSubcategories,
@@ -17,11 +16,11 @@ module('Integration | Component | issue-reports-modal', function (hooks) {
 
   test('it show candidate information in title', async function (assert) {
     // given
-    const report = EmberObject.create({
-      certificationCourseId: 1,
+    const store = this.owner.lookup('service:store');
+
+    const report = store.createRecord('certification-report', {
       firstName: 'Lisa',
       lastName: 'Monpud',
-      hasSeenEndTestScreen: false,
     });
     const onClickIssueReportStub = sinon.stub();
     const closeIssueReportsModalStub = sinon.stub();
@@ -45,12 +44,9 @@ module('Integration | Component | issue-reports-modal', function (hooks) {
 
   test('it should close modal onclick "Ajouter un signalement"', async function (assert) {
     // given
-    const report = EmberObject.create({
-      certificationCourseId: 1,
-      firstName: 'Lisa',
-      lastName: 'Monpud',
-      hasSeenEndTestScreen: false,
-    });
+    const store = this.owner.lookup('service:store');
+    const report = store.createRecord('certification-report');
+
     const onClickIssueReportStub = sinon.stub();
     const closeIssueReportsModalStub = sinon.stub();
     this.set('report', report);
@@ -74,23 +70,18 @@ module('Integration | Component | issue-reports-modal', function (hooks) {
 
   test('it should show Mes signalements (2)', async function (assert) {
     // given
-    const issue1 = EmberObject.create({
+    const store = this.owner.lookup('service:store');
+    const issue1 = store.createRecord('certification-issue-report', {
       category: certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES,
-      categoryLabel: categoryToLabel[certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES],
     });
-
-    const issue2 = EmberObject.create({
+    const issue2 = store.createRecord('certification-issue-report', {
       category: certificationIssueReportCategories.SIGNATURE_ISSUE,
-      categoryLabel: categoryToLabel[certificationIssueReportCategories.SIGNATURE_ISSUE],
     });
 
-    const report = EmberObject.create({
-      certificationCourseId: 1,
+    const report = store.createRecord('certification-report', {
       certificationIssueReports: [issue1, issue2],
-      firstName: 'Lisa',
-      lastName: 'Monpud',
-      hasSeenEndTestScreen: false,
     });
+
     const onClickIssueReportStub = sinon.stub();
     const closeIssueReportsModalStub = sinon.stub();
     this.set('report', report);
@@ -113,25 +104,19 @@ module('Integration | Component | issue-reports-modal', function (hooks) {
 
   test('it should list existing issue reports with subcategory', async function (assert) {
     // given
-    const issue1 = EmberObject.create({
+    const store = this.owner.lookup('service:store');
+    const issue1 = store.createRecord('certification-issue-report', {
       category: certificationIssueReportCategories.SIGNATURE_ISSUE,
-      categoryLabel: categoryToLabel[certificationIssueReportCategories.SIGNATURE_ISSUE],
     });
-
-    const issue2 = EmberObject.create({
+    const issue2 = store.createRecord('certification-issue-report', {
       category: certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES,
-      categoryLabel: categoryToLabel[certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES],
       subcategory: certificationIssueReportSubcategories.NAME_OR_BIRTHDATE,
-      subcategoryLabel: subcategoryToLabel[certificationIssueReportSubcategories.NAME_OR_BIRTHDATE],
     });
 
-    const report = EmberObject.create({
-      certificationCourseId: 1,
+    const report = store.createRecord('certification-report', {
       certificationIssueReports: [issue1, issue2],
-      firstName: 'Lisa',
-      lastName: 'Monpud',
-      hasSeenEndTestScreen: false,
     });
+
     const onClickIssueReportStub = sinon.stub();
     const closeIssueReportsModalStub = sinon.stub();
     this.set('report', report);


### PR DESCRIPTION
## :unicorn: Problème

Dans le cadre de la nouvelle certification, les signalements de type “Problème technique sur une question” sont gérés en direct pendant la session et non plus a posteriori comme pour la certif v2. Ces signalements faits en session sont ensuite visible depuis la page de finalisation de session afin que le référent de centre de certification puisse en être informé.

Il est actuellement possible de supprimer un signalement a posteriori depuis la page de finalisation de session, ce qui n’est absolument pas pertinent car la gestion du signalement s’est faite en direct pendant le test du candidat.

## :robot: Proposition

Sur la page de finalisation de session > modale “Signalement du candidat”, uniquement pour la certif v3 : 
Ne PAS afficher l’icône de suppression pour les signalement de type “Pb technique sur une question”

L’icône de suppression doit néanmoins rester bien présente et cliquable pour tous les autres types de signalements qui continueront d'être faits a posteriori pour la v3

![image](https://github.com/1024pix/pix/assets/36371437/c7d5c052-53ee-4c17-9afd-4349d8889061)

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

• Créer une session de certification dans un CDC taggué “Pilote certif v3” et y inscrire un candidat
• Lancer le test du candidat et “Signaler un problème avec la question” > “Oui, je suis sur”
• Depuis l’ES > “Gérer un signalement” > sélectionner une catégorie et valider le signalement
• Dans Pix certif, ouvrir la page de détails de la session et cliquer sur “Finaliser la session”
• Cliquer sur le lien “Ajouter/supprimer” 
• La modale “Signalement du candidat” s’affiche avec le signalement validé en étape 2
• Il n’y a PAS l’icône poubelle qui permet de supprimer le signalement
• Depuis la modale, cliquer sur “Ajouter un signalement” valider l’ajout d’un signalement (ex : C6 - Suspicion de fraude)
• Rouvrir la modale
• L’icône de suppression n’est toujours pas affiché pour le signalement de type “Problème technique sur une question” mais l’est pour le signalement ajouté à l'étape 6
