### PR TITLE
[FEATURE] Permettre à un utilisateur néerlandophone de recevoir des emails dans sa langue (PIX-10796)

### DIFF
--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -6,10 +6,11 @@ import { config } from '../../config.js';
 
 import frTranslations from '../../../translations/fr.json' assert { type: 'json' };
 import enTranslations from '../../../translations/en.json' assert { type: 'json' };
+import nlTranslations from '../../../translations/nl.json' assert { type: 'json' };
 
 import { LOCALE } from '../../../src/shared/domain/constants.js';
 
-const { ENGLISH_SPOKEN, FRENCH_FRANCE, FRENCH_SPOKEN } = LOCALE;
+const { ENGLISH_SPOKEN, FRENCH_FRANCE, FRENCH_SPOKEN, DUTCH_SPOKEN } = LOCALE;
 
 const EMAIL_ADDRESS_NO_RESPONSE = 'ne-pas-repondre@pix.fr';
 const PIX_ORGA_NAME_FR = 'Pix Orga - Ne pas répondre';
@@ -57,6 +58,18 @@ function sendAccountCreationEmail(email, locale, redirectionUrl) {
 
     pixName = enTranslations['email-sender-name']['pix-app'];
     accountCreationEmailSubject = enTranslations['pix-account-creation-email'].subject;
+  } else if (locale === DUTCH_SPOKEN) {
+    variables = {
+      homeName: PIX_HOME_NAME_INTERNATIONAL,
+      homeUrl: PIX_HOME_URL_INTERNATIONAL_ENGLISH_SPOKEN,
+      redirectionUrl: redirectionUrl || `${config.domain.pixApp + config.domain.tldOrg}/connexion/?lang=nl`,
+      helpdeskUrl: HELPDESK_ENGLISH_SPOKEN,
+      displayNationalLogo: false,
+      ...nlTranslations['pix-account-creation-email'].params,
+    };
+
+    pixName = nlTranslations['email-sender-name']['pix-app'];
+    accountCreationEmailSubject = nlTranslations['pix-account-creation-email'].subject;
   } else {
     variables = {
       homeName: PIX_HOME_NAME_FRENCH_FRANCE,
@@ -167,6 +180,20 @@ function sendResetPasswordDemandEmail({ email, locale, temporaryKey }) {
 
     pixName = enTranslations['email-sender-name']['pix-app'];
     resetPasswordEmailSubject = enTranslations['reset-password-demand-email'].subject;
+  }
+
+  if (localeParam === DUTCH_SPOKEN) {
+    templateParams = {
+      locale: localeParam,
+      ...nlTranslations['reset-password-demand-email'].params,
+      homeName: PIX_HOME_NAME_INTERNATIONAL,
+      homeUrl: PIX_HOME_URL_INTERNATIONAL_ENGLISH_SPOKEN,
+      resetUrl: `${config.domain.pixApp + config.domain.tldOrg}/changer-mot-de-passe/${temporaryKey}/?lang=nl`,
+      helpdeskURL: HELPDESK_ENGLISH_SPOKEN,
+    };
+
+    pixName = nlTranslations['email-sender-name']['pix-app'];
+    resetPasswordEmailSubject = nlTranslations['reset-password-demand-email'].subject;
   }
 
   return mailer.sendEmail({
@@ -420,6 +447,17 @@ function sendVerificationCodeEmail({ code, email, locale, translate }) {
       homeUrl: PIX_HOME_URL_INTERNATIONAL_ENGLISH_SPOKEN,
       displayNationalLogo: false,
       ...enTranslations['verification-code-email'].body,
+    };
+  } else if (locale === DUTCH_SPOKEN) {
+    options.subject = translate({ phrase: 'verification-code-email.subject', locale: 'nl' }, { code });
+    options.fromName = nlTranslations['email-sender-name']['pix-app'];
+
+    options.variables = {
+      code,
+      homeName: PIX_HOME_NAME_INTERNATIONAL,
+      homeUrl: PIX_HOME_URL_INTERNATIONAL_ENGLISH_SPOKEN,
+      displayNationalLogo: false,
+      ...nlTranslations['verification-code-email'].body,
     };
   }
 

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -412,6 +412,7 @@ function sendVerificationCodeEmail({ code, email, locale, translate }) {
     };
   } else if (locale === ENGLISH_SPOKEN) {
     options.subject = translate({ phrase: 'verification-code-email.subject', locale: 'en' }, { code });
+    options.fromName = enTranslations['email-sender-name']['pix-app'];
 
     options.variables = {
       code,

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -16,8 +16,6 @@ const PIX_ORGA_NAME_FR = 'Pix Orga - Ne pas répondre';
 const PIX_ORGA_NAME_EN = 'Pix Orga - Noreply';
 const PIX_CERTIF_NAME_FR = 'Pix Certif - Ne pas répondre';
 const PIX_CERTIF_NAME_EN = 'Pix Certif - Noreply';
-const PIX_NAME_FR = 'PIX - Ne pas répondre';
-const PIX_NAME_EN = 'PIX - Noreply';
 const HELPDESK_FRENCH_FRANCE = 'https://support.pix.fr';
 const HELPDESK_ENGLISH_SPOKEN = 'https://support.pix.org/en/support/home';
 const HELPDESK_FRENCH_SPOKEN = 'https://support.pix.org';
@@ -45,7 +43,7 @@ function sendAccountCreationEmail(email, locale, redirectionUrl) {
       ...frTranslations['pix-account-creation-email'].params,
     };
 
-    pixName = PIX_NAME_FR;
+    pixName = frTranslations['email-sender-name']['pix-app'];
     accountCreationEmailSubject = frTranslations['pix-account-creation-email'].subject;
   } else if (locale === ENGLISH_SPOKEN) {
     variables = {
@@ -57,7 +55,7 @@ function sendAccountCreationEmail(email, locale, redirectionUrl) {
       ...enTranslations['pix-account-creation-email'].params,
     };
 
-    pixName = PIX_NAME_EN;
+    pixName = enTranslations['email-sender-name']['pix-app'];
     accountCreationEmailSubject = enTranslations['pix-account-creation-email'].subject;
   } else {
     variables = {
@@ -69,7 +67,7 @@ function sendAccountCreationEmail(email, locale, redirectionUrl) {
       ...frTranslations['pix-account-creation-email'].params,
     };
 
-    pixName = PIX_NAME_FR;
+    pixName = frTranslations['email-sender-name']['pix-app'];
     accountCreationEmailSubject = frTranslations['pix-account-creation-email'].subject;
   }
 
@@ -125,7 +123,7 @@ function sendCertificationResultEmail({
 
   return mailer.sendEmail({
     from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: `${PIX_NAME_FR} / ${PIX_NAME_EN}`,
+    fromName: `${frTranslations['email-sender-name']['pix-app']} / ${enTranslations['email-sender-name']['pix-app']}`,
     to: email,
     template: mailer.certificationResultTemplateId,
     variables: templateParams,
@@ -135,7 +133,7 @@ function sendCertificationResultEmail({
 function sendResetPasswordDemandEmail({ email, locale, temporaryKey }) {
   const localeParam = locale ? locale : FRENCH_FRANCE;
 
-  let pixName = PIX_NAME_FR;
+  let pixName = frTranslations['email-sender-name']['pix-app'];
   let resetPasswordEmailSubject = frTranslations['reset-password-demand-email'].subject;
 
   let templateParams = {
@@ -167,7 +165,7 @@ function sendResetPasswordDemandEmail({ email, locale, temporaryKey }) {
       helpdeskURL: HELPDESK_ENGLISH_SPOKEN,
     };
 
-    pixName = PIX_NAME_EN;
+    pixName = enTranslations['email-sender-name']['pix-app'];
     resetPasswordEmailSubject = enTranslations['reset-password-demand-email'].subject;
   }
 
@@ -363,7 +361,7 @@ function sendCertificationCenterInvitationEmail({
 }
 
 function sendAccountRecoveryEmail({ email, firstName, temporaryKey }) {
-  const pixName = PIX_NAME_FR;
+  const pixName = frTranslations['email-sender-name']['pix-app'];
   const redirectionUrl = `${config.domain.pixApp + config.domain.tldFr}/recuperer-mon-compte/${temporaryKey}`;
   const variables = {
     firstName,
@@ -386,7 +384,7 @@ function sendAccountRecoveryEmail({ email, firstName, temporaryKey }) {
 function sendVerificationCodeEmail({ code, email, locale, translate }) {
   const options = {
     from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: PIX_NAME_FR,
+    fromName: frTranslations['email-sender-name']['pix-app'],
     to: email,
     template: mailer.emailVerificationCodeTemplateId,
     tags: [EMAIL_VERIFICATION_CODE_TAG],
@@ -430,7 +428,7 @@ function sendVerificationCodeEmail({ code, email, locale, translate }) {
 function sendCpfEmail({ email, generatedFiles }) {
   const options = {
     from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: PIX_NAME_FR,
+    fromName: frTranslations['email-sender-name']['pix-app'],
     to: email,
     template: mailer.cpfEmailTemplateId,
     variables: { generatedFiles },
@@ -444,7 +442,7 @@ function sendNotificationToCertificationCenterRefererForCleaResults({ email, ses
 
   const options = {
     from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: PIX_NAME_FR,
+    fromName: frTranslations['email-sender-name']['pix-app'],
     to: email,
     template: mailer.acquiredCleaResultTemplateId,
     variables: { sessionId, sessionDate: formattedSessionDate },
@@ -456,7 +454,7 @@ function sendNotificationToCertificationCenterRefererForCleaResults({ email, ses
 function sendNotificationToOrganizationMembersForTargetProfileDetached({ email, complementaryCertificationName }) {
   const options = {
     from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: PIX_NAME_FR,
+    fromName: frTranslations['email-sender-name']['pix-app'],
     to: email,
     template: mailer.targetProfileNotCertifiableTemplateId,
     variables: { complementaryCertificationName },

--- a/api/src/shared/domain/constants.js
+++ b/api/src/shared/domain/constants.js
@@ -4,6 +4,7 @@ const LOCALE = {
   ENGLISH_SPOKEN: 'en',
   FRENCH_FRANCE: 'fr-fr',
   FRENCH_SPOKEN: 'fr',
+  DUTCH_SPOKEN: 'nl',
 };
 
 const SUPPORTED_LOCALES = ['en', 'fr', 'fr-BE', 'fr-FR'];

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -279,6 +279,9 @@
     },
     "template-name": "import-template"
   },
+  "email-sender-name": {
+    "pix-app": "PIX - Noreply"
+  },
   "entity-validation-errors": {
     "ACCEPT_CGU": "Please agree to the terms and conditions of use.",
     "ALREADY_REGISTERED_EMAIL": "This email address is already registered, please log in.",

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -293,6 +293,9 @@
     },
     "template-name": "modele-import"
   },
+  "email-sender-name": {
+    "pix-app": "PIX - Ne pas répondre"
+  },
   "entity-validation-errors": {
     "ACCEPT_CGU": "Vous devez accepter les conditions d’utilisation de Pix pour créer un compte.",
     "ALREADY_REGISTERED_EMAIL": "Cette adresse e-mail est déjà enregistrée, connectez-vous.",

--- a/api/translations/nl.json
+++ b/api/translations/nl.json
@@ -293,6 +293,9 @@
     },
     "template-name": "importmodel"
   },
+  "email-sender-name": {
+    "pix-app": "PIX - Niet beantwoorden"
+  },
   "entity-validation-errors": {
     "ACCEPT_CGU": "Je moet de gebruiksvoorwaarden van Pix accepteren om een account aan te maken.",
     "ALREADY_REGISTERED_EMAIL": "Dit e-mailadres is al geregistreerd, log in.",


### PR DESCRIPTION
## :unicorn: Problème
Afin de préparer au mieux l'arrivée d'utilisateurs Pix néerlandophones, nous devons gérer l'envoi d'emails en néerlandais.

## :robot: Proposition
Ajouter la traduction néerlandaise pour les emails suivants :
- création de compte
- demande de réinitialisation de mot de passe
- demande changement d'adresse email

## :rainbow: Remarques
RAS.

## :100: Pour tester

1. Sur Pix App (.org), se rendre sur la page `/inscription?lang=nl`
2. Créer un compte utilisateur avec une adresse email à laquelle vous avez accès
3. Vérifier que vous avez reçu un mail Pix de confirmation de création de compte en néerlandais
4. Retourner sur Pix App, dans l'espace `Mon Compte`, changer votre adresse email
5. Vérifier que vous avez reçu un mail Pix avec un code pour changer votre adresse email en néerlandais
6. Se déconnecter de Pix App, sur la page de `/connexion?lang=nl`, faite une demande de réinitialisation de mot de passe
7. Vérifier que vous avez reçu un mail Pix de réinitialisation de mot de passe en néerlandais
