### PR TITLE
[BUGFIX] Vérifier le remplissage de sujets lors de la création des badges (PIX-10969).

### DIFF
--- a/admin/app/components/target-profiles/badge-form.hbs
+++ b/admin/app/components/target-profiles/badge-form.hbs
@@ -1,73 +1,85 @@
-<form {{on "submit" this.createBadgeAndCriteria}} class="badge-form">
-  <h2>Création d'un résultat thématique</h2>
-  <Card class="create-target-profile__card" @title="Informations">
-    <div class="badge-form__text-field">
-      <label for="title">Nom du résultat thématique : </label>
-      <Input id="title" class="form-control" @type="text" @value={{this.badge.title}} />
-    </div>
-    <div class="badge-form__text-field">
-      <label for="image-name" class="badge-form__label">Nom de l'image (svg) :</label>
-      <p class="badge-form__information">
-        <a
-          class="badge-form__information--link"
-          href="https://1024pix.github.io/pix-images-list/badges.html"
-          target="_blank"
-          rel="noopener noreferrer"
+<form class="admin-form admin-form--badge-form" {{on "submit" this.createBadgeAndCriteria}}>
+  <h2 class="badge-form__title">Création d'un résultat thématique</h2>
+  <section class="admin-form__content admin-form__content--with-counters">
+    <Card class="create-target-profile__card" @title="Remplir des informations sur le résultat thématique">
+      <div class="badge-form__text-field">
+        <PixInput
+          @id="title"
+          @value={{this.badge.title}}
+          @label={{"Nom du résultat thématique :"}}
+          @requiredLabel="Champ obligatoire"
+          {{on "change" (fn this.updateFormValue "title")}}
+        />
+      </div>
+      <div class="badge-form__text-field">
+        <label for="image-name" class="badge-form__label badge-form__label--required">Nom de l'image (svg) :</label>
+        <p class="badge-form__information">
+          <a
+            class="badge-form__information--link"
+            href="https://1024pix.github.io/pix-images-list/badges.html"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Voir la liste des résultats thématiques
+          </a>
+        </p>
+        <PixInput
+          @id="image-name"
+          @value={{this.imageName}}
+          @requiredLabel="Champ obligatoire"
+          placeholder="exemple: clea_num.svg"
+          {{on "change" (fn this.updateFormValue "imageName")}}
+        />
+      </div>
+      <div class="badge-form__text-field">
+        <PixInput
+          @id="alt-message"
+          @value={{this.badge.altMessage}}
+          @label="Texte alternatif pour l'image :"
+          @requiredLabel="Champ obligatoire"
+          {{on "change" (fn this.updateFormValue "altMessage")}}
+        />
+      </div>
+      <div class="badge-form__text-field">
+        <PixTextarea
+          @id="message"
+          @value={{this.badge.message}}
+          rows="4"
+          @label="Message :"
+          {{on "change" (fn this.updateFormValue "message")}}
+        />
+      </div>
+      <div class="badge-form__text-field">
+        <PixInput
+          @id="badge-key"
+          maxlength="255"
+          @value={{this.badge.key}}
+          @label="Clé (texte unique , vérifier qu'il n'existe pas) :"
+          @requiredLabel="Champ obligatoire"
+          {{on "change" (fn this.updateFormValue "key")}}
+        />
+      </div>
+      <div class="badge-form__check-field">
+        <PixCheckbox
+          @checked={{this.badge.isCertifiable}}
+          {{on "change" (fn this.updateFormCheckBoxValue "isCertifiable")}}
         >
-          Voir la liste des résultats thématiques
-        </a>
-      </p>
-      <Input
-        id="image-name"
-        required="true"
-        class="form-control"
-        @type="text"
-        @value={{this.imageName}}
-        placeholder="exemple: clea_num.svg"
-      />
-    </div>
-    <div class="badge-form__text-field">
-      <label for="alt-message">Texte alternatif pour l'image : </label>
-      <Input id="alt-message" required="true" class="form-control" @type="text" @value={{this.badge.altMessage}} />
-    </div>
-    <div class="badge-form__text-field">
-      <label for="message">Message : </label>
-      <Textarea id="message" class="form-control" @value={{this.badge.message}} rows="4" />
-    </div>
-    <div class="badge-form__text-field">
-      <label for="badge-key">Clé (texte unique , vérifier qu'il n'existe pas) : </label>
-      <Input
-        id="badge-key"
-        class="form-control"
-        maxlength="255"
-        @type="text"
-        required="true"
-        @value={{this.badge.key}}
-      />
-    </div>
-    <div class="badge-form__check-field">
-      <label for="isCertifiable">Certifiable : </label>
-      <Input
-        class="badge-form-check-field__control"
-        @type="checkbox"
-        @checked={{this.badge.isCertifiable}}
-        id="isCertifiable"
-      />
-    </div>
-    <div class="badge-form__check-field">
-      <label for="isAlwaysVisible">Lacunes : </label>
-      <Input
-        class="badge-form-check-field__control"
-        @type="checkbox"
-        @checked={{this.badge.isAlwaysVisible}}
-        id="isAlwaysVisible"
-      />
-    </div>
-  </Card>
-  <TargetProfiles::BadgeForm::Criteria @badge={{this.badge}} @areas={{@targetProfile.areas}} />
-  <div class="badge-form__action-buttons">
+          Certifiable
+        </PixCheckbox>
+      </div>
+      <div class="badge-form__check-field">
+        <PixCheckbox
+          @checked={{this.badge.isAlwaysVisible}}
+          {{on "change" (fn this.updateFormCheckBoxValue "isAlwaysVisible")}}
+        >
+          Lacunes
+        </PixCheckbox>
+      </div>
+    </Card>
+    <TargetProfiles::BadgeForm::Criteria @badge={{this.badge}} @areas={{@targetProfile.areas}} />
+  </section>
+  <section class="admin-form__actions">
     <PixButtonLink
-      class="badge-form-action-buttons__cancel"
       @backgroundColor="transparent-light"
       @isBorderVisible={{true}}
       @route="authenticated.target-profiles.target-profile.insights"
@@ -77,5 +89,5 @@
     <PixButton @backgroundColor="green" @type="submit">
       Enregistrer le RT
     </PixButton>
-  </div>
+  </section>
 </form>

--- a/admin/app/components/target-profiles/badge-form.hbs
+++ b/admin/app/components/target-profiles/badge-form.hbs
@@ -1,4 +1,4 @@
-<form class="admin-form admin-form--badge-form" {{on "submit" this.createBadgeAndCriteria}}>
+<form class="admin-form admin-form--badge-form" {{on "submit" this.submitBadgeCreation}}>
   <h2 class="badge-form__title">Création d'un résultat thématique</h2>
   <section class="admin-form__content admin-form__content--with-counters">
     <Card class="create-target-profile__card" @title="Remplir des informations sur le résultat thématique">

--- a/admin/app/components/target-profiles/badge-form.js
+++ b/admin/app/components/target-profiles/badge-form.js
@@ -23,6 +23,20 @@ export default class BadgeForm extends Component {
   imageName = '';
 
   @action
+  updateFormValue(key, event) {
+    if (key === 'imageName') {
+      this.imageName = event.target.value;
+    } else {
+      this.badge[key] = event.target.value;
+    }
+  }
+
+  @action
+  updateFormCheckBoxValue(key) {
+    this.badge[key] = !this.badge[key];
+  }
+
+  @action
   async createBadgeAndCriteria(event) {
     event.preventDefault();
     try {

--- a/admin/app/components/target-profiles/badge-form.js
+++ b/admin/app/components/target-profiles/badge-form.js
@@ -37,13 +37,23 @@ export default class BadgeForm extends Component {
   }
 
   @action
-  async createBadgeAndCriteria(event) {
+  async submitBadgeCreation(event) {
     event.preventDefault();
-    try {
-      await this._createBadge();
-    } catch (error) {
-      console.error(error);
+
+    const hasCampaignCriteria = this.badge.campaignThreshold;
+    const hasCappedTubesCriteria = this.badge.cappedTubesCriteria.length;
+
+    if (!hasCampaignCriteria && !hasCappedTubesCriteria) {
+      return this.notifications.error("Vous devez sélectionner au moins un critère d'obtention de résultat thématique");
     }
+
+    const hasSelectedCappedTubes = this.badge.cappedTubesCriteria[0]?.cappedTubes?.length;
+
+    if (hasCappedTubesCriteria && !hasSelectedCappedTubes) {
+      return this.notifications.error('Vous devez sélectionner au moins un sujet du profil cible');
+    }
+
+    await this._createBadge();
   }
 
   async _createBadge() {
@@ -52,6 +62,7 @@ export default class BadgeForm extends Component {
         ...this.badge,
         imageUrl: this.BASE_URL + this.imageName,
       };
+
       const badge = this.store.createRecord('badge', badgeWithFormattedImageUrl);
 
       await badge.save({

--- a/admin/app/components/target-profiles/badge-form/criteria.hbs
+++ b/admin/app/components/target-profiles/badge-form/criteria.hbs
@@ -7,19 +7,20 @@
     pour obtenir le résultat thématique.
   </PixMessage>
   <div class="badge-form-criteria-choice">
+    <p>Définir un critère d'obtention&nbsp;:</p>
     <PixCheckbox
       @id="hasCampaignCriterion"
       @checked={{this.hasCampaignCriterion}}
       {{on "change" this.onHasCampaignCriterionChange}}
     >
-      Définir sur l'ensemble du profil cible
+      sur l'ensemble du profil cible
     </PixCheckbox>
     <PixCheckbox
       @id="hasCappedTubesCriteria"
       @checked={{this.hasCappedTubesCriteria}}
       {{on "change" this.onHasCappedTubesCriteriaChange}}
     >
-      Définir sur une sélection de sujets du profil cible
+      sur une sélection de sujets du profil cible
     </PixCheckbox>
   </div>
   {{#if this.hasCampaignCriterion}}

--- a/admin/app/components/target-profiles/badge-form/criteria.hbs
+++ b/admin/app/components/target-profiles/badge-form/criteria.hbs
@@ -1,22 +1,25 @@
-<Card @title="Définir un ou plusieurs critères d'obtention">
-  <p>
-    Vous pouvez définir des critères de réussite du résultat thématique sur une liste de sujets ET/OU sur l’ensemble du
-    profil cible. Toutes les conditions devront être remplies pour obtenir le résultat thématique.
-  </p>
+<Card @title="Critères d'obtention du résultat thématique">
+  <PixMessage @type="info" @withIcon={{true}}>
+    Vous pouvez définir des critères de réussite du résultat thématique
+    <strong>sur une liste de sujets ET/OU sur l’ensemble du profil cible</strong>.
+    <br />
+    <strong>Toutes les conditions devront être remplies</strong>
+    pour obtenir le résultat thématique.
+  </PixMessage>
   <div class="badge-form-criteria-choice">
     <PixCheckbox
       @id="hasCampaignCriterion"
       @checked={{this.hasCampaignCriterion}}
       {{on "change" this.onHasCampaignCriterionChange}}
     >
-      Sur l'ensemble du profil cible
+      Définir sur l'ensemble du profil cible
     </PixCheckbox>
     <PixCheckbox
       @id="hasCappedTubesCriteria"
       @checked={{this.hasCappedTubesCriteria}}
       {{on "change" this.onHasCappedTubesCriteriaChange}}
     >
-      Sur une sélection de sujets du profil cible
+      Définir sur une sélection de sujets du profil cible
     </PixCheckbox>
   </div>
   {{#if this.hasCampaignCriterion}}

--- a/admin/app/styles/components/target-profiles/badge-form.scss
+++ b/admin/app/styles/components/target-profiles/badge-form.scss
@@ -34,9 +34,13 @@
     flex-direction: column;
   }
 
+  &__check-field {
+    margin-left: 0.25rem;
+  }
+
   &__text-field:not(:last-child),
   &__check-field:not(:last-child) {
-    margin-bottom: 16px;
+    margin-bottom: 1rem;
   }
 
   &-check-field__control {
@@ -99,8 +103,16 @@
   &-criteria-choice {
     margin-top: var(--pix-spacing-3x);
 
+    p {
+      margin-bottom: 0.75rem;
+    }
+
     label {
       margin-bottom: 0;
+    }
+
+    .pix-checkbox {
+      margin-left: 0.25rem;
     }
   }
 }

--- a/admin/app/styles/components/target-profiles/badge-form.scss
+++ b/admin/app/styles/components/target-profiles/badge-form.scss
@@ -1,12 +1,22 @@
 .badge-form {
+  &__title {
+    @extend %pix-title-xs;
 
-  h2 {
-    margin-bottom: 16px;
+    margin-bottom: var(--pix-spacing-3x);
     font-weight: 500;
   }
 
   &__label {
+    @extend %pix-body-s;
+
     margin-bottom: 2px;
+    color: var(--pix-neutral-900);
+    font-weight: 500;
+
+    &--required::before {
+      color: var(--pix-error-700);
+      content: '* ';
+    }
   }
 
   &__information {
@@ -62,10 +72,10 @@
   }
 
   &-criterion {
-    margin-bottom: 24px;
-    padding: 16px;
+    margin: var(--pix-spacing-3x) 0 var(--pix-spacing-6x);
+    padding: var(--pix-spacing-4x);
     background: var(--pix-neutral-20);
-    border: 1px solid #A5ADBA;
+    border: 1px solid #a5adba;
     border-radius: 8px;
 
     header {
@@ -76,19 +86,18 @@
     }
 
     &__add {
-
       svg {
         margin-right: 0.5rem;
       }
     }
   }
 
+  &-criteria-introduction {
+    @extend %pix-body-s;
+  }
+
   &-criteria-choice {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    align-items: start;
-    margin-bottom: 16px;
+    margin-top: var(--pix-spacing-3x);
 
     label {
       margin-bottom: 0;
@@ -97,9 +106,7 @@
 }
 
 input {
-
   &.badge-form-criterion {
-
     &__name {
       margin-bottom: 16px;
     }

--- a/admin/app/templates/authenticated/target-profiles/target-profile/badges/new.hbs
+++ b/admin/app/templates/authenticated/target-profiles/target-profile/badges/new.hbs
@@ -1,3 +1,3 @@
-<main>
+<main class="main-admin-form">
   <TargetProfiles::BadgeForm @targetProfile={{this.model}} />
 </main>

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
@@ -586,15 +586,15 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         const screen = await visit('/target-profiles/1');
         await clickByName('Clés de lecture');
         await clickByName('Nouveau résultat thématique');
-        await fillByLabel('Nom du résultat thématique :', 'Mon nouveau RT');
+        await fillByLabel(/Nom du résultat thématique :/, 'Mon nouveau RT');
         await fillByLabel("Nom de l'image (svg) :", 'troll.png');
-        await fillByLabel("Texte alternatif pour l'image :", 'Je mets du png je fais ce que je veux');
+        await fillByLabel(/Texte alternatif pour l'image :/, 'Je mets du png je fais ce que je veux');
         await fillByLabel('Message :', 'message de mon RT');
-        await fillByLabel("Clé (texte unique , vérifier qu'il n'existe pas) :", 'MY_BADGE');
-        await clickByName('Certifiable :');
-        await clickByName('Lacunes :');
-        await clickByName("Sur l'ensemble du profil cible");
-        await clickByName('Sur une sélection de sujets du profil cible');
+        await fillByLabel(/Clé/, 'MY_BADGE');
+        await clickByName('Certifiable');
+        await clickByName('Lacunes');
+        await clickByName("sur l'ensemble du profil cible");
+        await clickByName('sur une sélection de sujets du profil cible');
         await clickByName('Ajouter une nouvelle sélection de sujets');
 
         const [tubeGroupNameInput] = screen.getAllByLabelText('Nom du critère :');

--- a/admin/tests/integration/components/target-profiles/badge-form_test.js
+++ b/admin/tests/integration/components/target-profiles/badge-form_test.js
@@ -52,14 +52,14 @@ module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
     const screen = await render(hbs`<TargetProfiles::BadgeForm @targetProfile={{this.targetProfile}} />`);
 
     // then
-    assert.dom(screen.getByRole('checkbox', { name: "Sur l'ensemble du profil cible" })).exists();
-    assert.dom(screen.getByRole('checkbox', { name: 'Sur une sélection de sujets du profil cible' })).exists();
+    assert.dom(screen.getByRole('checkbox', { name: "Définir sur l'ensemble du profil cible" })).exists();
+    assert.dom(screen.getByRole('checkbox', { name: 'Définir sur une sélection de sujets du profil cible' })).exists();
   });
 
   test('it should display campaign-participation criterion form on click', async function (assert) {
     // when
     const screen = await render(hbs`<TargetProfiles::BadgeForm @targetProfile={{this.targetProfile}} />`);
-    await click(screen.getByRole('checkbox', { name: "Sur l'ensemble du profil cible" }));
+    await click(screen.getByRole('checkbox', { name: "Définir sur l'ensemble du profil cible" }));
 
     // then
     assert.dom(screen.getByRole('heading', { name: 'Critère d’obtention sur l’ensemble du profil cible' })).exists();
@@ -69,7 +69,7 @@ module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
   test('it should display capped tubes criterion form on click', async function (assert) {
     // when
     const screen = await render(hbs`<TargetProfiles::BadgeForm @targetProfile={{this.targetProfile}} />`);
-    await click(screen.getByRole('checkbox', { name: 'Sur une sélection de sujets du profil cible' }));
+    await click(screen.getByRole('checkbox', { name: 'Définir sur une sélection de sujets du profil cible' }));
 
     // then
     assert
@@ -84,7 +84,7 @@ module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
   test('it should add a new criteria on click', async function (assert) {
     // when
     const screen = await render(hbs`<TargetProfiles::BadgeForm @targetProfile={{this.targetProfile}} />`);
-    await click(screen.getByRole('checkbox', { name: 'Sur une sélection de sujets du profil cible' }));
+    await click(screen.getByRole('checkbox', { name: 'Définir sur une sélection de sujets du profil cible' }));
     await click(screen.getByRole('button', { name: 'Ajouter une nouvelle sélection de sujets' }));
 
     // then
@@ -98,7 +98,7 @@ module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
   test('it should delete criteria on click', async function (assert) {
     // when
     const screen = await render(hbs`<TargetProfiles::BadgeForm @targetProfile={{this.targetProfile}} />`);
-    await click(screen.getByRole('checkbox', { name: 'Sur une sélection de sujets du profil cible' }));
+    await click(screen.getByRole('checkbox', { name: 'Définir sur une sélection de sujets du profil cible' }));
     await click(screen.getByRole('button', { name: 'Ajouter une nouvelle sélection de sujets' }));
     await click(screen.getAllByRole('button', { name: 'Supprimer' })[0]);
 
@@ -113,9 +113,9 @@ module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
   test('it should remove all caped tubes criteria when checkox is unchecked ', async function (assert) {
     // when
     const screen = await render(hbs`<TargetProfiles::BadgeForm @targetProfile={{this.targetProfile}} />`);
-    await click(screen.getByRole('checkbox', { name: 'Sur une sélection de sujets du profil cible' }));
+    await click(screen.getByRole('checkbox', { name: 'Définir sur une sélection de sujets du profil cible' }));
     await click(screen.getByRole('button', { name: 'Ajouter une nouvelle sélection de sujets' }));
-    await click(screen.getByRole('checkbox', { name: 'Sur une sélection de sujets du profil cible' }));
+    await click(screen.getByRole('checkbox', { name: 'Définir sur une sélection de sujets du profil cible' }));
 
     // then
     assert.strictEqual(

--- a/admin/tests/integration/components/target-profiles/badge-form_test.js
+++ b/admin/tests/integration/components/target-profiles/badge-form_test.js
@@ -1,6 +1,8 @@
+import sinon from 'sinon';
+import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click } from '@ember/test-helpers';
+import { click, fillIn } from '@ember/test-helpers';
 import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
@@ -52,76 +54,131 @@ module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
     const screen = await render(hbs`<TargetProfiles::BadgeForm @targetProfile={{this.targetProfile}} />`);
 
     // then
-    assert.dom(screen.getByRole('checkbox', { name: "Définir sur l'ensemble du profil cible" })).exists();
-    assert.dom(screen.getByRole('checkbox', { name: 'Définir sur une sélection de sujets du profil cible' })).exists();
+    assert.dom(screen.getByRole('checkbox', { name: "sur l'ensemble du profil cible" })).exists();
+    assert.dom(screen.getByRole('checkbox', { name: 'sur une sélection de sujets du profil cible' })).exists();
   });
 
-  test('it should display campaign-participation criterion form on click', async function (assert) {
+  test('it should stop creation and display error message if no criteria is selected', async function (assert) {
+    // given
+    const notificationErrorStub = sinon.stub().returns();
+    class NotificationsStub extends Service {
+      error = notificationErrorStub;
+    }
+    this.owner.register('service:notifications', NotificationsStub);
+
     // when
     const screen = await render(hbs`<TargetProfiles::BadgeForm @targetProfile={{this.targetProfile}} />`);
-    await click(screen.getByRole('checkbox', { name: "Définir sur l'ensemble du profil cible" }));
+
+    await fillIn(screen.getByLabelText(/Nom du résultat thématique/), 'dummy');
+    await fillIn(screen.getByLabelText(/Nom de l'image/), 'dummy');
+    await fillIn(screen.getByLabelText(/Texte alternatif pour l'image/), 'dummy');
+    await fillIn(screen.getByLabelText(/Clé/), 'dummy');
+
+    await click(screen.getByRole('button', { name: 'Enregistrer le RT' }));
 
     // then
-    assert.dom(screen.getByRole('heading', { name: 'Critère d’obtention sur l’ensemble du profil cible' })).exists();
-    assert.dom(screen.getByLabelText('* Taux de réussite requis :')).exists();
-  });
-
-  test('it should display capped tubes criterion form on click', async function (assert) {
-    // when
-    const screen = await render(hbs`<TargetProfiles::BadgeForm @targetProfile={{this.targetProfile}} />`);
-    await click(screen.getByRole('checkbox', { name: 'Définir sur une sélection de sujets du profil cible' }));
-
-    // then
-    assert
-      .dom(screen.getByRole('heading', { name: 'Critère d’obtention sur une sélection de sujets du profil cible' }))
-      .exists();
-    assert.dom(screen.getByLabelText('Nom du critère :')).exists();
-    assert.dom(screen.getByLabelText('* Taux de réussite requis :')).exists();
-    assert.dom(screen.getByRole('button', { name: 'Supprimer' })).exists();
-    assert.dom(screen.getByRole('button', { name: 'Ajouter une nouvelle sélection de sujets' })).exists();
-  });
-
-  test('it should add a new criteria on click', async function (assert) {
-    // when
-    const screen = await render(hbs`<TargetProfiles::BadgeForm @targetProfile={{this.targetProfile}} />`);
-    await click(screen.getByRole('checkbox', { name: 'Définir sur une sélection de sujets du profil cible' }));
-    await click(screen.getByRole('button', { name: 'Ajouter une nouvelle sélection de sujets' }));
-
-    // then
-    assert.strictEqual(
-      screen.getAllByRole('heading', { name: 'Critère d’obtention sur une sélection de sujets du profil cible' })
-        .length,
-      2,
+    sinon.assert.calledWith(
+      notificationErrorStub,
+      "Vous devez sélectionner au moins un critère d'obtention de résultat thématique",
     );
+    assert.ok(true);
   });
 
-  test('it should delete criteria on click', async function (assert) {
-    // when
-    const screen = await render(hbs`<TargetProfiles::BadgeForm @targetProfile={{this.targetProfile}} />`);
-    await click(screen.getByRole('checkbox', { name: 'Définir sur une sélection de sujets du profil cible' }));
-    await click(screen.getByRole('button', { name: 'Ajouter une nouvelle sélection de sujets' }));
-    await click(screen.getAllByRole('button', { name: 'Supprimer' })[0]);
+  module('on campaign-participation criterion selection', function () {
+    test('it should display campaign-participation criterion form on click', async function (assert) {
+      // when
+      const screen = await render(hbs`<TargetProfiles::BadgeForm @targetProfile={{this.targetProfile}} />`);
+      await click(screen.getByRole('checkbox', { name: "sur l'ensemble du profil cible" }));
 
-    // then
-    assert.strictEqual(
-      screen.getAllByRole('heading', { name: 'Critère d’obtention sur une sélection de sujets du profil cible' })
-        .length,
-      1,
-    );
+      // then
+      assert.dom(screen.getByRole('heading', { name: 'Critère d’obtention sur l’ensemble du profil cible' })).exists();
+      assert.dom(screen.getByLabelText('* Taux de réussite requis :')).exists();
+    });
   });
 
-  test('it should remove all caped tubes criteria when checkox is unchecked ', async function (assert) {
-    // when
-    const screen = await render(hbs`<TargetProfiles::BadgeForm @targetProfile={{this.targetProfile}} />`);
-    await click(screen.getByRole('checkbox', { name: 'Définir sur une sélection de sujets du profil cible' }));
-    await click(screen.getByRole('button', { name: 'Ajouter une nouvelle sélection de sujets' }));
-    await click(screen.getByRole('checkbox', { name: 'Définir sur une sélection de sujets du profil cible' }));
+  module('on capped tubes criterion selection', function () {
+    test('it should display capped tubes criterion form on click', async function (assert) {
+      // when
+      const screen = await render(hbs`<TargetProfiles::BadgeForm @targetProfile={{this.targetProfile}} />`);
+      await click(screen.getByRole('checkbox', { name: 'sur une sélection de sujets du profil cible' }));
 
-    // then
-    assert.strictEqual(
-      screen.queryAllByRole('heading', { name: 'Critère d’obtention sur une sélection de sujets du profil cible' })
-        .length,
-      0,
-    );
+      // then
+      assert
+        .dom(screen.getByRole('heading', { name: 'Critère d’obtention sur une sélection de sujets du profil cible' }))
+        .exists();
+      assert.dom(screen.getByLabelText('Nom du critère :')).exists();
+      assert.dom(screen.getByLabelText('* Taux de réussite requis :')).exists();
+      assert.dom(screen.getByRole('button', { name: 'Supprimer' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Ajouter une nouvelle sélection de sujets' })).exists();
+    });
+
+    test('it should add a new criteria on click', async function (assert) {
+      // when
+      const screen = await render(hbs`<TargetProfiles::BadgeForm @targetProfile={{this.targetProfile}} />`);
+      await click(screen.getByRole('checkbox', { name: 'sur une sélection de sujets du profil cible' }));
+      await click(screen.getByRole('button', { name: 'Ajouter une nouvelle sélection de sujets' }));
+
+      // then
+      assert.strictEqual(
+        screen.getAllByRole('heading', { name: 'Critère d’obtention sur une sélection de sujets du profil cible' })
+          .length,
+        2,
+      );
+    });
+
+    test('it should delete criteria on click', async function (assert) {
+      // when
+      const screen = await render(hbs`<TargetProfiles::BadgeForm @targetProfile={{this.targetProfile}} />`);
+      await click(screen.getByRole('checkbox', { name: 'sur une sélection de sujets du profil cible' }));
+      await click(screen.getByRole('button', { name: 'Ajouter une nouvelle sélection de sujets' }));
+      await click(screen.getAllByRole('button', { name: 'Supprimer' })[0]);
+
+      // then
+      assert.strictEqual(
+        screen.getAllByRole('heading', { name: 'Critère d’obtention sur une sélection de sujets du profil cible' })
+          .length,
+        1,
+      );
+    });
+
+    test('it should remove all caped tubes criteria when checkox is unchecked ', async function (assert) {
+      // when
+      const screen = await render(hbs`<TargetProfiles::BadgeForm @targetProfile={{this.targetProfile}} />`);
+      await click(screen.getByRole('checkbox', { name: 'sur une sélection de sujets du profil cible' }));
+      await click(screen.getByRole('button', { name: 'Ajouter une nouvelle sélection de sujets' }));
+      await click(screen.getByRole('checkbox', { name: 'sur une sélection de sujets du profil cible' }));
+
+      // then
+      assert.strictEqual(
+        screen.queryAllByRole('heading', { name: 'Critère d’obtention sur une sélection de sujets du profil cible' })
+          .length,
+        0,
+      );
+    });
+
+    test('it should stop creation and display error message if no target-profile tube is selected', async function (assert) {
+      // given
+      const notificationErrorStub = sinon.stub().returns();
+      class NotificationsStub extends Service {
+        error = notificationErrorStub;
+      }
+      this.owner.register('service:notifications', NotificationsStub);
+
+      // when
+      const screen = await render(hbs`<TargetProfiles::BadgeForm @targetProfile={{this.targetProfile}} />`);
+
+      await fillIn(screen.getByLabelText(/Nom du résultat thématique/), 'dummy');
+      await fillIn(screen.getByLabelText(/Nom de l'image/), 'dummy');
+      await fillIn(screen.getByLabelText(/Texte alternatif pour l'image/), 'dummy');
+      await fillIn(screen.getByLabelText(/Clé/), 'dummy');
+
+      await click(screen.getByRole('checkbox', { name: 'sur une sélection de sujets du profil cible' }));
+      await fillIn(screen.getByLabelText(/Taux de réussite requis/), 20);
+      await click(screen.getByRole('button', { name: 'Enregistrer le RT' }));
+
+      // then
+      sinon.assert.calledWith(notificationErrorStub, 'Vous devez sélectionner au moins un sujet du profil cible');
+      assert.ok(true);
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Il est possible de soumettre un RT avec une sélection de sujets du profil cible sans choisir de sujets.
Cela entraine une erreur 500 sur l’API.

## :robot: Proposition

- Bloquer la soumission et afficher un message d'erreur si la case "Sur une sélection de sujets du profil cible" est sélectionnée mais qu'aucun sujet n'a été choisi.
- Rendre tous les autres champs requis vraiment requis

## :rainbow: Remarques

- Petite refonte visuelle et UX

## :100: Pour tester

Créer un badge sur la RA et simuler les 2 cas d'erreur :
1. Remplir les informations mais ne sélectionner aucun critère d'obtention : après la soumission du formulaire un message d'erreur devrait s'afficher
2. Sélectionner "sur une sélection de sujets du profil cible", remplir le taux de réussite : après la soumission du formulaire un autre message d'erreur devrait s'afficher
