### PR TITLE
[TECH] [PIX-10858] Rajouter un header qui indique la provenance de la requete sur Baleen

### DIFF
--- a/1d/servers.conf.erb
+++ b/1d/servers.conf.erb
@@ -106,6 +106,7 @@ server {
     proxy_pass https://api;
     proxy_redirect default;
     proxy_set_header Host <%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>;
+    proxy_set_header X-Source-front <% ENV['APP'] %>
   }
 
   <% end %>

--- a/1d/servers.conf.erb
+++ b/1d/servers.conf.erb
@@ -106,7 +106,7 @@ server {
     proxy_pass https://api;
     proxy_redirect default;
     proxy_set_header Host <%= ENV['APP'].gsub(/^pix-[^-]+-/, "pix-api-") %>.<%= ENV['API_HOST_SUFFIX'] || 'scalingo.io' %>;
-    proxy_set_header X-Source-front <% ENV['APP'] %>
+    proxy_set_header X-Source-Front <%= ENV['APP'] %>;
   }
 
   <% end %>

--- a/admin/servers.conf.erb
+++ b/admin/servers.conf.erb
@@ -111,6 +111,7 @@ server {
   location /api/ {
     proxy_pass https://$upstream;
     proxy_set_header Host $upstream_host;
+    proxy_set_header X-Source-front <% ENV['APP'] %>
   }
 
   <% end %>

--- a/admin/servers.conf.erb
+++ b/admin/servers.conf.erb
@@ -111,7 +111,7 @@ server {
   location /api/ {
     proxy_pass https://$upstream;
     proxy_set_header Host $upstream_host;
-    proxy_set_header X-Source-front <% ENV['APP'] %>
+    proxy_set_header X-Source-Front <%= ENV['APP'] %>;
   }
 
   <% end %>

--- a/certif/servers.conf.erb
+++ b/certif/servers.conf.erb
@@ -128,6 +128,7 @@ server {
   location /api/ {
     proxy_pass https://$upstream;
     proxy_set_header Host $upstream_host;
+    proxy_set_header X-Source-front <% ENV['APP'] %>
   }
 
   <% end %>

--- a/certif/servers.conf.erb
+++ b/certif/servers.conf.erb
@@ -128,7 +128,7 @@ server {
   location /api/ {
     proxy_pass https://$upstream;
     proxy_set_header Host $upstream_host;
-    proxy_set_header X-Source-front <% ENV['APP'] %>
+    proxy_set_header X-Source-Front <%= ENV['APP'] %>;
   }
 
   <% end %>

--- a/mon-pix/servers.conf.erb
+++ b/mon-pix/servers.conf.erb
@@ -135,6 +135,7 @@ server {
   location /api/ {
     proxy_pass https://$upstream;
     proxy_set_header Host $upstream_host;
+    proxy_set_header X-Source-front <% ENV['APP'] %>
   }
 
   <% end %>

--- a/mon-pix/servers.conf.erb
+++ b/mon-pix/servers.conf.erb
@@ -135,7 +135,7 @@ server {
   location /api/ {
     proxy_pass https://$upstream;
     proxy_set_header Host $upstream_host;
-    proxy_set_header X-Source-front <% ENV['APP'] %>
+    proxy_set_header X-Source-Front <%= ENV['APP'] %>;
   }
 
   <% end %>

--- a/orga/servers.conf.erb
+++ b/orga/servers.conf.erb
@@ -128,6 +128,7 @@ server {
   location /api/ {
     proxy_pass https://$upstream;
     proxy_set_header Host $upstream_host;
+    proxy_set_header X-Source-front <% ENV['APP'] %>
   }
 
   <% end %>

--- a/orga/servers.conf.erb
+++ b/orga/servers.conf.erb
@@ -128,7 +128,7 @@ server {
   location /api/ {
     proxy_pass https://$upstream;
     proxy_set_header Host $upstream_host;
-    proxy_set_header X-Source-front <% ENV['APP'] %>
+    proxy_set_header X-Source-Front <%= ENV['APP'] %>;
   }
 
   <% end %>


### PR DESCRIPTION
## :unicorn: Problème

Il n'est pas directement possible aujourd'hui dans l'API d'identifier la ressource exacte à l'origine de la requête.

## :robot: Proposition

Ajouter un header de tracking dans la configuration des Nginx sur les fronts

## :100: Pour tester

Vérifier que le header est bien ajouté par le front et loggué par l'API de la review APP
