### PR TITLE
[TECH] Ne pas supprimer un organization learner déjà supprimé (PIX-11001)

### DIFF
--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
@@ -7,6 +7,7 @@ const removeByIds = function ({ organizationLearnerIds, userId, domainTransactio
   return domainTransaction
     .knexTransaction('organization-learners')
     .whereIn('id', organizationLearnerIds)
+    .whereNull('deletedAt')
     .update({ deletedAt: new Date(), deletedBy: userId });
 };
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement nous pouvons supprimer deux fois le même learner et ainsi perdre son historique de suppression

## :robot: Proposition
Ne supprimer que les learners que ne sont pas encore supprimé

## :rainbow: Remarques
RAS - Un bout de dette en moins

## :100: Pour tester
test au vert