### PR TITLE
[FEAT] Ajouter un message d'erreur spécifique lors de la création de parcours autonome non-autorisée (PIX-10994).

### DIFF
--- a/admin/app/controllers/authenticated/autonomous-courses/new.js
+++ b/admin/app/controllers/authenticated/autonomous-courses/new.js
@@ -28,11 +28,11 @@ export default class NewController extends Controller {
       if (!autonomousCourse.targetProfileId) {
         return this.notifications.error('Aucun profil cible sélectionné !');
       }
-      const badRequestError = error.errors.find((error) => error.status === '400');
-      if (badRequestError) {
+      if (error.errors[0]?.detail) {
         return this.notifications.error(error.errors[0].detail);
+      } else {
+        return this.notifications.error('Une erreur est survenue.');
       }
-      return this.notifications.error('Une erreur est survenue.');
     }
   }
 }

--- a/admin/tests/unit/controllers/authenticated/autonomous-courses/new_test.js
+++ b/admin/tests/unit/controllers/authenticated/autonomous-courses/new_test.js
@@ -133,6 +133,31 @@ module('Unit | Controller | authenticated/autonomous-courses/new', function (hoo
       assert.ok(controller.notifications.error.calledWith('Le profil cible ne correspond pas'));
     });
 
+    test('it should display error message from API when it receives an "user does not have access to the organization" error message', async function (assert) {
+      // given
+      const autonomousCourse = {
+        targetProfileId: 32,
+      };
+      controller.notifications = {
+        error: sinon.stub(),
+      };
+      const errors = {
+        errors: [{ status: '403', detail: 'User does not have an access to the organization 14' }],
+      };
+      const saveStub = sinon.stub().rejects(errors);
+      controller.store.createRecord = sinon.stub().returns({ save: saveStub });
+      const event = {
+        preventDefault: sinon.stub(),
+      };
+
+      // when
+      await controller.createAutonomousCourse(event, autonomousCourse);
+
+      // then
+      assert.ok(saveStub.called);
+      assert.ok(controller.notifications.error.calledWith('User does not have an access to the organization 14'));
+    });
+
     test('it should display not selected target profile error notification when autonomous-course is saved without target profile', async function (assert) {
       // given
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu’un utilisateur Pix Admin n’a pas été ajouté en tant que membre de l’organisation des parcours autonomes et qu’il cherche à créer un parcours autonome, il reçoit un message d’erreur “Une erreur est survenue” qui ne lui apporte pas de solution ni de piste pour débloquer la situation.

## :robot: Proposition
On propose de rajouter un message spécifique à ce cas pour informer l’utilisateur qu’il n’est pas membre de l’orga et qu’il doit s’y ajouter s’il souhaite créer un parcours autonome.

## :100: Pour tester
- Se connecter à Pix Admin avec un profil pas ajouté en tant que membre de l'organisation des parcours autonomes.
- Cliquer sur l'onglet Parcours Autonomes 
- Cliquer sur Nouveau parcours autonome
- Remplir les champs et cliquer sur Créer le parcours autonome
- Constater qu'un message d'erreur "Vous n'êtes pas membre de l'organisation des parcours autonomes, ajoutez-vous en tant que membre de l'organisation des parcours autonomes pour en créer un." apparait. 