### PR TITLE
[FEATURE] Retirer le code de rapport d'erreur dans la modal de gestion d'alerte en certif (PIX-1943)

### DIFF
--- a/certif/app/components/session-supervising/handle-live-alert-modal.hbs
+++ b/certif/app/components/session-supervising/handle-live-alert-modal.hbs
@@ -14,7 +14,6 @@
             {{on "change" this.setIssueReportReason}}
             checked={{if (eq option.subCategory this.issueReportReason) true}}
           >
-            <b>{{option.code}}</b>
             {{t option.label}}
           </PixRadioButton>
         {{/each}}

--- a/certif/tests/acceptance/session-supervising_test.js
+++ b/certif/tests/acceptance/session-supervising_test.js
@@ -399,7 +399,7 @@ module('Acceptance | Session supervising', function (hooks) {
 
           await click(
             screen.getByLabelText(
-              "E5 Le site est bloqué par les restrictions réseau de l'établissement (réseaux sociaux par ex.)",
+              "Le site est bloqué par les restrictions réseau de l'établissement (réseaux sociaux par ex.)",
             ),
           );
 
@@ -453,7 +453,7 @@ module('Acceptance | Session supervising', function (hooks) {
           await click(screen.getByRole('button', { name: 'Gérer le signalement' }));
           await click(
             screen.getByLabelText(
-              "E5 Le site est bloqué par les restrictions réseau de l'établissement (réseaux sociaux par ex.)",
+              "Le site est bloqué par les restrictions réseau de l'établissement (réseaux sociaux par ex.)",
             ),
           );
 
@@ -501,7 +501,7 @@ module('Acceptance | Session supervising', function (hooks) {
           // when
           await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
           await click(screen.getByRole('button', { name: 'Gérer le signalement' }));
-          await click(screen.getByLabelText('E4 Le site à visiter est indisponible/en maintenance/inaccessible'));
+          await click(screen.getByLabelText('Le site à visiter est indisponible/en maintenance/inaccessible'));
           await click(screen.getByText('Refuser le signalement'));
 
           const closeButtons = screen.getAllByText('Fermer');
@@ -550,7 +550,7 @@ module('Acceptance | Session supervising', function (hooks) {
           // when
           await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
           await click(screen.getByRole('button', { name: 'Gérer le signalement' }));
-          await click(screen.getByLabelText('E4 Le site à visiter est indisponible/en maintenance/inaccessible'));
+          await click(screen.getByLabelText('Le site à visiter est indisponible/en maintenance/inaccessible'));
 
           const modal = await screen.findByRole('dialog');
           await click(within(modal).getByLabelText('Fermer'));


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur la modale qui permet au surveillant de sélectionner la catégorie de signalement pour un pb technique sur une question depuis l’ES, les codes de signalements sont affichés ce qui peut être confusant pour le surveillant.

## :robot: Proposition
Dans l’ES > modale “Signalement du candidat” : supprimer les codes de signalement et n’afficher que le nom de la catégorie

## :100: Pour tester
- créer une session de certification dans un CDC taggué “Pilote certif v3” et y inscrire un candidat
- lancer le test du candidat et “Signaler un problème avec la question” > “Oui, je suis sur”
- ouvrir l’ES et cliquer sur “Gérer un signalement”
- les noms des catégories sont affichés mais plus les codes de signalement