### PR TITLE
[BUGFIX] Améliorer les `ariaLabel` Modulix (PIX-11008)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/module.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module.json
@@ -100,7 +100,7 @@
                   "size": 1,
                   "display": "inline",
                   "placeholder": "",
-                  "ariaLabel": "Réponse 1",
+                  "ariaLabel": "Réponse 1 sur 3",
                   "defaultValue": "",
                   "tolerances": ["t1"],
                   "solutions": ["@"]
@@ -114,7 +114,7 @@
                   "type": "select",
                   "display": "inline",
                   "placeholder": "",
-                  "ariaLabel": "Réponse 2",
+                  "ariaLabel": "Réponse 2 sur 3",
                   "defaultValue": "",
                   "tolerances": [],
                   "options": [
@@ -138,7 +138,7 @@
                   "type": "select",
                   "display": "inline",
                   "placeholder": "",
-                  "ariaLabel": "Réponse 3",
+                  "ariaLabel": "Réponse 3 sur 3",
                   "defaultValue": "",
                   "tolerances": [],
                   "options": [
@@ -450,7 +450,7 @@
                   "size": 10,
                   "display": "inline",
                   "placeholder": "",
-                  "ariaLabel": "Réponse 1",
+                  "ariaLabel": "Nom de ce produit",
                   "defaultValue": "",
                   "tolerances": ["t1"],
                   "solutions": ["Modulix"]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/module.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module.json
@@ -444,7 +444,7 @@
               "instruction": "<p>Quel est le nom de ce nouveau produit Pix ?</p>",
               "proposals": [
                 {
-                  "input": "symbole",
+                  "input": "nom-produit",
                   "type": "input",
                   "inputType": "text",
                   "size": 10,


### PR DESCRIPTION
## :unicorn: Problème
Certains `ariaLabel` de nos QROCM ne sont pas suffisamment complets. 

Notamment les `ariaLabel` auto ne spécifient pas le nombre de champs à remplir.

## :robot: Proposition
Revoir ces `ariaLabel` pour améliorer l’accessibilité. 

## :rainbow: Remarques
J'en ai profité pour corriger un nom d'input qui était copié collé d'un autre module..

## :100: Pour tester
Vérifier avec le lecteur d'écran que l'expérience est meilleure sur nos deux modules.
