### PR TITLE
[TECH] Migration vers la nouvelle méthode d'import JSON (PIX-11011)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/module-datasource.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module-datasource.js
@@ -1,5 +1,5 @@
 import { LearningContentResourceNotFound } from '../../../../shared/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
-import referential from './module.json' assert { type: 'json' };
+import referential from './module.json' with { type: 'json' };
 
 const moduleDatasource = {
   getBySlug: async (slug) => {


### PR DESCRIPTION
## :unicorn: Problème
La proposition ESM d’import de json directement en JS avec `assert` a changé de choix d’implem pour utiliser le mot clé `with`.

Voir [la décision de 2023-03 sur cette proposition](https://github.com/tc39/proposal-import-attributes).

## :robot: Proposition
Migrer vers le mot clé `with`.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que les modules reste accessibles
