### PR TITLE
[TECH] Mise à jour de l'installation par défaut du projet (PIX-11009).

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -64,7 +64,7 @@ git reset --hard
 Le script d'installation effectue les tâches suivantes :
 
 - créer la base de données et le cache (conteneurs Docker)
-- installer les librairies
+- installer les librairies communes à tous les projets
 
 Il prend moins de 5 minutes.
 Exécutez-le avec  `npm run configure`

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -6,7 +6,7 @@ Vous devez au préalable avoir correctement installé les logiciels suivants :
 
 - [Git](https://git-scm.com/) (2.6.4)
 - [Node.js](https://nodejs.org/) (version utilisée disponible dans les fichiers [.nvmrc](https://github.com/1024pix/pix/blob/dev/.nvmrc)) il est recommandé d'utiliser un gestionnaire de versions tel que [nvm](https://github.com/nvm-sh/nvm)
-- [Docker](https://docs.docker.com/get-started/) (20.10) avec [Docker Compose](https://docs.docker.com/compose/install/)
+- [Docker](https://docs.docker.com/get-started/) (20.10)
 
 > ⚠️ Les versions indiquées sont celles utilisées et préconisées par l'équipe de développement. Il est possible que
 > l'application fonctionne avec des versions différentes.
@@ -34,13 +34,6 @@ git clone --filter tree:0  git@github.com:1024pix/pix.git && cd pix
 ```
 
 ### Configurer l'environnement de développement sous Windows (si applicable)
-
-Il se peut que la dernière version `windows-build-tools` ne s'installe pas sur votre machine.
-La `windows-build-tools@4.0.0` semble plus stable à l'installation.
-
-```bash
-npm install windows-build-tools
-```
 
 Définir dans `.npmrc` l'invite de commande à utiliser pour lancer les script-shell.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,4 +1,4 @@
-# stack pix en local avec docker-compose 
+# Stack pix en local avec docker compose 
 ## Environnements : 
 
 2 environnements sont proposés :  
@@ -8,24 +8,24 @@
 Les environnements sont disponible grace au multi-stage Dockerfile.
 https://docs.docker.com/develop/develop-images/multistage-build/
 
-L'utilisation de plusieurs environnements et fichiers docker-compose : 
+L'utilisation de plusieurs environnements et fichiers docker compose : 
 https://docs.docker.com/compose/extends/
 
 ## Utilisation non dev : 
 ```sh
-docker-compose build
-docker-compose up -d 
+docker compose build
+docker compose up -d 
 ```
 
 ## Utilisation du .env : 
 
-Copier le sample.env en .env et rajouter si besoin des valeurs nécessaires
+Copier le `sample.env` en `.env` et rajouter si besoin des valeurs nécessaires
 
 ## exemple utilisation Dev d'API : 
 
 ```sh
-docker-compose -f docker-compose.yaml -f docker-compose-dev-api.yaml build 
-docker-compose -f docker-compose.yaml -f docker-compose-dev-api.yaml up -d 
+docker compose -f docker-compose.yaml -f docker-compose-dev-api.yaml build 
+docker compose -f docker-compose.yaml -f docker-compose-dev-api.yaml up -d 
 ```
 
 ## exemple utilisation Dev Frontend : 
@@ -35,27 +35,27 @@ Pour coder sur pix-orga :
 
 ```sh
 
-docker-compose -f docker-compose.yaml -f docker-compose-dev-front.yaml build orga
-docker-compose -f docker-compose.yaml -f docker-compose-dev-front.yaml up -d orga
+docker compose -f docker-compose.yaml -f docker-compose-dev-front.yaml build orga
+docker compose -f docker-compose.yaml -f docker-compose-dev-front.yaml up -d orga
 ```
 
 ## Dev API + frontend : 
-docker-compose -f docker-compose.yaml -f docker-compose-dev-api.yaml -f docker-compose-dev-front.yaml build api orga
-docker-compose -f docker-compose.yaml -f docker-compose-dev-api.yaml -f docker-compose-dev-front.yaml up -d api orga
+docker compose -f docker-compose.yaml -f docker-compose-dev-api.yaml -f docker-compose-dev-front.yaml build api orga
+docker compose -f docker-compose.yaml -f docker-compose-dev-api.yaml -f docker-compose-dev-front.yaml up -d api orga
 
 
 ## Réinitialisation de la DB : 
 
 ```sh
-docker-compose exec  api npm run db:reset 
+docker compose exec  api npm run db:reset 
 ```
 
 ## Simplifier l'utilisation à l'aide d'un alias : 
 
 ```sh
-alias dcapi="docker-compose -f docker-compose.yaml -f docker-compose-dev-api.yaml"
-alias dcfront="docker-compose -f docker-compose.yaml -f docker-compose-dev-front.yaml"
-alias dcall="docker-compose -f docker-compose.yaml -f docker-compose-dev-api.yaml -f docker-compose-dev-front.yaml"
+alias dcapi="docker compose -f docker-compose.yaml -f docker-compose-dev-api.yaml"
+alias dcfront="docker compose -f docker-compose.yaml -f docker-compose-dev-front.yaml"
+alias dcall="docker compose -f docker-compose.yaml -f docker-compose-dev-api.yaml -f docker-compose-dev-front.yaml"
 ```
 
 ## Node_modules : 
@@ -63,7 +63,7 @@ alias dcall="docker-compose -f docker-compose.yaml -f docker-compose-dev-api.yam
 Dans l'environnement de dev, les node_modules sont stockés dans un volumes dédié et ne sont pas dans le dossier de travail afin d'ignorer les possibles modifications / différences entre l'environement local et docker.
 
 En cas de problème et afin de repartir à zéro sur les node_modules, supprimez le volume : 
-`docker volume rm <VOLUME_NAME>` (voir fichier docker-compose front dev)
+`docker volume rm <VOLUME_NAME>` (voir fichier docker-compose-dev-front)
 
 
 ## Rappel des URLs en local: 

--- a/docker/sample.env
+++ b/docker/sample.env
@@ -378,7 +378,7 @@ LOG_FOR_HUMANS=true
 # presence: required
 # type: String
 # default: none
-AUTH_SECRET=Change me!
+AUTH_SECRET=the-password-must-be-at-least-32-characters-long
 
 
 # SCO account recovery - token lifetime (minutes)

--- a/high-level-tests/e2e/README.md
+++ b/high-level-tests/e2e/README.md
@@ -5,7 +5,7 @@ Il est utilisé ici pour les tests de non-régression sur les chemins fonctionne
 
 ### Je veux lancer les tests rapidement, comment faire ?
 
-Si tu es sous Linux et que tu a `docker` et `docker-compose`, alors le plus simple est de lancer a la racine.
+Si tu es sous Linux et que tu a `docker`, alors le plus simple est de lancer a la racine.
 
     ./scripts/tests-e2e
 

--- a/high-level-tests/e2e/env-api
+++ b/high-level-tests/e2e/env-api
@@ -224,7 +224,7 @@ LOG_ENABLED=true
 # presence: required
 # type: String
 # default: none
-AUTH_SECRET=Change me!
+AUTH_SECRET=the-password-must-be-at-least-32-characters-long
 
 # Allow email change in API
 

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -66,12 +66,11 @@ function generate_environment_config_file() {
 }
 
 function install_apps_dependencies() {
-  echo "Installing Pix apps dependencies…"
+  echo "Installing Pix root dependencies…"
 
-  npm install
-  npm run ci:all
+  npm ci
 
-  echo "✅ Dependencies installed."
+  echo "✅ Root dependencies installed."
   echo ""
 }
 
@@ -109,6 +108,6 @@ display_banner
 display_header
 verify_prerequesite_programs
 generate_environment_config_file
-install_apps_dependencies
 setup_and_run_infrastructure
+install_apps_dependencies
 display_footer

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -51,7 +51,6 @@ function verify_prerequesite_programs() {
   assert_program_is_installed "node"
   assert_program_is_installed "npm"
   assert_program_is_installed "docker"
-  assert_program_is_installed "docker-compose"
 
   echo "✅ Required programs have been found."
   echo ""
@@ -79,14 +78,14 @@ function install_apps_dependencies() {
 function setup_and_run_infrastructure() {
   echo "Starting infrastructure building blocks…"
 
-  docker-compose up -d --force-recreate
+  docker compose up -d --force-recreate
 
   echo "✅ PostgreSQL and Redis servers started (using Docker Compose)."
   echo ""
 
   echo "Waiting for PostgreSQL server to be ready…"
 
-  timeout 20s bash -c "until docker-compose exec postgres pg_isready ; do sleep 1 ; done"
+  timeout 20s bash -c "until docker compose exec postgres pg_isready ; do sleep 1 ; done"
 
   echo "✅ PostgreSQL server is ready."
   echo ""

--- a/scripts/tests-e2e
+++ b/scripts/tests-e2e
@@ -11,10 +11,10 @@ fi
 
 npm run ci:all
 cd high-level-tests/e2e
-docker-compose stop
-docker-compose up -d postgres redis api monpix certif orga
-docker-compose run --name pix-e2e-run-prepare --rm api npm run db:prepare
-docker-compose exec redis redis-cli flushdb
-docker-compose run --name pix-e2e-run-wait --rm cypress npx wait-on http://api:3000/api http://monpix:4200 http://orga:4201 http://certif:4203
-docker-compose run --name pix-e2e-run-cypress --rm $DC_CYPRESS_ARGS cypress bash -c "npm ci && npx cypress $CYPRESS_ARGS --config baseUrl=http://monpix:4200 --env API_URL=http://api:3000,ORGA_URL=http://orga:4201,CERTIF_URL=http://certif:4203"
-docker-compose down
+docker compose stop
+docker compose up -d postgres redis api monpix certif orga
+docker compose run --name pix-e2e-run-prepare --rm api npm run db:prepare
+docker compose exec redis redis-cli flushdb
+docker compose run --name pix-e2e-run-wait --rm cypress npx wait-on http://api:3000/api http://monpix:4200 http://orga:4201 http://certif:4203
+docker compose run --name pix-e2e-run-cypress --rm $DC_CYPRESS_ARGS cypress bash -c "npm ci && npx cypress $CYPRESS_ARGS --config baseUrl=http://monpix:4200 --env API_URL=http://api:3000,ORGA_URL=http://orga:4201,CERTIF_URL=http://certif:4203"
+docker compose down


### PR DESCRIPTION
## :unicorn: Problème
Suite à une ré-installation de plusieurs PC pour travailler sur le projet Pix (l’un sous Windows, l’autre sous Linux), et en suivant les recommandations d'installation, plusieurs éceuils se produisent pour un nouvel arrivant.

## :robot: Proposition

1) `configure.sh` : ses références pointent vers docker-compose alors que depuis Juillet 2023 Compose V1 n'est plus supporté, Compose V2 est dans docker, et donc la commande peut passer à docker compose
Du coup cela plantait à assert_program_is_installed "docker-compose" sur des installations "fraiches"

2) `configure.sh` :  le lancement de la partie `install_apps_dependencies` prends beaucoup de temps au vu du nombre d’applications dans le mono-repo, proposition de revue de cette partie du script

3) Aussi sous windows, plus besoin de `windows-build-tools`, c'est dans Node.js nativement

4) Le `.env` contient un change me! avec un espace qui le rend pas super compatible avec les outils qui chargent automatique les .env ; on peut mettre une autre valeur + compatible avec les autres env

## :rainbow: Remarques

Sources pour docker compose : https://docs.docker.com/compose/migrate/#what-are-the-differences-between-compose-v1-and-compose-v2

Sources pour windows-build-tools : https://www.npmjs.com/package/windows-build-tools

## :100: Pour tester

* L'idéal serait d'essayer la procédure d'installation "from scratch" dans une VM par exemple, et suivre la procédure du `INSTALLATION.md`

* Lancer à la racine un `npm run configure` avec succès (Tout poste même déjà configuré)
* Tests de la CICD au vert
