### PR TITLE
[TECH] Récupérer le nombre de question d'une certif v3 depuis la config

### DIFF
--- a/admin/app/components/certifications/certification/details-v3.hbs
+++ b/admin/app/components/certifications/certification/details-v3.hbs
@@ -72,7 +72,7 @@
         /
         {{t "pages.certifications.certification.details.v3.more-informations.labels.total-numberof-questions"}}
       </dt>
-      <dd>{{@details.numberOfAnsweredQuestions}}/{{@details.totalNumberOfQuestions}}</dd>
+      <dd>{{@details.numberOfAnsweredQuestions}}/{{@details.numberOfChallenges}}</dd>
       <dt>{{t "pages.certifications.certification.details.v3.more-informations.labels.numberof-ok-questions"}} :</dt>
       <dd>{{@details.numberOfOkAnswers}}</dd>
       <dt>{{t "pages.certifications.certification.details.v3.more-informations.labels.numberof-ko-questions"}} :</dt>

--- a/admin/app/models/v3-certification-course-details-for-administration.js
+++ b/admin/app/models/v3-certification-course-details-for-administration.js
@@ -26,6 +26,7 @@ export default class V3CertificationCourseDetailsForAdministration extends Model
   @attr('string') assessmentState;
   @attr('string') abortReason;
   @attr('number') pixScore;
+  @attr('number') numberOfChallenges;
   @hasMany('certification-challenges-for-administration') certificationChallengesForAdministration;
   version = 3;
 
@@ -33,11 +34,6 @@ export default class V3CertificationCourseDetailsForAdministration extends Model
     return this.certificationChallengesForAdministration.filter((challenge) => {
       return challenge.answerStatus;
     }).length;
-  }
-
-  get totalNumberOfQuestions() {
-    // TODO: save the number of questions at the start of a certification to get it here
-    return 32;
   }
 
   get numberOfOkAnswers() {

--- a/admin/tests/integration/components/certifications/certification/details-v3_test.js
+++ b/admin/tests/integration/components/certifications/certification/details-v3_test.js
@@ -287,7 +287,7 @@ module('Integration | Component | Certifications | certification > details v3', 
         const expected = [
           {
             term: 'Nombre de question répondues\n/ Nombre total de questions',
-            definition: '9/32',
+            definition: '9/15',
           },
           {
             term: 'Nombre de question OK :',
@@ -504,6 +504,7 @@ function createCertificationCourseDetailsRecord({ certificationChallengesForAdmi
     assessmentState: 'completed',
     completedAt: new Date(),
     assessmentResultStatus: 'validated',
+    numberOfChallenges: 15,
     certificationChallengesForAdministration,
     ...params,
   });

--- a/api/db/seeds/data/team-certification/data-builder.js
+++ b/api/db/seeds/data/team-certification/data-builder.js
@@ -53,6 +53,7 @@ async function teamCertificationDataBuilder({ databaseBuilder }) {
   await _createProOrganization({ databaseBuilder });
   await _createProCertificationCenter({ databaseBuilder });
   await _createComplementaryCertificationCampaign({ databaseBuilder });
+  _createV3CertificationConfiguration({ databaseBuilder });
   await _createV3PilotCertificationCenter({ databaseBuilder });
   await _createSuccessCertifiableUser({ databaseBuilder });
   await _createScoSession({ databaseBuilder });
@@ -96,6 +97,22 @@ async function _createScoCertificationCenter({ databaseBuilder }) {
     updatedAt: new Date(),
     members: [{ id: SCO_CERTIFICATION_MANAGING_STUDENTS_CERTIFICATION_CENTER_USER_ID }],
     complementaryCertificationIds: [],
+  });
+}
+
+function _createV3CertificationConfiguration({ databaseBuilder }) {
+  databaseBuilder.factory.buildFlashAlgorithmConfiguration({
+    warmUpLength: null,
+    forcedCompetences: [],
+    maximumAssessmentLength: 32,
+    challengesBetweenSameCompetence: null,
+    minimumEstimatedSuccessRateRanges: [],
+    limitToOneQuestionPerTube: true,
+    enablePassageByAllCompetences: true,
+    doubleMeasuresUntil: null,
+    variationPercent: 0.5,
+    variationPercentUntil: null,
+    createdAt: new Date('2022-01-01'),
   });
 }
 

--- a/api/lib/domain/models/CertificationCourse.js
+++ b/api/lib/domain/models/CertificationCourse.js
@@ -36,6 +36,7 @@ class CertificationCourse {
     isCancelled = false,
     abortReason,
     complementaryCertificationCourses = [],
+    numberOfChallenges,
     version = CertificationVersion.V2,
     isRejectedForFraud = false,
   } = {}) {
@@ -65,6 +66,7 @@ class CertificationCourse {
     this._abortReason = abortReason;
     this._complementaryCertificationCourses = complementaryCertificationCourses;
     this._isRejectedForFraud = isRejectedForFraud;
+    this._numberOfChallenges = numberOfChallenges;
   }
 
   static from({
@@ -73,6 +75,7 @@ class CertificationCourse {
     verificationCode,
     maxReachableLevelOnCertificationDate,
     complementaryCertificationCourses,
+    numberOfChallenges,
     version,
   }) {
     return new CertificationCourse({
@@ -88,6 +91,7 @@ class CertificationCourse {
       birthplace: certificationCandidate.birthCity,
       externalId: certificationCandidate.externalId,
       challenges,
+      numberOfChallenges,
       verificationCode,
       maxReachableLevelOnCertificationDate,
       complementaryCertificationCourses,
@@ -238,6 +242,10 @@ class CertificationCourse {
 
   getMaxReachableLevelOnCertificationDate() {
     return this._maxReachableLevelOnCertificationDate;
+  }
+
+  getNumberOfChallenges() {
+    return this._version === CertificationVersion.V3 ? this._numberOfChallenges : this._challenges?.length ?? 0;
   }
 
   toDTO() {

--- a/api/lib/domain/models/CertificationCourse.js
+++ b/api/lib/domain/models/CertificationCourse.js
@@ -245,7 +245,15 @@ class CertificationCourse {
   }
 
   getNumberOfChallenges() {
-    return this._version === CertificationVersion.V3 ? this._numberOfChallenges : this._challenges?.length ?? 0;
+    if (this.isV3()) {
+      return this._numberOfChallenges;
+    }
+
+    return this._challenges?.length ?? 0;
+  }
+
+  isV3() {
+    return this._version === CertificationVersion.V3;
   }
 
   toDTO() {

--- a/api/lib/domain/models/CertificationCourse.js
+++ b/api/lib/domain/models/CertificationCourse.js
@@ -275,6 +275,7 @@ class CertificationCourse {
       isCancelled: this._isCancelled,
       abortReason: this._abortReason,
       complementaryCertificationCourses: this._complementaryCertificationCourses,
+      numberOfChallenges: this._numberOfChallenges,
       version: this._version,
     };
   }

--- a/api/lib/infrastructure/serializers/jsonapi/certification-course-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-course-serializer.js
@@ -1,5 +1,4 @@
 import jsonapiSerializer from 'jsonapi-serializer';
-import { config } from './../../../config.js';
 
 const { Serializer } = jsonapiSerializer;
 
@@ -7,7 +6,7 @@ const serialize = function (certificationCourse) {
   return new Serializer('certification-course', {
     transform(currentCertificationCourse) {
       const certificationCourseDTO = currentCertificationCourse.toDTO();
-      certificationCourseDTO.nbChallenges = _getChallengesNumberDependingOnVersion(certificationCourseDTO);
+      certificationCourseDTO.nbChallenges = currentCertificationCourse.getNumberOfChallenges();
       certificationCourseDTO.examinerComment = certificationCourseDTO.certificationIssueReports?.[0]?.description;
       return certificationCourseDTO;
     },
@@ -31,12 +30,5 @@ const serialize = function (certificationCourse) {
     },
   }).serialize(certificationCourse);
 };
-
-function _getChallengesNumberDependingOnVersion(certificationCourseDTO) {
-  if (certificationCourseDTO.version === 3) {
-    return config.v3Certification.numberOfChallengesPerCourse;
-  }
-  return certificationCourseDTO?.challenges?.length ?? 0;
-}
 
 export { serialize };

--- a/api/src/certification/course/domain/models/V3CertificationCourseDetailsForAdministration.js
+++ b/api/src/certification/course/domain/models/V3CertificationCourseDetailsForAdministration.js
@@ -10,6 +10,7 @@ export class V3CertificationCourseDetailsForAdministration {
     assessmentResultStatus,
     abortReason,
     pixScore,
+    numberOfChallenges,
   }) {
     this.certificationCourseId = certificationCourseId;
     this.isRejectedForFraud = isRejectedForFraud;
@@ -21,6 +22,7 @@ export class V3CertificationCourseDetailsForAdministration {
     this.assessmentResultStatus = assessmentResultStatus;
     this.abortReason = abortReason;
     this.pixScore = pixScore;
+    this.numberOfChallenges = numberOfChallenges;
   }
 
   setCompetencesDetails(competenceList) {

--- a/api/src/certification/course/infrastructure/repositories/v3-certification-course-details-for-administration-repository.js
+++ b/api/src/certification/course/infrastructure/repositories/v3-certification-course-details-for-administration-repository.js
@@ -44,6 +44,11 @@ const getV3DetailsByCertificationCourseId = async function ({ certificationCours
     })
     .first();
 
+  const { maximumAssessmentLength: numberOfChallenges } = await knex('flash-algorithm-configurations')
+    .where('createdAt', '<=', certificationCourseDTO.createdAt)
+    .orderBy('createdAt', 'desc')
+    .first();
+
   const certificationChallengesDetailsDTO = await knex
     .select({
       challengeId: 'certification-challenges.challengeId',
@@ -65,10 +70,10 @@ const getV3DetailsByCertificationCourseId = async function ({ certificationCours
     })
     .orderBy('certification-challenges.createdAt', 'asc');
 
-  return _toDomain({ certificationChallengesDetailsDTO, liveAlertsDTO, certificationCourseDTO });
+  return _toDomain({ certificationChallengesDetailsDTO, liveAlertsDTO, certificationCourseDTO, numberOfChallenges });
 };
 
-function _toDomain({ certificationChallengesDetailsDTO, liveAlertsDTO, certificationCourseDTO }) {
+function _toDomain({ certificationChallengesDetailsDTO, liveAlertsDTO, certificationCourseDTO, numberOfChallenges }) {
   const certificationChallengesForAdministration = certificationChallengesDetailsDTO.map(
     (certificationChallengeDetailsDTO) =>
       new V3CertificationChallengeForAdministration({
@@ -85,6 +90,7 @@ function _toDomain({ certificationChallengesDetailsDTO, liveAlertsDTO, certifica
 
   return new V3CertificationCourseDetailsForAdministration({
     ...certificationCourseDTO,
+    numberOfChallenges,
     certificationChallengesForAdministration,
   });
 }

--- a/api/src/certification/course/infrastructure/serializers/jsonapi/v3-certification-course-details-for-administration-serializer.js
+++ b/api/src/certification/course/infrastructure/serializers/jsonapi/v3-certification-course-details-for-administration-serializer.js
@@ -14,6 +14,7 @@ const serialize = function ({ certificationDetails }) {
     'assessmentResultStatus',
     'abortReason',
     'pixScore',
+    'numberOfChallenges',
   ];
 
   return new Serializer('v3-certification-course-details-for-administration', {

--- a/api/tests/certification/course/acceptance/application/certification-course-route_test.js
+++ b/api/tests/certification/course/acceptance/application/certification-course-route_test.js
@@ -243,6 +243,11 @@ describe('Acceptance | Route | certification-course', function () {
 
     beforeEach(async function () {
       certificationCourse = databaseBuilder.factory.buildCertificationCourse({ version: 3 });
+      databaseBuilder.factory.buildFlashAlgorithmConfiguration({
+        maximumAssessmentLength: 10,
+        createdAt: new Date('2020-01-01'),
+      });
+
       const user = await insertUserWithRoleSuperAdmin();
       ({ certificationChallenges, assessmentResult } = await createSuccessfulCertificationCourse({
         userId: user.id,
@@ -285,6 +290,7 @@ describe('Acceptance | Route | certification-course', function () {
           'is-rejected-for-fraud': false,
           'is-cancelled': false,
           'pix-score': assessmentResult.pixScore,
+          'number-of-challenges': 10,
           'assessment-state': 'completed',
           'assessment-result-status': 'validated',
         },

--- a/api/tests/certification/course/integration/infrastructure/repositories/v3-certification-course-details-for-administration-repository_test.js
+++ b/api/tests/certification/course/integration/infrastructure/repositories/v3-certification-course-details-for-administration-repository_test.js
@@ -18,6 +18,7 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
       const assessmentId = 78;
       const isRejectedForFraud = true;
       const createdAt = new Date('2022-02-02');
+      const flashAlgorithmConfigurationCreationDate = new Date('2022-02-01');
       const completedAt = new Date('2022-02-03');
       const assessmentState = Assessment.states.ENDED_DUE_TO_FINALIZATION;
       const assessmentResultStatus = AssessmentResult.status.VALIDATED;
@@ -47,6 +48,10 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
         certificationCourseId,
         assessmentId,
         assessmentResultStatus,
+      });
+      const { maximumAssessmentLength: numberOfChallenges } = databaseBuilder.factory.buildFlashAlgorithmConfiguration({
+        maximumAssessmentLength: 1,
+        createdAt: flashAlgorithmConfigurationCreationDate,
       });
 
       const answer = databaseBuilder.factory.buildAnswer({
@@ -83,6 +88,7 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
         abortReason,
         pixScore,
         isCancelled,
+        numberOfChallenges,
         certificationChallengesForAdministration: [certificationChallengeForAdministration],
       });
 
@@ -95,7 +101,13 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
       const firstChallengeId = 'recCHAL456';
       const secondChallengeId = 'recCHAL789';
       const thirdChallengeId = 'recCHAL123';
+      const flashAlgorithmConfigurationCreationDate = new Date('2020-01-01');
       const assessmentId = 78;
+
+      databaseBuilder.factory.buildFlashAlgorithmConfiguration({
+        maximumAssessmentLength: 3,
+        createdAt: flashAlgorithmConfigurationCreationDate,
+      });
 
       databaseBuilder.factory.buildCertificationCourse({ id: certificationCourseId });
       databaseBuilder.factory.buildCertificationChallenge({

--- a/api/tests/certification/course/unit/infrasctructure/serializers/jsonapi/v3-certification-course-details-for-administration-serializer_test.js
+++ b/api/tests/certification/course/unit/infrasctructure/serializers/jsonapi/v3-certification-course-details-for-administration-serializer_test.js
@@ -23,6 +23,7 @@ describe('Unit | Serializer | JSONAPI | v3-certification-details-for-administrat
       const answerValue = 'Some answer';
       const isRejectedForFraud = true;
       const isCancelled = true;
+      const numberOfChallenges = 20;
       const createdAt = new Date('2022-02-02');
       const completedAt = new Date('2022-02-03');
       const assessmentState = Assessment.states.ENDED_DUE_TO_FINALIZATION;
@@ -63,6 +64,7 @@ describe('Unit | Serializer | JSONAPI | v3-certification-details-for-administrat
             'assessment-result-status': assessmentResultStatus,
             'abort-reason': abortReason,
             'pix-score': pixScore,
+            'number-of-challenges': 20,
           },
         },
         included: [
@@ -95,6 +97,7 @@ describe('Unit | Serializer | JSONAPI | v3-certification-details-for-administrat
         assessmentResultStatus,
         abortReason,
         pixScore,
+        numberOfChallenges,
         certificationChallengesForAdministration: [certificationChallenge],
       });
 

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -120,125 +120,100 @@ describe('Integration | Repository | Certification Course', function () {
   });
 
   describe('#get', function () {
-    let expectedCertificationCourse;
-    let anotherCourseId;
-    let sessionId;
-    let userId;
     const description = 'Un commentaire du surveillant';
-
-    beforeEach(function () {
-      userId = databaseBuilder.factory.buildUser().id;
-      sessionId = databaseBuilder.factory.buildSession().id;
-      expectedCertificationCourse = databaseBuilder.factory.buildCertificationCourse({
-        userId,
-        sessionId,
-        completedAt: null,
-        firstName: 'Timon',
-        lastName: 'De La Havane',
-        birthdate: '1993-08-14',
-        birthplace: 'Cuba',
-        isPublished: true,
-        isRejectedForFraud: true,
-      });
-      anotherCourseId = databaseBuilder.factory.buildCertificationCourse({ userId }).id;
-      _.each(
-        [
-          { courseId: expectedCertificationCourse.id },
-          { courseId: expectedCertificationCourse.id },
-          { courseId: anotherCourseId },
-        ],
-        (certificationChallenge) => {
-          databaseBuilder.factory.buildCertificationChallenge(certificationChallenge);
-        },
-      );
-      _.each(
-        [
-          {
-            certificationCourseId: expectedCertificationCourse.id,
-            badge: databaseBuilder.factory.buildBadge({ key: 'forêt_noire' }),
-            complementaryCertificationId: databaseBuilder.factory.buildComplementaryCertification().id,
-          },
-          {
-            certificationCourseId: expectedCertificationCourse.id,
-            badge: databaseBuilder.factory.buildBadge({ key: 'baba_au_rhum' }),
-            complementaryCertificationId: databaseBuilder.factory.buildComplementaryCertification().id,
-          },
-          {
-            certificationCourseId: anotherCourseId,
-            badge: databaseBuilder.factory.buildBadge({ key: 'tropézienne' }),
-            complementaryCertificationId: databaseBuilder.factory.buildComplementaryCertification().id,
-          },
-        ],
-        ({ certificationCourseId, complementaryCertificationId, badge }) => {
-          const complementaryCertificationBadgeId = databaseBuilder.factory.buildComplementaryCertificationBadge({
-            badgeId: badge.id,
-            complementaryCertificationId,
-          }).id;
-          const complementaryCertificationCourseId = databaseBuilder.factory.buildComplementaryCertificationCourse({
-            certificationCourseId,
-            complementaryCertificationId,
-            complementaryCertificationBadgeId,
-          }).id;
-          databaseBuilder.factory.buildComplementaryCertificationCourseResult({
-            complementaryCertificationCourseId,
-            certificationCourseId,
-          });
-        },
-      );
-      databaseBuilder.factory.buildCertificationIssueReport({
-        certificationCourseId: expectedCertificationCourse.id,
-        description,
-      });
-      return databaseBuilder.commit();
-    });
+    let sessionId, expectedCertificationCourse, userId;
 
     context('When the certification course exists', function () {
-      it('should retrieve certification course informations', async function () {
-        // when
-        const actualCertificationCourse = await certificationCourseRepository.get(expectedCertificationCourse.id);
+      context('When the certification course is v2', function () {
+        beforeEach(async function () {
+          ({ sessionId, expectedCertificationCourse, userId } = _buildCertificationCourse({
+            description,
+          }));
 
-        // then
-        const actualCertificationCourseDTO = actualCertificationCourse.toDTO();
-        expect(actualCertificationCourseDTO.id).to.equal(expectedCertificationCourse.id);
-        expect(actualCertificationCourseDTO.completedAt).to.equal(expectedCertificationCourse.completedAt);
-        expect(actualCertificationCourseDTO.firstName).to.equal(expectedCertificationCourse.firstName);
-        expect(actualCertificationCourseDTO.lastName).to.equal(expectedCertificationCourse.lastName);
-        expect(actualCertificationCourseDTO.birthdate).to.equal(expectedCertificationCourse.birthdate);
-        expect(actualCertificationCourseDTO.birthplace).to.equal(expectedCertificationCourse.birthplace);
-        expect(actualCertificationCourseDTO.sessionId).to.equal(sessionId);
-        expect(actualCertificationCourseDTO.isPublished).to.equal(expectedCertificationCourse.isPublished);
-        expect(actualCertificationCourseDTO.isRejectedForFraud).to.equal(
-          expectedCertificationCourse.isRejectedForFraud,
-        );
-        expect(actualCertificationCourseDTO.certificationIssueReports[0].description).to.equal(description);
-      });
+          await databaseBuilder.commit();
+        });
+        it('should retrieve certification course informations', async function () {
+          // when
+          const actualCertificationCourse = await certificationCourseRepository.get(expectedCertificationCourse.id);
 
-      it('should retrieve associated challenges with the certification course', async function () {
-        // when
-        const thisCertificationCourse = await certificationCourseRepository.get(expectedCertificationCourse.id);
-
-        // then
-        expect(thisCertificationCourse.toDTO().challenges.length).to.equal(2);
-      });
-
-      context('When the certification course has one assessment', function () {
-        let assessmentId;
-
-        beforeEach(function () {
-          assessmentId = databaseBuilder.factory.buildAssessment({
-            type: 'CERTIFICATION',
-            certificationCourseId: expectedCertificationCourse.id,
-            userId,
-          }).id;
-          return databaseBuilder.commit();
+          // then
+          const actualCertificationCourseDTO = actualCertificationCourse.toDTO();
+          expect(actualCertificationCourseDTO.id).to.equal(expectedCertificationCourse.id);
+          expect(actualCertificationCourseDTO.completedAt).to.equal(expectedCertificationCourse.completedAt);
+          expect(actualCertificationCourseDTO.firstName).to.equal(expectedCertificationCourse.firstName);
+          expect(actualCertificationCourseDTO.lastName).to.equal(expectedCertificationCourse.lastName);
+          expect(actualCertificationCourseDTO.birthdate).to.equal(expectedCertificationCourse.birthdate);
+          expect(actualCertificationCourseDTO.birthplace).to.equal(expectedCertificationCourse.birthplace);
+          expect(actualCertificationCourseDTO.sessionId).to.equal(sessionId);
+          expect(actualCertificationCourseDTO.isPublished).to.equal(expectedCertificationCourse.isPublished);
+          expect(actualCertificationCourseDTO.isRejectedForFraud).to.equal(
+            expectedCertificationCourse.isRejectedForFraud,
+          );
+          expect(actualCertificationCourseDTO.certificationIssueReports[0].description).to.equal(description);
         });
 
-        it('should retrieve associated assessment', async function () {
+        it('should retrieve associated challenges with the certification course', async function () {
           // when
           const thisCertificationCourse = await certificationCourseRepository.get(expectedCertificationCourse.id);
 
           // then
-          expect(thisCertificationCourse.toDTO().assessment.id).to.equal(assessmentId);
+          expect(thisCertificationCourse.toDTO().challenges.length).to.equal(2);
+        });
+        context('When the certification course has one assessment', function () {
+          let assessmentId;
+
+          beforeEach(function () {
+            assessmentId = databaseBuilder.factory.buildAssessment({
+              type: 'CERTIFICATION',
+              certificationCourseId: expectedCertificationCourse.id,
+              userId,
+            }).id;
+            return databaseBuilder.commit();
+          });
+
+          it('should retrieve associated assessment', async function () {
+            // when
+            const thisCertificationCourse = await certificationCourseRepository.get(expectedCertificationCourse.id);
+
+            // then
+            expect(thisCertificationCourse.toDTO().assessment.id).to.equal(assessmentId);
+          });
+        });
+      });
+
+      context('When the certification course is v3', function () {
+        it('should retrieve the number of challenges from the configuration', async function () {
+          const maximumAssessmentLength = 10;
+          const { expectedCertificationCourse } = _buildCertificationCourse({
+            description,
+            version: 3,
+            createdAt: new Date('2022-01-03'),
+          });
+
+          // Active configuration on the certification day
+          databaseBuilder.factory.buildFlashAlgorithmConfiguration({
+            maximumAssessmentLength,
+            createdAt: new Date('2022-01-02'),
+          });
+
+          // Older configuration
+          databaseBuilder.factory.buildFlashAlgorithmConfiguration({
+            maximumAssessmentLength: 5,
+            createdAt: new Date('2022-01-01'),
+          });
+
+          // Newer configuration
+          databaseBuilder.factory.buildFlashAlgorithmConfiguration({
+            maximumAssessmentLength: 15,
+            createdAt: new Date('2022-01-04'),
+          });
+
+          await databaseBuilder.commit();
+          // when
+          const actualCertificationCourse = await certificationCourseRepository.get(expectedCertificationCourse.id);
+
+          // then
+          expect(actualCertificationCourse.getNumberOfChallenges()).to.equal(maximumAssessmentLength);
         });
       });
     });
@@ -473,3 +448,76 @@ describe('Integration | Repository | Certification Course', function () {
     });
   });
 });
+
+function _buildCertificationCourse({ createdAt, description, version = 2 }) {
+  const userId = databaseBuilder.factory.buildUser().id;
+  const sessionId = databaseBuilder.factory.buildSession().id;
+  const expectedCertificationCourse = databaseBuilder.factory.buildCertificationCourse({
+    userId,
+    sessionId,
+    completedAt: null,
+    createdAt,
+    firstName: 'Timon',
+    lastName: 'De La Havane',
+    birthdate: '1993-08-14',
+    birthplace: 'Cuba',
+    isPublished: true,
+    isRejectedForFraud: true,
+    version,
+  });
+  const anotherCourseId = databaseBuilder.factory.buildCertificationCourse({ userId }).id;
+  _.each(
+    [
+      { courseId: expectedCertificationCourse.id },
+      { courseId: expectedCertificationCourse.id },
+      { courseId: anotherCourseId },
+    ],
+    (certificationChallenge) => {
+      databaseBuilder.factory.buildCertificationChallenge(certificationChallenge);
+    },
+  );
+  _.each(
+    [
+      {
+        certificationCourseId: expectedCertificationCourse.id,
+        badge: databaseBuilder.factory.buildBadge({ key: 'forêt_noire' }),
+        complementaryCertificationId: databaseBuilder.factory.buildComplementaryCertification().id,
+      },
+      {
+        certificationCourseId: expectedCertificationCourse.id,
+        badge: databaseBuilder.factory.buildBadge({ key: 'baba_au_rhum' }),
+        complementaryCertificationId: databaseBuilder.factory.buildComplementaryCertification().id,
+      },
+      {
+        certificationCourseId: anotherCourseId,
+        badge: databaseBuilder.factory.buildBadge({ key: 'tropézienne' }),
+        complementaryCertificationId: databaseBuilder.factory.buildComplementaryCertification().id,
+      },
+    ],
+    ({ certificationCourseId, complementaryCertificationId, badge }) => {
+      const complementaryCertificationBadgeId = databaseBuilder.factory.buildComplementaryCertificationBadge({
+        badgeId: badge.id,
+        complementaryCertificationId,
+      }).id;
+      const complementaryCertificationCourseId = databaseBuilder.factory.buildComplementaryCertificationCourse({
+        certificationCourseId,
+        complementaryCertificationId,
+        complementaryCertificationBadgeId,
+      }).id;
+      databaseBuilder.factory.buildComplementaryCertificationCourseResult({
+        complementaryCertificationCourseId,
+        certificationCourseId,
+      });
+    },
+  );
+  databaseBuilder.factory.buildCertificationIssueReport({
+    certificationCourseId: expectedCertificationCourse.id,
+    description,
+  });
+
+  return {
+    userId,
+    sessionId,
+    expectedCertificationCourse,
+  };
+}

--- a/api/tests/tooling/domain-builder/factory/build-certification-course.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-course.js
@@ -31,6 +31,7 @@ function buildCertificationCourse({
   abortReason = null,
   complementaryCertificationCourses = [],
   maxReachableLevelOnCertificationDate = 7,
+  numberOfChallenges = 20,
 } = {}) {
   const certificationIssueReports = [];
   if (examinerComment && examinerComment !== '') {
@@ -72,6 +73,7 @@ function buildCertificationCourse({
     abortReason,
     complementaryCertificationCourses,
     maxReachableLevelOnCertificationDate,
+    numberOfChallenges,
   });
 }
 

--- a/api/tests/tooling/domain-builder/factory/build-v3-certification-course-details-for-administration.js
+++ b/api/tests/tooling/domain-builder/factory/build-v3-certification-course-details-for-administration.js
@@ -11,6 +11,7 @@ export const buildV3CertificationCourseDetailsForAdministration = ({
   assessmentResultStatus,
   abortReason,
   pixScore,
+  numberOfChallenges,
 }) => {
   return new V3CertificationCourseDetailsForAdministration({
     certificationCourseId,
@@ -23,5 +24,6 @@ export const buildV3CertificationCourseDetailsForAdministration = ({
     abortReason,
     pixScore,
     certificationChallengesForAdministration,
+    numberOfChallenges,
   });
 };

--- a/api/tests/unit/domain/models/CertificationCourse_test.js
+++ b/api/tests/unit/domain/models/CertificationCourse_test.js
@@ -1,5 +1,7 @@
 import { expect, domainBuilder } from '../../../test-helper.js';
 import { EntityValidationError } from '../../../../src/shared/domain/errors.js';
+import { generateChallengeList } from '../../../certification/shared/fixtures/challenges.js';
+import { CertificationVersion } from '../../../../src/shared/domain/models/CertificationVersion.js';
 
 describe('Unit | Domain | Models | CertificationCourse', function () {
   describe('#cancel #isCancelled', function () {
@@ -314,6 +316,43 @@ describe('Unit | Domain | Models | CertificationCourse', function () {
 
       // then
       expect(certificationCourse.toDTO().completedAt).to.deep.equal(new Date('1999-12-31'));
+    });
+  });
+
+  describe('#getNumberOfChallenges', function () {
+    describe('when certification course is version 3', function () {
+      it('should return the number of challenges defined when created', function () {
+        // given
+        const numberOfChallenges = 5;
+        const certificationCourse = domainBuilder.buildCertificationCourse({
+          version: CertificationVersion.V3,
+          numberOfChallenges,
+        });
+
+        // when
+        const computedNumberOfChallenges = certificationCourse.getNumberOfChallenges();
+
+        // then
+        expect(computedNumberOfChallenges).to.equal(numberOfChallenges);
+      });
+    });
+
+    describe('when certification course is version 2', function () {
+      it('should return the number of challenges based on the challenges length', function () {
+        // given
+        const numberOfChallenges = 5;
+        const challenges = generateChallengeList({ length: numberOfChallenges });
+        const certificationCourse = domainBuilder.buildCertificationCourse({
+          version: CertificationVersion.V2,
+          challenges,
+        });
+
+        // when
+        const computedNumberOfChallenges = certificationCourse.getNumberOfChallenges();
+
+        // then
+        expect(computedNumberOfChallenges).to.equal(numberOfChallenges);
+      });
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le nombre de question d'une certification v3 est défini en dur dans le front dans la page de détails de pix-admin.

## :robot: Proposition
Récupérer ces données depuis la configuration de l'algo

## :100: Pour tester
- Créer une certification v3 
- Rejoindre la certification et vérifier l'affichage du nombre de questions (1/32)
- Aller sur les détails de la certification dans admin, et vérifier l'affichage du nombre total de questions dans la certif.