### PR TITLE
[BUGFIX] Retirer le `<p>` par défaut du contenu des `PixModal` (PIX-11006)

### DIFF
--- a/mon-pix/app/pods/components/module/image/styles.scss
+++ b/mon-pix/app/pods/components/module/image/styles.scss
@@ -1,11 +1,13 @@
 .element-image {
-  &-container {
+  &__container {
     aspect-ratio: auto 16 / 9;
     margin: 0 auto var(--pix-spacing-3x) auto;
+  }
+}
 
-    img {
-      display: block;
-      height: 100%;
-    }
+.element-image-container {
+  &__image {
+    display: block;
+    height: 100%;
   }
 }

--- a/mon-pix/app/pods/components/module/image/template.hbs
+++ b/mon-pix/app/pods/components/module/image/template.hbs
@@ -18,9 +18,7 @@
     @onCloseButtonClick={{this.closeModal}}
   >
     <:content>
-      <p class="image__modal-instruction">
-        {{html-unsafe @image.alternativeText}}
-      </p>
+      {{html-unsafe @image.alternativeText}}
     </:content>
   </PixModal>
 </div>

--- a/mon-pix/app/pods/components/module/image/template.hbs
+++ b/mon-pix/app/pods/components/module/image/template.hbs
@@ -1,6 +1,6 @@
 <div class="element-image">
-  <div class="element-image-container">
-    <img alt={{@image.alt}} src={{@image.url}} />
+  <div class="element-image__container">
+    <img class="element-image-container__image" alt={{@image.alt}} src={{@image.url}} />
   </div>
   <PixButton
     @backgroundColor="transparent-light"
@@ -16,7 +16,6 @@
     @title={{t "pages.modulix.modals.alternativeText.title"}}
     @showModal={{this.modalIsOpen}}
     @onCloseButtonClick={{this.closeModal}}
-    class="element__image-modal"
   >
     <:content>
       <p class="image__modal-instruction">

--- a/mon-pix/app/pods/components/module/video/styles.scss
+++ b/mon-pix/app/pods/components/module/video/styles.scss
@@ -1,17 +1,11 @@
 .element-video {
-  &-container {
+  &__container {
     margin: 0 auto var(--pix-spacing-3x) auto;
     overflow: clip;
     border-radius: var(--pix-spacing-2x);
-    aspect-ratio: auto 16 / 9;
-
-    video {
-      display: block;
-      height: 100%;
-    }
   }
 }
 
 .pix-video-player {
-  width: 100%;
+  aspect-ratio: auto 16 / 9;
 }

--- a/mon-pix/app/pods/components/module/video/template.hbs
+++ b/mon-pix/app/pods/components/module/video/template.hbs
@@ -1,5 +1,5 @@
 <div class="element-video">
-  <div class="element-video-container">
+  <div class="element-video__container">
     <video
       {{did-insert this.launchPlyr}}
       id={{@video.id}}
@@ -13,7 +13,6 @@
       <source src={{@video.url}} type="video/mp4" />
       <track kind="captions" label="Français" src={{@video.subtitles}} srclang="fr" default />
     </video>
-
   </div>
   <PixButton
     @backgroundColor="transparent-light"
@@ -29,7 +28,6 @@
     @title={{t "pages.modulix.modals.transcription.title"}}
     @showModal={{this.modalIsOpen}}
     @onCloseButtonClick={{this.closeModal}}
-    class="element__video-modal"
   >
     <:content>
       <p class="video__modal-instruction">

--- a/mon-pix/app/pods/components/module/video/template.hbs
+++ b/mon-pix/app/pods/components/module/video/template.hbs
@@ -30,9 +30,7 @@
     @onCloseButtonClick={{this.closeModal}}
   >
     <:content>
-      <p class="video__modal-instruction">
-        {{html-unsafe @video.transcription}}
-      </p>
+      {{html-unsafe @video.transcription}}
     </:content>
   </PixModal>
 </div>

--- a/mon-pix/tests/integration/components/module/image_test.js
+++ b/mon-pix/tests/integration/components/module/image_test.js
@@ -49,7 +49,7 @@ module('Integration | Component | Module | Image', function (hooks) {
 
     // then
     await click(screen.getByRole('button', { name: "Afficher l'alternative textuelle" }));
-    assert.strictEqual(findAll('.element__image-modal').length, 1);
+    assert.ok(await screen.findByRole('dialog'));
     assert.ok(screen.getByText(alternativeText));
   });
 });

--- a/mon-pix/tests/integration/components/module/video_test.js
+++ b/mon-pix/tests/integration/components/module/video_test.js
@@ -52,7 +52,7 @@ module('Integration | Component | Module | Video', function (hooks) {
 
     // then
     await click(screen.getByRole('button', { name: 'Afficher la transcription' }));
-    assert.strictEqual(findAll('.element__video-modal').length, 1);
+    assert.ok(await screen.findByRole('dialog'));
     assert.ok(screen.getByText('transcription'));
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
On permet de mettre de l’HTML dans le contenu des transcriptions d’images et de vidéos.

Dans la PixModal qui les rend on force un paragraphe <p> qui englobe donc de l’HTML libre. Ça peut causer des soucis d’accessibilité.

## :robot: Proposition
Ce paragraphe ne semble pas utile, autant le supprimer !

## :rainbow: Remarques
J'ai refait un coup de propre sur le BEM, ça permet de forcer le 16/9 sur le lecteur vidéo également lors du chargement.

## :100: Pour tester
- Vérifier que les transcriptions d'images et vidéos sont mieux accessibles qu'avant.
- Vérifier aussi que si le lecteur vidéo a un `src` avec un lien inexistant, le lecteur reste en 16/9