### PR TITLE
[FEATURE] Ajouter le paramètre audience aux routes API 'oidc/token' et 'oidc/authentication-url' pour le besoin SSO Google (PIX-10966).

### DIFF
--- a/api/lib/application/authentication/oidc/index.js
+++ b/api/lib/application/authentication/oidc/index.js
@@ -90,6 +90,7 @@ const register = async function (server) {
                 code: Joi.string().required(),
                 redirect_uri: Joi.string().required(),
                 state: Joi.string().required(),
+                audience: Joi.string().valid('app', 'admin').optional(),
               },
             },
           }),

--- a/api/lib/application/authentication/oidc/index.js
+++ b/api/lib/application/authentication/oidc/index.js
@@ -66,6 +66,7 @@ const register = async function (server) {
           query: Joi.object({
             identity_provider: Joi.string().required(),
             redirect_uri: Joi.string().required(),
+            audience: Joi.string().valid('app', 'admin').optional(),
           }),
         },
         handler: oidcController.getAuthenticationUrl,

--- a/api/lib/application/authentication/oidc/oidc-controller.js
+++ b/api/lib/application/authentication/oidc/oidc-controller.js
@@ -103,7 +103,7 @@ const authenticateUser = async function (
     authenticationServiceRegistry,
   },
 ) {
-  const { code, identityProvider, redirectUri, state: stateReceived } = request.deserializedPayload;
+  const { code, identityProvider, redirectUri, state: stateReceived, audience } = request.deserializedPayload;
 
   const stateSent = request.yar.get('state', true);
   // eslint-disable-next-line no-unused-vars
@@ -111,6 +111,7 @@ const authenticateUser = async function (
 
   const oidcAuthenticationService = dependencies.authenticationServiceRegistry.getOidcProviderServiceByCode({
     identityProviderCode: identityProvider,
+    audience,
   });
 
   const result = await usecases.authenticateOidcUser({

--- a/api/lib/application/authentication/oidc/oidc-controller.js
+++ b/api/lib/application/authentication/oidc/oidc-controller.js
@@ -24,8 +24,9 @@ const getRedirectLogoutUrl = async function (
 ) {
   const userId = request.auth.credentials.userId;
   const { identity_provider: identityProvider, logout_url_uuid: logoutUrlUUID } = request.query;
-  const oidcAuthenticationService =
-    dependencies.authenticationServiceRegistry.getOidcProviderServiceByCode(identityProvider);
+  const oidcAuthenticationService = dependencies.authenticationServiceRegistry.getOidcProviderServiceByCode({
+    identityProviderCode: identityProvider,
+  });
   const redirectLogoutUrl = await oidcAuthenticationService.getRedirectLogoutUrl({
     userId,
     logoutUrlUUID,
@@ -61,8 +62,9 @@ const reconcileUser = async function (
   },
 ) {
   const { identityProvider, authenticationKey } = request.deserializedPayload;
-  const oidcAuthenticationService =
-    dependencies.authenticationServiceRegistry.getOidcProviderServiceByCode(identityProvider);
+  const oidcAuthenticationService = dependencies.authenticationServiceRegistry.getOidcProviderServiceByCode({
+    identityProviderCode: identityProvider,
+  });
 
   const result = await usecases.reconcileOidcUser({
     authenticationKey,
@@ -80,8 +82,9 @@ const getAuthenticationUrl = async function (
   },
 ) {
   const { identity_provider: identityProvider } = request.query;
-  const oidcAuthenticationService =
-    dependencies.authenticationServiceRegistry.getOidcProviderServiceByCode(identityProvider);
+  const oidcAuthenticationService = dependencies.authenticationServiceRegistry.getOidcProviderServiceByCode({
+    identityProviderCode: identityProvider,
+  });
   const { nonce, state, ...payload } = oidcAuthenticationService.getAuthenticationUrl({
     redirectUri: request.query['redirect_uri'],
   });
@@ -105,8 +108,9 @@ const authenticateUser = async function (
   // eslint-disable-next-line no-unused-vars
   const nonce = request.yar.get('nonce', true);
 
-  const oidcAuthenticationService =
-    dependencies.authenticationServiceRegistry.getOidcProviderServiceByCode(identityProvider);
+  const oidcAuthenticationService = dependencies.authenticationServiceRegistry.getOidcProviderServiceByCode({
+    identityProviderCode: identityProvider,
+  });
 
   const result = await usecases.authenticateOidcUser({
     code,
@@ -137,8 +141,9 @@ const createUser = async function (
   const { identityProvider, authenticationKey } = request.deserializedPayload;
   const localeFromCookie = request.state?.locale;
 
-  const oidcAuthenticationService =
-    dependencies.authenticationServiceRegistry.getOidcProviderServiceByCode(identityProvider);
+  const oidcAuthenticationService = dependencies.authenticationServiceRegistry.getOidcProviderServiceByCode({
+    identityProviderCode: identityProvider,
+  });
   const { accessToken, logoutUrlUUID } = await usecases.createOidcUser({
     authenticationKey,
     identityProvider,

--- a/api/lib/application/authentication/oidc/oidc-controller.js
+++ b/api/lib/application/authentication/oidc/oidc-controller.js
@@ -81,9 +81,10 @@ const getAuthenticationUrl = async function (
     authenticationServiceRegistry,
   },
 ) {
-  const { identity_provider: identityProvider } = request.query;
+  const { identity_provider: identityProvider, audience } = request.query;
   const oidcAuthenticationService = dependencies.authenticationServiceRegistry.getOidcProviderServiceByCode({
     identityProviderCode: identityProvider,
+    audience,
   });
   const { nonce, state, ...payload } = oidcAuthenticationService.getAuthenticationUrl({
     redirectUri: request.query['redirect_uri'],

--- a/api/lib/domain/services/authentication/authentication-service-registry.js
+++ b/api/lib/domain/services/authentication/authentication-service-registry.js
@@ -17,7 +17,7 @@ class OidcAuthenticationServiceRegistry {
     return this.#readyOidcProviderServicesForPixAdmin;
   }
 
-  getOidcProviderServiceByCode(identityProviderCode) {
+  getOidcProviderServiceByCode({ identityProviderCode }) {
     const oidcProviderService = this.#readyOidcProviderServices.find(
       (service) => identityProviderCode === service.code,
     );

--- a/api/lib/domain/services/authentication/authentication-service-registry.js
+++ b/api/lib/domain/services/authentication/authentication-service-registry.js
@@ -17,10 +17,10 @@ class OidcAuthenticationServiceRegistry {
     return this.#readyOidcProviderServicesForPixAdmin;
   }
 
-  getOidcProviderServiceByCode({ identityProviderCode }) {
-    const oidcProviderService = this.#readyOidcProviderServices.find(
-      (service) => identityProviderCode === service.code,
-    );
+  getOidcProviderServiceByCode({ identityProviderCode, audience = 'app' }) {
+    const services =
+      audience === 'admin' ? this.#readyOidcProviderServicesForPixAdmin : this.#readyOidcProviderServices;
+    const oidcProviderService = services.find((service) => identityProviderCode === service.code);
 
     if (!oidcProviderService) {
       throw new InvalidIdentityProviderError(identityProviderCode);

--- a/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
+++ b/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
@@ -167,6 +167,43 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       });
       expect(request.yar.set).to.have.been.calledTwice;
     });
+
+    context('when an audience is specified', function () {
+      it('calls oidc authentication service with audience as a parameter', async function () {
+        // given
+        const request = {
+          query: {
+            identity_provider: identityProvider,
+            redirect_uri: 'http:/exemple.net/',
+            audience: 'admin',
+          },
+          yar: { set: sinon.stub() },
+        };
+        const getAuthenticationUrlStub = sinon.stub();
+        const oidcAuthenticationService = {
+          getAuthenticationUrl: getAuthenticationUrlStub,
+        };
+        const authenticationServiceRegistryStub = {
+          getOidcProviderServiceByCode: sinon.stub(),
+        };
+
+        authenticationServiceRegistryStub.getOidcProviderServiceByCode.returns(oidcAuthenticationService);
+
+        const dependencies = {
+          authenticationServiceRegistry: authenticationServiceRegistryStub,
+        };
+        getAuthenticationUrlStub.returns('an authentication url');
+
+        // when
+        await oidcController.getAuthenticationUrl(request, hFake, dependencies);
+
+        // then
+        expect(authenticationServiceRegistryStub.getOidcProviderServiceByCode).to.have.been.calledWith({
+          identityProviderCode: identityProvider,
+          audience: 'admin',
+        });
+      });
+    });
   });
 
   describe('#authenticateUser', function () {

--- a/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
+++ b/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
@@ -150,7 +150,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       };
 
       authenticationServiceRegistryStub.getOidcProviderServiceByCode
-        .withArgs({ identityProviderCode: identityProvider })
+        .withArgs({ identityProviderCode: identityProvider, audience: undefined })
         .returns(oidcAuthenticationService);
 
       const dependencies = {

--- a/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
+++ b/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
@@ -115,7 +115,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
         };
 
         authenticationServiceRegistryStub.getOidcProviderServiceByCode
-          .withArgs(identityProvider)
+          .withArgs({ identityProviderCode: identityProvider })
           .returns(oidcAuthenticationService);
 
         const dependencies = {
@@ -150,7 +150,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       };
 
       authenticationServiceRegistryStub.getOidcProviderServiceByCode
-        .withArgs(identityProvider)
+        .withArgs({ identityProviderCode: identityProvider })
         .returns(oidcAuthenticationService);
 
       const dependencies = {
@@ -203,7 +203,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       };
 
       authenticationServiceRegistryStub.getOidcProviderServiceByCode
-        .withArgs(identityProvider)
+        .withArgs({ identityProviderCode: identityProvider, audience: undefined })
         .returns(oidcAuthenticationService);
 
       const dependencies = {
@@ -240,7 +240,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       };
 
       authenticationServiceRegistryStub.getOidcProviderServiceByCode
-        .withArgs(identityProvider)
+        .withArgs({ identityProviderCode: identityProvider })
         .returns(oidcAuthenticationService);
 
       const dependencies = {
@@ -271,7 +271,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       };
 
       authenticationServiceRegistryStub.getOidcProviderServiceByCode
-        .withArgs(identityProvider)
+        .withArgs({ identityProviderCode: identityProvider })
         .returns(oidcAuthenticationService);
 
       const dependencies = {
@@ -309,7 +309,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       };
 
       authenticationServiceRegistryStub.getOidcProviderServiceByCode
-        .withArgs(identityProvider)
+        .withArgs({ identityProviderCode: identityProvider })
         .returns(oidcAuthenticationService);
 
       const dependencies = {

--- a/api/tests/unit/domain/services/authentication/authentication-service-registry_test.js
+++ b/api/tests/unit/domain/services/authentication/authentication-service-registry_test.js
@@ -73,24 +73,54 @@ describe('Unit | Domain | Services | authentication registry', function () {
   });
 
   describe('#getOidcProviderServiceByCode', function () {
-    it('returns a ready OIDC Provider service', function () {
-      // given
-      const identityProviderCode = 'FIRST';
-      const firstOidcProviderService = {
-        code: identityProviderCode,
-        isReady: true,
-      };
-      const secondOidcProviderService = {
-        code: 'SECOND',
-      };
+    describe('when the audience is admin', function () {
+      it('returns a ready OIDC provider for Pix Admin', function () {
+        // given
+        const oidcProviderForPixApp = {
+          code: 'PROVIDER_FOR_APP',
+          isReady: true,
+        };
+        const oidcProviderForPixAdmin = {
+          code: 'PROVIDER_FOR_ADMIN',
+          isReadyForPixAdmin: true,
+        };
 
-      oidcAuthenticationServiceRegistry.loadOidcProviderServices([firstOidcProviderService, secondOidcProviderService]);
+        oidcAuthenticationServiceRegistry.loadOidcProviderServices([oidcProviderForPixApp, oidcProviderForPixAdmin]);
 
-      // when
-      const service = oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({ identityProviderCode });
+        // when
+        const service = oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({
+          identityProviderCode: 'PROVIDER_FOR_ADMIN',
+          audience: 'admin',
+        });
 
-      // then
-      expect(service.code).to.equal('FIRST');
+        // then
+        expect(service.code).to.equal('PROVIDER_FOR_ADMIN');
+      });
+    });
+
+    describe('when audience is not provided', function () {
+      it('returns a ready OIDC Provider for Pix App', function () {
+        // given
+        const identityProviderCode = 'FIRST';
+        const firstOidcProviderService = {
+          code: identityProviderCode,
+          isReady: true,
+        };
+        const secondOidcProviderService = {
+          code: 'SECOND',
+        };
+
+        oidcAuthenticationServiceRegistry.loadOidcProviderServices([
+          firstOidcProviderService,
+          secondOidcProviderService,
+        ]);
+
+        // when
+        const service = oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({ identityProviderCode });
+
+        // then
+        expect(service.code).to.equal('FIRST');
+      });
     });
 
     it('throws an error when identity provider is not supported', function () {

--- a/api/tests/unit/domain/services/authentication/authentication-service-registry_test.js
+++ b/api/tests/unit/domain/services/authentication/authentication-service-registry_test.js
@@ -87,7 +87,7 @@ describe('Unit | Domain | Services | authentication registry', function () {
       oidcAuthenticationServiceRegistry.loadOidcProviderServices([firstOidcProviderService, secondOidcProviderService]);
 
       // when
-      const service = oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode(identityProviderCode);
+      const service = oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({ identityProviderCode });
 
       // then
       expect(service.code).to.equal('FIRST');
@@ -110,7 +110,7 @@ describe('Unit | Domain | Services | authentication registry', function () {
       const error = catchErrSync(
         oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode,
         oidcAuthenticationServiceRegistry,
-      )(identityProviderCode);
+      )({ identityProviderCode });
 
       // then
       expect(error).to.be.an.instanceOf(InvalidIdentityProviderError);


### PR DESCRIPTION
## :unicorn: Contexte

Chaque fournisseur d'identité OIDC peut être activé indépendamment pour chacune des apps concernées (Pix App et Pix Admin). Les routes API utilisées lors de l'authentification doivent avoir connaissante de l'application appelante pour pouvoir répondre de manière adéquates.

## :robot: Proposition

Ajouter un query parameter `audience` qui peut prendre comme valeur `admin` ou `app` aux routes suivantes :

- `/api/oidc/token`
- `/api/oidc/authentication-url`

## :rainbow: Remarques

La valeur par défaut de ce paramètre est toujours `app` afin de ne pas avoir à modifier le comportement de Pix App. Le paramètre devra être ajouté côté Pix Admin lors de l'implémentation de la connexion SSO (à venir dans une prochaine paramètre).

## :100: Pour tester

**Note :** Les tests fonctionnels sont rendus difficiles par le fait que cette PR n'ajoute pas encore la connexion SSO dans Pix Admin côté front. L'important est surtout de valider qu'il n'y a pas de régression fonctionelle avec la connexion SSO dans Pix App, les tests fonctionnels côté Pix Admin seront faits dans une prochaine PR.

### Pour la route `/api/oidc/authentication-url`

- Configurer un fournisseur d'identité pour Pix App (par ex Pole Emploi) et un autre pour Pix Admin (par ex Google)
- Vérifier que l'appel à `/api/oidc/authentication-url?identity_provider=POLE_EMPLOI&redirect_uri=https%3A%2F%2Fadmin-pr7406.review.pix.fr%2Fconnexion%2Fpole-emploi` renvoie l'url de Pole Emploi
- Vérifier que l'appel à `/api/oidc/authentication-url?identity_provider=POLE_EMPLOI&redirect_uri=https%3A%2F%2Fadmin-pr7406.review.pix.fr%2Fconnexion%2Fpole-emploi&audience=app` renvoie l'url de Pole Emploi
- Vérifier que l'appel à `/api/oidc/authentication-url?identity_provider=GOOGLE&redirect_uri=https%3A%2F%2Fadmin-pr7406.review.pix.fr%2Fconnexion%2Fgoogle&audience=admin` renvoie l'url de Google
- Vérifier que l'appel à `/api/oidc/authentication-url?identity_provider=POLE_EMPLOI&redirect_uri=https%3A%2F%2Fadmin-pr7406.review.pix.fr%2Fconnexion%2Fpole-emploi&audience=abcd` renvoie une erreur 400

### Pour la route `/api/oidc/token`

On ne peut pas vérifier fonctionnellement le bon fonctionnement de cette route dans le cadre de cette PR, car il faut un code d'autorisation valide de Google. Mais on peut utiliser un mauvais code et vérifier que 
- si l'audience correspond à l'identity provider, alors l'API renvoie une erreur 400 avec le message "La valeur du paramètre state reçu ne correspond pas à celui envoyé."
- si l'audience ne correspond à l'identity provider, alors l'API renvoie aussi une erreur 400, mais avec le message "Identity provider GOOGLE is not supported."

Utiliser la requête ci-dessous en variant les paramètres :
- `GOOGLE` et `admin` : OK
- `GOOGLE` et `app` : KO
- `POLE_EMPLOI` et `admin` : KO
- `POLE_EMPLOI` et `app` : KO
- `POLE_EMPLOI` et `undefined` : OK

```js
const identityProvider = 'GOOGLE';
const audience = 'admin';
fetch("https://admin-pr7970.review.pix.fr/api/oidc/token", {
  "headers": {
    "accept": "application/json",
    "accept-language": "fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7",
    "content-type": "application/json",
  },
  "body": "{\"data\":{\"attributes\":{\"identity_provider\":\""+ identityProvider +"\",\"code\":\"4/0AeaYSHCfEw4TdA0g77dsszGkqCwUuioOjt3shNkL25CucrTFszjPOM3BQXrr2KXcDRamfg\",\"redirect_uri\":\"https://admin-pr7406.review.pix.fr/connexion/google\",\"state\":\"49ca0794-1ff5-4fab-8991-e13f83c1f5ce\",\"audience\":\""+ audience +"\"}}}",
  "method": "POST"
});
```

### Test de non-régression fonctionnel

- Tester la connexion SSO avec un fournisseur d'identité dans Pix App