### PR TITLE
[BUGFIX] Absence de message d'erreur lors de la perte de connexion internet dans l'espace surveillant sur Pix Certif (PIX-11017)

### DIFF
--- a/certif/app/routes/session-supervising.js
+++ b/certif/app/routes/session-supervising.js
@@ -3,8 +3,12 @@ import ENV from 'pix-certif/config/environment';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 
+const NO_INTERNET_MESSAGE = 'Failed to fetch';
 export default class SessionSupervisingRoute extends Route {
   @service store;
+  @service router;
+  @service notifications;
+  @service intl;
 
   async model(params) {
     return this.store.queryRecord('session-for-supervising', {
@@ -14,21 +18,35 @@ export default class SessionSupervisingRoute extends Route {
 
   afterModel(model) {
     this.poller = setInterval(async () => {
-      await this.store.queryRecord('session-for-supervising', { sessionId: model.id });
+      try {
+        await this.store.queryRecord('session-for-supervising', { sessionId: model.id });
+      } catch (response) {
+        this.#stopPolling();
+        if (response?.errors?.[0]?.status === '401') {
+          this.router.replaceWith('login-session-supervisor');
+        }
+
+        if (response.message === NO_INTERNET_MESSAGE) {
+          this.notifications.error(this.intl.t('pages.session-supervising-error.no-internet-error'));
+        }
+      }
     }, ENV.APP.sessionSupervisingPollingRate);
   }
 
   deactivate() {
-    if (this.poller) {
-      clearInterval(this.poller);
-    }
+    this.#stopPolling();
   }
 
   @action
   error() {
+    this.#stopPolling();
+    return true;
+  }
+
+  #stopPolling() {
     if (this.poller) {
       clearInterval(this.poller);
+      this.poller = null;
     }
-    return true;
   }
 }

--- a/certif/tests/unit/routes/session-supervising_test.js
+++ b/certif/tests/unit/routes/session-supervising_test.js
@@ -1,0 +1,116 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+import ENV from '../../../config/environment';
+import setupIntl from '../helpers/setup-intl';
+import Service from '@ember/service';
+
+module('Unit | Route | session-supervising', function (hooks) {
+  setupTest(hooks);
+  setupIntl(hooks);
+
+  module('#afterModel', function (hooks) {
+    let clock, sessionSupervisingPollingRate;
+    hooks.beforeEach(function () {
+      clock = sinon.useFakeTimers({ now: Date.now() });
+      sessionSupervisingPollingRate = ENV.APP.sessionSupervisingPollingRate;
+    });
+
+    hooks.afterEach(function () {
+      clock.restore();
+      ENV.APP.sessionSupervisingPollingRate = sessionSupervisingPollingRate;
+    });
+
+    module('when an error occurs in session supervising fetch', function () {
+      test('it should stop polling', async function (assert) {
+        // given
+        ENV.APP.sessionSupervisingPollingRate = 100;
+        const session = { id: 123 };
+
+        class StoreStub extends Service {
+          queryRecord = sinon.stub();
+        }
+
+        this.owner.register('service:store', StoreStub);
+
+        const route = this.owner.lookup('route:session-supervising');
+        route.store.queryRecord.onCall(0).returns(Promise.resolve());
+        route.store.queryRecord.onCall(1).throws(new Error());
+
+        // when
+        route.afterModel(session);
+
+        await clock.tickAsync(250);
+
+        // then
+        assert.strictEqual(route.poller, null);
+        assert.strictEqual(route.store.queryRecord.callCount, 2);
+      });
+
+      module('when the error has a 401 status', function () {
+        test('it should redirect to session supervising login page', async function (assert) {
+          // given
+          ENV.APP.sessionSupervisingPollingRate = 100;
+          const session = { id: 123 };
+
+          class RouterStub extends Service {
+            replaceWith = sinon.stub();
+          }
+
+          this.owner.register('service:router', RouterStub);
+
+          class StoreStub extends Service {
+            queryRecord = sinon.stub();
+          }
+
+          this.owner.register('service:store', StoreStub);
+
+          const route = this.owner.lookup('route:session-supervising');
+          route.store.queryRecord.rejects({ errors: [{ status: '401' }] });
+
+          // when
+          route.afterModel(session);
+          await clock.tickAsync(250);
+
+          // then
+          assert.ok(route.router.replaceWith.calledWith('login-session-supervisor'));
+        });
+      });
+
+      module('when the user loses connection', function () {
+        test('it should display a notification', async function (assert) {
+          // given
+          ENV.APP.sessionSupervisingPollingRate = 100;
+          const session = { id: 123 };
+
+          class NotificationStub extends Service {
+            error = sinon.stub();
+          }
+
+          this.owner.register('service:notifications', NotificationStub);
+
+          class StoreStub extends Service {
+            queryRecord = sinon.stub();
+          }
+
+          this.owner.register('service:store', StoreStub);
+          const route = this.owner.lookup('route:session-supervising');
+          const notification = this.owner.lookup('service:notifications');
+
+          route.store.queryRecord.rejects({ message: 'Failed to fetch' });
+
+          // when
+          route.afterModel(session);
+          await clock.tickAsync(250);
+
+          // then
+          assert.ok(
+            notification.error.calledWith(
+              'Votre connexion internet est actuellement interrompue, les données affichées ne sont plus à jour. Veuillez vous reconnecter à internet et recharger la page.',
+            ),
+          );
+        });
+      });
+    });
+  });
+});

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -519,6 +519,7 @@
     "session-supervising-error": {
       "title": "An error occurred",
       "description": "To access this session, click on the \"Invigilate a session\" button and fill in the details of the session",
+      "no-internet-error": "Your internet connection is currently interrupted, the data displayed is no longer up to date. Please reconnect to the internet and reload the page.",
       "page-title": "Access error to the session's invigilation"
     },
     "sessions": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -519,6 +519,7 @@
     "session-supervising-error": {
       "title": "Une erreur est survenue",
       "description": "Pour accéder à cette session, cliquez sur le bouton \"Surveiller une session\" et renseignez les informations de la session",
+      "no-internet-error": "Votre connexion internet est actuellement interrompue, les données affichées ne sont plus à jour. Veuillez vous reconnecter à internet et recharger la page.",
       "page-title": "Erreur d'accès à la surveillance de session"
     },
     "sessions": {


### PR DESCRIPTION
## :unicorn: Problème
Lorsque  la connexion internet est perdue, rien ne l'indique sur la page de l'espace surveillant. De plus lors de l'expiration de son token, si le surveillant est toujours sur l'espace surveillant, le polling continue de faire des appels à la route api ```/supervising```

## :robot: Proposition
Afficher un message lorsqu'il perd sa connexion et rediriger vers la page de login lors d'une erreur 401

## :100: Pour tester
- Se connecter à une certification depuis l'espace surveillant
- Ouvrir l'inspecteur
- simuler une perte de connexion
- Constater l'arrêt du polling et l'affichage d'une notification

<img width="1789" alt="Capture d’écran 2024-02-19 à 16 03 18" src="https://github.com/1024pix/pix/assets/58915422/13cf9dc5-6e33-493c-9108-852e229562da">
