### PR TITLE
[FEATURE] Accéder à la page de fin de module via l'URL (PIX-11026)

### DIFF
--- a/mon-pix/app/pods/components/module/details/styles.scss
+++ b/mon-pix/app/pods/components/module/details/styles.scss
@@ -66,8 +66,6 @@
   }
 
   &__objectives {
-    --modulix-objectives-counter: item;
-
     margin-bottom: var(--pix-spacing-8x);
   }
 }
@@ -94,37 +92,6 @@
 .module-details-infos-indications-category-title {
   &__icon {
     margin-right: var(--pix-spacing-2x);
-  }
-}
-
-.module-details-infos-objectives {
-  &__list {
-    padding: 0;
-    list-style: none;
-  }
-}
-
-.module-details-infos-objectives-list {
-  &__item {
-    display: flex;
-    align-items: center;
-    margin-bottom: var(--pix-spacing-4x);
-    counter-increment: var(--modulix-objectives-counter);
-
-    &::before {
-      @extend %pix-title-xs;
-
-      display: inline-block;
-      min-width: 2rem;
-      height: 2rem;
-      margin-right: var(--pix-spacing-3x);
-      color: var(--pix-primary-700);
-      line-height: var(--pix-spacing-8x);
-      text-align: center;
-      background: var(--pix-primary-100);
-      border-radius: 100%;
-      content: counter(var(--modulix-objectives-counter));
-    }
   }
 }
 

--- a/mon-pix/app/pods/components/module/details/template.hbs
+++ b/mon-pix/app/pods/components/module/details/template.hbs
@@ -41,11 +41,7 @@
 
     <div class="module-details-infos__objectives">
       <h2 class="module-details-infos-objectives__title">{{t "pages.modulix.details.objectives"}}</h2>
-      <ol class="module-details-infos-objectives__list">
-        {{#each @module.details.objectives as |objective|}}
-          <li class="module-details-infos-objectives-list__item">{{objective}}</li>
-        {{/each}}
-      </ol>
+      <Module::Objectives @objectives={{@module.details.objectives}} />
     </div>
 
     <div class="module-details-infos__explanation">

--- a/mon-pix/app/pods/components/module/objectives/styles.scss
+++ b/mon-pix/app/pods/components/module/objectives/styles.scss
@@ -1,0 +1,28 @@
+.module-objectives {
+  --modulix-objectives-counter: item;
+
+  padding: 0;
+  list-style: none;
+
+  &__item {
+    display: flex;
+    align-items: center;
+    margin-bottom: var(--pix-spacing-4x);
+    counter-increment: var(--modulix-objectives-counter);
+
+    &::before {
+      @extend %pix-title-xs;
+
+      display: inline-block;
+      min-width: 2rem;
+      height: 2rem;
+      margin-right: var(--pix-spacing-3x);
+      color: var(--pix-primary-700);
+      line-height: var(--pix-spacing-8x);
+      text-align: center;
+      background: var(--pix-primary-100);
+      border-radius: 100%;
+      content: counter(var(--modulix-objectives-counter));
+    }
+  }
+}

--- a/mon-pix/app/pods/components/module/objectives/template.hbs
+++ b/mon-pix/app/pods/components/module/objectives/template.hbs
@@ -1,0 +1,5 @@
+<ol class="module-objectives">
+  {{#each @objectives as |objective|}}
+    <li class="module-objectives__item">{{objective}}</li>
+  {{/each}}
+</ol>

--- a/mon-pix/app/pods/components/module/recap/styles.scss
+++ b/mon-pix/app/pods/components/module/recap/styles.scss
@@ -1,0 +1,56 @@
+.module-recap {
+  --modulix-objectives-max-width: 500px;
+
+  margin: var(--pix-spacing-6x);
+  padding: var(--pix-spacing-4x) var(--pix-spacing-4x) var(--pix-spacing-12x) var(--pix-spacing-4x);
+  background-color: var(--pix-primary-100);
+  border-radius: 16px;
+
+  &__header {
+    margin-bottom: var(--pix-spacing-6x);
+    text-align: right;
+  }
+
+  &__title, &__objectives {
+    margin-bottom: var(--pix-spacing-8x);
+  }
+
+  &__title {
+    @extend %pix-title-l;
+
+    text-align: center;
+  }
+
+  &__link-form,
+  &__link-details {
+    display: flex;
+    justify-content: center;
+  }
+
+  &__link-form {
+    margin-bottom: var(--pix-spacing-4x);
+  }
+
+  &__objectives {
+    max-width: var(--modulix-objectives-max-width);
+    margin: 0 auto var(--pix-spacing-8x) auto;
+    padding: var(--pix-spacing-8x) var(--pix-spacing-6x);
+    background-color: var(--pix-primary-10);
+    border-radius: 16px;
+  }
+}
+
+.module-recap-header {
+  &__icon {
+    color: var(--pix-primary-300);
+  }
+}
+
+.module-recap-objectives {
+  &__subtitle {
+    @extend %pix-title-s;
+
+    margin-bottom: var(--pix-spacing-8x);
+    text-align: center;
+  }
+}

--- a/mon-pix/app/pods/components/module/recap/styles.scss
+++ b/mon-pix/app/pods/components/module/recap/styles.scss
@@ -4,7 +4,7 @@
   margin: var(--pix-spacing-6x);
   padding: var(--pix-spacing-4x) var(--pix-spacing-4x) var(--pix-spacing-12x) var(--pix-spacing-4x);
   background-color: var(--pix-primary-100);
-  border-radius: 16px;
+  border-radius: var(--modulix-radius);
 
   &__header {
     margin-bottom: var(--pix-spacing-6x);
@@ -36,7 +36,7 @@
     margin: 0 auto var(--pix-spacing-8x) auto;
     padding: var(--pix-spacing-8x) var(--pix-spacing-6x);
     background-color: var(--pix-primary-10);
-    border-radius: 16px;
+    border-radius: var(--modulix-radius);
   }
 }
 

--- a/mon-pix/app/pods/components/module/recap/template.hbs
+++ b/mon-pix/app/pods/components/module/recap/template.hbs
@@ -1,0 +1,38 @@
+<div class="module-recap">
+  <div class="module-recap__header">
+    <FaIcon @icon="circle-check" class="module-recap-header__icon fa-3x" />
+  </div>
+  <h1 class="module-recap__title">{{t "pages.modulix.recap.title"}}</h1>
+
+  <div class="module-recap__objectives">
+    <p class="module-recap-objectives__subtitle">{{t "pages.modulix.recap.subtitle" htmlSafe=true}}</p>
+
+    <ol>
+      {{#each @module.details.objectives as |objective|}}
+        <li>{{objective}}</li>
+      {{/each}}
+    </ol>
+  </div>
+  <div class="module-recap__link-form">
+    <PixButtonLink
+      @shape="rounded"
+      @size="big"
+      target="_blank"
+      @href="https://form-eu.123formbuilder.com/71180/modulix-experimentation"
+    >
+      {{t "pages.modulix.recap.goToForm"}}
+    </PixButtonLink>
+  </div>
+  <div class="module-recap__link-details">
+    <PixButtonLink
+      @model={{@module.id}}
+      @shape="rounded"
+      @size="big"
+      @route="module.details"
+      @backgroundColor="transparent-light"
+      @isBorderVisible={{true}}
+    >
+      {{t "pages.modulix.recap.backToModuleDetails"}}
+    </PixButtonLink>
+  </div>
+</div>

--- a/mon-pix/app/pods/components/module/recap/template.hbs
+++ b/mon-pix/app/pods/components/module/recap/template.hbs
@@ -6,12 +6,7 @@
 
   <div class="module-recap__objectives">
     <p class="module-recap-objectives__subtitle">{{t "pages.modulix.recap.subtitle" htmlSafe=true}}</p>
-
-    <ol>
-      {{#each @module.details.objectives as |objective|}}
-        <li>{{objective}}</li>
-      {{/each}}
-    </ol>
+    <Module::Objectives @objectives={{@module.details.objectives}} />
   </div>
   <div class="module-recap__link-form">
     <PixButtonLink

--- a/mon-pix/app/pods/module/get/styles.scss
+++ b/mon-pix/app/pods/module/get/styles.scss
@@ -2,6 +2,7 @@
   @extend %pix-body-l;
 
   --modulix-max-content-width: 740px;
+  --modulix-radius: 16px;
 
   flex-grow: 1;
   color: var(--pix-neutral-900);

--- a/mon-pix/app/pods/module/index/route.js
+++ b/mon-pix/app/pods/module/index/route.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class ModuleIndexRoute extends Route {
+  @service router;
+
+  redirect() {
+    this.router.replaceWith('module.details');
+  }
+}

--- a/mon-pix/app/pods/module/recap/route.js
+++ b/mon-pix/app/pods/module/recap/route.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class ModuleRecapRoute extends Route {}

--- a/mon-pix/app/pods/module/recap/template.hbs
+++ b/mon-pix/app/pods/module/recap/template.hbs
@@ -1,1 +1,5 @@
-{{page-title "Bravo ! Module terminé"}}
+{{page-title (t "pages.modulix.recap.title")}}
+
+<div class="modulix">
+  <Module::Recap @module={{this.model}} />
+</div>

--- a/mon-pix/app/pods/module/recap/template.hbs
+++ b/mon-pix/app/pods/module/recap/template.hbs
@@ -1,0 +1,1 @@
+{{page-title "Bravo ! Module terminé"}}

--- a/mon-pix/app/pods/module/route.js
+++ b/mon-pix/app/pods/module/route.js
@@ -3,15 +3,8 @@ import { service } from '@ember/service';
 
 export default class ModuleRoute extends Route {
   @service store;
-  @service router;
 
   async model(params) {
     return await this.store.findRecord('module', params.slug);
-  }
-
-  redirect(model, transition) {
-    if (transition.targetName !== 'module.get') {
-      this.router.transitionTo('module.details', model);
-    }
   }
 }

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -117,6 +117,7 @@ Router.map(function () {
   this.route('module', { path: '/modules/:slug' }, function () {
     this.route('details');
     this.route('get', { path: '/passage' });
+    this.route('recap');
   });
 
   this.route('terms-of-service', { path: '/cgu' });

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
@@ -1,0 +1,65 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { visit } from '@1024pix/ember-testing-library';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { click, currentURL } from '@ember/test-helpers';
+import setupIntl from '../../helpers/setup-intl';
+
+module('Acceptance | Module | Routes | navigateIntoTheModuleRecap', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks);
+
+  module('when user arrive on the module recap page', function () {
+    test('should display the links to details button and to form builder', async function (assert) {
+      // given
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [],
+        details: {
+          image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+          description: 'Description',
+          duration: 'duration',
+          level: 'level',
+          objectives: ['Objectif #1'],
+        },
+      });
+
+      // when
+      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/recap');
+      const formLink = screen.getByRole('link', { name: this.intl.t('pages.modulix.recap.goToForm') });
+
+      // then
+      assert.ok(formLink);
+      assert.ok(screen.getByRole('link', { name: this.intl.t('pages.modulix.recap.backToModuleDetails') }));
+      assert.strictEqual(
+        formLink.getAttribute('href'),
+        'https://form-eu.123formbuilder.com/71180/modulix-experimentation',
+      );
+    });
+
+    test('should navigate to details page by clicking on back to module details button', async function (assert) {
+      // given
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [],
+        details: {
+          image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+          description: 'Description',
+          duration: 'duration',
+          level: 'level',
+          objectives: ['Objectif #1'],
+        },
+      });
+
+      // when
+      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/recap');
+      await click(screen.getByRole('link', { name: this.intl.t('pages.modulix.recap.backToModuleDetails') }));
+
+      // then
+      assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/details');
+    });
+  });
+});

--- a/mon-pix/tests/acceptance/module/visit-module-recap-page_test.js
+++ b/mon-pix/tests/acceptance/module/visit-module-recap-page_test.js
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { currentURL } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+module('Acceptance | Module | Routes | recap', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  test('can visit /modules/:slug/recap', async function (assert) {
+    // given
+    server.create('module', {
+      id: 'bien-ecrire-son-adresse-mail',
+    });
+
+    // when
+    await visit('/modules/bien-ecrire-son-adresse-mail/recap');
+
+    // then
+    assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/recap');
+  });
+
+  test('should include the right page title', async function (assert) {
+    // given
+    server.create('module', {
+      id: 'bien-ecrire-son-adresse-mail',
+    });
+
+    // when
+    await visit('/modules/bien-ecrire-son-adresse-mail/recap');
+
+    // then
+    assert.ok(document.title.includes('Bravo ! Module terminé'));
+  });
+});

--- a/mon-pix/tests/acceptance/module/visit-module-recap-page_test.js
+++ b/mon-pix/tests/acceptance/module/visit-module-recap-page_test.js
@@ -3,9 +3,11 @@ import { setupApplicationTest } from 'ember-qunit';
 import { currentURL } from '@ember/test-helpers';
 import { visit } from '@1024pix/ember-testing-library';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import setupIntl from '../../helpers/setup-intl';
 
 module('Acceptance | Module | Routes | recap', function (hooks) {
   setupApplicationTest(hooks);
+  setupIntl(hooks);
   setupMirage(hooks);
 
   test('can visit /modules/:slug/recap', async function (assert) {
@@ -28,9 +30,10 @@ module('Acceptance | Module | Routes | recap', function (hooks) {
     });
 
     // when
-    await visit('/modules/bien-ecrire-son-adresse-mail/recap');
+    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/recap');
 
     // then
-    assert.ok(document.title.includes('Bravo ! Module terminé'));
+    assert.ok(document.title.includes(this.intl.t('pages.modulix.recap.title')));
+    assert.ok(screen.getByRole('heading', { level: 1, name: this.intl.t('pages.modulix.recap.title') }));
   });
 });

--- a/mon-pix/tests/integration/components/module/recap_test.js
+++ b/mon-pix/tests/integration/components/module/recap_test.js
@@ -1,0 +1,34 @@
+import { module, test } from 'qunit';
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Module | Recap', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('should display the details of a given module', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const details = {
+      image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+      description: 'description',
+      duration: 12,
+      level: 'Débutant',
+      objectives: ['Objectif 1'],
+    };
+    const module = store.createRecord('module', { title: 'Module title', details });
+    this.set('module', module);
+
+    // when
+    const screen = await render(hbs`<Module::Recap @module={{this.module}} />`);
+
+    // then
+    assert.ok(screen.getByRole('heading', { level: 1, name: this.intl.t('pages.modulix.recap.title') }));
+    assert.ok(
+      screen.getByText((content, element) => {
+        return element.innerHTML.trim() === this.intl.t('pages.modulix.recap.subtitle');
+      }),
+    );
+    assert.ok(screen.getByText('Objectif 1'));
+  });
+});

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1220,6 +1220,12 @@
       "qrocm": {
         "direction": "Fill in the empty fields."
       },
+      "recap": {
+        "title": "Congratulations! Module completed",
+        "backToModuleDetails": "Back to module details",
+        "goToForm": "Répondre au questionnaire",
+        "subtitle": "Now you know '<span aria-hidden=\"true\">'👍'</span>'"
+      },
       "verification-precondition-failed-alert": {
         "qcu": "To validate, select an answer.",
         "qrocm": "To validate, please complete all response fields."

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1220,6 +1220,12 @@
       "qrocm": {
         "direction": "Remplissez les champs vides."
       },
+      "recap": {
+        "title": "Bravo ! Module terminé",
+        "backToModuleDetails": "Revenir aux détails du module",
+        "goToForm": "Répondre au questionnaire",
+        "subtitle": "Vous savez maintenant '<span aria-hidden=\"true\">'👍'</span>'"
+      },
       "verification-precondition-failed-alert": {
         "qcu": "Pour valider, sélectionnez une réponse.",
         "qrocm": "Pour valider, veuillez remplir tous les champs réponse."

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1220,6 +1220,12 @@
       "qrocm": {
         "direction": "Vul de lege velden in."
       },
+      "recap": {
+        "title": "Goed gedaan ! Module voltooid",
+        "backToModuleDetails": "Keer terug naar moduledetails",
+        "goToForm": "Répondre au questionnaire",
+        "subtitle": "Je weet nu '<span aria-hidden=\"true\">'👍'</span>'"
+      },
       "verification-precondition-failed-alert": {
         "qcu": "Selecteer een antwoord om te bevestigen.",
         "qrocm": "Vul alle antwoordvelden in om te valideren."


### PR DESCRIPTION
## :unicorn: Problème
En tant qu'apprenant, je souhaite pouvoir accéder à une page de fin de module afin d'avoir un récapitulatif de mon passage .

## :robot: Proposition
Dans cette première PR, nous souhaitons avoir une url `/modules/mon-module/recap` pour accéder à la page de fin de module.

## :rainbow: Remarques
L'url sera le seul moyen d'accéder à cette page le temps d'en valider le contenu en interne.

## :100: Pour tester
1. Se rendre sur [la page de recap](https://app-pr7974.review.pix.fr/modules/bien-ecrire-son-adresse-mail/recap) d'un module
2. Vérifier que le contenu de la page de fin est cohérent
3. Cliquer sur le bouton "Revenir au détail du module"
4. Vérifier que nous sommes bien redirigés vers la page `/details` du module.
5. Vérifier que le lien vers le formulaire fonctionne.
