### PR TITLE
[BUGFIX] Corrige un crash de l'API lorsque toutes les réponses à une certif v3 sont OK (PIX-11025)

### DIFF
--- a/api/db/database-builder/factory/build-certification-challenge.js
+++ b/api/db/database-builder/factory/build-certification-challenge.js
@@ -14,6 +14,8 @@ const buildCertificationChallenge = function ({
   isNeutralized = false,
   hasBeenSkippedAutomatically = false,
   certifiableBadgeKey = null,
+  difficulty = null,
+  discriminant = null,
 } = {}) {
   courseId = _.isUndefined(courseId) ? buildCertificationCourse().id : courseId;
 
@@ -29,6 +31,8 @@ const buildCertificationChallenge = function ({
     isNeutralized,
     hasBeenSkippedAutomatically,
     certifiableBadgeKey,
+    difficulty,
+    discriminant,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'certification-challenges',

--- a/api/lib/domain/events/handle-certification-scoring.js
+++ b/api/lib/domain/events/handle-certification-scoring.js
@@ -20,11 +20,11 @@ async function handleCertificationScoring({
   badgeAcquisitionRepository,
   certificationAssessmentRepository,
   certificationCourseRepository,
+  certificationChallengeForScoringRepository,
   competenceMarkRepository,
   competenceForScoringRepository,
   scoringCertificationService,
   answerRepository,
-  challengeRepository,
   flashAlgorithmConfigurationRepository,
   flashAlgorithmService,
 }) {
@@ -35,12 +35,12 @@ async function handleCertificationScoring({
 
     if (certificationAssessment.version === CertificationVersion.V3) {
       return _handleV3CertificationScoring({
-        challengeRepository,
         answerRepository,
         assessmentId: event.assessmentId,
         certificationAssessment,
         assessmentResultRepository,
         certificationCourseRepository,
+        certificationChallengeForScoringRepository,
         competenceForScoringRepository,
         competenceMarkRepository,
         flashAlgorithmConfigurationRepository,
@@ -103,7 +103,7 @@ async function _calculateCertificationScore({
 }
 
 async function _handleV3CertificationScoring({
-  challengeRepository,
+  certificationChallengeForScoringRepository,
   answerRepository,
   assessmentId,
   certificationAssessment,
@@ -115,11 +115,13 @@ async function _handleV3CertificationScoring({
   flashAlgorithmService,
   locale,
 }) {
+  const { certificationCourseId } = certificationAssessment;
   const allAnswers = await answerRepository.findByAssessment(assessmentId);
-  const challengeIds = allAnswers.map(({ challengeId }) => challengeId);
-  const challenges = await challengeRepository.getMany(challengeIds, locale);
+  const challenges = await certificationChallengeForScoringRepository.getByCertificationCourseId({
+    certificationCourseId,
+  });
 
-  const certificationCourse = await certificationCourseRepository.get(certificationAssessment.certificationCourseId);
+  const certificationCourse = await certificationCourseRepository.get(certificationCourseId);
 
   const abortReason = certificationCourse.isAbortReasonCandidateRelated()
     ? ABORT_REASONS.CANDIDATE

--- a/api/src/certification/flash-certification/domain/constants/competence-level-intervals.js
+++ b/api/src/certification/flash-certification/domain/constants/competence-level-intervals.js
@@ -5,7 +5,7 @@ export const competenceLevelIntervals = [
       {
         bounds: {
           max: -1.4290127754211426,
-          min: -5.3399882316589355,
+          min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
@@ -53,7 +53,7 @@ export const competenceLevelIntervals = [
       },
       {
         bounds: {
-          max: 7.374109745025635,
+          max: Number.MAX_SAFE_INTEGER,
           min: 5.012345314025879,
         },
         competenceLevel: 7,
@@ -66,7 +66,7 @@ export const competenceLevelIntervals = [
       {
         bounds: {
           max: -1.816159963607788,
-          min: -5.3399882316589355,
+          min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
@@ -114,7 +114,7 @@ export const competenceLevelIntervals = [
       },
       {
         bounds: {
-          max: 7.374109745025635,
+          max: Number.MAX_SAFE_INTEGER,
           min: 6.849133491516113,
         },
         competenceLevel: 7,
@@ -127,7 +127,7 @@ export const competenceLevelIntervals = [
       {
         bounds: {
           max: -0.6393653750419617,
-          min: -5.3399882316589355,
+          min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
@@ -175,7 +175,7 @@ export const competenceLevelIntervals = [
       },
       {
         bounds: {
-          max: 7.374109745025635,
+          max: Number.MAX_SAFE_INTEGER,
           min: 3.2087042331695557,
         },
         competenceLevel: 7,
@@ -188,7 +188,7 @@ export const competenceLevelIntervals = [
       {
         bounds: {
           max: -1.61019766330719,
-          min: -5.3399882316589355,
+          min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
@@ -236,7 +236,7 @@ export const competenceLevelIntervals = [
       },
       {
         bounds: {
-          max: 7.374109745025635,
+          max: Number.MAX_SAFE_INTEGER,
           min: 4.262047290802002,
         },
         competenceLevel: 7,
@@ -249,7 +249,7 @@ export const competenceLevelIntervals = [
       {
         bounds: {
           max: -1.6842528581619263,
-          min: -5.3399882316589355,
+          min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
@@ -290,7 +290,7 @@ export const competenceLevelIntervals = [
       },
       {
         bounds: {
-          max: 7.374109745025635,
+          max: Number.MAX_SAFE_INTEGER,
           min: 6.855661869049072,
         },
         competenceLevel: 6,
@@ -303,7 +303,7 @@ export const competenceLevelIntervals = [
       {
         bounds: {
           max: -1.290342926979065,
-          min: -5.3399882316589355,
+          min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
@@ -344,7 +344,7 @@ export const competenceLevelIntervals = [
       },
       {
         bounds: {
-          max: 7.374109745025635,
+          max: Number.MAX_SAFE_INTEGER,
           min: 4.602512359619141,
         },
         competenceLevel: 6,
@@ -357,7 +357,7 @@ export const competenceLevelIntervals = [
       {
         bounds: {
           max: -2.0458545684814453,
-          min: -5.3399882316589355,
+          min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
@@ -398,7 +398,7 @@ export const competenceLevelIntervals = [
       },
       {
         bounds: {
-          max: 7.374109745025635,
+          max: Number.MAX_SAFE_INTEGER,
           min: 4.221365928649902,
         },
         competenceLevel: 6,
@@ -411,7 +411,7 @@ export const competenceLevelIntervals = [
       {
         bounds: {
           max: -1.3573087453842163,
-          min: -5.3399882316589355,
+          min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
@@ -452,7 +452,7 @@ export const competenceLevelIntervals = [
       },
       {
         bounds: {
-          max: 7.374109745025635,
+          max: Number.MAX_SAFE_INTEGER,
           min: 3.0218923091888428,
         },
         competenceLevel: 6,
@@ -465,7 +465,7 @@ export const competenceLevelIntervals = [
       {
         bounds: {
           max: -2.3695690631866455,
-          min: -5.3399882316589355,
+          min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
@@ -506,7 +506,7 @@ export const competenceLevelIntervals = [
       },
       {
         bounds: {
-          max: 7.374109745025635,
+          max: Number.MAX_SAFE_INTEGER,
           min: 3.2162301540374756,
         },
         competenceLevel: 6,
@@ -519,7 +519,7 @@ export const competenceLevelIntervals = [
       {
         bounds: {
           max: -1.4244885444641113,
-          min: -5.3399882316589355,
+          min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
@@ -560,7 +560,7 @@ export const competenceLevelIntervals = [
       },
       {
         bounds: {
-          max: 7.374109745025635,
+          max: Number.MAX_SAFE_INTEGER,
           min: 3.189551830291748,
         },
         competenceLevel: 6,
@@ -573,7 +573,7 @@ export const competenceLevelIntervals = [
       {
         bounds: {
           max: 2.1766011714935303,
-          min: -5.3399882316589355,
+          min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
@@ -621,7 +621,7 @@ export const competenceLevelIntervals = [
       },
       {
         bounds: {
-          max: 7.374109745025635,
+          max: Number.MAX_SAFE_INTEGER,
           min: 2.088264226913452,
         },
         competenceLevel: 7,
@@ -634,7 +634,7 @@ export const competenceLevelIntervals = [
       {
         bounds: {
           max: -0.5992878079414368,
-          min: -5.3399882316589355,
+          min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
@@ -675,7 +675,7 @@ export const competenceLevelIntervals = [
       },
       {
         bounds: {
-          max: 7.374109745025635,
+          max: Number.MAX_SAFE_INTEGER,
           min: 3.9777281284332275,
         },
         competenceLevel: 6,
@@ -688,7 +688,7 @@ export const competenceLevelIntervals = [
       {
         bounds: {
           max: -0.5439767837524414,
-          min: -5.3399882316589355,
+          min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
@@ -736,7 +736,7 @@ export const competenceLevelIntervals = [
       },
       {
         bounds: {
-          max: 7.374109745025635,
+          max: Number.MAX_SAFE_INTEGER,
           min: 4.868575096130371,
         },
         competenceLevel: 7,
@@ -749,7 +749,7 @@ export const competenceLevelIntervals = [
       {
         bounds: {
           max: -1.5177412033081055,
-          min: -5.3399882316589355,
+          min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
@@ -790,7 +790,7 @@ export const competenceLevelIntervals = [
       },
       {
         bounds: {
-          max: 7.374109745025635,
+          max: Number.MAX_SAFE_INTEGER,
           min: 4.159452438354492,
         },
         competenceLevel: 6,
@@ -803,7 +803,7 @@ export const competenceLevelIntervals = [
       {
         bounds: {
           max: -1.9220428466796875,
-          min: -5.3399882316589355,
+          min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
@@ -851,7 +851,7 @@ export const competenceLevelIntervals = [
       },
       {
         bounds: {
-          max: 7.374109745025635,
+          max: Number.MAX_SAFE_INTEGER,
           min: 4.048096656799316,
         },
         competenceLevel: 7,
@@ -864,7 +864,7 @@ export const competenceLevelIntervals = [
       {
         bounds: {
           max: -0.8218916654586792,
-          min: -5.3399882316589355,
+          min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
@@ -912,7 +912,7 @@ export const competenceLevelIntervals = [
       },
       {
         bounds: {
-          max: 7.374109745025635,
+          max: Number.MAX_SAFE_INTEGER,
           min: 4.473289489746094,
         },
         competenceLevel: 7,

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -10,6 +10,7 @@ import {
   generateAnswersForChallenges,
   generateChallengeList,
 } from '../../../certification/shared/fixtures/challenges.js';
+import { CertificationChallengeForScoring } from '../../../../src/certification/scoring/domain/models/CertificationChallengeForScoring.js';
 
 const { handleCertificationScoring } = _forTestOnly.handlers;
 
@@ -24,11 +25,11 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
   let certificationCourseRepository;
   let competenceForScoringRepository;
   let competenceMarkRepository;
-  let challengeRepository;
   let answerRepository;
   let flashAlgorithmConfigurationRepository;
   let flashAlgorithmService;
   let baseFlashAlgorithmConfiguration;
+  let certificationChallengeForScoringRepository;
 
   const now = new Date('2019-01-01T05:06:07Z');
   let clock;
@@ -46,7 +47,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
     };
     competenceForScoringRepository = { listByLocale: sinon.stub() };
     competenceMarkRepository = { save: sinon.stub() };
-    challengeRepository = { getMany: sinon.stub() };
+    certificationChallengeForScoringRepository = { getByCertificationCourseId: sinon.stub() };
     answerRepository = { findByAssessment: sinon.stub() };
     flashAlgorithmConfigurationRepository = { get: sinon.stub() };
     baseFlashAlgorithmConfiguration = domainBuilder.buildFlashAlgorithmConfiguration({
@@ -339,14 +340,17 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
               abortReason: ABORT_REASONS.CANDIDATE,
             });
 
-            const challenges = generateChallengeList({ length: minimumAnswersRequiredToValidateACertification - 1 });
-            const challengeIds = challenges.map(({ id }) => id);
+            const challenges = _generateCertificationChallengeForScoringList({
+              length: minimumAnswersRequiredToValidateACertification - 1,
+            });
 
             const answers = generateAnswersForChallenges({ challenges });
 
             flashAlgorithmConfigurationRepository.get.resolves(baseFlashAlgorithmConfiguration);
 
-            challengeRepository.getMany.withArgs(challengeIds).resolves(challenges);
+            certificationChallengeForScoringRepository.getByCertificationCourseId
+              .withArgs({ certificationCourseId })
+              .resolves(challenges);
             answerRepository.findByAssessment.withArgs(assessmentId).resolves(answers);
             certificationCourseRepository.get.withArgs(certificationCourseId).resolves(abortedCertificationCourse);
 
@@ -366,7 +370,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
             // when
             await handleCertificationScoring({
               event,
-              challengeRepository,
+              certificationChallengeForScoringRepository,
               answerRepository,
               assessmentResultRepository,
               certificationCourseRepository,
@@ -417,14 +421,18 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
               abortReason,
             });
 
-            const challenges = generateChallengeList({ length: minimumAnswersRequiredToValidateACertification - 1 });
-            const challengeIds = challenges.map(({ id }) => id);
+            const challenges = _generateCertificationChallengeForScoringList({
+              length: minimumAnswersRequiredToValidateACertification - 1,
+            });
 
             const answers = generateAnswersForChallenges({ challenges });
 
             flashAlgorithmConfigurationRepository.get.resolves(baseFlashAlgorithmConfiguration);
 
-            challengeRepository.getMany.withArgs(challengeIds).resolves(challenges);
+            certificationChallengeForScoringRepository.getByCertificationCourseId
+              .withArgs({ certificationCourseId })
+              .resolves(challenges);
+
             answerRepository.findByAssessment.withArgs(assessmentId).resolves(answers);
             certificationCourseRepository.get.withArgs(certificationCourseId).resolves(abortedCertificationCourse);
 
@@ -444,7 +452,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
             // when
             await handleCertificationScoring({
               event,
-              challengeRepository,
+              certificationChallengeForScoringRepository,
               answerRepository,
               assessmentResultRepository,
               certificationCourseRepository,
@@ -499,12 +507,13 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
             // given
             const expectedEstimatedLevel = 2;
             const scoreForEstimatedLevel = 592;
-            const challenges = generateChallengeList({ length: maximumAssessmentLength });
-            const challengeIds = challenges.map(({ id }) => id);
+            const challenges = _generateCertificationChallengeForScoringList({ length: maximumAssessmentLength });
             const answers = generateAnswersForChallenges({ challenges });
             const assessmentResultId = 123;
 
-            challengeRepository.getMany.withArgs(challengeIds).resolves(challenges);
+            certificationChallengeForScoringRepository.getByCertificationCourseId
+              .withArgs({ certificationCourseId })
+              .resolves(challenges);
             answerRepository.findByAssessment.withArgs(assessmentId).resolves(answers);
             certificationCourseRepository.get.withArgs(certificationCourseId).resolves(certificationCourse);
             flashAlgorithmConfigurationRepository.get.resolves(baseFlashAlgorithmConfiguration);
@@ -525,7 +534,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
             // when
             await handleCertificationScoring({
               event,
-              challengeRepository,
+              certificationChallengeForScoringRepository,
               answerRepository,
               assessmentResultRepository,
               certificationCourseRepository,
@@ -577,12 +586,13 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
               // given
               const expectedEstimatedLevel = 8;
               const cappedScoreForEstimatedLevel = 896;
-              const challenges = generateChallengeList({ length: maximumAssessmentLength });
-              const challengeIds = challenges.map(({ id }) => id);
+              const challenges = _generateCertificationChallengeForScoringList({ length: maximumAssessmentLength });
 
               const answers = generateAnswersForChallenges({ challenges });
 
-              challengeRepository.getMany.withArgs(challengeIds).resolves(challenges);
+              certificationChallengeForScoringRepository.getByCertificationCourseId
+                .withArgs({ certificationCourseId })
+                .resolves(challenges);
               answerRepository.findByAssessment.withArgs(assessmentId).resolves(answers);
               certificationCourseRepository.get.withArgs(certificationCourseId).resolves(certificationCourse);
               flashAlgorithmConfigurationRepository.get.resolves(baseFlashAlgorithmConfiguration);
@@ -602,7 +612,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
               // when
               await handleCertificationScoring({
                 event,
-                challengeRepository,
+                certificationChallengeForScoringRepository,
                 answerRepository,
                 assessmentResultRepository,
                 certificationCourseRepository,
@@ -640,8 +650,9 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
               // given
               const expectedEstimatedLevel = 2;
               const rawScore = 592;
-              const challenges = generateChallengeList({ length: minimumAnswersRequiredToValidateACertification });
-              const challengeIds = challenges.map(({ id }) => id);
+              const challenges = _generateCertificationChallengeForScoringList({
+                length: minimumAnswersRequiredToValidateACertification,
+              });
               const abortReason = ABORT_REASONS.TECHNICAL;
               const abortedCertificationCourse = domainBuilder.buildCertificationCourse({
                 id: certificationCourseId,
@@ -651,7 +662,9 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
 
               const answers = generateAnswersForChallenges({ challenges });
 
-              challengeRepository.getMany.withArgs(challengeIds).resolves(challenges);
+              certificationChallengeForScoringRepository.getByCertificationCourseId
+                .withArgs({ certificationCourseId })
+                .resolves(challenges);
               answerRepository.findByAssessment.withArgs(assessmentId).resolves(answers);
               certificationCourseRepository.get.withArgs(certificationCourseId).resolves(abortedCertificationCourse);
               flashAlgorithmConfigurationRepository.get.resolves(baseFlashAlgorithmConfiguration);
@@ -671,7 +684,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
               // when
               await handleCertificationScoring({
                 event,
-                challengeRepository,
+                certificationChallengeForScoringRepository,
                 answerRepository,
                 assessmentResultRepository,
                 certificationCourseRepository,
@@ -714,8 +727,9 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
               // given
               const expectedEstimatedLevel = 2;
               const degradedScore = 474;
-              const challenges = generateChallengeList({ length: minimumAnswersRequiredToValidateACertification });
-              const challengeIds = challenges.map(({ id }) => id);
+              const challenges = _generateCertificationChallengeForScoringList({
+                length: minimumAnswersRequiredToValidateACertification,
+              });
               const abortReason = ABORT_REASONS.CANDIDATE;
               const abortedCertificationCourse = domainBuilder.buildCertificationCourse({
                 id: certificationCourseId,
@@ -725,7 +739,9 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
 
               const answers = generateAnswersForChallenges({ challenges });
 
-              challengeRepository.getMany.withArgs(challengeIds).resolves(challenges);
+              certificationChallengeForScoringRepository.getByCertificationCourseId
+                .withArgs({ certificationCourseId })
+                .resolves(challenges);
               answerRepository.findByAssessment.withArgs(assessmentId).resolves(answers);
               certificationCourseRepository.get.withArgs(certificationCourseId).resolves(abortedCertificationCourse);
               flashAlgorithmConfigurationRepository.get.resolves(baseFlashAlgorithmConfiguration);
@@ -745,7 +761,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
               // when
               await handleCertificationScoring({
                 event,
-                challengeRepository,
+                certificationChallengeForScoringRepository,
                 answerRepository,
                 assessmentResultRepository,
                 certificationCourseRepository,
@@ -787,13 +803,15 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
 
       it('should return a CertificationScoringCompleted', async function () {
         // given
-        const challenge1 = domainBuilder.buildChallenge();
-        const challenge2 = domainBuilder.buildChallenge();
+        const challenge1 = domainBuilder.buildCertificationChallengeForScoring();
+        const challenge2 = domainBuilder.buildCertificationChallengeForScoring();
         const challenges = [challenge1, challenge2];
         const answer1 = domainBuilder.buildAnswer({ challengeId: challenge1.id, assessmentId });
         const answer2 = domainBuilder.buildAnswer({ challengeId: challenge2.id, assessmentId });
         const answers = [answer1, answer2];
-        challengeRepository.getMany.withArgs([challenge1.id, challenge2.id]).resolves(challenges);
+        certificationChallengeForScoringRepository.getByCertificationCourseId
+          .withArgs({ certificationCourseId })
+          .resolves(challenges);
         answerRepository.findByAssessment.withArgs(assessmentId).resolves(answers);
         certificationCourseRepository.get.withArgs(certificationCourseId).resolves(certificationCourse);
         flashAlgorithmConfigurationRepository.get.resolves(baseFlashAlgorithmConfiguration);
@@ -814,7 +832,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
         const generatedEvent = await handleCertificationScoring({
           event,
           certificationAssessmentRepository,
-          challengeRepository,
+          certificationChallengeForScoringRepository,
           answerRepository,
           assessmentResultRepository,
           competenceMarkRepository,
@@ -859,3 +877,9 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
     });
   });
 });
+
+const _generateCertificationChallengeForScoringList = ({ length }) => {
+  return generateChallengeList({
+    length,
+  }).map(({ discriminant, difficulty }) => new CertificationChallengeForScoring({ discriminant, difficulty }));
+};


### PR DESCRIPTION
# Déroulé : 
- lancer une certif v3
- répondre à toutes les questions correctement


Résultat obtenu : le loader est affiché en continu, il faut refresh pour voir la page de fin de test
Résultat attendu : on devrait voir la page de fin de test sans refresh