### PR TITLE
[FEATURE] Restreindre les informations récupérées pour supprimer un signalement (PIX-11033)

### DIFF
--- a/api/lib/application/preHandlers/authorization.js
+++ b/api/lib/application/preHandlers/authorization.js
@@ -21,11 +21,11 @@ const verifyCertificationSessionAuthorization = async (
   const userId = request.auth.credentials.userId;
   const certificationCourseId = request.params.id;
 
-  const certificationCourse = await dependencies.certificationCourseRepository.get(certificationCourseId);
+  const sessionId = await dependencies.certificationCourseRepository.getSessionId(certificationCourseId);
 
   return _isAuthorizedToAccessSession({
     userId,
-    sessionId: certificationCourse.getSessionId(),
+    sessionId,
     sessionRepository: dependencies.sessionRepository,
   });
 };

--- a/api/lib/domain/usecases/delete-certification-issue-report.js
+++ b/api/lib/domain/usecases/delete-certification-issue-report.js
@@ -7,8 +7,8 @@ const deleteCertificationIssueReport = async function ({
   sessionRepository,
 }) {
   const certificationIssueReport = await certificationIssueReportRepository.get(certificationIssueReportId);
-  const certificationCourse = await certificationCourseRepository.get(certificationIssueReport.certificationCourseId);
-  const isFinalized = await sessionRepository.isFinalized(certificationCourse.getSessionId());
+  const sessionId = await certificationCourseRepository.getSessionId(certificationIssueReport.certificationCourseId);
+  const isFinalized = await sessionRepository.isFinalized(sessionId);
 
   if (isFinalized) {
     throw new ForbiddenAccess('Certification issue report deletion forbidden');

--- a/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
@@ -126,6 +126,15 @@ function _toDomain({
   });
 }
 
+async function getSessionId(id) {
+  const row = await knex('certification-courses').select('sessionId').where({ id }).first();
+  if (!row) {
+    throw new NotFoundError(`Certification course of id ${id} does not exist`);
+  }
+
+  return row.sessionId;
+}
+
 async function findOneCertificationCourseByUserIdAndSessionId({
   userId,
   sessionId,
@@ -189,6 +198,7 @@ async function findCertificationCoursesBySessionId({ sessionId }) {
 export {
   save,
   get,
+  getSessionId,
   findOneCertificationCourseByUserIdAndSessionId,
   update,
   isVerificationCodeAvailable,

--- a/api/src/certification/shared/infrastructure/repositories/certification-issue-report-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-issue-report-repository.js
@@ -4,6 +4,7 @@ const { omit } = lodash;
 
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { CertificationIssueReport } from '../../domain/models/CertificationIssueReport.js';
+import { NotFoundError } from '../../../../shared/domain/errors.js';
 
 const save = async function (certificationIssueReport) {
   const [data] = await knex
@@ -18,6 +19,9 @@ const save = async function (certificationIssueReport) {
 
 const get = async function (id) {
   const certificationIssueReport = await knex('certification-issue-reports').where({ id }).first();
+  if (!certificationIssueReport) {
+    throw new NotFoundError(`Certification issue report ${id} does not exist`);
+  }
   return new CertificationIssueReport(certificationIssueReport);
 };
 

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -119,6 +119,30 @@ describe('Integration | Repository | Certification Course', function () {
     });
   });
 
+  describe('#getSessionId', function () {
+    it('should get the related session id', async function () {
+      // given
+      databaseBuilder.factory.buildSession({ id: 99 });
+      databaseBuilder.factory.buildCertificationCourse({ id: 77, sessionId: 99 });
+      await databaseBuilder.commit();
+      // when
+
+      const sessionId = await certificationCourseRepository.getSessionId(77);
+
+      // then
+      expect(sessionId).to.deep.equal(99);
+    });
+
+    it('should throw an error if not found', async function () {
+      // when
+      const error = await catchErr(certificationCourseRepository.getSessionId)(77);
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+      expect(error.message).to.deep.equals('Certification course of id 77 does not exist');
+    });
+  });
+
   describe('#get', function () {
     const description = 'Un commentaire du surveillant';
     let sessionId, expectedCertificationCourse, userId;

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { expect, databaseBuilder, domainBuilder } from '../../../../../test-helper.js';
+import { expect, databaseBuilder, domainBuilder, catchErr } from '../../../../../test-helper.js';
 import * as certificationCourseRepository from '../../../../../../src/certification/shared/infrastructure/repositories/certification-course-repository.js';
 import { BookshelfCertificationCourse } from '../../../../../../lib/infrastructure/orm-models/CertificationCourse.js';
 import { NotFoundError } from '../../../../../../lib/domain/errors.js';

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-issue-report-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-issue-report-repository_test.js
@@ -1,11 +1,12 @@
 import _ from 'lodash';
-import { expect, domainBuilder, databaseBuilder, knex } from '../../../../../test-helper.js';
+import { expect, domainBuilder, databaseBuilder, knex, catchErr } from '../../../../../test-helper.js';
 import * as certificationIssueReportRepository from '../../../../../../src/certification/shared/infrastructure/repositories/certification-issue-report-repository.js';
 import { CertificationIssueReport } from '../../../../../../src/certification/shared/domain/models/CertificationIssueReport.js';
 import {
   CertificationIssueReportCategory,
   CertificationIssueReportSubcategories,
 } from '../../../../../../src/certification/shared/domain/models/CertificationIssueReportCategory.js';
+import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 
 describe('Integration | Repository | Certification Issue Report', function () {
   describe('#save', function () {
@@ -139,6 +140,20 @@ describe('Integration | Repository | Certification Issue Report', function () {
 
       expect(result).to.deep.equal(expectedIssueReport);
       expect(result).to.be.instanceOf(CertificationIssueReport);
+    });
+
+    context('when the issue report does not exists', function () {
+      it('should throw NotFoundError', async function () {
+        // given
+        const unknownCertificationIssueReportId = 999999;
+
+        // when
+        const error = await catchErr(certificationIssueReportRepository.get)(unknownCertificationIssueReportId);
+
+        // then
+        expect(error).to.be.instanceOf(NotFoundError);
+        expect(error.message).to.equal(`Certification issue report 999999 does not exist`);
+      });
     });
   });
 

--- a/api/tests/unit/application/preHandlers/authorization_test.js
+++ b/api/tests/unit/application/preHandlers/authorization_test.js
@@ -13,7 +13,7 @@ describe('Unit | Pre-handler | Authorization', function () {
   let dependencies;
 
   beforeEach(function () {
-    certificationCourseRepository = { get: sinon.stub() };
+    certificationCourseRepository = { getSessionId: sinon.stub() };
     sessionRepository = { doesUserHaveCertificationCenterMembershipForSession: sinon.stub() };
     dependencies = { certificationCourseRepository, sessionRepository };
   });
@@ -63,17 +63,15 @@ describe('Unit | Pre-handler | Authorization', function () {
       it('should return true', async function () {
         // given
         const userId = 1;
-        const certificationCourse = domainBuilder.buildCertificationCourse();
+        domainBuilder.buildCertificationCourse({ id: 77, sessionId: 99 });
         const request = {
           auth: { credentials: { accessToken: 'valid.access.token', userId } },
           params: {
-            id: certificationCourse.id,
+            id: 77,
           },
         };
-        certificationCourseRepository.get.resolves(certificationCourse);
-        sessionRepository.doesUserHaveCertificationCenterMembershipForSession
-          .withArgs(userId, certificationCourse.getSessionId())
-          .resolves(true);
+        certificationCourseRepository.getSessionId.withArgs(77).resolves(99);
+        sessionRepository.doesUserHaveCertificationCenterMembershipForSession.withArgs(userId, 99).resolves(true);
 
         // when
         const response = await verifyCertificationSessionAuthorization(request, hFake, dependencies);
@@ -87,17 +85,15 @@ describe('Unit | Pre-handler | Authorization', function () {
       it('should throw a NotFoundError', async function () {
         // given
         const userId = 1;
-        const certificationCourse = domainBuilder.buildCertificationCourse();
+        domainBuilder.buildCertificationCourse({ id: 77, sessionId: 99 });
         const request = {
           auth: { credentials: { accessToken: 'valid.access.token', userId } },
           params: {
-            id: certificationCourse.id,
+            id: 77,
           },
         };
-        certificationCourseRepository.get.resolves(certificationCourse);
-        sessionRepository.doesUserHaveCertificationCenterMembershipForSession
-          .withArgs(userId, certificationCourse.getSessionId())
-          .resolves(false);
+        certificationCourseRepository.getSessionId.withArgs(77).resolves(99);
+        sessionRepository.doesUserHaveCertificationCenterMembershipForSession.withArgs(userId, 99).resolves(false);
 
         // when
         const error = await catchErr(verifyCertificationSessionAuthorization)(request, hFake, dependencies);

--- a/api/tests/unit/domain/usecases/delete-certification-issue-report_test.js
+++ b/api/tests/unit/domain/usecases/delete-certification-issue-report_test.js
@@ -4,7 +4,7 @@ import { deleteCertificationIssueReport } from '../../../../lib/domain/usecases/
 import { ForbiddenAccess } from '../../../../src/shared/domain/errors.js';
 
 describe('Unit | UseCase | delete-certification-issue-report', function () {
-  const certificationCourseRepository = { get: () => _.noop() };
+  const certificationCourseRepository = { getSessionId: () => _.noop() };
   let certificationIssueReportRepository;
   const sessionRepository = { isFinalized: () => _.noop() };
   const certificationIssueReportId = 456;
@@ -13,14 +13,10 @@ describe('Unit | UseCase | delete-certification-issue-report', function () {
 
   beforeEach(function () {
     const certificationIssueReport = domainBuilder.buildCertificationIssueReport({ id: certificationIssueReportId });
-    const certificationCourse = domainBuilder.buildCertificationCourse({
-      id: certificationIssueReport.certificationCourseId,
-      sessionId,
-    });
-    sinon.stub(certificationCourseRepository, 'get');
-    certificationCourseRepository.get
+    sinon.stub(certificationCourseRepository, 'getSessionId');
+    certificationCourseRepository.getSessionId
       .withArgs(certificationIssueReport.certificationCourseId)
-      .resolves(certificationCourse);
+      .resolves(sessionId);
     certificationIssueReportRepository = {
       remove: sinon.stub(),
       get: sinon.stub(),

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -370,7 +370,7 @@
           "delete-reporting": "Delete the reporting"
         },
         "errors": {
-          "delete-reporting": "An error has occurred while deleting the reporting. Please try again"
+          "delete-reporting": "An error has occurred while deleting the reporting. Please try again after refresh"
         },
         "subtitle": "My reporting"
       },

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -370,7 +370,7 @@
           "delete-reporting": "Supprimer le signalement"
         },
         "errors": {
-          "delete-reporting": "Une erreur s'est produite lors de la suppression du signalement. Merci de réessayer"
+          "delete-reporting": "Une erreur s'est produite lors de la suppression du signalement. Merci de réessayer après avoir rechargé la page"
         },
         "subtitle": "Mes signalements"
       },


### PR DESCRIPTION
## :unicorn: Problème
Lors de la suppression des signalement (certification-issue-reports), on recupere par 2 fois le certification-courses avec toutes ses relations alors qu'on a uniquement besoin de l'id de session


## :robot: Proposition
Aller directement chercher l'id de la session associée via knex

## :rainbow: Remarques
Nous avons eu une erreur 500 lors de la suppression d'un certification issue report. 
L'erreur a eu lieu après un appel au `DELETE /api/certification-issue-reports/****`
Cela aurait semblé être un soucis de mauvaise gestion des erreurs (pas de verification si l'objet est deja supprimé). 

````
Error: Undefined binding(s) detected when compiling SELECT. Undefined column(s): [id] query: select "certification-courses".* from "certification-courses" where "id" = ? limit ?

file:///app/lib/domain/usecases/delete-certification-issue-report.js:10:67
````
Pour autant s'il n'existait pas, il n'aurait pas pu passer le pre-handler.
Il y a eu 8 ms entre les 2 appels.
Il serait possible que le pre-handler de la seconde requête ait eu lieu avant la suppression dans la 1ere
Pour autant nous n'avons pas pu reproduire le problème.

L'optimisation faite dans le ticket permet d'accelerer le prehandler. On ne devrait plus avoir le soucis


## :100: Pour tester
Aller sur une session à finalise `/sessions/7005/finalisation`, ajouter une certification-issue-report 
Ouvrir une nouvelle fenêtre avec le certification issue report
Le supprimer sur une fenêtre puis sur la seconde.
S'assurer que le certification-issue-report est bien supprimé et que le 2nd appel à renvoyé une 403