### PR TITLE
[TECH] Instancier entièrement le Module lors d'une vérification (PIX-11039)

### DIFF
--- a/api/src/devcomp/infrastructure/repositories/module-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-repository.js
@@ -89,6 +89,7 @@ function _toDomainForVerification(moduleData) {
     slug: moduleData.slug,
     title: moduleData.title,
     details: new Details(moduleData.details),
+    transitionTexts: moduleData.transitionTexts?.map((transitionText) => new TransitionText(transitionText)) ?? [],
     grains: moduleData.grains.map((grain) => {
       return new Grain({
         id: grain.id,


### PR DESCRIPTION
## :unicorn: Problème
Nous n'instancions pas le module completement lors de la vérification. Si le module est mal construit, certaines erreurs peuvent ne pas être levé.

## :robot: Proposition
Instancier le module complètement lors de la vérification d'une réponse

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
