### PR TITLE
[BUGFIX] Utiliser les tolérances lors de la vérification des QROCM-ind (PIX-11007)

### DIFF
--- a/api/src/devcomp/domain/models/element/QCU-for-answer-verification.js
+++ b/api/src/devcomp/domain/models/element/QCU-for-answer-verification.js
@@ -13,7 +13,7 @@ class QCUForAnswerVerification extends QCU {
 
     assertNotNullOrUndefined(solution, 'La solution est obligatoire pour un QCU de vérification');
 
-    this.solution = solution;
+    this.solutionValue = solution;
 
     if (feedbacks) {
       this.feedbacks = new Feedbacks(feedbacks);
@@ -22,7 +22,7 @@ class QCUForAnswerVerification extends QCU {
     if (validator) {
       this.validator = validator;
     } else {
-      this.validator = new ValidatorQCU({ solution: { value: this.solution } });
+      this.validator = new ValidatorQCU({ solution: { value: this.solutionValue } });
     }
   }
 
@@ -37,7 +37,7 @@ class QCUForAnswerVerification extends QCU {
     return new QcuCorrectionResponse({
       status: validation.result,
       feedback: validation.result.isOK() ? this.feedbacks.valid : this.feedbacks.invalid,
-      solution: this.solution,
+      solution: this.solutionValue,
     });
   }
 

--- a/api/src/devcomp/domain/models/element/QROCM-for-answer-verification.js
+++ b/api/src/devcomp/domain/models/element/QROCM-for-answer-verification.js
@@ -18,13 +18,18 @@ class QROCMForAnswerVerification extends QROCM {
     this.feedbacks = feedbacks;
 
     this.#solution = new QrocmSolutions(proposals);
-    this.solutions = this.#solution.value;
-    this.tolerances = this.#solution.tolerances;
+    this.solutionValues = this.#solution.value;
+    this.solutionTolerances = this.#solution.tolerances;
 
     if (validator) {
       this.validator = validator;
     } else {
-      this.validator = new ValidatorQROCMInd({ solution: { value: this.solutions } });
+      this.validator = new ValidatorQROCMInd({
+        solution: {
+          value: this.solutionValues,
+          enabledTreatments: this.solutionTolerances,
+        },
+      });
     }
   }
 
@@ -44,7 +49,7 @@ class QROCMForAnswerVerification extends QROCM {
     return new QrocmCorrectionResponse({
       status: validation.result,
       feedback: validation.result.isOK() ? this.feedbacks.valid : this.feedbacks.invalid,
-      solution: this.solutions,
+      solution: this.solutionValues,
     });
   }
 

--- a/api/tests/devcomp/integration/domain/models/element/QROCMForAnswerVerification_test.js
+++ b/api/tests/devcomp/integration/domain/models/element/QROCMForAnswerVerification_test.js
@@ -1,0 +1,81 @@
+import { expect } from '../../../../../test-helper.js';
+import { QROCMForAnswerVerification } from '../../../../../../src/devcomp/domain/models/element/QROCM-for-answer-verification.js';
+import { AnswerStatus } from '../../../../../../src/shared/domain/models/AnswerStatus.js';
+
+describe('Integration | Devcomp | Domain | Models | Element | QROCMForAnswerVerification', function () {
+  it('should return a valid answer when using tolerances with a right user response', function () {
+    // given
+    const qrocm = new QROCMForAnswerVerification({
+      id: '98c51fa7-03b7-49b1-8c5e-49341d35909c',
+      instruction: '<p>Complétez le texte ci-dessous.</p>',
+      proposals: [
+        {
+          input: 'appName',
+          type: 'input',
+          inputType: 'text',
+          size: 1,
+          display: 'inline',
+          placeholder: '',
+          ariaLabel: 'Réponse 1',
+          defaultValue: '',
+          tolerances: ['t1', 't2'],
+          solutions: ['Modulix'],
+        },
+      ],
+      feedbacks: {
+        valid: 'Bravo!',
+        invalid: 'Mince!',
+      },
+    });
+    qrocm.setUserResponse([
+      {
+        input: 'appName',
+        answer: 'modulix!',
+      },
+    ]);
+
+    // when
+    const correction = qrocm.assess();
+
+    // then
+    expect(correction.status).to.deep.equal(AnswerStatus.OK);
+  });
+
+  it('should return an invalid answer when using tolerances with a wrong user response', function () {
+    // given
+    const qrocm = new QROCMForAnswerVerification({
+      id: '98c51fa7-03b7-49b1-8c5e-49341d35909c',
+      instruction: '<p>Complétez le texte ci-dessous.</p>',
+      proposals: [
+        {
+          input: 'appName',
+          type: 'input',
+          inputType: 'text',
+          size: 1,
+          display: 'inline',
+          placeholder: '',
+          ariaLabel: 'Réponse 1',
+          defaultValue: '',
+          tolerances: [],
+          solutions: ['Modulix'],
+        },
+      ],
+      feedbacks: {
+        valid: 'Bravo!',
+        invalid: 'Mince!',
+      },
+    });
+    qrocm.setUserResponse([
+      {
+        input: 'appName',
+        answer: 'modulix',
+      },
+    ]);
+
+    // when
+    const correction = qrocm.assess();
+
+    // then
+    expect(correction.status).to.deep.equal(AnswerStatus.KO);
+  });
+});

--- a/api/tests/devcomp/unit/domain/models/element/QCU-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCU-for-answer-verification_test.js
@@ -28,7 +28,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QcuForAnswerVerification'
       expect(qcu.instruction).equal('instruction');
       expect(qcu.locales).deep.equal(['fr-FR']);
       expect(qcu.proposals).deep.equal([proposal1, proposal2]);
-      expect(qcu.solution).deep.equal(solution);
+      expect(qcu.solutionValue).deep.equal(solution);
       expect(qcu.feedbacks).to.be.instanceof(Feedbacks);
     });
 

--- a/api/tests/devcomp/unit/domain/models/element/QROCM-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QROCM-for-answer-verification_test.js
@@ -51,11 +51,11 @@ describe('Unit | Devcomp | Domain | Models | Element | QrocMForAnswerVerificatio
       });
 
       // then
-      expect(qrocm.solutions).deep.equal({
+      expect(qrocm.solutionValues).deep.equal({
         inputBlock: ['@'],
         selectBlock: ['2'],
       });
-      expect(qrocm.tolerances).deep.equal(['t1', 't2', 't3']);
+      expect(qrocm.solutionTolerances).deep.equal(['t1', 't2', 't3']);
       expect(qrocm.feedbacks).deep.equal({
         valid: 'Bravo!',
         invalid: 'Mince!',


### PR DESCRIPTION
## :unicorn: Problème
Sur le didacticiel, le dernier élément est un `QROCM` avec **T1**. Si on répond “_modulix_”, la réponse n’est pas acceptée car on attend “_Modulix_”.

Ce n’est pas le comportement attendu, on devrait valider cette réponse.

## :robot: Proposition
Après analyse, nous avons noté que nous passions une solution sans tolérances au `ValidatorQROCMInd`.
Nous ne nous en étions pas rendu compte plus tôt car nous ne testions l'appel de la méthode `assess` de `QROCMForAnswerVerification` qu'en unitaire.
Nous avons donc écrit des tests d'intégration qui nous ont permis de passer la bonne solution au `ValidatorQROCMInd`.

## :rainbow: Remarques


## :100: Pour tester

1. Se rendre sur [la page du module du didacticiel](https://app-pr7984.review.pix.fr/modules/didacticiel-modulix/details).
2. Commencer le passage.
3. Rentrer "_modulix_" dans le QROCM et vérifier la réponse.
4. Vérifier que l'on obtient bien un feedback de succès.

