### PR TITLE
[BUGFIX] Corriger l'extraction des résultats d'une collecte de profil en csv(PIX-11096)

### DIFF
--- a/api/lib/infrastructure/exports/campaigns/campaign-profiles-collection-result-line.js
+++ b/api/lib/infrastructure/exports/campaigns/campaign-profiles-collection-result-line.js
@@ -55,9 +55,11 @@ class CampaignProfilesCollectionResultLine {
   }
 
   _getIsCertifiableColumn() {
-    return this.campaignParticipationResult.isShared
-      ? this._yesOrNo(this.placementProfile.isCertifiable())
-      : this.notShared;
+    if (this.campaignParticipationResult.isShared) {
+      return this._yesOrNo(this.placementProfile.isCertifiable());
+    }
+
+    return this.notShared;
   }
 
   _getIdPixLabelColumn() {
@@ -94,9 +96,10 @@ class CampaignProfilesCollectionResultLine {
   _competenceColumns() {
     const columns = [];
     this.competences.forEach((competence) => {
-      const { estimatedLevel, pixScore } = this.placementProfile.userCompetences.find(({ id }) => id === competence.id);
-
       if (this.campaignParticipationResult.isShared) {
+        const { estimatedLevel, pixScore } = this.placementProfile.userCompetences.find(
+          ({ id }) => id === competence.id,
+        );
         columns.push(estimatedLevel, pixScore);
       } else {
         columns.push(this.notShared, this.notShared);

--- a/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-profiles-collection-export.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-profiles-collection-export.js
@@ -89,6 +89,7 @@ class CampaignProfilesCollectionExport {
         const sameUserId = campaignParticipationResultData.userId === userId;
         const sameDate =
           campaignParticipationResultData.sharedAt &&
+          profileDate &&
           campaignParticipationResultData.sharedAt.getTime() === profileDate.getTime();
 
         return sameUserId && sameDate;


### PR DESCRIPTION
## :unicorn: Problème
Si une participation n'est pas shared, le csv retourné est vide suite à une erreur côté API

## :robot: Proposition
Faire en sorte que l'erreur n'arrive plus, et qu'elle soit couverte par un test

## :rainbow: Remarques
RAS

## :100: Pour tester
Aller sur PixOrga et vérifier que 