### PR TITLE
[FEATURE] Pouvoir utiliser les logiques de `solution-service-qcm` et de `ValidatorQCM` dans notre BC `devcomp`

### DIFF
--- a/api/src/devcomp/domain/models/validator/ValidatorQCM.js
+++ b/api/src/devcomp/domain/models/validator/ValidatorQCM.js
@@ -1,0 +1,24 @@
+import * as solutionServiceQCM from '../../services/solution-service-qcm.js';
+import { Validation } from './Validation.js';
+import { Validator } from './Validator.js';
+
+/**
+ * Traduction: Vérificateur de réponse pour un QCM
+ */
+class ValidatorQCM extends Validator {
+  constructor({ solution, dependencies = { solutionServiceQCM } } = {}) {
+    super({ solution });
+    this.dependencies = dependencies;
+  }
+
+  assess({ answer }) {
+    const result = this.dependencies.solutionServiceQCM.match(answer.value, this.solution.value);
+
+    return new Validation({
+      result,
+      resultDetails: null,
+    });
+  }
+}
+
+export { ValidatorQCM };

--- a/api/src/devcomp/domain/services/solution-service-qcm.js
+++ b/api/src/devcomp/domain/services/solution-service-qcm.js
@@ -1,10 +1,12 @@
-import { _ } from '../../../shared/infrastructure/utils/lodash-utils.js';
 import { AnswerStatus } from '../models/validator/AnswerStatus.js';
 
-const match = function (answer, solution) {
-  if (_.areCSVequivalent(answer, solution)) {
+const match = function (answers, solutions) {
+  const areAnswersEqualToSolutions = JSON.stringify(answers.sort()) === JSON.stringify(solutions.sort());
+
+  if (areAnswersEqualToSolutions) {
     return AnswerStatus.OK;
   }
+
   return AnswerStatus.KO;
 };
 

--- a/api/src/devcomp/domain/services/solution-service-qcm.js
+++ b/api/src/devcomp/domain/services/solution-service-qcm.js
@@ -1,0 +1,11 @@
+import { _ } from '../../../shared/infrastructure/utils/lodash-utils.js';
+import { AnswerStatus } from '../models/validator/AnswerStatus.js';
+
+const match = function (answer, solution) {
+  if (_.areCSVequivalent(answer, solution)) {
+    return AnswerStatus.OK;
+  }
+  return AnswerStatus.KO;
+};
+
+export { match };

--- a/api/tests/devcomp/unit/domain/models/validator/ValidatorQCM_test.js
+++ b/api/tests/devcomp/unit/domain/models/validator/ValidatorQCM_test.js
@@ -1,0 +1,50 @@
+import { ValidatorQCM } from '../../../../../../src/devcomp/domain/models/validator/ValidatorQCM.js';
+import { Validation } from '../../../../../../src/devcomp/domain/models/validator/Validation.js';
+import { AnswerStatus } from '../../../../../../src/shared/domain/models/AnswerStatus.js';
+import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | ValidatorQCM', function () {
+  let solutionServiceQcmStub;
+  beforeEach(function () {
+    solutionServiceQcmStub = {
+      match: sinon.stub(),
+    };
+  });
+
+  describe('#assess', function () {
+    let uncorrectedAnswer;
+    let validation;
+    let validator;
+    let solution;
+
+    beforeEach(function () {
+      // given
+      solutionServiceQcmStub.match.returns(AnswerStatus.OK);
+      solution = domainBuilder.buildSolution({ type: 'QCM' });
+
+      uncorrectedAnswer = domainBuilder.buildAnswer.uncorrected();
+      validator = new ValidatorQCM({
+        solution: solution,
+        dependencies: { solutionServiceQCM: solutionServiceQcmStub },
+      });
+
+      // when
+      validation = validator.assess({ answer: uncorrectedAnswer });
+    });
+
+    it('should call solutionServiceQCU', function () {
+      // then
+      expect(solutionServiceQcmStub.match).to.have.been.calledWithExactly(uncorrectedAnswer.value, solution.value);
+    });
+    it('should return a validation object with the returned status', function () {
+      const expectedValidation = domainBuilder.buildValidation({
+        result: AnswerStatus.OK,
+        resultDetails: null,
+      });
+
+      // then
+      expect(validation).to.be.an.instanceOf(Validation);
+      expect(validation).to.deep.equal(expectedValidation);
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/models/validator/ValidatorQCM_test.js
+++ b/api/tests/devcomp/unit/domain/models/validator/ValidatorQCM_test.js
@@ -2,8 +2,9 @@ import { ValidatorQCM } from '../../../../../../src/devcomp/domain/models/valida
 import { Validation } from '../../../../../../src/devcomp/domain/models/validator/Validation.js';
 import { AnswerStatus } from '../../../../../../src/shared/domain/models/AnswerStatus.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+import * as devcompDomainBuilder from '../../../../tooling/domain-builder/factory/index.js';
 
-describe('Unit | Devcomp | Domain | Models | ValidatorQCM', function () {
+describe('Unit | Devcomp | Domain | Models | Validator | ValidatorQCM', function () {
   let solutionServiceQcmStub;
   beforeEach(function () {
     solutionServiceQcmStub = {
@@ -20,7 +21,7 @@ describe('Unit | Devcomp | Domain | Models | ValidatorQCM', function () {
     beforeEach(function () {
       // given
       solutionServiceQcmStub.match.returns(AnswerStatus.OK);
-      solution = domainBuilder.buildSolution({ type: 'QCM' });
+      solution = devcompDomainBuilder.buildSolution({ type: 'QCM' });
 
       uncorrectedAnswer = domainBuilder.buildAnswer.uncorrected();
       validator = new ValidatorQCM({
@@ -32,7 +33,7 @@ describe('Unit | Devcomp | Domain | Models | ValidatorQCM', function () {
       validation = validator.assess({ answer: uncorrectedAnswer });
     });
 
-    it('should call solutionServiceQCU', function () {
+    it('should call solutionServiceQCM', function () {
       // then
       expect(solutionServiceQcmStub.match).to.have.been.calledWithExactly(uncorrectedAnswer.value, solution.value);
     });

--- a/api/tests/devcomp/unit/domain/services/solution-service-qcm_test.js
+++ b/api/tests/devcomp/unit/domain/services/solution-service-qcm_test.js
@@ -1,0 +1,49 @@
+import { expect } from '../../../../test-helper.js';
+import { AnswerStatus } from '../../../../../src/devcomp/domain/models/validator/AnswerStatus.js';
+import * as service from '../../../../../src/devcomp/domain/services/solution-service-qcm.js';
+
+describe('Unit | Devcomp | Domain | Services | SolutionServiceQCM ', function () {
+  describe('if solution type is QCM', function () {
+    const successfulCases = [
+      { answerValue: '1', solutionValue: '1' },
+      { answerValue: '1, 2', solutionValue: '1, 2' },
+      { answerValue: '1, 2, 3', solutionValue: '1, 2, 3' },
+      { answerValue: '1,2,3', solutionValue: '1,2,3' },
+      { answerValue: '3, 2, 1', solutionValue: '1, 2, 3' },
+      { answerValue: '1,2,3', solutionValue: '1, 2, 3' },
+      { answerValue: '1,   2,   3   ', solutionValue: '1, 2, 3' },
+      { answerValue: '1, 2, 3', solutionValue: '1, 2, 3' },
+    ];
+
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    successfulCases.forEach(({ answerValue, solutionValue }) => {
+      it(
+        'should return "ok" when answer is "' + answerValue + '" and solution is "' + solutionValue + '"',
+        function () {
+          const result = service.match(answerValue, solutionValue);
+          expect(AnswerStatus.isOK(result)).to.be.true;
+        },
+      );
+    });
+
+    const failedCases = [
+      { answerValue: '2', solutionValue: '1' },
+      { answerValue: '1, 3', solutionValue: '1, 2' },
+      { answerValue: '1, 2, 3', solutionValue: '1, 2' },
+      { answerValue: '3, 1', solutionValue: '1, 2' },
+    ];
+
+    // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    failedCases.forEach(({ answerValue, solutionValue }) => {
+      it(
+        'should return "ko" when answer is "' + answerValue + '" and solution is "' + solutionValue + '"',
+        function () {
+          const result = service.match(answerValue, solutionValue);
+          expect(AnswerStatus.isKO(result)).to.be.true;
+        },
+      );
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/services/solution-service-qcm_test.js
+++ b/api/tests/devcomp/unit/domain/services/solution-service-qcm_test.js
@@ -5,42 +5,50 @@ import * as service from '../../../../../src/devcomp/domain/services/solution-se
 describe('Unit | Devcomp | Domain | Services | SolutionServiceQCM ', function () {
   describe('if solution type is QCM', function () {
     const successfulCases = [
-      { answerValue: '1', solutionValue: '1' },
-      { answerValue: '1, 2', solutionValue: '1, 2' },
-      { answerValue: '1, 2, 3', solutionValue: '1, 2, 3' },
-      { answerValue: '1,2,3', solutionValue: '1,2,3' },
-      { answerValue: '3, 2, 1', solutionValue: '1, 2, 3' },
-      { answerValue: '1,2,3', solutionValue: '1, 2, 3' },
-      { answerValue: '1,   2,   3   ', solutionValue: '1, 2, 3' },
-      { answerValue: '1, 2, 3', solutionValue: '1, 2, 3' },
+      { answerValues: ['1'], solutionValues: ['1'] },
+      { answerValues: ['1', '2'], solutionValues: ['1', '2'] },
+      { answerValues: ['1', '2', '3'], solutionValues: ['1', '2', '3'] },
+      { answerValues: ['1', '2', '3'], solutionValues: ['1', '2', '3'] },
+      { answerValues: ['3', '2', '1'], solutionValues: ['1', '2', '3'] },
+      { answerValues: ['1', '2', '3'], solutionValues: ['1', '2', '3'] },
+      { answerValues: ['1', '2', '3'], solutionValues: ['1', '2', '3'] },
+      { answerValues: ['1', '2', '3'], solutionValues: ['1', '2', '3'] },
     ];
 
     // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
-    successfulCases.forEach(({ answerValue, solutionValue }) => {
+    successfulCases.forEach(({ answerValues, solutionValues }) => {
       it(
-        'should return "ok" when answer is "' + answerValue + '" and solution is "' + solutionValue + '"',
+        'should return "ok" when answer is "' +
+          JSON.stringify(answerValues) +
+          '" and solution is "' +
+          JSON.stringify(solutionValues) +
+          '"',
         function () {
-          const result = service.match(answerValue, solutionValue);
+          const result = service.match(answerValues, solutionValues);
           expect(AnswerStatus.isOK(result)).to.be.true;
         },
       );
     });
 
     const failedCases = [
-      { answerValue: '2', solutionValue: '1' },
-      { answerValue: '1, 3', solutionValue: '1, 2' },
-      { answerValue: '1, 2, 3', solutionValue: '1, 2' },
-      { answerValue: '3, 1', solutionValue: '1, 2' },
+      { answerValues: ['2'], solutionValues: ['1'] },
+      { answerValues: ['1', '3'], solutionValues: ['1', '2'] },
+      { answerValues: ['1', '2', '3'], solutionValues: ['1', '2'] },
+      { answerValues: ['3', '1'], solutionValues: ['1', '2'] },
     ];
 
     // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
-    failedCases.forEach(({ answerValue, solutionValue }) => {
+    failedCases.forEach(({ answerValues, solutionValues }) => {
       it(
-        'should return "ko" when answer is "' + answerValue + '" and solution is "' + solutionValue + '"',
+        'should return "ko" when answer is "' +
+          JSON.stringify(answerValues) +
+          '" and solution is "' +
+          JSON.stringify(solutionValues) +
+          '"',
         function () {
-          const result = service.match(answerValue, solutionValue);
+          const result = service.match(answerValues, solutionValues);
           expect(AnswerStatus.isKO(result)).to.be.true;
         },
       );


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'ajout des activités QCM dans nos Modulix, nous avons besoin d'implémenter la logique de validation des réponses d'utilisateurs à ces QCM.

## :robot: Proposition
Comme pour les `QCU` et les `QROCM-ind`, nous souhaitons copier les logiques de `solution-service-qcm` et de `ValidatorQCM` présentes dans _./lib_ pour les retrouver dans notre bounded-context `devcomp`.

Puis nous devons adapter la logique de `solution-service-qcm` car dans _./lib_, elle prenait les `answer` et `solution` au format _yaml_ alors que nous souhaitons utiliser des tableaux.

## :rainbow: Remarques


## :100: Pour tester
La CI passe
