### PR TITLE
[FEATURE] Remplacer les chiffres de la barre d'avancement par Question X/Y (PIX-10921).

### DIFF
--- a/mon-pix/app/components/progress-bar.hbs
+++ b/mon-pix/app/components/progress-bar.hbs
@@ -1,16 +1,17 @@
 {{#if this.showProgressBar}}
   <div class="progress-bar-container">
     <div
-      class="progress-bar-stepnums"
+      class="progress-bar-current-step"
       role="progressbar"
       aria-valuenow={{this.currentStepNumber}}
       aria-valuemin="1"
       aria-valuemax="5"
       aria-label="{{t 'pages.challenge.parts.progress'}}"
     >
-      {{#each this.steps as |step|}}
-        <div class="progress-bar-stepnum {{step.status}}">{{step.stepnum}}</div>
-      {{/each}}
+      {{t "pages.challenge.progress-bar.label"}}
+      {{this.currentStepNumber}}
+      /
+      {{this.maxStepsNumber}}
     </div>
 
     <div class="progress-bar-content">

--- a/mon-pix/app/components/progress-bar.hbs
+++ b/mon-pix/app/components/progress-bar.hbs
@@ -27,11 +27,7 @@
     </div>
   </div>
 {{else}}
-  <div
-    class="assessment-progress {{if @shouldBlurProgressBar 'blur-progress-bar'}}"
-    role="progressbar"
-    aria-label="{{t 'pages.challenge.parts.progress'}}"
-  >
+  <div class="assessment-progress" role="progressbar" aria-label="{{t 'pages.challenge.parts.progress'}}">
     <div class="assessment-progress__label">{{t "pages.challenge.progress-bar.label"}}</div>
     <div class="assessment-progress__value">
       {{this.currentStepNumber}}

--- a/mon-pix/app/styles/components/_progress-bar.scss
+++ b/mon-pix/app/styles/components/_progress-bar.scss
@@ -8,23 +8,10 @@
   margin-bottom: 40px;
 }
 
-.progress-bar-stepnums {
-  @extend %pix-body-m;
-
-  display: flex;
-  justify-content: space-between;
+.progress-bar-current-step {
   margin-bottom: 7px;
-  padding: 0 4px;
-}
-
-.progress-bar-stepnum {
-  color: $pix-neutral-110;
-  opacity: 0.3;
-
-  &.active {
-    color: $pix-neutral-0;
-    opacity: 1;
-  }
+  color: $pix-neutral-0;
+  font-size: 1rem;
 }
 
 .progress-bar-content {

--- a/mon-pix/app/styles/components/_progress-bar.scss
+++ b/mon-pix/app/styles/components/_progress-bar.scss
@@ -1,7 +1,3 @@
-.blur-progress-bar {
-  filter: blur(30px);
-}
-
 .progress-bar-container {
   position: relative;
   margin-top: 12px;

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -35,11 +35,7 @@
   </div>
 
   <main class="challenge__content rounded-panel--over-background-banner" role="main">
-    <ProgressBar
-      @assessment={{@model.assessment}}
-      @currentChallengeNumber={{@model.currentChallengeNumber}}
-      @shouldBlurProgressBar={{this.shouldBlurBanner}}
-    />
+    <ProgressBar @assessment={{@model.assessment}} @currentChallengeNumber={{@model.currentChallengeNumber}} />
 
     {{#if this.displayTimedChallengeInstructions}}
       <TimedChallengeInstructions

--- a/mon-pix/tests/integration/components/progress-bar_test.js
+++ b/mon-pix/tests/integration/components/progress-bar_test.js
@@ -25,11 +25,10 @@ module('Integration | Component | progress-bar', function (hooks) {
 
     this.set('assessment', mockAssessment);
     this.set('currentChallengeNumber', 2);
-    this.set('shouldBlurBanner', false);
 
     // when
     const screen = await render(
-      hbs`<ProgressBar @assessment={{ this.assessment }} @currentChallengeNumber={{ this.currentChallengeNumber }} @shouldBlurProgressBar={{this.shouldBlurBanner}} />`,
+      hbs`<ProgressBar @assessment={{ this.assessment }} @currentChallengeNumber={{ this.currentChallengeNumber }} />`,
     );
 
     // then

--- a/mon-pix/tests/integration/components/progress-bar_test.js
+++ b/mon-pix/tests/integration/components/progress-bar_test.js
@@ -1,0 +1,38 @@
+import { module, test } from 'qunit';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+import { hbs } from 'ember-cli-htmlbars';
+import { render } from '@1024pix/ember-testing-library';
+import { run } from '@ember/runloop';
+
+module('Integration | Component | progress-bar', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('should render the progress bar current step', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+
+    const answers = [
+      store.createRecord('answer'),
+      store.createRecord('answer'),
+      store.createRecord('answer'),
+      store.createRecord('answer'),
+      store.createRecord('answer'),
+    ];
+    const mockAssessment = store.createRecord('assessment', {
+      type: 'CAMPAIGN',
+    });
+    run(() => (mockAssessment.answers = answers));
+
+    this.set('assessment', mockAssessment);
+    this.set('currentChallengeNumber', 2);
+    this.set('shouldBlurBanner', false);
+
+    // when
+    const screen = await render(
+      hbs`<ProgressBar @assessment={{ this.assessment }} @currentChallengeNumber={{ this.currentChallengeNumber }} @shouldBlurProgressBar={{this.shouldBlurBanner}} />`,
+    );
+
+    // then
+    assert.ok(screen.getByText('Question 3 / 5'));
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Au-dessus de la barre d'avancement dans les épreuves Pix, on ne souhaite plus afficher les numéros de questions courants mais "Question X/5".

## :robot: Proposition
Pour la taille d'écran d'ordinateur, afficher Question X/5 au lieu des chiffres affichés jusqu'ici. Pour la version mobile, l'affichage est déjà bon. 

## :rainbow: Remarques
Il n'y avait pas encore de test d'intégration sur ce composant.

## :100: Pour tester
- Lancer Pix App et se connecter (par exemple avec eval-sco@example.net)
- Cliquer sur une carte Compétence et pour lancer un parcours
- Sur un écran d'ordinateur, constater qu'est affiché en haut à gauche "Question 1/5"