### PR TITLE
[FEATURE] Modifier le message de sortie d'épreuve focus lors d'une certification V3 (PIX-11031).

### DIFF
--- a/mon-pix/app/components/challenge-actions.hbs
+++ b/mon-pix/app/components/challenge-actions.hbs
@@ -45,14 +45,18 @@
       >
         <FaIcon @icon="circle-info" class="challenge-actions-alert-message__icon" />
         {{#if @isCertification}}
-          <span data-test="certification-focused-out-error-message">{{t
-              "pages.challenge.has-focused-out-of-window.certification"
-              htmlSafe=true
-            }}</span>
+          {{#if (eq @certificationVersion 3)}}
+            <span data-test="certification-v3-focused-out-error-message">{{t
+                "pages.challenge.has-focused-out-of-window.v3-certification"
+              }}</span>
+          {{else}}
+            <span data-test="certification-focused-out-error-message">{{t
+                "pages.challenge.has-focused-out-of-window.certification"
+              }}</span>
+          {{/if}}
         {{else}}
           <span data-test="default-focused-out-error-message">{{t
               "pages.challenge.has-focused-out-of-window.default"
-              htmlSafe=true
             }}</span>
         {{/if}}
       </div>

--- a/mon-pix/app/components/challenge-item-qcm.hbs
+++ b/mon-pix/app/components/challenge-item-qcm.hbs
@@ -50,6 +50,7 @@
       @hasFocusedOutOfWindow={{@hasFocusedOutOfWindow}}
       @isDisabled={{this.isAnswerFieldDisabled}}
       @hasOngoingLiveAlert={{@assessment.hasOngoingLiveAlert}}
+      @certificationVersion={{@assessment.certificationCourse.version}}
     />
   {{/if}}
 </form>

--- a/mon-pix/app/components/challenge-item-qcu.hbs
+++ b/mon-pix/app/components/challenge-item-qcu.hbs
@@ -50,6 +50,7 @@
       @hasFocusedOutOfWindow={{@hasFocusedOutOfWindow}}
       @isDisabled={{this.isAnswerFieldDisabled}}
       @hasOngoingLiveAlert={{@assessment.hasOngoingLiveAlert}}
+      @certificationVersion={{@assessment.certificationCourse.version}}
     />
   {{/if}}
 </form>

--- a/mon-pix/app/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/components/challenge-item-qroc.hbs
@@ -133,6 +133,7 @@
       @hasChallengeTimedOut={{this.hasChallengeTimedOut}}
       @hasFocusedOutOfWindow={{@hasFocusedOutOfWindow}}
       @hasOngoingLiveAlert={{@assessment.hasOngoingLiveAlert}}
+      @certificationVersion={{@assessment.certificationCourse.version}}
     />
   {{/if}}
 </form>

--- a/mon-pix/app/components/challenge-item-qrocm.hbs
+++ b/mon-pix/app/components/challenge-item-qrocm.hbs
@@ -49,6 +49,7 @@
       @hasFocusedOutOfWindow={{@hasFocusedOutOfWindow}}
       @isDisabled={{this.isAnswerFieldDisabled}}
       @hasOngoingLiveAlert={{@assessment.hasOngoingLiveAlert}}
+      @certificationVersion={{@assessment.certificationCourse.version}}
     />
   {{/if}}
 </form>

--- a/mon-pix/tests/integration/components/challenge-actions_test.js
+++ b/mon-pix/tests/integration/components/challenge-actions_test.js
@@ -35,27 +35,60 @@ module('Integration | Component | challenge actions', function (hooks) {
 
   module('when user has focused out', function () {
     module('when assessent is of type certification', function () {
-      test("should show certification focus out's error message", async function (assert) {
-        // given
-        this.set('isValidateButtonEnabled', true);
-        this.set('isCertification', true);
-        this.set('hasFocusedOutOfWindow', true);
-        this.set('hasChallengeTimedOut', false);
-        this.set('isSkipButtonEnabled', true);
-        this.set('validateActionStub', () => {});
+      module('when certification course version is 2', function () {
+        test("should show certification focus out's error message", async function (assert) {
+          // given
+          this.set('isValidateButtonEnabled', true);
+          this.set('isCertification', true);
+          this.set('hasFocusedOutOfWindow', true);
+          this.set('hasChallengeTimedOut', false);
+          this.set('isSkipButtonEnabled', true);
+          this.set('validateActionStub', () => {});
+          this.set('certificationVersion', 2);
 
-        // when
-        await render(hbs`<ChallengeActions
+          // when
+          await render(hbs`<ChallengeActions
                             @isCertification={{this.isCertification}}
                             @validateAnswer={{this.validateActionStub}}
                             @hasFocusedOutOfWindow={{this.hasFocusedOutOfWindow}}
                             @hasChallengeTimedOut={{this.hasChallengeTimedOut}}
                             @isValidateButtonEnabled={{this.isValidateButtonEnabled}}
-                            @isSkipButtonEnabled={{this.isSkipButtonEnabled}}/>`);
+                            @isSkipButtonEnabled={{this.isSkipButtonEnabled}}
+                            @certificationVersion={{this.certificationVersion}}/>`);
 
-        // then
-        assert.dom('[data-test="certification-focused-out-error-message"]').exists();
-        assert.dom('[data-test="default-focused-out-error-message"]').doesNotExist();
+          // then
+          assert.dom('[data-test="default-focused-out-error-message"]').doesNotExist();
+          assert.dom('[data-test="certification-v3-focused-out-error-message"]').doesNotExist();
+          assert.dom('[data-test="certification-focused-out-error-message"]').exists();
+        });
+      });
+
+      module('when certification course version is 3', function () {
+        test("should show certification focus out's error message", async function (assert) {
+          // given
+          this.set('isValidateButtonEnabled', true);
+          this.set('isCertification', true);
+          this.set('hasFocusedOutOfWindow', true);
+          this.set('hasChallengeTimedOut', false);
+          this.set('isSkipButtonEnabled', true);
+          this.set('validateActionStub', () => {});
+          this.set('certificationVersion', 3);
+
+          // when
+          await render(hbs`<ChallengeActions
+                            @isCertification={{this.isCertification}}
+                            @validateAnswer={{this.validateActionStub}}
+                            @hasFocusedOutOfWindow={{this.hasFocusedOutOfWindow}}
+                            @hasChallengeTimedOut={{this.hasChallengeTimedOut}}
+                            @isValidateButtonEnabled={{this.isValidateButtonEnabled}}
+                            @isSkipButtonEnabled={{this.isSkipButtonEnabled}}
+                            @certificationVersion={{this.certificationVersion}}/>`);
+
+          // then
+          assert.dom('[data-test="default-focused-out-error-message"]').doesNotExist();
+          assert.dom('[data-test="certification-focused-out-error-message"]').doesNotExist();
+          assert.dom('[data-test="certification-v3-focused-out-error-message"]').exists();
+        });
       });
     });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -692,8 +692,9 @@
         "waiting-information": "En attente du surveillant..."
       },
       "has-focused-out-of-window": {
-        "certification": "We have detected a page switch. Your answer will not be validated.'<br>'If you have been forced to change pages, please inform your invigilator and answer the question in their presence.",
-        "default": "We have detected a page switch.'<br>'During a certification test, your answer would not be validated."
+        "certification": "We have detected a page switch. Your answer will not be validated. If you have been forced to change pages, please inform your invigilator and answer the question in their presence.",
+        "default": "We have detected a page switch.'<br>'During a certification test, your answer would not be validated.",
+        "v3-certification": "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse.'<br>'Si vous avez été contraint de changer de page, prévenez votre surveillant afin qu'il puisse le constater et le signaler, le cas échéant."
       },
       "illustration": {
         "placeholder": "Image loading"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -692,8 +692,9 @@
         "waiting-information": "En attente du surveillant..."
       },
       "has-focused-out-of-window": {
-        "certification": "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse.'<br>'Si vous avez été contraint de changer de page, prévenez votre surveillant et répondez à la question en sa présence.",
-        "default": "Nous avons détecté un changement de page.'<br>'En certification, votre réponse ne serait pas validée."
+        "certification": "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, prévenez votre surveillant et répondez à la question en sa présence.",
+        "default": "Nous avons détecté un changement de page.'<br>'En certification, votre réponse ne serait pas validée.",
+        "v3-certification": "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse.'<br>'Si vous avez été contraint de changer de page, prévenez votre surveillant afin qu'il puisse le constater et le signaler, le cas échéant."
       },
       "illustration": {
         "placeholder": "Chargement de l'image en cours"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -692,8 +692,9 @@
         "waiting-information": "Wachten op de supervisor..."
       },
       "has-focused-out-of-window": {
-        "certification": "We hebben een paginawissel geconstateerd. Je antwoord wordt als fout gerekend.'<br>'Als je gedwongen werd om van pagina te wisselen, informeer dan je supervisor en beantwoord de vraag in zijn of haar aanwezigheid.",
-        "default": "We hebben een paginawijziging gedetecteerd.'<br> 'In certificering zou uw antwoord niet worden gevalideerd."
+        "certification": "We hebben een paginawissel geconstateerd. Je antwoord wordt als fout gerekend. Als je gedwongen werd om van pagina te wisselen, informeer dan je supervisor en beantwoord de vraag in zijn of haar aanwezigheid.",
+        "default": "We hebben een paginawijziging gedetecteerd.'<br> 'In certificering zou uw antwoord niet worden gevalideerd.",
+        "v3-certification": "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse.'<br>'Si vous avez été contraint de changer de page, prévenez votre surveillant afin qu'il puisse le constater et le signaler, le cas échéant."
       },
       "illustration": {
         "placeholder": "De huidige afbeelding laden"


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu’un candidat perd le focus, un message lui indiquant que sa réponse ne sera pas validée sauf si un signalement est fait par le surveillant est affiché.

Le message affiché actuellement pour les certif v3 est le même que celui pour les certif v2, alors que la prise en charge par le surveillant est différente.

## :robot: Proposition
Afficher un message en cas de perte du focus spécifique pour les certifs v3 (:warning: ne pas modifier celui pour les certif v2). 

Wording pour la v3 : 
Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse.
Si vous avez été contraint de changer de page, prévenez votre surveillant afin qu'il puisse le constater et le signaler, le cas échéant.

## :100: Pour tester
- Lancer une certif v3
- Répondre à des questions jusqu'à obtenir une question "focus"
- Perdre le focus
- Le message affiché doit être : Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse.
Si vous avez été contraint de changer de page, prévenez votre surveillant afin qu'il puisse le constater et le signaler, le cas échéant.