### PR TITLE
[TECH] Stocke les fichiers d'import du SUP dans un bucket S3 (PIX-11064)

### DIFF
--- a/api/src/prescription/learner-management/application/sup-organization-management-route.js
+++ b/api/src/prescription/learner-management/application/sup-organization-management-route.js
@@ -30,6 +30,7 @@ const register = async function (server) {
         },
         payload: {
           maxBytes: 1048576 * 10, // 10MB
+          output: 'file',
           parse: 'gunzip',
           failAction: (request, h) => {
             return sendJsonApiError(
@@ -66,6 +67,7 @@ const register = async function (server) {
         },
         payload: {
           maxBytes: 1048576 * 10, // 10MB
+          output: 'file',
           parse: 'gunzip',
           failAction: (request, h) => {
             return sendJsonApiError(

--- a/api/tests/prescription/learner-management/unit/application/sup-organization-management-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/sup-organization-management-controller_test.js
@@ -1,80 +1,156 @@
 import { usecases } from '../../../../../src/prescription/learner-management/domain/usecases/index.js';
 import { supOrganizationManagementController } from '../../../../../src/prescription/learner-management/application/sup-organization-management-controller.js';
-import { expect, hFake, sinon } from '../../../../test-helper.js';
+import { expect, hFake, sinon, catchErr } from '../../../../test-helper.js';
 
 describe('Unit | Controller | sup-organization-management-controller', function () {
+  let organizationId;
+  let supOrganizationLearnerParser;
+  let path;
+  let filename;
+  let readableStream;
+  let i18n;
+  let warnings;
+  let serializedResponse;
+
+  let importStorageStub;
+  let supOrganizationLearnerWarningSerializerStub;
+  let logErrorWithCorrelationIdsStub;
+  let unlinkStub;
+  let makeOrganizationLearnerParserStub;
+
+  beforeEach(function () {
+    organizationId = Symbol('organizationId');
+    supOrganizationLearnerParser = Symbol('supOrgnaizationLearnerParser');
+    path = Symbol('path');
+    filename = Symbol('filename');
+    readableStream = Symbol('readableStream');
+    i18n = Symbol('i18n');
+    warnings = Symbol('warnings');
+    serializedResponse = Symbol('serializedResponse');
+
+    importStorageStub = {
+      sendFile: sinon.stub(),
+      readFile: sinon.stub(),
+      deleteFile: sinon.stub(),
+    };
+    sinon.stub(usecases, 'importSupOrganizationLearners');
+    supOrganizationLearnerWarningSerializerStub = { serialize: sinon.stub() };
+    logErrorWithCorrelationIdsStub = sinon.stub();
+    unlinkStub = sinon.stub();
+    makeOrganizationLearnerParserStub = sinon.stub();
+  });
+
   context('#importSupOrganizationLearners', function () {
     it('should call importSupOrganizationLearners usecase and return 200', async function () {
-      const organizationId = Symbol('organizationId');
-      const supOrganizationLearnerParser = Symbol('supOrgnaizationLearnerParser');
-      const path = Symbol('path');
-      const filename = Symbol('filename');
-      const readableStream = Symbol('readableStream');
       const params = { id: organizationId };
-      const i18n = Symbol('i18n');
-      const warnings = Symbol('warnings');
-      const serializedResponse = Symbol('serializedResponse');
       const request = {
         payload: { path },
         params,
         i18n,
       };
+      importStorageStub.sendFile.withArgs({ filepath: path }).resolves(filename);
 
-      const supOrganizationLearnerWarningSerializerStub = { serialize: sinon.stub() };
-      supOrganizationLearnerWarningSerializerStub.serialize
-        .withArgs({ id: organizationId, warnings })
-        .returns(serializedResponse);
-
-      sinon.stub(usecases, 'importSupOrganizationLearners');
       usecases.importSupOrganizationLearners
         .withArgs({
           supOrganizationLearnerParser,
         })
         .resolves(warnings);
 
-      const importStorageStub = {
-        sendFile: sinon.stub(),
-        readFile: sinon.stub(),
-        deleteFile: sinon.stub(),
-      };
-      importStorageStub.sendFile.withArgs({ filepath: path }).resolves(filename);
       importStorageStub.readFile.withArgs({ filename }).resolves(readableStream);
 
-      const makeOrganizationLearnerParserStub = sinon.stub();
       makeOrganizationLearnerParserStub
         .withArgs(readableStream, organizationId, i18n)
         .returns(supOrganizationLearnerParser);
 
+      supOrganizationLearnerWarningSerializerStub.serialize
+        .withArgs({ id: organizationId, warnings })
+        .returns(serializedResponse);
+
       // when
-      const dependencies = {
+      const response = await supOrganizationManagementController.importSupOrganizationLearners(request, hFake, {
         makeOrganizationLearnerParser: makeOrganizationLearnerParserStub,
         supOrganizationLearnerWarningSerializer: supOrganizationLearnerWarningSerializerStub,
         importStorage: importStorageStub,
-      };
-
-      const response = await supOrganizationManagementController.importSupOrganizationLearners(
-        request,
-        hFake,
-        dependencies,
-      );
+        logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub,
+        unlink: unlinkStub,
+      });
 
       // then
       expect(response.statusCode).to.be.equal(200);
       expect(response.source).to.be.equal(serializedResponse);
+
       expect(importStorageStub.deleteFile).to.have.been.calledWith({ filename });
+      expect(unlinkStub).to.have.been.calledWith(path);
+    });
+
+    it('should cleanup files on error', async function () {
+      const params = { id: organizationId };
+      const request = {
+        payload: { path },
+        params,
+        i18n,
+      };
+      importStorageStub.sendFile.withArgs({ filepath: path }).resolves(filename);
+
+      importStorageStub.readFile.withArgs({ filename }).resolves(readableStream);
+
+      makeOrganizationLearnerParserStub.rejects();
+
+      // when
+      await catchErr(supOrganizationManagementController.importSupOrganizationLearners)(request, hFake, {
+        makeOrganizationLearnerParser: makeOrganizationLearnerParserStub,
+        supOrganizationLearnerWarningSerializer: supOrganizationLearnerWarningSerializerStub,
+        importStorage: importStorageStub,
+        logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub,
+        unlink: unlinkStub,
+      });
+
+      expect(importStorageStub.deleteFile).to.have.been.calledWith({ filename });
+      expect(unlinkStub).to.have.been.calledWith(path);
+    });
+
+    it('should log an error if unlink fails', async function () {
+      const params = { id: organizationId };
+      const request = {
+        payload: { path },
+        params,
+        i18n,
+      };
+      importStorageStub.sendFile.withArgs({ filepath: path }).resolves(filename);
+
+      importStorageStub.readFile.withArgs({ filename }).resolves(readableStream);
+
+      makeOrganizationLearnerParserStub
+        .withArgs(readableStream, organizationId, i18n)
+        .returns(supOrganizationLearnerParser);
+
+      supOrganizationLearnerWarningSerializerStub.serialize
+        .withArgs({ id: organizationId, warnings })
+        .returns(serializedResponse);
+
+      const error = new Error();
+      unlinkStub.throws(error);
+
+      // when
+      const response = await supOrganizationManagementController.importSupOrganizationLearners(request, hFake, {
+        makeOrganizationLearnerParser: makeOrganizationLearnerParserStub,
+        supOrganizationLearnerWarningSerializer: supOrganizationLearnerWarningSerializerStub,
+        importStorage: importStorageStub,
+        logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub,
+        unlink: unlinkStub,
+      });
+
+      // then
+      expect(response.statusCode).to.be.equal(200);
+
+      expect(importStorageStub.deleteFile).to.have.been.calledWith({ filename });
+      expect(logErrorWithCorrelationIdsStub).to.have.been.calledWith(error);
     });
   });
   context('#replaceSupOrganizationLearner', function () {
     it('should call replaceSupOrganizationLearner usecase and return 200', async function () {
-      const organizationId = Symbol('organizationId');
       const userId = Symbol('userId');
-      const supOrganizationLearnerParser = Symbol('supOrgnaizationLearnerParser');
-      const path = Symbol('path');
-      const readableStream = Symbol('readableStream');
       const params = { id: organizationId };
-      const i18n = Symbol('i18n');
-      const warnings = Symbol('warnings');
-      const serializedResponse = Symbol('serializedResponse');
       const request = {
         payload: { path },
         params,

--- a/api/tests/prescription/learner-management/unit/application/sup-organization-management-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/sup-organization-management-controller_test.js
@@ -11,12 +11,14 @@ describe('Unit | Controller | sup-organization-management-controller', function 
   let i18n;
   let warnings;
   let serializedResponse;
+  let userId;
 
   let importStorageStub;
   let supOrganizationLearnerWarningSerializerStub;
   let logErrorWithCorrelationIdsStub;
   let unlinkStub;
   let makeOrganizationLearnerParserStub;
+  let requestResponseUtilsStub;
 
   beforeEach(function () {
     organizationId = Symbol('organizationId');
@@ -27,6 +29,7 @@ describe('Unit | Controller | sup-organization-management-controller', function 
     i18n = Symbol('i18n');
     warnings = Symbol('warnings');
     serializedResponse = Symbol('serializedResponse');
+    userId = Symbol('userId');
 
     importStorageStub = {
       sendFile: sinon.stub(),
@@ -34,10 +37,12 @@ describe('Unit | Controller | sup-organization-management-controller', function 
       deleteFile: sinon.stub(),
     };
     sinon.stub(usecases, 'importSupOrganizationLearners');
+    sinon.stub(usecases, 'replaceSupOrganizationLearners');
     supOrganizationLearnerWarningSerializerStub = { serialize: sinon.stub() };
     logErrorWithCorrelationIdsStub = sinon.stub();
     unlinkStub = sinon.stub();
     makeOrganizationLearnerParserStub = sinon.stub();
+    requestResponseUtilsStub = { extractUserIdFromRequest: sinon.stub() };
   });
 
   context('#importSupOrganizationLearners', function () {
@@ -149,7 +154,6 @@ describe('Unit | Controller | sup-organization-management-controller', function 
   });
   context('#replaceSupOrganizationLearner', function () {
     it('should call replaceSupOrganizationLearner usecase and return 200', async function () {
-      const userId = Symbol('userId');
       const params = { id: organizationId };
       const request = {
         payload: { path },
@@ -157,15 +161,16 @@ describe('Unit | Controller | sup-organization-management-controller', function 
         i18n,
       };
 
-      const requestResponseUtilsStub = { extractUserIdFromRequest: sinon.stub() };
       requestResponseUtilsStub.extractUserIdFromRequest.withArgs(request).returns(userId);
 
-      const supOrganizationLearnerWarningSerializerStub = { serialize: sinon.stub() };
-      supOrganizationLearnerWarningSerializerStub.serialize
-        .withArgs({ id: organizationId, warnings })
-        .returns(serializedResponse);
+      importStorageStub.sendFile.withArgs({ filepath: path }).resolves(filename);
 
-      sinon.stub(usecases, 'replaceSupOrganizationLearners');
+      importStorageStub.readFile.withArgs({ filename }).resolves(readableStream);
+
+      makeOrganizationLearnerParserStub
+        .withArgs(readableStream, organizationId, i18n)
+        .returns(supOrganizationLearnerParser);
+
       usecases.replaceSupOrganizationLearners
         .withArgs({
           organizationId,
@@ -174,31 +179,105 @@ describe('Unit | Controller | sup-organization-management-controller', function 
         })
         .resolves(warnings);
 
-      const createReadStreamStub = sinon.stub();
-      createReadStreamStub.withArgs(path).returns(readableStream);
-
-      const makeOrganizationLearnerParserStub = sinon.stub();
-      makeOrganizationLearnerParserStub
-        .withArgs(readableStream, organizationId, i18n)
-        .returns(supOrganizationLearnerParser);
+      supOrganizationLearnerWarningSerializerStub.serialize
+        .withArgs({ id: organizationId, warnings })
+        .returns(serializedResponse);
 
       // when
-      const dependencies = {
+      const response = await supOrganizationManagementController.replaceSupOrganizationLearners(request, hFake, {
         requestResponseUtils: requestResponseUtilsStub,
         makeOrganizationLearnerParser: makeOrganizationLearnerParserStub,
         supOrganizationLearnerWarningSerializer: supOrganizationLearnerWarningSerializerStub,
-        createReadStream: createReadStreamStub,
-      };
-
-      const response = await supOrganizationManagementController.replaceSupOrganizationLearners(
-        request,
-        hFake,
-        dependencies,
-      );
+        importStorage: importStorageStub,
+        logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub,
+        unlink: unlinkStub,
+      });
 
       // then
       expect(response.statusCode).to.be.equal(200);
       expect(response.source).to.be.equal(serializedResponse);
+
+      expect(importStorageStub.deleteFile).to.have.been.calledWith({ filename });
+      expect(unlinkStub).to.have.been.calledWith(path);
+    });
+
+    it('should cleanup files on error', async function () {
+      const params = { id: organizationId };
+      const request = {
+        payload: { path },
+        params,
+        i18n,
+      };
+
+      requestResponseUtilsStub.extractUserIdFromRequest.withArgs(request).returns(userId);
+
+      importStorageStub.sendFile.withArgs({ filepath: path }).resolves(filename);
+
+      importStorageStub.readFile.withArgs({ filename }).resolves(readableStream);
+
+      makeOrganizationLearnerParserStub.rejects();
+
+      // when
+      await catchErr(supOrganizationManagementController.replaceSupOrganizationLearners)(request, hFake, {
+        requestResponseUtils: requestResponseUtilsStub,
+        makeOrganizationLearnerParser: makeOrganizationLearnerParserStub,
+        supOrganizationLearnerWarningSerializer: supOrganizationLearnerWarningSerializerStub,
+        importStorage: importStorageStub,
+        logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub,
+        unlink: unlinkStub,
+      });
+
+      expect(importStorageStub.deleteFile).to.have.been.calledWith({ filename });
+      expect(unlinkStub).to.have.been.calledWith(path);
+    });
+
+    it('should log an error if unlink fails', async function () {
+      const params = { id: organizationId };
+      const request = {
+        payload: { path },
+        params,
+        i18n,
+      };
+      requestResponseUtilsStub.extractUserIdFromRequest.withArgs(request).returns(userId);
+
+      importStorageStub.sendFile.withArgs({ filepath: path }).resolves(filename);
+
+      importStorageStub.readFile.withArgs({ filename }).resolves(readableStream);
+
+      makeOrganizationLearnerParserStub
+        .withArgs(readableStream, organizationId, i18n)
+        .returns(supOrganizationLearnerParser);
+
+      usecases.replaceSupOrganizationLearners
+        .withArgs({
+          organizationId,
+          userId,
+          supOrganizationLearnerParser,
+        })
+        .resolves(warnings);
+
+      supOrganizationLearnerWarningSerializerStub.serialize
+        .withArgs({ id: organizationId, warnings })
+        .returns(serializedResponse);
+
+      const error = new Error();
+      unlinkStub.throws(error);
+
+      // when
+      const response = await supOrganizationManagementController.replaceSupOrganizationLearners(request, hFake, {
+        requestResponseUtils: requestResponseUtilsStub,
+        makeOrganizationLearnerParser: makeOrganizationLearnerParserStub,
+        supOrganizationLearnerWarningSerializer: supOrganizationLearnerWarningSerializerStub,
+        importStorage: importStorageStub,
+        logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub,
+        unlink: unlinkStub,
+      });
+
+      // then
+      expect(response.statusCode).to.be.equal(200);
+
+      expect(importStorageStub.deleteFile).to.have.been.calledWith({ filename });
+      expect(logErrorWithCorrelationIdsStub).to.have.been.calledWith(error);
     });
   });
 });

--- a/api/tests/prescription/learner-management/unit/application/sup-organization-management-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/sup-organization-management-controller_test.js
@@ -8,6 +8,7 @@ describe('Unit | Controller | sup-organization-management-controller', function 
       const organizationId = Symbol('organizationId');
       const supOrganizationLearnerParser = Symbol('supOrgnaizationLearnerParser');
       const path = Symbol('path');
+      const filename = Symbol('filename');
       const readableStream = Symbol('readableStream');
       const params = { id: organizationId };
       const i18n = Symbol('i18n');
@@ -31,8 +32,13 @@ describe('Unit | Controller | sup-organization-management-controller', function 
         })
         .resolves(warnings);
 
-      const createReadStreamStub = sinon.stub();
-      createReadStreamStub.withArgs(path).returns(readableStream);
+      const importStorageStub = {
+        sendFile: sinon.stub(),
+        readFile: sinon.stub(),
+        deleteFile: sinon.stub(),
+      };
+      importStorageStub.sendFile.withArgs({ filepath: path }).resolves(filename);
+      importStorageStub.readFile.withArgs({ filename }).resolves(readableStream);
 
       const makeOrganizationLearnerParserStub = sinon.stub();
       makeOrganizationLearnerParserStub
@@ -43,7 +49,7 @@ describe('Unit | Controller | sup-organization-management-controller', function 
       const dependencies = {
         makeOrganizationLearnerParser: makeOrganizationLearnerParserStub,
         supOrganizationLearnerWarningSerializer: supOrganizationLearnerWarningSerializerStub,
-        createReadStream: createReadStreamStub,
+        importStorage: importStorageStub,
       };
 
       const response = await supOrganizationManagementController.importSupOrganizationLearners(
@@ -55,6 +61,7 @@ describe('Unit | Controller | sup-organization-management-controller', function 
       // then
       expect(response.statusCode).to.be.equal(200);
       expect(response.source).to.be.equal(serializedResponse);
+      expect(importStorageStub.deleteFile).to.have.been.calledWith({ filename });
     });
   });
   context('#replaceSupOrganizationLearner', function () {

--- a/api/tests/prescription/learner-management/unit/application/sup-organization-management-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/sup-organization-management-controller_test.js
@@ -7,13 +7,14 @@ describe('Unit | Controller | sup-organization-management-controller', function 
     it('should call importSupOrganizationLearners usecase and return 200', async function () {
       const organizationId = Symbol('organizationId');
       const supOrganizationLearnerParser = Symbol('supOrgnaizationLearnerParser');
-      const payload = Symbol('payload');
+      const path = Symbol('path');
+      const readableStream = Symbol('readableStream');
       const params = { id: organizationId };
       const i18n = Symbol('i18n');
       const warnings = Symbol('warnings');
       const serializedResponse = Symbol('serializedResponse');
       const request = {
-        payload,
+        payload: { path },
         params,
         i18n,
       };
@@ -30,13 +31,19 @@ describe('Unit | Controller | sup-organization-management-controller', function 
         })
         .resolves(warnings);
 
+      const createReadStreamStub = sinon.stub();
+      createReadStreamStub.withArgs(path).returns(readableStream);
+
       const makeOrganizationLearnerParserStub = sinon.stub();
-      makeOrganizationLearnerParserStub.withArgs(payload, organizationId, i18n).returns(supOrganizationLearnerParser);
+      makeOrganizationLearnerParserStub
+        .withArgs(readableStream, organizationId, i18n)
+        .returns(supOrganizationLearnerParser);
 
       // when
       const dependencies = {
         makeOrganizationLearnerParser: makeOrganizationLearnerParserStub,
         supOrganizationLearnerWarningSerializer: supOrganizationLearnerWarningSerializerStub,
+        createReadStream: createReadStreamStub,
       };
 
       const response = await supOrganizationManagementController.importSupOrganizationLearners(
@@ -55,13 +62,14 @@ describe('Unit | Controller | sup-organization-management-controller', function 
       const organizationId = Symbol('organizationId');
       const userId = Symbol('userId');
       const supOrganizationLearnerParser = Symbol('supOrgnaizationLearnerParser');
-      const payload = Symbol('payload');
+      const path = Symbol('path');
+      const readableStream = Symbol('readableStream');
       const params = { id: organizationId };
       const i18n = Symbol('i18n');
       const warnings = Symbol('warnings');
       const serializedResponse = Symbol('serializedResponse');
       const request = {
-        payload,
+        payload: { path },
         params,
         i18n,
       };
@@ -83,14 +91,20 @@ describe('Unit | Controller | sup-organization-management-controller', function 
         })
         .resolves(warnings);
 
+      const createReadStreamStub = sinon.stub();
+      createReadStreamStub.withArgs(path).returns(readableStream);
+
       const makeOrganizationLearnerParserStub = sinon.stub();
-      makeOrganizationLearnerParserStub.withArgs(payload, organizationId, i18n).returns(supOrganizationLearnerParser);
+      makeOrganizationLearnerParserStub
+        .withArgs(readableStream, organizationId, i18n)
+        .returns(supOrganizationLearnerParser);
 
       // when
       const dependencies = {
         requestResponseUtils: requestResponseUtilsStub,
         makeOrganizationLearnerParser: makeOrganizationLearnerParserStub,
         supOrganizationLearnerWarningSerializer: supOrganizationLearnerWarningSerializerStub,
+        createReadStream: createReadStreamStub,
       };
 
       const response = await supOrganizationManagementController.replaceSupOrganizationLearners(


### PR DESCRIPTION
## :unicorn: Problème
On souhaite rendre l'import de fichier asynchrone pour améliorer l'expérience utilisateur. Un des pré-requis est de pouvoir stocker le fichier avant de pouvoir le traiter.

## :robot: Proposition
On stocke le fichier dans un bucket s3.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- Se connecter avec le compte SUP
- Tester l'import qui ajoute/modifie
- Tester l'import qui remplace
