### PR TITLE
[BUGFIX] Permettre de finaliser une session avec des certifications qui n'ont pas encore de scoring (PIX-11105)

### DIFF
--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -280,7 +280,10 @@ class UserShouldNotBeReconciledOnAnotherAccountError extends DomainError {
 }
 
 class CertificationCourseNotPublishableError extends DomainError {
-  constructor(message = "Une Certification avec le statut 'started' ou 'error' ne peut-être publiée.") {
+  constructor(
+    sessionId,
+    message = `Publication de la session ${sessionId}: Une Certification avec le statut 'started' ou 'error' ne peut-être publiée.`,
+  ) {
     super(message);
   }
 }

--- a/api/lib/infrastructure/repositories/certification-repository.js
+++ b/api/lib/infrastructure/repositories/certification-repository.js
@@ -25,7 +25,7 @@ const publishCertificationCoursesBySessionId = async function (sessionId) {
   const hasCertificationInError = _hasCertificationInError(certificationDTOs);
   const hasCertificationWithNoAssessmentResultStatus = _hasCertificationWithNoAssessmentResultStatus(certificationDTOs);
   if (hasCertificationInError || hasCertificationWithNoAssessmentResultStatus) {
-    throw new CertificationCourseNotPublishableError();
+    throw new CertificationCourseNotPublishableError(sessionId);
   }
 
   const certificationDataToUpdate = certificationDTOs.map(({ certificationId, assessmentResultStatus }) => ({

--- a/api/src/certification/session/application/http-error-mapper-configuration.js
+++ b/api/src/certification/session/application/http-error-mapper-configuration.js
@@ -4,6 +4,7 @@ import {
   SessionAlreadyFinalizedError,
   SessionAlreadyPublishedError,
   SessionWithAbortReasonOnCompletedCertificationCourseError,
+  SessionWithMissingAbortReasonError,
   SessionWithoutStartedCertificationError,
 } from '../domain/errors.js';
 import { DomainErrorMappingConfiguration } from '../../../shared/application/models/domain-error-mapping-configuration.js';
@@ -16,6 +17,10 @@ const sessionDomainErrorMappingConfiguration = [
   {
     name: SessionWithAbortReasonOnCompletedCertificationCourseError.name,
     httpErrorFn: (error) => new HttpErrors.ConflictError(error.message, error.code, error.meta),
+  },
+  {
+    name: SessionWithMissingAbortReasonError.name,
+    httpErrorFn: (error) => new HttpErrors.ConflictError(error.message, error.code),
   },
   {
     name: SessionAlreadyFinalizedError.name,

--- a/api/src/certification/session/domain/errors.js
+++ b/api/src/certification/session/domain/errors.js
@@ -40,6 +40,7 @@ class SessionWithMissingAbortReasonError extends DomainError {
     message = "Une ou plusieurs certifications non terminées n'ont pas de “Raison de l’abandon” renseignées. La session ne peut donc pas être finalisée.",
   ) {
     super(message);
+    this.code = 'UNTERMINATED_CERTIFICATION_WITHOUT_ABORT_REASON';
   }
 }
 

--- a/api/src/certification/session/domain/usecases/finalize-session.js
+++ b/api/src/certification/session/domain/usecases/finalize-session.js
@@ -36,7 +36,7 @@ const finalizeSession = async function ({
 
   const hasNoStartedCertification = await sessionRepository.hasNoStartedCertification(sessionId);
 
-  const uncompletedCertificationCount = await sessionRepository.countUncompletedCertifications(sessionId);
+  const uncompletedCertificationCount = await sessionRepository.countUncompletedCertificationsAssessment(sessionId);
 
   const abortReasonCount = _countAbortReasons(certificationReports);
 

--- a/api/src/certification/session/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/session/infrastructure/repositories/session-repository.js
@@ -8,6 +8,7 @@ import { CertificationCandidate } from '../../../../../lib/domain/models/Certifi
 import { ComplementaryCertification } from '../../../session/domain/models/ComplementaryCertification.js';
 import { ComplementaryCertificationKeys } from '../../../shared/domain/models/ComplementaryCertificationKeys.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { CertificationAssessment } from '../../../../../lib/domain/models/CertificationAssessment.js';
 
 const save = async function (sessionData, { knexTransaction } = DomainTransaction.emptyTransaction()) {
   const knexConn = knexTransaction ?? knex;
@@ -211,11 +212,12 @@ const hasNoStartedCertification = async function (sessionId) {
   return !result;
 };
 
-const countUncompletedCertifications = async function (sessionId) {
+const countUncompletedCertificationsAssessment = async function (sessionId) {
   const { count } = await knex
-    .count('id')
+    .count('certification-courses.id')
     .from('certification-courses')
-    .where({ sessionId, completedAt: null })
+    .join('assessments', 'certification-courses.id', 'certificationCourseId')
+    .where({ sessionId, state: CertificationAssessment.states.STARTED })
     .first();
   return count;
 };
@@ -239,7 +241,7 @@ export {
   remove,
   hasSomeCleaAcquired,
   hasNoStartedCertification,
-  countUncompletedCertifications,
+  countUncompletedCertificationsAssessment,
 };
 
 function _toDomain(results) {

--- a/api/tests/certification/session/unit/domain/usecases/finalize-session_test.js
+++ b/api/tests/certification/session/unit/domain/usecases/finalize-session_test.js
@@ -34,7 +34,7 @@ describe('Unit | UseCase | finalize-session', function () {
       finalize: sinon.stub(),
       isFinalized: sinon.stub(),
       hasNoStartedCertification: sinon.stub(),
-      countUncompletedCertifications: sinon.stub(),
+      countUncompletedCertificationsAssessment: sinon.stub(),
     };
     certificationReportRepository = {
       finalizeAll: sinon.stub(),
@@ -123,7 +123,7 @@ describe('Unit | UseCase | finalize-session', function () {
           abortReason: 'candidate',
           completedAt: '2022-01-01',
         });
-        sessionRepository.countUncompletedCertifications.withArgs(sessionId).resolves(0);
+        sessionRepository.countUncompletedCertificationsAssessment.withArgs(sessionId).resolves(0);
         certificationCourseRepository.findCertificationCoursesBySessionId
           .withArgs({ sessionId })
           .resolves([completedCertificationCourse]);
@@ -157,7 +157,7 @@ describe('Unit | UseCase | finalize-session', function () {
           abortReason: null,
           completedAt: null,
         });
-        sessionRepository.countUncompletedCertifications.withArgs(sessionId).resolves(1);
+        sessionRepository.countUncompletedCertificationsAssessment.withArgs(sessionId).resolves(1);
         certificationCourseRepository.findCertificationCoursesBySessionId
           .withArgs({ sessionId })
           .resolves([uncompletedCertificationCourse]);

--- a/api/tests/integration/infrastructure/repositories/certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-repository_test.js
@@ -15,12 +15,11 @@ describe('Integration | Repository | Certification', function () {
     });
 
     context('when some certifications latest assessment result is error', function () {
-      beforeEach(function () {
-        _buildErrorCertification({ id: 4, sessionId, isPublished: false });
-        return databaseBuilder.commit();
-      });
-
       it('should throw a CertificationCourseNotPublishableError without publishing any certification nor setting pixCertificationStatus', async function () {
+        // given
+        _buildErrorCertification({ id: 4, sessionId, isPublished: false });
+        await databaseBuilder.commit();
+
         // when
         const err = await catchErr(certificationRepository.publishCertificationCoursesBySessionId)(sessionId);
 
@@ -30,6 +29,9 @@ describe('Integration | Repository | Certification', function () {
           .pluck('pixCertificationStatus')
           .where({ sessionId });
         expect(err).to.be.instanceOf(CertificationCourseNotPublishableError);
+        expect(err.message).to.equal(
+          "Publication de la session 200: Une Certification avec le statut 'started' ou 'error' ne peut-être publiée.",
+        );
         expect(isPublishedStates).to.deep.equal([false, false, false, false]);
         expect(pixCertificationStatuses).to.deep.equal([null, null, null, null]);
       });

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -69,8 +69,6 @@ export default class SessionsFinalizeController extends Controller {
       await this.session.save({ adapterOptions: { finalization: true } });
       this.showSuccessNotification(this.intl.t('pages.session-finalization.notification.success'));
     } catch (responseError) {
-      // eslint-disable-next-line no-console
-      console.error({ responseError });
       const error = responseError?.errors?.[0];
       if (error?.code) {
         this.showConfirmModal = false;

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -24,6 +24,7 @@
       "SESSION_STARTED_CANDIDATE_ALREADY_LINKED_TO_USER": "The session has begun, you can’t upload a candidates' list anymore.<br />If you want to edit the list, you can enrol a candidate directly in the table below.",
       "SESSION_WITHOUT_STARTED_CERTIFICATION": "This session hasn't started, you can't finalise it. However, you may delete it.",
       "SESSION_WITH_ABORT_REASON_ON_COMPLETED_CERTIFICATION_COURSE": "The field \"Reason for abandonment\" has been filled in for a candidate who has finished their certification exam in between. The session therefore can't be finalised. Please refresh the page before finalising.",
+      "UNTERMINATED_CERTIFICATION_WITHOUT_ABORT_REASON": "One or more unterminated certifications have missing \"Abandon reason\". The session cannot be finalized",
       "authorize-resume-error": "An error has occurred, {firstName} {lastName} couldn't be allowed to resume his/her Pix certification exam.",
       "bad-request-error": "The data entered was not in the correct format.",
       "certification-candidate": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -24,6 +24,7 @@
       "SESSION_STARTED_CANDIDATE_ALREADY_LINKED_TO_USER": "La session a débuté, vous ne pouvez plus importer une liste de candidats.<br />Si vous souhaitez modifier la liste, vous pouvez inscrire un candidat directement dans le tableau ci-dessous.",
       "SESSION_WITHOUT_STARTED_CERTIFICATION": "Cette session n'a pas débuté, vous ne pouvez pas la finaliser. Vous pouvez néanmoins la supprimer.",
       "SESSION_WITH_ABORT_REASON_ON_COMPLETED_CERTIFICATION_COURSE": "Le champ “Raison de l’abandon” a été renseigné pour un candidat qui a terminé son test de certification entre temps. La session ne peut donc pas être finalisée. Merci de rafraîchir la page avant de finaliser.",
+      "UNTERMINATED_CERTIFICATION_WITHOUT_ABORT_REASON": "Une ou plusieurs certifications non terminées n'ont pas de \"Raison de l’abandon\" renseignées. La session ne peut donc pas être finalisée.",
       "authorize-resume-error": "Une erreur est survenue, {firstName} {lastName} n'a pas pu être autorisé à reprendre son test.",
       "bad-request-error": "Les données que vous avez soumises ne sont pas au bon format.",
       "certification-candidate": {


### PR DESCRIPTION
## :unicorn: Problème
Un scoring est lancé à la fin d'une certification via un `event handler`. S'il y a un crash ou un redemarrage (i.e. MEP) le scoring peut ne pas se faire. Ce n'est pas problematique, il sera fait à la finalisation. Cependant la finalisation est bloqué parce qu'elle attends une raison d'abandon.

## :robot: Proposition
Ne pas bloquer la finalisation en se basant sur le statut de l'assessment plutôt que la date de completion.

## :rainbow: Remarques
Le message d'erreur n'etait pas correctement affiché, c'est maintenant le cas bien qu'il ne devrait plus apparaitre.

## :100: Pour tester
Difficile à reproduire sur une VM
Creer une session avec 2 candidats. Passer une premiere certification avec succes. Pour la seconde, il faut redemarrer/couper l'API juste apres avoir repondu à la derniere question  (en local on peut throw sur ` handle-certification-scoring.js`). 
Il est necessaire d'avoir un assessment.state = 'completed' mais pas de completedAt sur le certification-course (et pas d'assessment-result)
```
select cc.id, cc."completedAt", ar.id ,state, status
from "certification-courses" cc
inner join "assessments" a on a."certificationCourseId" = cc.id
left join "assessment-results" ar on "a".id = ar."assessmentId" 
where "sessionId" in (360782, 362191, 362192)
and "status" is null and state = 'completed';
```
FInaliser, puis publier. 
Verifier sur pix admin que les deux certifications sont scorées et publier

