### PR TITLE
[BUGFIX] corrige la suppression de fichier temporaire après un import siecle (PIX-11118)

### DIFF
--- a/api/src/prescription/learner-management/application/sco-organization-management-controller.js
+++ b/api/src/prescription/learner-management/application/sco-organization-management-controller.js
@@ -1,23 +1,31 @@
 import fs from 'fs/promises';
 import { usecases } from '../domain/usecases/index.js';
+import { logErrorWithCorrelationIds } from '../../../../lib/infrastructure/monitoring-tools.js';
 
-const importOrganizationLearnersFromSIECLE = async function (request, h) {
+const importOrganizationLearnersFromSIECLE = async function (
+  request,
+  h,
+  dependencies = { logErrorWithCorrelationIds },
+) {
   const organizationId = request.params.id;
   const { format } = request.query;
+  try {
+    await usecases.importOrganizationLearnersFromSIECLEFormat({
+      organizationId,
+      payload: request.payload,
+      format,
+      i18n: request.i18n,
+    });
+  } finally {
+    // see https://hapi.dev/api/?v=21.3.3#-routeoptionspayloadoutput
+    // add a catch to avoid an error if unlink fails
+    try {
+      await fs.unlink(request.payload.path);
+    } catch (err) {
+      dependencies.logErrorWithCorrelationIds(err);
+    }
+  }
 
-  await usecases.importOrganizationLearnersFromSIECLEFormat({
-    organizationId,
-    payload: request.payload,
-    format,
-    i18n: request.i18n,
-  });
-  // see https://hapi.dev/api/?v=21.3.3#-routeoptionspayloadoutput
-  request.server.events.on('response', async () => {
-    fs.access(request.payload.path).then(
-      () => fs.unlink(request.payload.path),
-      () => undefined, // nothing to do since file not exists
-    );
-  });
   return h.response(null).code(204);
 };
 

--- a/api/tests/prescription/learner-management/unit/application/sco-organization-management-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/sco-organization-management-controller_test.js
@@ -11,6 +11,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
     const organizationId = 145;
     const payload = { path: 'path-to-file' };
     const format = 'xml';
+    let dependencies;
 
     const request = {
       auth: { credentials: { userId: connectedUserId } },
@@ -20,31 +21,40 @@ describe('Unit | Application | Organizations | organization-controller', functio
     };
 
     beforeEach(function () {
-      sinon.stub(fs, 'access').resolves();
-      sinon.stub(fs, 'unlink');
+      sinon.stub(fs, 'unlink').resolves();
       sinon.stub(usecases, 'importOrganizationLearnersFromSIECLEFormat');
       usecases.importOrganizationLearnersFromSIECLEFormat.resolves();
+      dependencies = { logErrorWithCorrelationIds: sinon.stub() };
     });
 
     it('should delete uploaded file', async function () {
       // given
       request.i18n = getI18n();
-      request.server = {
-        events: {
-          on: sinon.stub().callsFake((_, callback) => {
-            callback();
-          }),
-        },
-      };
       hFake.request = {
         path: '/api/organizations/145/sco-organization-learners/import-siecle',
       };
 
       // when
-      await scoOrganizationManagementController.importOrganizationLearnersFromSIECLE(request, hFake);
+      await scoOrganizationManagementController.importOrganizationLearnersFromSIECLE(request, hFake, dependencies);
 
       // then
       expect(fs.unlink).to.have.been.calledWithExactly(request.payload.path);
+    });
+    it('should not throw if delete uploaded file fails', async function () {
+      // given
+      const error = new Error();
+      fs.unlink.rejects(error);
+      request.i18n = getI18n();
+      hFake.request = {
+        path: '/api/organizations/145/sco-organization-learners/import-siecle',
+      };
+
+      // when
+      await scoOrganizationManagementController.importOrganizationLearnersFromSIECLE(request, hFake, dependencies);
+
+      // then
+      expect(fs.unlink).to.have.been.calledWithExactly(request.payload.path);
+      expect(dependencies.logErrorWithCorrelationIds).to.have.been.calledWith(error);
     });
 
     it('should call the usecase to import organizationLearners', async function () {
@@ -55,7 +65,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       };
 
       // when
-      await scoOrganizationManagementController.importOrganizationLearnersFromSIECLE(request, hFake);
+      await scoOrganizationManagementController.importOrganizationLearnersFromSIECLE(request, hFake, dependencies);
 
       // then
       expect(usecases.importOrganizationLearnersFromSIECLEFormat).to.have.been.calledWithExactly({


### PR DESCRIPTION
## :unicorn: Problème
La suppression de fichier temporaire fait cresher le conteneur si le fichier est déja supprimé.

## :robot: Proposition
Faire le unlink lorsqu'on est sur que le fichier existe encore (juste après le usecase)

## :rainbow: Remarques
Dans le doute on rajoute un catch sur le unlink pour éviter d'avoir une erreur et on en profite pour la logger.

## :100: Pour tester
Uploader un fichier et voir si ca crash sur scalingo