### PR TITLE
[FEATURE] Rediriger vers la page de fin de module (PIX-10471) (PIX-11027)

### DIFF
--- a/mon-pix/app/pods/components/module/grain/component.js
+++ b/mon-pix/app/pods/components/module/grain/component.js
@@ -60,4 +60,9 @@ export default class ModuleGrain extends Component {
       'pix-event-name': `Click sur le bouton passer du grain : ${this.grain.id}`,
     });
   }
+
+  @action
+  terminateAction() {
+    this.args.terminateAction();
+  }
 }

--- a/mon-pix/app/pods/components/module/grain/component.js
+++ b/mon-pix/app/pods/components/module/grain/component.js
@@ -7,11 +7,11 @@ export default class ModuleGrain extends Component {
   @service metrics;
 
   get shouldDisplayContinueButton() {
-    return this.args.canDisplayActionsButton && this.allElementsAreAnswered;
+    return this.args.canMoveToNextGrain && this.allElementsAreAnswered;
   }
 
   get shouldDisplaySkipButton() {
-    return this.args.canDisplayActionsButton && this.args.grain.hasAnswerableElements && !this.allElementsAreAnswered;
+    return this.args.canMoveToNextGrain && this.args.grain.hasAnswerableElements && !this.allElementsAreAnswered;
   }
 
   get allElementsAreAnswered() {

--- a/mon-pix/app/pods/components/module/grain/component.js
+++ b/mon-pix/app/pods/components/module/grain/component.js
@@ -5,17 +5,18 @@ import ModulePassage from '../passage/component';
 
 export default class ModuleGrain extends Component {
   @service metrics;
+  grain = this.args.grain;
 
   get shouldDisplayContinueButton() {
     return this.args.canMoveToNextGrain && this.allElementsAreAnswered;
   }
 
   get shouldDisplaySkipButton() {
-    return this.args.canMoveToNextGrain && this.args.grain.hasAnswerableElements && !this.allElementsAreAnswered;
+    return this.args.canMoveToNextGrain && this.grain.hasAnswerableElements && !this.allElementsAreAnswered;
   }
 
   get allElementsAreAnswered() {
-    return this.args.grain.allElementsAreAnswered;
+    return this.grain.allElementsAreAnswered;
   }
 
   get ariaLiveGrainValue() {
@@ -44,8 +45,8 @@ export default class ModuleGrain extends Component {
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.grain.module.id}`,
-      'pix-event-name': `Click sur le bouton continuer du grain : ${this.args.grain.id}`,
+      'pix-event-action': `Passage du module : ${this.grain.module.id}`,
+      'pix-event-name': `Click sur le bouton continuer du grain : ${this.grain.id}`,
     });
   }
 
@@ -55,8 +56,8 @@ export default class ModuleGrain extends Component {
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.args.grain.module.id}`,
-      'pix-event-name': `Click sur le bouton passer du grain : ${this.args.grain.id}`,
+      'pix-event-action': `Passage du module : ${this.grain.module.id}`,
+      'pix-event-name': `Click sur le bouton passer du grain : ${this.grain.id}`,
     });
   }
 }

--- a/mon-pix/app/pods/components/module/grain/style.scss
+++ b/mon-pix/app/pods/components/module/grain/style.scss
@@ -49,7 +49,7 @@
   }
 
   .grain__footer {
-    background: var(--pix-info-100);
+    background: var(--pix-info-50);
     border-top: 1px solid var(--pix-neutral-500);
   }
 }
@@ -60,7 +60,7 @@
   }
 
   .grain__footer {
-    background: var(--pix-neutral-100);
+    background: var(--pix-info-50);
     border-top: 1px solid var(--pix-neutral-500);
   }
 }

--- a/mon-pix/app/pods/components/module/grain/template.hbs
+++ b/mon-pix/app/pods/components/module/grain/template.hbs
@@ -50,4 +50,12 @@
       </PixButton>
     </footer>
   {{/if}}
+
+  {{#if @shouldDisplayTerminateButton}}
+    <footer class="grain__footer">
+      <PixButton @backgroundColor="primary" @shape="rounded" @triggerAction={{@terminateAction}}>
+        {{t "pages.modulix.buttons.grain.terminate"}}
+      </PixButton>
+    </footer>
+  {{/if}}
 </article>

--- a/mon-pix/app/pods/components/module/passage/component.js
+++ b/mon-pix/app/pods/components/module/passage/component.js
@@ -1,10 +1,11 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
 
 export default class ModulePassage extends Component {
+  @service router;
   @tracked grainsToDisplay = [this.args.module.grains[0]];
-
   static SCROLL_OFFSET_PX = 70;
 
   @action
@@ -52,5 +53,10 @@ export default class ModulePassage extends Component {
     }
 
     return this.grainsToDisplay.length - 1 === index;
+  }
+
+  @action
+  terminateModule() {
+    return this.router.transitionTo('module.recap', this.args.module);
   }
 }

--- a/mon-pix/app/pods/components/module/passage/component.js
+++ b/mon-pix/app/pods/components/module/passage/component.js
@@ -36,6 +36,11 @@ export default class ModulePassage extends Component {
   }
 
   @action
+  grainShouldDisplayTerminateButton(index) {
+    return this.lastIndex === index && !this.hasNextGrain;
+  }
+
+  @action
   grainTransition(grainId) {
     return this.args.module.transitionTexts.find((transition) => transition.grainId === grainId);
   }

--- a/mon-pix/app/pods/components/module/passage/component.js
+++ b/mon-pix/app/pods/components/module/passage/component.js
@@ -31,7 +31,7 @@ export default class ModulePassage extends Component {
   }
 
   @action
-  grainCanDisplayActionsButton(index) {
+  grainCanMoveToNextGrain(index) {
     return this.lastIndex === index && this.hasNextGrain;
   }
 

--- a/mon-pix/app/pods/components/module/passage/template.hbs
+++ b/mon-pix/app/pods/components/module/passage/template.hbs
@@ -11,7 +11,7 @@
         @grain={{grain}}
         @transition={{this.grainTransition grain.id}}
         @submitAnswer={{@submitAnswer}}
-        @canDisplayActionsButton={{this.grainCanDisplayActionsButton index}}
+        @canMoveToNextGrain={{this.grainCanMoveToNextGrain index}}
         @continueAction={{this.addNextGrainToDisplay}}
         @skipAction={{this.addNextGrainToDisplay}}
         @hasJustAppeared={{this.hasGrainJustAppeared index}}

--- a/mon-pix/app/pods/components/module/passage/template.hbs
+++ b/mon-pix/app/pods/components/module/passage/template.hbs
@@ -14,6 +14,8 @@
         @canMoveToNextGrain={{this.grainCanMoveToNextGrain index}}
         @continueAction={{this.addNextGrainToDisplay}}
         @skipAction={{this.addNextGrainToDisplay}}
+        @shouldDisplayTerminateButton={{this.grainShouldDisplayTerminateButton index}}
+        @terminateAction={{this.terminateModule}}
         @hasJustAppeared={{this.hasGrainJustAppeared index}}
       />
     {{/each}}

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { clickByName, visit } from '@1024pix/ember-testing-library';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { currentURL } from '@ember/test-helpers';
 
 module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (hooks) {
   setupApplicationTest(hooks);
@@ -85,6 +86,37 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
         // then
         assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
       });
+    });
+
+    test('should navigate to recap page when terminate is clicked', async function (assert) {
+      // given
+      const text1 = server.create('text', {
+        id: 'elementId-1',
+        type: 'texts',
+        content: 'content-1',
+      });
+      const grain1 = server.create('grain', {
+        id: 'grainId-1',
+        title: 'title grain 1',
+        elements: [text1],
+      });
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [grain1],
+      });
+
+      // when
+      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+      // then
+      assert.dom(screen.getByRole('button', { name: 'Terminer' })).exists({ count: 1 });
+
+      // when
+      await clickByName('Terminer');
+
+      // then
+      assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/recap');
     });
   });
 });

--- a/mon-pix/tests/integration/components/module/grain_test.js
+++ b/mon-pix/tests/integration/components/module/grain_test.js
@@ -189,7 +189,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // when
       const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canDisplayActionsButton={{true}} />`);
+            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} />`);
 
       // then
       assert
@@ -197,7 +197,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
         .doesNotExist();
     });
 
-    module('when canDisplayActionsButton is true', function () {
+    module('when canMoveToNextGrain is true', function () {
       test('should display continue button', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
@@ -211,13 +211,13 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
         // when
         const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canDisplayActionsButton={{true}} />`);
+            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} />`);
 
         // then
         assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists();
       });
     });
-    module('when canDisplayActionsButton is false', function () {
+    module('when canMoveToNextGrain is false', function () {
       test('should not display continue button', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
@@ -229,7 +229,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
         // when
         const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canDisplayActionsButton={{false}} />`);
+            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} />`);
 
         // then
         assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
@@ -238,7 +238,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
   });
 
   module('when at least one element has not been answered', function () {
-    module('when canDisplayActionsButton is true', function () {
+    module('when canMoveToNextGrain is true', function () {
       test('should not display continue button', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
@@ -250,7 +250,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
         // when
         const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canDisplayActionsButton={{true}} />`);
+            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} />`);
 
         // then
         assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
@@ -267,14 +267,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
         // when
         const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canDisplayActionsButton={{true}} />`);
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} />`);
 
         // then
         assert.dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') })).exists();
       });
     });
 
-    module('when canDisplayActionsButton is false', function () {
+    module('when canMoveToNextGrain is false', function () {
       test('should not display continue button', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
@@ -286,7 +286,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
         // when
         const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canDisplayActionsButton={{false}} />`);
+            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} />`);
 
         // then
         assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
@@ -303,7 +303,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
         // when
         const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canDisplayActionsButton={{false}} />`);
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} />`);
 
         // then
         assert
@@ -329,7 +329,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // when
       await render(
-        hbs`<Module::Grain @grain={{this.grain}} @canDisplayActionsButton={{true}} @continueAction={{this.continueAction}} />`,
+        hbs`<Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @continueAction={{this.continueAction}} />`,
       );
       await clickByName('Continuer');
 
@@ -363,7 +363,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // when
       await render(
-        hbs`<Module::Grain @grain={{this.grain}} @canDisplayActionsButton={{true}} @continueAction={{this.continueAction}} @skipAction={{this.skipAction}} />`,
+        hbs`<Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @continueAction={{this.continueAction}} @skipAction={{this.skipAction}} />`,
       );
       await clickByName(this.intl.t('pages.modulix.buttons.grain.skip'));
 

--- a/mon-pix/tests/integration/components/module/grain_test.js
+++ b/mon-pix/tests/integration/components/module/grain_test.js
@@ -14,7 +14,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
     this.set('grain', grain);
 
     // when
-    const screen = await render(hbs`<Module::Grain @grain={{this.grain}} />`);
+    const screen = await render(hbs`
+        <Module::Grain @grain={{this.grain}} />`);
 
     // then
     assert.ok(screen.getByRole('heading', { name: grain.title, level: 2 }));
@@ -30,7 +31,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
       this.set('transition', transition);
 
       // when
-      const screen = await render(hbs`<Module::Grain @grain={{this.grain}} @transition={{this.transition}} />`);
+      const screen = await render(hbs`
+          <Module::Grain @grain={{this.grain}} @transition={{this.transition}} />`);
 
       // then
       assert.ok(screen.getByText('transition text'));
@@ -45,7 +47,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
       this.set('grain', grain);
 
       // when
-      await render(hbs`<Module::Grain @grain={{this.grain}} />`);
+      await render(hbs`
+          <Module::Grain @grain={{this.grain}} />`);
 
       // then
       assert.dom('.grain__header').doesNotExist();
@@ -66,7 +69,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
       this.set('grain', grain);
 
       // when
-      const screen = await render(hbs`<Module::Grain @grain={{this.grain}} />`);
+      const screen = await render(hbs`
+          <Module::Grain @grain={{this.grain}} />`);
 
       // then
       assert.ok(screen.getByText('element content'));
@@ -88,7 +92,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
       this.set('grain', grain);
 
       // when
-      const screen = await render(hbs`<Module::Grain @grain={{this.grain}} />`);
+      const screen = await render(hbs`
+          <Module::Grain @grain={{this.grain}} />`);
 
       // then
       assert.strictEqual(screen.getAllByRole('radio').length, qcuElement.proposals.length);
@@ -143,7 +148,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
       this.set('grain', grain);
 
       // when
-      const screen = await render(hbs`<Module::Grain @grain={{this.grain}} />`);
+      const screen = await render(hbs`
+          <Module::Grain @grain={{this.grain}} />`);
 
       // then
       assert.ok(screen);
@@ -168,7 +174,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
       this.set('grain', grain);
 
       // when
-      const screen = await render(hbs`<Module::Grain @grain={{this.grain}} />`);
+      const screen = await render(hbs`
+          <Module::Grain @grain={{this.grain}} />`);
 
       // then
       assert.ok(screen.getByRole('img', { name: 'alt text' }).hasAttribute('src', url));
@@ -189,7 +196,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // when
       const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} />`);
+          <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} />`);
 
       // then
       assert
@@ -202,7 +209,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const element = store.createRecord('element', { type: 'qcus', isAnswerable: true });
-        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+        const grain = store.createRecord('grain', { title: '1st Grain title', elements: [element] });
+        store.createRecord('module', { grains: [grain] });
         this.set('grain', grain);
 
         const correction = store.createRecord('correction-response');
@@ -222,7 +230,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const element = store.createRecord('element', { type: 'qcus', isAnswerable: true });
-        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+        const grain = store.createRecord('grain', { title: '1st Grain title', elements: [element] });
+        store.createRecord('module', { grains: [grain] });
         this.set('grain', grain);
 
         assert.false(grain.allElementsAreAnswered);
@@ -260,14 +269,15 @@ module('Integration | Component | Module | Grain', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const element = store.createRecord('element', { type: 'qcus', isAnswerable: true });
-        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+        const grain = store.createRecord('grain', { title: '1st Grain title', elements: [element] });
+        store.createRecord('module', { grains: [grain] });
         this.set('grain', grain);
 
         assert.false(grain.allElementsAreAnswered);
 
         // when
         const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} />`);
+            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} />`);
 
         // then
         assert.dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') })).exists();
@@ -297,13 +307,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
         const store = this.owner.lookup('service:store');
         const element = store.createRecord('element', { type: 'qcus', isAnswerable: true });
         const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+        store.createRecord('module', { grains: [grain] });
         this.set('grain', grain);
 
         assert.false(grain.allElementsAreAnswered);
 
         // when
         const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} />`);
+            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} />`);
 
         // then
         assert
@@ -318,7 +329,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
       const element = store.createRecord('text', { type: 'texts', isAnswerable: false });
-      const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+      const grain = store.createRecord('grain', { title: '1st Grain title', elements: [element] });
       store.createRecord('module', { id: 'module-id', grains: [grain] });
       this.set('grain', grain);
 
@@ -329,7 +340,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // when
       await render(
-        hbs`<Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @continueAction={{this.continueAction}} />`,
+        hbs`
+            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}}
+                           @continueAction={{this.continueAction}} />`,
       );
       await clickByName('Continuer');
 
@@ -363,7 +376,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // when
       await render(
-        hbs`<Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @continueAction={{this.continueAction}} @skipAction={{this.skipAction}} />`,
+        hbs`
+            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}}
+                           @continueAction={{this.continueAction}} @skipAction={{this.skipAction}} />`,
       );
       await clickByName(this.intl.t('pages.modulix.buttons.grain.skip'));
 
@@ -376,6 +391,67 @@ module('Integration | Component | Module | Grain', function (hooks) {
         'pix-event-name': `Click sur le bouton passer du grain : ${this.grain.id}`,
       });
       assert.ok(true);
+    });
+  });
+
+  module('when shouldDisplayTerminateButton is true', function () {
+    test('should display the terminate button', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const element = store.createRecord('text', { type: 'texts', isAnswerable: false });
+      const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+      this.set('grain', grain);
+
+      // when
+      const screen = await render(hbs`
+          <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{true}} />`);
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.terminate') })).exists();
+    });
+
+    module('when terminateAction is called', function () {
+      test('should call terminateAction passed in argument', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = store.createRecord('qcu', { type: 'qcus', isAnswerable: true });
+        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+        this.set('grain', grain);
+
+        const terminateActionStub = sinon.stub();
+        this.set('terminateAction', terminateActionStub);
+
+        // when
+        await render(
+          hbs`
+            <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{true}}
+                           @terminateAction={{this.terminateAction}} />`,
+        );
+        await clickByName(this.intl.t('pages.modulix.buttons.grain.terminate'));
+
+        // then
+        sinon.assert.calledOnce(terminateActionStub);
+        assert.ok(true);
+      });
+    });
+  });
+
+  module('when shouldDisplayTerminateButton is false', function () {
+    test('should not display the terminate button', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const element = store.createRecord('text', { type: 'texts', isAnswerable: false });
+      const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+      this.set('grain', grain);
+
+      // when
+      const screen = await render(hbs`
+          <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{false}} />`);
+
+      // then
+      assert
+        .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.terminate') }))
+        .doesNotExist();
     });
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1194,7 +1194,8 @@
         },
         "grain": {
           "continue": "Continue",
-          "skip": "Skip"
+          "skip": "Skip",
+          "terminate": "Terminate"
         }
       },
       "details": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1194,7 +1194,8 @@
         },
         "grain": {
           "continue": "Continuer",
-          "skip": "Passer"
+          "skip": "Passer",
+          "terminate": "Terminer"
         }
       },
       "details": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1194,7 +1194,8 @@
         },
         "grain": {
           "continue": "Ga verder met",
-          "skip": "Ga naar"
+          "skip": "Ga naar",
+          "terminate": "Eindigen"
         }
       },
       "details": {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, la page de `/recap` a été implémentée mais elle n'est accessible que via son url `/modules/mon-module/recap`. Nous voulons qu'elle puisse être accessible à la fin d'un passage.

## :robot: Proposition
Nous ajoutons un bouton "terminer" sur le dernier grain d'un module.
Dans le composant `Module::Grain`, nous avons ajouté une nouvelle props `shouldDisplayTerminateButton`.
Et afin de clarifier le rôle de la props `canDisplayActionButtons`, nous l'avons renommée `canMoveToNextGrain`.

## :rainbow: Remarques
Vu avec Quentin, nous avons aussi changé la couleur de fond du footer des grains. Nous sommes passés d'un `pix-info-100` à un `pix-info-50`.

Actuellement, c'est le composant `Module::Grain` qui push les event `skip` et `continue` vers _Matomo_.
Ce devrait être le rôle du parent.

## :100: Pour tester

### Cas où le dernier élément du dernier grain n'est pas answerable (texte, image, etc.)
- se rendre sur le module [Mots de passe sécurisé](https://app-pr8006.review.pix.fr/modules/mots-de-passe-securises/passage)
- aller jusqu'à la fin du module
- vérifier que le bouton `terminer` est bien présent
- vérifier que le bouton `continuer` est absent
- vérifier qu'en cliquant sur `terminer`, nous sommes redirigé vers la page _/recap_ de ce module

### Cas où le dernier élément du dernier grain est answerable (qcu, qrocm)
- se rendre sur le module [Bien écrire son adresse mail](https://app-pr8006.review.pix.fr/modules/bien-ecrire-son-adresse-mail/passage)
- aller jusqu'à la fin du module
- vérifier que le bouton `terminer` est bien présent
- vérifier que le bouton `continuer` est absent
- vérifier que le bouton `passer` est absent
- vérifier qu'en cliquant sur `terminer`, nous sommes redirigé vers la page _/recap_ de ce module