### PR TITLE
[TECH] Ajouter la gestion des erreurs pour la librairie node-openid-client (PIX-11069)

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -309,10 +309,6 @@ function _mapToHttpError(error) {
     return new HttpErrors.BadRequestError(error.message);
   }
 
-  if (error instanceof DomainErrors.UnexpectedOidcStateError) {
-    return new HttpErrors.BadRequestError(error.message);
-  }
-
   if (error instanceof DomainErrors.OidcMissingFieldsError) {
     return new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta);
   }

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -321,10 +321,6 @@ function _mapToHttpError(error) {
     return new HttpErrors.ServiceUnavailableError(error.message, error.code, error.meta);
   }
 
-  if (error instanceof DomainErrors.OidcInvokingTokenEndpointError) {
-    return new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta);
-  }
-
   if (error instanceof DomainErrors.InvalidIdentityProviderError) {
     return new HttpErrors.BadRequestError(error.message);
   }

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -317,10 +317,6 @@ function _mapToHttpError(error) {
     return new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta);
   }
 
-  if (error instanceof DomainErrors.OidcUserInfoFormatError) {
-    return new HttpErrors.ServiceUnavailableError(error.message, error.code, error.meta);
-  }
-
   if (error instanceof DomainErrors.InvalidIdentityProviderError) {
     return new HttpErrors.BadRequestError(error.message);
   }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -963,14 +963,6 @@ class OidcUserInfoFormatError extends DomainError {
   }
 }
 
-class OidcInvokingTokenEndpointError extends DomainError {
-  constructor(message = 'Error in retrieving tokens from the partner.', code, meta) {
-    super(message);
-    this.code = code;
-    this.meta = meta;
-  }
-}
-
 class InvalidIdentityProviderError extends DomainError {
   constructor(identityProvider) {
     const message = `Identity provider ${identityProvider} is not supported.`;
@@ -1205,7 +1197,6 @@ export {
   NotFoundError,
   NotImplementedError,
   ObjectValidationError,
-  OidcInvokingTokenEndpointError,
   OidcMissingFieldsError,
   OidcUserInfoFormatError,
   OrganizationAlreadyExistError,

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -933,12 +933,6 @@ class UnableToAttachChildOrganizationToParentOrganizationError extends DomainErr
   }
 }
 
-class UnexpectedOidcStateError extends DomainError {
-  constructor(message = 'La valeur du paramètre state reçu ne correspond pas à celui envoyé.') {
-    super(message);
-  }
-}
-
 class OidcMissingFieldsError extends DomainError {
   constructor(
     message = 'Mandatory information returned by the identify provider about the user is missing.',
@@ -1217,7 +1211,6 @@ export {
   UnableToAttachChildOrganizationToParentOrganizationError,
   UncancellableCertificationCenterInvitationError,
   UncancellableOrganizationInvitationError,
-  UnexpectedOidcStateError,
   UnexpectedUserAccountError,
   UnknownCountryForStudentEnrolmentError,
   UserAlreadyExistsWithAuthenticationMethodError,

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -951,18 +951,6 @@ class OidcMissingFieldsError extends DomainError {
   }
 }
 
-class OidcUserInfoFormatError extends DomainError {
-  constructor(
-    message = 'The user information returned by your identity provider is not in the expected format.',
-    code,
-    meta,
-  ) {
-    super(message);
-    this.code = code;
-    this.meta = meta;
-  }
-}
-
 class InvalidIdentityProviderError extends DomainError {
   constructor(identityProvider) {
     const message = `Identity provider ${identityProvider} is not supported.`;
@@ -1198,7 +1186,6 @@ export {
   NotImplementedError,
   ObjectValidationError,
   OidcMissingFieldsError,
-  OidcUserInfoFormatError,
   OrganizationAlreadyExistError,
   OrganizationArchivedError,
   OrganizationLearnerAlreadyLinkedToInvalidUserError,

--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -285,21 +285,12 @@ class OidcAuthenticationService {
   }
 
   async _getUserInfoFromEndpoint({ accessToken }) {
-    const userInfo = await this.client.userinfo(accessToken);
+    let userInfo;
 
-    if (!userInfo || typeof userInfo !== 'object') {
-      const message = `Les informations utilisateur renvoyées par votre fournisseur d'identité ${this.organizationName} ne sont pas au format attendu.`;
-      const dataToLog = {
-        message,
-        typeOfUserInfo: typeof userInfo,
-        userInfo,
-      };
-      monitoringTools.logErrorWithCorrelationIds({ message: dataToLog });
-      const error = OIDC_ERRORS.USER_INFO.badResponseFormat;
-      const meta = {
-        shortCode: error.shortCode,
-      };
-      throw new OidcUserInfoFormatError(message, error.code, meta);
+    try {
+      userInfo = await this.client.userinfo(accessToken);
+    } catch (error) {
+      throw new OidcError({ message: error.message });
     }
 
     const missingRequiredClaims = this.#findMissingRequiredClaims(userInfo);

--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -4,7 +4,7 @@ import { randomUUID } from 'crypto';
 import { Issuer } from 'openid-client';
 
 import { logger } from '../../../infrastructure/logger.js';
-import { OidcMissingFieldsError, OidcUserInfoFormatError } from '../../errors.js';
+import { OidcMissingFieldsError } from '../../errors.js';
 import { AuthenticationMethod } from '../../models/AuthenticationMethod.js';
 import { AuthenticationSessionContent } from '../../models/AuthenticationSessionContent.js';
 import { config } from '../../../../src/shared/config.js';

--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -158,7 +158,13 @@ class OidcAuthenticationService {
   }
 
   async exchangeCodeForTokens({ code, nonce, state, sessionState }) {
-    const tokenSet = await this.client.callback(this.redirectUri, { code, state }, { nonce, state: sessionState });
+    let tokenSet;
+
+    try {
+      tokenSet = await this.client.callback(this.redirectUri, { code, state }, { nonce, state: sessionState });
+    } catch (error) {
+      throw new OidcError({ message: error.message });
+    }
 
     const {
       access_token: accessToken,

--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -12,6 +12,7 @@ import { DomainTransaction } from '../../../infrastructure/DomainTransaction.js'
 import { monitoringTools } from '../../../infrastructure/monitoring-tools.js';
 import { OIDC_ERRORS } from '../../constants.js';
 import { temporaryStorage } from '../../../infrastructure/temporary-storage/index.js';
+import { OidcError } from '../../../../src/shared/domain/errors.js';
 
 const DEFAULT_REQUIRED_PROPERTIES = ['clientId', 'clientSecret', 'authenticationUrl', 'userInfoUrl', 'tokenUrl'];
 const DEFAULT_SCOPE = 'openid profile';
@@ -188,7 +189,13 @@ class OidcAuthenticationService {
       Object.assign(authorizationParameters, this.extraAuthorizationUrlParameters);
     }
 
-    const redirectTarget = this.client.authorizationUrl(authorizationParameters);
+    let redirectTarget;
+
+    try {
+      redirectTarget = this.client.authorizationUrl(authorizationParameters);
+    } catch (error) {
+      throw new OidcError({ message: error.message });
+    }
 
     return { redirectTarget, state, nonce };
   }

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -4,6 +4,7 @@ import * as DomainErrors from '../domain/errors.js';
 import {
   AutonomousCourseRequiresATargetProfileWithSimplifiedAccessError,
   EntityValidationError,
+  OidcError,
   TargetProfileRequiresToBeLinkedToAutonomousCourseOrganization,
 } from '../domain/errors.js';
 import jsonapiSerializer from 'jsonapi-serializer';
@@ -134,6 +135,10 @@ function _mapToHttpError(error) {
 
   if (error instanceof CsvWithNoSessionDataError) {
     return new HttpErrors.UnprocessableEntityError(error.message, error.code);
+  }
+
+  if (error instanceof OidcError) {
+    return new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta);
   }
 
   return new HttpErrors.BaseHttpError(error.message);

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -5,9 +5,49 @@ class DomainError extends Error {
   }
 }
 
-class ForbiddenAccess extends DomainError {
-  constructor(message = 'Accès non autorisé.') {
+class AlreadyExistingEntityError extends DomainError {
+  constructor(message = 'L’entité existe déjà.') {
     super(message);
+  }
+}
+
+class AssessmentEndedError extends DomainError {
+  constructor(message = 'Evaluation terminée.') {
+    super(message);
+  }
+
+  getErrorMessage() {
+    return {
+      data: {
+        error: ["L'évaluation est terminée. Nous n'avons plus de questions à vous poser."],
+      },
+    };
+  }
+}
+
+class AssessmentResultNotCreatedError extends DomainError {
+  constructor(message = "L'assessment result n'a pas pu être généré.") {
+    super(message);
+  }
+}
+
+class AutonomousCourseRequiresATargetProfileWithSimplifiedAccessError extends DomainError {
+  constructor() {
+    super('Autonomous course requires a target profile with simplified access.');
+  }
+}
+
+class CertificationAttestationGenerationError extends DomainError {
+  constructor(message = "Une erreur est survenue durant la génération de l'attestation.") {
+    super(message);
+  }
+}
+
+class CsvImportError extends DomainError {
+  constructor(code, meta) {
+    super('An error occurred during CSV import');
+    this.code = code;
+    this.meta = meta;
   }
 }
 
@@ -33,16 +73,8 @@ class EntityValidationError extends DomainError {
   }
 }
 
-class CsvImportError extends DomainError {
-  constructor(code, meta) {
-    super('An error occurred during CSV import');
-    this.code = code;
-    this.meta = meta;
-  }
-}
-
-class AlreadyExistingEntityError extends DomainError {
-  constructor(message = 'L’entité existe déjà.') {
+class ForbiddenAccess extends DomainError {
+  constructor(message = 'Accès non autorisé.') {
     super(message);
   }
 }
@@ -79,38 +111,6 @@ class InvalidTemporaryKeyError extends DomainError {
   }
 }
 
-class NotFoundError extends DomainError {
-  constructor(message = 'Erreur, ressource introuvable.') {
-    super(message);
-  }
-}
-
-class AssessmentEndedError extends DomainError {
-  constructor(message = 'Evaluation terminée.') {
-    super(message);
-  }
-
-  getErrorMessage() {
-    return {
-      data: {
-        error: ["L'évaluation est terminée. Nous n'avons plus de questions à vous poser."],
-      },
-    };
-  }
-}
-
-class AssessmentResultNotCreatedError extends DomainError {
-  constructor(message = "L'assessment result n'a pas pu être généré.") {
-    super(message);
-  }
-}
-
-class MissingAssessmentId extends DomainError {
-  constructor(message = 'AssessmentId manquant ou incorrect') {
-    super(message);
-  }
-}
-
 class LanguageNotSupportedError extends DomainError {
   constructor(languageCode) {
     super(`Given language is not supported : "${languageCode}"`);
@@ -135,14 +135,14 @@ class LocaleNotSupportedError extends DomainError {
   }
 }
 
-class UserNotAuthorizedToAccessEntityError extends DomainError {
-  constructor(message = 'User is not authorized to access ressource') {
+class MissingAssessmentId extends DomainError {
+  constructor(message = 'AssessmentId manquant ou incorrect') {
     super(message);
   }
 }
 
-class CertificationAttestationGenerationError extends DomainError {
-  constructor(message = "Une erreur est survenue durant la génération de l'attestation.") {
+class MissingBadgeCriterionError extends DomainError {
+  constructor(message = 'Vous devez définir au moins un critère pour créer ce résultat thématique.') {
     super(message);
   }
 }
@@ -154,15 +154,9 @@ class NoCertificationAttestationForDivisionError extends DomainError {
   }
 }
 
-class MissingBadgeCriterionError extends DomainError {
-  constructor(message = 'Vous devez définir au moins un critère pour créer ce résultat thématique.') {
+class NotFoundError extends DomainError {
+  constructor(message = 'Erreur, ressource introuvable.') {
     super(message);
-  }
-}
-
-class AutonomousCourseRequiresATargetProfileWithSimplifiedAccessError extends DomainError {
-  constructor() {
-    super('Autonomous course requires a target profile with simplified access.');
   }
 }
 
@@ -172,27 +166,33 @@ class TargetProfileRequiresToBeLinkedToAutonomousCourseOrganization extends Doma
   }
 }
 
+class UserNotAuthorizedToAccessEntityError extends DomainError {
+  constructor(message = 'User is not authorized to access ressource') {
+    super(message);
+  }
+}
+
 export {
   DomainError,
   AlreadyExistingEntityError,
   AssessmentEndedError,
   AssessmentResultNotCreatedError,
-  ForbiddenAccess,
-  EntityValidationError,
+  AutonomousCourseRequiresATargetProfileWithSimplifiedAccessError,
   CertificationAttestationGenerationError,
   CsvImportError,
+  EntityValidationError,
+  ForbiddenAccess,
   InvalidExternalUserTokenError,
   InvalidResultRecipientTokenError,
   InvalidSessionResultTokenError,
   InvalidTemporaryKeyError,
-  MissingAssessmentId,
-  NotFoundError,
-  UserNotAuthorizedToAccessEntityError,
-  NoCertificationAttestationForDivisionError,
   LanguageNotSupportedError,
   LocaleFormatError,
   LocaleNotSupportedError,
+  MissingAssessmentId,
   MissingBadgeCriterionError,
-  AutonomousCourseRequiresATargetProfileWithSimplifiedAccessError,
+  NoCertificationAttestationForDivisionError,
+  NotFoundError,
   TargetProfileRequiresToBeLinkedToAutonomousCourseOrganization,
+  UserNotAuthorizedToAccessEntityError,
 };

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -160,6 +160,14 @@ class NotFoundError extends DomainError {
   }
 }
 
+class OidcError extends DomainError {
+  constructor({ code, message, meta }) {
+    super(message);
+    this.code = code;
+    this.meta = meta;
+  }
+}
+
 class TargetProfileRequiresToBeLinkedToAutonomousCourseOrganization extends DomainError {
   constructor() {
     super('Target profile requires to be linked to autonomous course organization.');
@@ -193,6 +201,7 @@ export {
   MissingBadgeCriterionError,
   NoCertificationAttestationForDivisionError,
   NotFoundError,
+  OidcError,
   TargetProfileRequiresToBeLinkedToAutonomousCourseOrganization,
   UserNotAuthorizedToAccessEntityError,
 };

--- a/api/tests/shared/unit/application/error-manager_test.js
+++ b/api/tests/shared/unit/application/error-manager_test.js
@@ -8,6 +8,7 @@ import {
   UserNotAuthorizedToAccessEntityError,
   CertificationAttestationGenerationError,
   NoCertificationAttestationForDivisionError,
+  OidcError,
 } from '../../../../src/shared/domain/errors.js';
 
 import { HttpErrors, UnauthorizedError } from '../../../../src/shared/application/http-errors.js';
@@ -218,6 +219,25 @@ describe('Shared | Unit | Application | ErrorManager', function () {
             { locale: 'nl-BE' },
           );
         });
+      });
+    });
+
+    context('when handling an OidcError', function () {
+      it('maps to UnprocessableEntityError', async function () {
+        // given
+        const error = new OidcError({ code: 'OIDC_ERROR_CODE', message: 'an oidc error occurred' });
+        sinon.stub(HttpErrors, 'UnprocessableEntityError');
+        const params = { request: {}, h: hFake, error };
+
+        // when
+        await handle(params.request, params.h, params.error);
+
+        // then
+        expect(HttpErrors.UnprocessableEntityError).to.have.been.calledWithExactly(
+          'an oidc error occurred',
+          'OIDC_ERROR_CODE',
+          undefined,
+        );
       });
     });
 

--- a/api/tests/shared/unit/domain/errors_test.js
+++ b/api/tests/shared/unit/domain/errors_test.js
@@ -1,5 +1,6 @@
-import * as errors from '../../../../src/shared/domain/errors.js';
 import { expect } from '../../../test-helper.js';
+
+import * as errors from '../../../../src/shared/domain/errors.js';
 
 describe('Unit | Shared | Domain | Errors', function () {
   it('should export NotFoundError', function () {
@@ -12,5 +13,33 @@ describe('Unit | Shared | Domain | Errors', function () {
 
   it('should export NoCertificationAttestationForDivisionError', function () {
     expect(errors.NoCertificationAttestationForDivisionError).to.exist;
+  });
+
+  context('OidcError', function () {
+    it('exports "OidcError" class', function () {
+      // then
+      expect(errors.OidcError).to.exist;
+      expect(errors.OidcError.prototype).to.be.instanceOf(errors.DomainError);
+    });
+
+    context('when an instance of "OidcError" is created', function () {
+      it('contains "message", "code" and "meta" attributes', function () {
+        // given
+        const code = 'OIDC_ERROR_CODE';
+        const message = 'An error occurred';
+        const meta = { data: 'data' };
+
+        // when
+        const error = new errors.OidcError({ code, message, meta });
+
+        // then
+        expect(error).to.have.property('code');
+        expect(error.code).to.equal('OIDC_ERROR_CODE');
+        expect(error).to.have.property('message');
+        expect(error.message).to.equal('An error occurred');
+        expect(error).to.have.property('meta');
+        expect(error.meta).to.deep.equal({ data: 'data' });
+      });
+    });
   });
 });

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -19,7 +19,6 @@ import {
   CandidateNotAuthorizedToResumeCertificationTestError,
   UncancellableOrganizationInvitationError,
   OidcMissingFieldsError,
-  OidcUserInfoFormatError,
   OrganizationLearnerAlreadyLinkedToInvalidUserError,
   OrganizationLearnerCannotBeDissociatedError,
   UserShouldNotBeReconciledOnAnotherAccountError,
@@ -455,23 +454,6 @@ describe('Unit | Application | ErrorManager', function () {
 
         // then
         expect(HttpErrors.UnprocessableEntityError).to.have.been.calledWithExactly(
-          error.message,
-          error.code,
-          error.meta,
-        );
-      });
-
-      it('instantiates ServiceUnavailableError when OidcUserInfoFormatError', async function () {
-        // given
-        const error = new OidcUserInfoFormatError('Some message', 'someCode', 'someMetaData');
-        sinon.stub(HttpErrors, 'ServiceUnavailableError');
-        const params = { request: {}, h: hFake, error };
-
-        // when
-        await handle(params.request, params.h, params.error);
-
-        // then
-        expect(HttpErrors.ServiceUnavailableError).to.have.been.calledWithExactly(
           error.message,
           error.code,
           error.meta,

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -18,7 +18,6 @@ import {
   CandidateNotAuthorizedToJoinSessionError,
   CandidateNotAuthorizedToResumeCertificationTestError,
   UncancellableOrganizationInvitationError,
-  OidcInvokingTokenEndpointError,
   OidcMissingFieldsError,
   OidcUserInfoFormatError,
   OrganizationLearnerAlreadyLinkedToInvalidUserError,
@@ -473,23 +472,6 @@ describe('Unit | Application | ErrorManager', function () {
 
         // then
         expect(HttpErrors.ServiceUnavailableError).to.have.been.calledWithExactly(
-          error.message,
-          error.code,
-          error.meta,
-        );
-      });
-
-      it('instantiates UnprocessableEntityError when OidcInvokingTokenEndpointError', async function () {
-        // given
-        const error = new OidcInvokingTokenEndpointError('Some message', 'someCode', 'someMetaData');
-        sinon.stub(HttpErrors, 'UnprocessableEntityError');
-        const params = { request: {}, h: hFake, error };
-
-        // when
-        await handle(params.request, params.h, params.error);
-
-        // then
-        expect(HttpErrors.UnprocessableEntityError).to.have.been.calledWithExactly(
           error.message,
           error.code,
           error.meta,

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -26,7 +26,6 @@ import {
   CertificationEndedByFinalizationError,
   CampaignTypeError,
   InvalidJuryLevelError,
-  UnexpectedOidcStateError,
   InvalidIdentityProviderError,
   SendingEmailToInvalidDomainError,
   SendingEmailToInvalidEmailAddressError,
@@ -402,19 +401,6 @@ describe('Unit | Application | ErrorManager', function () {
 
         // then
         expect(HttpErrors.ConflictError).to.have.been.calledWithExactly(error.message);
-      });
-
-      it('should instantiate BadRequestError when UnexpectedOidcStateError', async function () {
-        // given
-        const error = new UnexpectedOidcStateError();
-        sinon.stub(HttpErrors, 'BadRequestError');
-        const params = { request: {}, h: hFake, error };
-
-        // when
-        await handle(params.request, params.h, params.error);
-
-        // then
-        expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly(error.message);
       });
 
       it('should instantiate BadRequestError when InvalidIdentityProviderError', async function () {

--- a/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
@@ -1,6 +1,6 @@
 import { Issuer } from 'openid-client';
 
-import { expect, sinon, catchErr } from '../../../../test-helper.js';
+import { expect, sinon, catchErr, catchErrSync } from '../../../../test-helper.js';
 
 import { config as settings } from '../../../../../lib/config.js';
 import { OidcAuthenticationService } from '../../../../../lib/domain/services/authentication/oidc-authentication-service.js';
@@ -21,6 +21,7 @@ import * as OidcIdentityProviders from '../../../../../lib/domain/constants/oidc
 import { logger } from '../../../../../lib/infrastructure/logger.js';
 import { monitoringTools } from '../../../../../lib/infrastructure/monitoring-tools.js';
 import { OIDC_ERRORS } from '../../../../../lib/domain/constants.js';
+import { OidcError } from '../../../../../src/shared/domain/errors.js';
 
 describe('Unit | Domain | Services | oidc-authentication-service', function () {
   describe('constructor', function () {
@@ -386,6 +387,40 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         scope: 'openid profile',
         state,
         realm: '/individu',
+      });
+    });
+
+    context('when generating the authorization url fails', function () {
+      it('throws an error', async function () {
+        // given
+        const clientId = Symbol('clientId');
+        const clientSecret = Symbol('clientSecret');
+        const configKey = 'identityProviderConfigKey';
+        const identityProvider = Symbol('identityProvider');
+        const redirectUri = Symbol('redirectUri');
+        const openidConfigurationUrl = Symbol('openidConfigurationUrl');
+        sinon.stub(settings, 'identityProviderConfigKey').value({});
+        const Client = sinon
+          .stub()
+          .returns({ authorizationUrl: sinon.stub().throws(new Error('Fails to generate authorization url')) });
+        sinon.stub(Issuer, 'discover').resolves({ Client });
+
+        const oidcAuthenticationService = new OidcAuthenticationService({
+          clientId,
+          clientSecret,
+          configKey,
+          identityProvider,
+          redirectUri,
+          openidConfigurationUrl,
+        });
+        await oidcAuthenticationService.createClient();
+
+        // when
+        const error = catchErrSync(oidcAuthenticationService.getAuthenticationUrl, oidcAuthenticationService)();
+
+        // then
+        expect(error).to.be.instanceOf(OidcError);
+        expect(error.message).to.be.equal('Fails to generate authorization url');
       });
     });
   });

--- a/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
@@ -5,15 +5,10 @@ import { expect, sinon, catchErr, catchErrSync } from '../../../../test-helper.j
 import { config as settings } from '../../../../../lib/config.js';
 import { OidcAuthenticationService } from '../../../../../lib/domain/services/authentication/oidc-authentication-service.js';
 import jsonwebtoken from 'jsonwebtoken';
-import { httpAgent } from '../../../../../lib/infrastructure/http/http-agent.js';
 
 import { AuthenticationSessionContent } from '../../../../../lib/domain/models/AuthenticationSessionContent.js';
 
-import {
-  InvalidExternalAPIResponseError,
-  OidcMissingFieldsError,
-  OidcUserInfoFormatError,
-} from '../../../../../lib/domain/errors.js';
+import { OidcMissingFieldsError } from '../../../../../lib/domain/errors.js';
 import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';
 import { UserToCreate } from '../../../../../lib/domain/models/UserToCreate.js';
 import { AuthenticationMethod } from '../../../../../lib/domain/models/AuthenticationMethod.js';

--- a/api/tests/unit/domain/usecases/authentication/authenticate-oidc-user_test.js
+++ b/api/tests/unit/domain/usecases/authentication/authenticate-oidc-user_test.js
@@ -1,10 +1,7 @@
-import { catchErr, expect, sinon } from '../../../../test-helper.js';
+import { expect, sinon } from '../../../../test-helper.js';
 
-import { PAYSDELALOIRE, POLE_EMPLOI } from '../../../../../lib/domain/constants/oidc-identity-providers.js';
+import { POLE_EMPLOI } from '../../../../../lib/domain/constants/oidc-identity-providers.js';
 
-import { logger } from '../../../../../lib/infrastructure/logger.js';
-
-import { UnexpectedOidcStateError } from '../../../../../lib/domain/errors.js';
 import { authenticateOidcUser } from '../../../../../lib/domain/usecases/authentication/authenticate-oidc-user.js';
 import { AuthenticationSessionContent } from '../../../../../lib/domain/models/AuthenticationSessionContent.js';
 import { AuthenticationMethod } from '../../../../../lib/domain/models/AuthenticationMethod.js';
@@ -20,7 +17,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
 
     beforeEach(function () {
       oidcAuthenticationService = {
-        identityProvider: PAYSDELALOIRE.code,
+        identityProvider: 'OIDC_EXAMPLE_NET',
         createAccessToken: sinon.stub(),
         saveIdToken: sinon.stub(),
         createAuthenticationComplement: sinon.stub(),
@@ -40,28 +37,6 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
       userLoginRepository = {
         updateLastLoggedAt: sinon.stub().resolves(),
       };
-    });
-
-    // eslint-disable-next-line mocha/no-skipped-tests
-    context.skip('when the request state does not match the response state', function () {
-      it('throws an UnexpectedOidcStateError', async function () {
-        // given
-        const stateSent = 'stateSent';
-        const stateReceived = 'stateReceived';
-        sinon.stub(logger, 'error');
-
-        // when
-        const error = await catchErr(authenticateOidcUser)({
-          stateReceived,
-          stateSent,
-        });
-
-        // then
-        expect(error).to.be.an.instanceOf(UnexpectedOidcStateError);
-        expect(logger.error).to.have.been.calledWithExactly(
-          `State sent ${stateSent} did not match the state received ${stateReceived}`,
-        );
-      });
     });
 
     it('retrieves authentication token', async function () {


### PR DESCRIPTION
## :unicorn: Problème

Il manque actuellement la gestion des erreurs lors de l’utilisation des méthodes de la librairie `openid-client`.

Nous avons pris la décision, lors de la découpe, de déplacer la gestion des erreurs dans un ticket séparer de l’utilisation de la librairie pour éviter d’avoir une pull request difficile à traiter.

## :robot: Proposition

Créer une erreur `OidcError` générique pour toutes les erreurs concernant un fournisseur d’identité.

Ajouter la gestion des erreurs lors de l’utilisation des méthodes de la librairie `openid-client` lors  de :

- la génération de l’URL d’autorisation
- l'échange du code d’autorisation pour un jeton d’accès
- la récupération des informations du compte utilisateur via l'endpoint `userinfo`

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

⚠️ Uniquement possible en local

##### client.authorizationUrl()

##### client.callback()

##### client.userinfo()