### PR TITLE
[FEATURE] Changer le texte présent sous la barre d'avancement des écrans intermédiaires (PIX-10922).

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -784,7 +784,7 @@
         "header": "your answers"
       },
       "completion-percentage": {
-        "caption": "progression",
+        "caption": "course progression",
         "label": "'<p class=\"sr-only\">'You have completed '</p>'{completionPercentage}%'<p class=\"sr-only\">' of your customised test.'</p>'"
       }
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -784,7 +784,7 @@
         "header": "vos réponses"
       },
       "completion-percentage": {
-        "caption": "avancement",
+        "caption": "avancement dans le parcours",
         "label": "'<p class=\"sr-only\">'Vous avez effectué '</p>'{completionPercentage}%'<p class=\"sr-only\">' de votre parcours.'</p>'"
       }
     },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -784,7 +784,7 @@
         "header": "Uw antwoorden"
       },
       "completion-percentage": {
-        "caption": "vooruitgang",
+        "caption": "vooruitgang in de reis",
         "label": "'<p class=\"sr-only\">'Je hebt '</p>'{completionPercentage}%'<p class=\"sr-only\">' van je reis voltooid.'</p>'"
       }
     },


### PR DESCRIPTION
## :unicorn: Problème
On souhaite modifier l'affichage de la barre d'avancement pour respecter la nouvelle [maquette suivante](https://www.figma.com/file/y6p1FS5HKhJkMLrJN4i90P/Pix-App?type=design&node-id=8069-5183&mode=design&t=lHKUTCzzPxvhiqcO-4).

## :robot: Proposition
La barre d'avancement est un composant Pix UI et on ne souhaite pas modifier ce composant utilisé à de nombreux endroits. On se contente donc de modifier le texte présent sous la barre d'avancement actuelle par "Avancement dans le parcours".

## :100: Pour tester
- Lancer Pix App (avec eval-sco@example.net par exemple).
- Cliquer sur une carte de compétence pour lancer un parcours de questions.
- Passer les 5 premières questions pour arriver à l'écran intermédiaire.
- Constater que le texte présent sous la barre d'avancement est bien "Avancement dans le parcours".