### PR TITLE
[FEATURE] Ne pas écraser le statut "endedBySupervisor" à la finalisation d'une session (pix-11082)

### DIFF
--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -78,7 +78,9 @@ class CertificationAssessment {
   }
 
   endDueToFinalization() {
-    this.state = states.ENDED_DUE_TO_FINALIZATION;
+    if (this.state === states.STARTED) {
+      this.state = states.ENDED_DUE_TO_FINALIZATION;
+    }
   }
 
   neutralizeChallengeByNumberIfKoOrSkippedOrPartially(questionNumber) {

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -453,6 +453,19 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
       // when then
       expect(certificationAssessment.state).to.equal(CertificationAssessment.states.ENDED_DUE_TO_FINALIZATION);
     });
+
+    it('should NOT change the assessment state if it is "endedBySupervisor"', function () {
+      // given
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        state: CertificationAssessment.states.ENDED_BY_SUPERVISOR,
+      });
+
+      // when
+      certificationAssessment.endDueToFinalization();
+
+      // when then
+      expect(certificationAssessment.state).to.equal(CertificationAssessment.states.ENDED_BY_SUPERVISOR);
+    });
   });
 
   describe('#findAnswersAndChallengesForCertifiableBadgeKey', function () {


### PR DESCRIPTION
## :unicorn: Problème
Aujourd’hui, le statut en bdd qui permet d’identifier une certif terminée par un surveillant (state “endedBySupervisor” de l’assessement) est écrasé à la finalisation d’une session (le state devient “endedDueToFinalization”). 

## :robot: Proposition
Ne pas écraser le statut endedBySupervisor à la finalisation d’une session.

## :100: Pour tester
- créer une session de certif dans un CDC taggué pilote certif v3 et y inscrire 2 candidats
- lancer le test avec le candidat 1
- depuis l’ES, terminer le test du candidat 1
- lancer le test du candidat 2
- depuis pix certif, finaliser la session 
- dans pix admin, afficher la page de détails de la certif du candidat 1
- le champ “Terminée par” indique “Le surveillant”
- afficher la page de détails de la certif du candidat 2
- le champ “Terminée par” indique “Finalisation session”
