### PR TITLE
[BUGFIX] Permettre l'affichage du nom de campagne sur plusieurs ligne dans la liste sur PixOrga (PIX-11133)

### DIFF
--- a/orga/app/components/campaign/list.hbs
+++ b/orga/app/components/campaign/list.hbs
@@ -16,7 +16,7 @@
         <col class="table__column--wide" />
         <col class="table__column--small" />
         {{#unless @listOnlyCampaignsOfCurrentUser}}
-          <col class="table__column--wide hide-on-mobile" />
+          <col class="table__column--small hide-on-mobile" />
         {{/unless}}
         <col class="table__column--small hide-on-mobile" />
         <col class="table__column--small hide-on-mobile" />
@@ -39,7 +39,7 @@
         {{#each @campaigns as |campaign|}}
           <tr {{on "click" (fn @onClickCampaign campaign.id)}} class="tr--clickable">
             <td class="table__column">
-              <span class="campaign-list__campaign-link">
+              <span class="campaign-list__campaign-link-cell">
                 <Campaign::Detail::Type @labels={{this.labels}} @campaignType={{campaign.type}} @hideLabel={{true}} />
                 <LinkTo @route="authenticated.campaigns.campaign" @model={{campaign.id}}>
                   {{campaign.name}}
@@ -48,7 +48,7 @@
             </td>
             <td class="table__column--small" {{on "click" this.stopPropagation}}>{{campaign.code}}</td>
             {{#unless @listOnlyCampaignsOfCurrentUser}}
-              <td class="table__column--truncated hide-on-mobile">{{campaign.ownerFullName}}</td>
+              <td class="hide-on-mobile">{{campaign.ownerFullName}}</td>
             {{/unless}}
             <td class="hide-on-mobile">{{dayjs-format campaign.createdAt "DD/MM/YYYY" allow-empty=true}}</td>
             <td class="hide-on-mobile">{{campaign.participationsCount}}</td>

--- a/orga/app/styles/components/campaign/list.scss
+++ b/orga/app/styles/components/campaign/list.scss
@@ -1,10 +1,11 @@
 .campaign-list {
   padding: 0;
 
-  &__campaign-link {
+  &__campaign-link-cell {
     display: flex;
     gap: var(--pix-spacing-2x);
     align-items: center;
+    word-break: break-all;
   }
 
   &__item {


### PR DESCRIPTION
## :unicorn: Problème
Si un nom de campagne ne contient aucun - ou espace. Le nom de campagne déborde sur les autres colonnes

## :robot: Proposition
Afficher le nom de la campagne sur plusieurs ligne en cassant le nom par mot

## :rainbow: Remarques
Réduction de la colonne du propriétaire.

## :100: Pour tester
Créer une campagne avec un nom super long à la marie poppins