### PR TITLE
[BUGFIX] Modifier les noms des types d'organisation en réseau (PIX-11038)

### DIFF
--- a/admin/tests/acceptance/authenticated/organizations/get/children_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get/children_test.js
@@ -15,7 +15,7 @@ module('Acceptance | Organizations | Children', function (hooks) {
     await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
   });
 
-  test('"Organisations enfants" tab exists', async function (assert) {
+  test('"Organisations filles" tab exists', async function (assert) {
     // given
     const organizationId = this.server.create('organization').id;
 
@@ -24,7 +24,7 @@ module('Acceptance | Organizations | Children', function (hooks) {
 
     // then
     assert.strictEqual(currentURL(), `/organizations/${organizationId}/children`);
-    assert.dom(screen.getByRole('link', { name: 'Organisations enfants' })).hasClass('active');
+    assert.dom(screen.getByRole('link', { name: 'Organisations filles' })).hasClass('active');
   });
 
   module('when there is no child organization', function () {
@@ -37,8 +37,8 @@ module('Acceptance | Organizations | Children', function (hooks) {
       const screen = await visit(`/organizations/${organizationId}/children`);
 
       // then
-      assert.dom(screen.getByText('Aucune organisation enfant')).exists();
-      assert.dom(screen.getByRole('heading', { name: 'Organisations enfants', level: 2 })).exists();
+      assert.dom(screen.getByText('Aucune organisation fille')).exists();
+      assert.dom(screen.getByRole('heading', { name: 'Organisations filles', level: 2 })).exists();
     });
   });
 
@@ -51,8 +51,8 @@ module('Acceptance | Organizations | Children', function (hooks) {
       const screen = await visit(`/organizations/${parentOrganizationId}/children`);
 
       // then
-      assert.dom(screen.queryByText('Aucune organisation enfant')).doesNotExist();
-      assert.dom(screen.getByRole('table', { name: 'Liste des organisations enfants' })).exists();
+      assert.dom(screen.queryByText('Aucune organisation fille')).doesNotExist();
+      assert.dom(screen.getByRole('table', { name: 'Liste des organisations filles' })).exists();
     });
   });
 });

--- a/admin/tests/integration/components/organizations/children/list_test.js
+++ b/admin/tests/integration/components/organizations/children/list_test.js
@@ -26,7 +26,7 @@ module('Integration | Component | organizations/children/list', function (hooks)
     const screen = await renderScreen(hbs`<Organizations::Children::List @organizations={{this.organizations}}/>`);
 
     // then
-    assert.dom(screen.getByRole('table', { name: 'Liste des organisations enfants' })).exists();
+    assert.dom(screen.getByRole('table', { name: 'Liste des organisations filles' })).exists();
 
     assert.dom(screen.getByRole('columnheader', { name: 'ID' })).exists();
     assert.dom(screen.getByRole('columnheader', { name: 'Nom' })).exists();

--- a/admin/tests/integration/components/organizations/information-section-view_test.js
+++ b/admin/tests/integration/components/organizations/information-section-view_test.js
@@ -240,7 +240,7 @@ module('Integration | Component | organizations/information-section-view', funct
         const screen = await render(hbs`<Organizations::InformationSectionView @organization={{this.organization}} />`);
 
         // then
-        assert.dom(screen.getByText('Organisation parente')).exists();
+        assert.dom(screen.getByText('Organisation mère')).exists();
       });
     });
 
@@ -261,7 +261,7 @@ module('Integration | Component | organizations/information-section-view', funct
         const screen = await render(hbs`<Organizations::InformationSectionView @organization={{this.organization}} />`);
 
         // then
-        assert.dom(screen.getByText('Organisation enfant')).exists();
+        assert.dom(screen.getByText('Organisation fille')).exists();
         assert.dom(screen.getByText('Shibusen')).exists();
       });
     });
@@ -281,7 +281,7 @@ module('Integration | Component | organizations/information-section-view', funct
         const screen = await render(hbs`<Organizations::InformationSectionView @organization={{this.organization}} />`);
 
         // then
-        assert.dom(screen.queryByText('Organisation parente')).doesNotExist();
+        assert.dom(screen.queryByText('Organisation mère')).doesNotExist();
       });
     });
 

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -115,11 +115,11 @@
           "id": "ID",
           "name": "Nom"
         },
-        "table-name": "Liste des organisations enfants"
+        "table-name": "Liste des organisations filles"
       },
       "information-section-view": {
-        "child-organization": "Organisation enfant",
-        "parent-organization": "Organisation parente"
+        "child-organization": "Organisation fille",
+        "parent-organization": "Organisation mère"
       }
     },
     "users": {
@@ -285,12 +285,12 @@
     },
     "organization": {
       "navbar": {
-        "children": "Organisations enfants"
+        "children": "Organisations filles"
       }
     },
     "organization-children": {
-      "title": "Organisations enfants",
-      "empty-table": "Aucune organisation enfant"
+      "title": "Organisations filles",
+      "empty-table": "Aucune organisation fille"
     },
     "organizations": {
       "notifications": {

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -386,7 +386,7 @@ const register = async function (server) {
         tags: ['api', 'organizations'],
         notes: [
           "- **Cette route est restreinte aux utilisateurs authentifiés ayant un rôle permettant un accès à l'admin de Pix**\n" +
-            '- Elle permet de récupérer la liste des organisations enfants',
+            '- Elle permet de récupérer la liste des organisations filles',
         ],
       },
     },
@@ -412,7 +412,7 @@ const register = async function (server) {
         tags: ['api', 'admin', 'organizations'],
         notes: [
           "- **Cette route est restreinte aux utilisateurs authentifiés ayant un rôle SUPER_ADMIN, METIER ou SUPPORT permettant un accès à l'application d'administration de Pix**\n" +
-            "- Elle permet d'attacher une organization parente à une organization enfant",
+            "- Elle permet d'attacher une organisation mère à une organisation fille",
         ],
       },
     },


### PR DESCRIPTION


## :unicorn: Problème
Actuellement les noms des organisations en réseaux sont "Organisation parente" et "Organisation enfant".

## :robot: Proposition
Remplacer "Organisation parente" par "Organisation mère" et "Organisation enfant" par "Organisation fille"

## :rainbow: Remarques"
Dans la version anglaise et dans les clés de traduction, les appellations "Parent organisation" et "Child organisation" , plus idiomatiques, ont été conservées.

## :100: Pour tester
### 1. Cas d'une organisation fille
- Se connecter sur Pix Admin.
- Afficher la liste des organisations.
- Cliquer sur le lien de l'organisation 'Child of Collège House of The Dragon' pour afficher sa page d'informations.
- Constater que le label 'Organisation fille' apparaît, au singulier ou au pluriel, dans le label et l'onglet.
- Cliquer sur l'onglet 'Organisations filles' et constater que les mentions 'Organisations filles' et 'Aucune organisation fille' apparaissent sous l'onglet.
- Constater la mention 'Organisation mère : ' sous le label 'Organisation fille'.

### 2. Cas d'une organisation mère
- Revenir sur la liste des organisations et cliquer sur le lien de l'organisation 'Collège House of the Dragon'
- Constater que le label 'Organisation mère' apparaît.
