### PR TITLE
[FEATURE] Ajouter un QCM dans le referenciel Modulix (PIX-11099)

### DIFF
--- a/api/src/devcomp/domain/models/QcmProposal.js
+++ b/api/src/devcomp/domain/models/QcmProposal.js
@@ -1,0 +1,13 @@
+import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.js';
+
+class QcmProposal {
+  constructor({ id, content }) {
+    assertNotNullOrUndefined(id, 'The id is required for a QCM proposal');
+    assertNotNullOrUndefined(content, 'The content is required for a QCM proposal');
+
+    this.id = id;
+    this.content = content;
+  }
+}
+
+export { QcmProposal };

--- a/api/src/devcomp/domain/models/element/Element.js
+++ b/api/src/devcomp/domain/models/element/Element.js
@@ -2,8 +2,8 @@ import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asser
 
 class Element {
   constructor({ id, type }) {
-    assertNotNullOrUndefined(id, "L'id est obligatoire pour un élément");
-    assertNotNullOrUndefined(type, 'Le type est obligatoire pour un élément');
+    assertNotNullOrUndefined(id, 'The id is required for an element');
+    assertNotNullOrUndefined(type, 'The type is required for an element');
 
     this.id = id;
     this.type = type;

--- a/api/src/devcomp/domain/models/element/QCM.js
+++ b/api/src/devcomp/domain/models/element/QCM.js
@@ -1,0 +1,31 @@
+import { Element } from './Element.js';
+import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+
+class QCM extends Element {
+  constructor({ id, instruction, locales, proposals }) {
+    super({ id, type: 'qcm' });
+
+    assertNotNullOrUndefined(instruction, 'The instruction is required for a QCM');
+    this.#assertProposalsIsAnArray(proposals);
+    this.#assertProposalsAreNotEmpty(proposals);
+
+    this.instruction = instruction;
+    this.locales = locales;
+    this.proposals = proposals;
+    this.isAnswerable = true;
+  }
+
+  #assertProposalsAreNotEmpty(proposals) {
+    if (proposals.length === 0) {
+      throw new Error('The proposals are required for a QCM');
+    }
+  }
+
+  #assertProposalsIsAnArray(proposals) {
+    if (!Array.isArray(proposals)) {
+      throw new Error('The proposals should be in a list');
+    }
+  }
+}
+
+export { QCM };

--- a/api/src/devcomp/infrastructure/datasources/learning-content/module.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module.json
@@ -401,6 +401,45 @@
           ]
         },
         {
+          "id": "0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c",
+          "type": "activity",
+          "title": "Les 3 piliers de Pix",
+          "elements": [
+            {
+              "id": "30701e93-1b4d-4da4-b018-fa756c07d53f",
+              "type": "qcm",
+              "instruction": "<p>Quels sont les 3 piliers de Pix ?</p>",
+              "proposals": [
+                {
+                  "id": "1",
+                  "content": "Evaluer ses connaissances et savoir-faire sur 16 compétences du numérique"
+                },
+                {
+                  "id": "2",
+                  "content": "Développer son savoir-faire sur les jeux de type TPS"
+                },
+                {
+                  "id": "3",
+                  "content": "Développer ses compétences numériques"
+                },
+                {
+                  "id": "4",
+                  "content": "Certifier ses compétences Pix"
+                },
+                {
+                  "id": "5",
+                  "content": "Evaluer ses compétences de logique et compréhension mathématique"
+                }
+              ],
+              "feedbacks": {
+                "valid": "<p>Correct ! Vous nous avez bien cernés :)</p>",
+                "invalid": "<p>Et non ! Pix sert à évaluer, certifier et développer ses compétences numériques."
+              },
+              "solutions": ["1", "3", "4"]
+            }
+          ]
+        },
+        {
           "id": "2a77a10f-19a3-4544-80f9-8012dad6506a",
           "type": "activity",
           "title": "Activité remonter dans la page",

--- a/api/src/devcomp/infrastructure/repositories/module-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-repository.js
@@ -17,6 +17,8 @@ import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { QROCMForAnswerVerification } from '../../domain/models/element/QROCM-for-answer-verification.js';
 import { Video } from '../../domain/models/element/Video.js';
 import { Details } from '../../domain/models/module/Details.js';
+import { QCM } from '../../domain/models/element/QCM.js';
+import { QcmProposal } from '../../domain/models/QcmProposal.js';
 
 async function getBySlug({ slug, moduleDatasource }) {
   try {
@@ -63,6 +65,8 @@ function _toDomain(moduleData) {
                 return _toImageDomain(element);
               case 'text':
                 return _toTextDomain(element);
+              case 'qcm':
+                return _toQCMDomain(element);
               case 'qcu':
                 return _toQCUDomain(element);
               case 'qrocm':
@@ -174,6 +178,21 @@ function _toQCUDomain(element) {
     locales: element.locales,
     proposals: element.proposals.map((proposal) => {
       return new QcuProposal({
+        id: proposal.id,
+        content: proposal.content,
+      });
+    }),
+    type: element.type,
+  });
+}
+
+function _toQCMDomain(element) {
+  return new QCM({
+    id: element.id,
+    instruction: element.instruction,
+    locales: element.locales,
+    proposals: element.proposals.map((proposal) => {
+      return new QcmProposal({
         id: proposal.id,
         content: proposal.content,
       });

--- a/api/src/devcomp/infrastructure/repositories/module-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-repository.js
@@ -130,7 +130,6 @@ function _toTextDomain(element) {
   return new Text({
     id: element.id,
     content: element.content,
-    type: element.type,
   });
 }
 
@@ -140,7 +139,6 @@ function _toImageDomain(element) {
     url: element.url,
     alt: element.alt,
     alternativeText: element.alternativeText,
-    type: element.type,
   });
 }
 
@@ -182,7 +180,6 @@ function _toQCUDomain(element) {
         content: proposal.content,
       });
     }),
-    type: element.type,
   });
 }
 
@@ -197,7 +194,6 @@ function _toQCMDomain(element) {
         content: proposal.content,
       });
     }),
-    type: element.type,
   });
 }
 
@@ -232,7 +228,6 @@ function _toQROCMDomain(element) {
           logger.warn(`Type de proposal inconnu: ${proposal.type}`);
       }
     }),
-    type: element.type,
   });
 }
 

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
@@ -22,6 +22,11 @@ function serialize(module) {
                     ...element,
                     type: 'qcus',
                   };
+                case 'qcm':
+                  return {
+                    ...element,
+                    type: 'qcms',
+                  };
                 case 'qrocm':
                   return {
                     ...element,

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -16,6 +16,7 @@ import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
 import { Video } from '../../../../src/devcomp/domain/models/element/Video.js';
 import { QROCMForAnswerVerification } from '../../../../src/devcomp/domain/models/element/QROCM-for-answer-verification.js';
 import { TransitionText } from '../../../../src/devcomp/domain/models/TransitionText.js';
+import { QCM } from '../../../../src/devcomp/domain/models/element/QCM.js';
 
 describe('Integration | DevComp | Repositories | ModuleRepository', function () {
   describe('#getBySlug', function () {
@@ -223,6 +224,83 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
 
       // then
       expect(module.grains.every((grain) => grain.elements.every((element) => element instanceof QCU))).to.be.true;
+    });
+
+    it('should return a module which contains elements of type QCM if it exists', async function () {
+      // given
+      const existingModuleSlug = 'bien-ecrire-son-adresse-mail';
+      const expectedFoundModule = {
+        id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
+        slug: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        details: {
+          image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+          description:
+            'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
+          duration: 12,
+          level: 'Débutant',
+          objectives: [
+            'Écrire une adresse mail correctement, en évitant les erreurs courantes',
+            'Connaître les parties d’une adresse mail et les identifier sur des exemples',
+            'Comprendre les fonctions des parties d’une adresse mail',
+          ],
+        },
+        grains: [
+          {
+            id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
+            type: 'lesson',
+            title: 'Explications : les parties d’une adresse mail',
+            elements: [
+              {
+                id: '30701e93-1b4d-4da4-b018-fa756c07d53f',
+                type: 'qcm',
+                instruction: '<p>Quels sont les 3 piliers de Pix ?</p>',
+                proposals: [
+                  {
+                    id: '1',
+                    content: 'Evaluer ses connaissances et savoir-faire sur 16 compétences du numérique',
+                  },
+                  {
+                    id: '2',
+                    content: 'Développer son savoir-faire sur les jeux de type TPS',
+                  },
+                  {
+                    id: '3',
+                    content: 'Développer ses compétences numériques',
+                  },
+                  {
+                    id: '4',
+                    content: 'Certifier ses compétences Pix',
+                  },
+                  {
+                    id: '5',
+                    content: 'Evaluer ses compétences de logique et compréhension mathématique',
+                  },
+                ],
+                feedbacks: {
+                  valid: '<p>Correct ! Vous nous avez bien cernés :)</p>',
+                  invalid: '<p>Et non ! Pix sert à évaluer, certifier et développer ses compétences numériques.',
+                },
+                solutions: ['1', '3', '4'],
+              },
+            ],
+          },
+        ],
+      };
+      const moduleDatasourceStub = {
+        getBySlug: sinon.stub(),
+      };
+      moduleDatasourceStub.getBySlug.withArgs(existingModuleSlug).resolves(expectedFoundModule);
+
+      // when
+      const module = await moduleRepository.getBySlug({
+        slug: existingModuleSlug,
+        moduleDatasource: moduleDatasourceStub,
+      });
+
+      // then
+      expect(module.grains[0].elements).to.have.lengthOf(1);
+      expect(module.grains[0].elements[0]).to.be.instanceOf(QCM);
     });
 
     it('should return a module which contains elements of type Image if it exists', async function () {

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -108,12 +108,6 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
             title: 'Explications : les parties d’une adresse mail',
             elements: [
               {
-                id: 'c1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
-                type: 'text',
-                content:
-                  "<h3 class='screen-reader-only'>L'identifiant</h3><h4><span aria-hidden='true'>1️⃣</span><span class='screen-reader-only'>1</span> L’identifiant est la première partie de l’adresse mail. Il a été choisi par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque. Même avec des majuscules !</p><p><span aria-hidden='true'>✅</span> Par exemple : mika671 ou G3oDu671</p><p><span aria-hidden='true'>❌</span> Des caractères sont interdits :</p><ul><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>…</li></ul>",
-              },
-              {
                 id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
                 type: 'text',
                 content:
@@ -135,7 +129,8 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       });
 
       // then
-      expect(module.grains.every((grain) => grain.elements.every((element) => element instanceof Text))).to.be.true;
+      expect(module.grains[0].elements).to.have.lengthOf(1);
+      expect(module.grains[0].elements[0]).to.be.instanceOf(Text);
     });
 
     it('should return a module which contains elements of type QCU if it exists', async function () {
@@ -163,28 +158,6 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
             type: 'lesson',
             title: 'Explications : les parties d’une adresse mail',
             elements: [
-              {
-                id: 'z3b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p7',
-                type: 'qcu',
-                instruction: '<p>On peut avoir des chiffres dans l’identifiant de son adresse mail</p>',
-                proposals: [
-                  {
-                    id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
-                    content: 'Vrai',
-                  },
-                  {
-                    id: 'b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6',
-                    content: 'Faux',
-                  },
-                ],
-                feedbacks: {
-                  valid:
-                    '<p>Oui, aucun problème ! Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc…</li></ul>',
-                  invalid:
-                    '<p>Et si ! les chiffres sont autorisés dans l’identifiant d’une adresse mail. Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc…</li></ul>',
-                },
-                solution: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
-              },
               {
                 id: 'ba78dead-a806-4954-b408-e8ef28d28fab',
                 type: 'qcu',
@@ -223,7 +196,8 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       });
 
       // then
-      expect(module.grains.every((grain) => grain.elements.every((element) => element instanceof QCU))).to.be.true;
+      expect(module.grains[0].elements).to.have.lengthOf(1);
+      expect(module.grains[0].elements[0]).to.be.instanceOf(QCU);
     });
 
     it('should return a module which contains elements of type QCM if it exists', async function () {
@@ -351,7 +325,8 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       });
 
       // then
-      expect(module.grains.every((grain) => grain.elements.every((element) => element instanceof Image))).to.be.true;
+      expect(module.grains[0].elements).to.have.lengthOf(1);
+      expect(module.grains[0].elements[0]).to.be.instanceOf(Image);
     });
 
     it('should return a module which contains elements of type Video if it exists', async function () {
@@ -403,7 +378,8 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       });
 
       // then
-      expect(module.grains.every((grain) => grain.elements.every((element) => element instanceof Video))).to.be.true;
+      expect(module.grains[0].elements).to.have.lengthOf(1);
+      expect(module.grains[0].elements[0]).to.be.instanceOf(Video);
     });
 
     it('should return a module which contains elements of type QROCM if it exists', async function () {
@@ -499,7 +475,8 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       });
 
       // then
-      expect(module.grains.every((grain) => grain.elements.every((element) => element instanceof QROCM))).to.be.true;
+      expect(module.grains[0].elements).to.have.lengthOf(1);
+      expect(module.grains[0].elements[0]).to.be.instanceOf(QROCM);
       expect(module.grains[0].elements[0].proposals[BLOCK_TEXT_INDEX]).to.be.instanceOf(BlockText);
       expect(module.grains[0].elements[0].proposals[BLOCK_INPUT_INDEX]).to.be.instanceOf(BlockInput);
       expect(module.grains[0].elements[0].proposals[BLOCK_SELECT_INDEX]).to.be.instanceOf(BlockSelect);

--- a/api/tests/devcomp/unit/domain/models/QcmProposal_test.js
+++ b/api/tests/devcomp/unit/domain/models/QcmProposal_test.js
@@ -1,0 +1,32 @@
+import { expect } from '../../../../test-helper.js';
+import { QcmProposal } from '../../../../../src/devcomp/domain/models/QcmProposal.js';
+
+describe('Unit | Devcomp | Domain | Models | QcmProposal', function () {
+  describe('#constructor', function () {
+    it('should create a QCM proposal with correct attributes', function () {
+      // given
+      const id = '1';
+      const content = 'vrai';
+
+      // when
+      const proposal = new QcmProposal({ id, content });
+
+      // then
+      expect(proposal).not.to.be.undefined;
+      expect(proposal.id).to.equal(id);
+      expect(proposal.content).to.equal(content);
+    });
+  });
+
+  describe('A QCM proposal without id', function () {
+    it('should throw an error', function () {
+      expect(() => new QcmProposal({})).to.throw('The id is required for a QCM proposal');
+    });
+  });
+
+  describe('A QCM proposal without content', function () {
+    it('should throw an error', function () {
+      expect(() => new QcmProposal({ id: '1' })).to.throw('The content is required for a QCM proposal');
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/models/element/Image_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Image_test.js
@@ -18,7 +18,7 @@ describe('Unit | Devcomp | Domain | Models | Element | Image', function () {
 
   describe('An image without id', function () {
     it('should throw an error', function () {
-      expect(() => new Image({})).to.throw("L'id est obligatoire pour un élément");
+      expect(() => new Image({})).to.throw('The id is required for an element');
     });
   });
 

--- a/api/tests/devcomp/unit/domain/models/element/QCM_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCM_test.js
@@ -1,0 +1,56 @@
+import { expect } from '../../../../../test-helper.js';
+import { QCM } from '../../../../../../src/devcomp/domain/models/element/QCM.js';
+
+describe('Unit | Devcomp | Domain | Models | Element | QCM', function () {
+  describe('#constructor', function () {
+    it('should instanciate a QCM with right properties', function () {
+      // Given
+      const proposal1 = Symbol('proposal1');
+      const proposal2 = Symbol('proposal2');
+
+      // When
+      const qcm = new QCM({
+        id: '123',
+        instruction: 'instruction',
+        locales: ['fr-FR'],
+        proposals: [proposal1, proposal2],
+      });
+
+      // Then
+      expect(qcm.id).equal('123');
+      expect(qcm.instruction).equal('instruction');
+      expect(qcm.type).equal('qcm');
+      expect(qcm.locales).deep.equal(['fr-FR']);
+      expect(qcm.proposals).deep.equal([proposal1, proposal2]);
+      expect(qcm.feedbacks).to.be.undefined;
+    });
+  });
+
+  describe('A QCM without id', function () {
+    it('should throw an error', function () {
+      expect(() => new QCM({})).to.throw("L'id est obligatoire pour un élément");
+    });
+  });
+
+  describe('A QCM without instruction', function () {
+    it('should throw an error', function () {
+      expect(() => new QCM({ id: '123' })).to.throw('The instruction is required for a QCM');
+    });
+  });
+
+  describe('A QCM with an empty list of proposals', function () {
+    it('should throw an error', function () {
+      expect(() => new QCM({ id: '123', instruction: 'toto', proposals: [] })).to.throw(
+        'The proposals are required for a QCM',
+      );
+    });
+  });
+
+  describe('A QCM does not have a list of proposals', function () {
+    it('should throw an error', function () {
+      expect(() => new QCM({ id: '123', instruction: 'toto', proposals: 'toto' })).to.throw(
+        'The proposals should be in a list',
+      );
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/models/element/QCM_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCM_test.js
@@ -28,7 +28,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QCM', function () {
 
   describe('A QCM without id', function () {
     it('should throw an error', function () {
-      expect(() => new QCM({})).to.throw("L'id est obligatoire pour un élément");
+      expect(() => new QCM({})).to.throw('The id is required for an element');
     });
   });
 

--- a/api/tests/devcomp/unit/domain/models/element/QCU_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCU_test.js
@@ -28,7 +28,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QCU', function () {
 
   describe('A QCU without id', function () {
     it('should throw an error', function () {
-      expect(() => new QCU({})).to.throw("L'id est obligatoire pour un élément");
+      expect(() => new QCU({})).to.throw('The id is required for an element');
     });
   });
 

--- a/api/tests/devcomp/unit/domain/models/element/QROCM_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QROCM_test.js
@@ -26,7 +26,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QROCM', function () {
 
   describe('A QROCM without id', function () {
     it('should throw an error', function () {
-      expect(() => new QROCM({})).to.throw("L'id est obligatoire pour un élément");
+      expect(() => new QROCM({})).to.throw('The id is required for an element');
     });
   });
 

--- a/api/tests/devcomp/unit/domain/models/element/Text_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Text_test.js
@@ -16,7 +16,7 @@ describe('Unit | Devcomp | Domain | Models | Element | Text', function () {
 
   describe('A text without id', function () {
     it('should throw an error', function () {
-      expect(() => new Text({ content: 'content' })).to.throw("L'id est obligatoire pour un élément");
+      expect(() => new Text({ content: 'content' })).to.throw('The id is required for an element');
     });
   });
 

--- a/api/tests/devcomp/unit/domain/models/element/Video_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Video_test.js
@@ -25,7 +25,7 @@ describe('Unit | Devcomp | Domain | Models | Element | Video', function () {
 
   describe('An video without id', function () {
     it('should throw an error', function () {
-      expect(() => new Video({})).to.throw("L'id est obligatoire pour un élément");
+      expect(() => new Video({})).to.throw('The id is required for an element');
     });
   });
 

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/index.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/index.js
@@ -1,7 +1,15 @@
 import { imageElementSchema } from './image.js';
 import { qcuElementSchema } from './qcu.js';
+import { qcmElementSchema } from './qcm.js';
 import { qrocmElementSchema } from './qrocm.js';
 import { textElementSchema } from './text.js';
 import { videoElementSchema } from './video.js';
 
-export { imageElementSchema, qcuElementSchema, qrocmElementSchema, textElementSchema, videoElementSchema };
+export {
+  imageElementSchema,
+  qcuElementSchema,
+  qcmElementSchema,
+  qrocmElementSchema,
+  textElementSchema,
+  videoElementSchema,
+};

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcm.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcm.js
@@ -1,0 +1,22 @@
+import Joi from 'joi';
+import { uuidSchema, proposalIdSchema } from '../utils.js';
+
+const qcmElementSchema = Joi.object({
+  id: uuidSchema,
+  type: Joi.string().valid('qcm').required(),
+  instruction: Joi.string().required(),
+  proposals: Joi.array()
+    .items({
+      id: proposalIdSchema,
+      content: Joi.string().required(),
+    })
+    .min(3)
+    .required(),
+  feedbacks: Joi.object({
+    valid: Joi.string().required(),
+    invalid: Joi.string().required(),
+  }).required(),
+  solutions: Joi.array().items(proposalIdSchema).min(3).required(),
+}).required();
+
+export { qcmElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module.js
@@ -2,6 +2,7 @@ import Joi from 'joi';
 import {
   imageElementSchema,
   qcuElementSchema,
+  qcmElementSchema,
   qrocmElementSchema,
   textElementSchema,
   videoElementSchema,
@@ -39,6 +40,7 @@ const moduleSchema = Joi.object({
               textElementSchema,
               imageElementSchema,
               qcuElementSchema,
+              qcmElementSchema,
               qrocmElementSchema,
               videoElementSchema,
             ),

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -91,17 +91,15 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
             title: 'Grain 1',
             type: 'activity',
             elements: [
-              new Text({ id: '1', content: 'toto', type: 'text' }),
+              new Text({ id: '1', content: 'toto' }),
               new QCU({
                 id: '2',
-                type: 'qcu',
                 proposals: [{ id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'toto' }],
                 instruction: 'hello',
                 solution: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
               }),
               new QCM({
                 id: '2000',
-                type: 'qcm',
                 proposals: [
                   { id: '1', content: 'toto' },
                   { id: '2', content: 'tata' },
@@ -112,7 +110,6 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
               }),
               new QROCM({
                 id: '100',
-                type: 'qrocm',
                 instruction: '',
                 locales: ['fr-FR'],
                 proposals: [

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -10,6 +10,7 @@ import { BlockInput } from '../../../../../../src/devcomp/domain/models/block/Bl
 import { BlockSelect } from '../../../../../../src/devcomp/domain/models/block/BlockSelect.js';
 import { BlockSelectOption } from '../../../../../../src/devcomp/domain/models/block/BlockSelectOption.js';
 import { Video } from '../../../../../../src/devcomp/domain/models/element/Video.js';
+import { QCM } from '../../../../../../src/devcomp/domain/models/element/QCM.js';
 
 describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerializer', function () {
   describe('#serialize', function () {
@@ -97,6 +98,17 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
                 proposals: [{ id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'toto' }],
                 instruction: 'hello',
                 solution: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
+              }),
+              new QCM({
+                id: '2000',
+                type: 'qcm',
+                proposals: [
+                  { id: '1', content: 'toto' },
+                  { id: '2', content: 'tata' },
+                  { id: '3', content: 'titi' },
+                ],
+                instruction: 'hello',
+                solutions: ['1', '3'],
               }),
               new QROCM({
                 id: '100',
@@ -201,6 +213,29 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
           },
           {
             attributes: {
+              instruction: 'hello',
+              'is-answerable': true,
+              proposals: [
+                {
+                  content: 'toto',
+                  id: '1',
+                },
+                {
+                  content: 'tata',
+                  id: '2',
+                },
+                {
+                  content: 'titi',
+                  id: '3',
+                },
+              ],
+              type: 'qcms',
+            },
+            id: '2000',
+            type: 'qcms',
+          },
+          {
+            attributes: {
               instruction: '',
               'is-answerable': true,
               type: 'qrocms',
@@ -285,6 +320,10 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
                   {
                     id: '2',
                     type: 'qcus',
+                  },
+                  {
+                    id: '2000',
+                    type: 'qcms',
                   },
                   {
                     id: '100',


### PR DESCRIPTION
## :unicorn: Problème
En tant qu'utilisateur je souhaite répondre à un QCM afin de développer mes compétences.
Actuellement notre référentiel ne possède pas de modalité QCM.

## :robot: Proposition
Ajouter un QCM dans le module de didacticiel. Il sera pour ainsi dire identique au QCU.
Ajouter le modèle QCM dans le domaine (même constat, identique à QCU).
Mapping dans le repository puis dans le serializer.

## :rainbow: Remarques

### QcuProposal et QcmProposal

Dans le cas des `QCU` et des `QCM`, la structure des propositions est identique. Dans le modèle, pour les `QCU` nous avons une classe `QcuProposal`.

Nous avons choisi de la dupliquer pour créer `QcmProposal` car en l'état nous n'avons pas trouvé de terme métier satisfaisant pour factoriser ces deux classes dans une classe générique.

### Validation des QCM du référentiel

Nous avons mis une règle de validation dans les tests du datasource pour avoir un tableau de propositions et de solutions d'une taille minimum de 3. (dans le cas où nous ne voulons pas de `QCM` à 2 propositions et où les 2 sont donc valides. À discuter en équipe).

### Tests flaky

Dans les tests du module repository : `api/tests/devcomp/integration/repositories/module-repository_test.js`, les `expect` qui valident que les instances du modèle ont bien été retournées par le repository sont flaky.

Exemple ci-dessous avec l'expect sur les intances de `QCM`.

```javascript
expect(module.grains.every((grain) => grain.elements.every((element) => element instanceof QCM))).to.be.true;
```

Si pour x raisons, le repository n'a pas fait le mapping to domain pour les `QCM`, alors le second `every` va itérer sur un tableau d'éléments vide et dans ce cas il retourne `true`.

```javascript
[].every((a) => a.checkCondition); // retourne true
```
Dans le test spécifique autour du `QCM`, nous avons donc opté pour un `expect` plus précis:

```javascript
expect(module.grains[0].elements[0] instanceof QCM).to.be.true;
```
Nous avons donc pousser un commit de `sr` pour reprendre tous les `expect` similaires dans ce fichier de test.

### [SCOUT RULE] Traduction des messages d'erreur en anglais

Nous avons donc traduis nos messages d'erreur en anglais de notre modèle `QCM`. Et nous en avons profité pour pousser une `sr` afin de traduire en anglais les erreurs liées au modèle `Element` (en l'absence d'`id` et de `type`).

### [SCOUT RULE] Modification de la méthode toDomain du ModuleRepository 

Nous nous sommes rendus compte que nous mappions le type des éléments du référentiel au moment d'instancier nos modèle (QCM, Text, Video, etc.) alors que dans leur implémentation, le type est codé en dur et injecté dans le constructeur du parent `Element`.
Nous avons donc fait le choix de supprimer le mapping du type dans la méthode `toDomain` du `ModuleRepository` ainsi que dans notre `ModuleSerializer`. 

## :100: Pour tester
1. Requêter le contenu du module "_Didacticiel Modulix_"
```bash
curl https://api-pr8021.review.pix.fr/api/modules/didacticiel-modulix
```
2. Vérifier que la ressource qcms se trouve bien dans le body.
3. Vérifier qu'il correspond bien à la description de l'US
