### PR TITLE
[BUGFIX] Corrige l'export des campagnes de collecte de profils pour utiliser les chunks correctement (PIX-11141)

### DIFF
--- a/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-profiles-collection-export.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/csv/campaign-profiles-collection-export.js
@@ -16,12 +16,16 @@ class CampaignProfilesCollectionExport {
     this.translate = translate;
   }
 
-  export(campaignParticipationResultDatas, placementProfileService) {
+  export(
+    campaignParticipationResultDatas,
+    placementProfileService,
+    constants = { CHUNK_SIZE_CAMPAIGN_RESULT_PROCESSING, CONCURRENCY_HEAVY_OPERATIONS },
+  ) {
     this.stream.write(this._buildHeader());
 
     const campaignParticipationResultDataChunks = _.chunk(
       campaignParticipationResultDatas,
-      CHUNK_SIZE_CAMPAIGN_RESULT_PROCESSING,
+      constants.CHUNK_SIZE_CAMPAIGN_RESULT_PROCESSING,
     );
 
     return bluebird.map(
@@ -31,11 +35,11 @@ class CampaignProfilesCollectionExport {
           campaignParticipationResultDataChunk,
           placementProfileService,
         );
-        const csvLines = this._buildLines(placementProfiles, campaignParticipationResultDatas);
+        const csvLines = this._buildLines(placementProfiles, campaignParticipationResultDataChunk);
 
         this.stream.write(csvLines);
       },
-      { concurrency: CONCURRENCY_HEAVY_OPERATIONS },
+      { concurrency: constants.CONCURRENCY_HEAVY_OPERATIONS },
     );
   }
 

--- a/api/tests/prescription/campaign/unit/infrastrucutre/serializers/csv/campaign-profiles-collection-export_test.js
+++ b/api/tests/prescription/campaign/unit/infrastrucutre/serializers/csv/campaign-profiles-collection-export_test.js
@@ -1,0 +1,67 @@
+import { expect, sinon } from '../../../../../../test-helper.js';
+import { CampaignProfilesCollectionExport } from '../../../../../../../src/prescription/campaign/infrastructure/serializers/csv/campaign-profiles-collection-export.js';
+
+describe('Unit | Serializer | CSV | campaign-profiles-collection-export', function () {
+  describe('#export', function () {
+    it('should write csv lines to stream', async function () {
+      // given
+      const noOpStream = { write: sinon.stub() };
+      const organization = {};
+      const campaign = {};
+      const competences = [];
+      const translateStub = sinon.stub();
+      const exporter = new CampaignProfilesCollectionExport(
+        noOpStream,
+        organization,
+        campaign,
+        competences,
+        translateStub,
+      );
+      const placementProfileStub = {
+        getPlacementProfilesWithSnapshotting: sinon.stub().resolves([]),
+      };
+      const campaignParticipationResultDatas = [
+        {
+          id: 1,
+          createdAt: new Date(),
+          isShared: false,
+          sharedAt: null,
+          participantExternalId: null,
+          userId: 1,
+          isCompleted: false,
+          studentNumber: null,
+          participantFirstName: 'John',
+          participantLastName: 'Doe',
+          division: '3C',
+          pixScore: 136,
+          group: null,
+        },
+        {
+          id: 2,
+          createdAt: new Date(),
+          isShared: false,
+          sharedAt: null,
+          participantExternalId: null,
+          userId: 2,
+          isCompleted: false,
+          studentNumber: null,
+          participantFirstName: 'Jane',
+          participantLastName: 'Doe',
+          division: '3C',
+          pixScore: 200,
+          group: null,
+        },
+      ];
+
+      // when
+      await exporter.export(campaignParticipationResultDatas, placementProfileStub, {
+        CHUNK_SIZE_CAMPAIGN_RESULT_PROCESSING: 1,
+        CONCURRENCY_HEAVY_OPERATIONS: 1,
+      });
+
+      // then
+      expect(noOpStream.write.getCall(1).args[0]).to.includes('John');
+      expect(noOpStream.write.getCall(2).args[0]).to.includes('Jane');
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Suite à la feature sur l'historique des participations l'export des campagnes de collecte de profils ne fonctionne plus. On a plus constaté que l'export n'utilisait pas correctement le système de chunk. Ce qui fait que les campagnes avec plus de 10 participations ne peuvent plus exporter leurs résultats.

## :robot: Proposition
Utiliser la variable chunkée dans le CampaignProfilesCollectionExport.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- Faire un export d'une campagne de collecte de profils avec plus de 10 résultats