### PR TITLE
[BUGFIX] Réparer les barres de scroll non désirées des épreuves Ember (PIX-11139).

### DIFF
--- a/mon-pix/app/components/challenge-embed-simulator.hbs
+++ b/mon-pix/app/components/challenge-embed-simulator.hbs
@@ -1,5 +1,5 @@
 {{! template-lint-disable style-concatenation no-inline-styles }}
-<div class="challenge-embed-simulator" style="{{this.embedDocumentHeightStyle}}">
+<div class="challenge-embed-simulator">
   {{#if this.isLoadingEmbed}}
     <div class="embed placeholder blurred" aria-label="{{t 'pages.challenge.embed-simulator.placeholder'}}">
       <FaIcon @icon="image" />
@@ -28,6 +28,8 @@
         title="{{@embedDocument.title}}"
         {{did-insert this.configureIframe @embedDocument.url this}}
         {{did-update this.configureIframe @embedDocument.url this}}
+        frameBorder="0"
+        style="{{this.embedDocumentHeightStyle}}"
       ></iframe>
     </div>
 

--- a/mon-pix/app/styles/components/_challenge-embed-simulator.scss
+++ b/mon-pix/app/styles/components/_challenge-embed-simulator.scss
@@ -1,13 +1,13 @@
 .challenge-embed-simulator {
-  width: calc(100% + 10px);
+  position: relative;
+  width: calc(100% + 8px);
   margin: 35px 0 50px -4px;
   border-top: 1px solid var(--pix-neutral-22, #c1c7d0);
   border-bottom: 1px solid var(--pix-neutral-22, #c1c7d0);
 }
 
-.embed {
-  position: relative;
-  height: 100%;
+.challenge-embed-simulator .embed {
+  margin-bottom: 0;
 
   &.hidden-visibility {
     visibility: hidden;
@@ -46,7 +46,6 @@
 
 .embed__simulator {
   -webkit-overflow-scrolling: touch;
-  height: calc(100% + 5px);
   overflow: auto;
 
   &.blurred {
@@ -56,15 +55,15 @@
 
 .embed__iframe {
   position: relative;
+  display: block;
   width: 100%;
-  height: calc(100% - 5px);
   border: none;
 }
 
 .embed__reboot {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: $pix-spacing-xxs;
+  position: absolute;
+  top: calc(100% + $pix-spacing-xs);
+  right: 0;
   padding-right: $pix-spacing-xs;
 }
 

--- a/mon-pix/tests/integration/components/challenge-embed-simulator_test.js
+++ b/mon-pix/tests/integration/components/challenge-embed-simulator_test.js
@@ -87,7 +87,7 @@ module('Integration | Component | Challenge Embed Simulator', function (hooks) {
     });
 
     test('should have an height that is the one defined in the referential', function (assert) {
-      assert.strictEqual(find('.challenge-embed-simulator').style.cssText, 'height: 200px;');
+      assert.strictEqual(find('.embed__iframe').style.cssText, 'height: 200px;');
     });
 
     test('should define a title attribute on the iframe element that is the one defined in the referential for field "Embed title"', function (assert) {


### PR DESCRIPTION
## :unicorn: Problème

Sur les épreuves Ember, on avait des barres de scroll non souhaitées.
Exemple : https://editor.pix.fr/api/challenges/challengePI8VdwE7PALa5/preview

## :robot: Proposition

Améliorer le style pour ne plus avoir ces barres de scroll.

## :100: Pour tester

[Aller sur l'épreuve](https://app-pr8025.review.pix.fr/challenges/challengePI8VdwE7PALa5/preview) et constater que les barres de scroll ne sont plus présentes
