### PR TITLE
[BUGFIX] Téléchargement import en masse KO si pas d'habilitations (PIX-11144).

### DIFF
--- a/api/src/certification/session/infrastructure/repositories/center-repository.js
+++ b/api/src/certification/session/infrastructure/repositories/center-repository.js
@@ -8,7 +8,7 @@ const getById = async ({ id }) => {
       id: 'certification-centers.id',
       type: 'certification-centers.type',
       habilitations: knex.raw(
-        'array_agg("complementary-certification-habilitations"."complementaryCertificationId" order by "complementary-certification-habilitations"."complementaryCertificationId")',
+        'array_remove(array_agg("complementary-certification-habilitations"."complementaryCertificationId" order by "complementary-certification-habilitations"."complementaryCertificationId"), NULL)',
       ),
     })
     .from('certification-centers')

--- a/api/tests/certification/session/integration/infrastructure/repositories/center-repository_test.js
+++ b/api/tests/certification/session/integration/infrastructure/repositories/center-repository_test.js
@@ -1,6 +1,7 @@
 import { databaseBuilder, domainBuilder, expect, catchErr } from '../../../../../test-helper.js';
 import * as centerRepository from '../../../../../../src/certification/session/infrastructure/repositories/center-repository.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
+import { CertificationCenter } from '../../../../../../lib/domain/models/CertificationCenter.js';
 
 describe('Integration | Certification |  Center | Repository | center-repository', function () {
   describe('#getById', function () {
@@ -16,12 +17,37 @@ describe('Integration | Certification |  Center | Repository | center-repository
       });
     });
 
+    context('when the certification center has no habilitations', function () {
+      it('should return the certification center without habilitations', async function () {
+        // given
+        const centerId = 1;
+        databaseBuilder.factory.buildCertificationCenter({
+          id: centerId,
+          type: CertificationCenter.types.PRO,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const result = await centerRepository.getById({
+          id: centerId,
+        });
+
+        // then
+        const expectedCenter = domainBuilder.certification.session.buildCenter({
+          id: centerId,
+          type: 'PRO',
+          habilitations: [],
+        });
+        expect(result).to.deepEqualInstance(expectedCenter);
+      });
+    });
+
     it('should return the certification center by its id', async function () {
       // given
       const centerId = 1;
       databaseBuilder.factory.buildCertificationCenter({
         id: centerId,
-        type: 'SCO',
+        type: CertificationCenter.types.SCO,
       });
       const cleaId = databaseBuilder.factory.buildComplementaryCertification.clea({}).id;
       const droitId = databaseBuilder.factory.buildComplementaryCertification.droit({}).id;


### PR DESCRIPTION
## :unicorn: Problème
Le template d’import en masse tombe en 404 car l'absence d'habilitations pour les certifications complémentaires récupérées remonte le centre avec une habilitation pour certification complémentaire nulle au lieu de ne pas remonter d'habilitation.
En local vous pouvez utiliser [certifv3@example.net](mailto:certifv3@example.net) sur l'integration pour le reproduire.

## :robot: Proposition
* Sécuriser la récupération des habilitations en traitant correctement le cas où le centre n'a pas d'habilitations

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

* Sur Pix Certif avec certifv3@example.net
* Créer/Editer plusieurs sessions
* Télécharger le modele, vérifier que pas de complémentaires dans le ficheir téléchargé
* Le téléchargement doit réussir
* Le même test sur l'integration tombe en échec pour comparaison
* Préconisation : faire le test avec d'autres compte (par exemple: certif-pro@example.net), et que des colonnes de complémentaires existent dans le fichier téléchargé
