### PR TITLE
[BUGFIX] Retirer les balises '<br>' dans le message lorsque l'utilisateur quitte le focus. (PIX-11148)

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -693,8 +693,8 @@
       },
       "has-focused-out-of-window": {
         "certification": "We have detected a page switch. Your answer will not be validated. If you have been forced to change pages, please inform your invigilator and answer the question in their presence.",
-        "default": "We have detected a page switch.'<br>'During a certification test, your answer would not be validated.",
-        "v3-certification": "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse.'<br>'Si vous avez été contraint de changer de page, prévenez votre surveillant afin qu'il puisse le constater et le signaler, le cas échéant."
+        "default": "We have detected a page switch. During a certification test, your answer would not be validated.",
+        "v3-certification": "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, prévenez votre surveillant afin qu'il puisse le constater et le signaler, le cas échéant."
       },
       "illustration": {
         "placeholder": "Image loading"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -693,8 +693,8 @@
       },
       "has-focused-out-of-window": {
         "certification": "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, prévenez votre surveillant et répondez à la question en sa présence.",
-        "default": "Nous avons détecté un changement de page.'<br>'En certification, votre réponse ne serait pas validée.",
-        "v3-certification": "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse.'<br>'Si vous avez été contraint de changer de page, prévenez votre surveillant afin qu'il puisse le constater et le signaler, le cas échéant."
+        "default": "Nous avons détecté un changement de page. En certification, votre réponse ne serait pas validée.",
+        "v3-certification": "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, prévenez votre surveillant afin qu'il puisse le constater et le signaler, le cas échéant."
       },
       "illustration": {
         "placeholder": "Chargement de l'image en cours"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -693,8 +693,8 @@
       },
       "has-focused-out-of-window": {
         "certification": "We hebben een paginawissel geconstateerd. Je antwoord wordt als fout gerekend. Als je gedwongen werd om van pagina te wisselen, informeer dan je supervisor en beantwoord de vraag in zijn of haar aanwezigheid.",
-        "default": "We hebben een paginawijziging gedetecteerd.'<br> 'In certificering zou uw antwoord niet worden gevalideerd.",
-        "v3-certification": "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse.'<br>'Si vous avez été contraint de changer de page, prévenez votre surveillant afin qu'il puisse le constater et le signaler, le cas échéant."
+        "default": "We hebben een paginawijziging gedetecteerd. In certificering zou uw antwoord niet worden gevalideerd.",
+        "v3-certification": "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, prévenez votre surveillant afin qu'il puisse le constater et le signaler, le cas échéant."
       },
       "illustration": {
         "placeholder": "De huidige afbeelding laden"


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre d’une question focus, un message est affiché lorsque l’utilisateur change de page. Dans ce message, des balises <br> apparaissent. Il faut les supprimer.

## :100: Pour tester

### Certif v3
- Créer une session de certif v3 : certifv3@example.net//pix123
- La rejoindre avec un compte certifiable certifiable-contenu-user@example.net//pix123
- Passer les questions jusqu'à avoir une question focus
- Changer de fenêtre afin de déclencher l'affichage du message de perte de focus
- Le message que contient pas la balise `<br>`

### Certif v2
- Lancer une certif v2 : certifsup@example.net//pix123
- La rejoindre avec un compte certifiable certifiable-contenu-user@example.net//pix123
- Aller en BDD pour modifier un certification-challenge par un challengeId d'un challenge focus
- Passer les question jusqu'à la question focus
- Changer de fenêtre afin de déclencher l'affichage du message de perte de focus
- Le message que contient pas la balise `<br>`
