### PR TITLE
[BUGFIX] Remise à jour du contenu du didacticiel Modulix (image et vidéo)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/module.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module.json
@@ -363,13 +363,13 @@
               "type": "text",
               "content": "<p>À la fin de cette vidéo, une question sera posée sur les compétences Pix.</p>"
             },
+            {
               "id": "3a9f2269-99ba-4631-b6fd-6802c88d5c26",
               "type": "video",
               "title": "Vidéo de présentation de Pix",
               "url": "https://videos.pix.fr/modulix/didacticiel/presentation.mp4",
               "subtitles": "-",
-              "transcription": "<p>Le numérique évolue en permanence, vos compétences aussi, pour travailler, communiquer et s'informer, se déplacer, réaliser des démarches, un enjeu tout au long de la vie.</p><p>Sur <a href='https://pix.fr' target='blank'>pix.fr</a>, testez-vous et cultivez vos compétences numériques.</p><p>Les tests Pix sont personnalisés, les questions s'adaptent à votre niveau, réponse après réponse.</p><p>Évaluez vos connaissances et savoir-faire sur 16 compétences, dans 5 domaines, sur 5 niveaux de débutants à confirmer, avec des mises en situation ludiques, recherches en ligne, manipulation de fichiers et de données, culture numérique...</p><p>Allez à votre rythme, vous pouvez arrêter et reprendre quand vous le voulez.</p><p>Toutes les 5 questions, découvrez vos résultats et progressez grâce aux astuces et aux tutos.</p><p>En relevant les défis Pix, vous apprendrez de nouvelles choses et aurez envie d'aller plus loin.</p><p>Vous pensez pouvoir faire mieux ?</p><p>Retentez les tests et améliorez votre score.</p><p>Faites reconnaître officiellement votre niveau en passant la certification Pix, reconnue par l'État et le monde professionnel.</p><p>Pix : le service public en ligne pour évaluer, développer et certifier ses compétences numériques.</p>",
-              "alternativeText": "Vidéo de présentation de Pix"
+              "transcription": "<p>Le numérique évolue en permanence, vos compétences aussi, pour travailler, communiquer et s'informer, se déplacer, réaliser des démarches, un enjeu tout au long de la vie.</p><p>Sur <a href='https://pix.fr' target='blank'>pix.fr</a>, testez-vous et cultivez vos compétences numériques.</p><p>Les tests Pix sont personnalisés, les questions s'adaptent à votre niveau, réponse après réponse.</p><p>Évaluez vos connaissances et savoir-faire sur 16 compétences, dans 5 domaines, sur 5 niveaux de débutants à confirmer, avec des mises en situation ludiques, recherches en ligne, manipulation de fichiers et de données, culture numérique...</p><p>Allez à votre rythme, vous pouvez arrêter et reprendre quand vous le voulez.</p><p>Toutes les 5 questions, découvrez vos résultats et progressez grâce aux astuces et aux tutos.</p><p>En relevant les défis Pix, vous apprendrez de nouvelles choses et aurez envie d'aller plus loin.</p><p>Vous pensez pouvoir faire mieux ?</p><p>Retentez les tests et améliorez votre score.</p><p>Faites reconnaître officiellement votre niveau en passant la certification Pix, reconnue par l'État et le monde professionnel.</p><p>Pix : le service public en ligne pour évaluer, développer et certifier ses compétences numériques.</p>"
             }
           ]
         },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/module.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module.json
@@ -347,9 +347,9 @@
             {
               "id": "8d7687c8-4a02-4d7e-bf6c-693a6d481c78",
               "type": "image",
-              "url": "https://images.pix.fr/modulix/placeholder-image.svg",
+              "url": "https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg",
               "alt": "",
-              "alternativeText": ""
+              "alternativeText": "Dessin d'un ordinateur dans un univers spatial."
             }
           ]
         },
@@ -363,13 +363,13 @@
               "type": "text",
               "content": "<p>À la fin de cette vidéo, une question sera posée sur les compétences Pix.</p>"
             },
-            {
               "id": "3a9f2269-99ba-4631-b6fd-6802c88d5c26",
               "type": "video",
               "title": "Vidéo de présentation de Pix",
-              "url": "https://videos.pix.fr/modulix/placeholder-video.mp4",
-              "subtitles": "https://videos.pix.fr/modulix/placeholder-video.vtt",
-              "transcription": "<p>Le numérique évolue en permanence, vos compétences aussi, pour travailler, communiquer et s'informer, se déplacer, réaliser des démarches, un enjeu tout au long de la vie.</p><p>Sur <a href='https://pix.fr' target='blank'>pix.fr</a>, testez-vous et cultivez vos compétences numériques.</p><p>Les tests Pix sont personnalisés, les questions s'adaptent à votre niveau, réponse après réponse.</p><p>Évaluez vos connaissances et savoir-faire sur 16 compétences, dans 5 domaines, sur 5 niveaux de débutants à confirmer, avec des mises en situation ludiques, recherches en ligne, manipulation de fichiers et de données, culture numérique...</p><p>Allez à votre rythme, vous pouvez arrêter et reprendre quand vous le voulez.</p><p>Toutes les 5 questions, découvrez vos résultats et progressez grâce aux astuces et aux tutos.</p><p>En relevant les défis Pix, vous apprendrez de nouvelles choses et aurez envie d'aller plus loin.</p><p>Vous pensez pouvoir faire mieux ?</p><p>Retentez les tests et améliorez votre score.</p><p>Faites reconnaître officiellement votre niveau en passant la certification Pix, reconnue par l'État et le monde professionnel.</p><p>Pix : le service public en ligne pour évaluer, développer et certifier ses compétences numériques.</p>"
+              "url": "https://videos.pix.fr/modulix/didacticiel/presentation.mp4",
+              "subtitles": "-",
+              "transcription": "<p>Le numérique évolue en permanence, vos compétences aussi, pour travailler, communiquer et s'informer, se déplacer, réaliser des démarches, un enjeu tout au long de la vie.</p><p>Sur <a href='https://pix.fr' target='blank'>pix.fr</a>, testez-vous et cultivez vos compétences numériques.</p><p>Les tests Pix sont personnalisés, les questions s'adaptent à votre niveau, réponse après réponse.</p><p>Évaluez vos connaissances et savoir-faire sur 16 compétences, dans 5 domaines, sur 5 niveaux de débutants à confirmer, avec des mises en situation ludiques, recherches en ligne, manipulation de fichiers et de données, culture numérique...</p><p>Allez à votre rythme, vous pouvez arrêter et reprendre quand vous le voulez.</p><p>Toutes les 5 questions, découvrez vos résultats et progressez grâce aux astuces et aux tutos.</p><p>En relevant les défis Pix, vous apprendrez de nouvelles choses et aurez envie d'aller plus loin.</p><p>Vous pensez pouvoir faire mieux ?</p><p>Retentez les tests et améliorez votre score.</p><p>Faites reconnaître officiellement votre niveau en passant la certification Pix, reconnue par l'État et le monde professionnel.</p><p>Pix : le service public en ligne pour évaluer, développer et certifier ses compétences numériques.</p>",
+              "alternativeText": "Vidéo de présentation de Pix"
             }
           ]
         },


### PR DESCRIPTION
## :unicorn: Problème
Suite à un remplacement de contenu "massif" pour des images placeholder, rétro-pédalage pour màj les contenus images et vidéos du module didacticiel

## :robot: Proposition
Rétablir les anciennes images et vidéos depuis la dernière PR https://github.com/1024pix/pix/pull/7946/files 

## :rainbow: Remarques
RAS
## :100: Pour tester
Suivre le lien pour accéder au didacticiel et vérifier l'image et la vidéo présentées : https://app-pr8045.review.pix.fr/modules/didacticiel-modulix/