### PR TITLE
[BUGFIX] Corriger l'affichage de la progression dans l'export des CSV (PIX-11163)

### DIFF
--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -68,6 +68,18 @@ async function _countValidatedByCompetencesForUsersWithinCampaign(userIdsAndDate
   );
 }
 
+const findUniqByUserIds = function (userIds) {
+  return Promise.all(
+    userIds.map(async (userId) => {
+      const knowledgeElements = await _findAssessedByUserIdAndLimitDateQuery({
+        userId,
+      });
+
+      return { userId, knowledgeElements };
+    }),
+  );
+};
+
 const save = async function (knowledgeElement) {
   const knowledgeElementToSave = _.omit(knowledgeElement, ['id', 'createdAt']);
   const [savedKnowledgeElement] = await knex(tableName).insert(knowledgeElementToSave).returning('*');
@@ -162,6 +174,7 @@ export {
   save,
   batchSave,
   findUniqByUserId,
+  findUniqByUserIds,
   findUniqByUserIdAndAssessmentId,
   findUniqByUserIdAndCompetenceId,
   findUniqByUserIdGroupedByCompetenceId,

--- a/api/src/prescription/campaign/domain/usecases/index.js
+++ b/api/src/prescription/campaign/domain/usecases/index.js
@@ -24,6 +24,7 @@ import * as badgeAcquisitionRepository from '../../../../../lib/infrastructure/r
 import * as campaignRepository from '../../../../../lib/infrastructure/repositories/campaign-repository.js';
 import * as codeGenerator from '../../../../../lib/domain/services/code-generator.js';
 import * as knowledgeElementSnapshotRepository from '../../../../../lib/infrastructure/repositories/knowledge-element-snapshot-repository.js';
+import * as knowledgeElementRepository from '../../../../../lib/infrastructure/repositories/knowledge-element-repository.js';
 import * as learningContentRepository from '../../../../../lib/infrastructure/repositories/learning-content-repository.js';
 import * as membershipRepository from '../../../../../lib/infrastructure/repositories/membership-repository.js';
 import * as organizationRepository from '../../../../../lib/infrastructure/repositories/organization-repository.js';
@@ -51,6 +52,7 @@ const dependencies = {
   campaignUpdateValidator,
   competenceRepository,
   knowledgeElementSnapshotRepository,
+  knowledgeElementRepository,
   learningContentRepository,
   membershipRepository,
   organizationRepository,

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -1385,4 +1385,51 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
       expect(knowledgeElements).to.have.length(0);
     });
   });
+
+  describe('#findKeForUsers', function () {
+    let userId1;
+    let userId2;
+
+    beforeEach(function () {
+      userId1 = databaseBuilder.factory.buildUser().id;
+      userId2 = databaseBuilder.factory.buildUser().id;
+      return databaseBuilder.commit();
+    });
+
+    it('should return knowledge elements for given users', async function () {
+      // given
+
+      const user1knowledgeElement1 = databaseBuilder.factory.buildKnowledgeElement({
+        userId: userId1,
+        createdAt: new Date('2020-01-01'),
+        skillId: 'rec1',
+      });
+      const user2knowledgeElement1 = databaseBuilder.factory.buildKnowledgeElement({
+        userId: userId2,
+        createdAt: new Date('2019-01-01'),
+        skillId: 'rec2',
+      });
+      const user2knowledgeElement2 = databaseBuilder.factory.buildKnowledgeElement({
+        userId: userId2,
+        createdAt: new Date('2019-01-02'),
+        skillId: 'rec3',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const knowledgeElementsByUserIdAndCompetenceId = await knowledgeElementRepository.findUniqByUserIds([
+        userId1,
+        userId2,
+      ]);
+
+      // then
+      expect(knowledgeElementsByUserIdAndCompetenceId[0].knowledgeElements).to.have.deep.members([
+        user1knowledgeElement1,
+      ]);
+      expect(knowledgeElementsByUserIdAndCompetenceId[1].knowledgeElements).to.have.deep.members([
+        user2knowledgeElement1,
+        user2knowledgeElement2,
+      ]);
+    });
+  });
 });

--- a/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -272,5 +272,173 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
         expect(csvLines[1]).to.equal(csvSecondLine);
       });
     });
+
+    context('multiple participations', function () {
+      let secondParticipationDateCreatedAt;
+      beforeEach(async function () {
+        secondParticipationDateCreatedAt = new Date('2019-03-05');
+        // on utilise un nouveau learner
+        participant = databaseBuilder.factory.buildUser();
+
+        organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+          firstName: '@Jean',
+          lastName: '=Bono',
+          organizationId: organization.id,
+          userId: participant.id,
+        });
+
+        campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          organizationLearnerId: organizationLearner.id,
+          userId: participant.id,
+          participantExternalId: 'toto',
+          isImproved: true,
+          masteryRate: 0.67,
+          createdAt,
+          sharedAt,
+        });
+
+        databaseBuilder.factory.buildAssessment({
+          campaignParticipationId: campaignParticipation.id,
+          userId: participant.id,
+          state: Assessment.states.COMPLETED,
+          type: Assessment.types.CAMPAIGN,
+        });
+
+        // second participation
+        campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          status: CampaignParticipationStatuses.STARTED,
+          campaignId: campaign.id,
+          organizationLearnerId: organizationLearner.id,
+          userId: participant.id,
+          participantExternalId: 'toto',
+          isImproved: false,
+          createdAt: secondParticipationDateCreatedAt,
+        });
+
+        databaseBuilder.factory.buildAssessment({
+          campaignParticipationId: campaignParticipation.id,
+          userId: participant.id,
+          state: Assessment.states.STARTED,
+          type: Assessment.types.CAMPAIGN,
+        });
+
+        const ke1 = databaseBuilder.factory.buildKnowledgeElement({
+          status: 'validated',
+          skillId: 'recSkillWeb1',
+          competenceId: 'recCompetence1',
+          userId: participant.id,
+          createdAt,
+        });
+        const ke2 = databaseBuilder.factory.buildKnowledgeElement({
+          status: 'invalidated',
+          skillId: 'recSkillWeb2',
+          competenceId: 'recCompetence1',
+          userId: participant.id,
+          createdAt,
+        });
+        const ke3 = databaseBuilder.factory.buildKnowledgeElement({
+          status: 'validated',
+          skillId: 'recSkillWeb3',
+          competenceId: 'recCompetence1',
+          userId: participant.id,
+          createdAt,
+        });
+
+        databaseBuilder.factory.buildKnowledgeElement({
+          status: KnowledgeElement.StatusType.RESET,
+          skillId: 'recSkillWeb2',
+          competenceId: 'recCompetence1',
+          userId: participant.id,
+          createdAt: secondParticipationDateCreatedAt,
+        });
+
+        databaseBuilder.factory.buildKnowledgeElementSnapshot({
+          userId: participant.id,
+          snappedAt: sharedAt,
+          snapshot: JSON.stringify([ke1, ke2, ke3]),
+        });
+
+        ['recSkillWeb1', 'recSkillWeb2', 'recSkillWeb3'].forEach((skillId) => {
+          databaseBuilder.factory.buildCampaignSkill({
+            campaignId: campaign.id,
+            skillId: skillId,
+          });
+        });
+        await databaseBuilder.commit();
+      });
+      it('should return 2 lines', async function () {
+        // given
+        const expectedCsvFirstCell = '\uFEFF"Nom de l\'organisation"';
+
+        const csvSecondLine =
+          `"${organization.name}";` +
+          `${campaign.id};` +
+          `"${campaign.code}";` +
+          `"'${campaign.name}";` +
+          `"'${targetProfile.name}";` +
+          `"'${organizationLearner.lastName}";` +
+          `"'${organizationLearner.firstName}";` +
+          `"${campaignParticipation.participantExternalId}";` +
+          '0,667;' +
+          `2019-03-05;` +
+          '"Non";' +
+          `"NA";` +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA"';
+
+        const csvThirdLine =
+          `"${organization.name}";` +
+          `${campaign.id};` +
+          `"${campaign.code}";` +
+          `"'${campaign.name}";` +
+          `"'${targetProfile.name}";` +
+          `"'${organizationLearner.lastName}";` +
+          `"'${organizationLearner.firstName}";` +
+          `"${campaignParticipation.participantExternalId}";` +
+          '1;' +
+          '2019-02-25;' +
+          '"Oui";' +
+          '2019-03-01;' +
+          '1;' +
+          '"Non";' +
+          '0,67;' +
+          '0,67;' +
+          '3;' +
+          '2;' +
+          '0,67;' +
+          '3;' +
+          '2;' +
+          '"OK";' +
+          '"KO";' +
+          '"OK"';
+        // when
+        await usecases.startWritingCampaignAssessmentResultsToStream({
+          campaignId: campaign.id,
+          writableStream,
+          i18n,
+        });
+
+        const csv = await csvPromise;
+        const csvLines = csv.split('\n');
+        const csvFirstLineCells = csvLines[0].split(';');
+
+        // then
+        expect(csvLines.length).to.equals(4);
+        expect(csvFirstLineCells[0]).to.equal(expectedCsvFirstCell);
+        expect(csvLines[1]).to.equals(csvSecondLine);
+        expect(csvLines[2]).to.equal(csvThirdLine);
+      });
+    });
   });
 });

--- a/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -6,12 +6,12 @@ import { expect, mockLearningContent, databaseBuilder, streamToPromise } from '.
 import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
 import { Assessment } from '../../../../../../src/shared/domain/models/Assessment.js';
 import { getI18n } from '../../../../../tooling/i18n/i18n.js';
+import { CampaignParticipationStatuses, KnowledgeElement } from '../../../../../../lib/domain/models/index.js';
 
 describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-results-to-stream', function () {
   describe('#startWritingCampaignAssessmentResultsToStream', function () {
     let organization;
     let targetProfile;
-    let user;
     let participant;
     let campaign;
     let campaignParticipation;
@@ -19,40 +19,19 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
     let writableStream;
     let csvPromise;
     let i18n;
+    let createdAt, sharedAt;
 
     beforeEach(async function () {
       i18n = getI18n();
       organization = databaseBuilder.factory.buildOrganization({ showSkills: true });
-      user = databaseBuilder.factory.buildUser();
-      databaseBuilder.factory.buildMembership({ userId: user.id, organizationId: organization.id });
 
-      participant = databaseBuilder.factory.buildUser();
-      const createdAt = new Date('2019-02-25');
-      const sharedAt = new Date('2019-03-01');
-      const ke1 = databaseBuilder.factory.buildKnowledgeElement({
-        status: 'validated',
-        skillId: 'recSkillWeb1',
-        competenceId: 'recCompetence1',
-        userId: participant.id,
-        createdAt,
-      });
-      const ke2 = databaseBuilder.factory.buildKnowledgeElement({
-        status: 'validated',
-        skillId: 'recSkillWeb2',
-        competenceId: 'recCompetence1',
-        userId: participant.id,
-        createdAt,
-      });
-      const ke3 = databaseBuilder.factory.buildKnowledgeElement({
-        status: 'invalidated',
-        skillId: 'recSkillWeb3',
-        competenceId: 'recCompetence1',
-        userId: participant.id,
-        createdAt,
-      });
-
+      // Profil cible
       targetProfile = databaseBuilder.factory.buildTargetProfile({ name: '+Profile 1' });
+      databaseBuilder.factory.buildStage({ targetProfileId: targetProfile.id, threshold: 0 });
+      databaseBuilder.factory.buildStage({ targetProfileId: targetProfile.id, threshold: 1 });
+      databaseBuilder.factory.buildBadge({ targetProfileId: targetProfile.id });
 
+      // campagne
       campaign = databaseBuilder.factory.buildCampaign({
         name: '@Campagne de Test N°1',
         code: 'AZERTY123',
@@ -61,42 +40,10 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
         type: 'ASSESSMENT',
         targetProfileId: targetProfile.id,
       });
-      ['recSkillWeb1', 'recSkillWeb2', 'recSkillWeb3'].forEach((skillId) => {
-        databaseBuilder.factory.buildCampaignSkill({
-          campaignId: campaign.id,
-          skillId: skillId,
-        });
-      });
 
-      organizationLearner = { firstName: '@Jean', lastName: '=Bono' };
-      campaignParticipation = databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
-        organizationLearner,
-        {
-          createdAt,
-          sharedAt,
-          participantExternalId: '+Mon mail pro',
-          campaignId: campaign.id,
-          userId: participant.id,
-          masteryRate: 0.67,
-        },
-      );
-      databaseBuilder.factory.buildAssessment({
-        campaignParticipationId: campaignParticipation.id,
-        userId: participant.id,
-        state: Assessment.states.COMPLETED,
-        type: Assessment.types.CAMPAIGN,
-      });
-      databaseBuilder.factory.buildStage({ targetProfileId: targetProfile.id, threshold: 0 });
-      databaseBuilder.factory.buildStage({ targetProfileId: targetProfile.id, threshold: 1 });
-      databaseBuilder.factory.buildBadge({ targetProfileId: targetProfile.id });
-
-      databaseBuilder.factory.buildKnowledgeElementSnapshot({
-        userId: participant.id,
-        snappedAt: sharedAt,
-        snapshot: JSON.stringify([ke1, ke2, ke3]),
-      });
-
-      await databaseBuilder.commit();
+      // participation
+      createdAt = new Date('2019-02-25');
+      sharedAt = new Date('2019-03-01');
 
       const learningContent = {
         frameworks: [{ id: 'frameworkId', name: 'frameworkName' }],
@@ -119,57 +66,211 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
         ],
         challenges: [],
       };
-
       mockLearningContent(learningContent);
 
       writableStream = new PassThrough();
       csvPromise = streamToPromise(writableStream);
     });
 
-    it('should return the complete line', async function () {
-      // given
-      const expectedCsvFirstCell = '\uFEFF"Nom de l\'organisation"';
-      const csvSecondLine =
-        `"${organization.name}";` +
-        `${campaign.id};` +
-        `"${campaign.code}";` +
-        `"'${campaign.name}";` +
-        `"'${targetProfile.name}";` +
-        `"'${organizationLearner.lastName}";` +
-        `"'${organizationLearner.firstName}";` +
-        `"'${campaignParticipation.participantExternalId}";` +
-        '1;' +
-        '2019-02-25;' +
-        '"Oui";' +
-        '2019-03-01;' +
-        '1;' +
-        '"Non";' +
-        '0,67;' +
-        '0,67;' +
-        '3;' +
-        '2;' +
-        '0,67;' +
-        '3;' +
-        '2;' +
-        '"OK";' +
-        '"OK";' +
-        '"KO"';
+    context('participation shared', function () {
+      beforeEach(async function () {
+        // learner
+        participant = databaseBuilder.factory.buildUser();
+        organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+          firstName: '@Jean',
+          lastName: '=Bono',
+          organizationId: organization.id,
+          userId: participant.id,
+        });
 
-      // when
-      await usecases.startWritingCampaignAssessmentResultsToStream({
-        userId: user.id,
-        campaignId: campaign.id,
-        writableStream,
-        i18n,
+        campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          organizationLearnerId: organizationLearner.id,
+          userId: participant.id,
+          participantExternalId: 'toto',
+          masteryRate: 0.67,
+          createdAt,
+          sharedAt,
+        });
+
+        databaseBuilder.factory.buildAssessment({
+          campaignParticipationId: campaignParticipation.id,
+          userId: participant.id,
+          state: Assessment.states.COMPLETED,
+          type: Assessment.types.CAMPAIGN,
+        });
+
+        const ke1 = databaseBuilder.factory.buildKnowledgeElement({
+          status: 'validated',
+          skillId: 'recSkillWeb1',
+          competenceId: 'recCompetence1',
+          userId: participant.id,
+          createdAt,
+        });
+        const ke2 = databaseBuilder.factory.buildKnowledgeElement({
+          status: 'validated',
+          skillId: 'recSkillWeb2',
+          competenceId: 'recCompetence1',
+          userId: participant.id,
+          createdAt,
+        });
+        const ke3 = databaseBuilder.factory.buildKnowledgeElement({
+          status: 'invalidated',
+          skillId: 'recSkillWeb3',
+          competenceId: 'recCompetence1',
+          userId: participant.id,
+          createdAt,
+        });
+        databaseBuilder.factory.buildKnowledgeElementSnapshot({
+          userId: participant.id,
+          snappedAt: sharedAt,
+          snapshot: JSON.stringify([ke1, ke2, ke3]),
+        });
+
+        ['recSkillWeb1', 'recSkillWeb2', 'recSkillWeb3'].forEach((skillId) => {
+          databaseBuilder.factory.buildCampaignSkill({
+            campaignId: campaign.id,
+            skillId: skillId,
+          });
+        });
+
+        await databaseBuilder.commit();
       });
 
-      const csv = await csvPromise;
-      const csvLines = csv.split('\n');
-      const csvFirstLineCells = csvLines[0].split(';');
+      it('should return the complete line', async function () {
+        // given
+        const expectedCsvFirstCell = '\uFEFF"Nom de l\'organisation"';
+        const csvSecondLine =
+          `"${organization.name}";` +
+          `${campaign.id};` +
+          `"${campaign.code}";` +
+          `"'${campaign.name}";` +
+          `"'${targetProfile.name}";` +
+          `"'${organizationLearner.lastName}";` +
+          `"'${organizationLearner.firstName}";` +
+          `"${campaignParticipation.participantExternalId}";` +
+          '1;' +
+          '2019-02-25;' +
+          '"Oui";' +
+          '2019-03-01;' +
+          '1;' +
+          '"Non";' +
+          '0,67;' +
+          '0,67;' +
+          '3;' +
+          '2;' +
+          '0,67;' +
+          '3;' +
+          '2;' +
+          '"OK";' +
+          '"OK";' +
+          '"KO"';
 
-      // then
-      expect(csvFirstLineCells[0]).to.equal(expectedCsvFirstCell);
-      expect(csvLines[1]).to.equal(csvSecondLine);
+        // when
+        await usecases.startWritingCampaignAssessmentResultsToStream({
+          campaignId: campaign.id,
+          writableStream,
+          i18n,
+        });
+        const csv = await csvPromise;
+
+        const csvLines = csv.split('\n');
+        const csvFirstLineCells = csvLines[0].split(';');
+
+        // then
+        expect(csvFirstLineCells[0]).to.equal(expectedCsvFirstCell);
+        expect(csvLines[1]).to.equal(csvSecondLine);
+      });
+    });
+
+    context('participation started', function () {
+      beforeEach(async function () {
+        // learner
+        participant = databaseBuilder.factory.buildUser();
+        organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+          firstName: '@Jean',
+          lastName: '=Bono',
+          organizationId: organization.id,
+          userId: participant.id,
+        });
+
+        campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          organizationLearnerId: organizationLearner.id,
+          userId: participant.id,
+          participantExternalId: 'toto',
+          status: CampaignParticipationStatuses.STARTED,
+          createdAt,
+        });
+
+        databaseBuilder.factory.buildAssessment({
+          campaignParticipationId: campaignParticipation.id,
+          userId: participant.id,
+          state: Assessment.states.STARTED,
+          type: Assessment.types.CAMPAIGN,
+        });
+
+        databaseBuilder.factory.buildKnowledgeElement({
+          status: 'validated',
+          skillId: 'recSkillWeb1',
+          competenceId: 'recCompetence1',
+          userId: participant.id,
+        });
+
+        ['recSkillWeb1', 'recSkillWeb2', 'recSkillWeb3'].forEach((skillId) => {
+          databaseBuilder.factory.buildCampaignSkill({
+            campaignId: campaign.id,
+            skillId: skillId,
+          });
+        });
+
+        await databaseBuilder.commit();
+      });
+
+      it('should return a csv line with progression', async function () {
+        // given
+        const expectedCsvFirstCell = '\uFEFF"Nom de l\'organisation"';
+        const csvSecondLine =
+          `"${organization.name}";` +
+          `${campaign.id};` +
+          `"${campaign.code}";` +
+          `"'${campaign.name}";` +
+          `"'${targetProfile.name}";` +
+          `"'${organizationLearner.lastName}";` +
+          `"'${organizationLearner.firstName}";` +
+          `"${campaignParticipation.participantExternalId}";` +
+          '0,333;' +
+          `2019-02-25;` +
+          '"Non";' +
+          `"NA";` +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA";' +
+          '"NA"';
+
+        // when
+        await usecases.startWritingCampaignAssessmentResultsToStream({
+          campaignId: campaign.id,
+          writableStream,
+          i18n,
+        });
+
+        const csv = await csvPromise;
+        const csvLines = csv.split('\n');
+        const csvFirstLineCells = csvLines[0].split(';');
+
+        // then
+        expect(csvFirstLineCells[0]).to.equal(expectedCsvFirstCell);
+        expect(csvLines[1]).to.equal(csvSecondLine);
+      });
     });
   });
 });

--- a/api/tests/prescription/campaign/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -13,6 +13,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
   let campaignRepository,
     campaignParticipationInfoRepository,
     organizationRepository,
+    knowledgeElementRepository,
     knowledgeElementSnapshotRepository,
     badgeAcquisitionRepository,
     stageCollectionRepository,
@@ -25,6 +26,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
     campaignRepository = { get: sinon.stub() };
     campaignParticipationInfoRepository = { findByCampaignId: sinon.stub() };
     organizationRepository = { get: sinon.stub() };
+    knowledgeElementRepository = { findUniqByUserIds: sinon.stub() };
     knowledgeElementSnapshotRepository = { findMultipleUsersFromUserIdsAndSnappedAtDates: sinon.stub() };
     badgeAcquisitionRepository = { getAcquiredBadgesByCampaignParticipations: sinon.stub() };
     stageCollectionRepository = { findStageCollection: sinon.stub() };
@@ -612,6 +614,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       new StageCollection({ campaignId: campaign.id, stages: [] }),
     );
     campaignParticipationInfoRepository.findByCampaignId.withArgs(campaign.id).resolves([participantInfo]);
+
     knowledgeElementSnapshotRepository.findMultipleUsersFromUserIdsAndSnappedAtDates.resolves([
       {
         userId: participantInfo.userId,
@@ -676,6 +679,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       learningContentRepository,
       organizationRepository,
       campaignParticipationInfoRepository,
+      knowledgeElementRepository,
       knowledgeElementSnapshotRepository,
       badgeAcquisitionRepository,
       campaignCsvExportService,


### PR DESCRIPTION
## :unicorn: Problème
Suite à l'optimisation des exports CSV, une coquille s'est glissé. En effet nous avons besoin de ke ( hors snapshot) afin de calculer le % de progression d'un utilisateur

## :robot: Proposition
Rajouter l'appel au ke pour les export de type assessment afin de connaitre la progression dans ce cas là

## :rainbow: Remarques
Si nous voulons faire une optimisation des exports. ce champs progression est problématique puiqu'il nous oblige à parcourir les ke des utilisateurs n'ayant pas partagé leur parcours

## :100: Pour tester
Utiliser le learner1005_0@example.net répondre à une question (ok/ko pas d'importance)
Se connecter sur PixOrga en pro-orga@example.net télécharger l'export csv de la campagne d'assessment et vérifier que la progression n'est plus à 0 .