### PR TITLE
[REFACTOR] Améliorer la validation de charge utile de création des RT (PIX-10971).

### DIFF
--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -279,9 +279,22 @@ const register = async function (server) {
                 title: Joi.string().required().allow('').allow(null),
                 'is-certifiable': Joi.boolean().required(),
                 'is-always-visible': Joi.boolean().required(),
-                'campaign-threshold': Joi.number().min(0).max(100).allow(null),
-                'capped-tubes-criteria': Joi.array().allow(null),
-              }).required(),
+                'campaign-threshold': Joi.number().min(0).max(100),
+                'capped-tubes-criteria': Joi.array()
+                  .min(1)
+                  .items({
+                    name: Joi.string(),
+                    threshold: Joi.string().required(),
+                    cappedTubes: Joi.array()
+                      .min(1)
+                      .items({
+                        id: Joi.string(),
+                        level: Joi.number().min(0),
+                      }),
+                  }),
+              })
+                .or('campaign-threshold', 'capped-tubes-criteria')
+                .required(),
               type: Joi.string().required(),
             }).required(),
           }).required(),


### PR DESCRIPTION
## :unicorn: Problème

Nous avons vu qu’il est possible de soumettre des données sur la route “POST /api/admin/target-profiles/4310/badges” qui génèrent une erreur 500. 

Notamment il est possible de ne pas sélectionner de sujets de profil cible.

## :robot: Proposition

Améliorer la validation de charge utile de la route de création des RT.

## :rainbow: Remarques

Documentation du `.or()` de JOI : https://joi.dev/api/?v=17.12.0#objectorpeers-options

## :100: Pour tester

✅ Tests OK.
