### PR TITLE
[FEATURE] Affichage et vérification des QCM (PIX-11100) (PIX-11024) (PIX-11135)

### DIFF
--- a/api/src/devcomp/domain/models/QcmCorrectionResponse.js
+++ b/api/src/devcomp/domain/models/QcmCorrectionResponse.js
@@ -1,14 +1,14 @@
 import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.js';
 
 class QcmCorrectionResponse {
-  constructor({ status, feedback, solutions }) {
+  constructor({ status, feedback, solution }) {
     assertNotNullOrUndefined(status, 'The result is required for a QCM answer');
     assertNotNullOrUndefined(feedback, 'The feedback is required for a QCM answer');
-    assertNotNullOrUndefined(solutions, 'The solutions are required for a QCM answer');
+    assertNotNullOrUndefined(solution, 'The solutions are required for a QCM answer');
 
     this.status = status;
     this.feedback = feedback;
-    this.solutions = solutions;
+    this.solution = solution;
   }
 }
 

--- a/api/src/devcomp/domain/models/element/QCM-for-answer-verification.js
+++ b/api/src/devcomp/domain/models/element/QCM-for-answer-verification.js
@@ -38,7 +38,7 @@ class QCMForAnswerVerification extends QCM {
     return new QcmCorrectionResponse({
       status: validation.result,
       feedback: validation.result.isOK() ? this.feedbacks.valid : this.feedbacks.invalid,
-      solutions: this.solutionsValue,
+      solution: this.solutionsValue,
     });
   }
 

--- a/api/src/devcomp/infrastructure/datasources/learning-content/module.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module.json
@@ -320,6 +320,10 @@
           "grainId": "533c69b8-a836-41be-8ffc-8d4636e31224"
         },
         {
+          "content": "<p>Vous l’aurez compris, on aime varier les plaisirs et proposer différents types d’activité, après le questionnaire à choix unique on vous laisse découvrir le QCM !</p>",
+          "grainId": "0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c"
+        },
+        {
           "content": "<p>Vous l'avez peut-être remarqué : dans un module, vous pouvez voir tous les contenus en remontant la page <span aria-hidden=\"true\">⬆️</span>️</p>",
           "grainId": "2a77a10f-19a3-4544-80f9-8012dad6506a"
         },

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/element-answer-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/element-answer-serializer.js
@@ -19,7 +19,7 @@ function serialize(elementAnswer) {
     correction: {
       ref: 'id',
       includes: true,
-      attributes: ['feedback', 'status', 'solution', 'solutions'],
+      attributes: ['feedback', 'status', 'solution'],
       type: 'correction-responses',
     },
     typeForAttribute(attribute, { type }) {

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -105,12 +105,7 @@ describe('Acceptance | Controller | passage-controller', function () {
           expect(response.result.data.attributes['element-id']).to.equal(testCase.elementId);
           expect(response.result.included[0].attributes.status).to.equal('ok');
           expect(response.result.included[0].attributes.feedback).to.equal(testCase.expectedFeedback);
-          if (testCase.case === 'QCM') {
-            expect(response.result.included[0].attributes.solutions).to.deep.equal(testCase.expectedSolution);
-          }
-          if (['QCU', 'QROCM-ind'].includes(testCase.case)) {
-            expect(response.result.included[0].attributes.solution).to.deep.equal(testCase.expectedSolution);
-          }
+          expect(response.result.included[0].attributes.solution).to.deep.equal(testCase.expectedSolution);
         }),
       );
     });

--- a/api/tests/devcomp/unit/domain/models/QcmCorrectionResponse_test.js
+++ b/api/tests/devcomp/unit/domain/models/QcmCorrectionResponse_test.js
@@ -8,16 +8,16 @@ describe('Unit | Devcomp | Domain | Models | QcmCorrectionResponse', function ()
       // given
       const status = AnswerStatus.OK;
       const feedback = 'Bien joué !';
-      const solutions = ['1', '2'];
+      const solution = ['1', '2'];
 
       // when
-      const qcmCorrectionResponse = new QcmCorrectionResponse({ status, feedback, solutions });
+      const qcmCorrectionResponse = new QcmCorrectionResponse({ status, feedback, solution });
 
       // then
       expect(qcmCorrectionResponse).not.to.be.undefined;
       expect(qcmCorrectionResponse.status).to.deep.equal(status);
       expect(qcmCorrectionResponse.feedback).to.equal(feedback);
-      expect(qcmCorrectionResponse.solutions).to.deep.equal(solutions);
+      expect(qcmCorrectionResponse.solution).to.deep.equal(solution);
     });
   });
 

--- a/api/tests/devcomp/unit/domain/models/element/QCM-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCM-for-answer-verification_test.js
@@ -83,7 +83,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QcmForAnswerVerification'
       const expectedCorrection = {
         status: assessResult.result,
         feedback: qcm.feedbacks.valid,
-        solutions: qcmSolutions,
+        solution: qcmSolutions,
       };
 
       // when
@@ -127,7 +127,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QcmForAnswerVerification'
       const expectedCorrection = {
         status: assessResult.result,
         feedback: qcm.feedbacks.invalid,
-        solutions: qcmSolutions,
+        solution: qcmSolutions,
       };
 
       // when

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/element-answer-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/element-answer-serializer_test.js
@@ -133,7 +133,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ElementAnswe
         const givenCorrectionResponse = new QcmCorrectionResponse({
           status: AnswerStatus.OK,
           feedback: 'Good job!',
-          solutions,
+          solution: solutions,
         });
 
         const elementAnswer = new ElementAnswer({
@@ -164,7 +164,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ElementAnswe
               attributes: {
                 feedback: 'Good job!',
                 status: 'ok',
-                solutions: givenCorrectionResponse.solutions,
+                solution: givenCorrectionResponse.solution,
               },
               id: '222',
               type: 'correction-responses',

--- a/mon-pix/app/pods/components/module/grain/template.hbs
+++ b/mon-pix/app/pods/components/module/grain/template.hbs
@@ -27,6 +27,12 @@
             @submitAnswer={{@submitAnswer}}
             @correction={{this.getLastCorrectionForElement element}}
           />
+        {{else if element.isQcm}}
+          <Module::Qcm
+            @qcm={{element}}
+            @submitAnswer={{@submitAnswer}}
+            @correction={{this.getLastCorrectionForElement element}}
+          />
         {{else if element.isQrocm}}
           <Module::Qrocm
             @qrocm={{element}}

--- a/mon-pix/app/pods/components/module/qcm/component.js
+++ b/mon-pix/app/pods/components/module/qcm/component.js
@@ -1,0 +1,40 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class ModuleQcm extends Component {
+  selectedAnswerIds = new Set();
+  @tracked requiredMessage = false;
+
+  qcm = this.args.qcm;
+
+  get feedbackType() {
+    return this.args.correction?.isOk ? 'success' : 'error';
+  }
+
+  get disableInput() {
+    return !!this.args.correction;
+  }
+
+  get shouldDisplayFeedback() {
+    return !!this.args.correction;
+  }
+
+  @action
+  checkboxSelected(proposalId) {
+    this.selectedAnswerId = proposalId;
+  }
+
+  @action
+  async submitAnswer(event) {
+    event.preventDefault();
+    if (!this.selectedAnswerId) {
+      this.requiredMessage = true;
+
+      return;
+    }
+    this.requiredMessage = false;
+    const answerData = { userResponse: [this.selectedAnswerId], element: this.qcm };
+    await this.args.submitAnswer(answerData);
+  }
+}

--- a/mon-pix/app/pods/components/module/qcm/component.js
+++ b/mon-pix/app/pods/components/module/qcm/component.js
@@ -22,19 +22,23 @@ export default class ModuleQcm extends Component {
 
   @action
   checkboxSelected(proposalId) {
-    this.selectedAnswerId = proposalId;
+    if (this.selectedAnswerIds.has(proposalId)) {
+      this.selectedAnswerIds.delete(proposalId);
+    } else {
+      this.selectedAnswerIds.add(proposalId);
+    }
   }
 
   @action
   async submitAnswer(event) {
     event.preventDefault();
-    if (!this.selectedAnswerId) {
+    if (this.selectedAnswerIds.size < 2) {
       this.requiredMessage = true;
 
       return;
     }
     this.requiredMessage = false;
-    const answerData = { userResponse: [this.selectedAnswerId], element: this.qcm };
+    const answerData = { userResponse: [...this.selectedAnswerIds], element: this.qcm };
     await this.args.submitAnswer(answerData);
   }
 }

--- a/mon-pix/app/pods/components/module/qcm/styles.scss
+++ b/mon-pix/app/pods/components/module/qcm/styles.scss
@@ -1,0 +1,36 @@
+.element-qcm {
+  &__proposals {
+    margin-bottom: var(--pix-spacing-4x);
+  }
+
+  &__required-field-missing {
+    margin-bottom: var(--pix-spacing-4x);
+  }
+}
+
+.element-qcm-header {
+  &__instruction {
+    margin-bottom: var(--pix-spacing-2x);
+    font-weight: var(--pix-font-medium);
+  }
+
+  &__direction {
+    @extend %pix-body-s;
+
+    margin-bottom: var(--pix-spacing-4x);
+    color: var(--pix-neutral-500);
+  }
+}
+
+.element-qcm-proposals {
+  &__proposal {
+    padding: var(--pix-spacing-2x);
+    background: var(--pix-neutral-0);
+    border: 1px solid var(--pix-neutral-100);
+    border-radius: var(--pix-spacing-2x);
+
+    &:not(:last-child) {
+      margin-bottom: var(--pix-spacing-2x);
+    }
+  }
+}

--- a/mon-pix/app/pods/components/module/qcm/template.hbs
+++ b/mon-pix/app/pods/components/module/qcm/template.hbs
@@ -1,0 +1,52 @@
+<form class="element-qcm">
+  <fieldset disabled={{this.disableInput}}>
+    <div class="element-qcm__header">
+      <div class="element-qcm-header__instruction">
+        {{html-unsafe @qcm.instruction}}
+      </div>
+
+      <legend class="element-qcm-header__direction">
+        {{t "pages.modulix.qcm.direction"}}
+      </legend>
+    </div>
+
+    <div class="element-qcm__proposals">
+      {{#each @qcm.proposals as |proposal|}}
+        <div class="element-qcm-proposals__proposal">
+          <PixCheckbox
+            name={{@qcm.id}}
+            {{on "click" (fn this.checkboxSelected proposal.id)}}
+          >{{proposal.content}}</PixCheckbox>
+        </div>
+      {{/each}}
+    </div>
+  </fieldset>
+
+  {{#if this.requiredMessage}}
+    <div class="element-qcm__required-field-missing">
+      <PixMessage role="alert" @type="error" @withIcon={{true}}>
+        {{t "pages.modulix.verification-precondition-failed-alert.qcm"}}
+      </PixMessage>
+    </div>
+  {{/if}}
+
+  {{#unless @correction}}
+    <PixButton
+      @backgroundColor="success"
+      @shape="rounded"
+      @type="submit"
+      class="element-qcm__verify_button"
+      @triggerAction={{this.submitAnswer}}
+    >
+      {{t "pages.modulix.buttons.activity.verify"}}
+    </PixButton>
+  {{/unless}}
+
+  <div role="status" tabindex="-1">
+    {{#if this.shouldDisplayFeedback}}
+      <PixMessage @type={{this.feedbackType}} @withIcon={{true}} class="element-qcm__feedback">
+        {{html-unsafe @correction.feedback}}
+      </PixMessage>
+    {{/if}}
+  </div>
+</form>

--- a/mon-pix/app/pods/element/model.js
+++ b/mon-pix/app/pods/element/model.js
@@ -19,6 +19,10 @@ export default class Element extends Model {
     return this.type === 'qcus';
   }
 
+  get isQcm() {
+    return this.type === 'qcms';
+  }
+
   get isQrocm() {
     return this.type === 'qrocms';
   }

--- a/mon-pix/tests/acceptance/module/verify-qcm_test.js
+++ b/mon-pix/tests/acceptance/module/verify-qcm_test.js
@@ -1,0 +1,83 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { visit } from '@1024pix/ember-testing-library';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { click } from '@ember/test-helpers';
+
+module('Acceptance | Module | Routes | verifyQcm', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  test('can validate my QCM answer', async function (assert) {
+    // given
+    const qcm1 = server.create('qcm', {
+      id: 'elementId-1',
+      type: 'qcms',
+      instruction: 'instruction',
+      proposals: [
+        { id: '1', content: 'I am one of the wrong answers!' },
+        { id: '2', content: 'I am the first right answer!' },
+        { id: '3', content: 'I am the second right answer!' },
+        { id: '4', content: 'I am one of the wrong answers!' },
+      ],
+    });
+    const qcm2 = server.create('qcm', {
+      id: 'elementId-2',
+      type: 'qcms',
+      instruction: 'instruction',
+      proposals: [
+        { id: '1', content: 'I am one of the right answers!' },
+        { id: '2', content: 'I am the first wrong answer!' },
+        { id: '3', content: 'Click Me!' },
+        { id: '4', content: 'I am the second wrong answer!' },
+      ],
+    });
+
+    const grain = server.create('grain', {
+      id: 'grainId',
+      title: 'title',
+      elements: [qcm1, qcm2],
+    });
+
+    server.create('module', {
+      id: 'bien-ecrire-son-adresse-mail',
+      title: 'Bien écrire son adresse mail',
+      grains: [grain],
+    });
+
+    server.create('correction-response', {
+      id: 'elementId-1',
+      feedback: "Bravo ! C'est la bonne réponse.",
+      status: 'ok',
+      solution: [qcm1.proposals[1].id, qcm1.proposals[2].id],
+    });
+
+    server.create('correction-response', {
+      id: 'elementId-2',
+      feedback: 'Pas ouf',
+      status: 'ko',
+      solution: [qcm2.proposals[0].id, qcm2.proposals[2].id],
+    });
+
+    // when
+    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+    const allVerifyButtons = screen.getAllByRole('button', { name: 'Vérifier' });
+    const [firstQcmVerifyButton, nextQcmVerifyButton] = allVerifyButtons;
+
+    // when
+    await click(screen.getByLabelText('I am the first right answer!'));
+    await click(screen.getByLabelText('I am the second right answer!'));
+    await click(firstQcmVerifyButton);
+
+    // then
+    assert.dom(screen.getByText("Bravo ! C'est la bonne réponse.")).exists();
+
+    // when
+    await click(screen.getByLabelText('I am the first wrong answer!'));
+    await click(screen.getByLabelText('Click Me!'));
+    await click(nextQcmVerifyButton);
+
+    // then
+    assert.dom(screen.getByText('Pas ouf')).exists();
+  });
+});

--- a/mon-pix/tests/integration/components/module/qcm_test.js
+++ b/mon-pix/tests/integration/components/module/qcm_test.js
@@ -1,0 +1,40 @@
+import { module, test } from 'qunit';
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import { findAll } from '@ember/test-helpers';
+
+module('Integration | Component | Module | QCM', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('should display a QCM', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const qcmElement = store.createRecord('qcm', {
+      instruction: 'Instruction',
+      proposals: [
+        { id: '1', content: 'option1' },
+        { id: '2', content: 'option2' },
+        { id: '3', content: 'option3' },
+      ],
+      type: 'qcms',
+    });
+    this.set('qcm', qcmElement);
+    const screen = await render(hbs`<Module::Qcm @qcm={{this.qcm}} />`);
+
+    // then
+    assert.ok(screen);
+    assert.strictEqual(findAll('.element-qcm-header__instruction').length, 1);
+    assert.strictEqual(findAll('.element-qcm-header__direction').length, 1);
+    assert.ok(screen.getByText('Instruction'));
+    assert.ok(screen.getByText('Choisissez plusieurs réponses.'));
+
+    assert.strictEqual(screen.getAllByRole('checkbox').length, qcmElement.proposals.length);
+    assert.ok(screen.getByLabelText('option1'));
+    assert.ok(screen.getByLabelText('option2'));
+    assert.ok(screen.getByLabelText('option3'));
+
+    const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
+    assert.dom(verifyButton).exists();
+  });
+});

--- a/mon-pix/tests/integration/components/module/qcm_test.js
+++ b/mon-pix/tests/integration/components/module/qcm_test.js
@@ -2,7 +2,8 @@ import { module, test } from 'qunit';
 import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
-import { findAll } from '@ember/test-helpers';
+import { click, findAll } from '@ember/test-helpers';
+import sinon from 'sinon';
 
 module('Integration | Component | Module | QCM', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -13,9 +14,9 @@ module('Integration | Component | Module | QCM', function (hooks) {
     const qcmElement = store.createRecord('qcm', {
       instruction: 'Instruction',
       proposals: [
-        { id: '1', content: 'option1' },
-        { id: '2', content: 'option2' },
-        { id: '3', content: 'option3' },
+        { id: '1', content: 'checkbox1' },
+        { id: '2', content: 'checkbox2' },
+        { id: '3', content: 'checkbox3' },
       ],
       type: 'qcms',
     });
@@ -30,11 +31,166 @@ module('Integration | Component | Module | QCM', function (hooks) {
     assert.ok(screen.getByText('Choisissez plusieurs réponses.'));
 
     assert.strictEqual(screen.getAllByRole('checkbox').length, qcmElement.proposals.length);
-    assert.ok(screen.getByLabelText('option1'));
-    assert.ok(screen.getByLabelText('option2'));
-    assert.ok(screen.getByLabelText('option3'));
+    assert.ok(screen.getByLabelText('checkbox1'));
+    assert.ok(screen.getByLabelText('checkbox2'));
+    assert.ok(screen.getByLabelText('checkbox3'));
 
     const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
     assert.dom(verifyButton).exists();
   });
+
+  test('should call action when verify button is clicked', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const answeredProposal = [
+      { id: '1', content: 'select1' },
+      { id: '2', content: 'select2' },
+    ];
+    const qcmElement = store.createRecord('qcm', {
+      id: 'qcm-id-1',
+      instruction: 'Instruction',
+      proposals: [
+        { id: '1', content: 'select1' },
+        { id: '2', content: 'select2' },
+        { id: '3', content: 'select3' },
+      ],
+      type: 'qcms',
+    });
+    this.set('qcm', qcmElement);
+    const userResponse = [answeredProposal[0].id, answeredProposal[1].id];
+    const givenSubmitAnswerSpy = sinon.spy();
+    this.set('submitAnswer', givenSubmitAnswerSpy);
+    const screen = await render(hbs`<Module::Qcm @qcm={{this.qcm}} @submitAnswer={{this.submitAnswer}} />`);
+    const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
+
+    // when
+    await click(screen.getByLabelText(answeredProposal[0].content));
+    await click(screen.getByLabelText(answeredProposal[1].content));
+    await click(verifyButton);
+
+    // then
+    sinon.assert.calledWith(givenSubmitAnswerSpy, { userResponse, element: qcmElement });
+    assert.ok(true);
+  });
+
+  test('should display an ok feedback when exists', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+
+    const correctionResponse = store.createRecord('correction-response', {
+      feedback: 'Good job!',
+      status: 'ok',
+      solution: ['1', '4'],
+    });
+
+    prepareContextRecords.call(this, store, correctionResponse);
+    this.set('submitAnswer', () => {});
+
+    // when
+    const screen = await render(
+      hbs`<Module::Qcm @qcm={{this.qcm}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
+    );
+
+    // then
+    const status = screen.getByRole('status');
+    assert.strictEqual(status.innerText, 'Good job!');
+    assert.ok(screen.getByRole('group').disabled);
+    assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+  });
+
+  test('should display a ko feedback when exists', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const correctionResponse = store.createRecord('correction-response', {
+      feedback: 'Too Bad!',
+      status: 'ko',
+      solution: ['1', '4'],
+    });
+
+    prepareContextRecords.call(this, store, correctionResponse);
+    this.set('submitAnswer', () => {});
+
+    // when
+    const screen = await render(
+      hbs`<Module::Qcm @qcm={{this.qcm}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
+    );
+
+    // then
+    const status = screen.getByRole('status');
+    assert.strictEqual(status.innerText, 'Too Bad!');
+    assert.ok(screen.getByRole('group').disabled);
+    assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+  });
+
+  test('should display an error message if QCM is validated with less than two responses', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const qcmElement = store.createRecord('qcm', {
+      instruction: 'Instruction',
+      proposals: [
+        { id: '1', content: 'checkbox1' },
+        { id: '2', content: 'checkbox2' },
+        { id: '3', content: 'checkbox3' },
+      ],
+      type: 'qcms',
+    });
+    this.set('qcm', qcmElement);
+    const screen = await render(hbs`<Module::Qcm @qcm={{this.qcm}} @submitAnswer={{this.submitAnswer}} />`);
+
+    // when
+    await click(screen.getByLabelText('checkbox1'));
+    await click(screen.queryByRole('button', { name: 'Vérifier' }));
+
+    // then
+    assert.dom(screen.getByRole('alert')).exists();
+  });
+
+  test('should hide the error message when QCM is validated with response', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const qcmElement = store.createRecord('qcm', {
+      instruction: 'Instruction',
+      proposals: [
+        { id: '1', content: 'checkbox1' },
+        { id: '2', content: 'checkbox2' },
+        { id: '3', content: 'checkbox3' },
+      ],
+      type: 'qcms',
+    });
+    const givenSubmitAnswerStub = function () {};
+    this.set('submitAnswer', givenSubmitAnswerStub);
+    this.set('qcm', qcmElement);
+    const screen = await render(hbs`<Module::Qcm @qcm={{this.qcm}} @submitAnswer={{this.submitAnswer}} />`);
+
+    // when
+    await click(screen.queryByRole('button', { name: 'Vérifier' }));
+    await click(screen.getByLabelText('checkbox1'));
+    await click(screen.queryByRole('button', { name: 'Vérifier' }));
+
+    // then
+    assert.dom(screen.queryByRole('alert', { name: 'Pour valider, sélectionnez une réponse.' })).doesNotExist();
+  });
 });
+
+function prepareContextRecords(store, correctionResponse) {
+  const elementAnswer = store.createRecord('element-answer', {
+    correction: correctionResponse,
+  });
+  const qcmElement = store.createRecord('qcm', {
+    instruction: 'Instruction',
+    proposals: [
+      { id: '1', content: 'checkbox1' },
+      { id: '2', content: 'checkbox2' },
+      { id: '3', content: 'checkbox3' },
+    ],
+    type: 'qcms',
+    elementAnswers: [elementAnswer],
+  });
+  store.createRecord('grain', { id: 'id', elements: [qcmElement] });
+  store.createRecord('element-answer', {
+    correction: correctionResponse,
+    element: qcmElement,
+  });
+  this.set('qcm', qcmElement);
+  this.set('correctionResponse', correctionResponse);
+}

--- a/mon-pix/tests/unit/models/modules/element_test.js
+++ b/mon-pix/tests/unit/models/modules/element_test.js
@@ -19,6 +19,19 @@ module('Unit | Model | Module | Element', function (hooks) {
       ],
     },
     {
+      getterName: 'isQcm',
+      cases: [
+        {
+          modelType: 'qcms',
+          expectedResult: true,
+        },
+        {
+          modelType: 'texts',
+          expectedResult: false,
+        },
+      ],
+    },
+    {
       getterName: 'isText',
       cases: [
         {

--- a/mon-pix/tests/unit/models/modules/grain_test.js
+++ b/mon-pix/tests/unit/models/modules/grain_test.js
@@ -10,10 +10,11 @@ module('Unit | Model | Module | Grain', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const qcu = store.createRecord('qcu', { type: 'qcus', isAnswerable: true });
+        const qcm = store.createRecord('qcm', { type: 'qcms', isAnswerable: true });
         const qrocm = store.createRecord('qrocm', { type: 'qrocms', isAnswerable: true });
         const text = store.createRecord('text', { type: 'texts', isAnswerable: false });
         const grain = store.createRecord('grain', {
-          elements: [qcu, qrocm, text],
+          elements: [qcu, qcm, qrocm, text],
         });
 
         // when
@@ -48,18 +49,19 @@ module('Unit | Model | Module | Grain', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const qcu = store.createRecord('qcu', { type: 'qcus', isAnswerable: true });
+        const qcm = store.createRecord('qcm', { type: 'qcms', isAnswerable: true });
         const qrocm = store.createRecord('qrocm', { type: 'qrocms', isAnswerable: true });
         const text = store.createRecord('text', { type: 'texts', isAnswerable: false });
         const grain = store.createRecord('grain', {
-          elements: [qcu, qrocm, text],
+          elements: [qcu, qcm, qrocm, text],
         });
 
         // when
         const answerableElements = grain.answerableElements;
 
         // then
-        assert.strictEqual(answerableElements.length, 2);
-        assert.deepEqual(answerableElements, [qcu, qrocm]);
+        assert.strictEqual(answerableElements.length, 3);
+        assert.deepEqual(answerableElements, [qcu, qcm, qrocm]);
       });
     });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1216,6 +1216,9 @@
           "title": "Transcription"
         }
       },
+      "qcm": {
+        "direction": "Select several answers."
+      },
       "qcu": {
         "direction": "Select one answer."
       },
@@ -1229,6 +1232,7 @@
         "subtitle": "Now you know '<span aria-hidden=\"true\">'👍'</span>'"
       },
       "verification-precondition-failed-alert": {
+        "qcm": "To validate, select at least two answers.",
         "qcu": "To validate, select an answer.",
         "qrocm": "To validate, please complete all response fields."
       }

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1216,6 +1216,9 @@
           "title": "Transcription"
         }
       },
+      "qcm": {
+        "direction": "Choisissez plusieurs réponses."
+      },
       "qcu": {
         "direction": "Choisissez une seule réponse."
       },
@@ -1229,6 +1232,7 @@
         "subtitle": "Vous savez maintenant '<span aria-hidden=\"true\">'👍'</span>'"
       },
       "verification-precondition-failed-alert": {
+        "qcm": "Pour valider, sélectionnez au moins deux réponses.",
         "qcu": "Pour valider, sélectionnez une réponse.",
         "qrocm": "Pour valider, veuillez remplir tous les champs réponse."
       }

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1216,6 +1216,10 @@
           "title": "Transcriptie"
         }
       },
+
+      "qcm": {
+        "direction": "Kies meerdere antwoorden."
+      },
       "qcu": {
         "direction": "Kies slechts één antwoord."
       },
@@ -1229,6 +1233,7 @@
         "subtitle": "Je weet nu '<span aria-hidden=\"true\">'👍'</span>'"
       },
       "verification-precondition-failed-alert": {
+        "qcm": "Selecteer ten minste twee antwoorden om te bevestigen.",
         "qcu": "Selecteer een antwoord om te bevestigen.",
         "qrocm": "Vul alle antwoordvelden in om te valideren."
       }


### PR DESCRIPTION
## :unicorn: Problème
En tant qu’apprenant je souhaite pouvoir répondre à un QCM.

## :robot: Proposition
Implémenter l'affichage du QCM et la possibilité d'y répondre.

## :rainbow: Remarques
Feedback générique, comme pour les autres modalités, pas de feedback local pour le moment.

On avait prévu `solutions` dans `QCMCorrectionResponse` mais ça fait une différence avec les autres modalités. On a choisi d'utiliser `solution` pour ne pas avoir besoin de bidouiller (au niveau de serializer notamment).

## :100: Pour tester
Constater l'apparition et la vérification de 3 QCM dans :
- [Didacticiel](https://app-pr8057.review.pix.fr/modules/didacticiel-modulix/passage)
- [Distinguer vrai et faux sur internet](https://app-pr8057.review.pix.fr/modules/distinguer-vrai-faux-sur-internet/passage)
