### PR TITLE
[FEATURE] Ajouter la vérification d'un QCM pour modulix (PIX-11134)

### DIFF
--- a/api/src/devcomp/domain/models/QcmCorrectionResponse.js
+++ b/api/src/devcomp/domain/models/QcmCorrectionResponse.js
@@ -1,0 +1,15 @@
+import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.js';
+
+class QcmCorrectionResponse {
+  constructor({ status, feedback, solutions }) {
+    assertNotNullOrUndefined(status, 'The result is required for a QCM answer');
+    assertNotNullOrUndefined(feedback, 'The feedback is required for a QCM answer');
+    assertNotNullOrUndefined(solutions, 'The solutions are required for a QCM answer');
+
+    this.status = status;
+    this.feedback = feedback;
+    this.solutions = solutions;
+  }
+}
+
+export { QcmCorrectionResponse };

--- a/api/src/devcomp/domain/models/element/QCM-for-answer-verification.js
+++ b/api/src/devcomp/domain/models/element/QCM-for-answer-verification.js
@@ -1,0 +1,59 @@
+import { QCM } from './QCM.js';
+import { Feedbacks } from '../Feedbacks.js';
+import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { ValidatorQCM } from '../validator/ValidatorQCM.js';
+import { QcmCorrectionResponse } from '../QcmCorrectionResponse.js';
+import Joi from 'joi';
+import { EntityValidationError } from '../../../../shared/domain/errors.js';
+
+class QCMForAnswerVerification extends QCM {
+  userResponse;
+
+  constructor({ id, instruction, locales, proposals, solutions, feedbacks, validator }) {
+    super({ id, instruction, locales, proposals });
+
+    assertNotNullOrUndefined(solutions, 'The solutions are required for a QCM for verification');
+
+    this.solutionsValue = solutions;
+
+    if (feedbacks) {
+      this.feedbacks = new Feedbacks(feedbacks);
+    }
+
+    if (validator) {
+      this.validator = validator;
+    } else {
+      this.validator = new ValidatorQCM({ solution: { value: this.solutionsValue } });
+    }
+  }
+
+  setUserResponse(userResponse) {
+    this.#validateUserResponseFormat(userResponse);
+    this.userResponse = userResponse;
+  }
+
+  assess() {
+    const validation = this.validator.assess({ answer: { value: this.userResponse } });
+
+    return new QcmCorrectionResponse({
+      status: validation.result,
+      feedback: validation.result.isOK() ? this.feedbacks.valid : this.feedbacks.invalid,
+      solutions: this.solutionsValue,
+    });
+  }
+
+  #validateUserResponseFormat(userResponse) {
+    const qcmResponseSchema = Joi.string()
+      .pattern(/^[0-9]+$/)
+      .required();
+
+    const validUserResponseSchema = Joi.array().items(qcmResponseSchema).min(2).required();
+
+    const { error } = validUserResponseSchema.validate(userResponse);
+    if (error) {
+      throw EntityValidationError.fromJoiErrors(error.details);
+    }
+  }
+}
+
+export { QCMForAnswerVerification };

--- a/api/src/devcomp/infrastructure/repositories/module-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-repository.js
@@ -1,24 +1,25 @@
-import { NotFoundError } from '../../../shared/domain/errors.js';
-import { Module } from '../../domain/models/module/Module.js';
-import { Text } from '../../domain/models/element/Text.js';
-import { Image } from '../../domain/models/element/Image.js';
-import { QCU } from '../../domain/models/element/QCU.js';
-import { QcuProposal } from '../../domain/models/QcuProposal.js';
-import { Grain } from '../../domain/models/Grain.js';
-import { TransitionText } from '../../domain/models/TransitionText.js';
-import { LearningContentResourceNotFound } from '../../../shared/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
-import { QCUForAnswerVerification } from '../../domain/models/element/QCU-for-answer-verification.js';
-import { BlockText } from '../../domain/models/block/BlockText.js';
 import { BlockInput } from '../../domain/models/block/BlockInput.js';
 import { BlockSelect } from '../../domain/models/block/BlockSelect.js';
 import { BlockSelectOption } from '../../domain/models/block/BlockSelectOption.js';
-import { QROCM } from '../../domain/models/element/QROCM.js';
-import { logger } from '../../../shared/infrastructure/utils/logger.js';
-import { QROCMForAnswerVerification } from '../../domain/models/element/QROCM-for-answer-verification.js';
-import { Video } from '../../domain/models/element/Video.js';
+import { BlockText } from '../../domain/models/block/BlockText.js';
 import { Details } from '../../domain/models/module/Details.js';
+import { Grain } from '../../domain/models/Grain.js';
+import { Image } from '../../domain/models/element/Image.js';
+import { LearningContentResourceNotFound } from '../../../shared/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
+import { Module } from '../../domain/models/module/Module.js';
+import { NotFoundError } from '../../../shared/domain/errors.js';
 import { QCM } from '../../domain/models/element/QCM.js';
+import { QCMForAnswerVerification } from '../../domain/models/element/QCM-for-answer-verification.js';
+import { QCU } from '../../domain/models/element/QCU.js';
+import { QCUForAnswerVerification } from '../../domain/models/element/QCU-for-answer-verification.js';
+import { QROCM } from '../../domain/models/element/QROCM.js';
+import { QROCMForAnswerVerification } from '../../domain/models/element/QROCM-for-answer-verification.js';
 import { QcmProposal } from '../../domain/models/QcmProposal.js';
+import { QcuProposal } from '../../domain/models/QcuProposal.js';
+import { Text } from '../../domain/models/element/Text.js';
+import { TransitionText } from '../../domain/models/TransitionText.js';
+import { Video } from '../../domain/models/element/Video.js';
+import { logger } from '../../../shared/infrastructure/utils/logger.js';
 
 async function getBySlug({ slug, moduleDatasource }) {
   try {
@@ -108,6 +109,8 @@ function _toDomainForVerification(moduleData) {
                 return _toTextDomain(element);
               case 'qcu':
                 return _toQCUForAnswerVerificationDomain(element);
+              case 'qcm':
+                return _toQCMForAnswerVerificationDomain(element);
               case 'qrocm':
                 return _toQROCMForAnswerVerificationDomain(element);
               case 'video':
@@ -165,7 +168,6 @@ function _toQCUForAnswerVerificationDomain(element) {
     }),
     feedbacks: element.feedbacks,
     solution: element.solution,
-    type: element.type,
   });
 }
 
@@ -197,6 +199,22 @@ function _toQCMDomain(element) {
   });
 }
 
+function _toQCMForAnswerVerificationDomain(element) {
+  return new QCMForAnswerVerification({
+    id: element.id,
+    instruction: element.instruction,
+    locales: element.locales,
+    proposals: element.proposals.map((proposal) => {
+      return new QcmProposal({
+        id: proposal.id,
+        content: proposal.content,
+      });
+    }),
+    feedbacks: element.feedbacks,
+    solutions: element.solutions,
+  });
+}
+
 function _toQROCMForAnswerVerificationDomain(element) {
   return new QROCMForAnswerVerification({
     id: element.id,
@@ -204,7 +222,6 @@ function _toQROCMForAnswerVerificationDomain(element) {
     locales: element.locales,
     proposals: element.proposals,
     feedbacks: element.feedbacks,
-    type: element.type,
   });
 }
 

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/element-answer-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/element-answer-serializer.js
@@ -19,7 +19,7 @@ function serialize(elementAnswer) {
     correction: {
       ref: 'id',
       includes: true,
-      attributes: ['feedback', 'status', 'solution'],
+      attributes: ['feedback', 'status', 'solution', 'solutions'],
       type: 'correction-responses',
     },
     typeForAttribute(attribute, { type }) {

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -44,6 +44,7 @@ describe('Acceptance | Controller | passage-controller', function () {
       const cases = [
         {
           case: 'QCU',
+          moduleId: 'bien-ecrire-son-adresse-mail',
           elementId: '29195dde-b603-488f-a554-f391fbdf3b24',
           userResponse: ['1'],
           expectedUserResponseValue: '1',
@@ -53,6 +54,7 @@ describe('Acceptance | Controller | passage-controller', function () {
         },
         {
           case: 'QROCM-ind',
+          moduleId: 'bien-ecrire-son-adresse-mail',
           elementId: '8709ad92-093e-447a-a7b6-3223e6171196',
           userResponse: [{ input: 'email', answer: 'naomizao457@yahoo.com' }],
           expectedUserResponseValue: { email: 'naomizao457@yahoo.com' },
@@ -62,13 +64,22 @@ describe('Acceptance | Controller | passage-controller', function () {
             email: ['naomizao457@yahoo.com', 'naomizao457@yahoo.fr'],
           },
         },
+        {
+          case: 'QCM',
+          moduleId: 'didacticiel-modulix',
+          elementId: '30701e93-1b4d-4da4-b018-fa756c07d53f',
+          userResponse: ['1', '3', '4'],
+          expectedUserResponseValue: ['1', '3', '4'],
+          expectedFeedback: '<p>Correct ! Vous nous avez bien cernés :)</p>',
+          expectedSolution: ['1', '3', '4'],
+        },
       ];
 
       // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       cases.forEach((testCase, i) =>
         it(`should return a valid ${testCase.case} element answer`, async function () {
-          const passage = databaseBuilder.factory.buildPassage({ id: i + 1, moduleId: 'bien-ecrire-son-adresse-mail' });
+          const passage = databaseBuilder.factory.buildPassage({ id: i + 1, moduleId: testCase.moduleId });
           await databaseBuilder.commit();
 
           const options = {
@@ -94,7 +105,12 @@ describe('Acceptance | Controller | passage-controller', function () {
           expect(response.result.data.attributes['element-id']).to.equal(testCase.elementId);
           expect(response.result.included[0].attributes.status).to.equal('ok');
           expect(response.result.included[0].attributes.feedback).to.equal(testCase.expectedFeedback);
-          expect(response.result.included[0].attributes.solution).to.deep.equal(testCase.expectedSolution);
+          if (testCase.case === 'QCM') {
+            expect(response.result.included[0].attributes.solutions).to.deep.equal(testCase.expectedSolution);
+          }
+          if (['QCU', 'QROCM-ind'].includes(testCase.case)) {
+            expect(response.result.included[0].attributes.solution).to.deep.equal(testCase.expectedSolution);
+          }
         }),
       );
     });

--- a/api/tests/devcomp/integration/domain/models/element/QCMForAnswerVerification_test.js
+++ b/api/tests/devcomp/integration/domain/models/element/QCMForAnswerVerification_test.js
@@ -1,0 +1,89 @@
+import { expect } from '../../../../../test-helper.js';
+import { QCMForAnswerVerification } from '../../../../../../src/devcomp/domain/models/element/QCM-for-answer-verification.js';
+import { AnswerStatus } from '../../../../../../src/shared/domain/models/AnswerStatus.js';
+
+describe('Integration | Devcomp | Domain | Models | Element | QCMForAnswerVerification', function () {
+  it('should return a valid answer when using tolerances with a right user response', function () {
+    // given
+    const qcm = new QCMForAnswerVerification({
+      id: '98c51fa7-03b7-49b1-8c5e-49341d35909c',
+      instruction: '<p>Quels sont les 3 piliers de Pix ?</p>',
+      proposals: [
+        {
+          id: '1',
+          content: 'Evaluer ses connaissances et savoir-faire sur 16 compétences du numérique',
+        },
+        {
+          id: '2',
+          content: 'Développer son savoir-faire sur les jeux de type TPS',
+        },
+        {
+          id: '3',
+          content: 'Développer ses compétences numériques',
+        },
+        {
+          id: '4',
+          content: 'Certifier ses compétences Pix',
+        },
+        {
+          id: '5',
+          content: 'Evaluer ses compétences de logique et compréhension mathématique',
+        },
+      ],
+      feedbacks: {
+        valid: '<p>Correct ! Vous nous avez bien cernés :)</p>',
+        invalid: '<p>Et non ! Pix sert à évaluer, certifier et développer ses compétences numériques.',
+      },
+      solutions: ['1', '3', '4'],
+    });
+    qcm.setUserResponse(['1', '3', '4']);
+
+    // when
+    const correction = qcm.assess();
+
+    // then
+    expect(correction.status).to.deep.equal(AnswerStatus.OK);
+  });
+
+  it('should return an invalid answer when using tolerances with a wrong user response', function () {
+    // given
+    const qcm = new QCMForAnswerVerification({
+      id: '98c51fa7-03b7-49b1-8c5e-49341d35909c',
+      instruction: '<p>Quels sont les 3 piliers de Pix ?</p>',
+      proposals: [
+        {
+          id: '1',
+          content: 'Evaluer ses connaissances et savoir-faire sur 16 compétences du numérique',
+        },
+        {
+          id: '2',
+          content: 'Développer son savoir-faire sur les jeux de type TPS',
+        },
+        {
+          id: '3',
+          content: 'Développer ses compétences numériques',
+        },
+        {
+          id: '4',
+          content: 'Certifier ses compétences Pix',
+        },
+        {
+          id: '5',
+          content: 'Evaluer ses compétences de logique et compréhension mathématique',
+        },
+      ],
+      feedbacks: {
+        valid: '<p>Correct ! Vous nous avez bien cernés :)</p>',
+        invalid: '<p>Et non ! Pix sert à évaluer, certifier et développer ses compétences numériques.',
+      },
+      solutions: ['1', '3', '4'],
+    });
+    qcm.setUserResponse(['1', '4']);
+
+    // when
+    const correction = qcm.assess();
+
+    // then
+    expect(correction.status).to.deep.equal(AnswerStatus.KO);
+  });
+});

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -582,11 +582,113 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
     it('should return a module if it exists', async function () {
       // given
       const existingModuleSlug = 'bien-ecrire-son-adresse-mail';
+      const expectedFoundModule = {
+        id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
+        slug: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        details: {
+          image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+          description:
+            'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
+          duration: 12,
+          level: 'Débutant',
+          objectives: [
+            'Écrire une adresse mail correctement, en évitant les erreurs courantes',
+            'Connaître les parties d’une adresse mail et les identifier sur des exemples',
+            'Comprendre les fonctions des parties d’une adresse mail',
+          ],
+        },
+        grains: [
+          {
+            id: 'b7ea7630-824a-4a49-83d1-abb9b8d0d120',
+            type: 'activity',
+            title: 'Écrire une adresse mail correctement',
+            elements: [
+              {
+                id: '98c51fa7-03b7-49b1-8c5e-49341d35909c',
+                type: 'qrocm',
+                instruction:
+                  "<p>Pour être sûr que tout est clair, complétez le texte ci-dessous <span aria-hidden='true'>🧩</span></p><p>Si vous avez besoin d’aide, revenez en arrière <span aria-hidden='true'>⬆️</span></p>",
+                proposals: [
+                  {
+                    type: 'text',
+                    content: '<p>Le symbole</>',
+                  },
+                  {
+                    input: 'symbole',
+                    type: 'input',
+                    inputType: 'text',
+                    size: 1,
+                    display: 'inline',
+                    placeholder: '',
+                    ariaLabel: 'Réponse 1',
+                    defaultValue: '',
+                    tolerances: ['t1'],
+                    solutions: ['@'],
+                  },
+                  {
+                    input: 'premiere-partie',
+                    type: 'select',
+                    display: 'inline',
+                    placeholder: '',
+                    ariaLabel: 'Réponse 2',
+                    defaultValue: '',
+                    tolerances: [],
+                    options: [
+                      {
+                        id: '1',
+                        content: "l'identifiant",
+                      },
+                      {
+                        id: '2',
+                        content: "le fournisseur d'adresse mail",
+                      },
+                    ],
+                    solutions: ['1'],
+                  },
+                ],
+                feedbacks: {
+                  valid: '<p>Bravo ! 🎉 </p>',
+                  invalid: "<p class='pix-list-inline'>Et non !</p>",
+                },
+              },
+              {
+                id: '0a5e77e8-1c8e-4cb6-a41d-cf6ad7935447',
+                type: 'qcu',
+                instruction: '<p>Remontez la page pour trouver le premier mot de ce module.<br>Quel est ce mot ?</p>',
+                proposals: [
+                  {
+                    id: '1',
+                    content: 'Bienvenue',
+                  },
+                  {
+                    id: '2',
+                    content: 'Bonjour',
+                  },
+                  {
+                    id: '3',
+                    content: 'Nous',
+                  },
+                ],
+                feedbacks: {
+                  valid: '<p>Correct ! Vous avez bien remonté la page</p>',
+                  invalid: '<p>Incorrect. Remonter la page pour retrouver le premier mot !</p>',
+                },
+                solution: '2',
+              },
+            ],
+          },
+        ],
+      };
+      const moduleDatasourceStub = {
+        getBySlug: sinon.stub(),
+      };
+      moduleDatasourceStub.getBySlug.withArgs(existingModuleSlug).resolves(expectedFoundModule);
 
       // when
       const module = await moduleRepository.getBySlugForVerification({
         slug: existingModuleSlug,
-        moduleDatasource,
+        moduleDatasource: moduleDatasourceStub,
       });
 
       // then

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -696,11 +696,11 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
 
       const qcus = module.grains.flatMap((grain) => grain.elements.filter((element) => element.type === 'qcu'));
       expect(qcus).to.have.length(1);
-      qcus.every((qcu) => qcu instanceof QCUForAnswerVerification);
+      qcus.forEach((qcu) => expect(qcu).to.be.instanceOf(QCUForAnswerVerification));
 
       const qrocms = module.grains.flatMap((grain) => grain.elements.filter((element) => element.type === 'qrocm'));
       expect(qrocms).to.have.length(1);
-      qrocms.every((qrocm) => qrocm instanceof QROCMForAnswerVerification);
+      qrocms.forEach((qrocm) => expect(qrocm).to.be.instanceOf(QROCMForAnswerVerification));
     });
 
     it('should log a warning if none of the element types match and return an empty element', async function () {

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -695,11 +695,11 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       expect(module).to.be.instanceOf(Module);
 
       const qcus = module.grains.flatMap((grain) => grain.elements.filter((element) => element.type === 'qcu'));
-      expect(qcus).to.not.have.length(0);
+      expect(qcus).to.have.length(1);
       qcus.every((qcu) => qcu instanceof QCUForAnswerVerification);
 
       const qrocms = module.grains.flatMap((grain) => grain.elements.filter((element) => element.type === 'qrocm'));
-      expect(qrocms).to.not.have.length(0);
+      expect(qrocms).to.have.length(1);
       qrocms.every((qrocm) => qrocm instanceof QROCMForAnswerVerification);
     });
 

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -1,22 +1,23 @@
-import { catchErr, expect, sinon } from '../../../test-helper.js';
-import { NotFoundError } from '../../../../src/shared/domain/errors.js';
 import * as moduleRepository from '../../../../src/devcomp/infrastructure/repositories/module-repository.js';
-import { Module } from '../../../../src/devcomp/domain/models/module/Module.js';
-import { Grain } from '../../../../src/devcomp/domain/models/Grain.js';
-import { Text } from '../../../../src/devcomp/domain/models/element/Text.js';
-import { QCU } from '../../../../src/devcomp/domain/models/element/QCU.js';
-import { QROCM } from '../../../../src/devcomp/domain/models/element/QROCM.js';
-import { Image } from '../../../../src/devcomp/domain/models/element/Image.js';
 import moduleDatasource from '../../../../src/devcomp/infrastructure/datasources/learning-content/module-datasource.js';
-import { QCUForAnswerVerification } from '../../../../src/devcomp/domain/models/element/QCU-for-answer-verification.js';
 import { BlockInput } from '../../../../src/devcomp/domain/models/block/BlockInput.js';
 import { BlockSelect } from '../../../../src/devcomp/domain/models/block/BlockSelect.js';
 import { BlockText } from '../../../../src/devcomp/domain/models/block/BlockText.js';
-import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
-import { Video } from '../../../../src/devcomp/domain/models/element/Video.js';
-import { QROCMForAnswerVerification } from '../../../../src/devcomp/domain/models/element/QROCM-for-answer-verification.js';
-import { TransitionText } from '../../../../src/devcomp/domain/models/TransitionText.js';
+import { Grain } from '../../../../src/devcomp/domain/models/Grain.js';
+import { Image } from '../../../../src/devcomp/domain/models/element/Image.js';
+import { Module } from '../../../../src/devcomp/domain/models/module/Module.js';
+import { NotFoundError } from '../../../../src/shared/domain/errors.js';
 import { QCM } from '../../../../src/devcomp/domain/models/element/QCM.js';
+import { QCMForAnswerVerification } from '../../../../src/devcomp/domain/models/element/QCM-for-answer-verification.js';
+import { QCU } from '../../../../src/devcomp/domain/models/element/QCU.js';
+import { QCUForAnswerVerification } from '../../../../src/devcomp/domain/models/element/QCU-for-answer-verification.js';
+import { QROCM } from '../../../../src/devcomp/domain/models/element/QROCM.js';
+import { QROCMForAnswerVerification } from '../../../../src/devcomp/domain/models/element/QROCM-for-answer-verification.js';
+import { Text } from '../../../../src/devcomp/domain/models/element/Text.js';
+import { TransitionText } from '../../../../src/devcomp/domain/models/TransitionText.js';
+import { Video } from '../../../../src/devcomp/domain/models/element/Video.js';
+import { catchErr, expect, sinon } from '../../../test-helper.js';
+import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
 
 describe('Integration | DevComp | Repositories | ModuleRepository', function () {
   describe('#getBySlug', function () {
@@ -579,7 +580,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       expect(error).not.to.be.instanceOf(NotFoundError);
     });
 
-    it('should return a module if it exists', async function () {
+    it('should return a module with valid answerable elements if it exists', async function () {
       // given
       const existingModuleSlug = 'bien-ecrire-son-adresse-mail';
       const expectedFoundModule = {
@@ -676,6 +677,38 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
                 },
                 solution: '2',
               },
+              {
+                id: '30701e93-1b4d-4da4-b018-fa756c07d53f',
+                type: 'qcm',
+                instruction: '<p>Quels sont les 3 piliers de Pix ?</p>',
+                proposals: [
+                  {
+                    id: '1',
+                    content: 'Evaluer ses connaissances et savoir-faire sur 16 compétences du numérique',
+                  },
+                  {
+                    id: '2',
+                    content: 'Développer son savoir-faire sur les jeux de type TPS',
+                  },
+                  {
+                    id: '3',
+                    content: 'Développer ses compétences numériques',
+                  },
+                  {
+                    id: '4',
+                    content: 'Certifier ses compétences Pix',
+                  },
+                  {
+                    id: '5',
+                    content: 'Evaluer ses compétences de logique et compréhension mathématique',
+                  },
+                ],
+                feedbacks: {
+                  valid: '<p>Correct ! Vous nous avez bien cernés :)</p>',
+                  invalid: '<p>Et non ! Pix sert à évaluer, certifier et développer ses compétences numériques.',
+                },
+                solutions: ['1', '3', '4'],
+              },
             ],
           },
         ],
@@ -701,6 +734,10 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       const qrocms = module.grains.flatMap((grain) => grain.elements.filter((element) => element.type === 'qrocm'));
       expect(qrocms).to.have.length(1);
       qrocms.forEach((qrocm) => expect(qrocm).to.be.instanceOf(QROCMForAnswerVerification));
+
+      const qcms = module.grains.flatMap((grain) => grain.elements.filter((element) => element.type === 'qcm'));
+      expect(qcms).to.have.length(1);
+      qcms.forEach((qcm) => expect(qcm).to.be.instanceOf(QCMForAnswerVerification));
     });
 
     it('should log a warning if none of the element types match and return an empty element', async function () {

--- a/api/tests/devcomp/unit/domain/models/QcmCorrectionResponse_test.js
+++ b/api/tests/devcomp/unit/domain/models/QcmCorrectionResponse_test.js
@@ -1,0 +1,45 @@
+import { expect } from '../../../../test-helper.js';
+import { QcmCorrectionResponse } from '../../../../../src/devcomp/domain/models/QcmCorrectionResponse.js';
+import { AnswerStatus } from '../../../../../src/devcomp/domain/models/validator/AnswerStatus.js';
+
+describe('Unit | Devcomp | Domain | Models | QcmCorrectionResponse', function () {
+  describe('#constructor', function () {
+    it('should create a QCM correction response and keep attributes', function () {
+      // given
+      const status = AnswerStatus.OK;
+      const feedback = 'Bien joué !';
+      const solutions = ['1', '2'];
+
+      // when
+      const qcmCorrectionResponse = new QcmCorrectionResponse({ status, feedback, solutions });
+
+      // then
+      expect(qcmCorrectionResponse).not.to.be.undefined;
+      expect(qcmCorrectionResponse.status).to.deep.equal(status);
+      expect(qcmCorrectionResponse.feedback).to.equal(feedback);
+      expect(qcmCorrectionResponse.solutions).to.deep.equal(solutions);
+    });
+  });
+
+  describe('A QCM correction response without status', function () {
+    it('should throw an error', function () {
+      expect(() => new QcmCorrectionResponse({})).to.throw('The result is required for a QCM answer');
+    });
+  });
+
+  describe('A QCM correction response without feedback', function () {
+    it('should throw an error', function () {
+      expect(() => new QcmCorrectionResponse({ status: AnswerStatus.OK })).to.throw(
+        'The feedback is required for a QCM answer',
+      );
+    });
+  });
+
+  describe('A QCM correction response without proposal id', function () {
+    it('should throw an error', function () {
+      expect(() => new QcmCorrectionResponse({ status: AnswerStatus.OK, feedback: 'Bien joué !' })).to.throw(
+        'The solutions are required for a QCM answer',
+      );
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/models/element/QCM-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCM-for-answer-verification_test.js
@@ -1,0 +1,220 @@
+import { expect, sinon } from '../../../../../test-helper.js';
+import { QCMForAnswerVerification } from '../../../../../../src/devcomp/domain/models/element/QCM-for-answer-verification.js';
+import { QcmCorrectionResponse } from '../../../../../../src/devcomp/domain/models/QcmCorrectionResponse.js';
+import { Feedbacks } from '../../../../../../src/devcomp/domain/models/Feedbacks.js';
+import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
+import { ValidatorQCM } from '../../../../../../src/devcomp/domain/models/validator/ValidatorQCM.js';
+
+describe('Unit | Devcomp | Domain | Models | Element | QcmForAnswerVerification', function () {
+  describe('#constructor', function () {
+    it('should instanciate a QCM For Verification with right attributes', function () {
+      // Given
+      const proposal1 = Symbol('proposal1');
+      const proposal2 = Symbol('proposal2');
+      const feedbacks = { valid: 'valid', invalid: 'invalid' };
+      const solutions = Symbol('solutions');
+
+      // When
+      const qcm = new QCMForAnswerVerification({
+        id: '123',
+        instruction: 'instruction',
+        locales: ['fr-FR'],
+        proposals: [proposal1, proposal2],
+        feedbacks,
+        solutions,
+      });
+
+      // Then
+      expect(qcm.id).equal('123');
+      expect(qcm.instruction).equal('instruction');
+      expect(qcm.locales).deep.equal(['fr-FR']);
+      expect(qcm.proposals).deep.equal([proposal1, proposal2]);
+      expect(qcm.solutionsValue).deep.equal(solutions);
+      expect(qcm.feedbacks).to.be.instanceof(Feedbacks);
+      expect(qcm.type).to.be.equal('qcm');
+      expect(qcm.validator).to.be.instanceof(ValidatorQCM);
+    });
+
+    describe('A QCM For Verification without a solution', function () {
+      it('should throw an error', function () {
+        expect(
+          () =>
+            new QCMForAnswerVerification({
+              id: '123',
+              instruction: 'toto',
+              proposals: [Symbol('proposal1')],
+            }),
+        ).to.throw('The solutions are required for a QCM for verification');
+      });
+    });
+  });
+
+  describe('#assess', function () {
+    it('should return a QcmCorrectionResponse for a valid answer', function () {
+      // given
+      const stubedIsOk = sinon.stub().returns(true);
+      const assessResult = { result: { isOK: stubedIsOk } };
+      const qcmSolution1 = Symbol('correctSolution1');
+      const qcmSolution2 = Symbol('correctSolution2');
+      const qcmSolutions = [qcmSolution1, qcmSolution2];
+      const userResponse = [qcmSolution1, qcmSolution2];
+
+      const validator = {
+        assess: sinon.stub(),
+      };
+      const qcm = new QCMForAnswerVerification({
+        id: 'qcm-id',
+        instruction: '',
+        proposals: [{ id: qcmSolution1 }, { id: qcmSolution2 }, { id: Symbol('proposal3') }],
+        feedbacks: { valid: 'OK', invalid: 'KO' },
+        solutions: qcmSolutions,
+        validator,
+      });
+      qcm.userResponse = userResponse;
+
+      validator.assess
+        .withArgs({
+          answer: {
+            value: userResponse,
+          },
+        })
+        .returns(assessResult);
+
+      const expectedCorrection = {
+        status: assessResult.result,
+        feedback: qcm.feedbacks.valid,
+        solutions: qcmSolutions,
+      };
+
+      // when
+      const correction = qcm.assess();
+
+      // then
+      expect(correction).to.deep.equal(expectedCorrection);
+      expect(correction).to.deepEqualInstance(new QcmCorrectionResponse(expectedCorrection));
+    });
+
+    it('should return a QcmCorrectionResponse for a invalid answer', function () {
+      // given
+      const stubedIsOk = sinon.stub().returns(false);
+      const assessResult = { result: { isOK: stubedIsOk } };
+      const qcmSolution1 = Symbol('correctSolution1');
+      const qcmSolution2 = Symbol('correctSolution2');
+      const qcmSolutions = [qcmSolution1, qcmSolution2];
+      const userResponse = ['wrongAnswer'];
+
+      const validator = {
+        assess: sinon.stub(),
+      };
+      const qcm = new QCMForAnswerVerification({
+        id: 'qcm-id',
+        instruction: '',
+        proposals: [{ id: qcmSolution1 }, { id: qcmSolution2 }, { id: Symbol('proposal3') }],
+        feedbacks: { valid: 'OK', invalid: 'KO' },
+        solutions: qcmSolutions,
+        validator,
+      });
+      qcm.userResponse = userResponse;
+
+      validator.assess
+        .withArgs({
+          answer: {
+            value: userResponse,
+          },
+        })
+        .returns(assessResult);
+
+      const expectedCorrection = {
+        status: assessResult.result,
+        feedback: qcm.feedbacks.invalid,
+        solutions: qcmSolutions,
+      };
+
+      // when
+      const correction = qcm.assess();
+
+      // then
+      expect(correction).to.deep.equal(expectedCorrection);
+      expect(correction).to.deepEqualInstance(new QcmCorrectionResponse(expectedCorrection));
+    });
+  });
+
+  describe('#setUserResponse', function () {
+    describe('if userResponse is valid', function () {
+      it('should return the user response value', function () {
+        // given
+        const qcmSolution1 = '1';
+        const qcmSolution2 = '2';
+        const qcmSolutions = [qcmSolution1, qcmSolution2];
+        const userResponse = [qcmSolution1, qcmSolution2];
+        const expectedUserResponse = userResponse;
+
+        const qcm = new QCMForAnswerVerification({
+          id: 'qcm-id',
+          instruction: '',
+          proposals: [{}],
+          feedbacks: { valid: 'OK', invalid: 'KO' },
+          solutions: qcmSolutions,
+        });
+
+        // when
+        qcm.setUserResponse(userResponse);
+
+        // then
+        expect(qcm.userResponse).to.deep.equal(expectedUserResponse);
+      });
+    });
+
+    describe('if userResponse is not valid', function () {
+      const cases = [
+        {
+          case: 'When the response number is not a string',
+          userResponse: [1, 3],
+        },
+        {
+          case: 'When the response is not a stringified number',
+          userResponse: ['not a number', 'not a number'],
+        },
+        {
+          case: 'When there are less than two response',
+          userResponse: ['1'],
+        },
+        {
+          case: 'When list of responses is empty',
+          userResponse: [],
+        },
+        {
+          case: 'When response is not an array',
+          userResponse: {},
+        },
+        {
+          case: 'When the list of responses is undefined',
+          userResponse: undefined,
+        },
+      ];
+
+      // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      cases.forEach((testCase) => {
+        it(`${testCase.case}, should throw error`, function () {
+          // given
+          const userResponse = testCase.userResponse;
+          const qcmSolution1 = Symbol('correctSolution1');
+          const qcmSolution2 = Symbol('correctSolution2');
+          const qcmSolutions = [qcmSolution1, qcmSolution2];
+
+          const qcm = new QCMForAnswerVerification({
+            id: 'qcm-id',
+            instruction: '',
+            proposals: [{}],
+            feedbacks: { valid: 'OK', invalid: 'KO' },
+            solutions: qcmSolutions,
+          });
+
+          // when/then
+          expect(() => qcm.setUserResponse(userResponse)).to.throw(EntityValidationError);
+        });
+      });
+    });
+  });
+});

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/element-answer-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/element-answer-serializer_test.js
@@ -4,6 +4,7 @@ import { AnswerStatus } from '../../../../../../lib/domain/models/index.js';
 import * as elementAnswerSerializer from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/element-answer-serializer.js';
 import { ElementAnswer } from '../../../../../../src/devcomp/domain/models/ElementAnswer.js';
 import { QrocmCorrectionResponse } from '../../../../../../src/devcomp/domain/models/QrocmCorrectionResponse.js';
+import { QcmCorrectionResponse } from '../../../../../../src/devcomp/domain/models/QcmCorrectionResponse.js';
 
 describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ElementAnswerSerializer', function () {
   describe('#serialize', function () {
@@ -109,6 +110,61 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ElementAnswe
                 feedback: 'Good job!',
                 status: 'ok',
                 solution: givenCorrectionResponse.solution,
+              },
+              id: '222',
+              type: 'correction-responses',
+            },
+          ],
+        };
+
+        // when
+        const result = elementAnswerSerializer.serialize(elementAnswer);
+
+        // then
+        expect(result).to.deep.equal(expectedResult);
+      });
+    });
+
+    describe('When correction response is for QCM', function () {
+      it('should return a serialized ElementAnswer', function () {
+        // given
+        const solutions = ['1', '2'];
+        const userAnswerValue = ['3', '4'];
+        const givenCorrectionResponse = new QcmCorrectionResponse({
+          status: AnswerStatus.OK,
+          feedback: 'Good job!',
+          solutions,
+        });
+
+        const elementAnswer = new ElementAnswer({
+          id: 222,
+          elementId: '123',
+          userResponseValue: userAnswerValue,
+          correction: givenCorrectionResponse,
+        });
+        const expectedResult = {
+          data: {
+            attributes: {
+              'element-id': '123',
+              'user-response-value': userAnswerValue,
+            },
+            relationships: {
+              correction: {
+                data: {
+                  id: '222',
+                  type: 'correction-responses',
+                },
+              },
+            },
+            id: '222',
+            type: 'element-answers',
+          },
+          included: [
+            {
+              attributes: {
+                feedback: 'Good job!',
+                status: 'ok',
+                solutions: givenCorrectionResponse.solutions,
               },
               id: '222',
               type: 'correction-responses',


### PR DESCRIPTION
## :unicorn: Problème
Actuellement notre API peut envoyer la ressource `QCM` mais n'a pas encore la mécanique pour vérifier les réponses des utilisateurs.

## :robot: Proposition
Dans la continuité des `QCU` et des `QROCM`, nous avons implémenté un modèle `QCMForAnswerVerification` qui portera la méthode `assess` pour vérifier les réponses. Il est couplé au `ValidatorQCM` et au `SolutionServiceQcm` afin de répondre à ce besoin.

## :rainbow: Remarques
La taille de cette PR (+ ou - 700 nouvelles lignes) s'explique en grande partie par le fait que dans certains fichiers nous avons réordonné les imports et que nous avons _stubé_ une partie des tests du `ModuleRepository` qui ne l'étaient pas.

On a défini une règle de validation du référentiel qcm : au moins 3 propositions. Afin de ne pas pouvoir avoir de qcm où toutes les réponses sont valides.
On a aussi défini une règle de validation de la réponse des utilisateurs : au moins 2 réponses. Afin de forcer le fait qu'il s'agisse d'une question à choix **multiples**.

Contrairement aux modèles `QrocmCorrectionResponse` et `QcuCorrectionResponse` qui ont une propriété `solution` (au singulier), le modèle `QcmCorrectionResponse` a une propriété `solutions` (au pluriel).
Cela nous a amené à complexifier notre test d'acceptance de la route `/api/passages/{passageId}/answers` car les cas de tests pour le passage d'un `QCU`, d'un `QROCM` et d'un `QCM` partagent la même logique d'`expect`.

## :100: Pour tester
La CI passe (?)
