### PR TITLE
[BUGFIX] Finalisation session impossible si le test est terminé par le surveillant par le surveillant (PIX-11179)

### DIFF
--- a/api/src/certification/session/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/session/infrastructure/repositories/session-repository.js
@@ -217,7 +217,8 @@ const countUncompletedCertificationsAssessment = async function (sessionId) {
     .count('certification-courses.id')
     .from('certification-courses')
     .join('assessments', 'certification-courses.id', 'certificationCourseId')
-    .where({ sessionId, state: CertificationAssessment.states.STARTED })
+    .whereIn('state', [CertificationAssessment.states.ENDED_BY_SUPERVISOR, CertificationAssessment.states.STARTED])
+    .andWhere({ sessionId })
     .first();
   return count;
 };

--- a/api/tests/certification/session/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/certification/session/integration/infrastructure/repositories/session-repository_test.js
@@ -949,7 +949,19 @@ describe('Integration | Repository | Session', function () {
         });
         databaseBuilder.factory.buildAssessment({
           certificationCourseId: 98,
-          state: CertificationAssessment.states.STARTED,
+          state: CertificationAssessment.states.ENDED_BY_SUPERVISOR,
+        });
+
+        const userId3 = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildCertificationCandidate({ sessionId, userId: userId3 });
+        databaseBuilder.factory.buildCertificationCourse({
+          id: 99,
+          sessionId,
+          userId: userId3,
+        });
+        databaseBuilder.factory.buildAssessment({
+          certificationCourseId: 99,
+          state: CertificationAssessment.states.COMPLETED,
         });
 
         await databaseBuilder.commit();


### PR DESCRIPTION
## :unicorn: Problème
Il est impossible de finaliser une session avec un test de certification terminé par le surveillant

## :robot: Proposition
Dans le usecase finalize-session, faire remonter les certification terminées par le surveillant dans compteur de test en cours

## :100: Pour tester
lors d'une session de certification: 
- terminer le test d'un candidat depuis l'espace surveillant
- tenter de finaliser la session depuis pix-certif
- constater le succès de l'opération :tada: 