### PR TITLE
[TECH] extraction d'une erreur spécifique au domaine `school` : `ActivityErrorNotFound`

### DIFF
--- a/api/src/school/domain/school-errors.js
+++ b/api/src/school/domain/school-errors.js
@@ -1,0 +1,16 @@
+class DomainError extends Error {
+  constructor(message, code, meta) {
+    super(message);
+    this.code = code;
+    this.meta = meta;
+  }
+}
+
+class ActivityNotFoundError extends DomainError {
+  constructor(message = 'Erreur, activitée introuvable.', code) {
+    super(message);
+    this.code = code;
+  }
+}
+
+export { ActivityNotFoundError };

--- a/api/src/school/domain/services/activity.js
+++ b/api/src/school/domain/services/activity.js
@@ -1,10 +1,10 @@
-import { NotFoundError } from '../../../../lib/domain/errors.js';
+import { ActivityNotFoundError } from '../school-errors.js';
 
 export async function getCurrentActivity(activityRepository, assessmentId) {
   try {
     return await activityRepository.getLastActivity(assessmentId);
   } catch (error) {
-    if (!(error instanceof NotFoundError)) {
+    if (!(error instanceof ActivityNotFoundError)) {
       throw error;
     }
   }

--- a/api/src/school/infrastructure/repositories/activity-repository.js
+++ b/api/src/school/infrastructure/repositories/activity-repository.js
@@ -1,6 +1,6 @@
 import { knex } from '../../../../db/knex-database-connection.js';
 import { Activity } from '../../domain/models/Activity.js';
-import { NotFoundError } from '../../../../lib/domain/errors.js';
+import { ActivityNotFoundError } from '../../domain/school-errors.js';
 
 const save = async function (activity) {
   const [savedAttributes] = await knex('activities').insert(activity).returning('*');
@@ -9,14 +9,14 @@ const save = async function (activity) {
 const updateStatus = async function ({ activityId, status }) {
   const [updatedActivity] = await knex('activities').update({ status }).where('id', activityId).returning('*');
   if (!updatedActivity) {
-    throw new NotFoundError(`There is no activity corresponding to the id: ${activityId}`);
+    throw new ActivityNotFoundError(`There is no activity corresponding to the id: ${activityId}`);
   }
   return updatedActivity;
 };
 const getLastActivity = async function (assessmentId) {
   const activity = await knex('activities').where({ assessmentId }).orderBy('createdAt', 'DESC').first();
   if (!activity) {
-    throw new NotFoundError(`No activity found for the assessment: ${assessmentId}`);
+    throw new ActivityNotFoundError(`No activity found for the assessment: ${assessmentId}`);
   }
   return activity;
 };

--- a/api/tests/school/integration/infrastructure/repositories/activity-repository_test.js
+++ b/api/tests/school/integration/infrastructure/repositories/activity-repository_test.js
@@ -1,7 +1,7 @@
 import { catchErr, databaseBuilder, expect, knex } from '../../../../test-helper.js';
 import * as activityRepository from '../../../../../src/school/infrastructure/repositories/activity-repository.js';
 import { Activity } from '../../../../../src/school/domain/models/Activity.js';
-import { NotFoundError } from '../../../../../lib/domain/errors.js';
+import { ActivityNotFoundError } from '../../../../../src/school/domain/school-errors.js';
 
 describe('Integration | Repository | activityRepository', function () {
   describe('#save', function () {
@@ -49,7 +49,7 @@ describe('Integration | Repository | activityRepository', function () {
         const error = await catchErr(activityRepository.updateStatus)({ activityId, status: Activity.status.SKIPPED });
 
         // then
-        expect(error).to.be.instanceof(NotFoundError);
+        expect(error).to.be.instanceof(ActivityNotFoundError);
       });
     });
   });
@@ -65,7 +65,7 @@ describe('Integration | Repository | activityRepository', function () {
         const error = await catchErr(activityRepository.getLastActivity)(assessmentId);
 
         // then
-        expect(error).to.be.instanceof(NotFoundError);
+        expect(error).to.be.instanceof(ActivityNotFoundError);
       });
     });
     context('when there is an activity for the given assessmentId', function () {

--- a/api/tests/school/unit/domain/services/activity_test.js
+++ b/api/tests/school/unit/domain/services/activity_test.js
@@ -1,5 +1,5 @@
 import { expect, sinon, catchErr } from '../../../../test-helper.js';
-import { NotFoundError } from '../../../../../lib/domain/errors.js';
+import { ActivityNotFoundError } from '../../../../../src/school/domain/school-errors.js';
 import { getCurrentActivity } from '../../../../../src/school/domain/services/activity.js';
 
 describe('Unit | Service | Activity', function () {
@@ -15,13 +15,13 @@ describe('Unit | Service | Activity', function () {
       expect(activityRepository.getLastActivity).to.have.been.calledOnceWith(assessmentId);
     });
 
-    it('does not throw an error with a NotFoundError', async function () {
+    it('does not throw an error with a ActivityNotFoundError', async function () {
       const assessmentId = 'id_assessment';
       const activityRepository = {
         getLastActivity: sinon.stub(),
       };
 
-      activityRepository.getLastActivity.withArgs(assessmentId).rejects(new NotFoundError());
+      activityRepository.getLastActivity.withArgs(assessmentId).rejects(new ActivityNotFoundError());
 
       const functionToCall = async () => {
         await getCurrentActivity(activityRepository, assessmentId);
@@ -30,7 +30,7 @@ describe('Unit | Service | Activity', function () {
       expect(functionToCall).to.not.throw();
     });
 
-    it('throws an error when the error is not a NotFoundError', async function () {
+    it('throws an error when the error is not a ActivityNotFoundError', async function () {
       const assessmentId = 'id_assessment';
       const activityRepository = {
         getLastActivity: sinon.stub(),
@@ -39,7 +39,7 @@ describe('Unit | Service | Activity', function () {
       activityRepository.getLastActivity.withArgs(assessmentId).rejects(new Error());
 
       const error = await catchErr(getCurrentActivity)(activityRepository, assessmentId);
-      expect(error).not.to.be.instanceOf(NotFoundError);
+      expect(error).not.to.be.instanceOf(ActivityNotFoundError);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Les erreurs sont mélangé dans un gros paquet `lib/domain/errors.js`. Difficile de s'y retrouver.

## :robot: Proposition

Extraction d'une `ActivityNotFoundError` pour amorcer le mouvement des erreurs spécirfique au domaine `school`.

## :rainbow: Remarques

n/a

## :100: Pour tester

Les tests doivent être vert :green_circle:  et fonctionnalités doivent rester identique 
