### PR TITLE
[TECH] Extraction d'une erreur spécifique pour pix 1d : `MissionNotFoundError`

### DIFF
--- a/api/src/school/domain/school-errors.js
+++ b/api/src/school/domain/school-errors.js
@@ -14,4 +14,11 @@ class SchoolNotFoundError extends DomainError {
   }
 }
 
-export { ActivityNotFoundError, SchoolNotFoundError };
+class MissionNotFoundError extends DomainError {
+  constructor(missionId) {
+    super(`Il n'existe pas de mission ayant pour id ${missionId}`);
+    this.code = missionId;
+  }
+}
+
+export { ActivityNotFoundError, SchoolNotFoundError, MissionNotFoundError };

--- a/api/src/school/infrastructure/repositories/mission-repository.js
+++ b/api/src/school/infrastructure/repositories/mission-repository.js
@@ -2,7 +2,7 @@ import { Mission } from '../../domain/models/Mission.js';
 import { missionDatasource } from '../datasources/learning-content/mission-datasource.js';
 import { getTranslatedKey } from '../../../../lib/domain/services/get-translated-text.js';
 import { LOCALE } from '../../../shared/domain/constants.js';
-import { NotFoundError } from '../../../../lib/domain/errors.js';
+import { MissionNotFoundError } from '../../domain/school-errors.js';
 
 const { FRENCH_FRANCE } = LOCALE;
 
@@ -27,7 +27,7 @@ async function get(id, locale = { locale: FRENCH_FRANCE }) {
     const missionData = await missionDatasource.get(id);
     return _toDomain(missionData, locale);
   } catch (error) {
-    throw new NotFoundError(`Il n'existe pas de mission ayant pour id ${id}`);
+    throw new MissionNotFoundError(id);
   }
 }
 

--- a/api/tests/school/integration/infrastructure/repositories/mission-repository_test.js
+++ b/api/tests/school/integration/infrastructure/repositories/mission-repository_test.js
@@ -1,7 +1,7 @@
 import { expect, mockLearningContent, catchErr } from '../../../../test-helper.js';
 import * as missionRepository from '../../../../../src/school/infrastructure/repositories/mission-repository.js';
 import { Mission } from '../../../../../src/school/domain/models/Mission.js';
-import { NotFoundError } from '../../../../../lib/domain/errors.js';
+import { MissionNotFoundError } from '../../../../../src/school/domain/school-errors.js';
 describe('Integration | Repository | mission-repository', function () {
   describe('#get', function () {
     context('when there is a mission for the given id', function () {
@@ -47,7 +47,7 @@ describe('Integration | Repository | mission-repository', function () {
         const error = await catchErr(missionRepository.get)(missionId);
 
         // then
-        expect(error).to.be.instanceOf(NotFoundError);
+        expect(error).to.be.instanceOf(MissionNotFoundError);
         expect(error.message).to.deep.equal(`Il n'existe pas de mission ayant pour id ${missionId}`);
       });
     });


### PR DESCRIPTION
## :unicorn: Problème

Les erreurs sont mélangé dans un gros paquet `lib/domain/errors.js`. Difficile de s'y retrouver.

## :robot: Proposition

Extraction d'une `MissionNotFoundError` pour amorcer le mouvement des erreurs spécirfique au domaine school.

## :rainbow: Remarques

n/a

## :100: Pour tester

Les tests doivent être vert 🟢 et fonctionnalités doivent rester identique
