### PR TITLE
[BUGFIX] Afficher correctement le module de didacticiel

### DIFF
--- a/mon-pix/app/pods/qcm/model.js
+++ b/mon-pix/app/pods/qcm/model.js
@@ -1,0 +1,7 @@
+import { attr } from '@ember-data/model';
+import Element from '../element/model';
+
+export default class Qcm extends Element {
+  @attr('string') instruction;
+  @attr() proposals;
+}


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le didacticiel ne s'affiche pas car ember data cherche à instancier un qcm qu'il recoit du module didacticiel, mais le modèle n'existe pas. 

## :robot: Proposition
Ajouter le modèle sans l'utiliser, ember data peut alors tranquillement faire sa vie. 

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
