### PR TITLE
[BUGFIX] Re finalisation session impossible si le test est terminé par la finalisation (PIX-11215)

### DIFF
--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -166,6 +166,10 @@ class CertificationAssessment {
       }
     });
   }
+
+  static get uncompletedAssessmentStates() {
+    return [states.STARTED, states.ENDED_BY_SUPERVISOR, states.ENDED_DUE_TO_FINALIZATION];
+  }
 }
 
 function _isAnswerKoOrSkippedOrPartially(answerStatus) {

--- a/api/src/certification/session/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/session/infrastructure/repositories/session-repository.js
@@ -217,7 +217,7 @@ const countUncompletedCertificationsAssessment = async function (sessionId) {
     .count('certification-courses.id')
     .from('certification-courses')
     .join('assessments', 'certification-courses.id', 'certificationCourseId')
-    .whereIn('state', [CertificationAssessment.states.ENDED_BY_SUPERVISOR, CertificationAssessment.states.STARTED])
+    .whereIn('state', CertificationAssessment.uncompletedAssessmentStates)
     .andWhere({ sessionId })
     .first();
   return count;

--- a/api/tests/certification/session/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/certification/session/integration/infrastructure/repositories/session-repository_test.js
@@ -940,6 +940,7 @@ describe('Integration | Repository | Session', function () {
           certificationCourseId: 97,
           state: CertificationAssessment.states.STARTED,
         });
+
         const userId2 = databaseBuilder.factory.buildUser().id;
         databaseBuilder.factory.buildCertificationCandidate({ sessionId, userId: userId2 });
         databaseBuilder.factory.buildCertificationCourse({
@@ -961,6 +962,18 @@ describe('Integration | Repository | Session', function () {
         });
         databaseBuilder.factory.buildAssessment({
           certificationCourseId: 99,
+          state: CertificationAssessment.states.ENDED_DUE_TO_FINALIZATION,
+        });
+
+        const userId4 = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildCertificationCandidate({ sessionId, userId: userId4 });
+        databaseBuilder.factory.buildCertificationCourse({
+          id: 100,
+          sessionId,
+          userId: userId4,
+        });
+        databaseBuilder.factory.buildAssessment({
+          certificationCourseId: 100,
           state: CertificationAssessment.states.COMPLETED,
         });
 
@@ -971,7 +984,7 @@ describe('Integration | Repository | Session', function () {
           await sessionRepository.countUncompletedCertificationsAssessment(sessionId);
 
         // then
-        expect(unfinishedCertificationsCount).to.equal(2);
+        expect(unfinishedCertificationsCount).to.equal(3);
       });
     });
 

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -877,4 +877,18 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
       });
     });
   });
+
+  describe('#get uncompletedAssessmentStates', function () {
+    it('should return the uncompleted assessment states', function () {
+      //given / when
+      const result = CertificationAssessment.uncompletedAssessmentStates;
+
+      // then
+      expect(result).to.deep.equal([
+        CertificationAssessment.states.STARTED,
+        CertificationAssessment.states.ENDED_BY_SUPERVISOR,
+        CertificationAssessment.states.ENDED_DUE_TO_FINALIZATION,
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Il est impossible de re finaliser une session avec un test de certification terminé par une première finalisation
## :robot: Proposition
Dans le usecase finalize-session, faire remonter les certification terminées par une premère finalisation dans le compteur de test en cours

## :100: Pour tester
lors d'une session de certification: 
- terminer le test d'un candidat depuis l'espace surveillant
- finaliser la session depuis pix-certif
- définaliser la session depuis pix-admin
- re finaliser la session dans pix-certif
- constater le succès de l'opération :tada: 
