### PR TITLE
[FEATURE] Affichage dynamique des objectifs pour la page de présentation et la page de fin d'une mission(Pix-10278)

### DIFF
--- a/1d/app/models/mission.js
+++ b/1d/app/models/mission.js
@@ -3,4 +3,6 @@ import Model, { attr } from '@ember-data/model';
 export default class Mission extends Model {
   @attr('string') name;
   @attr('string') areaCode;
+  @attr('string') learningObjectives;
+  @attr('string') validatedObjectives;
 }

--- a/1d/app/pods/assessment/results/controller.js
+++ b/1d/app/pods/assessment/results/controller.js
@@ -1,0 +1,7 @@
+import Controller from '@ember/controller';
+
+export default class Missions extends Controller {
+  get validatedObjectives() {
+    return this.model.validatedObjectives.split('\n');
+  }
+}

--- a/1d/app/pods/assessment/results/template.hbs
+++ b/1d/app/pods/assessment/results/template.hbs
@@ -3,37 +3,21 @@
     <Bubble @message={{t "pages.missions.end-page.congratulations"}} @color="success" />
   </RobotDialog>
   <div class="mission-page__body">
-    {{#if (eq @model.id "recExjO7RHeDI48HK")}}
-      <MissionCard @title="Recherche sur internet" @colorClass="red" @imageName="internet-search" />
-    {{else}}
-      <MissionCard @title="Données personnelles" @colorClass="blue" @imageName="personal-data" />
-    {{/if}}
+    <MissionCard
+      @title={{@model.name}}
+      @colorClass="area-{{@model.areaCode}}"
+      @imageName="img-area-{{@model.areaCode}}"
+    />
+
     <div class="mission-page__details">
       <p class="details-list__title">{{t "pages.missions.end-page.details-list"}}</p>
       <ul class="details-list">
-        {{#if (eq @model.id "recExjO7RHeDI48HK")}}
+        {{#each this.validatedObjectives as |element|}}
           <li class="details-list__item">
             <img src="/images/icons/objectif.svg" alt="" />
-            <p>ce qu'est un moteur de recherche et donner le nom d'un moteur de recherche que tu connais,</p>
+            <Markdown::MarkdownToHtml @markdown={{element}} />
           </li>
-          <li class="details-list__item">
-            <img src="/images/icons/objectif.svg" alt="" />
-            <p>choisir correctement les mots pour faire une recherche,</p>
-          </li>
-          <li class="details-list__item">
-            <img src="/images/icons/objectif.svg" alt="" />
-            <p>utiliser un moteur de recherche.</p>
-          </li>
-        {{else}}
-          <li class="details-list__item">
-            <img src="/images/icons/objectif.svg" alt="" />
-            <p>ce qu'est une donnée personelle,</p>
-          </li>
-          <li class="details-list__item">
-            <img src="/images/icons/objectif.svg" alt="" />
-            <p>protéger tes données personnelles en évitant de les diffuser.</p>
-          </li>
-        {{/if}}
+        {{/each}}
       </ul>
 
       <PixButtonLink @route="identified.missions" @shape="rounded" class="details-action">

--- a/1d/app/pods/identified/missions/list/route.js
+++ b/1d/app/pods/identified/missions/list/route.js
@@ -7,10 +7,10 @@ export default class MissionsRoute extends Route {
   @service currentLearner;
 
   async model() {
-    const missions = await this.store.findAll('mission');
+    const result = await this.store.findAll('mission');
     const organizationLearner = await this.store.findRecord('organization-learner', this.currentLearner.learner.id);
     return {
-      missions,
+      missions: [...result].sort((mission) => mission.id),
       organizationLearner,
     };
   }

--- a/1d/app/pods/identified/missions/mission/controller.js
+++ b/1d/app/pods/identified/missions/mission/controller.js
@@ -12,4 +12,8 @@ export default class Mission extends Controller {
       .getElementsByClassName('details-action__loader')[0]
       .classList.replace('details-action__loader', 'details-action__loader--visible');
   }
+
+  get learningObjectives() {
+    return this.model.learningObjectives.split('\n');
+  }
 }

--- a/1d/app/pods/identified/missions/mission/template.hbs
+++ b/1d/app/pods/identified/missions/mission/template.hbs
@@ -3,26 +3,23 @@
     <Bubble @message={{t "pages.missions.start-page.welcome"}} />
   </RobotDialog>
   <div class="mission-page__body">
-    {{#if (eq @model.id "recExjO7RHeDI48HK")}}
-      <MissionCard @title="Recherche sur internet" @colorClass="red" @imageName="internet-search" />
-    {{else}}
-      <MissionCard @title="Données personnelles" @colorClass="blue" @imageName="personal-data" />
-    {{/if}}
-
+    <MissionCard
+      @title={{@model.name}}
+      @colorClass="area-{{@model.areaCode}}"
+      @imageName="img-area-{{@model.areaCode}}"
+    />
     <div class="mission-page__details">
       <LinkTo @route="identified.missions" class="details-go-back">{{t
           "pages.missions.start-page.back-to-missions"
         }}</LinkTo>
       <p class="details-list__title details-list__title--big">{{t "pages.missions.start-page.purpose-title"}}</p>
       <ul class="details-list">
-        <li class="details-list__item">
-          <FaIcon @icon="arrow-right" class="icon" />
-          {{#if (eq @model.id "recExjO7RHeDI48HK")}}
-            <p>Savoir utiliser un moteur de recherche en ligne</p>
-          {{else}}
-            <p>Connaître la notion de données personnelles et savoir les protéger</p>
-          {{/if}}
-        </li>
+        {{#each this.learningObjectives as |element|}}
+          <li class="details-list__item">
+            <FaIcon @icon="arrow-right" class="icon" />
+            <Markdown::MarkdownToHtml @markdown={{element}} />
+          </li>
+        {{/each}}
       </ul>
 
       <PixButtonLink

--- a/1d/mirage/factories/mission.js
+++ b/1d/mirage/factories/mission.js
@@ -2,4 +2,7 @@ import { Factory } from 'miragejs';
 
 export default Factory.extend({
   name: 'Recherche sur internet',
+  areaCode: 1,
+  learningObjectives: 'learningObjectives',
+  validatedObjectives: 'validatedObjectives',
 });

--- a/1d/tests/acceptance/display-mission-info_test.js
+++ b/1d/tests/acceptance/display-mission-info_test.js
@@ -12,7 +12,8 @@ module('Acceptance | Display informations about the mission', function (hooks) {
     // when
     const screen = await visit(`/missions/${mission.id}`);
     // then
-    assert.dom(screen.getByText('Connaître la notion de données personnelles et savoir les protéger')).exists();
+    assert.dom(screen.getByText('Recherche sur internet')).exists();
+    assert.dom(screen.getByText('learningObjectives')).exists();
     assert.dom(screen.getByText(this.intl.t('pages.missions.start-page.start-mission'))).exists();
   });
 });

--- a/1d/tests/acceptance/end-mission_test.js
+++ b/1d/tests/acceptance/end-mission_test.js
@@ -6,6 +6,21 @@ import { setupApplicationTest } from '../helpers';
 
 module('Acceptance | End mission', function (hooks) {
   setupApplicationTest(hooks);
+  test('displays mission validated objectives', async function (assert) {
+    // given
+    const mission = this.server.create('mission');
+    const assessment = this.server.create('assessment', { missionId: mission.id });
+    identifyLearner(this.owner);
+
+    // when
+    const screen = await visit(`/assessments/${assessment.id}/results`);
+
+    // then
+    assert.dom(screen.getByText('Recherche sur internet')).exists();
+    assert.dom(screen.getByText('validatedObjectives')).exists();
+    assert.dom(screen.getByText(this.intl.t('pages.missions.end-page.back-to-missions'))).exists();
+  });
+
   test('redirect to home page after clicking on return button', async function (assert) {
     // given
     const mission = this.server.create('mission');

--- a/1d/translations/fr.json
+++ b/1d/translations/fr.json
@@ -41,7 +41,7 @@
       "end-page": {
         "congratulations": "Bravo ! <br> Tu as terminé ta mission !",
         "back-to-missions": "Voir d'autres missions",
-        "details-list": "POUR CETTE MISSION, TU AS MONTRÉ QUE TU SAIS :"
+        "details-list": "Tu as pu validé les notions suivantes:"
       }
     },
     "error": {

--- a/api/src/school/application/mission-controller.js
+++ b/api/src/school/application/mission-controller.js
@@ -3,7 +3,7 @@ import { usecases } from '../domain/usecases/index.js';
 
 const getById = async function (request, h, dependencies = { missionSerializer }) {
   const { id: missionId } = request.params;
-  const mission = await usecases.getMission({ missionId });
+  const mission = await usecases.getMission({ missionId: parseInt(missionId) });
   return dependencies.missionSerializer.serialize(mission);
 };
 

--- a/api/src/school/domain/services/inject-code-from-area-to-mission.js
+++ b/api/src/school/domain/services/inject-code-from-area-to-mission.js
@@ -1,0 +1,12 @@
+const cacheArea = {};
+async function injectCodeFromAreaTo(mission, areaRepository) {
+  let areaCode = cacheArea[mission.competenceId];
+  if (!areaCode) {
+    areaCode = await areaRepository.getAreaCodeByCompetenceId(mission.competenceId);
+    cacheArea[mission.competenceId] = areaCode;
+  }
+
+  return { ...mission, areaCode };
+}
+
+export { injectCodeFromAreaTo };

--- a/api/src/school/domain/usecases/find-all-missions.js
+++ b/api/src/school/domain/usecases/find-all-missions.js
@@ -1,19 +1,8 @@
-const cacheArea = {};
-
-async function _injectCodeFromAreaTo(mission, areaRepository) {
-  let areaCode = cacheArea[mission.competenceId];
-
-  if (!areaCode) {
-    areaCode = await areaRepository.getAreaCodeByCompetenceId(mission.competenceId);
-    cacheArea[mission.competenceId] = areaCode;
-  }
-
-  return { ...mission, areaCode };
-}
+import { injectCodeFromAreaTo } from '../services/inject-code-from-area-to-mission.js';
 
 async function findAllMissions({ missionRepository, areaRepository }) {
   const missions = await missionRepository.findAllMissions();
-  return Promise.all(missions.map(async (mission) => await _injectCodeFromAreaTo(mission, areaRepository)));
+  return Promise.all(missions.map(async (mission) => await injectCodeFromAreaTo(mission, areaRepository)));
 }
 
 export { findAllMissions };

--- a/api/src/school/domain/usecases/get-mission.js
+++ b/api/src/school/domain/usecases/get-mission.js
@@ -1,5 +1,8 @@
-const getMission = async function ({ missionId, missionRepository }) {
-  return await missionRepository.get(missionId);
+import { injectCodeFromAreaTo } from '../services/inject-code-from-area-to-mission.js';
+
+const getMission = async function ({ missionId, missionRepository, areaRepository }) {
+  const mission = await missionRepository.get(missionId);
+  return await injectCodeFromAreaTo(mission, areaRepository);
 };
 
 export { getMission };

--- a/api/src/school/infrastructure/repositories/mission-repository.js
+++ b/api/src/school/infrastructure/repositories/mission-repository.js
@@ -1,5 +1,4 @@
 import { Mission } from '../../domain/models/Mission.js';
-import { thematicDatasource } from '../../../shared/infrastructure/datasources/learning-content/thematic-datasource.js';
 import { missionDatasource } from '../datasources/learning-content/mission-datasource.js';
 import { getTranslatedKey } from '../../../../lib/domain/services/get-translated-text.js';
 import { LOCALE } from '../../../shared/domain/constants.js';
@@ -25,8 +24,8 @@ function _toDomain(data, locale) {
 async function get(id, locale = { locale: FRENCH_FRANCE }) {
   try {
     // Les missions sont stockées en tant que thématiques dans PixEditor :)
-    const thematicData = await thematicDatasource.get(id);
-    return _toDomain(thematicData, locale);
+    const missionData = await missionDatasource.get(id);
+    return _toDomain(missionData, locale);
   } catch (error) {
     throw new NotFoundError(`Il n'existe pas de mission ayant pour id ${id}`);
   }

--- a/api/src/school/infrastructure/serializers/mission-serializer.js
+++ b/api/src/school/infrastructure/serializers/mission-serializer.js
@@ -2,7 +2,7 @@ import { Serializer } from 'jsonapi-serializer';
 
 const serialize = function (missions) {
   return new Serializer('missions', {
-    attributes: ['name', 'areaCode'],
+    attributes: ['name', 'areaCode', 'validatedObjectives', 'learningObjectives'],
   }).serialize(missions);
 };
 export { serialize };

--- a/api/tests/school/integration/application/mission-controller_test.js
+++ b/api/tests/school/integration/application/mission-controller_test.js
@@ -7,7 +7,13 @@ describe('Integration | Controller | mission-controller', function () {
   describe('#getById', function () {
     it('should get mission by id', async function () {
       // given
-      const mission = new Mission({ name: 'TAG1', id: 1 });
+      const mission = new Mission({
+        name: 'TAG1',
+        id: 1,
+        areaCode: 1,
+        learningObjectives: 'learningObjectives',
+        validatedObjectives: 'validatedObjectives',
+      });
       sinon.stub(usecases, 'getMission').withArgs({ missionId: mission.id }).resolves(mission);
 
       // when
@@ -25,6 +31,8 @@ describe('Integration | Controller | mission-controller', function () {
         attributes: {
           name: mission.name,
           'area-code': mission.areaCode,
+          'learning-objectives': mission.learningObjectives,
+          'validated-objectives': mission.validatedObjectives,
         },
         id: mission.id.toString(),
         type: 'missions',
@@ -46,6 +54,8 @@ describe('Integration | Controller | mission-controller', function () {
           attributes: {
             name: mission.name,
             'area-code': mission.areaCode,
+            'learning-objectives': mission.learningObjectives,
+            'validated-objectives': mission.validatedObjectives,
           },
           id: mission.id.toString(),
           type: 'missions',

--- a/api/tests/school/integration/domain/usecases/get-mission_test.js
+++ b/api/tests/school/integration/domain/usecases/get-mission_test.js
@@ -1,0 +1,44 @@
+import { Mission } from '../../../../../src/school/domain/models/Mission.js';
+import { expect, mockLearningContent } from '../../../../test-helper.js';
+import { getMission } from '../../../../../src/school/domain/usecases/get-mission.js';
+import * as missionRepository from '../../../../../src/school/infrastructure/repositories/mission-repository.js';
+import * as areaRepository from '../../../../../lib/infrastructure/repositories/area-repository.js';
+import * as learningContentBuilder from '../../../../tooling/learning-content-builder/index.js';
+describe('Integration | UseCase | getMission', function () {
+  it('Should return a mission', async function () {
+    const mission = learningContentBuilder.buildMission({
+      id: 12,
+      name_i18n: { fr: 'truc' },
+      competenceId: 'competenceId',
+      thematicId: 'thematicId',
+      status: 'a status',
+      learningObjectives_i18n: { fr: 'Il était une fois' },
+      validatedObjectives_i18n: { fr: 'Bravo ! tu as réussi !' },
+    });
+
+    const area = learningContentBuilder.buildArea({
+      code: 3,
+      competenceIds: ['competenceId'],
+    });
+
+    mockLearningContent({
+      missions: [mission],
+      areas: [area],
+    });
+
+    const expectedMission = new Mission({
+      id: 12,
+      name: 'truc',
+      competenceId: 'competenceId',
+      thematicId: 'thematicId',
+      status: 'a status',
+      areaCode: 3,
+      learningObjectives: 'Il était une fois',
+      validatedObjectives: 'Bravo ! tu as réussi !',
+    });
+
+    const returnedMission = await getMission({ missionId: 12, missionRepository, areaRepository });
+
+    expect(returnedMission).to.deep.equal(expectedMission);
+  });
+});

--- a/api/tests/school/integration/infrastructure/repositories/mission-repository_test.js
+++ b/api/tests/school/integration/infrastructure/repositories/mission-repository_test.js
@@ -8,21 +8,29 @@ describe('Integration | Repository | mission-repository', function () {
       it('should return the correct mission with FR default language', async function () {
         // given
         const expectedMission = new Mission({
-          id: 'recThematic1',
+          id: 1,
           name: 'nameThemaFR1',
+          competenceId: 'competenceId',
+          thematicId: 'thematicId',
+          learningObjectives: 'learningObjectivesi18n',
+          validatedObjectives: 'validatedObjectivesi18n',
         });
 
         mockLearningContent({
-          thematics: [
+          missions: [
             {
-              id: 'recThematic1',
+              id: 1,
               name_i18n: { fr: 'nameThemaFR1' },
+              competenceId: 'competenceId',
+              thematicId: 'thematicId',
+              learningObjectives_i18n: { fr: 'learningObjectivesi18n' },
+              validatedObjectives_i18n: { fr: 'validatedObjectivesi18n' },
             },
           ],
         });
 
         // when
-        const mission = await missionRepository.get('recThematic1');
+        const mission = await missionRepository.get(1);
 
         // then
         expect(mission).to.deep.equal(expectedMission);

--- a/api/tests/school/unit/domain/services/inject-code-from-area-to-mission_test.js
+++ b/api/tests/school/unit/domain/services/inject-code-from-area-to-mission_test.js
@@ -1,0 +1,23 @@
+import { Mission } from '../../../../../src/school/domain/models/Mission.js';
+import { sinon, expect } from '../../../../test-helper.js';
+import { injectCodeFromAreaTo } from '../../../../../src/school/domain/services/inject-code-from-area-to-mission.js';
+describe('Unit | Service | injectCodeFromAreaToMission', function () {
+  it('Should add areaCode to Mission', async function () {
+    const areaRepository = { getAreaCodeByCompetenceId: sinon.stub() };
+    const areaCode = 1;
+    areaRepository.getAreaCodeByCompetenceId.returns(areaCode);
+
+    const mission = new Mission({
+      id: 1,
+      name: 'nameThemaFR1',
+      competenceId: 'competenceId',
+      thematicId: 'thematicId',
+      learningObjectives: 'learningObjectivesi18n',
+      validatedObjectives: 'validatedObjectivesi18n',
+    });
+
+    const mutatedMission = await injectCodeFromAreaTo(mission, areaRepository);
+
+    expect(mutatedMission.areaCode).to.deep.equal(areaCode);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on commence une mission, on affiche les objectifs à atteindre et lorsqu'on a fini la mission, on affiche un récap des objectifs atteints.
Sauf que ces objectifs sont en « dur » dans le code.

## :robot: Proposition
Rendre l'affichage des objectifs dynamiques en fonction des missions pour l'écran de présentation de la mission et la page de fin de mission.

## :rainbow: Remarques
Les missions pouvaient s'affichées dans un ordre aléatoire. On a réparé ça en mettant un sort sur la liste des missions

## :100: Pour tester
- Aller sur pix1d, et commencer une mission : regarder la beauté de la page de présentation de la mission.
- finir une mission, et admirer la page de fin de mission avec objectifs atteints