### PR TITLE
[FEATURE] Résoudre automatiquement les signalements validés par le surveillant (PIX-11207).

### DIFF
--- a/api/db/database-builder/factory/build-certification-report.js
+++ b/api/db/database-builder/factory/build-certification-report.js
@@ -12,7 +12,7 @@ const buildCertificationReport = function ({
   abortReason = null,
 } = {}) {
   certificationCourseId = _.isUndefined(certificationCourseId)
-    ? buildCertificationCourse({ firstName, lastName, sessionId, hasSeenEndTestScreen }).id
+    ? buildCertificationCourse({ firstName, lastName, sessionId, hasSeenEndTestScreen, abortReason }).id
     : certificationCourseId;
 
   const id = CertificationReport.idFromCertificationCourseId(certificationCourseId);

--- a/api/src/certification/session/domain/usecases/validate-live-alert.js
+++ b/api/src/certification/session/domain/usecases/validate-live-alert.js
@@ -54,6 +54,10 @@ export const validateLiveAlert = async ({
     liveAlertId: certificationChallengeLiveAlert.id,
   });
 
+  const ISSUE_REPORT_RESOLUTION =
+    'Le signalement a été validé par le surveillant pendant la session. Une nouvelle question a été proposée au candidat';
+  certificationIssueReport.resolveAutomatically(ISSUE_REPORT_RESOLUTION);
+
   await certificationIssueReportRepository.save(certificationIssueReport);
 
   await certificationChallengeLiveAlertRepository.save({

--- a/api/tests/certification/session/acceptance/application/session-route_test.js
+++ b/api/tests/certification/session/acceptance/application/session-route_test.js
@@ -12,7 +12,9 @@ import {
   CertificationIssueReportCategory,
   CertificationIssueReportSubcategories,
 } from '../../../../../src/certification/shared/domain/models/CertificationIssueReportCategory.js';
-import { AnswerStatus, CertificationResult } from '../../../../../lib/domain/models/index.js';
+import { AnswerStatus, Assessment, CertificationResult } from '../../../../../lib/domain/models/index.js';
+
+const examinerGlobalComment = 'It was a fine session my dear';
 
 describe('Acceptance | Controller | Session | session-route', function () {
   let server;
@@ -160,61 +162,11 @@ describe('Acceptance | Controller | Session | session-route', function () {
   describe('PUT /sessions/{id}/finalization', function () {
     let options;
     let session;
-    const examinerGlobalComment = 'It was a fine session my dear';
-
-    beforeEach(async function () {
-      session = databaseBuilder.factory.buildSession();
-      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({ sessionId: session.id }).id;
-      const report1 = databaseBuilder.factory.buildCertificationReport({
-        sessionId: session.id,
-        certificationCourseId,
-      });
-      const report2 = databaseBuilder.factory.buildCertificationReport({
-        sessionId: session.id,
-        certificationCourseId,
-      });
-      databaseBuilder.factory.buildAssessment({ certificationCourseId });
-      options = {
-        method: 'PUT',
-        payload: {
-          data: {
-            attributes: {
-              'examiner-global-comment': examinerGlobalComment,
-              'has-incident': true,
-              'has-joining-issue': true,
-            },
-            included: [
-              {
-                id: report1.id,
-                type: 'certification-reports',
-                attributes: {
-                  'certification-course-id': report1.certificationCourseId,
-                  'examiner-comment': 'What a fine lad this one',
-                  'has-seen-end-test-screen': false,
-                  'is-completed': true,
-                },
-              },
-              {
-                id: report2.id,
-                type: 'certification-reports',
-                attributes: {
-                  'certification-course-id': report2.certificationCourseId,
-                  'examiner-comment': 'What a fine lad this two',
-                  'has-seen-end-test-screen': true,
-                  'is-completed': true,
-                },
-              },
-            ],
-          },
-        },
-        headers: {},
-        url: `/api/sessions/${session.id}/finalization`,
-      };
-
-      return databaseBuilder.commit();
-    });
 
     describe('Resource access management', function () {
+      beforeEach(async function () {
+        ({ options, session } = await _createSession());
+      });
       it('should respond with a 401 Forbidden if the user is not authenticated', async function () {
         // given
         options.headers.authorization = 'invalid.access.token';
@@ -241,388 +193,641 @@ describe('Acceptance | Controller | Session | session-route', function () {
     });
 
     describe('Success case', function () {
-      it('should update session', async function () {
-        // given
-        const userId = databaseBuilder.factory.buildUser().id;
-        databaseBuilder.factory.buildCertificationCenterMembership({
-          userId,
-          certificationCenterId: session.certificationCenterId,
+      describe('when session is v2', function () {
+        beforeEach(async function () {
+          ({ options, session } = await _createSession());
+        });
+        it('should update session', async function () {
+          // given
+          const userId = databaseBuilder.factory.buildUser().id;
+          databaseBuilder.factory.buildCertificationCenterMembership({
+            userId,
+            certificationCenterId: session.certificationCenterId,
+          });
+
+          await databaseBuilder.commit();
+          options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
+
+          // when
+          await server.inject(options);
+
+          // then
+          const finalizedSession = await knex.from('sessions').where({ id: session.id }).first();
+          expect(finalizedSession.hasIncident).to.be.true;
+          expect(finalizedSession.hasJoiningIssue).to.be.true;
         });
 
-        await databaseBuilder.commit();
-        options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
-
-        // when
-        await server.inject(options);
-
-        // then
-        const finalizedSession = await knex.from('sessions').where({ id: session.id }).first();
-        expect(finalizedSession.hasIncident).to.be.true;
-        expect(finalizedSession.hasJoiningIssue).to.be.true;
-      });
-
-      it('should neutralize auto-neutralizable challenges', async function () {
-        // given
-        const learningContent = [
-          {
-            id: 'recArea0',
-            code: '66',
-            competences: [
-              {
-                id: 'recCompetence0',
-                index: '1',
-                tubes: [
-                  {
-                    id: 'recTube0_0',
-                    skills: [
-                      {
-                        id: 'recSkill0_0',
-                        nom: '@recSkill0_0',
-                        challenges: [{ id: 'recChallenge0_0_0' }, { id: 'recChallenge0_0_1' }],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        ];
-        const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-        mockLearningContent(learningContentObjects);
-
-        const userId = databaseBuilder.factory.buildUser().id;
-        const session = databaseBuilder.factory.buildSession();
-        const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({ sessionId: session.id }).id;
-        databaseBuilder.factory.buildCertificationCenterMembership({
-          userId,
-          certificationCenterId: session.certificationCenterId,
-        });
-        const report = databaseBuilder.factory.buildCertificationReport({
-          certificationCourseId,
-          sessionId: session.id,
-        });
-
-        const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
-        databaseBuilder.factory.buildCertificationIssueReport({
-          certificationCourseId,
-          category: CertificationIssueReportCategory.IN_CHALLENGE,
-          description: '',
-          subcategory: CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
-          questionNumber: 1,
-        });
-
-        const certificationChallengeKo = databaseBuilder.factory.buildCertificationChallenge({
-          courseId: certificationCourseId,
-          isNeutralized: false,
-          challengeId: 'recChallenge0_0_1',
-          competenceId: 'recCompetence0',
-          associatedSkillName: '@recSkill0_0',
-          associatedSkillId: 'recSkill0_0',
-        });
-
-        const certificationChallengeOk = databaseBuilder.factory.buildCertificationChallenge({
-          courseId: certificationCourseId,
-          isNeutralized: false,
-          challengeId: 'recChallenge0_0_0',
-          competenceId: 'recCompetence0',
-          associatedSkillName: '@recSkill0_0',
-          associatedSkillId: 'recSkill0_0',
-        });
-
-        databaseBuilder.factory.buildAnswer({
-          assessmentId,
-          challengeId: certificationChallengeKo.challengeId,
-          result: AnswerStatus.KO.status,
-        });
-        databaseBuilder.factory.buildAnswer({
-          assessmentId,
-          challengeId: certificationChallengeOk.challengeId,
-          result: AnswerStatus.OK.status,
-        });
-
-        await databaseBuilder.commit();
-
-        options = {
-          method: 'PUT',
-          payload: {
-            data: {
-              attributes: {
-                'examiner-global-comment': examinerGlobalComment,
-                'has-incident': true,
-                'has-joining-issue': true,
-              },
-              included: [
+        it('should neutralize auto-neutralizable challenges', async function () {
+          // given
+          const learningContent = [
+            {
+              id: 'recArea0',
+              code: '66',
+              competences: [
                 {
-                  id: report.id,
-                  type: 'certification-reports',
-                  attributes: {
-                    'certification-course-id': report.certificationCourseId,
-                    'examiner-comment': 'What a fine lad this one',
-                    'has-seen-end-test-screen': false,
-                    'is-completed': true,
-                  },
+                  id: 'recCompetence0',
+                  index: '1',
+                  tubes: [
+                    {
+                      id: 'recTube0_0',
+                      skills: [
+                        {
+                          id: 'recSkill0_0',
+                          nom: '@recSkill0_0',
+                          challenges: [{ id: 'recChallenge0_0_0' }, { id: 'recChallenge0_0_1' }],
+                        },
+                      ],
+                    },
+                  ],
                 },
               ],
             },
-          },
-          headers: {
-            authorization: generateValidRequestAuthorizationHeader(userId),
-          },
-          url: `/api/sessions/${session.id}/finalization`,
-        };
+          ];
+          const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
+          mockLearningContent(learningContentObjects);
 
-        // when
-        const response = await server.inject(options);
+          const userId = databaseBuilder.factory.buildUser().id;
+          const session = databaseBuilder.factory.buildSession();
+          const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({ sessionId: session.id }).id;
+          databaseBuilder.factory.buildCertificationCenterMembership({
+            userId,
+            certificationCenterId: session.certificationCenterId,
+          });
+          const report = databaseBuilder.factory.buildCertificationReport({
+            certificationCourseId,
+            sessionId: session.id,
+          });
 
-        // then
-        expect(response.statusCode).to.equal(200);
-        const actualKoCertificationChallenge = await knex('certification-challenges')
-          .where({ id: certificationChallengeKo.id })
-          .first();
-        const actualOkCertificationChallenge = await knex('certification-challenges')
-          .where({ id: certificationChallengeOk.id })
-          .first();
-        expect(actualKoCertificationChallenge.isNeutralized).to.be.true;
-        expect(actualOkCertificationChallenge.isNeutralized).to.be.false;
-      });
+          const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
+          databaseBuilder.factory.buildCertificationIssueReport({
+            certificationCourseId,
+            category: CertificationIssueReportCategory.IN_CHALLENGE,
+            description: '',
+            subcategory: CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
+            questionNumber: 1,
+          });
 
-      it('should set the finalized session as publishable when the issue reports have been resolved', async function () {
-        // given
-        const learningContent = [
-          {
-            id: 'recArea0',
-            code: '66',
-            competences: [
-              {
-                id: 'recCompetence0',
-                index: '1',
-                tubes: [
+          const certificationChallengeKo = databaseBuilder.factory.buildCertificationChallenge({
+            courseId: certificationCourseId,
+            isNeutralized: false,
+            challengeId: 'recChallenge0_0_1',
+            competenceId: 'recCompetence0',
+            associatedSkillName: '@recSkill0_0',
+            associatedSkillId: 'recSkill0_0',
+          });
+
+          const certificationChallengeOk = databaseBuilder.factory.buildCertificationChallenge({
+            courseId: certificationCourseId,
+            isNeutralized: false,
+            challengeId: 'recChallenge0_0_0',
+            competenceId: 'recCompetence0',
+            associatedSkillName: '@recSkill0_0',
+            associatedSkillId: 'recSkill0_0',
+          });
+
+          databaseBuilder.factory.buildAnswer({
+            assessmentId,
+            challengeId: certificationChallengeKo.challengeId,
+            result: AnswerStatus.KO.status,
+          });
+          databaseBuilder.factory.buildAnswer({
+            assessmentId,
+            challengeId: certificationChallengeOk.challengeId,
+            result: AnswerStatus.OK.status,
+          });
+
+          await databaseBuilder.commit();
+
+          options = {
+            method: 'PUT',
+            payload: {
+              data: {
+                attributes: {
+                  'examiner-global-comment': examinerGlobalComment,
+                  'has-incident': true,
+                  'has-joining-issue': true,
+                },
+                included: [
                   {
-                    id: 'recTube0_0',
-                    skills: [
-                      {
-                        id: 'recSkill0_0',
-                        nom: '@recSkill0_0',
-                        challenges: [{ id: 'recChallenge0_0_0' }],
-                      },
-                    ],
+                    id: report.id,
+                    type: 'certification-reports',
+                    attributes: {
+                      'certification-course-id': report.certificationCourseId,
+                      'examiner-comment': 'What a fine lad this one',
+                      'has-seen-end-test-screen': false,
+                      'is-completed': true,
+                    },
                   },
                 ],
               },
-            ],
-          },
-        ];
-        const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-        mockLearningContent(learningContentObjects);
+            },
+            headers: {
+              authorization: generateValidRequestAuthorizationHeader(userId),
+            },
+            url: `/api/sessions/${session.id}/finalization`,
+          };
 
-        const userId = databaseBuilder.factory.buildUser().id;
-        const session = databaseBuilder.factory.buildSession();
-        const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
-          sessionId: session.id,
-          completedAt: new Date(),
-        }).id;
-        databaseBuilder.factory.buildCertificationCenterMembership({
-          userId,
-          certificationCenterId: session.certificationCenterId,
-        });
-        const report = databaseBuilder.factory.buildCertificationReport({
-          certificationCourseId,
-          sessionId: session.id,
-        });
+          // when
+          const response = await server.inject(options);
 
-        const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
-        databaseBuilder.factory.buildCertificationIssueReport({
-          certificationCourseId,
-          category: CertificationIssueReportCategory.IN_CHALLENGE,
-          description: '',
-          subcategory: CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
-          questionNumber: 1,
+          // then
+          expect(response.statusCode).to.equal(200);
+          const actualKoCertificationChallenge = await knex('certification-challenges')
+            .where({ id: certificationChallengeKo.id })
+            .first();
+          const actualOkCertificationChallenge = await knex('certification-challenges')
+            .where({ id: certificationChallengeOk.id })
+            .first();
+          expect(actualKoCertificationChallenge.isNeutralized).to.be.true;
+          expect(actualOkCertificationChallenge.isNeutralized).to.be.false;
         });
 
-        databaseBuilder.factory.buildAssessmentResult({ assessmentId });
-
-        const certificationChallenge = databaseBuilder.factory.buildCertificationChallenge({
-          courseId: certificationCourseId,
-          isNeutralized: false,
-          challengeId: 'recChallenge0_0_0',
-          competenceId: 'recCompetence0',
-          associatedSkillName: '@recSkill0_0',
-          associatedSkillId: 'recSkill0_0',
-        });
-        databaseBuilder.factory.buildAnswer({
-          assessmentId,
-          challengeId: certificationChallenge.challengeId,
-          result: AnswerStatus.KO.status,
-        });
-
-        await databaseBuilder.commit();
-
-        options = {
-          method: 'PUT',
-          payload: {
-            data: {
-              attributes: {
-                'examiner-global-comment': '',
-                'has-incident': true,
-                'has-joining-issue': true,
-              },
-              included: [
+        it('should set the finalized session as publishable when the issue reports have been resolved', async function () {
+          // given
+          const learningContent = [
+            {
+              id: 'recArea0',
+              code: '66',
+              competences: [
                 {
-                  id: report.id,
-                  type: 'certification-reports',
-                  attributes: {
-                    'certification-course-id': report.certificationCourseId,
-                    'examiner-comment': 'What a fine lad this one',
-                    'has-seen-end-test-screen': true,
-                    'is-completed': true,
-                  },
+                  id: 'recCompetence0',
+                  index: '1',
+                  tubes: [
+                    {
+                      id: 'recTube0_0',
+                      skills: [
+                        {
+                          id: 'recSkill0_0',
+                          nom: '@recSkill0_0',
+                          challenges: [{ id: 'recChallenge0_0_0' }],
+                        },
+                      ],
+                    },
+                  ],
                 },
               ],
             },
-          },
-          headers: {
-            authorization: generateValidRequestAuthorizationHeader(userId),
-          },
-          url: `/api/sessions/${session.id}/finalization`,
-        };
+          ];
+          const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
+          mockLearningContent(learningContentObjects);
 
-        // when
-        const response = await server.inject(options);
+          const userId = databaseBuilder.factory.buildUser().id;
+          const session = databaseBuilder.factory.buildSession();
+          const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+            sessionId: session.id,
+            completedAt: new Date(),
+          }).id;
+          databaseBuilder.factory.buildCertificationCenterMembership({
+            userId,
+            certificationCenterId: session.certificationCenterId,
+          });
+          const report = databaseBuilder.factory.buildCertificationReport({
+            certificationCourseId,
+            sessionId: session.id,
+          });
 
-        // then
-        expect(response.statusCode).to.equal(200);
-        const finalizedSession = await knex('finalized-sessions').where({ sessionId: session.id }).first();
-        expect(finalizedSession.isPublishable).to.be.true;
-      });
+          const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
+          databaseBuilder.factory.buildCertificationIssueReport({
+            certificationCourseId,
+            category: CertificationIssueReportCategory.IN_CHALLENGE,
+            description: '',
+            subcategory: CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
+            questionNumber: 1,
+          });
 
-      it('should re score assessment when there is auto-neutralizable challenge', async function () {
-        // given
+          databaseBuilder.factory.buildAssessmentResult({ assessmentId });
 
-        const learningContent = [
-          {
-            id: 'recArea0',
-            code: '66',
-            competences: [
-              {
-                id: 'recCompetence0',
-                index: '1',
-                tubes: [
+          const certificationChallenge = databaseBuilder.factory.buildCertificationChallenge({
+            courseId: certificationCourseId,
+            isNeutralized: false,
+            challengeId: 'recChallenge0_0_0',
+            competenceId: 'recCompetence0',
+            associatedSkillName: '@recSkill0_0',
+            associatedSkillId: 'recSkill0_0',
+          });
+          databaseBuilder.factory.buildAnswer({
+            assessmentId,
+            challengeId: certificationChallenge.challengeId,
+            result: AnswerStatus.KO.status,
+          });
+
+          await databaseBuilder.commit();
+
+          options = {
+            method: 'PUT',
+            payload: {
+              data: {
+                attributes: {
+                  'examiner-global-comment': '',
+                  'has-incident': true,
+                  'has-joining-issue': true,
+                },
+                included: [
                   {
-                    id: 'recTube0_0',
-                    skills: [
-                      {
-                        id: 'recSkill0_0',
-                        nom: '@recSkill0_0',
-                        challenges: [{ id: 'recChallenge0_0_0' }],
-                      },
-                    ],
+                    id: report.id,
+                    type: 'certification-reports',
+                    attributes: {
+                      'certification-course-id': report.certificationCourseId,
+                      'examiner-comment': 'What a fine lad this one',
+                      'has-seen-end-test-screen': true,
+                      'is-completed': true,
+                    },
                   },
                 ],
               },
-            ],
-          },
-        ];
-        const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
-        mockLearningContent(learningContentObjects);
+            },
+            headers: {
+              authorization: generateValidRequestAuthorizationHeader(userId),
+            },
+            url: `/api/sessions/${session.id}/finalization`,
+          };
 
-        const userId = databaseBuilder.factory.buildUser().id;
-        const session = databaseBuilder.factory.buildSession();
-        const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
-          sessionId: session.id,
-          userId,
-          createdAt: new Date(),
-        }).id;
-        databaseBuilder.factory.buildCertificationCenterMembership({
-          userId,
-          certificationCenterId: session.certificationCenterId,
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          const finalizedSession = await knex('finalized-sessions').where({ sessionId: session.id }).first();
+          expect(finalizedSession.isPublishable).to.be.true;
         });
 
-        const report = databaseBuilder.factory.buildCertificationReport({
-          certificationCourseId,
-          sessionId: session.id,
-        });
+        it('should re score assessment when there is auto-neutralizable challenge', async function () {
+          // given
 
-        const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId, userId }).id;
-        databaseBuilder.factory.buildCertificationIssueReport({
-          certificationCourseId,
-          category: CertificationIssueReportCategory.IN_CHALLENGE,
-          description: '',
-          subcategory: CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
-          questionNumber: 1,
-        });
-
-        const assessmentResultKo = databaseBuilder.factory.buildAssessmentResult({
-          assessmentId,
-          pixScore: 42,
-        });
-
-        databaseBuilder.factory.buildCompetenceMark({
-          assessmentResultId: assessmentResultKo.id,
-          competenceId: 'recCompetence0',
-        });
-
-        const certificationChallengeKo = databaseBuilder.factory.buildCertificationChallenge({
-          courseId: certificationCourseId,
-          isNeutralized: false,
-          challengeId: 'recChallenge0_0_0',
-          competenceId: 'recCompetence0',
-        });
-
-        const answerId = databaseBuilder.factory.buildAnswer({
-          assessmentId,
-          challengeId: certificationChallengeKo.challengeId,
-          result: AnswerStatus.KO.status,
-        }).id;
-
-        databaseBuilder.factory.buildKnowledgeElement({
-          assessmentId,
-          answerId,
-          skillId: 'recSkill0_0',
-          competenceId: 'recCompetence0',
-          userId,
-          earnedPix: 16,
-        });
-
-        await databaseBuilder.commit();
-
-        options = {
-          method: 'PUT',
-          payload: {
-            data: {
-              attributes: {
-                'examiner-global-comment': examinerGlobalComment,
-                'has-incident': true,
-                'has-joining-issue': true,
-              },
-              included: [
+          const learningContent = [
+            {
+              id: 'recArea0',
+              code: '66',
+              competences: [
                 {
-                  id: report.id,
-                  type: 'certification-reports',
-                  attributes: {
-                    'certification-course-id': report.certificationCourseId,
-                    'examiner-comment': 'What a fine lad this one',
-                    'has-seen-end-test-screen': false,
-                    'is-completed': true,
-                  },
+                  id: 'recCompetence0',
+                  index: '1',
+                  tubes: [
+                    {
+                      id: 'recTube0_0',
+                      skills: [
+                        {
+                          id: 'recSkill0_0',
+                          nom: '@recSkill0_0',
+                          challenges: [{ id: 'recChallenge0_0_0' }],
+                        },
+                      ],
+                    },
+                  ],
                 },
               ],
             },
-          },
-          headers: {
-            authorization: generateValidRequestAuthorizationHeader(userId),
-          },
-          url: `/api/sessions/${session.id}/finalization`,
-        };
+          ];
+          const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
+          mockLearningContent(learningContentObjects);
 
-        // when
-        const response = await server.inject(options);
+          const userId = databaseBuilder.factory.buildUser().id;
+          const session = databaseBuilder.factory.buildSession();
+          const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+            sessionId: session.id,
+            userId,
+            createdAt: new Date(),
+          }).id;
+          databaseBuilder.factory.buildCertificationCenterMembership({
+            userId,
+            certificationCenterId: session.certificationCenterId,
+          });
 
-        // then
-        expect(response.statusCode).to.equal(200);
-        const actualKoAssessmentResult = await knex('assessment-results')
-          .where({ assessmentId, emitter: CertificationResult.emitters.PIX_ALGO_AUTO_JURY })
-          .first();
-        expect(actualKoAssessmentResult.pixScore).not.to.equal(assessmentResultKo.pixScore);
+          const report = databaseBuilder.factory.buildCertificationReport({
+            certificationCourseId,
+            sessionId: session.id,
+          });
+
+          const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId, userId }).id;
+          databaseBuilder.factory.buildCertificationIssueReport({
+            certificationCourseId,
+            category: CertificationIssueReportCategory.IN_CHALLENGE,
+            description: '',
+            subcategory: CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
+            questionNumber: 1,
+          });
+
+          const assessmentResultKo = databaseBuilder.factory.buildAssessmentResult({
+            assessmentId,
+            pixScore: 42,
+          });
+
+          databaseBuilder.factory.buildCompetenceMark({
+            assessmentResultId: assessmentResultKo.id,
+            competenceId: 'recCompetence0',
+          });
+
+          const certificationChallengeKo = databaseBuilder.factory.buildCertificationChallenge({
+            courseId: certificationCourseId,
+            isNeutralized: false,
+            challengeId: 'recChallenge0_0_0',
+            competenceId: 'recCompetence0',
+          });
+
+          const answerId = databaseBuilder.factory.buildAnswer({
+            assessmentId,
+            challengeId: certificationChallengeKo.challengeId,
+            result: AnswerStatus.KO.status,
+          }).id;
+
+          databaseBuilder.factory.buildKnowledgeElement({
+            assessmentId,
+            answerId,
+            skillId: 'recSkill0_0',
+            competenceId: 'recCompetence0',
+            userId,
+            earnedPix: 16,
+          });
+
+          await databaseBuilder.commit();
+
+          options = {
+            method: 'PUT',
+            payload: {
+              data: {
+                attributes: {
+                  'examiner-global-comment': examinerGlobalComment,
+                  'has-incident': true,
+                  'has-joining-issue': true,
+                },
+                included: [
+                  {
+                    id: report.id,
+                    type: 'certification-reports',
+                    attributes: {
+                      'certification-course-id': report.certificationCourseId,
+                      'examiner-comment': 'What a fine lad this one',
+                      'has-seen-end-test-screen': false,
+                      'is-completed': true,
+                    },
+                  },
+                ],
+              },
+            },
+            headers: {
+              authorization: generateValidRequestAuthorizationHeader(userId),
+            },
+            url: `/api/sessions/${session.id}/finalization`,
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          const actualKoAssessmentResult = await knex('assessment-results')
+            .where({ assessmentId, emitter: CertificationResult.emitters.PIX_ALGO_AUTO_JURY })
+            .first();
+          expect(actualKoAssessmentResult.pixScore).not.to.equal(assessmentResultKo.pixScore);
+        });
+      });
+
+      describe('when session is v3', function () {
+        beforeEach(async function () {
+          ({ options, session } = await _createSession({ version: 3 }));
+        });
+        it('should update session', async function () {
+          // given
+          const userId = databaseBuilder.factory.buildUser().id;
+          databaseBuilder.factory.buildCertificationCenterMembership({
+            userId,
+            certificationCenterId: session.certificationCenterId,
+          });
+
+          await databaseBuilder.commit();
+          options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
+
+          // when
+          await server.inject(options);
+
+          // then
+          const finalizedSession = await knex.from('sessions').where({ id: session.id }).first();
+          expect(finalizedSession.hasIncident).to.be.true;
+          expect(finalizedSession.hasJoiningIssue).to.be.true;
+        });
+
+        it('should set the finalized session as publishable', async function () {
+          // given
+          const learningContent = [
+            {
+              id: 'recArea0',
+              code: '66',
+              competences: [
+                {
+                  id: 'recCompetence0',
+                  index: '1',
+                  tubes: [
+                    {
+                      id: 'recTube0_0',
+                      skills: [
+                        {
+                          id: 'recSkill0_0',
+                          nom: '@recSkill0_0',
+                          challenges: [{ id: 'recChallenge0_0_0' }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ];
+          const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
+          mockLearningContent(learningContentObjects);
+
+          const userId = databaseBuilder.factory.buildUser().id;
+          const session = databaseBuilder.factory.buildSession();
+          const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+            sessionId: session.id,
+            completedAt: new Date(),
+          }).id;
+          databaseBuilder.factory.buildCertificationCenterMembership({
+            userId,
+            certificationCenterId: session.certificationCenterId,
+          });
+          const report = databaseBuilder.factory.buildCertificationReport({
+            certificationCourseId,
+            sessionId: session.id,
+          });
+
+          const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
+          databaseBuilder.factory.buildCertificationIssueReport({
+            certificationCourseId,
+            category: CertificationIssueReportCategory.IN_CHALLENGE,
+            description: '',
+            subcategory: CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
+            questionNumber: 1,
+          });
+
+          databaseBuilder.factory.buildAssessmentResult({ assessmentId });
+
+          const certificationChallenge = databaseBuilder.factory.buildCertificationChallenge({
+            courseId: certificationCourseId,
+            isNeutralized: false,
+            challengeId: 'recChallenge0_0_0',
+            competenceId: 'recCompetence0',
+            associatedSkillName: '@recSkill0_0',
+            associatedSkillId: 'recSkill0_0',
+          });
+          databaseBuilder.factory.buildAnswer({
+            assessmentId,
+            challengeId: certificationChallenge.challengeId,
+            result: AnswerStatus.KO.status,
+          });
+
+          await databaseBuilder.commit();
+
+          options = {
+            method: 'PUT',
+            payload: {
+              data: {
+                attributes: {
+                  'examiner-global-comment': '',
+                  'has-incident': true,
+                  'has-joining-issue': true,
+                },
+                included: [
+                  {
+                    id: report.id,
+                    type: 'certification-reports',
+                    attributes: {
+                      'certification-course-id': report.certificationCourseId,
+                      'examiner-comment': 'What a fine lad this one',
+                      'has-seen-end-test-screen': true,
+                      'is-completed': true,
+                    },
+                  },
+                ],
+              },
+            },
+            headers: {
+              authorization: generateValidRequestAuthorizationHeader(userId),
+            },
+            url: `/api/sessions/${session.id}/finalization`,
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          const finalizedSession = await knex('finalized-sessions').where({ sessionId: session.id }).first();
+          expect(finalizedSession.isPublishable).to.be.true;
+        });
+
+        it('should mark the assessment as ended due to finalization', async function () {
+          // given
+          const abortReason = 'candidate';
+          const learningContent = [
+            {
+              id: 'recArea0',
+              code: '66',
+              competences: [
+                {
+                  id: 'recCompetence0',
+                  index: '1',
+                  tubes: [
+                    {
+                      id: 'recTube0_0',
+                      skills: [
+                        {
+                          id: 'recSkill0_0',
+                          nom: '@recSkill0_0',
+                          challenges: [{ id: 'recChallenge0_0_0' }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ];
+          const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
+          mockLearningContent(learningContentObjects);
+
+          const userId = databaseBuilder.factory.buildUser().id;
+          const session = databaseBuilder.factory.buildSession();
+          const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+            sessionId: session.id,
+            completedAt: null,
+          }).id;
+          databaseBuilder.factory.buildCertificationCenterMembership({
+            userId,
+            certificationCenterId: session.certificationCenterId,
+          });
+          const report = databaseBuilder.factory.buildCertificationReport({
+            certificationCourseId,
+            sessionId: session.id,
+          });
+
+          const assessmentId = databaseBuilder.factory.buildAssessment({
+            certificationCourseId,
+            state: Assessment.states.STARTED,
+          }).id;
+          databaseBuilder.factory.buildCertificationIssueReport({
+            certificationCourseId,
+            category: CertificationIssueReportCategory.IN_CHALLENGE,
+            description: '',
+            subcategory: CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
+            questionNumber: 1,
+          });
+
+          databaseBuilder.factory.buildAssessmentResult({ assessmentId });
+
+          const certificationChallenge = databaseBuilder.factory.buildCertificationChallenge({
+            courseId: certificationCourseId,
+            isNeutralized: false,
+            challengeId: 'recChallenge0_0_0',
+            competenceId: 'recCompetence0',
+            associatedSkillName: '@recSkill0_0',
+            associatedSkillId: 'recSkill0_0',
+          });
+          databaseBuilder.factory.buildAnswer({
+            assessmentId,
+            challengeId: certificationChallenge.challengeId,
+            result: AnswerStatus.KO.status,
+          });
+
+          await databaseBuilder.commit();
+
+          options = {
+            method: 'PUT',
+            payload: {
+              data: {
+                attributes: {
+                  'examiner-global-comment': '',
+                  'has-incident': true,
+                  'has-joining-issue': true,
+                },
+                included: [
+                  {
+                    id: report.id,
+                    type: 'certification-reports',
+                    attributes: {
+                      'certification-course-id': report.certificationCourseId,
+                      'examiner-comment': 'What a fine lad this one',
+                      'has-seen-end-test-screen': true,
+                      'is-completed': true,
+                      'abort-reason': abortReason,
+                    },
+                  },
+                ],
+              },
+            },
+            headers: {
+              authorization: generateValidRequestAuthorizationHeader(userId),
+            },
+            url: `/api/sessions/${session.id}/finalization`,
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          const assessment = await knex('assessments').where({ certificationCourseId }).first();
+          expect(assessment.state).to.equal('endedDueToFinalization');
+        });
       });
     });
   });
@@ -660,3 +865,60 @@ describe('Acceptance | Controller | Session | session-route', function () {
     });
   });
 });
+
+const _createSession = async ({ version = 2 } = {}) => {
+  const session = databaseBuilder.factory.buildSession({ version });
+  const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({ sessionId: session.id, version }).id;
+  const report1 = databaseBuilder.factory.buildCertificationReport({
+    sessionId: session.id,
+    certificationCourseId,
+  });
+  const report2 = databaseBuilder.factory.buildCertificationReport({
+    sessionId: session.id,
+    certificationCourseId,
+  });
+  databaseBuilder.factory.buildAssessment({ certificationCourseId });
+  const options = {
+    method: 'PUT',
+    payload: {
+      data: {
+        attributes: {
+          'examiner-global-comment': examinerGlobalComment,
+          'has-incident': true,
+          'has-joining-issue': true,
+        },
+        included: [
+          {
+            id: report1.id,
+            type: 'certification-reports',
+            attributes: {
+              'certification-course-id': report1.certificationCourseId,
+              'examiner-comment': 'What a fine lad this one',
+              'has-seen-end-test-screen': false,
+              'is-completed': true,
+            },
+          },
+          {
+            id: report2.id,
+            type: 'certification-reports',
+            attributes: {
+              'certification-course-id': report2.certificationCourseId,
+              'examiner-comment': 'What a fine lad this two',
+              'has-seen-end-test-screen': true,
+              'is-completed': true,
+            },
+          },
+        ],
+      },
+    },
+    headers: {},
+    url: `/api/sessions/${session.id}/finalization`,
+  };
+
+  await databaseBuilder.commit();
+
+  return {
+    session,
+    options,
+  };
+};

--- a/api/tests/certification/session/unit/domain/usecases/validate-live-alert_test.js
+++ b/api/tests/certification/session/unit/domain/usecases/validate-live-alert_test.js
@@ -57,7 +57,7 @@ describe('Unit | UseCase | validate-live-alert', function () {
   });
 
   describe('when the liveAlert exists', function () {
-    it('should update the LiveAlert and create a new CertificationIssueReport', async function () {
+    it('should update the LiveAlert and create a new resolved CertificationIssueReport', async function () {
       // given
       const sessionId = 123;
       const userId = 456;
@@ -127,6 +127,10 @@ describe('Unit | UseCase | validate-live-alert', function () {
         category,
         questionNumber,
         liveAlertId: liveAlert.id,
+        resolvedAt: sinon.match.date,
+        resolution:
+          'Le signalement a été validé par le surveillant pendant la session. Une nouvelle question a été proposée au candidat',
+        hasBeenAutomaticallyResolved: true,
       });
       expectedCertificationIssueReport.id = undefined;
       expectedCertificationIssueReport.description = undefined;

--- a/api/tests/unit/domain/events/handle-auto-jury_test.js
+++ b/api/tests/unit/domain/events/handle-auto-jury_test.js
@@ -11,426 +11,66 @@ import {
 import { ABORT_REASONS } from '../../../../lib/domain/models/CertificationCourse.js';
 
 describe('Unit | Domain | Events | handle-auto-jury', function () {
-  it('fails when event is not of correct type', async function () {
-    // given
-    const event = 'not an event of the correct type';
+  describe('when certification is V2', function () {
+    it('fails when event is not of correct type', async function () {
+      // given
+      const event = 'not an event of the correct type';
 
-    // when
-    const error = await catchErr(handleAutoJury)(event);
+      // when
+      const error = await catchErr(handleAutoJury)(event);
 
-    // / then
-    expect(error).not.to.be.null;
-  });
-
-  it('auto neutralizes challenges', async function () {
-    // given
-    const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
-    const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
-    const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
-    const challengeRepository = { get: sinon.stub() };
-    const challengeToBeNeutralized1 = domainBuilder.buildCertificationChallengeWithType({
-      challengeId: 'recChal123',
-      isNeutralized: false,
-    });
-    const challengeToBeNeutralized2 = domainBuilder.buildCertificationChallengeWithType({
-      challengeId: 'recChal456',
-      isNeutralized: false,
-    });
-    const challengeNotToBeNeutralized = domainBuilder.buildCertificationChallengeWithType({
-      challengeId: 'recChal789',
-      isNeutralized: false,
-    });
-    const certificationAssessment = domainBuilder.buildCertificationAssessment({
-      certificationAnswersByDate: [
-        domainBuilder.buildAnswer({ challengeId: 'recChal123', result: AnswerStatus.SKIPPED }),
-        domainBuilder.buildAnswer({ challengeId: 'recChal456', result: AnswerStatus.KO }),
-        domainBuilder.buildAnswer({ challengeId: 'recChal789', result: AnswerStatus.OK }),
-      ],
-      certificationChallenges: [challengeToBeNeutralized1, challengeToBeNeutralized2, challengeNotToBeNeutralized],
-    });
-    const certificationCourse = domainBuilder.buildCertificationCourse();
-    const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-      category: CertificationIssueReportCategory.IN_CHALLENGE,
-      subcategory: CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
-      questionNumber: 1,
-    });
-    const certificationIssueReport2 = domainBuilder.buildCertificationIssueReport({
-      category: CertificationIssueReportCategory.FRAUD,
-      subcategory: undefined,
-      questionNumber: 1,
+      // / then
+      expect(error).not.to.be.null;
     });
 
-    certificationCourseRepository.findCertificationCoursesBySessionId
-      .withArgs({ sessionId: 1234 })
-      .resolves([certificationCourse]);
-    certificationIssueReportRepository.findByCertificationCourseId
-      .withArgs(certificationCourse.getId())
-      .resolves([certificationIssueReport, certificationIssueReport2]);
-    certificationAssessmentRepository.getByCertificationCourseId
-      .withArgs({ certificationCourseId: certificationCourse.getId() })
-      .resolves(certificationAssessment);
-    certificationAssessmentRepository.save.resolves();
-    const event = new SessionFinalized({
-      sessionId: 1234,
-      finalizedAt: new Date(),
-      hasExaminerGlobalComment: false,
-      certificationCenterName: 'A certification center name',
-      sessionDate: '2021-01-29',
-      sessionTime: '14:00',
-    });
-
-    // when
-    await handleAutoJury({
-      event,
-      certificationIssueReportRepository,
-      certificationAssessmentRepository,
-      certificationCourseRepository,
-      challengeRepository,
-    });
-
-    // then
-    expect(certificationIssueReport.isResolved()).to.be.true;
-    expect(certificationIssueReport.hasBeenAutomaticallyResolved).to.be.true;
-    expect(certificationAssessmentRepository.save).to.have.been.calledWithExactly(certificationAssessment);
-  });
-
-  it('returns an AutoJuryDone event as last event', async function () {
-    // given
-    const now = Date.now();
-    const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
-    const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub() };
-    const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
-    const certificationAssessment = domainBuilder.buildCertificationAssessment({
-      certificationAnswersByDate: [
-        domainBuilder.buildAnswer({ challengeId: 'recChal123', result: AnswerStatus.SKIPPED }),
-        domainBuilder.buildAnswer({ challengeId: 'recChal456', result: AnswerStatus.KO }),
-        domainBuilder.buildAnswer({ challengeId: 'recChal789', result: AnswerStatus.OK }),
-      ],
-      certificationChallenges: [
-        domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal123' }),
-        domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal456' }),
-        domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal789' }),
-      ],
-    });
-
-    const certificationCourse = domainBuilder.buildCertificationCourse();
-    certificationAssessmentRepository.getByCertificationCourseId
-      .withArgs({ certificationCourseId: certificationCourse.getId() })
-      .resolves(certificationAssessment);
-    certificationCourseRepository.findCertificationCoursesBySessionId
-      .withArgs({ sessionId: 1234 })
-      .resolves([certificationCourse]);
-    certificationIssueReportRepository.findByCertificationCourseId.withArgs(certificationCourse.getId()).resolves([]);
-
-    const event = new SessionFinalized({
-      sessionId: 1234,
-      finalizedAt: now,
-      hasExaminerGlobalComment: false,
-      certificationCenterName: 'A certification center name',
-      sessionDate: '2021-01-29',
-      sessionTime: '14:00',
-    });
-
-    // when
-    const resultEvents = await handleAutoJury({
-      event,
-      certificationIssueReportRepository,
-      certificationAssessmentRepository,
-      certificationCourseRepository,
-    });
-
-    // then
-    const autoJuryDoneEvent = resultEvents[resultEvents.length - 1];
-    expect(autoJuryDoneEvent).to.be.an.instanceof(AutoJuryDone);
-    expect(autoJuryDoneEvent).to.deep.equal(
-      new AutoJuryDone({
-        sessionId: 1234,
-        finalizedAt: now,
-        hasExaminerGlobalComment: false,
-        certificationCenterName: 'A certification center name',
-        sessionDate: '2021-01-29',
-        sessionTime: '14:00',
-      }),
-    );
-  });
-
-  it('returns a CertificationJuryDone event first in returned collection', async function () {
-    // given
-    const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
-    const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
-    const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
-    const challengeToBeNeutralized1 = domainBuilder.buildCertificationChallengeWithType({
-      challengeId: 'recChal123',
-      isNeutralized: false,
-    });
-    const certificationAssessment = domainBuilder.buildCertificationAssessment({
-      certificationAnswersByDate: [
-        domainBuilder.buildAnswer({ challengeId: 'recChal123', result: AnswerStatus.SKIPPED }),
-      ],
-      certificationChallenges: [challengeToBeNeutralized1],
-    });
-    const certificationCourse = domainBuilder.buildCertificationCourse();
-    const certificationIssueReport1 = domainBuilder.buildCertificationIssueReport({
-      category: CertificationIssueReportCategory.IN_CHALLENGE,
-      subcategory: CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
-      questionNumber: 1,
-    });
-    certificationCourseRepository.findCertificationCoursesBySessionId
-      .withArgs({ sessionId: 1234 })
-      .resolves([certificationCourse]);
-    certificationIssueReportRepository.findByCertificationCourseId
-      .withArgs(certificationCourse.getId())
-      .resolves([certificationIssueReport1]);
-    certificationAssessmentRepository.getByCertificationCourseId
-      .withArgs({ certificationCourseId: certificationCourse.getId() })
-      .resolves(certificationAssessment);
-    certificationAssessmentRepository.save.resolves();
-    const event = new SessionFinalized({
-      sessionId: 1234,
-      finalizedAt: new Date(),
-      hasExaminerGlobalComment: false,
-      certificationCenterName: 'A certification center name',
-      sessionDate: '2021-01-29',
-      sessionTime: '14:00',
-    });
-
-    // when
-    const events = await handleAutoJury({
-      event,
-      certificationIssueReportRepository,
-      certificationAssessmentRepository,
-      certificationCourseRepository,
-    });
-
-    // then
-    expect(events[0]).to.be.an.instanceof(CertificationJuryDone);
-    expect(events[0]).to.deep.equal(
-      new CertificationJuryDone({
-        certificationCourseId: certificationCourse.getId(),
-      }),
-    );
-  });
-
-  context('when the certification is not completed', function () {
-    it('returns a CertificationJuryDone event first in returned collection', async function () {
+    it('auto neutralizes challenges', async function () {
       // given
       const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
       const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
       const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
-      const certificationAssessment = domainBuilder.buildCertificationAssessment({ certificationCourseId: 4567 });
-      const certificationCourse = domainBuilder.buildCertificationCourse({
-        sessionId: 1234,
-        id: 4567,
-        completedAt: null,
-        abortReason: ABORT_REASONS.CANDIDATE,
+      const challengeRepository = { get: sinon.stub() };
+      const challengeToBeNeutralized1 = domainBuilder.buildCertificationChallengeWithType({
+        challengeId: 'recChal123',
+        isNeutralized: false,
       });
+      const challengeToBeNeutralized2 = domainBuilder.buildCertificationChallengeWithType({
+        challengeId: 'recChal456',
+        isNeutralized: false,
+      });
+      const challengeNotToBeNeutralized = domainBuilder.buildCertificationChallengeWithType({
+        challengeId: 'recChal789',
+        isNeutralized: false,
+      });
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationAnswersByDate: [
+          domainBuilder.buildAnswer({ challengeId: 'recChal123', result: AnswerStatus.SKIPPED }),
+          domainBuilder.buildAnswer({ challengeId: 'recChal456', result: AnswerStatus.KO }),
+          domainBuilder.buildAnswer({ challengeId: 'recChal789', result: AnswerStatus.OK }),
+        ],
+        certificationChallenges: [challengeToBeNeutralized1, challengeToBeNeutralized2, challengeNotToBeNeutralized],
+      });
+      const certificationCourse = domainBuilder.buildCertificationCourse();
+      const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+        category: CertificationIssueReportCategory.IN_CHALLENGE,
+        subcategory: CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
+        questionNumber: 1,
+      });
+      const certificationIssueReport2 = domainBuilder.buildCertificationIssueReport({
+        category: CertificationIssueReportCategory.FRAUD,
+        subcategory: undefined,
+        questionNumber: 1,
+      });
+
       certificationCourseRepository.findCertificationCoursesBySessionId
         .withArgs({ sessionId: 1234 })
         .resolves([certificationCourse]);
-      certificationIssueReportRepository.findByCertificationCourseId.withArgs(certificationCourse.getId()).resolves([]);
+      certificationIssueReportRepository.findByCertificationCourseId
+        .withArgs(certificationCourse.getId())
+        .resolves([certificationIssueReport, certificationIssueReport2]);
       certificationAssessmentRepository.getByCertificationCourseId
         .withArgs({ certificationCourseId: certificationCourse.getId() })
         .resolves(certificationAssessment);
       certificationAssessmentRepository.save.resolves();
-      const event = new SessionFinalized({
-        sessionId: 1234,
-        finalizedAt: new Date(),
-        hasExaminerGlobalComment: false,
-        certificationCenterName: 'A certification center name',
-        sessionDate: '2021-01-29',
-        sessionTime: '14:00',
-      });
-
-      // when
-      const events = await handleAutoJury({
-        event,
-        certificationIssueReportRepository,
-        certificationAssessmentRepository,
-        certificationCourseRepository,
-      });
-
-      // then
-      expect(events[0]).to.deepEqualInstance(
-        new CertificationJuryDone({
-          certificationCourseId: certificationCourse.getId(),
-        }),
-      );
-    });
-
-    context('when abort reason is candidate', function () {
-      it('should skip unpassed challenges', async function () {
-        // given
-        const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
-        const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
-        const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
-        const challengeToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({
-          challengeId: 'recChal123',
-          isNeutralized: false,
-          hasBeenSkippedAutomatically: false,
-        });
-        const challengeNotToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({
-          challengeId: 'recChal456',
-          isNeutralized: false,
-          hasBeenSkippedAutomatically: false,
-        });
-        const answeredChallenge = domainBuilder.buildAnswer({
-          challengeId: challengeNotToBeConsideredAsSkipped.challengeId,
-        });
-        const certificationAssessment = domainBuilder.buildCertificationAssessment({
-          certificationAnswersByDate: [answeredChallenge],
-          certificationChallenges: [challengeToBeConsideredAsSkipped, challengeNotToBeConsideredAsSkipped],
-        });
-        const certificationCourse = domainBuilder.buildCertificationCourse({
-          completedAt: null,
-          abortReason: ABORT_REASONS.CANDIDATE,
-        });
-        certificationCourseRepository.findCertificationCoursesBySessionId
-          .withArgs({ sessionId: 1234 })
-          .resolves([certificationCourse]);
-        certificationIssueReportRepository.findByCertificationCourseId
-          .withArgs(certificationCourse.getId())
-          .resolves([]);
-        certificationAssessmentRepository.getByCertificationCourseId
-          .withArgs({ certificationCourseId: certificationCourse.getId() })
-          .resolves(certificationAssessment);
-        certificationAssessmentRepository.save.resolves();
-        const event = new SessionFinalized({
-          sessionId: 1234,
-          finalizedAt: new Date(),
-          hasExaminerGlobalComment: false,
-          certificationCenterName: 'A certification center name',
-          sessionDate: '2021-01-29',
-          sessionTime: '14:00',
-        });
-
-        // when
-        await handleAutoJury({
-          event,
-          certificationIssueReportRepository,
-          certificationAssessmentRepository,
-          certificationCourseRepository,
-        });
-
-        // then
-        expect(
-          certificationAssessment.certificationChallenges.find(
-            (certificationChallenge) => certificationChallenge.challengeId === 'recChal123',
-          ).hasBeenSkippedAutomatically,
-        ).to.be.true;
-        expect(
-          certificationAssessment.certificationChallenges.find(
-            (certificationChallenge) => certificationChallenge.challengeId === 'recChal456',
-          ).hasBeenSkippedAutomatically,
-        ).to.be.false;
-      });
-    });
-
-    context('when abort reason is technical', function () {
-      it('should neutralize unpassed challenges', async function () {
-        // given
-        const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
-        const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
-        const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
-        const challengeToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({
-          challengeId: 'recChal123',
-          isNeutralized: false,
-          hasBeenSkippedAutomatically: false,
-        });
-        const challengeNotToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({
-          challengeId: 'recChal456',
-          isNeutralized: false,
-          hasBeenSkippedAutomatically: false,
-        });
-        const answeredChallenge = domainBuilder.buildAnswer({
-          challengeId: challengeNotToBeConsideredAsSkipped.challengeId,
-        });
-        const certificationAssessment = domainBuilder.buildCertificationAssessment({
-          certificationAnswersByDate: [answeredChallenge],
-          certificationChallenges: [challengeToBeConsideredAsSkipped, challengeNotToBeConsideredAsSkipped],
-        });
-        const certificationCourse = domainBuilder.buildCertificationCourse({
-          completedAt: null,
-          abortReason: ABORT_REASONS.TECHNICAL,
-        });
-        certificationCourseRepository.findCertificationCoursesBySessionId
-          .withArgs({ sessionId: 1234 })
-          .resolves([certificationCourse]);
-        certificationIssueReportRepository.findByCertificationCourseId
-          .withArgs(certificationCourse.getId())
-          .resolves([]);
-        certificationAssessmentRepository.getByCertificationCourseId
-          .withArgs({ certificationCourseId: certificationCourse.getId() })
-          .resolves(certificationAssessment);
-        certificationAssessmentRepository.save.resolves();
-        const event = new SessionFinalized({
-          sessionId: 1234,
-          finalizedAt: new Date(),
-          hasExaminerGlobalComment: false,
-          certificationCenterName: 'A certification center name',
-          sessionDate: '2021-01-29',
-          sessionTime: '14:00',
-        });
-
-        // when
-        await handleAutoJury({
-          event,
-          certificationIssueReportRepository,
-          certificationAssessmentRepository,
-          certificationCourseRepository,
-        });
-
-        // then
-        expect(certificationAssessment.certificationChallenges[0].isNeutralized).to.be.true;
-        expect(certificationAssessment.certificationChallenges[0].challengeId).to.equal('recChal123');
-        expect(certificationAssessment.certificationChallenges[1].isNeutralized).to.be.false;
-      });
-    });
-
-    it('should save certification assessment', async function () {
-      // given
-      const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
-      const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
-      const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
-      const challengeToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({
-        id: 123,
-        associatedSkillName: 'cueillir des fleurs',
-        challengeId: 'recChal123',
-        type: 'QCU',
-        competenceId: 'recCOMP',
-        isNeutralized: false,
-        hasBeenSkippedAutomatically: true,
-        certifiableBadgeKey: null,
-        createdAt: new Date('2020-01-01'),
-      });
-      const challengeNotToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({
-        id: 123,
-        associatedSkillName: 'cueillir des fleurs',
-        challengeId: 'recChal456',
-        type: 'QCU',
-        competenceId: 'recCOMP',
-        isNeutralized: false,
-        hasBeenSkippedAutomatically: false,
-        certifiableBadgeKey: null,
-        createdAt: new Date('2020-01-02'),
-      });
-      const answeredChallenge = domainBuilder.buildAnswer({
-        challengeId: challengeNotToBeConsideredAsSkipped.challengeId,
-      });
-      const certificationAssessment = domainBuilder.buildCertificationAssessment({
-        certificationAnswersByDate: [answeredChallenge],
-        certificationChallenges: [challengeToBeConsideredAsSkipped, challengeNotToBeConsideredAsSkipped],
-      });
-      const certificationCourse = domainBuilder.buildCertificationCourse({
-        completedAt: null,
-        abortReason: ABORT_REASONS.CANDIDATE,
-      });
-      certificationCourseRepository.findCertificationCoursesBySessionId
-        .withArgs({ sessionId: 1234 })
-        .resolves([certificationCourse]);
-      certificationIssueReportRepository.findByCertificationCourseId.withArgs(certificationCourse.getId()).resolves([]);
-      certificationAssessmentRepository.getByCertificationCourseId
-        .withArgs({ certificationCourseId: certificationCourse.getId() })
-        .resolves(certificationAssessment);
       const event = new SessionFinalized({
         sessionId: 1234,
         finalizedAt: new Date(),
@@ -446,98 +86,22 @@ describe('Unit | Domain | Events | handle-auto-jury', function () {
         certificationIssueReportRepository,
         certificationAssessmentRepository,
         certificationCourseRepository,
+        challengeRepository,
       });
 
       // then
-      const expectedCertificationAssessment = domainBuilder.buildCertificationAssessment({
-        id: 123,
-        userId: 123,
-        certificationCourseId: 123,
-        createdAt: new Date('2020-01-01T00:00:00Z'),
-        completedAt: new Date('2020-01-01T00:00:00Z'),
-        endedAt: challengeNotToBeConsideredAsSkipped.createdAt,
-        state: 'endedDueToFinalization',
-        version: 2,
-        certificationChallenges: [
-          domainBuilder.buildCertificationChallengeWithType({
-            ...challengeToBeConsideredAsSkipped,
-            hasBeenSkippedAutomatically: true,
-          }),
-          challengeNotToBeConsideredAsSkipped,
-        ],
-        certificationAnswersByDate: [
-          domainBuilder.buildAnswer({
-            id: 123,
-            result: 'ok',
-            resultDetails: null,
-            timeout: null,
-            focusedOut: false,
-            value: '1',
-            levelup: undefined,
-            assessmentId: 456,
-            challengeId: 'recChal456',
-            timeSpent: 20,
-          }),
-        ],
-      });
-      expect(certificationAssessmentRepository.save.getCall(0).args[0]).to.deep.equal(expectedCertificationAssessment);
+      expect(certificationIssueReport.isResolved()).to.be.true;
+      expect(certificationIssueReport.hasBeenAutomaticallyResolved).to.be.true;
+      expect(certificationAssessmentRepository.save).to.have.been.calledWithExactly(certificationAssessment);
     });
-  });
 
-  context('when certificationCourse is completed', function () {
-    it('should not return a CertificationJuryDone', async function () {
+    it('returns an AutoJuryDone event as last event', async function () {
       // given
-      const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
-      const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
-      const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
-      const certificationAssessment = domainBuilder.buildCertificationAssessment({
-        certificationCourseId: 4567,
-      });
-      const certificationCourse = domainBuilder.buildCertificationCourse({
-        id: 4567,
-        sessionId: 1234,
-        completedAt: '2010-01-01',
-        abortReason: null,
-      });
-      certificationCourseRepository.findCertificationCoursesBySessionId
-        .withArgs({ sessionId: 1234 })
-        .resolves([certificationCourse]);
-      certificationIssueReportRepository.findByCertificationCourseId.withArgs(certificationCourse.getId()).resolves([]);
-      certificationAssessmentRepository.getByCertificationCourseId
-        .withArgs({ certificationCourseId: certificationCourse.getId() })
-        .resolves(certificationAssessment);
-      certificationAssessmentRepository.save.resolves();
-      const event = new SessionFinalized({
-        sessionId: 1234,
-        finalizedAt: new Date(),
-        hasExaminerGlobalComment: false,
-        certificationCenterName: 'A certification center name',
-        sessionDate: '2021-01-29',
-        sessionTime: '14:00',
-      });
-
-      // when
-      const events = await handleAutoJury({
-        event,
-        certificationIssueReportRepository,
-        certificationAssessmentRepository,
-        certificationCourseRepository,
-      });
-
-      // then
-      expect(events[0]).not.to.be.an.instanceof(CertificationJuryDone);
-      expect(events.length).to.equal(1);
-    });
-  });
-
-  context('when there is no certification issue report', function () {
-    it('does not return a CertificationJuryDone event', async function () {
-      // given
+      const now = Date.now();
       const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
       const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub() };
       const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
-        certificationCourseId: 4567,
         certificationAnswersByDate: [
           domainBuilder.buildAnswer({ challengeId: 'recChal123', result: AnswerStatus.SKIPPED }),
           domainBuilder.buildAnswer({ challengeId: 'recChal456', result: AnswerStatus.KO }),
@@ -550,7 +114,7 @@ describe('Unit | Domain | Events | handle-auto-jury', function () {
         ],
       });
 
-      const certificationCourse = domainBuilder.buildCertificationCourse({ id: 4567, sessionId: 1234 });
+      const certificationCourse = domainBuilder.buildCertificationCourse();
       certificationAssessmentRepository.getByCertificationCourseId
         .withArgs({ certificationCourseId: certificationCourse.getId() })
         .resolves(certificationAssessment);
@@ -558,9 +122,10 @@ describe('Unit | Domain | Events | handle-auto-jury', function () {
         .withArgs({ sessionId: 1234 })
         .resolves([certificationCourse]);
       certificationIssueReportRepository.findByCertificationCourseId.withArgs(certificationCourse.getId()).resolves([]);
+
       const event = new SessionFinalized({
         sessionId: 1234,
-        finalizedAt: new Date(),
+        finalizedAt: now,
         hasExaminerGlobalComment: false,
         certificationCenterName: 'A certification center name',
         sessionDate: '2021-01-29',
@@ -568,7 +133,7 @@ describe('Unit | Domain | Events | handle-auto-jury', function () {
       });
 
       // when
-      const events = await handleAutoJury({
+      const resultEvents = await handleAutoJury({
         event,
         certificationIssueReportRepository,
         certificationAssessmentRepository,
@@ -576,30 +141,39 @@ describe('Unit | Domain | Events | handle-auto-jury', function () {
       });
 
       // then
-      expect(events.length).to.equal(1);
-      expect(events[0]).not.to.be.an.instanceOf(CertificationJuryDone);
+      const autoJuryDoneEvent = resultEvents[resultEvents.length - 1];
+      expect(autoJuryDoneEvent).to.be.an.instanceof(AutoJuryDone);
+      expect(autoJuryDoneEvent).to.deep.equal(
+        new AutoJuryDone({
+          sessionId: 1234,
+          finalizedAt: now,
+          hasExaminerGlobalComment: false,
+          certificationCenterName: 'A certification center name',
+          sessionDate: '2021-01-29',
+          sessionTime: '14:00',
+        }),
+      );
     });
-  });
 
-  context('when there is no impacted certification', function () {
-    it('does not return a CertificationJuryDone event', async function () {
+    it('returns a CertificationJuryDone event first in returned collection', async function () {
       // given
       const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
-      const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub() };
+      const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
       const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
-      const challenge = domainBuilder.buildCertificationChallengeWithType({
+      const challengeToBeNeutralized1 = domainBuilder.buildCertificationChallengeWithType({
         challengeId: 'recChal123',
         isNeutralized: false,
       });
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
-        certificationCourseId: 4567,
-        certificationAnswersByDate: [domainBuilder.buildAnswer({ challengeId: 'recChal123', result: AnswerStatus.OK })],
-        certificationChallenges: [challenge],
+        certificationAnswersByDate: [
+          domainBuilder.buildAnswer({ challengeId: 'recChal123', result: AnswerStatus.SKIPPED }),
+        ],
+        certificationChallenges: [challengeToBeNeutralized1],
       });
-      const certificationCourse = domainBuilder.buildCertificationCourse({ id: 4567, sessionId: 1234 });
+      const certificationCourse = domainBuilder.buildCertificationCourse();
       const certificationIssueReport1 = domainBuilder.buildCertificationIssueReport({
-        category: CertificationIssueReportCategory.FRAUD,
-        subcategory: null,
+        category: CertificationIssueReportCategory.IN_CHALLENGE,
+        subcategory: CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
         questionNumber: 1,
       });
       certificationCourseRepository.findCertificationCoursesBySessionId
@@ -630,60 +204,622 @@ describe('Unit | Domain | Events | handle-auto-jury', function () {
       });
 
       // then
-      expect(events.length).to.equal(1);
-      expect(events[0]).not.to.be.an.instanceOf(CertificationJuryDone);
+      expect(events[0]).to.be.an.instanceof(CertificationJuryDone);
+      expect(events[0]).to.deep.equal(
+        new CertificationJuryDone({
+          certificationCourseId: certificationCourse.getId(),
+        }),
+      );
+    });
+
+    describe('when the certification is not completed', function () {
+      it('returns a CertificationJuryDone event first in returned collection', async function () {
+        // given
+        const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
+        const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+        const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({ certificationCourseId: 4567 });
+        const certificationCourse = domainBuilder.buildCertificationCourse({
+          sessionId: 1234,
+          id: 4567,
+          completedAt: null,
+          abortReason: ABORT_REASONS.CANDIDATE,
+        });
+        certificationCourseRepository.findCertificationCoursesBySessionId
+          .withArgs({ sessionId: 1234 })
+          .resolves([certificationCourse]);
+        certificationIssueReportRepository.findByCertificationCourseId
+          .withArgs(certificationCourse.getId())
+          .resolves([]);
+        certificationAssessmentRepository.getByCertificationCourseId
+          .withArgs({ certificationCourseId: certificationCourse.getId() })
+          .resolves(certificationAssessment);
+        certificationAssessmentRepository.save.resolves();
+        const event = new SessionFinalized({
+          sessionId: 1234,
+          finalizedAt: new Date(),
+          hasExaminerGlobalComment: false,
+          certificationCenterName: 'A certification center name',
+          sessionDate: '2021-01-29',
+          sessionTime: '14:00',
+        });
+
+        // when
+        const events = await handleAutoJury({
+          event,
+          certificationIssueReportRepository,
+          certificationAssessmentRepository,
+          certificationCourseRepository,
+        });
+
+        // then
+        expect(events[0]).to.deepEqualInstance(
+          new CertificationJuryDone({
+            certificationCourseId: certificationCourse.getId(),
+          }),
+        );
+      });
+
+      describe('when abort reason is candidate', function () {
+        it('should skip unpassed challenges', async function () {
+          // given
+          const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
+          const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+          const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+          const challengeToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({
+            challengeId: 'recChal123',
+            isNeutralized: false,
+            hasBeenSkippedAutomatically: false,
+          });
+          const challengeNotToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({
+            challengeId: 'recChal456',
+            isNeutralized: false,
+            hasBeenSkippedAutomatically: false,
+          });
+          const answeredChallenge = domainBuilder.buildAnswer({
+            challengeId: challengeNotToBeConsideredAsSkipped.challengeId,
+          });
+          const certificationAssessment = domainBuilder.buildCertificationAssessment({
+            certificationAnswersByDate: [answeredChallenge],
+            certificationChallenges: [challengeToBeConsideredAsSkipped, challengeNotToBeConsideredAsSkipped],
+          });
+          const certificationCourse = domainBuilder.buildCertificationCourse({
+            completedAt: null,
+            abortReason: ABORT_REASONS.CANDIDATE,
+          });
+          certificationCourseRepository.findCertificationCoursesBySessionId
+            .withArgs({ sessionId: 1234 })
+            .resolves([certificationCourse]);
+          certificationIssueReportRepository.findByCertificationCourseId
+            .withArgs(certificationCourse.getId())
+            .resolves([]);
+          certificationAssessmentRepository.getByCertificationCourseId
+            .withArgs({ certificationCourseId: certificationCourse.getId() })
+            .resolves(certificationAssessment);
+          certificationAssessmentRepository.save.resolves();
+          const event = new SessionFinalized({
+            sessionId: 1234,
+            finalizedAt: new Date(),
+            hasExaminerGlobalComment: false,
+            certificationCenterName: 'A certification center name',
+            sessionDate: '2021-01-29',
+            sessionTime: '14:00',
+          });
+
+          // when
+          await handleAutoJury({
+            event,
+            certificationIssueReportRepository,
+            certificationAssessmentRepository,
+            certificationCourseRepository,
+          });
+
+          // then
+          expect(
+            certificationAssessment.certificationChallenges.find(
+              (certificationChallenge) => certificationChallenge.challengeId === 'recChal123',
+            ).hasBeenSkippedAutomatically,
+          ).to.be.true;
+          expect(
+            certificationAssessment.certificationChallenges.find(
+              (certificationChallenge) => certificationChallenge.challengeId === 'recChal456',
+            ).hasBeenSkippedAutomatically,
+          ).to.be.false;
+        });
+      });
+
+      describe('when abort reason is technical', function () {
+        it('should neutralize unpassed challenges', async function () {
+          // given
+          const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
+          const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+          const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+          const challengeToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({
+            challengeId: 'recChal123',
+            isNeutralized: false,
+            hasBeenSkippedAutomatically: false,
+          });
+          const challengeNotToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({
+            challengeId: 'recChal456',
+            isNeutralized: false,
+            hasBeenSkippedAutomatically: false,
+          });
+          const answeredChallenge = domainBuilder.buildAnswer({
+            challengeId: challengeNotToBeConsideredAsSkipped.challengeId,
+          });
+          const certificationAssessment = domainBuilder.buildCertificationAssessment({
+            certificationAnswersByDate: [answeredChallenge],
+            certificationChallenges: [challengeToBeConsideredAsSkipped, challengeNotToBeConsideredAsSkipped],
+          });
+          const certificationCourse = domainBuilder.buildCertificationCourse({
+            completedAt: null,
+            abortReason: ABORT_REASONS.TECHNICAL,
+          });
+          certificationCourseRepository.findCertificationCoursesBySessionId
+            .withArgs({ sessionId: 1234 })
+            .resolves([certificationCourse]);
+          certificationIssueReportRepository.findByCertificationCourseId
+            .withArgs(certificationCourse.getId())
+            .resolves([]);
+          certificationAssessmentRepository.getByCertificationCourseId
+            .withArgs({ certificationCourseId: certificationCourse.getId() })
+            .resolves(certificationAssessment);
+          certificationAssessmentRepository.save.resolves();
+          const event = new SessionFinalized({
+            sessionId: 1234,
+            finalizedAt: new Date(),
+            hasExaminerGlobalComment: false,
+            certificationCenterName: 'A certification center name',
+            sessionDate: '2021-01-29',
+            sessionTime: '14:00',
+          });
+
+          // when
+          await handleAutoJury({
+            event,
+            certificationIssueReportRepository,
+            certificationAssessmentRepository,
+            certificationCourseRepository,
+          });
+
+          // then
+          expect(certificationAssessment.certificationChallenges[0].isNeutralized).to.be.true;
+          expect(certificationAssessment.certificationChallenges[0].challengeId).to.equal('recChal123');
+          expect(certificationAssessment.certificationChallenges[1].isNeutralized).to.be.false;
+        });
+      });
+
+      it('should save certification assessment', async function () {
+        // given
+        const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
+        const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+        const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+        const challengeToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({
+          id: 123,
+          associatedSkillName: 'cueillir des fleurs',
+          challengeId: 'recChal123',
+          type: 'QCU',
+          competenceId: 'recCOMP',
+          isNeutralized: false,
+          hasBeenSkippedAutomatically: true,
+          certifiableBadgeKey: null,
+          createdAt: new Date('2020-01-01'),
+        });
+        const challengeNotToBeConsideredAsSkipped = domainBuilder.buildCertificationChallengeWithType({
+          id: 123,
+          associatedSkillName: 'cueillir des fleurs',
+          challengeId: 'recChal456',
+          type: 'QCU',
+          competenceId: 'recCOMP',
+          isNeutralized: false,
+          hasBeenSkippedAutomatically: false,
+          certifiableBadgeKey: null,
+          createdAt: new Date('2020-01-02'),
+        });
+        const answeredChallenge = domainBuilder.buildAnswer({
+          challengeId: challengeNotToBeConsideredAsSkipped.challengeId,
+        });
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationAnswersByDate: [answeredChallenge],
+          certificationChallenges: [challengeToBeConsideredAsSkipped, challengeNotToBeConsideredAsSkipped],
+        });
+        const certificationCourse = domainBuilder.buildCertificationCourse({
+          completedAt: null,
+          abortReason: ABORT_REASONS.CANDIDATE,
+        });
+        certificationCourseRepository.findCertificationCoursesBySessionId
+          .withArgs({ sessionId: 1234 })
+          .resolves([certificationCourse]);
+        certificationIssueReportRepository.findByCertificationCourseId
+          .withArgs(certificationCourse.getId())
+          .resolves([]);
+        certificationAssessmentRepository.getByCertificationCourseId
+          .withArgs({ certificationCourseId: certificationCourse.getId() })
+          .resolves(certificationAssessment);
+        const event = new SessionFinalized({
+          sessionId: 1234,
+          finalizedAt: new Date(),
+          hasExaminerGlobalComment: false,
+          certificationCenterName: 'A certification center name',
+          sessionDate: '2021-01-29',
+          sessionTime: '14:00',
+        });
+
+        // when
+        await handleAutoJury({
+          event,
+          certificationIssueReportRepository,
+          certificationAssessmentRepository,
+          certificationCourseRepository,
+        });
+
+        // then
+        const expectedCertificationAssessment = domainBuilder.buildCertificationAssessment({
+          id: 123,
+          userId: 123,
+          certificationCourseId: 123,
+          createdAt: new Date('2020-01-01T00:00:00Z'),
+          completedAt: new Date('2020-01-01T00:00:00Z'),
+          endedAt: challengeNotToBeConsideredAsSkipped.createdAt,
+          state: 'endedDueToFinalization',
+          version: 2,
+          certificationChallenges: [
+            domainBuilder.buildCertificationChallengeWithType({
+              ...challengeToBeConsideredAsSkipped,
+              hasBeenSkippedAutomatically: true,
+            }),
+            challengeNotToBeConsideredAsSkipped,
+          ],
+          certificationAnswersByDate: [
+            domainBuilder.buildAnswer({
+              id: 123,
+              result: 'ok',
+              resultDetails: null,
+              timeout: null,
+              focusedOut: false,
+              value: '1',
+              levelup: undefined,
+              assessmentId: 456,
+              challengeId: 'recChal456',
+              timeSpent: 20,
+            }),
+          ],
+        });
+        expect(certificationAssessmentRepository.save).to.have.been.calledWithExactly(expectedCertificationAssessment);
+      });
+    });
+
+    describe('when certificationCourse is completed', function () {
+      it('should not return a CertificationJuryDone', async function () {
+        // given
+        const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
+        const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+        const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationCourseId: 4567,
+        });
+        const certificationCourse = domainBuilder.buildCertificationCourse({
+          id: 4567,
+          sessionId: 1234,
+          completedAt: '2010-01-01',
+          abortReason: null,
+        });
+        certificationCourseRepository.findCertificationCoursesBySessionId
+          .withArgs({ sessionId: 1234 })
+          .resolves([certificationCourse]);
+        certificationIssueReportRepository.findByCertificationCourseId
+          .withArgs(certificationCourse.getId())
+          .resolves([]);
+        certificationAssessmentRepository.getByCertificationCourseId
+          .withArgs({ certificationCourseId: certificationCourse.getId() })
+          .resolves(certificationAssessment);
+        certificationAssessmentRepository.save.resolves();
+        const event = new SessionFinalized({
+          sessionId: 1234,
+          finalizedAt: new Date(),
+          hasExaminerGlobalComment: false,
+          certificationCenterName: 'A certification center name',
+          sessionDate: '2021-01-29',
+          sessionTime: '14:00',
+        });
+
+        // when
+        const events = await handleAutoJury({
+          event,
+          certificationIssueReportRepository,
+          certificationAssessmentRepository,
+          certificationCourseRepository,
+        });
+
+        // then
+        expect(events[0]).not.to.be.an.instanceof(CertificationJuryDone);
+        expect(events.length).to.equal(1);
+      });
+    });
+
+    describe('when there is no certification issue report', function () {
+      it('does not return a CertificationJuryDone event', async function () {
+        // given
+        const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
+        const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub() };
+        const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationCourseId: 4567,
+          certificationAnswersByDate: [
+            domainBuilder.buildAnswer({ challengeId: 'recChal123', result: AnswerStatus.SKIPPED }),
+            domainBuilder.buildAnswer({ challengeId: 'recChal456', result: AnswerStatus.KO }),
+            domainBuilder.buildAnswer({ challengeId: 'recChal789', result: AnswerStatus.OK }),
+          ],
+          certificationChallenges: [
+            domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal123' }),
+            domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal456' }),
+            domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal789' }),
+          ],
+        });
+
+        const certificationCourse = domainBuilder.buildCertificationCourse({ id: 4567, sessionId: 1234 });
+        certificationAssessmentRepository.getByCertificationCourseId
+          .withArgs({ certificationCourseId: certificationCourse.getId() })
+          .resolves(certificationAssessment);
+        certificationCourseRepository.findCertificationCoursesBySessionId
+          .withArgs({ sessionId: 1234 })
+          .resolves([certificationCourse]);
+        certificationIssueReportRepository.findByCertificationCourseId
+          .withArgs(certificationCourse.getId())
+          .resolves([]);
+        const event = new SessionFinalized({
+          sessionId: 1234,
+          finalizedAt: new Date(),
+          hasExaminerGlobalComment: false,
+          certificationCenterName: 'A certification center name',
+          sessionDate: '2021-01-29',
+          sessionTime: '14:00',
+        });
+
+        // when
+        const events = await handleAutoJury({
+          event,
+          certificationIssueReportRepository,
+          certificationAssessmentRepository,
+          certificationCourseRepository,
+        });
+
+        // then
+        expect(events.length).to.equal(1);
+        expect(events[0]).not.to.be.an.instanceOf(CertificationJuryDone);
+      });
+    });
+
+    describe('when there is no impacted certification', function () {
+      it('does not return a CertificationJuryDone event', async function () {
+        // given
+        const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
+        const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub() };
+        const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+        const challenge = domainBuilder.buildCertificationChallengeWithType({
+          challengeId: 'recChal123',
+          isNeutralized: false,
+        });
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationCourseId: 4567,
+          certificationAnswersByDate: [
+            domainBuilder.buildAnswer({ challengeId: 'recChal123', result: AnswerStatus.OK }),
+          ],
+          certificationChallenges: [challenge],
+        });
+        const certificationCourse = domainBuilder.buildCertificationCourse({ id: 4567, sessionId: 1234 });
+        const certificationIssueReport1 = domainBuilder.buildCertificationIssueReport({
+          category: CertificationIssueReportCategory.FRAUD,
+          subcategory: null,
+          questionNumber: 1,
+        });
+        certificationCourseRepository.findCertificationCoursesBySessionId
+          .withArgs({ sessionId: 1234 })
+          .resolves([certificationCourse]);
+        certificationIssueReportRepository.findByCertificationCourseId
+          .withArgs(certificationCourse.getId())
+          .resolves([certificationIssueReport1]);
+        certificationAssessmentRepository.getByCertificationCourseId
+          .withArgs({ certificationCourseId: certificationCourse.getId() })
+          .resolves(certificationAssessment);
+        certificationAssessmentRepository.save.resolves();
+        const event = new SessionFinalized({
+          sessionId: 1234,
+          finalizedAt: new Date(),
+          hasExaminerGlobalComment: false,
+          certificationCenterName: 'A certification center name',
+          sessionDate: '2021-01-29',
+          sessionTime: '14:00',
+        });
+
+        // when
+        const events = await handleAutoJury({
+          event,
+          certificationIssueReportRepository,
+          certificationAssessmentRepository,
+          certificationCourseRepository,
+        });
+
+        // then
+        expect(events.length).to.equal(1);
+        expect(events[0]).not.to.be.an.instanceOf(CertificationJuryDone);
+      });
+    });
+
+    describe('when a resolution throws an exception', function () {
+      it('should go on and try to resolve the others certification issue reports', async function () {
+        // given
+        const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
+        const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+        const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+        const challengeToBeNeutralized1 = domainBuilder.buildCertificationChallengeWithType({
+          challengeId: 'recChal123',
+          isNeutralized: false,
+        });
+        const challengeToBeNeutralized2 = domainBuilder.buildCertificationChallengeWithType({
+          challengeId: 'recChal456',
+          isNeutralized: false,
+        });
+        const challengeNotToBeNeutralized = domainBuilder.buildCertificationChallengeWithType({
+          challengeId: 'recChal789',
+          isNeutralized: false,
+        });
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationCourseId: 4567,
+          certificationAnswersByDate: [
+            domainBuilder.buildAnswer({ challengeId: 'recChal123', result: AnswerStatus.SKIPPED }),
+            domainBuilder.buildAnswer({ challengeId: 'recChal456', result: AnswerStatus.KO }),
+            domainBuilder.buildAnswer({ challengeId: 'recChal789', result: AnswerStatus.OK }),
+          ],
+          certificationChallenges: [challengeToBeNeutralized1, challengeToBeNeutralized2, challengeNotToBeNeutralized],
+        });
+        const certificationCourse = domainBuilder.buildCertificationCourse({ id: 4567, sessionId: 1234 });
+        const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
+          category: CertificationIssueReportCategory.IN_CHALLENGE,
+          subcategory: CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING,
+          questionNumber: 1,
+        });
+        const certificationIssueReport2 = domainBuilder.buildCertificationIssueReport({
+          category: CertificationIssueReportCategory.IN_CHALLENGE,
+          subcategory: CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
+          questionNumber: 1,
+        });
+        const challengeRepository = {
+          get: sinon.stub(),
+        };
+        const anError = new Error('something bad happened');
+        challengeRepository.get.rejects(anError);
+        certificationCourseRepository.findCertificationCoursesBySessionId
+          .withArgs({ sessionId: 1234 })
+          .resolves([certificationCourse]);
+        certificationIssueReportRepository.findByCertificationCourseId
+          .withArgs(certificationCourse.getId())
+          .resolves([certificationIssueReport, certificationIssueReport2]);
+        certificationAssessmentRepository.getByCertificationCourseId
+          .withArgs({ certificationCourseId: certificationCourse.getId() })
+          .resolves(certificationAssessment);
+        certificationAssessmentRepository.save.resolves();
+        const event = new SessionFinalized({
+          sessionId: 1234,
+          finalizedAt: new Date(),
+          hasExaminerGlobalComment: false,
+          certificationCenterName: 'A certification center name',
+          sessionDate: '2021-01-29',
+          sessionTime: '14:00',
+        });
+        const logger = {
+          error: sinon.stub(),
+        };
+
+        // when
+        await handleAutoJury({
+          event,
+          certificationIssueReportRepository,
+          certificationAssessmentRepository,
+          certificationCourseRepository,
+          challengeRepository,
+          logger,
+        });
+
+        // then
+        expect(certificationIssueReport2.isResolved()).to.be.true;
+        expect(logger.error).to.have.been.calledWithExactly(anError);
+      });
     });
   });
 
-  context('when a resolution throws an exception', function () {
-    it('should go on and try to resolve the others certification issue reports', async function () {
+  describe('when certification is V3', function () {
+    it('fails when event is not of correct type', async function () {
       // given
+      const event = 'not an event of the correct type';
+
+      // when
+      const error = await catchErr(handleAutoJury)(event);
+
+      // / then
+      expect(error).not.to.be.null;
+    });
+
+    it('returns an AutoJuryDone event as last event', async function () {
+      // given
+      const now = Date.now();
       const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
-      const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+      const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub() };
       const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
-      const challengeToBeNeutralized1 = domainBuilder.buildCertificationChallengeWithType({
-        challengeId: 'recChal123',
-        isNeutralized: false,
-      });
-      const challengeToBeNeutralized2 = domainBuilder.buildCertificationChallengeWithType({
-        challengeId: 'recChal456',
-        isNeutralized: false,
-      });
-      const challengeNotToBeNeutralized = domainBuilder.buildCertificationChallengeWithType({
-        challengeId: 'recChal789',
-        isNeutralized: false,
-      });
       const certificationAssessment = domainBuilder.buildCertificationAssessment({
-        certificationCourseId: 4567,
+        version: 3,
         certificationAnswersByDate: [
           domainBuilder.buildAnswer({ challengeId: 'recChal123', result: AnswerStatus.SKIPPED }),
           domainBuilder.buildAnswer({ challengeId: 'recChal456', result: AnswerStatus.KO }),
           domainBuilder.buildAnswer({ challengeId: 'recChal789', result: AnswerStatus.OK }),
         ],
-        certificationChallenges: [challengeToBeNeutralized1, challengeToBeNeutralized2, challengeNotToBeNeutralized],
+        certificationChallenges: [
+          domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal123' }),
+          domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal456' }),
+          domainBuilder.buildCertificationChallengeWithType({ challengeId: 'recChal789' }),
+        ],
       });
-      const certificationCourse = domainBuilder.buildCertificationCourse({ id: 4567, sessionId: 1234 });
-      const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
-        category: CertificationIssueReportCategory.IN_CHALLENGE,
-        subcategory: CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING,
-        questionNumber: 1,
-      });
-      const certificationIssueReport2 = domainBuilder.buildCertificationIssueReport({
-        category: CertificationIssueReportCategory.IN_CHALLENGE,
-        subcategory: CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
-        questionNumber: 1,
-      });
-      const challengeRepository = {
-        get: sinon.stub(),
-      };
-      const anError = new Error('something bad happened');
-      challengeRepository.get.rejects(anError);
+
+      const certificationCourse = domainBuilder.buildCertificationCourse({ version: 3 });
+      certificationAssessmentRepository.getByCertificationCourseId
+        .withArgs({ certificationCourseId: certificationCourse.getId() })
+        .resolves(certificationAssessment);
       certificationCourseRepository.findCertificationCoursesBySessionId
         .withArgs({ sessionId: 1234 })
         .resolves([certificationCourse]);
-      certificationIssueReportRepository.findByCertificationCourseId
-        .withArgs(certificationCourse.getId())
-        .resolves([certificationIssueReport, certificationIssueReport2]);
+      certificationIssueReportRepository.findByCertificationCourseId.withArgs(certificationCourse.getId()).resolves([]);
+
+      const event = new SessionFinalized({
+        sessionId: 1234,
+        finalizedAt: now,
+        hasExaminerGlobalComment: false,
+        certificationCenterName: 'A certification center name',
+        sessionDate: '2021-01-29',
+        sessionTime: '14:00',
+      });
+
+      // when
+      const resultEvents = await handleAutoJury({
+        event,
+        certificationIssueReportRepository,
+        certificationAssessmentRepository,
+        certificationCourseRepository,
+      });
+
+      // then
+      const autoJuryDoneEvent = resultEvents[resultEvents.length - 1];
+      expect(autoJuryDoneEvent).to.be.an.instanceof(AutoJuryDone);
+      expect(autoJuryDoneEvent).to.deep.equal(
+        new AutoJuryDone({
+          sessionId: 1234,
+          finalizedAt: now,
+          hasExaminerGlobalComment: false,
+          certificationCenterName: 'A certification center name',
+          sessionDate: '2021-01-29',
+          sessionTime: '14:00',
+        }),
+      );
+    });
+
+    it('returns a CertificationJuryDone event first in returned collection', async function () {
+      // given
+      const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
+      const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+      const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+      const challenge = domainBuilder.buildCertificationChallengeWithType({
+        challengeId: 'recChal123',
+      });
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        version: 3,
+        certificationAnswersByDate: [
+          domainBuilder.buildAnswer({ challengeId: 'recChal123', result: AnswerStatus.SKIPPED }),
+        ],
+        certificationChallenges: [challenge],
+      });
+      const certificationCourse = domainBuilder.buildCertificationCourse({ version: 3 });
+      certificationCourseRepository.findCertificationCoursesBySessionId
+        .withArgs({ sessionId: 1234 })
+        .resolves([certificationCourse]);
       certificationAssessmentRepository.getByCertificationCourseId
         .withArgs({ certificationCourseId: certificationCourse.getId() })
         .resolves(certificationAssessment);
@@ -696,23 +832,260 @@ describe('Unit | Domain | Events | handle-auto-jury', function () {
         sessionDate: '2021-01-29',
         sessionTime: '14:00',
       });
-      const logger = {
-        error: sinon.stub(),
-      };
 
       // when
-      await handleAutoJury({
+      const events = await handleAutoJury({
         event,
         certificationIssueReportRepository,
         certificationAssessmentRepository,
         certificationCourseRepository,
-        challengeRepository,
-        logger,
       });
 
       // then
-      expect(certificationIssueReport2.isResolved()).to.be.true;
-      expect(logger.error).to.have.been.calledWithExactly(anError);
+      expect(events[0]).to.be.an.instanceof(CertificationJuryDone);
+      expect(events[0]).to.deep.equal(
+        new CertificationJuryDone({
+          certificationCourseId: certificationCourse.getId(),
+        }),
+      );
+    });
+
+    describe('when the certification is not completed', function () {
+      it('returns a CertificationJuryDone event first in returned collection', async function () {
+        // given
+        const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
+        const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+        const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationCourseId: 4567,
+          version: 3,
+        });
+        const certificationCourse = domainBuilder.buildCertificationCourse({
+          version: 3,
+          sessionId: 1234,
+          id: 4567,
+          completedAt: null,
+          abortReason: ABORT_REASONS.CANDIDATE,
+        });
+        certificationCourseRepository.findCertificationCoursesBySessionId
+          .withArgs({ sessionId: 1234 })
+          .resolves([certificationCourse]);
+        certificationIssueReportRepository.findByCertificationCourseId
+          .withArgs(certificationCourse.getId())
+          .resolves([]);
+        certificationAssessmentRepository.getByCertificationCourseId
+          .withArgs({ certificationCourseId: certificationCourse.getId() })
+          .resolves(certificationAssessment);
+        certificationAssessmentRepository.save.resolves();
+        const event = new SessionFinalized({
+          sessionId: 1234,
+          finalizedAt: new Date(),
+          hasExaminerGlobalComment: false,
+          certificationCenterName: 'A certification center name',
+          sessionDate: '2021-01-29',
+          sessionTime: '14:00',
+        });
+
+        // when
+        const events = await handleAutoJury({
+          event,
+          certificationIssueReportRepository,
+          certificationAssessmentRepository,
+          certificationCourseRepository,
+        });
+
+        // then
+        expect(events[0]).to.deepEqualInstance(
+          new CertificationJuryDone({
+            certificationCourseId: certificationCourse.getId(),
+          }),
+        );
+      });
+
+      it('should save certification assessment', async function () {
+        // given
+        const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
+        const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+        const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+        const challenge = domainBuilder.buildCertificationChallengeWithType({
+          id: 123,
+          associatedSkillName: 'cueillir des fleurs',
+          challengeId: 'recChal456',
+          type: 'QCU',
+          competenceId: 'recCOMP',
+          isNeutralized: false,
+          hasBeenSkippedAutomatically: false,
+          certifiableBadgeKey: null,
+          createdAt: new Date('2020-01-01'),
+        });
+        const answeredChallenge = domainBuilder.buildAnswer({
+          challengeId: challenge.challengeId,
+        });
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          version: 3,
+          certificationAnswersByDate: [answeredChallenge],
+          certificationChallenges: [challenge],
+        });
+        const certificationCourse = domainBuilder.buildCertificationCourse({
+          version: 3,
+          completedAt: null,
+          abortReason: ABORT_REASONS.CANDIDATE,
+        });
+        certificationCourseRepository.findCertificationCoursesBySessionId
+          .withArgs({ sessionId: 1234 })
+          .resolves([certificationCourse]);
+
+        certificationAssessmentRepository.getByCertificationCourseId
+          .withArgs({ certificationCourseId: certificationCourse.getId() })
+          .resolves(certificationAssessment);
+
+        const event = new SessionFinalized({
+          sessionId: 1234,
+          finalizedAt: new Date(),
+          hasExaminerGlobalComment: false,
+          certificationCenterName: 'A certification center name',
+          sessionDate: '2021-01-29',
+          sessionTime: '14:00',
+        });
+
+        // when
+        await handleAutoJury({
+          event,
+          certificationIssueReportRepository,
+          certificationAssessmentRepository,
+          certificationCourseRepository,
+        });
+
+        // then
+        const expectedCertificationAssessment = domainBuilder.buildCertificationAssessment({
+          id: 123,
+          userId: 123,
+          certificationCourseId: 123,
+          createdAt: new Date('2020-01-01T00:00:00Z'),
+          completedAt: new Date('2020-01-01T00:00:00Z'),
+          endedAt: challenge.createdAt,
+          state: 'endedDueToFinalization',
+          version: 3,
+          certificationChallenges: [challenge],
+          certificationAnswersByDate: [
+            domainBuilder.buildAnswer({
+              id: 123,
+              result: 'ok',
+              resultDetails: null,
+              timeout: null,
+              focusedOut: false,
+              value: '1',
+              levelup: undefined,
+              assessmentId: 456,
+              challengeId: 'recChal456',
+              timeSpent: 20,
+            }),
+          ],
+        });
+        expect(certificationAssessmentRepository.save).to.have.been.calledWithExactly(expectedCertificationAssessment);
+      });
+    });
+
+    describe('when certificationCourse is completed', function () {
+      it('should not return a CertificationJuryDone', async function () {
+        // given
+        const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
+        const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+        const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          version: 3,
+          certificationCourseId: 4567,
+          state: 'completed',
+        });
+        const certificationCourse = domainBuilder.buildCertificationCourse({
+          version: 3,
+          id: 4567,
+          sessionId: 1234,
+          completedAt: '2010-01-01',
+          abortReason: null,
+        });
+
+        certificationCourseRepository.findCertificationCoursesBySessionId
+          .withArgs({ sessionId: 1234 })
+          .resolves([certificationCourse]);
+
+        certificationAssessmentRepository.getByCertificationCourseId
+          .withArgs({ certificationCourseId: certificationCourse.getId() })
+          .resolves(certificationAssessment);
+
+        certificationAssessmentRepository.save.resolves();
+        const event = new SessionFinalized({
+          sessionId: 1234,
+          finalizedAt: new Date(),
+          hasExaminerGlobalComment: false,
+          certificationCenterName: 'A certification center name',
+          sessionDate: '2021-01-29',
+          sessionTime: '14:00',
+        });
+
+        // when
+        const events = await handleAutoJury({
+          event,
+          certificationIssueReportRepository,
+          certificationAssessmentRepository,
+          certificationCourseRepository,
+        });
+
+        // then
+        expect(events[0]).not.to.be.an.instanceof(CertificationJuryDone);
+        expect(events.length).to.equal(1);
+      });
+    });
+
+    describe('when there is no impacted certification', function () {
+      it('does not return a CertificationJuryDone event', async function () {
+        // given
+        const certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
+        const certificationIssueReportRepository = { findByCertificationCourseId: sinon.stub() };
+        const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub(), save: sinon.stub() };
+        const challenge = domainBuilder.buildCertificationChallengeWithType({
+          challengeId: 'recChal123',
+          isNeutralized: false,
+        });
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          version: 3,
+          certificationCourseId: 4567,
+          certificationAnswersByDate: [
+            domainBuilder.buildAnswer({ challengeId: 'recChal123', result: AnswerStatus.OK }),
+          ],
+          certificationChallenges: [challenge],
+        });
+        const certificationCourse = domainBuilder.buildCertificationCourse({ id: 4567, sessionId: 1234, version: 3 });
+        certificationCourseRepository.findCertificationCoursesBySessionId
+          .withArgs({ sessionId: 1234 })
+          .resolves([certificationCourse]);
+
+        certificationAssessmentRepository.getByCertificationCourseId
+          .withArgs({ certificationCourseId: certificationCourse.getId() })
+          .resolves(certificationAssessment);
+        certificationAssessmentRepository.save.resolves();
+
+        const event = new SessionFinalized({
+          sessionId: 1234,
+          finalizedAt: new Date(),
+          hasExaminerGlobalComment: false,
+          certificationCenterName: 'A certification center name',
+          sessionDate: '2021-01-29',
+          sessionTime: '14:00',
+        });
+
+        // when
+        const events = await handleAutoJury({
+          event,
+          certificationIssueReportRepository,
+          certificationAssessmentRepository,
+          certificationCourseRepository,
+        });
+
+        // then
+        expect(events.length).to.equal(2);
+        expect(events[0]).to.be.an.instanceOf(CertificationJuryDone);
+      });
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Dans le cadre de la certif v3, les signalements de type “Problème technique sur une question” sont gérés en direct pendant une session, et non plus à posteriori comme pour la certif v2. Lorsqu’un signalement pour une certif v3 est validé par le surveillant, il est considéré comme résolu.

Actuellement, lorsqu’un signalement est fait en session pour une certif v3, il n’est pas considéré comme résolu avant que la session soit finalisée. Le bouton “Résoudre un signalement manuellement” est donc disponible depuis la page de détails d’une certif dans Pix Admin.

## :robot: Proposition

• tagguer comme “résolu” le signalement avant même la finalisation
• indiquer comme “resolution” automatique : Le signalement a été validé par le surveillant pendant la session. Une nouvelle question a été proposée au candidat”

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

• Créer une session dans un centre de certif taggué pilote v3 et inscrire un candidat
• Depuis app, lancer le test du candidat
• Cliquer sur “Signaler un problème” >”Oui, je suis sûre”
• Depuis l’espace surveillant, cliquer sur “Gérer le signalement” > sélectionner une catégorie et valider le signalement
• Dans Pix Admin, ouvrir la page de détails de la certification
• Le signalement validé est affiché dans la section “Signalements impactants” avec une coche verte (indiquant que le • signalement a été résolu”

-> La résolution indique qu’une nouvelle question a été proposée au candidat
-> Le bouton “Résoudre un signalement” n’est pas visible pour ce signalement
