### PR TITLE
[BUGFIX] Corriges l'affichage des participantExternalId sur les participations dans PixAdmin (PIX-11214)

### DIFF
--- a/admin/app/components/campaigns/participation-row.hbs
+++ b/admin/app/components/campaigns/participation-row.hbs
@@ -5,7 +5,7 @@
   </LinkTo>
 </td>
 {{#if @idPixLabel}}
-  <td>
+  <td class="table__column table__column--break-word">
     {{#if this.isEditionMode}}
       <PixInput
         type="text"

--- a/admin/app/styles/globals/tables.scss
+++ b/admin/app/styles/globals/tables.scss
@@ -63,6 +63,10 @@ td.td--bold {
   &--id {
     width: 140px;
   }
+
+  &--break-word {
+    word-break: break-all;
+  }
 }
 
 .table__empty {


### PR DESCRIPTION
## :unicorn: Problème
les mots sans espaces dans participantExternalId des campaign participations ne vont pas tout seul à la ligne et font un overflow sur les colonnes d'a côté.

Nous avons besoin de voir l'entiereté du participantExternalId

## :robot: Proposition
Breakons le mot comme un peut. c'est dommage. 

## :rainbow: Remarques
RAS

## :100: Pour tester
Editer une participation avec un externalId et en mettre un très très très long sans espace. et vérifier qu'il retourne bien à la ligne