### PR TITLE
[BUGFIX] Supprimer les feedbacks précédents lorsqu'un utilisateur repasse un module (PIX-11175)

### DIFF
--- a/mon-pix/app/adapters/element-answer.js
+++ b/mon-pix/app/adapters/element-answer.js
@@ -14,6 +14,7 @@ export default class ElementAnswer extends ApplicationAdapter {
         data: {
           attributes: {
             'element-id': serializedSnapshot.data.relationships.element.data.id,
+            'passage-id': serializedSnapshot.data.relationships.passage.data.id,
             'user-response': serializedSnapshot.data.attributes['user-response'],
           },
         },

--- a/mon-pix/app/pods/components/module/grain/component.js
+++ b/mon-pix/app/pods/components/module/grain/component.js
@@ -5,6 +5,11 @@ import ModulePassage from '../passage/component';
 export default class ModuleGrain extends Component {
   grain = this.args.grain;
 
+  @action
+  getLastCorrectionForElement(element) {
+    return this.args.passage.getLastCorrectionForElement(element);
+  }
+
   get shouldDisplayContinueButton() {
     return this.args.canMoveToNextGrain && this.allElementsAreAnswered;
   }
@@ -14,7 +19,7 @@ export default class ModuleGrain extends Component {
   }
 
   get allElementsAreAnswered() {
-    return this.grain.allElementsAreAnswered;
+    return this.grain.allElementsAreAnsweredForPassage(this.args.passage);
   }
 
   get ariaLiveGrainValue() {

--- a/mon-pix/app/pods/components/module/grain/template.hbs
+++ b/mon-pix/app/pods/components/module/grain/template.hbs
@@ -22,9 +22,17 @@
         {{else if element.isVideo}}
           <Module::Video @video={{element}} />
         {{else if element.isQcu}}
-          <Module::Qcu @qcu={{element}} @submitAnswer={{@submitAnswer}} />
+          <Module::Qcu
+            @qcu={{element}}
+            @submitAnswer={{@submitAnswer}}
+            @correction={{this.getLastCorrectionForElement element}}
+          />
         {{else if element.isQrocm}}
-          <Module::Qrocm @qrocm={{element}} @submitAnswer={{@submitAnswer}} />
+          <Module::Qrocm
+            @qrocm={{element}}
+            @submitAnswer={{@submitAnswer}}
+            @correction={{this.getLastCorrectionForElement element}}
+          />
         {{/if}}
       </div>
     {{/each}}

--- a/mon-pix/app/pods/components/module/passage/template.hbs
+++ b/mon-pix/app/pods/components/module/passage/template.hbs
@@ -9,6 +9,7 @@
     {{#each this.grainsToDisplay as |grain index|}}
       <Module::Grain
         @grain={{grain}}
+        @passage={{@passage}}
         @transition={{this.grainTransition grain.id}}
         @submitAnswer={{@submitAnswer}}
         @canMoveToNextGrain={{this.grainCanMoveToNextGrain index}}

--- a/mon-pix/app/pods/components/module/qcu/component.js
+++ b/mon-pix/app/pods/components/module/qcu/component.js
@@ -9,15 +9,15 @@ export default class ModuleQcu extends Component {
   qcu = this.args.qcu;
 
   get feedbackType() {
-    return this.qcu.lastCorrection?.isOk ? 'success' : 'error';
+    return this.args.correction?.isOk ? 'success' : 'error';
   }
 
   get disableInput() {
-    return !!this.qcu.lastCorrection;
+    return !!this.args.correction;
   }
 
   get shouldDisplayFeedback() {
-    return !!this.qcu.lastCorrection;
+    return !!this.args.correction;
   }
 
   @action

--- a/mon-pix/app/pods/components/module/qcu/template.hbs
+++ b/mon-pix/app/pods/components/module/qcu/template.hbs
@@ -29,7 +29,7 @@
     </div>
   {{/if}}
 
-  {{#unless this.qcu.lastCorrection}}
+  {{#unless @correction}}
     <PixButton
       @backgroundColor="success"
       @shape="rounded"
@@ -44,7 +44,7 @@
   <div role="status" tabindex="-1">
     {{#if this.shouldDisplayFeedback}}
       <PixMessage @type={{this.feedbackType}} @withIcon={{true}} class="element-qcu__feedback">
-        {{html-unsafe this.qcu.lastCorrection.feedback}}
+        {{html-unsafe @correction.feedback}}
       </PixMessage>
     {{/if}}
   </div>

--- a/mon-pix/app/pods/components/module/qrocm/component.js
+++ b/mon-pix/app/pods/components/module/qrocm/component.js
@@ -19,15 +19,15 @@ export default class ModuleQrocm extends Component {
   }
 
   get disableInput() {
-    return !!this.qrocm.lastCorrection;
+    return !!this.args.correction;
   }
 
   get feedbackType() {
-    return this.qrocm.lastCorrection?.isOk ? 'success' : 'error';
+    return this.args.correction?.isOk ? 'success' : 'error';
   }
 
   get shouldDisplayFeedback() {
-    return !!this.qrocm.lastCorrection;
+    return !!this.args.correction;
   }
 
   @action

--- a/mon-pix/app/pods/components/module/qrocm/template.hbs
+++ b/mon-pix/app/pods/components/module/qrocm/template.hbs
@@ -52,7 +52,7 @@
     </div>
   {{/if}}
 
-  {{#unless this.qrocm.lastCorrection}}
+  {{#unless @correction}}
     <PixButton
       @backgroundColor="success"
       @shape="rounded"
@@ -67,7 +67,7 @@
   <div role="status" tabindex="-1">
     {{#if this.shouldDisplayFeedback}}
       <PixMessage @type={{this.feedbackType}} @withIcon={{true}} class="element-qrocm__feedback">
-        {{html-unsafe this.qrocm.lastCorrection.feedback}}
+        {{html-unsafe @correction.feedback}}
       </PixMessage>
     {{/if}}
   </div>

--- a/mon-pix/app/pods/element-answer/model.js
+++ b/mon-pix/app/pods/element-answer/model.js
@@ -3,6 +3,7 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 export default class ElementAnswer extends Model {
   @attr('array') userResponse;
   @belongsTo('correction-response', { async: false, inverse: null }) correction;
-
   @belongsTo('element', { async: true, polymorphic: true, inverse: 'elementAnswers' }) element;
+
+  @belongsTo('passage', { async: false, inverse: 'elementAnswers' }) passage;
 }

--- a/mon-pix/app/pods/grain/model.js
+++ b/mon-pix/app/pods/grain/model.js
@@ -16,9 +16,9 @@ export default class Grain extends Model {
     });
   }
 
-  get allElementsAreAnswered() {
+  allElementsAreAnsweredForPassage(passage) {
     return this.answerableElements.every((element) => {
-      return element.isAnswered;
+      return !!passage.getLastCorrectionForElement(element);
     });
   }
 }

--- a/mon-pix/app/pods/module/get/controller.js
+++ b/mon-pix/app/pods/module/get/controller.js
@@ -12,6 +12,7 @@ export default class GetController extends Controller {
       .createRecord('element-answer', {
         userResponse: answerData.userResponse,
         element: answerData.element,
+        passage: this.model.passage,
       })
       .save({
         adapterOptions: { passageId: this.model.passage.id },

--- a/mon-pix/app/pods/module/get/template.hbs
+++ b/mon-pix/app/pods/module/get/template.hbs
@@ -1,3 +1,3 @@
 <div class="modulix">
-  <Module::Passage @module={{@model.module}} @submitAnswer={{this.submitAnswer}} />
+  <Module::Passage @module={{@model.module}} @submitAnswer={{this.submitAnswer}} @passage={{@model.passage}} />
 </div>

--- a/mon-pix/app/pods/passage/model.js
+++ b/mon-pix/app/pods/passage/model.js
@@ -4,4 +4,8 @@ export default class Passage extends Model {
   @attr('string') moduleId;
 
   @hasMany('element-answer', { async: false, inverse: 'passage' }) elementAnswers;
+
+  getLastCorrectionForElement(element) {
+    return this.elementAnswers.find((answer) => answer.element.get('id') === element.id)?.correction;
+  }
 }

--- a/mon-pix/app/pods/passage/model.js
+++ b/mon-pix/app/pods/passage/model.js
@@ -1,5 +1,7 @@
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class Passage extends Model {
   @attr('string') moduleId;
+
+  @hasMany('element-answer', { async: false, inverse: 'passage' }) elementAnswers;
 }

--- a/mon-pix/mirage/routes/modules/submit-answer.js
+++ b/mon-pix/mirage/routes/modules/submit-answer.js
@@ -3,5 +3,7 @@ export default function (schema, request) {
   const elementId = params.data.attributes['element-id'];
 
   const correction = schema.correctionResponses.find(elementId);
-  return schema.elementAnswers.create({ correction });
+
+  const passage = schema.passages.find(request.params.passageId);
+  return schema.elementAnswers.create({ correction, passage });
 }

--- a/mon-pix/mirage/serializers/element-answer.js
+++ b/mon-pix/mirage/serializers/element-answer.js
@@ -1,5 +1,5 @@
 import ApplicationSerializer from './application';
 
 export default ApplicationSerializer.extend({
-  include: ['correction'],
+  include: ['correction', 'passage'],
 });

--- a/mon-pix/tests/acceptance/module/retake_completed_module_test.js
+++ b/mon-pix/tests/acceptance/module/retake_completed_module_test.js
@@ -1,0 +1,83 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { visit } from '@1024pix/ember-testing-library';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { click } from '@ember/test-helpers';
+
+module('Acceptance | Module | Routes | retakeCompletedModule', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  test('should reset activities when I retake a completed module', async function (assert) {
+    // given
+    const qcu = server.create('qcu', {
+      id: 'elementId-1',
+      type: 'qcus',
+      instruction: 'instruction',
+      isAnswerable: true,
+      proposals: [
+        { id: 'qcu-1-proposal-1', content: 'I am the wrong answer!' },
+        { id: 'qcu-1-proposal-2', content: 'I am the right answer!' },
+      ],
+    });
+
+    const grain1 = server.create('grain', {
+      id: 'grainId1',
+      title: 'title',
+      elements: [qcu],
+    });
+
+    const text = server.create('text', {
+      id: 'elementId-1',
+      type: 'texts',
+      content: 'content-1',
+      isAnswerable: false,
+    });
+
+    const grain2 = server.create('grain', {
+      id: 'grainId2',
+      title: 'title',
+      elements: [text],
+    });
+
+    server.create('module', {
+      id: 'bien-ecrire-son-adresse-mail',
+      title: 'Bien écrire son adresse mail',
+      grains: [grain1, grain2],
+    });
+
+    server.create('correction-response', {
+      id: 'elementId-1',
+      feedback: "Bravo ! C'est la bonne réponse.",
+      status: 'ok',
+      solution: 'qcu-1-proposal-2',
+    });
+
+    // when
+    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+    await click(screen.getByLabelText('I am the right answer!'));
+
+    const verifyButton = screen.getByRole('button', { name: 'Vérifier' });
+    await click(verifyButton);
+
+    assert.dom(screen.queryByText("Bravo ! C'est la bonne réponse.")).exists();
+
+    const continueButton = screen.getByRole('button', { name: 'Continuer' });
+    await click(continueButton);
+
+    const terminateButton = screen.getByRole('button', { name: 'Terminer' });
+    await click(terminateButton);
+
+    const backToDetailsButton = screen.getByRole('link', { name: 'Revenir aux détails du module' });
+    await click(backToDetailsButton);
+
+    const startModuleButton = screen.getByRole('link', { name: 'Commencer le module' });
+    await click(startModuleButton);
+
+    // then
+    assert.dom(screen.queryByText("Bravo ! C'est la bonne réponse.")).doesNotExist();
+
+    assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+    assert.dom(screen.queryByRole('button', { name: 'Passer' })).exists();
+  });
+});

--- a/mon-pix/tests/acceptance/module/verify-qcu_test.js
+++ b/mon-pix/tests/acceptance/module/verify-qcu_test.js
@@ -15,8 +15,8 @@ module('Acceptance | Module | Routes | verifyQcu', function (hooks) {
       type: 'qcus',
       instruction: 'instruction',
       proposals: [
-        { id: 'qcu-1-proposal-1', content: 'I am the wrong answer!' },
-        { id: 'qcu-1-proposal-2', content: 'I am the right answer!' },
+        { id: '1', content: 'I am the wrong answer!' },
+        { id: '2', content: 'I am the right answer!' },
       ],
     });
     const qcu2 = server.create('qcu', {
@@ -24,8 +24,8 @@ module('Acceptance | Module | Routes | verifyQcu', function (hooks) {
       type: 'qcus',
       instruction: 'instruction',
       proposals: [
-        { id: 'qcu-2-proposal-1', content: 'Vrai' },
-        { id: 'qcu-2-proposal-2', content: 'Faux' },
+        { id: '1', content: 'Vrai' },
+        { id: '2', content: 'Faux' },
       ],
     });
 
@@ -45,14 +45,14 @@ module('Acceptance | Module | Routes | verifyQcu', function (hooks) {
       id: 'elementId-1',
       feedback: "Bravo ! C'est la bonne réponse.",
       status: 'ok',
-      solution: 'qcu-1-proposal-2',
+      solution: qcu1.proposals[1].id,
     });
 
     server.create('correction-response', {
       id: 'elementId-2',
       feedback: 'Pas ouf',
       status: 'ko',
-      solution: 'qcu-2-proposal-1',
+      solution: qcu2.proposals[0].id,
     });
 
     // when

--- a/mon-pix/tests/integration/components/module/grain_test.js
+++ b/mon-pix/tests/integration/components/module/grain_test.js
@@ -90,10 +90,12 @@ module('Integration | Component | Module | Grain', function (hooks) {
       const elements = [qcuElement];
       const grain = store.createRecord('grain', { title: 'Grain title', elements });
       this.set('grain', grain);
+      const passage = store.createRecord('passage');
+      this.set('passage', passage);
 
       // when
       const screen = await render(hbs`
-          <Module::Grain @grain={{this.grain}} />`);
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} />`);
 
       // then
       assert.strictEqual(screen.getAllByRole('radio').length, qcuElement.proposals.length);
@@ -146,10 +148,12 @@ module('Integration | Component | Module | Grain', function (hooks) {
       const elements = [qrocmElement];
       const grain = store.createRecord('grain', { title: 'Grain title', elements });
       this.set('grain', grain);
+      const passage = store.createRecord('passage');
+      this.set('passage', passage);
 
       // when
       const screen = await render(hbs`
-          <Module::Grain @grain={{this.grain}} />`);
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} />`);
 
       // then
       assert.ok(screen);
@@ -189,14 +193,16 @@ module('Integration | Component | Module | Grain', function (hooks) {
       const element = store.createRecord('element', { type: 'qcus', isAnswerable: true });
       const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
       this.set('grain', grain);
+      const passage = store.createRecord('passage');
+      this.set('passage', passage);
 
       const correction = store.createRecord('correction-response');
-      store.createRecord('element-answer', { element, correction });
-      assert.true(grain.allElementsAreAnswered);
+      store.createRecord('element-answer', { element, correction, passage });
+      assert.true(grain.allElementsAreAnsweredForPassage(passage));
 
       // when
       const screen = await render(hbs`
-          <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} />`);
+          <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
 
       // then
       assert
@@ -212,14 +218,16 @@ module('Integration | Component | Module | Grain', function (hooks) {
         const grain = store.createRecord('grain', { title: '1st Grain title', elements: [element] });
         store.createRecord('module', { grains: [grain] });
         this.set('grain', grain);
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
 
         const correction = store.createRecord('correction-response');
-        store.createRecord('element-answer', { element, correction });
-        assert.true(grain.allElementsAreAnswered);
+        store.createRecord('element-answer', { element, correction, passage });
+        assert.true(grain.allElementsAreAnsweredForPassage(passage));
 
         // when
         const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} />`);
+            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
 
         // then
         assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists();
@@ -233,12 +241,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
         const grain = store.createRecord('grain', { title: '1st Grain title', elements: [element] });
         store.createRecord('module', { grains: [grain] });
         this.set('grain', grain);
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
 
-        assert.false(grain.allElementsAreAnswered);
+        assert.false(grain.allElementsAreAnsweredForPassage(passage));
 
         // when
         const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} />`);
+            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
 
         // then
         assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
@@ -254,12 +264,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
         const element = store.createRecord('element', { type: 'qcus', isAnswerable: true });
         const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
         this.set('grain', grain);
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
 
-        assert.false(grain.allElementsAreAnswered);
+        assert.false(grain.allElementsAreAnsweredForPassage(passage));
 
         // when
         const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} />`);
+            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
 
         // then
         assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
@@ -272,12 +284,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
         const grain = store.createRecord('grain', { title: '1st Grain title', elements: [element] });
         store.createRecord('module', { grains: [grain] });
         this.set('grain', grain);
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
 
-        assert.false(grain.allElementsAreAnswered);
+        assert.false(grain.allElementsAreAnsweredForPassage(passage));
 
         // when
         const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} />`);
+            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
 
         // then
         assert.dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') })).exists();
@@ -291,12 +305,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
         const element = store.createRecord('element', { type: 'qcus', isAnswerable: true });
         const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
         this.set('grain', grain);
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
 
-        assert.false(grain.allElementsAreAnswered);
+        assert.false(grain.allElementsAreAnsweredForPassage(passage));
 
         // when
         const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} />`);
+            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
 
         // then
         assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
@@ -309,12 +325,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
         const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
         store.createRecord('module', { grains: [grain] });
         this.set('grain', grain);
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
 
-        assert.false(grain.allElementsAreAnswered);
+        assert.false(grain.allElementsAreAnsweredForPassage(passage));
 
         // when
         const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} />`);
+            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
 
         // then
         assert
@@ -358,6 +376,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
       const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
       store.createRecord('module', { id: 'module-id', grains: [grain] });
       this.set('grain', grain);
+      const passage = store.createRecord('passage');
+      this.set('passage', passage);
 
       const skipActionStub = sinon.stub();
       this.set('skipAction', skipActionStub);
@@ -368,7 +388,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
       await render(
         hbs`
             <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}}
-                           @continueAction={{this.continueAction}} @skipAction={{this.skipAction}} />`,
+                           @continueAction={{this.continueAction}} @skipAction={{this.skipAction}} @passage={{this.passage}} />`,
       );
       await clickByName(this.intl.t('pages.modulix.buttons.grain.skip'));
 
@@ -401,6 +421,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
         const element = store.createRecord('qcu', { type: 'qcus', isAnswerable: true });
         const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
         this.set('grain', grain);
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
 
         const terminateActionStub = sinon.stub();
         this.set('terminateAction', terminateActionStub);
@@ -409,7 +431,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
         await render(
           hbs`
             <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{true}}
-                           @terminateAction={{this.terminateAction}} />`,
+                           @terminateAction={{this.terminateAction}} @passage={{this.passage}} />`,
         );
         await clickByName(this.intl.t('pages.modulix.buttons.grain.terminate'));
 

--- a/mon-pix/tests/integration/components/module/passage_test.js
+++ b/mon-pix/tests/integration/components/module/passage_test.js
@@ -24,8 +24,11 @@ module('Integration | Component | Module | Passage', function (hooks) {
     const module = store.createRecord('module', { title: 'Module title', grains: [grain], transitionTexts });
     this.set('module', module);
 
+    const passage = store.createRecord('passage');
+    this.set('passage', passage);
+
     // when
-    const screen = await render(hbs`<Module::Passage @module={{this.module}} />`);
+    const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
 
     // then
     assert.ok(screen.getByRole('heading', { name: module.title, level: 1 }));
@@ -51,8 +54,11 @@ module('Integration | Component | Module | Passage', function (hooks) {
     const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
     this.set('module', module);
 
+    const passage = store.createRecord('passage');
+    this.set('passage', passage);
+
     // when
-    const screen = await render(hbs`<Module::Passage @module={{this.module}} />`);
+    const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
 
     // then
     assert.ok(screen.getByRole('heading', { name: module.title, level: 1 }));
@@ -79,7 +85,11 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
       this.set('module', module);
 
-      await render(hbs`<Module::Passage @module={{this.module}} />`);
+      const passage = store.createRecord('passage');
+      this.set('passage', passage);
+
+      await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
+
       assert.strictEqual(findAll('.element-text').length, 0);
 
       // when
@@ -105,7 +115,10 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
       this.set('module', module);
 
-      await render(hbs`<Module::Passage @module={{this.module}} />`);
+      const passage = store.createRecord('passage');
+      this.set('passage', passage);
+
+      await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
 
       const metrics = this.owner.lookup('service:metrics');
       metrics.add = sinon.stub();
@@ -141,7 +154,10 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
       this.set('module', module);
 
-      const screen = await render(hbs`<Module::Passage @module={{this.module}} />`);
+      const passage = store.createRecord('passage');
+      this.set('passage', passage);
+
+      const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
 
       const grainsBeforeAnyAction = screen.getAllByRole('article');
       assert.strictEqual(grainsBeforeAnyAction.length, 1);
@@ -167,7 +183,10 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2, grain3] });
       this.set('module', module);
 
-      const screen = await render(hbs`<Module::Passage @module={{this.module}} />`);
+      const passage = store.createRecord('passage');
+      this.set('passage', passage);
+
+      const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
 
       const grainsBeforeAnyAction = screen.getAllByRole('article');
       assert.strictEqual(grainsBeforeAnyAction.length, 1);
@@ -208,7 +227,10 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2, grain3] });
       this.set('module', module);
 
-      const screen = await render(hbs`<Module::Passage @module={{this.module}} />`);
+      const passage = store.createRecord('passage');
+      this.set('passage', passage);
+
+      const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
 
       const grainsBeforeAnyAction = screen.getAllByRole('article');
       assert.strictEqual(grainsBeforeAnyAction.length, 1);
@@ -244,7 +266,10 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
       this.set('module', module);
 
-      await render(hbs`<Module::Passage @module={{this.module}} />`);
+      const passage = store.createRecord('passage');
+      this.set('passage', passage);
+
+      await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
 
       const metrics = this.owner.lookup('service:metrics');
       metrics.add = sinon.stub();

--- a/mon-pix/tests/integration/components/module/qcu_test.js
+++ b/mon-pix/tests/integration/components/module/qcu_test.js
@@ -14,8 +14,8 @@ module('Integration | Component | Module | QCU', function (hooks) {
     const qcuElement = store.createRecord('qcu', {
       instruction: 'Instruction',
       proposals: [
-        { id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'radio1' },
-        { id: 'b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'radio2' },
+        { id: '1', content: 'radio1' },
+        { id: '2', content: 'radio2' },
       ],
       type: 'qcus',
     });
@@ -42,11 +42,11 @@ module('Integration | Component | Module | QCU', function (hooks) {
   test('should call action when verify button is clicked', async function (assert) {
     // given
     const store = this.owner.lookup('service:store');
-    const answeredProposal = { id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'radio1' };
+    const answeredProposal = { id: '1', content: 'radio1' };
     const qcuElement = store.createRecord('qcu', {
       id: 'qcu-id-1',
       instruction: 'Instruction',
-      proposals: [answeredProposal, { id: 'b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'radio2' }],
+      proposals: [answeredProposal, { id: '2', content: 'radio2' }],
       type: 'qcus',
     });
     this.set('qcu', qcuElement);
@@ -120,8 +120,8 @@ module('Integration | Component | Module | QCU', function (hooks) {
     const qcuElement = store.createRecord('qcu', {
       instruction: 'Instruction',
       proposals: [
-        { id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'radio1' },
-        { id: 'b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'radio2' },
+        { id: '1', content: 'radio1' },
+        { id: '2', content: 'radio2' },
       ],
       type: 'qcus',
     });
@@ -141,8 +141,8 @@ module('Integration | Component | Module | QCU', function (hooks) {
     const qcuElement = store.createRecord('qcu', {
       instruction: 'Instruction',
       proposals: [
-        { id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'radio1' },
-        { id: 'b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'radio2' },
+        { id: '1', content: 'radio1' },
+        { id: '2', content: 'radio2' },
       ],
       type: 'qcus',
     });
@@ -168,8 +168,8 @@ function prepareContextRecords(store, correctionResponse) {
   const qcuElement = store.createRecord('qcu', {
     instruction: 'Instruction',
     proposals: [
-      { id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'radio1' },
-      { id: 'b5a4c3d2-e1f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'radio2' },
+      { id: '1', content: 'radio1' },
+      { id: '2', content: 'radio2' },
     ],
     type: 'qcus',
     elementAnswers: [elementAnswer],

--- a/mon-pix/tests/integration/components/module/qcu_test.js
+++ b/mon-pix/tests/integration/components/module/qcu_test.js
@@ -79,7 +79,9 @@ module('Integration | Component | Module | QCU', function (hooks) {
     this.set('submitAnswer', () => {});
 
     // when
-    const screen = await render(hbs`<Module::Qcu @qcu={{this.qcu}} @submitAnswer={{this.submitAnswer}} />`);
+    const screen = await render(
+      hbs`<Module::Qcu @qcu={{this.qcu}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
+    );
 
     // then
     const status = screen.getByRole('status');
@@ -101,7 +103,9 @@ module('Integration | Component | Module | QCU', function (hooks) {
     this.set('submitAnswer', () => {});
 
     // when
-    const screen = await render(hbs`<Module::Qcu @qcu={{this.qcu}} @submitAnswer={{this.submitAnswer}} />`);
+    const screen = await render(
+      hbs`<Module::Qcu @qcu={{this.qcu}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+    );
 
     // then
     const status = screen.getByRole('status');
@@ -176,4 +180,5 @@ function prepareContextRecords(store, correctionResponse) {
     element: qcuElement,
   });
   this.set('qcu', qcuElement);
+  this.set('correctionResponse', correctionResponse);
 }

--- a/mon-pix/tests/integration/components/module/qrocm_test.js
+++ b/mon-pix/tests/integration/components/module/qrocm_test.js
@@ -298,7 +298,9 @@ module('Integration | Component | Module | QROCM', function (hooks) {
     this.set('submitAnswer', () => {});
 
     // when
-    const screen = await render(hbs`<Module::Qrocm @qrocm={{this.qrocm}} @submitAnswer={{this.submitAnswer}} />`);
+    const screen = await render(
+      hbs`<Module::Qrocm @qrocm={{this.qrocm}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+    );
 
     // then
     const status = screen.getByRole('status');
@@ -319,7 +321,9 @@ module('Integration | Component | Module | QROCM', function (hooks) {
     this.set('submitAnswer', () => {});
 
     // when
-    const screen = await render(hbs`<Module::Qrocm @qrocm={{this.qrocm}} @submitAnswer={{this.submitAnswer}} />`);
+    const screen = await render(
+      hbs`<Module::Qrocm @qrocm={{this.qrocm}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
+    );
 
     // then
     const status = screen.getByRole('status');
@@ -364,4 +368,5 @@ function prepareContextRecords(store, correctionResponse) {
     element: qrocm,
   });
   this.set('qrocm', qrocm);
+  this.set('correctionResponse', correctionResponse);
 }

--- a/mon-pix/tests/unit/adapters/element-answer_test.js
+++ b/mon-pix/tests/unit/adapters/element-answer_test.js
@@ -29,10 +29,13 @@ module('Unit | Adapter | Module | ElementAnswer', function (hooks) {
       adapter.ajax = sinon.stub().resolves();
 
       const passageId = 12;
+      const passage = {
+        id: passageId,
+      };
       const userResponse = [];
       const element = { id: 'element-id' };
 
-      const expectedUrl = `http://localhost:3000/api/passages/12/answers`;
+      const expectedUrl = `http://localhost:3000/api/passages/${passageId}/answers`;
       const expectedMethod = 'POST';
       const expectedData = {
         data: {
@@ -40,12 +43,13 @@ module('Unit | Adapter | Module | ElementAnswer', function (hooks) {
             attributes: {
               'element-id': element.id,
               'user-response': userResponse,
+              'passage-id': passage.id,
             },
           },
         },
       };
       const snapshot = {
-        record: { element, userResponse },
+        record: { element, userResponse, passage },
         adapterOptions: {
           passageId,
         },
@@ -54,9 +58,12 @@ module('Unit | Adapter | Module | ElementAnswer', function (hooks) {
             data: {
               attributes: {
                 'user-response': userResponse,
+                'element-id': element.id,
+                'passage-id': passage.id,
               },
               relationships: {
                 element: { data: element },
+                passage: { data: passage },
               },
             },
           };

--- a/mon-pix/tests/unit/components/module/qcu_test.js
+++ b/mon-pix/tests/unit/components/module/qcu_test.js
@@ -30,7 +30,7 @@ module('Unit | Component | Module | QCU', function (hooks) {
         const correctionResponse = store.createRecord('correction-response', { status: 'ok' });
         const elementAnswer = store.createRecord('element-answer', { correction: correctionResponse });
         const qcuElement = store.createRecord('qcu', { elementAnswers: [elementAnswer] });
-        const component = createPodsComponent('module/qcu', { qcu: qcuElement });
+        const component = createPodsComponent('module/qcu', { qcu: qcuElement, correction: correctionResponse });
 
         // when
         const feedbackType = component.feedbackType;

--- a/mon-pix/tests/unit/controllers/modules/get_test.js
+++ b/mon-pix/tests/unit/controllers/modules/get_test.js
@@ -15,6 +15,9 @@ module('Unit | Module | Controller | get', function (hooks) {
       const passageId = 'passageId';
       const element = { id: elementId };
       const moduleSlug = 'moduleSlug';
+      const passage = {
+        id: passageId,
+      };
 
       const answerData = {
         userResponse,
@@ -35,9 +38,7 @@ module('Unit | Module | Controller | get', function (hooks) {
         module: {
           id: moduleSlug,
         },
-        passage: {
-          id: passageId,
-        },
+        passage,
       };
 
       controller.store = {
@@ -49,6 +50,7 @@ module('Unit | Module | Controller | get', function (hooks) {
         .withArgs('element-answer', {
           userResponse,
           element,
+          passage,
         })
         .returns({
           save: saveStub,
@@ -57,7 +59,7 @@ module('Unit | Module | Controller | get', function (hooks) {
       saveStub
         .withArgs({
           adapterOptions: {
-            passageId,
+            passageId: passage.id,
           },
         })
         .resolves({ correction: expectedCorrection });

--- a/mon-pix/tests/unit/models/modules/grain_test.js
+++ b/mon-pix/tests/unit/models/modules/grain_test.js
@@ -81,21 +81,24 @@ module('Unit | Model | Module | Grain', function (hooks) {
     });
   });
 
-  module('#allElementsAreAnswered', function () {
+  module('#allElementsAreAnsweredForPassage', function () {
     module('when all answerable elements are answered', function () {
       test('should return true', function (assert) {
         // given
         const store = this.owner.lookup('service:store');
         const qcu = store.createRecord('qcu', { type: 'qcus' });
-        store.createRecord('element-answer', {
+        const elementAnswer = store.createRecord('element-answer', {
           element: qcu,
+        });
+        const passage = store.createRecord('passage', {
+          elementAnswers: [elementAnswer],
         });
         const grain = store.createRecord('grain', {
           elements: [qcu],
         });
 
         // when
-        const allElementsAreAnswered = grain.allElementsAreAnswered;
+        const allElementsAreAnswered = grain.allElementsAreAnsweredForPassage(passage);
 
         // then
         assert.true(allElementsAreAnswered);
@@ -110,9 +113,10 @@ module('Unit | Model | Module | Grain', function (hooks) {
         const grain = store.createRecord('grain', {
           elements: [qcu],
         });
+        const passage = store.createRecord('passage');
 
         // when
-        const allElementsAreAnswered = grain.allElementsAreAnswered;
+        const allElementsAreAnswered = grain.allElementsAreAnsweredForPassage(passage);
 
         // then
         assert.false(allElementsAreAnswered);

--- a/mon-pix/tests/unit/models/modules/passage_test.js
+++ b/mon-pix/tests/unit/models/modules/passage_test.js
@@ -1,0 +1,61 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | Module | Passage', function (hooks) {
+  setupTest(hooks);
+
+  module('#getLastCorrectionForElement', function () {
+    module('when the element has been answered', function () {
+      test('should return the element correction', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const expectedCorrection = store.createRecord('correction-response', {
+          feedback: 'Too Bad!',
+          status: 'ko',
+          solution: 'solution',
+        });
+        const elementAnswer = store.createRecord('element-answer', {
+          correction: expectedCorrection,
+        });
+        const passage = store.createRecord('passage', { moduleId: '234', elementAnswers: [elementAnswer] });
+        const qcuElement = store.createRecord('qcu', {
+          instruction: 'Instruction',
+          proposals: [
+            { id: '1', content: 'radio1' },
+            { id: '2', content: 'radio2' },
+          ],
+          type: 'qcus',
+          elementAnswers: [elementAnswer],
+        });
+
+        // when
+        const correction = passage.getLastCorrectionForElement(qcuElement);
+
+        // then
+        assert.strictEqual(correction, expectedCorrection);
+      });
+    });
+
+    module('when the element has never been answered', function () {
+      test('should return undefined', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const passage = store.createRecord('passage', { moduleId: '234' });
+        const qcuElement = store.createRecord('qcu', {
+          instruction: 'Instruction',
+          proposals: [
+            { id: '1', content: 'radio1' },
+            { id: '2', content: 'radio2' },
+          ],
+          type: 'qcus',
+        });
+
+        // when
+        const correction = passage.getLastCorrectionForElement(qcuElement);
+
+        // then
+        assert.strictEqual(correction, undefined);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on recommence un passage (en cliquant sur le bouton de retour aux détails puis en recommençant le module ou bien lorsqu'on retourne à la page précédente une fois sur le recap), les feedbacks précédemment reçues sont toujours là et les modalités liées sont _disabled_.

## :robot: Proposition
En premier lieu, couvrir ce scénario par un test d'acceptance.
Le problème venait du fait qu'entre deux passages sur le même module, le store ember conservait les feedbacks associées aux éléments.
Nous avons donc décidé d'associer les modèles `element-answer` et `passage`.
Ainsi, pour savoir si un élément possède déjà des feedbacks, on passe par le passage en cours pour récupérer la correction associée à chaque élément.

## :rainbow: Remarques


## :100: Pour tester

1. Aller sur [un module](https://app-pr8078.review.pix.fr/modules/didacticiel-modulix)
2. Vérifier au moins une réponse
3. Continuer jusqu'à la page recap
4. Cliquer sur le bouton pour revenir à la page des détails
5. Recommencer le module
6. Constater que le feedback précédent a disparu et que la modalité liée est de nouveau accessible
