### PR TITLE
[TECH] Deplacement des versions de navigateurs pour docker (PIX-11235)

### DIFF
--- a/1d/config/targets.js
+++ b/1d/config/targets.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { browsers } = require('../../config/targets.js');
+const browsers = ['defaults', 'last 4 years'];
 
 module.exports = {
   browsers,

--- a/admin/config/targets.js
+++ b/admin/config/targets.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { browsers } = require('../../config/targets.js');
+const browsers = ['defaults', 'last 4 years'];
 
 module.exports = {
   browsers,

--- a/certif/config/targets.js
+++ b/certif/config/targets.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { browsers } = require('../../config/targets.js');
+const browsers = ['defaults', 'last 4 years'];
 
 module.exports = {
   browsers,

--- a/config/targets.js
+++ b/config/targets.js
@@ -1,7 +1,0 @@
-'use strict';
-
-const browsers = ['defaults', 'last 4 years'];
-
-module.exports = {
-  browsers,
-};

--- a/mon-pix/config/targets.js
+++ b/mon-pix/config/targets.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { browsers } = require('../../config/targets.js');
+const browsers = ['defaults', 'last 4 years'];
 
 module.exports = {
   browsers,

--- a/orga/config/targets.js
+++ b/orga/config/targets.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { browsers } = require('../../config/targets.js');
+const browsers = ['defaults', 'last 4 years'];
 
 module.exports = {
   browsers,


### PR DESCRIPTION
Cette PR revert la PR [7156](https://github.com/1024pix/pix/pull/7156). 
Elle déplace la définition des navigateurs compatibles dans le dossier de chaque front.
Cela permet notamment de déployer l'application en utilisant docker.

## :unicorn: Problème
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Les scripts docker-compose pour lancer l’environnement de test dans des dockers ne sont plus à jours à cause de la PR #7156.


## :robot: Proposition
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
Cette PR revient sur ce changement et permet de tout lancer en local avec 
```bash
docker compose build
docker compose up -d
```


## :rainbow: Remarques
Il y a un arbitrage à faire entre : 
 * maintenir les docker-compose
 * les supprimer si personne ne les utilise
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

