### PR TITLE
[TECH] Revue Matomo pour Modulix (PIX-11162)

### DIFF
--- a/mon-pix/app/pods/components/module/grain/component.js
+++ b/mon-pix/app/pods/components/module/grain/component.js
@@ -1,10 +1,8 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
 import ModulePassage from '../passage/component';
 
 export default class ModuleGrain extends Component {
-  @service metrics;
   grain = this.args.grain;
 
   get shouldDisplayContinueButton() {
@@ -37,22 +35,6 @@ export default class ModuleGrain extends Component {
       top: newGrainY - ModulePassage.SCROLL_OFFSET_PX,
       behavior: userPrefersReducedMotion.matches ? 'instant' : 'smooth',
     });
-  }
-
-  @action
-  async continueAction() {
-    await this.args.continueAction();
-    this.metrics.add({
-      event: 'custom-event',
-      'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.grain.module.id}`,
-      'pix-event-name': `Click sur le bouton continuer du grain : ${this.grain.id}`,
-    });
-  }
-
-  @action
-  skipAction() {
-    this.args.skipAction();
   }
 
   @action

--- a/mon-pix/app/pods/components/module/grain/component.js
+++ b/mon-pix/app/pods/components/module/grain/component.js
@@ -53,12 +53,6 @@ export default class ModuleGrain extends Component {
   @action
   skipAction() {
     this.args.skipAction();
-    this.metrics.add({
-      event: 'custom-event',
-      'pix-event-category': 'Modulix',
-      'pix-event-action': `Passage du module : ${this.grain.module.id}`,
-      'pix-event-name': `Click sur le bouton passer du grain : ${this.grain.id}`,
-    });
   }
 
   @action

--- a/mon-pix/app/pods/components/module/grain/template.hbs
+++ b/mon-pix/app/pods/components/module/grain/template.hbs
@@ -45,7 +45,7 @@
 
   {{#if this.shouldDisplayContinueButton}}
     <footer class="grain__footer">
-      <PixButton @backgroundColor="primary" @shape="rounded" @triggerAction={{this.continueAction}}>
+      <PixButton @backgroundColor="primary" @shape="rounded" @triggerAction={{@continueAction}}>
         {{t "pages.modulix.buttons.grain.continue"}}
       </PixButton>
     </footer>

--- a/mon-pix/app/pods/components/module/grain/template.hbs
+++ b/mon-pix/app/pods/components/module/grain/template.hbs
@@ -36,7 +36,7 @@
         @backgroundColor="transparent-light"
         @isBorderVisible={{true}}
         @shape="rounded"
-        @triggerAction={{this.skipAction}}
+        @triggerAction={{@skipAction}}
       >
         {{t "pages.modulix.buttons.grain.skip"}}
       </PixButton>

--- a/mon-pix/app/pods/components/module/image/component.js
+++ b/mon-pix/app/pods/components/module/image/component.js
@@ -13,7 +13,7 @@ export default class ModuleImage extends Component {
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
-      'pix-event-action': `Afficher l’alternative textuelle : ${this.args.image.id}`,
+      'pix-event-action': `Passage du module : ${this.args.image.grain.get('module').get('id')}`,
       'pix-event-name': `Click sur le bouton alternative textuelle : ${this.args.image.id}`,
     });
   }

--- a/mon-pix/app/pods/components/module/passage/component.js
+++ b/mon-pix/app/pods/components/module/passage/component.js
@@ -5,6 +5,7 @@ import { service } from '@ember/service';
 
 export default class ModulePassage extends Component {
   @service router;
+  @service metrics;
   @tracked grainsToDisplay = [this.args.module.grains[0]];
   static SCROLL_OFFSET_PX = 70;
 
@@ -22,6 +23,19 @@ export default class ModulePassage extends Component {
   }
 
   @action
+  skipToNextGrain() {
+    const lastGrain = this.args.module.grains[this.lastIndex];
+
+    this.addNextGrainToDisplay();
+
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Modulix',
+      'pix-event-action': `Passage du module : ${this.args.module.id}`,
+      'pix-event-name': `Click sur le bouton passer du grain : ${lastGrain.id}`,
+    });
+  }
+
   addNextGrainToDisplay() {
     if (!this.hasNextGrain) {
       return;

--- a/mon-pix/app/pods/components/module/passage/component.js
+++ b/mon-pix/app/pods/components/module/passage/component.js
@@ -36,6 +36,20 @@ export default class ModulePassage extends Component {
     });
   }
 
+  @action
+  continueToNextGrain() {
+    const lastGrain = this.args.module.grains[this.lastIndex];
+
+    this.addNextGrainToDisplay();
+
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Modulix',
+      'pix-event-action': `Passage du module : ${this.args.module.id}`,
+      'pix-event-name': `Click sur le bouton continuer du grain : ${lastGrain.id}`,
+    });
+  }
+
   addNextGrainToDisplay() {
     if (!this.hasNextGrain) {
       return;

--- a/mon-pix/app/pods/components/module/passage/template.hbs
+++ b/mon-pix/app/pods/components/module/passage/template.hbs
@@ -13,7 +13,7 @@
         @submitAnswer={{@submitAnswer}}
         @canMoveToNextGrain={{this.grainCanMoveToNextGrain index}}
         @continueAction={{this.addNextGrainToDisplay}}
-        @skipAction={{this.addNextGrainToDisplay}}
+        @skipAction={{this.skipToNextGrain}}
         @shouldDisplayTerminateButton={{this.grainShouldDisplayTerminateButton index}}
         @terminateAction={{this.terminateModule}}
         @hasJustAppeared={{this.hasGrainJustAppeared index}}

--- a/mon-pix/app/pods/components/module/passage/template.hbs
+++ b/mon-pix/app/pods/components/module/passage/template.hbs
@@ -12,7 +12,7 @@
         @transition={{this.grainTransition grain.id}}
         @submitAnswer={{@submitAnswer}}
         @canMoveToNextGrain={{this.grainCanMoveToNextGrain index}}
-        @continueAction={{this.addNextGrainToDisplay}}
+        @continueAction={{this.continueToNextGrain}}
         @skipAction={{this.skipToNextGrain}}
         @shouldDisplayTerminateButton={{this.grainShouldDisplayTerminateButton index}}
         @terminateAction={{this.terminateModule}}

--- a/mon-pix/app/pods/components/module/video/component.js
+++ b/mon-pix/app/pods/components/module/video/component.js
@@ -15,7 +15,7 @@ export default class ModuleVideo extends Component {
     this.metrics.add({
       event: 'custom-event',
       'pix-event-category': 'Modulix',
-      'pix-event-action': `Afficher la transcription : ${this.args.video.id}`,
+      'pix-event-action': `Passage du module : ${this.args.video.grain.get('module').get('id')}`,
       'pix-event-name': `Clic sur le bouton transcription : ${this.args.video.id}`,
     });
   }

--- a/mon-pix/tests/integration/components/module/grain_test.js
+++ b/mon-pix/tests/integration/components/module/grain_test.js
@@ -325,7 +325,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
   });
 
   module('when continueAction is called', function () {
-    test('should call continueAction pass in argument and push event', async function (assert) {
+    test('should call continueAction pass in argument', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
       const element = store.createRecord('text', { type: 'texts', isAnswerable: false });
@@ -335,8 +335,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       const stubContinueAction = sinon.stub();
       this.set('continueAction', stubContinueAction);
-      const metrics = this.owner.lookup('service:metrics');
-      metrics.add = sinon.stub();
 
       // when
       await render(
@@ -348,12 +346,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // then
       sinon.assert.calledOnce(stubContinueAction);
-      sinon.assert.calledWithExactly(metrics.add, {
-        event: 'custom-event',
-        'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${this.grain.module.id}`,
-        'pix-event-name': `Click sur le bouton continuer du grain : ${this.grain.id}`,
-      });
       assert.ok(true);
     });
   });

--- a/mon-pix/tests/integration/components/module/grain_test.js
+++ b/mon-pix/tests/integration/components/module/grain_test.js
@@ -359,7 +359,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
   });
 
   module('when skipAction is called', function () {
-    test('should call skipAction pass in argument and push event', async function (assert) {
+    test('should call skipAction pass in argument', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
       const element = store.createRecord('qcu', { type: 'qcus', isAnswerable: true });
@@ -369,8 +369,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       const skipActionStub = sinon.stub();
       this.set('skipAction', skipActionStub);
-      const metrics = this.owner.lookup('service:metrics');
-      metrics.add = sinon.stub();
 
       this.set('continueAction', () => {});
 
@@ -384,12 +382,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // then
       sinon.assert.calledOnce(skipActionStub);
-      sinon.assert.calledWithExactly(metrics.add, {
-        event: 'custom-event',
-        'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${this.grain.module.id}`,
-        'pix-event-name': `Click sur le bouton passer du grain : ${this.grain.id}`,
-      });
       assert.ok(true);
     });
   });

--- a/mon-pix/tests/integration/components/module/image_test.js
+++ b/mon-pix/tests/integration/components/module/image_test.js
@@ -41,6 +41,8 @@ module('Integration | Component | Module | Image', function (hooks) {
       alt: 'alt text',
       alternativeText,
     });
+    const grain = store.createRecord('grain', { id: 'grain-id', elements: [imageElement] });
+    store.createRecord('module', { id: 'module-id', grains: [grain] });
 
     this.set('image', imageElement);
 

--- a/mon-pix/tests/integration/components/module/passage_test.js
+++ b/mon-pix/tests/integration/components/module/passage_test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { clickByName, render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import { findAll } from '@ember/test-helpers';
+import sinon from 'sinon';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Module | Passage', function (hooks) {
@@ -86,6 +87,40 @@ module('Integration | Component | Module | Passage', function (hooks) {
 
       // then
       assert.strictEqual(findAll('.element-text').length, 1);
+    });
+
+    test('should push event', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const textElement = store.createRecord('text', { content: 'content', type: 'texts' });
+      const qcuElement = store.createRecord('qcu', {
+        instruction: 'instruction',
+        proposals: ['radio1', 'radio2'],
+        type: 'qcus',
+        isAnswerable: true,
+      });
+      const grain1 = store.createRecord('grain', { elements: [qcuElement] });
+      const grain2 = store.createRecord('grain', { elements: [textElement] });
+
+      const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+      this.set('module', module);
+
+      await render(hbs`<Module::Passage @module={{this.module}} />`);
+
+      const metrics = this.owner.lookup('service:metrics');
+      metrics.add = sinon.stub();
+
+      // when
+      await clickByName(this.intl.t('pages.modulix.buttons.grain.skip'));
+
+      // then
+      sinon.assert.calledWithExactly(metrics.add, {
+        event: 'custom-event',
+        'pix-event-category': 'Modulix',
+        'pix-event-action': `Passage du module : ${module.id}`,
+        'pix-event-name': `Click sur le bouton passer du grain : ${grain1.id}`,
+      });
+      assert.ok(true);
     });
   });
 

--- a/mon-pix/tests/integration/components/module/video_test.js
+++ b/mon-pix/tests/integration/components/module/video_test.js
@@ -41,6 +41,8 @@ module('Integration | Component | Module | Video', function (hooks) {
       subtitles: 'subtitles',
       transcription: 'transcription',
     });
+    const grain = store.createRecord('grain', { id: 'grain-id', elements: [videoElement] });
+    store.createRecord('module', { id: 'module-id', grains: [grain] });
 
     this.set('video', videoElement);
 

--- a/mon-pix/tests/unit/components/module/image_test.js
+++ b/mon-pix/tests/unit/components/module/image_test.js
@@ -11,9 +11,8 @@ module('Unit | Component | Module | Image', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
       const image = store.createRecord('image', { id: 'image-id' });
-
-      const metrics = this.owner.lookup('service:metrics');
-      metrics.add = () => {};
+      const grain = store.createRecord('grain', { id: 'grain-id', elements: [image] });
+      store.createRecord('module', { id: 'module-id', grains: [grain] });
 
       const component = createPodsComponent('module/image', { image });
       assert.false(component.modalIsOpen);
@@ -29,6 +28,8 @@ module('Unit | Component | Module | Image', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
       const image = store.createRecord('image', { id: 'image-id' });
+      const grain = store.createRecord('grain', { id: 'grain-id', elements: [image] });
+      const module = store.createRecord('module', { id: 'module-id', grains: [grain] });
 
       const metrics = this.owner.lookup('service:metrics');
       metrics.add = sinon.stub();
@@ -44,7 +45,7 @@ module('Unit | Component | Module | Image', function (hooks) {
         metrics.add.calledWithExactly({
           event: 'custom-event',
           'pix-event-category': 'Modulix',
-          'pix-event-action': `Afficher l’alternative textuelle : ${image.id}`,
+          'pix-event-action': `Passage du module : ${module.id}`,
           'pix-event-name': `Click sur le bouton alternative textuelle : ${image.id}`,
         }),
       );
@@ -57,6 +58,8 @@ module('Unit | Component | Module | Image', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const image = store.createRecord('image', { id: 'image-id' });
+        const grain = store.createRecord('grain', { id: 'grain-id', elements: [image] });
+        store.createRecord('module', { id: 'module-id', grains: [grain] });
 
         const component = createPodsComponent('module/image', { image });
         assert.false(component.modalIsOpen);

--- a/mon-pix/tests/unit/components/module/video_test.js
+++ b/mon-pix/tests/unit/components/module/video_test.js
@@ -11,6 +11,8 @@ module('Unit | Component | Module | Video', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
       const video = store.createRecord('video', { id: 'video-id' });
+      const grain = store.createRecord('grain', { id: 'grain-id', elements: [video] });
+      store.createRecord('module', { id: 'module-id', grains: [grain] });
 
       const metrics = this.owner.lookup('service:metrics');
       metrics.add = () => {};
@@ -29,6 +31,8 @@ module('Unit | Component | Module | Video', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
       const video = store.createRecord('video', { id: 'video-id' });
+      const grain = store.createRecord('grain', { id: 'grain-id', elements: [video] });
+      const module = store.createRecord('module', { id: 'module-id', grains: [grain] });
 
       const metrics = this.owner.lookup('service:metrics');
       metrics.add = sinon.stub();
@@ -44,7 +48,7 @@ module('Unit | Component | Module | Video', function (hooks) {
         metrics.add.calledWithExactly({
           event: 'custom-event',
           'pix-event-category': 'Modulix',
-          'pix-event-action': `Afficher la transcription : ${video.id}`,
+          'pix-event-action': `Passage du module : ${module.id}`,
           'pix-event-name': `Clic sur le bouton transcription : ${video.id}`,
         }),
       );
@@ -57,6 +61,8 @@ module('Unit | Component | Module | Video', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const video = store.createRecord('video', { id: 'video-id' });
+        const grain = store.createRecord('grain', { id: 'grain-id', elements: [video] });
+        store.createRecord('module', { id: 'module-id', grains: [grain] });
 
         const component = createPodsComponent('module/video', { video });
         assert.false(component.modalIsOpen);


### PR DESCRIPTION
## :unicorn: Problèmes
- Dans notre component `Grain`, on ajoute les appels Matomo dans les action `continueAction` et `skipAction`. Certes le `grain` a la connaissance de ces actions, mais la vraie intelligence de ces actions se situe à la maille du `passage`.
- Les évenements d'image et vidéo ne sont pas structuré de la même manière que les autres (car ce sont les plus historiques).

## :robot: Proposition
- Déplacer les actions de tracking au niveau du passage.
- Revue des noms d'évènements d'ouverture d'alternative textuelle avec @AnaisAllamand 

## :rainbow: Remarques
RAS

## :100: Pour tester
CI verte 🟢 
