### PR TITLE
[FEATURE] Filtrer les parcours autonomes de la liste des participations de campagnes (PIX-10674).

### DIFF
--- a/api/lib/domain/read-models/CampaignParticipationOverview.js
+++ b/api/lib/domain/read-models/CampaignParticipationOverview.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 import { CampaignParticipationStatuses } from '../../../src/prescription/shared/domain/constants.js';
-import { config } from '../../config.js';
 
 const { SHARED } = CampaignParticipationStatuses;
 
@@ -10,7 +9,6 @@ class CampaignParticipationOverview {
     createdAt,
     sharedAt,
     organizationName,
-    organizationId,
     status,
     campaignId,
     targetProfileId,
@@ -28,8 +26,7 @@ class CampaignParticipationOverview {
     this.targetProfileId = targetProfileId;
     this.isShared = status === SHARED;
     this.sharedAt = sharedAt;
-    this.organizationName =
-      organizationId === config.autonomousCourse.autonomousCoursesOrganizationId ? 'Pix' : organizationName;
+    this.organizationName = organizationName;
     this.status = status;
     this.campaignId = campaignId;
     this.campaignCode = campaignCode;

--- a/api/lib/domain/read-models/CampaignToJoin.js
+++ b/api/lib/domain/read-models/CampaignToJoin.js
@@ -1,6 +1,5 @@
 import { Assessment } from '../../../src/shared/domain/models/Assessment.js';
 import { CampaignTypes } from '../../../src/prescription/shared/domain/constants.js';
-import { config } from '../../config.js';
 
 class CampaignToJoin {
   constructor({
@@ -44,8 +43,7 @@ class CampaignToJoin {
     this.isSimplifiedAccess = targetProfileIsSimplifiedAccess;
     this.isForAbsoluteNovice = isForAbsoluteNovice;
     this.organizationId = organizationId;
-    this.organizationName =
-      organizationId === config.autonomousCourse.autonomousCoursesOrganizationId ? 'Pix' : organizationName;
+    this.organizationName = organizationName;
     this.organizationType = organizationType;
     this.organizationLogoUrl = organizationLogoUrl;
     this.identityProvider = identityProvider;

--- a/api/lib/infrastructure/repositories/campaign-participation-overview-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-overview-repository.js
@@ -1,5 +1,6 @@
 import { knex } from '../../../db/knex-database-connection.js';
 import { fetchPage } from '../utils/knex-utils.js';
+import { constants } from '../../domain/constants.js';
 import { CampaignParticipationStatuses, CampaignTypes } from '../../../src/prescription/shared/domain/constants.js';
 import { CampaignParticipationOverview } from '../../domain/read-models/CampaignParticipationOverview.js';
 
@@ -44,6 +45,7 @@ function _findByUserId({ userId }) {
         .from('campaign-participations')
         .innerJoin('campaigns', 'campaign-participations.campaignId', 'campaigns.id')
         .innerJoin('organizations', 'organizations.id', 'campaigns.organizationId')
+        .whereNot('organizations.id', constants.AUTONOMOUS_COURSES_ORGANIZATION_ID)
         .where('campaign-participations.userId', userId)
         .where('campaign-participations.isImproved', false)
         .where('campaigns.type', CampaignTypes.ASSESSMENT)

--- a/api/lib/infrastructure/repositories/campaign-participation-overview-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-overview-repository.js
@@ -37,7 +37,6 @@ function _findByUserId({ userId }) {
         targetProfileId: 'campaigns.targetProfileId',
         campaignArchivedAt: 'campaigns.archivedAt',
         organizationName: 'organizations.name',
-        organizationId: 'organizations.id',
         deletedAt: 'campaign-participations.deletedAt',
         participationState: _computeCampaignParticipationState(),
         campaignId: 'campaigns.id',

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -5,6 +5,7 @@ import { Assessment } from '../../../src/shared/domain/models/Assessment.js';
 import { Campaign } from '../../domain/models/Campaign.js';
 import { DomainTransaction } from '../DomainTransaction.js';
 import { NotFoundError } from '../../domain/errors.js';
+import { constants } from '../../domain/constants.js';
 
 const { SHARED, TO_SHARE, STARTED } = CampaignParticipationStatuses;
 
@@ -12,6 +13,7 @@ const hasAssessmentParticipations = async function (userId) {
   const { count } = await knex('campaign-participations')
     .count('campaign-participations.id')
     .join('campaigns', 'campaigns.id', 'campaignId')
+    .whereNot('campaigns.organizationId', constants.AUTONOMOUS_COURSES_ORGANIZATION_ID)
     .where('campaigns.type', '=', CampaignTypes.ASSESSMENT)
     .andWhere({ userId })
     .first();

--- a/api/tests/acceptance/application/users/users-controller-get-campaign-participation-overviews_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-campaign-participation-overviews_test.js
@@ -5,7 +5,9 @@ import {
   generateValidRequestAuthorizationHeader,
   learningContentBuilder,
   mockLearningContent,
+  sinon,
 } from '../../../test-helper.js';
+import { constants } from '../../../../lib/domain/constants.js';
 
 describe('Acceptance | Controller | users-controller-get-campaign-participation-overviews', function () {
   let server;
@@ -50,6 +52,8 @@ describe('Acceptance | Controller | users-controller-get-campaign-participation-
 
     it('should return participation which match with filters', async function () {
       // given
+      sinon.stub(constants, 'AUTONOMOUS_COURSES_ORGANIZATION_ID').value(777);
+
       const startedCampaignParticipation = databaseBuilder.factory.campaignParticipationOverviewFactory.buildOnGoing({
         userId,
         campaignSkills: ['recSkillId1'],

--- a/api/tests/acceptance/application/users/users-controller-get-current-user_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-current-user_test.js
@@ -3,7 +3,9 @@ import {
   databaseBuilder,
   expect,
   generateValidRequestAuthorizationHeader,
+  sinon,
 } from '../../../test-helper.js';
+import { constants } from '../../../../lib/domain/constants.js';
 
 describe('Acceptance | Controller | users-controller-get-current-user', function () {
   let options;
@@ -43,6 +45,8 @@ describe('Acceptance | Controller | users-controller-get-current-user', function
   describe('GET /users/me', function () {
     it('should return found user with 200 HTTP status code', async function () {
       // given
+      sinon.stub(constants, 'AUTONOMOUS_COURSES_ORGANIZATION_ID').value(777);
+
       const expectedUserJSONApi = {
         data: {
           type: 'users',

--- a/api/tests/integration/domain/usecases/find-user-campaign-participation-overviews_test.js
+++ b/api/tests/integration/domain/usecases/find-user-campaign-participation-overviews_test.js
@@ -1,11 +1,15 @@
-import { databaseBuilder, expect } from '../../../test-helper.js';
+import { databaseBuilder, expect, sinon } from '../../../test-helper.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
+import { constants } from '../../../../lib/domain/constants.js';
+
 describe('Integration | UseCase | find-user-campaign-participation-overviews_test', function () {
   describe('when there are several campaigns for several target profiles', function () {
     let user;
 
     beforeEach(async function () {
       // given
+      sinon.stub(constants, 'AUTONOMOUS_COURSES_ORGANIZATION_ID').value(777);
+
       user = databaseBuilder.factory.buildUser();
 
       const targetProfile1 = databaseBuilder.factory.buildTargetProfile();
@@ -77,6 +81,8 @@ describe('Integration | UseCase | find-user-campaign-participation-overviews_tes
 
     beforeEach(async function () {
       // given
+      sinon.stub(constants, 'AUTONOMOUS_COURSES_ORGANIZATION_ID').value(777);
+
       user = databaseBuilder.factory.buildUser();
 
       const targetProfile = databaseBuilder.factory.buildTargetProfile();

--- a/api/tests/unit/domain/read-models/CampaignParticipationOverview_test.js
+++ b/api/tests/unit/domain/read-models/CampaignParticipationOverview_test.js
@@ -1,7 +1,6 @@
 import { CampaignParticipationOverview } from '../../../../lib/domain/read-models/CampaignParticipationOverview.js';
 import { CampaignParticipationStatuses } from '../../../../src/prescription/shared/domain/constants.js';
-import { expect, domainBuilder, sinon } from '../../../test-helper.js';
-import { config } from '../../../../lib/config.js';
+import { expect, domainBuilder } from '../../../test-helper.js';
 
 const { SHARED } = CampaignParticipationStatuses;
 
@@ -32,20 +31,6 @@ describe('Unit | Domain | Read-Models | CampaignParticipationOverview', function
       expect(campaignParticipationOverview.campaignCode).to.equal('campaignCode');
       expect(campaignParticipationOverview.campaignTitle).to.equal('campaignTitle');
       expect(campaignParticipationOverview.masteryRate).to.equal(0.5);
-    });
-
-    describe('when the campaign is an autonomous course', function () {
-      it('should return Pix as organization name', function () {
-        // given
-        sinon.stub(config.autonomousCourse, 'autonomousCoursesOrganizationId').value(777);
-        const campaignParticipationOverview = new CampaignParticipationOverview({
-          organizationName: 'Other organization name',
-          organizationId: 777,
-        });
-
-        // when / then
-        expect(campaignParticipationOverview.organizationName).to.equal('Pix');
-      });
     });
 
     describe('masteryRate', function () {

--- a/api/tests/unit/domain/read-models/CampaignToJoin_test.js
+++ b/api/tests/unit/domain/read-models/CampaignToJoin_test.js
@@ -1,6 +1,5 @@
-import { expect, domainBuilder, sinon } from '../../../test-helper.js';
+import { expect, domainBuilder } from '../../../test-helper.js';
 import { CampaignTypes } from '../../../../src/prescription/shared/domain/constants.js';
-import { config } from '../../../../lib/config.js';
 
 describe('Unit | Domain | Models | CampaignToJoin', function () {
   describe('#isAssessment', function () {
@@ -54,28 +53,6 @@ describe('Unit | Domain | Models | CampaignToJoin', function () {
 
       // when / then
       expect(campaignToJoin.isArchived).to.be.false;
-    });
-  });
-
-  describe('#organizationName', function () {
-    it('should return organization name', function () {
-      // given
-      const campaignToJoin = domainBuilder.buildCampaignToJoin({ organizationName: 'My organization' });
-
-      // when / then
-      expect(campaignToJoin.organizationName).to.equal('My organization');
-    });
-
-    it('should return Pix as organization name if the organization is the autonomous course organization', function () {
-      // given
-      sinon.stub(config.autonomousCourse, 'autonomousCoursesOrganizationId').value(777);
-      const campaignToJoin = domainBuilder.buildCampaignToJoin({
-        organizationName: 'Not displayed organization name',
-        organizationId: 777,
-      });
-
-      // when / then
-      expect(campaignToJoin.organizationName).to.equal('Pix');
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Les participations aux parcours autonome terminées proposent un envoi des résultats, or ce n'est pas une action souhaitée.
Nous ne souhaitons plus voir les cartes de participation aux parcours autonomes sur PixApp.

## :robot: Proposition

Ne plus afficher de carte de participation aux parcours autonomes.
Pour se faire, on filtre les parcours autonomes de la liste des participations de campagne dans l'API.

Aussi, nous ne voulons pas que les parcours autonomes soient pris en compte pour indiquer qu'il y a eu des participations d'une campagne de type `ASSESSMENT` (voir `hasAssessmentParticipations`).

## :100: Pour tester

- Aller[ sur la RA](https://app-pr8081.review.pix.fr/) avec le compte `eval-sco@example.net`
- Constater qu'une participation au [parcours autonome AUTOCOURS1](https://app-pr8081.review.pix.fr/campagnes/AUTOCOURS1/presentation) a été complétée
- Constater qu'il n'y a pas de carte de participation à des parcours autonomes sur la page d'accueil et que l'on a pas accès à la page "Mes parcours".
