### PR TITLE
[TECH] Extraction d'une erreur spécifique pour pix 1d : `SchoolNotFoundError`

### DIFF
--- a/api/src/school/domain/school-errors.js
+++ b/api/src/school/domain/school-errors.js
@@ -1,10 +1,4 @@
-class DomainError extends Error {
-  constructor(message, code, meta) {
-    super(message);
-    this.code = code;
-    this.meta = meta;
-  }
-}
+import { DomainError } from '../../../lib/domain/errors.js';
 
 class ActivityNotFoundError extends DomainError {
   constructor(message = 'Erreur, activitée introuvable.', code) {
@@ -13,4 +7,11 @@ class ActivityNotFoundError extends DomainError {
   }
 }
 
-export { ActivityNotFoundError };
+class SchoolNotFoundError extends DomainError {
+  constructor(message = 'Erreur, École introuvable.', code) {
+    super(message);
+    this.code = code;
+  }
+}
+
+export { ActivityNotFoundError, SchoolNotFoundError };

--- a/api/src/school/infrastructure/repositories/school-repository.js
+++ b/api/src/school/infrastructure/repositories/school-repository.js
@@ -1,6 +1,6 @@
 import { knex } from '../../../../db/knex-database-connection.js';
 import { School } from '../../domain/models/School.js';
-import { NotFoundError } from '../../../../lib/domain/errors.js';
+import { SchoolNotFoundError } from '../../domain/school-errors.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 
 const save = async function ({ organizationId, code, domainTransaction = DomainTransaction.emptyTransaction() }) {
@@ -20,7 +20,7 @@ const getByCode = async function (code) {
     .first();
 
   if (!data) {
-    throw new NotFoundError(`No school found for code ${code}`);
+    throw new SchoolNotFoundError(`No school found for code ${code}`);
   }
 
   return new School(data);

--- a/api/tests/school/integration/infrastructure/repositories/school-repository_test.js
+++ b/api/tests/school/integration/infrastructure/repositories/school-repository_test.js
@@ -1,7 +1,7 @@
 import { catchErr, databaseBuilder, expect, knex } from '../../../../test-helper.js';
 import * as schoolRepository from '../../../../../src/school/infrastructure/repositories/school-repository.js';
 import { School } from '../../../../../src/school/domain/models/School.js';
-import { NotFoundError } from '../../../../../lib/domain/errors.js';
+import { SchoolNotFoundError } from '../../../../../src/school/domain/school-errors.js';
 import { Organization } from '../../../../../lib/domain/models/index.js';
 
 describe('Integration | Repository | School', function () {
@@ -35,7 +35,7 @@ describe('Integration | Repository | School', function () {
       expect(result).to.deep.equal(expectedSchool);
     });
 
-    it('throws a NotFoundError if code does not exist', async function () {
+    it('throws a SchoolNotFoundError if code does not exist', async function () {
       // given
       const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO-1D', name: 'École des fans' });
       databaseBuilder.factory.buildSchool({ organizationId: organization.id, code: 'HAPPYY123' });
@@ -45,7 +45,7 @@ describe('Integration | Repository | School', function () {
       const error = await catchErr(schoolRepository.getByCode)('NOTHAPPY');
 
       // then
-      expect(error).to.be.an.instanceof(NotFoundError);
+      expect(error).to.be.an.instanceof(SchoolNotFoundError);
       expect(error.message).to.equal('No school found for code NOTHAPPY');
     });
   });


### PR DESCRIPTION
## :unicorn: Problème

Les erreurs sont mélangé dans un gros paquet `lib/domain/errors.js`. Difficile de s'y retrouver.

## :robot: Proposition

Extraction d'une `SchoolNotFoundError` pour amorcer le mouvement des erreurs spécirfique au domaine school.

## :rainbow: Remarques

n/a

## :100: Pour tester

Les tests doivent être vert 🟢 et fonctionnalités doivent rester identique