### PR TITLE
[BUGFIX] Erreur lors du patch d'une thématique dans le cache LCMS de recette (PIX-11260)

### DIFF
--- a/api/lib/infrastructure/datasources/learning-content/index.js
+++ b/api/lib/infrastructure/datasources/learning-content/index.js
@@ -4,6 +4,7 @@ import { competenceDatasource } from './competence-datasource.js';
 import { courseDatasource } from './course-datasource.js';
 import { frameworkDatasource } from './framework-datasource.js';
 import { skillDatasource } from './skill-datasource.js';
+import { thematicDatasource } from '../../../../src/shared/infrastructure/datasources/learning-content/thematic-datasource.js';
 import { tubeDatasource } from './tube-datasource.js';
 import { tutorialDatasource } from './tutorial-datasource.js';
 
@@ -14,6 +15,7 @@ export {
   courseDatasource,
   frameworkDatasource,
   skillDatasource,
+  thematicDatasource,
   tubeDatasource,
   tutorialDatasource,
 };

--- a/api/tests/unit/application/cache/cache-controller_test.js
+++ b/api/tests/unit/application/cache/cache-controller_test.js
@@ -15,13 +15,42 @@ describe('Unit | Controller | cache-controller', function () {
       },
     };
 
-    beforeEach(function () {
-      sinon.stub(learningContentDatasources.challengeDatasource, 'refreshLearningContentCacheRecord');
-    });
+    for (const entity of [
+      'area',
+      'challenge',
+      'competence',
+      'course',
+      'framework',
+      'skill',
+      'thematic',
+      'tube',
+      'tutorial',
+    ]) {
+      it(`should reply 204 when patching ${entity}`, async function () {
+        // given
+        // eslint-disable-next-line import/namespace
+        sinon.stub(learningContentDatasources[`${entity}Datasource`], 'refreshLearningContentCacheRecord').resolves();
+        const request = {
+          params: {
+            model: `${entity}s`,
+            id: 'recId',
+          },
+          payload: {
+            property: 'updatedValue',
+          },
+        };
+
+        // when
+        const response = await cacheController.refreshCacheEntry(request, hFake);
+
+        // then
+        expect(response.statusCode).to.equal(204);
+      });
+    }
 
     it('should reply with null when the cache key exists', async function () {
       // given
-      learningContentDatasources.challengeDatasource.refreshLearningContentCacheRecord.resolves();
+      sinon.stub(learningContentDatasources.challengeDatasource, 'refreshLearningContentCacheRecord').resolves();
 
       // when
       const response = await cacheController.refreshCacheEntry(request, hFake);
@@ -35,7 +64,7 @@ describe('Unit | Controller | cache-controller', function () {
 
     it('should reply with null when the cache key does not exist', async function () {
       // given
-      learningContentDatasources.challengeDatasource.refreshLearningContentCacheRecord.resolves();
+      sinon.stub(learningContentDatasources.challengeDatasource, 'refreshLearningContentCacheRecord').resolves();
 
       // when
       const response = await cacheController.refreshCacheEntry(request, hFake);


### PR DESCRIPTION
## :unicorn: Problème
L'API de recette renvoie une erreur 500 quand on patch une thématique.

La datasource des thématiques n'est plus exportée de l'index des datasources LCMS.

## :robot: Proposition
Réexporter la datasource des thématiques.

## :rainbow: Remarques
N/A

## :100: Pour tester
On a ajouté des tests unitaires pour vérifier que les différentes entités peuvent bien être patchées.