### PR TITLE
[TECH] Permettre de tracer les challenge non trouver en certification (PIX-11261)

### DIFF
--- a/api/src/certification/shared/infrastructure/repositories/certification-challenge-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-challenge-repository.js
@@ -38,7 +38,7 @@ const getNextNonAnsweredChallengeByCourseId = async function (assessmentId, cour
     .first();
 
   if (!certificationChallenge) {
-    logger.trace(logContext, 'no found challenges');
+    logger.info(logContext, `no found challenges for certificationCourseId : ${courseId}`);
     throw new AssessmentEndedError();
   }
 


### PR DESCRIPTION
## :unicorn: Problème
Suite à de nombreux demande support pour des certifications terminées en plein milieu d'un test de certification, on voudrait pouvoir constater que l'api n'a pas été en mesure de fournir le pochain challenge à l'utilisateur.

## :robot: Proposition
changer le logger.trace par logger.info lorque l'erreur ```AssessmentEndedError``` est remontée par la méthode de repo ```getNextNonAnsweredChallengeByCourseId```


## :100: Pour tester
Pas grand chose à tester