### PR TITLE
[FEATURE] Ajout des traductions en anglais (PIX-11176)

### DIFF
--- a/admin/app/components/certification-centers/information-view.hbs
+++ b/admin/app/components/certification-centers/information-view.hbs
@@ -23,8 +23,9 @@
         {{@certificationCenter.dataProtectionOfficerEmail}}
       </li>
       <li>
-        Pilote certification V3 :
-        {{if (eq @certificationCenter.isV3Pilot true) "Oui" "Non"}}
+        {{t "pages.certification-centers.information-view.is-v3-pilot"}}
+        :
+        {{if (eq @certificationCenter.isV3Pilot true) (t "common.words.yes") (t "common.words.no")}}
       </li>
     </ul>
   </div>

--- a/admin/app/templates/authenticated/sessions/list.hbs
+++ b/admin/app/templates/authenticated/sessions/list.hbs
@@ -18,10 +18,11 @@
       @query={{hash version=3}}
       class="navbar-item navbar-item--right"
     >
-      Sessions à traiter V3 ({{this.sessionsWithRequiredActionCountVersion3}})
+      {{t "pages.sessions.list.v3-required-actions"}}
+      ({{this.sessionsWithRequiredActionCountVersion3}})
     </LinkTo>
     <LinkTo @route="authenticated.sessions.list.to-be-published" @query={{hash version=3}} class="navbar-item">
-      Sessions à publier V3
+      {{t "pages.sessions.list.v3-to-be-published"}}
     </LinkTo>
   </nav>
 </header>

--- a/admin/tests/integration/components/certification-centers/information-view_test.js
+++ b/admin/tests/integration/components/certification-centers/information-view_test.js
@@ -1,8 +1,8 @@
 import { module, test } from 'qunit';
 import { render } from '@1024pix/ember-testing-library';
-import { setupRenderingTest } from 'ember-qunit';
 import { hbs } from 'ember-cli-htmlbars';
 import ArrayProxy from '@ember/array/proxy';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 function _createEmberDataHabilitations(store) {
   return ArrayProxy.create({
@@ -14,7 +14,7 @@ function _createEmberDataHabilitations(store) {
 }
 
 module('Integration | Component | certification-centers/information-view', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('it should display label and values in read mode', async function (assert) {
     // given

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -149,6 +149,9 @@
   },
   "pages": {
     "certification-centers": {
+      "information-view": {
+        "is-v3-pilot": "V3 certification pilot"
+      },
       "notifications": {
         "failure": {
           "update-certification-center-membership-role": "An error has occurred, the member's role has not been changed."
@@ -168,32 +171,32 @@
       "certification": {
         "title": "Certif",
         "details": {
-          "title": "Détails",
+          "title": "Details",
           "v3": {
             "abort-reason": {
-              "candidate": "Abandon : Manque de temps ou départ prématuré",
-              "technical": "Problème technique"
+              "candidate": "Withdrawal: Lack of time or early departure",
+              "technical": "Technical problem"
             },
             "answer-status": {
-              "aband": "Abandonnée",
+              "aband": "Abandoned",
               "focused-out": "Focus out",
               "ko": "KO",
               "ok": "OK",
-              "partially-ok": "Partiellement OK",
-              "timedout": "Temps écoulé",
-              "unimplemented": "Non implémentée",
-              "validated-live-alert": "Signalement validé"
+              "partially-ok": "Partially OK",
+              "timedout": "Time out",
+              "unimplemented": "Not implemented",
+              "validated-live-alert": "Report validated"
             },
             "assessment-result-status": {
-              "cancelled": "Annulée",
-              "error": "Erreur",
-              "fraud": "Rejetée pour fraude",
-              "rejected": "Rejetée",
-              "validated": "Validée"
+              "cancelled": "Cancelled",
+              "error": "Error",
+              "fraud": "Rejected for fraud",
+              "rejected": "Rejected",
+              "validated": "Validated"
             },
             "assessment-state": {
-              "ended-by-supervisor": "Le surveillant",
-              "ended-due-to-finalization": "Finalisation session"
+              "ended-by-supervisor": "The invigilator",
+              "ended-due-to-finalization": "Session finalised"
             },
             "completion-date-tooltip": {
               "ended-by-supervisor": "Date et heure à laquelle le test de certification a été terminé par le surveillant.",
@@ -202,57 +205,57 @@
             "general-informations": {
               "title": "Certification N°{certificationCourseId}",
               "labels": {
-                "abort-reason": "Raison de l'abandon",
-                "created-at": "Créée le",
-                "ended-at": "Terminée le",
-                "ended-by": "Certification terminée par",
-                "pix-score": "Score (en pix)"
+                "abort-reason": "Reason for withdrawal",
+                "created-at": "Created on",
+                "ended-at": "Completed on",
+                "ended-by": "Certification completed by",
+                "pix-score": "Score (in pix)"
               }
             },
             "live-alert-modal": {
               "title": {
-                "answer": "Réponse",
-                "report": "Signalement"
+                "answer": "Response",
+                "report": "Report"
               }
             },
             "more-informations": {
-              "title": "Informations complémentaires",
+              "title": "Additional information",
               "labels": {
-                "numberof-aband-answers": "Nombre de question abandonnées",
-                "numberof-answered-questions": "Nombre de question répondues",
-                "numberof-ko-questions": "Nombre de question KO",
-                "numberof-ok-questions": "Nombre de question OK",
-                "numberof-validated-live-alerts": "Nombre de problèmes techniques validés",
-                "total-numberof-questions": "Nombre total de questions"
+                "numberof-aband-answers": "Number of questions abandoned",
+                "numberof-answered-questions": "Number of questions answered",
+                "numberof-ko-questions": "Number of questions KO",
+                "numberof-ok-questions": "Number of questions OK",
+                "numberof-validated-live-alerts": "Number of technical problems validated",
+                "total-numberof-questions": "Total number of questions"
               }
             },
             "questions-list": {
-              "title": "Liste des questions",
+              "title": "List of questions",
               "actions": {
                 "challenge-preview": {
-                  "extra-information": "Lien vers l'aperçu de l'épreuve (Ouverture dans une nouvelle fenêtre)",
-                  "label": "Lien vers l'aperçu de l'épreuve"
+                  "extra-information": "Link to test preview (opens in new window)",
+                  "label": "Link to the test preview"
                 },
                 "display-answer": {
-                  "extra-information": "Afficher la réponse du candidat",
-                  "label": "Afficher la réponse du candidat"
+                  "extra-information": "Display candidate's answer",
+                  "label": "Show candidate's answer"
                 },
                 "display-live-alert": {
-                  "extra-information": "Afficher le signalement de la question",
-                  "label": "Afficher le signalement de la question"
+                  "extra-information": "Show question description",
+                  "label": "Show question description"
                 },
                 "informations": {
-                  "extra-information": "Lien vers les informations de la question (Ouverture dans une nouvelle fenêtre)"
+                  "extra-information": "Link to question information (Opens in new window)"
                 }
               },
               "labels": {
                 "actions": "Actions",
-                "answer-status": "Statut",
-                "answered-at": "Heure de réponse",
-                "challenge-id": "RecID (voir dans Pix Editor)",
-                "competence": "Compétence concernée",
+                "answer-status": "Status",
+                "answered-at": "Response time",
+                "challenge-id": "RecID (see in Pix Editor)",
+                "competence": "Competence concerned",
                 "number": "N°",
-                "skill": "Nom de l'acquis"
+                "skill": "Name of the asset"
               }
             }
           }
@@ -290,6 +293,10 @@
       "informations": {
         "assignment-confirmation-modal": "This session is already assigned to the user {fullName}.'<br/>'Do you still want to assign it to yourself?",
         "unfinalization-confirmation-modal": "Are you sure you want to unfinalize this session ? Click on confirm to process."
+      },
+      "list": {
+        "v3-required-actions": "V3 sessions with required actions",
+        "v3-to-be-published": "V3 sessions to be published"
       }
     },
     "target-profiles": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -159,6 +159,9 @@
   },
   "pages": {
     "certification-centers": {
+      "information-view": {
+        "is-v3-pilot": "Pilote certification V3"
+      },
       "notifications": {
         "failure": {
           "update-certification-center-membership-role": "Une erreur est survenue, le rôle du membre n'a pas été modifié."
@@ -307,6 +310,10 @@
       "informations": {
         "assignment-confirmation-modal": "L'utilisateur {fullName} s'est déjà assigné cette session.'<br/>'Voulez-vous vous quand même vous assigner cette session ?",
         "unfinalization-confirmation-modal": "Êtes-vous sûr.e de vouloir définaliser cette session ? Cliquez sur confirmer pour poursuivre."
+      },
+      "list": {
+        "v3-required-actions": "Sessions à traiter V3",
+        "v3-to-be-published": "Sessions à publier V3"
       }
     },
     "target-profiles": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -681,20 +681,20 @@
       },
       "feedback-panel-v3": {
         "actions": {
-          "no-send-feedback": "Non, je reviens à l'épreuve",
-          "open-close": "Signaler un problème avec la question",
-          "refresh-page": "Rafraîchir la page",
-          "send-feedback": "Oui, je suis sûr(e)"
+          "no-send-feedback": "No, I'm coming back to the test",
+          "open-close": "Report a problem with the question",
+          "refresh-page": "Refresh the page",
+          "send-feedback": "Yes, I'm sure"
         },
-        "description": "Êtes-vous sûr(e) de vouloir signaler un problème ?",
-        "information": "En signalant un problème, votre certification est mise en pause le temps que le surveillant intervienne pour valider ou invalider votre signalement.",
-        "problem-banner": "Prévenez votre surveillant afin qu'il puisse constater votre problème.",
-        "waiting-information": "En attente du surveillant..."
+        "description": "Are you sure you want to report a problem?",
+        "information": "By reporting a problem, your certification is paused while the supervisor intervenes to validate or invalidate your report",
+        "problem-banner": "Notify your supervisor so that he/she can check your problem",
+        "waiting-information": "Waiting for the supervisor..."
       },
       "has-focused-out-of-window": {
         "certification": "We have detected a page switch. Your answer will not be validated. If you have been forced to change pages, please inform your invigilator and answer the question in their presence.",
         "default": "We have detected a page switch. During a certification test, your answer would not be validated.",
-        "v3-certification": "Nous avons détecté un changement de page. Votre réponse sera comptée comme fausse. Si vous avez été contraint de changer de page, prévenez votre surveillant afin qu'il puisse le constater et le signaler, le cas échéant."
+        "v3-certification": "We have detected a page change. Your answer will be counted as wrong. If you have been forced to change page, tell your supervisor so that he or she can see this and report it, if necessary."
       },
       "illustration": {
         "placeholder": "Image loading"
@@ -712,7 +712,7 @@
           "qcu": "Select one answer"
         },
         "feedback": "Report a problem",
-        "feedback-v3": "Signaler un problème avec la question",
+        "feedback-v3": "Report a problem with the question",
         "instruction": "Instructions to answer the question",
         "progress": "Your progression",
         "validation": "Validate or skip this question"


### PR DESCRIPTION
## :unicorn: Problème
Les textes ajoutés pour certif v3 sont actuellement tous en français

## :robot: Proposition
Traduire les clés en français dans le fichier `en`

## :rainbow: Remarques
Les traductions ont été générées automatiquement via DeepL

## :100: Pour tester
Passer une certif en anglais, vérifier que les textes sont traduits
Aller sur la page de détails d'une certif v3 en anglais, vérifier que les textes sont traduits
