### PR TITLE
[BUGFIX] Rendre les placeholders des inputs sur Pix Admin (PIX-11258)

### DIFF
--- a/admin/app/components/trainings/create-or-update-training-form.hbs
+++ b/admin/app/components/trainings/create-or-update-training-form.hbs
@@ -91,7 +91,7 @@
           aria-required={{true}}
           @label="Nom du fichier du logo éditeur"
           @screenReaderOnly={{true}}
-          @placeholder="logo-ministere-education-nationale-et-jeunesse.svg"
+          placeholder="logo-ministere-education-nationale-et-jeunesse.svg"
           @value={{this.form.editorLogoUrl}}
           {{on "change" (fn this.updateForm "editorLogoUrl")}}
         />

--- a/admin/app/components/trainings/edit-trigger-threshold.hbs
+++ b/admin/app/components/trainings/edit-trigger-threshold.hbs
@@ -6,7 +6,7 @@
     type="number"
     @id="thresholdInput"
     @label="Seuil en % :"
-    @placeholder="Exemple : 16"
+    placeholder="Exemple : 16"
     min="0"
     max="100"
   />

--- a/admin/app/templates/authenticated/users/list.hbs
+++ b/admin/app/templates/authenticated/users/list.hbs
@@ -7,7 +7,7 @@
       <PixInput
         @id="userId"
         {{on "change" this.onChangeUserId}}
-        @placeholder="ID"
+        placeholder="ID"
         @label="Identifiant de l'utilisateur"
         @screenReaderOnly={{true}}
         class="user-list-form__input--small"
@@ -17,7 +17,7 @@
       <PixInput
         @id="firstName"
         {{on "change" this.onChangeFirstName}}
-        @placeholder="Prénom"
+        placeholder="Prénom"
         @label="Prénom"
         @screenReaderOnly={{true}}
         class="user-list-form__input--small"
@@ -25,7 +25,7 @@
       <PixInput
         @id="lastName"
         {{on "change" this.onChangeLastName}}
-        @placeholder="Nom"
+        placeholder="Nom"
         @label="Nom"
         @screenReaderOnly={{true}}
         class="user-list-form__input--small"
@@ -33,7 +33,7 @@
       <PixInput
         @id="email"
         {{on "change" this.onChangeEmail}}
-        @placeholder="Adresse e-mail"
+        placeholder="Adresse e-mail"
         @label="Adresse e-mail"
         @screenReaderOnly={{true}}
         type="text"
@@ -41,7 +41,7 @@
       <PixInput
         @id="username"
         {{on "change" this.onChangeUsername}}
-        @placeholder="Identifiant"
+        placeholder="Identifiant"
         @label="Identifiant"
         @screenReaderOnly={{true}}
         class="user-list-form__input--small"


### PR DESCRIPTION
## :unicorn: Problème
Les placeholders ne s'affichaient plus

## :robot: Proposition
Rendre les placeholders

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- Se connecter à PixAdmin
- Vérifier la présence de placeholders dans les inputs ici : /users/list
- Vérifier la présence de placeholders dans les inputs sur la page de création ou modification  de formulaire de training
- Vérifier la présence de placeholders dans les inputs sur l'édition de thresholds
- Des bisous 🎉 