### PR TITLE
[BUGFIX] Permettre de renvoyer un fichier PDF / JSON du profil cible ayant des caractères spéciaux (PIX-11265)

### DIFF
--- a/admin/app/components/target-profiles/target-profile.hbs
+++ b/admin/app/components/target-profiles/target-profile.hbs
@@ -70,19 +70,14 @@
             Marquer comme accès simplifié
           </PixButton>
         {{/unless}}
-        <PixButtonLink
-          @size="small"
-          @backgroundColor="green"
-          @href={{@model.urlToJsonContent}}
-          target="_blank"
-          rel="noopener noreferrer"
-          download
-        >
+        <PixButton @triggerAction={{this.downloadJSON}} @size="small" @backgroundColor="success">
           Télécharger le profil cible (JSON)
-        </PixButtonLink>
-        <PixButton @triggerAction={{this.toggleDisplayPdfParametersModal}} @size="small" @backgroundColor="green">
+        </PixButton>
+
+        <PixButton @triggerAction={{this.toggleDisplayPdfParametersModal}} @size="small" @backgroundColor="success">
           Télécharger le profil cible (PDF)
         </PixButton>
+
         {{#unless @model.outdated}}
           <div class="target-profile__actions-spacer"></div>
           <PixButton @size="small" @backgroundColor="error" @triggerAction={{this.toggleDisplayConfirm}}>

--- a/admin/app/components/target-profiles/target-profile.js
+++ b/admin/app/components/target-profiles/target-profile.js
@@ -106,4 +106,17 @@ export default class TargetProfile extends Component {
       this.notifications.error(error.message, { autoClear: false });
     }
   }
+
+  @action
+  async downloadJSON() {
+    try {
+      const targetProfileId = this.args.model.id;
+      const url = `/api/admin/target-profiles/${targetProfileId}/content-json`;
+      const fileName = 'whatever.json';
+      const token = this.session.data.authenticated.access_token;
+      await this.fileSaver.save({ url, fileName, token });
+    } catch (error) {
+      this.notifications.error(error.message, { autoClear: false });
+    }
+  }
 }

--- a/admin/app/models/target-profile.js
+++ b/admin/app/models/target-profile.js
@@ -1,6 +1,5 @@
 import { memberAction } from 'ember-api-actions';
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
-import ENV from 'pix-admin/config/environment';
 import { service } from '@ember/service';
 import formatList from '../utils/format-select-options';
 
@@ -37,10 +36,6 @@ export default class TargetProfile extends Model {
   @hasMany('training-summary') trainingSummaries;
 
   @hasMany('area') areas;
-
-  get urlToJsonContent() {
-    return `${ENV.APP.API_HOST}/api/admin/target-profiles/${this.id}/content-json?accessToken=${this.session.data.authenticated.access_token}`;
-  }
 
   attachOrganizations = memberAction({
     path: 'attach-organizations',

--- a/api/lib/infrastructure/utils/request-response-utils.js
+++ b/api/lib/infrastructure/utils/request-response-utils.js
@@ -10,7 +10,13 @@ const requestResponseUtils = { escapeFileName, extractUserIdFromRequest, extract
 export { escapeFileName, extractUserIdFromRequest, extractLocaleFromRequest, requestResponseUtils };
 
 function escapeFileName(fileName) {
-  return fileName.replace(/[^_. A-Za-z0-9-]/g, '_');
+  return fileName
+    .normalize('NFD')
+    .toLowerCase()
+    .replace(/\p{Diacritic}/gu, '')
+    .replace(/[^_. a-z0-9-]/g, '')
+    .trim()
+    .replace(/ /g, '_');
 }
 
 function extractUserIdFromRequest(request) {

--- a/api/src/prescription/target-profile/application/admin-target-profile-controller.js
+++ b/api/src/prescription/target-profile/application/admin-target-profile-controller.js
@@ -8,12 +8,12 @@ const getContentAsJsonFile = async function (request, h) {
 
   const { jsonContent, targetProfileName } = await usecases.getTargetProfileContentAsJson({ targetProfileId });
 
-  const filename = escapeFileName(`${dayjs().format('YYYYMMDD')}_profil_cible_${targetProfileName}.json`);
+  const filename = escapeFileName(`${dayjs().format('YYYYMMDD')}_profil_cible_${targetProfileName}`);
 
   return h
     .response(jsonContent)
-    .header('Content-Type', 'text/json;charset=utf-8')
-    .header('Content-Disposition', `attachment; filename=${filename}`);
+    .header('Content-Type', 'application/json;charset=utf-8')
+    .header('Content-Disposition', `attachment; filename=${filename}.json`);
 };
 
 const getLearningContentAsPdf = async function (request, h, dependencies = { learningContentPDFPresenter }) {
@@ -25,7 +25,7 @@ const getLearningContentAsPdf = async function (request, h, dependencies = { lea
     language,
   });
 
-  const filename = `${dayjs().format('YYYYMMDD')}_profil_cible_${targetProfileName}.pdf`;
+  const filename = escapeFileName(`${dayjs().format('YYYYMMDD')}_profil_cible_${targetProfileName}`);
 
   const pdfBuffer = await dependencies.learningContentPDFPresenter.present(
     learningContent,
@@ -35,7 +35,7 @@ const getLearningContentAsPdf = async function (request, h, dependencies = { lea
 
   return h
     .response(pdfBuffer)
-    .header('Content-Disposition', `attachment; filename=${filename}`)
+    .header('Content-Disposition', `attachment; filename=${filename}.pdf`)
     .header('Content-Type', 'application/pdf');
 };
 

--- a/api/src/prescription/target-profile/application/admin-target-profile-controller.js
+++ b/api/src/prescription/target-profile/application/admin-target-profile-controller.js
@@ -1,21 +1,19 @@
 import { usecases } from '../domain/usecases/index.js';
-import { tokenService } from '../../../shared/domain/services/token-service.js';
 import { escapeFileName } from '../../../../lib/infrastructure/utils/request-response-utils.js';
 import * as learningContentPDFPresenter from './presenter/pdf/learning-content-pdf-presenter.js';
 import dayjs from 'dayjs';
 
-const getContentAsJsonFile = async function (request, h, dependencies = { tokenService }) {
+const getContentAsJsonFile = async function (request, h) {
   const targetProfileId = request.params.id;
-  const token = request.query.accessToken;
-  const userId = dependencies.tokenService.extractUserId(token);
 
-  const { jsonContent, fileName } = await usecases.getTargetProfileContentAsJson({ userId, targetProfileId });
-  const escapedFilename = escapeFileName(fileName);
+  const { jsonContent, targetProfileName } = await usecases.getTargetProfileContentAsJson({ targetProfileId });
+
+  const filename = escapeFileName(`${dayjs().format('YYYYMMDD')}_profil_cible_${targetProfileName}.json`);
 
   return h
     .response(jsonContent)
     .header('Content-Type', 'text/json;charset=utf-8')
-    .header('Content-Disposition', `attachment; filename=${escapedFilename}`);
+    .header('Content-Disposition', `attachment; filename=${filename}`);
 };
 
 const getLearningContentAsPdf = async function (request, h, dependencies = { learningContentPDFPresenter }) {

--- a/api/src/prescription/target-profile/application/admin-target-profile-route.js
+++ b/api/src/prescription/target-profile/application/admin-target-profile-route.js
@@ -34,14 +34,24 @@ const register = async function (server) {
           "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
             '- Elle permet de récupérer le référentiel du profil cible en version pdf',
         ],
-        tags: ['api', 'learning-content', 'target-profile', 'PDF'],
+        tags: ['api', 'admin', 'target-profile', 'pdf'],
       },
     },
     {
       method: 'GET',
       path: '/api/admin/target-profiles/{id}/content-json',
       config: {
-        auth: false,
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
         validate: {
           params: Joi.object({
             id: identifiersType.targetProfileId,

--- a/api/src/prescription/target-profile/domain/usecases/get-target-profile-content-as-json.js
+++ b/api/src/prescription/target-profile/domain/usecases/get-target-profile-content-as-json.js
@@ -1,34 +1,18 @@
-import dayjs from 'dayjs';
-import { ForbiddenAccess } from '../../../../shared/domain/errors.js';
-
 const getTargetProfileContentAsJson = async function ({
-  userId,
   targetProfileId,
-  adminMemberRepository,
   targetProfileForAdminRepository,
   learningContentConversionService,
 }) {
-  const adminMember = await adminMemberRepository.get({ userId });
-  if (!_hasAuthorizationToDownloadContent(adminMember))
-    throw new ForbiddenAccess("L'utilisateur n'est pas autorisé à effectuer cette opération.");
   const targetProfileForAdmin = await targetProfileForAdminRepository.get({ id: targetProfileId });
   const skills = await learningContentConversionService.findActiveSkillsForCappedTubes(
     targetProfileForAdmin.cappedTubes,
   );
   const jsonContent = targetProfileForAdmin.getContentAsJson(skills);
-  const now = dayjs();
-  const fileName = `${now.format('YYYYMMDD')}_profil_cible_${targetProfileForAdmin.name}.json`;
+
   return {
     jsonContent,
-    fileName,
+    targetProfileName: targetProfileForAdmin.name,
   };
 };
 
 export { getTargetProfileContentAsJson };
-
-function _hasAuthorizationToDownloadContent(adminMember) {
-  if (!adminMember) {
-    return false;
-  }
-  return adminMember.isMetier || adminMember.isSupport || adminMember.isSuperAdmin;
-}

--- a/api/tests/prescription/campaign/unit/application/campaign-detail-controller_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-detail-controller_test.js
@@ -188,14 +188,14 @@ describe('Unit | Application | Controller | Campaign detail', function () {
 
       sinon
         .stub(usecases, 'startWritingCampaignProfilesCollectionResultsToStream')
-        .resolves({ fileName: 'expected file name' });
+        .resolves({ fileName: 'expected file name.csv' });
 
       // when
       const response = await campaignDetailController.getCsvProfilesCollectionResults(request, hFake);
 
       // then
       expect(response.headers['content-type']).to.equal('text/csv;charset=utf-8');
-      expect(response.headers['content-disposition']).to.equal('attachment; filename="expected file name"');
+      expect(response.headers['content-disposition']).to.equal('attachment; filename="expected_file_name.csv"');
       expect(response.headers['content-encoding']).to.equal('identity');
     });
 
@@ -213,7 +213,7 @@ describe('Unit | Application | Controller | Campaign detail', function () {
 
       // then
       expect(response.headers['content-disposition']).to.equal(
-        'attachment; filename="file-name with invalid_chars _____________.csv"',
+        'attachment; filename="file-name_with_invalid_chars_.csv"',
       );
     });
   });
@@ -242,14 +242,14 @@ describe('Unit | Application | Controller | Campaign detail', function () {
 
       sinon
         .stub(usecases, 'startWritingCampaignAssessmentResultsToStream')
-        .resolves({ fileName: 'expected file name' });
+        .resolves({ fileName: 'expected file name.csv' });
 
       // when
       const response = await campaignDetailController.getCsvAssessmentResults(request, hFake);
 
       // then
       expect(response.headers['content-type']).to.equal('text/csv;charset=utf-8');
-      expect(response.headers['content-disposition']).to.equal('attachment; filename="expected file name"');
+      expect(response.headers['content-disposition']).to.equal('attachment; filename="expected_file_name.csv"');
       expect(response.headers['content-encoding']).to.equal('identity');
     });
 
@@ -259,7 +259,7 @@ describe('Unit | Application | Controller | Campaign detail', function () {
       const request = _getRequestForCampaignId(campaignId);
 
       sinon.stub(usecases, 'startWritingCampaignAssessmentResultsToStream').resolves({
-        fileName: 'file-name with invalid_chars •’<>:"/\\|?*"\n.csv',
+        fileName: 'file-name_with_invalid_chars •’<>:"/\\|?*"\n.csv',
       });
 
       // when
@@ -267,7 +267,7 @@ describe('Unit | Application | Controller | Campaign detail', function () {
 
       // then
       expect(response.headers['content-disposition']).to.equal(
-        'attachment; filename="file-name with invalid_chars _____________.csv"',
+        'attachment; filename="file-name_with_invalid_chars_.csv"',
       );
     });
   });

--- a/api/tests/prescription/target-profile/acceptance/application/admin-target-profile-route_test.js
+++ b/api/tests/prescription/target-profile/acceptance/application/admin-target-profile-route_test.js
@@ -2,54 +2,145 @@ import {
   databaseBuilder,
   expect,
   generateValidRequestAuthorizationHeader,
+  learningContentBuilder,
   MockDate,
   mockLearningContent,
-  learningContentBuilder,
   createServer,
 } from '../../../../test-helper.js';
 
 describe('Acceptance | Route | admin-target-profile', function () {
   let server;
+  let user;
+  let targetProfileId;
 
   beforeEach(async function () {
     server = await createServer();
+
+    MockDate.set(new Date('2020-11-01'));
+
+    const learningContent = learningContentBuilder([
+      {
+        id: 'recFramework1',
+        name: 'Mon référentiel 1',
+        areas: [
+          {
+            id: 'recArea1',
+            name: 'area1_name',
+            title_i18n: { fr: 'domaine1_TitreFr', en: 'area1_TitleEn' },
+            color: 'area1_color',
+            code: 'area1_code',
+            frameworkId: 'recFramework1',
+            competences: [
+              {
+                id: 'recCompetence2',
+                name_i18n: { fr: 'competence2_nomFr', en: 'competence2_nameEn' },
+                index: 2,
+                description_i18n: { fr: 'competence2_descriptionFr', en: 'competence2_descriptionEn' },
+                origin: 'Pix',
+                thematics: [
+                  {
+                    id: 'recThematic2',
+                    name_i18n: {
+                      fr: 'thematique2_nomFr',
+                      en: 'thematic2_nameEn',
+                    },
+                    index: '20',
+                    tubes: [
+                      {
+                        id: 'recTube2',
+                        name: '@tube2_name',
+                        title: '@tube2_title',
+                        description: '@tube2_description',
+                        practicalTitle_i18n: { fr: 'tube2_practicalTitleFr', en: 'tube2_practicalTitleEn' },
+                        practicalDescription_i18n: {
+                          fr: 'tube2_practicalDescriptionFr',
+                          en: 'tube2_practicalDescriptionEn',
+                        },
+                        isMobileCompliant: false,
+                        isTabletCompliant: true,
+                        skills: [
+                          {
+                            id: 'recSkill2',
+                            name: '@tube2_name1',
+                            status: 'actif',
+                            level: 1,
+                            pixValue: 34,
+                            version: 76,
+                          },
+                          {
+                            id: 'recSkill3',
+                            name: '@tube2_name2',
+                            status: 'archivé',
+                            level: 2,
+                            pixValue: 56,
+                            version: 54,
+                          },
+                          {
+                            id: 'recSkill4',
+                            status: 'périmé',
+                          },
+                        ],
+                      },
+                      {
+                        id: 'recTube3',
+                        name: '@tube3_name',
+                        title: '@tube3_title',
+                        description: '@tube3_description',
+                        practicalTitle_i18n: { fr: 'tube3_practicalTitleFr', en: 'tube3_practicalTitleEn' },
+                        practicalDescription_i18n: {
+                          fr: 'tube3_practicalDescriptionFr',
+                          en: 'tube3_practicalDescriptionEn',
+                        },
+                        isMobileCompliant: true,
+                        isTabletCompliant: true,
+                        skills: [
+                          {
+                            id: 'recSkill5',
+                            name: '@tube3_name5',
+                            status: 'archivé',
+                            level: 5,
+                            pixValue: 44,
+                            version: 55,
+                          },
+                          {
+                            id: 'recSkill6',
+                            status: 'périmé',
+                          },
+                          {
+                            id: 'recSkill7',
+                            status: 'périmé',
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+    mockLearningContent(learningContent);
+    mockLearningContent(learningContent);
+
+    targetProfileId = databaseBuilder.factory.buildTargetProfile({ name: 'Roxane est très jolie' }).id;
+    databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube2', level: 2 });
+    user = databaseBuilder.factory.buildUser.withRole();
+    return databaseBuilder.commit();
+  });
+
+  afterEach(function () {
+    MockDate.reset();
   });
 
   describe('GET /api/admin/target-profiles/{id}/content-json', function () {
-    let user;
-    let targetProfileId;
-
-    beforeEach(function () {
-      MockDate.set(new Date('2020-11-01'));
-      const learningContent = {
-        areas: [{ id: 'recArea', frameworkId: 'recFmwk', competenceIds: ['recCompetence'] }],
-        competences: [{ id: 'recCompetence', areaId: 'recArea', thematicIds: ['recThematic'] }],
-        thematics: [
-          { id: 'recThematic', name_i18n: { fr: 'somename' }, tubeIds: ['recTube'], competenceId: 'recCompetence' },
-        ],
-        tubes: [{ id: 'recTube', thematicId: 'recThematic' }],
-        skills: [{ id: 'recSkill', tubeId: 'recTube', status: 'actif', level: 5, name: 'skill5' }],
-        challenges: [],
-      };
-      mockLearningContent(learningContent);
-      targetProfileId = databaseBuilder.factory.buildTargetProfile({ name: 'Roxane est très jolie' }).id;
-      databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube', level: 6 });
-      user = databaseBuilder.factory.buildUser.withRole();
-
-      return databaseBuilder.commit();
-    });
-
-    afterEach(function () {
-      MockDate.reset();
-    });
-
     it('should return 200 and the json file', async function () {
-      const authHeader = generateValidRequestAuthorizationHeader(user.id);
-      const token = authHeader.replace('Bearer ', '');
       const options = {
         method: 'GET',
-        url: `/api/admin/target-profiles/${targetProfileId}/content-json?accessToken=${token}`,
+        url: `/api/admin/target-profiles/${targetProfileId}/content-json`,
         payload: {},
+        headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
       };
 
       // when
@@ -57,7 +148,9 @@ describe('Acceptance | Route | admin-target-profile', function () {
 
       // then
       expect(response.statusCode).to.equal(200);
-      expect(response.payload).to.equal('[{"id":"recTube","level":6,"frameworkId":"recFmwk","skills":["recSkill"]}]');
+      expect(response.payload).to.equal(
+        '[{"id":"recTube2","level":2,"frameworkId":"recFramework1","skills":["recSkill2"]}]',
+      );
       expect(response.headers['content-disposition']).to.equal(
         'attachment; filename=20201101_profil_cible_Roxane est tr_s jolie.json',
       );
@@ -66,232 +159,7 @@ describe('Acceptance | Route | admin-target-profile', function () {
   });
 
   describe('GET /api/admin/target-profiles/{id}/learning-content-pdf?language=fr', function () {
-    let targetProfileId;
-    let user;
-
-    beforeEach(function () {
-      MockDate.set(new Date('2020-11-01'));
-
-      const learningContent = learningContentBuilder([
-        {
-          id: 'recFramework1',
-          name: 'Mon référentiel 1',
-          areas: [
-            {
-              id: 'recArea1',
-              name: 'area1_name',
-              title_i18n: { fr: 'domaine1_TitreFr', en: 'area1_TitleEn' },
-              color: 'area1_color',
-              code: 'area1_code',
-              frameworkId: 'recFramework1',
-              competences: [
-                {
-                  id: 'recCompetence1',
-                  name_i18n: { fr: 'competence1_nomFr', en: 'competence1_nameEn' },
-                  index: 1,
-                  description_i18n: { fr: 'competence1_descriptionFr', en: 'competence1_descriptionEn' },
-                  origin: 'Pix',
-                  thematics: [
-                    {
-                      id: 'recThematic1',
-                      name_i18n: {
-                        fr: 'thematique1_nomFr',
-                        en: 'thematic1_nameEn',
-                      },
-                      index: '10',
-                      tubes: [
-                        {
-                          id: 'recTube1',
-                          name: '@tube1_name',
-                          title: 'tube1_title',
-                          description: 'tube1_description',
-                          practicalTitle_i18n: { fr: 'tube1_practicalTitleFr', en: 'tube1_practicalTitleEn' },
-                          practicalDescription_i18n: {
-                            fr: 'tube1_practicalDescriptionFr',
-                            en: 'tube1_practicalDescriptionEn',
-                          },
-                          isMobileCompliant: true,
-                          isTabletCompliant: false,
-                          skills: [
-                            {
-                              id: 'recSkill1',
-                              name: '@tube1_name4',
-                              status: 'actif',
-                              level: 4,
-                              pixValue: 12,
-                              version: 98,
-                            },
-                          ],
-                        },
-                      ],
-                    },
-                  ],
-                },
-                {
-                  id: 'recCompetence2',
-                  name_i18n: { fr: 'competence2_nomFr', en: 'competence2_nameEn' },
-                  index: 2,
-                  description_i18n: { fr: 'competence2_descriptionFr', en: 'competence2_descriptionEn' },
-                  origin: 'Pix',
-                  thematics: [
-                    {
-                      id: 'recThematic2',
-                      name_i18n: {
-                        fr: 'thematique2_nomFr',
-                        en: 'thematic2_nameEn',
-                      },
-                      index: '20',
-                      tubes: [
-                        {
-                          id: 'recTube2',
-                          name: '@tube2_name',
-                          title: '@tube2_title',
-                          description: '@tube2_description',
-                          practicalTitle_i18n: { fr: 'tube2_practicalTitleFr', en: 'tube2_practicalTitleEn' },
-                          practicalDescription_i18n: {
-                            fr: 'tube2_practicalDescriptionFr',
-                            en: 'tube2_practicalDescriptionEn',
-                          },
-                          isMobileCompliant: false,
-                          isTabletCompliant: true,
-                          skills: [
-                            {
-                              id: 'recSkill2',
-                              name: '@tube2_name1',
-                              status: 'actif',
-                              level: 1,
-                              pixValue: 34,
-                              version: 76,
-                            },
-                            {
-                              id: 'recSkill3',
-                              name: '@tube2_name2',
-                              status: 'archivé',
-                              level: 2,
-                              pixValue: 56,
-                              version: 54,
-                            },
-                            {
-                              id: 'recSkill4',
-                              status: 'périmé',
-                            },
-                          ],
-                        },
-                        {
-                          id: 'recTube3',
-                          name: '@tube3_name',
-                          title: '@tube3_title',
-                          description: '@tube3_description',
-                          practicalTitle_i18n: { fr: 'tube3_practicalTitleFr', en: 'tube3_practicalTitleEn' },
-                          practicalDescription_i18n: {
-                            fr: 'tube3_practicalDescriptionFr',
-                            en: 'tube3_practicalDescriptionEn',
-                          },
-                          isMobileCompliant: true,
-                          isTabletCompliant: true,
-                          skills: [
-                            {
-                              id: 'recSkill5',
-                              name: '@tube3_name5',
-                              status: 'archivé',
-                              level: 5,
-                              pixValue: 44,
-                              version: 55,
-                            },
-                            {
-                              id: 'recSkill6',
-                              status: 'périmé',
-                            },
-                            {
-                              id: 'recSkill7',
-                              status: 'périmé',
-                            },
-                          ],
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-        {
-          id: 'recFramework2',
-          name: 'Mon référentiel 2',
-          areas: [
-            {
-              id: 'recArea2',
-              name: 'area2_name',
-              title_i18n: { fr: 'domaine2_TitreFr', en: 'area2_TitleEn' },
-              color: 'area2_color',
-              code: 'area2_code',
-              frameworkId: 'recFramework2',
-              competences: [
-                {
-                  id: 'recCompetence3',
-                  name_i18n: { fr: 'competence3_nomFr', en: 'competence3_nameEn' },
-                  index: 1,
-                  description_i18n: { fr: 'competence3_descriptionFr', en: 'competence3_descriptionEn' },
-                  origin: 'Pix',
-                  thematics: [
-                    {
-                      id: 'recThematic3',
-                      name_i18n: {
-                        fr: 'thematique3_nomFr',
-                        en: 'thematic3_nameEn',
-                      },
-                      index: '30',
-                      tubes: [
-                        {
-                          id: 'recTube4',
-                          name: '@tube4_name',
-                          title: 'tube4_title',
-                          description: 'tube4_description',
-                          practicalTitle_i18n: { fr: 'tube4_practicalTitleFr', en: 'tube4_practicalTitleEn' },
-                          practicalDescription_i18n: {
-                            fr: 'tube4_practicalDescriptionFr',
-                            en: 'tube4_practicalDescriptionEn',
-                          },
-                          isMobileCompliant: false,
-                          isTabletCompliant: false,
-                          skills: [
-                            {
-                              id: 'recSkill8',
-                              name: '@tube4_name8',
-                              status: 'actif',
-                              level: 7,
-                              pixValue: 78,
-                              version: 32,
-                            },
-                          ],
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      ]);
-      mockLearningContent(learningContent);
-
-      targetProfileId = databaseBuilder.factory.buildTargetProfile({ name: 'Jeanne & Serge' }).id;
-      databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube1', level: 4 });
-      databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube2', level: 2 });
-      databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube3', level: 5 });
-      databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube4', level: 7 });
-      user = databaseBuilder.factory.buildUser.withRole();
-
-      return databaseBuilder.commit();
-    });
-
-    afterEach(function () {
-      MockDate.reset();
-    });
-
-    it('should return 200 and the json file', async function () {
+    it('should return 200 and the pdf file', async function () {
       const options = {
         method: 'GET',
         url: `/api/admin/target-profiles/${targetProfileId}/learning-content-pdf?language=fr`,
@@ -305,7 +173,7 @@ describe('Acceptance | Route | admin-target-profile', function () {
       // then
       expect(response.statusCode).to.equal(200);
       expect(response.headers['content-disposition']).to.equal(
-        'attachment; filename=20201101_profil_cible_Jeanne & Serge.pdf',
+        'attachment; filename=20201101_profil_cible_Roxane est tr_s jolie.pdf',
       );
       expect(response.headers['content-type']).to.equal('application/pdf');
     });

--- a/api/tests/prescription/target-profile/acceptance/application/admin-target-profile-route_test.js
+++ b/api/tests/prescription/target-profile/acceptance/application/admin-target-profile-route_test.js
@@ -152,9 +152,9 @@ describe('Acceptance | Route | admin-target-profile', function () {
         '[{"id":"recTube2","level":2,"frameworkId":"recFramework1","skills":["recSkill2"]}]',
       );
       expect(response.headers['content-disposition']).to.equal(
-        'attachment; filename=20201101_profil_cible_Roxane est tr_s jolie.json',
+        'attachment; filename=20201101_profil_cible_roxane_est_tres_jolie.json',
       );
-      expect(response.headers['content-type']).to.equal('text/json;charset=utf-8');
+      expect(response.headers['content-type']).to.equal('application/json;charset=utf-8');
     });
   });
 
@@ -173,7 +173,7 @@ describe('Acceptance | Route | admin-target-profile', function () {
       // then
       expect(response.statusCode).to.equal(200);
       expect(response.headers['content-disposition']).to.equal(
-        'attachment; filename=20201101_profil_cible_Roxane est tr_s jolie.pdf',
+        'attachment; filename=20201101_profil_cible_roxane_est_tres_jolie.pdf',
       );
       expect(response.headers['content-type']).to.equal('application/pdf');
     });

--- a/api/tests/prescription/target-profile/unit/application/admin-target-profile-controller_test.js
+++ b/api/tests/prescription/target-profile/unit/application/admin-target-profile-controller_test.js
@@ -33,7 +33,7 @@ describe('Unit | Controller | admin-target-profile-controller', function () {
       // then
       expect(response.source).to.equal('json_content');
       expect(response.headers).to.deep.equal({
-        'Content-Type': 'text/json;charset=utf-8',
+        'Content-Type': 'application/json;charset=utf-8',
         'Content-Disposition': 'attachment; filename=20220201_profil_cible_target_profile_name.json',
       });
     });

--- a/api/tests/prescription/target-profile/unit/application/admin-target-profile-controller_test.js
+++ b/api/tests/prescription/target-profile/unit/application/admin-target-profile-controller_test.js
@@ -3,56 +3,48 @@ import { targetProfileController } from '../../../../../src/prescription/target-
 import { usecases } from '../../../../../src/prescription/target-profile/domain/usecases/index.js';
 
 describe('Unit | Controller | admin-target-profile-controller', function () {
+  let clock;
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers({ now: new Date('2022-02-01'), toFake: ['Date'] });
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
   describe('#getContentAsJsonFile', function () {
     it('should succeed', async function () {
       // given
-      const accessToken = 'ABC123';
       sinon.stub(usecases, 'getTargetProfileContentAsJson');
-      usecases.getTargetProfileContentAsJson.withArgs({ userId: 66, targetProfileId: 123 }).resolves({
+      usecases.getTargetProfileContentAsJson.withArgs({ targetProfileId: 123 }).resolves({
         jsonContent: 'json_content',
-        fileName: 'file_name',
+        targetProfileName: 'target_profile_name',
       });
       const request = {
         params: {
           id: 123,
         },
-        query: {
-          accessToken,
-        },
       };
-      const tokenService = {
-        extractUserId: sinon.stub(),
-      };
-      tokenService.extractUserId.withArgs(accessToken).returns(66);
 
       // when
-      const response = await targetProfileController.getContentAsJsonFile(request, hFake, { tokenService });
+      const response = await targetProfileController.getContentAsJsonFile(request, hFake);
 
       // then
       expect(response.source).to.equal('json_content');
       expect(response.headers).to.deep.equal({
         'Content-Type': 'text/json;charset=utf-8',
-        'Content-Disposition': 'attachment; filename=file_name',
+        'Content-Disposition': 'attachment; filename=20220201_profil_cible_target_profile_name.json',
       });
     });
   });
 
   describe('#getLearningContentAsPdf', function () {
-    let clock;
-
-    beforeEach(function () {
-      clock = sinon.useFakeTimers({ now: new Date('2022-02-01'), toFake: ['Date'] });
-    });
-
-    afterEach(function () {
-      clock.restore();
-    });
-
     it('should return the pdf', async function () {
       // given
       const learningContent = domainBuilder.buildLearningContent();
       const pdfBuffer = 'some_pdf_buffer';
-      const docTitle = 'titre du doc';
+      const docTitle = 'titre_du_doc';
       sinon
         .stub(usecases, 'getLearningContentByTargetProfile')
         .withArgs({ targetProfileId: 123, language: 'fr' })

--- a/api/tests/prescription/target-profile/unit/application/admin-target-profiles-route_test.js
+++ b/api/tests/prescription/target-profile/unit/application/admin-target-profiles-route_test.js
@@ -4,119 +4,61 @@ import { targetProfileController } from '../../../../../src/prescription/target-
 import * as moduleUnderTest from '../../../../../src/prescription/target-profile/application/admin-target-profile-route.js';
 
 describe('Unit | Application | Target Profiles | Routes', function () {
+  beforeEach(function () {
+    sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport');
+    sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin');
+    sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier');
+    sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf');
+  });
+
   describe('GET /api/admin/target-profiles/{id}/learning-content-pdf?language={language}', function () {
     let method, httpTestServer;
 
     beforeEach(function () {
       httpTestServer = new HttpTestServer();
       method = 'GET';
+      sinon.stub(targetProfileController, 'getLearningContentAsPdf');
     });
 
-    context('Success cases', function () {
-      beforeEach(function () {
-        sinon.stub(targetProfileController, 'getLearningContentAsPdf').returns('ok');
-      });
+    it('should called controller when acces is granted by pre handler validation', async function () {
+      // given
+      securityPreHandlers.hasAtLeastOneAccessOf.returns(() => true);
+      targetProfileController.getLearningContentAsPdf.returns('ok');
 
-      it("should call controller's handler when everything is ok - language fr", async function () {
-        // given
-        sinon
-          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-          .callsFake((request, h) => h.response(true));
-        await httpTestServer.register(moduleUnderTest);
+      await httpTestServer.register(moduleUnderTest);
+      // when
+      const url = '/api/admin/target-profiles/123/learning-content-pdf?language=en';
+      await httpTestServer.request(method, url);
 
-        // when
-        const url = '/api/admin/target-profiles/123/learning-content-pdf?language=fr';
-        await httpTestServer.request(method, url);
-
-        // then
-        expect(targetProfileController.getLearningContentAsPdf).to.have.been.called;
-      });
-
-      it("should call controller's handler when everything is ok - language en", async function () {
-        // given
-        sinon
-          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-          .callsFake((request, h) => h.response(true));
-        await httpTestServer.register(moduleUnderTest);
-
-        // when
-        const url = '/api/admin/target-profiles/123/learning-content-pdf?language=en';
-        await httpTestServer.request(method, url);
-
-        // then
-        expect(targetProfileController.getLearningContentAsPdf).to.have.been.called;
-      });
-
-      it("should call controller's handler when everything is ok - role Super Admin", async function () {
-        // given
-        sinon
-          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-        sinon
-          .stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-        sinon
-          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-          .callsFake((request, h) => h.response(true));
-        await httpTestServer.register(moduleUnderTest);
-
-        // when
-        const url = '/api/admin/target-profiles/123/learning-content-pdf?language=en';
-        await httpTestServer.request(method, url);
-
-        // then
-        expect(targetProfileController.getLearningContentAsPdf).to.have.been.called;
-      });
-
-      it("should call controller's handler when everything is ok - role Metier", async function () {
-        // given
-        sinon
-          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-        sinon
-          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
-        await httpTestServer.register(moduleUnderTest);
-
-        // when
-        const url = '/api/admin/target-profiles/123/learning-content-pdf?language=en';
-        await httpTestServer.request(method, url);
-
-        // then
-        expect(targetProfileController.getLearningContentAsPdf).to.have.been.called;
-      });
-
-      it("should call controller's handler when everything is ok - role Support", async function () {
-        // given
-        sinon
-          .stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-        sinon
-          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport').callsFake((request, h) => h.response(true));
-        await httpTestServer.register(moduleUnderTest);
-
-        // when
-        const url = '/api/admin/target-profiles/123/learning-content-pdf?language=en';
-        await httpTestServer.request(method, url);
-
-        // then
-        expect(targetProfileController.getLearningContentAsPdf).to.have.been.called;
-      });
+      // then
+      expect(securityPreHandlers.hasAtLeastOneAccessOf).to.have.been.calledWithExactly([
+        securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+        securityPreHandlers.checkAdminMemberHasRoleSupport,
+        securityPreHandlers.checkAdminMemberHasRoleMetier,
+      ]);
+      expect(targetProfileController.getLearningContentAsPdf).to.have.been.calledOnce;
     });
 
     context('Error cases', function () {
       beforeEach(function () {
-        sinon.stub(targetProfileController, 'getLearningContentAsPdf').throws('I should not be called');
+        targetProfileController.getLearningContentAsPdf.throws('I should not be called');
+      });
+
+      it('should not called controller when acces is denied', async function () {
+        // given
+        securityPreHandlers.hasAtLeastOneAccessOf.throws();
+
+        await httpTestServer.register(moduleUnderTest);
+        // when
+        const url = '/api/admin/target-profiles/123/learning-content-pdf?language=en';
+        await httpTestServer.request(method, url);
+
+        // then
+        expect(targetProfileController.getLearningContentAsPdf).to.not.have.been.called;
       });
 
       it("should not call controller's handler and return error code 404 when id is not provided", async function () {
         // given
-        sinon
-          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-          .callsFake((request, h) => h.response(true));
         await httpTestServer.register(moduleUnderTest);
 
         // when
@@ -130,9 +72,6 @@ describe('Unit | Application | Target Profiles | Routes', function () {
 
       it("should not call controller's handler and return error code 400 when id is not valid", async function () {
         // given
-        sinon
-          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-          .callsFake((request, h) => h.response(true));
         await httpTestServer.register(moduleUnderTest);
 
         // when
@@ -152,9 +91,6 @@ describe('Unit | Application | Target Profiles | Routes', function () {
 
       it("should not call controller's handler and return error code 400 when language is not provided", async function () {
         // given
-        sinon
-          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-          .callsFake((request, h) => h.response(true));
         await httpTestServer.register(moduleUnderTest);
 
         // when
@@ -174,9 +110,6 @@ describe('Unit | Application | Target Profiles | Routes', function () {
 
       it("should not call controller's handler and return error code 400 when language is not in allowed values", async function () {
         // given
-        sinon
-          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-          .callsFake((request, h) => h.response(true));
         await httpTestServer.register(moduleUnderTest);
 
         // when
@@ -193,27 +126,86 @@ describe('Unit | Application | Target Profiles | Routes', function () {
         });
         expect(targetProfileController.getLearningContentAsPdf).to.not.have.been.called;
       });
+    });
+  });
 
-      it("should not call controller's handler and return error code 403 when user has not the right role", async function () {
+  describe('GET /api/admin/target-profiles/{id}/content-json', function () {
+    let method, httpTestServer;
+
+    beforeEach(function () {
+      httpTestServer = new HttpTestServer();
+      method = 'GET';
+      sinon.stub(targetProfileController, 'getContentAsJsonFile');
+    });
+
+    it('should called controller when acces is granted by securiry pre handler validation', async function () {
+      // given
+      securityPreHandlers.hasAtLeastOneAccessOf.returns(() => true);
+      targetProfileController.getContentAsJsonFile.returns('ok');
+
+      await httpTestServer.register(moduleUnderTest);
+      // when
+      const url = '/api/admin/target-profiles/123/content-json';
+      await httpTestServer.request(method, url);
+
+      // then
+      expect(securityPreHandlers.hasAtLeastOneAccessOf).to.have.been.calledWithExactly([
+        securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+        securityPreHandlers.checkAdminMemberHasRoleSupport,
+        securityPreHandlers.checkAdminMemberHasRoleMetier,
+      ]);
+
+      expect(targetProfileController.getContentAsJsonFile).to.have.been.calledOnce;
+    });
+
+    context('Error cases', function () {
+      beforeEach(function () {
+        targetProfileController.getContentAsJsonFile.throws('I should not be called');
+      });
+
+      it('should not called controller when acces is denied', async function () {
         // given
-        sinon
-          .stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-        sinon
-          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-        sinon
-          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
-          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        securityPreHandlers.hasAtLeastOneAccessOf.throws();
+
+        await httpTestServer.register(moduleUnderTest);
+        // when
+        const url = '/api/admin/target-profiles/123/content-json';
+        await httpTestServer.request(method, url);
+
+        // then
+        expect(targetProfileController.getContentAsJsonFile).to.not.have.been.called;
+      });
+
+      it("should not call controller's handler and return error code 404 when id is not provided", async function () {
+        // given
         await httpTestServer.register(moduleUnderTest);
 
         // when
-        const url = '/api/admin/target-profiles/123/learning-content-pdf?language=en';
+        const url = '/api/admin/target-profiles//content-json';
         const response = await httpTestServer.request(method, url);
 
         // then
-        expect(response.statusCode).to.equal(403);
-        expect(targetProfileController.getLearningContentAsPdf).to.not.have.been.called;
+        expect(response.statusCode).to.equal(404);
+        expect(targetProfileController.getContentAsJsonFile).to.not.have.been.called;
+      });
+
+      it("should not call controller's handler and return error code 400 when id is not valid", async function () {
+        // given
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const url = '/api/admin/target-profiles/coucou/content-json';
+        const response = await httpTestServer.request(method, url);
+
+        // then
+        const error = response?.result?.errors?.[0];
+        expect(response.statusCode).to.equal(400);
+        expect(error).to.deep.equal({
+          status: '400',
+          title: 'Bad Request',
+          detail: '"id" must be a number',
+        });
+        expect(targetProfileController.getContentAsJsonFile).to.not.have.been.called;
       });
     });
   });

--- a/api/tests/prescription/target-profile/unit/domain/usecases/get-target-profile-content-as-json_test.js
+++ b/api/tests/prescription/target-profile/unit/domain/usecases/get-target-profile-content-as-json_test.js
@@ -1,10 +1,8 @@
-import { expect, sinon, catchErr, domainBuilder, MockDate } from '../../../../../test-helper.js';
+import { expect, sinon, domainBuilder, MockDate } from '../../../../../test-helper.js';
 import { getTargetProfileContentAsJson } from '../../../../../../src/prescription/target-profile/domain/usecases/get-target-profile-content-as-json.js';
-import { ForbiddenAccess } from '../../../../../../src/shared/domain/errors.js';
 
 describe('Unit | UseCase | get-target-profile-content-as-json', function () {
   let targetProfileForAdminRepository;
-  let adminMemberRepository;
   let learningContentConversionService;
 
   beforeEach(function () {
@@ -15,59 +13,6 @@ describe('Unit | UseCase | get-target-profile-content-as-json', function () {
     MockDate.reset();
   });
 
-  context('when the user has not pix admin role', function () {
-    beforeEach(function () {
-      targetProfileForAdminRepository = { get: sinon.stub() };
-      targetProfileForAdminRepository.get.rejects(new Error('I should not be called'));
-      learningContentConversionService.findActiveSkillsForCappedTubes.rejects(new Error('I should not be called'));
-    });
-
-    it('should throw a ForbiddenAccess error', async function () {
-      // given
-      adminMemberRepository = { get: sinon.stub() };
-      adminMemberRepository.get.withArgs({ userId: 66 }).resolves(undefined);
-
-      // when
-      const error = await catchErr(getTargetProfileContentAsJson)({
-        userId: 66,
-        targetProfileId: 123,
-        adminMemberRepository,
-        targetProfileForAdminRepository,
-        learningContentConversionService,
-      });
-
-      // then
-      expect(error).to.be.instanceOf(ForbiddenAccess);
-      expect(error.message).to.equal("L'utilisateur n'est pas autorisé à effectuer cette opération.");
-    });
-  });
-
-  context('when the user does not have the authorization to get the content', function () {
-    beforeEach(function () {
-      targetProfileForAdminRepository = { get: sinon.stub() };
-      targetProfileForAdminRepository.get.rejects(new Error('I should not be called'));
-      learningContentConversionService.findActiveSkillsForCappedTubes.rejects(new Error('I should not be called'));
-    });
-
-    it('should throw a ForbiddenAccess error', async function () {
-      // given
-      const certifMember = domainBuilder.buildAdminMember.withRoleCertif({ userId: 66 });
-      adminMemberRepository = { get: sinon.stub().withArgs({ userId: 66 }).resolves(certifMember) };
-
-      // when
-      const error = await catchErr(getTargetProfileContentAsJson)({
-        userId: 66,
-        targetProfileId: 123,
-        adminMemberRepository,
-        targetProfileForAdminRepository,
-        learningContentConversionService,
-      });
-
-      // then
-      expect(error).to.be.instanceOf(ForbiddenAccess);
-      expect(error.message).to.equal("L'utilisateur n'est pas autorisé à effectuer cette opération.");
-    });
-  });
   context('when the user has the authorization to get the content', function () {
     beforeEach(function () {
       MockDate.set(new Date('2020-12-01'));
@@ -124,73 +69,20 @@ describe('Unit | UseCase | get-target-profile-content-as-json', function () {
         .resolves([...skillsForTube1, ...skillsForTube2, ...skillsForTube3]);
     });
 
-    context('when the user has role SUPPORT', function () {
-      it('should return the json content and the filename for the target profile to export', async function () {
-        // given
-        const supportMember = domainBuilder.buildAdminMember.withRoleSupport({ userId: 66 });
-        adminMemberRepository = { get: sinon.stub().withArgs({ userId: 66 }).resolves(supportMember) };
-
-        // when
-        const { jsonContent, fileName } = await getTargetProfileContentAsJson({
-          userId: 66,
-          targetProfileId: 123,
-          adminMemberRepository,
-          targetProfileForAdminRepository,
-          learningContentConversionService,
-        });
-
-        // then
-        expect(fileName).to.equal('20201201_profil_cible_Profil Rentrée scolaire.json');
-        expect(jsonContent).to.equal(
-          '[{"id":"recTube1","level":8,"frameworkId":"recFramework","skills":["skill1Tube1"]},{"id":"recTube2","level":7,"frameworkId":"recFramework","skills":["skill1Tube2","skill2Tube2"]},{"id":"recTube3","level":1,"frameworkId":"recFramework","skills":[]}]',
-        );
+    it('should return the json content and the filename for the target profile to export', async function () {
+      // when
+      const { jsonContent, targetProfileName } = await getTargetProfileContentAsJson({
+        userId: 66,
+        targetProfileId: 123,
+        targetProfileForAdminRepository,
+        learningContentConversionService,
       });
-    });
 
-    context('when the user has role METIER', function () {
-      it('should return the json content and the filename for the target profile to export', async function () {
-        // given
-        const metierMember = domainBuilder.buildAdminMember.withRoleMetier({ userId: 66 });
-        adminMemberRepository = { get: sinon.stub().withArgs({ userId: 66 }).resolves(metierMember) };
-
-        // when
-        const { jsonContent, fileName } = await getTargetProfileContentAsJson({
-          userId: 66,
-          targetProfileId: 123,
-          adminMemberRepository,
-          targetProfileForAdminRepository,
-          learningContentConversionService,
-        });
-
-        // then
-        expect(fileName).to.equal('20201201_profil_cible_Profil Rentrée scolaire.json');
-        expect(jsonContent).to.equal(
-          '[{"id":"recTube1","level":8,"frameworkId":"recFramework","skills":["skill1Tube1"]},{"id":"recTube2","level":7,"frameworkId":"recFramework","skills":["skill1Tube2","skill2Tube2"]},{"id":"recTube3","level":1,"frameworkId":"recFramework","skills":[]}]',
-        );
-      });
-    });
-
-    context('when the user has role SUPER_ADMIN', function () {
-      it('should return the json content and the filename for the target profile to export', async function () {
-        // given
-        const superAdminMember = domainBuilder.buildAdminMember.withRoleSuperAdmin({ userId: 66 });
-        adminMemberRepository = { get: sinon.stub().withArgs({ userId: 66 }).resolves(superAdminMember) };
-
-        // when
-        const { jsonContent, fileName } = await getTargetProfileContentAsJson({
-          userId: 66,
-          targetProfileId: 123,
-          adminMemberRepository,
-          targetProfileForAdminRepository,
-          learningContentConversionService,
-        });
-
-        // then
-        expect(fileName).to.equal('20201201_profil_cible_Profil Rentrée scolaire.json');
-        expect(jsonContent).to.equal(
-          '[{"id":"recTube1","level":8,"frameworkId":"recFramework","skills":["skill1Tube1"]},{"id":"recTube2","level":7,"frameworkId":"recFramework","skills":["skill1Tube2","skill2Tube2"]},{"id":"recTube3","level":1,"frameworkId":"recFramework","skills":[]}]',
-        );
-      });
+      // then
+      expect(targetProfileName).to.equal('Profil Rentrée scolaire');
+      expect(jsonContent).to.equal(
+        '[{"id":"recTube1","level":8,"frameworkId":"recFramework","skills":["skill1Tube1"]},{"id":"recTube2","level":7,"frameworkId":"recFramework","skills":["skill1Tube2","skill2Tube2"]},{"id":"recTube3","level":1,"frameworkId":"recFramework","skills":[]}]',
+      );
     });
   });
 });

--- a/api/tests/unit/infrastructure/utils/request-response-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/request-response-utils_test.js
@@ -37,13 +37,13 @@ describe('Unit | Utils | Request Utils', function () {
   describe('#escapeFileName', function () {
     it('should allow only a restricted set of characters', function () {
       // given
-      const fileName = 'file-name with invalid_chars •’<>:"/\\|?*"\n.csv';
+      const fileName = 'file-name with é invalid_chars •’<>:"/\\|?*"\n👌.csv';
 
       // when
       const escapedFileName = escapeFileName(fileName);
 
       // then
-      expect(escapedFileName).to.equal('file-name with invalid_chars _____________.csv');
+      expect(escapedFileName).to.equal('file-name_with_e_invalid_chars_.csv');
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Le téléchargement du PDF d'un profil cible remonte une 500, après investigation. certains caractères spéciaux ne sont pas echappé/remplacé ( notamment l'apostophe chelou )

## :robot: Proposition
Revoir le escape file name pour prendre en compte tout les caractères spéciaux

## :rainbow: Remarques
Uniformisation des valiations de la route au niveau de la route et non du usecase

## :100: Pour tester
Se connecter sur Pix Admin, modifier un PC existant avec moult caractère spéciaux notamment celui là `’`