### PR TITLE
[FEATURE] Ajout en DB des configurations pour les niveaux par compétences (PIX-11272)

### DIFF
--- a/api/db/database-builder/factory/build-competence-scoring-configuration.js
+++ b/api/db/database-builder/factory/build-competence-scoring-configuration.js
@@ -1,0 +1,16 @@
+import { databaseBuffer } from '../database-buffer.js';
+
+export const buildCompetenceScoringConfiguration = function ({
+  id = databaseBuffer.getNextId(),
+  configuration,
+  createdAt = new Date('2020-01-01'),
+}) {
+  return databaseBuffer.pushInsertable({
+    tableName: 'competence-scoring-configurations',
+    values: {
+      id,
+      configuration: JSON.stringify(configuration),
+      createdAt,
+    },
+  });
+};

--- a/api/db/migrations/20240216103316_add-competence-scoring-configurations-table.js
+++ b/api/db/migrations/20240216103316_add-competence-scoring-configurations-table.js
@@ -1,0 +1,24 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/DEV/pages/2153512965/Cr+er+une+migration
+
+// If your migrations target `answers` or `knowledge-elements`
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+const TABLE_NAME = 'competence-scoring-configurations';
+
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.increments('id').primary();
+    table.jsonb('configuration').notNullable();
+    table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+const down = async function (knex) {
+  return knex.schema.dropTable(TABLE_NAME);
+};
+
+export { up, down };

--- a/api/db/seeds/data/team-certification/create-competence-scoring-configuration.js
+++ b/api/db/seeds/data/team-certification/create-competence-scoring-configuration.js
@@ -1,60 +1,60 @@
-export const competenceLevelIntervals = [
+const configuration = [
   {
     competence: '1.1',
     values: [
       {
         bounds: {
-          max: -1.4290127754211426,
+          max: -2,
           min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
       {
         bounds: {
-          max: 0.4440346658229828,
-          min: -1.4290127754211426,
+          max: -1,
+          min: -2,
         },
         competenceLevel: 1,
       },
       {
         bounds: {
-          max: 1.5982208251953125,
-          min: 0.4440346658229828,
+          max: 0.5,
+          min: -1,
         },
         competenceLevel: 2,
       },
       {
         bounds: {
-          max: 1.6521581411361694,
-          min: 1.5982208251953125,
+          max: 1,
+          min: 0.5,
         },
         competenceLevel: 3,
       },
       {
         bounds: {
-          max: 2.6340444087982178,
-          min: 1.6521581411361694,
+          max: 2,
+          min: 1,
         },
         competenceLevel: 4,
       },
       {
         bounds: {
-          max: 3.2923648357391357,
-          min: 2.6340444087982178,
+          max: 3,
+          min: 2,
         },
         competenceLevel: 5,
       },
       {
         bounds: {
-          max: 5.012345314025879,
-          min: 3.2923648357391357,
+          max: 4,
+          min: 3,
         },
         competenceLevel: 6,
       },
       {
         bounds: {
           max: Number.MAX_SAFE_INTEGER,
-          min: 5.012345314025879,
+          min: 4,
         },
         competenceLevel: 7,
       },
@@ -65,57 +65,57 @@ export const competenceLevelIntervals = [
     values: [
       {
         bounds: {
-          max: -1.816159963607788,
+          max: -2,
           min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
       {
         bounds: {
-          max: -0.9718785285949707,
-          min: -1.816159963607788,
+          max: -1,
+          min: -2,
         },
         competenceLevel: 1,
       },
       {
         bounds: {
-          max: 0.9403377175331116,
-          min: -0.9718785285949707,
+          max: 0.5,
+          min: -1,
         },
         competenceLevel: 2,
       },
       {
         bounds: {
-          max: 2.816800832748413,
-          min: 0.9403377175331116,
+          max: 1,
+          min: 0.5,
         },
         competenceLevel: 3,
       },
       {
         bounds: {
-          max: 2.167752742767334,
-          min: 2.816800832748413,
+          max: 2,
+          min: 1,
         },
         competenceLevel: 4,
       },
       {
         bounds: {
-          max: 5.497085094451904,
-          min: 2.167752742767334,
+          max: 3,
+          min: 2,
         },
         competenceLevel: 5,
       },
       {
         bounds: {
-          max: 6.849133491516113,
-          min: 5.497085094451904,
+          max: 4,
+          min: 3,
         },
         competenceLevel: 6,
       },
       {
         bounds: {
           max: Number.MAX_SAFE_INTEGER,
-          min: 6.849133491516113,
+          min: 4,
         },
         competenceLevel: 7,
       },
@@ -126,57 +126,57 @@ export const competenceLevelIntervals = [
     values: [
       {
         bounds: {
-          max: -0.6393653750419617,
+          max: -2,
           min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
       {
         bounds: {
-          max: 0.24656331539154053,
-          min: -0.6393653750419617,
+          max: -1,
+          min: -2,
         },
         competenceLevel: 1,
       },
       {
         bounds: {
-          max: 0.8987030982971191,
-          min: 0.24656331539154053,
+          max: 0.5,
+          min: -1,
         },
         competenceLevel: 2,
       },
       {
         bounds: {
-          max: 1.7216020822525024,
-          min: 0.8987030982971191,
+          max: 1,
+          min: 0.5,
         },
         competenceLevel: 3,
       },
       {
         bounds: {
-          max: 2.062549114227295,
-          min: 1.7216020822525024,
+          max: 2,
+          min: 1,
         },
         competenceLevel: 4,
       },
       {
         bounds: {
-          max: 2.6246471405029297,
-          min: 2.062549114227295,
+          max: 3,
+          min: 2,
         },
         competenceLevel: 5,
       },
       {
         bounds: {
-          max: 3.2087042331695557,
-          min: 2.6246471405029297,
+          max: 4,
+          min: 3,
         },
         competenceLevel: 6,
       },
       {
         bounds: {
           max: Number.MAX_SAFE_INTEGER,
-          min: 3.2087042331695557,
+          min: 4,
         },
         competenceLevel: 7,
       },
@@ -187,57 +187,57 @@ export const competenceLevelIntervals = [
     values: [
       {
         bounds: {
-          max: -1.61019766330719,
+          max: -2,
           min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
       {
         bounds: {
-          max: -0.22345975041389465,
-          min: -1.61019766330719,
+          max: -1,
+          min: -2,
         },
         competenceLevel: 1,
       },
       {
         bounds: {
-          max: 0.19168642163276672,
-          min: -0.22345975041389465,
+          max: 0.5,
+          min: -1,
         },
         competenceLevel: 2,
       },
       {
         bounds: {
-          max: 1.6601377725601196,
-          min: 0.19168642163276672,
+          max: 1,
+          min: 0.5,
         },
         competenceLevel: 3,
       },
       {
         bounds: {
-          max: 3.844524621963501,
-          min: 1.6601377725601196,
+          max: 2,
+          min: 1,
         },
         competenceLevel: 4,
       },
       {
         bounds: {
-          max: 3.3029592037200928,
-          min: 3.844524621963501,
+          max: 3,
+          min: 2,
         },
         competenceLevel: 5,
       },
       {
         bounds: {
-          max: 4.262047290802002,
-          min: 3.3029592037200928,
+          max: 4,
+          min: 3,
         },
         competenceLevel: 6,
       },
       {
         bounds: {
           max: Number.MAX_SAFE_INTEGER,
-          min: 4.262047290802002,
+          min: 4,
         },
         competenceLevel: 7,
       },
@@ -248,52 +248,59 @@ export const competenceLevelIntervals = [
     values: [
       {
         bounds: {
-          max: -1.6842528581619263,
+          max: -2,
           min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
       {
         bounds: {
-          max: -0.1598442941904068,
-          min: -1.6842528581619263,
+          max: -1,
+          min: -2,
         },
         competenceLevel: 1,
       },
       {
         bounds: {
-          max: 1.3476699590682983,
-          min: -0.1598442941904068,
+          max: 0.5,
+          min: -1,
         },
         competenceLevel: 2,
       },
       {
         bounds: {
-          max: 0.5933959484100342,
-          min: 1.3476699590682983,
+          max: 1,
+          min: 0.5,
         },
         competenceLevel: 3,
       },
       {
         bounds: {
-          max: 1.5587767362594604,
-          min: 0.5933959484100342,
+          max: 2,
+          min: 1,
         },
         competenceLevel: 4,
       },
       {
         bounds: {
-          max: 6.855661869049072,
-          min: 1.5587767362594604,
+          max: 3,
+          min: 2,
         },
         competenceLevel: 5,
       },
       {
         bounds: {
-          max: Number.MAX_SAFE_INTEGER,
-          min: 6.855661869049072,
+          max: 4,
+          min: 3,
         },
         competenceLevel: 6,
+      },
+      {
+        bounds: {
+          max: Number.MAX_SAFE_INTEGER,
+          min: 4,
+        },
+        competenceLevel: 7,
       },
     ],
   },
@@ -302,52 +309,59 @@ export const competenceLevelIntervals = [
     values: [
       {
         bounds: {
-          max: -1.290342926979065,
+          max: -2,
           min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
       {
         bounds: {
-          max: -0.7296794056892395,
-          min: -1.290342926979065,
+          max: -1,
+          min: -2,
         },
         competenceLevel: 1,
       },
       {
         bounds: {
-          max: 1.8645321130752563,
-          min: -0.7296794056892395,
+          max: 0.5,
+          min: -1,
         },
         competenceLevel: 2,
       },
       {
         bounds: {
-          max: 2.075043201446533,
-          min: 1.8645321130752563,
+          max: 1,
+          min: 0.5,
         },
         competenceLevel: 3,
       },
       {
         bounds: {
-          max: 1.5695146322250366,
-          min: 2.075043201446533,
+          max: 2,
+          min: 1,
         },
         competenceLevel: 4,
       },
       {
         bounds: {
-          max: 4.602512359619141,
-          min: 1.5695146322250366,
+          max: 3,
+          min: 2,
         },
         competenceLevel: 5,
       },
       {
         bounds: {
-          max: Number.MAX_SAFE_INTEGER,
-          min: 4.602512359619141,
+          max: 4,
+          min: 3,
         },
         competenceLevel: 6,
+      },
+      {
+        bounds: {
+          max: Number.MAX_SAFE_INTEGER,
+          min: 4,
+        },
+        competenceLevel: 7,
       },
     ],
   },
@@ -356,52 +370,59 @@ export const competenceLevelIntervals = [
     values: [
       {
         bounds: {
-          max: -2.0458545684814453,
+          max: -2,
           min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
       {
         bounds: {
-          max: 0.6524333357810974,
-          min: -2.0458545684814453,
+          max: -1,
+          min: -2,
         },
         competenceLevel: 1,
       },
       {
         bounds: {
-          max: 1.3245508670806885,
-          min: 0.6524333357810974,
+          max: 0.5,
+          min: -1,
         },
         competenceLevel: 2,
       },
       {
         bounds: {
-          max: 1.8602700233459473,
-          min: 1.3245508670806885,
+          max: 1,
+          min: 0.5,
         },
         competenceLevel: 3,
       },
       {
         bounds: {
-          max: 3.5241336822509766,
-          min: 1.8602700233459473,
+          max: 2,
+          min: 1,
         },
         competenceLevel: 4,
       },
       {
         bounds: {
-          max: 4.221365928649902,
-          min: 3.5241336822509766,
+          max: 3,
+          min: 2,
         },
         competenceLevel: 5,
       },
       {
         bounds: {
-          max: Number.MAX_SAFE_INTEGER,
-          min: 4.221365928649902,
+          max: 4,
+          min: 3,
         },
         competenceLevel: 6,
+      },
+      {
+        bounds: {
+          max: Number.MAX_SAFE_INTEGER,
+          min: 4,
+        },
+        competenceLevel: 7,
       },
     ],
   },
@@ -410,52 +431,59 @@ export const competenceLevelIntervals = [
     values: [
       {
         bounds: {
-          max: -1.3573087453842163,
+          max: -2,
           min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
       {
         bounds: {
-          max: -0.4166012108325958,
-          min: -1.3573087453842163,
+          max: -1,
+          min: -2,
         },
         competenceLevel: 1,
       },
       {
         bounds: {
-          max: 1.6104117631912231,
-          min: -0.4166012108325958,
+          max: 0.5,
+          min: -1,
         },
         competenceLevel: 2,
       },
       {
         bounds: {
-          max: 1.7363076210021973,
-          min: 1.6104117631912231,
+          max: 1,
+          min: 0.5,
         },
         competenceLevel: 3,
       },
       {
         bounds: {
-          max: 2.7112088203430176,
-          min: 1.7363076210021973,
+          max: 2,
+          min: 1,
         },
         competenceLevel: 4,
       },
       {
         bounds: {
-          max: 3.0218923091888428,
-          min: 2.7112088203430176,
+          max: 3,
+          min: 2,
         },
         competenceLevel: 5,
       },
       {
         bounds: {
-          max: Number.MAX_SAFE_INTEGER,
-          min: 3.0218923091888428,
+          max: 4,
+          min: 3,
         },
         competenceLevel: 6,
+      },
+      {
+        bounds: {
+          max: Number.MAX_SAFE_INTEGER,
+          min: 4,
+        },
+        competenceLevel: 7,
       },
     ],
   },
@@ -464,52 +492,59 @@ export const competenceLevelIntervals = [
     values: [
       {
         bounds: {
-          max: -2.3695690631866455,
+          max: -2,
           min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
       {
         bounds: {
-          max: -0.374176025390625,
-          min: -2.3695690631866455,
+          max: -1,
+          min: -2,
         },
         competenceLevel: 1,
       },
       {
         bounds: {
-          max: 0.11621341854333878,
-          min: -0.374176025390625,
+          max: 0.5,
+          min: -1,
         },
         competenceLevel: 2,
       },
       {
         bounds: {
-          max: 1.95041823387146,
-          min: 0.11621341854333878,
+          max: 1,
+          min: 0.5,
         },
         competenceLevel: 3,
       },
       {
         bounds: {
-          max: 4.512263774871826,
-          min: 1.95041823387146,
+          max: 2,
+          min: 1,
         },
         competenceLevel: 4,
       },
       {
         bounds: {
-          max: 3.2162301540374756,
-          min: 4.512263774871826,
+          max: 3,
+          min: 2,
         },
         competenceLevel: 5,
       },
       {
         bounds: {
-          max: Number.MAX_SAFE_INTEGER,
-          min: 3.2162301540374756,
+          max: 4,
+          min: 3,
         },
         competenceLevel: 6,
+      },
+      {
+        bounds: {
+          max: Number.MAX_SAFE_INTEGER,
+          min: 4,
+        },
+        competenceLevel: 7,
       },
     ],
   },
@@ -518,52 +553,59 @@ export const competenceLevelIntervals = [
     values: [
       {
         bounds: {
-          max: -1.4244885444641113,
+          max: -2,
           min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
       {
         bounds: {
-          max: 1.598168969154358,
-          min: -1.4244885444641113,
+          max: -1,
+          min: -2,
         },
         competenceLevel: 1,
       },
       {
         bounds: {
-          max: 0.8326226472854614,
-          min: 1.598168969154358,
+          max: 0.5,
+          min: -1,
         },
         competenceLevel: 2,
       },
       {
         bounds: {
-          max: 2.065073251724243,
-          min: 0.8326226472854614,
+          max: 1,
+          min: 0.5,
         },
         competenceLevel: 3,
       },
       {
         bounds: {
-          max: 2.385699510574341,
-          min: 2.065073251724243,
+          max: 2,
+          min: 1,
         },
         competenceLevel: 4,
       },
       {
         bounds: {
-          max: 3.189551830291748,
-          min: 2.385699510574341,
+          max: 3,
+          min: 2,
         },
         competenceLevel: 5,
       },
       {
         bounds: {
-          max: Number.MAX_SAFE_INTEGER,
-          min: 3.189551830291748,
+          max: 4,
+          min: 3,
         },
         competenceLevel: 6,
+      },
+      {
+        bounds: {
+          max: Number.MAX_SAFE_INTEGER,
+          min: 4,
+        },
+        competenceLevel: 7,
       },
     ],
   },
@@ -572,57 +614,57 @@ export const competenceLevelIntervals = [
     values: [
       {
         bounds: {
-          max: 2.1766011714935303,
+          max: -2,
           min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
       {
         bounds: {
-          max: -0.1402435302734375,
-          min: 2.1766011714935303,
+          max: -1,
+          min: -2,
         },
         competenceLevel: 1,
       },
       {
         bounds: {
-          max: 1.49162757396698,
-          min: -0.1402435302734375,
+          max: 0.5,
+          min: -1,
         },
         competenceLevel: 2,
       },
       {
         bounds: {
-          max: 1.632764458656311,
-          min: 1.49162757396698,
+          max: 1,
+          min: 0.5,
         },
         competenceLevel: 3,
       },
       {
         bounds: {
-          max: 2.2066235542297363,
-          min: 1.632764458656311,
+          max: 2,
+          min: 1,
         },
         competenceLevel: 4,
       },
       {
         bounds: {
-          max: 2.659951686859131,
-          min: 2.2066235542297363,
+          max: 3,
+          min: 2,
         },
         competenceLevel: 5,
       },
       {
         bounds: {
-          max: 2.088264226913452,
-          min: 2.659951686859131,
+          max: 4,
+          min: 3,
         },
         competenceLevel: 6,
       },
       {
         bounds: {
           max: Number.MAX_SAFE_INTEGER,
-          min: 2.088264226913452,
+          min: 4,
         },
         competenceLevel: 7,
       },
@@ -633,52 +675,59 @@ export const competenceLevelIntervals = [
     values: [
       {
         bounds: {
-          max: -0.5992878079414368,
+          max: -2,
           min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
       {
         bounds: {
-          max: 0.34635910391807556,
-          min: -0.5992878079414368,
+          max: -1,
+          min: -2,
         },
         competenceLevel: 1,
       },
       {
         bounds: {
-          max: 0.5798754096031189,
-          min: 0.34635910391807556,
+          max: 0.5,
+          min: -1,
         },
         competenceLevel: 2,
       },
       {
         bounds: {
-          max: 3.021275520324707,
-          min: 0.5798754096031189,
+          max: 1,
+          min: 0.5,
         },
         competenceLevel: 3,
       },
       {
         bounds: {
-          max: 3.289098024368286,
-          min: 3.021275520324707,
+          max: 2,
+          min: 1,
         },
         competenceLevel: 4,
       },
       {
         bounds: {
-          max: 3.9777281284332275,
-          min: 3.289098024368286,
+          max: 3,
+          min: 2,
         },
         competenceLevel: 5,
       },
       {
         bounds: {
-          max: Number.MAX_SAFE_INTEGER,
-          min: 3.9777281284332275,
+          max: 4,
+          min: 3,
         },
         competenceLevel: 6,
+      },
+      {
+        bounds: {
+          max: Number.MAX_SAFE_INTEGER,
+          min: 4,
+        },
+        competenceLevel: 7,
       },
     ],
   },
@@ -687,57 +736,57 @@ export const competenceLevelIntervals = [
     values: [
       {
         bounds: {
-          max: -0.5439767837524414,
+          max: -2,
           min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
       {
         bounds: {
-          max: -0.2565813958644867,
-          min: -0.5439767837524414,
+          max: -1,
+          min: -2,
         },
         competenceLevel: 1,
       },
       {
         bounds: {
-          max: 1.3130837678909302,
-          min: -0.2565813958644867,
+          max: 0.5,
+          min: -1,
         },
         competenceLevel: 2,
       },
       {
         bounds: {
-          max: 3.375800371170044,
-          min: 1.3130837678909302,
+          max: 1,
+          min: 0.5,
         },
         competenceLevel: 3,
       },
       {
         bounds: {
-          max: 2.1648192405700684,
-          min: 3.375800371170044,
+          max: 2,
+          min: 1,
         },
         competenceLevel: 4,
       },
       {
         bounds: {
-          max: 3.933257579803467,
-          min: 2.1648192405700684,
+          max: 3,
+          min: 2,
         },
         competenceLevel: 5,
       },
       {
         bounds: {
-          max: 4.868575096130371,
-          min: 3.933257579803467,
+          max: 4,
+          min: 3,
         },
         competenceLevel: 6,
       },
       {
         bounds: {
           max: Number.MAX_SAFE_INTEGER,
-          min: 4.868575096130371,
+          min: 4,
         },
         competenceLevel: 7,
       },
@@ -748,52 +797,59 @@ export const competenceLevelIntervals = [
     values: [
       {
         bounds: {
-          max: -1.5177412033081055,
+          max: -2,
           min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
       {
         bounds: {
-          max: -0.6453593969345093,
-          min: -1.5177412033081055,
+          max: -1,
+          min: -2,
         },
         competenceLevel: 1,
       },
       {
         bounds: {
-          max: 1.5937426090240479,
-          min: -0.6453593969345093,
+          max: 0.5,
+          min: -1,
         },
         competenceLevel: 2,
       },
       {
         bounds: {
-          max: 2.0802462100982666,
-          min: 1.5937426090240479,
+          max: 1,
+          min: 0.5,
         },
         competenceLevel: 3,
       },
       {
         bounds: {
-          max: 3.965420722961426,
-          min: 2.0802462100982666,
+          max: 2,
+          min: 1,
         },
         competenceLevel: 4,
       },
       {
         bounds: {
-          max: 4.159452438354492,
-          min: 3.965420722961426,
+          max: 3,
+          min: 2,
         },
         competenceLevel: 5,
       },
       {
         bounds: {
-          max: Number.MAX_SAFE_INTEGER,
-          min: 4.159452438354492,
+          max: 4,
+          min: 3,
         },
         competenceLevel: 6,
+      },
+      {
+        bounds: {
+          max: Number.MAX_SAFE_INTEGER,
+          min: 4,
+        },
+        competenceLevel: 7,
       },
     ],
   },
@@ -802,57 +858,57 @@ export const competenceLevelIntervals = [
     values: [
       {
         bounds: {
-          max: -1.9220428466796875,
+          max: -2,
           min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
       {
         bounds: {
-          max: -2.1660995483398438,
-          min: -1.9220428466796875,
+          max: -1,
+          min: -2,
         },
         competenceLevel: 1,
       },
       {
         bounds: {
-          max: 0.7407174706459045,
-          min: -2.1660995483398438,
+          max: 0.5,
+          min: -1,
         },
         competenceLevel: 2,
       },
       {
         bounds: {
-          max: 1.57998526096344,
-          min: 0.7407174706459045,
+          max: 1,
+          min: 0.5,
         },
         competenceLevel: 3,
       },
       {
         bounds: {
-          max: 2.226930856704712,
-          min: 1.57998526096344,
+          max: 2,
+          min: 1,
         },
         competenceLevel: 4,
       },
       {
         bounds: {
-          max: 4.622072219848633,
-          min: 2.226930856704712,
+          max: 3,
+          min: 2,
         },
         competenceLevel: 5,
       },
       {
         bounds: {
-          max: 4.048096656799316,
-          min: 4.622072219848633,
+          max: 4,
+          min: 3,
         },
         competenceLevel: 6,
       },
       {
         bounds: {
           max: Number.MAX_SAFE_INTEGER,
-          min: 4.048096656799316,
+          min: 4,
         },
         competenceLevel: 7,
       },
@@ -863,60 +919,66 @@ export const competenceLevelIntervals = [
     values: [
       {
         bounds: {
-          max: -0.8218916654586792,
+          max: -2,
           min: Number.MIN_SAFE_INTEGER,
         },
         competenceLevel: 0,
       },
       {
         bounds: {
-          max: -0.20230929553508759,
-          min: -0.8218916654586792,
+          max: -1,
+          min: -2,
         },
         competenceLevel: 1,
       },
       {
         bounds: {
-          max: 0.15905971825122833,
-          min: -0.20230929553508759,
+          max: 0.5,
+          min: -1,
         },
         competenceLevel: 2,
       },
       {
         bounds: {
-          max: 1.8799850940704346,
-          min: 0.15905971825122833,
+          max: 1,
+          min: 0.5,
         },
         competenceLevel: 3,
       },
       {
         bounds: {
-          max: 2.9971206188201904,
-          min: 1.8799850940704346,
+          max: 2,
+          min: 1,
         },
         competenceLevel: 4,
       },
       {
         bounds: {
-          max: 5.060043811798096,
-          min: 2.9971206188201904,
+          max: 3,
+          min: 2,
         },
         competenceLevel: 5,
       },
       {
         bounds: {
-          max: 4.473289489746094,
-          min: 5.060043811798096,
+          max: 4,
+          min: 3,
         },
         competenceLevel: 6,
       },
       {
         bounds: {
           max: Number.MAX_SAFE_INTEGER,
-          min: 4.473289489746094,
+          min: 4,
         },
         competenceLevel: 7,
       },
     ],
   },
 ];
+
+export const createCompetenceScoringConfiguration = ({ databaseBuilder }) => {
+  databaseBuilder.factory.buildCompetenceScoringConfiguration({
+    configuration,
+  });
+};

--- a/api/db/seeds/data/team-certification/data-builder.js
+++ b/api/db/seeds/data/team-certification/data-builder.js
@@ -10,6 +10,7 @@ import {
 } from '../common/common-builder.js';
 import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
 import { getV3CertificationChallenges } from '../common/tooling/learning-content.js';
+import { createCompetenceScoringConfiguration } from './create-competence-scoring-configuration.js';
 
 const TEAM_CERTIFICATION_OFFSET_ID = 7000;
 // IDS
@@ -59,6 +60,7 @@ async function teamCertificationDataBuilder({ databaseBuilder }) {
   await _createProCertificationCenter({ databaseBuilder });
   await _createComplementaryCertificationCampaign({ databaseBuilder });
   _createV3CertificationConfiguration({ databaseBuilder });
+  createCompetenceScoringConfiguration({ databaseBuilder });
   await _createV3PilotCertificationCenter({ databaseBuilder });
   await _createSuccessCertifiableUser({ databaseBuilder });
   await _createScoSession({ databaseBuilder });

--- a/api/server.js
+++ b/api/server.js
@@ -23,6 +23,7 @@ import {
 } from './src/certification/complementary-certification/routes.js';
 import { flashCertificationRoutes } from './src/certification/flash-certification/routes.js';
 import { certificationCourseRoutes } from './src/certification/course/routes.js';
+import { scoringRoutes } from './src/certification/scoring/routes.js';
 import { setupErrorHandling } from './config/server-setup-error-handling.js';
 
 import { learnerManagementRoutes } from './src/prescription/learner-management/routes.js';
@@ -46,6 +47,7 @@ const certificationRoutes = [
   attachTargetProfileRoutes,
   complementaryCertificationRoutes,
   certificationCourseRoutes,
+  scoringRoutes,
 ];
 
 const prescriptionRoutes = [

--- a/api/src/certification/scoring/application/competence-for-scoring-configuration-controller.js
+++ b/api/src/certification/scoring/application/competence-for-scoring-configuration-controller.js
@@ -1,0 +1,11 @@
+import { usecases } from '../../shared/domain/usecases/index.js';
+
+const saveCompetenceForScoringConfiguration = async (request, h) => {
+  const data = request.payload;
+  await usecases.saveCompetenceForScoringConfiguration({ data });
+  return h.response().code(201);
+};
+
+export const competenceForScoringConfigurationController = {
+  saveCompetenceForScoringConfiguration,
+};

--- a/api/src/certification/scoring/application/competence-for-scoring-configuration-route.js
+++ b/api/src/certification/scoring/application/competence-for-scoring-configuration-route.js
@@ -1,0 +1,48 @@
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
+import { competenceForScoringConfigurationController } from './competence-for-scoring-configuration-controller.js';
+import Joi from 'joi';
+
+const register = async (server) => {
+  server.route([
+    {
+      method: 'POST',
+      path: '/api/competence-for-scoring-configuration',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          payload: Joi.array()
+            .items(
+              Joi.object({
+                competence: Joi.string(),
+                values: Joi.array().items(
+                  Joi.object({
+                    bounds: Joi.object({
+                      max: Joi.number(),
+                      min: Joi.number(),
+                    }),
+                    competenceLevel: Joi.number(),
+                  }),
+                ),
+              }),
+            )
+            .required(),
+        },
+        handler: competenceForScoringConfigurationController.saveCompetenceForScoringConfiguration,
+        tags: ['api', 'competence-for-scoring-configuration'],
+        notes: [
+          '**Cette route est restreinte aux super-administrateurs** \n' +
+            "Création d'une nouvelle configuration de niveau par compétence pour la certification v3",
+        ],
+      },
+    },
+  ]);
+};
+
+const name = 'competence-for-scoring-configuration';
+
+export { register, name };

--- a/api/src/certification/scoring/domain/usecases/save-competence-for-scoring-configuration.js
+++ b/api/src/certification/scoring/domain/usecases/save-competence-for-scoring-configuration.js
@@ -1,0 +1,5 @@
+const saveCompetenceForScoringConfiguration = async ({ data, competenceForScoringRepository }) => {
+  await competenceForScoringRepository.save(data);
+};
+
+export { saveCompetenceForScoringConfiguration };

--- a/api/src/certification/scoring/infrastructure/repositories/competence-for-scoring-repository.js
+++ b/api/src/certification/scoring/infrastructure/repositories/competence-for-scoring-repository.js
@@ -2,6 +2,7 @@ import * as competenceRepository from '../../../../shared/infrastructure/reposit
 import * as areaRepository from '../../../../../lib/infrastructure/repositories/area-repository.js';
 import { competenceLevelIntervals } from '../../../flash-certification/domain/constants/competence-level-intervals.js';
 import { CompetenceForScoring } from '../../domain/models/CompetenceForScoring.js';
+import { knex } from '../../../../../db/knex-database-connection.js';
 
 export const listByLocale = async ({ locale }) => {
   const allAreas = await areaRepository.list();
@@ -17,4 +18,11 @@ export const listByLocale = async ({ locale }) => {
       intervals: values,
     });
   });
+};
+
+export const save = async (configuration) => {
+  const data = {
+    configuration: JSON.stringify(configuration),
+  };
+  await knex('competence-scoring-configurations').insert(data);
 };

--- a/api/src/certification/scoring/infrastructure/repositories/competence-for-scoring-repository.js
+++ b/api/src/certification/scoring/infrastructure/repositories/competence-for-scoring-repository.js
@@ -1,6 +1,5 @@
 import * as competenceRepository from '../../../../shared/infrastructure/repositories/competence-repository.js';
 import * as areaRepository from '../../../../../lib/infrastructure/repositories/area-repository.js';
-import { competenceLevelIntervals } from '../../../flash-certification/domain/constants/competence-level-intervals.js';
 import { CompetenceForScoring } from '../../domain/models/CompetenceForScoring.js';
 import { knex } from '../../../../../db/knex-database-connection.js';
 
@@ -8,7 +7,12 @@ export const listByLocale = async ({ locale }) => {
   const allAreas = await areaRepository.list();
   const competenceList = await competenceRepository.list({ locale });
 
-  return competenceLevelIntervals.map(({ competence: competenceCode, values }) => {
+  const competenceScoringConfiguration = await knex('competence-scoring-configurations')
+    .select('configuration')
+    .orderBy('createdAt', 'desc')
+    .first();
+
+  return competenceScoringConfiguration.configuration.map(({ competence: competenceCode, values }) => {
     const competence = competenceList.find(({ index: code }) => code === competenceCode);
     const area = allAreas.find((area) => area.id === competence.areaId);
     return new CompetenceForScoring({

--- a/api/src/certification/scoring/routes.js
+++ b/api/src/certification/scoring/routes.js
@@ -1,0 +1,5 @@
+import * as competenceForScoringConfiguration from './application/competence-for-scoring-configuration-route.js';
+
+const scoringRoutes = [competenceForScoringConfiguration];
+
+export { scoringRoutes };

--- a/api/src/certification/shared/domain/usecases/index.js
+++ b/api/src/certification/shared/domain/usecases/index.js
@@ -151,6 +151,9 @@ const usecasesWithoutInjectedDependencies = {
     path: join(path, '../../../flash-certification/domain/usecases/'),
   })),
   ...(await importNamedExportsFromDirectory({
+    path: join(path, '../../../scoring/domain/usecases/'),
+  })),
+  ...(await importNamedExportsFromDirectory({
     path: join(path, '../../../course/domain/usecases/'),
     ignoredFileNames: ['index.js', 'update-jury-comments.js', 'get-sco-certification-results-by-division.js'],
   })),

--- a/api/tests/certification/scoring/acceptance/application/competence-for-scoring-configuration-route_test.js
+++ b/api/tests/certification/scoring/acceptance/application/competence-for-scoring-configuration-route_test.js
@@ -1,0 +1,142 @@
+import {
+  createServer,
+  databaseBuilder,
+  expect,
+  generateValidRequestAuthorizationHeader,
+  knex,
+} from '../../../../test-helper.js';
+import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
+
+describe('Acceptance | Application | competence-for-scoring-configuration-route', function () {
+  let server;
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('POST /api/competence-for-scoring-configuration', function () {
+    describe('when called without being authenticated', function () {
+      it('should return a 401', async function () {
+        // given
+        const options = {
+          method: 'POST',
+          url: '/api/competence-for-scoring-configuration',
+        };
+        // when
+        const response = await server.inject(options);
+        // then
+        expect(response.statusCode).to.equal(401);
+      });
+    });
+
+    describe('when called without a super admin role', function () {
+      it('should return a 403', async function () {
+        // given
+        const authorization = generateValidRequestAuthorizationHeader();
+
+        const options = {
+          method: 'POST',
+          url: '/api/competence-for-scoring-configuration',
+          headers: {
+            authorization,
+          },
+          payload: [
+            {
+              competence: '1.1',
+              values: [
+                {
+                  bounds: {
+                    max: -2.2,
+                    min: -9.8,
+                  },
+                  competenceLevel: 0,
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+
+    describe('when called with a super admin role', function () {
+      describe('when called with an invalid payload', function () {
+        it('should return a 400', async function () {
+          // given
+          const superAdmin = databaseBuilder.factory.buildUser.withRole({
+            role: PIX_ADMIN.ROLES.SUPER_ADMIN,
+          });
+
+          await databaseBuilder.commit();
+
+          const authorization = generateValidRequestAuthorizationHeader(superAdmin.id);
+
+          const options = {
+            method: 'POST',
+            url: '/api/competence-for-scoring-configuration',
+            headers: {
+              authorization,
+            },
+            payload: {
+              lol: 0.5,
+            },
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+      });
+
+      describe('when called with a valid payload', function () {
+        it('should return a 204 and update the configuration', async function () {
+          // given
+          const superAdmin = databaseBuilder.factory.buildUser.withRole({
+            role: PIX_ADMIN.ROLES.SUPER_ADMIN,
+          });
+
+          await databaseBuilder.commit();
+
+          const authorization = generateValidRequestAuthorizationHeader(superAdmin.id);
+
+          const options = {
+            method: 'POST',
+            url: '/api/competence-for-scoring-configuration',
+            headers: {
+              authorization,
+            },
+            payload: [
+              {
+                competence: '1.1',
+                values: [
+                  {
+                    bounds: {
+                      max: -2.2,
+                      min: -9.8,
+                    },
+                    competenceLevel: 0,
+                  },
+                ],
+              },
+            ],
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(201);
+
+          const configurations = await knex('competence-scoring-configurations');
+          expect(configurations.length).to.equal(1);
+        });
+      });
+    });
+  });
+});

--- a/api/tests/certification/scoring/integration/application/competence-for-scoring-configuration-controller_test.js
+++ b/api/tests/certification/scoring/integration/application/competence-for-scoring-configuration-controller_test.js
@@ -1,0 +1,29 @@
+import { competenceForScoringConfigurationController } from '../../../../../src/certification/scoring/application/competence-for-scoring-configuration-controller.js';
+import { sinon, expect, hFake } from '../../../../test-helper.js';
+import { usecases } from '../../../../../src/certification/shared/domain/usecases/index.js';
+
+describe('Integration | Application | CompetenceForScoringConfigurationController', function () {
+  describe('#saveCompetenceForScoringConfiguration', function () {
+    it('should save the competence for scoring configuration', async function () {
+      sinon.stub(usecases, 'saveCompetenceForScoringConfiguration');
+
+      const request = {
+        payload: {
+          data: {
+            warmUpLength: 12,
+          },
+        },
+      };
+
+      const response = await competenceForScoringConfigurationController.saveCompetenceForScoringConfiguration(
+        request,
+        hFake,
+      );
+
+      expect(response.statusCode).to.equal(201);
+      expect(usecases.saveCompetenceForScoringConfiguration).to.have.been.calledWith({
+        data: request.payload,
+      });
+    });
+  });
+});

--- a/api/tests/certification/scoring/integration/infrastructure/repositories/competence-for-scoring-repository_test.js
+++ b/api/tests/certification/scoring/integration/infrastructure/repositories/competence-for-scoring-repository_test.js
@@ -3,43 +3,41 @@ import { buildArea, buildCompetence, buildFramework } from '../../../../../tooli
 import { buildLearningContent } from '../../../../../tooling/learning-content-builder/index.js';
 import { competenceLevelIntervals } from '../../../../../../src/certification/flash-certification/domain/constants/competence-level-intervals.js';
 import _ from 'lodash';
-import { listByLocale } from '../../../../../../src/certification/scoring/infrastructure/repositories/competence-for-scoring-repository.js';
+import {
+  listByLocale,
+  save,
+} from '../../../../../../src/certification/scoring/infrastructure/repositories/competence-for-scoring-repository.js';
 import { CompetenceForScoring } from '../../../../../../src/certification/scoring/domain/models/CompetenceForScoring.js';
+import { knex } from '../../../../../../db/knex-database-connection.js';
 
 describe('Unit | Repository | competence-for-scoring-repository', function () {
-  beforeEach(function () {
-    const frameworkId = 'frameworkId';
-
-    const getAreaCode = (competenceCode) => competenceCode.split('.').shift();
-    const competenceLevelIntervalsWithAreaCode = competenceLevelIntervals.map((competenceLevelInterval) => ({
-      ...competenceLevelInterval,
-      areaCode: getAreaCode(competenceLevelInterval.competence),
-    }));
-
-    const competenceLevelIntervalsByArea = _.groupBy(competenceLevelIntervalsWithAreaCode, 'areaCode');
-
-    const areas = Object.entries(competenceLevelIntervalsByArea).map(([areaCode, competenceLevelIntervals]) => {
-      const areaId = `recArea${areaCode}`;
-
-      const competences = competenceLevelIntervals.map((competenceLevelInterval) => {
-        const competenceIndex = competenceLevelInterval.competence;
-        const competenceId = `recCompetence${competenceIndex}`;
-
-        return buildCompetence({ id: competenceId, areaId, index: competenceIndex });
-      });
-
-      return buildArea({ id: areaId, frameworkId, code: areaCode, competences });
-    });
-
-    const framework = buildFramework({ id: frameworkId, name: 'someFramework', areas });
-
-    const learningContent = buildLearningContent([framework]);
-
-    mockLearningContent(learningContent);
-  });
-
   describe('#listByLocale', function () {
     it('should return a list of competences for scoring', async function () {
+      // given
+      const frameworkId = 'frameworkId';
+      const getAreaCode = (competenceCode) => competenceCode.split('.').shift();
+      const competenceLevelIntervalsWithAreaCode = competenceLevelIntervals.map((competenceLevelInterval) => ({
+        ...competenceLevelInterval,
+        areaCode: getAreaCode(competenceLevelInterval.competence),
+      }));
+      const competenceLevelIntervalsByArea = _.groupBy(competenceLevelIntervalsWithAreaCode, 'areaCode');
+      const areas = Object.entries(competenceLevelIntervalsByArea).map(([areaCode, competenceLevelIntervals]) => {
+        const areaId = `recArea${areaCode}`;
+
+        const competences = competenceLevelIntervals.map((competenceLevelInterval) => {
+          const competenceIndex = competenceLevelInterval.competence;
+          const competenceId = `recCompetence${competenceIndex}`;
+
+          return buildCompetence({ id: competenceId, areaId, index: competenceIndex });
+        });
+
+        return buildArea({ id: areaId, frameworkId, code: areaCode, competences });
+      });
+      const framework = buildFramework({ id: frameworkId, name: 'someFramework', areas });
+      const learningContent = buildLearningContent([framework]);
+
+      mockLearningContent(learningContent);
+
       // when
       const resultList = await listByLocale({ locale: 'fr-fr' });
 
@@ -48,6 +46,21 @@ describe('Unit | Repository | competence-for-scoring-repository', function () {
         expect(result).to.be.instanceOf(CompetenceForScoring);
       });
       expect(resultList.length).to.equal(16);
+    });
+  });
+
+  describe('#save', function () {
+    it('should save a configuration for competence scoring', async function () {
+      // given
+      const data = { some: 'data' };
+
+      // when
+      await save(data);
+
+      // then
+      const configurations = await knex('competence-scoring-configurations');
+      expect(configurations.length).to.equal(1);
+      expect(configurations[0].configuration).to.deep.equal({ some: 'data' });
     });
   });
 });

--- a/api/tests/certification/scoring/integration/infrastructure/repositories/competence-for-scoring-repository_test.js
+++ b/api/tests/certification/scoring/integration/infrastructure/repositories/competence-for-scoring-repository_test.js
@@ -1,7 +1,6 @@
-import { expect, mockLearningContent } from '../../../../../test-helper.js';
+import { databaseBuilder, expect, mockLearningContent } from '../../../../../test-helper.js';
 import { buildArea, buildCompetence, buildFramework } from '../../../../../tooling/domain-builder/factory/index.js';
 import { buildLearningContent } from '../../../../../tooling/learning-content-builder/index.js';
-import { competenceLevelIntervals } from '../../../../../../src/certification/flash-certification/domain/constants/competence-level-intervals.js';
 import _ from 'lodash';
 import {
   listByLocale,
@@ -15,8 +14,23 @@ describe('Unit | Repository | competence-for-scoring-repository', function () {
     it('should return a list of competences for scoring', async function () {
       // given
       const frameworkId = 'frameworkId';
+
+      const configuration = [
+        {
+          competence: '1.1',
+          values: [
+            {
+              bounds: {
+                max: -2.2,
+                min: -9.8,
+              },
+              competenceLevel: 0,
+            },
+          ],
+        },
+      ];
       const getAreaCode = (competenceCode) => competenceCode.split('.').shift();
-      const competenceLevelIntervalsWithAreaCode = competenceLevelIntervals.map((competenceLevelInterval) => ({
+      const competenceLevelIntervalsWithAreaCode = configuration.map((competenceLevelInterval) => ({
         ...competenceLevelInterval,
         areaCode: getAreaCode(competenceLevelInterval.competence),
       }));
@@ -38,6 +52,10 @@ describe('Unit | Repository | competence-for-scoring-repository', function () {
 
       mockLearningContent(learningContent);
 
+      databaseBuilder.factory.buildCompetenceScoringConfiguration({ configuration });
+
+      await databaseBuilder.commit();
+
       // when
       const resultList = await listByLocale({ locale: 'fr-fr' });
 
@@ -45,7 +63,7 @@ describe('Unit | Repository | competence-for-scoring-repository', function () {
       resultList.map((result) => {
         expect(result).to.be.instanceOf(CompetenceForScoring);
       });
-      expect(resultList.length).to.equal(16);
+      expect(resultList.length).to.equal(1);
     });
   });
 

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
@@ -394,6 +394,30 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
       state: Assessment.states.STARTED,
     });
 
+    databaseBuilder.factory.buildCompetenceScoringConfiguration({
+      configuration: [
+        {
+          competence: '1.1',
+          values: [
+            {
+              bounds: {
+                max: 0,
+                min: Number.MIN_SAFE_INTEGER,
+              },
+              competenceLevel: 0,
+            },
+            {
+              bounds: {
+                max: Number.MAX_SAFE_INTEGER,
+                min: 0,
+              },
+              competenceLevel: 1,
+            },
+          ],
+        },
+      ],
+    });
+
     await databaseBuilder.commit();
 
     options = {
@@ -680,7 +704,12 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
   });
 });
 
-function _buildValidAnswersAndCertificationChallenges({ certificationCourseId, assessmentId, difficulty = 0 }) {
+function _buildValidAnswersAndCertificationChallenges({
+  certificationCourseId,
+  assessmentId,
+  difficulty = 0,
+  competenceId = 'recCompetence0',
+}) {
   const answers = _.flatten(
     _.range(0, 3).map((skillIndex) =>
       _.range(0, 3).map((level) => {
@@ -696,6 +725,7 @@ function _buildValidAnswersAndCertificationChallenges({ certificationCourseId, a
   const certificationChallenges = answers.map(({ challengeId }) =>
     databaseBuilder.factory.buildCertificationChallenge({
       challengeId,
+      competenceId,
       courseId: certificationCourseId,
       difficulty,
       discriminant: 2,


### PR DESCRIPTION
## :unicorn: Problème
Les niveaux par compétences sont présents en dur dans le code

## :robot: Proposition
Ajouter une table pour enregistrer les niveaux fournis par DATA avec une requête CurL

## :100: Pour tester

Pour créer une configuration

```
TOKEN=$(curl 'https://api-pr8092.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr8092.review.pix.fr/api/competence-for-scoring-configuration \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d @<jsonFilePath>
```    
    
Exemple de schéma à importer :

```
[
    {
        "competence": "1.1",
        "values": [
            {
                "bounds": {
                    "max": -2.123,
                    "min": -6.789,
                },
                "competenceLevel": 0
            },
            {
                "bounds": {
                    "max": -1.234,
                    "min": -5.678,
                },
                "competenceLevel": 1
            },
       ],
]
```
   