### PR TITLE
[FEATURE] créer la table organization-imports (PIX-11255)

### DIFF
--- a/api/db/migrations/20240216103739_create-organization-imports.js
+++ b/api/db/migrations/20240216103739_create-organization-imports.js
@@ -1,0 +1,29 @@
+const TABLE_NAME = 'organization-imports';
+
+const up = async function (knex) {
+  await knex.schema.raw(`CREATE TYPE "organization-imports-statuses" AS ENUM ( 'UPLOADED',
+	'VALIDATED',
+	'IMPORTED',
+	'VALIDATION_ERROR',
+	'IMPORT_ERROR'
+);`);
+
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.increments('id').primary().notNullable();
+    table.specificType('status', '"organization-imports-statuses"');
+    table.text('filename').notNullable();
+    table.text('encoding').nullable();
+    table.jsonb('errors').nullable();
+    table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    table.bigInteger('createdBy').notNullable().index().references('users.id');
+    table.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
+    table.integer('organizationId').notNullable().unsigned().references('organizations.id').index();
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+  await knex.schema.raw(`DROP TYPE "organization-imports-statuses"`);
+};
+
+export { up, down };


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la refonte technique des imports, nous avons besoin de rendre asynchrone les différentes parties du processus (upload, validation du fichier et traitement des données). Nous avons besoin de garder informer l'utilisateur tout au long du processus. L'import n'étant plus asynchrone on doit pouvoir différer dans le temps les informations que nous fournissons aux utilisateurs. Il faut donc qu'on soit mesure de stocker les informations relatives aux imports.

## :robot: Proposition
Ajoute une table organization-imports dans laquelle on va stocker les informations relative aux imports. Notamment, qui a fait la demande pour quel organisation et l'état en cours de l'import et les informations relatives comme les erreurs.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- La migration s'effectue correctement