### PR TITLE
[BUGFIX] Mise à jour des seeds pour la configuration de la certif v3 (PIX-11278)

### DIFF
--- a/api/db/seeds/data/team-certification/data-builder.js
+++ b/api/db/seeds/data/team-certification/data-builder.js
@@ -118,7 +118,7 @@ function _createV3CertificationConfiguration({ databaseBuilder }) {
     doubleMeasuresUntil: null,
     variationPercent: 0.5,
     variationPercentUntil: null,
-    createdAt: new Date('2022-01-01'),
+    createdAt: new Date('1977-10-19'),
   });
 }
 


### PR DESCRIPTION
## :unicorn: Problème
En dev, la configuration a une date de création trop récente pour des certifications créées avant 2022, empêchant l'affichage de la page de détails dans admin

## :robot: Proposition
Modification de la date de création à la date de sortie du premier Star Wars (1977)

## :rainbow: Remarques
Aucune certification n'a été créée en 1977

## :100: Pour tester
- Dans admin, aller dans la page de détails d'une certif V3
- Cliquer sur l'onglet Détails
- Vérifier que les détails s'affichent