### PR TITLE
[FEATURE] Créé des scripts pour générer des élements Modulix (PIX-11270)

### DIFF
--- a/api/scripts/modulix/get-sample-image-element.js
+++ b/api/scripts/modulix/get-sample-image-element.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import { getImageSample } from '../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/image.sample.js';
 
 console.log('');

--- a/api/scripts/modulix/get-sample-image-element.js
+++ b/api/scripts/modulix/get-sample-image-element.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+import { getImageSample } from '../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/image.sample.js';
+
+console.log('');
+console.log(JSON.stringify(getImageSample(), null, 2));
+console.log('');
+console.log('Voici un joli élément image. Pensez à remplir les alternatives !');

--- a/api/scripts/modulix/get-sample-qcm-element.js
+++ b/api/scripts/modulix/get-sample-qcm-element.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import { getQcmSample } from '../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/qcm.sample.js';
 
 console.log('');

--- a/api/scripts/modulix/get-sample-qcm-element.js
+++ b/api/scripts/modulix/get-sample-qcm-element.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+import { getQcmSample } from '../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/qcm.sample.js';
+
+console.log('');
+console.log(JSON.stringify(getQcmSample(), null, 2));
+console.log('');
+console.log('Voici un petit QCM.');

--- a/api/scripts/modulix/get-sample-qcu-element.js
+++ b/api/scripts/modulix/get-sample-qcu-element.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+import { getQcuSample } from '../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/qcu.sample.js';
+
+console.log('');
+console.log(JSON.stringify(getQcuSample(), null, 2));
+console.log('');
+console.log('Voici un QCU.');

--- a/api/scripts/modulix/get-sample-qcu-element.js
+++ b/api/scripts/modulix/get-sample-qcu-element.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import { getQcuSample } from '../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/qcu.sample.js';
 
 console.log('');

--- a/api/scripts/modulix/get-sample-qrocm-element.js
+++ b/api/scripts/modulix/get-sample-qrocm-element.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+import { getQrocmSample } from '../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/qrocm.sample.js';
+
+console.log('');
+console.log(JSON.stringify(getQrocmSample(), null, 2));
+console.log('');
+console.log('Voici un QROCM. Bon courage pour la contrib !');

--- a/api/scripts/modulix/get-sample-qrocm-element.js
+++ b/api/scripts/modulix/get-sample-qrocm-element.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import { getQrocmSample } from '../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/qrocm.sample.js';
 
 console.log('');

--- a/api/scripts/modulix/get-sample-text-element.js
+++ b/api/scripts/modulix/get-sample-text-element.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+import { getTextSample } from '../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/text.sample.js';
+
+console.log('');
+console.log(JSON.stringify(getTextSample(), null, 2));
+console.log('');
+console.log('Voici un petit texte.');

--- a/api/scripts/modulix/get-sample-text-element.js
+++ b/api/scripts/modulix/get-sample-text-element.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import { getTextSample } from '../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/text.sample.js';
 
 console.log('');

--- a/api/scripts/modulix/get-sample-video-element.js
+++ b/api/scripts/modulix/get-sample-video-element.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import { getVideoSample } from '../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/video.sample.js';
 
 console.log('');

--- a/api/scripts/modulix/get-sample-video-element.js
+++ b/api/scripts/modulix/get-sample-video-element.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+import { getVideoSample } from '../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/video.sample.js';
+
+console.log('');
+console.log(JSON.stringify(getVideoSample(), null, 2));
+console.log('');
+console.log("Voici un joli élément vidéo. N'oubliez pas de compléter la transcription !");

--- a/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/image.sample.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/image.sample.js
@@ -1,0 +1,11 @@
+import { randomUUID } from 'node:crypto';
+
+export function getImageSample() {
+  return {
+    id: randomUUID(),
+    type: 'image',
+    url: 'https://images.pix.fr/modulix/placeholder-image.svg',
+    alt: '',
+    alternativeText: '',
+  };
+}

--- a/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/qcm.sample.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/qcm.sample.js
@@ -1,0 +1,18 @@
+import { randomUUID } from 'node:crypto';
+
+export function getQcmSample(nbOfProposals = 3) {
+  return {
+    id: randomUUID(),
+    type: 'qcm',
+    instruction: '<p>Une question à choix multiples ?</p>',
+    proposals: Array.from(Array(nbOfProposals)).map((_, i) => ({
+      id: `${i + 1}`,
+      content: `Proposition ${i + 1}`,
+    })),
+    feedbacks: {
+      valid: '<p>Correct !</p>',
+      invalid: '<p>Incorrect !</p>',
+    },
+    solutions: ['1', '2'],
+  };
+}

--- a/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/qcu.sample.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/qcu.sample.js
@@ -1,0 +1,18 @@
+import { randomUUID } from 'node:crypto';
+
+export function getQcuSample(nbOfProposals = 3) {
+  return {
+    id: randomUUID(),
+    type: 'qcu',
+    instruction: '<p>Une question à choix unique ?</p>',
+    proposals: Array.from(Array(nbOfProposals)).map((_, i) => ({
+      id: `${i + 1}`,
+      content: `Proposition ${i + 1}`,
+    })),
+    feedbacks: {
+      valid: '<p>Correct !</p>',
+      invalid: '<p>Incorrect !</p>',
+    },
+    solution: '1',
+  };
+}

--- a/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/qrocm.sample.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/qrocm.sample.js
@@ -1,0 +1,59 @@
+import { randomUUID } from 'node:crypto';
+
+export function getQrocmSample() {
+  return {
+    id: randomUUID(),
+    type: 'qrocm',
+    instruction: '<p>Complétez le texte ci-dessous.</p>',
+    proposals: [
+      {
+        type: 'text',
+        content: "<p>Il est possible d'utiliser des textes à champs libres&nbsp;:</p>",
+      },
+      {
+        input: 'symbole-separateur-email',
+        type: 'input',
+        inputType: 'text',
+        size: 1,
+        display: 'inline',
+        placeholder: '',
+        ariaLabel: "Remplir avec le caractère qui permet de séparer les deux parties d'une adresse mail",
+        defaultValue: '',
+        tolerances: ['t1'],
+        solutions: ['@'],
+      },
+      {
+        type: 'text',
+        content: '<p>On peut aussi utiliser des liste déroulantes&nbsp;:</p>',
+      },
+      {
+        input: 'modulix',
+        type: 'select',
+        display: 'inline',
+        placeholder: '',
+        ariaLabel: "Choisir l'adjectif le plus adapté",
+        defaultValue: '',
+        tolerances: [],
+        options: [
+          {
+            id: '1',
+            content: 'Génial',
+          },
+          {
+            id: '2',
+            content: 'Incroyable',
+          },
+          {
+            id: '2',
+            content: 'Légendaire',
+          },
+        ],
+        solutions: ['3'],
+      },
+    ],
+    feedbacks: {
+      valid: '<p>Correct !</p>',
+      invalid: '<p>Incorrect !</p>',
+    },
+  };
+}

--- a/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/text.sample.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/text.sample.js
@@ -1,0 +1,9 @@
+import { randomUUID } from 'node:crypto';
+
+export function getTextSample() {
+  return {
+    id: randomUUID(),
+    type: 'text',
+    content: "<p>Ceci est un texte qui accepte de l'HTML.</p>",
+  };
+}

--- a/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/video.sample.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/video.sample.js
@@ -1,0 +1,12 @@
+import { randomUUID } from 'node:crypto';
+
+export function getVideoSample() {
+  return {
+    id: randomUUID(),
+    type: 'video',
+    title: 'Une vidéo',
+    url: 'https://videos.pix.fr/modulix/placeholder-video.mp4',
+    subtitles: 'https://videos.pix.fr/modulix/placeholder-video.vtt',
+    transcription: '<p>Vidéo manquante</p>',
+  };
+}

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -1,0 +1,65 @@
+import { expect } from '../../../../../../test-helper.js';
+import {
+  imageElementSchema,
+  qcmElementSchema,
+  qcuElementSchema,
+  qrocmElementSchema,
+  textElementSchema,
+  videoElementSchema,
+} from './element/index.js';
+import { getImageSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/image.sample.js';
+import { getQcmSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/qcm.sample.js';
+import { getQcuSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/qcu.sample.js';
+import { getQrocmSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/qrocm.sample.js';
+import { getTextSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/text.sample.js';
+import { getVideoSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/video.sample.js';
+
+describe('Unit | Infrastructure | Datasources | Learning Content | Module Datasource | format validation', function () {
+  it('should validate sample image structure', function () {
+    // When
+    const result = imageElementSchema.validate(getImageSample());
+
+    // Then
+    expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));
+  });
+
+  it('should validate sample qcm structure', function () {
+    // When
+    const result = qcmElementSchema.validate(getQcmSample());
+
+    // Then
+    expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));
+  });
+
+  it('should validate sample qcu structure', function () {
+    // When
+    const result = qcuElementSchema.validate(getQcuSample());
+
+    // Then
+    expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));
+  });
+
+  it('should validate sample qrocm structure', function () {
+    // When
+    const result = qrocmElementSchema.validate(getQrocmSample());
+
+    // Then
+    expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));
+  });
+
+  it('should validate sample text structure', function () {
+    // When
+    const result = textElementSchema.validate(getTextSample());
+
+    // Then
+    expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));
+  });
+
+  it('should validate sample video structure', function () {
+    // When
+    const result = videoElementSchema.validate(getVideoSample());
+
+    // Then
+    expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
La contribution aux Modulix est un peu limitée pour le moment :
- il faut générer des UUID très régulièrement,
- on ne peut pas retenir le format de chaque élément
  * du coup les éléments sont copiés-collés puis modifiés avec des oublis possibles...
- JSON n'aide pas à la contribution pour des personnes moins techniques.

## :robot: Proposition
Donner accès à des scripts dans l'API pour générer des éléments : 
```shell
# Générer un élément "texte"
node ./api/scripts/modulix/get-sample-text-element.js

# Générer un élément "image"
node ./api/scripts/modulix/get-sample-image-element.js

# Générer un élément "vidéo"
node ./api/scripts/modulix/get-sample-video-element.js

# Générer un élément "QCU"
node ./api/scripts/modulix/get-sample-qcu-element.js

# Générer un élément "QROCM"
node ./api/scripts/modulix/get-sample-qrocm-element.js

# Générer un élément "QCM"
node ./api/scripts/modulix/get-sample-qcm-element.js
```

Chacun de ces scripts renvoie l'élément demandé au format à jour avec un nouvel UUID :sparkles: .

Il est aussi possible de copier directement en ajoutant ` | pbcopy` (sur Mac). Une ligne complète donne donc :

```shell
node ./api/scripts/modulix/get-sample-qcm-element.js | pbcopy
```

## :rainbow: Remarques
J'avais prévu initialement de permettre l'usage de script directement en bash grâce à l'usage du shebang mais notre linter nous en empêche. À voir une fois que nous seront passé dans la version 17 de `n` [si l'option `ignoreUnpublished` nous permet de mettre ça en place](https://github.com/eslint-community/eslint-plugin-n/pull/172).

## :100: Pour tester
Récupérer la branche en local et vérifier que chaque script génère bien le bon type d'élément !
