### PR TITLE
[TECH] Utiliser les bon arguments couleurs sur les PixButton dans PixCertif (Pix-11287)

### DIFF
--- a/certif/app/components/select-referer-modal.hbs
+++ b/certif/app/components/select-referer-modal.hbs
@@ -34,7 +34,7 @@
         @triggerAction={{@onValidateReferer}}
         @loadingColor="white"
         @isDisabled={{@noSelectedReferer}}
-        @backgroundColor="blue"
+        @backgroundColor="primary"
       >
         {{t "pages.team.select-referer-modal.actions.validate"}}
       </PixButton>

--- a/certif/app/components/session-delete-confirm-modal.hbs
+++ b/certif/app/components/session-delete-confirm-modal.hbs
@@ -35,7 +35,7 @@
       aria-label={{t "pages.sessions.list.delete-modal.actions.confirm.extra-information"}}
       @triggerAction={{@confirm}}
       @loadingColor="white"
-      @backgroundColor="blue"
+      @backgroundColor="primary"
     >
       {{t "common.actions.delete"}}
     </PixButton>

--- a/certif/app/components/session-supervising/confirmation-modal.hbs
+++ b/certif/app/components/session-supervising/confirmation-modal.hbs
@@ -15,7 +15,7 @@
     <PixButton
       data-test-id="finalize-session-modal__confirm-button"
       @triggerAction={{@actionOnConfirmation}}
-      @backgroundColor="yellow"
+      @backgroundColor="secondary"
     >
       {{@modalConfirmationButtonText}}
     </PixButton>

--- a/certif/app/components/session-supervising/handle-live-alert-modal.hbs
+++ b/certif/app/components/session-supervising/handle-live-alert-modal.hbs
@@ -30,7 +30,7 @@
           <PixButton @backgroundColor="red" @triggerAction={{this.onReject}}>
             {{t "pages.session-supervising.candidate-in-list.handle-live-alert-modal.ask.dismiss-alert-button"}}
           </PixButton>
-          <PixButton @backgroundColor="green" @type="submit" @isDisabled={{this.isValidateButtonDisabled}}>
+          <PixButton @backgroundColor="success" @type="submit" @isDisabled={{this.isValidateButtonDisabled}}>
             {{t "pages.session-supervising.candidate-in-list.handle-live-alert-modal.ask.validate-alert-button"}}
           </PixButton>
         </div>

--- a/certif/app/components/session-supervising/handle-live-alert-modal.hbs
+++ b/certif/app/components/session-supervising/handle-live-alert-modal.hbs
@@ -27,7 +27,7 @@
           </p>
         </div>
         <div class="handle-live-alert-modal__actions-list">
-          <PixButton @backgroundColor="red" @triggerAction={{this.onReject}}>
+          <PixButton @backgroundColor="error" @triggerAction={{this.onReject}}>
             {{t "pages.session-supervising.candidate-in-list.handle-live-alert-modal.ask.dismiss-alert-button"}}
           </PixButton>
           <PixButton @backgroundColor="success" @type="submit" @isDisabled={{this.isValidateButtonDisabled}}>

--- a/certif/app/templates/authenticated/sessions/details/parameters.hbs
+++ b/certif/app/templates/authenticated/sessions/details/parameters.hbs
@@ -116,7 +116,7 @@
 
   <div class="session-details-buttons">
     {{#if this.sessionHasStarted}}
-      <PixButtonLink @route="authenticated.sessions.update" @model={{this.session.id}} @backgroundColor="grey">
+      <PixButtonLink @route="authenticated.sessions.update" @model={{this.session.id}} @backgroundColor="neutral">
         {{t "common.actions.update"}}
       </PixButtonLink>
       {{#if this.session.isFinalized}}


### PR DESCRIPTION
## :unicorn: Problème
Pareil que pour Pix APP / Admin / Orga . On utilise des valeurs déprécié.

## :robot: Proposition
ça suffit

## :rainbow: Remarques
RAS

## :100: Pour tester
Faire un tour de pix certif et vérifier que tout va bien