### PR TITLE
[BUGFIX] Autoriser le champ participantExternalId à s'afficher sur plusieurs ligne (PIX-11288)

### DIFF
--- a/orga/app/components/campaign/activity/participants-list.hbs
+++ b/orga/app/components/campaign/activity/participants-list.hbs
@@ -19,7 +19,7 @@
         <col class="table__column--wide" />
         <col class="table__column--wide" />
         {{#if @campaign.idPixLabel}}
-          <col class="table__column--wide" />
+          <col class="table__column--medium" />
         {{/if}}
         <col class="table__column--wide" />
         {{#if @showParticipationCount}}
@@ -84,7 +84,7 @@
               </td>
               <td>{{participation.firstName}}</td>
               {{#if @campaign.idPixLabel}}
-                <td>{{participation.participantExternalId}}</td>
+                <td class="table__column table__column--break-word">{{participation.participantExternalId}}</td>
               {{/if}}
               <td>
                 <Ui::ParticipationStatus @status={{participation.status}} @campaignType={{@campaign.type}} />

--- a/orga/app/components/campaign/results/assessment-list.hbs
+++ b/orga/app/components/campaign/results/assessment-list.hbs
@@ -20,7 +20,7 @@
         <col />
         <col />
         {{#if @campaign.idPixLabel}}
-          <col />
+          <col class="table__column--medium" />
         {{/if}}
         <col />
         {{#if @campaign.hasBadges}}

--- a/orga/app/components/campaign/results/assessment-row.hbs
+++ b/orga/app/components/campaign/results/assessment-row.hbs
@@ -10,7 +10,7 @@
   </td>
   <td>{{@participation.firstName}}</td>
   {{#if @hasExternalId}}
-    <td>{{@participation.participantExternalId}}</td>
+    <td class="table__column table__column--break-word">{{@participation.participantExternalId}}</td>
   {{/if}}
   <td>
     <Ui::MasteryPercentageDisplay

--- a/orga/app/components/campaign/results/profile-list.hbs
+++ b/orga/app/components/campaign/results/profile-list.hbs
@@ -19,7 +19,7 @@
         <col />
         <col />
         {{#if @campaign.idPixLabel}}
-          <col />
+          <col class="table__column--medium" />
         {{/if}}
         <col />
         <col />
@@ -62,7 +62,7 @@
               </td>
               <td>{{profile.firstName}}</td>
               {{#if @campaign.idPixLabel}}
-                <td>{{profile.participantExternalId}}</td>
+                <td class="table__column table__column--break-word">{{profile.participantExternalId}}</td>
               {{/if}}
               <td class="table__column--center">
                 {{#if profile.sharedAt}}

--- a/orga/app/styles/globals/tables.scss
+++ b/orga/app/styles/globals/tables.scss
@@ -134,6 +134,10 @@ th::first-letter {
     max-width: 150px;
   }
 
+  &--break-word {
+    word-break: break-all;
+  }
+
   &--medium {
     width: 15%;
   }


### PR DESCRIPTION
## :unicorn: Problème
Si un partitipantExternalId est trop long ( space ou hyphen ) il passe sur les autres colonnes ce qui n'est pas tip top

## :robot: Proposition
Permettre au participant externalId de s'afficher sur plusieurs dans le cas ou les espaces ne sont pas possible

## :rainbow: Remarques
RAS

## :100: Pour tester
Modifier dans PixAdmin un participant externalId super long. et voir que tout va bien dans PixOrga