### PR TITLE
[FEATURE] Créer une route pour tester l'algorithme Smart Random (PIX-11177).

### DIFF
--- a/api/src/evaluation/application/smart-random-simulator/index.js
+++ b/api/src/evaluation/application/smart-random-simulator/index.js
@@ -1,0 +1,105 @@
+import Joi from 'joi';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
+import { smartRandomSimulatorController } from './smart-random-simulator-controller.js';
+import { AnswerStatus, KnowledgeElement } from '../../../../lib/domain/models/index.js';
+import { LOCALE } from '../../../shared/domain/constants.js';
+import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'POST',
+      path: '/api/admin/smart-random-simulator/get-next-challenge',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          payload: Joi.object({
+            data: {
+              attributes: {
+                'knowledge-elements': Joi.array()
+                  .items({
+                    source: Joi.string()
+                      .valid(KnowledgeElement.SourceType.DIRECT, KnowledgeElement.SourceType.INFERRED)
+                      .required(),
+                    status: Joi.string()
+                      .valid(
+                        KnowledgeElement.StatusType.VALIDATED,
+                        KnowledgeElement.StatusType.INVALIDATED,
+                        KnowledgeElement.StatusType.RESET,
+                      )
+                      .required(),
+                    'answer-id': identifiersType.answerId,
+                    'skill-id': identifiersType.skillId,
+                  })
+                  .min(1)
+                  .required(),
+                answers: Joi.array().items({
+                  result: Joi.string()
+                    .valid(
+                      AnswerStatus.statuses.OK,
+                      AnswerStatus.statuses.KO,
+                      AnswerStatus.statuses.SKIPPED,
+                      AnswerStatus.statuses.FOCUSEDOUT,
+                      AnswerStatus.statuses.PARTIALLY,
+                    )
+                    .required(),
+                  'challenge-id': identifiersType.challengeId,
+                }),
+                skills: Joi.array()
+                  .items({
+                    id: identifiersType.skillId,
+                    difficulty: Joi.number().integer().min(1).max(8).required(),
+                    name: Joi.string().required(),
+                  })
+                  .required(),
+                challenges: Joi.array()
+                  .items({
+                    id: identifiersType.challengeId,
+                    skill: {
+                      id: identifiersType.skillId,
+                      name: Joi.string().required(),
+                    },
+                    locales: Joi.array()
+                      .items(
+                        Joi.string().valid(
+                          LOCALE.FRENCH_FRANCE,
+                          LOCALE.FRENCH_SPOKEN,
+                          LOCALE.ENGLISH_SPOKEN,
+                          LOCALE.DUTCH_SPOKEN,
+                        ),
+                      )
+                      .required(),
+                  })
+                  .required(),
+                locale: Joi.string()
+                  .valid(LOCALE.FRENCH_FRANCE, LOCALE.FRENCH_SPOKEN, LOCALE.ENGLISH_SPOKEN, LOCALE.DUTCH_SPOKEN)
+                  .required(),
+                'assessment-id': identifiersType.assessmentId,
+              },
+            },
+          }),
+        },
+        handler: smartRandomSimulatorController.getNextChallenge,
+        notes: [
+          '- **Route nécessitant une authentification**\n' +
+            "- Cette route permet d'appeler le simulateur d'algorithme de sélection des épreuves Smart Random.",
+        ],
+        tags: ['api', 'admin', 'smart-random-simulator'],
+      },
+    },
+  ]);
+};
+
+const name = 'smart-random-simulator-api';
+export { register, name };

--- a/api/src/evaluation/application/smart-random-simulator/smart-random-simulator-controller.js
+++ b/api/src/evaluation/application/smart-random-simulator/smart-random-simulator-controller.js
@@ -1,0 +1,15 @@
+import * as requestResponseUtils from '../../../../lib/infrastructure/utils/request-response-utils.js';
+import * as algorithmSimulatorSerializer from '../../infrastructure/serializers/jsonapi/smart-random-simulator-serializer.js';
+import { evaluationUsecases } from '../../../evaluation/domain/usecases/index.js';
+
+const getNextChallenge = async function (
+  request,
+  h,
+  dependencies = { requestResponseUtils, algorithmSimulatorSerializer },
+) {
+  const deserializedPayload = await dependencies.algorithmSimulatorSerializer.deserialize(request.payload);
+
+  return evaluationUsecases.getNextChallengeForSimulator({ simulationParameters: deserializedPayload });
+};
+const smartRandomSimulatorController = { getNextChallenge };
+export { smartRandomSimulatorController };

--- a/api/src/evaluation/domain/models/SimulationParameters.js
+++ b/api/src/evaluation/domain/models/SimulationParameters.js
@@ -1,0 +1,20 @@
+class SimulationParameters {
+  /**
+   * @param {KnowledgeElement[]} knowledgeElements
+   * @param {Answer[]} answers
+   * @param {Skill[]} skills
+   * @param {Challenge[]} challenges
+   * @param {('en'|'fr-fr'|'fr'|'nl')} locale
+   * @param {number} assessmentId
+   */
+  constructor({ knowledgeElements, answers, skills, challenges, locale, assessmentId } = {}) {
+    this.knowledgeElements = knowledgeElements;
+    this.answers = answers;
+    this.skills = skills;
+    this.challenges = challenges;
+    this.locale = locale;
+    this.assessmentId = assessmentId;
+  }
+}
+
+export { SimulationParameters };

--- a/api/src/evaluation/domain/usecases/get-next-challenge-for-simulator.js
+++ b/api/src/evaluation/domain/usecases/get-next-challenge-for-simulator.js
@@ -1,0 +1,27 @@
+/**
+ * @param {simulationParameters: SimulationParameters} simulationParameters
+ * @param pickChallengeService
+ * @param smartRandomService
+ * @returns {Promise<Challenge | null>}
+ */
+const getNextChallengeForSimulator = function ({ simulationParameters, pickChallengeService, smartRandomService }) {
+  const { possibleSkillsForNextChallenge, hasAssessmentEnded } = smartRandomService.getPossibleSkillsForNextChallenge({
+    knowledgeElements: simulationParameters.knowledgeElements,
+    challenges: simulationParameters.challenges,
+    locale: simulationParameters.locale,
+    targetSkills: simulationParameters.skills,
+    allAnswers: simulationParameters.answers,
+  });
+
+  if (hasAssessmentEnded) {
+    return null;
+  }
+
+  return pickChallengeService.pickChallenge({
+    skills: possibleSkillsForNextChallenge,
+    randomSeed: simulationParameters.assessmentId,
+    locale: simulationParameters.locale,
+  });
+};
+
+export { getNextChallengeForSimulator };

--- a/api/src/evaluation/domain/usecases/index.js
+++ b/api/src/evaluation/domain/usecases/index.js
@@ -20,7 +20,9 @@ import * as stageRepository from '../../infrastructure/repositories/stage-reposi
 import * as targetProfileRepository from '../../../../lib/infrastructure/repositories/target-profile-repository.js';
 import * as targetProfileForAdminRepository from '../../../shared/infrastructure/repositories/target-profile-for-admin-repository.js';
 import { getCompetenceLevel } from '../services/get-competence-level.js';
+import * as smartRandomService from '../../../../lib/domain/services/algorithm-methods/smart-random.js';
 import * as improvementService from '../../../../lib/domain/services/improvement-service.js';
+import { pickChallengeService } from '../../../certification/flash-certification/domain/services/pick-challenge-service.js';
 import * as scorecardService from '../services/scorecard-service.js';
 
 const path = dirname(fileURLToPath(import.meta.url));
@@ -48,7 +50,9 @@ const dependencies = {
   targetProfileForAdminRepository,
   targetProfileRepository,
   getCompetenceLevel,
+  smartRandomService,
   improvementService,
+  pickChallengeService,
   scorecardService,
 };
 

--- a/api/src/evaluation/infrastructure/serializers/jsonapi/smart-random-simulator-serializer.js
+++ b/api/src/evaluation/infrastructure/serializers/jsonapi/smart-random-simulator-serializer.js
@@ -1,0 +1,28 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+import { SimulationParameters } from '../../../domain/models/SimulationParameters.js';
+import { Answer } from '../../../domain/models/Answer.js';
+import { Challenge, KnowledgeElement, Skill } from '../../../../../lib/domain/models/index.js';
+
+const { Deserializer } = jsonapiSerializer;
+
+/**
+ * @param payload
+ * @returns {Promise<SimulationParameters>}
+ */
+const deserialize = async function (payload) {
+  const deserializedPayload = await new Deserializer({
+    keyForAttribute: 'camelCase',
+  }).deserialize(payload);
+
+  return new SimulationParameters({
+    ...deserializedPayload,
+    answers: deserializedPayload.answers.map((answer) => new Answer(answer)),
+    knowledgeElements: deserializedPayload.knowledgeElements.map(
+      (knowledgeElement) => new KnowledgeElement(knowledgeElement),
+    ),
+    skills: deserializedPayload.skills.map((skill) => new Skill(skill)),
+    challenges: deserializedPayload.challenges.map((challenge) => new Challenge(challenge)),
+  });
+};
+
+export { deserialize };

--- a/api/src/evaluation/routes.js
+++ b/api/src/evaluation/routes.js
@@ -1,3 +1,4 @@
+import * as smartRandomSimulatorRoutes from './application/smart-random-simulator/index.js';
 import * as answersRoutes from './application/answers/index.js';
 import * as autonomousCoursesRoutes from './application/autonomous-courses/index.js';
 import * as competenceEvaluationsRoutes from './application/competence-evaluations/index.js';
@@ -8,6 +9,7 @@ import * as stagesRoutes from './application/stages/index.js';
 import * as stageCollectionRoutes from './application/stage-collections/index.js';
 
 const evaluationRoutes = [
+  smartRandomSimulatorRoutes,
   answersRoutes,
   autonomousCoursesRoutes,
   competenceEvaluationsRoutes,

--- a/api/src/shared/domain/models/AnswerStatus.js
+++ b/api/src/shared/domain/models/AnswerStatus.js
@@ -1,10 +1,12 @@
-const OK = 'ok';
-const KO = 'ko';
-const SKIPPED = 'aband';
-const TIMEDOUT = 'timedout';
-const FOCUSEDOUT = 'focusedOut';
-const PARTIALLY = 'partially';
-const UNIMPLEMENTED = 'unimplemented';
+const statuses = {
+  OK: 'ok',
+  KO: 'ko',
+  SKIPPED: 'aband',
+  TIMEDOUT: 'timedout',
+  FOCUSEDOUT: 'focusedOut',
+  PARTIALLY: 'partially',
+  UNIMPLEMENTED: 'unimplemented',
+};
 
 class AnswerStatus {
   constructor({ status } = {}) {
@@ -14,52 +16,52 @@ class AnswerStatus {
 
   /* PUBLIC INTERFACE */
   isFailed() {
-    return this.status !== OK;
+    return this.status !== statuses.OK;
   }
 
   isOK() {
-    return this.status === OK;
+    return this.status === statuses.OK;
   }
   isKO() {
-    return this.status === KO;
+    return this.status === statuses.KO;
   }
   isSKIPPED() {
-    return this.status === SKIPPED;
+    return this.status === statuses.SKIPPED;
   }
   isTIMEDOUT() {
-    return this.status === TIMEDOUT;
+    return this.status === statuses.TIMEDOUT;
   }
   isFOCUSEDOUT() {
-    return this.status === FOCUSEDOUT;
+    return this.status === statuses.FOCUSEDOUT;
   }
   isPARTIALLY() {
-    return this.status === PARTIALLY;
+    return this.status === statuses.PARTIALLY;
   }
   isUNIMPLEMENTED() {
-    return this.status === UNIMPLEMENTED;
+    return this.status === statuses.UNIMPLEMENTED;
   }
 
   /* PUBLIC CONSTRUCTORS */
   static get OK() {
-    return new AnswerStatus({ status: OK });
+    return new AnswerStatus({ status: statuses.OK });
   }
   static get KO() {
-    return new AnswerStatus({ status: KO });
+    return new AnswerStatus({ status: statuses.KO });
   }
   static get SKIPPED() {
-    return new AnswerStatus({ status: SKIPPED });
+    return new AnswerStatus({ status: statuses.SKIPPED });
   }
   static get TIMEDOUT() {
-    return new AnswerStatus({ status: TIMEDOUT });
+    return new AnswerStatus({ status: statuses.TIMEDOUT });
   }
   static get FOCUSEDOUT() {
-    return new AnswerStatus({ status: FOCUSEDOUT });
+    return new AnswerStatus({ status: statuses.FOCUSEDOUT });
   }
   static get PARTIALLY() {
-    return new AnswerStatus({ status: PARTIALLY });
+    return new AnswerStatus({ status: statuses.PARTIALLY });
   }
   static get UNIMPLEMENTED() {
-    return new AnswerStatus({ status: UNIMPLEMENTED });
+    return new AnswerStatus({ status: statuses.UNIMPLEMENTED });
   }
 
   /* METHODES DE TRANSITION */
@@ -91,5 +93,7 @@ class AnswerStatus {
     }
   }
 }
+
+AnswerStatus.statuses = statuses;
 
 export { AnswerStatus };

--- a/api/src/shared/domain/types/identifiers-type.js
+++ b/api/src/shared/domain/types/identifiers-type.js
@@ -63,7 +63,7 @@ const typesPositiveInteger32bits = [
 ];
 
 const typesAlphanumeric = ['courseId', 'tutorialId'];
-const typesAlphanumeric255 = ['challengeId', 'competenceId', 'frameworkId', 'tubeId', 'missionId', 'code'];
+const typesAlphanumeric255 = ['challengeId', 'competenceId', 'frameworkId', 'tubeId', 'missionId', 'code', 'skillId'];
 
 _assignValueToExport(typesPositiveInteger32bits, implementationType.positiveInteger32bits);
 _assignValueToExport(typesAlphanumeric, implementationType.alphanumeric);

--- a/api/tests/evaluation/acceptance/application/smart-random-simulator/smart-random-simulator-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/smart-random-simulator/smart-random-simulator-controller_test.js
@@ -1,0 +1,108 @@
+import {
+  expect,
+  generateValidRequestAuthorizationHeader,
+  createServer,
+  databaseBuilder,
+} from '../../../../test-helper.js';
+
+describe('Acceptance | API | Smart Random Simulator', function () {
+  let userId;
+  let server;
+
+  beforeEach(async function () {
+    userId = databaseBuilder.factory.buildUser.withRole().id;
+    await databaseBuilder.commit();
+    server = await createServer();
+  });
+
+  const buildPayload = (withChallengesMatchingUserLocale = true) => {
+    return {
+      data: {
+        attributes: {
+          'knowledge-elements': [
+            {
+              source: 'direct',
+              status: 'validated',
+              'answer-id': 12345678,
+              'skill-id': 'rec45678765',
+            },
+          ],
+          answers: [
+            {
+              result: 'ok',
+              'challenge-id': 'rec1234567',
+            },
+          ],
+          skills: [
+            {
+              id: 'recoaijndozia123',
+              difficulty: 3,
+              name: '@skillname3',
+            },
+          ],
+          challenges: [
+            {
+              id: 'challengerec1234567',
+              skill: {
+                id: 'recoaijndozia123',
+                name: '@skillname3',
+              },
+              locales: withChallengesMatchingUserLocale ? ['fr-fr'] : ['en'],
+            },
+          ],
+          locale: 'fr-fr',
+          'assessment-id': 12346,
+        },
+      },
+    };
+  };
+
+  describe('POST /api/admin/smart-random-simulator/get-next-challenge', function () {
+    context('when user is authenticated and has a role', function () {
+      context('when the route should return a challenge', function () {
+        let options, response;
+
+        beforeEach(async function () {
+          options = {
+            method: 'POST',
+            url: '/api/admin/smart-random-simulator/get-next-challenge',
+            headers: {
+              authorization: generateValidRequestAuthorizationHeader(userId),
+            },
+            payload: buildPayload(),
+          };
+          response = await server.inject(options);
+        });
+
+        it('should return a 200 status code', async function () {
+          expect(response.statusCode).to.equal(200);
+        });
+        it('should return a challenge', async function () {
+          expect(JSON.parse(response.payload).id).to.equal('challengerec1234567');
+        });
+      });
+      context('when the route should not return a challenge', function () {
+        let options, response;
+
+        beforeEach(async function () {
+          options = {
+            method: 'POST',
+            url: '/api/admin/smart-random-simulator/get-next-challenge',
+            headers: {
+              authorization: generateValidRequestAuthorizationHeader(userId),
+            },
+            payload: buildPayload(false),
+          };
+          response = await server.inject(options);
+        });
+
+        it('should return a 204 status code', async function () {
+          expect(response.statusCode).to.equal(204);
+        });
+        it('should return an empty payload', async function () {
+          expect(response.payload).to.be.empty;
+        });
+      });
+    });
+  });
+});

--- a/api/tests/evaluation/integration/domain/usecases/get-next-challenge-for-simulator_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/get-next-challenge-for-simulator_test.js
@@ -1,0 +1,51 @@
+import { domainBuilder, expect } from '../../../../test-helper.js';
+import { evaluationUsecases } from '../../../../../src/evaluation/domain/usecases/index.js';
+import { SimulationParameters } from '../../../../../src/evaluation/domain/models/SimulationParameters.js';
+import { Challenge } from '../../../../../src/shared/domain/models/Challenge.js';
+
+describe('Integration | Usecases | Get next challenge for simulator', function () {
+  context('when there is still some challenges to pick', function () {
+    it('should return the next challenge', async function () {
+      // given
+      const skill = domainBuilder.buildSkill({ difficulty: 2 });
+      const challenge = domainBuilder.buildChallenge({ skill, locales: ['fr-fr'] });
+      const simulationParameters = new SimulationParameters({
+        skills: [skill],
+        challenges: [challenge],
+        answers: [],
+        knowledgeElements: [],
+        locale: 'fr-fr',
+      });
+
+      // when
+      const nextChallenge = await evaluationUsecases.getNextChallengeForSimulator({
+        simulationParameters,
+      });
+
+      // then
+      expect(nextChallenge).to.be.instanceOf(Challenge);
+      expect(nextChallenge.skill.id).to.equal(skill.id);
+    });
+  });
+
+  context('when there is no more challenge', function () {
+    it('should return null', async function () {
+      // given
+      const simulationParameters = new SimulationParameters({
+        skills: [],
+        challenges: [],
+        answers: [],
+        knowledgeElements: [],
+        locale: 'fr-fr',
+      });
+
+      // when
+      const nextChallenge = await evaluationUsecases.getNextChallengeForSimulator({
+        simulationParameters,
+      });
+
+      // then
+      expect(nextChallenge).to.be.null;
+    });
+  });
+});

--- a/api/tests/evaluation/unit/application/smart-random-simulator/index_test.js
+++ b/api/tests/evaluation/unit/application/smart-random-simulator/index_test.js
@@ -1,0 +1,74 @@
+import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
+import { smartRandomSimulatorController } from '../../../../../src/evaluation/application/smart-random-simulator/smart-random-simulator-controller.js';
+import * as algorithmSimulatorRouter from '../../../../../src/evaluation/application/smart-random-simulator/index.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
+
+describe('Unit | Router | smart-random-simulator', function () {
+  describe('POST /api/admin/smart-random-simulator/get-next-challenge', function () {
+    it('should return 200', async function () {
+      // given
+      const method = 'POST';
+      const url = '/api/admin/smart-random-simulator/get-next-challenge';
+      const payload = {
+        data: {
+          attributes: {
+            'knowledge-elements': [
+              {
+                source: 'direct',
+                status: 'validated',
+                'answer-id': 12345678,
+                'skill-id': 'rec45678765',
+              },
+            ],
+            answers: [
+              {
+                result: 'ok',
+                'challenge-id': 'rec1234567',
+              },
+            ],
+            skills: [
+              {
+                id: 'recoaijndozia123',
+                difficulty: 3,
+                name: '@skillname3',
+              },
+            ],
+            challenges: [
+              {
+                id: 'challengerec1234567',
+                skill: {
+                  id: 'recoaijndozia123',
+                  name: '@skillname3',
+                },
+                locales: ['fr-fr'],
+              },
+            ],
+            locale: 'fr-fr',
+            'assessment-id': 12346,
+          },
+        },
+      };
+
+      sinon
+        .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
+        .withArgs([
+          securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+          securityPreHandlers.checkAdminMemberHasRoleSupport,
+          securityPreHandlers.checkAdminMemberHasRoleMetier,
+          securityPreHandlers.checkAdminMemberHasRoleCertif,
+        ])
+        .callsFake(() => (request, h) => h.response(true));
+      sinon
+        .stub(smartRandomSimulatorController, 'getNextChallenge')
+        .callsFake((request, h) => h.response('ok').code(200));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(algorithmSimulatorRouter);
+
+      // when
+      const result = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(result.statusCode).to.equal(200);
+    });
+  });
+});

--- a/api/tests/evaluation/unit/domain/usecases/get-next-challenge-for-simulator_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/get-next-challenge-for-simulator_test.js
@@ -1,0 +1,76 @@
+import { expect, sinon } from '../../../../test-helper.js';
+import { getNextChallengeForSimulator } from '../../../../../src/evaluation/domain/usecases/get-next-challenge-for-simulator.js';
+
+describe('Unit | UseCase | get-next-challenge-for-simulator', function () {
+  describe('#getNextChallengeForSimulator', function () {
+    let pickChallengeService;
+    let smartRandomService;
+
+    beforeEach(function () {
+      pickChallengeService = {
+        pickChallenge: sinon.stub(),
+      };
+
+      smartRandomService = {
+        getPossibleSkillsForNextChallenge: sinon.stub(),
+      };
+    });
+
+    context('when smartRandomService hasAssessmentEnded property is true', function () {
+      it('should return null and call only smartRandomService', function () {
+        // given
+        smartRandomService.getPossibleSkillsForNextChallenge.returns({
+          hasAssessmentEnded: true,
+          possibleSkillsForNextChallenge: [],
+        });
+
+        // when
+        const result = getNextChallengeForSimulator({
+          simulationParameters: {},
+          pickChallengeService,
+          smartRandomService,
+        });
+
+        // then
+        expect(smartRandomService.getPossibleSkillsForNextChallenge).to.have.been.calledOnce;
+        expect(pickChallengeService.pickChallenge).to.not.have.been.called;
+        expect(result).to.be.null;
+      });
+    });
+
+    context('when smartRandomService hasAssessmentEnded property is false', function () {
+      it('should return pickChallengeService response', function () {
+        // given
+        const possibleSkillsForNextChallenge = Symbol('possibleSkillsForNextChallenge');
+        const pickChallengeServiceResult = Symbol('pickChallengeServiceResult');
+        const simulationParameters = {
+          assessmentId: Symbol('assessmentId'),
+          locale: Symbol('locale'),
+        };
+
+        smartRandomService.getPossibleSkillsForNextChallenge.returns({
+          hasAssessmentEnded: false,
+          possibleSkillsForNextChallenge,
+        });
+
+        pickChallengeService.pickChallenge.returns(pickChallengeServiceResult);
+
+        // when
+        const result = getNextChallengeForSimulator({
+          simulationParameters,
+          pickChallengeService,
+          smartRandomService,
+        });
+
+        // then
+        expect(smartRandomService.getPossibleSkillsForNextChallenge).to.have.been.calledOnce;
+        expect(pickChallengeService.pickChallenge).to.have.been.calledWithExactly({
+          skills: possibleSkillsForNextChallenge,
+          randomSeed: simulationParameters.assessmentId,
+          locale: simulationParameters.locale,
+        });
+        expect(result).to.equal(pickChallengeServiceResult);
+      });
+    });
+  });
+});

--- a/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/smart-random-simulator-serializer_test.js
+++ b/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/smart-random-simulator-serializer_test.js
@@ -1,0 +1,65 @@
+import { expect } from '../../../../../test-helper.js';
+import * as serializer from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/smart-random-simulator-serializer.js';
+import { SimulationParameters } from '../../../../../../src/evaluation/domain/models/SimulationParameters.js';
+import { Answer } from '../../../../../../src/evaluation/domain/models/Answer.js';
+import { Challenge, KnowledgeElement, Skill } from '../../../../../../lib/domain/models/index.js';
+
+describe('Unit | Serializer | JSONAPI | smart-random-simulator-serializer', function () {
+  describe('#deserialize()', function () {
+    let jsonAnswer;
+
+    beforeEach(function () {
+      jsonAnswer = {
+        data: {
+          attributes: {
+            'knowledge-elements': [
+              {
+                source: 'direct',
+                status: 'validated',
+                'answer-id': 12345678,
+                'skill-id': 'rec45678765',
+              },
+            ],
+            answers: [
+              {
+                result: 'ok',
+                'challenge-id': 'rec1234567',
+              },
+            ],
+            skills: [
+              {
+                id: 'recoaijndozia123',
+                difficulty: 3,
+                name: '@skillname3',
+              },
+            ],
+            challenges: [
+              {
+                id: 'challengerec1234567',
+                skill: {
+                  id: 'recoaijndozia123',
+                  name: '@skillname3',
+                },
+                locales: ['fr-fr'],
+              },
+            ],
+            locale: 'fr-fr',
+            'assessment-id': 12346,
+          },
+        },
+      };
+    });
+
+    it('should convert JSON API data into an object', async function () {
+      // when
+      const simulatorParameters = await serializer.deserialize(jsonAnswer);
+
+      // then
+      expect(simulatorParameters).to.be.instanceOf(SimulationParameters);
+      expect(simulatorParameters.answers[0]).to.be.instanceOf(Answer);
+      expect(simulatorParameters.skills[0]).to.be.instanceOf(Skill);
+      expect(simulatorParameters.knowledgeElements[0]).to.be.instanceOf(KnowledgeElement);
+      expect(simulatorParameters.challenges[0]).to.be.instanceOf(Challenge);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Nous voulons créer une nouvelle page sur Admin pour tester l'algorithme de sélection d'épreuve.
Pour ce faire, nous avons besoin de renseigner des paramètres à l'algorithme pour étudier son comportement.

## :robot: Proposition

Créer une route POST qui permet de retourner la prochaine épreuve à partir de critères (KE, answers, challenges, skills, assessmentId) choisis.

## :100: Pour tester

✅ Vérifier les tests + tests verts + bons tests + tests OK
