### PR TITLE
[BUGFIX] Affichage le pourcentage de réussite qu'une fois sur la page de résultat (PIX-10469).

### DIFF
--- a/orga/app/components/participant/assessment/header.hbs
+++ b/orga/app/components/participant/assessment/header.hbs
@@ -57,18 +57,18 @@
           aria-label={{t "pages.assessment-individual-results.result"}}
           class="panel-header-data__content panel-header-data-content__stages"
         >
-          {{#unless @campaign.hasStages}}
+          {{#if @campaign.hasStages}}
+            <Ui::MasteryPercentageDisplay
+              @masteryRate={{@participation.masteryRate}}
+              @hasStages={{@campaign.hasStages}}
+              @reachedStage={{@participation.reachedStage}}
+              @totalStage={{@participation.totalStage}}
+              @prescriberTitle={{@participation.prescriberTitle}}
+              @prescriberDescription={{@participation.prescriberDescription}}
+            />
+          {{else}}
             <PixProgressGauge @value={{this.percentage}} @color="blue" />
-          {{/unless}}
-
-          <Ui::MasteryPercentageDisplay
-            @masteryRate={{@participation.masteryRate}}
-            @hasStages={{@campaign.hasStages}}
-            @reachedStage={{@participation.reachedStage}}
-            @totalStage={{@participation.totalStage}}
-            @prescriberTitle={{@participation.prescriberTitle}}
-            @prescriberDescription={{@participation.prescriberDescription}}
-          />
+          {{/if}}
         </li>
       </ul>
     {{/if}}

--- a/orga/app/components/participant/assessment/header.hbs
+++ b/orga/app/components/participant/assessment/header.hbs
@@ -67,7 +67,7 @@
               @prescriberDescription={{@participation.prescriberDescription}}
             />
           {{else}}
-            <PixProgressGauge @value={{this.percentage}} @color="blue" />
+            <PixProgressGauge @value={{this.percentage}} @color="primary" />
           {{/if}}
         </li>
       </ul>

--- a/orga/tests/integration/components/participant/assessment/header_test.js
+++ b/orga/tests/integration/components/participant/assessment/header_test.js
@@ -169,6 +169,8 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
             hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
           );
 
+          // We should keep getAllByText instead of getByText because in the ci the npm run test fails.
+          // It finds two occurences instead of one for some reason related to a nbsp; not being present in this context.
           assert.dom(screen.getAllByText('65%')[0]).exists();
         });
       });


### PR DESCRIPTION
## :unicorn: Problème
Le pourcentage de réussite est affiché deux fois dans l'entête de la page de résultat. Cela a été introduit suite à un changement de design sur le composant ProgressGauge.

## :robot: Proposition
Cacher le pourcentage de réussite sur les campagnes d'évaluation sans paliers.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- Se connecter avec le compte PRO et constater qu'il n'y a plus qu'un pourcentage
- Se connecter avec le compte SCO et constater qu'il n'y a pas de régression sur la campagne avec paliers
