### PR TITLE
[TECH] Protéger la route récupérant la liste des fournisseurs d'identité sur Pix Admin (PIX-10706)

### DIFF
--- a/api/lib/application/authentication/oidc/index.js
+++ b/api/lib/application/authentication/oidc/index.js
@@ -8,7 +8,6 @@ const register = async function (server) {
       method: 'GET',
       path: '/api/admin/oidc/identity-providers',
       config: {
-        auth: false,
         handler: oidcController.getAllIdentityProvidersForAdmin,
         notes: [
           "Cette route renvoie un objet contenant tous les fournisseurs d'identité OIDC (même désactivés) pour leur gestion dans Pix Admin",


### PR DESCRIPTION
## :unicorn: Problème
La route `/api/admin/oidc/identity-providers` ne requiert pas d’authentification, or elle n’est appelée que lorsqu’un utilisateur est connecté à Pix Admin.

## :robot: Proposition
Retirer l’option `auth: false` pour cette route API.

## :rainbow: Remarques
RAS.

## :100: Pour tester

1. Se connecter à Pix Admin.
2. Se rendre sur la page d'un utilisateur et vérifier que l'appel sur la route `/api/admin/oidc/identity-providers` retourne un statut 200 avec la liste des fournisseurs d'identité.
