### PR TITLE
[BUGFIX] Empêcher de cliquer sur un autre bouton lorsque l'on partage ou tente d'améliorer son résultat sur Pix APP (PIX-11304)

### DIFF
--- a/mon-pix/app/components/campaign-share-button.hbs
+++ b/mon-pix/app/components/campaign-share-button.hbs
@@ -15,6 +15,7 @@
     @backgroundColor="secondary"
     @shape="rounded"
     @triggerAction={{@shareCampaignParticipation}}
+    @isLoading={{@isLoading}}
   >
     {{t "pages.skill-review.actions.send"}}
   </PixButton>

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -100,6 +100,7 @@
               {{else}}
                 <CampaignShareButton
                   @isShared={{this.isShared}}
+                  @isLoading={{this.isLoading}}
                   @displayPixLink={{this.displayPixLink}}
                   @shareCampaignParticipation={{this.shareCampaignParticipation}}
                   @redirectToSignupIfUserIsAnonymous={{this.redirectToSignupIfUserIsAnonymous}}
@@ -285,7 +286,7 @@
       {{/if}}
 
       {{#if this.showImproveButton}}
-        <SkillReviewImprove @improve={{this.improve}} />
+        <SkillReviewImprove @improve={{this.improve}} @isLoading={{this.isLoading}} />
       {{/if}}
 
       {{#unless @model.campaign.isForAbsoluteNovice}}

--- a/mon-pix/app/components/skill-review-improve.hbs
+++ b/mon-pix/app/components/skill-review-improve.hbs
@@ -7,7 +7,7 @@
       {{t "pages.skill-review.improve.description"}}
     </p>
   </div>
-  <PixButton @backgroundColor="neutral" @triggerAction={{@improve}}>
+  <PixButton @backgroundColor="neutral" @triggerAction={{@improve}} @isLoading={{@isLoading}}>
     {{t "pages.skill-review.actions.improve"}}
   </PixButton>
 </div>

--- a/mon-pix/tests/integration/components/campaign/skill-review_test.js
+++ b/mon-pix/tests/integration/components/campaign/skill-review_test.js
@@ -257,6 +257,57 @@ module('Integration | Component | Campaign | skill-review', function (hooks) {
     });
   });
 
+  module('Share button', function (hooks) {
+    hooks.beforeEach(function () {
+      model.campaignParticipationResult.set('canReset', false);
+      model.campaignParticipationResult.set('isDisabled', false);
+
+      this.set('model', model);
+    });
+
+    test('display share button', async function (assert) {
+      model.campaignParticipationResult.set('isShared', false);
+      // when
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
+
+      assert.ok(screen.getByRole('button', { name: this.intl.t('pages.skill-review.actions.send') }));
+    });
+
+    test('not display share button', async function (assert) {
+      model.campaignParticipationResult.set('isShared', true);
+      // when
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
+
+      assert.notOk(screen.queryByRole('button', { name: this.intl.t('pages.skill-review.actions.send') }));
+    });
+  });
+
+  module('Improve button', function (hooks) {
+    hooks.beforeEach(function () {
+      model.campaignParticipationResult.set('canReset', false);
+      model.campaignParticipationResult.set('isDisabled', false);
+      model.campaignParticipationResult.set('isShared', false);
+
+      this.set('model', model);
+    });
+
+    test('display improve button', async function (assert) {
+      model.campaignParticipationResult.set('canImprove', true);
+      // when
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
+
+      assert.ok(screen.getByRole('button', { name: this.intl.t('pages.skill-review.actions.improve') }));
+    });
+
+    test('not display improve button', async function (assert) {
+      model.campaignParticipationResult.set('canImprove', false);
+      // when
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
+
+      assert.notOk(screen.queryByRole('button', { name: this.intl.t('pages.skill-review.actions.improve') }));
+    });
+  });
+
   test('it should not display skill review infos if isForabsoluteNovice is true', async function (assert) {
     model.campaign.set('isForAbsoluteNovice', true);
     this.set('model', model);

--- a/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
@@ -154,36 +154,29 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
 
     store = this.owner.lookup('service:store');
     adapter = store.adapterFor('campaign-participation-result');
-    sinon.stub(adapter, 'share').resolves();
-    sinon.stub(adapter, 'beginImprovement').resolves();
+    sinon.stub(adapter, 'share');
+    sinon.stub(adapter, 'beginImprovement');
 
     component.router.transitionTo = sinon.stub();
   });
 
   module('#shareCampaignParticipation', function () {
-    test('should call adapter', async function (assert) {
+    test('should call adapter once', async function (assert) {
       // when
-      await component.actions.shareCampaignParticipation.call(component);
+      await Promise.all([
+        component.actions.shareCampaignParticipation.call(component),
+        component.actions.shareCampaignParticipation.call(component),
+      ]);
 
       // then
-      sinon.assert.calledWithExactly(adapter.share, 12345);
+      sinon.assert.calledOnceWithExactly(adapter.share, 12345);
       assert.ok(true);
     });
 
     module('before share', function () {
-      test('isShareButtonClicked should be false', async function (assert) {
+      test('isLoading should be false', async function (assert) {
         // then
-        assert.false(component.isShareButtonClicked);
-      });
-    });
-
-    module('when share is not yet effective but button is pressed', function () {
-      test('should set isShareButtonClicked to true', async function (assert) {
-        // when
-        await component.actions.shareCampaignParticipation.call(component);
-
-        // then
-        assert.true(component.isShareButtonClicked);
+        assert.false(component.isLoading);
       });
     });
 
@@ -197,6 +190,18 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
 
         // then
         assert.true(component.args.model.campaignParticipationResult.isShared);
+      });
+
+      test('should set canImprove to false', async function (assert) {
+        // given
+        adapter.share.resolves();
+        component.args.model.campaignParticipationResult.canImprove = true;
+
+        // when
+        await component.actions.shareCampaignParticipation.call(component);
+
+        // then
+        assert.false(component.args.model.campaignParticipationResult.canImprove);
       });
     });
 
@@ -229,12 +234,18 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
   });
 
   module('#improve', function () {
-    test('should save the campaignParticipation to start the improvement', async function (assert) {
+    test('isLoading should be false', async function (assert) {
+      // then
+      assert.false(component.isLoading);
+    });
+
+    test('should call the adapter once', async function (assert) {
       // when
-      await component.actions.improve.call(component);
+
+      await Promise.all([component.actions.improve.call(component), component.actions.improve.call(component)]);
 
       // then
-      sinon.assert.calledWithExactly(adapter.beginImprovement, 12345);
+      sinon.assert.calledOnceWithExactly(adapter.beginImprovement, 12345);
       assert.ok(true);
     });
 
@@ -1023,7 +1034,7 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
     test('should return false when canImprove is false', function (assert) {
       // given
       component.args.model.campaignParticipationResult.canImprove = false;
-      component.isShareButtonClicked = false;
+
       // when
       const result = component.showImproveButton;
 
@@ -1031,21 +1042,10 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
       assert.false(result);
     });
 
-    test('should return false when isShareButtonClicked is true', function (assert) {
+    test('should return true when canImprove is true and isLoading is false', function (assert) {
       // given
       component.args.model.campaignParticipationResult.canImprove = true;
-      component.isShareButtonClicked = true;
-      // when
-      const result = component.showImproveButton;
 
-      // then
-      assert.false(result);
-    });
-
-    test('should return true when canImprove is true and isShareButtonClicked is false', function (assert) {
-      // given
-      component.args.model.campaignParticipationResult.canImprove = true;
-      component.isShareButtonClicked = false;
       // when
       const result = component.showImproveButton;
 


### PR DESCRIPTION
## :unicorn: Problème
Nous avons remarqué que parfois certains utilisateur arrive à partager et à begin improvment dans la foulée 🏃 . il s'avère qu'il n'y a aucune protection sur un clique pour executer une autre action sur la page de fin de parcours

## :robot: Proposition
Ajouter une propriété isLoading afin d'empêcher de pouvoir cliquer sur le bouton partager et en même temps sur le bouton improve en page de fin de parcours

## :rainbow: Remarques
Pour des questions d'accessiblité. le bouton begin improvement ne disparaît plus. il passe en loading comme le boutons j'envoi mes résultats. Afin de montrer qu'une action est en cours.

Il sera possible aussi dans un autre ticket de modifier le comportement du job de calcul afin qu'il vérifie si la participation est bel est bien partagé. avant de faire quoi que ce soit. 

## :100: Pour tester
Vérifier qu'un loading apparaît lorsque l'on partage sa campagne