### PR TITLE
[FEATURE] Valider l'HTML des champs qui requièrent de l'HTML (PIX-10242)

### DIFF
--- a/api/.eslintrc.cjs
+++ b/api/.eslintrc.cjs
@@ -49,6 +49,7 @@ module.exports = {
           'split2',
           'stream-to-promise',
           'pino-pretty',
+          'html-validate',
         ],
       },
     ],

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -98,6 +98,7 @@
         "eslint-plugin-prettier": "^5.0.0",
         "eslint-plugin-unicorn": "^50.0.0",
         "form-data": "^4.0.0",
+        "html-validate": "^8.9.1",
         "inquirer": "^9.0.0",
         "jsdoc-to-markdown": "^8.0.0",
         "libxmljs2": "0.32.0",
@@ -1934,6 +1935,18 @@
         "@hapi/statehood": "^8.0.1"
       }
     },
+    "node_modules/@html-validate/stylish": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@html-validate/stylish/-/stylish-4.2.0.tgz",
+      "integrity": "sha512-Nl8HCv0hGRSLQ+n1OD4Hk3a+Urwk9HH0vQkAzzCarT4KlA7bRl+6xEiS5PZVwOmjtC7XiH/oNe3as9Fxcr2A1w==",
+      "dev": true,
+      "dependencies": {
+        "kleur": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -1993,6 +2006,116 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
       "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
     },
     "node_modules/@joi/date": {
       "version": "2.1.0",
@@ -2328,6 +2451,16 @@
         "pako": "^1.0.10"
       }
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@pkgr/core": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
@@ -2420,6 +2553,100 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
+    },
+    "node_modules/@sidvind/better-ajv-errors": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@sidvind/better-ajv-errors/-/better-ajv-errors-2.1.3.tgz",
+      "integrity": "sha512-lWuod/rh7Xz5uXiEGSfm2Sd5PG7K/6yJfoAZVqzsEswjPJhUz15R7Gn/o8RczA041QS15hBd/BCSeu9vwPArkA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.16.0",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16.14"
+      },
+      "peerDependencies": {
+        "ajv": "4.11.8 - 8"
+      }
+    },
+    "node_modules/@sidvind/better-ajv-errors/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@sidvind/better-ajv-errors/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@sidvind/better-ajv-errors/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@sidvind/better-ajv-errors/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@sidvind/better-ajv-errors/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sidvind/better-ajv-errors/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -4675,6 +4902,15 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -4986,6 +5222,17 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/dmd": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/dmd/-/dmd-6.2.0.tgz",
@@ -5031,6 +5278,12 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -5508,6 +5761,24 @@
       "peerDependencies": {
         "eslint": ">=4.0.0"
       }
+    },
+    "node_modules/eslint-plugin-i18n-json/node_modules/jest-diff": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
+      "integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.0.1",
+        "diff": "^3.2.0",
+        "jest-get-type": "^22.4.3",
+        "pretty-format": "^22.4.3"
+      }
+    },
+    "node_modules/eslint-plugin-i18n-json/node_modules/jest-get-type": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+      "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+      "dev": true
     },
     "node_modules/eslint-plugin-import": {
       "version": "2.29.1",
@@ -6580,6 +6851,34 @@
         "is-callable": "^1.1.3"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -7172,6 +7471,152 @@
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
+    },
+    "node_modules/html-validate": {
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/html-validate/-/html-validate-8.9.1.tgz",
+      "integrity": "sha512-2tWa2FtFALooZ5wMDbY+HS0BieoiRfS5IeiG2XeM6bb3Jx4dmN1HFPFt0v3j7r3SpNxEVKiXYLdkBZI3kkca/g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.0",
+        "@html-validate/stylish": "^4.1.0",
+        "@sidvind/better-ajv-errors": "2.1.3",
+        "ajv": "^8.0.0",
+        "deepmerge": "4.3.1",
+        "glob": "^10.0.0",
+        "ignore": "5.3.0",
+        "kleur": "^4.1.0",
+        "minimist": "^1.2.0",
+        "prompts": "^2.0.0",
+        "semver": "^7.0.0"
+      },
+      "bin": {
+        "html-validate": "bin/html-validate.js"
+      },
+      "engines": {
+        "node": ">= 16.14"
+      },
+      "peerDependencies": {
+        "jest": "^27.1 || ^28.1.3 || ^29.0.3",
+        "jest-diff": "^27.1 || ^28.1.3 || ^29.0.3",
+        "jest-snapshot": "^27.1 || ^28.1.3 || ^29.0.3",
+        "vitest": "^0.34 || ^1"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        },
+        "jest-diff": {
+          "optional": true
+        },
+        "jest-snapshot": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/html-validate/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/html-validate/node_modules/glob": {
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/html-validate/node_modules/ignore": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
+      "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/html-validate/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "node_modules/html-validate/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/html-validate/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/html-validate/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/html-validate/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "node_modules/http-status": {
@@ -7769,23 +8214,163 @@
         "ws": "*"
       }
     },
-    "node_modules/jest-diff": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
-      "integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
+    "node_modules/jackspeak": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
+      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
       "dev": true,
       "dependencies": {
-        "chalk": "^2.0.1",
-        "diff": "^3.2.0",
-        "jest-get-type": "^22.4.3",
-        "pretty-format": "^22.4.3"
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/jest-diff/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-diff/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jest-get-type": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
-      "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
-      "dev": true
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
     },
     "node_modules/joi": {
       "version": "17.12.1",
@@ -8133,6 +8718,15 @@
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.1.9"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/knex": {
@@ -9838,6 +10432,31 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
+    "node_modules/path-scurry": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^9.1.1 || ^10.0.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+      "dev": true,
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
@@ -10344,6 +10963,28 @@
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
       "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ=="
     },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/prompts/node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/propagate": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
@@ -10463,6 +11104,14 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/read-package-json-fast": {
       "version": "3.0.2",
@@ -10845,6 +11494,15 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11463,6 +12121,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true
+    },
     "node_modules/sonic-boom": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.0.tgz",
@@ -11681,6 +12345,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string.prototype.trim": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
@@ -11733,6 +12412,28 @@
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -12490,6 +13191,57 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "4.3.0",

--- a/api/package.json
+++ b/api/package.json
@@ -104,6 +104,7 @@
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-unicorn": "^50.0.0",
     "form-data": "^4.0.0",
+    "html-validate": "^8.9.1",
     "inquirer": "^9.0.0",
     "jsdoc-to-markdown": "^8.0.0",
     "libxmljs2": "0.32.0",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/module.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module.json
@@ -17,15 +17,15 @@
       },
       "transitionTexts": [
         {
-          "content": "<p>Naomi a perdu l’adresse mail de son ami Mickaël. Elle n’arrive pas à retrouver cette adresse <span aria-hidden='true'>🤷‍♀</span>️. Elle a besoin de l’adresse mail de Mickaël pour lui envoyer un document. Elle demande donc à Mickaël par SMS. <br> Lancez la vidéo pour voir leur discussion <span aria-hidden='true'>▶️</span></p>",
+          "content": "<p>Naomi a perdu l’adresse mail de son ami Mickaël. Elle n’arrive pas à retrouver cette adresse <span aria-hidden=\"true\">🤷‍♀</span>️. Elle a besoin de l’adresse mail de Mickaël pour lui envoyer un document. Elle demande donc à Mickaël par SMS. <br> Lancez la vidéo pour voir leur discussion <span aria-hidden=\"true\">▶️</span></p>",
           "grainId": "34d225e8-5d52-4ebd-9acd-8bde8438cfc9"
         },
         {
-          "content": "<p>Et oui ! Naomi le sait : les adresses mail ont un certain format.</p><p>Étudions en détails l’adresse mail de Mickaël <span aria-hidden='true'>👨‍🏫👩‍🏫</span></p>",
+          "content": "<p>Et oui ! Naomi le sait : les adresses mail ont un certain format.</p><p>Étudions en détails l’adresse mail de Mickaël <span aria-hidden=\"true\">👨‍🏫👩‍🏫</span></p>",
           "grainId": "af860b1e-0566-4b06-bcb4-a68a5151d621"
         },
         {
-          "content": "<p>Pour être sûr que tout est clair, voici un texte à trous ! <span aria-hidden='true'>🧩</span></p>",
+          "content": "<p>Pour être sûr que tout est clair, voici un texte à trous ! <span aria-hidden=\"true\">🧩</span></p>",
           "grainId": "edd7fec3-a649-425b-b8e3-65b13c6c47ea"
         },
         {
@@ -45,7 +45,7 @@
               "title": "Le format des adresses mail",
               "url": "https://videos.pix.fr/modulix/chat_animation_2.mp4",
               "subtitles": "https://videos.pix.fr/modulix/chat_animation_2.vtt",
-              "transcription": "<ul><li>Naomi : Salut, tu peux me redonner ton adresse mail stp ? <span aria-hidden='true'>😇</span></li> <li>Mickaël : Oui, c’est mickael.aubert123#laposte.net</li><li>Naomi : T’es sûr ? <span aria-hidden='true'>😬</span></li><li>Naomi : Tu veux dire mickael.aubert123@laposte.net</li><li>Mickaël : Ah oui désolé ! <span aria-hidden='true'>😣</span></li><li>Mickaël : comment tu as su ? </li><li>Naomi : …</li>"
+              "transcription": "<ul><li>Naomi : Salut, tu peux me redonner ton adresse mail stp ? <span aria-hidden=\"true\">😇</span></li> <li>Mickaël : Oui, c’est mickael.aubert123#laposte.net</li><li>Naomi : T’es sûr ? <span aria-hidden=\"true\">😬</span></li><li>Naomi : Tu veux dire mickael.aubert123@laposte.net</li><li>Mickaël : Ah oui désolé ! <span aria-hidden=\"true\">😣</span></li><li>Mickaël : comment tu as su ? </li><li>Naomi : …</li>"
             }
           ]
         },
@@ -64,17 +64,17 @@
             {
               "id": "c1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d",
               "type": "text",
-              "content": "<h3 class='screen-reader-only'>L'identifiant</h3><h4>L’identifiant est la première partie de l’adresse mail. Il a été choisi par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque. Même avec des majuscules !</p><p><span aria-hidden='true'>✅</span> Par exemple&nbsp;: mika671 ou G3oDu671</p><p class='pix-list-inline'><span aria-hidden='true'>❌</span> Des caractères sont interdits&nbsp;:</p><ul><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>"
+              "content": "<h3 class=\"screen-reader-only\">L'identifiant</h3><h4>L’identifiant est la première partie de l’adresse mail. Il a été choisi par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque. Même avec des majuscules !</p><p><span aria-hidden=\"true\">✅</span> Par exemple&nbsp;: mika671 ou G3oDu671</p><p class=\"pix-list-inline\"><span aria-hidden=\"true\">❌</span> Des caractères sont interdits&nbsp;:</p><ul><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>"
             },
             {
               "id": "ad8ad08a-3ff7-4228-8233-6cd5ce0f4812",
               "type": "text",
-              "content": "<h3 class='screen-reader-only'>L'arobase</h3><h4>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</h4><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous&nbsp;: c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>"
+              "content": "<h3 class=\"screen-reader-only\">L'arobase</h3><h4>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</h4><p><span aria-hidden=\"true\">🇬🇧</span> En anglais, ce symbole se lit <i lang=\"en\">“at”</i> qui veut dire “chez”.</p><p><span aria-hidden=\"true\">🤔</span> Le saviez-vous&nbsp;: c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>"
             },
             {
               "id": "1fd829f8-1799-4779-a28d-5d26fba31b8b",
               "type": "text",
-              "content": "<h3 class='screen-reader-only'>Le fournisseur d’adresse mail</h3><h4>Le fournisseur d’adresse mail est la deuxième partie de l’adresse mail.</h4><p>Cette partie de l’adresse est donnée par le fournisseur.</p><p><span aria-hidden='true'>✅</span> Des exemples de fournisseurs d’adresses mail&nbsp;: </p><ul><li>La Poste (laposte.net)</li><li>Google (gmail.com)</li><li>Yahoo (yahoo.com)</li><li>Microsoft (hotmail.com, live.fr)</li></ul>"
+              "content": "<h3 class=\"screen-reader-only\">Le fournisseur d’adresse mail</h3><h4>Le fournisseur d’adresse mail est la deuxième partie de l’adresse mail.</h4><p>Cette partie de l’adresse est donnée par le fournisseur.</p><p><span aria-hidden=\"true\">✅</span> Des exemples de fournisseurs d’adresses mail&nbsp;: </p><ul><li>La Poste (laposte.net)</li><li>Google (gmail.com)</li><li>Yahoo (yahoo.com)</li><li>Microsoft (hotmail.com, live.fr)</li></ul>"
             }
           ]
         },
@@ -154,8 +154,8 @@
                 }
               ],
               "feedbacks": {
-                "valid": "<p>Correct ! <span aria-hidden='true'>🎉</span>&nbsp;Vous avez retrouvé le bon format d’une adresse mail</p>",
-                "invalid": "<p>Incorrect ! pour avoir de l’aide, revenez en arrière <span aria-hidden='true'>⬆️</span></p>"
+                "valid": "<p>Correct ! <span aria-hidden=\"true\">🎉</span>&nbsp;Vous avez retrouvé le bon format d’une adresse mail</p>",
+                "invalid": "<p>Incorrect ! pour avoir de l’aide, revenez en arrière <span aria-hidden=\"true\">⬆️</span></p>"
               }
             }
           ]
@@ -180,8 +180,8 @@
                 }
               ],
               "feedbacks": {
-                "valid": "<p class='pix-list-inline'>Oui, aucun problème ! Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>",
-                "invalid": "<p class='pix-list-inline'>Et si ! les chiffres sont autorisés dans l’identifiant d’une adresse mail. Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>"
+                "valid": "<p class=\"pix-list-inline\">Oui, aucun problème ! Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>",
+                "invalid": "<p class=\"pix-list-inline\">Et si ! les chiffres sont autorisés dans l’identifiant d’une adresse mail. Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>"
               },
               "solution": "1"
             },
@@ -255,7 +255,7 @@
             {
               "id": "b0fcb950-b5b1-4384-886e-79fb852d5bb7",
               "type": "text",
-              "content": "<h3>Ce qu’il faut retenir</h3><ul><li>Il peut y avoir des chiffres dans l’identifiant d’une adresse mail. Ils peuvent être n’importe où dans l’adresse. <br/><span aria-hidden='true'>💡</span> Ça peut être utile si deux personnes ont le même nom et qu’elles veulent le même fournisseur d’adresse mail.</li><li>Il y a une seule @ (arobase) dans une adresse mail. Elle permet de séparer l’identifiant du fournisseur d’adresse mail.</li><li>Les adresses mails se terminent de différentes manières après l'@, selon le fournisseur d’adresse mail.<br/><span aria-hidden='true'>✅</span> Exemples&nbsp;: laposte.net, free.fr, gmail.com, yahoo.com, etc.</li></ul>"
+              "content": "<h3>Ce qu’il faut retenir</h3><ul><li>Il peut y avoir des chiffres dans l’identifiant d’une adresse mail. Ils peuvent être n’importe où dans l’adresse. <br/><span aria-hidden=\"true\">💡</span> Ça peut être utile si deux personnes ont le même nom et qu’elles veulent le même fournisseur d’adresse mail.</li><li>Il y a une seule @ (arobase) dans une adresse mail. Elle permet de séparer l’identifiant du fournisseur d’adresse mail.</li><li>Les adresses mails se terminent de différentes manières après l'@, selon le fournisseur d’adresse mail.<br/><span aria-hidden=\"true\">✅</span> Exemples&nbsp;: laposte.net, free.fr, gmail.com, yahoo.com, etc.</li></ul>"
             }
           ]
         },
@@ -287,8 +287,8 @@
                 }
               ],
               "feedbacks": {
-                "valid": "<p>Correct ! <span aria-hidden='true'>🎉</span> Tout est en ordre : identifiant, arobase, fournisseur d'adresse mail</p>",
-                "invalid": "<p class='pix-list-inline'>Et non, essaie à nouveau <span aria-hidden='true'>⏮️</span> ! Voici de l'aide pour réussir :</p><ul><li>L'ordre à suivre est : identifiant, arobase, fournisseur d'adresse mail</li></ul><p>Les adresses mail fournies par Yahoo se terminent par yahoo.com</p>"
+                "valid": "<p>Correct ! <span aria-hidden=\"true\">🎉</span> Tout est en ordre : identifiant, arobase, fournisseur d'adresse mail</p>",
+                "invalid": "<p class=\"pix-list-inline\">Et non, essaie à nouveau <span aria-hidden=\"true\">⏮️</span> ! Voici de l'aide pour réussir :</p><ul><li>L'ordre à suivre est : identifiant, arobase, fournisseur d'adresse mail</li></ul><p>Les adresses mail fournies par Yahoo se terminent par yahoo.com</p>"
               }
             }
           ]
@@ -312,19 +312,19 @@
           "grainId": "f312c33d-e7c9-4a69-9ba0-913957b8f7dd"
         },
         {
-          "content": "<p>Chaque leçon a un objectif pédagogique précis.</p><p>Dans la prochaine leçon, nous vous proposons de découvrir Pix avec une courte vidéo <span aria-hidden='true'>▶️</span></p>",
+          "content": "<p>Chaque leçon a un objectif pédagogique précis.</p><p>Dans la prochaine leçon, nous vous proposons de découvrir Pix avec une courte vidéo <span aria-hidden=\"true\">▶️</span></p>",
           "grainId": "73ac3644-7637-4cee-86d4-1a75f53f0b9c"
         },
         {
-          "content": "<p>Vous allez faire votre première activité. Les activités servent à vérifier que vous avez compris l'essentiel des leçons.<br>Dans les activités Modulix, vous avez votre résultat immédiatement. À vous de jouer <span aria-hidden='true'>🚀</span></p>",
+          "content": "<p>Vous allez faire votre première activité. Les activités servent à vérifier que vous avez compris l'essentiel des leçons.<br>Dans les activités Modulix, vous avez votre résultat immédiatement. À vous de jouer <span aria-hidden=\"true\">🚀</span></p>",
           "grainId": "533c69b8-a836-41be-8ffc-8d4636e31224"
         },
         {
-          "content": "<p>Vous l'avez peut-être remarqué : dans un module, vous pouvez voir tous les contenus en remontant la page <span aria-hidden='true'>⬆️</span>️</p>",
+          "content": "<p>Vous l'avez peut-être remarqué : dans un module, vous pouvez voir tous les contenus en remontant la page <span aria-hidden=\"true\">⬆️</span>️</p>",
           "grainId": "2a77a10f-19a3-4544-80f9-8012dad6506a"
         },
         {
-          "content": "<p>Vous arrivez à la fin de ce didacticiel. Une dernière activité et vous serez prêt à explorer tous les modules que vous souhaitez !<span aria-hidden='true'>🌟</span>️ </p>",
+          "content": "<p>Vous arrivez à la fin de ce didacticiel. Une dernière activité et vous serez prêt à explorer tous les modules que vous souhaitez !<span aria-hidden=\"true\">🌟</span>️ </p>",
           "grainId": "7cf75e70-8749-4392-8081-f2c02badb0fb"
         }
       ],
@@ -342,7 +342,7 @@
             {
               "id": "a2372bf4-86a4-4ecc-a188-b51f4f98bca2",
               "type": "text",
-              "content": "<p>Voici un texte de leçon. Parfois, il y a des émojis pour aider à la lecture <span aria-hidden='true'>📚</span>️.<br>Et là, voici une image !</p>"
+              "content": "<p>Voici un texte de leçon. Parfois, il y a des émojis pour aider à la lecture <span aria-hidden=\"true\">📚</span>️.<br>Et là, voici une image !</p>"
             },
             {
               "id": "8d7687c8-4a02-4d7e-bf6c-693a6d481c78",
@@ -369,7 +369,7 @@
               "title": "Vidéo de présentation de Pix",
               "url": "https://videos.pix.fr/modulix/didacticiel/presentation.mp4",
               "subtitles": "-",
-              "transcription": "<p>Le numérique évolue en permanence, vos compétences aussi, pour travailler, communiquer et s'informer, se déplacer, réaliser des démarches, un enjeu tout au long de la vie.</p><p>Sur <a href='https://pix.fr' target='blank'>pix.fr</a>, testez-vous et cultivez vos compétences numériques.</p><p>Les tests Pix sont personnalisés, les questions s'adaptent à votre niveau, réponse après réponse.</p><p>Évaluez vos connaissances et savoir-faire sur 16 compétences, dans 5 domaines, sur 5 niveaux de débutants à confirmer, avec des mises en situation ludiques, recherches en ligne, manipulation de fichiers et de données, culture numérique...</p><p>Allez à votre rythme, vous pouvez arrêter et reprendre quand vous le voulez.</p><p>Toutes les 5 questions, découvrez vos résultats et progressez grâce aux astuces et aux tutos.</p><p>En relevant les défis Pix, vous apprendrez de nouvelles choses et aurez envie d'aller plus loin.</p><p>Vous pensez pouvoir faire mieux ?</p><p>Retentez les tests et améliorez votre score.</p><p>Faites reconnaître officiellement votre niveau en passant la certification Pix, reconnue par l'État et le monde professionnel.</p><p>Pix : le service public en ligne pour évaluer, développer et certifier ses compétences numériques.</p>"
+              "transcription": "<p>Le numérique évolue en permanence, vos compétences aussi, pour travailler, communiquer et s'informer, se déplacer, réaliser des démarches, un enjeu tout au long de la vie.</p><p>Sur <a href='https://pix.fr' target=\"blank\">pix.fr</a>, testez-vous et cultivez vos compétences numériques.</p><p>Les tests Pix sont personnalisés, les questions s'adaptent à votre niveau, réponse après réponse.</p><p>Évaluez vos connaissances et savoir-faire sur 16 compétences, dans 5 domaines, sur 5 niveaux de débutants à confirmer, avec des mises en situation ludiques, recherches en ligne, manipulation de fichiers et de données, culture numérique...</p><p>Allez à votre rythme, vous pouvez arrêter et reprendre quand vous le voulez.</p><p>Toutes les 5 questions, découvrez vos résultats et progressez grâce aux astuces et aux tutos.</p><p>En relevant les défis Pix, vous apprendrez de nouvelles choses et aurez envie d'aller plus loin.</p><p>Vous pensez pouvoir faire mieux ?</p><p>Retentez les tests et améliorez votre score.</p><p>Faites reconnaître officiellement votre niveau en passant la certification Pix, reconnue par l'État et le monde professionnel.</p><p>Pix : le service public en ligne pour évaluer, développer et certifier ses compétences numériques.</p>"
             }
           ]
         },
@@ -394,7 +394,7 @@
               ],
               "feedbacks": {
                 "valid": "<p>Correct ! Ces 16 compétences sont rangées dans 5 domaines.</p>",
-                "invalid": "<p>Incorrect. Retourner voir la vidéo si besoin <span aria-hidden='true'>⬆️</span>️!</p>"
+                "invalid": "<p>Incorrect. Retourner voir la vidéo si besoin <span aria-hidden=\"true\">⬆️</span>️!</p>"
               },
               "solution": "1"
             }
@@ -494,7 +494,7 @@
                 }
               ],
               "feedbacks": {
-                "valid": "<p>Correct ! vous êtes prêt à explorer <span aria-hidden='true'>🎉</span></p>",
+                "valid": "<p>Correct ! vous êtes prêt à explorer <span aria-hidden=\"true\">🎉</span></p>",
                 "invalid": "<p>Incorrect ! vous y arriverez la prochaine fois !</p>"
               }
             }
@@ -518,11 +518,11 @@
       },
       "transitionTexts": [
         {
-          "content": "<p>Sur un ordinateur, on peut souvent brancher des appareils, comme une souris ou un clavier.<br>On peut aussi brancher une clé USB. Elle n’est pas toujours facile à brancher <span aria-hidden='true'>🤯</span></p>",
+          "content": "<p>Sur un ordinateur, on peut souvent brancher des appareils, comme une souris ou un clavier.<br>On peut aussi brancher une clé USB. Elle n’est pas toujours facile à brancher <span aria-hidden=\"true\">🤯</span></p>",
           "grainId": "8bb146db-104c-41e2-aa79-14f7a06e0930"
         },
         {
-          "content": "<p>Une clé USB se branche sur un port de connexion USB.<br>Ce n'est pas la seule ! Il y a d'autres objets qui se branchent aussi via USB. Voici quelques explications <span aria-hidden='true'>📚</span>.</p>",
+          "content": "<p>Une clé USB se branche sur un port de connexion USB.<br>Ce n'est pas la seule ! Il y a d'autres objets qui se branchent aussi via USB. Voici quelques explications <span aria-hidden=\"true\">📚</span>.</p>",
           "grainId": "75091cc6-61ca-4b9e-a6a0-89701ed721a8"
         },
         {
@@ -562,8 +562,8 @@
                 }
               ],
               "feedbacks": {
-                "valid": "<p>Ça arrive à tout le monde ! <span aria-hidden='true'>🏅</span></p>",
-                "invalid": "<p>Toujours ?! on ne vous croit pas... <span aria-hidden='true'>😉</span></p>"
+                "valid": "<p>Ça arrive à tout le monde ! <span aria-hidden=\"true\">🏅</span></p>",
+                "invalid": "<p>Toujours ?! on ne vous croit pas... <span aria-hidden=\"true\">😉</span></p>"
               },
               "solution": "2"
             }
@@ -669,7 +669,7 @@
             {
               "id": "270b0408-be92-484a-b9b2-5d302f01eecf",
               "type": "text",
-              "content": "<h4>Pour chaque affirmation, choisissez si elle est vraie ou fausse <span aria-hidden='true'>✅</span> <span aria-hidden='true'>❌</span></h4>"
+              "content": "<h4>Pour chaque affirmation, choisissez si elle est vraie ou fausse <span aria-hidden=\"true\">✅</span> <span aria-hidden=\"true\">❌</span></h4>"
             },
             {
               "id": "6f276b50-a00c-49f7-b22c-23dbef0c2bf2",
@@ -784,7 +784,7 @@
             {
               "id": "df4b59c7-b4d8-450c-985a-dc9bc9735f26",
               "type": "text",
-              "content": "<p>C’est un <strong>port de l’alimentation électrique</strong>.<br> Il sert à recharger son ordinateur ou à le connecter au réseau électrique <span aria-hidden='true'>🔌</span>. Sur les ordinateurs portables il y a beaucoup de variantes possibles et sur un ordinateur fixe il est plus gros.</p>"
+              "content": "<p>C’est un <strong>port de l’alimentation électrique</strong>.<br> Il sert à recharger son ordinateur ou à le connecter au réseau électrique <span aria-hidden=\"true\">🔌</span>. Sur les ordinateurs portables il y a beaucoup de variantes possibles et sur un ordinateur fixe il est plus gros.</p>"
             },
             {
               "id": "02e82529-bcbc-4d0d-b9ad-e50d28bec4f3",
@@ -801,7 +801,7 @@
             {
               "id": "466f1f93-de01-4c1e-9624-2783a875fcf2",
               "type": "text",
-              "content": "<p>C’est un <strong>port VGA</strong>.<br> On le reconnaît grâce à sa forme et ses petits pointillés. Ce port sert à connecter un écran ou un vidéo-projecteur à l’ordinateur <span aria-hidden='true'>📽️</span>.</p>"
+              "content": "<p>C’est un <strong>port VGA</strong>.<br> On le reconnaît grâce à sa forme et ses petits pointillés. Ce port sert à connecter un écran ou un vidéo-projecteur à l’ordinateur <span aria-hidden=\"true\">📽️</span>.</p>"
             },
             {
               "id": "3a445423-faac-460b-b407-c8d80dfeb5d3",
@@ -818,7 +818,7 @@
             {
               "id": "86851d7d-0ce8-48a3-b8ac-433da8134dec",
               "type": "text",
-              "content": "<p>C’est un <strong>port HDMI</strong>.<br> On peut le reconnaître grâce à sa forme et il y a souvent la mention “HDMI” juste à côté. Ce port sert principalement à connecter un écran ou un vidéo-projecteur à l’ordinateur, comme le port VGA <span aria-hidden='true'>📽️</span>.</p>"
+              "content": "<p>C’est un <strong>port HDMI</strong>.<br> On peut le reconnaître grâce à sa forme et il y a souvent la mention “HDMI” juste à côté. Ce port sert principalement à connecter un écran ou un vidéo-projecteur à l’ordinateur, comme le port VGA <span aria-hidden=\"true\">📽️</span>.</p>"
             },
             {
               "id": "4ad6f499-244f-4f74-9112-feaebdd62305",
@@ -835,7 +835,7 @@
             {
               "id": "706f1c55-3009-4cff-affe-6548076d65ac",
               "type": "text",
-              "content": "<p>C’est un <strong>port USB</strong>.<br> Il sert à connecter différents appareils externes à l’ordinateur <span aria-hidden='true'>🖱️</span> <span aria-hidden='true'>🎮</span>.</p>"
+              "content": "<p>C’est un <strong>port USB</strong>.<br> Il sert à connecter différents appareils externes à l’ordinateur <span aria-hidden=\"true\">🖱️</span> <span aria-hidden=\"true\">🎮</span>.</p>"
             },
             {
               "id": "aa3f93df-8348-47f2-bb3c-2c32c114fcd0",
@@ -852,7 +852,7 @@
             {
               "id": "be359a9d-19d2-49a7-8699-8921156e554c",
               "type": "text",
-              "content": "<p>C’est un <strong>port ethernet</strong>.<br> Il est utilisé pour connecter l’ordinateur à internet grâce à un câble éthernet <span aria-hidden='true'>🌐</span>. Le câble ethernet relie l’ordinateur à la box internet.</p>"
+              "content": "<p>C’est un <strong>port ethernet</strong>.<br> Il est utilisé pour connecter l’ordinateur à internet grâce à un câble éthernet <span aria-hidden=\"true\">🌐</span>. Le câble ethernet relie l’ordinateur à la box internet.</p>"
             },
             {
               "id": "53eca1dc-8f9f-46bc-a132-1c1e65fadb70",
@@ -869,7 +869,7 @@
             {
               "id": "12ac3b9a-286c-4587-9a0d-6dc56e13caf9",
               "type": "text",
-              "content": "<p>C’est un <strong>port jack</strong>. On dit aussi <strong>prise jack</strong>.<br> Il est petit et rond. Il est souvent accompagné d’une image de casque <span aria-hidden='true'>🎧</span>. Il sert à connecter des appareils audios à l’ordinateur : écouteurs, casque, micro, etc.</p>"
+              "content": "<p>C’est un <strong>port jack</strong>. On dit aussi <strong>prise jack</strong>.<br> Il est petit et rond. Il est souvent accompagné d’une image de casque <span aria-hidden=\"true\">🎧</span>. Il sert à connecter des appareils audios à l’ordinateur : écouteurs, casque, micro, etc.</p>"
             },
             {
               "id": "117eebac-f2be-4a14-808a-7adcceabf653",
@@ -980,17 +980,17 @@
             {
               "id": "826281e7-865f-462d-abc0-77537c42a2b4",
               "type": "text",
-              "content": "<h4><span aria-hidden='true'>🔮&nbsp;</span>Une personne a deviné votre mot de passe…</h4><p>Une personne qui vous connaît bien a accès à de nombreuses informations vous concernant. <br />Si vous utilisez des informations privées en guise de mot de passe, il est probable qu’une personne de votre entourage puisse deviner facilement votre mot de passe et ainsi accéder à des données privées. Et ce n’est peut être pas pour vous faire un cadeau d’anniversaire surprise, malheureusement.<span aria-hidden='true'> 🙃</span></p>"
+              "content": "<h4><span aria-hidden=\"true\">🔮&nbsp;</span>Une personne a deviné votre mot de passe…</h4><p>Une personne qui vous connaît bien a accès à de nombreuses informations vous concernant. <br />Si vous utilisez des informations privées en guise de mot de passe, il est probable qu’une personne de votre entourage puisse deviner facilement votre mot de passe et ainsi accéder à des données privées. Et ce n’est peut être pas pour vous faire un cadeau d’anniversaire surprise, malheureusement.<span aria-hidden=\"true\"> 🙃</span></p>"
             },
             {
               "id": "9d0b7aff-a9da-453f-a6ba-c61fbaa7bb25",
               "type": "text",
-              "content": "<h4><span aria-hidden='true'>🤖&nbsp;</span>Un programme a deviné votre mot de passe…</h4><p>En 2023, un mot de passe de 8 caractères avec minuscules, majuscules, nombres et caractères spéciaux sera piraté en 5 minutes seulement ! <span aria-hidden='true'>😰 </span>Avec 12 caractères, cette durée passe à 226 ans ! <span aria-hidden='true'>😮 </span><br />En général, dans le cas d’attaques automatisées, votre attaquant ne vous connaît pas personnellement, et cherche certainement à revendre vos informations ou à vous soutirer de l’argent.</p>"
+              "content": "<h4><span aria-hidden=\"true\">🤖&nbsp;</span>Un programme a deviné votre mot de passe…</h4><p>En 2023, un mot de passe de 8 caractères avec minuscules, majuscules, nombres et caractères spéciaux sera piraté en 5 minutes seulement ! <span aria-hidden=\"true\">😰 </span>Avec 12 caractères, cette durée passe à 226 ans ! <span aria-hidden=\"true\">😮 </span><br />En général, dans le cas d’attaques automatisées, votre attaquant ne vous connaît pas personnellement, et cherche certainement à revendre vos informations ou à vous soutirer de l’argent.</p>"
             },
             {
               "id": "e17089d4-a166-4bf4-a18b-155caaebe081",
               "type": "text",
-              "content": "<h4><span aria-hidden='true'>🔓&nbsp;</span>Votre mot de passe est compromis…</h4><p>Qu’il s’agisse d’une attaque automatisée ou d’une attaque ciblée vous concernant, si votre mot de passe a été deviné, les conséquences peuvent être graves. En particulier si le mot de passe compromis est celui de votre boîte mail <span aria-hidden='true'>😬</span></p>"
+              "content": "<h4><span aria-hidden=\"true\">🔓&nbsp;</span>Votre mot de passe est compromis…</h4><p>Qu’il s’agisse d’une attaque automatisée ou d’une attaque ciblée vous concernant, si votre mot de passe a été deviné, les conséquences peuvent être graves. En particulier si le mot de passe compromis est celui de votre boîte mail <span aria-hidden=\"true\">😬</span></p>"
             }
           ]
         },
@@ -1108,8 +1108,8 @@
                 }
               ],
               "feedbacks": {
-                "valid": "<p>Bien vu ! Vous maîtrisez maintenant la méthode, à vous de jouer <span aria-hidden='true'>😁</span></p>",
-                "invalid": "<p>Et non ! Essayez peut-être de vérifier la ponctuation ? <span aria-hidden='true'>🧐</span></p>"
+                "valid": "<p>Bien vu ! Vous maîtrisez maintenant la méthode, à vous de jouer <span aria-hidden=\"true\">😁</span></p>",
+                "invalid": "<p>Et non ! Essayez peut-être de vérifier la ponctuation ? <span aria-hidden=\"true\">🧐</span></p>"
               }
             }
           ]
@@ -1153,7 +1153,7 @@
                 }
               ],
               "feedbacks": {
-                "valid": "<p>Correct ! <span aria-hidden='true'>🎉</span> </p>",
+                "valid": "<p>Correct ! <span aria-hidden=\"true\">🎉</span> </p>",
                 "invalid": "<p>Incorrect !</p>"
               },
               "solution": "1"
@@ -1173,7 +1173,7 @@
                 }
               ],
               "feedbacks": {
-                "valid": "<p>Correct ! <span aria-hidden='true'>🎉</span> </p>",
+                "valid": "<p>Correct ! <span aria-hidden=\"true\">🎉</span> </p>",
                 "invalid": "<p>Incorrect !</p>"
               },
               "solution": "1"
@@ -1193,7 +1193,7 @@
                 }
               ],
               "feedbacks": {
-                "valid": "<p>Correct ! <span aria-hidden='true'>🎉</span> </p>",
+                "valid": "<p>Correct ! <span aria-hidden=\"true\">🎉</span> </p>",
                 "invalid": "<p>Incorrect !</p>"
               },
               "solution": "1"
@@ -1234,23 +1234,23 @@
       },
       "transitionTexts": [
         {
-          "content": "<p>En naviguant sur internet, il arrive qu'un site sache où vous vous trouvez alors que vous n'avez pas partagé votre localisation <span aria-hidden='true'>📍</span>️<br>Mystère ? Pas vraiment. On vous explique tout dans ce module.</p>",
+          "content": "<p>En naviguant sur internet, il arrive qu'un site sache où vous vous trouvez alors que vous n'avez pas partagé votre localisation <span aria-hidden=\"true\">📍</span>️<br>Mystère ? Pas vraiment. On vous explique tout dans ce module.</p>",
           "grainId": "1d516eb9-e7b7-48a3-a3b5-7971ad171d6f"
         },
         {
-          "content": "<p>Dans la vidéo suivante, on vous explique ce qu'est une adresse IP publique et à quoi elle sert&nbsp;<span aria-hidden='true'>▶️</span>️</p>",
+          "content": "<p>Dans la vidéo suivante, on vous explique ce qu'est une adresse IP publique et à quoi elle sert&nbsp;<span aria-hidden=\"true\">▶️</span>️</p>",
           "grainId": "4f4ada91-e239-4991-9fc8-ab491aabc424"
         },
         {
-          "content": "<p>Vous en savez désormais plus sur les adresses IP publiques&nbsp;<span aria-hidden='true'>👩‍💻</span>️<span aria-hidden='true'>👨🏿‍💻</span>️. Pour le vérifier, répondez à cette question. </p>",
+          "content": "<p>Vous en savez désormais plus sur les adresses IP publiques&nbsp;<span aria-hidden=\"true\">👩‍💻</span>️<span aria-hidden=\"true\">👨🏿‍💻</span>️. Pour le vérifier, répondez à cette question. </p>",
           "grainId": "eba0b676-c0c4-4b32-b5e4-dd94d13766a5"
         },
         {
-          "content": "<p>Lorsque vous êtes en ligne, votre IP publique est partagée et utilisée. Mais savez-vous quelles informations cette adresse donne sur vous ? <span aria-hidden='true'>👁️‍🗨️</span>️</p>",
+          "content": "<p>Lorsque vous êtes en ligne, votre IP publique est partagée et utilisée. Mais savez-vous quelles informations cette adresse donne sur vous ? <span aria-hidden=\"true\">👁️‍🗨️</span>️</p>",
           "grainId": "96cdedc1-2d31-40c2-ac02-d3fd83f26e30"
         },
         {
-          "content": "<p>On l'a vu, on peut déterminer une zone géographique à partir d'une adresse IP publique. Place à la pratique&nbsp;<span aria-hidden='true'>🌍</span>️&nbsp;!</p>",
+          "content": "<p>On l'a vu, on peut déterminer une zone géographique à partir d'une adresse IP publique. Place à la pratique&nbsp;<span aria-hidden=\"true\">🌍</span>️&nbsp;!</p>",
           "grainId": "09304128-193f-4ea8-bda7-edffd72b1bf2"
         },
         {
@@ -1271,7 +1271,7 @@
             {
               "id": "67b68f2a-349d-4df7-90a5-c9f5dc930a1a",
               "type": "text",
-              "content": "<p> Voici la page de résultats d'une recherche en ligne sur des recettes végétariennes <span aria-hidden='true'>🥗</span>️<br>Le moteur de recherche indique que l'utilisateur se trouve actuellement vers Toulouse.</p>"
+              "content": "<p> Voici la page de résultats d'une recherche en ligne sur des recettes végétariennes <span aria-hidden=\"true\">🥗</span>️<br>Le moteur de recherche indique que l'utilisateur se trouve actuellement vers Toulouse.</p>"
             },
             {
               "id": "2098be0b-e994-4bcd-8e52-5a6559963f8c",
@@ -1442,7 +1442,7 @@
                 }
               ],
               "feedbacks": {
-                "valid": "<p>Correct. Au mieux, on peut connaître votre pays ou votre ville. Si quelqu’un vous menace de venir chez vous juste parce qu’elle connaît votre adresse IP … c’est du bluff ! <span aria-hidden='true'>😎</span>️</p>",
+                "valid": "<p>Correct. Au mieux, on peut connaître votre pays ou votre ville. Si quelqu’un vous menace de venir chez vous juste parce qu’elle connaît votre adresse IP … c’est du bluff ! <span aria-hidden=\"true\">😎</span>️</p>",
                 "invalid": "<p>Incorrect. Une adresse IP permet d'identifier un pays voire une ville de connexion, mais difficile d’en savoir plus !</p>"
               },
               "solution": "2"
@@ -1457,7 +1457,7 @@
             {
               "id": "27fc867a-7258-4f85-b8cc-bdd1ab2d26a5",
               "type": "text",
-              "content": "<h3>Ce qu'il faut retenir <span aria-hidden='true'>🎓</span>️</h3><br><p>L’adresse IP publique donne une information sur la zone géographique de la connexion.</p><br><p>Votre adresse IP publique est celle de votre point d’accès (box) internet.</p><br><p>Les personnes connectées au même point d’accès ont la même adresse IP publique.</p><br>À partir d'une adresse IP publique, on peut seulement identifier un pays voire une ville de connexion. Les fournisseurs d'accès internet et les autorités peuvent cependant avoir des informations beaucoup plus complètes sur la base d'une IP publique.</p>"
+              "content": "<h3>Ce qu'il faut retenir <span aria-hidden=\"true\">🎓</span>️</h3><br><p>L’adresse IP publique donne une information sur la zone géographique de la connexion.</p><br><p>Votre adresse IP publique est celle de votre point d’accès (box) internet.</p><br><p>Les personnes connectées au même point d’accès ont la même adresse IP publique.</p><br>À partir d'une adresse IP publique, on peut seulement identifier un pays voire une ville de connexion. Les fournisseurs d'accès internet et les autorités peuvent cependant avoir des informations beaucoup plus complètes sur la base d'une IP publique.</p>"
             }
           ]
         },
@@ -1485,7 +1485,7 @@
                 }
               ],
               "feedbacks": {
-                "valid": "<p>Correct <span aria-hidden='true'>🎉</span></p>",
+                "valid": "<p>Correct <span aria-hidden=\"true\">🎉</span></p>",
                 "invalid": "<p>Incorrect. Pour réussir, faites une recherche sur internet avec les mots-clés \"localisation adresse IP\".</p>"
               }
             }
@@ -1535,7 +1535,7 @@
                 }
               ],
               "feedbacks": {
-                "valid": "<p>Correct <span aria-hidden='true'>🎉</span></p>",
+                "valid": "<p>Correct <span aria-hidden=\"true\">🎉</span></p>",
                 "invalid": "<p>Incorrect. L'IP privée (locale) est visible uniquement par les appareils du réseaux local.</p>"
               },
               "solution": "1"
@@ -1555,7 +1555,7 @@
                 }
               ],
               "feedbacks": {
-                "valid": "<p>Correct <span aria-hidden='true'>🎉</span></p>",
+                "valid": "<p>Correct <span aria-hidden=\"true\">🎉</span></p>",
                 "invalid": "<p>Incorrect. L'IP publique permet les échanges entre une box internet et les sites visités.</p>"
               },
               "solution": "2"
@@ -1575,7 +1575,7 @@
                 }
               ],
               "feedbacks": {
-                "valid": "<p>Correct <span aria-hidden='true'>🎉</span></p>",
+                "valid": "<p>Correct <span aria-hidden=\"true\">🎉</span></p>",
                 "invalid": "<p>Incorrect. L'adresse IP publique est spécifique à la box internet, pas les appreils qui y sont connectés.</p>"
               },
               "solution": "2"
@@ -1590,12 +1590,12 @@
             {
               "id": "786e42f3-e33b-46e0-be56-59fa9f26d3bf",
               "type": "text",
-              "content": "<h4>Pour finir ce module, trouvez votre adresse IP publique actuelle <span aria-hidden='true'>🕵️‍♂️</span>️<span aria-hidden='true'>🕵🏽‍♀️</span>️</h4>"
+              "content": "<h4>Pour finir ce module, trouvez votre adresse IP publique actuelle <span aria-hidden=\"true\">🕵️‍♂️</span>️<span aria-hidden=\"true\">🕵🏽‍♀️</span>️</h4>"
             },
             {
               "id": "1203cc2d-fc07-4641-88f8-2b3d42020b39",
               "type": "text",
-              "content": "<p><span aria-hidden='true'>🗝️</span>️ Pour vérifier votre réponse, suivez ce lien vers <a href=\"http://monip.org/\" target=\"_blank\">le site monip.org</a></p>"
+              "content": "<p><span aria-hidden=\"true\">🗝️</span>️ Pour vérifier votre réponse, suivez ce lien vers <a href=\"http://monip.org/\" target=\"_blank\">le site monip.org</a></p>"
             }
           ]
         }
@@ -1610,15 +1610,19 @@
         "description": "Sur internet, de nombreuses informations circulent. Certaines sont vraies, d'autres sont fausses. Dans ce module, vous appliquerez des méthodes pour analyser une information et aiguiser votre esprit critique !",
         "duration": 10,
         "level": "Intermédiaire",
-        "objectives": ["Vérifier une information en ligne", "Connaître et appliquer une méthode de vérification d’une information", "Repérer une information douteuse et agir en conséquence"]
+        "objectives": [
+          "Vérifier une information en ligne",
+          "Connaître et appliquer une méthode de vérification d’une information",
+          "Repérer une information douteuse et agir en conséquence"
+        ]
       },
       "transitionTexts": [
         {
-          "content": "<p>Commençons par un jeu <span aria-hidden='true'>🎮</span>️<br>Sans chercher sur internet, devinez si l’information proposée est vraie ou fausse. Bonne chance !</p>",
+          "content": "<p>Commençons par un jeu <span aria-hidden=\"true\">🎮</span>️<br>Sans chercher sur internet, devinez si l’information proposée est vraie ou fausse. Bonne chance !</p>",
           "grainId": "f242e81e-b182-44a1-a668-557f26b5ff8b"
         },
         {
-          "content": "<p>En lisant seulement le titre d’un article, c’est presque impossible d’être sûr de ce qui est vrai ou faux <span aria-hidden='true'>🤔</span>️<br>Pour vérifier une information, il y a une méthode à suivre <span aria-hidden='true'>📚</span>️</p>",
+          "content": "<p>En lisant seulement le titre d’un article, c’est presque impossible d’être sûr de ce qui est vrai ou faux <span aria-hidden=\"true\">🤔</span>️<br>Pour vérifier une information, il y a une méthode à suivre <span aria-hidden=\"true\">📚</span>️</p>",
           "grainId": "eb83569f-2e37-49ed-aa6f-31c420b673b9"
         },
         {
@@ -1630,7 +1634,7 @@
           "grainId": "428ea826-6e21-4c56-a5a2-f97373f1e833"
         },
         {
-          "content": "<p>Maintenant, à vous d’étudier une situation <span aria-hidden='true'>🕵️</span>️<span aria-hidden='true'>🕵🏿‍♀️</span>️</p>",
+          "content": "<p>Maintenant, à vous d’étudier une situation <span aria-hidden=\"true\">🕵️</span>️<span aria-hidden=\"true\">🕵🏿‍♀️</span>️</p>",
           "grainId": "9f56f75e-3e2d-4a6e-8623-9b74747b236d"
         }
       ],
@@ -1912,7 +1916,7 @@
               ],
               "feedbacks": {
                 "valid": "<p>Correct. Vous allez maintenant pouvoir appliquer cette méthode. </p>",
-                "invalid": "<p>Incorrect. Retourner voir la vidéo si besoin <span aria-hidden='true'>⬆</span>️!</p>"
+                "invalid": "<p>Incorrect. Retourner voir la vidéo si besoin <span aria-hidden=\"true\">⬆</span>️!</p>"
               },
               "solutions": ["2", "3", "5"]
             }
@@ -2065,7 +2069,7 @@
             {
               "id": "eb90d3ea-797f-4e4a-9675-e679b9f5bf3c",
               "type": "text",
-              "content": "<p>Stéphane a du mal à faire pousser sa nouvelle plante verte d’intérieur <span aria-hidden='true'>🪴</span>️. Il cherche des astuces sur les réseaux sociaux.<br>Il trouve ces informations publiées par SuperJardinier le 28 août 2023 :</p>"
+              "content": "<p>Stéphane a du mal à faire pousser sa nouvelle plante verte d’intérieur <span aria-hidden=\"true\">🪴</span>️. Il cherche des astuces sur les réseaux sociaux.<br>Il trouve ces informations publiées par SuperJardinier le 28 août 2023 :</p>"
             },
             {
               "id": "2c525ab3-23bf-4b43-867d-ea1fac54efad",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/module.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module.json
@@ -59,7 +59,7 @@
               "type": "image",
               "url": "https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg",
               "alt": "Schéma de la syntaxe d'une adresse mail, en trois blocs distincts, décrit dans l'alternative textuelle",
-              "alternativeText": "Bloc 1&nbsp;: Identifiant, exemple&nbsp;: mickael.aubert123<br/>Bloc 2&nbsp;: Arobase<br/>Bloc 3&nbsp;: Fournisseur d'adresse mail, exemple&nbsp;: laposte.net "
+              "alternativeText": "Bloc 1&nbsp;: Identifiant, exemple&nbsp;: mickael.aubert123<br>Bloc 2&nbsp;: Arobase<br>Bloc 3&nbsp;: Fournisseur d'adresse mail, exemple&nbsp;: laposte.net "
             },
             {
               "id": "c1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d",
@@ -255,7 +255,7 @@
             {
               "id": "b0fcb950-b5b1-4384-886e-79fb852d5bb7",
               "type": "text",
-              "content": "<h3>Ce qu’il faut retenir</h3><ul><li>Il peut y avoir des chiffres dans l’identifiant d’une adresse mail. Ils peuvent être n’importe où dans l’adresse. <br/><span aria-hidden=\"true\">💡</span> Ça peut être utile si deux personnes ont le même nom et qu’elles veulent le même fournisseur d’adresse mail.</li><li>Il y a une seule @ (arobase) dans une adresse mail. Elle permet de séparer l’identifiant du fournisseur d’adresse mail.</li><li>Les adresses mails se terminent de différentes manières après l'@, selon le fournisseur d’adresse mail.<br/><span aria-hidden=\"true\">✅</span> Exemples&nbsp;: laposte.net, free.fr, gmail.com, yahoo.com, etc.</li></ul>"
+              "content": "<h3>Ce qu’il faut retenir</h3><ul><li>Il peut y avoir des chiffres dans l’identifiant d’une adresse mail. Ils peuvent être n’importe où dans l’adresse. <br><span aria-hidden=\"true\">💡</span> Ça peut être utile si deux personnes ont le même nom et qu’elles veulent le même fournisseur d’adresse mail.</li><li>Il y a une seule @ (arobase) dans une adresse mail. Elle permet de séparer l’identifiant du fournisseur d’adresse mail.</li><li>Les adresses mails se terminent de différentes manières après l'@, selon le fournisseur d’adresse mail.<br><span aria-hidden=\"true\">✅</span> Exemples&nbsp;: laposte.net, free.fr, gmail.com, yahoo.com, etc.</li></ul>"
             }
           ]
         },
@@ -913,7 +913,7 @@
           "grainId": "00962dcd-9636-44b1-b1c8-d4a5ab2d90c8"
         },
         {
-          "content": "<p>C’est très clair : si tout le monde utilise le même mot de passe, ça ne sert pas à grand chose !<br />Regardons d’un peu plus près les situations dont il faut se protéger...</p>",
+          "content": "<p>C’est très clair : si tout le monde utilise le même mot de passe, ça ne sert pas à grand chose !<br>Regardons d’un peu plus près les situations dont il faut se protéger...</p>",
           "grainId": "831fd61c-54ae-4b21-bd3f-61f40887a869"
         },
         {
@@ -925,7 +925,7 @@
           "grainId": "1564f763-5ba5-48ef-b752-dac463319899"
         },
         {
-          "content": "<p>Cela fait beaucoup de règles à respecter !<br />Et si on essayait d'utiliser une méthode pour que ce soit un peu plus facile ?</p>",
+          "content": "<p>Cela fait beaucoup de règles à respecter !<br>Et si on essayait d'utiliser une méthode pour que ce soit un peu plus facile ?</p>",
           "grainId": "f6bd140c-4f63-4fe7-94f4-b4d7a51db7a5"
         },
         {
@@ -980,12 +980,12 @@
             {
               "id": "826281e7-865f-462d-abc0-77537c42a2b4",
               "type": "text",
-              "content": "<h4><span aria-hidden=\"true\">🔮&nbsp;</span>Une personne a deviné votre mot de passe…</h4><p>Une personne qui vous connaît bien a accès à de nombreuses informations vous concernant. <br />Si vous utilisez des informations privées en guise de mot de passe, il est probable qu’une personne de votre entourage puisse deviner facilement votre mot de passe et ainsi accéder à des données privées. Et ce n’est peut être pas pour vous faire un cadeau d’anniversaire surprise, malheureusement.<span aria-hidden=\"true\"> 🙃</span></p>"
+              "content": "<h4><span aria-hidden=\"true\">🔮&nbsp;</span>Une personne a deviné votre mot de passe…</h4>Une personne qui vous connaît bien a accès à de nombreuses informations vous concernant. <br>Si vous utilisez des informations privées en guise de mot de passe, il est probable qu’une personne de votre entourage puisse deviner facilement votre mot de passe et ainsi accéder à des données privées. Et ce n’est peut être pas pour vous faire un cadeau d’anniversaire surprise, malheureusement.<span aria-hidden=\"true\"> 🙃</span></p>"
             },
             {
               "id": "9d0b7aff-a9da-453f-a6ba-c61fbaa7bb25",
               "type": "text",
-              "content": "<h4><span aria-hidden=\"true\">🤖&nbsp;</span>Un programme a deviné votre mot de passe…</h4><p>En 2023, un mot de passe de 8 caractères avec minuscules, majuscules, nombres et caractères spéciaux sera piraté en 5 minutes seulement ! <span aria-hidden=\"true\">😰 </span>Avec 12 caractères, cette durée passe à 226 ans ! <span aria-hidden=\"true\">😮 </span><br />En général, dans le cas d’attaques automatisées, votre attaquant ne vous connaît pas personnellement, et cherche certainement à revendre vos informations ou à vous soutirer de l’argent.</p>"
+              "content": "<h4><span aria-hidden=\"true\">🤖&nbsp;</span>Un programme a deviné votre mot de passe…</h4><p>En 2023, un mot de passe de 8 caractères avec minuscules, majuscules, nombres et caractères spéciaux sera piraté en 5 minutes seulement ! <span aria-hidden=\"true\">😰 </span>Avec 12 caractères, cette durée passe à 226 ans ! <span aria-hidden=\"true\">😮 </span><br>En général, dans le cas d’attaques automatisées, votre attaquant ne vous connaît pas personnellement, et cherche certainement à revendre vos informations ou à vous soutirer de l’argent.</p>"
             },
             {
               "id": "e17089d4-a166-4bf4-a18b-155caaebe081",
@@ -1087,7 +1087,7 @@
             {
               "id": "fd4b05ee-8cda-4bfe-b18a-468f1a895f80",
               "type": "text",
-              "content": "<h4>Voici la méthode pour construire un mot de passe sécurisé</h4><p>Partez d'une phrase facile à retenir, qui a du sens pour vous. Elle doit contenir des nombres et de la ponctuation. Par exemple : <em>J'ai 2 chats, 3 poissons exotiques et j'adore faire de la plongée!</em><br />Ensuite, prenez les premières lettres de chaque mot, gardez les nombres, la ponctuation, et le tour est joué !<br />Le mot de passe corespondant est : <strong>J'a2c,3peej'afdlp!</strong><br />Maintenant à vous de jouer </p>"
+              "content": "<h4>Voici la méthode pour construire un mot de passe sécurisé</h4><p>Partez d'une phrase facile à retenir, qui a du sens pour vous. Elle doit contenir des nombres et de la ponctuation. Par exemple : <em>J'ai 2 chats, 3 poissons exotiques et j'adore faire de la plongée!</em><br>Ensuite, prenez les premières lettres de chaque mot, gardez les nombres, la ponctuation, et le tour est joué !<br>Le mot de passe corespondant est : <strong>J'a2c,3peej'afdlp!</strong><br>Maintenant à vous de jouer </p>"
             },
             {
               "id": "718ee7f6-19bf-4787-a025-2a70b89c6288",
@@ -1457,7 +1457,7 @@
             {
               "id": "27fc867a-7258-4f85-b8cc-bdd1ab2d26a5",
               "type": "text",
-              "content": "<h3>Ce qu'il faut retenir <span aria-hidden=\"true\">🎓</span>️</h3><br><p>L’adresse IP publique donne une information sur la zone géographique de la connexion.</p><br><p>Votre adresse IP publique est celle de votre point d’accès (box) internet.</p><br><p>Les personnes connectées au même point d’accès ont la même adresse IP publique.</p><br>À partir d'une adresse IP publique, on peut seulement identifier un pays voire une ville de connexion. Les fournisseurs d'accès internet et les autorités peuvent cependant avoir des informations beaucoup plus complètes sur la base d'une IP publique.</p>"
+              "content": "<h3>Ce qu'il faut retenir <span aria-hidden=\"true\">🎓</span>️</h3><br><p>L’adresse IP publique donne une information sur la zone géographique de la connexion.</p><br><p>Votre adresse IP publique est celle de votre point d’accès (box) internet.</p><br><p>Les personnes connectées au même point d’accès ont la même adresse IP publique.</p><br><p>À partir d'une adresse IP publique, on peut seulement identifier un pays voire une ville de connexion. Les fournisseurs d'accès internet et les autorités peuvent cependant avoir des informations beaucoup plus complètes sur la base d'une IP publique.</p>"
             }
           ]
         },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/module.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module.json
@@ -180,8 +180,8 @@
                 }
               ],
               "feedbacks": {
-                "valid": "<p class=\"pix-list-inline\">Oui, aucun problème ! Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>",
-                "invalid": "<p class=\"pix-list-inline\">Et si ! les chiffres sont autorisés dans l’identifiant d’une adresse mail. Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>"
+                "valid": "<p class=\"pix-list-inline\">Oui, aucun problème ! Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>",
+                "invalid": "<p class=\"pix-list-inline\">Et si ! les chiffres sont autorisés dans l’identifiant d’une adresse mail. Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>"
               },
               "solution": "1"
             },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/module.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module.json
@@ -45,7 +45,7 @@
               "title": "Le format des adresses mail",
               "url": "https://videos.pix.fr/modulix/chat_animation_2.mp4",
               "subtitles": "https://videos.pix.fr/modulix/chat_animation_2.vtt",
-              "transcription": "<ul><li>Naomi : Salut, tu peux me redonner ton adresse mail stp ? <span aria-hidden=\"true\">😇</span></li> <li>Mickaël : Oui, c’est mickael.aubert123#laposte.net</li><li>Naomi : T’es sûr ? <span aria-hidden=\"true\">😬</span></li><li>Naomi : Tu veux dire mickael.aubert123@laposte.net</li><li>Mickaël : Ah oui désolé ! <span aria-hidden=\"true\">😣</span></li><li>Mickaël : comment tu as su ? </li><li>Naomi : …</li>"
+              "transcription": "<ul><li>Naomi : Salut, tu peux me redonner ton adresse mail stp ? <span aria-hidden=\"true\">😇</span></li> <li>Mickaël : Oui, c’est mickael.aubert123#laposte.net</li><li>Naomi : T’es sûr ? <span aria-hidden=\"true\">😬</span></li><li>Naomi : Tu veux dire mickael.aubert123@laposte.net</li><li>Mickaël : Ah oui désolé ! <span aria-hidden=\"true\">😣</span></li><li>Mickaël : comment tu as su ? </li><li>Naomi : …</li></ul>"
             }
           ]
         },
@@ -369,7 +369,7 @@
               "title": "Vidéo de présentation de Pix",
               "url": "https://videos.pix.fr/modulix/didacticiel/presentation.mp4",
               "subtitles": "-",
-              "transcription": "<p>Le numérique évolue en permanence, vos compétences aussi, pour travailler, communiquer et s'informer, se déplacer, réaliser des démarches, un enjeu tout au long de la vie.</p><p>Sur <a href='https://pix.fr' target=\"blank\">pix.fr</a>, testez-vous et cultivez vos compétences numériques.</p><p>Les tests Pix sont personnalisés, les questions s'adaptent à votre niveau, réponse après réponse.</p><p>Évaluez vos connaissances et savoir-faire sur 16 compétences, dans 5 domaines, sur 5 niveaux de débutants à confirmer, avec des mises en situation ludiques, recherches en ligne, manipulation de fichiers et de données, culture numérique...</p><p>Allez à votre rythme, vous pouvez arrêter et reprendre quand vous le voulez.</p><p>Toutes les 5 questions, découvrez vos résultats et progressez grâce aux astuces et aux tutos.</p><p>En relevant les défis Pix, vous apprendrez de nouvelles choses et aurez envie d'aller plus loin.</p><p>Vous pensez pouvoir faire mieux ?</p><p>Retentez les tests et améliorez votre score.</p><p>Faites reconnaître officiellement votre niveau en passant la certification Pix, reconnue par l'État et le monde professionnel.</p><p>Pix : le service public en ligne pour évaluer, développer et certifier ses compétences numériques.</p>"
+              "transcription": "<p>Le numérique évolue en permanence, vos compétences aussi, pour travailler, communiquer et s'informer, se déplacer, réaliser des démarches, un enjeu tout au long de la vie.</p><p>Sur <a href=\"https://pix.fr\" target=\"blank\">pix.fr</a>, testez-vous et cultivez vos compétences numériques.</p><p>Les tests Pix sont personnalisés, les questions s'adaptent à votre niveau, réponse après réponse.</p><p>Évaluez vos connaissances et savoir-faire sur 16 compétences, dans 5 domaines, sur 5 niveaux de débutants à confirmer, avec des mises en situation ludiques, recherches en ligne, manipulation de fichiers et de données, culture numérique...</p><p>Allez à votre rythme, vous pouvez arrêter et reprendre quand vous le voulez.</p><p>Toutes les 5 questions, découvrez vos résultats et progressez grâce aux astuces et aux tutos.</p><p>En relevant les défis Pix, vous apprendrez de nouvelles choses et aurez envie d'aller plus loin.</p><p>Vous pensez pouvoir faire mieux ?</p><p>Retentez les tests et améliorez votre score.</p><p>Faites reconnaître officiellement votre niveau en passant la certification Pix, reconnue par l'État et le monde professionnel.</p><p>Pix : le service public en ligne pour évaluer, développer et certifier ses compétences numériques.</p>"
             }
           ]
         },
@@ -433,7 +433,7 @@
               ],
               "feedbacks": {
                 "valid": "<p>Correct ! Vous nous avez bien cernés :)</p>",
-                "invalid": "<p>Et non ! Pix sert à évaluer, certifier et développer ses compétences numériques."
+                "invalid": "<p>Et non ! Pix sert à évaluer, certifier et développer ses compétences numériques.</p>"
               },
               "solutions": ["1", "3", "4"]
             }
@@ -980,7 +980,7 @@
             {
               "id": "826281e7-865f-462d-abc0-77537c42a2b4",
               "type": "text",
-              "content": "<h4><span aria-hidden=\"true\">🔮&nbsp;</span>Une personne a deviné votre mot de passe…</h4>Une personne qui vous connaît bien a accès à de nombreuses informations vous concernant. <br>Si vous utilisez des informations privées en guise de mot de passe, il est probable qu’une personne de votre entourage puisse deviner facilement votre mot de passe et ainsi accéder à des données privées. Et ce n’est peut être pas pour vous faire un cadeau d’anniversaire surprise, malheureusement.<span aria-hidden=\"true\"> 🙃</span></p>"
+              "content": "<h4><span aria-hidden=\"true\">🔮&nbsp;</span>Une personne a deviné votre mot de passe…</h4>Une personne qui vous connaît bien a accès à de nombreuses informations vous concernant. <br><p>Si vous utilisez des informations privées en guise de mot de passe, il est probable qu’une personne de votre entourage puisse deviner facilement votre mot de passe et ainsi accéder à des données privées. Et ce n’est peut être pas pour vous faire un cadeau d’anniversaire surprise, malheureusement.<span aria-hidden=\"true\"> 🙃</span></p>"
             },
             {
               "id": "9d0b7aff-a9da-453f-a6ba-c61fbaa7bb25",
@@ -1002,7 +1002,7 @@
             {
               "id": "7ef31e68-e798-4a92-86a0-ad61ebd9b915",
               "type": "text",
-              "content": "<p>Austin est producteur de miel dans les Vosges. Austin<ul><li>est né le 15 novembre 1984,</li><li>a un enfant qui s’appelle Bill.</li></ul>Il a utilisé ces deux informations pour créer son mot de passe.</p>"
+              "content": "<p>Austin est producteur de miel dans les Vosges. Austin</p><ul><li>est né le 15 novembre 1984,</li><li>a un enfant qui s’appelle Bill.</li></ul><p>Il a utilisé ces deux informations pour créer son mot de passe.</p>"
             },
             {
               "id": "2695bb89-112c-49d1-80b2-469d824af58f",
@@ -1469,7 +1469,7 @@
             {
               "id": "21842978-ba1c-4e16-8c2a-c7d1db082c2a",
               "type": "qrocm",
-              "instruction": "<p>Dans quel pays est située l’adresse IP suivante&nbsp;? <strong>77.205.153.196</strong>",
+              "instruction": "<p>Dans quel pays est située l’adresse IP suivante&nbsp;? <strong>77.205.153.196</strong></p>",
               "proposals": [
                 {
                   "input": "pays",

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -49,7 +49,7 @@ describe('Acceptance | Controller | passage-controller', function () {
           userResponse: ['1'],
           expectedUserResponseValue: '1',
           expectedFeedback:
-            "<p class='pix-list-inline'>Oui, aucun problème ! Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>",
+            '<p class="pix-list-inline">Oui, aucun problème ! Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>',
           expectedSolution: '1',
         },
         {
@@ -59,7 +59,7 @@ describe('Acceptance | Controller | passage-controller', function () {
           userResponse: [{ input: 'email', answer: 'naomizao457@yahoo.com' }],
           expectedUserResponseValue: { email: 'naomizao457@yahoo.com' },
           expectedFeedback:
-            "<p>Correct ! <span aria-hidden='true'>🎉</span> Tout est en ordre : identifiant, arobase, fournisseur d'adresse mail</p>",
+            '<p>Correct ! <span aria-hidden="true">🎉</span> Tout est en ordre : identifiant, arobase, fournisseur d\'adresse mail</p>',
           expectedSolution: {
             email: ['naomizao457@yahoo.com', 'naomizao457@yahoo.fr'],
           },

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -49,7 +49,7 @@ describe('Acceptance | Controller | passage-controller', function () {
           userResponse: ['1'],
           expectedUserResponseValue: '1',
           expectedFeedback:
-            '<p class="pix-list-inline">Oui, aucun problème ! Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>',
+            '<p class="pix-list-inline">Oui, aucun problème ! Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>',
           expectedSolution: '1',
         },
         {

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
@@ -34,9 +34,9 @@ describe('Unit | Infrastructure | Datasources | Learning Content | ModuleDatasou
       // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
       // eslint-disable-next-line mocha/no-setup-in-describe
       modules.forEach((module) => {
-        it(`module "${module.slug}" should contain a valid structure`, function () {
+        it(`module "${module.slug}" should contain a valid structure`, async function () {
           // When
-          const result = moduleSchema.validate(module);
+          const result = await moduleSchema.validateAsync(module);
 
           // Then
           expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/image.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/image.js
@@ -1,12 +1,12 @@
 import Joi from 'joi';
-import { uuidSchema } from '../utils.js';
+import { htmlSchema, uuidSchema } from '../utils.js';
 
 const imageElementSchema = Joi.object({
   id: uuidSchema,
   type: Joi.string().valid('image').required(),
   url: Joi.string().uri().required(),
   alt: Joi.string().allow('').required(),
-  alternativeText: Joi.string().allow('').required(),
+  alternativeText: htmlSchema.allow(''),
 }).required();
 
 export { imageElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcm.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcm.js
@@ -1,20 +1,20 @@
 import Joi from 'joi';
-import { uuidSchema, proposalIdSchema } from '../utils.js';
+import { uuidSchema, proposalIdSchema, htmlSchema } from '../utils.js';
 
 const qcmElementSchema = Joi.object({
   id: uuidSchema,
   type: Joi.string().valid('qcm').required(),
-  instruction: Joi.string().required(),
+  instruction: htmlSchema,
   proposals: Joi.array()
     .items({
       id: proposalIdSchema,
-      content: Joi.string().required(),
+      content: htmlSchema,
     })
     .min(3)
     .required(),
   feedbacks: Joi.object({
-    valid: Joi.string().required(),
-    invalid: Joi.string().required(),
+    valid: htmlSchema,
+    invalid: htmlSchema,
   }).required(),
   solutions: Joi.array().items(proposalIdSchema).min(2).required(),
 }).required();

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu.js
@@ -1,19 +1,19 @@
 import Joi from 'joi';
-import { uuidSchema, proposalIdSchema } from '../utils.js';
+import { uuidSchema, proposalIdSchema, htmlSchema } from '../utils.js';
 
 const qcuElementSchema = Joi.object({
   id: uuidSchema,
   type: Joi.string().valid('qcu').required(),
-  instruction: Joi.string().required(),
+  instruction: htmlSchema,
   proposals: Joi.array()
     .items({
       id: proposalIdSchema,
-      content: Joi.string().required(),
+      content: htmlSchema,
     })
     .required(),
   feedbacks: Joi.object({
-    valid: Joi.string().required(),
-    invalid: Joi.string().required(),
+    valid: htmlSchema,
+    invalid: htmlSchema,
   }).required(),
   solution: proposalIdSchema,
 }).required();

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qrocm.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qrocm.js
@@ -1,5 +1,5 @@
 import Joi from 'joi';
-import { uuidSchema, proposalIdSchema } from '../utils.js';
+import { uuidSchema, proposalIdSchema, htmlSchema } from '../utils.js';
 
 const blockInputSchema = Joi.object({
   input: Joi.string().required(),
@@ -38,19 +38,19 @@ const blockSelectSchema = Joi.object({
 
 const blockTextSchema = Joi.object({
   type: Joi.string().valid('text').required(),
-  content: Joi.string().required(),
+  content: htmlSchema,
 }).required();
 
 const qrocmElementSchema = Joi.object({
   id: uuidSchema,
   type: Joi.string().valid('qrocm').required(),
-  instruction: Joi.string().required(),
+  instruction: htmlSchema,
   proposals: Joi.array()
     .items(Joi.alternatives().try(blockTextSchema, blockInputSchema, blockSelectSchema))
     .required(),
   feedbacks: Joi.object({
-    valid: Joi.string().required(),
-    invalid: Joi.string().required(),
+    valid: htmlSchema,
+    invalid: htmlSchema,
   }).required(),
 });
 

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/text.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/text.js
@@ -1,10 +1,10 @@
 import Joi from 'joi';
-import { uuidSchema } from '../utils.js';
+import { htmlSchema, uuidSchema } from '../utils.js';
 
 const textElementSchema = Joi.object({
   id: uuidSchema,
   type: Joi.string().valid('text').required(),
-  content: Joi.string().required(),
+  content: htmlSchema,
 }).required();
 
 export { textElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/video.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/video.js
@@ -1,5 +1,5 @@
 import Joi from 'joi';
-import { uuidSchema } from '../utils.js';
+import { htmlSchema, uuidSchema } from '../utils.js';
 
 const videoElementSchema = Joi.object({
   id: uuidSchema,
@@ -7,7 +7,7 @@ const videoElementSchema = Joi.object({
   title: Joi.string().required(),
   url: Joi.string().uri().required(),
   subtitles: Joi.string().required(),
-  transcription: Joi.string().allow('').required(),
+  transcription: htmlSchema.allow(''),
 }).required();
 
 export { videoElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -31,9 +31,9 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
     expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));
   });
 
-  it('should validate sample qcu structure', function () {
+  it('should validate sample qcu structure', async function () {
     // When
-    const result = qcuElementSchema.validate(getQcuSample());
+    const result = await qcuElementSchema.validateAsync(getQcuSample());
 
     // Then
     expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -23,9 +23,9 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
     expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));
   });
 
-  it('should validate sample qcm structure', function () {
+  it('should validate sample qcm structure', async function () {
     // When
-    const result = qcmElementSchema.validate(getQcmSample());
+    const result = await qcmElementSchema.validateAsync(getQcmSample());
 
     // Then
     expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -47,9 +47,9 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
     expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));
   });
 
-  it('should validate sample text structure', function () {
+  it('should validate sample text structure', async function () {
     // When
-    const result = textElementSchema.validate(getTextSample());
+    const result = await textElementSchema.validateAsync(getTextSample());
 
     // Then
     expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -15,9 +15,9 @@ import { getTextSample } from '../../../../../../../src/devcomp/infrastructure/d
 import { getVideoSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/video.sample.js';
 
 describe('Unit | Infrastructure | Datasources | Learning Content | Module Datasource | format validation', function () {
-  it('should validate sample image structure', function () {
+  it('should validate sample image structure', async function () {
     // When
-    const result = imageElementSchema.validate(getImageSample());
+    const result = await imageElementSchema.validateAsync(getImageSample());
 
     // Then
     expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -39,9 +39,9 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
     expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));
   });
 
-  it('should validate sample qrocm structure', function () {
+  it('should validate sample qrocm structure', async function () {
     // When
-    const result = qrocmElementSchema.validate(getQrocmSample());
+    const result = await qrocmElementSchema.validateAsync(getQrocmSample());
 
     // Then
     expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -55,9 +55,9 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
     expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));
   });
 
-  it('should validate sample video structure', function () {
+  it('should validate sample video structure', async function () {
     // When
-    const result = videoElementSchema.validate(getVideoSample());
+    const result = await videoElementSchema.validateAsync(getVideoSample());
 
     // Then
     expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module.js
@@ -7,11 +7,11 @@ import {
   textElementSchema,
   videoElementSchema,
 } from './element/index.js';
-import { uuidSchema } from './utils.js';
+import { htmlSchema, uuidSchema } from './utils.js';
 
 const transitionTextSchema = Joi.object({
   grainId: uuidSchema,
-  content: Joi.string().required(),
+  content: htmlSchema,
 }).required();
 
 const moduleSchema = Joi.object({

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/utils.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/utils.js
@@ -1,7 +1,37 @@
 import Joi from 'joi';
+import { HtmlValidate } from 'html-validate';
 
 const uuidSchema = Joi.string().guid({ version: 'uuidv4' }).required();
 
 const proposalIdSchema = Joi.string().regex(/^\d+$/);
 
-export { uuidSchema, proposalIdSchema };
+const htmlValidate = new HtmlValidate();
+const severity = ['', 'Warning', 'Error'];
+const htmlSchema = Joi.string()
+  .external(async (value) => {
+    const report = await htmlValidate.validateString(value);
+
+    if (!report.valid) {
+      let errorLog = '';
+      errorLog = errorLog.concat('\n', `${report.errorCount} error(s), ${report.warningCount} warning(s)\n`);
+      errorLog = errorLog.concat('\n', '─'.repeat(60));
+      for (const result of report.results) {
+        const line = result.source ?? '';
+        for (const message of result.messages) {
+          errorLog = errorLog.concat('\n');
+          errorLog = errorLog.concat('\n', severity[message.severity], `(${message.ruleId}): `, message.message);
+          errorLog = errorLog.concat('\n', message.ruleUrl);
+          errorLog = errorLog.concat('\n');
+          errorLog = errorLog.concat('\n', line);
+          errorLog = errorLog.concat('\n');
+          errorLog = errorLog.concat('\n', '─'.repeat(60));
+          errorLog = errorLog.concat('\n');
+        }
+      }
+
+      throw new Error(errorLog);
+    }
+  })
+  .required();
+
+export { uuidSchema, proposalIdSchema, htmlSchema };


### PR DESCRIPTION
## :unicorn: Problème
Il est pour le moment possible de contribuer à certains champs de Modulix avec de l'HTML invalide syntaxiquement et/ou sémantiquement.

## :robot: Proposition
Renforcer la validation du contenu HTML contribué avec la libraire [`html-validate`](https://html-validate.org/). Merci à @alexandrecoin et @mcampourcy pour le coup de main !

Cela a permis de détecter déjà : 
- les balises non fermées,
- des caractères non échapés,
- les balises autofermantes
- l'usage de simple guillemets,

Il y a d'[autres choses encore plus intéressantes documentées sur la librairie](https://html-validate.org/#content-model).

Je l'ai mis en place sur tous les champs acceptant de l'HTML. Toutes les erreurs déjà présentes ont été corrigées.

## :rainbow: Remarques
RAS

## :100: Pour tester
Récupérer les modifs en local et tenter des erreurs de syntaxe et/ou sémantique sur les champs acceptant de l'HTML. Constater qu'un test unitaire casse dans ce cas.

CI 🍏 