### PR TITLE
[FEATURE] Afficher les erreurs sur la page d'import des nouveaux participants/élèves/étudiants (PIX-10954)

### DIFF
--- a/orga/app/components/import.hbs
+++ b/orga/app/components/import.hbs
@@ -4,8 +4,10 @@
       {{t this.textsByOrganizationType.title}}
     </h1>
   </header>
-  {{#if @isLoading}}
+
+  {{#if this.displayBanner}}
     <Ui::PixLoader />
+
     <PixMessage @type="information" @withIcon="true">
       {{t "pages.organization-participants-import.information"}}
     </PixMessage>

--- a/orga/app/components/import.hbs
+++ b/orga/app/components/import.hbs
@@ -1,6 +1,6 @@
 <article class="import-students-page">
   <header class="import-students-page__header">
-    <h1 class="page-title import-students-page-header__title">
+    <h1>
       {{t this.textsByOrganizationType.title}}
     </h1>
   </header>

--- a/orga/app/components/import.hbs
+++ b/orga/app/components/import.hbs
@@ -6,13 +6,17 @@
   </header>
 
   {{#if this.displayBanner}}
-    <Ui::PixLoader />
-
-    <PixMessage @type="information" @withIcon="true">
-      {{t "pages.organization-participants-import.information"}}
+    <PixMessage @type={{this.bannerType}} @withIcon="true">
+      {{this.bannerMessage}}
     </PixMessage>
-  {{else}}
-    <div class="import-type-list">
+  {{/if}}
+
+  {{#if @isLoading}}
+    <Ui::PixLoader />
+  {{/if}}
+
+  {{#unless @isLoading}}
+    <div class="import-students-page__type-list">
       {{#if this.currentUser.isSCOManagingStudents}}
         <ScoOrganizationParticipant::ImportCard
           @onImportStudents={{@onImportScoStudents}}
@@ -32,5 +36,17 @@
         />
       {{/if}}
     </div>
+  {{/unless}}
+
+  {{#if this.displayErrorImportPanel}}
+    <section class={{this.panelClasses}} aria-live="assertive">
+      <h2 class="screen-reader-only">{{t "pages.organization-participants-import.error-panel.title"}}</h2>
+
+      <ul class="import-students-page__error-panel-list">
+        {{#each this.errorDetailList as |errorElement|}}
+          <li class="import-students-page__error-panel-list__item">{{errorElement}}</li>
+        {{/each}}
+      </ul>
+    </section>
   {{/if}}
 </article>

--- a/orga/app/components/import.js
+++ b/orga/app/components/import.js
@@ -6,8 +6,42 @@ export default class Import extends Component {
   @service session;
   @service intl;
 
+  get displayErrorImportPanel() {
+    return Boolean(this.args.errors) || this.hasWarnings;
+  }
+
+  get hasWarnings() {
+    return Boolean(this.args.warnings);
+  }
+
   get displayBanner() {
-    return this.args.isLoading;
+    return this.args.isLoading || Boolean(this.args.warningBanner);
+  }
+
+  get panelClasses() {
+    const classes = ['import-students-page__error-panel'];
+
+    if (this.hasWarnings) classes.push('import-students-page__error-panel--warning');
+
+    return classes.join(' ');
+  }
+
+  get bannerType() {
+    if (this.hasWarnings) {
+      return 'warning';
+    } else {
+      return 'information';
+    }
+  }
+
+  get bannerMessage() {
+    if (this.hasWarnings) return this.args.warningBanner;
+
+    return this.intl.t('pages.organization-participants-import.information');
+  }
+
+  get errorDetailList() {
+    return this.args.errors || this.args.warnings;
   }
 
   get supportedFormats() {

--- a/orga/app/components/import.js
+++ b/orga/app/components/import.js
@@ -6,6 +6,10 @@ export default class Import extends Component {
   @service session;
   @service intl;
 
+  get displayBanner() {
+    return this.args.isLoading;
+  }
+
   get supportedFormats() {
     if (
       (this.currentUser.isSCOManagingStudents && this.currentUser.isAgriculture) ||

--- a/orga/app/components/sco-organization-participant/import-card.hbs
+++ b/orga/app/components/sco-organization-participant/import-card.hbs
@@ -15,7 +15,7 @@
     </ul>
   </div>
 
-  <div class="import-card__button">
+  <div class="import-card__footer">
     <PixButtonUpload
       @id="students-file-upload"
       @size="small"
@@ -25,9 +25,9 @@
     >
       {{t "pages.organization-participants-import.actions.add-sco.label"}}
     </PixButtonUpload>
-  </div>
 
-  <p class="import-card__accepted-files" id="accepted-files">
-    {{@acceptedFileType}}
-  </p>
+    <p class="import-card__accepted-files" id="accepted-files">
+      {{@acceptedFileType}}
+    </p>
+  </div>
 </section>

--- a/orga/app/components/sup-organization-participant/import-cards/add.hbs
+++ b/orga/app/components/sup-organization-participant/import-cards/add.hbs
@@ -1,11 +1,13 @@
-<section class="import-students-page__section">
-  <h2 class="import-students-page-section__title">
+<section class="import-card">
+  <h2 class="import-card__title">
     {{t "pages.organization-participants-import.actions.add-sup.title"}}
   </h2>
-  <p class="import-students-page-section__details">
+
+  <p class="import-card__details">
     {{t "pages.organization-participants-import.actions.add-sup.details"}}
   </p>
-  <div class="import-students-page-section__button-and-type">
+
+  <div class="import-card__footer">
     <PixButtonUpload
       @id="students-file-upload-add"
       @size="small"
@@ -15,7 +17,8 @@
     >
       {{t "pages.organization-participants-import.actions.add-sup.label"}}
     </PixButtonUpload>
-    <p class="import-students-page-section__details" id="accepted-files-add">
+
+    <p class="import-card__accepted-files" id="accepted-files-add">
       {{@acceptedFileType}}
     </p>
   </div>

--- a/orga/app/components/sup-organization-participant/import-cards/add.hbs
+++ b/orga/app/components/sup-organization-participant/import-cards/add.hbs
@@ -11,10 +11,11 @@
       @size="small"
       @onChange={{@onAddStudents}}
       accept={{@supportedFormats}}
+      aria-describedby="accepted-files-add"
     >
       {{t "pages.organization-participants-import.actions.add-sup.label"}}
     </PixButtonUpload>
-    <p class="import-students-page-section__details">
+    <p class="import-students-page-section__details" id="accepted-files-add">
       {{@acceptedFileType}}
     </p>
   </div>

--- a/orga/app/components/sup-organization-participant/import-cards/replace.hbs
+++ b/orga/app/components/sup-organization-participant/import-cards/replace.hbs
@@ -7,11 +7,7 @@
   </p>
 
   <div class="import-students-page-section__button-and-type">
-    <PixButton
-      @triggerAction={{this.toggleModal}}
-      @size="small"
-      aria-describedby="accepted-files-replace"
-    >
+    <PixButton @triggerAction={{this.toggleModal}} @size="small" aria-describedby="accepted-files-replace">
       {{t "pages.organization-participants-import.actions.replace.label"}}
     </PixButton>
     <p class="import-students-page-section__details" id="accepted-files-replace">

--- a/orga/app/components/sup-organization-participant/import-cards/replace.hbs
+++ b/orga/app/components/sup-organization-participant/import-cards/replace.hbs
@@ -1,16 +1,17 @@
-<section class="import-students-page__section">
-  <h2 class="import-students-page-section__title">
+<section class="import-card">
+  <h2 class="import-card__title">
     {{t "pages.organization-participants-import.actions.replace.title"}}
   </h2>
-  <p class="import-students-page-section__details">
+  <p class="import-card__details">
     {{t "pages.organization-participants-import.actions.replace.details"}}
   </p>
 
-  <div class="import-students-page-section__button-and-type">
+  <div class="import-card__footer">
     <PixButton @triggerAction={{this.toggleModal}} @size="small" aria-describedby="accepted-files-replace">
       {{t "pages.organization-participants-import.actions.replace.label"}}
     </PixButton>
-    <p class="import-students-page-section__details" id="accepted-files-replace">
+
+    <p class="import-card__accepted-files" id="accepted-files-replace">
       {{@acceptedFileType}}
     </p>
   </div>

--- a/orga/app/components/sup-organization-participant/import-cards/replace.hbs
+++ b/orga/app/components/sup-organization-participant/import-cards/replace.hbs
@@ -7,10 +7,14 @@
   </p>
 
   <div class="import-students-page-section__button-and-type">
-    <PixButton @triggerAction={{this.toggleModal}} @size="small">
+    <PixButton
+      @triggerAction={{this.toggleModal}}
+      @size="small"
+      aria-describedby="accepted-files-replace"
+    >
       {{t "pages.organization-participants-import.actions.replace.label"}}
     </PixButton>
-    <p class="import-students-page-section__details">
+    <p class="import-students-page-section__details" id="accepted-files-replace">
       {{@acceptedFileType}}
     </p>
   </div>

--- a/orga/app/routes/authenticated/import-organization-participants.js
+++ b/orga/app/routes/authenticated/import-organization-participants.js
@@ -12,4 +12,10 @@ export default class ImportOrganizationParticipantsRoute extends Route {
       return this.router.replaceWith('application');
     }
   }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      ['errors', 'warnings', 'warningBanner'].forEach((args) => controller.set(args, null));
+    }
+  }
 }

--- a/orga/app/styles/components/import.scss
+++ b/orga/app/styles/components/import.scss
@@ -1,75 +1,43 @@
 .import-students-page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pix-spacing-10x);
 
   &__header {
-    margin: 0 0 var(--pix-spacing-8x);
+    @extend %pix-title-m;
   }
 
-  &__section {
+  &__error-panel {
     @extend %pix-shadow-xs;
+    @extend %pix-body-s;
 
-    display: flex;
-    flex-direction: column;
-    gap: var(--pix-spacing-6x);
-    align-items: center;
-    justify-content: space-between;
-    width:calc(50% - var(--pix-spacing-6x));
-    margin: var(--pix-spacing-4x);
-    padding: var(--pix-spacing-4x);
+    &--warning {
+      color:var(--pix-warning-700);
+    }
+
+    padding: var(--pix-spacing-6x);
+    color:var(--pix-error-700);
+    font-weight: var(--pix-font-medium);
+    text-align: left;
     background-color: var(--pix-neutral-0);
     border-radius: 8px;
   }
-}
 
-.import-students-page-header {
-  &__title {
-    @extend %pix-title-m;
+  &__error-panel-list {
+    &__item {
+      margin-bottom: var(--pix-spacing-2x);
 
-    margin: var(--pix-spacing-2x);
+      &:last-child {
+        margin: 0;
+      }
+    }
   }
 
-  &__subtitle {
-    @extend %pix-body-m;
-
-    margin: var(--pix-spacing-2x);
-    font-weight: var(--pix-font-medium);
-  }
-
-  &__details {
-    @extend %pix-body-m;
-
-    margin: var(--pix-spacing-2x);
-    color: var(--pix-neutral-20)0;
-    font-family: $font-roboto;
-  }
-}
-
-.import-students-page-section {
-  &__title {
-    @extend %pix-title-xs;
-
-    margin: var(--pix-spacing-2x);
-  }
-
-  &__details {
-    @extend %pix-body-m;
-
-    margin: var(--pix-spacing-4x);
-    color: var(--pix-neutral-20)0;
-    font-family: $font-roboto;
-    line-height: 22px;
-    letter-spacing: 0.15px;
-  }
-
-  &__button-and-type {
+  &__type-list {
     display: flex;
-    flex-direction: column;
-    align-items: center;
+    flex-direction: row;
+    gap: var(--pix-spacing-8x);
+    align-items: stretch;
+    justify-content: center;
   }
-}
-
-.import-type-list {
-  display: flex;
-  flex-direction: row;
-  align-items: stretch;
-  justify-content: center;
 }

--- a/orga/app/styles/components/sco-organization-participant/import-card.scss
+++ b/orga/app/styles/components/sco-organization-participant/import-card.scss
@@ -2,7 +2,10 @@
   @extend %pix-shadow-xs;
   @extend %pix-body-m;
 
-  min-width: 50%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-width: calc(50% - var(--pix-spacing-4x));
   padding: var(--pix-spacing-6x);
   text-align: center;
   background-color: var(--pix-neutral-0);
@@ -30,8 +33,11 @@
     list-style-type: disc;
   }
 
-  &__button {
-    width: fit-content;
-    margin: 0 auto var(--pix-spacing-2x) auto;
+  &__footer {
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-4x);
+    align-items: center;
+    margin: 0 auto;
   }
 }

--- a/orga/app/templates/authenticated/import-organization-participants.hbs
+++ b/orga/app/templates/authenticated/import-organization-participants.hbs
@@ -9,4 +9,7 @@
   @onImportSupStudents={{this.importSupStudents}}
   @onReplaceStudents={{this.replaceStudents}}
   @isLoading={{this.isLoading}}
+  @errors={{this.errors}}
+  @warnings={{this.warnings}}
+  @warningBanner={{this.warningBanner}}
 />

--- a/orga/tests/acceptance/import-organization-participants_test.js
+++ b/orga/tests/acceptance/import-organization-participants_test.js
@@ -1,15 +1,18 @@
 import { module, test } from 'qunit';
-import { find, triggerEvent, visit, currentURL } from '@ember/test-helpers';
+import { currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import authenticateSession from '../helpers/authenticate-session';
+import { visit } from '@1024pix/ember-testing-library';
 
 import { createUserManagingStudents, createPrescriberByUser } from '../helpers/test-init';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import setupIntl from '../helpers/setup-intl';
 
 module('Acceptance | Student Import', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks);
 
   let user;
 
@@ -26,59 +29,23 @@ module('Acceptance | Student Import', function (hooks) {
       await authenticateSession(user.id);
     });
 
-    module('And uploads a file', function () {
+    module('have access to upload file', function () {
       test('it should display success message and reload students', async function (assert) {
         // given
-        await visit('/import-participants');
-
-        const file = new Blob(['foo'], { type: 'valid-file' });
-
-        // when
-        const input = find('#students-file-upload-add');
-        await triggerEvent(input, 'change', { files: [file] });
+        const screen = await visit('/import-participants');
 
         // then
-        assert.dom('[data-test-notification-message="success"]').hasText('La liste a été importée avec succès.');
-        assert.dom('[data-test-notification-message="warning"]').doesNotExist();
-
-        assert.dom('[aria-label="Étudiant"]').exists({ count: 1 });
-        assert.contains('Cover');
-        assert.contains('Harry');
-      });
-
-      test('it should display warnings message and reload students', async function (assert) {
-        // given
-        await visit('/import-participants');
-
-        const file = new Blob(['foo'], { type: 'valid-file-with-warnings' });
-
-        // when
-        const input = find('#students-file-upload-add');
-        await triggerEvent(input, 'change', { files: [file] });
-
-        // then
-        assert
-          .dom('[data-test-notification-message="warning"]')
-          .hasText(
-            'La liste a été importée avec succès.Cependant les valeurs suivantes n’ont pas été reconnues.Diplômes non reconnus : BAD; Elles ont été remplacées par “Non reconnu”. Si vous considérez qu’il manque des valeurs dans la liste limitative, veuillez nous contacter à sup@pix.fr',
-          );
-        assert.dom('[aria-label="Étudiant"]').exists({ count: 1 });
-        assert.contains('Cover');
-        assert.contains('Harry');
-      });
-
-      test('it should display an error message when import failed', async function (assert) {
-        // given
-        await visit('/import-participants');
-
-        const file = new Blob(['foo'], { type: 'invalid-file' });
-
-        // when
-        const input = find('#students-file-upload-add');
-        await triggerEvent(input, 'change', { files: [file] });
-
-        // then
-        assert.dom('[data-test-notification-message="error"]').exists();
+        assert.strictEqual(currentURL(), '/import-participants');
+        assert.ok(
+          screen.getByRole('heading', {
+            name: this.intl.t('pages.organization-participants-import.actions.add-sup.title'),
+          }),
+        );
+        assert.ok(
+          screen.getByRole('heading', {
+            name: this.intl.t('pages.organization-participants-import.actions.replace.title'),
+          }),
+        );
       });
     });
   });

--- a/orga/tests/acceptance/import-organization-participants_test.js
+++ b/orga/tests/acceptance/import-organization-participants_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { currentURL } from '@ember/test-helpers';
+import { currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import authenticateSession from '../helpers/authenticate-session';
 import { visit } from '@1024pix/ember-testing-library';
@@ -32,20 +32,14 @@ module('Acceptance | Student Import', function (hooks) {
     module('have access to upload file', function () {
       test('it should display success message and reload students', async function (assert) {
         // given
-        const screen = await visit('/import-participants');
+        const screen = await visit('/etudiants');
 
+        // when
+        await click(
+          screen.getByRole('link', { name: this.intl.t('pages.sup-organization-participants.actions.import-file') }),
+        );
         // then
         assert.strictEqual(currentURL(), '/import-participants');
-        assert.ok(
-          screen.getByRole('heading', {
-            name: this.intl.t('pages.organization-participants-import.actions.add-sup.title'),
-          }),
-        );
-        assert.ok(
-          screen.getByRole('heading', {
-            name: this.intl.t('pages.organization-participants-import.actions.replace.title'),
-          }),
-        );
       });
     });
   });

--- a/orga/tests/integration/components/import_test.js
+++ b/orga/tests/integration/components/import_test.js
@@ -49,8 +49,7 @@ module('Integration | Component | OrganizationParticipantImport', function (hook
           .length,
         2,
       );
-
-      assert.notOk(screen.queryByText(this.intl.t('common.loading')));
+      assert.notOk(screen.queryByText(this.intl.t('pages.organization-participants-import.information')));
     });
 
     test('it should display loading message', async function (assert) {
@@ -68,7 +67,7 @@ module('Integration | Component | OrganizationParticipantImport', function (hook
       );
 
       // then
-      assert.ok(screen.getByText(this.intl.t('common.loading')));
+      assert.ok(await screen.findByText(this.intl.t('pages.organization-participants-import.information')));
     });
 
     module('replaceStudents', function (hooks) {
@@ -254,7 +253,7 @@ module('Integration | Component | OrganizationParticipantImport', function (hook
       );
 
       // then
-      assert.ok(screen.getByText(this.intl.t('common.loading')));
+      assert.ok(await screen.findByText(this.intl.t('pages.organization-participants-import.information')));
     });
 
     test('it trigger importStudentsSpy when clicking on the import button', async function (assert) {

--- a/orga/tests/unit/components/import_test.js
+++ b/orga/tests/unit/components/import_test.js
@@ -28,6 +28,54 @@ module('Unit | Component | import', (hooks) => {
     });
   });
 
+  module('get#errorDetailList', () => {
+    test('should return errors when has errors', function (assert) {
+      //when
+      component.args.errors = [Symbol('ERROR')];
+      component.args.warnings = null;
+
+      // then
+      assert.deepEqual(component.errorDetailList, component.args.errors);
+    });
+
+    test('should return warnings when has warnings', async function (assert) {
+      // when
+      component.args.errors = null;
+      component.args.warnings = [Symbol('WARNING')];
+      // then
+      assert.deepEqual(component.errorDetailList, component.args.warnings);
+    });
+  });
+
+  module('get#displayErrorImportPanel', () => {
+    test('should return false as default value', function (assert) {
+      //when
+      component.args.errors = null;
+      component.args.warnings = null;
+
+      // then
+      assert.false(component.displayErrorImportPanel);
+    });
+
+    test('should return true when has errors', function (assert) {
+      //when
+      component.args.errors = [Symbol('ERROR')];
+      component.args.warnings = null;
+
+      // then
+      assert.true(component.displayErrorImportPanel);
+    });
+
+    test('should return true when has warnings', function (assert) {
+      //when
+      component.args.errors = null;
+      component.args.warnings = [Symbol('WARNING')];
+
+      // then
+      assert.true(component.displayErrorImportPanel);
+    });
+  });
+
   module('get#supportedFormats', () => {
     test('should return .csv when organization isManagingStudent SCO and isAgriculuture to true', function (assert) {
       // when

--- a/orga/tests/unit/components/import_test.js
+++ b/orga/tests/unit/components/import_test.js
@@ -1,0 +1,53 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
+
+module('Unit | Component | import', (hooks) => {
+  setupTest(hooks);
+
+  let component;
+
+  hooks.beforeEach(function () {
+    component = createGlimmerComponent('component:import');
+  });
+
+  module('get#displayBanner', () => {
+    test('should return false as default value', function (assert) {
+      //when
+      component.args.isLoading = false;
+
+      // then
+      assert.false(component.displayBanner);
+    });
+
+    test('should return true when loading is active', async function (assert) {
+      // when
+      component.args.isLoading = true;
+      // then
+      assert.true(component.displayBanner);
+    });
+  });
+
+  module('get#supportedFormats', () => {
+    test('should return .csv when organization isManagingStudent SCO and isAgriculuture to true', function (assert) {
+      // when
+      component.currentUser = { isSCOManagingStudents: true, isAgriculture: true };
+      // then
+      assert.deepEqual(component.supportedFormats, ['.csv']);
+    });
+
+    test('should return .csv when organization isManagingStudent SUP', function (assert) {
+      // when
+      component.currentUser = { isSUPManagingStudents: true };
+      // then
+      assert.deepEqual(component.supportedFormats, ['.csv']);
+    });
+
+    test('should return .xml .zip when organization isManagingStudent SCO', function (assert) {
+      // when
+      component.currentUser = { isSCOManagingStudents: true, isAgriculture: false };
+      // then
+      assert.deepEqual(component.supportedFormats, ['.xml', '.zip']);
+    });
+  });
+});

--- a/orga/tests/unit/controllers/authenticated/import-organization-participants_test.js
+++ b/orga/tests/unit/controllers/authenticated/import-organization-participants_test.js
@@ -49,7 +49,7 @@ module('Unit | Controller | authenticated/organization-participants-import', fun
 
         assert.strictEqual(
           notificationMessage,
-          '<div>Aucun étudiant n’a été importé.<br/>Veuillez réessayer ou nous contacter via <a target="_blank" rel="noopener noreferrer" href="https://support.pix.fr/support/tickets/new">le formulaire du centre d’aide</a>.</div>',
+          this.intl.t('pages.organization-participants-import.error-panel.error-wrapper'),
         );
       });
 
@@ -64,7 +64,7 @@ module('Unit | Controller | authenticated/organization-participants-import', fun
 
         assert.strictEqual(
           notificationMessage,
-          '<div>Aucun étudiant n’a été importé.<br/><strong>Error message</strong><br/> Veuillez modifier votre fichier et l’importer à nouveau.</div>',
+          this.intl.t('pages.organization-participants-import.error-panel.error-wrapper'),
         );
       });
 
@@ -79,7 +79,7 @@ module('Unit | Controller | authenticated/organization-participants-import', fun
 
         assert.strictEqual(
           notificationMessage,
-          '<div>Aucun étudiant n’a été importé.<br/><strong>Error message</strong><br/> Veuillez modifier votre fichier et l’importer à nouveau.</div>',
+          this.intl.t('pages.organization-participants-import.error-panel.error-wrapper'),
         );
       });
     });
@@ -122,7 +122,7 @@ module('Unit | Controller | authenticated/organization-participants-import', fun
 
         assert.strictEqual(
           notificationMessage,
-          '<div>Aucun élève n’a été importé.<br/>Veuillez réessayer ou nous contacter via <a target="_blank" rel="noopener noreferrer" href="https://support.pix.fr/support/tickets/new">le formulaire du centre d’aide</a>.</div>',
+          this.intl.t('pages.organization-participants-import.error-panel.error-wrapper'),
         );
       });
 
@@ -137,7 +137,7 @@ module('Unit | Controller | authenticated/organization-participants-import', fun
 
         assert.strictEqual(
           notificationMessage,
-          '<div>Aucun élève n’a été importé.<br/><strong>Error message</strong><br/> Veuillez vérifier ou modifier votre base élèves et importer à nouveau.</div>',
+          this.intl.t('pages.organization-participants-import.error-panel.error-wrapper'),
         );
       });
 
@@ -152,7 +152,7 @@ module('Unit | Controller | authenticated/organization-participants-import', fun
 
         assert.strictEqual(
           notificationMessage,
-          '<div>Aucun élève n’a été importé.<br/><strong>Error message</strong><br/> Veuillez vérifier ou modifier votre base élèves et importer à nouveau.</div>',
+          this.intl.t('pages.organization-participants-import.error-panel.error-wrapper'),
         );
       });
 
@@ -167,7 +167,7 @@ module('Unit | Controller | authenticated/organization-participants-import', fun
 
         assert.strictEqual(
           notificationMessage,
-          '<div>Aucun élève n’a été importé.<br/><strong>Error message</strong><br/> Veuillez vérifier ou modifier votre base élèves et importer à nouveau.</div>',
+          this.intl.t('pages.organization-participants-import.error-panel.error-wrapper'),
         );
       });
 
@@ -180,10 +180,10 @@ module('Unit | Controller | authenticated/organization-participants-import', fun
         await controller.importScoStudents(files);
 
         // then
-        const notificationMessage = controller.notifications.sendError.firstCall.firstArg.toString();
+        const errorMessages = controller.errors;
 
         assert.true(
-          notificationMessage.includes(
+          errorMessages.includes(
             this.intl.t('api-error-messages.student-xml-import.sex-code-required', { nationalStudentId: '1234' }),
           ),
         );
@@ -214,7 +214,7 @@ module('Unit | Controller | authenticated/organization-participants-import', fun
 
         assert.strictEqual(
           notificationMessage,
-          '<div>Aucun étudiant n’a été importé.<br/>Veuillez réessayer ou nous contacter via <a target="_blank" rel="noopener noreferrer" href="https://support.pix.fr/support/tickets/new">le formulaire du centre d’aide</a>.</div>',
+          this.intl.t('pages.organization-participants-import.error-panel.error-wrapper'),
         );
       });
 
@@ -229,7 +229,7 @@ module('Unit | Controller | authenticated/organization-participants-import', fun
 
         assert.strictEqual(
           notificationMessage,
-          '<div>Aucun étudiant n’a été importé.<br/><strong>Error message</strong><br/> Veuillez modifier votre fichier et l’importer à nouveau.</div>',
+          this.intl.t('pages.organization-participants-import.error-panel.error-wrapper'),
         );
       });
 
@@ -244,7 +244,7 @@ module('Unit | Controller | authenticated/organization-participants-import', fun
 
         assert.strictEqual(
           notificationMessage,
-          '<div>Aucun étudiant n’a été importé.<br/><strong>Error message</strong><br/> Veuillez modifier votre fichier et l’importer à nouveau.</div>',
+          this.intl.t('pages.organization-participants-import.error-panel.error-wrapper'),
         );
       });
     });

--- a/orga/tests/unit/controllers/authenticated/import-organization-participants_test.js
+++ b/orga/tests/unit/controllers/authenticated/import-organization-participants_test.js
@@ -17,7 +17,6 @@ module('Unit | Controller | authenticated/organization-participants-import', fun
     this.owner.lookup('service:intl').setLocale('fr');
     controller = this.owner.lookup('controller:authenticated/import-organization-participants');
     controller.send = sinon.stub();
-    controller.router.transitionTo = sinon.stub();
     controller.currentUser = currentUser;
 
     const store = this.owner.lookup('service:store');

--- a/orga/tests/unit/routes/authenticated/import-organization-participants_test.js
+++ b/orga/tests/unit/routes/authenticated/import-organization-participants_test.js
@@ -46,4 +46,16 @@ module('Unit | Route | authenticated/import-organization-participant', function 
       assert.ok(true);
     });
   });
+
+  module('resetController', function () {
+    test('should reset errors and warnings to null when isExiting true', function (assert) {
+      const route = this.owner.lookup('route:authenticated.import-organization-participants');
+
+      const controller = { set: sinon.stub() };
+      route.resetController(controller, true);
+      assert.true(controller.set.calledWithExactly('errors', null));
+      assert.true(controller.set.calledWithExactly('warnings', null));
+      assert.true(controller.set.calledWithExactly('warningBanner', null));
+    });
+  });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -901,21 +901,22 @@
           "label": "Overwrite list"
         }
       },
+      "error-panel": {
+        "title": "Errors list encountered",
+        "error-wrapper": "Import has failed. Please check or edit your file and try to import it again.",
+        "global-error": "Import has failed. Please try again or contact us through '<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://pix.org/en-gb/contact-form\">'the help form'</a>'."
+      },
       "file-type-separator": " or ",
       "global-success": "The list has been successfully imported.",
-      "global-success-with-warnings": "'<div>'The list has been successfully imported.'<br/><br/>'However some values were not recognised:'<br/>'{warnings}'<br/><br/>'They have been replaced by \"Not recognised\". If you need other values, please contact us at '<a href=\"mailto:sup@pix.fr\">'sup@pix.fr'</a></div>'",
       "information": "Importing your file may take a few minutes. Some features may be temporarily inaccessible.",
       "sco": {
-        "title": "Import students",
-        "error-wrapper": "<div>Import has failed.<br/><strong>{message}</strong><br/> Please check or edit your file and try to import it again.</div>",
-        "global-error": "'<div>'Import has failed.'<br/>'Please try again or contact us through '<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://pix.org/en-gb/contact-form\">'the help form'</a>'.'</div>'"
+        "title": "Import students"
       },
       "sup": {
-        "title": "Import students",
-        "error-wrapper": "<div>Import has failed.<br/><strong>{message}</strong><br/> Please check or edit your file and try to import it again.</div>",
-        "global-error": "'<div>'Import has failed.'<br/>'Please try again or contact us through '<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://pix.org/en-gb/contact-form\">'the help form'</a>'.'</div>'"
+        "title": "Import students"
       },
       "supported-formats": "(supported format: {types})",
+      "warning-banner": "However some values were not recognised. They have been replaced by \"Not recognised\". If you need other values, please contact us at '<a href=\"mailto:sup@pix.fr\">'sup@pix.fr'</a></div>'",
       "warnings": {
         "diploma": "Diplomas unknown: {diplomas}; ",
         "study-scheme": "Study schemes unknown: {studySchemes}; "

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -901,21 +901,22 @@
           "label": "Importer une nouvelle liste"
         }
       },
+      "error-panel": {
+        "title": "Liste des erreurs rencontrées",
+        "error-wrapper": "Aucun participant n’a été importé. Veuillez modifier votre fichier et l’importer à nouveau.",
+        "global-error": "Aucun participant n’a été importé. Veuillez réessayer ou nous contacter via '<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://support.pix.fr/support/tickets/new\">'le formulaire du centre d’aide'</a>'."
+      },
       "file-type-separator": ", ",
       "global-success": "La liste a été importée avec succès.",
-      "global-success-with-warnings": "'<div>'La liste a été importée avec succès.'<br/><br/>'Cependant les valeurs suivantes n’ont pas été reconnues.'<br />'{warnings}'<br/><br/>'Elles ont été remplacées par “Non reconnu”. Si vous considérez qu’il manque des valeurs dans la liste limitative, veuillez nous contacter à '<a href=\"mailto:sup@pix.fr\">'sup@pix.fr'</a></div>'",
       "information": "L'import de votre fichier peut prendre quelques minutes. Certaines fonctionnalités sont temporairement inaccessibles.",
       "sco": {
-        "title": "Importer des élèves",
-        "error-wrapper": "'<div>'Aucun élève n’a été importé.'<br/><strong>'{message}'</strong><br/>' Veuillez vérifier ou modifier votre base élèves et importer à nouveau.'</div>'",
-        "global-error": "'<div>'Aucun élève n’a été importé.'<br/>'Veuillez réessayer ou nous contacter via '<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://support.pix.fr/support/tickets/new\">'le formulaire du centre d’aide'</a>.</div>'"
+        "title": "Importer des élèves"
       },
       "sup": {
-        "title": "Importer des étudiants",
-        "error-wrapper": "'<div>'Aucun étudiant n’a été importé.'<br/><strong>'{message}'</strong><br/>' Veuillez modifier votre fichier et l’importer à nouveau.'</div>'",
-        "global-error": "'<div>'Aucun étudiant n’a été importé.'<br/>'Veuillez réessayer ou nous contacter via '<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://support.pix.fr/support/tickets/new\">'le formulaire du centre d’aide'</a>.</div>'"
+        "title": "Importer des étudiants"
       },
       "supported-formats": "(formats supportés : {types})",
+      "warning-banner": "Certaines valeurs n’ont pas été reconnues. Elles ont été remplacées par “Non reconnu”. Si vous considérez qu’il manque des valeurs dans la liste limitative, veuillez nous contacter à '<a href=\"mailto:sup@pix.fr\">'sup@pix.fr'</a></div>'",
       "warnings": {
         "diploma": "Diplômes non reconnus : {diplomas}; ",
         "study-scheme": "Régimes non reconnus : {studySchemes}; "


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, un seul message apparaît dans une notification d'erreur. lorsque l'import est réalisé avec succès, un redirection apparaît aussi avec un message de notification warning ou succes en fonction du retour API.

## :robot: Proposition
Rester sur la même page maintenant.
Ne plus utiliser notifications. mais afficher dans un encart la liste des erreurs/warning remonté

## :rainbow: Remarques
RAS

## :100: Pour tester
Faire des imports sur PixOrga en SCO / SUP / SCO Agri .
Utiliser de préférences des import KO
Vérifier que l'encart apparaît avec la liste ( pour le moment unique de l'erreur/warning) remontés