### PR TITLE
[FEATURE] Enregistrer les capacités d'un candidat tout au long de sa certif v3 (PIX-11262)

### DIFF
--- a/api/db/database-builder/factory/build-certification-challenge-capacity.js
+++ b/api/db/database-builder/factory/build-certification-challenge-capacity.js
@@ -1,0 +1,12 @@
+import { databaseBuffer } from '../database-buffer.js';
+
+export const buildCertificationChallengeCapacity = ({ certificationChallengeId, capacity, createdAt }) => {
+  return databaseBuffer.pushInsertable({
+    tableName: 'certification-challenge-capacities',
+    values: {
+      certificationChallengeId,
+      capacity,
+      createdAt,
+    },
+  });
+};

--- a/api/db/migrations/20240220144834_create-table-certification-challenge-capacity-history.js
+++ b/api/db/migrations/20240220144834_create-table-certification-challenge-capacity-history.js
@@ -1,0 +1,24 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/DEV/pages/2153512965/Cr+er+une+migration
+
+// If your migrations target `answers` or `knowledge-elements`
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+const TABLE_NAME = 'certification-challenge-capacities';
+
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.integer('certificationChallengeId').primary().unsigned().references('certification-challenges.id');
+    table.float('capacity').notNullable();
+    table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { up, down };

--- a/api/lib/domain/events/handle-certification-scoring.js
+++ b/api/lib/domain/events/handle-certification-scoring.js
@@ -10,6 +10,7 @@ import { ABORT_REASONS } from '../models/CertificationCourse.js';
 import { FlashAssessmentAlgorithm } from '../../../src/certification/flash-certification/domain/models/FlashAssessmentAlgorithm.js';
 import { config } from '../../../src/shared/config.js';
 import { AssessmentResultFactory } from '../../../src/certification/scoring/domain/models/factories/AssessmentResultFactory.js';
+import { CertificationAssessmentHistory } from '../../../src/certification/scoring/domain/models/CertificationAssessmentHistory.js';
 
 const eventTypes = [AssessmentCompleted];
 const EMITTER = 'PIX-ALGO';
@@ -18,6 +19,7 @@ async function handleCertificationScoring({
   event,
   assessmentResultRepository,
   badgeAcquisitionRepository,
+  certificationAssessmentHistoryRepository,
   certificationAssessmentRepository,
   certificationCourseRepository,
   certificationChallengeForScoringRepository,
@@ -38,6 +40,7 @@ async function handleCertificationScoring({
         answerRepository,
         assessmentId: event.assessmentId,
         certificationAssessment,
+        certificationAssessmentHistoryRepository,
         assessmentResultRepository,
         certificationCourseRepository,
         certificationChallengeForScoringRepository,
@@ -103,6 +106,7 @@ async function _calculateCertificationScore({
 }
 
 async function _handleV3CertificationScoring({
+  certificationAssessmentHistoryRepository,
   certificationChallengeForScoringRepository,
   answerRepository,
   assessmentId,
@@ -150,6 +154,14 @@ async function _handleV3CertificationScoring({
   } else {
     certificationCourse.complete({ now: new Date() });
   }
+
+  const certificationAssessmentHistory = CertificationAssessmentHistory.fromChallengesAndAnswers({
+    algorithm,
+    challenges,
+    allAnswers,
+  });
+
+  await certificationAssessmentHistoryRepository.save(certificationAssessmentHistory);
 
   await _saveResult({
     certificationAssessment,

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -15,6 +15,7 @@ import * as badgeAcquisitionRepository from '../../infrastructure/repositories/b
 import * as campaignRepository from '../../infrastructure/repositories/campaign-repository.js';
 import * as campaignParticipationRepository from '../../infrastructure/repositories/campaign-participation-repository.js';
 import * as campaignParticipationResultRepository from '../../infrastructure/repositories/campaign-participation-result-repository.js';
+import * as certificationAssessmentHistoryRepository from '../../../src/certification/scoring/infrastructure/repositories/certification-assessment-history-repository.js';
 import * as certificationAssessmentRepository from '../../../src/certification/shared/infrastructure/repositories/certification-assessment-repository.js';
 import * as certificationCenterRepository from '../../../src/certification/shared/infrastructure/repositories/certification-center-repository.js';
 import * as certificationChallengeForScoringRepository from '../../../src/certification/scoring/infrastructure/repositories/certification-challenge-for-scoring-repository.js';
@@ -69,6 +70,7 @@ const dependencies = {
   campaignRepository,
   campaignParticipationRepository,
   campaignParticipationResultRepository,
+  certificationAssessmentHistoryRepository,
   certificationAssessmentRepository,
   certificationCenterRepository,
   certificationChallengeForScoringRepository,

--- a/api/src/certification/flash-certification/domain/models/FlashAssessmentAlgorithm.js
+++ b/api/src/certification/flash-certification/domain/models/FlashAssessmentAlgorithm.js
@@ -106,6 +106,21 @@ class FlashAssessmentAlgorithm {
     });
   }
 
+  getEstimatedLevelAndErrorRateHistory({
+    allAnswers,
+    challenges,
+    initialCapacity = config.v3Certification.defaultCandidateCapacity,
+  }) {
+    return this.flashAlgorithmImplementation.getEstimatedLevelAndErrorRateHistory({
+      allAnswers,
+      challenges,
+      estimatedLevel: initialCapacity,
+      variationPercent: this._configuration.variationPercent,
+      variationPercentUntil: this._configuration.variationPercentUntil,
+      doubleMeasuresUntil: this._configuration.doubleMeasuresUntil,
+    });
+  }
+
   getReward({ estimatedLevel, discriminant, difficulty }) {
     return this.flashAlgorithmImplementation.getReward({ estimatedLevel, discriminant, difficulty });
   }

--- a/api/src/certification/scoring/domain/models/CertificationAssessmentHistory.js
+++ b/api/src/certification/scoring/domain/models/CertificationAssessmentHistory.js
@@ -1,0 +1,24 @@
+import { CertificationChallengeCapacity } from './CertificationChallengeCapacity.js';
+
+export class CertificationAssessmentHistory {
+  constructor({ capacityHistory }) {
+    this.capacityHistory = capacityHistory;
+  }
+  static fromChallengesAndAnswers({ algorithm, challenges, allAnswers }) {
+    const estimatedLevelAndErrorRateHistory = algorithm.getEstimatedLevelAndErrorRateHistory({
+      allAnswers,
+      challenges,
+    });
+
+    const capacityHistory = estimatedLevelAndErrorRateHistory.map(({ estimatedLevel }, index) =>
+      CertificationChallengeCapacity.create({
+        certificationChallengeId: challenges[index].certificationChallengeId,
+        capacity: estimatedLevel,
+      }),
+    );
+
+    return new CertificationAssessmentHistory({
+      capacityHistory,
+    });
+  }
+}

--- a/api/src/certification/scoring/domain/models/CertificationChallengeCapacity.js
+++ b/api/src/certification/scoring/domain/models/CertificationChallengeCapacity.js
@@ -1,0 +1,14 @@
+export class CertificationChallengeCapacity {
+  constructor({ certificationChallengeId, capacity, createdAt }) {
+    this.certificationChallengeId = certificationChallengeId;
+    this.capacity = capacity;
+    this.createdAt = createdAt;
+  }
+
+  static create({ certificationChallengeId, capacity }) {
+    return new CertificationChallengeCapacity({
+      certificationChallengeId,
+      capacity,
+    });
+  }
+}

--- a/api/src/certification/scoring/domain/models/CertificationChallengeForScoring.js
+++ b/api/src/certification/scoring/domain/models/CertificationChallengeForScoring.js
@@ -1,7 +1,8 @@
 export class CertificationChallengeForScoring {
-  constructor({ id, discriminant, difficulty }) {
+  constructor({ id, discriminant, difficulty, certificationChallengeId }) {
     this.id = id;
     this.discriminant = discriminant;
     this.difficulty = difficulty;
+    this.certificationChallengeId = certificationChallengeId;
   }
 }

--- a/api/src/certification/scoring/infrastructure/repositories/certification-assessment-history-repository.js
+++ b/api/src/certification/scoring/infrastructure/repositories/certification-assessment-history-repository.js
@@ -1,8 +1,8 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 
-export const saveBatch = (certificationChallengeCapacities) => {
+export const save = (certificationChallengeHistory) => {
   return knex('certification-challenge-capacities')
-    .insert(certificationChallengeCapacities)
+    .insert(certificationChallengeHistory.capacityHistory)
     .onConflict('certificationChallengeId')
     .merge();
 };

--- a/api/src/certification/scoring/infrastructure/repositories/certification-challenge-capacity-repository.js
+++ b/api/src/certification/scoring/infrastructure/repositories/certification-challenge-capacity-repository.js
@@ -1,0 +1,8 @@
+import { knex } from '../../../../../db/knex-database-connection.js';
+
+export const saveBatch = (certificationChallengeCapacities) => {
+  return knex('certification-challenge-capacities')
+    .insert(certificationChallengeCapacities)
+    .onConflict('certificationChallengeId')
+    .merge();
+};

--- a/api/src/certification/scoring/infrastructure/repositories/certification-challenge-for-scoring-repository.js
+++ b/api/src/certification/scoring/infrastructure/repositories/certification-challenge-for-scoring-repository.js
@@ -3,7 +3,12 @@ import { CertificationChallengeForScoring } from '../../domain/models/Certificat
 
 export const getByCertificationCourseId = async ({ certificationCourseId }) => {
   const certificationChallengesForScoringDTO = await knex('certification-challenges')
-    .select('challengeId', 'discriminant', 'difficulty')
+    .select({
+      challengeId: 'challengeId',
+      discriminant: 'discriminant',
+      difficulty: 'difficulty',
+      certificationChallengeId: 'id',
+    })
     .where({ courseId: certificationCourseId });
 
   return _toDomain(certificationChallengesForScoringDTO);

--- a/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
@@ -495,6 +495,70 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
     });
   });
 
+  describe('#getEstimatedLevelAndErrorRateHistory', function () {
+    context('when single measure', function () {
+      it('should return 0 when there is no answers', function () {
+        // given
+        const allAnswers = [];
+
+        // when
+        const result = flash.getEstimatedLevelAndErrorRateHistory({ allAnswers });
+
+        // then
+        expect(result).to.deep.equal([]);
+      });
+
+      it('should return the correct estimatedLevel when there is one answer', function () {
+        // given
+        const challenges = [
+          domainBuilder.buildChallenge({
+            discriminant: 1.86350005965093,
+            difficulty: 0.194712138508747,
+          }),
+        ];
+
+        const allAnswers = [domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id })];
+
+        // when
+        const [{ estimatedLevel, errorRate }] = flash.getEstimatedLevelAndErrorRateHistory({ allAnswers, challenges });
+
+        // then
+        expect(estimatedLevel).to.be.closeTo(0.859419960298745, 0.00000000001);
+        expect(errorRate).to.be.closeTo(0.9327454634914153, 0.00000000001);
+      });
+
+      it('should return the correct estimatedLevel when there are two answers', function () {
+        // given
+        const challenges = [
+          domainBuilder.buildChallenge({
+            id: 'ChallengeFirstAnswers',
+            discriminant: 1.86350005965093,
+            difficulty: 0.194712138508747,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'ChallengeSecondAnswers',
+            discriminant: 2.25422414740233,
+            difficulty: 0.823376599163319,
+          }),
+        ];
+
+        const allAnswers = [
+          domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id }),
+          domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[1].id }),
+        ];
+
+        // when
+        const results = flash.getEstimatedLevelAndErrorRateHistory({ allAnswers, challenges });
+
+        // then
+        expect(results[0].estimatedLevel).to.be.closeTo(0.859419960298745, 0.00000000001);
+        expect(results[0].errorRate).to.be.closeTo(0.9327454634914153, 0.00000000001);
+        expect(results[1].estimatedLevel).to.be.closeTo(1.802340122865396, 0.00000000001);
+        expect(results[1].errorRate).to.be.closeTo(0.8549014053951466, 0.00000000001);
+      });
+    });
+  });
+
   describe('#getChallengesForNonAnsweredSkills', function () {
     it('should return the same list of challenges if there is no answers', function () {
       // given

--- a/api/tests/certification/scoring/integration/infrastructure/repositories/certification-assessment-history-repository_test.js
+++ b/api/tests/certification/scoring/integration/infrastructure/repositories/certification-assessment-history-repository_test.js
@@ -1,17 +1,17 @@
 import { knex } from '../../../../../../db/knex-database-connection.js';
 import { databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
-import { saveBatch } from '../../../../../../src/certification/scoring/infrastructure/repositories/certification-challenge-capacity-repository.js';
+import { save } from '../../../../../../src/certification/scoring/infrastructure/repositories/certification-assessment-history-repository.js';
 import _ from 'lodash';
 
 describe('Integration | Infrastructure | Repository | CertificationChallengeCapacityRepository', function () {
-  describe('#saveBatch', function () {
+  describe('#save', function () {
     describe('when there is no certification challenge capacity', function () {
       it('should save the certification challenge capacities', async function () {
         // given
         const certificationChallenge1 = databaseBuilder.factory.buildCertificationChallenge();
         const certificationChallenge2 = databaseBuilder.factory.buildCertificationChallenge();
 
-        const certificationChallengeCapacities = [
+        const capacityHistory = [
           domainBuilder.buildCertificationChallengeCapacity({
             certificationChallengeId: certificationChallenge1.id,
             capacity: 10,
@@ -22,10 +22,14 @@ describe('Integration | Infrastructure | Repository | CertificationChallengeCapa
           }),
         ];
 
+        const certificationAssessmentHistory = domainBuilder.buildCertificationAssessmentHistory({
+          capacityHistory,
+        });
+
         await databaseBuilder.commit();
 
         // when
-        await saveBatch(certificationChallengeCapacities);
+        await save(certificationAssessmentHistory);
 
         // then
         const capacities = await knex('certification-challenge-capacities').select();
@@ -53,7 +57,7 @@ describe('Integration | Infrastructure | Repository | CertificationChallengeCapa
 
         await databaseBuilder.commit();
 
-        const certificationChallengeCapacities = [
+        const capacityHistory = [
           domainBuilder.buildCertificationChallengeCapacity({
             certificationChallengeId: certificationChallenge1.id,
             capacity: 10,
@@ -64,8 +68,12 @@ describe('Integration | Infrastructure | Repository | CertificationChallengeCapa
           }),
         ];
 
+        const certificationAssessmentHistory = domainBuilder.buildCertificationAssessmentHistory({
+          capacityHistory,
+        });
+
         // when
-        await saveBatch(certificationChallengeCapacities);
+        await save(certificationAssessmentHistory);
 
         // then
         const capacities = await knex('certification-challenge-capacities').select();

--- a/api/tests/certification/scoring/integration/infrastructure/repositories/certification-challenge-capacity-repository_test.js
+++ b/api/tests/certification/scoring/integration/infrastructure/repositories/certification-challenge-capacity-repository_test.js
@@ -1,0 +1,84 @@
+import { knex } from '../../../../../../db/knex-database-connection.js';
+import { databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
+import { saveBatch } from '../../../../../../src/certification/scoring/infrastructure/repositories/certification-challenge-capacity-repository.js';
+import _ from 'lodash';
+
+describe('Integration | Infrastructure | Repository | CertificationChallengeCapacityRepository', function () {
+  describe('#saveBatch', function () {
+    describe('when there is no certification challenge capacity', function () {
+      it('should save the certification challenge capacities', async function () {
+        // given
+        const certificationChallenge1 = databaseBuilder.factory.buildCertificationChallenge();
+        const certificationChallenge2 = databaseBuilder.factory.buildCertificationChallenge();
+
+        const certificationChallengeCapacities = [
+          domainBuilder.buildCertificationChallengeCapacity({
+            certificationChallengeId: certificationChallenge1.id,
+            capacity: 10,
+          }),
+          domainBuilder.buildCertificationChallengeCapacity({
+            certificationChallengeId: certificationChallenge2.id,
+            capacity: 20,
+          }),
+        ];
+
+        await databaseBuilder.commit();
+
+        // when
+        await saveBatch(certificationChallengeCapacities);
+
+        // then
+        const capacities = await knex('certification-challenge-capacities').select();
+        expect(capacities).to.have.lengthOf(2);
+        expect(_.omit(capacities[0], 'createdAt')).to.deep.equal({
+          certificationChallengeId: certificationChallenge1.id,
+          capacity: 10,
+        });
+        expect(_.omit(capacities[1], 'createdAt')).to.deep.equal({
+          certificationChallengeId: certificationChallenge2.id,
+          capacity: 20,
+        });
+      });
+    });
+
+    describe('when a certification challenge capacity already exists', function () {
+      it('should update the preexisting certification challenge capacity', async function () {
+        const certificationChallenge1 = databaseBuilder.factory.buildCertificationChallenge();
+        const certificationChallenge2 = databaseBuilder.factory.buildCertificationChallenge();
+
+        databaseBuilder.factory.buildCertificationChallengeCapacity({
+          certificationChallengeId: certificationChallenge1.id,
+          capacity: 0,
+        });
+
+        await databaseBuilder.commit();
+
+        const certificationChallengeCapacities = [
+          domainBuilder.buildCertificationChallengeCapacity({
+            certificationChallengeId: certificationChallenge1.id,
+            capacity: 10,
+          }),
+          domainBuilder.buildCertificationChallengeCapacity({
+            certificationChallengeId: certificationChallenge2.id,
+            capacity: 20,
+          }),
+        ];
+
+        // when
+        await saveBatch(certificationChallengeCapacities);
+
+        // then
+        const capacities = await knex('certification-challenge-capacities').select();
+        expect(capacities).to.have.lengthOf(2);
+        expect(_.omit(capacities[0], 'createdAt')).to.deep.equal({
+          certificationChallengeId: certificationChallenge1.id,
+          capacity: 10,
+        });
+        expect(_.omit(capacities[1], 'createdAt')).to.deep.equal({
+          certificationChallengeId: certificationChallenge2.id,
+          capacity: 20,
+        });
+      });
+    });
+  });
+});

--- a/api/tests/certification/scoring/unit/domain/models/CertificationAssessmentHistory_test.js
+++ b/api/tests/certification/scoring/unit/domain/models/CertificationAssessmentHistory_test.js
@@ -1,0 +1,65 @@
+import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+import { CertificationAssessmentHistory } from '../../../../../../src/certification/scoring/domain/models/CertificationAssessmentHistory.js';
+
+describe('Unit | Domain | Models | CertificationAssessmentHistory', function () {
+  describe('#fromChallengesAndAnswers', function () {
+    it('should return a CertificationAssessmentHistory with the capacity history', function () {
+      // given
+      const algorithm = {
+        getEstimatedLevelAndErrorRateHistory: sinon.stub(),
+      };
+
+      const challenges = [
+        domainBuilder.buildCertificationChallengeForScoring({
+          id: 'challenge1',
+          certificationChallengeId: 'certificationChallengeId1',
+        }),
+        domainBuilder.buildCertificationChallengeForScoring({
+          id: 'challenge2',
+          certificationChallengeId: 'certificationChallengeId2',
+        }),
+        domainBuilder.buildCertificationChallengeForScoring({
+          id: 'challenge3',
+          certificationChallengeId: 'certificationChallengeId3',
+        }),
+      ];
+      const allAnswers = [
+        domainBuilder.buildAnswer({ challengeId: 'challenge1', value: 'answer1' }),
+        domainBuilder.buildAnswer({ challengeId: 'challenge2', value: 'answer1' }),
+        domainBuilder.buildAnswer({ challengeId: 'challenge3', value: 'answer1' }),
+      ];
+
+      algorithm.getEstimatedLevelAndErrorRateHistory
+        .withArgs({
+          allAnswers,
+          challenges,
+        })
+        .returns([{ estimatedLevel: 1 }, { estimatedLevel: 2 }, { estimatedLevel: 3 }]);
+
+      // when
+      const certificationAssessmentHistory = CertificationAssessmentHistory.fromChallengesAndAnswers({
+        algorithm,
+        challenges,
+        allAnswers,
+      });
+
+      // then
+      const expectedCapacityHistory = [
+        domainBuilder.buildCertificationChallengeCapacity({
+          certificationChallengeId: 'certificationChallengeId1',
+          capacity: 1,
+        }),
+        domainBuilder.buildCertificationChallengeCapacity({
+          certificationChallengeId: 'certificationChallengeId2',
+          capacity: 2,
+        }),
+        domainBuilder.buildCertificationChallengeCapacity({
+          certificationChallengeId: 'certificationChallengeId3',
+          capacity: 3,
+        }),
+      ];
+
+      expect(certificationAssessmentHistory.capacityHistory).to.deep.equal(expectedCapacityHistory);
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/certification/scoring/build-certification-assessment-history.js
+++ b/api/tests/tooling/domain-builder/factory/certification/scoring/build-certification-assessment-history.js
@@ -1,0 +1,7 @@
+import { CertificationAssessmentHistory } from '../../../../../../src/certification/scoring/domain/models/CertificationAssessmentHistory.js';
+
+export const buildCertificationAssessmentHistory = ({ capacityHistory }) => {
+  return new CertificationAssessmentHistory({
+    capacityHistory,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/certification/scoring/build-certification-challenge-capacity.js
+++ b/api/tests/tooling/domain-builder/factory/certification/scoring/build-certification-challenge-capacity.js
@@ -1,0 +1,9 @@
+import { CertificationChallengeCapacity } from '../../../../../../src/certification/scoring/domain/models/CertificationChallengeCapacity.js';
+
+export const buildCertificationChallengeCapacity = ({ certificationChallengeId, capacity, createdAt }) => {
+  return new CertificationChallengeCapacity({
+    certificationChallengeId,
+    capacity,
+    createdAt,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/certification/scoring/build-certification-challenge-for-scoring.js
+++ b/api/tests/tooling/domain-builder/factory/certification/scoring/build-certification-challenge-for-scoring.js
@@ -1,10 +1,16 @@
 import { CertificationChallengeForScoring } from '../../../../../../src/certification/scoring/domain/models/CertificationChallengeForScoring.js';
 
-const buildCertificationChallengeForScoring = function ({ id = 123, discriminant = 0.5, difficulty = 2.1 } = {}) {
+const buildCertificationChallengeForScoring = function ({
+  id = 123,
+  discriminant = 0.5,
+  difficulty = 2.1,
+  certificationChallengeId = 'certificationChallengeId1',
+} = {}) {
   return new CertificationChallengeForScoring({
     id,
     discriminant,
     difficulty,
+    certificationChallengeId,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -46,6 +46,7 @@ import { buildCertificationCenterForAdmin } from './build-certification-center-f
 import { buildCertificationCenterInvitation } from './build-certification-center-invitation.js';
 import { buildCertificationCenterMembership } from './build-certification-center-membership.js';
 import { buildCertificationChallenge } from './build-certification-challenge.js';
+import { buildCertificationChallengeCapacity } from './certification/scoring/build-certification-challenge-capacity.js';
 import { buildCertificationChallengeWithType } from './build-certification-challenge-with-type.js';
 import { buildCertificationCourse } from './build-certification-course.js';
 import { buildCertificationCpfCity } from './build-certification-cpf-city.js';
@@ -242,6 +243,7 @@ export {
   buildCertificationCandidateForAttendanceSheet,
   buildCertificationCandidateForSupervising,
   buildCertificationCandidateSubscription,
+  buildCertificationChallengeCapacity,
   buildCertificationChallengeForScoring,
   buildCertificationEligibility,
   buildCertificationIssueReport,

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -28,6 +28,7 @@ import { buildCampaignToStartParticipation } from './build-campaign-to-start-par
 import { buildCertifiableBadgeAcquisition } from './build-certifiable-badge-acquisition.js';
 import { buildCenter } from './certification/session/build-center.js';
 import { buildCertificationAssessment } from './build-certification-assessment.js';
+import { buildCertificationAssessmentHistory } from './certification/scoring/build-certification-assessment-history.js';
 import { buildCertificationAssessmentScore } from './build-certification-assessment-score.js';
 import { buildCertificationAssessmentScoreV3 } from './build-certification-assessment-score-v3.js';
 import { buildCertificationCandidate } from './build-certification-candidate.js';
@@ -237,6 +238,7 @@ export {
   buildCampaignToStartParticipation,
   buildCertifiableBadgeAcquisition,
   buildCertificationAssessment,
+  buildCertificationAssessmentHistory,
   buildCertificationAssessmentScore,
   buildCertificationAssessmentScoreV3,
   buildCertificationCandidate,

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -31,7 +31,8 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
       answerRepository,
       certificationCourseRepository,
       flashAlgorithmConfigurationRepository,
-      flashAlgorithmService;
+      flashAlgorithmService,
+      certificationAssessmentHistoryRepository;
 
     let baseFlashAlgorithmConfig;
 
@@ -59,6 +60,11 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
       };
       flashAlgorithmService = {
         getEstimatedLevelAndErrorRate: sinon.stub(),
+        getEstimatedLevelAndErrorRateHistory: sinon.stub(),
+      };
+
+      certificationAssessmentHistoryRepository = {
+        save: sinon.stub(),
       };
 
       dependencies = {
@@ -69,6 +75,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         certificationCourseRepository,
         flashAlgorithmConfigurationRepository,
         flashAlgorithmService,
+        certificationAssessmentHistoryRepository,
       };
 
       baseFlashAlgorithmConfig = domainBuilder.buildFlashAlgorithmConfiguration({
@@ -97,6 +104,17 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           const scoreForEstimatedLevel = 592;
           const { certificationCourseId } = certificationAssessment;
 
+          const capacityHistory = [
+            domainBuilder.buildCertificationChallengeCapacity({
+              certificationChallengeId: certificationChallengesForScoring[0].certificationChallengeId,
+              capacity: expectedEstimatedLevel,
+            }),
+          ];
+
+          const certificationAssessmentHistory = domainBuilder.buildCertificationAssessmentHistory({
+            capacityHistory,
+          });
+
           certificationChallengeForScoringRepository.getByCertificationCourseId
             .withArgs({ certificationCourseId })
             .resolves(certificationChallengesForScoring);
@@ -123,6 +141,21 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
             .returns({
               estimatedLevel: expectedEstimatedLevel,
             });
+
+          flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
+            .withArgs({
+              challenges: certificationChallengesForScoring,
+              allAnswers: answers,
+              estimatedLevel: sinon.match.number,
+              variationPercent: undefined,
+              variationPercentUntil: undefined,
+              doubleMeasuresUntil: undefined,
+            })
+            .returns([
+              {
+                estimatedLevel: expectedEstimatedLevel,
+              },
+            ]);
 
           const event = new CertificationJuryDone({
             certificationCourseId,
@@ -154,6 +187,9 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           });
 
           expect(result).to.deep.equal(expectedEvent);
+          expect(certificationAssessmentHistoryRepository.save).to.have.been.calledWithExactly(
+            certificationAssessmentHistory,
+          );
         });
       });
 
@@ -176,6 +212,17 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           const expectedEstimatedLevel = 2;
           const scoreForEstimatedLevel = 592;
           const { certificationCourseId } = certificationAssessment;
+
+          const capacityHistory = [
+            domainBuilder.buildCertificationChallengeCapacity({
+              certificationChallengeId: certificationChallengesForScoring[0].certificationChallengeId,
+              capacity: expectedEstimatedLevel,
+            }),
+          ];
+
+          const certificationAssessmentHistory = domainBuilder.buildCertificationAssessmentHistory({
+            capacityHistory,
+          });
 
           certificationChallengeForScoringRepository.getByCertificationCourseId
             .withArgs({ certificationCourseId })
@@ -203,6 +250,21 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
             .returns({
               estimatedLevel: expectedEstimatedLevel,
             });
+
+          flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
+            .withArgs({
+              challenges: certificationChallengesForScoring,
+              allAnswers: answers,
+              estimatedLevel: sinon.match.number,
+              variationPercent: undefined,
+              variationPercentUntil: undefined,
+              doubleMeasuresUntil: undefined,
+            })
+            .returns([
+              {
+                estimatedLevel: expectedEstimatedLevel,
+              },
+            ]);
 
           const event = new CertificationJuryDone({
             certificationCourseId,
@@ -250,6 +312,9 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           });
 
           expect(result).to.deep.equal(expectedEvent);
+          expect(certificationAssessmentHistoryRepository.save).to.have.been.calledWithExactly(
+            certificationAssessmentHistory,
+          );
         });
       });
     });
@@ -274,6 +339,17 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           const expectedEstimatedLevel = 2;
           const rawScore = 592;
           const { certificationCourseId } = certificationAssessment;
+
+          const capacityHistory = [
+            domainBuilder.buildCertificationChallengeCapacity({
+              certificationChallengeId: certificationChallengesForScoring[0].certificationChallengeId,
+              capacity: expectedEstimatedLevel,
+            }),
+          ];
+
+          const certificationAssessmentHistory = domainBuilder.buildCertificationAssessmentHistory({
+            capacityHistory,
+          });
 
           certificationChallengeForScoringRepository.getByCertificationCourseId
             .withArgs({ certificationCourseId })
@@ -303,6 +379,21 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
             .returns({
               estimatedLevel: expectedEstimatedLevel,
             });
+
+          flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
+            .withArgs({
+              challenges: certificationChallengesForScoring,
+              allAnswers: answers,
+              estimatedLevel: sinon.match.number,
+              variationPercent: undefined,
+              variationPercentUntil: undefined,
+              doubleMeasuresUntil: undefined,
+            })
+            .returns([
+              {
+                estimatedLevel: expectedEstimatedLevel,
+              },
+            ]);
 
           const event = new CertificationJuryDone({
             certificationCourseId,
@@ -334,6 +425,9 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           });
 
           expect(result).to.deep.equal(expectedEvent);
+          expect(certificationAssessmentHistoryRepository.save).to.have.been.calledWithExactly(
+            certificationAssessmentHistory,
+          );
         });
       });
 
@@ -356,6 +450,17 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           const expectedEstimatedLevel = 2;
           const degradedScore = 474;
           const { certificationCourseId } = certificationAssessment;
+
+          const capacityHistory = [
+            domainBuilder.buildCertificationChallengeCapacity({
+              certificationChallengeId: certificationChallengesForScoring[0].certificationChallengeId,
+              capacity: expectedEstimatedLevel,
+            }),
+          ];
+
+          const certificationAssessmentHistory = domainBuilder.buildCertificationAssessmentHistory({
+            capacityHistory,
+          });
 
           certificationChallengeForScoringRepository.getByCertificationCourseId
             .withArgs({ certificationCourseId })
@@ -385,6 +490,21 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
             .returns({
               estimatedLevel: expectedEstimatedLevel,
             });
+
+          flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
+            .withArgs({
+              challenges: certificationChallengesForScoring,
+              allAnswers: answers,
+              estimatedLevel: sinon.match.number,
+              variationPercent: undefined,
+              variationPercentUntil: undefined,
+              doubleMeasuresUntil: undefined,
+            })
+            .returns([
+              {
+                estimatedLevel: expectedEstimatedLevel,
+              },
+            ]);
 
           const event = new CertificationJuryDone({
             certificationCourseId,
@@ -416,6 +536,9 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           });
 
           expect(result).to.deep.equal(expectedEvent);
+          expect(certificationAssessmentHistoryRepository.save).to.have.been.calledWithExactly(
+            certificationAssessmentHistory,
+          );
         });
       });
     });
@@ -439,6 +562,17 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         const expectedEstimatedLevel = 2;
         const scoreForEstimatedLevel = 592;
         const { certificationCourseId } = certificationAssessment;
+
+        const capacityHistory = [
+          domainBuilder.buildCertificationChallengeCapacity({
+            certificationChallengeId: certificationChallengesForScoring[0].certificationChallengeId,
+            capacity: expectedEstimatedLevel,
+          }),
+        ];
+
+        const certificationAssessmentHistory = domainBuilder.buildCertificationAssessmentHistory({
+          capacityHistory,
+        });
 
         certificationChallengeForScoringRepository.getByCertificationCourseId
           .withArgs({ certificationCourseId })
@@ -468,6 +602,21 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           .returns({
             estimatedLevel: expectedEstimatedLevel,
           });
+
+        flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
+          .withArgs({
+            challenges: certificationChallengesForScoring,
+            allAnswers: answers,
+            estimatedLevel: sinon.match.number,
+            variationPercent: undefined,
+            variationPercentUntil: undefined,
+            doubleMeasuresUntil: undefined,
+          })
+          .returns([
+            {
+              estimatedLevel: expectedEstimatedLevel,
+            },
+          ]);
 
         const event = new CertificationJuryDone({
           certificationCourseId,
@@ -499,6 +648,9 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         });
 
         expect(result).to.deep.equal(expectedEvent);
+        expect(certificationAssessmentHistoryRepository.save).to.have.been.calledWithExactly(
+          certificationAssessmentHistory,
+        );
       });
 
       describe('when certification is rejected for fraud', function () {
@@ -520,6 +672,17 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           const expectedEstimatedLevel = 2;
           const scoreForEstimatedLevel = 592;
           const { certificationCourseId } = certificationAssessment;
+
+          const capacityHistory = [
+            domainBuilder.buildCertificationChallengeCapacity({
+              certificationChallengeId: certificationChallengesForScoring[0].certificationChallengeId,
+              capacity: expectedEstimatedLevel,
+            }),
+          ];
+
+          const certificationAssessmentHistory = domainBuilder.buildCertificationAssessmentHistory({
+            capacityHistory,
+          });
 
           certificationChallengeForScoringRepository.getByCertificationCourseId
             .withArgs({ certificationCourseId })
@@ -549,6 +712,21 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
             .returns({
               estimatedLevel: expectedEstimatedLevel,
             });
+
+          flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
+            .withArgs({
+              challenges: certificationChallengesForScoring,
+              allAnswers: answers,
+              estimatedLevel: sinon.match.number,
+              variationPercent: undefined,
+              variationPercentUntil: undefined,
+              doubleMeasuresUntil: undefined,
+            })
+            .returns([
+              {
+                estimatedLevel: expectedEstimatedLevel,
+              },
+            ]);
 
           const event = new CertificationCourseRejected({
             certificationCourseId,
@@ -577,6 +755,9 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           });
 
           expect(result).to.deep.equal(expectedEvent);
+          expect(certificationAssessmentHistoryRepository.save).to.have.been.calledWithExactly(
+            certificationAssessmentHistory,
+          );
         });
       });
 
@@ -598,6 +779,17 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           const expectedEstimatedLevel = 8;
           const cappedScoreForEstimatedLevel = 896;
           const { certificationCourseId } = certificationAssessment;
+
+          const capacityHistory = [
+            domainBuilder.buildCertificationChallengeCapacity({
+              certificationChallengeId: certificationChallengesForScoring[0].certificationChallengeId,
+              capacity: expectedEstimatedLevel,
+            }),
+          ];
+
+          const certificationAssessmentHistory = domainBuilder.buildCertificationAssessmentHistory({
+            capacityHistory,
+          });
 
           certificationChallengeForScoringRepository.getByCertificationCourseId
             .withArgs({ certificationCourseId })
@@ -628,6 +820,21 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
               estimatedLevel: expectedEstimatedLevel,
             });
 
+          flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
+            .withArgs({
+              challenges: certificationChallengesForScoring,
+              allAnswers: answers,
+              estimatedLevel: sinon.match.number,
+              variationPercent: undefined,
+              variationPercentUntil: undefined,
+              doubleMeasuresUntil: undefined,
+            })
+            .returns([
+              {
+                estimatedLevel: expectedEstimatedLevel,
+              },
+            ]);
+
           const expectedResult = {
             certificationCourseId,
             assessmentResult: new AssessmentResult({
@@ -650,6 +857,9 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           });
 
           expect(assessmentResultRepository.save).to.have.been.calledWith(expectedResult);
+          expect(certificationAssessmentHistoryRepository.save).to.have.been.calledWithExactly(
+            certificationAssessmentHistory,
+          );
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
La capacité d’un candidat évolue tout le long de son test selon les réponses (ou non réponses) apportées aux questions.

Aujourd’hui, la capacité n’est pas stockée en bdd, la team data ne peut donc pas mettre en place des métriques facilement sur cette capacité

## :robot: Proposition
Enregistrer en bdd la capacité d’un candidat tout au long de son test

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
