### PR TITLE
[FEATURE][ADMIN] Ajouter un formulaire pour rattacher une organisation fille à une organisation mère (PIX-10046)

### DIFF
--- a/admin/app/adapters/organization.js
+++ b/admin/app/adapters/organization.js
@@ -32,4 +32,9 @@ export default class OrganizationAdapter extends ApplicationAdapter {
 
     return super.updateRecord(...arguments);
   }
+
+  attachChildOrganization({ childOrganizationId, parentOrganizationId }) {
+    const url = `${this.host}/${this.namespace}/organizations/${parentOrganizationId}/attach-child-organization`;
+    return this.ajax(url, 'POST', { data: { childOrganizationId } });
+  }
 }

--- a/admin/app/components/organizations/children/attach-child-form.hbs
+++ b/admin/app/components/organizations/children/attach-child-form.hbs
@@ -1,0 +1,16 @@
+<form
+  aria-label={{t "components.organizations.children.attach-child-form.name"}}
+  class="organization__attach-child-form"
+  {{on "submit" this.submitForm}}
+>
+  <div class="organization__attach-child-form__content">
+    <PixInput
+      @id="child-organization"
+      @label={{t "components.organizations.children.attach-child-form.input-label"}}
+      @information={{t "components.organizations.children.attach-child-form.input-information"}}
+      value={{this.childOrganization}}
+      {{on "change" this.childOrganizationInputValueChanged}}
+    />
+    <PixButton @size="small" @type="submit">{{t "common.actions.add"}}</PixButton>
+  </div>
+</form>

--- a/admin/app/components/organizations/children/attach-child-form.js
+++ b/admin/app/components/organizations/children/attach-child-form.js
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class OrganizationsChildrenAttachChildFormComponent extends Component {
+  @tracked childOrganization = '';
+
+  @action
+  childOrganizationInputValueChanged(event) {
+    this.childOrganization = event.target.value;
+  }
+
+  @action
+  submitForm(event) {
+    event.preventDefault();
+    this.args.onFormSubmitted(this.childOrganization);
+    this.childOrganization = '';
+  }
+}

--- a/admin/app/controllers/authenticated/organizations/get/children.js
+++ b/admin/app/controllers/authenticated/organizations/get/children.js
@@ -4,6 +4,8 @@ import { action } from '@ember/object';
 
 export default class AuthenticatedOrganizationsGetChildrenController extends Controller {
   @service accessControl;
+  @service intl;
+  @service notifications;
   @service store;
 
   @action
@@ -13,5 +15,8 @@ export default class AuthenticatedOrganizationsGetChildrenController extends Con
 
     await organizationAdapter.attachChildOrganization({ childOrganizationId, parentOrganizationId });
     await this.model.organizations.reload();
+      this.notifications.success(
+        this.intl.t('pages.organization-children.notifications.success.attach-child-organization'),
+      );
   }
 }

--- a/admin/app/controllers/authenticated/organizations/get/children.js
+++ b/admin/app/controllers/authenticated/organizations/get/children.js
@@ -20,7 +20,7 @@ export default class AuthenticatedOrganizationsGetChildrenController extends Con
         this.intl.t('pages.organization-children.notifications.success.attach-child-organization'),
       );
 
-      await this.model.organizations.reload();
+      await this.model.organization.children.reload();
     } catch (responseError) {
       const error = get(responseError, 'errors[0]');
       let message;

--- a/admin/app/controllers/authenticated/organizations/get/children.js
+++ b/admin/app/controllers/authenticated/organizations/get/children.js
@@ -1,0 +1,6 @@
+import Controller from '@ember/controller';
+import { service } from '@ember/service';
+
+export default class AuthenticatedOrganizationsGetChildrenController extends Controller {
+  @service accessControl;
+}

--- a/admin/app/controllers/authenticated/organizations/get/children.js
+++ b/admin/app/controllers/authenticated/organizations/get/children.js
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
 import { service } from '@ember/service';
 import { action } from '@ember/object';
+import get from 'lodash/get';
 
 export default class AuthenticatedOrganizationsGetChildrenController extends Controller {
   @service accessControl;
@@ -13,10 +14,47 @@ export default class AuthenticatedOrganizationsGetChildrenController extends Con
     const organizationAdapter = this.store.adapterFor('organization');
     const parentOrganizationId = this.model.organization.id;
 
-    await organizationAdapter.attachChildOrganization({ childOrganizationId, parentOrganizationId });
-    await this.model.organizations.reload();
+    try {
+      await organizationAdapter.attachChildOrganization({ childOrganizationId, parentOrganizationId });
       this.notifications.success(
         this.intl.t('pages.organization-children.notifications.success.attach-child-organization'),
       );
+
+      await this.model.organizations.reload();
+    } catch (responseError) {
+      const error = get(responseError, 'errors[0]');
+      let message;
+      switch (error?.code) {
+        case 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_ITSELF':
+          message = this.intl.t(
+            'pages.organization-children.notifications.error.unable-to-attach-child-organization-to-itself',
+          );
+          break;
+        case 'UNABLE_TO_ATTACH_ALREADY_ATTACHED_CHILD_ORGANIZATION':
+          message = this.intl.t(
+            'pages.organization-children.notifications.error.unable-to-attach-already-attached-child-organization',
+          );
+          break;
+        case 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_ANOTHER_CHILD_ORGANIZATION':
+          message = this.intl.t(
+            'pages.organization-children.notifications.error.unable-to-attach-child-organization-to-another-child-organization',
+          );
+          break;
+        case 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_WITHOUT_SAME_TYPE':
+          message = this.intl.t(
+            'pages.organization-children.notifications.error.unable-to-attach-child-organization-without-same-type',
+          );
+          break;
+        case 'UNABLE_TO_ATTACH_PARENT_ORGANIZATION_AS_CHILD_ORGANIZATION':
+          message = this.intl.t(
+            'pages.organization-children.notifications.error.unable-to-attach-parent-organization-as-child-organization',
+          );
+          break;
+        default:
+          message = this.intl.t('common.notifications.generic-error');
+      }
+
+      this.notifications.error(message);
+    }
   }
 }

--- a/admin/app/controllers/authenticated/organizations/get/children.js
+++ b/admin/app/controllers/authenticated/organizations/get/children.js
@@ -1,6 +1,17 @@
 import Controller from '@ember/controller';
 import { service } from '@ember/service';
+import { action } from '@ember/object';
 
 export default class AuthenticatedOrganizationsGetChildrenController extends Controller {
   @service accessControl;
+  @service store;
+
+  @action
+  async handleFormSubmitted(childOrganizationId) {
+    const organizationAdapter = this.store.adapterFor('organization');
+    const parentOrganizationId = this.model.organization.id;
+
+    await organizationAdapter.attachChildOrganization({ childOrganizationId, parentOrganizationId });
+    await this.model.organizations.reload();
+  }
 }

--- a/admin/app/routes/authenticated/organizations/get/children.js
+++ b/admin/app/routes/authenticated/organizations/get/children.js
@@ -4,6 +4,7 @@ export default class AuthenticatedOrganizationsGetChildrenRoute extends Route {
   async model() {
     const organization = this.modelFor('authenticated.organizations.get');
     return {
+      organization,
       organizations: organization.children,
     };
   }

--- a/admin/app/routes/authenticated/organizations/get/children.js
+++ b/admin/app/routes/authenticated/organizations/get/children.js
@@ -3,9 +3,6 @@ import Route from '@ember/routing/route';
 export default class AuthenticatedOrganizationsGetChildrenRoute extends Route {
   async model() {
     const organization = this.modelFor('authenticated.organizations.get');
-    return {
-      organization,
-      organizations: organization.children,
-    };
+    return { organization };
   }
 }

--- a/admin/app/services/access-control.js
+++ b/admin/app/services/access-control.js
@@ -59,4 +59,8 @@ export default class AccessControlService extends Service {
   get hasAccessToCampaignIsForAbsoluteNoviceEditionScope() {
     return !!this.currentUser.adminMember.isSuperAdmin;
   }
+
+  get hasAccessToAttachChildOrganizationActionsScope() {
+    return !!this.currentUser.adminMember.isSuperAdmin;
+  }
 }

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -59,6 +59,7 @@
 @import 'components/confirm-popup';
 @import 'components/member-item';
 @import 'components/menu-bar';
+@import 'components/organizations/children/attach-child-form';
 @import 'components/organizations/all-tags';
 @import 'components/organizations/archiving-confirmation-modal';
 @import 'components/organizations/campaigns-section';

--- a/admin/app/styles/components/organizations/children/attach-child-form.scss
+++ b/admin/app/styles/components/organizations/children/attach-child-form.scss
@@ -1,0 +1,5 @@
+.organization__attach-child-form__content {
+  display: flex;
+  gap: var(--pix-spacing-1x);
+  align-items: flex-end;
+}

--- a/admin/app/templates/authenticated/organizations/get/children.hbs
+++ b/admin/app/templates/authenticated/organizations/get/children.hbs
@@ -12,9 +12,9 @@
   </header>
   <div class="content-text content-text--small">
     <div class="table-admin">
-      <Organizations::Children::List @organizations={{@model.organizations}} />
+      <Organizations::Children::List @organizations={{@model.organization.children}} />
 
-      {{#unless @model.organizations}}
+      {{#unless @model.organization.children}}
         <p class="table__empty">{{t "pages.organization-children.empty-table"}}</p>
       {{/unless}}
     </div>

--- a/admin/app/templates/authenticated/organizations/get/children.hbs
+++ b/admin/app/templates/authenticated/organizations/get/children.hbs
@@ -2,7 +2,7 @@
 {{#if this.accessControl.hasAccessToAttachChildOrganizationActionsScope}}
   <section class="page-section">
     <div class="content-text content-text--small">
-      <Organizations::Children::AttachChildForm />
+      <Organizations::Children::AttachChildForm @onFormSubmitted={{this.handleFormSubmitted}} />
     </div>
   </section>
 {{/if}}

--- a/admin/app/templates/authenticated/organizations/get/children.hbs
+++ b/admin/app/templates/authenticated/organizations/get/children.hbs
@@ -1,4 +1,11 @@
 {{page-title "Children"}}
+{{#if this.accessControl.hasAccessToAttachChildOrganizationActionsScope}}
+  <section class="page-section">
+    <div class="content-text content-text--small">
+      <Organizations::Children::AttachChildForm />
+    </div>
+  </section>
+{{/if}}
 <section class="page-section">
   <header class="page-section__header">
     <h2 class="page-section__title">{{t "pages.organization-children.title"}}</h2>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -601,22 +601,21 @@ function routes() {
 }
 
 function _configureOrganizationsRoutes(context) {
-  context.get('/admin/organizations/:organizationId/children', () => {
-    return {
-      data: [
-        {
-          type: 'organization',
-          id: '1234',
-          attributes: {
-            name: 'UA',
-            'external-id': 'UA123456',
-          },
-        },
-      ],
-    };
   context.get('/admin/organizations/:organizationId/children', (schema, request) => {
     return schema.organizations.where({ parentOrganizationId: request.params.organizationId });
   });
+
+  context.post('/admin/organizations/:organizationId/attach-child-organization', (schema, request) => {
+    const parentOrganization = schema.organizations.find(request.params.organizationId);
+    const { childOrganizationId } = JSON.parse(request.requestBody);
+    const childOrganization = schema.organizations.find(childOrganizationId);
+
+    childOrganization.update({
+      parentOrganizationId: parentOrganization.id,
+      parentOrganizationName: parentOrganization.name,
+    });
+
+    return new Response(204);
   });
 }
 

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -614,6 +614,9 @@ function _configureOrganizationsRoutes(context) {
         },
       ],
     };
+  context.get('/admin/organizations/:organizationId/children', (schema, request) => {
+    return schema.organizations.where({ parentOrganizationId: request.params.organizationId });
+  });
   });
 }
 

--- a/admin/tests/acceptance/authenticated/organizations/get/children_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get/children_test.js
@@ -45,7 +45,8 @@ module('Acceptance | Organizations | Children', function (hooks) {
   module('when there is at least one child organization', function () {
     test('displays a list of child organizations', async function (assert) {
       // given
-      const parentOrganizationId = this.server.create('organization').id;
+      const parentOrganizationId = this.server.create('organization', { id: 1 }).id;
+      this.server.create('organization', { id: 2, parentOrganizationId: 1, name: 'Child' });
 
       // when
       const screen = await visit(`/organizations/${parentOrganizationId}/children`);

--- a/admin/tests/acceptance/authenticated/organizations/get/children_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get/children_test.js
@@ -70,7 +70,7 @@ module('Acceptance | Organizations | Children', function (hooks) {
     });
 
     module('when attaching child organization', function () {
-      test('attaches child organization to parent organization', async function (assert) {
+      test('attaches child organization to parent organization and displays success notification', async function (assert) {
         // given
         const parentOrganization = this.server.create('organization', { id: 1, name: 'Parent Organization Name' });
         this.server.create('organization', { id: 2, name: 'Child Organization Name' });
@@ -82,6 +82,7 @@ module('Acceptance | Organizations | Children', function (hooks) {
 
         // then
         assert.dom(screen.getByRole('cell', { name: 'Child Organization Name' })).exists();
+        assert.dom(screen.getByText(`L'organisation fille a bien été liée à l'organisation mère`)).exists();
       });
     });
   });

--- a/admin/tests/acceptance/authenticated/organizations/get/children_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get/children_test.js
@@ -55,4 +55,37 @@ module('Acceptance | Organizations | Children', function (hooks) {
       assert.dom(screen.getByRole('table', { name: 'Liste des organisations filles' })).exists();
     });
   });
+
+  module('when user has role "SUPER_ADMIN"', function () {
+    test('displays attach child organization form', async function (assert) {
+      // given
+      const parentOrganizationId = this.server.create('organization').id;
+
+      // when
+      const screen = await visit(`/organizations/${parentOrganizationId}/children`);
+
+      // then
+      assert.dom(screen.getByRole('form', { name: `Formulaire d'ajout d'une organisation fille` })).exists();
+    });
+  });
+
+  [
+    { name: 'CERTIF', authData: { isCertif: true } },
+    { name: 'METIER', authData: { isMetier: true } },
+    { name: 'SUPPORT', authData: { isSupport: true } },
+  ].forEach((role) => {
+    module(`when user has role "${role.name}"`, function () {
+      test('hides attach child organization form', async function (assert) {
+        // given
+        await authenticateAdminMemberWithRole(role.authData)(server);
+        const parentOrganizationId = this.server.create('organization').id;
+
+        // when
+        const screen = await visit(`/organizations/${parentOrganizationId}/children`);
+
+        // then
+        assert.dom(screen.queryByRole('form', { name: `Formulaire d'ajout d'une organisation fille` })).doesNotExist();
+      });
+    });
+  });
 });

--- a/admin/tests/acceptance/authenticated/organizations/get/children_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/get/children_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { visit } from '@1024pix/ember-testing-library';
+import { clickByName, fillByLabel, visit } from '@1024pix/ember-testing-library';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 import setupIntl from 'pix-admin/tests/helpers/setup-intl';
 import { currentURL } from '@ember/test-helpers';
@@ -67,6 +67,22 @@ module('Acceptance | Organizations | Children', function (hooks) {
 
       // then
       assert.dom(screen.getByRole('form', { name: `Formulaire d'ajout d'une organisation fille` })).exists();
+    });
+
+    module('when attaching child organization', function () {
+      test('attaches child organization to parent organization', async function (assert) {
+        // given
+        const parentOrganization = this.server.create('organization', { id: 1, name: 'Parent Organization Name' });
+        this.server.create('organization', { id: 2, name: 'Child Organization Name' });
+        const screen = await visit(`/organizations/${parentOrganization.id}/children`);
+        await fillByLabel(`Ajouter une organisation fille ID de l'organisation à ajouter`, '2');
+
+        // when
+        await clickByName('Ajouter');
+
+        // then
+        assert.dom(screen.getByRole('cell', { name: 'Child Organization Name' })).exists();
+      });
     });
   });
 

--- a/admin/tests/integration/components/organizations/children/attach-child-form_test.js
+++ b/admin/tests/integration/components/organizations/children/attach-child-form_test.js
@@ -1,0 +1,43 @@
+import { module, test } from 'qunit';
+import { hbs } from 'ember-cli-htmlbars';
+import { clickByName, fillByLabel, render as renderScreen } from '@1024pix/ember-testing-library';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component |  organizations/children/attach-child-form', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('display attach child form', async function (assert) {
+    //  when
+    const screen = await renderScreen(hbs`<Organizations::Children::AttachChildForm />`);
+
+    // then
+    assert.dom(screen.getByRole('form', { name: `Formulaire d'ajout d'une organisation fille` })).exists();
+    assert
+      .dom(screen.getByRole('textbox', { name: `Ajouter une organisation fille ID de l'organisation à ajouter` }))
+      .exists();
+    assert.dom(screen.getByRole('button', { name: 'Ajouter' })).exists();
+  });
+
+  module('when submitting the form', function () {
+    test('emits an event with "childOrganization" component attribute value and clears the input', async function (assert) {
+      // given
+      const onFormSubmitted = sinon.stub();
+      this.set('onFormSubmitted', onFormSubmitted);
+      const screen = await renderScreen(
+        hbs`<Organizations::Children::AttachChildForm @onFormSubmitted={{this.onFormSubmitted}} />`,
+      );
+      await fillByLabel(`Ajouter une organisation fille ID de l'organisation à ajouter`, '12345');
+
+      // when
+      await clickByName('Ajouter');
+
+      // then
+      assert.true(onFormSubmitted.calledOnceWithExactly('12345'));
+      assert
+        .dom(screen.getByRole('textbox', { name: `Ajouter une organisation fille ID de l'organisation à ajouter` }))
+        .hasValue('');
+    });
+  });
+});

--- a/admin/tests/unit/adapters/organization_test.js
+++ b/admin/tests/unit/adapters/organization_test.js
@@ -46,4 +46,24 @@ module('Unit | Adapters | organization', function (hooks) {
       assert.ok(adapter.ajax.calledWith(`${ENV.APP.API_HOST}/api/organizations/1/target-profiles`, 'GET'));
     });
   });
+
+  module('#attachChildOrganization', function () {
+    test('sends an HTTP POST request', async function (assert) {
+      // given
+      const childOrganizationId = 123;
+      const parentOrganizationId = 2;
+
+      // when
+      await adapter.attachChildOrganization({ childOrganizationId, parentOrganizationId });
+
+      // then
+      assert.true(
+        adapter.ajax.calledOnceWithExactly(
+          'http://localhost:3000/api/admin/organizations/2/attach-child-organization',
+          'POST',
+          { data: { childOrganizationId } },
+        ),
+      );
+    });
+  });
 });

--- a/admin/tests/unit/adapters/organization_test.js
+++ b/admin/tests/unit/adapters/organization_test.js
@@ -7,12 +7,14 @@ module('Unit | Adapters | organization', function (hooks) {
   setupTest(hooks);
 
   let adapter;
-  let ajaxStub;
 
   hooks.beforeEach(function () {
     adapter = this.owner.lookup('adapter:organization');
-    ajaxStub = sinon.stub();
-    adapter.ajax = ajaxStub;
+    sinon.stub(adapter, 'ajax').resolves();
+  });
+
+  hooks.afterEach(function () {
+    adapter.ajax.restore();
   });
 
   module('#findHasMany', function () {
@@ -27,7 +29,7 @@ module('Unit | Adapters | organization', function (hooks) {
 
       // then
       assert.ok(
-        ajaxStub.calledWith(`${ENV.APP.API_HOST}/api/admin/organizations/1/memberships?page%5Bsize%5D=2`, 'GET'),
+        adapter.ajax.calledWith(`${ENV.APP.API_HOST}/api/admin/organizations/1/memberships?page%5Bsize%5D=2`, 'GET'),
       );
     });
 
@@ -41,7 +43,7 @@ module('Unit | Adapters | organization', function (hooks) {
       await adapter.findHasMany({}, snapshot, url, relationship);
 
       // then
-      assert.ok(ajaxStub.calledWith(`${ENV.APP.API_HOST}/api/organizations/1/target-profiles`, 'GET'));
+      assert.ok(adapter.ajax.calledWith(`${ENV.APP.API_HOST}/api/organizations/1/target-profiles`, 'GET'));
     });
   });
 });

--- a/admin/tests/unit/components/organizations/children/attach-children-form_test.js
+++ b/admin/tests/unit/components/organizations/children/attach-children-form_test.js
@@ -1,0 +1,47 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+import createGlimmerComponent from '../../../../helpers/create-glimmer-component';
+
+module('Unit | Component | organizations/children/attach-child-form', function (hooks) {
+  setupTest(hooks);
+
+  let component;
+
+  hooks.beforeEach(function () {
+    component = createGlimmerComponent('component:organizations/children/attach-child-form');
+  });
+
+  module('when form input value changes', function () {
+    test('updates "childOrganization" component attribute', function (assert) {
+      // given
+      const event = { target: { value: '5432' } };
+
+      // when
+      component.childOrganizationInputValueChanged(event);
+
+      // then
+      assert.strictEqual(component.childOrganization, '5432');
+    });
+  });
+
+  module('when submitting the form', function () {
+    test('emits an event with "childOrganization" component attribute value and resets form input', function (assert) {
+      // given
+      const onFormSubmitted = sinon.stub();
+      const event = { preventDefault: sinon.stub() };
+
+      component.childOrganization = '1234';
+      component.args.onFormSubmitted = onFormSubmitted;
+
+      // when
+      component.submitForm(event);
+
+      // then
+      assert.true(event.preventDefault.calledOnce);
+      assert.true(onFormSubmitted.calledOnceWithExactly('1234'));
+      assert.strictEqual(component.childOrganization, '');
+    });
+  });
+});

--- a/admin/tests/unit/controllers/authenticated/organizations/get/children_test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/get/children_test.js
@@ -1,0 +1,42 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Controller | authenticated/organizations/get/children', function (hooks) {
+  setupTest(hooks);
+
+  let controller;
+  let store;
+
+  hooks.beforeEach(function () {
+    controller = this.owner.lookup('controller:authenticated/organizations/get/children');
+    store = this.owner.lookup('service:store');
+  });
+
+  module('#handleFormSubmitted', function () {
+    test('attaches child organization to parent organization', async function (assert) {
+      // given
+      const childOrganizationId = '1234';
+      const organizationAdapter = { attachChildOrganization: sinon.stub().resolves() };
+
+      sinon.stub(store, 'adapterFor').returns(organizationAdapter);
+      controller.model = {
+        organization: store.createRecord('organization', { id: '12' }),
+        organizations: { reload: sinon.stub().resolves() },
+      };
+
+      // when
+      await controller.handleFormSubmitted(childOrganizationId);
+
+      // then
+      assert.true(store.adapterFor.calledWithExactly('organization'));
+      assert.true(
+        organizationAdapter.attachChildOrganization.calledWithExactly({
+          childOrganizationId: '1234',
+          parentOrganizationId: '12',
+        }),
+      );
+      assert.true(controller.model.organizations.reload.calledOnce);
+    });
+  });
+});

--- a/admin/tests/unit/controllers/authenticated/organizations/get/children_test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/get/children_test.js
@@ -28,8 +28,8 @@ module('Unit | Controller | authenticated/organizations/get/children', function 
       sinon.stub(notifications, 'success');
       controller.model = {
         organization: store.createRecord('organization', { id: '12' }),
-        organizations: { reload: sinon.stub().resolves() },
       };
+      controller.model.organization.children.reload = sinon.stub().resolves();
 
       // when
       await controller.handleFormSubmitted(childOrganizationId);
@@ -45,7 +45,7 @@ module('Unit | Controller | authenticated/organizations/get/children', function 
       assert.true(
         notifications.success.calledWithExactly(`L'organisation fille a bien été liée à l'organisation mère`),
       );
-      assert.true(controller.model.organizations.reload.calledOnce);
+      assert.true(controller.model.organization.children.reload.calledOnce);
     });
 
     module('when form submit fails', function () {

--- a/admin/tests/unit/controllers/authenticated/organizations/get/children_test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/get/children_test.js
@@ -2,24 +2,30 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
+import setupIntl from '../../../../../helpers/setup-intl';
+
 module('Unit | Controller | authenticated/organizations/get/children', function (hooks) {
   setupTest(hooks);
+  setupIntl(hooks);
 
   let controller;
+  let notifications;
   let store;
 
   hooks.beforeEach(function () {
     controller = this.owner.lookup('controller:authenticated/organizations/get/children');
+    notifications = this.owner.lookup('service:notifications');
     store = this.owner.lookup('service:store');
   });
 
   module('#handleFormSubmitted', function () {
-    test('attaches child organization to parent organization', async function (assert) {
+    test('attaches child organization to parent organization and displays success notification', async function (assert) {
       // given
       const childOrganizationId = '1234';
       const organizationAdapter = { attachChildOrganization: sinon.stub().resolves() };
 
       sinon.stub(store, 'adapterFor').returns(organizationAdapter);
+      sinon.stub(notifications, 'success');
       controller.model = {
         organization: store.createRecord('organization', { id: '12' }),
         organizations: { reload: sinon.stub().resolves() },
@@ -35,6 +41,9 @@ module('Unit | Controller | authenticated/organizations/get/children', function 
           childOrganizationId: '1234',
           parentOrganizationId: '12',
         }),
+      );
+      assert.true(
+        notifications.success.calledWithExactly(`L'organisation fille a bien été liée à l'organisation mère`),
       );
       assert.true(controller.model.organizations.reload.calledOnce);
     });

--- a/admin/tests/unit/controllers/authenticated/organizations/get/children_test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/get/children_test.js
@@ -47,5 +47,57 @@ module('Unit | Controller | authenticated/organizations/get/children', function 
       );
       assert.true(controller.model.organizations.reload.calledOnce);
     });
+
+    module('when form submit fails', function () {
+      [
+        {
+          code: 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_ITSELF',
+          message: `Impossible d'attacher l'organisation à elle-même`,
+        },
+        {
+          code: 'UNABLE_TO_ATTACH_ALREADY_ATTACHED_CHILD_ORGANIZATION',
+          message: `L'organisation fille est déjà liée.`,
+        },
+        {
+          code: 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_TO_ANOTHER_CHILD_ORGANIZATION',
+          message: `Impossible d'attacher une organisation fille à une autre organisation fille.`,
+        },
+        {
+          code: 'UNABLE_TO_ATTACH_CHILD_ORGANIZATION_WITHOUT_SAME_TYPE',
+          message: `Vérifiez et sélectionnez une organisation fille qui correspond au type de l'organisation mère.`,
+        },
+        {
+          code: 'UNABLE_TO_ATTACH_PARENT_ORGANIZATION_AS_CHILD_ORGANIZATION',
+          message: `Impossible d'attacher une organisation mère en tant qu'organisation fille.`,
+        },
+      ].forEach(({ code, message }) => {
+        module(`when receiving ${code} error code`, function () {
+          test('calls notification service error', async function (assert) {
+            // given
+            const childOrganizationId = '1234';
+            const organizationAdapter = {
+              attachChildOrganization: sinon.stub().rejects({
+                errors: [{ code }],
+              }),
+            };
+
+            sinon.stub(store, 'adapterFor').returns(organizationAdapter);
+            sinon.stub(notifications, 'error');
+
+            controller.model = {
+              organization: store.createRecord('organization', { id: '12' }),
+              organizations: { reload: sinon.stub().resolves() },
+            };
+
+            // when
+            await controller.handleFormSubmitted(childOrganizationId);
+
+            // then
+            assert.true(notifications.error.calledWithExactly(message));
+            assert.true(controller.model.organizations.reload.notCalled);
+          });
+        });
+      });
+    });
   });
 });

--- a/admin/tests/unit/services/access-control_test.js
+++ b/admin/tests/unit/services/access-control_test.js
@@ -256,4 +256,36 @@ module('Unit | Service | access-control', function (hooks) {
       assert.false(service.hasAccessToCampaignIsForAbsoluteNoviceEditionScope);
     });
   });
+
+  module('#hasAccessToAttachChildOrganizationActionsScope', function () {
+    module(`when user has role "SUPER_ADMIN"`, function () {
+      test(`returns "true"`, function (assert) {
+        // given
+        const currentUser = this.owner.lookup('service:currentUser');
+        const service = this.owner.lookup('service:access-control');
+        currentUser.adminMember = { isSuperAdmin: true };
+
+        // then
+        assert.true(service.hasAccessToAttachChildOrganizationActionsScope);
+      });
+    });
+
+    [
+      { role: 'METIER', roleKey: 'isMetier', hasAccess: false },
+      { role: 'CERTIF', roleKey: 'isCertif', hasAccess: false },
+      { role: 'SUPPORT', roleKey: 'isSupport', hasAccess: false },
+    ].forEach(({ role, roleKey, hasAccess }) => {
+      module(`when user has role "${role}"`, function () {
+        test(`returns "${hasAccess}"`, function (assert) {
+          // given
+          const currentUser = this.owner.lookup('service:currentUser');
+          const service = this.owner.lookup('service:access-control');
+          currentUser.adminMember = { [roleKey]: hasAccess };
+
+          // then
+          assert.false(service.hasAccessToAttachChildOrganizationActionsScope);
+        });
+      });
+    });
+  });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -295,9 +295,15 @@
     },
     "organization-children": {
       "title": "Children organisations",
-      "empty-table": "No child organisation"
       "empty-table": "No child organisation",
       "notifications": {
+        "error": {
+          "unable-to-attach-already-attached-child-organization": "Child organization already linked",
+          "unable-to-attach-child-organization-to-another-child-organization": "Unable to attach a child organization to another child organization",
+          "unable-to-attach-child-organization-to-itself": "Unable to attach organization to itself",
+          "unable-to-attach-child-organization-without-same-type": "Check and select a child organization that matches the parent organization's type",
+          "unable-to-attach-parent-organization-as-child-organization": "Unable to attach a parent organization as child organization"
+        },
         "success": {
           "attach-child-organization": "The child organization has been linked to the parent organization"
         }

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1,6 +1,7 @@
 {
   "common": {
     "actions": {
+      "add": "Add",
       "cancel": "Cancel",
       "close": "Close",
       "deactivate": "Deactivate",
@@ -100,6 +101,13 @@
     "organizations": {
       "all-tags": {
         "recently-used-tags": "List of tags recently used with {tagName}"
+      },
+      "children": {
+        "attach-child-form": {
+          "input-information": "ID of organisation to add",
+          "input-label": "Add a child organisation",
+          "name": "Add a child organisation form"
+        }
       },
       "children-list": {
         "table-headers": {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -296,6 +296,12 @@
     "organization-children": {
       "title": "Children organisations",
       "empty-table": "No child organisation"
+      "empty-table": "No child organisation",
+      "notifications": {
+        "success": {
+          "attach-child-organization": "The child organization has been linked to the parent organization"
+        }
+      }
     },
     "sessions": {
       "informations": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -306,6 +306,12 @@
     "organization-children": {
       "title": "Organisations filles",
       "empty-table": "Aucune organisation fille"
+      "empty-table": "Aucune organisation fille",
+      "notifications": {
+        "success": {
+          "attach-child-organization": "L'organisation fille a bien été liée à l'organisation mère"
+        }
+      }
     },
     "organizations": {
       "notifications": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1,6 +1,7 @@
 {
   "common": {
     "actions": {
+      "add": "Ajouter",
       "cancel": "Annuler",
       "close": "Fermer",
       "deactivate": "Désactiver",
@@ -108,6 +109,13 @@
     "organizations": {
       "all-tags": {
         "recently-used-tags": "Liste de tags récemment utilisés avec {tagName}"
+      },
+      "children": {
+        "attach-child-form": {
+          "input-information": "ID de l'organisation à ajouter",
+          "input-label": "Ajouter une organisation fille",
+          "name": "Formulaire d'ajout d'une organisation fille"
+        }
       },
       "children-list": {
         "table-headers": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -305,9 +305,15 @@
     },
     "organization-children": {
       "title": "Organisations filles",
-      "empty-table": "Aucune organisation fille"
       "empty-table": "Aucune organisation fille",
       "notifications": {
+        "error": {
+          "unable-to-attach-already-attached-child-organization": "L'organisation fille est déjà liée.",
+          "unable-to-attach-child-organization-to-another-child-organization": "Impossible d'attacher une organisation fille à une autre organisation fille.",
+          "unable-to-attach-child-organization-to-itself": "Impossible d'attacher l'organisation à elle-même",
+          "unable-to-attach-child-organization-without-same-type": "Vérifiez et sélectionnez une organisation fille qui correspond au type de l'organisation mère.",
+          "unable-to-attach-parent-organization-as-child-organization": "Impossible d'attacher une organisation mère en tant qu'organisation fille."
+        },
         "success": {
           "attach-child-organization": "L'organisation fille a bien été liée à l'organisation mère"
         }


### PR DESCRIPTION
## :unicorn: Problème
On ne peut pas ajouter une organisation fille à une organisation mère depuis Pix Admin.

## :robot: Proposition

- Ajouter une formulaire sur la page des organisations mères, afin d'ajouter directement les organisations filles.
- Création d'un nouveau composant `ChildOrganizationAddForm` avec un label, un sous label, un input et un button.
- Ajouter une notification succès/erreur lors de l'ajout d'une organisation fille.

## :rainbow: Remarques
Pour le moment, seuls les utilisateurs ayant un rôle `SUPER_ADMIN` ont accès à ce formulaire.

## :100: Pour tester

### Compte ayant le rôle `SUPER_ADMIN`

1. Se connecter à Pix Admin avec le compte `superadmin@example.net`
2. Dans la liste des organisations, sélectionner `Collège House of The Dragon`
3. Vérifier que c'est bien une organisation mère (avec le label au dessous de son nom)
4. Dans l'onglet `Organisations filles`, vous devriez voir un formulaire pour ajouter une organisation fille
5. Ajouter une organisation une organisation fille du même type (ex: `Lycée Joséphine Baker`)
6. Vérifier que l'organisation ajoutée apparait bien dans la liste `Organisations filles` et qu'une notification de succès apparait bien

### Compte n'ayant pas le rôle adéquat

1. Se connecter à Pix Admin avec le compte `pixsupport@example.net`
2. Dans la liste des organisations, sélectionner `Collège House of The Dragon`
3. Vérifier que c'est bien une organisation mère (avec le label au dessous de son nom)
4. Dans l'onglet `Organisations filles`, le formulaire d'ajout d'une organisation fille ne devrait pas être visible

### Cas d'erreurs

#### Attacher une organisation a elle-même

1. Se connecter à Pix Admin avec le compte `superadmin@example.net`
2. Dans la liste des organisations, sélectionner `Collège House of The Dragon`
4. Cliquer sur l'onglet `Organisations filles`
5. Ajouter l'organisation avec son propre identifiant (que vous pouvez retrouver dans l'URL)
6. Vérifier qu'une notification d'erreur s'affiche avec le message `Impossible d'attacher l'organisation à elle-même`

#### Attacher une organisation fille déjà liée à cette organisation ou à une autre organisation

1. Se connecter à Pix Admin avec le compte `superadmin@example.net`
2. Dans la liste des organisations, sélectionner `Collège House of The Dragon`
4. Cliquer sur l'onglet `Organisations filles`
5. Tenter d'ajouter de nouveau l'une des organisations filles présentes dans la liste
6. Vérifier qu'une notification d'erreur s'affiche avec le message `L'organisation fille est déjà liée.`

#### Attacher une organisation fille à une autre organisation fille

1. Se connecter à Pix Admin avec le compte `superadmin@example.net`
2. Dans la liste des organisations, sélectionner `Child of "Collège House of The Dragon"`
4. Cliquer sur l'onglet `Organisations filles`
5. Tenter d'ajouter une organisation fille du même type (SCO)
6. Vérifier qu'une notification d'erreur s'affiche avec le message `Impossible d'attacher une organisation fille à une autre organisation fille.`

#### Attacher une organisation fille n'ayant pas le même type que l'organisation mère

1. Se connecter à Pix Admin avec le compte `superadmin@example.net`
2. Dans la liste des organisations, sélectionner `Collège House of The Dragon`
4. Cliquer sur l'onglet `Organisations filles`
5. Tenter d'ajouter une organisation fille d'un autre type **PRO**, **SCO-1D** ou **SUP**
6. Vérifier qu'une notification d'erreur s'affiche avec le message `Vérifiez et sélectionnez une organisation fille qui correspond au type de l'organisation mère.`

#### Attacher une organisation mère en tant qu'organisation fille

1. Se connecter à Pix Admin avec le compte `superadmin@example.net`
2. Dans la liste des organisations, sélectionner `Sco Orga team eval`
4. Cliquer sur l'onglet `Organisations filles`
5. Tenter d'ajouter l'organisation `Collège House of The Dragon` avec l'ID **2023**
6. Vérifier qu'une notification d'erreur s'affiche avec le message `Impossible d'attacher une organisation mère en tant qu'organisation fille.`