### PR TITLE
[BUGFIX] Corrige le lien vers la dernière participation partagée depuis l'activité d'un participant (PIX-11170)

### DIFF
--- a/api/src/prescription/organization-learner/domain/read-models/OrganizationLearnerParticipation.js
+++ b/api/src/prescription/organization-learner/domain/read-models/OrganizationLearnerParticipation.js
@@ -1,5 +1,15 @@
 class OrganizationLearnerParticipation {
-  constructor({ id, campaignType, campaignName, createdAt, sharedAt, status, campaignId, participationCount }) {
+  constructor({
+    id,
+    campaignType,
+    campaignName,
+    createdAt,
+    sharedAt,
+    status,
+    campaignId,
+    participationCount,
+    lastSharedOrCurrentCampaignParticipationId,
+  }) {
     this.id = id;
     this.campaignType = campaignType;
     this.campaignName = campaignName;
@@ -8,6 +18,7 @@ class OrganizationLearnerParticipation {
     this.status = status;
     this.campaignId = campaignId;
     this.participationCount = participationCount;
+    this.lastSharedOrCurrentCampaignParticipationId = lastSharedOrCurrentCampaignParticipationId || id;
   }
 }
 

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-activity-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-activity-repository.js
@@ -1,6 +1,7 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { OrganizationLearnerParticipation } from '../../domain/read-models/OrganizationLearnerParticipation.js';
 import { OrganizationLearnerActivity } from '../../domain/read-models/OrganizationLearnerActivity.js';
+import { CampaignParticipationStatuses } from '../../../shared/domain/constants.js';
 
 async function get(organizationLearnerId) {
   const organizationLearnerParticipations = await knex('campaign-participations')
@@ -12,6 +13,15 @@ async function get(organizationLearnerId) {
       'campaigns.name',
       'campaigns.type',
       'campaign-participations.campaignId',
+      knex('campaign-participations')
+        .select('campaign-participations.id')
+        .whereRaw('"campaignId" = "campaigns"."id"')
+        .where('organizationLearnerId', organizationLearnerId)
+        .and.where('status', CampaignParticipationStatuses.SHARED)
+        .whereNull('deletedAt')
+        .orderBy('sharedAt', 'desc')
+        .limit(1)
+        .as('lastSharedCampaignsParticipationId'),
     )
     .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
     .where('campaign-participations.organizationLearnerId', '=', organizationLearnerId)
@@ -19,7 +29,7 @@ async function get(organizationLearnerId) {
     .where('campaign-participations.isImproved', '=', false)
     .orderBy('campaign-participations.createdAt', 'desc');
 
-  const partipationsCount = await knex('campaign-participations')
+  const participationsCount = await knex('campaign-participations')
     .select('campaignId')
     .where('organizationLearnerId', organizationLearnerId)
     .whereNull('deletedAt')
@@ -36,9 +46,10 @@ async function get(organizationLearnerId) {
         campaignName: participation.name,
         campaignType: participation.type,
         campaignId: participation.campaignId,
-        participationCount: partipationsCount.find(
+        participationCount: participationsCount.find(
           (participationCount) => participationCount.campaignId === participation.campaignId,
         ).count,
+        lastSharedOrCurrentCampaignParticipationId: participation.lastSharedCampaignsParticipationId,
       }),
   );
   return new OrganizationLearnerActivity({ organizationLearnerId, participations });

--- a/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/organization-learner-activity-serializer.js
+++ b/api/src/prescription/organization-learner/infrastructure/serializers/jsonapi/organization-learner-activity-serializer.js
@@ -22,6 +22,7 @@ const serialize = function (organizationLearnerActivity) {
         'status',
         'campaignId',
         'participationCount',
+        'lastSharedOrCurrentCampaignParticipationId',
       ],
     },
     organizationLearnerStatistics: {

--- a/api/tests/prescription/organization-learner/unit/domain/read-models/OrganizationLearnerParticipation_test.js
+++ b/api/tests/prescription/organization-learner/unit/domain/read-models/OrganizationLearnerParticipation_test.js
@@ -1,0 +1,51 @@
+import { expect } from '../../../../../test-helper.js';
+import { CampaignParticipationStatuses } from '../../../../../../src/prescription/shared/domain/constants.js';
+import { OrganizationLearnerParticipation } from '../../../../../../src/prescription/organization-learner/domain/read-models/OrganizationLearnerParticipation.js';
+const { SHARED } = CampaignParticipationStatuses;
+
+describe('Unit | Domain | Read-Models | OrganizationLearner | OrganizationLearnerParticipation', function () {
+  describe('constructor', function () {
+    it('should correctly initialize the information about organizationLearner participation', function () {
+      //given
+      const organizationLearnerParticipation = new OrganizationLearnerParticipation({
+        id: 202,
+        campaignType: 'ASSESSMENT',
+        campaignName: 'Hulk',
+        createdAt: new Date('2000-01-03'),
+        sharedAt: new Date('2000-12-12'),
+        status: SHARED,
+        campaignId: 404,
+        participationCount: 1,
+        lastSharedOrCurrentCampaignParticipationId: 202,
+      });
+
+      expect(organizationLearnerParticipation).to.deep.equal({
+        id: 202,
+        campaignType: 'ASSESSMENT',
+        campaignName: 'Hulk',
+        createdAt: new Date('2000-01-03'),
+        sharedAt: new Date('2000-12-12'),
+        status: 'SHARED',
+        campaignId: 404,
+        participationCount: 1,
+        lastSharedOrCurrentCampaignParticipationId: 202,
+      });
+    });
+    it('should use participation id if the lastSharedCampaignParticipationId is not provided', function () {
+      const organizationLearnerParticipation = new OrganizationLearnerParticipation({
+        id: 202,
+        campaignType: 'ASSESSMENT',
+        campaignName: 'Hulk',
+        createdAt: new Date('2000-01-03'),
+        sharedAt: new Date('2000-12-12'),
+        status: SHARED,
+        campaignId: 404,
+        participationCount: 1,
+      });
+
+      expect(organizationLearnerParticipation.lastSharedOrCurrentCampaignParticipationId).to.deep.equal(
+        organizationLearnerParticipation.id,
+      );
+    });
+  });
+});

--- a/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/organization-learner-activity-serializer_test.js
+++ b/api/tests/prescription/organization-learner/unit/infrastructure/serializers/jsonapi/organization-learner-activity-serializer_test.js
@@ -19,6 +19,7 @@ describe('Unit | Serializer | JSONAPI | organization-learner-participation-seria
             sharedAt: '2000-02-01T10:00:00Z',
             status: 'SHARED',
             participationCount: '1',
+            lastSharedOrCurrentCampaignParticipationId: '99999',
           }),
           new OrganizationLearnerParticipation({
             id: '100000',
@@ -29,6 +30,7 @@ describe('Unit | Serializer | JSONAPI | organization-learner-participation-seria
             sharedAt: '2000-04-01T10:00:00Z',
             status: 'STARTED',
             participationCount: '2',
+            lastSharedOrCurrentCampaignParticipationId: '100000',
           }),
         ],
         statistics: [
@@ -95,6 +97,7 @@ describe('Unit | Serializer | JSONAPI | organization-learner-participation-seria
               'shared-at': '2000-02-01T10:00:00Z',
               status: 'SHARED',
               'participation-count': '1',
+              'last-shared-or-current-campaign-participation-id': '99999',
             },
           },
           {
@@ -108,6 +111,7 @@ describe('Unit | Serializer | JSONAPI | organization-learner-participation-seria
               'shared-at': '2000-04-01T10:00:00Z',
               status: 'STARTED',
               'participation-count': '2',
+              'last-shared-or-current-campaign-participation-id': '100000',
             },
           },
           {

--- a/orga/app/components/organization-learner/activity/participation-row.js
+++ b/orga/app/components/organization-learner/activity/participation-row.js
@@ -21,6 +21,10 @@ export default class ParticipationRow extends Component {
   @action
   goToParticipationDetail(event) {
     event.preventDefault();
-    this.router.transitionTo(this.routeName, this.args.participation.campaignId, this.args.participation.id);
+    this.router.transitionTo(
+      this.routeName,
+      this.args.participation.campaignId,
+      this.args.participation.lastSharedOrCurrentCampaignParticipationId,
+    );
   }
 }

--- a/orga/app/models/campaign-participant-activity.js
+++ b/orga/app/models/campaign-participant-activity.js
@@ -5,6 +5,6 @@ export default class CampaignParticipantActivity extends Model {
   @attr('string') lastName;
   @attr('string') participantExternalId;
   @attr('string') status;
-  @attr('string') lastSharedOrCurrentCampaignParticipationId;
+  @attr('number') lastSharedOrCurrentCampaignParticipationId;
   @attr('number') participationCount;
 }

--- a/orga/app/models/organization-learner-participation.js
+++ b/orga/app/models/organization-learner-participation.js
@@ -8,6 +8,7 @@ export default class OrganizationLearnerParticipation extends Model {
   @attr('string') status;
   @attr('number') campaignId;
   @attr('number') participationCount;
+  @attr('number') lastSharedOrCurrentCampaignParticipationId;
 
   @belongsTo('OrganizationLearnerActivity') organizationLearnerActivity;
 }

--- a/orga/tests/integration/components/organization-learner/activity/participation-row_test.js
+++ b/orga/tests/integration/components/organization-learner/activity/participation-row_test.js
@@ -78,6 +78,7 @@ module('Integration | Component | OrganizationLearner | Activity::ParticipationR
       createdAt: new Date('2023-02-01'),
       sharedAt: new Date('2023-03-01'),
       status: 'SHARED',
+      lastSharedOrCurrentCampaignParticipationId: 345,
     };
     this.route = 'authenticated.campaigns.participant-assessment';
 
@@ -89,7 +90,13 @@ module('Integration | Component | OrganizationLearner | Activity::ParticipationR
     await click(await screen.findByRole('cell', { name: '01/02/2023' }));
 
     // then
-    assert.ok(router.transitionTo.calledWith(this.route, this.participation.campaignId, this.participation.id));
+    assert.ok(
+      router.transitionTo.calledWith(
+        this.route,
+        this.participation.campaignId,
+        this.participation.lastSharedOrCurrentCampaignParticipationId,
+      ),
+    );
   });
 
   test('it should transition to profile collection detail when campaignType is PROFILE_COLLECTION', async function (assert) {
@@ -102,6 +109,7 @@ module('Integration | Component | OrganizationLearner | Activity::ParticipationR
       createdAt: new Date('2023-02-01'),
       sharedAt: new Date('2023-03-01'),
       status: 'SHARED',
+      lastSharedOrCurrentCampaignParticipationId: 345,
     };
     this.route = 'authenticated.campaigns.participant-profile';
 
@@ -113,6 +121,12 @@ module('Integration | Component | OrganizationLearner | Activity::ParticipationR
     await click(await screen.findByRole('cell', { name: '01/02/2023' }));
 
     // then
-    assert.ok(router.transitionTo.calledWith(this.route, this.participation.campaignId, this.participation.id));
+    assert.ok(
+      router.transitionTo.calledWith(
+        this.route,
+        this.participation.campaignId,
+        this.participation.lastSharedOrCurrentCampaignParticipationId,
+      ),
+    );
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Dans le cas d’une campagne d'évaluation à envoi multiple. 
Si je fais ce chemin Campagnes → Nom de la campagne → Participation de X, je vois la dernière participation partagée par le prescrit. 

Si je fais ce chemin Participants → Participant X → Participation de X, je vois la participation en cours avec un % d’avancement de 100%. 

le % d’avancement est donc incorrect

Il était prévu que nous voyons pour le moment la dernière participation partagée.

Pour mémoire : Nous avons prévu dans la “V0.5” de mettre un sélecteur pour permettre au prescripteur de choisir la participation qu’il veut consulter. 

Communication : Tenir Nat informée quand la correction est passée en prod 

## :robot: Proposition
Renvoyer vers la dernière participation partagée si il y en a une au lieu de renvoyer vers la participation la plus récente

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- Se connecter à PixOrga
- comparer les 2 chemins suivants  et remarquer qu'ils renvoient au même résultat :
- - Campagnes → Nom de la campagne → Participation de X, je vois la dernière participation partagée par le prescrit. 
- -  Participants → Participant X → Participation de X, je vois la participation en cours avec un % d’avancement de 100%.
 - 🎉 