### PR TITLE
[BUGFIX] Revue de l'attribut rel sur les liens de tutos (PIX-11306) (PIX-11307)

### DIFF
--- a/mon-pix/app/components/tutorials/card.hbs
+++ b/mon-pix/app/components/tutorials/card.hbs
@@ -2,7 +2,7 @@
   <article class="tutorial-card" role="article">
     <div class="tutorial-card__content">
       <h4 class="tutorial-card-content__title">
-        <a target="_blank" rel="noreferrer" href="{{@tutorial.link}}" title="{{@tutorial.title}}">
+        <a target="_blank" rel={{this.linkRel}} href="{{@tutorial.link}}" title="{{@tutorial.title}}">
           {{@tutorial.title}}
         </a>
       </h4>

--- a/mon-pix/app/components/tutorials/card.hbs
+++ b/mon-pix/app/components/tutorials/card.hbs
@@ -2,7 +2,7 @@
   <article class="tutorial-card" role="article">
     <div class="tutorial-card__content">
       <h4 class="tutorial-card-content__title">
-        <a target="_blank" rel="noopener noreferrer" href="{{@tutorial.link}}" title="{{@tutorial.title}}">
+        <a target="_blank" rel="noreferrer" href="{{@tutorial.link}}" title="{{@tutorial.title}}">
           {{@tutorial.title}}
         </a>
       </h4>

--- a/mon-pix/app/components/tutorials/card.js
+++ b/mon-pix/app/components/tutorials/card.js
@@ -12,6 +12,8 @@ export default class Card extends Component {
   @tracked savingStatus;
   @tracked evaluationStatus;
 
+  static TUTORIAL_PIX_URL_HOST = 'tutorial.pix.fr';
+
   constructor(owner, args) {
     super(owner, args);
     this.savingStatus = args.tutorial.isSaved ? buttonStatusTypes.recorded : buttonStatusTypes.unrecorded;
@@ -44,6 +46,12 @@ export default class Card extends Component {
 
   get isTutorialSaved() {
     return this.savingStatus !== buttonStatusTypes.unrecorded;
+  }
+
+  get linkRel() {
+    const tutorialUrl = new URL(this.args.tutorial.link);
+    const isKnownHost = tutorialUrl.host === Card.TUTORIAL_PIX_URL_HOST;
+    return isKnownHost ? null : 'noreferrer';
   }
 
   @action

--- a/mon-pix/mirage/factories/user.js
+++ b/mon-pix/mirage/factories/user.js
@@ -250,7 +250,7 @@ function _createTutorial(server) {
     'tube-practical-description': 'tube_1_practical_description',
     duration: '00:15:00',
     format: 'page',
-    link: 'www.monlien.net',
+    link: 'https://www.monlien.net',
     source: 'Pix',
   });
 }

--- a/mon-pix/mirage/handlers/find-paginated-and-filtered-tutorials.js
+++ b/mon-pix/mirage/handlers/find-paginated-and-filtered-tutorials.js
@@ -34,7 +34,12 @@ function _findPaginatedAndFilteredRecommendedTutorials(schema, request) {
   let tutorials;
 
   if (competenceFilters) {
-    tutorials = [schema.tutorials.create({ name: `Le tuto de la compétence ${competenceFilters[0]}` })];
+    tutorials = [
+      schema.tutorials.create({
+        link: 'https://example.net/',
+        name: `Le tuto de la compétence ${competenceFilters[0]}`,
+      }),
+    ];
   } else {
     tutorials = schema.tutorials.all().models;
   }

--- a/mon-pix/tests/integration/components/comparison-window_test.js
+++ b/mon-pix/tests/integration/components/comparison-window_test.js
@@ -86,7 +86,9 @@ module('Integration | Component | comparison-window', function (hooks) {
     test('should render a learningMoreTutorials panel when correction has a list of LearningMoreTutorials elements', async function (assert) {
       // given
       correction.setProperties({
-        learningMoreTutorials: [{ titre: 'Ceci est un tuto', duration: '20:00:00', type: 'video' }],
+        learningMoreTutorials: [
+          { titre: 'Ceci est un tuto', link: 'https://example.net', duration: '20:00:00', type: 'video' },
+        ],
       });
 
       // when
@@ -140,7 +142,9 @@ module('Integration | Component | comparison-window', function (hooks) {
       test('should not render a hint or a tutorial', async function (assert) {
         // given
         correction.setProperties({
-          learningMoreTutorials: [{ titre: 'Ceci est un tuto', duration: '20:00:00', type: 'video' }],
+          learningMoreTutorials: [
+            { titre: 'Ceci est un tuto', link: 'https://example.net', duration: '20:00:00', type: 'video' },
+          ],
         });
 
         // when

--- a/mon-pix/tests/integration/components/learning-more-panel_test.js
+++ b/mon-pix/tests/integration/components/learning-more-panel_test.js
@@ -13,7 +13,14 @@ module('Integration | Component | learning-more-panel', function (hooks) {
   module('when there is at least one learningMore item', function () {
     test('renders a list item when there is at least one learningMore item', async function (assert) {
       // given
-      this.set('learningMoreTutorials', [{ titre: 'Ceci est un tuto', duration: '20:00:00', type: 'video' }]);
+      this.set('learningMoreTutorials', [
+        {
+          link: 'https://example.net/1',
+          titre: 'Ceci est un tuto',
+          duration: '20:00:00',
+          type: 'video',
+        },
+      ]);
 
       // when
       await render(hbs`<LearningMorePanel @learningMoreTutorials={{this.learningMoreTutorials}}/>`);
@@ -29,6 +36,7 @@ module('Integration | Component | learning-more-panel', function (hooks) {
         // given
         const tuto1 = EmberObject.create({
           title: 'Tuto 1.1',
+          link: 'https://example.net/1',
           tubeName: '@first_tube',
           tubePracticalTitle: 'Practical Title',
           duration: '00:15:10',

--- a/mon-pix/tests/integration/components/scorecard-details_test.js
+++ b/mon-pix/tests/integration/components/scorecard-details_test.js
@@ -290,18 +290,21 @@ module('Integration | Component | scorecard-details', function (hooks) {
           const store = this.owner.lookup('service:store');
           const tuto1 = store.createRecord('tutorial', {
             title: 'Tuto 1.1',
+            link: 'https://example.net/1',
             tubeName: '@first_tube',
             tubePracticalTitle: 'Practical Title',
             duration: '00:15:10',
           });
           const tuto2 = store.createRecord('tutorial', {
             title: 'Tuto 2.1',
+            link: 'https://example.net/2',
             tubeName: '@second_tube',
             tubePracticalTitle: 'Practical Title 1',
             duration: '00:04:00',
           });
           const tuto3 = store.createRecord('tutorial', {
             title: 'Tuto 2.2',
+            link: 'https://example.net/3',
             tubeName: '@second_tube',
             tubePracticalTitle: 'Practical Title',
             duration: '00:04:00',

--- a/mon-pix/tests/integration/components/tutorial-panel_test.js
+++ b/mon-pix/tests/integration/components/tutorial-panel_test.js
@@ -38,6 +38,7 @@ module('Integration | Component | Tutorial Panel', function (hooks) {
           {
             title: 'Ceci est un tuto',
             duration: '20:00:00',
+            link: 'https://example.com',
           },
         ]);
       });

--- a/mon-pix/tests/integration/components/tutorials/card_test.js
+++ b/mon-pix/tests/integration/components/tutorials/card_test.js
@@ -32,20 +32,18 @@ module('Integration | Component | Tutorials | Card', function (hooks) {
       );
 
       // when
-      await render(hbs`<Tutorials::Card @tutorial={{this.tutorial}} />`);
+      const screen = await render(hbs`<Tutorials::Card @tutorial={{this.tutorial}} />`);
 
       // then
-      assert.dom('.tutorial-card').exists();
-      assert.dom('.tutorial-card__content').exists();
-      assert.ok(find('.tutorial-card-content__title a').textContent.includes('Mon super tutoriel'));
-      assert.strictEqual(find('.tutorial-card-content__title a').href, 'https://exemple.net/');
+      const link = screen.getByRole('link', { name: 'Mon super tutoriel' });
+      assert.strictEqual(link.href, 'https://exemple.net/');
       assert.ok(find('.tutorial-card-content__details').textContent.includes('mon-tuto'));
       assert.ok(find('.tutorial-card-content__details').textContent.includes('vidéo'));
       assert.ok(find('.tutorial-card-content__details').textContent.includes('une minute'));
-      assert.dom('.tutorial-card-content__actions').exists();
-      assert.dom('[aria-label="Ne plus considérer ce tuto comme utile"]').exists();
-      assert.dom('[aria-label="Retirer de ma liste de tutos"]').exists();
-      assert.dom('[title="Ne plus considérer ce tuto comme utile"]').exists();
+      assert.dom(screen.getByRole('list')).exists();
+      const evaluationButton = screen.getByRole('button', { name: 'Ne plus considérer ce tuto comme utile' });
+      assert.strictEqual(evaluationButton.title, 'Ne plus considérer ce tuto comme utile');
+      assert.dom(screen.getByRole('button', { name: 'Retirer de ma liste de tutos' })).exists();
     });
   });
 
@@ -72,17 +70,15 @@ module('Integration | Component | Tutorials | Card', function (hooks) {
       );
 
       // when
-      await render(hbs`<Tutorials::Card @tutorial={{this.tutorial}} />`);
+      const screen = await render(hbs`<Tutorials::Card @tutorial={{this.tutorial}} />`);
 
       // then
-      assert.dom('.tutorial-card').exists();
-      assert.dom('.tutorial-card__content').exists();
-      assert.ok(find('.tutorial-card-content__title a').textContent.includes('Mon super tutoriel'));
-      assert.strictEqual(find('.tutorial-card-content__title a').href, 'https://exemple.net/');
+      const link = screen.getByRole('link', { name: 'Mon super tutoriel' });
+      assert.strictEqual(link.href, 'https://exemple.net/');
       assert.ok(find('.tutorial-card-content__details').textContent.includes('mon-tuto'));
       assert.ok(find('.tutorial-card-content__details').textContent.includes('vidéo'));
       assert.ok(find('.tutorial-card-content__details').textContent.includes('une minute'));
-      assert.dom('.tutorial-card-content__actions').doesNotExist();
+      assert.dom(screen.queryByRole('list')).doesNotExist();
     });
   });
 });

--- a/mon-pix/tests/integration/components/tutorials/card_test.js
+++ b/mon-pix/tests/integration/components/tutorials/card_test.js
@@ -36,7 +36,7 @@ module('Integration | Component | Tutorials | Card', function (hooks) {
 
       // then
       const link = screen.getByRole('link', { name: 'Mon super tutoriel' });
-      assert.strictEqual(link.href, 'https://exemple.net/');
+      assert.strictEqual(link.getAttribute('href'), 'https://exemple.net/');
       assert.ok(find('.tutorial-card-content__details').textContent.includes('mon-tuto'));
       assert.ok(find('.tutorial-card-content__details').textContent.includes('vidéo'));
       assert.ok(find('.tutorial-card-content__details').textContent.includes('une minute'));
@@ -74,11 +74,61 @@ module('Integration | Component | Tutorials | Card', function (hooks) {
 
       // then
       const link = screen.getByRole('link', { name: 'Mon super tutoriel' });
-      assert.strictEqual(link.href, 'https://exemple.net/');
+      assert.strictEqual(link.getAttribute('href'), 'https://exemple.net/');
       assert.ok(find('.tutorial-card-content__details').textContent.includes('mon-tuto'));
       assert.ok(find('.tutorial-card-content__details').textContent.includes('vidéo'));
       assert.ok(find('.tutorial-card-content__details').textContent.includes('une minute'));
       assert.dom(screen.queryByRole('list')).doesNotExist();
+    });
+  });
+
+  module('link rel', function () {
+    test('should set rel="noreferrer" on external links', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      this.set(
+        'tutorial',
+        store.createRecord('tutorial', {
+          title: 'Mon super tutoriel',
+          link: 'https://exemple.net/',
+          source: 'mon-tuto',
+          format: 'vidéo',
+          duration: '60',
+          userSavedTutorial: store.createRecord('user-saved-tutorial', {}),
+          tutorialEvaluation: store.createRecord('tutorial-evaluation', { status: 'LIKED' }),
+        }),
+      );
+
+      // when
+      const screen = await render(hbs`<Tutorials::Card @tutorial={{this.tutorial}} />`);
+
+      // then
+      const link = screen.getByRole('link', { name: 'Mon super tutoriel' });
+      assert.strictEqual(link.getAttribute('rel'), 'noreferrer');
+    });
+
+    test('should not set rel="noreferrer" on internal links', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      this.set(
+        'tutorial',
+        store.createRecord('tutorial', {
+          title: 'Mon super tutoriel',
+          link: 'https://tutorial.pix.fr:443/known-link',
+          source: 'mon-tuto',
+          format: 'vidéo',
+          duration: '60',
+          userSavedTutorial: store.createRecord('user-saved-tutorial', {}),
+          tutorialEvaluation: store.createRecord('tutorial-evaluation', { status: 'LIKED' }),
+        }),
+      );
+
+      // when
+      const screen = await render(hbs`<Tutorials::Card @tutorial={{this.tutorial}} />`);
+
+      // then
+      const tutorialLink = screen.getByRole('link', { name: 'Mon super tutoriel' });
+      assert.strictEqual(tutorialLink.getAttribute('rel'), null);
     });
   });
 });

--- a/mon-pix/tests/unit/components/tutorials/card_test.js
+++ b/mon-pix/tests/unit/components/tutorials/card_test.js
@@ -179,4 +179,30 @@ module('Unit | Component | Tutorial | card item', function (hooks) {
       });
     });
   });
+
+  module('#linkRel', function () {
+    test('should return noreferrer if unknown destination link', function (assert) {
+      // given
+      component = createGlimmerComponent('tutorials/card', { tutorial: { ...tutorial, link: 'https://exemple.net/' } });
+
+      // when
+      const result = component.linkRel;
+
+      // then
+      assert.strictEqual(result, 'noreferrer');
+    });
+
+    test('should return empty string if tutorial.pix.fr', function (assert) {
+      // given
+      component = createGlimmerComponent('tutorials/card', {
+        tutorial: { ...tutorial, link: 'https://tutorial.pix.fr:443/known-link' },
+      });
+
+      // when
+      const result = component.linkRel;
+
+      // then
+      assert.strictEqual(result, null);
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Les `rel="noopener noreferrer"` servent si on ne veut pas montrer que du traffic viens de chez nous.

La valeur d'attribut `noopener` est un doublon si `target="_blank"`.

## :robot: Proposition
- Les tutos “tutos.pix.fr” étant maîtrisés par Pix, conserver l’info.
- Supprimer la valeur `noopener`.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que les tutoriels ont bien `rel="noreferrer"` uniquement, ou pas d'attribut `rel` si c'est une URL en tutoriels.pix.fr.
