### PR TITLE
[BUGFIX] Correction et amélioration générateurs d'éléments Modulix

### DIFF
--- a/api/scripts/modulix/get-sample-image-element.js
+++ b/api/scripts/modulix/get-sample-image-element.js
@@ -1,6 +1,3 @@
 import { getImageSample } from '../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/image.sample.js';
 
-console.log('');
 console.log(JSON.stringify(getImageSample(), null, 2));
-console.log('');
-console.log('Voici un joli élément image. Pensez à remplir les alternatives !');

--- a/api/scripts/modulix/get-sample-qcm-element.js
+++ b/api/scripts/modulix/get-sample-qcm-element.js
@@ -1,6 +1,3 @@
 import { getQcmSample } from '../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/qcm.sample.js';
 
-console.log('');
 console.log(JSON.stringify(getQcmSample(), null, 2));
-console.log('');
-console.log('Voici un petit QCM.');

--- a/api/scripts/modulix/get-sample-qcu-element.js
+++ b/api/scripts/modulix/get-sample-qcu-element.js
@@ -1,6 +1,3 @@
 import { getQcuSample } from '../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/qcu.sample.js';
 
-console.log('');
 console.log(JSON.stringify(getQcuSample(), null, 2));
-console.log('');
-console.log('Voici un QCU.');

--- a/api/scripts/modulix/get-sample-qrocm-element.js
+++ b/api/scripts/modulix/get-sample-qrocm-element.js
@@ -1,6 +1,3 @@
 import { getQrocmSample } from '../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/qrocm.sample.js';
 
-console.log('');
 console.log(JSON.stringify(getQrocmSample(), null, 2));
-console.log('');
-console.log('Voici un QROCM. Bon courage pour la contrib !');

--- a/api/scripts/modulix/get-sample-text-element.js
+++ b/api/scripts/modulix/get-sample-text-element.js
@@ -1,6 +1,3 @@
 import { getTextSample } from '../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/text.sample.js';
 
-console.log('');
 console.log(JSON.stringify(getTextSample(), null, 2));
-console.log('');
-console.log('Voici un petit texte.');

--- a/api/scripts/modulix/get-sample-video-element.js
+++ b/api/scripts/modulix/get-sample-video-element.js
@@ -1,6 +1,3 @@
 import { getVideoSample } from '../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/video.sample.js';
 
-console.log('');
 console.log(JSON.stringify(getVideoSample(), null, 2));
-console.log('');
-console.log("Voici un joli élément vidéo. N'oubliez pas de compléter la transcription !");

--- a/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/qrocm.sample.js
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/samples/elements/qrocm.sample.js
@@ -44,7 +44,7 @@ export function getQrocmSample() {
             content: 'Incroyable',
           },
           {
-            id: '2',
+            id: '3',
             content: 'Légendaire',
           },
         ],


### PR DESCRIPTION
## :unicorn: Problème
- Le générateur de QROCM renvoie un `select` avec un `id` de `proposal` incorrect.
- Les espaces et petites phrases complémentaires des générateurs d'éléments gênent légèrement le copier-coller.

## :robot: Proposition
- Corriger l'`id` incorrect dans l'exemple de QROCM.
- Afficher uniquement l'élément généré lors de la génération.

## :rainbow: Remarques
Pas eu le courage d'aller plus loin sur la validation les identifiants pour éviter que ça n'arrive dans d'autres contenus.

## :100: Pour tester
Dans l'API
- `node ./scripts/modulix/get-sample-qrocm-element.js` doit renvoyer un QROCM correct sans surplus.
