### PR TITLE
[FEATURE] Ajouter un bandeau beta pour expérimentation (PIX-10992)

### DIFF
--- a/mon-pix/app/pods/components/beta-banner/template.hbs
+++ b/mon-pix/app/pods/components/beta-banner/template.hbs
@@ -1,0 +1,3 @@
+<PixBanner @type="communication">
+  {{t "pages.modulix.beta-banner"}}
+</PixBanner>

--- a/mon-pix/app/pods/components/module/details/template.hbs
+++ b/mon-pix/app/pods/components/module/details/template.hbs
@@ -1,4 +1,5 @@
 {{page-title @module.title}}
+<BetaBanner />
 
 <main class="module-details">
   <div class="module-details__image">

--- a/mon-pix/app/pods/components/module/passage/template.hbs
+++ b/mon-pix/app/pods/components/module/passage/template.hbs
@@ -1,4 +1,5 @@
 {{page-title @module.title}}
+<BetaBanner />
 
 <main class="module-passage">
   <div class="module-passage__title">

--- a/mon-pix/app/pods/components/module/recap/template.hbs
+++ b/mon-pix/app/pods/components/module/recap/template.hbs
@@ -1,4 +1,6 @@
-<div class="module-recap">
+<BetaBanner />
+
+<main class="module-recap">
   <div class="module-recap__header">
     <FaIcon @icon="circle-check" class="module-recap-header__icon fa-3x" />
   </div>
@@ -30,4 +32,4 @@
       {{t "pages.modulix.recap.backToModuleDetails"}}
     </PixButtonLink>
   </div>
-</div>
+</main>

--- a/mon-pix/tests/integration/components/module/details_test.js
+++ b/mon-pix/tests/integration/components/module/details_test.js
@@ -7,6 +7,26 @@ import { findAll } from '@ember/test-helpers';
 module('Integration | Component | Module | Details', function (hooks) {
   setupIntlRenderingTest(hooks);
 
+  test('should display a banner at the top of the screen for module details', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const details = {
+      image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+      description: 'description',
+      duration: 12,
+      level: 'Débutant',
+      objectives: ['Objectif 1'],
+    };
+    const module = store.createRecord('module', { title: 'Module title', details });
+    this.set('module', module);
+
+    // when
+    const screen = await render(hbs`<Module::Details @module={{this.module}} />`);
+
+    // then
+    assert.dom(screen.getByRole('alert')).exists();
+  });
+
   test('should display the details of a given module', async function (assert) {
     // given
     const store = this.owner.lookup('service:store');

--- a/mon-pix/tests/integration/components/module/passage_test.js
+++ b/mon-pix/tests/integration/components/module/passage_test.js
@@ -8,6 +8,25 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | Module | Passage', function (hooks) {
   setupIntlRenderingTest(hooks);
 
+  test('should display a banner at the top of the screen for a passage', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const textElement = store.createRecord('text', { content: 'content', type: 'texts' });
+    const elements = [textElement];
+    const grain = store.createRecord('grain', { id: 'grainId1', elements });
+    const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
+    this.set('module', module);
+
+    const passage = store.createRecord('passage');
+    this.set('passage', passage);
+
+    // when
+    const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
+
+    // then
+    assert.dom(screen.getByRole('alert')).exists();
+  });
+
   test('should display given module with one grain', async function (assert) {
     // given
     const store = this.owner.lookup('service:store');

--- a/mon-pix/tests/integration/components/module/recap_test.js
+++ b/mon-pix/tests/integration/components/module/recap_test.js
@@ -6,6 +6,26 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | Module | Recap', function (hooks) {
   setupIntlRenderingTest(hooks);
 
+  test('should display a banner at the top of the screen for module recap', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const details = {
+      image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+      description: 'description',
+      duration: 12,
+      level: 'Débutant',
+      objectives: ['Objectif 1'],
+    };
+    const module = store.createRecord('module', { title: 'Module title', details });
+    this.set('module', module);
+
+    // when
+    const screen = await render(hbs`<Module::Recap @module={{this.module}} />`);
+
+    // then
+    assert.dom(screen.getByRole('alert')).exists();
+  });
+
   test('should display the details of a given module', async function (assert) {
     // given
     const store = this.owner.lookup('service:store');

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1184,6 +1184,7 @@
       }
     },
     "modulix": {
+      "beta-banner": "This module is in beta version. You can send us your feedback at the end of this module to help us improve it.",
       "buttons": {
         "activity": {
           "verify": "Verify"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1184,6 +1184,7 @@
       }
     },
     "modulix": {
+      "beta-banner": "Ce module est en version bêta. Vous pourrez faire vos retours à la fin de ce module pour nous permettre de l’améliorer.",
       "buttons": {
         "activity": {
           "verify": "Vérifier"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1184,6 +1184,7 @@
       }
     },
     "modulix": {
+      "beta-banner": "Deze module is in bètaversie. Je kunt ons feedback sturen aan het einde van deze module om ons te helpen deze te verbeteren.",
       "buttons": {
         "activity": {
           "verify": "Kijk op"


### PR DESCRIPTION
## :unicorn: Problème
A ce moment, quand on acces les pages du modulix, il y n'a pas les indications que cette modalité c'est en beta pour experimentation

## :robot: Proposition
Ajoute un banner en violet en haut de page `/details` et `/passage` pour expliquer que les modules sont en phase beta pour experimentation

## :rainbow: Remarques
On en a profité pour remplacer la `div` principale par une balise `main` dans la page de recap

## :100: Pour tester
Vérifier que le bandeau s’affiche sur les pages [détails](https://app-pr8128.review.pix.fr/modules/didacticiel-modulix/details) + [les modules](https://app-pr8128.review.pix.fr/modules/didacticiel-modulix/passage)
