### PR TITLE
[BUGFIX] Bug lors d'un enchainement de 2 QCM  (pix-11357)

### DIFF
--- a/1d/app/pods/components/challenge/challenge-item-qcm/component.js
+++ b/1d/app/pods/components/challenge/challenge-item-qcm/component.js
@@ -15,6 +15,7 @@ export default class ChallengeItemQcm extends Component {
     if (this.args.challenge.shuffled) {
       pshuffle(labeledCheckboxesList, this.args.assessment?.id);
     }
+    this.checkedValues.clear();
     return labeledCheckboxesList;
   }
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu’on fait 2 épreuves QCM d’affilé, la 2ème garde en mémoire les réponses données précédemment, et lorsque l’utilisateur coche une réponse déjà donnée lors de la première épreuve, alors ça supprime la réponse du tableau des réponses envoyés lorsqu’on clique sur “Je valide”.

## :robot: Proposition
Remettre à 0 notre variable qui garde les réponses données par l'utilisateur à l'affichage du nouveau QCM

## :rainbow: Remarques
la solution trouvée n'est pas la plus optimale, elle nécéssite une désactivation du linter

## :100: Pour tester
- aller sur pix1d et commencer la mission 'Données perso"
- À la 1ère épreuve, choisir de fausses réponses, clique sur 'je valide' ce qui va nous emmener sur la 1ère épreuve du niveau inférieur et mettre les bonnes réponses et voir qu'on a bon.