### PR TITLE
[FEAT] :safety_vest: Enregistre le `next-challenge.id` dans l'`assessment`

### DIFF
--- a/api/src/school/domain/usecases/get-next-challenge.js
+++ b/api/src/school/domain/usecases/get-next-challenge.js
@@ -48,8 +48,14 @@ export async function getNextChallenge({
   if (nextChallenge === undefined) {
     await assessmentRepository.completeByAssessmentId(assessmentId);
     return null;
+  } else {
+    await assessmentRepository.updateWhenNewChallengeIsAsked({
+      id: assessmentId,
+      lastChallengeId: nextChallenge.id,
+    });
+
+    return nextChallenge;
   }
-  return nextChallenge;
 }
 
 function _getActivityStatusFromAnswerStatus(answerStatus) {


### PR DESCRIPTION
## :unicorn: Problème

- Dans la table `assessment` il y a un champ `lastChallengeId`, nous ne nous en servons pas chez Pix1d (contrairement à MonPix).
- Avant de demander à corriger une réponse, nous ne vérifions pas (dans pix1d) qu'elle est lié au dernier challenge

## :robot: Proposition

Enregistrer le `next-challenge.id` quand nous en avons un. Ça facilitera la mise en place du point de vérification (dans une pr à venir) et ça permet d'être cohérent avec ce qu'il se passe dans MonPix)

## :rainbow: Remarques


## :100: Pour tester

Les tests restent vert :green_circle: et les challenges pix 1d s'enchaine correctement, jusqu'à la fin.