### PR TITLE
[FEATURE] Enregistrer l'userId dans le passage lorsque c'est possible (PIX-11309).

### DIFF
--- a/api/db/database-builder/factory/build-passage.js
+++ b/api/db/database-builder/factory/build-passage.js
@@ -3,12 +3,14 @@ import { databaseBuffer } from '../database-buffer.js';
 const buildPassage = ({
   id = databaseBuffer.getNextId(),
   moduleId = 'mon-super-module',
+  userId = null,
   createdAt = new Date('2024-01-01'),
   updatedAt = new Date('2024-01-01'),
 } = {}) => {
   const values = {
     id,
     moduleId,
+    userId,
     createdAt,
     updatedAt,
   };

--- a/api/db/migrations/20240222101244_add-userId-in-passages.js
+++ b/api/db/migrations/20240222101244_add-userId-in-passages.js
@@ -1,0 +1,17 @@
+const TABLE_NAME = 'passages';
+const COLUMN_NAME = 'userId';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME).nullable();
+    table.foreign(COLUMN_NAME).references('users.id');
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { up, down };

--- a/api/src/devcomp/application/passages/controller.js
+++ b/api/src/devcomp/application/passages/controller.js
@@ -1,6 +1,7 @@
-const create = async function (request, h, { usecases, passageSerializer }) {
+const create = async function (request, h, { usecases, passageSerializer, extractUserIdFromRequest }) {
   const { 'module-id': moduleId } = request.payload.data.attributes;
-  const passage = await usecases.createPassage({ moduleId });
+  const userId = extractUserIdFromRequest(request);
+  const passage = await usecases.createPassage({ moduleId, userId });
 
   const serializedPassage = passageSerializer.serialize(passage);
   return h.response(serializedPassage).created();

--- a/api/src/devcomp/domain/models/Passage.js
+++ b/api/src/devcomp/domain/models/Passage.js
@@ -1,7 +1,8 @@
 class Passage {
-  constructor({ id, moduleId, createdAt, updatedAt }) {
+  constructor({ id, moduleId, userId, createdAt, updatedAt }) {
     this.id = id;
     this.moduleId = moduleId;
+    this.userId = userId;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
   }

--- a/api/src/devcomp/domain/usecases/create-passage.js
+++ b/api/src/devcomp/domain/usecases/create-passage.js
@@ -1,10 +1,10 @@
 import { ModuleDoesNotExistError } from '../errors.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
 
-const createPassage = async function ({ moduleId, moduleRepository, passageRepository }) {
+const createPassage = async function ({ moduleId, userId, moduleRepository, passageRepository }) {
   await _verifyIfModuleExists({ moduleId, moduleRepository });
 
-  return passageRepository.save({ moduleId });
+  return passageRepository.save({ moduleId, userId });
 };
 
 async function _verifyIfModuleExists({ moduleId, moduleRepository }) {

--- a/api/src/devcomp/infrastructure/repositories/passage-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/passage-repository.js
@@ -3,11 +3,12 @@ import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransact
 import { Passage } from '../../domain/models/Passage.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
 
-const save = async function ({ moduleId, domainTransaction = DomainTransaction.emptyTransaction() }) {
+const save = async function ({ moduleId, userId, domainTransaction = DomainTransaction.emptyTransaction() }) {
   const knexConn = domainTransaction?.knexTransaction || knex;
   const [passage] = await knexConn('passages')
     .insert({
       moduleId,
+      userId,
       createdAt: new Date(),
       updatedAt: new Date(),
     })
@@ -26,8 +27,8 @@ const get = async function ({ passageId, domainTransaction = DomainTransaction.e
   return _toDomain(passage);
 };
 
-function _toDomain({ id, moduleId, createdAt, updatedAt }) {
-  return new Passage({ id, moduleId, createdAt, updatedAt });
+function _toDomain({ id, moduleId, userId, createdAt, updatedAt }) {
+  return new Passage({ id, moduleId, userId, createdAt, updatedAt });
 }
 
 export { get, save };

--- a/api/src/devcomp/infrastructure/utils/handlerWithDependencies.js
+++ b/api/src/devcomp/infrastructure/utils/handlerWithDependencies.js
@@ -2,12 +2,14 @@ import { usecases } from '../../domain/usecases/index.js';
 import * as elementAnswerSerializer from '../serializers/jsonapi/element-answer-serializer.js';
 import * as moduleSerializer from '../serializers/jsonapi/module-serializer.js';
 import * as passageSerializer from '../serializers/jsonapi/passage-serializer.js';
+import { extractUserIdFromRequest } from '../../../../lib/infrastructure/utils/request-response-utils.js';
 
 const dependencies = {
   usecases,
   elementAnswerSerializer,
   moduleSerializer,
   passageSerializer,
+  extractUserIdFromRequest,
 };
 
 const handlerWithDependencies = (handler) => {

--- a/api/tests/devcomp/integration/repositories/passage-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/passage-repository_test.js
@@ -15,10 +15,14 @@ describe('Integration | DevComp | Repositories | PassageRepository', function ()
       clock.restore();
     });
 
-    it('should save a passage', async function () {
+    it('should save a passage with a userId provided', async function () {
       // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      await databaseBuilder.commit();
+
       const passage = {
         moduleId: 'recModuleId',
+        userId: userId,
       };
 
       // when
@@ -27,11 +31,37 @@ describe('Integration | DevComp | Repositories | PassageRepository', function ()
       // then
       expect(returnedPassage).to.be.instanceOf(Passage);
       expect(returnedPassage.moduleId).to.equal(passage.moduleId);
+      expect(returnedPassage.userId).to.equal(passage.userId);
       expect(returnedPassage.createdAt).to.deep.equal(new Date('2023-12-31'));
       expect(returnedPassage.updatedAt).to.deep.equal(new Date('2023-12-31'));
 
       const savedPassage = await knex('passages').where({ id: returnedPassage.id }).first();
       expect(savedPassage.moduleId).to.equal(passage.moduleId);
+      expect(savedPassage.userId).to.equal(passage.userId);
+      expect(savedPassage.createdAt).to.deep.equal(new Date('2023-12-31'));
+      expect(savedPassage.updatedAt).to.deep.equal(new Date('2023-12-31'));
+    });
+
+    it('should save a passage no userId provided', async function () {
+      // given
+      const passage = {
+        moduleId: 'recModuleId',
+        userId: null,
+      };
+
+      // when
+      const returnedPassage = await passageRepository.save(passage);
+
+      // then
+      expect(returnedPassage).to.be.instanceOf(Passage);
+      expect(returnedPassage.moduleId).to.equal(passage.moduleId);
+      expect(returnedPassage.userId).to.equal(passage.userId);
+      expect(returnedPassage.createdAt).to.deep.equal(new Date('2023-12-31'));
+      expect(returnedPassage.updatedAt).to.deep.equal(new Date('2023-12-31'));
+
+      const savedPassage = await knex('passages').where({ id: returnedPassage.id }).first();
+      expect(savedPassage.moduleId).to.equal(passage.moduleId);
+      expect(savedPassage.userId).to.equal(passage.userId);
       expect(savedPassage.createdAt).to.deep.equal(new Date('2023-12-31'));
       expect(savedPassage.updatedAt).to.deep.equal(new Date('2023-12-31'));
     });
@@ -41,7 +71,7 @@ describe('Integration | DevComp | Repositories | PassageRepository', function ()
     describe('when passage exists', function () {
       it('should return the found passage', async function () {
         // given
-        const passage = databaseBuilder.factory.buildPassage({ id: 1, moduleId: 'my-module' });
+        const passage = databaseBuilder.factory.buildPassage({ id: 1, moduleId: 'my-module', userId: null });
         await databaseBuilder.commit();
 
         // when
@@ -52,6 +82,7 @@ describe('Integration | DevComp | Repositories | PassageRepository', function ()
           new Passage({
             id: passage.id,
             moduleId: passage.moduleId,
+            userId: passage.userId,
             createdAt: passage.createdAt,
             updatedAt: passage.updatedAt,
           }),

--- a/api/tests/devcomp/unit/application/passages/controller_test.js
+++ b/api/tests/devcomp/unit/application/passages/controller_test.js
@@ -8,10 +8,11 @@ describe('Unit | Devcomp | Application | Passages | Controller', function () {
       const serializedPassage = Symbol('serialized modules');
       const moduleId = Symbol('module-id');
       const passage = Symbol('passage');
+      const userId = Symbol('user-id');
       const usecases = {
         createPassage: sinon.stub(),
       };
-      usecases.createPassage.withArgs({ moduleId }).returns(passage);
+      usecases.createPassage.withArgs({ moduleId, userId }).returns(passage);
       const passageSerializer = {
         serialize: sinon.stub(),
       };
@@ -22,10 +23,16 @@ describe('Unit | Devcomp | Application | Passages | Controller', function () {
       const created = sinon.stub();
       hStub.response.withArgs(serializedPassage).returns({ created });
 
+      const request = { payload: { data: { attributes: { 'module-id': moduleId } } } };
+
+      const extractUserIdFromRequest = sinon.stub();
+      extractUserIdFromRequest.withArgs(request).returns(userId);
+
       // when
       await passageController.create({ payload: { data: { attributes: { 'module-id': moduleId } } } }, hStub, {
         passageSerializer,
         usecases,
+        extractUserIdFromRequest,
       });
 
       // then

--- a/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
@@ -25,6 +25,7 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
   it('should call passage repository to save the passage', async function () {
     // given
     const moduleId = Symbol('moduleId');
+    const userId = Symbol('userId');
     const repositoryResult = Symbol('repository-result');
 
     const moduleRepositoryStub = {
@@ -39,6 +40,7 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
     // when
     const result = await createPassage({
       moduleId,
+      userId,
       passageRepository: passageRepositoryStub,
       moduleRepository: moduleRepositoryStub,
     });
@@ -46,6 +48,7 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
     // then
     expect(passageRepositoryStub.save).to.have.been.calledWithExactly({
       moduleId,
+      userId,
     });
     expect(result).to.equal(repositoryResult);
   });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, des users connectées peuvent passer des modules, mais nous les lions pas à leur passage. C'est dommage, à l'avenir ils pourraient devoir repasser le module, alors qu'ils l'avaient déjà passé.

## :robot: Proposition
Enregistrer l'userId quand nous l'avons grâce au token. 

## :rainbow: Remarques
Pour info, quand une route peut-être dispo connectée et non connectée `(auth: false)` uniquement : `extractUserIdFromRequest ` fonctionne, car sinon on ne rentre pas dans le `validateUser ` qui lui set le fameux `auth.credentials.userId `

## :100: Pour tester
- Se connecter sur Pix App
- Passer un modules `/modules/bien-ecrire-son-adresse-mail`
- En base, vérifier que le passage contient l'userId