### PR TITLE
[BUGFIX] Empêche le job de calcul de résultat de s'effectuer si la participation n'est pas partagée (PIX-11350)

### DIFF
--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -180,6 +180,12 @@ class CantImproveCampaignParticipationError extends DomainError {
   }
 }
 
+class CantCalculateCampaignParticipationResultError extends DomainError {
+  constructor(message = `Impossible de calculer le résultat de la participation car elle n'a pas été partagée.`) {
+    super(message);
+  }
+}
+
 class NoCampaignParticipationForUserAndCampaign extends DomainError {
   constructor(message = "L'utilisateur n'a pas encore participé à la campagne") {
     super(message);
@@ -1114,6 +1120,7 @@ export {
   CandidateNotAuthorizedToJoinSessionError,
   CandidateNotAuthorizedToResumeCertificationTestError,
   CantImproveCampaignParticipationError,
+  CantCalculateCampaignParticipationResultError,
   CertificateVerificationCodeGenerationTooManyTrials,
   CertificationBadgeForbiddenDeletionError,
   CertificationCandidateAlreadyLinkedToUserError,

--- a/api/lib/domain/usecases/save-computed-campaign-participation-result.js
+++ b/api/lib/domain/usecases/save-computed-campaign-participation-result.js
@@ -1,7 +1,13 @@
+import { CantCalculateCampaignParticipationResultError } from '../errors.js';
+
 const saveComputedCampaignParticipationResult = async function ({
   participantResultsSharedRepository,
+  campaignParticipationRepository,
   campaignParticipationId,
 }) {
+  const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId);
+  if (!campaignParticipation.isShared()) throw new CantCalculateCampaignParticipationResultError();
+
   const participantResultsShared = await participantResultsSharedRepository.get(campaignParticipationId);
   return participantResultsSharedRepository.save(participantResultsShared);
 };

--- a/api/tests/unit/domain/usecases/save-computed-campaign-participation-result_test.js
+++ b/api/tests/unit/domain/usecases/save-computed-campaign-participation-result_test.js
@@ -1,7 +1,24 @@
-import { expect, sinon } from '../../../test-helper.js';
+import { expect, catchErr, sinon } from '../../../test-helper.js';
 import { saveComputedCampaignParticipationResult } from '../../../../lib/domain/usecases/save-computed-campaign-participation-result.js';
+import { CantCalculateCampaignParticipationResultError } from '../../../../lib/domain/errors.js';
 
 describe('Unit | Domain | UseCases | SaveComputedCompaignParticipationResult', function () {
+  it('should throw an error if participation is not shared', async function () {
+    // given
+    const campaignParticipationRepository = {
+      get: sinon.stub().resolves({ isShared: () => false }),
+    };
+
+    // when
+    const error = await catchErr(saveComputedCampaignParticipationResult)({
+      campaignParticipationRepository,
+      campaignParticipationId: 1,
+    });
+
+    // then
+    expect(error).to.be.instanceof(CantCalculateCampaignParticipationResultError);
+  });
+
   it('should compute results and save', async function () {
     // given
     const participationResultsShared = Symbol('participation results shared');
@@ -9,9 +26,13 @@ describe('Unit | Domain | UseCases | SaveComputedCompaignParticipationResult', f
       get: sinon.stub().resolves(participationResultsShared),
       save: sinon.stub(),
     };
+    const campaignParticipationRepository = {
+      get: sinon.stub().resolves({ isShared: () => true }),
+    };
 
     // when
     await saveComputedCampaignParticipationResult({
+      campaignParticipationRepository,
       participantResultsSharedRepository,
       campaignParticipationId: 1,
     });


### PR DESCRIPTION
## :unicorn: Problème
Il était possible lorsque la requête de partage du résultat d'une participation à une campagne d'évaluation prenait du temps de cliquer sur le bouton "Je retente". Ce qui avait pour résultat : 
- Remettre le statut de la campagne à STARTED 
- Déclencher un job de calcul de résultat

La conséquence est que le job de calcul de résultat échoue à trouver le snapshot associé à la participation. Une erreur de syntaxe est renvoyée par le job dans ces cas là : 
```
TypeError: Cannot destructure property 'snapshot' of '(intermediate value)' as it is undefined.
```

## :robot: Proposition
L'erreur n'aide pas a comprendre ce qui s'est passé et si on doit intervenir ou non. Dans cette PR on renvoit une erreur qui explicite que la participation n'est pas dans le bon état et c'est pour ça que le job a échoué.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- Insérer un job dans pgboss pour une participation qui n'est pas shared
