### PR TITLE
[FEATURE] Amélioration du design de la page de la liste élèves (pix-11068)

### DIFF
--- a/1d/app/pods/school/divisions/template.hbs
+++ b/1d/app/pods/school/divisions/template.hbs
@@ -1,7 +1,7 @@
 <RobotDialog>
   <Bubble @message={{t "pages.school.division-list.welcome" schoolName=@model.name}} />
 </RobotDialog>
-<div class="divisions">
+<div class="list list__divisions">
   {{#each @model.divisions as |division|}}
     <LinkTo @route="school.students" @query={{hash division=division}} class="divisions__item">
       <p>{{division}}</p>

--- a/1d/app/pods/school/school.scss
+++ b/1d/app/pods/school/school.scss
@@ -1,4 +1,4 @@
-.divisions, .learners {
+.list {
   display: flex;
   flex-wrap: wrap;
   gap: 40px;
@@ -6,9 +6,15 @@
   justify-content: center;
   min-height: 300px;
   margin: auto 50px 35px;
-  font-size: 1.125rem;
 
-  &__item {
+  &__learners {
+    align-items: center;
+    justify-content: normal;
+    min-height: 0;
+    margin: 30px auto 35px 170px;
+  }
+
+  .divisions__item {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -16,7 +22,6 @@
     min-width: 150px;
     height: 70px;
     color: black;
-    font-size: 1.125rem;
     background: #FFFFFF;
     border-radius: 8px;
     box-shadow: 0 0 1px 0 #3D68FF, 8px 8px 32px -8px rgb(61 104 255 / 20%);
@@ -25,10 +30,26 @@
       background-color: var(--pix-primary-10);
     }
   }
-}
 
-.pix-button.learners__item {
-  &:hover, &:focus, &:active, &:focus-visible {
-    background-color: var(--pix-primary-10);
+  .learners__item {
+    width: 190px;
+    height: 55px;
+    color: var(--pix-neutral-900);
+    font-size: 1.125rem;
+    background: #FFFFFF;
+    border-radius: 30px;
+    box-shadow: 0 0 1px 0 #3D68FF, 8px 8px 32px -8px rgb(61 104 255 / 20%);
   }
 }
+
+ .pix-button.learners__item {
+   &:hover, &:focus, &:active, &:focus-visible {
+     background-color: var(--pix-primary-10);
+   }
+
+   &:focus, &:focus-visible {
+     outline:2px solid var(--pix-primary-300);
+     outline-offset: 0;
+   }
+ }
+

--- a/1d/app/pods/school/students/controller.js
+++ b/1d/app/pods/school/students/controller.js
@@ -8,8 +8,8 @@ export default class Students extends Controller {
 
   queryParams = ['division'];
 
-  uppercaseFirstLetter(name) {
-    return name.charAt(0).toUpperCase() + name.slice(1);
+  getFullName(learner) {
+    return `${learner.firstName} ${learner.lastName.charAt(0).toUpperCase()}.`;
   }
 
   @action

--- a/1d/app/pods/school/students/template.hbs
+++ b/1d/app/pods/school/students/template.hbs
@@ -1,12 +1,12 @@
+{{page-title (t "pages.school.division.page-title")}}
 <RobotDialog>
   <Bubble @message={{t "pages.school.division.find-name" division=@model.division}} />
   <Bubble @message={{t "pages.school.division.back-to-divisions" backUrl=@model.schoolUrl}} />
 </RobotDialog>
-<div class="learners">
+<div class="list list__learners">
   {{#each @model.organizationLearners as |learner|}}
     <PixButton @triggerAction={{fn this.identifyUser learner}} class="learners__item">
-      <p>{{learner.firstName}}</p>
-      <p>{{this.uppercaseFirstLetter learner.lastName}}</p>
+      <p>{{this.getFullName learner}}</p>
     </PixButton>
   {{/each}}
 </div>

--- a/1d/tests/acceptance/access-school_test.js
+++ b/1d/tests/acceptance/access-school_test.js
@@ -92,8 +92,8 @@ module('Acceptance | School', function (hooks) {
       // then
       assert.strictEqual(currentURL(), '/schools/MINIPIXOU/students?division=CM2-B');
       assert.dom(screen.getByText(division)).exists();
-      assert.dom(screen.getByRole('button', { name: 'Sara Crewe' })).exists();
-      assert.dom(screen.getByRole('button', { name: 'Maya Labeille' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Sara C.' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Maya L.' })).exists();
     });
   });
 
@@ -109,8 +109,8 @@ module('Acceptance | School', function (hooks) {
       // then
       assert.strictEqual(currentURL(), '/schools/MINIPIXOU/students?division=CM2%20A');
       assert.dom(screen.getByText(division)).exists();
-      assert.dom(screen.getByRole('button', { name: 'Mickey Mouse' })).exists();
-      assert.dom(screen.getByRole('button', { name: 'Donald Duck' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Mickey M.' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Donald D.' })).exists();
     });
   });
 
@@ -121,7 +121,7 @@ module('Acceptance | School', function (hooks) {
       // when
       const screen = await visit('/schools/MINIPIXOU');
       await click(screen.getByRole('link', { name: 'CM2-B' }));
-      await click(screen.getByRole('button', { name: 'Maya Labeille' }));
+      await click(screen.getByRole('button', { name: 'Maya L.' }));
 
       // then
       assert.strictEqual(currentURL(), '/');
@@ -133,7 +133,7 @@ module('Acceptance | School', function (hooks) {
       // when
       const screen = await visit('/schools/MINIPIXOU');
       await click(screen.getByRole('link', { name: 'CM2-B' }));
-      await click(screen.getByRole('button', { name: 'Maya Labeille' }));
+      await click(screen.getByRole('button', { name: 'Maya L.' }));
 
       // then
       assert.deepEqual(currentLearner.learner, {
@@ -170,7 +170,7 @@ module('Acceptance | School', function (hooks) {
       this.server.create('school');
       const currentLearner = this.owner.lookup('service:currentLearner');
       const screen = await visit('/schools/MINIPIXOU/students?division=CM2%20A');
-      await click(screen.getByRole('button', { name: 'Mickey Mouse' }));
+      await click(screen.getByRole('button', { name: 'Mickey M.' }));
 
       // when
       await visit('/schools/MINIPIXOU/students?division=CM2%20A');
@@ -184,7 +184,7 @@ module('Acceptance | School', function (hooks) {
       const currentLearner = this.owner.lookup('service:currentLearner');
       // when
       const screen = await visit('/schools/MINIPIXOU/students?division=CM2%20A');
-      await click(screen.getByRole('button', { name: 'Mickey Mouse' }));
+      await click(screen.getByRole('button', { name: 'Mickey M.' }));
       await visit('/organization-code');
 
       // then

--- a/1d/translations/fr.json
+++ b/1d/translations/fr.json
@@ -54,6 +54,7 @@
         "welcome": "Bienvenue sur la page de l'école : <strong>{schoolName}</strong><br>Maintenant, choisis ta classe."
       },
       "division": {
+        "page-title": "Liste des élèves",
         "find-name": "Voici les élèves de la classe : <strong>{division}</strong><br>Clique sur ton prénom dans la liste.",
         "back-to-divisions": "Si ce n'est pas ta classe, <a href=\"{backUrl}\" class=\"internal-link\">clique ici pour retourner à la liste des classes</a>"
       }


### PR DESCRIPTION
## :unicorn: Problème
Nous avons eu de nouvelles maquettes pour la page de la liste des élèves 

## :robot: Proposition
Appliquer le nouveau design
<img width="700" alt="Capture d’écran 2024-02-07 à 10 01 20" src="https://github.com/1024pix/pix/assets/35958509/b3771b6e-d061-41f8-95b9-3bbde1e55f18">

## :rainbow: Remarques
 Quelques améliorations a11y: ajout d'un titre pour l'onglet, mise en valeur du focus sur les boutons.
 
## :100: Pour tester
- Se connecter sur 1d et renseigner le code d'une orga `minipixou` et voir comment la liste des élèves pour pour les 2 classes