### PR TITLE
[BUGFIX] Permettre de publier un certification en erreur si elle est annulée  (PIX-11374)

### DIFF
--- a/api/lib/domain/services/session-publication-service.js
+++ b/api/lib/domain/services/session-publication-service.js
@@ -4,7 +4,11 @@
  * @typedef {import('../../../lib/domain/usecases/index.js').SessionRepository} SessionRepository
  * @typedef {import('../../../lib/domain/usecases/index.js').MailService} MailService
  */
-import { SendingEmailToResultRecipientError, SendingEmailToRefererError } from '../../domain/errors.js';
+import {
+  SendingEmailToResultRecipientError,
+  SendingEmailToRefererError,
+  CertificationCourseNotPublishableError,
+} from '../../domain/errors.js';
 import { SessionAlreadyPublishedError } from '../../../src/certification/session/domain/errors.js';
 import * as mailService from '../../domain/services/mail-service.js';
 import lodash from 'lodash';
@@ -12,6 +16,7 @@ import lodash from 'lodash';
 const { some, uniqBy } = lodash;
 
 import { logger } from '../../infrastructure/logger.js';
+import { status } from '../../../src/shared/domain/models/AssessmentResult.js';
 
 /**
  * @param {Object} params
@@ -31,7 +36,15 @@ async function publishSession({
     throw new SessionAlreadyPublishedError();
   }
 
-  await certificationRepository.publishCertificationCoursesBySessionId(sessionId);
+  const certificationStatuses = await certificationRepository.getStatusesBySessionId(sessionId);
+
+  const hasCertificationInError = _hasCertificationInError(certificationStatuses);
+  const hasCertificationWithNoAssessmentResultStatus = _hasCertificationWithNoScoring(certificationStatuses);
+  if (hasCertificationInError || hasCertificationWithNoAssessmentResultStatus) {
+    throw new CertificationCourseNotPublishableError(sessionId);
+  }
+
+  await certificationRepository.publishCertificationCourses(certificationStatuses);
 
   await sessionRepository.updatePublishedAt({ id: sessionId, publishedAt });
 
@@ -168,6 +181,16 @@ async function _updateFinalizedSession(finalizedSessionRepository, sessionId, pu
   const finalizedSession = await finalizedSessionRepository.get({ sessionId });
   finalizedSession.publish(publishedAt);
   await finalizedSessionRepository.save(finalizedSession);
+}
+
+function _hasCertificationInError(certificationStatus) {
+  return certificationStatus.some(({ pixCertificationStatus }) => pixCertificationStatus === status.ERROR);
+}
+
+function _hasCertificationWithNoScoring(certificationStatuses) {
+  return certificationStatuses.some(
+    ({ pixCertificationStatus, isCancelled }) => pixCertificationStatus === null && !isCancelled,
+  );
 }
 
 export { publishSession, manageEmails };

--- a/api/lib/domain/services/session-publication-service.js
+++ b/api/lib/domain/services/session-publication-service.js
@@ -184,7 +184,9 @@ async function _updateFinalizedSession(finalizedSessionRepository, sessionId, pu
 }
 
 function _hasCertificationInError(certificationStatus) {
-  return certificationStatus.some(({ pixCertificationStatus }) => pixCertificationStatus === status.ERROR);
+  return certificationStatus.some(
+    ({ pixCertificationStatus, isCancelled }) => pixCertificationStatus === status.ERROR && !isCancelled,
+  );
 }
 
 function _hasCertificationWithNoScoring(certificationStatuses) {


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'une certification n'a pas suffisamment de reponse elle peut passer en erreur (pas 2 challenge par competence).
La publication est alors bloquée

## :robot: Proposition
Permettre de publier en gardant le statut en erreur si celle ci est annulée (cancelled)

## :rainbow: Remarques
Le passage en erreur est peu frequent. Lorsque c'etait plus frequent il etait possible de modifier le statut dans la page d'info de la certif sur admin

## :100: Pour tester
Demarrer une certification
Forcer la fin apres qques questions: `https://app-pr8151.review.pix.fr/api/assessments/1100019/complete-assessment`
Finaliser
Tenter de publier
verifier que ca ne fonctionne pas
Annuler la certification
Tenter de publier
Constater que ca publie corrctement
