### PR TITLE
[BUGFIX] Vide la table job de PGBOSS après chaque test (PIX-11301)

### DIFF
--- a/api/tests/integration/infrastructure/jobs/JobPgBoss_test.js
+++ b/api/tests/integration/infrastructure/jobs/JobPgBoss_test.js
@@ -2,6 +2,9 @@ import { expect, knex } from '../../../test-helper.js';
 import { JobPgBoss as Job } from '../../../../lib/infrastructure/jobs/JobPgBoss.js';
 
 describe('Integration | Infrastructure | Jobs | JobPgBoss', function () {
+  afterEach(function () {
+    return knex('pgboss.job').truncate();
+  });
   it('schedule a job and create in db with given config', async function () {
     // given
     const name = 'JobTest';

--- a/api/tests/integration/infrastructure/jobs/campaign-result/ParticipationResultCalculationJob_test.js
+++ b/api/tests/integration/infrastructure/jobs/campaign-result/ParticipationResultCalculationJob_test.js
@@ -2,6 +2,10 @@ import { expect, knex } from '../../../../test-helper.js';
 import { ParticipationResultCalculationJob } from '../../../../../lib/infrastructure/jobs/campaign-result/ParticipationResultCalculationJob.js';
 
 describe('Integration | Infrastructure | Jobs | CampaignResult | ParticipationResultCalculation', function () {
+  afterEach(function () {
+    return knex('pgboss.job').truncate();
+  });
+
   describe('#schedule', function () {
     it('creates the results calculation job', async function () {
       const handler = new ParticipationResultCalculationJob(knex);

--- a/api/tests/integration/infrastructure/jobs/campaign-result/SendSharedParticipationResultsToPoleEmploiJob_test.js
+++ b/api/tests/integration/infrastructure/jobs/campaign-result/SendSharedParticipationResultsToPoleEmploiJob_test.js
@@ -2,6 +2,10 @@ import { expect, knex } from '../../../../test-helper.js';
 import { SendSharedParticipationResultsToPoleEmploiJob } from '../../../../../lib/infrastructure/jobs/campaign-result/SendSharedParticipationResultsToPoleEmploiJob.js';
 
 describe('Integration | Infrastructure | Jobs | CampaignResult | SendSharedParticipationResultsToPoleEmploiJob', function () {
+  afterEach(function () {
+    return knex('pgboss.job').truncate();
+  });
+
   describe('#schedule', function () {
     it('creates the send results job', async function () {
       const job = new SendSharedParticipationResultsToPoleEmploiJob(knex);

--- a/api/tests/prescription/campaign-participation/acceptance/application/learner-participation-route_test.js
+++ b/api/tests/prescription/campaign-participation/acceptance/application/learner-participation-route_test.js
@@ -61,6 +61,10 @@ describe('Acceptance | API | Campaign Participations', function () {
       };
     });
 
+    afterEach(function () {
+      return knex('pgboss.job').truncate();
+    });
+
     it('shares the campaign participation', async function () {
       // given
       const campaign = databaseBuilder.factory.buildCampaign();


### PR DESCRIPTION
## :unicorn: Problème
Les tests de pgboss cassent en local car la table n'est pas vidé entre chaque test comme c'est le cas pour les tables du namespace public.

## :robot: Proposition
On truncate la table pgboss.job après chaque test.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
En local les personnes pour qui ça arrive nous confirme que c'est bien corrigé 😄 