### PR TITLE
[TECH] Séparer le lint du test pour PixAPP (PIX-11392)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,10 +122,20 @@ workflows:
           requires:
             - checkout
 
-      - mon_pix_build_and_test:
+      - mon_pix_install:
           context: Pix
           requires:
             - checkout
+
+      - mon_pix_lint:
+          context: Pix
+          requires:
+            - mon_pix_install
+
+      - mon_pix_test:
+          context: Pix
+          requires:
+            - mon_pix_install
 
       - orga_build_and_test:
           context: Pix
@@ -348,13 +358,11 @@ jobs:
       - store_artifacts:
           path: /home/circleci/test-results
 
-  mon_pix_build_and_test:
+  mon_pix_install:
     executor:
-      name: node-browsers-docker
+      name: node-docker
     working_directory: ~/pix/mon-pix
-    parallelism: 3
     steps:
-      - browser-tools/install-chrome
       - attach_workspace:
           at: ~/pix
       - run: cat package*.json > cachekey
@@ -366,14 +374,38 @@ jobs:
           key: v7-mon-pix-npm-{{ checksum "cachekey" }}
           paths:
             - ~/.npm
+      - persist_to_workspace:
+          root: ~/pix
+          paths:
+            - mon-pix
+
+  mon_pix_lint:
+    executor:
+      name: node-docker
+    working_directory: ~/pix/mon-pix
+    steps:
+      - attach_workspace:
+          at: ~/pix
       - run:
           name: Lint
           command: npm run lint
+          when: always
+
+  mon_pix_test:
+    executor:
+      name: node-browsers-docker
+    working_directory: ~/pix/mon-pix
+    parallelism: 3
+    steps:
+      - browser-tools/install-chrome
+      - attach_workspace:
+          at: ~/pix
       - run:
           environment:
             RESULTS_PATH: ../../test-results/mon_pix
           name: Test
           command: npm run test:ci
+          when: always
       - store_test_results:
           path: /home/circleci/test-results/mon_pix
       - store_artifacts:


### PR DESCRIPTION
## :unicorn: Problème
Il est dommage que le lint empêche de voir si les tests sont OK sur la CI.

## :robot: Proposition
Séparer les job lint et test pour mon pix

## :rainbow: Remarques
Est ce qu'il faut le généraliser à tout les packages ? Coût CI ?

## :100: Pour tester
Test aux verts