### PR TITLE
[TECH] Ajouter le workflow de prise en charge de dépréciation d'Ember.js sur Pix App 

### DIFF
--- a/mon-pix/config/deprecation-workflow.js
+++ b/mon-pix/config/deprecation-workflow.js
@@ -1,0 +1,12 @@
+// eslint-disable-next-line no-undef
+self.deprecationWorkflow = self.deprecationWorkflow || {};
+// eslint-disable-next-line no-undef
+self.deprecationWorkflow.config = {
+  workflow: [
+    { handler: 'silence', matchId: 'ember-polyfills.deprecate-assign' },
+    { handler: 'silence', matchId: 'deprecate-ember-error' },
+    { handler: 'silence', matchId: 'ember-data:deprecate-promise-many-array-behaviors' },
+    { handler: 'silence', matchId: 'ember-data:deprecate-store-find' },
+    { handler: 'silence', matchId: 'ember-data:deprecate-array-like' },
+  ],
+};

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -47,6 +47,7 @@
         "ember-cli-babel": "^8.0.0",
         "ember-cli-clipboard": "^1.0.0",
         "ember-cli-dependency-checker": "^3.3.1",
+        "ember-cli-deprecation-workflow": "^2.2.0",
         "ember-cli-head": "^2.0.0",
         "ember-cli-htmlbars": "^6.1.1",
         "ember-cli-inject-live-reload": "^2.1.0",
@@ -27844,6 +27845,21 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/ember-cli-deprecation-workflow": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-deprecation-workflow/-/ember-cli-deprecation-workflow-2.2.0.tgz",
+      "integrity": "sha512-23bXZqZJBJSKBTfT0LK7qzSJX861TgafL6RVdMfn/iubpLnoZIWergYwEdgs24CNTUbuehVbHy2Q71o8jYfwfw==",
+      "dev": true,
+      "dependencies": {
+        "@ember/string": "^3.0.0",
+        "broccoli-funnel": "^3.0.3",
+        "broccoli-merge-trees": "^4.2.0",
+        "broccoli-plugin": "^4.0.5"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
       }
     },
     "node_modules/ember-cli-get-component-path-option": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -78,6 +78,7 @@
     "ember-cli-babel": "^8.0.0",
     "ember-cli-clipboard": "^1.0.0",
     "ember-cli-dependency-checker": "^3.3.1",
+    "ember-cli-deprecation-workflow": "^2.2.0",
     "ember-cli-head": "^2.0.0",
     "ember-cli-htmlbars": "^6.1.1",
     "ember-cli-inject-live-reload": "^2.1.0",


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, il est compliqué de suivre les dépréciations d'Ember.js. Les nouvelles dépréciations sont juste des `console.info` et ne sont pas particulièrement suivies. 

## :robot: Proposition
Pour remédier à ça, [Ember.js propose un workflow de prise en charge de dépréciation.](https://guides.emberjs.com/v4.8.0/configuring-ember/handling-deprecations/#toc_deprecation-workflow). 

L'idée est : 
1. Installer la librairie `ember-cli-deprecation-workflow`
2. Lancer les tests dans le navigateur
3. A la fin des tests, lancer `deprecationWorkflow.flushDeprecations()`
4. Copier le résultat dans `config/deprecation-workflow.js`

Une fois les dépréciations copiées dans le fichier, alors on peut activer le fait de jeter des erreurs pour une dépréciation spécifique pour la prendre en compte ET pour éviter que des devs utilisent l'ancienne méthode à nouveau sans faire exprès. 
 
## :rainbow: Remarques
Pour information,[ Ember.js a la volonté de rapatrier cette librairie directement dans le framework](https://github.com/emberjs/rfcs/pull/1009), pour que ça soit bénéfique au plus grand nombre

Autre information, nous avions déjà ce paquet fut un temps, mais il avait été [retiré pour de mauvaise raison lors de la migration en Ember.js v4](https://github.com/1024pix/pix/pull/5190) 

## :100: Pour tester
- CI OK 