### PR TITLE
[BUGFIX][API] Ajouter l'import manquant des traductions Néerlandaises (PIX-11218)

### DIFF
--- a/api/translations/index.js
+++ b/api/translations/index.js
@@ -1,4 +1,5 @@
 import fr from "./fr.json" assert {type:'json'};
 import en from "./en.json" assert {type:'json'};
+import nl from "./nl.json" assert {type:'json'};
 
-export { fr, en };
+export { fr, en, nl };


### PR DESCRIPTION
## :unicorn: Problème
Actuellement les traductions néerlandaises ne sont pas disponibles dans l'error manager.

## :robot: Proposition
Importer le fichier `nl.json` dans `api/translations/index.js`.

## :rainbow: Remarques
RAS.

## :100: Pour tester
Ce parcours permet de reproduire le problème sur la branche `dev` et de constater qu'il est résolu sur la branche `pix-11218-fix-error-manager-missing-nederlands-translations`
1. Se mettre sur la branche  `dev`
2. Lancer l'`api` et `mon-pix`
3. Aller sur la page suivante : https://app.dev.pix.org/inscription?lang=nl 
4. Remplir le formulaire avec un email déjà utilisé (par exemple james-paledroits@example.net). 
5. Ouvrir la console développeur sur l'onglet Réseau|Network
6. Valider l'inscription
7. constater l'affichage d'un message d'erreur au-dessus du formulaire
8. Constater que la console développeur renvoie une erreur 500 sur la requête d'inscription avec comme données de retour : 
```
{"statusCode":500,"error":"Internal Server Error","message":"An internal server error occurred"}
```
9. Revenir sur la branche `pix-11218-fix-error-manager-missing-nederlands-translations`
10. Répéter les étapes 2 à 6
11. Constater l'affichage d'un message d'erreur sous le champ `email`
12. Constater que la console développeur renvoie une erreur 422 sur la requête d'inscription avec comme données de retour  :
```
{
	"errors": [
		{
			"status": "422",
			"title": "Invalid data attribute \"email\"",
			"detail": "Dit e-mailadres is al geregistreerd, log in.",
			"source": {
				"pointer": "/data/attributes/email"
			}
		}
	]
}
```