### PR TITLE
[FEATURE] Afficher l'adresse où se déroule la session en tant que nom du site sur la page surveillant (PIX-11340)

### DIFF
--- a/api/lib/domain/read-models/SessionForSupervising.js
+++ b/api/lib/domain/read-models/SessionForSupervising.js
@@ -1,5 +1,15 @@
 class SessionForSupervising {
-  constructor({ id, date, time, examiner, certificationCenterName, room, certificationCandidates, accessCode } = {}) {
+  constructor({
+    id,
+    date,
+    time,
+    examiner,
+    certificationCenterName,
+    room,
+    certificationCandidates,
+    accessCode,
+    address,
+  } = {}) {
     this.id = id;
     this.date = date;
     this.time = time;
@@ -8,6 +18,7 @@ class SessionForSupervising {
     this.room = room;
     this.certificationCandidates = certificationCandidates;
     this.accessCode = accessCode;
+    this.address = address;
   }
 }
 

--- a/api/lib/domain/read-models/SessionForSupervising.js
+++ b/api/lib/domain/read-models/SessionForSupervising.js
@@ -1,20 +1,9 @@
 class SessionForSupervising {
-  constructor({
-    id,
-    date,
-    time,
-    examiner,
-    certificationCenterName,
-    room,
-    certificationCandidates,
-    accessCode,
-    address,
-  } = {}) {
+  constructor({ id, date, time, examiner, room, certificationCandidates, accessCode, address } = {}) {
     this.id = id;
     this.date = date;
     this.time = time;
     this.examiner = examiner;
-    this.certificationCenterName = certificationCenterName;
     this.room = room;
     this.certificationCandidates = certificationCandidates;
     this.accessCode = accessCode;

--- a/api/lib/infrastructure/repositories/sessions/session-for-supervising-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-for-supervising-repository.js
@@ -22,6 +22,7 @@ const get = async function (idSession) {
       room: 'sessions.room',
       examiner: 'sessions.examiner',
       accessCode: 'sessions.accessCode',
+      address: 'sessions.address',
       certificationCenterName: 'certification-centers.name',
       version: 'sessions.version',
       certificationCandidates: knex.raw(`

--- a/api/lib/infrastructure/repositories/sessions/session-for-supervising-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-for-supervising-repository.js
@@ -23,7 +23,6 @@ const get = async function (idSession) {
       examiner: 'sessions.examiner',
       accessCode: 'sessions.accessCode',
       address: 'sessions.address',
-      certificationCenterName: 'certification-centers.name',
       version: 'sessions.version',
       certificationCandidates: knex.raw(`
         json_agg(json_build_object(
@@ -58,7 +57,6 @@ const get = async function (idSession) {
       this.on('certification-courses.userId', '=', 'certification-candidates.userId');
     })
     .leftJoin('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
-    .innerJoin('certification-centers', 'certification-centers.id', 'sessions.certificationCenterId')
     .leftJoin(
       'complementary-certification-subscriptions',
       'complementary-certification-subscriptions.certificationCandidateId',
@@ -70,7 +68,7 @@ const get = async function (idSession) {
       'complementary-certification-subscriptions.complementaryCertificationId',
     )
     .leftJoin('ongoing-live-alerts', 'ongoing-live-alerts.assessmentId', 'assessments.id')
-    .groupBy('sessions.id', 'certification-centers.id')
+    .groupBy('sessions.id')
     .where({ 'sessions.id': idSession })
     .first();
   if (!results) {

--- a/api/lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer.js
@@ -23,6 +23,7 @@ const serialize = function (sessions) {
       'time',
       'certificationCenterName',
       'certificationCandidates',
+      'address',
     ],
     typeForAttribute: (attribute) =>
       attribute === 'certificationCandidates' ? 'certification-candidate-for-supervising' : attribute,

--- a/api/lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer.js
@@ -15,16 +15,7 @@ const serialize = function (sessions) {
 
       return cloneSession;
     },
-    attributes: [
-      'room',
-      'examiner',
-      'accessCode',
-      'date',
-      'time',
-      'certificationCenterName',
-      'certificationCandidates',
-      'address',
-    ],
+    attributes: ['room', 'examiner', 'accessCode', 'date', 'time', 'certificationCandidates', 'address'],
     typeForAttribute: (attribute) =>
       attribute === 'certificationCandidates' ? 'certification-candidate-for-supervising' : attribute,
     certificationCandidates: {

--- a/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
@@ -15,6 +15,7 @@ describe('Integration | Repository | SessionForSupervising', function () {
         databaseBuilder.factory.buildCertificationCenter({ name: 'Toto', id: 1234 });
         const session = databaseBuilder.factory.buildSession({
           certificationCenter: 'Tour Gamma',
+          address: 'centre de certification 1',
           room: 'Salle A',
           examiner: 'Monsieur Examinateur',
           accessCode: 'CODE12',
@@ -33,6 +34,7 @@ describe('Integration | Repository | SessionForSupervising', function () {
           new SessionForSupervising({
             id: session.id,
             certificationCenterName: 'Toto',
+            address: 'centre de certification 1',
             room: 'Salle A',
             examiner: 'Monsieur Examinateur',
             accessCode: 'CODE12',
@@ -228,12 +230,14 @@ describe('Integration | Repository | SessionForSupervising', function () {
         expect(error).to.be.instanceOf(NotFoundError);
       });
     });
+
     describe('when certification session is v3', function () {
       it('should return session informations in a SessionForSupervising Object', async function () {
         // given
         databaseBuilder.factory.buildCertificationCenter({ name: 'Toto', id: 1234 });
         const session = databaseBuilder.factory.buildSession({
           version: CertificationVersion.V3,
+          address: 'centre de certification 1',
           certificationCenter: 'Tour Gamma',
           room: 'Salle A',
           examiner: 'Monsieur Examinateur',
@@ -253,6 +257,7 @@ describe('Integration | Repository | SessionForSupervising', function () {
           new SessionForSupervising({
             id: session.id,
             certificationCenterName: 'Toto',
+            address: 'centre de certification 1',
             room: 'Salle A',
             examiner: 'Monsieur Examinateur',
             accessCode: 'CODE12',

--- a/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
@@ -33,7 +33,6 @@ describe('Integration | Repository | SessionForSupervising', function () {
         expect(actualSession).to.be.deepEqualInstance(
           new SessionForSupervising({
             id: session.id,
-            certificationCenterName: 'Toto',
             address: 'centre de certification 1',
             room: 'Salle A',
             examiner: 'Monsieur Examinateur',
@@ -256,7 +255,6 @@ describe('Integration | Repository | SessionForSupervising', function () {
         expect(actualSession).to.be.deepEqualInstance(
           new SessionForSupervising({
             id: session.id,
-            certificationCenterName: 'Toto',
             address: 'centre de certification 1',
             room: 'Salle A',
             examiner: 'Monsieur Examinateur',

--- a/api/tests/tooling/domain-builder/factory/build-session-for-supervising.js
+++ b/api/tests/tooling/domain-builder/factory/build-session-for-supervising.js
@@ -2,7 +2,6 @@ import { SessionForSupervising } from '../../../../lib/domain/read-models/Sessio
 
 const buildSessionForSupervising = function ({
   id = 123,
-  certificationCenterName = 'Centre de certif pix',
   certificationCenterId = 565,
   examiner = 'Monkey D Luffy',
   accessCode = 'ACCES1',
@@ -14,7 +13,6 @@ const buildSessionForSupervising = function ({
 } = {}) {
   return new SessionForSupervising({
     id,
-    certificationCenterName,
     examiner,
     certificationCenterId,
     accessCode,

--- a/api/tests/tooling/domain-builder/factory/build-session-for-supervising.js
+++ b/api/tests/tooling/domain-builder/factory/build-session-for-supervising.js
@@ -10,6 +10,7 @@ const buildSessionForSupervising = function ({
   room = '28D',
   time = '14:30',
   certificationCandidates = [],
+  address = 'centre de certification 1',
 } = {}) {
   return new SessionForSupervising({
     id,
@@ -21,6 +22,7 @@ const buildSessionForSupervising = function ({
     room,
     time,
     certificationCandidates,
+    address,
   });
 };
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-for-supervising-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-for-supervising-serializer_test.js
@@ -13,7 +13,6 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
         const expectedPayload = {
           data: {
             attributes: {
-              'certification-center-name': 'Toto',
               address: 'centre de certification 1',
               'access-code': 'CODE12',
               date: '2017-01-20',
@@ -65,7 +64,6 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
           accessCode: 'CODE12',
           date: '2017-01-20',
           time: '14:30',
-          certificationCenterName: 'Toto',
           certificationCandidates: [
             new CertificationCandidateForSupervising({
               id: 1234,
@@ -105,7 +103,6 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
         const expectedPayload = {
           data: {
             attributes: {
-              'certification-center-name': 'Toto',
               address: 'centre de certification 1',
               'access-code': 'CODE12',
               date: '2017-01-20',
@@ -163,7 +160,6 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
           accessCode: 'CODE12',
           date: '2017-01-20',
           time: '14:30',
-          certificationCenterName: 'Toto',
           certificationCandidates: [
             new CertificationCandidateForSupervisingV3({
               id: 1234,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-for-supervising-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-for-supervising-serializer_test.js
@@ -14,6 +14,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
           data: {
             attributes: {
               'certification-center-name': 'Toto',
+              address: 'centre de certification 1',
               'access-code': 'CODE12',
               date: '2017-01-20',
               examiner: 'Antoine Toutvenant',
@@ -58,7 +59,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
 
         const modelSession = domainBuilder.buildSessionForSupervising({
           id: 12,
-          address: 'Nice',
+          address: 'centre de certification 1',
           room: '28D',
           examiner: 'Antoine Toutvenant',
           accessCode: 'CODE12',
@@ -105,6 +106,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
           data: {
             attributes: {
               'certification-center-name': 'Toto',
+              address: 'centre de certification 1',
               'access-code': 'CODE12',
               date: '2017-01-20',
               examiner: 'Antoine Toutvenant',
@@ -155,7 +157,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
 
         const modelSession = domainBuilder.buildSessionForSupervising({
           id: 12,
-          address: 'Nice',
+          address: 'centre de certification 1',
           room: '28D',
           examiner: 'Antoine Toutvenant',
           accessCode: 'CODE12',

--- a/certif/app/components/session-supervising/header.hbs
+++ b/certif/app/components/session-supervising/header.hbs
@@ -20,24 +20,40 @@
     {{dayjs-format @session.time "HH:mm" inputFormat="HH:mm:ss" allow-empty=true}}
   </time>
 
-  <div>
-    <p class="session-supervising-header__line">
-      <span class="session-supervising-header__label">{{t "pages.session-supervising.header.address"}}</span>
-      {{@session.address}}
-    </p>
-    <p class="session-supervising-header__line">
-      <span class="session-supervising-header__label">{{t "pages.session-supervising.header.room"}}</span>
-      {{@session.room}}
-    </p>
-    <p class="session-supervising-header__line">
-      <span class="session-supervising-header__label">{{t "pages.session-supervising.header.invigilator"}}</span>
-      {{@session.examiner}}
-    </p>
-    <p class="session-supervising-header__line">
-      <span class="session-supervising-header__label">{{t "pages.session-supervising.header.access-code"}}</span>
-      {{@session.accessCode}}
-    </p>
-  </div>
+  <dl>
+    <div class="session-supervising-header__line">
+      <dt class="session-supervising-header__label">
+        {{t "pages.session-supervising.header.address"}}
+      </dt>
+      <dd>
+        {{@session.address}}
+      </dd>
+    </div>
+    <div class="session-supervising-header__line">
+      <dt class="session-supervising-header__label">
+        {{t "pages.session-supervising.header.room"}}
+      </dt>
+      <dd>
+        {{@session.room}}
+      </dd>
+    </div>
+    <div class="session-supervising-header__line">
+      <dt class="session-supervising-header__label">
+        {{t "pages.session-supervising.header.invigilator"}}
+      </dt>
+      <dd>
+        {{@session.examiner}}
+      </dd>
+    </div>
+    <div class="session-supervising-header__line">
+      <dt class="session-supervising-header__label">
+        {{t "pages.session-supervising.header.access-code"}}
+      </dt>
+      <dd>
+        {{@session.accessCode}}
+      </dd>
+    </div>
+  </dl>
 
   <SessionSupervising::ConfirmationModal
     @showModal={{this.isConfirmationModalDisplayed}}

--- a/certif/app/components/session-supervising/header.hbs
+++ b/certif/app/components/session-supervising/header.hbs
@@ -22,15 +22,15 @@
 
   <div>
     <p class="session-supervising-header__line">
-      <span class="session-supervising-header__label">{{t "common.forms.session-labels.center-name"}}</span>
+      <span class="session-supervising-header__label">{{t "pages.session-supervising.header.address"}}</span>
       {{@session.address}}
     </p>
     <p class="session-supervising-header__line">
-      <span class="session-supervising-header__label">{{t "common.forms.session-labels.room"}}</span>
+      <span class="session-supervising-header__label">{{t "pages.session-supervising.header.room"}}</span>
       {{@session.room}}
     </p>
     <p class="session-supervising-header__line">
-      <span class="session-supervising-header__label">{{t "common.forms.session-labels.invigilator"}}</span>
+      <span class="session-supervising-header__label">{{t "pages.session-supervising.header.invigilator"}}</span>
       {{@session.examiner}}
     </p>
     <p class="session-supervising-header__line">

--- a/certif/app/components/session-supervising/header.hbs
+++ b/certif/app/components/session-supervising/header.hbs
@@ -23,7 +23,7 @@
   <div>
     <p class="session-supervising-header__line">
       <span class="session-supervising-header__label">{{t "common.forms.session-labels.center-name"}}</span>
-      {{@session.certificationCenterName}}
+      {{@session.address}}
     </p>
     <p class="session-supervising-header__line">
       <span class="session-supervising-header__label">{{t "common.forms.session-labels.room"}}</span>

--- a/certif/app/models/session-for-supervising.js
+++ b/certif/app/models/session-for-supervising.js
@@ -7,5 +7,6 @@ export default class SessionForSupervising extends Model {
   @attr('string') room;
   @attr('string') certificationCenterName;
   @attr('string') accessCode;
+  @attr('string') address;
   @hasMany('certification-candidate-for-supervising', { async: false, inverse: null }) certificationCandidates;
 }

--- a/certif/app/models/session-for-supervising.js
+++ b/certif/app/models/session-for-supervising.js
@@ -5,7 +5,6 @@ export default class SessionForSupervising extends Model {
   @attr('string') time;
   @attr('string') examiner;
   @attr('string') room;
-  @attr('string') certificationCenterName;
   @attr('string') accessCode;
   @attr('string') address;
   @hasMany('certification-candidate-for-supervising', { async: false, inverse: null }) certificationCandidates;

--- a/certif/tests/integration/components/session-supervising/header_test.js
+++ b/certif/tests/integration/components/session-supervising/header_test.js
@@ -26,6 +26,7 @@ module('Integration | Component | SessionSupervising::Header', function (hooks) 
       room: 'Salle 12',
       examiner: 'Star Lord',
       certificationCenterName: 'Knowhere',
+      address: 'centre de certification 1',
       certificationCandidates: [],
       accessCode: 'ACCES1',
     });
@@ -37,6 +38,7 @@ module('Integration | Component | SessionSupervising::Header', function (hooks) 
 
     // then
     assert.dom(screen.getByText('Session 12345')).exists();
+    assert.dom(screen.getByText('centre de certification 1')).exists();
     assert.dom(screen.getByText('Salle 12')).exists();
     assert.dom(screen.getByText('Star Lord')).exists();
     assert.dom(screen.getByText('ACCES1')).exists();

--- a/certif/tests/integration/components/session-supervising/header_test.js
+++ b/certif/tests/integration/components/session-supervising/header_test.js
@@ -36,12 +36,23 @@ module('Integration | Component | SessionSupervising::Header', function (hooks) 
     const screen = await renderScreen(hbs`<SessionSupervising::Header @session={{this.sessionForSupervising}}  />`);
 
     // then
+    const termsList = screen.getAllByRole('term');
+    const definitionsList = screen.getAllByRole('definition');
+
     assert.dom(screen.getByText('Session 12345')).exists();
-    assert.dom(screen.getByText('centre de certification 1')).exists();
-    assert.dom(screen.getByText('Salle 12')).exists();
-    assert.dom(screen.getByText('Star Lord')).exists();
-    assert.dom(screen.getByText('ACCES1')).exists();
     assert.dom(screen.getByText('01/01/2020 · 12:00')).exists();
+
+    assert.strictEqual(termsList[0].textContent.trim(), 'Nom du site');
+    assert.strictEqual(definitionsList[0].textContent.trim(), 'centre de certification 1');
+
+    assert.strictEqual(termsList[1].textContent.trim(), 'Salle');
+    assert.strictEqual(definitionsList[1].textContent.trim(), 'Salle 12');
+
+    assert.strictEqual(termsList[2].textContent.trim(), 'Surveillant(s)');
+    assert.strictEqual(definitionsList[2].textContent.trim(), 'Star Lord');
+
+    assert.strictEqual(termsList[3].textContent.trim(), "Code d'accès (candidats)");
+    assert.strictEqual(definitionsList[3].textContent.trim(), 'ACCES1');
   });
 
   module("when 'Quitter' button is clicked", function () {

--- a/certif/tests/integration/components/session-supervising/header_test.js
+++ b/certif/tests/integration/components/session-supervising/header_test.js
@@ -25,7 +25,6 @@ module('Integration | Component | SessionSupervising::Header', function (hooks) 
       time: '12:00:00',
       room: 'Salle 12',
       examiner: 'Star Lord',
-      certificationCenterName: 'Knowhere',
       address: 'centre de certification 1',
       certificationCandidates: [],
       accessCode: 'ACCES1',
@@ -54,7 +53,6 @@ module('Integration | Component | SessionSupervising::Header', function (hooks) 
         time: '12:00:00',
         room: 'Salle 12',
         examiner: 'Star Lord',
-        certificationCenterName: 'Knowhere',
         certificationCandidates: [],
       });
 
@@ -87,7 +85,6 @@ module('Integration | Component | SessionSupervising::Header', function (hooks) 
         time: '12:00:00',
         room: 'Salle 12',
         examiner: 'Star Lord',
-        certificationCenterName: 'Knowhere',
         certificationCandidates: [],
       });
 
@@ -115,7 +112,6 @@ module('Integration | Component | SessionSupervising::Header', function (hooks) 
         time: '12:00:00',
         room: 'Salle 12',
         examiner: 'Star Lord',
-        certificationCenterName: 'Knowhere',
         certificationCandidates: [],
       });
 

--- a/certif/tests/unit/models/session-for-supervising_test.js
+++ b/certif/tests/unit/models/session-for-supervising_test.js
@@ -8,7 +8,6 @@ module('Unit | Model | session-for-supervising', function (hooks) {
   test('it creates a SessionForSupervisingModel', function (assert) {
     const store = this.owner.lookup('service:store');
     const data = {
-      certificationCenterName: 'Centre des chocolats',
       address: 'Centre de certification 1',
       examiner: 'Monsieur Marmotte',
       room: "Salle de mise en papier d'alu",
@@ -21,14 +20,6 @@ module('Unit | Model | session-for-supervising', function (hooks) {
   });
 
   function _pickModelData(sessionForSupervising) {
-    return pick(sessionForSupervising, [
-      'address',
-      'certificationCenterName',
-      'examiner',
-      'room',
-      'accessCode',
-      'date',
-      'time',
-    ]);
+    return pick(sessionForSupervising, ['address', 'examiner', 'room', 'accessCode', 'date', 'time']);
   }
 });

--- a/certif/tests/unit/models/session-for-supervising_test.js
+++ b/certif/tests/unit/models/session-for-supervising_test.js
@@ -9,6 +9,7 @@ module('Unit | Model | session-for-supervising', function (hooks) {
     const store = this.owner.lookup('service:store');
     const data = {
       certificationCenterName: 'Centre des chocolats',
+      address: 'Centre de certification 1',
       examiner: 'Monsieur Marmotte',
       room: "Salle de mise en papier d'alu",
       accessCode: 'MARM01',
@@ -20,6 +21,14 @@ module('Unit | Model | session-for-supervising', function (hooks) {
   });
 
   function _pickModelData(sessionForSupervising) {
-    return pick(sessionForSupervising, ['certificationCenterName', 'examiner', 'room', 'accessCode', 'date', 'time']);
+    return pick(sessionForSupervising, [
+      'address',
+      'certificationCenterName',
+      'examiner',
+      'room',
+      'accessCode',
+      'date',
+      'time',
+    ]);
   }
 });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -490,7 +490,10 @@
           "confirmation": "Exit the invigilation",
           "exit-extra-information": "Exit the session’s invigilation {sessionId}"
         },
+        "address": "Location name",
         "information": "Warning, make sure that all the candidates have finished their exam before exiting the invigilation. To resume the invigilation of this session, you will have to enter again it’s session number and it’s password.",
+        "invigilator": "Invigilator(s)",
+        "room": "Room",
         "session-id": "Session {sessionId}"
       },
       "login": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -490,7 +490,10 @@
           "confirmation": "Quitter la surveillance",
           "exit-extra-information": "Quitter la surveillance de la session {sessionId}"
         },
+        "address": "Nom du site",
         "information": "Attention, assurez-vous que tous les candidats aient terminé leur test avant de quitter la surveillance. Pour reprendre la surveillance de cette session, vous devrez entrer à nouveau son numéro de session et son mot de passe.",
+        "invigilator": "Surveillant(s)",
+        "room": "Salle",
         "session-id": "Session {sessionId}"
       },
       "login": {


### PR DESCRIPTION
## :unicorn: Problème
Sur la page dédié au surveillant dans l'app Certif, le champ `nom du site` est affiché dans l'en-tête de la page. Actuellement dans ce champ, nous affichons le nom du CDC provenant de la table `certification-centers`, or on devrait afficher le champ `address` provenant de la table `session`.

Il peut paraître illogique dû au nommage `Nom du site` de renseigner l'adresse de la session à cet endroit, mais dans les données BDD de production de la table `session`, on peut se rendre compte que dans la colonne `address` un nom de centre est très souvent renseigné à la place du adresse à proprement dit.

## :robot: Proposition
Rajouter le champ `session.address` dans le retour de l'api et l'afficher sur la page surveillant en tant que `Nom du site` à la place du nom du centre de certification.

## :rainbow: Remarques
1. Les clés de traduction ont été renommer pour gagner en clarté, car c'était les même clés de traduction qu'un formulaire affiché sur une autre page.
2. La sémantique HTML a été modifiée dans le but d'améliorer l'accessibilité ainsi que la lecture du contenu via les lecteurs d'écrans. Une [liste de description](https://developer.mozilla.org/fr/docs/Web/HTML/Element/dl) est implémentée car le contenu s'y prête bien.

## :100: Pour tester

1. Se rendre sur la liste des sessions sur app certif avec le compte `certif-pro@example.net` / mdp: `pix123`.
3. Choisir une certification et se connecter à la page surveillant avec le mot de passe de session.
4. **Vérifier sur cette page** que l'information `Nom du site` s'affiche correctement et qu'elle corrsponf bien à l'adresse de la session (le contenu est le même que celui présent sur la liste des sessions - voir screenshots pour une meilleure compréhension).
