### PR TITLE
[FEATURE][API] Supprimer la contrainte sur la locale dans la table users (PIX-11231)

### DIFF
--- a/api/db/migrations/20240223150108_remove-locale-constraint-in-users-table.js
+++ b/api/db/migrations/20240223150108_remove-locale-constraint-in-users-table.js
@@ -1,0 +1,11 @@
+const up = async function (knex) {
+  return knex.raw('ALTER TABLE "users" DROP CONSTRAINT "users_locale_check"');
+};
+
+const down = async function (knex) {
+  return knex.raw(
+    "ALTER TABLE \"users\" ADD CONSTRAINT \"users_locale_check\" CHECK ( \"locale\" IN ('en', 'fr', 'fr-FR', 'fr-BE') )",
+  );
+};
+
+export { up, down };


### PR DESCRIPTION
## :unicorn: Problème
La contrainte sur la colonne `locale` de la table `users` nous empêche d'ajouter d'autres locales que `en`, `fr`, `fr-FR` ou `fr-BE`. Cela pause problème dans le cadre de l'ajout d'une nouvelle locale.

## :robot: Proposition
Ajouter une migration pour supprimer cette contrainte.

## :rainbow: Remarques
Dans le cas où cette migration devait être rollback, Il faudrait que toutes les valeurs dans la colonne `locale` soient `en`, `fr`, `fr-FR` ou `fr-BE`. Cela rendrait pénible un rollback si on a plusieurs valeurs différentes et un UPDATE massif devrait être fait.

## :100: Pour tester
### Test de la migration

1. Lançer la commande `npm run db:reset` en local
2. Vérifier que la contrainte `users_locale_check` n'est plus présente.
3. Modifier la locale d'un ou plusieurs utilisateurs en base de donnée avec une valeur autre que fr-FR, fr-BE, `fr` ou en (ex: `en-JP`). Vérifier que ça fonctionne.

### Test du rollback de la migration

1. 🚨 Annuler les changements en BDD afin de tester le down de la migration.
2. Lançer la commande `npm run db:rollback:latest`.
3. Modifier de nouveau la locale d'un utilisateur avec une valeur `en-JP` par exemple, et vérifier qu'il y a une erreur à cause de la contrainte.
