### PR TITLE
[BUGFIX] Corrige le score par compétences pour les capacités très hautes et très basses (PIX-11395)

### DIFF
--- a/api/src/certification/scoring/domain/models/CompetenceForScoring.js
+++ b/api/src/certification/scoring/domain/models/CompetenceForScoring.js
@@ -25,7 +25,7 @@ export class CompetenceForScoring {
     this.competenceId = competenceId;
     this.areaCode = areaCode;
     this.competenceCode = competenceCode;
-    this.intervals = intervals;
+    this.intervals = this._extendExtremeIntervals(intervals);
   }
 
   getCompetenceMark(estimatedLevel) {
@@ -38,6 +38,38 @@ export class CompetenceForScoring {
       level,
       score: 0,
     });
+  }
+
+  _extendExtremeIntervals(intervals) {
+    const maximumCapacity = Math.max(...intervals.map(({ bounds }) => bounds.max));
+    const minimumCapacity = Math.min(...intervals.map(({ bounds }) => bounds.min));
+    return intervals
+      .map((interval) => {
+        if (interval.bounds.max !== maximumCapacity) {
+          return interval;
+        }
+
+        return {
+          ...interval,
+          bounds: {
+            ...interval.bounds,
+            max: Number.MAX_SAFE_INTEGER,
+          },
+        };
+      })
+      .map((interval) => {
+        if (interval.bounds.min !== minimumCapacity) {
+          return interval;
+        }
+
+        return {
+          ...interval,
+          bounds: {
+            ...interval.bounds,
+            min: Number.MIN_SAFE_INTEGER,
+          },
+        };
+      });
   }
 
   _findInterval(estimatedLevel) {

--- a/api/tests/certification/scoring/unit/domain/models/CompetenceForScoring_test.js
+++ b/api/tests/certification/scoring/unit/domain/models/CompetenceForScoring_test.js
@@ -14,7 +14,7 @@ describe('Unit | Certification | CompetenceForScoring', function () {
         {
           bounds: {
             max: -1,
-            min: Number.MIN_SAFE_INTEGER,
+            min: -5,
           },
           competenceLevel: 0,
         },
@@ -27,7 +27,7 @@ describe('Unit | Certification | CompetenceForScoring', function () {
         },
         {
           bounds: {
-            max: Number.MAX_SAFE_INTEGER,
+            max: 5,
             min: -1,
           },
           competenceLevel: 2,
@@ -87,7 +87,7 @@ describe('Unit | Certification | CompetenceForScoring', function () {
 
     describe('when the capacity is above the highest interval', function () {
       it('should return the CompetenceMark with a level of the highest interval', function () {
-        const estimatedLevel = 3;
+        const estimatedLevel = 6;
 
         const competenceForScoring = new CompetenceForScoring({
           competenceId,
@@ -103,6 +103,31 @@ describe('Unit | Certification | CompetenceForScoring', function () {
           area_code: areaCode,
           competence_code: competenceCode,
           level: 2,
+          score: 0,
+        });
+
+        expect(competenceMark).to.deep.equal(expectedCompetenceMark);
+      });
+    });
+
+    describe('when the capacity is below the lowest interval', function () {
+      it('should return the CompetenceMark with a level of the highest interval', function () {
+        const estimatedLevel = -6;
+
+        const competenceForScoring = new CompetenceForScoring({
+          competenceId,
+          areaCode,
+          competenceCode,
+          intervals,
+        });
+
+        const competenceMark = competenceForScoring.getCompetenceMark(estimatedLevel);
+
+        const expectedCompetenceMark = domainBuilder.buildCompetenceMark({
+          competenceId,
+          area_code: areaCode,
+          competence_code: competenceCode,
+          level: 0,
           score: 0,
         });
 

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
@@ -402,13 +402,13 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
             {
               bounds: {
                 max: 0,
-                min: Number.MIN_SAFE_INTEGER,
+                min: -5,
               },
               competenceLevel: 0,
             },
             {
               bounds: {
-                max: Number.MAX_SAFE_INTEGER,
+                max: 5,
                 min: 0,
               },
               competenceLevel: 1,
@@ -697,6 +697,16 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
               .first();
 
             expect(assessmentResult.pixScore).to.exist;
+
+            const competenceMarks = await knex('competence-marks')
+              .where({
+                assessmentResultId: assessmentResult.id,
+              })
+              .orderBy('competenceId');
+
+            expect(competenceMarks).to.have.length(1);
+
+            expect(competenceMarks[0].level).to.equal(1);
           });
         });
       });


### PR DESCRIPTION
## :unicorn: Problème
Les fichiers de configuration du score par compétence ne prennent pas en compte les capacités extrêmement hautes et basses. 

## :robot: Proposition
Elargir les plages extrêmes du score par capacité

## :100: Pour tester
- Créer une session de certif v3  (certif => certifv3@example.net // pix123)
- Rejoindre la session avec un candidat et passer toutes les questions (mon-pix => certifiable-contenu-user@example.net // pix123)
- Passer toutes les questions de la certification
- Finaliser la session sur pix certif
- Aller sur les détails de la session dans pix admin (admin =>  superadmin@example.net // pix123)