### PR TITLE
[FEATURE] Améliorer l'affichage des explications pour signaler une question lors d'une certification sur Pix App (PIX-11383).

### DIFF
--- a/mon-pix/app/components/feedback-certification-section.hbs
+++ b/mon-pix/app/components/feedback-certification-section.hbs
@@ -1,4 +1,4 @@
-<div class="feedback-certification-section__div">
+<div>
   {{t "pages.challenge.certification.feedback-panel.description"}}
   <ul>
     <li>

--- a/mon-pix/app/components/feedback-certification-section.hbs
+++ b/mon-pix/app/components/feedback-certification-section.hbs
@@ -1,6 +1,6 @@
 <div>
   {{t "pages.challenge.certification.feedback-panel.description"}}
-  <ul>
+  <ul class="feedback-certification-section-list">
     <li>
       {{t "pages.challenge.certification.feedback-panel.certification-number"}}
     </li>

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -53,6 +53,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @import 'components/competence-card/list';
 @import 'components/dashboard/content';
 @import 'components/feedback-panel';
+@import 'components/feedback-certification-section';
 @import 'components/feedback-panel-v3';
 @import 'components/footer';
 @import 'components/form-textfield';

--- a/mon-pix/app/styles/components/_feedback-certification-section.scss
+++ b/mon-pix/app/styles/components/_feedback-certification-section.scss
@@ -1,0 +1,4 @@
+.feedback-certification-section-list li {
+  margin: var(--pix-spacing-2x) 0 0 var(--pix-spacing-4x);
+  list-style: disc;
+}

--- a/mon-pix/tests/integration/components/feedback-certification-section_test.js
+++ b/mon-pix/tests/integration/components/feedback-certification-section_test.js
@@ -1,22 +1,28 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-// eslint-disable-next-line no-restricted-imports
-import { find } from '@ember/test-helpers';
-import { render } from '@1024pix/ember-testing-library';
+import { render, within } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | feedback-certification-section', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   test('renders', async function (assert) {
-    await render(hbs`<FeedbackCertificationSection />`);
+    // given & when
+    const screen = await render(hbs`<FeedbackCertificationSection />`);
 
-    assert.ok(
-      find('.feedback-certification-section__div')
-        .textContent.trim()
-        .includes(
+    // then
+    const list = screen.getByRole('list');
+    const items = within(list).getAllByRole('listitem');
+    assert.strictEqual(items[0].textContent.trim(), "votre numéro de certification (en haut à droite de l'écran)");
+    assert.strictEqual(items[1].textContent.trim(), "le numéro de la question (en haut à droite de l'écran)");
+    assert.strictEqual(items[2].textContent.trim(), 'le problème rencontré');
+
+    assert
+      .dom(
+        screen.getByText(
           'Pour signaler un problème, appelez votre surveillant et communiquez-lui les informations suivantes :',
         ),
-    );
+      )
+      .exists();
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -565,7 +565,7 @@
           "certification-number": "Certification no."
         },
         "feedback-panel": {
-          "certification-number": "your certification no. (in the top-right of the screen)",
+          "certification-number": "your certification number (in the top-right of the screen)",
           "description": "To report a problem, please call your invigilator and provide the following information:",
           "problem": "the problem encountered",
           "question-number": "the question number (in the top-right of the screen)"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -565,7 +565,7 @@
           "certification-number": "N° de certification"
         },
         "feedback-panel": {
-          "certification-number": "votre n° de certification (en haut à droite de l'écran)",
+          "certification-number": "votre numéro de certification (en haut à droite de l'écran)",
           "description": "Pour signaler un problème, appelez votre surveillant et communiquez-lui les informations suivantes :",
           "problem": "le problème rencontré",
           "question-number": "le numéro de la question (en haut à droite de l'écran)"


### PR DESCRIPTION
## :unicorn: Problème
Actuellement la section de signalement d'un problème lors d'une certification ressemble à ceci 

<img width="1044" alt="Capture d’écran 2024-02-22 à 17 11 18" src="https://github.com/1024pix/pix/assets/58915422/5db20cf3-e592-4288-acaf-8895a94951ed">


- Il manque des points (bullet points) pour la liste des éléments à donner au surveillant
- Sur le wording, on a à la fois "n°" et le mot entier "numéro" plus bas.

## :robot: Proposition
<img width="640" alt="Capture d’écran 2024-02-23 à 16 34 56" src="https://github.com/1024pix/pix/assets/58915422/ef75b63b-5646-4898-9686-c7942872e319">


## :100: Pour tester

- Passer une certification sur Pix App
- (Avec le cli certif (`scripts/data-generation/generate-certif-cli.js`), générer un candidat pour passer la certif sans avoir à passer par le portail surveillant, autrement passer par Pix Certif pour trouver une session, ajouter un candidat et donner l'accès via l'espace surveillant)
- Lors de la première question, cliquer sur le lien pour signaler un problème
- Constater que c'est mieux 👀
