### PR TITLE
[TECH][API] Améliorer le passage des détails d'une erreur OIDC vers datadog (PIX-11391)

### DIFF
--- a/api/lib/infrastructure/monitoring-tools.js
+++ b/api/lib/infrastructure/monitoring-tools.js
@@ -36,6 +36,24 @@ function logInfoWithCorrelationIds(data) {
   );
 }
 
+/**
+ * In order to be displayed properly in Datadog,
+ * the parameter "data" should contain
+ * - a required property message as string
+ * - all other properties you need to pass to Datadog
+ *
+ * @example
+ * const data = {
+ *   message: 'Error message',
+ *   context: 'My Context',
+ *   data: { more: 'data', if: 'needed' },
+ *   event: 'Event which trigger this error',
+ *   team: 'My Team',
+ * };
+ * monitoringTools.logErrorWithCorrelationIds(data);
+ *
+ * @param {object} data
+ */
 function logErrorWithCorrelationIds(data) {
   const context = getCorrelationContext();
   logger.error(

--- a/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
@@ -318,15 +318,12 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         expect(error).to.be.instanceOf(OidcError);
         expect(error.message).to.be.equal('Fails to generate endSessionUrl');
         expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWithExactly({
-          message: {
-            context: 'oidc',
-            data: {
-              organizationName: 'Oidc Example',
-            },
-            error: errorThrown,
-            event: 'get-redirect-logout-url',
-            team: 'acces',
-          },
+          context: 'oidc',
+          data: { organizationName: 'Oidc Example' },
+          error: { name: errorThrown.name },
+          event: 'get-redirect-logout-url',
+          message: errorThrown.message,
+          team: 'acces',
         });
       });
     });
@@ -399,6 +396,9 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         const state = 'state';
         const errorThrown = new Error('Fails to get tokens');
 
+        errorThrown.error_uri = '/oauth2/token';
+        errorThrown.response = 'api call response here';
+
         const clientInstance = { callback: sinon.stub().rejects(errorThrown) };
         const Client = sinon.stub().returns(clientInstance);
 
@@ -425,19 +425,22 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         expect(error).to.be.instanceOf(OidcError);
         expect(error.message).to.be.equal('Fails to get tokens');
         expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWithExactly({
-          message: {
-            context: 'oidc',
-            data: {
-              code,
-              nonce,
-              organizationName: 'Oidc Example',
-              sessionState,
-              state,
-            },
-            error: errorThrown,
-            event: 'exchange-code-for-tokens',
-            team: 'acces',
+          context: 'oidc',
+          data: {
+            code,
+            nonce,
+            organizationName: 'Oidc Example',
+            sessionState,
+            state,
           },
+          error: {
+            name: errorThrown.name,
+            errorUri: '/oauth2/token',
+            response: 'api call response here',
+          },
+          event: 'exchange-code-for-tokens',
+          message: errorThrown.message,
+          team: 'acces',
         });
       });
     });
@@ -512,15 +515,12 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         expect(error).to.be.instanceOf(OidcError);
         expect(error.message).to.be.equal('Fails to generate authorization url');
         expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWithExactly({
-          message: {
-            context: 'oidc',
-            data: {
-              organizationName: 'Oidc Example',
-            },
-            error: errorThrown,
-            event: 'generate-authorization-url',
-            team: 'acces',
-          },
+          context: 'oidc',
+          data: { organizationName: 'Oidc Example' },
+          error: { name: errorThrown.name },
+          event: 'generate-authorization-url',
+          message: errorThrown.message,
+          team: 'acces',
         });
       });
     });
@@ -668,15 +668,12 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         expect(error).to.be.instanceOf(OidcError);
         expect(error.message).to.be.equal('Fails to get user info');
         expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWithExactly({
-          message: {
-            context: 'oidc',
-            data: {
-              organizationName: 'Oidc Example',
-            },
-            error: errorThrown,
-            event: 'get-user-info-from-endpoint',
-            team: 'acces',
-          },
+          message: errorThrown.message,
+          context: 'oidc',
+          data: { organizationName: 'Oidc Example' },
+          error: { name: errorThrown.name },
+          event: 'get-user-info-from-endpoint',
+          team: 'acces',
         });
       });
     });
@@ -724,13 +721,18 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         expect(error.message).to.be.equal(errorMessage);
         expect(error.code).to.be.equal(OIDC_ERRORS.USER_INFO.missingFields.code);
         expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWithExactly({
-          message: errorMessage,
-          missingFields: 'family_name',
-          userInfo: {
-            sub: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
-            given_name: 'givenName',
-            family_name: undefined,
+          context: 'oidc',
+          data: {
+            missingFields: 'family_name',
+            userInfo: {
+              sub: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
+              given_name: 'givenName',
+              family_name: undefined,
+            },
           },
+          event: 'find-missing-required-claims',
+          message: errorMessage,
+          team: 'acces',
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème

Avec le code actuel, c’est-à-dire le passage de l’instance de l’erreur directement, seul le nom de l’erreur est visible sur Datadog sous la forme suivante : `error: { name: 'OPError' }`.

Sous cette forme cela ne nous aide pas du tout. Il faudrait passer les bonnes informations concernant l’erreur.

## :robot: Proposition

Ne plus passer l’instance de l’erreur mais plutôt un nouvel objet contenant des propriétés dont on a la main en se basant sur les erreurs retournées par la librairie `openid-client`.

## :rainbow: Remarques

Un peu de documentation a été ajouté sur l'utilisation de la méthode `logErrorWithCorrelationIds` du module `monitoringTools`.

![Screenshot 2024-02-26 at 12 21 14](https://github.com/1024pix/pix/assets/6919604/4acb6afa-e947-4641-b6d7-f1316f335495)

## :100: Pour tester

La CI est ✅ 
