### PR TITLE
[FEATURE] Supprimer le pluriel dans la section de la certification complémentaire dans l'attestation Pix (PIX-11385).

### DIFF
--- a/mon-pix/tests/integration/components/user-certifications-detail-result_test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-result_test.js
@@ -53,12 +53,14 @@ module('Integration | Component | user certifications detail result', function (
 
       // when
       const screen = await renderScreen(hbs`<UserCertificationsDetailResult @certification={{this.certification}}/>`);
+
+      // then
       assert.notOk(screen.queryByRole('heading', { name: this.intl.t('pages.certificate.jury-title') }));
     });
   });
 
-  module('when certification has a certified badge image', function () {
-    test('should show the complementary certification badge', async function (assert) {
+  module('when certification has complementary certified badge', function () {
+    test('should show the complementary certification section', async function (assert) {
       // given
       certification = EmberObject.create({
         id: 1,
@@ -84,11 +86,11 @@ module('Integration | Component | user certifications detail result', function (
       const screen = await renderScreen(hbs`<UserCertificationsDetailResult @certification={{this.certification}}/>`);
 
       // then
-      assert.ok(screen.getByRole('img', { name: 'Certification complémentaire' }));
+      assert.ok(screen.getByRole('heading', { name: this.intl.t('pages.certificate.complementary.title') }));
     });
 
-    module('when the certified badge image has a message', function () {
-      test('should display the message', async function (assert) {
+    module('when certification has a certified badge image', function () {
+      test('should show the complementary certification badge', async function (assert) {
         // given
         certification = EmberObject.create({
           id: 1,
@@ -104,8 +106,7 @@ module('Integration | Component | user certifications detail result', function (
           certifiedBadgeImages: [
             {
               url: '/some/img',
-              message: 'Bravo Coco!',
-              levelName: 'Level Name',
+              isTemporaryBadge: false,
             },
           ],
         });
@@ -115,37 +116,72 @@ module('Integration | Component | user certifications detail result', function (
         const screen = await renderScreen(hbs`<UserCertificationsDetailResult @certification={{this.certification}}/>`);
 
         // then
-        assert.ok(screen.getByText('Bravo Coco!'));
+        assert.ok(screen.getByRole('img', { name: 'Certification complémentaire' }));
+      });
+
+      module('when the certified badge image has a message', function () {
+        test('should display the message', async function (assert) {
+          // given
+          certification = EmberObject.create({
+            id: 1,
+            birthdate: new Date('2000-01-22T15:15:52Z'),
+            firstName: 'Jean',
+            lastName: 'Bon',
+            date: new Date('2018-02-15T15:15:52Z'),
+            certificationCenter: 'Université de Lyon',
+            isPublished: true,
+            pixScore: 654,
+            status: 'validated',
+            hasAcquiredComplementaryCertifications: true,
+            certifiedBadgeImages: [
+              {
+                url: '/some/img',
+                message: 'Bravo Coco!',
+                levelName: 'Level Name',
+              },
+            ],
+          });
+          this.set('certification', certification);
+
+          // when
+          const screen = await renderScreen(
+            hbs`<UserCertificationsDetailResult @certification={{this.certification}}/>`,
+          );
+
+          // then
+          assert.ok(screen.getByText('Bravo Coco!'));
+        });
+      });
+    });
+
+    module('when certification has no certified badge image', function () {
+      test('should not show the complementary certification badge', async function (assert) {
+        // given
+        certification = EmberObject.create({
+          id: 1,
+          birthdate: new Date('2000-01-22T15:15:52Z'),
+          firstName: 'Jean',
+          lastName: 'Bon',
+          date: new Date('2018-02-15T15:15:52Z'),
+          certificationCenter: 'Université de Lyon',
+          isPublished: true,
+          pixScore: 654,
+          status: 'validated',
+          commentForCandidate: null,
+          certifiedBadgeImages: [],
+        });
+        this.set('certification', certification);
+
+        // when
+        const screen = await renderScreen(hbs`<UserCertificationsDetailResult @certification={{this.certification}}/>`);
+
+        // then
+        assert.notOk(screen.queryByRole('img', { name: 'Certification complémentaire' }));
       });
     });
   });
 
-  module('when certification has no certifed badge image', function () {
-    test('should not show the complementary certification badge', async function (assert) {
-      // given
-      certification = EmberObject.create({
-        id: 1,
-        birthdate: new Date('2000-01-22T15:15:52Z'),
-        firstName: 'Jean',
-        lastName: 'Bon',
-        date: new Date('2018-02-15T15:15:52Z'),
-        certificationCenter: 'Université de Lyon',
-        isPublished: true,
-        pixScore: 654,
-        status: 'validated',
-        commentForCandidate: null,
-        certifiedBadgeImages: [],
-      });
-      this.set('certification', certification);
-
-      // when
-      const screen = await renderScreen(hbs`<UserCertificationsDetailResult @certification={{this.certification}}/>`);
-      // then
-      assert.notOk(screen.queryByRole('img', { name: 'Certification complémentaire' }));
-    });
-  });
-
-  module('when certification has jury comments but no complementary certifed badges', function () {
+  module('when certification has jury comments but no complementary certified badge', function () {
     test('should not show the complementary certification badge section', async function (assert) {
       // given
       certification = EmberObject.create({

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -386,7 +386,7 @@
         "subtitle": "(levels out of {maxReachableLevel})"
       },
       "complementary": {
-        "title": "Other certification(s) awarded",
+        "title": "Other certification awarded",
         "alternative": "Additional certification"
       },
       "exam-date": "Completion date:",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -386,7 +386,7 @@
         "subtitle": "(niveaux sur {maxReachableLevel})"
       },
       "complementary": {
-        "title": "Autre(s) certification(s) obtenue(s)",
+        "title": "Autre certification obtenue",
         "alternative": "Certification complémentaire"
       },
       "exam-date": "Date de passage :",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -386,7 +386,7 @@
         "subtitle": "(niveaus op {maxReachableLevel})"
       },
       "complementary": {
-        "title": "Andere behaalde certificering(en)",
+        "title": "Andere behaalde certificering",
         "alternative": "Aanvullende certificering"
       },
       "exam-date": "Datum bezoek :",


### PR DESCRIPTION
## :unicorn: Problème
Autrefois, il y a fort longtemps, il était possible d'avoir plusieurs certification complémentaire par certification Pix.
Désormais on ne peut en avoir qu'un.
Il restait une petite coquille dans l'attestation Pix laissant croire qu'on peut en avoir plusieurs.

<img width="342" alt="Capture d’écran 2024-02-23 à 17 10 59" src="https://github.com/1024pix/pix/assets/58915422/a3f4c1f8-685d-499c-b7cb-1458f4ea9999">

## :robot: Proposition
<img width="334" alt="Capture d’écran 2024-02-23 à 17 09 38" src="https://github.com/1024pix/pix/assets/58915422/f8963b95-0f2c-4981-a894-a1ec3e062a3f">

## :100: Pour tester

- Se connecter sur Pix App avec user-1-7403@example.net
- Aller dans ses certification obtenues (menu de droite, mes certifications)
- Constater la présence du titre au singulier
