### PR TITLE
[FEATURE] Améliorer les messages d'erreur lors de la validation des modules (PIX-11303)

### DIFF
--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
@@ -2,6 +2,7 @@ import moduleDatasource from '../../../../../../src/devcomp/infrastructure/datas
 import { expect } from '../../../../../test-helper.js';
 import { LearningContentResourceNotFound } from '../../../../../../src/shared/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
 import { moduleSchema } from './validation/module.js';
+import { joiErrorParser } from './validation/joi-error-parser.js';
 
 const modules = await moduleDatasource.list();
 
@@ -35,11 +36,13 @@ describe('Unit | Infrastructure | Datasources | Learning Content | ModuleDatasou
       // eslint-disable-next-line mocha/no-setup-in-describe
       modules.forEach((module) => {
         it(`module "${module.slug}" should contain a valid structure`, async function () {
-          // When
-          const result = await moduleSchema.validateAsync(module);
+          try {
+            await moduleSchema.validateAsync(module, { abortEarly: false });
+          } catch (joiError) {
+            const formattedError = joiErrorParser.format(joiError);
 
-          // Then
-          expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));
+            expect(joiError).to.equal(undefined, formattedError);
+          }
         });
       });
     });

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/joi-error-parser.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/joi-error-parser.js
@@ -35,11 +35,8 @@ function logHtmlErrors(errorDetail, objectErrorSeparator) {
 }
 
 function logSchemaErrors(errorDetail) {
-  let errorLog = '';
-  errorLog = errorLog.concat('\n');
-  errorLog = errorLog.concat(`Error: ${errorDetail.message}.`);
-  errorLog = errorLog.concat('\n');
-  errorLog = errorLog.concat(`Valeur concernée à rechercher : ${JSON.stringify(errorDetail.context.value)}`);
-  errorLog = errorLog.concat('\n');
-  return errorLog;
+  const errorLog = [];
+  errorLog.push(`\nError: ${errorDetail.message}.`);
+  errorLog.push(`Valeur concernée à rechercher : ${JSON.stringify(errorDetail.context.value)}\n`);
+  return errorLog.join('\n');
 }

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/joi-error-parser.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/joi-error-parser.js
@@ -14,6 +14,8 @@ export const joiErrorParser = {
             for (const message of result.messages) {
               let errorLog = '';
               errorLog = errorLog.concat('\n');
+              errorLog = errorLog.concat('\nChemin : ', errorDetail.context.label);
+              errorLog = errorLog.concat('\n');
               errorLog = errorLog.concat('\n', severity[message.severity], `(${message.ruleId}): `, message.message);
               errorLog = errorLog.concat('\n', message.ruleUrl);
               errorLog = errorLog.concat('\n');

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/joi-error-parser.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/joi-error-parser.js
@@ -1,0 +1,12 @@
+export const joiErrorParser = {
+  format(error) {
+    const objectErrorSeparator = `\n${'─'.repeat(60)}\n`;
+    const visualSeparator = `\n${'='.repeat(60)}\n`;
+    return `${visualSeparator}${error.details
+      .map(
+        (error) =>
+          `\nError: ${error.message}.\nValeur concernée à rechercher : ${JSON.stringify(error.context.value)}\n`,
+      )
+      .join(objectErrorSeparator)}${visualSeparator}`;
+  },
+};

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/joi-error-parser.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/joi-error-parser.js
@@ -1,36 +1,48 @@
 export const joiErrorParser = {
   format(error) {
-    const severity = ['', 'Warning', 'Error'];
     const visualSeparator = `\n${'='.repeat(60)}\n`;
     const objectErrorSeparator = `\n${'─'.repeat(60)}\n`;
 
     return `${visualSeparator}${error.details
       .map((errorDetail) => {
         if (errorDetail.type === 'external') {
-          const report = errorDetail.context.value;
-          const errorLogs = [];
-          for (const result of report.results) {
-            const line = result.source ?? '';
-            for (const message of result.messages) {
-              let errorLog = '';
-              errorLog = errorLog.concat('\n');
-              errorLog = errorLog.concat('\nChemin : ', errorDetail.context.label);
-              errorLog = errorLog.concat('\n');
-              errorLog = errorLog.concat('\n', severity[message.severity], `(${message.ruleId}): `, message.message);
-              errorLog = errorLog.concat('\n', message.ruleUrl);
-              errorLog = errorLog.concat('\n');
-              errorLog = errorLog.concat('\n', 'Valeur concernée à rechercher :\n', line);
-              errorLog = errorLog.concat('\n');
-              errorLogs.push(errorLog);
-            }
-          }
-          return errorLogs.join(objectErrorSeparator);
+          return logHtmlErrors(errorDetail, objectErrorSeparator);
         } else {
-          return `\nError: ${errorDetail.message}.\nValeur concernée à rechercher : ${JSON.stringify(
-            errorDetail.context.value,
-          )}\n`;
+          return logSchemaErrors(errorDetail);
         }
       })
       .join(objectErrorSeparator)}${visualSeparator}`;
   },
 };
+
+function logHtmlErrors(errorDetail, objectErrorSeparator) {
+  const severity = ['', 'Warning', 'Error'];
+  const report = errorDetail.context.value;
+  const errorLogs = [];
+  for (const result of report.results) {
+    const line = result.source ?? '';
+    for (const message of result.messages) {
+      let errorLog = '';
+      errorLog = errorLog.concat('\n');
+      errorLog = errorLog.concat('\nChemin : ', errorDetail.context.label);
+      errorLog = errorLog.concat('\n');
+      errorLog = errorLog.concat('\n', severity[message.severity], `(${message.ruleId}): `, message.message);
+      errorLog = errorLog.concat('\n', message.ruleUrl);
+      errorLog = errorLog.concat('\n');
+      errorLog = errorLog.concat('\n', 'Valeur concernée à rechercher :\n', line);
+      errorLog = errorLog.concat('\n');
+      errorLogs.push(errorLog);
+    }
+  }
+  return errorLogs.join(objectErrorSeparator);
+}
+
+function logSchemaErrors(errorDetail) {
+  let errorLog = '';
+  errorLog = errorLog.concat('\n');
+  errorLog = errorLog.concat(`Error: ${errorDetail.message}.`);
+  errorLog = errorLog.concat('\n');
+  errorLog = errorLog.concat(`Valeur concernée à rechercher : ${JSON.stringify(errorDetail.context.value)}`);
+  errorLog = errorLog.concat('\n');
+  return errorLog;
+}

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/joi-error-parser.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/joi-error-parser.js
@@ -1,12 +1,34 @@
 export const joiErrorParser = {
   format(error) {
-    const objectErrorSeparator = `\n${'─'.repeat(60)}\n`;
+    const severity = ['', 'Warning', 'Error'];
     const visualSeparator = `\n${'='.repeat(60)}\n`;
+    const objectErrorSeparator = `\n${'─'.repeat(60)}\n`;
+
     return `${visualSeparator}${error.details
-      .map(
-        (error) =>
-          `\nError: ${error.message}.\nValeur concernée à rechercher : ${JSON.stringify(error.context.value)}\n`,
-      )
+      .map((errorDetail) => {
+        if (errorDetail.type === 'external') {
+          const report = errorDetail.context.value;
+          const errorLogs = [];
+          for (const result of report.results) {
+            const line = result.source ?? '';
+            for (const message of result.messages) {
+              let errorLog = '';
+              errorLog = errorLog.concat('\n');
+              errorLog = errorLog.concat('\n', severity[message.severity], `(${message.ruleId}): `, message.message);
+              errorLog = errorLog.concat('\n', message.ruleUrl);
+              errorLog = errorLog.concat('\n');
+              errorLog = errorLog.concat('\n', 'Valeur concernée à rechercher :\n', line);
+              errorLog = errorLog.concat('\n');
+              errorLogs.push(errorLog);
+            }
+          }
+          return errorLogs.join(objectErrorSeparator);
+        } else {
+          return `\nError: ${errorDetail.message}.\nValeur concernée à rechercher : ${JSON.stringify(
+            errorDetail.context.value,
+          )}\n`;
+        }
+      })
       .join(objectErrorSeparator)}${visualSeparator}`;
   },
 };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/joi-error-parser.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/joi-error-parser.js
@@ -22,16 +22,13 @@ function logHtmlErrors(errorDetail, objectErrorSeparator) {
   for (const result of report.results) {
     const line = result.source ?? '';
     for (const message of result.messages) {
-      let errorLog = '';
-      errorLog = errorLog.concat('\n');
-      errorLog = errorLog.concat('\nChemin : ', errorDetail.context.label);
-      errorLog = errorLog.concat('\n');
-      errorLog = errorLog.concat('\n', severity[message.severity], `(${message.ruleId}): `, message.message);
-      errorLog = errorLog.concat('\n', message.ruleUrl);
-      errorLog = errorLog.concat('\n');
-      errorLog = errorLog.concat('\n', 'Valeur concernée à rechercher :\n', line);
-      errorLog = errorLog.concat('\n');
-      errorLogs.push(errorLog);
+      const errorLog = [];
+      errorLog.push('\n');
+      errorLog.push(`Chemin : ${errorDetail.context.label}`);
+      errorLog.push(`\n${severity[message.severity]}(${message.ruleId}): ${message.message}`);
+      errorLog.push(`${message.ruleUrl}`);
+      errorLog.push(`\nValeur concernée à rechercher :\n${line}\n`);
+      errorLogs.push(errorLog.join('\n'));
     }
   }
   return errorLogs.join(objectErrorSeparator);

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/joi-error-parser_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/joi-error-parser_test.js
@@ -1,0 +1,76 @@
+import { expect } from '../../../../../../test-helper.js';
+import { joiErrorParser } from './joi-error-parser.js';
+
+describe('Unit | Infrastructure | Datasources | Learning Content | Module Datasource | joi error parser', function () {
+  it('should parse sync error', async function () {
+    const error = {
+      details: [
+        {
+          message: '"id" must be a valid GUID',
+          path: ['id'],
+          type: 'string.guid',
+          context: { label: 'id', value: 'f7b3a2-1a3d8f7e9f5d', key: 'id' },
+        },
+        {
+          message: '"transitionTexts[0].grainId" must be a valid GUID',
+          path: ['transitionTexts', 0, 'grainId'],
+          type: 'string.guid',
+          context: {
+            label: 'transitionTexts[0].grainId',
+            value: '34d225e8-de8438cfc9',
+            key: 'grainId',
+          },
+        },
+        {
+          message: '"grains[0].elements[0]" does not match any of the allowed types',
+          path: ['grains', 0, 'elements', 0],
+          type: 'alternatives.any',
+          context: {
+            label: 'grains[0].elements[0]',
+            value: {
+              id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
+              type: 'videox',
+              title: 'Le format des adresses mail',
+              url: 'https://videos.pix.fr/modulix/chat_animation_2.mp4',
+              subtitles: 'https://videos.pix.fr/modulix/chat_animation_2.vtt',
+              transcription: '<p>Coucou</p>',
+            },
+            key: 0,
+          },
+        },
+        {
+          message: '"grains[5].id" must be a valid GUID',
+          path: ['grains', 5, 'id'],
+          type: 'string.guid',
+          context: { label: 'grains[5].id', value: 'b7ea7630-824', key: 'id' },
+        },
+      ],
+    };
+
+    const expectedLog = `
+============================================================
+
+Error: "id" must be a valid GUID.
+Valeur concernée à rechercher : "f7b3a2-1a3d8f7e9f5d"
+
+────────────────────────────────────────────────────────────
+
+Error: "transitionTexts[0].grainId" must be a valid GUID.
+Valeur concernée à rechercher : "34d225e8-de8438cfc9"
+
+────────────────────────────────────────────────────────────
+
+Error: "grains[0].elements[0]" does not match any of the allowed types.
+Valeur concernée à rechercher : {"id":"3a9f2269-99ba-4631-b6fd-6802c88d5c26","type":"videox","title":"Le format des adresses mail","url":"https://videos.pix.fr/modulix/chat_animation_2.mp4","subtitles":"https://videos.pix.fr/modulix/chat_animation_2.vtt","transcription":"<p>Coucou</p>"}
+
+────────────────────────────────────────────────────────────
+
+Error: "grains[5].id" must be a valid GUID.
+Valeur concernée à rechercher : "b7ea7630-824"
+
+============================================================
+`;
+
+    expect(joiErrorParser.format(error)).to.equal(expectedLog);
+  });
+});

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/joi-error-parser_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/joi-error-parser_test.js
@@ -73,4 +73,82 @@ Valeur concernée à rechercher : "b7ea7630-824"
 
     expect(joiErrorParser.format(error)).to.equal(expectedLog);
   });
+
+  it('should parse html error', async function () {
+    const error = {
+      details: [
+        {
+          message: 'htmlvalidationerror',
+          path: ['transitionTexts', 0, 'content'],
+          type: 'external',
+          context: {
+            value: {
+              valid: false,
+              results: [
+                {
+                  filePath: 'inline',
+                  messages: [
+                    {
+                      ruleId: 'no-raw-characters',
+                      severity: 2,
+                      message: 'Raw "&" must be encoded as "&amp;"',
+                      offset: 13,
+                      line: 2,
+                      column: 13,
+                      size: 1,
+                      selector: 'h1',
+                      ruleUrl: 'https://html-validate.org/rules/no-raw-characters.html',
+                    },
+                    {
+                      ruleId: 'void-content',
+                      severity: 2,
+                      message: 'End tag for <input> must be omitted',
+                      offset: 51,
+                      line: 3,
+                      column: 23,
+                      size: 6,
+                      selector: null,
+                      ruleUrl: 'https://html-validate.org/rules/void-content.html',
+                      context: 'input',
+                    },
+                  ],
+                  errorCount: 2,
+                  warningCount: 0,
+                  source: '<h1>Hello & goodbye!</h1><input type="text"></input>',
+                },
+              ],
+              errorCount: 2,
+              warningCount: 0,
+            },
+            label: 'transitionTexts[0].content',
+            key: 'content',
+          },
+        },
+      ],
+    };
+
+    const expectedLog = `
+============================================================
+
+
+Error(no-raw-characters): Raw "&" must be encoded as "&amp;"
+https://html-validate.org/rules/no-raw-characters.html
+
+Valeur concernée à rechercher :
+<h1>Hello & goodbye!</h1><input type="text"></input>
+
+────────────────────────────────────────────────────────────
+
+
+Error(void-content): End tag for <input> must be omitted
+https://html-validate.org/rules/void-content.html
+
+Valeur concernée à rechercher :
+<h1>Hello & goodbye!</h1><input type="text"></input>
+
+============================================================
+`;
+
+    expect(joiErrorParser.format(error)).to.equal(expectedLog);
+  });
 });

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/joi-error-parser_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/joi-error-parser_test.js
@@ -2,7 +2,7 @@ import { expect } from '../../../../../../test-helper.js';
 import { joiErrorParser } from './joi-error-parser.js';
 
 describe('Unit | Infrastructure | Datasources | Learning Content | Module Datasource | joi error parser', function () {
-  it('should parse sync error', async function () {
+  it('should parse schema errors', async function () {
     const error = {
       details: [
         {
@@ -74,7 +74,7 @@ Valeur concernée à rechercher : "b7ea7630-824"
     expect(joiErrorParser.format(error)).to.equal(expectedLog);
   });
 
-  it('should parse html error', async function () {
+  it('should parse html errors', async function () {
     const error = {
       details: [
         {

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/joi-error-parser_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/joi-error-parser_test.js
@@ -116,6 +116,49 @@ Valeur concernée à rechercher : "b7ea7630-824"
                   warningCount: 0,
                   source: '<h1>Hello & goodbye!</h1><input type="text"></input>',
                 },
+                {
+                  filePath: 'inline',
+                  messages: [
+                    {
+                      ruleId: 'attr-quotes',
+                      severity: 2,
+                      message: 'Attribute "href" used \' instead of expected "',
+                      offset: 60,
+                      line: 1,
+                      column: 61,
+                      size: 52,
+                      selector: 'h4 > a',
+                      ruleUrl: 'https://html-validate.org/rules/attr-quotes.html',
+                      context: {
+                        error: 'style',
+                        attr: 'href',
+                        actual: "'",
+                        expected: '"',
+                      },
+                    },
+                    {
+                      ruleId: 'attr-quotes',
+                      severity: 2,
+                      message: 'Attribute "target" used \' instead of expected "',
+                      offset: 113,
+                      line: 1,
+                      column: 114,
+                      size: 14,
+                      selector: 'h4 > a',
+                      ruleUrl: 'https://html-validate.org/rules/attr-quotes.html',
+                      context: {
+                        error: 'style',
+                        attr: 'target',
+                        actual: "'",
+                        expected: '"',
+                      },
+                    },
+                  ],
+                  errorCount: 2,
+                  warningCount: 0,
+                  source:
+                    "<h4>Répondez aux questions ci-dessous en naviguant dans  <a href='https://fr.wikipedia.org/wiki/Charlie_Chaplin' target='blank'>l'article Wikipédia de Charlie Chaplin.</a></h4>",
+                },
               ],
               errorCount: 2,
               warningCount: 0,
@@ -124,12 +167,55 @@ Valeur concernée à rechercher : "b7ea7630-824"
             key: 'content',
           },
         },
+        {
+          message: 'htmlvalidationerror',
+          path: ['grains', 2, 'elements', 0, 'feedbacks', 'invalid'],
+          type: 'external',
+          context: {
+            value: {
+              valid: false,
+              results: [
+                {
+                  filePath: 'inline',
+                  messages: [
+                    {
+                      ruleId: 'attr-quotes',
+                      severity: 2,
+                      message: 'Attribute "aria-hidden" used \' instead of expected "',
+                      offset: 58,
+                      line: 1,
+                      column: 59,
+                      size: 18,
+                      selector: 'p > span',
+                      ruleUrl: 'https://html-validate.org/rules/attr-quotes.html',
+                      context: {
+                        error: 'style',
+                        attr: 'aria-hidden',
+                        actual: "'",
+                        expected: '"',
+                      },
+                    },
+                  ],
+                  errorCount: 1,
+                  warningCount: 0,
+                  source: "<p>Incorrect. Remonter la page pour relire la leçon <span aria-hidden='true'>⬆</span>️</p>",
+                },
+              ],
+              errorCount: 1,
+              warningCount: 0,
+            },
+            label: 'grains[2].elements[0].feedbacks.invalid',
+            key: 'invalid',
+          },
+        },
       ],
     };
 
     const expectedLog = `
 ============================================================
 
+
+Chemin : transitionTexts[0].content
 
 Error(no-raw-characters): Raw "&" must be encoded as "&amp;"
 https://html-validate.org/rules/no-raw-characters.html
@@ -140,11 +226,46 @@ Valeur concernée à rechercher :
 ────────────────────────────────────────────────────────────
 
 
+Chemin : transitionTexts[0].content
+
 Error(void-content): End tag for <input> must be omitted
 https://html-validate.org/rules/void-content.html
 
 Valeur concernée à rechercher :
 <h1>Hello & goodbye!</h1><input type="text"></input>
+
+────────────────────────────────────────────────────────────
+
+
+Chemin : transitionTexts[0].content
+
+Error(attr-quotes): Attribute "href" used ' instead of expected "
+https://html-validate.org/rules/attr-quotes.html
+
+Valeur concernée à rechercher :
+<h4>Répondez aux questions ci-dessous en naviguant dans  <a href='https://fr.wikipedia.org/wiki/Charlie_Chaplin' target='blank'>l'article Wikipédia de Charlie Chaplin.</a></h4>
+
+────────────────────────────────────────────────────────────
+
+
+Chemin : transitionTexts[0].content
+
+Error(attr-quotes): Attribute "target" used ' instead of expected "
+https://html-validate.org/rules/attr-quotes.html
+
+Valeur concernée à rechercher :
+<h4>Répondez aux questions ci-dessous en naviguant dans  <a href='https://fr.wikipedia.org/wiki/Charlie_Chaplin' target='blank'>l'article Wikipédia de Charlie Chaplin.</a></h4>
+
+────────────────────────────────────────────────────────────
+
+
+Chemin : grains[2].elements[0].feedbacks.invalid
+
+Error(attr-quotes): Attribute "aria-hidden" used ' instead of expected "
+https://html-validate.org/rules/attr-quotes.html
+
+Valeur concernée à rechercher :
+<p>Incorrect. Remonter la page pour relire la leçon <span aria-hidden='true'>⬆</span>️</p>
 
 ============================================================
 `;

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -13,53 +13,60 @@ import { getQcuSample } from '../../../../../../../src/devcomp/infrastructure/da
 import { getQrocmSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/qrocm.sample.js';
 import { getTextSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/text.sample.js';
 import { getVideoSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/video.sample.js';
+import { joiErrorParser } from './joi-error-parser.js';
 
 describe('Unit | Infrastructure | Datasources | Learning Content | Module Datasource | format validation', function () {
   it('should validate sample image structure', async function () {
-    // When
-    const result = await imageElementSchema.validateAsync(getImageSample());
-
-    // Then
-    expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));
+    try {
+      await imageElementSchema.validateAsync(getImageSample(), { abortEarly: false });
+    } catch (joiError) {
+      const formattedError = joiErrorParser.format(joiError);
+      expect(joiError).to.equal(undefined, formattedError);
+    }
   });
 
   it('should validate sample qcm structure', async function () {
-    // When
-    const result = await qcmElementSchema.validateAsync(getQcmSample());
-
-    // Then
-    expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));
+    try {
+      await qcmElementSchema.validateAsync(getQcmSample(), { abortEarly: false });
+    } catch (joiError) {
+      const formattedError = joiErrorParser.format(joiError);
+      expect(joiError).to.equal(undefined, formattedError);
+    }
   });
 
   it('should validate sample qcu structure', async function () {
-    // When
-    const result = await qcuElementSchema.validateAsync(getQcuSample());
-
-    // Then
-    expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));
+    try {
+      await qcuElementSchema.validateAsync(getQcuSample(), { abortEarly: false });
+    } catch (joiError) {
+      const formattedError = joiErrorParser.format(joiError);
+      expect(joiError).to.equal(undefined, formattedError);
+    }
   });
 
   it('should validate sample qrocm structure', async function () {
-    // When
-    const result = await qrocmElementSchema.validateAsync(getQrocmSample());
-
-    // Then
-    expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));
+    try {
+      await qrocmElementSchema.validateAsync(getQrocmSample(), { abortEarly: false });
+    } catch (joiError) {
+      const formattedError = joiErrorParser.format(joiError);
+      expect(joiError).to.equal(undefined, formattedError);
+    }
   });
 
   it('should validate sample text structure', async function () {
-    // When
-    const result = await textElementSchema.validateAsync(getTextSample());
-
-    // Then
-    expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));
+    try {
+      await textElementSchema.validateAsync(getTextSample(), { abortEarly: false });
+    } catch (joiError) {
+      const formattedError = joiErrorParser.format(joiError);
+      expect(joiError).to.equal(undefined, formattedError);
+    }
   });
 
   it('should validate sample video structure', async function () {
-    // When
-    const result = await videoElementSchema.validateAsync(getVideoSample());
-
-    // Then
-    expect(result.error).to.equal(undefined, result.error?.details.map((error) => error.message).join('. '));
+    try {
+      await videoElementSchema.validateAsync(getVideoSample(), { abortEarly: false });
+    } catch (joiError) {
+      const formattedError = joiErrorParser.format(joiError);
+      expect(joiError).to.equal(undefined, formattedError);
+    }
   });
 });

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module.js
@@ -36,14 +36,16 @@ const moduleSchema = Joi.object({
         title: Joi.string().required(),
         elements: Joi.array()
           .items(
-            Joi.alternatives().try(
-              textElementSchema,
-              imageElementSchema,
-              qcuElementSchema,
-              qcmElementSchema,
-              qrocmElementSchema,
-              videoElementSchema,
-            ),
+            Joi.alternatives().conditional('.type', {
+              switch: [
+                { is: 'text', then: textElementSchema },
+                { is: 'image', then: imageElementSchema },
+                { is: 'qcu', then: qcuElementSchema },
+                { is: 'qcm', then: qcmElementSchema },
+                { is: 'qrocm', then: qrocmElementSchema },
+                { is: 'video', then: videoElementSchema },
+              ],
+            }),
           )
           .required(),
       }).required(),

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/utils.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/utils.js
@@ -6,30 +6,12 @@ const uuidSchema = Joi.string().guid({ version: 'uuidv4' }).required();
 const proposalIdSchema = Joi.string().regex(/^\d+$/);
 
 const htmlValidate = new HtmlValidate();
-const severity = ['', 'Warning', 'Error'];
 const htmlSchema = Joi.string()
-  .external(async (value) => {
+  .external(async (value, helpers) => {
     const report = await htmlValidate.validateString(value);
 
     if (!report.valid) {
-      let errorLog = '';
-      errorLog = errorLog.concat('\n', `${report.errorCount} error(s), ${report.warningCount} warning(s)\n`);
-      errorLog = errorLog.concat('\n', '─'.repeat(60));
-      for (const result of report.results) {
-        const line = result.source ?? '';
-        for (const message of result.messages) {
-          errorLog = errorLog.concat('\n');
-          errorLog = errorLog.concat('\n', severity[message.severity], `(${message.ruleId}): `, message.message);
-          errorLog = errorLog.concat('\n', message.ruleUrl);
-          errorLog = errorLog.concat('\n');
-          errorLog = errorLog.concat('\n', line);
-          errorLog = errorLog.concat('\n');
-          errorLog = errorLog.concat('\n', '─'.repeat(60));
-          errorLog = errorLog.concat('\n');
-        }
-      }
-
-      throw new Error(errorLog);
+      return helpers.message('htmlvalidationerror', { value: report });
     }
   })
   .required();


### PR DESCRIPTION
## :unicorn: Problème
Jusqu'ici, les erreurs renvoyées par Joi lors des tests unitaires de validation du référentiel sont difficilement lisibles pour l'équipe Contenu. De plus, nous n'affichons qu'une erreur de validation à la fois.

## :robot: Proposition
Implémenter un parser d'erreur Joi qui permette d'afficher distinctement aussi bien les erreurs de validation synchrones que celles asynchrones (erreurs des string HTML).

## :rainbow: Remarques
Malgré tout, Joi évalue d'abord les erreurs de validation synchrones. S'il en trouve, il ne remontera pas les erreurs asynchrones s'il en existe.

Si on se réfère à [la documentation de Joi](https://joi.dev/api/?v=17.12.2#anyexternalmethod-description) :


> Note that external validation rules are only called after the all other validation rules for the entire schema (from the value root) are checked. This means that any changes made to the value by the external rules are not available to any other validation rules during the non-external validation phase.
>
> If schema validation failed, no external validation rules are called.

Dans une prochaine PR, il faudra faire en sorte que nos tests puissent remonter d'un coup toutes les erreurs rencontrées (sync et async).

## :100: Pour tester

1. Alternativement, ajouter une erreur synchrone dans le référentiel et lancer le test `#list` du `module-datasource`.
2. Constater le formatage humainement lisible.
3. Retirer votre erreur du référentiel.
4. Puis ajouter une erreur HTML.
5. Relancer le test.
6. Constater le formatage humainement lisible.
