### PR TITLE
[FEATURE] Créer la route PATCH /api/admin/certification-courses/{id} (PIX-10820).

### DIFF
--- a/admin/app/adapters/certification.js
+++ b/admin/app/adapters/certification.js
@@ -9,8 +9,8 @@ export default class Certification extends ApplicationAdapter {
     return `${this.host}/${this.namespace}/admin/certification-courses/${id}/assessment-results`;
   }
 
-  urlForUpdateRecord(id) {
-    return `${this.host}/${this.namespace}/certification-courses/${id}`;
+  urlForUpdateRecord(certificationCourseId) {
+    return `${this.host}/${this.namespace}/admin/certification-courses/${certificationCourseId}`;
   }
 
   updateRecord(store, type, snapshot) {

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -423,7 +423,7 @@ function routes() {
   this.patch('/cache', () => {});
   this.post('/lcms/releases', () => {});
 
-  this.patch('/certification-courses/:id', (schema, request) => {
+  this.patch('/admin/certification-courses/:id', (schema, request) => {
     const certificationId = request.params.id;
     const params = JSON.parse(request.requestBody).data.attributes;
 

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -589,7 +589,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
             // given
             await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
             this.server.patch(
-              '/certification-courses/:id',
+              'admin/certification-courses/:id',
               () => ({
                 errors: [{ detail: "Candidate's first name must not be blank or empty" }],
               }),
@@ -612,7 +612,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
             // given
             await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
             this.server.patch(
-              '/certification-courses/:id',
+              'admin/certification-courses/:id',
               () => ({
                 errors: [{ detail: "Candidate's first name must not be blank or empty" }],
               }),
@@ -635,7 +635,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
             // given
             await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
             this.server.patch(
-              '/certification-courses/:id',
+              'admin/certification-courses/:id',
               () => ({
                 errors: [{ detail: "Candidate's first name must not be blank or empty" }],
               }),

--- a/admin/tests/unit/adapters/certification_test.js
+++ b/admin/tests/unit/adapters/certification_test.js
@@ -108,7 +108,7 @@ module('Unit | Adapter | certification', function (hooks) {
         await adapter.updateRecord(store, { modelName: 'someModelName' }, { id: 123, adapterOptions: {} });
 
         // then
-        sinon.assert.calledWith(adapter.ajax, 'http://localhost:3000/api/certification-courses/123', 'PATCH');
+        sinon.assert.calledWith(adapter.ajax, 'http://localhost:3000/api/admin/certification-courses/123', 'PATCH');
         assert.ok(adapter); /* required because QUnit wants at least one expect (and does not accept Sinon's one) */
       });
     });

--- a/api/lib/application/certification-courses/certification-course-controller.js
+++ b/api/lib/application/certification-courses/certification-course-controller.js
@@ -25,7 +25,7 @@ const getJuryCertification = async function (request, h, dependencies = { juryCe
 };
 
 const update = async function (request, h, dependencies = { certificationSerializer }) {
-  const certificationCourseId = request.params.id;
+  const certificationCourseId = request.params.certificationCourseId;
   const userId = request.auth.credentials.userId;
   const command = await dependencies.certificationSerializer.deserializeCertificationCandidateModificationCommand(
     request.payload,

--- a/api/lib/application/certification-courses/index.js
+++ b/api/lib/application/certification-courses/index.js
@@ -5,7 +5,38 @@ import { certificationCourseController } from './certification-course-controller
 import { identifiersType } from '../../../src/shared/domain/types/identifiers-type.js';
 
 const register = async function (server) {
+  const adminRoutes = [
+    {
+      method: 'PATCH',
+      path: '/api/admin/certification-courses/{certificationCourseId}',
+      config: {
+        validate: {
+          params: Joi.object({
+            certificationCourseId: identifiersType.certificationCourseId,
+          }),
+        },
+        handler: certificationCourseController.update,
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        notes: [
+          'Cette route est utilisé par Pix Admin',
+          "Elle permet de modifier les informations d'un candidat de certification",
+        ],
+        tags: ['api', 'admin'],
+      },
+    },
+  ];
   server.route([
+    ...adminRoutes,
     {
       method: 'GET',
       path: '/api/admin/certifications/{id}/details',
@@ -92,11 +123,11 @@ const register = async function (server) {
     },
     {
       method: 'PATCH',
-      path: '/api/certification-courses/{id}',
+      path: '/api/certification-courses/{certificationCourseId}',
       config: {
         validate: {
           params: Joi.object({
-            id: identifiersType.certificationCourseId,
+            certificationCourseId: identifiersType.certificationCourseId,
           }),
         },
         handler: certificationCourseController.update,

--- a/api/lib/application/certification-courses/index.js
+++ b/api/lib/application/certification-courses/index.js
@@ -34,9 +34,6 @@ const register = async function (server) {
         tags: ['api', 'admin'],
       },
     },
-  ];
-  server.route([
-    ...adminRoutes,
     {
       method: 'GET',
       path: '/api/admin/certifications/{id}/details',
@@ -122,6 +119,57 @@ const register = async function (server) {
       },
     },
     {
+      method: 'POST',
+      path: '/api/admin/certification-courses/{id}/cancel',
+      config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.certificationCourseId,
+          }),
+        },
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: certificationCourseController.cancel,
+        tags: ['api'],
+      },
+    },
+    {
+      method: 'POST',
+      path: '/api/admin/certification-courses/{id}/uncancel',
+      config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.certificationCourseId,
+          }),
+        },
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: certificationCourseController.uncancel,
+        tags: ['api'],
+      },
+    },
+  ];
+  server.route([
+    ...adminRoutes,
+    {
       method: 'PATCH',
       path: '/api/certification-courses/{certificationCourseId}',
       config: {
@@ -190,54 +238,6 @@ const register = async function (server) {
           }),
         },
         handler: certificationCourseController.get,
-        tags: ['api'],
-      },
-    },
-    {
-      method: 'POST',
-      path: '/api/admin/certification-courses/{id}/cancel',
-      config: {
-        validate: {
-          params: Joi.object({
-            id: identifiersType.certificationCourseId,
-          }),
-        },
-        pre: [
-          {
-            method: (request, h) =>
-              securityPreHandlers.hasAtLeastOneAccessOf([
-                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-                securityPreHandlers.checkAdminMemberHasRoleCertif,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-              ])(request, h),
-            assign: 'hasAuthorizationToAccessAdminScope',
-          },
-        ],
-        handler: certificationCourseController.cancel,
-        tags: ['api'],
-      },
-    },
-    {
-      method: 'POST',
-      path: '/api/admin/certification-courses/{id}/uncancel',
-      config: {
-        validate: {
-          params: Joi.object({
-            id: identifiersType.certificationCourseId,
-          }),
-        },
-        pre: [
-          {
-            method: (request, h) =>
-              securityPreHandlers.hasAtLeastOneAccessOf([
-                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-                securityPreHandlers.checkAdminMemberHasRoleCertif,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-              ])(request, h),
-            assign: 'hasAuthorizationToAccessAdminScope',
-          },
-        ],
-        handler: certificationCourseController.uncancel,
         tags: ['api'],
       },
     },

--- a/api/lib/application/certification-courses/index.js
+++ b/api/lib/application/certification-courses/index.js
@@ -169,6 +169,11 @@ const register = async function (server) {
   ];
   server.route([
     ...adminRoutes,
+    /**
+     * @deprecated
+     * Route in no longer maintained
+     * Use instead PATCH /api/admin/certification-courses/{certificationCourseId}
+     */
     {
       method: 'PATCH',
       path: '/api/certification-courses/{certificationCourseId}',

--- a/api/tests/acceptance/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-courses/certification-course-controller_test.js
@@ -975,6 +975,114 @@ describe('Acceptance | API | Certification Course', function () {
       expect(response.statusCode).to.equal(200);
     });
   });
+
+  describe('PATCH /api/admin/certification-courses/{certificationCourseId}', function () {
+    context('when the user does not have role super admin', function () {
+      it('should return 403 HTTP status code', async function () {
+        // given
+        const options = {
+          headers: { authorization: generateValidRequestAuthorizationHeader() },
+          method: 'PATCH',
+          url: '/api/admin/certification-courses/1',
+          payload: {
+            data: {},
+          },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+
+    context('when the user does have role super admin', function () {
+      let options;
+      let certificationCourseId;
+
+      beforeEach(async function () {
+        await insertUserWithRoleSuperAdmin();
+        databaseBuilder.factory.buildCertificationCpfCountry({
+          code: '99100',
+          commonName: 'FRANCE',
+          matcher: 'ACEFNR',
+        });
+        databaseBuilder.factory.buildCertificationCpfCity({
+          name: 'CHATILLON EN MICHAILLE',
+          INSEECode: '01091',
+          isActualName: true,
+        });
+        certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+          verificationCode: 'ABCD123',
+          createdAt: new Date('2019-12-21T15:44:38Z'),
+          completedAt: new Date('2017-12-21T15:48:38Z'),
+          sex: 'F',
+        }).id;
+
+        options = {
+          headers: { authorization: generateValidRequestAuthorizationHeader() },
+          method: 'PATCH',
+          url: `/api/admin/certification-courses/${certificationCourseId}`,
+          payload: {
+            data: {
+              type: 'certifications',
+              id: certificationCourseId,
+              attributes: {
+                'first-name': 'Freezer',
+                'last-name': 'The all mighty',
+                birthplace: null,
+                birthdate: '1989-10-24',
+                'external-id': 'xenoverse2',
+                sex: 'M',
+                'birth-country': 'FRANCE',
+                'birth-insee-code': '01091',
+                'birth-postal-code': null,
+              },
+            },
+          },
+        };
+
+        return databaseBuilder.commit();
+      });
+
+      it('should update the certification course', async function () {
+        // when
+        const response = await server.inject(options);
+
+        // then
+        const result = response.result.data;
+        expect(result.attributes['first-name']).to.equal('Freezer');
+        expect(result.attributes['last-name']).to.equal('The all mighty');
+        expect(result.attributes['birthplace']).to.equal('CHATILLON EN MICHAILLE');
+        expect(result.attributes['birthdate']).to.equal('1989-10-24');
+        expect(result.attributes['sex']).to.equal('M');
+        expect(result.attributes['birth-country']).to.equal('FRANCE');
+        expect(result.attributes['birth-insee-code']).to.equal('01091');
+        expect(result.attributes['birth-postal-code']).to.be.null;
+        const { version, verificationCode } = await knex
+          .select('version', 'verificationCode')
+          .from('certification-courses')
+          .where({ id: certificationCourseId })
+          .first();
+        expect(version).to.equal(2);
+        expect(verificationCode).to.equal('ABCD123');
+      });
+
+      context('when birthdate is not a date', function () {
+        it('should return a wrong format error', async function () {
+          // given
+          options.payload.data.attributes.birthdate = 'aaaaaaa';
+
+          // when
+          const error = await server.inject(options);
+
+          // then
+          expect(error.statusCode).to.be.equal(400);
+        });
+      });
+    });
+  });
 });
 
 function _createRequestOptions(


### PR DESCRIPTION
## :unicorn: Problème
Dans cette PR de nettoyage https://github.com/1024pix/pix/pull/7858/files a été évoqué le besoin d'ajouter `admin` au path de la route existante `PATCH /api/certification-courses/{id}`

Seulement pour éviter tout risque de décalage de version entre le front et le back, il nous fallait créer une nouvelle route avec cette mention `admin` tout en gardant l'ancienne effective le temps que le front des utilisateurs s'adapte à l'api.

## :robot: Proposition
Créer la route PATCH /api/admin/certification-courses/{id}

## :rainbow: Remarques
l'ancienne route sera donc supprimé dans une autre PR.

## :100: Pour tester

- Se connecter à Pix Admin
- Se rendre dans une certification
- Cliquer sur un des candidats ayant participé à la certif
- Modifier ses infos
- constater dans la console admin dans la route
- constater que la modification s'est bien déroulé

<img width="487" alt="Capture d’écran 2024-02-23 à 17 26 03" src="https://github.com/1024pix/pix/assets/58915422/5a549673-63e9-4961-b419-c2f4a3177443">

