### PR TITLE
[TECH] Prendre en charge les dépréciations d'ember-data sur Pix App

### DIFF
--- a/mon-pix/app/models/assessment.js
+++ b/mon-pix/app/models/assessment.js
@@ -60,10 +60,10 @@ export default class Assessment extends Model {
       howManyAnswersSinceTheLastCheckpoint === 0
         ? -ENV.APP.NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS
         : -howManyAnswersSinceTheLastCheckpoint;
-    return this.answers.slice(sliceAnswersFrom);
+    return this.hasMany('answers').value().slice(sliceAnswersFrom);
   }
 
   get currentChallengeNumber() {
-    return this.answers.length;
+    return this.hasMany('answers').value().length;
   }
 }

--- a/mon-pix/app/models/campaign-participation-result.js
+++ b/mon-pix/app/models/campaign-participation-result.js
@@ -17,11 +17,11 @@ export default class CampaignParticipationResult extends Model {
 
   // includes
   @hasMany('campaignParticipationBadges', {
-    async: true,
+    async: false,
     inverse: 'campaignParticipationResult',
   })
   campaignParticipationBadges;
-  @hasMany('competenceResult', { async: true, inverse: 'campaignParticipationResult' }) competenceResults;
+  @hasMany('competenceResult', { async: false, inverse: 'campaignParticipationResult' }) competenceResults;
   @belongsTo('reachedStage', { async: false, inverse: 'campaignParticipationResult' }) reachedStage;
 
   get hasReachedStage() {

--- a/mon-pix/app/models/shared-profile-for-campaign.js
+++ b/mon-pix/app/models/shared-profile-for-campaign.js
@@ -9,7 +9,7 @@ export default class SharedProfileForCampaign extends Model {
   @attr('number') maxReachableLevel;
   @attr('date') sharedAt;
   @attr('boolean') canRetry;
-  @hasMany('scorecard', { async: true, inverse: null }) scorecards;
+  @hasMany('scorecard', { async: false, inverse: null }) scorecards;
 
   get areas() {
     return uniqBy(

--- a/mon-pix/app/routes/courses/start.js
+++ b/mon-pix/app/routes/courses/start.js
@@ -5,9 +5,12 @@ export default class CreateAssessmentRoute extends Route {
   @service store;
   @service router;
 
+  model(params) {
+    return this.store.findRecord('course', params.course_id);
+  }
+
   async afterModel(course) {
-    const store = this.store;
-    const assessment = await store.createRecord('assessment', { course, type: 'DEMO' }).save();
+    const assessment = await this.store.createRecord('assessment', { course, type: 'DEMO' }).save();
     return this.router.replaceWith('assessments.resume', assessment.id);
   }
 }

--- a/mon-pix/tests/unit/models/assessment_test.js
+++ b/mon-pix/tests/unit/models/assessment_test.js
@@ -18,8 +18,7 @@ module('Unit | Model | Assessment', function (hooks) {
 
     test('should return an empty array when no answers has been given', function (assert) {
       // given
-      const assessment = store.createRecord('assessment');
-      assessment.answers = [];
+      const assessment = store.createRecord('assessment', { answers: [] });
 
       // when
       const answersSinceLastCheckpoints = assessment.answersSinceLastCheckpoints;


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, il nous reste quelque dépréciations d'ember-data sur Pix App. Pour info, les dépréciations sont disponibles sur [cette page.](https://api.emberjs.com/ember-data/4.12/classes/currentdeprecations/properties/)

## :robot: Proposition
Prendre en charge les différentes dépréciations.

### Modèle `campaign-participation-result` : 

Le modèle `campaign-participation-result`, référence une relation `hasMany` pour `competenceResult` et est notée injustement de manière asynchrone, [alors qu'elle ne l'est pas. ](https://github.com/1024pix/pix/blob/754588636b611bce2ba4ea545d8bdae14529b2cc/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js)

### Modèle `shared-profile-for-campaign`
Le modèle `shared-profile-for-campaign`, référence une relation `hasMany` pour `scorecard` et est notée injustement de manière asynchrone, [alors qu'elle ne l'est pas. ](https://github.com/1024pix/pix/blob/754588636b611bce2ba4ea545d8bdae14529b2cc/api/lib/infrastructure/serializers/jsonapi/shared-profile-for-campaign-serializer.js)

### Usage de `store.find`

Ce petit filou, par défaut Ember.js quand la fonction `model` dans la route n'est pas définie fait lui même l'appel à la ressource. Cependant, il fait l'appel avec `store.find` ce qui est déprécié. Pour éviter ça, une fonction `model` a été créé. 

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- Passer une démo sur Pix App
- Passer une campagne de collecte de profile
- Passer une campagne et voir les résultats à la fin