### PR TITLE
[BUGFIX] Réactivation des stats d'accès aux tutos (PIX-11408)

### DIFF
--- a/mon-pix/app/components/tutorials/card.hbs
+++ b/mon-pix/app/components/tutorials/card.hbs
@@ -2,7 +2,13 @@
   <article class="tutorial-card" role="article">
     <div class="tutorial-card__content">
       <h4 class="tutorial-card-content__title">
-        <a target="_blank" rel={{this.linkRel}} href="{{@tutorial.link}}" title="{{@tutorial.title}}">
+        <a
+          target="_blank"
+          rel={{this.linkRel}}
+          href="{{@tutorial.link}}"
+          title="{{@tutorial.title}}"
+          {{on "click" this.trackAccess}}
+        >
           {{@tutorial.title}}
         </a>
       </h4>

--- a/mon-pix/app/components/tutorials/card.js
+++ b/mon-pix/app/components/tutorials/card.js
@@ -8,6 +8,8 @@ export default class Card extends Component {
   @service intl;
   @service store;
   @service currentUser;
+  @service metrics;
+  @service router;
 
   @tracked savingStatus;
   @tracked evaluationStatus;
@@ -97,5 +99,15 @@ export default class Card extends Component {
     } finally {
       this.evaluationStatus = tutorialEvaluation.isLiked ? buttonStatusTypes.recorded : buttonStatusTypes.unrecorded;
     }
+  }
+
+  @action
+  trackAccess() {
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Accès tuto',
+      'pix-event-action': `Click depuis : ${this.router.currentRouteName}`,
+      'pix-event-name': `Ouvre le tutoriel : ${this.args.tutorial.title}`,
+    });
   }
 }

--- a/mon-pix/tests/unit/components/tutorials/card_test.js
+++ b/mon-pix/tests/unit/components/tutorials/card_test.js
@@ -205,4 +205,30 @@ module('Unit | Component | Tutorial | card item', function (hooks) {
       assert.strictEqual(result, null);
     });
   });
+
+  module('#trackAccess', function () {
+    test('should push event on click', function (assert) {
+      // given
+      const metrics = this.owner.lookup('service:metrics');
+      metrics.add = sinon.stub();
+      const tutorialTitle = 'Mon super tutoriel';
+      component = createGlimmerComponent('tutorials/card', {
+        tutorial: { ...tutorial, title: tutorialTitle, link: 'https://exemple.net/' },
+      });
+      const currentRouteName = 'current.route.name';
+      component.router = { currentRouteName };
+
+      // when
+      component.trackAccess();
+
+      // then
+      sinon.assert.calledWithExactly(metrics.add, {
+        event: 'custom-event',
+        'pix-event-category': 'Accès tuto',
+        'pix-event-action': `Click depuis : ${currentRouteName}`,
+        'pix-event-name': `Ouvre le tutoriel : ${tutorialTitle}`,
+      });
+      assert.ok(true);
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Les accès aux tutos ne sont plus mesurés depuis #5560 car on se basait sur une classe CSS...

## :robot: Proposition
Rendre visible le tracking via une action dans le code JS du composant.

Il ne faudra pas oublier de nettoyer Matomo Tag Manager.

## :rainbow: Remarques
Pas de certitude que l'événement "click" attrape tous les événements qui ouvrent un lien.

Je ne sais pas correctement tester ce tracking : j'ai essayé avec un test d'intégration avec un "vrai" click (ce qui fonctionne) mais je n'ai pas envie qu'une nouvelle page s'ouvre pendant l'exécution des tests ^^".

## :100: Pour tester
Vérifier qu'un appel à Matomo est bien fait lors d'un clic sur un tutoriel.
