### PR TITLE
[TECH] Avoir des erreurs serveurs en anglais (PIX-10792)

### DIFF
--- a/api/src/devcomp/domain/errors.js
+++ b/api/src/devcomp/domain/errors.js
@@ -13,7 +13,7 @@ class PassageDoesNotExistError extends DomainError {
 }
 
 class UserNotAuthorizedToFindTrainings extends DomainError {
-  constructor(message = "Cet utilisateur n'est pas autorisé à récupérer les formations.") {
+  constructor(message = 'This user is not authorized to access the trainings.') {
     super(message);
   }
 }

--- a/api/src/devcomp/domain/models/ElementAnswer.js
+++ b/api/src/devcomp/domain/models/ElementAnswer.js
@@ -2,12 +2,9 @@ import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.
 
 class ElementAnswer {
   constructor({ id, elementId, userResponseValue, correction }) {
-    assertNotNullOrUndefined(elementId, "L'id de l'élément est obligatoire pour une réponse d'élément");
-    assertNotNullOrUndefined(
-      userResponseValue,
-      "La réponse de l'utilisateur est obligatoire pour une réponse d'élément",
-    );
-    assertNotNullOrUndefined(correction, "La correction est obligatoire pour une réponse d'élément");
+    assertNotNullOrUndefined(elementId, 'The id of the element is required for an element answer.');
+    assertNotNullOrUndefined(userResponseValue, 'The user response is required for an element answer.');
+    assertNotNullOrUndefined(correction, 'The correction is required for an element answer.');
 
     this.id = id;
     this.elementId = elementId;

--- a/api/src/devcomp/domain/models/Feedbacks.js
+++ b/api/src/devcomp/domain/models/Feedbacks.js
@@ -2,8 +2,8 @@ import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.
 
 class Feedbacks {
   constructor({ valid, invalid }) {
-    assertNotNullOrUndefined(valid, 'Le message de feedback valide est obligatoire');
-    assertNotNullOrUndefined(invalid, 'Le message de feedback invalide est obligatoire');
+    assertNotNullOrUndefined(valid, 'The feedback message for the field valid is required');
+    assertNotNullOrUndefined(invalid, 'The feedback message for the field invalid is required');
 
     this.valid = valid;
     this.invalid = invalid;

--- a/api/src/devcomp/domain/models/Grain.js
+++ b/api/src/devcomp/domain/models/Grain.js
@@ -3,9 +3,9 @@ import { NotFoundError } from '../../../shared/domain/errors.js';
 
 class Grain {
   constructor({ id, title, type, elements }) {
-    assertNotNullOrUndefined(id, "L'id est obligatoire pour un grain");
-    assertNotNullOrUndefined(title, 'Le titre est obligatoire pour un grain');
-    assertNotNullOrUndefined(elements, `Une liste d'éléments est obligatoire pour un grain`);
+    assertNotNullOrUndefined(id, 'The id is required for a grain');
+    assertNotNullOrUndefined(title, 'The title is required for a grain');
+    assertNotNullOrUndefined(elements, `A list of elements is required for a grain`);
     this.#assertElementsIsAnArray(elements);
 
     this.id = id;
@@ -26,7 +26,7 @@ class Grain {
 
   #assertElementsIsAnArray(elements) {
     if (!Array.isArray(elements)) {
-      throw new Error(`Un Grain doit forcément posséder une liste d'éléments`);
+      throw new Error(`A grain should have a list of elements`);
     }
   }
 }

--- a/api/src/devcomp/domain/models/QcuCorrectionResponse.js
+++ b/api/src/devcomp/domain/models/QcuCorrectionResponse.js
@@ -2,9 +2,9 @@ import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.
 
 class QcuCorrectionResponse {
   constructor({ status, feedback, solution }) {
-    assertNotNullOrUndefined(status, 'Le résultat est obligatoire pour une réponse de QCU');
-    assertNotNullOrUndefined(feedback, 'Le feedback est obligatoire pour une réponse de QCU');
-    assertNotNullOrUndefined(solution, "L'id de la proposition correcte est obligatoire pour une réponse de QCU");
+    assertNotNullOrUndefined(status, 'The result is required for a QCU response');
+    assertNotNullOrUndefined(feedback, 'The feedback is required for a QCU response');
+    assertNotNullOrUndefined(solution, 'The id of the correct proposal is required for a QCU response');
 
     this.status = status;
     this.feedback = feedback;

--- a/api/src/devcomp/domain/models/QcuProposal.js
+++ b/api/src/devcomp/domain/models/QcuProposal.js
@@ -2,8 +2,8 @@ import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.
 
 class QcuProposal {
   constructor({ id, content }) {
-    assertNotNullOrUndefined(id, "L'id est obligatoire pour une proposition de QCU");
-    assertNotNullOrUndefined(content, 'Le contenu est obligatoire pour une proposition de QCU');
+    assertNotNullOrUndefined(id, 'The id is required for a QCU proposal.');
+    assertNotNullOrUndefined(content, 'The content is required for a QCU proposal.');
 
     this.id = id;
     this.content = content;

--- a/api/src/devcomp/domain/models/QrocmCorrectionResponse.js
+++ b/api/src/devcomp/domain/models/QrocmCorrectionResponse.js
@@ -2,9 +2,9 @@ import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.
 
 class QrocmCorrectionResponse {
   constructor({ status, feedback, solution }) {
-    assertNotNullOrUndefined(status, 'Le résultat est obligatoire pour une réponse de QROCM');
-    assertNotNullOrUndefined(feedback, 'Le feedback est obligatoire pour une réponse de QROCM');
-    assertNotNullOrUndefined(solution, 'La solution est obligatoire pour une réponse de QROCM');
+    assertNotNullOrUndefined(status, 'The result is required in a QROCM correction');
+    assertNotNullOrUndefined(feedback, 'The feedback is required in a QROCM correction');
+    assertNotNullOrUndefined(solution, 'The solution is required in a QROCM correction');
 
     this.status = status;
     this.feedback = feedback;

--- a/api/src/devcomp/domain/models/QrocmSolutions.js
+++ b/api/src/devcomp/domain/models/QrocmSolutions.js
@@ -7,17 +7,17 @@ class QrocmSolutions {
       .forEach((proposal) => {
         assertNotNullOrUndefined(
           proposal.solutions,
-          'Les solutions sont obligatoires pour toutes les solutions de QROCM',
+          'The solutions are required for each QROCM proposal in QROCM solutions',
         );
         assertNotNullOrUndefined(
           proposal.tolerances,
-          'Les tolérances sont obligatoires pour toutes les solutions de QROCM',
+          'The tolerances are required for each QROCM proposal in QROCM solutions',
         );
         if (!Array.isArray(proposal.solutions)) {
-          throw new Error('Une solution de QROCM doit forcément posséder une liste de solutions');
+          throw new Error('Each proposal in QROCM solutions should have a list of solutions');
         }
         if (!Array.isArray(proposal.tolerances)) {
-          throw new Error('Une solution de QROCM doit forcément posséder une liste de tolérances');
+          throw new Error('A QROCM solution should have a list of tolerances');
         }
       });
 

--- a/api/src/devcomp/domain/models/TransitionText.js
+++ b/api/src/devcomp/domain/models/TransitionText.js
@@ -2,8 +2,8 @@ import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.
 
 class TransitionText {
   constructor({ content, grainId }) {
-    assertNotNullOrUndefined(content, 'Le contenu est obligatoire pour un texte de transition');
-    assertNotNullOrUndefined(grainId, "L'id de grain est obligatoire pour un texte de transition");
+    assertNotNullOrUndefined(content, 'The content is required for a transition text');
+    assertNotNullOrUndefined(grainId, 'The grain id is required for a transition text');
 
     this.content = content;
     this.grainId = grainId;

--- a/api/src/devcomp/domain/models/block/BlockInput.js
+++ b/api/src/devcomp/domain/models/block/BlockInput.js
@@ -2,15 +2,15 @@ import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asser
 
 class BlockInput {
   constructor({ input, inputType, size, display, placeholder, ariaLabel, defaultValue, tolerances, solutions }) {
-    assertNotNullOrUndefined(input, "L'input est obligatoire pour un bloc d'input");
-    assertNotNullOrUndefined(inputType, "Le type d'input est obligatoire pour un bloc d'input");
-    assertNotNullOrUndefined(size, "La taille est obligatoire pour un bloc d'input");
-    assertNotNullOrUndefined(display, "Le display est obligatoire pour un bloc d'input");
-    assertNotNullOrUndefined(placeholder, "Le placeholder est obligatoire pour un bloc d'input");
-    assertNotNullOrUndefined(ariaLabel, "L'aria Label est obligatoire pour un bloc d'input");
-    assertNotNullOrUndefined(defaultValue, "La valeur par défaut est obligatoire pour un bloc d'input");
-    assertNotNullOrUndefined(tolerances, "Les tolérances sont obligatoires pour un bloc d'input");
-    assertNotNullOrUndefined(solutions, "Les solutions sont obligatoires pour un bloc d'input");
+    assertNotNullOrUndefined(input, 'The input is required for an input block');
+    assertNotNullOrUndefined(inputType, 'The input type is required for an input block');
+    assertNotNullOrUndefined(size, 'The size is required for an input block');
+    assertNotNullOrUndefined(display, 'The display is required for an input block');
+    assertNotNullOrUndefined(placeholder, 'The placeholder is required for an input block');
+    assertNotNullOrUndefined(ariaLabel, 'The aria Label is required for an input block');
+    assertNotNullOrUndefined(defaultValue, 'The default value is required for an input block');
+    assertNotNullOrUndefined(tolerances, 'The tolerances are required for an input block');
+    assertNotNullOrUndefined(solutions, 'The solutions are required for an input block');
 
     this.type = 'input';
     this.input = input;

--- a/api/src/devcomp/domain/models/block/BlockSelect.js
+++ b/api/src/devcomp/domain/models/block/BlockSelect.js
@@ -2,14 +2,14 @@ import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asser
 
 class BlockSelect {
   constructor({ input, display, placeholder, ariaLabel, defaultValue, tolerances, options, solutions }) {
-    assertNotNullOrUndefined(input, "L'input est obligatoire pour un bloc de selection");
-    assertNotNullOrUndefined(display, 'Le display est obligatoire pour un bloc de selection');
-    assertNotNullOrUndefined(placeholder, 'Le placeholder est obligatoire pour un bloc de selection');
-    assertNotNullOrUndefined(ariaLabel, "L'aria Label est obligatoire pour un bloc de selection");
-    assertNotNullOrUndefined(defaultValue, 'La valeur par défaut est obligatoire pour un bloc de selection');
-    assertNotNullOrUndefined(tolerances, 'Les tolérances sont obligatoires pour un bloc de selection');
-    assertNotNullOrUndefined(options, 'Les options sont obligatoires pour un bloc de selection');
-    assertNotNullOrUndefined(solutions, 'Les solutions sont obligatoires pour un bloc de selection');
+    assertNotNullOrUndefined(input, 'The input is required for a select block');
+    assertNotNullOrUndefined(display, 'The display is required for a select block');
+    assertNotNullOrUndefined(placeholder, 'The placeholder is required for a select block');
+    assertNotNullOrUndefined(ariaLabel, 'The aria Label is required for a select block');
+    assertNotNullOrUndefined(defaultValue, 'The default value is required for a select block');
+    assertNotNullOrUndefined(tolerances, 'The tolerances are required for a select block');
+    assertNotNullOrUndefined(options, 'The options are required for a select block');
+    assertNotNullOrUndefined(solutions, 'The solutions are required for a select block');
 
     this.type = 'select';
     this.input = input;

--- a/api/src/devcomp/domain/models/block/BlockSelectOption.js
+++ b/api/src/devcomp/domain/models/block/BlockSelectOption.js
@@ -2,8 +2,8 @@ import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asser
 
 class BlockSelectOption {
   constructor({ id, content }) {
-    assertNotNullOrUndefined(id, "L'id est obligatoire pour une option de bloc select");
-    assertNotNullOrUndefined(content, 'Le contenu est obligatoire pour une option de bloc select');
+    assertNotNullOrUndefined(id, 'The id is required for a select block option');
+    assertNotNullOrUndefined(content, 'The content is required for a select block option');
 
     this.id = id;
     this.content = content;

--- a/api/src/devcomp/domain/models/block/BlockText.js
+++ b/api/src/devcomp/domain/models/block/BlockText.js
@@ -2,7 +2,7 @@ import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asser
 
 class BlockText {
   constructor({ content }) {
-    assertNotNullOrUndefined(content, 'Le contenu est obligatoire pour un bloc de texte');
+    assertNotNullOrUndefined(content, 'The content is required for a text block');
     this.content = content;
     this.type = 'text';
   }

--- a/api/src/devcomp/domain/models/element/Image.js
+++ b/api/src/devcomp/domain/models/element/Image.js
@@ -5,9 +5,9 @@ class Image extends Element {
   constructor({ id, url, alt, alternativeText }) {
     super({ id, type: 'image' });
 
-    assertNotNullOrUndefined(url, "L'URL est obligatoire pour une image");
-    assertNotNullOrUndefined(alt, 'Le contenu alt est obligatoire pour une image');
-    assertNotNullOrUndefined(alternativeText, "L'instruction alternative est obligatoire pour une image");
+    assertNotNullOrUndefined(url, 'The URL is required for an image');
+    assertNotNullOrUndefined(alt, 'The alt text is required for an image');
+    assertNotNullOrUndefined(alternativeText, 'The alternative instruction is required for an image');
 
     this.url = url;
     this.alt = alt;

--- a/api/src/devcomp/domain/models/element/QCU-for-answer-verification.js
+++ b/api/src/devcomp/domain/models/element/QCU-for-answer-verification.js
@@ -11,7 +11,7 @@ class QCUForAnswerVerification extends QCU {
   constructor({ id, instruction, locales, proposals, solution, feedbacks, validator }) {
     super({ id, instruction, locales, proposals });
 
-    assertNotNullOrUndefined(solution, 'La solution est obligatoire pour un QCU de vérification');
+    assertNotNullOrUndefined(solution, 'The solution is required for a verification QCU');
 
     this.solutionValue = solution;
 

--- a/api/src/devcomp/domain/models/element/QCU.js
+++ b/api/src/devcomp/domain/models/element/QCU.js
@@ -5,7 +5,7 @@ class QCU extends Element {
   constructor({ id, instruction, locales, proposals }) {
     super({ id, type: 'qcu' });
 
-    assertNotNullOrUndefined(instruction, "L'instruction est obligatoire pour un QCU");
+    assertNotNullOrUndefined(instruction, 'The instruction is required for a QCU');
     this.#assertProposalsIsAnArray(proposals);
     this.#assertProposalsAreNotEmpty(proposals);
 
@@ -17,13 +17,13 @@ class QCU extends Element {
 
   #assertProposalsAreNotEmpty(proposals) {
     if (proposals.length === 0) {
-      throw new Error('Les propositions sont obligatoires pour un QCU');
+      throw new Error('The proposals are required for a QCU');
     }
   }
 
   #assertProposalsIsAnArray(proposals) {
     if (!Array.isArray(proposals)) {
-      throw new Error('Les propositions doivent apparaître dans une liste');
+      throw new Error('The QCU proposals should be a list');
     }
   }
 }

--- a/api/src/devcomp/domain/models/element/QROCM-for-answer-verification.js
+++ b/api/src/devcomp/domain/models/element/QROCM-for-answer-verification.js
@@ -13,7 +13,7 @@ class QROCMForAnswerVerification extends QROCM {
   constructor({ id, instruction, feedbacks, proposals, locales, validator }) {
     super({ id, instruction, proposals, locales });
 
-    assertNotNullOrUndefined(feedbacks, 'Les feedbacks sont obligatoires pour un QROCM de vérification');
+    assertNotNullOrUndefined(feedbacks, 'The feedbacks are required for a verification QROCM.');
 
     this.feedbacks = feedbacks;
 

--- a/api/src/devcomp/domain/models/element/Text.js
+++ b/api/src/devcomp/domain/models/element/Text.js
@@ -5,7 +5,7 @@ class Text extends Element {
   constructor({ id, content }) {
     super({ id, type: 'text' });
 
-    assertNotNullOrUndefined(content, 'Le contenu est obligatoire pour un texte');
+    assertNotNullOrUndefined(content, 'The content is required for a text');
 
     this.content = content;
   }

--- a/api/src/devcomp/domain/models/element/Video.js
+++ b/api/src/devcomp/domain/models/element/Video.js
@@ -5,10 +5,10 @@ class Video extends Element {
   constructor({ id, title, url, subtitles, transcription }) {
     super({ id, type: 'video' });
 
-    assertNotNullOrUndefined(url, "L'URL est obligatoire pour un video");
-    assertNotNullOrUndefined(title, 'Le titre est obligatoire pour un video');
-    assertNotNullOrUndefined(subtitles, 'Les sous-titres sont obligatoire pour un video');
-    assertNotNullOrUndefined(transcription, 'Les transcriptions sont obligatoire pour un video');
+    assertNotNullOrUndefined(title, 'The title is required for a video');
+    assertNotNullOrUndefined(url, 'The URL is required for a video');
+    assertNotNullOrUndefined(subtitles, 'The subtitles are required for a video');
+    assertNotNullOrUndefined(transcription, 'The transcription is required for a video');
 
     this.url = url;
     this.title = title;

--- a/api/src/devcomp/domain/models/module/Module.js
+++ b/api/src/devcomp/domain/models/module/Module.js
@@ -3,10 +3,10 @@ import { NotFoundError } from '../../../../shared/domain/errors.js';
 
 class Module {
   constructor({ id, slug, title, grains, details, transitionTexts = [] }) {
-    assertNotNullOrUndefined(id, "L'id est obligatoire pour un module");
-    assertNotNullOrUndefined(title, 'Le titre est obligatoire pour un module');
-    assertNotNullOrUndefined(slug, 'Le slug est obligatoire pour un module');
-    assertNotNullOrUndefined(grains, 'Une liste de grains est obligatoire pour un module');
+    assertNotNullOrUndefined(id, 'The id is required for a module');
+    assertNotNullOrUndefined(title, 'The title is required for a module');
+    assertNotNullOrUndefined(slug, 'The slug is required for a module');
+    assertNotNullOrUndefined(grains, 'A list of grains is required for a module');
     this.#assertGrainsIsAnArray(grains);
     assertNotNullOrUndefined(details, 'The details are required for a module');
     this.#assertTransitionTextsLinkedToGrain(transitionTexts, grains);
@@ -24,13 +24,13 @@ class Module {
       ({ grainId }) => !!grains.find(({ id }) => grainId === id),
     );
     if (!isTransitionTextsLinkedToGrain) {
-      throw new Error('Tous les textes de transition doivent être lié à un grain présent dans le module');
+      throw new Error('All the transition texts should be linked to a grain contained in the module.');
     }
   }
 
   #assertGrainsIsAnArray(grains) {
     if (!Array.isArray(grains)) {
-      throw new Error('Un Module doit forcément posséder une liste de grains');
+      throw new Error('A module should have a list of grains');
     }
   }
 

--- a/api/src/devcomp/domain/services/solution-service-qrocm-ind.js
+++ b/api/src/devcomp/domain/services/solution-service-qrocm-ind.js
@@ -77,7 +77,7 @@ function _compareAnswersAndSolutions(answers, solutions, enabledTreatments, qroc
           Object.keys(solutions)[0]
         }`,
       );
-      throw new Error("Une erreur s'est produite lors de l'interprétation des réponses.");
+      throw new Error('An error occurred because there is no solution found for an answer.');
     }
     if (useLevenshteinRatio(enabledTreatments) && qrocBlocksTypes[answerKey] != 'select') {
       results[answerKey] = _areApproximatelyEqualAccordingToLevenshteinDistanceRatio(answer, solutionVariants);

--- a/api/tests/devcomp/integration/domain/models/Module_test.js
+++ b/api/tests/devcomp/integration/domain/models/Module_test.js
@@ -29,7 +29,7 @@ describe('Integration | Devcomp | Domain | Models | Module', function () {
       const details = Symbol('details');
 
       expect(() => new Module({ id, slug, title, grains, transitionTexts, details })).to.throw(
-        'Tous les textes de transition doivent être lié à un grain présent dans le module',
+        'All the transition texts should be linked to a grain contained in the module.',
       );
     });
   });

--- a/api/tests/devcomp/unit/domain/models/ElementAnswer_test.js
+++ b/api/tests/devcomp/unit/domain/models/ElementAnswer_test.js
@@ -22,14 +22,14 @@ describe('Unit | Devcomp | Domain | Models | ElementAnswer', function () {
 
     describe('An element answer without element id', function () {
       it('should throw an error', function () {
-        expect(() => new ElementAnswer({})).to.throw("L'id de l'élément est obligatoire pour une réponse d'élément");
+        expect(() => new ElementAnswer({})).to.throw('The id of the element is required for an element answer.');
       });
     });
 
     describe('An element answer without user response value', function () {
       it('should throw an error', function () {
         expect(() => new ElementAnswer({ elementId: 'elementId' })).to.throw(
-          "La réponse de l'utilisateur est obligatoire pour une réponse d'élément",
+          'The user response is required for an element answer.',
         );
       });
     });
@@ -37,7 +37,7 @@ describe('Unit | Devcomp | Domain | Models | ElementAnswer', function () {
     describe('An element answer without correction', function () {
       it('should throw an error', function () {
         expect(() => new ElementAnswer({ elementId: 'elementId', userResponseValue: 'userResponseValue' })).to.throw(
-          "La correction est obligatoire pour une réponse d'élément",
+          'The correction is required for an element answer.',
         );
       });
     });

--- a/api/tests/devcomp/unit/domain/models/Feedbacks_test.js
+++ b/api/tests/devcomp/unit/domain/models/Feedbacks_test.js
@@ -22,13 +22,15 @@ describe('Unit | Devcomp | Domain | Models | Feedbacks', function () {
 
   describe('An empty Feedbacks', function () {
     it('should throw an error', function () {
-      expect(() => new Feedbacks({})).to.throw('Le message de feedback valide est obligatoire');
+      expect(() => new Feedbacks({})).to.throw('The feedback message for the field valid is required');
     });
   });
 
   describe('A Feedbacks without invalid key', function () {
     it('should throw an error', function () {
-      expect(() => new Feedbacks({ valid: 'valid' })).to.throw('Le message de feedback invalide est obligatoire');
+      expect(() => new Feedbacks({ valid: 'valid' })).to.throw(
+        'The feedback message for the field invalid is required',
+      );
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/Grain_test.js
+++ b/api/tests/devcomp/unit/domain/models/Grain_test.js
@@ -21,13 +21,13 @@ describe('Unit | Devcomp | Domain | Models | Grain', function () {
 
     describe('if a grain does not have an id', function () {
       it('should throw an error', function () {
-        expect(() => new Grain({})).to.throw("L'id est obligatoire pour un grain");
+        expect(() => new Grain({})).to.throw('The id is required for a grain');
       });
     });
 
     describe('if a grain does not have a title', function () {
       it('should throw an error', function () {
-        expect(() => new Grain({ id: 1 })).to.throw('Le titre est obligatoire pour un grain');
+        expect(() => new Grain({ id: 1 })).to.throw('The title is required for a grain');
       });
     });
 
@@ -35,7 +35,7 @@ describe('Unit | Devcomp | Domain | Models | Grain', function () {
       describe('given no grain param', function () {
         it('should throw an error', function () {
           expect(() => new Grain({ id: 'id_grain_1', title: 'Bien écrire son adresse mail' })).to.throw(
-            `Une liste d'éléments est obligatoire pour un grain`,
+            `A list of elements is required for a grain`,
           );
         });
       });
@@ -49,7 +49,7 @@ describe('Unit | Devcomp | Domain | Models | Grain', function () {
                 title: 'Bien écrire son adresse mail',
                 elements: 'elements',
               }),
-          ).to.throw(`Un Grain doit forcément posséder une liste d'éléments`);
+          ).to.throw(`A grain should have a list of elements`);
         });
       });
     });

--- a/api/tests/devcomp/unit/domain/models/QcuCorrectionResponse_test.js
+++ b/api/tests/devcomp/unit/domain/models/QcuCorrectionResponse_test.js
@@ -23,14 +23,14 @@ describe('Unit | Devcomp | Domain | Models | QcuCorrectionResponse', function ()
 
   describe('A QCU correction response without status', function () {
     it('should throw an error', function () {
-      expect(() => new QcuCorrectionResponse({})).to.throw('Le résultat est obligatoire pour une réponse de QCU');
+      expect(() => new QcuCorrectionResponse({})).to.throw('The result is required for a QCU response');
     });
   });
 
   describe('A QCU correction response without feedback', function () {
     it('should throw an error', function () {
       expect(() => new QcuCorrectionResponse({ status: AnswerStatus.OK })).to.throw(
-        'Le feedback est obligatoire pour une réponse de QCU',
+        'The feedback is required for a QCU response',
       );
     });
   });
@@ -38,7 +38,7 @@ describe('Unit | Devcomp | Domain | Models | QcuCorrectionResponse', function ()
   describe('A QCU correction response without proposal id', function () {
     it('should throw an error', function () {
       expect(() => new QcuCorrectionResponse({ status: AnswerStatus.OK, feedback: 'Bien joué !' })).to.throw(
-        "L'id de la proposition correcte est obligatoire pour une réponse de QCU",
+        'The id of the correct proposal is required for a QCU response',
       );
     });
   });

--- a/api/tests/devcomp/unit/domain/models/QcuProposal_test.js
+++ b/api/tests/devcomp/unit/domain/models/QcuProposal_test.js
@@ -20,13 +20,13 @@ describe('Unit | Devcomp | Domain | Models | QcuProposal', function () {
 
   describe('A QCU proposal without id', function () {
     it('should throw an error', function () {
-      expect(() => new QcuProposal({})).to.throw("L'id est obligatoire pour une proposition de QCU");
+      expect(() => new QcuProposal({})).to.throw('The id is required for a QCU proposal.');
     });
   });
 
   describe('A QCU proposal without content', function () {
     it('should throw an error', function () {
-      expect(() => new QcuProposal({ id: '1' })).to.throw('Le contenu est obligatoire pour une proposition de QCU');
+      expect(() => new QcuProposal({ id: '1' })).to.throw('The content is required for a QCU proposal.');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/QrocmCorrectionResponse_test.js
+++ b/api/tests/devcomp/unit/domain/models/QrocmCorrectionResponse_test.js
@@ -23,14 +23,14 @@ describe('Unit | Devcomp | Domain | Models | QrocmCorrectionResponse', function 
 
   describe('A QROCM correction response without status', function () {
     it('should throw an error', function () {
-      expect(() => new QrocmCorrectionResponse({})).to.throw('Le résultat est obligatoire pour une réponse de QROCM');
+      expect(() => new QrocmCorrectionResponse({})).to.throw('The result is required in a QROCM correction');
     });
   });
 
   describe('A QROCM correction response without feedback', function () {
     it('should throw an error', function () {
       expect(() => new QrocmCorrectionResponse({ status: AnswerStatus.OK })).to.throw(
-        'Le feedback est obligatoire pour une réponse de QROCM',
+        'The feedback is required in a QROCM correction',
       );
     });
   });
@@ -38,7 +38,7 @@ describe('Unit | Devcomp | Domain | Models | QrocmCorrectionResponse', function 
   describe('A QROCM correction response without solutions', function () {
     it('should throw an error', function () {
       expect(() => new QrocmCorrectionResponse({ status: AnswerStatus.OK, feedback: 'Bien joué !' })).to.throw(
-        'La solution est obligatoire pour une réponse de QROCM',
+        'The solution is required in a QROCM correction',
       );
     });
   });

--- a/api/tests/devcomp/unit/domain/models/QrocmSolutions_test.js
+++ b/api/tests/devcomp/unit/domain/models/QrocmSolutions_test.js
@@ -72,7 +72,7 @@ describe('Unit | Devcomp | Domain | Models | QrocmSolutions', function () {
                 tolerances: ['t1', 't2'],
               },
             ]),
-        ).to.throw('Les solutions sont obligatoires pour toutes les solutions de QROCM');
+        ).to.throw('The solutions are required for each QROCM proposal in QROCM solutions');
       });
     });
 
@@ -93,7 +93,7 @@ describe('Unit | Devcomp | Domain | Models | QrocmSolutions', function () {
                 solutions: ['@'],
               },
             ]),
-        ).to.throw('Les tolérances sont obligatoires pour toutes les solutions de QROCM');
+        ).to.throw('The tolerances are required for each QROCM proposal in QROCM solutions');
       });
     });
 
@@ -115,7 +115,7 @@ describe('Unit | Devcomp | Domain | Models | QrocmSolutions', function () {
                 solutions: '@',
               },
             ]),
-        ).to.throw('Une solution de QROCM doit forcément posséder une liste de solutions');
+        ).to.throw('Each proposal in QROCM solutions should have a list of solutions');
       });
     });
 
@@ -137,7 +137,7 @@ describe('Unit | Devcomp | Domain | Models | QrocmSolutions', function () {
                 tolerances: 't1',
               },
             ]),
-        ).to.throw('Une solution de QROCM doit forcément posséder une liste de tolérances');
+        ).to.throw('A QROCM solution should have a list of tolerances');
       });
     });
   });

--- a/api/tests/devcomp/unit/domain/models/TransitionText_test.js
+++ b/api/tests/devcomp/unit/domain/models/TransitionText_test.js
@@ -15,15 +15,13 @@ describe('Unit | Devcomp | Domain | Models | TransitionText', function () {
 
   describe('if a transition text does not have a content', function () {
     it('should throw an error', function () {
-      expect(() => new TransitionText({})).to.throw('Le contenu est obligatoire pour un texte de transition');
+      expect(() => new TransitionText({})).to.throw('The content is required for a transition text');
     });
   });
 
   describe('if a transition text does not have a grain id', function () {
     it('should throw an error', function () {
-      expect(() => new TransitionText({ content: '' })).to.throw(
-        "L'id de grain est obligatoire pour un texte de transition",
-      );
+      expect(() => new TransitionText({ content: '' })).to.throw('The grain id is required for a transition text');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/block/BlockInput_test.js
+++ b/api/tests/devcomp/unit/domain/models/block/BlockInput_test.js
@@ -36,7 +36,7 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
 
   describe('If input is missing', function () {
     it('should throw an error', function () {
-      expect(() => new BlockInput({})).to.throw("L'input est obligatoire pour un bloc d'input");
+      expect(() => new BlockInput({})).to.throw('The input is required for an input block');
     });
   });
 
@@ -47,7 +47,7 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
           new BlockInput({
             input: 'symbole',
           }),
-      ).to.throw("Le type d'input est obligatoire pour un bloc d'input");
+      ).to.throw('The input type is required for an input block');
     });
   });
   describe('If size is missing', function () {
@@ -58,7 +58,7 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
             input: 'symbole',
             inputType: 'text',
           }),
-      ).to.throw("La taille est obligatoire pour un bloc d'input");
+      ).to.throw('The size is required for an input block');
     });
   });
   describe('If display is missing', function () {
@@ -70,7 +70,7 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
             inputType: 'text',
             size: 1,
           }),
-      ).to.throw("Le display est obligatoire pour un bloc d'input");
+      ).to.throw('The display is required for an input block');
     });
   });
   describe('If placeholder is missing', function () {
@@ -83,7 +83,7 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
             size: 1,
             display: 'inline',
           }),
-      ).to.throw("Le placeholder est obligatoire pour un bloc d'input");
+      ).to.throw('The placeholder is required for an input block');
     });
   });
   describe('If ariaLabel is missing', function () {
@@ -97,7 +97,7 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
             display: 'inline',
             placeholder: '',
           }),
-      ).to.throw("L'aria Label est obligatoire pour un bloc d'input");
+      ).to.throw('The aria Label is required for an input block');
     });
   });
   describe('If defaultValue is missing', function () {
@@ -112,7 +112,7 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
             placeholder: '',
             ariaLabel: 'Réponse 1',
           }),
-      ).to.throw("La valeur par défaut est obligatoire pour un bloc d'input");
+      ).to.throw('The default value is required for an input block');
     });
   });
   describe('If tolerances are missing', function () {
@@ -128,7 +128,7 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
             ariaLabel: 'Réponse 1',
             defaultValue: '',
           }),
-      ).to.throw("Les tolérances sont obligatoires pour un bloc d'input");
+      ).to.throw('The tolerances are required for an input block');
     });
   });
 
@@ -146,7 +146,7 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockInput', function () {
             defaultValue: '',
             tolerances: ['t1'],
           }),
-      ).to.throw("Les solutions sont obligatoires pour un bloc d'input");
+      ).to.throw('The solutions are required for an input block');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/block/BlockSelectOption_test.js
+++ b/api/tests/devcomp/unit/domain/models/block/BlockSelectOption_test.js
@@ -15,15 +15,13 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockSelectOption', functio
 
   describe('If id is missing', function () {
     it('should throw an error', function () {
-      expect(() => new BlockSelectOption({})).to.throw("L'id est obligatoire pour une option de bloc select");
+      expect(() => new BlockSelectOption({})).to.throw('The id is required for a select block option');
     });
   });
 
   describe('If content is missing', function () {
     it('should throw an error', function () {
-      expect(() => new BlockSelectOption({ id: '1' })).to.throw(
-        'Le contenu est obligatoire pour une option de bloc select',
-      );
+      expect(() => new BlockSelectOption({ id: '1' })).to.throw('The content is required for a select block option');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/block/BlockSelect_test.js
+++ b/api/tests/devcomp/unit/domain/models/block/BlockSelect_test.js
@@ -34,7 +34,7 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockSelect', function () {
 
   describe('If input is missing', function () {
     it('should throw an error', function () {
-      expect(() => new BlockSelect({})).to.throw("L'input est obligatoire pour un bloc de selection");
+      expect(() => new BlockSelect({})).to.throw('The input is required for a select block');
     });
   });
   describe('If display is missing', function () {
@@ -44,7 +44,7 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockSelect', function () {
           new BlockSelect({
             input: 'symbole',
           }),
-      ).to.throw('Le display est obligatoire pour un bloc de selection');
+      ).to.throw('The display is required for a select block');
     });
   });
   describe('If placeholder is missing', function () {
@@ -55,7 +55,7 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockSelect', function () {
             input: 'symbole',
             display: 'inline',
           }),
-      ).to.throw('Le placeholder est obligatoire pour un bloc de selection');
+      ).to.throw('The placeholder is required for a select block');
     });
   });
   describe('If ariaLabel is missing', function () {
@@ -67,7 +67,7 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockSelect', function () {
             display: 'inline',
             placeholder: 'a placeholder',
           }),
-      ).to.throw("L'aria Label est obligatoire pour un bloc de selection");
+      ).to.throw('The aria Label is required for a select block');
     });
   });
   describe('If defaultValue is missing', function () {
@@ -80,7 +80,7 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockSelect', function () {
             placeholder: 'a placeholder',
             ariaLabel: 'Réponse 1',
           }),
-      ).to.throw('La valeur par défaut est obligatoire pour un bloc de selection');
+      ).to.throw('The default value is required for a select block');
     });
   });
   describe('If tolerances are missing', function () {
@@ -94,7 +94,7 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockSelect', function () {
             ariaLabel: 'Réponse 1',
             defaultValue: 'default',
           }),
-      ).to.throw('Les tolérances sont obligatoires pour un bloc de selection');
+      ).to.throw('The tolerances are required for a select block');
     });
   });
   describe('If options are missing', function () {
@@ -109,7 +109,7 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockSelect', function () {
             defaultValue: 'default',
             tolerances: ['t1'],
           }),
-      ).to.throw('Les options sont obligatoires pour un bloc de selection');
+      ).to.throw('The options are required for a select block');
     });
   });
 
@@ -126,7 +126,7 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockSelect', function () {
             tolerances: ['t1'],
             options: [Symbol('option')],
           }),
-      ).to.throw('Les solutions sont obligatoires pour un bloc de selection');
+      ).to.throw('The solutions are required for a select block');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/block/BlockText_test.js
+++ b/api/tests/devcomp/unit/domain/models/block/BlockText_test.js
@@ -15,7 +15,7 @@ describe('Unit | Devcomp | Domain | Models | Block | BlockText', function () {
 
   describe('If content is missing', function () {
     it('should throw an error', function () {
-      expect(() => new BlockText({})).to.throw('Le contenu est obligatoire pour un bloc de texte');
+      expect(() => new BlockText({})).to.throw('The content is required for a text block');
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/element/Image_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Image_test.js
@@ -24,20 +24,20 @@ describe('Unit | Devcomp | Domain | Models | Element | Image', function () {
 
   describe('An image without url', function () {
     it('should throw an error', function () {
-      expect(() => new Image({ id: 'id' })).to.throw("L'URL est obligatoire pour une image");
+      expect(() => new Image({ id: 'id' })).to.throw('The URL is required for an image');
     });
   });
 
   describe('An image without alt', function () {
     it('should throw an error', function () {
-      expect(() => new Image({ id: 'id', url: 'url' })).to.throw('Le contenu alt est obligatoire pour une image');
+      expect(() => new Image({ id: 'id', url: 'url' })).to.throw('The alt text is required for an image');
     });
   });
 
   describe('An image without an alternative Instruction', function () {
     it('should throw an error', function () {
       expect(() => new Image({ id: 'id', url: 'url', alt: 'alt' })).to.throw(
-        "L'instruction alternative est obligatoire pour une image",
+        'The alternative instruction is required for an image',
       );
     });
   });

--- a/api/tests/devcomp/unit/domain/models/element/QCU-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCU-for-answer-verification_test.js
@@ -41,7 +41,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QcuForAnswerVerification'
               instruction: 'toto',
               proposals: [Symbol('proposal1')],
             }),
-        ).to.throw('La solution est obligatoire pour un QCU de vérification');
+        ).to.throw('The solution is required for a verification QCU');
       });
     });
   });

--- a/api/tests/devcomp/unit/domain/models/element/QCU_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCU_test.js
@@ -34,14 +34,14 @@ describe('Unit | Devcomp | Domain | Models | Element | QCU', function () {
 
   describe('A QCU without instruction', function () {
     it('should throw an error', function () {
-      expect(() => new QCU({ id: '123' })).to.throw("L'instruction est obligatoire pour un QCU");
+      expect(() => new QCU({ id: '123' })).to.throw('The instruction is required for a QCU');
     });
   });
 
   describe('A QCU with an empty list of proposals', function () {
     it('should throw an error', function () {
       expect(() => new QCU({ id: '123', instruction: 'toto', proposals: [] })).to.throw(
-        'Les propositions sont obligatoires pour un QCU',
+        'The proposals are required for a QCU',
       );
     });
   });
@@ -49,7 +49,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QCU', function () {
   describe('A QCU does not have a list of proposals', function () {
     it('should throw an error', function () {
       expect(() => new QCU({ id: '123', instruction: 'toto', proposals: 'toto' })).to.throw(
-        'Les propositions doivent apparaître dans une liste',
+        'The QCU proposals should be a list',
       );
     });
   });

--- a/api/tests/devcomp/unit/domain/models/element/QROCM-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QROCM-for-answer-verification_test.js
@@ -84,7 +84,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QrocMForAnswerVerificatio
                 },
               ],
             }),
-        ).to.throw('Les feedbacks sont obligatoires pour un QROCM de vérification');
+        ).to.throw('The feedbacks are required for a verification QROCM.');
       });
     });
   });

--- a/api/tests/devcomp/unit/domain/models/element/Text_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Text_test.js
@@ -22,7 +22,7 @@ describe('Unit | Devcomp | Domain | Models | Element | Text', function () {
 
   describe('A text without content', function () {
     it('should throw an error', function () {
-      expect(() => new Text({ id: '1' })).to.throw('Le contenu est obligatoire pour un texte');
+      expect(() => new Text({ id: '1' })).to.throw('The content is required for a text');
     });
   });
 

--- a/api/tests/devcomp/unit/domain/models/element/Video_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Video_test.js
@@ -31,20 +31,20 @@ describe('Unit | Devcomp | Domain | Models | Element | Video', function () {
 
   describe('An video without a title', function () {
     it('should throw an error', function () {
-      expect(() => new Video({ id: 'id' })).to.throw("L'URL est obligatoire pour un video");
+      expect(() => new Video({ id: 'id' })).to.throw('The title is required for a video');
     });
   });
 
   describe('An image without a url', function () {
     it('should throw an error', function () {
-      expect(() => new Video({ id: 'id', title: 'title' })).to.throw("L'URL est obligatoire pour un video");
+      expect(() => new Video({ id: 'id', title: 'title' })).to.throw('The URL is required for a video');
     });
   });
 
   describe('A video without subtitles', function () {
     it('should throw an error', function () {
       expect(() => new Video({ id: 'id', title: 'title', url: 'url' })).to.throw(
-        'Les sous-titres sont obligatoire pour un video',
+        'The subtitles are required for a video',
       );
     });
   });
@@ -52,7 +52,7 @@ describe('Unit | Devcomp | Domain | Models | Element | Video', function () {
   describe('A video without a transcription', function () {
     it('should throw an error', function () {
       expect(() => new Video({ id: 'id', title: 'title', url: 'url', subtitles: 'subtitles' })).to.throw(
-        'Les transcriptions sont obligatoire pour un video',
+        'The transcription is required for a video',
       );
     });
   });

--- a/api/tests/devcomp/unit/domain/models/module/Module_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/Module_test.js
@@ -27,19 +27,19 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
 
     describe('if a module does not have an id', function () {
       it('should throw an error', function () {
-        expect(() => new Module({})).to.throw("L'id est obligatoire pour un module");
+        expect(() => new Module({})).to.throw('The id is required for a module');
       });
     });
 
     describe('if a module does not have a title', function () {
       it('should throw an error', function () {
-        expect(() => new Module({ id: 1 })).to.throw('Le titre est obligatoire pour un module');
+        expect(() => new Module({ id: 1 })).to.throw('The title is required for a module');
       });
     });
 
     describe('if a module does not have a slug', function () {
       it('should throw an error', function () {
-        expect(() => new Module({ id: 1, title: '' })).to.throw('Le slug est obligatoire pour un module');
+        expect(() => new Module({ id: 1, title: '' })).to.throw('The slug is required for a module');
       });
     });
 
@@ -52,7 +52,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               slug: 'bien-ecrire-son-adresse-mail',
               title: 'Bien écrire son adresse mail',
             }),
-        ).to.throw('Une liste de grains est obligatoire pour un module');
+        ).to.throw('A list of grains is required for a module');
       });
     });
 
@@ -66,7 +66,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               title: 'Bien écrire son adresse mail',
               grains: 'elements',
             }),
-        ).to.throw(`Un Module doit forcément posséder une liste de grains`);
+        ).to.throw(`A module should have a list of grains`);
       });
     });
 

--- a/api/tests/devcomp/unit/domain/services/solution-service-qrocm-ind_test.js
+++ b/api/tests/devcomp/unit/domain/services/solution-service-qrocm-ind_test.js
@@ -83,7 +83,7 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
 
       // then
       expect(error).to.be.an.instanceOf(Error);
-      expect(error.message).to.equal("Une erreur s'est produite lors de l'interprétation des réponses.");
+      expect(error.message).to.equal('An error occurred because there is no solution found for an answer.');
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Contrairement à ce qui est requis dans l'[ADR 0044](https://github.com/1024pix/pix/blob/dev/docs/adr/0044-gestion-erreurs-i18n-reference.md), les messages d'erreurs serveurs du BC devcomp sont écrits en français.

## :robot: Proposition
Nous les avons traduit en anglais.

## :rainbow: Remarques
Etant donné que ce ne sont pas des messages à destination du front, nous nous sommes donc contentés de faire la traduction en anglais sans ajouter de code.

## :100: Pour tester
La CI continue de passer (?)
