### PR TITLE
[FEATURE] change le code campagne depuis l'admin (PIX-11401)

### DIFF
--- a/admin/app/adapters/update-campaign-code.js
+++ b/admin/app/adapters/update-campaign-code.js
@@ -1,0 +1,9 @@
+import ApplicationAdapter from './application';
+
+export default class UpdateCampaignCode extends ApplicationAdapter {
+  updateCampaignCode({ campaignId, campaignCode }) {
+    const url = `${this.host}/${this.namespace}/admin/campaigns/${campaignId}/update-code`;
+
+    return this.ajax(url, 'PATCH', { data: { campaignCode } });
+  }
+}

--- a/admin/app/components/administration/update-campaign-code.hbs
+++ b/admin/app/components/administration/update-campaign-code.hbs
@@ -1,0 +1,24 @@
+<section class="page-section">
+  <header class="page-section__header">
+    <h2 class="page-section__title">{{t "components.administration.update-campaign-code.title"}}</h2>
+  </header>
+
+  <form {{on "submit" this.updateCode}}>
+    <fieldset class="campaign-update-code">
+      <legend>{{t "components.administration.update-campaign-code.description"}}</legend>
+      <PixInput
+        @id="firstCampaignId"
+        {{on "change" this.onChangeCampaignId}}
+        @label={{t "components.administration.update-campaign-code.form.campaignId"}}
+      />
+      <PixInput
+        @id="secondCampaignId"
+        {{on "change" this.onChangeCampaignCode}}
+        @label={{t "components.administration.update-campaign-code.form.campaignCode"}}
+      />
+    </fieldset>
+    <PixButton @type="submit" @size="small" @isLoading={{this.isLoading}}>
+      {{t "components.administration.update-campaign-code.form.button"}}
+    </PixButton>
+  </form>
+</section>

--- a/admin/app/components/administration/update-campaign-code.js
+++ b/admin/app/components/administration/update-campaign-code.js
@@ -1,0 +1,60 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class UpdateCampaignCode extends Component {
+  @service intl;
+  @service notifications;
+  @service store;
+
+  @tracked isLoading;
+
+  @action
+  async updateCode(event) {
+    event.preventDefault();
+    this.isLoading = true;
+    this.notifications.clearAll();
+
+    const adapter = this.store.adapterFor('update-campaign-code');
+    try {
+      await adapter.updateCampaignCode({ campaignId: this.campaignId, campaignCode: this.campaignCode });
+      this.notifications.success(this.intl.t('components.administration.update-campaign-code.notifications.success'));
+    } catch (errorResponse) {
+      const errors = errorResponse.errors;
+
+      if (!errors) {
+        return this.notifications.error(this.intl.t('common.notifications.generic-error'));
+      } else {
+        const error = errors[0];
+
+        if (error.code === 'CAMPAIGN_CODE_BAD_FORMAT') {
+          return this.notifications.error(
+            this.intl.t('components.administration.update-campaign-code.notifications.error.campaign-code-format'),
+          );
+        } else if (error.code === 'CAMPAIGN_CODE_NOT_UNIQUE') {
+          return this.notifications.error(
+            this.intl.t('components.administration.update-campaign-code.notifications.error.unique-code-error'),
+          );
+        } else if (error.code === 'UNKNOWN_CAMPAIGN_ID') {
+          this.notifications.error(
+            this.intl.t('components.administration.update-campaign-code.notifications.error.campaign-id-error'),
+          );
+        } else {
+          this.notifications.error(this.intl.t('common.notifications.generic-error'));
+        }
+      }
+    } finally {
+      this.isLoading = false;
+    }
+  }
+
+  @action
+  onChangeCampaignId(event) {
+    this.campaignId = event.target.value;
+  }
+  @action
+  onChangeCampaignCode(event) {
+    this.campaignCode = event.target.value;
+  }
+}

--- a/admin/app/styles/components/administration/campaign-update-code.scss
+++ b/admin/app/styles/components/administration/campaign-update-code.scss
@@ -1,0 +1,9 @@
+.campaign-update-code {
+  display: flex;
+  gap: var(--pix-spacing-2x);
+  margin: var(--pix-spacing-8x) 0;
+
+  legend {
+    margin-bottom: var(--pix-spacing-8x)
+  }
+}

--- a/admin/app/styles/components/administration/index.scss
+++ b/admin/app/styles/components/administration/index.scss
@@ -1,1 +1,2 @@
+@import 'campaign-update-code';
 @import 'campaigns-swap-code';

--- a/admin/app/templates/authenticated/administration.hbs
+++ b/admin/app/templates/authenticated/administration.hbs
@@ -16,6 +16,8 @@
     <Administration::CampaignsImport />
 
     <Administration::SwapCampaignCodes />
+
+    <Administration::UpdateCampaignCode />
   </main>
 
 </div>

--- a/admin/tests/integration/components/administration/update-campaign-code_test.js
+++ b/admin/tests/integration/components/administration/update-campaign-code_test.js
@@ -1,0 +1,60 @@
+import { module, test } from 'qunit';
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+import { click, fillIn } from '@ember/test-helpers';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering.js';
+
+module('Integration | Component | administration/update-campaign-code', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  let store, notificationService, adapter, updateAdapterStub;
+
+  hooks.beforeEach(function () {
+    notificationService = this.owner.lookup('service:notifications');
+    store = this.owner.lookup('service:store');
+
+    sinon.stub(notificationService, 'success');
+    sinon.stub(notificationService, 'clearAll');
+    sinon.stub(notificationService, 'error');
+
+    adapter = store.adapterFor('update-campaign-code');
+    updateAdapterStub = sinon.stub(adapter, 'updateCampaignCode');
+  });
+
+  test("it should update campaign's code", async function (assert) {
+    // given
+    const campaignId = '18';
+    const campaignCode = 'SCOSCO123';
+
+    updateAdapterStub.withArgs({ campaignId, campaignCode }).resolves();
+
+    //when
+    const screen = await render(hbs`<Administration::UpdateCampaignCode />`);
+
+    await fillIn(
+      screen.getByLabelText(this.intl.t('components.administration.update-campaign-code.form.campaignId')),
+      campaignId,
+    );
+    await fillIn(
+      screen.getByLabelText(this.intl.t('components.administration.update-campaign-code.form.campaignCode')),
+      campaignCode,
+    );
+
+    await click(
+      screen.getByRole('button', {
+        name: this.intl.t('components.administration.update-campaign-code.form.button'),
+      }),
+    );
+
+    // then
+    assert.true(updateAdapterStub.calledOnce);
+    assert.true(
+      notificationService.success.calledOnceWithExactly(
+        this.intl.t('components.administration.update-campaign-code.notifications.success'),
+      ),
+    );
+    assert.true(notificationService.error.notCalled);
+    assert.true(notificationService.clearAll.called);
+  });
+});

--- a/admin/tests/unit/adapters/update-campaign-code_test.js
+++ b/admin/tests/unit/adapters/update-campaign-code_test.js
@@ -1,0 +1,28 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Adapter | UpdateCampaignCode', function (hooks) {
+  setupTest(hooks);
+  let adapter;
+
+  hooks.beforeEach(function () {
+    adapter = this.owner.lookup('adapter:update-campaign-code');
+    adapter.ajax = sinon.stub();
+  });
+
+  module('#updateCampaignCode', function () {
+    test('should add campaign IDs and campaign code inside the request', function (assert) {
+      // when
+      const campaignId = 123;
+      const campaignCode = 'YOLO';
+      adapter.updateCampaignCode({ campaignId, campaignCode });
+      // then
+      assert.ok(
+        adapter.ajax.calledWithExactly(`http://localhost:3000/api/admin/campaigns/${campaignId}/update-code`, 'PATCH', {
+          data: { campaignCode },
+        }),
+      );
+    });
+  });
+});

--- a/admin/tests/unit/components/administration/update-campaign-code_test.js
+++ b/admin/tests/unit/components/administration/update-campaign-code_test.js
@@ -1,0 +1,149 @@
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+
+module('Unit | Component | update-campaign-code', function (hooks) {
+  setupTest(hooks);
+
+  let component, updateCampaignCodeStub, event, notificationStub, intlStub;
+
+  hooks.beforeEach(function () {
+    // given
+    updateCampaignCodeStub = sinon.stub();
+    notificationStub = { clearAll: sinon.stub(), success: sinon.stub(), error: sinon.stub() };
+    intlStub = sinon.stub();
+    component = createGlimmerComponent('component:administration/update-campaign-code');
+    component.notifications = notificationStub;
+    component.store.adapterFor = sinon.stub().returns({ updateCampaignCode: updateCampaignCodeStub });
+    component.campaignId = 123;
+    component.campaignCode = 'ABC';
+    component.intl = { t: intlStub };
+    event = {
+      preventDefault: sinon.stub(),
+    };
+  });
+
+  module('#updateCode', function () {
+    module('when updateCampaignCode works', function () {
+      test('it should call preventDefault', async function (assert) {
+        // when
+        await component.updateCode(event);
+
+        // then
+        assert.ok(event.preventDefault.calledOnce);
+      });
+      test('it should call updateCampaignCode', async function (assert) {
+        // when
+        await component.updateCode(event);
+
+        // then
+        assert.ok(updateCampaignCodeStub.calledOnce);
+        assert.ok(updateCampaignCodeStub.calledWithExactly({ campaignId: 123, campaignCode: 'ABC' }));
+      });
+      test('it should call notification', async function (assert) {
+        const successMsg = Symbol('successMsg');
+        intlStub.returns(successMsg);
+        // when
+        await component.updateCode(event);
+
+        // then
+        assert.ok(notificationStub.clearAll.calledOnce);
+        assert.ok(intlStub.calledWithExactly('components.administration.update-campaign-code.notifications.success'));
+        assert.ok(notificationStub.success.calledWithExactly(successMsg));
+      });
+    });
+    module('when updateCampaignCode returns a CAMPAIGN_CODE_BAD_FORMAT error', function (hooks) {
+      hooks.beforeEach(function () {
+        updateCampaignCodeStub.throws({ errors: [{ code: 'CAMPAIGN_CODE_BAD_FORMAT' }] });
+      });
+      test('it should call notification with bad format message', async function (assert) {
+        const errorMsg = Symbol('errorMsg');
+        intlStub.returns(errorMsg);
+        // when
+        await component.updateCode(event);
+
+        // then
+        assert.ok(notificationStub.clearAll.calledOnce);
+        assert.ok(
+          intlStub.calledWithExactly(
+            'components.administration.update-campaign-code.notifications.error.campaign-code-format',
+          ),
+        );
+        assert.ok(notificationStub.error.calledWithExactly(errorMsg));
+      });
+    });
+    module('when updateCampaignCode returns a CAMPAIGN_CODE_NOT_UNIQUE error', function (hooks) {
+      hooks.beforeEach(function () {
+        updateCampaignCodeStub.throws({ errors: [{ code: 'CAMPAIGN_CODE_NOT_UNIQUE' }] });
+      });
+      test('it should call notification with bad format message', async function (assert) {
+        const errorMsg = Symbol('errorMsg');
+        intlStub.returns(errorMsg);
+        // when
+        await component.updateCode(event);
+
+        // then
+        assert.ok(notificationStub.clearAll.calledOnce);
+        assert.ok(
+          intlStub.calledWithExactly(
+            'components.administration.update-campaign-code.notifications.error.unique-code-error',
+          ),
+        );
+        assert.ok(notificationStub.error.calledWithExactly(errorMsg));
+      });
+    });
+    module('when updateCampaignCode returns a UNKNOWN_CAMPAIGN_ID error', function (hooks) {
+      hooks.beforeEach(function () {
+        updateCampaignCodeStub.throws({ errors: [{ code: 'UNKNOWN_CAMPAIGN_ID' }] });
+      });
+      test('it should call notification with bad format message', async function (assert) {
+        const errorMsg = Symbol('errorMsg');
+        intlStub.returns(errorMsg);
+        // when
+        await component.updateCode(event);
+
+        // then
+        assert.ok(notificationStub.clearAll.calledOnce);
+        assert.ok(
+          intlStub.calledWithExactly(
+            'components.administration.update-campaign-code.notifications.error.campaign-id-error',
+          ),
+        );
+        assert.ok(notificationStub.error.calledWithExactly(errorMsg));
+      });
+    });
+    module('when updateCampaignCode returns a generic error', function (hooks) {
+      hooks.beforeEach(function () {
+        updateCampaignCodeStub.throws({ errors: [{ code: 'unknown' }] });
+      });
+      test('it should call notification with bad format message', async function (assert) {
+        const errorMsg = Symbol('errorMsg');
+        intlStub.returns(errorMsg);
+        // when
+        await component.updateCode(event);
+
+        // then
+        assert.ok(notificationStub.clearAll.calledOnce);
+        assert.ok(intlStub.calledWithExactly('common.notifications.generic-error'));
+        assert.ok(notificationStub.error.calledWithExactly(errorMsg));
+      });
+    });
+    module('when updateCampaignCode fails with no error', function (hooks) {
+      hooks.beforeEach(function () {
+        updateCampaignCodeStub.throws();
+      });
+      test('it should call notification with bad format message', async function (assert) {
+        const errorMsg = Symbol('errorMsg');
+        intlStub.returns(errorMsg);
+        // when
+        await component.updateCode(event);
+
+        // then
+        assert.ok(notificationStub.clearAll.calledOnce);
+        assert.ok(intlStub.calledWithExactly('common.notifications.generic-error'));
+        assert.ok(notificationStub.error.calledWithExactly(errorMsg));
+      });
+    });
+  });
+});

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -56,6 +56,23 @@
           },
           "success": "Campaign code switch success"
         }
+      },
+      "update-campaign-code": {
+        "title": "Update campaign code",
+        "description": "Allow to modify the campaign code from the campaign ID. The campaign's code must be unique and composed of 9 uppercase alphanumeric characters.",
+        "form": {
+          "button": "Update",
+          "campaignCode": "Campaign code",
+          "campaignId": "Campaign ID"
+        },
+        "notifications": {
+          "error": {
+            "campaign-code-format": "Campaign's code should contains only uppercase alpha numeric characters.",
+            "campaign-id-error": "Campaign id does not exist.",
+            "unique-code-error": "Campaign's code is not unique."
+          },
+          "success": "Campaign code update succeed."
+        }
       }
     },
     "certification-centers": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -64,6 +64,23 @@
           },
           "success": "Les codes campagnes ont bien été échangé."
         }
+      },
+      "update-campaign-code": {
+        "title": "Modifier le code d'une campagne",
+        "description": "Permet de modifier le code campagne à partir de l'identifiant d'une campagne. Le code campagne doit être unique et composé de 9 caractères alphanumériques en majuscules.",
+        "form": {
+          "button": "Modifier",
+          "campaignCode": "Nouveau code campagne",
+          "campaignId": "ID de le campagne"
+        },
+        "notifications": {
+          "error": {
+            "campaign-code-format": "Le code campagne doit être composé de 9 caractères alpha-numérique en majuscule.",
+            "campaign-id-error": "L'id de campagne n'existe pas.",
+            "unique-code-error": "Le code est déjà utilisé dans une autre campagne."
+          },
+          "success": "Le code campagne a bien été modifié."
+        }
       }
     },
     "certification-centers": {

--- a/api/lib/domain/services/code-generator.js
+++ b/api/lib/domain/services/code-generator.js
@@ -23,4 +23,8 @@ function generate(repository, pendingList = []) {
   });
 }
 
-export { generate };
+function validate(code) {
+  return /^[A-Z0-9]{9}$/.test(code);
+}
+
+export { generate, validate };

--- a/api/src/prescription/campaign/application/campaign-administration-route.js
+++ b/api/src/prescription/campaign/application/campaign-administration-route.js
@@ -164,6 +164,33 @@ const register = async function (server) {
         tags: ['api', 'admin', 'campaigns'],
       },
     },
+    {
+      method: 'PATCH',
+      path: '/api/admin/campaigns/{campaignId}/update-code',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+            assign: 'hasRoleSuperAdmin',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            campaignId: identifiersType.campaignId,
+          }),
+          payload: Joi.object({
+            campaignCode: Joi.string().trim().required(),
+          }),
+        },
+        handler: campaignAdministrationController.updateCampaignCode,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés ayant pour rôle SUPER_ADMIN**\n' +
+            "- Modifier le code d'une campagne\n" +
+            '- Elle ne retourne aucune valeur',
+        ],
+        tags: ['api', 'admin', 'campaigns'],
+      },
+    },
   ]);
 };
 

--- a/api/src/prescription/campaign/application/campaign-adminstration-controller.js
+++ b/api/src/prescription/campaign/application/campaign-adminstration-controller.js
@@ -75,12 +75,22 @@ const updateCampaignDetails = async function (request, h) {
   return h.response({}).code(204);
 };
 
+const updateCampaignCode = async function (request, h) {
+  const { campaignId } = request.params;
+  const { campaignCode } = request.payload;
+
+  await usecases.updateCampaignCode({ campaignId, campaignCode });
+
+  return h.response(null).code(204);
+};
+
 const campaignAdministrationController = {
   save,
   update,
   createCampaigns,
   swapCampaignCodes,
   updateCampaignDetails,
+  updateCampaignCode,
 };
 
 export { campaignAdministrationController };

--- a/api/src/prescription/campaign/application/http-error-mapper-configuration.js
+++ b/api/src/prescription/campaign/application/http-error-mapper-configuration.js
@@ -4,6 +4,8 @@ import {
   SwapCampaignMismatchOrganizationError,
   IsForAbsoluteNoviceUpdateError,
   MultipleSendingsUpdateError,
+  CampaignCodeFormatError,
+  CampaignUniqueCodeError,
 } from '../../campaign/domain/errors.js';
 
 const campaignDomainErrorMappingConfiguration = [
@@ -24,6 +26,14 @@ const campaignDomainErrorMappingConfiguration = [
   {
     name: MultipleSendingsUpdateError.name,
     httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message, error.code, error.meta),
+  },
+  {
+    name: CampaignUniqueCodeError.name,
+    httpErrorFn: (error) => new HttpErrors.ConflictError(error.message, error.code, error.meta),
+  },
+  {
+    name: CampaignCodeFormatError.name,
+    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
   },
 ];
 

--- a/api/src/prescription/campaign/domain/errors.js
+++ b/api/src/prescription/campaign/domain/errors.js
@@ -13,6 +13,13 @@ class SwapCampaignMismatchOrganizationError extends DomainError {
   }
 }
 
+class CampaignUniqueCodeError extends DomainError {
+  constructor(message = "Campaign's code must be unique") {
+    super(message);
+    this.code = 'CAMPAIGN_CODE_NOT_UNIQUE';
+  }
+}
+
 class IsForAbsoluteNoviceUpdateError extends DomainError {
   constructor(message = 'Update isForAbsoluteNovice campaign unauthorized') {
     super(message);
@@ -26,10 +33,18 @@ class MultipleSendingsUpdateError extends DomainError {
     this.code = 'CANT_UPDATE_ATTRIBUTE_WHEN_CAMPAIGN_HAS_PARTICIPATIONS';
   }
 }
+class CampaignCodeFormatError extends DomainError {
+  constructor(message = "Campaign's should contains invalid char. Only uppercase alphanumeric char are allowed ") {
+    super(message);
+    this.code = 'CAMPAIGN_CODE_BAD_FORMAT';
+  }
+}
 
 export {
   UnknownCampaignId,
   SwapCampaignMismatchOrganizationError,
   IsForAbsoluteNoviceUpdateError,
   MultipleSendingsUpdateError,
+  CampaignUniqueCodeError,
+  CampaignCodeFormatError,
 };

--- a/api/src/prescription/campaign/domain/usecases/update-campaign-code.js
+++ b/api/src/prescription/campaign/domain/usecases/update-campaign-code.js
@@ -1,0 +1,23 @@
+import { CampaignCodeFormatError, CampaignUniqueCodeError, UnknownCampaignId } from './../errors.js';
+
+const updateCampaignCode = async function ({
+  campaignId,
+  campaignCode,
+  campaignAdministrationRepository,
+  codeGenerator,
+}) {
+  const campaign = await campaignAdministrationRepository.get(campaignId);
+  if (!campaign) {
+    throw new UnknownCampaignId();
+  }
+  if (!codeGenerator.validate(campaignCode)) {
+    throw new CampaignCodeFormatError();
+  }
+  const isCodeAvailable = await campaignAdministrationRepository.isCodeAvailable(campaignCode);
+  if (!isCodeAvailable) {
+    throw new CampaignUniqueCodeError();
+  }
+  await campaignAdministrationRepository.update({ campaignId, campaignAttributes: { code: campaignCode } });
+};
+
+export { updateCampaignCode };

--- a/api/tests/prescription/campaign/acceptance/application/campaign-administration-route_test.js
+++ b/api/tests/prescription/campaign/acceptance/application/campaign-administration-route_test.js
@@ -337,4 +337,26 @@ describe('Acceptance | API | campaign-administration-route', function () {
       expect(updatedCampaign.multipleSendings).to.be.true;
     });
   });
+
+  describe('PATCH /api/admin/campaigns/{campaignId}/update-code', function () {
+    it('it updates campaign code', async function () {
+      const userId = databaseBuilder.factory.buildUser.withRole({ role: ROLES.SUPER_ADMIN }).id;
+      const campaignId = databaseBuilder.factory.buildCampaign({ code: 'ABCEFG123' }).id;
+      await databaseBuilder.commit();
+      const authorization = generateValidRequestAuthorizationHeader(userId);
+      const payload = {
+        campaignCode: 'GOODCODE1',
+      };
+
+      const options = {
+        method: 'PATCH',
+        url: `/api/admin/campaigns/${campaignId}/update-code`,
+        headers: { authorization },
+        payload,
+      };
+
+      const response = await server.inject(options);
+      expect(response.statusCode).to.equal(204);
+    });
+  });
 });

--- a/api/tests/prescription/campaign/integration/application/campaign-administration-route_test.js
+++ b/api/tests/prescription/campaign/integration/application/campaign-administration-route_test.js
@@ -52,4 +52,35 @@ describe('Integration | Application | Route | campaign administration router', f
       expect(response.statusCode).to.equal(403);
     });
   });
+
+  describe('PATCH /api/admin/campaigns/{campaignId}/update-code', function () {
+    it('should return 403 when user has not super admin role', async function () {
+      // given
+      const simpleUserId = databaseBuilder.factory.buildUser().id;
+      await databaseBuilder.commit();
+
+      httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const headers = {
+        authorization: generateValidRequestAuthorizationHeader(simpleUserId),
+      };
+
+      const payload = {
+        campaignCode: 'CAMPAIGN',
+      };
+
+      // when
+      const response = await httpTestServer.request(
+        'PATCH',
+        '/api/admin/campaigns/123/update-code',
+        payload,
+        null,
+        headers,
+      );
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+  });
 });

--- a/api/tests/prescription/campaign/unit/application/campaign-administration-controller_test.js
+++ b/api/tests/prescription/campaign/unit/application/campaign-administration-controller_test.js
@@ -203,4 +203,22 @@ describe('Unit | Application | Controller | Campaign administration', function (
       });
     });
   });
+
+  describe('#updateCampaignCode', function () {
+    it('should return a 204', async function () {
+      // given
+      const campaignId = Symbol('campaign-id');
+      const campaignCode = Symbol('campaign-code');
+      const request = { params: { campaignId }, payload: { campaignCode: campaignCode } };
+
+      sinon.stub(usecases, 'updateCampaignCode');
+
+      // when
+      const response = await campaignAdministrationController.updateCampaignCode(request, hFake);
+
+      // then
+      expect(response.statusCode).to.be.equal(204);
+      expect(usecases.updateCampaignCode).to.have.been.calledWithExactly({ campaignId, campaignCode });
+    });
+  });
 });

--- a/api/tests/prescription/campaign/unit/domain/usecases/update-campaign-code_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/update-campaign-code_test.js
@@ -1,0 +1,87 @@
+import { expect, sinon, catchErr } from '../../../../../test-helper.js';
+import { updateCampaignCode } from '../../../../../../src/prescription/campaign/domain/usecases/update-campaign-code.js';
+import {
+  CampaignCodeFormatError,
+  CampaignUniqueCodeError,
+  UnknownCampaignId,
+} from '../../../../../../src/prescription/campaign/domain/errors.js';
+
+describe('Unit | UseCase | update-campaign-code', function () {
+  let campaignAdministrationRepository, codeGenerator;
+
+  beforeEach(function () {
+    campaignAdministrationRepository = { get: sinon.stub(), isCodeAvailable: sinon.stub(), update: sinon.stub() };
+    codeGenerator = { validate: sinon.stub() };
+  });
+
+  it('should update campaign code', async function () {
+    // given
+    const campaignId = Symbol('campaign-id');
+    const campaignCode = Symbol('campaign-code');
+
+    codeGenerator.validate.withArgs(campaignCode).returns(true);
+    campaignAdministrationRepository.get.withArgs(campaignId).resolves(Symbol('campaign'));
+    campaignAdministrationRepository.isCodeAvailable.withArgs(campaignCode).resolves(true);
+
+    // when
+    await updateCampaignCode({ campaignId, campaignCode, campaignAdministrationRepository, codeGenerator });
+
+    // then
+    expect(campaignAdministrationRepository.update).to.have.been.calledOnceWithExactly({
+      campaignId,
+      campaignAttributes: { code: campaignCode },
+    });
+  });
+  context('when campaignId not match a campaign', function () {
+    it('should throw an UnknonwCampaignId', async function () {
+      // given
+      const campaignId = Symbol('campaign-id');
+      const campaignCode = Symbol('campaign-code');
+      campaignAdministrationRepository.get.withArgs(campaignId).resolves(null);
+
+      // when
+      const error = await catchErr(updateCampaignCode)({ campaignId, campaignCode, campaignAdministrationRepository });
+
+      expect(error).to.be.an.instanceOf(UnknownCampaignId);
+    });
+  });
+
+  context("when campaign's code has a wrong format", function () {
+    it('should throw a CampaignCodeFormatError', async function () {
+      // given
+      const campaignId = Symbol('campaign-id');
+      const campaignCode = Symbol('campaign-code');
+      campaignAdministrationRepository.get.withArgs(campaignId).resolves(Symbol('campaign'));
+      codeGenerator.validate.withArgs(campaignCode).returns(false);
+      // when
+      const error = await catchErr(updateCampaignCode)({
+        campaignId,
+        campaignCode,
+        campaignAdministrationRepository,
+        codeGenerator,
+      });
+
+      expect(error).to.be.an.instanceOf(CampaignCodeFormatError);
+    });
+  });
+
+  context("when campaign's code already exists", function () {
+    it('should throw a CampaignUniqueCodeError', async function () {
+      // given
+      const campaignId = Symbol('campaign-id');
+      const campaignCode = Symbol('campaign-code');
+      campaignAdministrationRepository.get.withArgs(campaignId).resolves(Symbol('campaign'));
+      codeGenerator.validate.withArgs(campaignCode).returns(true);
+      campaignAdministrationRepository.isCodeAvailable.withArgs(campaignCode).resolves(false);
+      // when
+      const error = await catchErr(updateCampaignCode)({
+        campaignId,
+        campaignCode,
+        campaignAdministrationRepository,
+        codeGenerator,
+      });
+
+      expect(error).to.be.an.instanceOf(CampaignUniqueCodeError);
+    });
+  });
+});

--- a/api/tests/unit/domain/services/code-generator_test.js
+++ b/api/tests/unit/domain/services/code-generator_test.js
@@ -113,4 +113,18 @@ describe('Unit | Domain | Services | code generator', function () {
       });
     });
   });
+  describe('#validate', function () {
+    it('should return false if code is less than 9 char', function () {
+      expect(codeGenerator.validate('ABC123')).to.be.false;
+    });
+    it('should return false if code is more than 9 char', function () {
+      expect(codeGenerator.validate('ABC123ABC123')).to.be.false;
+    });
+    it('should return false if code contains char other than uppercase Alphanumeric or numbers', function () {
+      expect(codeGenerator.validate('abc abc @')).to.be.false;
+    });
+    it('should return true if code contains only uppercase alphanumeric chars', function () {
+      expect(codeGenerator.validate('123ABDCDE')).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Certaines campagnes sont utilisées au long cours comme c'est le cas pour la campagne pole-emploi. Suite au changement d'identité, il faudrait pouvoir changer le code campagne pour refléter la nouvelle identité.
Or il n'est pas possible lorsqu'on est admin de modifier le code d'une campagne existante. 

## :robot: Proposition
On rajoute un formulaire pour modifier un code campagne à partir de l'id de la campagne

## :rainbow: Remarques
RAS

## :100: Pour tester
- se connecter sur admin
- se rendre dans l'onglet "Administration"
- erreur campaignID 
  - saisir 123 dans le champ ID de la campagne
  - saisir PROPRO dans le champ code campagne 
  - valider / voir le toast d'erreur campagne id inexistant
- erreur code unique
  - saisir 104698 dans le champ ID de la campagne
  - saisir SCOCOLMUL dans le champ code campagne 
  - valider / voir le toast d'erreur code campagne unique
- cas nominal  
  - saisir 104698 dans le champ ID de la campagne
  - saisir PROPRO dans le champ code campagne 
  - valider
  - voir le toast de succés
  - afficher les campagnes de l'orga 1000
  - voir le code PROPRO

