### PR TITLE
[BUGFIX] Activer le scoring pour les certifications v3 terminées par le surveillant (PIX-11421)

### DIFF
--- a/api/lib/domain/events/handle-auto-jury.js
+++ b/api/lib/domain/events/handle-auto-jury.js
@@ -111,7 +111,7 @@ async function _handleAutoJuryV3({ certificationCourses, certificationAssessment
       certificationCourseId: certificationCourse.getId(),
     });
 
-    if (certificationAssessment.state === CertificationAssessment.states.STARTED) {
+    if (_v3CertificationShouldBeScored(certificationAssessment)) {
       const certificationJuryDoneEvent = new CertificationJuryDone({
         certificationCourseId: certificationCourse.getId(),
       });
@@ -135,6 +135,13 @@ async function _handleAutoJuryV3({ certificationCourses, certificationAssessment
       hasExaminerGlobalComment: event.hasExaminerGlobalComment,
     }),
   ];
+}
+
+function _v3CertificationShouldBeScored(certificationAssessment) {
+  return (
+    certificationAssessment.state === CertificationAssessment.states.STARTED ||
+    certificationAssessment.state === CertificationAssessment.states.ENDED_BY_SUPERVISOR
+  );
 }
 
 async function _autoCompleteUnfinishedTest({


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, les certification v3 terminées par le surveillant ne sont pas scorées.

## :100: Pour tester
- créer une session de certif dans un CDC taggué pilote v3 et inscrire un candidat à cette session (certifv3@example.net // pix123)
- rejoindre la session avec le candidat et lancer le test
- depuis l’ES, terminer le test 
- finaliser la session
- Aller voir la session dans Pix admin : la certification doit être scorée.