### PR TITLE
[BUGFIX] Créer une session de certification sur d'anciens navigateurs (PIX-11269)

### DIFF
--- a/certif/ember-cli-build.js
+++ b/certif/ember-cli-build.js
@@ -22,6 +22,13 @@ module.exports = function (defaults) {
     'ember-cli-template-lint': {
       testGenerator: 'qunit',
     },
+    '@embroider/macros': {
+      setConfig: {
+        '@ember-data/store': {
+          polyfillUUID: true,
+        },
+      },
+    },
   });
 
   // Use `app.import` to add additional libraries to the generated

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -21,6 +21,7 @@
         "@ember/test-helpers": "^3.1.0",
         "@embroider/compat": "^3.0.0",
         "@embroider/core": "^3.0.0",
+        "@embroider/macros": "^1.13.3",
         "@embroider/webpack": "^3.0.0",
         "@formatjs/intl": "^2.9.1",
         "@fortawesome/ember-fontawesome": "^2.0.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -52,6 +52,7 @@
     "@ember/test-helpers": "^3.1.0",
     "@embroider/compat": "^3.0.0",
     "@embroider/core": "^3.0.0",
+    "@embroider/macros": "^1.13.3",
     "@embroider/webpack": "^3.0.0",
     "@formatjs/intl": "^2.9.1",
     "@fortawesome/ember-fontawesome": "^2.0.0",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -22,6 +22,7 @@
         "@ember/test-helpers": "^3.0.0",
         "@embroider/compat": "^3.0.0",
         "@embroider/core": "^3.0.0",
+        "@embroider/macros": "^1.13.5",
         "@embroider/util": "^1.11.1",
         "@embroider/webpack": "^3.0.0",
         "@formatjs/intl": "^2.5.1",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -53,6 +53,7 @@
     "@ember/test-helpers": "^3.0.0",
     "@embroider/compat": "^3.0.0",
     "@embroider/core": "^3.0.0",
+    "@embroider/macros": "^1.13.5",
     "@embroider/util": "^1.11.1",
     "@embroider/webpack": "^3.0.0",
     "@formatjs/intl": "^2.5.1",


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l’utilisateur utilise son navigateur Firefox 91.0 et essaie de cliquer sur le bouton “Créer une session”, rien ne se passe. La création en masse de session quant à elle fonctionne (bouton d'à côté “Créer/éditer plusieurs sessions”)

La méthode crypto.randomUUID n'existe pas sur cette version de navigateur.

## :robot: Proposition
Mettre en place le polyfill de cette méthode proposé par [ember-data](https://github.com/emberjs/data?tab=readme-ov-file#randomuuid-polyfill).


## :rainbow: Remarques
La doc de polyfill ne le mentionne pas, mais depuis la version 4.12 de ember-data, le simple ajout du polyfill ne fonctionne pas. Il faut également que `embroider/macros` soit installé et **listé** dans les dépendances du package.json pour que le polyfill soit installé. cf [cette issue](https://github.com/emberjs/data/issues/8675). 

Je propose également le listing de la version sur mon-pix même s'il n'y a pas de bug actuellement. Concrètement, c'est à l'utilisation de la config pour mettre en place le polyfill que la dépendance aurait dû être listée. Ainsi, on évitera le même bug silencieux lors de la montée d'ember-data de mon-pix en 4.12. 

PI: [un tableau montrant la disponibilité de randomUUID sur chaque navigateur](https://developer.mozilla.org/fr/docs/Web/API/Crypto/randomUUID#compatibilit%C3%A9_des_navigateurs)


## :100: Pour tester
Installer une ancienne version de firefox e.g la [91](https://download-installer.cdn.mozilla.net/pub/firefox/releases/91.9.1esr/mac/fr/).
Se connecter sur [pix certif](https://certif-pr8200.review.pix.fr/) (certif-pro@example.net/pix123)
Créer une nouvelle session

Non régression: 
Mêmes étapes sur un chrome à jour par exemple.