### PR TITLE
[FEATURE] Ajouter le header et le footer sur la page d'accueil du module. (PIX-11422)

### DIFF
--- a/mon-pix/app/pods/components/beta-banner/styles.scss
+++ b/mon-pix/app/pods/components/beta-banner/styles.scss
@@ -1,0 +1,3 @@
+.beta-banner {
+  z-index: 2;
+}

--- a/mon-pix/app/pods/components/beta-banner/template.hbs
+++ b/mon-pix/app/pods/components/beta-banner/template.hbs
@@ -1,3 +1,3 @@
-<PixBanner @type="communication">
+<PixBanner class="beta-banner" @type="communication">
   {{t "pages.modulix.beta-banner"}}
 </PixBanner>

--- a/mon-pix/app/pods/components/module/details/template.hbs
+++ b/mon-pix/app/pods/components/module/details/template.hbs
@@ -1,7 +1,5 @@
 {{page-title @module.title}}
-<BetaBanner />
-
-<main class="module-details">
+<main id="main" class="module-details" role="main">
   <div class="module-details__image">
     <img alt="" class="module-details-image__illustration" src={{@module.details.image}} />
   </div>

--- a/mon-pix/app/pods/module/details/template.hbs
+++ b/mon-pix/app/pods/module/details/template.hbs
@@ -1,3 +1,8 @@
+<BetaBanner />
+<header>
+  <NavbarHeader />
+</header>
 <div class="modulix">
   <Module::Details @module={{@model}} />
 </div>
+<Footer />

--- a/mon-pix/tests/acceptance/module/visit-module-details-page_test.js
+++ b/mon-pix/tests/acceptance/module/visit-module-details-page_test.js
@@ -4,37 +4,11 @@ import { currentURL } from '@ember/test-helpers';
 import { visit } from '@1024pix/ember-testing-library';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
-module('Acceptance | Module | Routes | get', function (hooks) {
+module('Acceptance | Module | Routes | details', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  test('can visit /modules/:slug/details', async function (assert) {
-    // given
-    const grain = server.create('grain', {
-      id: 'grain1',
-    });
-    server.create('module', {
-      id: 'bien-ecrire-son-adresse-mail',
-      title: 'Bien écrire son adresse mail',
-      details: {
-        image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
-        description:
-          'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
-        duration: 12,
-        level: 'Débutant',
-        objectives: ['Écrire une adresse mail correctement, en évitant les erreurs courantes'],
-      },
-      grains: [grain],
-    });
-
-    // when
-    await visit('/modules/bien-ecrire-son-adresse-mail/details');
-
-    // then
-    assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/details');
-  });
-
-  test('should include the module title inside the page title', async function (assert) {
+  test('should visit and include the module title, header and footer', async function (assert) {
     // given
     const module = server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
@@ -51,10 +25,14 @@ module('Acceptance | Module | Routes | get', function (hooks) {
     });
 
     // when
-    await visit('/modules/bien-ecrire-son-adresse-mail/details');
+    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/details');
 
     // then
+    assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/details');
     assert.ok(document.title.includes(module.title));
+    assert.dom(screen.getByRole('alert')).exists();
+    assert.dom(screen.getByRole('banner')).exists();
+    assert.dom(screen.getByRole('contentinfo')).exists();
   });
 
   test('should redirect /modules/:slug to /modules/:slug/details', async function (assert) {

--- a/mon-pix/tests/integration/components/module/details_test.js
+++ b/mon-pix/tests/integration/components/module/details_test.js
@@ -7,26 +7,6 @@ import { findAll } from '@ember/test-helpers';
 module('Integration | Component | Module | Details', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('should display a banner at the top of the screen for module details', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const details = {
-      image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
-      description: 'description',
-      duration: 12,
-      level: 'Débutant',
-      objectives: ['Objectif 1'],
-    };
-    const module = store.createRecord('module', { title: 'Module title', details });
-    this.set('module', module);
-
-    // when
-    const screen = await render(hbs`<Module::Details @module={{this.module}} />`);
-
-    // then
-    assert.dom(screen.getByRole('alert')).exists();
-  });
-
   test('should display the details of a given module', async function (assert) {
     // given
     const store = this.owner.lookup('service:store');


### PR DESCRIPTION
## :unicorn: Problème
On veut que les cgu soient accessible depuis la page d'accueil des modules, ainsi que le header avec la possibilité de se connecter.

## :robot: Proposition
Ajouter le header et le footer à la page details

## 🌈 Remarque
Nous avons décidé de ne pas mettre le role "banner" sur la balise header car le `getByRole('banner')` détecte la balise sans la précision de ce role.
Nous avons également décidé de réunir en un test d'acceptance le check du titre, des header, footer et de l'url

## :100: Pour tester
- Aller sur la page [du module de didacticiel](https://app-pr8202.review.pix.fr/modules/didacticiel-modulix) par exemple
- Constater la présence du header et du footer
- Répéter l'opération en étant connecté à Pix App