### PR TITLE
[TECH] Modifier l'expression régulière pour le nettoyage automatique de la base de données de test (PIX-11399)

### DIFF
--- a/api/db/database-builder/database-builder.js
+++ b/api/db/database-builder/database-builder.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import bluebird from 'bluebird';
 import { factory } from './factory/index.js';
 import { databaseBuffer } from './database-buffer.js';
+import * as databaseHelpers from './database-helpers.js';
 
 class DatabaseBuilder {
   constructor({ knex, emptyFirst = true, beforeEmptyDatabase = () => undefined }) {
@@ -194,14 +195,11 @@ class DatabaseBuilder {
 
   #addListeners() {
     this.knex?.on('query', (queryData) => {
-      {
-        if (queryData.method?.toLowerCase() === 'insert') {
-          const tableNameRegExp = /insert into "(?<tableName>(?:\\.|[^"\\])*)"/g;
-          const tableName = tableNameRegExp.exec(queryData.sql)?.groups?.tableName;
+      if (queryData.method?.toLowerCase() === 'insert') {
+        const tableName = databaseHelpers.getTableNameFromInsertSqlQuery(queryData.sql);
 
-          if (!_.isEmpty(tableName)) {
-            this._setTableAsDirty(tableName);
-          }
+        if (!_.isEmpty(tableName)) {
+          this._setTableAsDirty(tableName);
         }
       }
     });

--- a/api/db/database-builder/database-builder.js
+++ b/api/db/database-builder/database-builder.js
@@ -52,13 +52,22 @@ class DatabaseBuilder {
 
   async clean() {
     let rawQuery = '';
-    const tablesToDelete = this._selectDirtyTables();
-    _.times(tablesToDelete.length, () => {
-      rawQuery += 'DELETE FROM ??;';
-    });
+
+    this._selectDirtyTables()
+      .map((tableName) => {
+        return tableName
+          .split('.')
+          .map((element) => `"${element}"`)
+          .join('.');
+      })
+      .forEach((tableName) => {
+        rawQuery += `DELETE FROM ${tableName};`;
+      });
+
     if (rawQuery !== '') {
-      await this.knex.raw(rawQuery, tablesToDelete);
+      await this.knex.raw(rawQuery);
     }
+
     this.databaseBuffer.purge();
     this._purgeDirtiness();
   }

--- a/api/db/database-builder/database-builder.js
+++ b/api/db/database-builder/database-builder.js
@@ -191,6 +191,7 @@ class DatabaseBuilder {
       });
     });
     pgbossResults.rows.forEach(({ table_name }) => {
+      if (table_name === 'version') return;
       this.tablesOrderedByDependencyWithDirtinessMap.push({
         table: `pgboss.${table_name}`,
         isDirty: false,
@@ -220,6 +221,7 @@ class DatabaseBuilder {
         const tableName = databaseHelpers.getTableNameFromInsertSqlQuery(queryData.sql);
 
         if (!_.isEmpty(tableName)) {
+          if (tableName === 'pgboss.version') return;
           this._setTableAsDirty(tableName);
         }
       }

--- a/api/db/database-builder/database-builder.js
+++ b/api/db/database-builder/database-builder.js
@@ -1,3 +1,4 @@
+/* eslint-disable knex/avoid-injections */
 import _ from 'lodash';
 import bluebird from 'bluebird';
 import { factory } from './factory/index.js';
@@ -94,7 +95,6 @@ class DatabaseBuilder {
     return bluebird.mapSeries(dirtyTablesSequencesInfo, async ({ tableName, sequenceName }) => {
       const sequenceRestartAtNumber = (await this._getTableMaxId(tableName)) + 1;
       if (sequenceRestartAtNumber !== 0) {
-        /* eslint-disable-next-line knex/avoid-injections */
         await this.knex.raw(`ALTER SEQUENCE "${sequenceName}" RESTART WITH ${sequenceRestartAtNumber};`);
       }
     });
@@ -186,10 +186,8 @@ class DatabaseBuilder {
       from all_tables at where last_table_row = 1 order by level DESC;`;
     }
 
-    /* eslint-disable knex/avoid-injections */
     const publicResults = await this.knex.raw(_constructRawQuery('public'));
     const pgbossResults = await this.knex.raw(_constructRawQuery('pgboss'));
-    /* eslint-enable knex/avoid-injections */
 
     this.tablesOrderedByDependencyWithDirtinessMap = [];
 
@@ -237,5 +235,6 @@ class DatabaseBuilder {
     });
   }
 }
+/* eslint-enable knex/avoid-injections */
 
 export { DatabaseBuilder };

--- a/api/db/database-builder/database-builder.js
+++ b/api/db/database-builder/database-builder.js
@@ -123,15 +123,21 @@ class DatabaseBuilder {
 
   async _emptyDatabase() {
     this._beforeEmptyDatabase();
-    const sortedTables = _.without(
+    const sortedTableNames = _.without(
       _.map(this.tablesOrderedByDependencyWithDirtinessMap, 'table'),
       'knex_migrations',
       'knex_migrations_lock',
       'view-active-organization-learners',
-    );
-    const tables = _.map(sortedTables, (tableToDelete) => `"${tableToDelete}"`).join();
-    // eslint-disable-next-line knex/avoid-injections
-    return this.knex.raw(`TRUNCATE ${tables}`);
+    )
+      .map((tableName) => {
+        return tableName
+          .split('.')
+          .map((element) => `"${element}"`)
+          .join('.');
+      })
+      .join();
+
+    return this.knex.raw(`TRUNCATE ${sortedTableNames}`);
   }
 
   async _initTablesOrderedByDependencyWithDirtinessMap() {

--- a/api/db/database-builder/database-helpers.js
+++ b/api/db/database-builder/database-helpers.js
@@ -1,0 +1,6 @@
+const TABLE_NAME_REGEXP = /(?<=insert into\s)(?<tableName>(".*"))(?=\s\(.*)/i;
+
+export function getTableNameFromInsertSqlQuery(insertSqlQuery) {
+  const tableName = TABLE_NAME_REGEXP.exec(insertSqlQuery)?.groups?.tableName?.replaceAll('"', '');
+  return tableName;
+}

--- a/api/tests/acceptance/application/saml/saml-controller_test.js
+++ b/api/tests/acceptance/application/saml/saml-controller_test.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import { createServer, databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
+import { createServer, databaseBuilder, expect, sinon } from '../../../test-helper.js';
 
 import samlify from 'samlify';
 import { config as settings } from '../../../../lib/config.js';
@@ -183,10 +183,6 @@ describe('Acceptance | Controller | saml-controller', function () {
     const firstName = 'Saml';
     const lastName = 'Jackson';
     const samlId = 'IDO-for-saml-jackson';
-
-    afterEach(async function () {
-      await knex('user-logins').truncate();
-    });
 
     it('should return externalUser idToken if the user does not a have an account yet', async function () {
       // given

--- a/api/tests/integration/infrastructure/jobs/JobPgBoss_test.js
+++ b/api/tests/integration/infrastructure/jobs/JobPgBoss_test.js
@@ -2,9 +2,6 @@ import { expect, knex } from '../../../test-helper.js';
 import { JobPgBoss as Job } from '../../../../lib/infrastructure/jobs/JobPgBoss.js';
 
 describe('Integration | Infrastructure | Jobs | JobPgBoss', function () {
-  afterEach(function () {
-    return knex('pgboss.job').truncate();
-  });
   it('schedule a job and create in db with given config', async function () {
     // given
     const name = 'JobTest';

--- a/api/tests/integration/infrastructure/jobs/campaign-result/ParticipationResultCalculationJob_test.js
+++ b/api/tests/integration/infrastructure/jobs/campaign-result/ParticipationResultCalculationJob_test.js
@@ -2,10 +2,6 @@ import { expect, knex } from '../../../../test-helper.js';
 import { ParticipationResultCalculationJob } from '../../../../../lib/infrastructure/jobs/campaign-result/ParticipationResultCalculationJob.js';
 
 describe('Integration | Infrastructure | Jobs | CampaignResult | ParticipationResultCalculation', function () {
-  afterEach(function () {
-    return knex('pgboss.job').truncate();
-  });
-
   describe('#schedule', function () {
     it('creates the results calculation job', async function () {
       const handler = new ParticipationResultCalculationJob(knex);

--- a/api/tests/integration/infrastructure/jobs/campaign-result/SendSharedParticipationResultsToPoleEmploiJob_test.js
+++ b/api/tests/integration/infrastructure/jobs/campaign-result/SendSharedParticipationResultsToPoleEmploiJob_test.js
@@ -2,10 +2,6 @@ import { expect, knex } from '../../../../test-helper.js';
 import { SendSharedParticipationResultsToPoleEmploiJob } from '../../../../../lib/infrastructure/jobs/campaign-result/SendSharedParticipationResultsToPoleEmploiJob.js';
 
 describe('Integration | Infrastructure | Jobs | CampaignResult | SendSharedParticipationResultsToPoleEmploiJob', function () {
-  afterEach(function () {
-    return knex('pgboss.job').truncate();
-  });
-
   describe('#schedule', function () {
     it('creates the send results job', async function () {
       const job = new SendSharedParticipationResultsToPoleEmploiJob(knex);

--- a/api/tests/integration/infrastructure/repositories/pgboss-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/pgboss-repository_test.js
@@ -3,10 +3,6 @@ import * as pgBossRepository from '../../../../lib/infrastructure/repositories/p
 import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
 
 describe('Integration | Repository | PgBoss', function () {
-  afterEach(function () {
-    return knex('pgboss.job').truncate();
-  });
-
   describe('#insert', function () {
     it('should insert two jobs', async function () {
       await pgBossRepository.insert([

--- a/api/tests/prescription/campaign-participation/acceptance/application/learner-participation-route_test.js
+++ b/api/tests/prescription/campaign-participation/acceptance/application/learner-participation-route_test.js
@@ -61,10 +61,6 @@ describe('Acceptance | API | Campaign Participations', function () {
       };
     });
 
-    afterEach(function () {
-      return knex('pgboss.job').truncate();
-    });
-
     it('shares the campaign participation', async function () {
       // given
       const campaign = databaseBuilder.factory.buildCampaign();

--- a/api/tests/unit/tooling/database-builder/database-builder_test.js
+++ b/api/tests/unit/tooling/database-builder/database-builder_test.js
@@ -125,7 +125,7 @@ describe('Unit | Tooling | DatabaseBuilder | database-builder', function () {
         databaseBuilder.isFirstCommit = true;
       });
 
-      it('should init the database by cleaning tables according to dirtyness map order except for specific tables', async function () {
+      it('should init the database by cleaning tables according to dirtiness map order except for specific tables', async function () {
         // given
         const insertStub = sinon.stub().resolves();
         const trxStub = sinon.stub().returns({ insert: insertStub });
@@ -139,7 +139,8 @@ describe('Unit | Tooling | DatabaseBuilder | database-builder', function () {
         knex.raw.onCall(0).resolves({
           rows: [{ table_name: 'table2' }, { table_name: 'knex_migrations' }, { table_name: 'table1' }],
         });
-        knex.raw.onCall(1).resolves();
+        knex.raw.onCall(1).resolves({ rows: [] });
+        knex.raw.onCall(2).resolves();
         databaseBuilder.knex = knex;
         databaseBuilder.isFirstCommit = true;
 

--- a/api/tests/unit/tooling/database-builder/database-builder_test.js
+++ b/api/tests/unit/tooling/database-builder/database-builder_test.js
@@ -37,13 +37,19 @@ describe('Unit | Tooling | DatabaseBuilder | database-builder', function () {
           table: 'table3',
           isDirty: false,
         },
+        {
+          table: 'namespace1.table4',
+          isDirty: true,
+        },
       ];
 
       // when
       await databaseBuilder.clean();
 
       // then
-      expect(knex.raw).to.have.been.calledWithExactly('DELETE FROM ??;DELETE FROM ??;', ['table2', 'table1']);
+      expect(knex.raw).to.have.been.calledWithExactly(
+        'DELETE FROM "table2";DELETE FROM "table1";DELETE FROM "namespace1"."table4";',
+      );
     });
 
     it('should avoid deleting anything if not table are set for deletion in database buffer', async function () {

--- a/api/tests/unit/tooling/database-builder/database-helpers_test.js
+++ b/api/tests/unit/tooling/database-builder/database-helpers_test.js
@@ -1,0 +1,37 @@
+// eslint-disable-next-line eslint-comments/disable-enable-pair
+/* eslint-disable import/no-restricted-paths */
+import { expect } from '../../../test-helper.js';
+import * as databaseHelpers from '../../../../db/database-builder/database-helpers.js';
+
+describe('Unit | Tooling | DatabaseBuilder | database-helpers', function () {
+  describe('#getTableNameFromInsertSqlQuery', function () {
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    [
+      {
+        expectedTableName: 'users',
+        insertSqlQuery:
+          '/* path:  */ insert into "users" ("cgu", "createdAt", "email", "emailConfirmedAt", "firstName", "hasBeenAnonymised", "hasBeenAnonymisedBy", "hasSeenAssessmentInstructions", "hasSeenFocusedChallengeTooltip", "hasSeenLevelSevenInfo", "hasSeenNewDashboardInfo", "hasSeenOtherChallengesTooltip", "id", "isAnonymous", "lang", "lastDataProtectionPolicySeenAt", "lastName", "lastPixCertifTermsOfServiceValidatedAt", "lastPixOrgaTermsOfServiceValidatedAt", "lastTermsOfServiceValidatedAt", "locale", "mustValidateTermsOfService", "pixCertifTermsOfServiceAccepted", "pixOrgaTermsOfServiceAccepted", "updatedAt", "username") values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, DEFAULT, $21, $22, $23, $24, $25)',
+      },
+      {
+        expectedTableName: 'pgboss.job',
+        insertSqlQuery:
+          '/* path: /api/campaign-participations/{campaignParticipationId} */ insert into "pgboss"."job" ("data", "expirein", "name", "on_complete", "retrybackoff", "retrydelay", "retrylimit") values ($1, $2, $3, $4, $5, $6, $7)',
+      },
+      {
+        expectedTableName: 'user-logins',
+        insertSqlQuery:
+          '/* path: /api/oidc/user/reconcile */ insert into "user-logins" ("lastLoggedAt", "userId") values ($1, $2) on conflict ("userId") do update set "lastLoggedAt" = excluded."lastLoggedAt", "userId" = excluded."userId"',
+      },
+    ].forEach(({ expectedTableName, insertSqlQuery }) => {
+      context(`when receiving "${insertSqlQuery}" as insert SQL query`, function () {
+        it(`returns "${expectedTableName}" as value`, function () {
+          // when
+          const result = databaseHelpers.getTableNameFromInsertSqlQuery(insertSqlQuery);
+
+          // then
+          expect(result).to.equal(expectedTableName);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, les tables du namespace pgboss ne sont pas nettoyées automatiquement après chaque test.

La cause étant l'expression régulière ne prennant pas en compte un nom de table composé du namespace comme par exemple `"pgboss"."job"`.

## :robot: Proposition

Mettre à jour l'expression régulière pour prendre en compte le cas cité `"pgboss"."job"`.

## :rainbow: Remarques

Pour permettre le nettoyage des tables du namespace `pgboss`, il a fallu lister les tables comme pour le namespace `public`, en ajoutant comme préfixe `pgboss.`.

```
// exemple
job > pgboss.job
```
## :100: Pour tester

1. Vérifier que les tests sur la CI sont ✅ 
2. Vérifier en local, en exécutant les tests plusieurs fois que les tests sont ✅ 
3. Vérifier que les tables du namespace `pgboss` sont nettoyées à la fin de tous les tests lancés par `npm run test` sauf la table `pgboss.version` : 

```
pix=# \dt pgboss.*
             Liste des relations
 Schéma |     Nom      | Type  | Propriétaire 
--------+--------------+-------+--------------
 pgboss | archive      | table | postgres
 pgboss | job          | table | postgres
 pgboss | schedule     | table | postgres
 pgboss | subscription | table | postgres
 pgboss | version      | table | postgres
(5 lignes)

pix=# select count(*) from pgboss.archive;
 count 
-------
     0
(1 ligne)

pix=# select count(*) from pgboss.job;
 count 
-------
     0
(1 ligne)

pix=# select count(*) from pgboss.schedule;
 count 
-------
     0
(1 ligne)

pix=# select count(*) from pgboss.subscription;
 count 
-------
     0
(1 ligne)
```