### PR TITLE
[BUGFIX] corrige le calcul du score la participation (Pix-11428)

### DIFF
--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -180,6 +180,12 @@ class CantImproveCampaignParticipationError extends DomainError {
   }
 }
 
+class CantCalculateCampaignParticipationResultError extends DomainError {
+  constructor(message = `Impossible de calculer le résultat de la participation car elle n'a pas été partagée.`) {
+    super(message);
+  }
+}
+
 class NoCampaignParticipationForUserAndCampaign extends DomainError {
   constructor(message = "L'utilisateur n'a pas encore participé à la campagne") {
     super(message);
@@ -1114,6 +1120,7 @@ export {
   CandidateNotAuthorizedToJoinSessionError,
   CandidateNotAuthorizedToResumeCertificationTestError,
   CantImproveCampaignParticipationError,
+  CantCalculateCampaignParticipationResultError,
   CertificateVerificationCodeGenerationTooManyTrials,
   CertificationBadgeForbiddenDeletionError,
   CertificationCandidateAlreadyLinkedToUserError,

--- a/api/lib/domain/usecases/save-computed-campaign-participation-result.js
+++ b/api/lib/domain/usecases/save-computed-campaign-participation-result.js
@@ -1,7 +1,13 @@
+import { CantCalculateCampaignParticipationResultError } from '../errors.js';
+
 const saveComputedCampaignParticipationResult = async function ({
   participantResultsSharedRepository,
+  campaignParticipationRepository,
   campaignParticipationId,
 }) {
+  const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId);
+  if (!campaignParticipation.isShared()) throw new CantCalculateCampaignParticipationResultError();
+
   const participantResultsShared = await participantResultsSharedRepository.get(campaignParticipationId);
   return participantResultsSharedRepository.save(participantResultsShared);
 };

--- a/api/lib/domain/usecases/save-computed-campaign-participation-result.js
+++ b/api/lib/domain/usecases/save-computed-campaign-participation-result.js
@@ -6,7 +6,7 @@ const saveComputedCampaignParticipationResult = async function ({
   campaignParticipationId,
 }) {
   const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId);
-  if (!campaignParticipation.isShared()) throw new CantCalculateCampaignParticipationResultError();
+  if (!campaignParticipation.isShared) throw new CantCalculateCampaignParticipationResultError();
 
   const participantResultsShared = await participantResultsSharedRepository.get(campaignParticipationId);
   return participantResultsSharedRepository.save(participantResultsShared);

--- a/api/tests/integration/infrastructure/jobs/campaign-result/ParticipationResultCalculationJobHandler_test.js
+++ b/api/tests/integration/infrastructure/jobs/campaign-result/ParticipationResultCalculationJobHandler_test.js
@@ -1,0 +1,63 @@
+import { CampaignParticipationStatuses, CampaignTypes } from '../../../../../lib/domain/models/index.js';
+import { ParticipationResultCalculationJobHandler } from '../../../../../lib/infrastructure/jobs/campaign-result/ParticipationResultCalculationJobHandler.js';
+import { databaseBuilder, expect, knex, learningContentBuilder, mockLearningContent } from '../../../../test-helper.js';
+
+describe('Integration | Infrastructure | Jobs | CampaignResult | ParticipationResultCalculationJobHandler', function () {
+  describe('#handle', function () {
+    let participationId;
+    beforeEach(async function () {
+      const learningContentObjects = learningContentBuilder.fromAreas([
+        {
+          id: 'recArea1',
+          title_i18n: {
+            fr: 'area1_Title',
+          },
+          color: 'specialColor',
+          competences: [
+            {
+              id: 'recCompetence1',
+              name: 'Fabriquer un meuble',
+              index: '1.1',
+              tubes: [
+                {
+                  id: 'recTube1',
+                  skills: [{ id: 'recSkillId1', nom: '@web1', challenges: [] }],
+                },
+              ],
+            },
+          ],
+        },
+      ]);
+      mockLearningContent(learningContentObjects);
+
+      const { id: campaignId, organizationId } = databaseBuilder.factory.buildCampaign({
+        type: CampaignTypes.ASSESSMENT,
+      });
+      const sharedAt = new Date();
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'recSkillId1' });
+      const learner = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+      participationId = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        organizationLearnerId: learner.id,
+        userId: learner.userId,
+        status: CampaignParticipationStatuses.SHARED,
+        sharedAt,
+      }).id;
+      const ke = databaseBuilder.factory.buildKnowledgeElement({ skillId: 'recSkillId1', userId: learner.userId });
+      databaseBuilder.factory.buildKnowledgeElementSnapshot({
+        userId: learner.userId,
+        snappedAt: sharedAt,
+        snapshot: JSON.stringify([ke]),
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    it('should compute masteryRate', async function () {
+      const handler = new ParticipationResultCalculationJobHandler();
+      await handler.handle({ campaignParticipationId: participationId });
+      const result = await knex('campaign-participations').where({ id: participationId }).first();
+      expect(result.masteryRate).to.be.ok;
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/save-computed-campaign-participation-result_test.js
+++ b/api/tests/unit/domain/usecases/save-computed-campaign-participation-result_test.js
@@ -6,7 +6,7 @@ describe('Unit | Domain | UseCases | SaveComputedCompaignParticipationResult', f
   it('should throw an error if participation is not shared', async function () {
     // given
     const campaignParticipationRepository = {
-      get: sinon.stub().resolves({ isShared: () => false }),
+      get: sinon.stub().resolves({ isShared: false }),
     };
 
     // when
@@ -27,7 +27,7 @@ describe('Unit | Domain | UseCases | SaveComputedCompaignParticipationResult', f
       save: sinon.stub(),
     };
     const campaignParticipationRepository = {
-      get: sinon.stub().resolves({ isShared: () => true }),
+      get: sinon.stub().resolves({ isShared: true }),
     };
 
     // when

--- a/api/tests/unit/domain/usecases/save-computed-campaign-participation-result_test.js
+++ b/api/tests/unit/domain/usecases/save-computed-campaign-participation-result_test.js
@@ -1,7 +1,24 @@
-import { expect, sinon } from '../../../test-helper.js';
+import { expect, catchErr, sinon } from '../../../test-helper.js';
 import { saveComputedCampaignParticipationResult } from '../../../../lib/domain/usecases/save-computed-campaign-participation-result.js';
+import { CantCalculateCampaignParticipationResultError } from '../../../../lib/domain/errors.js';
 
 describe('Unit | Domain | UseCases | SaveComputedCompaignParticipationResult', function () {
+  it('should throw an error if participation is not shared', async function () {
+    // given
+    const campaignParticipationRepository = {
+      get: sinon.stub().resolves({ isShared: () => false }),
+    };
+
+    // when
+    const error = await catchErr(saveComputedCampaignParticipationResult)({
+      campaignParticipationRepository,
+      campaignParticipationId: 1,
+    });
+
+    // then
+    expect(error).to.be.instanceof(CantCalculateCampaignParticipationResultError);
+  });
+
   it('should compute results and save', async function () {
     // given
     const participationResultsShared = Symbol('participation results shared');
@@ -9,9 +26,13 @@ describe('Unit | Domain | UseCases | SaveComputedCompaignParticipationResult', f
       get: sinon.stub().resolves(participationResultsShared),
       save: sinon.stub(),
     };
+    const campaignParticipationRepository = {
+      get: sinon.stub().resolves({ isShared: () => true }),
+    };
 
     // when
     await saveComputedCampaignParticipationResult({
+      campaignParticipationRepository,
       participantResultsSharedRepository,
       campaignParticipationId: 1,
     });


### PR DESCRIPTION
## :unicorn: Problème
Un bug a été introduit lors de la PR #8144 qui fait que le calcul échoue

## :robot: Proposition
on fix le problème :muscle: 

## :rainbow: Remarques
On en profites pour rajouter un test d'intégration du cas nominal du job

## :100: Pour tester

- on participe à une campagne d'eval et on partage ses résultat
- on se connecte sur orga 
- on affiche la participation fraîchement partagée
- on voit le résultat de la personne