### PR TITLE
[TECH] Créer la route de réconciliation pour le SSO Google sur Pix Admin (PIX-1143).

### DIFF
--- a/api/lib/application/admin-members/index.js
+++ b/api/lib/application/admin-members/index.js
@@ -29,6 +29,18 @@ const register = async function (server) {
       path: '/api/admin/admin-members/me',
       config: {
         handler: adminMemberController.getCurrentAdminMember,
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
         notes: [
           "- **Cette route n'est pas restreinte**\n" +
             '- Récupération du membre admin pix courant ayant accès à Pix Admin\n',

--- a/api/lib/application/authentication/oidc/index.js
+++ b/api/lib/application/authentication/oidc/index.js
@@ -15,6 +15,31 @@ const register = async function (server) {
         tags: ['api', 'oidc'],
       },
     },
+    {
+      method: 'POST',
+      path: '/api/admin/oidc/user/reconcile',
+      config: {
+        auth: false,
+        validate: {
+          payload: Joi.object({
+            data: Joi.object({
+              attributes: Joi.object({
+                email: Joi.string().email().required(),
+                identity_provider: Joi.string().required(),
+                authentication_key: Joi.string().required(),
+              }),
+              type: Joi.string(),
+            }),
+          }),
+        },
+        handler: oidcController.reconcileUserForAdmin,
+        notes: [
+          "- Cette route permet d'ajouter le fournisseur d'identité d'où provient l'utilisateur comme méthode de connexion à son compte Pix.\n" +
+            "- Cette action s'effectue après que l'utilisateur se soit identifié auprès de son fournisseur d'identité",
+        ],
+        tags: ['api', 'admin', 'oidc'],
+      },
+    },
   ];
 
   server.route([

--- a/api/lib/application/authentication/oidc/oidc-controller.js
+++ b/api/lib/application/authentication/oidc/oidc-controller.js
@@ -1,9 +1,9 @@
+import { PIX_ADMIN } from '../../../../src/authorization/domain/constants.js';
 import { oidcAuthenticationServiceRegistry as authenticationServiceRegistry } from '../../../domain/services/authentication/authentication-service-registry.js';
 import { usecases } from '../../../domain/usecases/index.js';
 import * as oidcProviderSerializer from '../../../infrastructure/serializers/jsonapi/oidc-identity-providers-serializer.js';
 import * as oidcSerializer from '../../../infrastructure/serializers/jsonapi/oidc-serializer.js';
 import { UnauthorizedError } from '../../http-errors.js';
-import { PIX_ADMIN } from '../../../../src/authorization/domain/constants.js';
 
 const getAllIdentityProvidersForAdmin = async function (request, h) {
   const identityProviders = usecases.getAllIdentityProviders();

--- a/api/lib/application/authentication/oidc/oidc-controller.js
+++ b/api/lib/application/authentication/oidc/oidc-controller.js
@@ -130,8 +130,9 @@ const authenticateUser = async function (
   } else {
     const message = "L'utilisateur n'a pas de compte Pix";
     const responseCode = 'SHOULD_VALIDATE_CGU';
-    const { authenticationKey, givenName, familyName } = result;
+    const { authenticationKey, givenName, familyName, email } = result;
     const meta = { authenticationKey, givenName, familyName };
+    if (email) Object.assign(meta, { email });
     throw new UnauthorizedError(message, responseCode, meta);
   }
 };

--- a/api/lib/domain/services/authentication/authentication-service-registry.js
+++ b/api/lib/domain/services/authentication/authentication-service-registry.js
@@ -9,6 +9,9 @@ class OidcAuthenticationServiceRegistry {
     await Promise.allSettled(
       this.#readyOidcProviderServices.map((oidcProviderService) => oidcProviderService.createClient()),
     );
+    await Promise.allSettled(
+      this.#readyOidcProviderServicesForPixAdmin.map((oidcProviderService) => oidcProviderService.createClient()),
+    );
   }
 
   getAllOidcProviderServices() {

--- a/api/lib/domain/services/authentication/google-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/google-oidc-authentication-service.js
@@ -1,3 +1,5 @@
+import jsonwebtoken from 'jsonwebtoken';
+
 import { OidcAuthenticationService } from '../../../../src/authentication/domain/services/oidc-authentication-service.js';
 import { config } from '../../../config.js';
 import { GOOGLE } from '../../constants/oidc-identity-providers.js';
@@ -17,9 +19,19 @@ class GoogleOidcAuthenticationService extends OidcAuthenticationService {
       redirectUri: config[configKey].redirectUri,
       slug: 'google',
       source: 'google',
+      scope: 'openid profile email',
     });
 
     this.temporaryStorage = config[configKey].temporaryStorage;
+  }
+
+  async getUserInfo({ idToken }) {
+    const userInfo = jsonwebtoken.decode(idToken);
+
+    return {
+      externalIdentityId: userInfo.sub,
+      email: userInfo.email,
+    };
   }
 }
 

--- a/api/lib/domain/usecases/authentication/authenticate-oidc-user.js
+++ b/api/lib/domain/usecases/authentication/authenticate-oidc-user.js
@@ -28,8 +28,8 @@ const authenticateOidcUser = async function ({
 
   if (!user) {
     const authenticationKey = await authenticationSessionService.save({ userInfo, sessionContent });
-    const { firstName: givenName, lastName: familyName } = userInfo;
-    return { authenticationKey, givenName, familyName, isAuthenticationComplete: false };
+    const { firstName: givenName, lastName: familyName, email } = userInfo;
+    return { authenticationKey, givenName, familyName, email, isAuthenticationComplete: false };
   }
 
   await _updateAuthenticationMethodWithComplement({

--- a/api/lib/domain/usecases/authentication/authenticate-oidc-user.js
+++ b/api/lib/domain/usecases/authentication/authenticate-oidc-user.js
@@ -1,5 +1,5 @@
-import { ForbiddenAccess } from '../../../../src/shared/domain/errors.js';
 import { PIX_ADMIN } from '../../../../src/authorization/domain/constants.js';
+import { ForbiddenAccess } from '../../../../src/shared/domain/errors.js';
 
 const authenticateOidcUser = async function ({
   sessionState,

--- a/api/lib/domain/usecases/get-admin-member-details.js
+++ b/api/lib/domain/usecases/get-admin-member-details.js
@@ -1,13 +1,14 @@
-import { NotFoundError } from '../errors.js';
+/**
+ * @typedef {import ('./index.js').AdminMemberRepository} AdminMemberRepository
+ */
 
-const getAdminMemberDetails = async function ({ adminMemberRepository, userId }) {
-  const adminMemberDetail = await adminMemberRepository.get({ userId });
-
-  if (!adminMemberDetail) {
-    throw new NotFoundError();
-  }
-
-  return adminMemberDetail;
+/**
+ * @param {Object} params
+ * @param {number} params.userId
+ * @param {AdminMemberRepository} params.adminMemberRepository
+ */
+const getAdminMemberDetails = async function ({ userId, adminMemberRepository }) {
+  return await adminMemberRepository.get({ userId });
 };
 
 export { getAdminMemberDetails };

--- a/api/lib/domain/usecases/reconcile-oidc-user-for-admin.js
+++ b/api/lib/domain/usecases/reconcile-oidc-user-for-admin.js
@@ -1,0 +1,86 @@
+/**
+ * @typedef {import ('./index.js').OidcAuthenticationService} OidcAuthenticationService
+ * @typedef {import ('./index.js').AuthenticationSessionService} AuthenticationSessionService
+ * @typedef {import ('./index.js').AuthenticationMethodRepository} AuthenticationMethodRepository
+ * @typedef {import ('./index.js').UserRepository} UserRepository
+ * @typedef {import ('./index.js').UserLoginRepository} UserLoginRepository
+ */
+
+import { AuthenticationKeyExpired, DifferentExternalIdentifierError } from '../errors.js';
+import { AuthenticationMethod } from '../models/index.js';
+
+/**
+ * @param {Object} params
+ * @param {string} params.authenticationKey
+ * @param {string} params.email
+ * @param {string} params.identityProvider
+ * @param {OidcAuthenticationService} params.oidcAuthenticationService
+ * @param {AuthenticationSessionService} params.authenticationSessionService
+ * @param {AuthenticationMethodRepository} params.authenticationMethodRepository
+ * @param {UserRepository} params.userRepository
+ * @param {UserLoginRepository} params.userLoginRepository
+ */
+const reconcileOidcUserForAdmin = async function ({
+  authenticationKey,
+  email,
+  identityProvider,
+  oidcAuthenticationService,
+  authenticationSessionService,
+  authenticationMethodRepository,
+  userRepository,
+  userLoginRepository,
+}) {
+  const sessionContentAndUserInfo = await authenticationSessionService.getByKey(authenticationKey);
+  if (!sessionContentAndUserInfo) {
+    throw new AuthenticationKeyExpired();
+  }
+
+  const foundUser = await userRepository.getByEmail(email);
+  const userId = foundUser.id;
+
+  await _assertExternalIdentifier({
+    sessionContentAndUserInfo,
+    identityProvider,
+    userId,
+    authenticationMethodRepository,
+  });
+
+  const { userInfo } = sessionContentAndUserInfo;
+  const { externalIdentityId } = userInfo;
+
+  const authenticationComplement = oidcAuthenticationService.createAuthenticationComplement({ userInfo });
+  await authenticationMethodRepository.create({
+    authenticationMethod: new AuthenticationMethod({
+      identityProvider: oidcAuthenticationService.identityProvider,
+      userId,
+      externalIdentifier: externalIdentityId,
+      authenticationComplement,
+    }),
+  });
+
+  const accessToken = await oidcAuthenticationService.createAccessToken(userId);
+  userLoginRepository.updateLastLoggedAt({ userId });
+
+  return accessToken;
+};
+
+export { reconcileOidcUserForAdmin };
+
+async function _assertExternalIdentifier({
+  sessionContentAndUserInfo,
+  identityProvider,
+  userId,
+  authenticationMethodRepository,
+}) {
+  const oidcAuthenticationMethod = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({
+    userId,
+    identityProvider,
+  });
+
+  const isSameExternalIdentifier =
+    oidcAuthenticationMethod?.externalIdentifier === sessionContentAndUserInfo.userInfo.externalIdentityId;
+
+  if (oidcAuthenticationMethod && !isSameExternalIdentifier) {
+    throw new DifferentExternalIdentifierError();
+  }
+}

--- a/api/src/authorization/domain/constants.js
+++ b/api/src/authorization/domain/constants.js
@@ -7,6 +7,7 @@ const PIX_ADMIN = {
     SUPPORT: 'SUPPORT',
   },
   SCOPE: 'pix-admin',
+  AUDIENCE: 'admin',
 };
 
 const PIX_ORGA = {

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -77,7 +77,7 @@ function _mapToHttpError(error) {
     return new HttpErrors.NotFoundError(error.message);
   }
   if (error instanceof DomainErrors.ForbiddenAccess) {
-    return new HttpErrors.ForbiddenError(error.message);
+    return new HttpErrors.ForbiddenError(error.message, error.code);
   }
   if (error instanceof DomainErrors.CsvImportError) {
     return new HttpErrors.PreconditionFailedError(error.message, error.code, error.meta);

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -380,6 +380,7 @@ const configuration = (function () {
       clientId: 'client',
       clientSecret: 'secret',
       isEnabled: true,
+      isEnabledForPixAdmin: true,
       openidConfigurationUrl: 'https://oidc.example.net/.well-known/openid-configuration',
       organizationName: 'Oidc Example',
       postLogoutRedirectUri: 'https://app.dev.pix.local/connexion',

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -80,8 +80,9 @@ class EntityValidationError extends DomainError {
 }
 
 class ForbiddenAccess extends DomainError {
-  constructor(message = 'Accès non autorisé.') {
+  constructor(message = 'Accès non autorisé.', code) {
     super(message);
+    this.code = code;
   }
 }
 

--- a/api/tests/acceptance/application/admin-members/admin-members-routes_test.js
+++ b/api/tests/acceptance/application/admin-members/admin-members-routes_test.js
@@ -30,24 +30,27 @@ describe('Acceptance | Application | Admin-members | Routes', function () {
       // then
       expect(response.statusCode).to.equal(200);
     });
-    it('should return 404 http status code when user is not a member of pix admin and has no role', async function () {
-      // given
-      const user = databaseBuilder.factory.buildUser();
-      await databaseBuilder.commit();
-      const server = await createServer();
 
-      // when
-      const response = await server.inject({
-        headers: {
-          authorization: generateValidRequestAuthorizationHeader(user.id),
-        },
-        method: 'GET',
-        url: '/api/admin/admin-members/me',
+    context('when user is not a member of pix admin and has no role', function () {
+      it('should return 403 http status code', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser();
+        await databaseBuilder.commit();
+        const server = await createServer();
+
+        // when
+        const response = await server.inject({
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(user.id),
+          },
+          method: 'GET',
+          url: '/api/admin/admin-members/me',
+        });
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        expect(response.statusMessage).to.equal('Forbidden');
       });
-
-      // then
-      expect(response.statusCode).to.equal(404);
-      expect(response.statusMessage).to.equal('Not Found');
     });
   });
 

--- a/api/tests/acceptance/application/authentication/oidc/reconcile-route-admin-post_test.js
+++ b/api/tests/acceptance/application/authentication/oidc/reconcile-route-admin-post_test.js
@@ -1,6 +1,7 @@
-import { expect, databaseBuilder, createServer } from '../../../../test-helper.js';
 import jsonwebtoken from 'jsonwebtoken';
+
 import * as authenticationSessionService from '../../../../../lib/domain/services/authentication/authentication-session-service.js';
+import { createServer, databaseBuilder, expect } from '../../../../test-helper.js';
 
 describe('Acceptance | Application | Oidc | Routes', function () {
   describe('POST /api/admin/oidc/user/reconcile', function () {

--- a/api/tests/acceptance/application/authentication/oidc/reconcile-route-admin-post_test.js
+++ b/api/tests/acceptance/application/authentication/oidc/reconcile-route-admin-post_test.js
@@ -1,0 +1,53 @@
+import { expect, databaseBuilder, createServer } from '../../../../test-helper.js';
+import jsonwebtoken from 'jsonwebtoken';
+import * as authenticationSessionService from '../../../../../lib/domain/services/authentication/authentication-session-service.js';
+
+describe('Acceptance | Application | Oidc | Routes', function () {
+  describe('POST /api/admin/oidc/user/reconcile', function () {
+    it('should return 200 HTTP status', async function () {
+      // given
+      const user = databaseBuilder.factory.buildUser.withRawPassword({
+        email: 'eva.poree@example.net',
+        rawPassword: 'pix123',
+      });
+      await databaseBuilder.commit();
+      const server = await createServer();
+
+      const idToken = jsonwebtoken.sign(
+        {
+          given_name: 'Brice',
+          family_name: 'Glace',
+          sub: 'some-user-unique-id',
+        },
+        'secret',
+      );
+      const userAuthenticationKey = await authenticationSessionService.save({
+        sessionContent: { idToken },
+        userInfo: {
+          firstName: 'Brice',
+          lastName: 'Glace',
+          externalIdentityId: 'some-user-unique-id',
+        },
+      });
+
+      // when
+      const response = await server.inject({
+        method: 'POST',
+        url: `/api/admin/oidc/user/reconcile`,
+        payload: {
+          data: {
+            attributes: {
+              identity_provider: 'OIDC_EXAMPLE_NET',
+              authentication_key: userAuthenticationKey,
+              email: user.email,
+            },
+          },
+        },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result['access_token']).to.exist;
+    });
+  });
+});

--- a/api/tests/acceptance/application/authentication/oidc/token-route-post_test.js
+++ b/api/tests/acceptance/application/authentication/oidc/token-route-post_test.js
@@ -57,9 +57,9 @@ describe('Acceptance | Route | oidc | token', function () {
         // given
         const idToken = jsonwebtoken.sign(
           {
-            sub: 'sub',
             given_name: 'John',
             family_name: 'Doe',
+            sub: 'sub',
           },
           'secret',
         );
@@ -135,7 +135,6 @@ describe('Acceptance | Route | oidc | token', function () {
           {
             given_name: firstName,
             family_name: lastName,
-            nonce: 'nonce',
             sub: externalIdentifier,
           },
           'secret',

--- a/api/tests/authentication/unit/domain/services/oidc-authentication-service_test.js
+++ b/api/tests/authentication/unit/domain/services/oidc-authentication-service_test.js
@@ -630,8 +630,8 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       expect(clientInstance.userinfo).to.have.been.calledOnceWithExactly(accessToken);
       expect(pickedUserInfo).to.deep.equal({
         sub: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
-        family_name: 'familyName',
         given_name: 'givenName',
+        family_name: 'familyName',
       });
     });
 

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -353,11 +353,12 @@ describe('Integration | API | Controller Error', function () {
     });
 
     it('responds Forbidden when a ForbiddenAccess error occurs', async function () {
-      routeHandler.throws(new ForbiddenAccess('Accès non autorisé.'));
+      routeHandler.throws(new ForbiddenAccess('Accès non autorisé.', 'FORBIDDEN_ACCESS'));
       const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
       expect(responseDetail(response)).to.equal('Accès non autorisé.');
+      expect(responseCode(response)).to.equal('FORBIDDEN_ACCESS');
     });
 
     it('responds Forbidden when a UserAlreadyLinkedToCandidateInSessionError error occurs', async function () {

--- a/api/tests/unit/application/admin-members/index_test.js
+++ b/api/tests/unit/application/admin-members/index_test.js
@@ -8,23 +8,6 @@ import * as adminMembersRouter from '../../../../lib/application/admin-members/i
 import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 
 describe('Unit | Application | Router | admin-members-router', function () {
-  describe('GET /api/admin/admin-members/me', function () {
-    it('should return a response with an HTTP status code 200', async function () {
-      // given
-      const adminMember = domainBuilder.buildAdminMember();
-      sinon.stub(adminMemberController, 'getCurrentAdminMember').returns(adminMember);
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(adminMembersRouter);
-
-      // when
-      const { statusCode } = await httpTestServer.request('GET', '/api/admin/admin-members/me');
-
-      // then
-      expect(adminMemberController.getCurrentAdminMember).to.have.be.called;
-      expect(statusCode).to.equal(200);
-    });
-  });
-
   describe('GET /api/admin/admin-members', function () {
     it('should return a response with an HTTP status code 200 when user has role "SUPER_ADMIN"', async function () {
       // given

--- a/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
+++ b/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
@@ -2,6 +2,7 @@ import { oidcController } from '../../../../../lib/application/authentication/oi
 import { UnauthorizedError } from '../../../../../lib/application/http-errors.js';
 import { usecases } from '../../../../../lib/domain/usecases/index.js';
 import { catchErr, domainBuilder, expect, hFake, sinon } from '../../../../test-helper.js';
+import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
 
 describe('Unit | Application | Controller | Authentication | OIDC', function () {
   const identityProvider = 'OIDC';
@@ -175,7 +176,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
           query: {
             identity_provider: identityProvider,
             redirect_uri: 'http:/exemple.net/',
-            audience: 'admin',
+            audience: PIX_ADMIN.AUDIENCE,
           },
           yar: { set: sinon.stub(), commit: sinon.stub() },
         };
@@ -199,7 +200,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
         // then
         expect(authenticationServiceRegistryStub.getOidcProviderServiceByCode).to.have.been.calledWith({
           identityProviderCode: identityProvider,
-          audience: 'admin',
+          audience: PIX_ADMIN.AUDIENCE,
         });
       });
     });
@@ -277,7 +278,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
           ...request,
           deserializedPayload: {
             ...request.deserializedPayload,
-            audience: 'admin',
+            audience: PIX_ADMIN.AUDIENCE,
           },
         };
         const oidcAuthenticationService = {};
@@ -308,7 +309,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
         // then
         expect(authenticationServiceRegistryStub.getOidcProviderServiceByCode).to.have.been.calledWithExactly({
           identityProviderCode: identityProvider,
-          audience: 'admin',
+          audience: PIX_ADMIN.AUDIENCE,
         });
       });
     });
@@ -490,6 +491,33 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
 
       // then
       expect(result.source).to.deep.equal({ access_token: 'accessToken', logout_url_uuid: 'logoutUrlUUID' });
+    });
+  });
+
+  describe('#reconcileUserForAdmin', function () {
+    it('should call use case and return the result', async function () {
+      // given
+      const request = {
+        deserializedPayload: {
+          identityProvider: 'OIDC',
+          authenticationKey: '123abc',
+          email: 'user@example.net',
+        },
+      };
+      const authenticationServiceRegistryStub = {
+        getOidcProviderServiceByCode: sinon.stub(),
+      };
+
+      const dependencies = {
+        authenticationServiceRegistry: authenticationServiceRegistryStub,
+      };
+      sinon.stub(usecases, 'reconcileOidcUserForAdmin').resolves('accessToken');
+
+      // when
+      const result = await oidcController.reconcileUserForAdmin(request, hFake, dependencies);
+
+      // then
+      expect(result.source).to.deep.equal({ access_token: 'accessToken' });
     });
   });
 });

--- a/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
+++ b/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
@@ -1,8 +1,8 @@
 import { oidcController } from '../../../../../lib/application/authentication/oidc/oidc-controller.js';
 import { UnauthorizedError } from '../../../../../lib/application/http-errors.js';
 import { usecases } from '../../../../../lib/domain/usecases/index.js';
-import { catchErr, domainBuilder, expect, hFake, sinon } from '../../../../test-helper.js';
 import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
+import { catchErr, domainBuilder, expect, hFake, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Application | Controller | Authentication | OIDC', function () {
   const identityProvider = 'OIDC';

--- a/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
+++ b/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
@@ -362,7 +362,8 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       const authenticationKey = 'aaa-bbb-ccc';
       const givenName = 'Mélusine';
       const familyName = 'TITEGOUTTE';
-      usecases.authenticateOidcUser.resolves({ authenticationKey, givenName, familyName });
+      const email = 'melu@example.net';
+      usecases.authenticateOidcUser.resolves({ authenticationKey, givenName, familyName, email });
 
       // when
       const error = await catchErr(oidcController.authenticateUser)(request, hFake, dependencies);
@@ -371,7 +372,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       expect(error).to.be.an.instanceOf(UnauthorizedError);
       expect(error.message).to.equal("L'utilisateur n'a pas de compte Pix");
       expect(error.code).to.equal('SHOULD_VALIDATE_CGU');
-      expect(error.meta).to.deep.equal({ authenticationKey, givenName, familyName });
+      expect(error.meta).to.deep.equal({ authenticationKey, givenName, familyName, email });
     });
   });
 

--- a/api/tests/unit/domain/services/authentication/authentication-service-registry_test.js
+++ b/api/tests/unit/domain/services/authentication/authentication-service-registry_test.js
@@ -1,7 +1,7 @@
 import { InvalidIdentityProviderError } from '../../../../../lib/domain/errors.js';
 import { oidcAuthenticationServiceRegistry } from '../../../../../lib/domain/services/authentication/authentication-service-registry.js';
-import { catchErrSync, expect, sinon } from '../../../../test-helper.js';
 import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
+import { catchErrSync, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Domain | Services | authentication registry', function () {
   describe('#getAllOidcProviderServices', function () {

--- a/api/tests/unit/domain/services/authentication/authentication-service-registry_test.js
+++ b/api/tests/unit/domain/services/authentication/authentication-service-registry_test.js
@@ -147,6 +147,7 @@ describe('Unit | Domain | Services | authentication registry', function () {
       expect(error.message).to.equal(`Identity provider ${identityProviderCode} is not supported.`);
     });
   });
+
   describe('#loadOidcProviderServices', function () {
     it('loads all given oidc provider services and filters them', function () {
       // given
@@ -178,12 +179,30 @@ describe('Unit | Domain | Services | authentication registry', function () {
   describe('#configureReadyOidcProviderServices', function () {
     it('configures openid client for ready oidc provider services', async function () {
       // given
-      sinon.restore();
       const createClient = sinon.stub().resolves();
       const oidcProviderServices = [
         {
           code: 'OIDC',
           isReady: true,
+          createClient,
+        },
+      ];
+      oidcAuthenticationServiceRegistry.loadOidcProviderServices(oidcProviderServices);
+
+      // when
+      await oidcAuthenticationServiceRegistry.configureReadyOidcProviderServices();
+
+      // then
+      expect(createClient).to.have.been.calledOnce;
+    });
+
+    it('configures openid client for ready oidc provider services for Pix Admin', async function () {
+      // given
+      const createClient = sinon.stub().resolves();
+      const oidcProviderServices = [
+        {
+          code: 'OIDC',
+          isReadyForPixAdmin: true,
           createClient,
         },
       ];

--- a/api/tests/unit/domain/services/authentication/authentication-service-registry_test.js
+++ b/api/tests/unit/domain/services/authentication/authentication-service-registry_test.js
@@ -1,6 +1,7 @@
 import { InvalidIdentityProviderError } from '../../../../../lib/domain/errors.js';
 import { oidcAuthenticationServiceRegistry } from '../../../../../lib/domain/services/authentication/authentication-service-registry.js';
 import { catchErrSync, expect, sinon } from '../../../../test-helper.js';
+import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
 
 describe('Unit | Domain | Services | authentication registry', function () {
   describe('#getAllOidcProviderServices', function () {
@@ -90,7 +91,7 @@ describe('Unit | Domain | Services | authentication registry', function () {
         // when
         const service = oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({
           identityProviderCode: 'PROVIDER_FOR_ADMIN',
-          audience: 'admin',
+          audience: PIX_ADMIN.AUDIENCE,
         });
 
         // then

--- a/api/tests/unit/domain/services/authentication/google-oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/google-oidc-authentication-service_test.js
@@ -1,0 +1,41 @@
+import jsonwebtoken from 'jsonwebtoken';
+
+import { GoogleOidcAuthenticationService } from '../../../../../lib/domain/services/authentication/google-oidc-authentication-service.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Domain | Services | google-oidc-authentication-service', function () {
+  describe('#getUserInfo', function () {
+    it('returns email and external identity id', async function () {
+      // given
+      function generateIdToken(payload) {
+        return jsonwebtoken.sign(
+          {
+            ...payload,
+          },
+          'secret',
+        );
+      }
+
+      const idToken = generateIdToken({
+        given_name: 'givenName',
+        family_name: 'familyName',
+        nonce: 'bb041272-d6e6-457c-99fb-ff1aa02217fd',
+        sub: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
+        email: 'given.family@example.net',
+      });
+
+      const googleOidcAuthenticationService = new GoogleOidcAuthenticationService({});
+
+      // when
+      const result = await googleOidcAuthenticationService.getUserInfo({
+        idToken,
+      });
+
+      // then
+      expect(result).to.deep.equal({
+        externalIdentityId: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
+        email: 'given.family@example.net',
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/authentication/authenticate-oidc-user_test.js
+++ b/api/tests/unit/domain/usecases/authentication/authenticate-oidc-user_test.js
@@ -1,11 +1,11 @@
 import { POLE_EMPLOI } from '../../../../../lib/domain/constants/oidc-identity-providers.js';
 import { AuthenticationMethod } from '../../../../../lib/domain/models/AuthenticationMethod.js';
 import { AuthenticationSessionContent } from '../../../../../lib/domain/models/AuthenticationSessionContent.js';
-import { AdminMember } from '../../../../../src/shared/domain/models/AdminMember.js';
 import { authenticateOidcUser } from '../../../../../lib/domain/usecases/authentication/authenticate-oidc-user.js';
-import { catchErr, expect, sinon } from '../../../../test-helper.js';
-import { ForbiddenAccess } from '../../../../../src/shared/domain/errors.js';
 import * as appMessages from '../../../../../src/authorization/domain/constants.js';
+import { ForbiddenAccess } from '../../../../../src/shared/domain/errors.js';
+import { AdminMember } from '../../../../../src/shared/domain/models/AdminMember.js';
+import { catchErr, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | UseCase | authenticate-oidc-user', function () {
   context('when identityProvider is generic', function () {

--- a/api/tests/unit/domain/usecases/get-admin-member-details_test.js
+++ b/api/tests/unit/domain/usecases/get-admin-member-details_test.js
@@ -1,39 +1,19 @@
-import { NotFoundError } from '../../../../lib/domain/errors.js';
 import { getAdminMemberDetails } from '../../../../lib/domain/usecases/get-admin-member-details.js';
-import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';
+import { domainBuilder, expect, sinon } from '../../../test-helper.js';
 
 describe('Unit | UseCase | get-admin-member-details', function () {
-  context('when it exists', function () {
-    it('should return an admin member details', async function () {
-      // given
-      const adminMemberRepository = {
-        get: sinon.stub(),
-      };
-      const adminMember = domainBuilder.buildAdminMember();
-      adminMemberRepository.get.withArgs({ userId: adminMember.id }).resolves(adminMember);
+  it('should return an admin member details', async function () {
+    // given
+    const adminMemberRepository = {
+      get: sinon.stub(),
+    };
+    const adminMember = domainBuilder.buildAdminMember();
+    adminMemberRepository.get.withArgs({ userId: adminMember.id }).resolves(adminMember);
 
-      // when
-      const adminMemberDetails = await getAdminMemberDetails({ adminMemberRepository, userId: adminMember.id });
+    // when
+    const adminMemberDetails = await getAdminMemberDetails({ adminMemberRepository, userId: adminMember.id });
 
-      // then
-      expect(adminMemberDetails).to.deep.equal(adminMember);
-    });
-  });
-
-  context('when it does not exist', function () {
-    it('should thrown a NotFound error', async function () {
-      // given
-      const adminMemberRepository = {
-        get: sinon.stub(),
-      };
-      const adminMember = domainBuilder.buildAdminMember();
-      adminMemberRepository.get.withArgs({ userId: adminMember.id }).resolves(undefined);
-
-      // when
-      const error = await catchErr(getAdminMemberDetails)({ adminMemberRepository, userId: adminMember.id });
-
-      // then
-      expect(error).to.be.instanceOf(NotFoundError);
-    });
+    // then
+    expect(adminMemberDetails).to.deep.equal(adminMember);
   });
 });

--- a/api/tests/unit/domain/usecases/get-ready-identity-providers_test.js
+++ b/api/tests/unit/domain/usecases/get-ready-identity-providers_test.js
@@ -1,5 +1,6 @@
 import { getReadyIdentityProviders } from '../../../../lib/domain/usecases/get-ready-identity-providers.js';
 import { expect, sinon } from '../../../test-helper.js';
+import { PIX_ADMIN } from '../../../../src/authorization/domain/constants.js';
 
 describe('Unit | UseCase | get-ready-identity-providers', function () {
   describe('when an audience is provided', function () {
@@ -16,7 +17,7 @@ describe('Unit | UseCase | get-ready-identity-providers', function () {
 
         // when
         const identityProviders = getReadyIdentityProviders({
-          audience: 'admin',
+          audience: PIX_ADMIN.AUDIENCE,
           authenticationServiceRegistry: authenticationServiceRegistryStub,
         });
 

--- a/api/tests/unit/domain/usecases/get-ready-identity-providers_test.js
+++ b/api/tests/unit/domain/usecases/get-ready-identity-providers_test.js
@@ -1,6 +1,6 @@
 import { getReadyIdentityProviders } from '../../../../lib/domain/usecases/get-ready-identity-providers.js';
-import { expect, sinon } from '../../../test-helper.js';
 import { PIX_ADMIN } from '../../../../src/authorization/domain/constants.js';
+import { expect, sinon } from '../../../test-helper.js';
 
 describe('Unit | UseCase | get-ready-identity-providers', function () {
   describe('when an audience is provided', function () {

--- a/api/tests/unit/domain/usecases/reconcile-oidc-user-for-admin_test.js
+++ b/api/tests/unit/domain/usecases/reconcile-oidc-user-for-admin_test.js
@@ -1,0 +1,172 @@
+import { expect, sinon, catchErr, domainBuilder } from '../../../test-helper.js';
+import { reconcileOidcUserForAdmin } from '../../../../lib/domain/usecases/reconcile-oidc-user-for-admin.js';
+import { AuthenticationKeyExpired, DifferentExternalIdentifierError } from '../../../../lib/domain/errors.js';
+import { AuthenticationMethod } from '../../../../lib/domain/models/index.js';
+import * as OidcIdentityProviders from '../../../../lib/domain/constants/oidc-identity-providers.js';
+
+describe('Unit | UseCase | reconcile-oidc-user-for-admin', function () {
+  let authenticationMethodRepository,
+    userRepository,
+    userLoginRepository,
+    authenticationSessionService,
+    oidcAuthenticationService;
+  const identityProvider = 'GOOGLE';
+
+  beforeEach(function () {
+    authenticationMethodRepository = { create: sinon.stub(), findOneByUserIdAndIdentityProvider: sinon.stub() };
+    userRepository = { getByEmail: sinon.stub() };
+    userLoginRepository = { updateLastLoggedAt: sinon.stub() };
+    authenticationSessionService = { getByKey: sinon.stub() };
+    oidcAuthenticationService = {
+      identityProvider,
+      createAccessToken: sinon.stub(),
+      createAuthenticationComplement: sinon.stub(),
+    };
+  });
+
+  it('should retrieve user session content and user info', async function () {
+    // given
+    const email = 'anne@example.net';
+    const userInfo = { externalIdentityId: 'external_id', firstName: 'Anne', email };
+    authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(null);
+    userRepository.getByEmail.resolves({ email, id: 2 });
+    authenticationSessionService.getByKey.resolves({
+      sessionContent: {},
+      userInfo,
+    });
+    oidcAuthenticationService.createAuthenticationComplement
+      .withArgs({ userInfo })
+      .returns(AuthenticationMethod.OidcAuthenticationComplement);
+
+    // when
+    await reconcileOidcUserForAdmin({
+      email,
+      authenticationKey: 'authenticationKey',
+      oidcAuthenticationService,
+      authenticationSessionService,
+      authenticationMethodRepository,
+      userRepository,
+      userLoginRepository,
+    });
+
+    // then
+    expect(authenticationSessionService.getByKey).to.be.calledOnceWith('authenticationKey');
+  });
+
+  it('should find user and his authentication methods', async function () {
+    // given
+    const email = 'sarah.pix@example.net';
+    const userInfo = { externalIdentityId: 'external_id', firstName: 'Sarah', email };
+    authenticationSessionService.getByKey.resolves({
+      sessionContent: {},
+      userInfo,
+    });
+    userRepository.getByEmail.resolves({ email, id: 2 });
+    authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(null);
+    oidcAuthenticationService.createAuthenticationComplement
+      .withArgs({ userInfo })
+      .returns(AuthenticationMethod.OidcAuthenticationComplement);
+
+    // when
+    await reconcileOidcUserForAdmin({
+      email,
+      identityProvider,
+      authenticationKey: 'authenticationKey',
+      oidcAuthenticationService,
+      authenticationSessionService,
+      authenticationMethodRepository,
+      userRepository,
+      userLoginRepository,
+    });
+
+    // then
+    expect(userRepository.getByEmail).to.be.calledOnceWith(email);
+    expect(authenticationMethodRepository.findOneByUserIdAndIdentityProvider).to.be.calledOnceWith({
+      userId: 2,
+      identityProvider,
+    });
+  });
+
+  it('should return an access token and update the last logged date', async function () {
+    // given
+    const email = 'anne@example.net';
+    const externalIdentifier = 'external_id';
+    const userInfo = { externalIdentityId: externalIdentifier, firstName: 'Sarah', email };
+    const userId = 1;
+    authenticationSessionService.getByKey.resolves({
+      sessionContent: {},
+      userInfo,
+    });
+    authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(null);
+    userRepository.getByEmail.resolves({ email: 'anne@example.net', id: userId });
+    oidcAuthenticationService.createAuthenticationComplement
+      .withArgs({ userInfo })
+      .returns(AuthenticationMethod.OidcAuthenticationComplement);
+    oidcAuthenticationService.createAccessToken.withArgs(userId).returns('accessToken');
+
+    // when
+    const result = await reconcileOidcUserForAdmin({
+      authenticationKey: 'authenticationKey',
+      oidcAuthenticationService,
+      authenticationSessionService,
+      authenticationMethodRepository,
+      userRepository,
+      userLoginRepository,
+    });
+
+    // then
+    expect(oidcAuthenticationService.createAccessToken).to.be.calledOnceWith(userId);
+    expect(userLoginRepository.updateLastLoggedAt).to.be.calledOnceWith({ userId });
+    expect(result).to.equal('accessToken');
+  });
+
+  context('when authentication key is expired', function () {
+    it('should throw an AuthenticationKeyExpired', async function () {
+      // given
+      authenticationSessionService.getByKey.resolves(null);
+
+      // when
+      const error = await catchErr(reconcileOidcUserForAdmin)({
+        authenticationKey: 'authenticationKey',
+        oidcAuthenticationService,
+        authenticationSessionService,
+        authenticationMethodRepository,
+        userRepository,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(AuthenticationKeyExpired);
+      expect(error.message).to.be.equal('This authentication key has expired.');
+    });
+  });
+
+  context('when user has an oidc authentication method and external identifiers are different', function () {
+    it('should throw an DifferentExternalIdentifierError', async function () {
+      // given
+      const oidcAuthenticationMethod = domainBuilder.buildAuthenticationMethod.withIdentityProvider({
+        externalIdentifier: '789fge',
+        identityProvider: OidcIdentityProviders.GOOGLE.code,
+      });
+      userRepository.getByEmail.resolves({ email: 'anne@example.net', id: 1 });
+      authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(oidcAuthenticationMethod);
+      authenticationSessionService.getByKey.resolves({
+        sessionContent: {},
+        userInfo: { externalIdentityId: '123abc' },
+      });
+
+      // when
+      const error = await catchErr(reconcileOidcUserForAdmin)({
+        authenticationKey: 'authenticationKey',
+        email: 'anne@example.net',
+        identityProvider: 'GOOGLE',
+        oidcAuthenticationService,
+        authenticationSessionService,
+        authenticationMethodRepository,
+        userRepository,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(DifferentExternalIdentifierError);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/reconcile-oidc-user-for-admin_test.js
+++ b/api/tests/unit/domain/usecases/reconcile-oidc-user-for-admin_test.js
@@ -1,8 +1,8 @@
-import { expect, sinon, catchErr, domainBuilder } from '../../../test-helper.js';
-import { reconcileOidcUserForAdmin } from '../../../../lib/domain/usecases/reconcile-oidc-user-for-admin.js';
+import * as OidcIdentityProviders from '../../../../lib/domain/constants/oidc-identity-providers.js';
 import { AuthenticationKeyExpired, DifferentExternalIdentifierError } from '../../../../lib/domain/errors.js';
 import { AuthenticationMethod } from '../../../../lib/domain/models/index.js';
-import * as OidcIdentityProviders from '../../../../lib/domain/constants/oidc-identity-providers.js';
+import { reconcileOidcUserForAdmin } from '../../../../lib/domain/usecases/reconcile-oidc-user-for-admin.js';
+import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';
 
 describe('Unit | UseCase | reconcile-oidc-user-for-admin', function () {
   let authenticationMethodRepository,


### PR DESCRIPTION
## :unicorn: Problème
Pour le SSO Google sur Pix Admin, nous avons besoin d'effectuer une réconciliation silencieuse, à la différence de ce qui existe actuellement coté Pix App. Il est donc nécessaire de créer une route API spécifique à ce besoin.

## :robot: Proposition
Créer une route API pour la recherche et la réconciliation d'un utilisateur à un compte Pix existant.

## :rainbow: Remarques
[La PR qui ajoute le SSO Google sur Pix Admin](https://github.com/1024pix/pix/pull/7406) est encore très grosse, aussi nous faisons le choix de merger le code coté API dans un premier temps.

En plus de la création de la route, nous ajoutons : 
- [Récupération de l'adresse](https://github.com/1024pix/pix/pull/8213/commits/2113280def157db6c2ac74789ebfdac8fd836fda) email de l'utilisateur par le fournisseur d'identité ( ajout du scope email coté google)
- [Vérifier que l'utilisateur à les droits pour accéder à Pix Admin](https://github.com/1024pix/pix/pull/8213/commits/ce489eda607d25270744e4614d1212ffeccc6a8a) via l'authentification OIDC (s'il possède un rôle admin)
- [Amélioration de l'erreur (notFound => ForbiddenAccess) ](https://github.com/1024pix/pix/pull/8213/commits/1d9a79fa70a5688b5ddda0865974f863fa6e3d0e) lorsqu'un utilisateur n'a pas les droits pour se connecter à Pix Admin (pas de rôle ou disabled)


## :100: Pour tester
- Les tests automatisés passent
- Tests de non régression sur les SSO de Pix App
