### PR TITLE
[BUGFIX] Remise en place des propriétés de config.js nécessaires pour les envois de résutats de France Travail

### DIFF
--- a/1d/package-lock.json
+++ b/1d/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1d",
-  "version": "4.107.1",
+  "version": "4.107.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1d",
-      "version": "4.107.1",
+      "version": "4.107.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {

--- a/1d/package.json
+++ b/1d/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1d",
-  "version": "4.107.1",
+  "version": "4.107.2",
   "private": false,
   "description": "Small description for pix1d goes here",
   "repository": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Pix Changelog
 
+## v4.107.2 (28/02/2024)
+
+
+### :bug: Correction
+- [#8214](https://github.com/1024pix/pix/pull/8214) [BUGFIX] Remise en place des propriétés de config.js nécessaires pour les envois de résutats de France Travail.
+
 ## v4.107.1 (27/02/2024)
 
 

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pix-admin",
-  "version": "4.107.1",
+  "version": "4.107.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pix-admin",
-      "version": "4.107.1",
+      "version": "4.107.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-admin",
-  "version": "4.107.1",
+  "version": "4.107.2",
   "private": false,
   "description": "Interface d'administration pour les membres de Pix.",
   "license": "AGPL-3.0",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pix-api",
-  "version": "4.107.1",
+  "version": "4.107.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pix-api",
-      "version": "4.107.1",
+      "version": "4.107.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-api",
-  "version": "4.107.1",
+  "version": "4.107.2",
   "private": false,
   "description": "Plateforme d'évaluation et de certification des compétences numériques",
   "license": "AGPL-3.0",

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -313,6 +313,7 @@ const configuration = (function () {
     poleEmploi: {
       accessTokenLifespanMs: ms(process.env.POLE_EMPLOI_ACCESS_TOKEN_LIFESPAN || '7d'),
       afterLogoutUrl: process.env.POLE_EMPLOI_OIDC_AFTER_LOGOUT_URL,
+      authenticationUrl: process.env.POLE_EMPLOI_OIDC_AUTHENTICATION_URL,
       clientId: process.env.POLE_EMPLOI_CLIENT_ID,
       clientSecret: process.env.POLE_EMPLOI_CLIENT_SECRET,
       isEnabled: isFeatureEnabled(process.env.POLE_EMPLOI_ENABLED),
@@ -323,7 +324,9 @@ const configuration = (function () {
       pushEnabled: isFeatureEnabled(process.env.PUSH_DATA_TO_POLE_EMPLOI_ENABLED),
       redirectUri: process.env.POLE_EMPLOI_REDIRECT_URI,
       sendingUrl: process.env.POLE_EMPLOI_SENDING_URL,
+      tokenUrl: process.env.POLE_EMPLOI_TOKEN_URL,
       temporaryStorage: { idTokenLifespanMs: ms(process.env.POLE_EMPLOI_ID_TOKEN_LIFESPAN || '7d') },
+      userInfoUrl: process.env.POLE_EMPLOI_OIDC_USER_INFO_URL,
     },
     port: parseInt(process.env.PORT, 10) || 3000,
     rootPath: path.normalize(__dirname + '/..'),

--- a/audit-logger/package-lock.json
+++ b/audit-logger/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pix-audit-logger",
-  "version": "4.107.1",
+  "version": "4.107.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pix-audit-logger",
-      "version": "4.107.1",
+      "version": "4.107.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/audit-logger/package.json
+++ b/audit-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-audit-logger",
-  "version": "4.107.1",
+  "version": "4.107.2",
   "description": "",
   "scripts": {
     "build": "npx tsc --project tsconfig.production.json",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pix-certif",
-  "version": "4.107.1",
+  "version": "4.107.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pix-certif",
-      "version": "4.107.1",
+      "version": "4.107.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-certif",
-  "version": "4.107.1",
+  "version": "4.107.2",
   "private": false,
   "description": "Plateforme en ligne de gestion des sessions de certification",
   "license": "AGPL-3.0",

--- a/high-level-tests/e2e/package-lock.json
+++ b/high-level-tests/e2e/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pix-e2e",
-  "version": "1.107.1",
+  "version": "1.107.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pix-e2e",
-      "version": "1.107.1",
+      "version": "1.107.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/high-level-tests/e2e/package.json
+++ b/high-level-tests/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-e2e",
-  "version": "1.107.1",
+  "version": "1.107.2",
   "description": "Permet d'exécuter des tests de bout en bout sur la plateforme Pix",
   "homepage": "https://github.com/1024pix/pix#readme",
   "author": "GIP Pix",

--- a/high-level-tests/load-testing/package-lock.json
+++ b/high-level-tests/load-testing/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pix-load-testing",
-  "version": "2.107.1",
+  "version": "2.107.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pix-load-testing",
-      "version": "2.107.1",
+      "version": "2.107.2",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/high-level-tests/load-testing/package.json
+++ b/high-level-tests/load-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-load-testing",
-  "version": "2.107.1",
+  "version": "2.107.2",
   "description": "Permet d'exécuter des tests de charge sur l'API de la plateforme Pix.",
   "homepage": "https://github.com/1024pix/pix/tree/dev/high-level-tests/load-testing#readme",
   "author": "GIP Pix",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mon-pix",
-  "version": "4.107.1",
+  "version": "4.107.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mon-pix",
-      "version": "4.107.1",
+      "version": "4.107.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mon-pix",
-  "version": "4.107.1",
+  "version": "4.107.2",
   "private": false,
   "description": "Plateforme d'évaluation et de certification des compétences numériques",
   "license": "AGPL-3.0",

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pix-orga",
-  "version": "4.107.1",
+  "version": "4.107.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pix-orga",
-      "version": "4.107.1",
+      "version": "4.107.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {

--- a/orga/package.json
+++ b/orga/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-orga",
-  "version": "4.107.1",
+  "version": "4.107.2",
   "private": false,
   "description": "Plateforme en ligne de gestion de campagne d'évaluation",
   "license": "AGPL-3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pix",
-  "version": "4.107.1",
+  "version": "4.107.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pix",
-      "version": "4.107.1",
+      "version": "4.107.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix",
-  "version": "4.107.1",
+  "version": "4.107.2",
   "private": false,
   "description": "Plateforme d'évaluation et de certification des compétences numériques",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## :unicorn: Problème

La #8136 a cassé l'envoi des résultats à France Travail, car la propriété `tokenUrl` est utilisée pour obtenir des refresh tokens.

## :robot: Proposition

Remettre en place les 3 propriétés liées au SSO `POLE_EMPLOI` dans `config.js` qui ont été supprimées par erreur.

## :rainbow: Remarques

A priori les propriétés `authenticationUrl` et `userInfoUrl` ne sont, elles, pas utiles, mais dans la nécessité de faire un correctif rapide pour la production nous avons préféré remettre en place toutes les propriétés liées au SSO `POLE_EMPLOI` qui avaient été supprimées. Une suppression des propriétés inutiles et la mise en place d'une solution plus propre en terme de découpage/architecture du code sera fait plus tard. 

## :100: Pour tester

La CI passe.