### PR TITLE
[TECH] Renommage de la mise à jour des commentaires de certification sur admin en commentaire jury

### DIFF
--- a/admin/app/adapters/certification.js
+++ b/admin/app/adapters/certification.js
@@ -5,7 +5,7 @@ export default class Certification extends ApplicationAdapter {
     return `${this.host}/${this.namespace}/admin/certifications/${id}`;
   }
 
-  urlForUpdateComments(id) {
+  urlForUpdateJuryComment(id) {
     return `${this.host}/${this.namespace}/admin/certification-courses/${id}/assessment-results`;
   }
 
@@ -14,7 +14,7 @@ export default class Certification extends ApplicationAdapter {
   }
 
   updateRecord(store, type, snapshot) {
-    if (snapshot.adapterOptions.updateComments) {
+    if (snapshot.adapterOptions.updateJuryComment) {
       const {
         data: { attributes },
       } = this.serialize(snapshot);
@@ -25,7 +25,7 @@ export default class Certification extends ApplicationAdapter {
           },
         },
       };
-      return this.ajax(this.urlForUpdateComments(snapshot.id), 'POST', { data: payload });
+      return this.ajax(this.urlForUpdateJuryComment(snapshot.id), 'POST', { data: payload });
     } else {
       const data = {};
       const serializer = store.serializerFor(type.modelName);

--- a/admin/app/components/certifications/certification/comments.hbs
+++ b/admin/app/components/certifications/certification/comments.hbs
@@ -15,34 +15,34 @@
     />
     <Certifications::InfoField
       @value={{@certification.commentByJury}}
-      @edition={{this.editingComments}}
+      @edition={{this.isEditingJuryComment}}
       @label="Notes internes Jury Pix :"
       @fieldId="certification-commentByJury"
       @isTextarea={{true}}
     />
     <Certifications::InfoField @value={{@certification.juryId}} @edition={{false}} @label="Identifiant jury :" />
 
-    {{#if this.editingComments}}
+    {{#if this.isEditingJuryComment}}
       <ul class="certification-information-comments">
         <li>
           <PixButton
             @size="small"
             @backgroundColor="transparent-light"
             @isBorderVisible={{true}}
-            @triggerAction={{this.cancelCommentsEdit}}
+            @triggerAction={{this.cancelJuryCommentEdition}}
           >
             Annuler
           </PixButton>
         </li>
         <li>
-          <PixButton @size="small" @triggerAction={{this.saveComments}}>
+          <PixButton @size="small" @triggerAction={{this.saveJuryComment}}>
             Enregistrer
           </PixButton>
         </li>
       </ul>
     {{else}}
-      <PixButton @size="small" @triggerAction={{this.editComments}}>
-        Modifier commentaires jury
+      <PixButton @size="small" @triggerAction={{this.editJuryComment}}>
+        Modifier le commentaire jury
       </PixButton>
     {{/if}}
   </div>

--- a/admin/app/components/certifications/certification/comments.js
+++ b/admin/app/components/certifications/certification/comments.js
@@ -3,23 +3,23 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class Comments extends Component {
-  @tracked editingComments = false;
+  @tracked isEditingJuryComment = false;
 
   @action
-  editComments() {
-    this.editingComments = true;
+  editJuryComment() {
+    this.isEditingJuryComment = true;
   }
 
   @action
-  async saveComments() {
-    const hasBeenSaved = await this.args.onCommentsSave();
+  async saveJuryComment() {
+    const hasBeenSaved = await this.args.onJuryCommentSave();
     if (hasBeenSaved) {
-      this.cancelCommentsEdit();
+      this.cancelJuryCommentEdition();
     }
   }
 
   @action
-  cancelCommentsEdit() {
-    this.editingComments = false;
+  cancelJuryCommentEdition() {
+    this.isEditingJuryComment = false;
   }
 }

--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -98,11 +98,11 @@ export default class CertificationInformationsController extends Controller {
   }
 
   saveAssessmentResult() {
-    return this.certification.save({ adapterOptions: { updateComments: true } });
+    return this.certification.save({ adapterOptions: { updateJuryComment: true } });
   }
 
   saveCertificationCourse() {
-    return this.certification.save({ adapterOptions: { updateComments: false } });
+    return this.certification.save({ adapterOptions: { updateJuryComment: false } });
   }
 
   @action
@@ -228,13 +228,13 @@ export default class CertificationInformationsController extends Controller {
   }
 
   @action
-  async onCommentsSave() {
+  async onJuryCommentSave() {
     try {
       await this.saveAssessmentResult();
-      this.notifications.success('Les commentaires du jury ont bien été enregistrés.');
+      this.notifications.success('Le commentaire du jury a bien été enregistré.');
       return true;
     } catch (e) {
-      this.notifications.error("Les commentaires du jury n'ont pas pu être enregistrés.");
+      this.notifications.error("Le commentaire du jury n'a pas pu être enregistré.");
       return false;
     }
   }

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -233,7 +233,7 @@
   {{/if}}
 
   <Certifications::Certification::Comments
-    @onCommentsSave={{this.onCommentsSave}}
+    @onJuryCommentSave={{this.onJuryCommentSave}}
     @certification={{this.certification}}
   />
 

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -1093,7 +1093,7 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
           // when
           const screen = await visit(`/certifications/${certification.id}`);
-          await clickByName('Modifier commentaires jury');
+          await clickByName('Modifier le commentaire jury');
 
           // then
           assert.dom(screen.getByRole('textbox', { name: 'Notes internes Jury Pix :' })).exists();
@@ -1109,11 +1109,11 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
           // when
           const screen = await visit(`/certifications/${certification.id}`);
-          await clickByName('Modifier commentaires jury');
+          await clickByName('Modifier le commentaire jury');
           await clickByName('Annuler');
 
           // then
-          assert.dom(screen.getByRole('button', { name: 'Modifier commentaires jury' })).exists();
+          assert.dom(screen.getByRole('button', { name: 'Modifier le commentaire jury' })).exists();
         });
       });
 
@@ -1125,14 +1125,14 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
             // when
             const screen = await visit(`/certifications/${certification.id}`);
-            await clickByName('Modifier commentaires jury');
+            await clickByName('Modifier le commentaire jury');
             await fillByLabel('Notes internes Jury Pix :', 'Whatever jury said');
 
             await clickByName('Enregistrer');
 
             // then
-            assert.dom(screen.getByRole('button', { name: 'Modifier commentaires jury' })).exists();
-            assert.dom(screen.getByText('Les commentaires du jury ont bien été enregistrés.')).exists();
+            assert.dom(screen.getByRole('button', { name: 'Modifier le commentaire jury' })).exists();
+            assert.dom(screen.getByText('Le commentaire du jury a bien été enregistré.')).exists();
           });
         });
 
@@ -1147,14 +1147,14 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
             // when
             const screen = await visit(`/certifications/${certification.id}`);
-            await clickByName('Modifier commentaires jury');
+            await clickByName('Modifier le commentaire jury');
             await fillByLabel('Notes internes Jury Pix :', 'Whatever jury said');
 
             await clickByName('Enregistrer');
 
             // then
-            assert.dom(screen.queryByText('button', { name: 'Modifier commentaires jury' })).doesNotExist();
-            assert.dom(screen.getByText("Les commentaires du jury n'ont pas pu être enregistrés.")).exists();
+            assert.dom(screen.queryByText('button', { name: 'Modifier le commentaire jury' })).doesNotExist();
+            assert.dom(screen.getByText("Le commentaire du jury n'a pas pu être enregistré.")).exists();
           });
         });
       });

--- a/admin/tests/unit/adapters/certification_test.js
+++ b/admin/tests/unit/adapters/certification_test.js
@@ -31,10 +31,10 @@ module('Unit | Adapter | certification', function (hooks) {
     });
   });
 
-  module('#urlForUpdateComments', function () {
-    test('should build update comments url from certification course id', function (assert) {
+  module('#urlForUpdateJuryComment', function () {
+    test('should build update jury comment url from certification course id', function (assert) {
       // when
-      const url = adapter.urlForUpdateComments(1001);
+      const url = adapter.urlForUpdateJuryComment(1001);
 
       // then
       assert.ok(url.endsWith('/admin/certification-courses/1001/assessment-results'));
@@ -52,11 +52,11 @@ module('Unit | Adapter | certification', function (hooks) {
   });
 
   module('#updateRecord', function () {
-    module('when updateComments adapter option passed', function () {
-      test('it should trigger an ajax call with the updateComments url, data and method', async function (assert) {
+    module('when updateJuryComment adapter option passed', function () {
+      test('it should trigger an ajax call with the updateJuryComment url, data and method', async function (assert) {
         // given
         sinon
-          .stub(adapter, 'urlForUpdateComments')
+          .stub(adapter, 'urlForUpdateJuryComment')
           .returns('https://example.net/api/admin/certification-courses/123/assessment-results');
         const store = Symbol();
         const attributes = {
@@ -69,7 +69,7 @@ module('Unit | Adapter | certification', function (hooks) {
           { modelName: 'someModelName' },
           {
             id: 123,
-            adapterOptions: { updateComments: true },
+            adapterOptions: { updateJuryComment: true },
             serialize: sinon.stub().returns({ data: { attributes } }),
           },
         );

--- a/admin/tests/unit/components/certifications/certification/comments_test.js
+++ b/admin/tests/unit/components/certifications/certification/comments_test.js
@@ -12,33 +12,33 @@ module('Unit | Component | certifications/certification/comments', function (hoo
     component = createGlimmerComponent('component:certifications/certification/comments');
   });
 
-  test('it does not close the edition panel when comments cannot be saved', async function (assert) {
+  test('it does not close the edition panel when comment cannot be saved', async function (assert) {
     // given
-    component.editingComments = true;
+    component.isEditingJuryComment = true;
     component.args = {
-      onCommentsSave: sinon.stub(),
+      onJuryCommentSave: sinon.stub(),
     };
 
     // when
-    await component.saveComments();
+    await component.saveJuryComment();
 
     // then
-    assert.true(component.editingComments);
+    assert.true(component.isEditingJuryComment);
   });
 
-  test('it closes the edition panel when comments are saved', async function (assert) {
+  test('it closes the edition panel when comment is saved', async function (assert) {
     // given
-    component.editingComments = true;
+    component.isEditingJuryComment = true;
     component.args = {
-      onCommentsSave: sinon.stub(),
+      onJuryCommentSave: sinon.stub(),
     };
 
-    component.args.onCommentsSave.resolves(true);
+    component.args.onJuryCommentSave.resolves(true);
 
     // when
-    await component.saveComments();
+    await component.saveJuryComment();
 
     // then
-    assert.false(component.editingComments);
+    assert.false(component.isEditingJuryComment);
   });
 });

--- a/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
@@ -401,7 +401,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
       await controller.onCandidateInformationSave();
 
       // then
-      sinon.assert.calledWith(certification.save, { adapterOptions: { updateComments: false } });
+      sinon.assert.calledWith(certification.save, { adapterOptions: { updateJuryComment: false } });
       assert.ok(true);
     });
   });
@@ -583,8 +583,8 @@ module('Unit | Controller | authenticated/certifications/certification/informati
     });
   });
 
-  module('#onCommentsSave', function () {
-    test('it displays a success notification if comments are saved', async function (assert) {
+  module('#onJuryCommentSave', function () {
+    test('it displays a success notification if jury comment is saved', async function (assert) {
       // given
       const controller = this.owner.lookup('controller:authenticated/certifications/certification/informations');
       controller.saveAssessmentResult = sinon.stub();
@@ -597,14 +597,14 @@ module('Unit | Controller | authenticated/certifications/certification/informati
       this.owner.register('service:notifications', NotificationsStub);
 
       // when
-      await controller.onCommentsSave();
+      await controller.onJuryCommentSave();
 
       // then
       sinon.assert.calledOnce(notificationSuccessStub);
       assert.ok(controller);
     });
 
-    test('it displays an error notification if comments cannot be saved', async function (assert) {
+    test('it displays an error notification if jury comment cannot be saved', async function (assert) {
       // given
       const controller = this.owner.lookup('controller:authenticated/certifications/certification/informations');
       controller.saveAssessmentResult = sinon.stub();
@@ -617,7 +617,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
       this.owner.register('service:notifications', NotificationsStub);
 
       // when
-      await controller.onCommentsSave();
+      await controller.onJuryCommentSave();
 
       // then
       sinon.assert.calledOnce(notificationErrorStub);


### PR DESCRIPTION
## :unicorn: Problème
Suite à l'US PIX-10538 on a laissé un pan de refacto de naming en plan pour débloquer d'autres sujets plus importants.
Il n'y a plus qu'un commentaire éditable manuellement sur une certification. Or le code mentionne encore des commentaires (au pluriel).

## :robot: Proposition
Renommer les variables et les méthodes et changer le wording pour refléter ce passage à un seul commentaire éditable. 

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->
Nope
## :100: Pour tester
De la non-régression sur l'édition de commentaires de certifications:
Se rendre sur une [certification de pix-admin](https://admin-pr8215.review.pix.fr/certifications/148192) (superadmin@example.net/pix123)
Editer et sauvegarder les notes internes Jury.
Le wording du bouton et les messages de succès et d'erreur doivent mentionner un commentaire au singulier

=>  

<img width="965" alt="image" src="https://github.com/1024pix/pix/assets/3033624/d3de7701-84ae-4616-8b8f-8bebd94c7774">

