### PR TITLE
[FEATURE] Pouvoir mettre en pause des contenus formatifs sur Pix Admin (PIX-6509).

### DIFF
--- a/admin/app/components/trainings/create-or-update-training-form.hbs
+++ b/admin/app/components/trainings/create-or-update-training-form.hbs
@@ -106,6 +106,11 @@
         @value={{this.form.editorName}}
         {{on "change" (fn this.updateForm "editorName")}}
       />
+      {{#if @model}}
+        <PixCheckbox @checked={{this.form.isDisabled}} {{on "change" this.toggleIsDisabled}}>
+          Mettre en pause
+        </PixCheckbox>
+      {{/if}}
     </Card>
   </section>
   <section class="admin-form__actions">

--- a/admin/app/components/trainings/create-or-update-training-form.js
+++ b/admin/app/components/trainings/create-or-update-training-form.js
@@ -17,8 +17,9 @@ class Form {
   @tracked locale;
   @tracked editorLogoUrl;
   @tracked editorName;
+  @tracked isDisabled;
 
-  constructor({ title, link, type, duration, locale, editorLogoUrl, editorName } = {}) {
+  constructor({ title, link, type, duration, locale, editorLogoUrl, editorName, isDisabled } = {}) {
     this.title = title || null;
     this.link = link || null;
     this.type = type || null;
@@ -26,6 +27,7 @@ class Form {
     this.locale = locale || null;
     this.editorLogoUrl = editorLogoUrl?.split('/').at(-1) || null;
     this.editorName = editorName || null;
+    this.isDisabled = isDisabled || false;
   }
 }
 
@@ -47,6 +49,11 @@ export default class CreateOrUpdateTrainingForm extends Component {
   }
 
   @action
+  toggleIsDisabled() {
+    set(this.form, 'isDisabled', !this.form.isDisabled);
+  }
+
+  @action
   updateSelect(key, value) {
     set(this.form, key, value);
   }
@@ -62,6 +69,7 @@ export default class CreateOrUpdateTrainingForm extends Component {
       duration: this.form.duration,
       locale: this.form.locale,
       editorName: this.form.editorName,
+      isDisabled: this.form.isDisabled,
     };
     training.editorLogoUrl = `https://images.pix.fr/contenu-formatif/editeur/${this.form.editorLogoUrl}`;
 

--- a/admin/app/components/trainings/list-summary-items.hbs
+++ b/admin/app/components/trainings/list-summary-items.hbs
@@ -9,6 +9,7 @@
           <th id="training-prerequisite-threshold" scope="col" class="col-status">Prérequis</th>
           <th id="training-goal-threshold" scope="col" class="col-status">Objectif à ne pas dépasser</th>
           <th id="training-target-profile-count" scope="col" class="col-status">Profils cibles associés</th>
+          <th id="training-state" scope="col" class="col-status">État</th>
         </tr>
         {{#if @triggerFiltering}}
           <tr>
@@ -30,6 +31,7 @@
                 aria-label="Filtrer les contenus formatifs par un titre"
               />
             </td>
+            <td></td>
             <td></td>
             <td></td>
             <td></td>
@@ -55,6 +57,9 @@
               </td>
               <td headers="training-target-profiles-count">
                 {{summary.targetProfilesCount}}
+              </td>
+              <td headers="training-state">
+                <Trainings::StateTag @isDisabled={{summary.isDisabled}} />
               </td>
             </tr>
           {{/each}}

--- a/admin/app/components/trainings/state-tag.hbs
+++ b/admin/app/components/trainings/state-tag.hbs
@@ -1,0 +1,1 @@
+<PixTag @color={{this.color}}>{{this.content}}</PixTag>

--- a/admin/app/components/trainings/state-tag.js
+++ b/admin/app/components/trainings/state-tag.js
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+
+export default class StateTag extends Component {
+  get color() {
+    if (this.args.isDisabled === true) {
+      return 'error';
+    } else {
+      return 'primary';
+    }
+  }
+
+  get content() {
+    if (this.args.isDisabled === true) {
+      return 'En pause';
+    } else {
+      return 'Actif';
+    }
+  }
+}

--- a/admin/app/components/trainings/training-details-card.hbs
+++ b/admin/app/components/trainings/training-details-card.hbs
@@ -2,6 +2,7 @@
 <article class="training-details-card" role="article">
   <div class="training-details-card__content">
     <h1 class="training-details-card__title">{{@training.title}}</h1>
+    <Trainings::StateTag @isDisabled={{@training.isDisabled}} />
     <dl class="training-details-card__details">
       <dt class="training-details-card__details-label">Publié sur&nbsp;:&nbsp;</dt>
       <dd class="training-details-card__details-value">

--- a/admin/app/models/training-summary.js
+++ b/admin/app/models/training-summary.js
@@ -5,4 +5,5 @@ export default class TrainingSummary extends Model {
   @attr('number') targetProfilesCount;
   @attr('number') prerequisiteThreshold;
   @attr('number') goalThreshold;
+  @attr('boolean') isDisabled;
 }

--- a/admin/app/models/training.js
+++ b/admin/app/models/training.js
@@ -29,6 +29,7 @@ export default class Training extends Model {
   @attr('string') editorName;
   @attr('string') editorLogoUrl;
   @attr('boolean') isRecommendable;
+  @attr('boolean') isDisabled;
   @attr({
     defaultValue: () => ({
       days: 0,

--- a/admin/tests/integration/components/target-profiles/list-summary-items_test.js
+++ b/admin/tests/integration/components/target-profiles/list-summary-items_test.js
@@ -16,6 +16,7 @@ module('Integration | Component | TargetProfiles::ListSummaryItems', function (h
       id: 123,
       name: 'Profile Cible',
       oudated: false,
+      isDisabled: true,
       createdAt: new Date('2021-01-01'),
     };
     const summaries = [summary];
@@ -39,5 +40,6 @@ module('Integration | Component | TargetProfiles::ListSummaryItems', function (h
     assert.dom(screen.getByText('Profile Cible')).exists();
     assert.dom(screen.getByText('Actif')).exists();
     assert.dom(screen.getByText('01/01/2021')).exists();
+    assert.dom(screen.getByText('Actif')).exists();
   });
 });

--- a/admin/tests/integration/components/trainings/create-or-update-training-form_test.js
+++ b/admin/tests/integration/components/trainings/create-or-update-training-form_test.js
@@ -50,6 +50,7 @@ module('Integration | Component | Trainings::CreateOrUpdateTrainingForm', functi
     assert.dom(screen.getByLabelText('Minutes (MM)')).exists();
     assert.dom(screen.getByLabelText('Langue localisée')).exists();
     assert.dom(screen.getByLabelText('Nom du fichier du logo éditeur')).exists();
+    assert.dom(screen.queryByLabelText('Mettre en pause')).doesNotExist();
     assert
       .dom(
         screen.getByLabelText(
@@ -105,6 +106,7 @@ module('Integration | Component | Trainings::CreateOrUpdateTrainingForm', functi
         editorName: 'Un éditeur de contenu formatif',
         editorLogoUrl: `https://example.net/${editorLogo}`,
         duration: { days: 0, hours: 0, minutes: 0 },
+        isDisabled: false,
       };
 
       this.set('model', model);
@@ -125,6 +127,7 @@ module('Integration | Component | Trainings::CreateOrUpdateTrainingForm', functi
       assert.dom(screen.getByLabelText('Minutes (MM)')).hasValue(model.duration.minutes.toString());
       assert.strictEqual(screen.getByLabelText('Langue localisée').innerText, localeCategories[model.locale]);
       assert.dom(screen.getByLabelText('Nom du fichier du logo éditeur')).hasValue(editorLogo);
+      assert.strictEqual(screen.getByLabelText('Mettre en pause').checked, model.isDisabled);
       assert
         .dom(
           screen.getByLabelText(

--- a/admin/tests/integration/components/trainings/training-details-card_test.js
+++ b/admin/tests/integration/components/trainings/training-details-card_test.js
@@ -53,4 +53,22 @@ module('Integration | Component | Trainings::TrainingDetailsCard', function (hoo
     // then
     assert.dom(screen.getByText('Non déclenchable')).exists();
   });
+
+  test('it should display "Actif" when training is not disabled', async function (assert) {
+    // given
+    this.set('training.isDisabled', false);
+    const screen = await render(hbs`<Trainings::TrainingDetailsCard @training={{this.training}} />`);
+
+    // then
+    assert.dom(screen.getByText('Actif')).exists();
+  });
+
+  test('it should display "En pause" when training is disabled', async function (assert) {
+    // given
+    this.set('training.isDisabled', true);
+    const screen = await render(hbs`<Trainings::TrainingDetailsCard @training={{this.training}} />`);
+
+    // then
+    assert.dom(screen.getByText('En pause')).exists();
+  });
 });

--- a/admin/tests/unit/components/trainings/create-or-update-training-form_test.js
+++ b/admin/tests/unit/components/trainings/create-or-update-training-form_test.js
@@ -59,5 +59,16 @@ module('Unit | Component | Trainings | CreateOrUpdateTrainingForm', function (ho
       // then
       assert.deepEqual(component.args.onSubmit.getCall(0).firstArg.editorLogoUrl, `${baseURL}new-logo.svg`);
     });
+
+    test('it should update isDisabled field', async function (assert) {
+      // given
+      component.toggleIsDisabled();
+
+      // when
+      await component.onSubmit(submitEvent);
+
+      // then
+      assert.true(component.args.onSubmit.getCall(0).firstArg.isDisabled);
+    });
   });
 });

--- a/admin/tests/unit/components/trainings/state-tag_test.js
+++ b/admin/tests/unit/components/trainings/state-tag_test.js
@@ -1,0 +1,53 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+import createComponent from '../../../helpers/create-glimmer-component';
+
+module('Unit | Component | Trainings::StateTag', function (hooks) {
+  setupTest(hooks);
+
+  module('When isDisabled is true', function (hooks) {
+    let component;
+    hooks.beforeEach(() => {
+      component = createComponent('component:trainings/state-tag', {
+        isDisabled: true,
+      });
+    });
+
+    module('#color', function () {
+      test('color should be "error"', function (assert) {
+        // then
+        assert.strictEqual(component.color, 'error');
+      });
+    });
+
+    module('#content', function () {
+      test('content should be "En pause"', function (assert) {
+        // then
+        assert.strictEqual(component.content, 'En pause');
+      });
+    });
+  });
+  module('When isDisabled is false', function (hooks) {
+    let component;
+    hooks.beforeEach(() => {
+      component = createComponent('component:trainings/state-tag', {
+        isDisabled: false,
+      });
+    });
+
+    module('#color', function () {
+      test('color should be "primary"', function (assert) {
+        // then
+        assert.strictEqual(component.color, 'primary');
+      });
+    });
+
+    module('#content', function () {
+      test('content should be "Actif"', function (assert) {
+        // then
+        assert.strictEqual(component.content, 'Actif');
+      });
+    });
+  });
+});

--- a/api/db/database-builder/factory/build-training.js
+++ b/api/db/database-builder/factory/build-training.js
@@ -9,6 +9,7 @@ function buildTraining({
   locale = 'fr-fr',
   editorName = "Ministère de l'Éducation nationale et de la Jeunesse. Liberté égalité fraternité",
   editorLogoUrl = 'https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
+  isDisabled = false,
   createdAt = new Date(),
   updatedAt = new Date(),
 } = {}) {
@@ -21,6 +22,7 @@ function buildTraining({
     locale,
     editorName,
     editorLogoUrl,
+    isDisabled,
     createdAt,
     updatedAt,
   };

--- a/api/db/migrations/20240228131722_add-is-disabled-in-trainings.js
+++ b/api/db/migrations/20240228131722_add-is-disabled-in-trainings.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'trainings';
+const COLUMN_NAME = 'isDisabled';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.boolean(COLUMN_NAME).defaultTo(false);
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { up, down };

--- a/api/src/devcomp/application/trainings/training-controller.js
+++ b/api/src/devcomp/application/trainings/training-controller.js
@@ -43,7 +43,7 @@ const update = async function (request, h, dependencies = { trainingSerializer }
   const { trainingId } = request.params;
   const training = await dependencies.trainingSerializer.deserialize(request.payload);
   const updatedTraining = await usecases.updateTraining({ training: { ...training, id: trainingId } });
-  return dependencies.trainingSerializer.serialize(updatedTraining);
+  return dependencies.trainingSerializer.serializeForAdmin(updatedTraining);
 };
 
 const createOrUpdateTrigger = async function (request, h, dependencies = { trainingTriggerSerializer }) {

--- a/api/src/devcomp/domain/read-models/TrainingForAdmin.js
+++ b/api/src/devcomp/domain/read-models/TrainingForAdmin.js
@@ -10,6 +10,7 @@ class TrainingForAdmin {
     editorName,
     editorLogoUrl,
     trainingTriggers,
+    isDisabled,
   } = {}) {
     this.id = id;
     this.title = title;
@@ -21,6 +22,7 @@ class TrainingForAdmin {
     this.editorName = editorName;
     this.editorLogoUrl = editorLogoUrl;
     this.trainingTriggers = trainingTriggers;
+    this.isDisabled = isDisabled;
   }
 
   get isRecommendable() {

--- a/api/src/devcomp/domain/read-models/TrainingSummary.js
+++ b/api/src/devcomp/domain/read-models/TrainingSummary.js
@@ -1,10 +1,11 @@
 class TrainingSummary {
-  constructor({ id, title, prerequisiteThreshold, goalThreshold, targetProfilesCount } = {}) {
+  constructor({ id, title, prerequisiteThreshold, goalThreshold, targetProfilesCount, isDisabled } = {}) {
     this.id = id;
     this.title = title;
     this.prerequisiteThreshold = prerequisiteThreshold;
     this.goalThreshold = goalThreshold;
     this.targetProfilesCount = targetProfilesCount;
+    this.isDisabled = isDisabled;
   }
 }
 

--- a/api/src/devcomp/infrastructure/repositories/training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/training-repository.js
@@ -184,7 +184,7 @@ async function findPaginatedByUserId({
     .select('trainings.*')
     .distinct('trainings.id')
     .join('user-recommended-trainings', 'trainings.id', 'trainingId')
-    .where({ userId, locale })
+    .where({ userId, locale, isDisabled: false })
     .orderBy('id', 'asc');
   const { results, pagination } = await fetchPage(query, page);
 

--- a/api/src/devcomp/infrastructure/repositories/training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/training-repository.js
@@ -160,6 +160,7 @@ async function update({ id, attributesToUpdate, domainTransaction = DomainTransa
     'locale',
     'editorName',
     'editorLogoUrl',
+    'isDisabled',
   ]);
   const knexConn = domainTransaction?.knexTransaction || knex;
   const [updatedTraining] = await knexConn(TABLE_NAME)

--- a/api/src/devcomp/infrastructure/repositories/training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/training-repository.js
@@ -46,6 +46,7 @@ async function findPaginatedSummaries({ filter, page, domainTransaction = Domain
     .select(
       'trainings.id',
       'trainings.title',
+      'trainings.isDisabled',
       knexConn.raw('coalesce("targetProfilesCount", 0) as "targetProfilesCount"'),
     )
     .leftJoin(
@@ -80,6 +81,7 @@ async function findPaginatedSummariesByTargetProfileId({
       'trainings.id',
       'trainings.title',
       knexConn.raw('coalesce("targetProfilesCount", 0) as "targetProfilesCount"'),
+      'trainings.isDisabled',
     )
     .innerJoin('target-profile-trainings', `${TABLE_NAME}.id`, 'target-profile-trainings.trainingId')
     .leftJoin(

--- a/api/src/devcomp/infrastructure/repositories/user-recommended-training-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/user-recommended-training-repository.js
@@ -26,7 +26,7 @@ const findByCampaignParticipationId = async function ({
   const trainings = await knexConn(TABLE_NAME)
     .select('trainings.*')
     .innerJoin('trainings', 'trainings.id', `${TABLE_NAME}.trainingId`)
-    .where({ campaignParticipationId, locale })
+    .where({ campaignParticipationId, locale, isDisabled: false })
     .orderBy('id', 'asc');
   return trainings.map(_toDomain);
 };

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js
@@ -24,6 +24,7 @@ const serializeForAdmin = function (training = {}, meta) {
       'trainingTriggers',
       'targetProfileSummaries',
       'isRecommendable',
+      'isDisabled',
     ],
     trainingTriggers: {
       ref: 'id',

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/training-summary-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/training-summary-serializer.js
@@ -4,7 +4,7 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (trainingSummaries, meta) {
   return new Serializer('training-summaries', {
-    attributes: ['title', 'targetProfilesCount', 'prerequisiteThreshold', 'goalThreshold'],
+    attributes: ['title', 'targetProfilesCount', 'prerequisiteThreshold', 'goalThreshold', 'isDisabled'],
     meta,
   }).serialize(trainingSummaries);
 };

--- a/api/tests/acceptance/application/target-profiles/index_test.js
+++ b/api/tests/acceptance/application/target-profiles/index_test.js
@@ -600,6 +600,7 @@ describe('Acceptance | Route | target-profiles', function () {
           attributes: {
             'goal-threshold': undefined,
             'prerequisite-threshold': undefined,
+            'is-disabled': false,
             'target-profiles-count': 1,
             title: 'title',
           },

--- a/api/tests/devcomp/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/trainings/training-controller_test.js
@@ -238,6 +238,7 @@ describe('Acceptance | Controller | training-controller', function () {
                   hours: 2,
                   minutes: 2,
                 },
+                'is-disabled': true,
               },
             },
           },
@@ -253,6 +254,7 @@ describe('Acceptance | Controller | training-controller', function () {
               duration: training.duration,
               editorName: updatedTraining.editorName,
               editorLogoUrl: updatedTraining.editorLogoUrl,
+              isDisabled: updatedTraining.isDisabled,
             },
           },
         };
@@ -272,6 +274,7 @@ describe('Acceptance | Controller | training-controller', function () {
         expect(response.result.data.attributes['editor-logo-url']).to.deep.equal(
           expectedResponse.data.attributes.editorLogoUrl,
         );
+        expect(response.result.data.attributes['is-disabled']).to.be.true;
       });
     });
   });

--- a/api/tests/devcomp/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/trainings/training-controller_test.js
@@ -306,6 +306,7 @@ describe('Acceptance | Controller | training-controller', function () {
               'prerequisite-threshold': undefined,
               'target-profiles-count': 0,
               title: training.title,
+              'is-disabled': false,
             },
           },
         };

--- a/api/tests/devcomp/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/trainings/training-controller_test.js
@@ -99,6 +99,7 @@ describe('Acceptance | Controller | training-controller', function () {
           },
           'editor-logo-url': trainingAttributes.editorLogoUrl,
           'editor-name': trainingAttributes.editorName,
+          'is-disabled': false,
         },
       };
 

--- a/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
@@ -178,16 +178,19 @@ describe('Integration | Repository | training-repository', function () {
           prerequisiteThreshold: 0,
           goalThreshold: 100,
           targetProfilesCount: 2,
+          isDisabled: true,
         });
         const trainingSummary2 = domainBuilder.buildTrainingSummary({
           id: 2,
           prerequisiteThreshold: 10,
           goalThreshold: 90,
+          isDisabled: false,
         });
         const trainingSummary3 = domainBuilder.buildTrainingSummary({
           id: 3,
           prerequisiteThreshold: undefined,
           goalThreshold: undefined,
+          isDisabled: false,
         });
 
         createDatabaseRepresentationForTrainingSummary({ trainingSummary: trainingSummary1, databaseBuilder });
@@ -281,6 +284,7 @@ describe('Integration | Repository | training-repository', function () {
           id: 1,
           goalThreshold: 10,
           prerequisiteThreshold: 20,
+          isDisabled: true,
         });
         const trainingSummary2 = domainBuilder.buildTrainingSummary({ id: 2, goalThreshold: 30 });
         const trainingSummaryLinkToAnotherTargetProfile = domainBuilder.buildTrainingSummary({ id: 3 });

--- a/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
@@ -616,6 +616,7 @@ describe('Integration | Repository | training-repository', function () {
         link: 'https://example.net/mon-nouveau-lien',
         editorName: 'Mon nouvel editeur',
         editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/nouveau-logo.svg',
+        isDisabled: true,
         notExistingAttribute: 'notExistingValue',
       };
 
@@ -631,6 +632,7 @@ describe('Integration | Repository | training-repository', function () {
       expect(updatedTraining.editorName).to.be.equal(attributesToUpdate.editorName);
       expect(updatedTraining.editorLogoUrl).to.be.equal(attributesToUpdate.editorLogoUrl);
       expect(updatedTraining.updatedAt).to.be.above(currentTraining.updatedAt);
+      expect(updatedTraining.isDisabled).to.be.true;
     });
 
     it('should return updated training', async function () {
@@ -648,6 +650,7 @@ describe('Integration | Repository | training-repository', function () {
         link: 'https://example.net/mon-nouveau-lien',
         editorName: 'Mon nouvel editeur',
         editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/nouveau-logo.svg',
+        isDisabled: true,
       };
 
       // when
@@ -660,6 +663,7 @@ describe('Integration | Repository | training-repository', function () {
       expect(updatedTraining.editorName).to.be.equal(attributesToUpdate.editorName);
       expect(updatedTraining.editorLogoUrl).to.be.equal(attributesToUpdate.editorLogoUrl);
       expect(updatedTraining.targetProfileIds).to.deep.equal([targetProfile.id]);
+      expect(updatedTraining.isDisabled).to.be.true;
     });
 
     it('should not update other raws', async function () {

--- a/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
@@ -783,6 +783,28 @@ describe('Integration | Repository | training-repository', function () {
       expect(userRecommendedTrainings).to.be.lengthOf(0);
       expect(pagination).to.deep.equal({ page: 1, pageSize: 10, rowCount: 0, pageCount: 0 });
     });
+
+    it('should not return disabled trainings', async function () {
+      // given
+      const { userId, id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation();
+      const training1 = databaseBuilder.factory.buildTraining({ isDisabled: true });
+      databaseBuilder.factory.buildUserRecommendedTraining({
+        userId,
+        trainingId: training1.id,
+        campaignParticipationId,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const { userRecommendedTrainings, pagination } = await trainingRepository.findPaginatedByUserId({
+        userId,
+        locale: 'fr-fr',
+      });
+
+      // then
+      expect(userRecommendedTrainings).to.be.lengthOf(0);
+      expect(pagination).to.deep.equal({ page: 1, pageSize: 10, rowCount: 0, pageCount: 0 });
+    });
   });
 });
 

--- a/api/tests/devcomp/integration/infrastructure/repositories/user-recommended-training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/user-recommended-training-repository_test.js
@@ -100,6 +100,36 @@ describe('Integration | Repository | user-recommended-training-repository', func
       expect(result[0]).to.deep.equal(new UserRecommendedTraining({ ...training, duration: { hours: 6 } }));
     });
 
+    it('should not return disabled recommended trainings for given campaignParticipationId and locale', async function () {
+      // given
+      const { id: campaignParticipationId, userId } = databaseBuilder.factory.buildCampaignParticipation();
+      const training = databaseBuilder.factory.buildTraining();
+      const userRecommendedTrainingDisabled = {
+        userId,
+        trainingId: databaseBuilder.factory.buildTraining({ isDisabled: true }).id,
+        campaignParticipationId,
+      };
+      const userRecommendedTrainingEnabled = {
+        userId,
+        trainingId: training.id,
+        campaignParticipationId,
+      };
+      databaseBuilder.factory.buildUserRecommendedTraining(userRecommendedTrainingDisabled);
+      databaseBuilder.factory.buildUserRecommendedTraining(userRecommendedTrainingEnabled);
+      await databaseBuilder.commit();
+
+      // when
+      const result = await userRecommendedTrainingRepository.findByCampaignParticipationId({
+        campaignParticipationId,
+        locale: 'fr-fr',
+      });
+
+      // then
+      expect(result.length).to.equal(1);
+      expect(result[0]).to.be.instanceOf(UserRecommendedTraining);
+      expect(result[0]).to.deep.equal(new UserRecommendedTraining({ ...training, duration: { hours: 6 } }));
+    });
+
     it('should return an empty array when user has no recommended training for this campaignParticipation', async function () {
       // given
       const { id: campaignParticipationId, userId } = databaseBuilder.factory.buildCampaignParticipation();

--- a/api/tests/devcomp/unit/application/trainings/training-controller_test.js
+++ b/api/tests/devcomp/unit/application/trainings/training-controller_test.js
@@ -162,7 +162,7 @@ describe('Unit | Devcomp | Application | Trainings | Controller | training-contr
 
     beforeEach(function () {
       trainingSerializer = {
-        serialize: sinon.stub(),
+        serializeForAdmin: sinon.stub(),
         deserialize: sinon.stub(),
       };
       trainingSerializer.deserialize.returns(deserializedTraining);
@@ -212,7 +212,7 @@ describe('Unit | Devcomp | Application | Trainings | Controller | training-contr
           },
         };
         const expectedSerializedUser = { message: 'serialized user' };
-        trainingSerializer.serialize.returns(expectedSerializedUser);
+        trainingSerializer.serializeForAdmin.returns(expectedSerializedUser);
 
         // when
         const response = await trainingController.update(
@@ -227,7 +227,7 @@ describe('Unit | Devcomp | Application | Trainings | Controller | training-contr
         );
 
         // then
-        expect(trainingSerializer.serialize).to.have.been.calledWithExactly(updatedTraining);
+        expect(trainingSerializer.serializeForAdmin).to.have.been.calledWithExactly(updatedTraining);
         expect(response).to.deep.equal(expectedSerializedUser);
       });
     });

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
@@ -422,6 +422,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-ser
             locale: 'fr-fr',
             'editor-name': 'Ministère education nationale',
             'editor-logo-url': 'https://images.pix.fr/contenu-formatif/editeur/editor_logo_url.svg',
+            'is-disabled': true,
           },
         },
       };
@@ -438,6 +439,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-ser
         type: 'webinaire',
         editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/editor_logo_url.svg',
         editorName: 'Ministère education nationale',
+        isDisabled: true,
       });
     });
 

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
@@ -74,6 +74,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-ser
             },
             'editor-logo-url': 'https://images.pix.fr/contenu-formatif/editeur/editor_logo_url.svg',
             'editor-name': 'Ministère education nationale',
+            'is-disabled': false,
             'is-recommendable': true,
             link: 'https://example.net',
             locale: 'fr-fr',

--- a/api/tests/tooling/domain-builder/factory/build-training-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-training-for-admin.js
@@ -13,6 +13,7 @@ const buildTrainingForAdmin = function ({
   editorName = 'Ministère education nationale',
   editorLogoUrl = 'https://images.pix.fr/contenu-formatif/editeur/editor_logo_url.svg',
   trainingTriggers,
+  isDisabled = false,
 } = {}) {
   return new TrainingForAdmin({
     id,
@@ -25,6 +26,7 @@ const buildTrainingForAdmin = function ({
     editorName,
     editorLogoUrl,
     trainingTriggers,
+    isDisabled,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/build-training-summary.js
+++ b/api/tests/tooling/domain-builder/factory/build-training-summary.js
@@ -6,6 +6,7 @@ const buildTrainingSummary = function ({
   prerequisiteThreshold,
   goalThreshold,
   targetProfilesCount = 0,
+  isDisabled = false,
 } = {}) {
   return new TrainingSummary({
     id,
@@ -13,6 +14,7 @@ const buildTrainingSummary = function ({
     prerequisiteThreshold,
     goalThreshold,
     targetProfilesCount,
+    isDisabled,
   });
 };
 

--- a/api/tests/unit/devcomp/infrastructure/serializers/jsonapi/training-summary-serializer_test.js
+++ b/api/tests/unit/devcomp/infrastructure/serializers/jsonapi/training-summary-serializer_test.js
@@ -31,6 +31,7 @@ describe('Unit | Serializer | JSONAPI | training-summary-serializer', function (
               'prerequisite-threshold': 2,
               'target-profiles-count': 1,
               title: 'Training Summary 1',
+              'is-disabled': false,
             },
           },
           {
@@ -41,6 +42,7 @@ describe('Unit | Serializer | JSONAPI | training-summary-serializer', function (
               'prerequisite-threshold': undefined,
               'target-profiles-count': 0,
               title: 'Training Summary 2',
+              'is-disabled': false,
             },
           },
         ],


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, il n'est pas possible de mettre en pause un contenu formatif quand par exemple en attendant que l'url soit mise à jour ou autres.

## :robot: Proposition
- Mettre à disposition une checkbox dans l'édition sur Pix Admin pour mettre en pause le CF. 
- Ne pas retourner les contenus formatif en pause sur la page "Mes formations" et sur les formations recommandées en fin de parcours

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
### Sur Pix Admin
- Modifier un CF et activer la checkbox et enregistrer
- Reload la page de détail et voir que tag affiche "En pause"

### Sur Pix App 
- Passer une campagne qui permet d'obtenir le CF 
- Voir à la fin que le CF n'est pas affichée 
- Réactiver le CF
- Recharger la page et voir qu'il est visible 
- Refaire ce test sur la page "Mes formations"