### PR TITLE
[BUGFIX] Récupérer les SSO OIDC dans le formulaire de modification d'une organisation qui ne l'étaient plus (PIX-11450)

### DIFF
--- a/admin/app/routes/authenticated/organizations/get.js
+++ b/admin/app/routes/authenticated/organizations/get.js
@@ -2,7 +2,12 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
 export default class GetRoute extends Route {
+  @service oidcIdentityProviders;
   @service store;
+
+  async beforeModel() {
+    await this.oidcIdentityProviders.loadAllAvailableIdentityProviders();
+  }
 
   model(params) {
     return this.store.findRecord('organization', params.organization_id, { reload: true });


### PR DESCRIPTION
## :unicorn: Problème

Dans Pix Admin, dans le formulaire de modification d’une organisation, les SSO OIDC ne sont plus affichés. Seul le SSO GAR est affiché.

## :robot: Proposition

Récupérer les SSO OIDC chaque fois qu'on affiche le formulaire de modification avec un `beforeModel` comme cela est fait pour l'onglet de détail pour la fiche utilisateur : https://github.com/1024pix/pix/blob/dev/admin/app/routes/authenticated/users/get.js#L9-L11

## :rainbow: Remarques

Cette solution n'est pas idéale car elle récupère la liste des SSO OIDC chaque fois que le formulaire de modification d'une organisation est affiché, ce qui est inutile car la liste des SSO OIDC change peu, il suffirait de la récupérer au moment où l'utilisateur se connecte à Pix Admin. Mais ce correctif utilise la même logique que ce qui a été fait pour l'onglet de détail pour la fiche utilisateur.

## :100: Pour tester

1. Se connecter à Pix Admin
2. Aller sur la fiche d'une orga
3. Cliquer sur le bouton « Modifier »
4. Constater que la liste déroulante des SSO contient tous les SSO OIDC et pas uniquement le SSO GAR