### PR TITLE
[TECH] Ajoute la version de l'application client dans un entête HTTP spécifique (PIX-11356).

### DIFF
--- a/1d/app/adapters/application.js
+++ b/1d/app/adapters/application.js
@@ -4,4 +4,10 @@ import ENV from '1d/config/environment';
 export default class Application extends JSONAPIAdapter {
   host = ENV.APP.API_HOST;
   namespace = 'api/pix1d';
+
+  get headers() {
+    return {
+      'X-App-Version': ENV.APP.version,
+    };
+  }
 }

--- a/admin/app/adapters/application.js
+++ b/admin/app/adapters/application.js
@@ -14,6 +14,7 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
     if (this.session.isAuthenticated) {
       headers['Authorization'] = `Bearer ${this.session.data.authenticated.access_token}`;
     }
+    headers['X-App-Version'] = ENV.APP.version;
     return headers;
   }
 

--- a/certif/app/adapters/application.js
+++ b/certif/app/adapters/application.js
@@ -16,6 +16,7 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
       headers['Authorization'] = `Bearer ${this.session.data.authenticated.access_token}`;
     }
     headers['Accept-Language'] = this._locale;
+    headers['X-App-Version'] = ENV.APP.version;
 
     return headers;
   }

--- a/mon-pix/app/adapters/application.js
+++ b/mon-pix/app/adapters/application.js
@@ -21,6 +21,7 @@ export default class Application extends JSONAPIAdapter {
       headers['Authorization'] = `Bearer ${this.session.data.authenticated.access_token}`;
     }
     headers['Accept-Language'] = this._locale;
+    headers['X-App-Version'] = ENV.APP.version;
     return headers;
   }
 

--- a/orga/app/adapters/application.js
+++ b/orga/app/adapters/application.js
@@ -21,6 +21,7 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
       headers['Authorization'] = `Bearer ${this.session.data.authenticated.access_token}`;
     }
     headers['Accept-Language'] = this._locale;
+    headers['X-App-Version'] = ENV.APP.version;
     return headers;
   }
 


### PR DESCRIPTION
We add the frontend application version in a dedicated
X-App-Version for every API call.
Thus, we will be able to monitor, thanks to log monitoring,
how fast or nor newer version are actually used by end users.

## :unicorn: Problème

Les utilisateurs ayant en cache une version N de l'application cliente (Pix Admin / Pix App / Pix Certif / Pix Orga) ne bénéficie pas automatiquement de l'application N+1 lors de son déploiement.
Nous n'avons aucun moyen de mesurer le taux d'utilisation d'une nouvelle version dans le temps.

## :robot: Proposition

Dans un premier temps, on ajoute la version de l'application cliente dans un entête dédié (`X-App-Version`).
Cet entête étant envoyé dans chaque requête vers l'API, on pourra mesurer le taux d'utilisation d'une version via les logs.

## :rainbow: Remarques

RAS

## :100: Pour tester

Vérifier que l'entête `X-App-Version` est présent et valorisé dans les appels d'une application front.
Ajouter le log drain sur la Review App et vérifier qu'on reçoit des logs contenant la version de l'application dans notre monitoring.
