### PR TITLE
[TECH] Déplacement du service de récupération de texte traduit

### DIFF
--- a/api/lib/infrastructure/repositories/area-repository.js
+++ b/api/lib/infrastructure/repositories/area-repository.js
@@ -1,7 +1,7 @@
 import { Area } from '../../domain/models/Area.js';
 import { areaDatasource } from '../datasources/learning-content/area-datasource.js';
 import * as competenceRepository from '../../../src/shared/infrastructure/repositories/competence-repository.js';
-import { getTranslatedKey } from '../../domain/services/get-translated-text.js';
+import { getTranslatedKey } from '../../../src/shared/domain/services/get-translated-text.js';
 import _ from 'lodash';
 import { NotFoundError } from '../../domain/errors.js';
 

--- a/api/lib/infrastructure/repositories/correction-repository.js
+++ b/api/lib/infrastructure/repositories/correction-repository.js
@@ -4,7 +4,7 @@ import { Correction } from '../../domain/models/Correction.js';
 import { Hint } from '../../domain/models/Hint.js';
 import { challengeDatasource } from '../datasources/learning-content/challenge-datasource.js';
 import { skillDatasource } from '../datasources/learning-content/skill-datasource.js';
-import { getTranslatedKey } from '../../domain/services/get-translated-text.js';
+import { getTranslatedKey } from '../../../src/shared/domain/services/get-translated-text.js';
 import { Challenge } from '../../../src/shared/domain/models/Challenge.js';
 import { Answer } from '../../../src/evaluation/domain/models/Answer.js';
 

--- a/api/lib/infrastructure/repositories/thematic-repository.js
+++ b/api/lib/infrastructure/repositories/thematic-repository.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { Thematic } from '../../domain/models/Thematic.js';
 import { thematicDatasource } from '../../../src/shared/infrastructure/datasources/learning-content/thematic-datasource.js';
-import { getTranslatedKey } from '../../domain/services/get-translated-text.js';
+import { getTranslatedKey } from '../../../src/shared/domain/services/get-translated-text.js';
 import { LOCALE } from '../../../src/shared/domain/constants.js';
 
 const { FRENCH_FRANCE } = LOCALE;

--- a/api/lib/infrastructure/repositories/tube-repository.js
+++ b/api/lib/infrastructure/repositories/tube-repository.js
@@ -3,7 +3,7 @@ import bluebird from 'bluebird';
 import { Tube } from '../../domain/models/Tube.js';
 import { tubeDatasource } from '../datasources/learning-content/tube-datasource.js';
 import { skillDatasource } from '../datasources/learning-content/skill-datasource.js';
-import { getTranslatedKey } from '../../domain/services/get-translated-text.js';
+import { getTranslatedKey } from '../../../src/shared/domain/services/get-translated-text.js';
 
 function _toDomain({ tubeData, locale }) {
   const translatedPracticalTitle = getTranslatedKey(tubeData.practicalTitle_i18n, locale);

--- a/api/src/school/infrastructure/repositories/mission-repository.js
+++ b/api/src/school/infrastructure/repositories/mission-repository.js
@@ -1,6 +1,6 @@
 import { Mission } from '../../domain/models/Mission.js';
 import { missionDatasource } from '../datasources/learning-content/mission-datasource.js';
-import { getTranslatedKey } from '../../../../lib/domain/services/get-translated-text.js';
+import { getTranslatedKey } from '../../../shared/domain/services/get-translated-text.js';
 import { LOCALE } from '../../../shared/domain/constants.js';
 import { MissionNotFoundError } from '../../domain/school-errors.js';
 

--- a/api/src/shared/domain/services/get-translated-text.js
+++ b/api/src/shared/domain/services/get-translated-text.js
@@ -1,4 +1,4 @@
-import { LOCALE } from '../../../src/shared/domain/constants.js';
+import { LOCALE } from '../constants.js';
 
 const { FRENCH_SPOKEN } = LOCALE;
 

--- a/api/src/shared/infrastructure/repositories/competence-repository.js
+++ b/api/src/shared/infrastructure/repositories/competence-repository.js
@@ -8,7 +8,7 @@ import { LOCALE } from '../../../../src/shared/domain/constants.js';
 
 const { FRENCH_FRANCE } = LOCALE;
 
-import { getTranslatedKey } from '../../../../lib/domain/services/get-translated-text.js';
+import { getTranslatedKey } from '../../domain/services/get-translated-text.js';
 
 function _toDomain({ competenceData, locale }) {
   const translatedCompetenceName = getTranslatedKey(competenceData.name_i18n, locale);

--- a/api/tests/unit/domain/services/get-translated-text_test.js
+++ b/api/tests/unit/domain/services/get-translated-text_test.js
@@ -1,5 +1,5 @@
 import { expect } from '../../../test-helper.js';
-import * as service from '../../../../lib/domain/services/get-translated-text.js';
+import * as service from '../../../../src/shared/domain/services/get-translated-text.js';
 describe('Unit | Domain | Services | get-translated-text', function () {
   describe('#getTranslatedKey', function () {
     const translatedKey = {


### PR DESCRIPTION
## :unicorn: Problème

cf https://github.com/1024pix/pix/blob/dev/docs/adr/0051-nouvelle-arborescence-api.md

## :robot: Proposition

Déplacement du fichier `get-translated-text` dans le répertoire `src/shared/domain/services`

## :rainbow: Remarques


## :100: Pour tester

Tests vert 🟢 et rien de changer dans les diverses applications.
