### PR TITLE
[BUGFIX] supprime le message d'alerte du l'import sup après un import sco (PIX-11440)

### DIFF
--- a/orga/app/controllers/authenticated/import-organization-participants.js
+++ b/orga/app/controllers/authenticated/import-organization-participants.js
@@ -29,7 +29,7 @@ export default class ImportController extends Controller {
 
     try {
       const response = await adapter.addStudentsCsv(organizationId, files);
-      this._sendNotifications(response);
+      this._sendSupNotifications(response);
     } catch (errorResponse) {
       this._instantiateErrorsDetail(errorResponse);
     } finally {
@@ -43,18 +43,17 @@ export default class ImportController extends Controller {
 
     const adapter = this.store.adapterFor('students-import');
     const organizationId = this.currentUser.organization.id;
+    const format = this.currentUser.isAgriculture ? 'csv' : 'xml';
 
     const confirmBeforeClose = (event) => {
       event.preventDefault();
       return (event.returnValue = '');
     };
-
     window.addEventListener('beforeunload', confirmBeforeClose);
-    try {
-      const format = this.currentUser.isAgriculture ? 'csv' : 'xml';
-      const response = await adapter.importStudentsSiecle(organizationId, files, format);
 
-      this._sendNotifications(response);
+    try {
+      await adapter.importStudentsSiecle(organizationId, files, format);
+      this.notifications.sendSuccess(this.intl.t('pages.organization-participants-import.global-success'));
     } catch (errorResponse) {
       this._instantiateErrorsDetail(errorResponse);
     } finally {
@@ -72,7 +71,7 @@ export default class ImportController extends Controller {
 
     try {
       const response = await adapter.replaceStudentsCsv(organizationId, files);
-      this._sendNotifications(response);
+      this._sendSupNotifications(response);
     } catch (errorResponse) {
       this._instantiateErrorsDetail(errorResponse);
     } finally {
@@ -80,7 +79,7 @@ export default class ImportController extends Controller {
     }
   }
 
-  _sendNotifications(response) {
+  _sendSupNotifications(response) {
     const warningsArray = get(response, 'data.attributes.warnings', []);
 
     this.notifications.sendSuccess(this.intl.t('pages.organization-participants-import.global-success'));

--- a/orga/tests/unit/controllers/authenticated/import-organization-participants_test.js
+++ b/orga/tests/unit/controllers/authenticated/import-organization-participants_test.js
@@ -18,6 +18,7 @@ module('Unit | Controller | authenticated/organization-participants-import', fun
     controller = this.owner.lookup('controller:authenticated/import-organization-participants');
     controller.send = sinon.stub();
     controller.currentUser = currentUser;
+    controller.notifications = { sendError: sinon.stub(), sendSuccess: sinon.stub(), clearAll: sinon.stub() };
 
     const store = this.owner.lookup('service:store');
     const adapter = store.adapterFor('students-import');
@@ -103,6 +104,9 @@ module('Unit | Controller | authenticated/organization-participants-import', fun
         await controller.importScoStudents(files);
 
         assert.ok(importScoStudentStub.calledWith(1, files, 'xml'));
+        assert.ok(controller.notifications.sendSuccess.calledOnce);
+        assert.ok(controller.notifications.sendError.notCalled);
+        assert.strictEqual(controller.warningBanner, null);
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Suite au refacto de l'import, on a introduit un message d'alerte du sup dans l'import sco

## :robot: Proposition
On enlève le message non voulu

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter à une orga sco
Faire un import sco 
Ne pas voir le message d'alerte avec le mail du sup