### PR TITLE
[BUGFIX] Remonter le dernier résultat publié d'un élève quand il est bien entré en session (PIX-11398).

### DIFF
--- a/api/src/certification/course/infrastructure/repositories/sco-certification-candidate-repository.js
+++ b/api/src/certification/course/infrastructure/repositories/sco-certification-candidate-repository.js
@@ -1,7 +1,10 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 
 /**
- * @returns {Array<number>} certification candidates ids
+ * @param {Object} params
+ * @param {number} params.organizationId
+ * @param {string} params.division
+ * @returns {Array<number>} candidates identifiers of active students participants to certification sessions within given division
  */
 const findIdsByOrganizationIdAndDivision = async function ({ organizationId, division }) {
   const uniqLastCandidatesByOrganizationLearners = knex
@@ -11,14 +14,21 @@ const findIdsByOrganizationIdAndDivision = async function ({ organizationId, div
         'row_number() OVER (PARTITION BY "certification-candidates"."organizationLearnerId" ORDER BY "sessions"."publishedAt" DESC NULLS LAST) as session_number',
       ),
     )
-    .from('view-active-organization-learners as learners')
-    .innerJoin('certification-candidates', 'learners.id', 'certification-candidates.organizationLearnerId')
-    .innerJoin('sessions', 'certification-candidates.sessionId', 'sessions.id')
-    .where({
-      'learners.organizationId': organizationId,
-      'learners.isDisabled': false,
+    .from('certification-candidates')
+    .innerJoin('sessions', 'sessions.id', 'certification-candidates.sessionId')
+    .innerJoin('certification-courses', (builder) => {
+      builder
+        .on('certification-courses.sessionId', '=', 'certification-candidates.sessionId')
+        .andOn('certification-courses.userId', '=', 'certification-candidates.userId');
     })
-    .whereRaw('LOWER(learners.division) = ?', division.toLowerCase())
+    .innerJoin(
+      { learners: 'view-active-organization-learners' },
+      'learners.id',
+      'certification-candidates.organizationLearnerId',
+    )
+    .where(_sessionHasBeenPublished)
+    .where(_candidateJoinedTheSession)
+    .where(_candidateIsAnActiveStudentOfTheDivision({ organizationId, division }))
     .orderBy('certification-candidates.lastName', 'ASC')
     .orderBy('certification-candidates.firstName', 'ASC')
     .as('uniqLastCandidatesByOrganizationLearners');
@@ -27,6 +37,23 @@ const findIdsByOrganizationIdAndDivision = async function ({ organizationId, div
     .pluck('id')
     .from(uniqLastCandidatesByOrganizationLearners)
     .where('uniqLastCandidatesByOrganizationLearners.session_number', 1);
+};
+
+const _sessionHasBeenPublished = (builder) =>
+  builder.whereNotNull('sessions.publishedAt').where('certification-courses.isPublished', '=', true);
+
+const _candidateJoinedTheSession = (builder) =>
+  builder.whereNotNull('certification-candidates.userId').whereNotNull('certification-courses.id');
+
+const _candidateIsAnActiveStudentOfTheDivision = ({ organizationId, division }) => {
+  return (builder) =>
+    builder
+      .whereNotNull('certification-candidates.organizationLearnerId')
+      .where({
+        'learners.organizationId': organizationId,
+        'learners.isDisabled': false,
+      })
+      .whereRaw('LOWER(learners.division) = ?', division.toLowerCase());
 };
 
 export { findIdsByOrganizationIdAndDivision };

--- a/api/tests/certification/course/acceptance/application/organization-controller_test.js
+++ b/api/tests/certification/course/acceptance/application/organization-controller_test.js
@@ -8,8 +8,10 @@ import {
 import { createServer } from '../../../../../server.js';
 import { Membership } from '../../../../../lib/domain/models/Membership.js';
 import { AutoJuryCommentKeys } from '../../../../../src/certification/shared/domain/models/JuryComment.js';
+import { AssessmentResult } from '../../../../../lib/domain/models/index.js';
 
 describe('Certification | Course | Acceptance | Application | organization-controller', function () {
+  const BOM_CHAR = '\ufeff';
   let server;
 
   beforeEach(async function () {
@@ -29,22 +31,42 @@ describe('Certification | Course | Acceptance | Application | organization-contr
         organizationRole: Membership.roles.ADMIN,
       });
 
+      const sessionId = databaseBuilder.factory.buildSession({ id: 10242048, publishedAt: new Date('2024-01-01') }).id;
+
       const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
         organizationId: organization.id,
         division: 'aDivision',
       });
       const candidate = databaseBuilder.factory.buildCertificationCandidate({
         organizationLearnerId: organizationLearner.id,
+        sessionId,
       });
       const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
+        id: 20484096,
         userId: candidate.userId,
         sessionId: candidate.sessionId,
         isPublished: true,
+        isCancelled: true,
       });
-
       databaseBuilder.factory.buildAssessmentResult.last({
+        pixScore: 0,
+        status: AssessmentResult.status.REJECTED,
         certificationCourseId: certificationCourse.id,
         commentByAutoJury: AutoJuryCommentKeys.CANCELLED_DUE_TO_NEUTRALIZATION,
+      });
+
+      const organizationLearnerDidNotComeToTheSession = databaseBuilder.factory.buildOrganizationLearner({
+        firstName: 'didNotCome',
+        organizationId: organization.id,
+        division: 'aDivision',
+      });
+      const candidateDidNotComeToTheSession = databaseBuilder.factory.buildCertificationCandidate({
+        organizationLearnerId: organizationLearnerDidNotComeToTheSession.id,
+        sessionId,
+      });
+      databaseBuilder.factory.buildCertificationCourse({
+        sessionId: candidateDidNotComeToTheSession.sessionId,
+        isPublished: true,
       });
       await databaseBuilder.commit();
 
@@ -59,6 +81,9 @@ describe('Certification | Course | Acceptance | Application | organization-contr
 
       // then
       expect(response.statusCode).to.equal(200);
+      expect(response.payload).to.equal(
+        `${BOM_CHAR}"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Statut";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Commentaire jury pour l’organisation";"Session";"Date de passage de la certification"\n20484096;"first-name";"last-name";"21/05/2001";"Paris";"externalId";"Annulée";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"Un ou plusieurs problème(s) technique(s), a/ont affecté le bon déroulement du test de certification. Nous ne sommes pas en mesure de délivrer la certification, celle-ci est donc annulée. Cette information peut vous conduire à proposer une nouvelle session de certification pour ce(cette) candidat(e).";10242048;"01/01/2022"`,
+      );
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Suite à de récentes modifications sur le sujet, on remonte désormais uniquement la dernière session **publiée** d'un élève à une certification (plutôt que toutes, éliminant ainsi les doublons).
Cela a introduit une régression : au cours d'une année un élève est parfois inscrit à plusieurs sessions, mais s'il réussit la première de l'année il ne va pas forcèment en rattrapage. Mais le rattrapage reste publié.
Il faut donc prendre en compte la dernière session publiée certes, mais à laquelle le candidat est **entré en certification**
A noter que l'on veut l'état actuel, c'est à dire que si un élève est entré plusieurs fois en certification, c'est bien la dernière entrée en certification que l'on veut.

## :robot: Proposition

* Limiter la remontée des identifiants de candidats au candidats qui sont rentrés en certification.

## :rainbow: Remarques

⚠️ Pour des raisons de GDPR, on part aussi uniquement des données de certification, et on évite de passer par la table qui donne beaucoup d'informations personnelles d'un candidat. Cela pour préparer le terrain à terme d'une séparation encore plus forte à venir de ces données du reste des données.

## :100: Pour tester

* Créer 4 sessions SCO avec `certif-sco@example.net`, y inscrire dans toutes ces sessions **un même élève** (même organization-learner)
* Faire rentre dans la session 1 le candidat, passer la session, réussir la certification, finaliser et publier la session
* Aller sur Pix Orga avec `orga-sco-managing-students@example.net` , aller dans certifications pour extraire la liste des résultats, y constater la certification **validée** pour l'élève
* Lancer la session numéro 2, faire passer le même élève, et terminer vite son test (qu'importe son statut, faites le échouer, au pire vous le rejeterez pour fraude), finaliser et publier la session
* Aller sur Pix Orga avec `orga-sco-managing-students@example.net` , aller dans certifications pour extraire la liste des résultats, y constater la certification **rejetée** pour l'élève
* Lancer la session numéro 3, **ne pas faire entrer le candidat en session**, finaliser et publier la session
* Aller sur Pix Orga avec `orga-sco-managing-students@example.net` , aller dans certifications pour extraire la liste des résultats, y constater la certification **rejetée** pour l'élève (le résultat numéro 2)
* Lancer la session numéro 4, faire rentrer le candidat en session, réussir la certification, finaliser  **mais ne publiez pas** la session
  * Cas particulier, on a  donc un candidat, avec un résultat, mais pas encore publié
* Aller sur Pix Orga avec `orga-sco-managing-students@example.net` , aller dans certifications pour extraire la liste des résultats, y constater la certification **rejetée** pour l'élève (le résultat numéro 2)
* Maintenant publiez la session numéro 4
* Aller sur Pix Orga avec `orga-sco-managing-students@example.net` , aller dans certifications pour extraire la liste des résultats, y constater la certification **validée** pour l'élève (le résultat numéro 4)

- todo : créer un orga-learner lié à la 1èreA, l'inscrire à une session, ne pas le faire passer et vérifier dans l'export de de résultats qu'il n'apparaît pas. Puis le faire rejeter et voir que l'attestation ne le retourne pas.

En principe après tout cela c'est déjà l'heure du goûter.