### PR TITLE
[FEATURE] Stocke l'état de l'import SIECLE au fur et à mesure des étapes (PIX-11345)

### DIFF
--- a/api/db/migrations/20240226135807_organization-imports-make-filename-nullable.js
+++ b/api/db/migrations/20240226135807_organization-imports-make-filename-nullable.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'organization-imports';
+const COLUMN_NAME = 'filename';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.text(COLUMN_NAME).nullable().defaultTo(null).alter();
+  });
+};
+
+const down = async function () {
+  // No existing data at this stage
+};
+
+export { up, down };

--- a/api/src/prescription/learner-management/application/sco-organization-management-controller.js
+++ b/api/src/prescription/learner-management/application/sco-organization-management-controller.js
@@ -10,11 +10,13 @@ const importOrganizationLearnersFromSIECLE = async function (
   h,
   dependencies = { logErrorWithCorrelationIds },
 ) {
+  const authenticatedUserId = request.auth.credentials.userId;
   const organizationId = request.params.id;
   const { format } = request.query;
   try {
     if (format === 'xml') {
       await usecases.importOrganizationLearnersFromSIECLEXMLFormat({
+        userId: authenticatedUserId,
         organizationId,
         payload: request.payload,
       });

--- a/api/src/prescription/learner-management/domain/models/OrganizationImport.js
+++ b/api/src/prescription/learner-management/domain/models/OrganizationImport.js
@@ -35,7 +35,7 @@ export class OrganizationImport {
       this.errors = [...errors, ...warnings];
     } else {
       this.status = IMPORT_STATUSES.VALIDATED;
-      this.errors = warnings;
+      this.errors = warnings.length > 0 ? warnings : null;
     }
     this.updatedAt = new Date();
   }

--- a/api/src/prescription/learner-management/domain/usecases/import-organization-learners-from-siecle-xml-format.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-organization-learners-from-siecle-xml-format.js
@@ -12,6 +12,7 @@ import { SiecleParser } from '../../infrastructure/serializers/xml/siecle-parser
 import { SiecleFileStreamer } from '../../infrastructure/utils/xml/siecle-file-streamer.js';
 import * as zip from '../../infrastructure/utils/xml/zip.js';
 import { detectEncoding } from '../../infrastructure/utils/xml/detect-encoding.js';
+import { OrganizationImport } from '../models/OrganizationImport.js';
 
 const ERRORS = {
   EMPTY: 'EMPTY',
@@ -19,11 +20,13 @@ const ERRORS = {
 };
 
 const importOrganizationLearnersFromSIECLEXMLFormat = async function ({
+  userId,
   organizationId,
   payload,
   organizationLearnerRepository,
   organizationRepository,
   importStorage,
+  organizationImportRepository,
   siecleService = {
     unzip: zip.unzip,
     detectEncoding,
@@ -31,18 +34,30 @@ const importOrganizationLearnersFromSIECLEXMLFormat = async function ({
 }) {
   let organizationLearnerData = [];
 
+  let organizationImport = OrganizationImport.create({ organizationId, createdBy: userId });
+
   const organization = await organizationRepository.get(organizationId);
   const path = payload.path;
 
   const { file: filePath, directory } = await siecleService.unzip(path);
   const encoding = await siecleService.detectEncoding(filePath);
 
-  const filename = await importStorage.sendFile({ filepath: filePath });
-
+  let filename;
+  const errors = [];
   try {
+    filename = await importStorage.sendFile({ filepath: filePath });
     if (directory) {
       await fs.rm(directory, { recursive: true });
     }
+  } catch (error) {
+    errors.push(error);
+    throw error;
+  } finally {
+    organizationImport.upload({ filename, encoding, errors });
+    await organizationImportRepository.save(organizationImport);
+  }
+
+  try {
     const readableStreamForUAJ = await importStorage.readFile({ filename });
     const siecleFileStreamerForUAJ = await SiecleFileStreamer.create(readableStreamForUAJ, encoding);
     const parserForUAJ = SiecleParser.create(organization, siecleFileStreamerForUAJ);
@@ -52,32 +67,46 @@ const importOrganizationLearnersFromSIECLEXMLFormat = async function ({
     const siecleFileStreamer = await SiecleFileStreamer.create(readableStream, encoding);
     const parser = SiecleParser.create(organization, siecleFileStreamer);
     organizationLearnerData = await parser.parse();
+    if (isEmpty(organizationLearnerData)) {
+      throw new SiecleXmlImportError(ERRORS.EMPTY);
+    }
+  } catch (error) {
+    errors.push(error);
+    throw error;
   } finally {
+    organizationImport = await organizationImportRepository.getByOrganizationId(organizationId);
+    organizationImport.validate({ errors });
+    await organizationImportRepository.save(organizationImport);
     await importStorage.deleteFile({ filename });
   }
 
-  if (isEmpty(organizationLearnerData)) {
-    throw new SiecleXmlImportError(ERRORS.EMPTY);
-  }
-
-  const organizationLearnersChunks = chunk(organizationLearnerData, ORGANIZATION_LEARNER_CHUNK_SIZE);
-
-  const nationalStudentIdData = organizationLearnerData.map((learner) => learner.nationalStudentId, []);
-
   return DomainTransaction.execute(async (domainTransaction) => {
-    await organizationLearnerRepository.disableAllOrganizationLearnersInOrganization({
-      domainTransaction,
-      organizationId,
-      nationalStudentIds: nationalStudentIdData,
-    });
+    try {
+      const organizationLearnersChunks = chunk(organizationLearnerData, ORGANIZATION_LEARNER_CHUNK_SIZE);
 
-    await bluebird.mapSeries(organizationLearnersChunks, (chunk) => {
-      return organizationLearnerRepository.addOrUpdateOrganizationOfOrganizationLearners(
-        chunk,
-        organizationId,
+      const nationalStudentIdData = organizationLearnerData.map((learner) => learner.nationalStudentId, []);
+
+      await organizationLearnerRepository.disableAllOrganizationLearnersInOrganization({
         domainTransaction,
-      );
-    });
+        organizationId,
+        nationalStudentIds: nationalStudentIdData,
+      });
+
+      await bluebird.mapSeries(organizationLearnersChunks, (chunk) => {
+        return organizationLearnerRepository.addOrUpdateOrganizationOfOrganizationLearners(
+          chunk,
+          organizationId,
+          domainTransaction,
+        );
+      });
+    } catch (error) {
+      errors.push(error);
+      throw error;
+    } finally {
+      organizationImport = await organizationImportRepository.getByOrganizationId(organizationId);
+      organizationImport.process({ errors });
+      await organizationImportRepository.save(organizationImport);
+    }
   });
 };
 

--- a/api/src/prescription/learner-management/domain/usecases/index.js
+++ b/api/src/prescription/learner-management/domain/usecases/index.js
@@ -8,6 +8,7 @@ import * as campaignParticipationRepository from '../../infrastructure/repositor
 import { importStorage } from '../../infrastructure/storage/import-storage.js';
 
 import * as organizationRepository from '../../../../../lib/infrastructure/repositories/organization-repository.js';
+import * as organizationImportRepository from '../../infrastructure/repositories/organization-import-repository.js';
 
 import * as organizationLearnersCsvService from '../services/organization-learners-csv-service.js';
 import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
@@ -19,6 +20,7 @@ const dependencies = {
   campaignParticipationRepository,
   organizationRepository,
   organizationLearnersCsvService,
+  organizationImportRepository,
   importStorage,
 };
 

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-import-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-import-repository.js
@@ -21,14 +21,22 @@ const get = async function (id) {
   return _toDomain(result);
 };
 
+function _toJson(errors) {
+  if (!errors) return null;
+  const errorsWithProperties = errors.map((err) => {
+    const properties = Object.getOwnPropertyNames(err);
+    return properties.reduce((acc, property) => ({ ...acc, [property]: err[property] }), {});
+  });
+  return JSON.stringify(errorsWithProperties);
+}
+
 const save = async function (organizationImport) {
+  const attributes = { ...organizationImport, errors: _toJson(organizationImport.errors) };
   if (organizationImport.id) {
-    const updatedRows = await knex('organization-imports')
-      .update(organizationImport)
-      .where({ id: organizationImport.id });
+    const updatedRows = await knex('organization-imports').update(attributes).where({ id: organizationImport.id });
     if (updatedRows === 0) throw new Error();
   } else {
-    await knex('organization-imports').insert(organizationImport);
+    await knex('organization-imports').insert(attributes);
   }
 };
 

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-import-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-import-repository_test.js
@@ -19,6 +19,24 @@ describe('Integration | Repository | Organization Learner Management | Organizat
       expect(savedImport.createdBy).to.equal(userId);
     });
 
+    it('should save import state with errors', async function () {
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const userId = databaseBuilder.factory.buildUser().id;
+      await databaseBuilder.commit();
+
+      const organizationImport = OrganizationImport.create({ organizationId, createdBy: userId });
+      organizationImport.upload({
+        filename: undefined,
+        encoding: undefined,
+        errors: [new Error('Something went wrong')],
+      });
+
+      await organizationImportRepository.save(organizationImport);
+
+      const savedImport = await organizationImportRepository.getByOrganizationId(organizationId);
+      expect(savedImport.errors[0].message).to.equal('Something went wrong');
+    });
+
     it('should update import state', async function () {
       const organizationId = databaseBuilder.factory.buildOrganizationImport().organizationId;
       await databaseBuilder.commit();

--- a/api/tests/prescription/learner-management/unit/application/sco-organization-management-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/sco-organization-management-controller_test.js
@@ -60,7 +60,9 @@ describe('Unit | Application | Organizations | organization-controller', functio
 
     it('should call the usecase to import organizationLearners', async function () {
       // given
+      const userId = 1;
       request.i18n = getI18n();
+      request.auth = { credentials: { userId } };
       hFake.request = {
         path: '/api/organizations/145/sco-organization-learners/import-siecle',
       };
@@ -70,6 +72,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
 
       // then
       expect(usecases.importOrganizationLearnersFromSIECLEXMLFormat).to.have.been.calledWithExactly({
+        userId,
         organizationId,
         payload,
       });

--- a/api/tests/prescription/learner-management/unit/domain/models/OrganizationImport_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/models/OrganizationImport_test.js
@@ -86,6 +86,7 @@ describe('Unit | Models | OrganizationImport', function () {
       expect(organizationImport).to.includes({
         status: IMPORT_STATUSES.VALIDATED,
       });
+      expect(organizationImport.errors).to.be.null;
     });
 
     it('should validate an OrganizationImport with success and warnings', function () {


### PR DESCRIPTION
## :unicorn: Problème
Maintenant que nous stockons le fichier d'import dans un S3. On doit stocker l'état de l'import (SIECLE dans le cas de cette PR) dans la table organization-imports à chaque étape de l'import.

## :robot: Proposition
On ajoute le stockage du statut pour chaque étape de l'import, ainsi que les erreurs associées si il y en a.

## :rainbow: Remarques
Il existe 6 statuts différents possible : 
- UPLOADED : Cas nominal
- UPLOAD_ERROR : En cas de soucis lors de l'upload sur le S3
- VALIDATED : Cas nominal
- VALIDATION_ERROR : En cas de soucis lors de la validation du fichier (INE manquant, UAI ne correspondant pas à l'orga ....)
- IMPORTED : Cas nominal
- IMPORT_ERROR : En cas de soucis lors de l'insertion en BDD (Une contrainte qui casse ... )


## :100: Pour tester
Cas nominal : 
Le plus simple étant en local .. Pour pouvoir stopper le code dans le usecase aux différents endroits avec des points d'arrêts
-> UPLOADED : Après l'upload MAIS avant la validation (L.59 IE)
-> VALIDATED : Après la validation MAIS avant l'insertion en BDD (L.82 IE)
-> IMPORTED : A la fin de toutes les étapes


Pour les erreurs à tester : 
-> UPLOAD_ERROR : couper le docker du s3. Importer. Vérifier en BDD
-> VALIDATION_ERROR : enlever un INE, mettre un UAI autre. Importer. Vérifier en BDD
-> IMPORT_ERROR : Le plus embêtant à tester, possible de throw une erreur dans la méthode `addOrUpdateOrganizationOfOrganizationLearners` afin que l'insertion ne se passe pas bien. Importer. Vérifier en BDD

Après tout ça, une bonne pause est méritée ! 
🐈‍⬛ 