### PR TITLE
[FEATURE] Revue des clés de trad Modulix

### DIFF
--- a/mon-pix/app/pods/components/module/qrocm/component.js
+++ b/mon-pix/app/pods/components/module/qrocm/component.js
@@ -20,6 +20,10 @@ export default class ModuleQrocm extends Component {
     });
   }
 
+  get nbOfProposals() {
+    return this.qrocm.proposals.length;
+  }
+
   @action
   onInputChanged(block, { target }) {
     this.#updateSelectedValues(block, target.value);

--- a/mon-pix/app/pods/components/module/qrocm/template.hbs
+++ b/mon-pix/app/pods/components/module/qrocm/template.hbs
@@ -6,7 +6,7 @@
       </div>
 
       <legend class="element-qrocm-header__direction">
-        {{t "pages.modulix.qrocm.direction"}}
+        {{t "pages.modulix.qrocm.direction" count=this.nbOfProposals}}
       </legend>
     </div>
 

--- a/mon-pix/tests/integration/components/module/qcm_test.js
+++ b/mon-pix/tests/integration/components/module/qcm_test.js
@@ -27,7 +27,7 @@ module('Integration | Component | Module | QCM', function (hooks) {
     assert.strictEqual(findAll('.element-qcm-header__instruction').length, 1);
     assert.strictEqual(findAll('.element-qcm-header__direction').length, 1);
     assert.ok(screen.getByText('Instruction'));
-    assert.ok(screen.getByText(this.intl.t('pages.modulix.qcm.direction')));
+    assert.ok(screen.getByRole('group', { legend: this.intl.t('pages.modulix.qcm.direction') }));
 
     assert.strictEqual(screen.getAllByRole('checkbox').length, qcmElement.proposals.length);
     assert.ok(screen.getByLabelText('checkbox1'));

--- a/mon-pix/tests/integration/components/module/qcm_test.js
+++ b/mon-pix/tests/integration/components/module/qcm_test.js
@@ -27,7 +27,7 @@ module('Integration | Component | Module | QCM', function (hooks) {
     assert.strictEqual(findAll('.element-qcm-header__instruction').length, 1);
     assert.strictEqual(findAll('.element-qcm-header__direction').length, 1);
     assert.ok(screen.getByText('Instruction'));
-    assert.ok(screen.getByText('Choisissez plusieurs réponses.'));
+    assert.ok(screen.getByText(this.intl.t('pages.modulix.qcm.direction')));
 
     assert.strictEqual(screen.getAllByRole('checkbox').length, qcmElement.proposals.length);
     assert.ok(screen.getByLabelText('checkbox1'));

--- a/mon-pix/tests/integration/components/module/qcu_test.js
+++ b/mon-pix/tests/integration/components/module/qcu_test.js
@@ -29,7 +29,7 @@ module('Integration | Component | Module | QCU', function (hooks) {
     assert.strictEqual(findAll('.element-qcu-header__instruction').length, 1);
     assert.strictEqual(findAll('.element-qcu-header__direction').length, 1);
     assert.ok(screen.getByText('Instruction'));
-    assert.ok(screen.getByText(this.intl.t('pages.modulix.qcu.direction')));
+    assert.ok(screen.getByRole('group', { legend: this.intl.t('pages.modulix.qcu.direction') }));
 
     assert.strictEqual(screen.getAllByRole('radio').length, qcuElement.proposals.length);
     assert.ok(screen.getByLabelText('radio1'));

--- a/mon-pix/tests/integration/components/module/qcu_test.js
+++ b/mon-pix/tests/integration/components/module/qcu_test.js
@@ -29,7 +29,7 @@ module('Integration | Component | Module | QCU', function (hooks) {
     assert.strictEqual(findAll('.element-qcu-header__instruction').length, 1);
     assert.strictEqual(findAll('.element-qcu-header__direction').length, 1);
     assert.ok(screen.getByText('Instruction'));
-    assert.ok(screen.getByText('Choisissez une seule réponse.'));
+    assert.ok(screen.getByText(this.intl.t('pages.modulix.qcu.direction')));
 
     assert.strictEqual(screen.getAllByRole('radio').length, qcuElement.proposals.length);
     assert.ok(screen.getByLabelText('radio1'));

--- a/mon-pix/tests/integration/components/module/qrocm_test.js
+++ b/mon-pix/tests/integration/components/module/qrocm_test.js
@@ -53,6 +53,11 @@ module('Integration | Component | Module | QROCM', function (hooks) {
     // then
     assert.ok(screen);
     assert.dom(screen.getByText('Mon instruction')).exists({ count: 1 });
+    assert.ok(
+      screen.getByRole('group', {
+        legend: this.intl.t('pages.modulix.qrocm.direction', { count: qrocm.proposals.length }),
+      }),
+    );
     assert.dom(screen.getByText('Ma première proposition')).exists({ count: 1 });
     assert.ok(screen.getByRole('textbox', { name: 'input-aria' }));
     assert.dom(screen.getByText("l'identifiant")).exists({ count: 1 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1229,7 +1229,7 @@
       "recap": {
         "title": "Congratulations! Module completed",
         "backToModuleDetails": "Back to module details",
-        "goToForm": "Répondre au questionnaire",
+        "goToForm": "Answer the questionnaire",
         "subtitle": "You have achieved the following objectives:"
       },
       "verification-precondition-failed-alert": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1224,7 +1224,7 @@
         "direction": "Select a single answer."
       },
       "qrocm": {
-        "direction": "Fill in the blank(s)"
+        "direction": "Fill in the {count, plural, =1 {blank} other {blanks}}."
       },
       "recap": {
         "title": "Congratulations! Module completed",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1202,8 +1202,8 @@
       "details": {
         "duration": "Duration",
         "durationValue": "≈{duration} min",
-        "explanationText1": "The Pix training modules are comprised of lessons and activities for you to train and develop your digital skills. The lessons take the form of videos, audios, images and texts. During an activity, your response is directly verified and you can retry! If needed you can always go back to previous lessons. A module would take around 10 minutes, on a specific subject with a level of difficulty from beginner to expert.",
-        "explanationText2": "This is actually a beta phase product, you can send us all of your suggestions for improvement.",
+        "explanationText1": "The Pix training modules are comprised of lessons and activities to practice and develop your digital skills. The lessons take the form of videos, audios, images and texts. The activities allow you to practice and verify your answers directly. Each module takes around 10 minutes to complete on a particular subject with a level of difficulty from beginner to expert.",
+        "explanationText2": "These training modules are actually in beta test phase. You can send us your suggestions for improvement in the questionnaire at the end of each module.",
         "explanationTitle": "What is a module?",
         "level": "Level",
         "objectives": "Objectives",
@@ -1230,7 +1230,7 @@
         "title": "Congratulations! Module completed",
         "backToModuleDetails": "Back to module details",
         "goToForm": "Répondre au questionnaire",
-        "subtitle": "Now you know '<span aria-hidden=\"true\">'👍'</span>'"
+        "subtitle": "You have achieved the following objectives:"
       },
       "verification-precondition-failed-alert": {
         "qcm": "To validate, select at least two answers.",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1221,10 +1221,10 @@
         "direction": "Select several answers."
       },
       "qcu": {
-        "direction": "Select one answer."
+        "direction": "Select a single answer."
       },
       "qrocm": {
-        "direction": "Fill in the empty fields."
+        "direction": "Fill in the blank(s)"
       },
       "recap": {
         "title": "Congratulations! Module completed",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1218,13 +1218,13 @@
         }
       },
       "qcm": {
-        "direction": "Choisissez plusieurs réponses."
+        "direction": "Sélectionnez plusieurs réponses."
       },
       "qcu": {
-        "direction": "Choisissez une seule réponse."
+        "direction": "Sélectionnez une seule réponse."
       },
       "qrocm": {
-        "direction": "Remplissez les champs vides."
+        "direction": "Remplissez le(s) champ(s) vide(s)."
       },
       "recap": {
         "title": "Bravo ! Module terminé",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1202,8 +1202,8 @@
       "details": {
         "duration": "Durée",
         "durationValue": "≈{duration} min",
-        "explanationText1": "Les modules de formations Pix sont composés de leçons et d’activités pour vous exercer et développer vos compétences numériques. Les leçons prennent la forme de vidéos, d'audios, d'images et de textes. Lors d’une activité, votre réponse est directement vérifiée et vous pouvez retenter ! Si besoin, vous pouvez toujours revenir en arrière. Un module dure environ 10 minutes, sur un sujet précis avec un niveau de difficulté de Débutant à Expert.",
-        "explanationText2": "Ce produit est actuellement en phase bêta, vous pouvez nous envoyer toutes vos suggestions d’amélioration ici.",
+        "explanationText1": "Les modules de formation Pix sont composés de leçons et d’activités pour vous exercer et développer vos compétences numériques. Les leçons prennent la forme de vidéos, d'audios, d'images et de textes. Les activités vous permettent de vous entraîner et de vérifier directement vos réponses. Un module dure environ 10 minutes, sur un sujet précis, avec un niveau de difficulté allant de débutant à expert.",
+        "explanationText2": "Ces modules de formation sont actuellement en phase de bêta-test. Vous pouvez nous envoyer toutes vos suggestions d’amélioration dans le questionnaire de fin de module.",
         "explanationTitle": "C'est quoi un module ?",
         "level": "Niveau",
         "objectives": "Objectifs",
@@ -1230,7 +1230,7 @@
         "title": "Bravo ! Module terminé",
         "backToModuleDetails": "Revenir aux détails du module",
         "goToForm": "Répondre au questionnaire",
-        "subtitle": "Vous savez maintenant '<span aria-hidden=\"true\">'👍'</span>'"
+        "subtitle": "Vous avez atteint les objectifs suivants :"
       },
       "verification-precondition-failed-alert": {
         "qcm": "Pour valider, sélectionnez au moins deux réponses.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1224,7 +1224,7 @@
         "direction": "Sélectionnez une seule réponse."
       },
       "qrocm": {
-        "direction": "Remplissez le(s) champ(s) vide(s)."
+        "direction": "Remplissez {count, plural, =1 {le champ vide} other {les champs vides}}."
       },
       "recap": {
         "title": "Bravo ! Module terminé",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1219,13 +1219,13 @@
       },
 
       "qcm": {
-        "direction": "Kies meerdere antwoorden."
+        "direction": "Selecteer meerdere antwoorden."
       },
       "qcu": {
-        "direction": "Kies slechts één antwoord."
+        "direction": "Selecteer één antwoord."
       },
       "qrocm": {
-        "direction": "Vul de lege velden in."
+        "direction": "Vul de lege veld(en) in."
       },
       "recap": {
         "title": "Goed gedaan ! Module voltooid",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1202,8 +1202,8 @@
       "details": {
         "duration": "Duur",
         "durationValue": "≈{duration} min",
-        "explanationText1": "De Pix trainingsmodules bestaan uit lessen en activiteiten waarmee je je digitale vaardigheden kunt trainen en ontwikkelen. De lessen zijn in de vorm van video's, audio, afbeeldingen en teksten. Tijdens een activiteit wordt je reactie direct gecontroleerd en kun je het opnieuw proberen! Indien nodig kun je altijd terug naar vorige lessen. Een module duurt ongeveer 10 minuten, over een specifiek onderwerp met een moeilijkheidsgraad van beginner tot expert.",
-        "explanationText2": "Dit is eigenlijk een betafase product, je kunt ons al je suggesties voor verbetering sturen.",
+        "explanationText1": "Pix training modules bestaan uit lessen en activiteiten om je te helpen je digitale vaardigheden te oefenen en te ontwikkelen. De lessen hebben de vorm van video's, audio, afbeeldingen en tekst. Met de activiteiten kun je direct je antwoorden oefenen en controleren. Elke module duurt ongeveer 10 minuten, gaat over een specifiek onderwerp en heeft een moeilijkheidsgraad van beginner tot expert.",
+        "explanationText2": "Deze trainingsmodules bevinden zich momenteel in de beta-testfase. Je kunt ons suggesties voor verbetering sturen via de vragenlijst aan het einde van elke module.",
         "explanationTitle": "Wat is een module?",
         "level": "Niveau",
         "objectives": "Doelstellingen",
@@ -1231,7 +1231,7 @@
         "title": "Goed gedaan ! Module voltooid",
         "backToModuleDetails": "Keer terug naar moduledetails",
         "goToForm": "Répondre au questionnaire",
-        "subtitle": "Je weet nu '<span aria-hidden=\"true\">'👍'</span>'"
+        "subtitle": "Je hebt de volgende doelen bereikt:"
       },
       "verification-precondition-failed-alert": {
         "qcm": "Selecteer ten minste twee antwoorden om te bevestigen.",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1225,7 +1225,7 @@
         "direction": "Selecteer één antwoord."
       },
       "qrocm": {
-        "direction": "Vul de lege veld(en) in."
+        "direction": "Vul de lege {count, plural, =1 {veld} other {velden}} in."
       },
       "recap": {
         "title": "Goed gedaan ! Module voltooid",


### PR DESCRIPTION
## :unicorn: Problème
Certaines clés de trad doivent être revues pour Modulix.

## :robot: Proposition
Revoir les valeurs des trads.

## :rainbow: Remarques
RAS

## :100: Pour tester
Sur n'importe quel module Modulix (par exemple `/modules/bien-ecrire-son-adresse-mail/details`) :
- la description de Modulix a été revue (page de détails)
- le sous titre des objectifs a été revue (page de récap)
- les champs de consigne fonctionnelle ont été revues : QCU/QCM/QROCM (page de passage)

Pour tester en anglais :
Aller sur pix.org , choisir la langue EN puis se connecter avec son compte (iso .fr)
puis aller sur le module 
