### PR TITLE
[BUGFIX] Répare le dégradé de fond sur la page des CGU de PixOrga (PIX-11464)

### DIFF
--- a/orga/app/styles/pages/authenticated/terms-of-service.scss
+++ b/orga/app/styles/pages/authenticated/terms-of-service.scss
@@ -6,7 +6,7 @@
   width: 100%;
   height: 100%;
   min-height: 800px;
-  background: var(--pix-secondary-500)-orga-gradient;
+  background: $pix-secondary-orga-gradient;
 }
 
 .terms-of-service-form {


### PR DESCRIPTION
## :unicorn: Problème
Suite au passage du script de cette PR #7723 , une coquille s'était introduite dans le dégradé de fond de la page des CGU

## :robot: Proposition
Remettre la bonne variable, pour afficher le bon dégradé

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

- Aller sur PixOrga
- Se connecter avec une Orga n'ayant jamais accepté les CGU 👿 
- Vérifier le dégradé de fond
- 🐈‍⬛ 
- 🐶 
