### PR TITLE
[BUGFIX] rafraichit les divisions après un import (PIX-11463)

### DIFF
--- a/orga/app/controllers/authenticated/import-organization-participants.js
+++ b/orga/app/controllers/authenticated/import-organization-participants.js
@@ -54,6 +54,7 @@ export default class ImportController extends Controller {
     try {
       await adapter.importStudentsSiecle(organizationId, files, format);
       this.notifications.sendSuccess(this.intl.t('pages.organization-participants-import.global-success'));
+      this.send('refreshDivisions');
     } catch (errorResponse) {
       this._instantiateErrorsDetail(errorResponse);
     } finally {

--- a/orga/app/controllers/authenticated/import-organization-participants.js
+++ b/orga/app/controllers/authenticated/import-organization-participants.js
@@ -29,6 +29,7 @@ export default class ImportController extends Controller {
 
     try {
       const response = await adapter.addStudentsCsv(organizationId, files);
+      this.send('refreshGroups');
       this._sendSupNotifications(response);
     } catch (errorResponse) {
       this._instantiateErrorsDetail(errorResponse);
@@ -72,6 +73,7 @@ export default class ImportController extends Controller {
 
     try {
       const response = await adapter.replaceStudentsCsv(organizationId, files);
+      this.send('refreshGroups');
       this._sendSupNotifications(response);
     } catch (errorResponse) {
       this._instantiateErrorsDetail(errorResponse);

--- a/orga/app/routes/authenticated/import-organization-participants.js
+++ b/orga/app/routes/authenticated/import-organization-participants.js
@@ -24,4 +24,9 @@ export default class ImportOrganizationParticipantsRoute extends Route {
   async refreshDivisions() {
     await this.currentUser.organization.hasMany('divisions').reload();
   }
+
+  @action
+  async refreshGroups() {
+    await this.currentUser.organization.hasMany('groups').reload();
+  }
 }

--- a/orga/app/routes/authenticated/import-organization-participants.js
+++ b/orga/app/routes/authenticated/import-organization-participants.js
@@ -1,5 +1,6 @@
 import { service } from '@ember/service';
 import Route from '@ember/routing/route';
+import { action } from '@ember/object';
 
 export default class ImportOrganizationParticipantsRoute extends Route {
   @service currentUser;
@@ -17,5 +18,10 @@ export default class ImportOrganizationParticipantsRoute extends Route {
     if (isExiting) {
       ['errors', 'warnings', 'warningBanner'].forEach((args) => controller.set(args, null));
     }
+  }
+
+  @action
+  async refreshDivisions() {
+    await this.currentUser.organization.hasMany('divisions').reload();
   }
 }

--- a/orga/tests/unit/controllers/authenticated/import-organization-participants_test.js
+++ b/orga/tests/unit/controllers/authenticated/import-organization-participants_test.js
@@ -34,6 +34,13 @@ module('Unit | Controller | authenticated/import-organization-participant', func
       assert.ok(addStudentsCsvStub.calledWith(1, files));
     });
 
+    module('refresh groups', () => {
+      test('should refresh current groups', async (assert) => {
+        await controller.importSupStudents(files);
+        assert.ok(controller.send.calledWithExactly('refreshGroups'));
+      });
+    });
+
     module('manage CSV import errors', function (hooks) {
       hooks.beforeEach(function () {
         controller.notifications.sendError = sinon.spy();
@@ -207,6 +214,12 @@ module('Unit | Controller | authenticated/import-organization-participant', func
       await controller.replaceStudents(files);
 
       assert.ok(replaceStudentsCsvStub.calledWith(1, files));
+    });
+    module('refresh groups', () => {
+      test('should refresh current groups', async (assert) => {
+        await controller.replaceStudents(files);
+        assert.ok(controller.send.calledWithExactly('refreshGroups'));
+      });
     });
 
     module('manage CSV import errors', function (hooks) {

--- a/orga/tests/unit/controllers/authenticated/import-organization-participants_test.js
+++ b/orga/tests/unit/controllers/authenticated/import-organization-participants_test.js
@@ -3,7 +3,7 @@ import { setupTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import sinon from 'sinon';
 
-module('Unit | Controller | authenticated/organization-participants-import', function (hooks) {
+module('Unit | Controller | authenticated/import-organization-participant', function (hooks) {
   setupTest(hooks);
   setupIntl(hooks);
   const files = Symbol('files');
@@ -87,6 +87,13 @@ module('Unit | Controller | authenticated/organization-participants-import', fun
   });
 
   module('#importScoStudents', function () {
+    module('refresh divisions', () => {
+      test('should refresh current divisions', async (assert) => {
+        await controller.importScoStudents(files);
+        assert.ok(controller.send.calledWithExactly('refreshDivisions'));
+      });
+    });
+
     module('when file is csv', function () {
       test('it sends the chosen csv file to the API', async function (assert) {
         currentUser.isAgriculture = true;

--- a/orga/tests/unit/routes/authenticated/import-organization-participants_test.js
+++ b/orga/tests/unit/routes/authenticated/import-organization-participants_test.js
@@ -76,4 +76,22 @@ module('Unit | Route | authenticated/import-organization-participant', function 
       assert.true(reloadDivisionStub.calledOnce);
     });
   });
+  module('refreshGroups', function () {
+    test('should reload group relation on organization', function (assert) {
+      const reloadGroupStub = sinon.stub();
+      class CurrentUserStub extends Service {
+        organization = {
+          hasMany: sinon.stub(),
+        };
+      }
+
+      this.owner.register('service:current-user', CurrentUserStub);
+      const route = this.owner.lookup('route:authenticated.import-organization-participants');
+
+      route.currentUser.organization.hasMany.withArgs('groups').returns({ reload: reloadGroupStub });
+
+      route.refreshGroups();
+      assert.true(reloadGroupStub.calledOnce);
+    });
+  });
 });

--- a/orga/tests/unit/routes/authenticated/import-organization-participants_test.js
+++ b/orga/tests/unit/routes/authenticated/import-organization-participants_test.js
@@ -58,4 +58,22 @@ module('Unit | Route | authenticated/import-organization-participant', function 
       assert.true(controller.set.calledWithExactly('warningBanner', null));
     });
   });
+  module('refreshDivisions', function () {
+    test('should reload division relation on organization', function (assert) {
+      const reloadDivisionStub = sinon.stub();
+      class CurrentUserStub extends Service {
+        organization = {
+          hasMany: sinon.stub(),
+        };
+      }
+
+      this.owner.register('service:current-user', CurrentUserStub);
+      const route = this.owner.lookup('route:authenticated.import-organization-participants');
+
+      route.currentUser.organization.hasMany.withArgs('divisions').returns({ reload: reloadDivisionStub });
+
+      route.refreshDivisions();
+      assert.true(reloadDivisionStub.calledOnce);
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Après un import, les éléments du filtre sur la classe / groupe ne sont pas mis à jour alors que les infos ont changées

## :robot: Proposition
on force le rechargement des relations divisions pour les import sco et groups pour les imports sup

## :rainbow: Remarques

## :100: Pour tester

- **import siecle**
  - se connecter sur l'orga sco managing
  - réaliser un import de fichier siecle
  - voir que le contenu du filtre division correspond bien aux données dans la liste
- **import fregata**
  - se connecter sur l'orga sco managing
  - réaliser un import de fichier fregata
  - voir que le contenu du filtre division correspond bien aux données dans la liste
- **import sup (ajout)**
  - se connecter sur l'orga sup managing
  - réaliser un import de fichier csv (ajouter)
  - voir que le contenu du filtre group correspond bien aux données dans la liste
- **import sup (remplacer)**
  - se connecter sur l'orga sup managing
  - réaliser un import de fichier csv (remplacer)
  - voir que le contenu du filtre groupe correspond bien aux données dans la liste