### PR TITLE
[FEATURE] Ajout de commentaire jury automatique en cas d'annulation de certification pour trop de challenges neutralisés pour la V2 (PIX-10532)

### DIFF
--- a/api/src/certification/scoring/domain/models/factories/AssessmentResultFactory.js
+++ b/api/src/certification/scoring/domain/models/factories/AssessmentResultFactory.js
@@ -28,21 +28,12 @@ export class AssessmentResultFactory {
   static buildNotTrustableAssessmentResult({ pixScore, reproducibilityRate, status, assessmentId, juryId, emitter }) {
     const commentForCandidate = new JuryComment({
       context: JuryCommentContexts.CANDIDATE,
-      fallbackComment:
-        'Un ou plusieurs problème(s) technique(s), signalé(s) à votre surveillant pendant la session de certification' +
-        ', a/ont affecté la qualité du test de certification. En raison du trop grand nombre de questions auxquelles vous ' +
-        "n'avez pas pu répondre dans de bonnes conditions, nous ne sommes malheureusement pas en mesure de calculer un " +
-        'score fiable et de fournir un certificat. La certification est annulée, le prescripteur de votre certification' +
-        '(le cas échéant), en est informé.',
+      commentByAutoJury: AutoJuryCommentKeys.CANCELLED_DUE_TO_NEUTRALIZATION,
     });
 
     const commentForOrganization = new JuryComment({
       context: JuryCommentContexts.ORGANIZATION,
-      fallbackComment:
-        'Un ou plusieurs problème(s) technique(s), signalés par ce(cette) candidate au surveillant' +
-        'de la session de certification, a/ont affecté le bon déroulement du test de certification. Nous sommes dans ' +
-        "l'incapacité de le/la certifier, sa certification est donc annulée. Cette information est à prendre en compte " +
-        'et peut vous conduire à proposer une nouvelle session de certification pour ce(cette) candidat(e).',
+      commentByAutoJury: AutoJuryCommentKeys.CANCELLED_DUE_TO_NEUTRALIZATION,
     });
 
     return new AssessmentResult({

--- a/api/src/certification/shared/domain/models/JuryComment.js
+++ b/api/src/certification/shared/domain/models/JuryComment.js
@@ -1,8 +1,9 @@
 import { assertEnumValue } from '../../../../shared/domain/models/asserts.js';
 
 /**
+ * @typedef {string} JuryCommentContext
  * @readonly
- * @enum {string}
+ * @enum {JuryCommentContext}
  */
 const JuryCommentContexts = Object.freeze({
   CANDIDATE: 'candidate',
@@ -10,8 +11,9 @@ const JuryCommentContexts = Object.freeze({
 });
 
 /**
+ * @typedef {string} AutoJuryCommentKey
  * @readonly
- * @enum {string}
+ * @enum {AutoJuryCommentKey}
  */
 const AutoJuryCommentKeys = Object.freeze({
   FRAUD: 'FRAUD',
@@ -21,9 +23,9 @@ const AutoJuryCommentKeys = Object.freeze({
 class JuryComment {
   /**
    * @param {Object} props
-   * @param {AutoJuryCommentKeys} props.commentByAutoJury
-   * @param {string} props.fallbackComment
-   * @param {JuryCommentContexts} props.context mandatory if AutoJuryCommentKeys given
+   * @param {AutoJuryCommentKey} [props.commentByAutoJury]
+   * @param {string} [props.fallbackComment]
+   * @param {JuryCommentContext} props.context mandatory if AutoJuryCommentKeys given
    */
   constructor({ commentByAutoJury, fallbackComment, context }) {
     this.commentByAutoJury = AutoJuryCommentKeys[commentByAutoJury];

--- a/api/tests/certification/scoring/unit/domain/factories/AssessmentResultFactory_test.js
+++ b/api/tests/certification/scoring/unit/domain/factories/AssessmentResultFactory_test.js
@@ -90,19 +90,10 @@ describe('Certification | Scoring | Unit | Domain | Factories | AssessmentResult
         reproducibilityRate: 50.25,
         competenceMarks: [],
         commentForCandidate: domainBuilder.certification.shared.buildJuryComment.candidate({
-          fallbackComment:
-            'Un ou plusieurs problème(s) technique(s), signalé(s) à votre surveillant pendant la session de certification' +
-            ', a/ont affecté la qualité du test de certification. En raison du trop grand nombre de questions auxquelles vous ' +
-            "n'avez pas pu répondre dans de bonnes conditions, nous ne sommes malheureusement pas en mesure de calculer un " +
-            'score fiable et de fournir un certificat. La certification est annulée, le prescripteur de votre certification' +
-            '(le cas échéant), en est informé.',
+          commentByAutoJury: AutoJuryCommentKeys.CANCELLED_DUE_TO_NEUTRALIZATION,
         }),
         commentForOrganization: domainBuilder.certification.shared.buildJuryComment.organization({
-          fallbackComment:
-            'Un ou plusieurs problème(s) technique(s), signalés par ce(cette) candidate au surveillant' +
-            'de la session de certification, a/ont affecté le bon déroulement du test de certification. Nous sommes dans ' +
-            "l'incapacité de le/la certifier, sa certification est donc annulée. Cette information est à prendre en compte " +
-            'et peut vous conduire à proposer une nouvelle session de certification pour ce(cette) candidat(e).',
+          commentByAutoJury: AutoJuryCommentKeys.CANCELLED_DUE_TO_NEUTRALIZATION,
         }),
       });
       expectedAssessmentResult.id = undefined;


### PR DESCRIPTION
## :unicorn: Problème
Pour les certifications v2, si plus de 33% des questions posées au candidat sont neutralisées, alors la certification est annulée.

Un message automatique doit être adressé dans ce cas au candidat et à l’organisation pour les en informer.

## :robot: Proposition
Insertion des clés de traduction dans la colonne commentByAutoJury pour le cas où la certification est annulée suite à la neutralisation de plus de 33% des questions posées au candidat.

## :rainbow: Remarques
- La quasi-totalité du boulot est déjà fait 💪 
- Il n'y a que des tests unitaires sur le scoring... Vu l'ampleur de la PR, je n'en rajoute pas à cette occasion

ℹ️ La certification v3 n'est pas concerné par ce cas de figure, on ne neutralise pas les questions dans cette version.

## :100: Pour tester
- Se connecter sur [une certification scorée sur admin](https://admin-pr8233.review.pix.fr/certifications/151190) (superadmin@example.net/pix123)
- neutraliser au moins 17 questions et voir apparaitre le commentaire suivant:
<img width="1625" alt="image" src="https://github.com/1024pix/pix/assets/3033624/6bcfa2d6-51a4-4325-994b-40e747ea9226">

 