### PR TITLE
[TECH] Séparation de l'injection du scoring et de shared (PIX-11472).

### DIFF
--- a/api/src/certification/scoring/application/competence-for-scoring-configuration-controller.js
+++ b/api/src/certification/scoring/application/competence-for-scoring-configuration-controller.js
@@ -1,4 +1,4 @@
-import { usecases } from '../../shared/domain/usecases/index.js';
+import { usecases } from '../domain/usecases/index.js';
 
 const saveCompetenceForScoringConfiguration = async (request, h) => {
   const data = request.payload;

--- a/api/src/certification/scoring/domain/usecases/index.js
+++ b/api/src/certification/scoring/domain/usecases/index.js
@@ -1,0 +1,27 @@
+// eslint-disable import/no-restricted-paths
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
+import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
+
+import * as competenceForScoringRepository from '../../infrastructure/repositories/competence-for-scoring-repository.js';
+
+/**
+ * Using {@link https://jsdoc.app/tags-type "Closure Compiler's syntax"} to document injected dependencies
+ * @typedef {competenceForScoringRepository} CompetenceForScoringRepository
+ **/
+const dependencies = { competenceForScoringRepository };
+
+const path = dirname(fileURLToPath(import.meta.url));
+
+const usecasesWithoutInjectedDependencies = {
+  ...(await importNamedExportsFromDirectory({
+    path: join(path, './'),
+    ignoredFileNames: ['index.js'],
+  })),
+};
+
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+
+export { usecases };

--- a/api/src/certification/scoring/domain/usecases/save-competence-for-scoring-configuration.js
+++ b/api/src/certification/scoring/domain/usecases/save-competence-for-scoring-configuration.js
@@ -1,3 +1,11 @@
+/**
+ * @typedef {import ('./index.js').CompetenceForScoringRepository} CompetenceForScoringRepository
+ */
+
+/**
+ * @param {Object} params
+ * @param {CompetenceForScoringRepository} params.competenceForScoringRepository
+ */
 const saveCompetenceForScoringConfiguration = async ({ data, competenceForScoringRepository }) => {
   await competenceForScoringRepository.save(data);
 };

--- a/api/src/certification/shared/domain/usecases/index.js
+++ b/api/src/certification/shared/domain/usecases/index.js
@@ -15,7 +15,6 @@ import * as certificationChallengeLiveAlertRepository from '../../../session/inf
 import * as certificationCourseRepository from '../../infrastructure/repositories/certification-course-repository.js';
 import * as certificationIssueReportRepository from '../../../shared/infrastructure/repositories/certification-issue-report-repository.js';
 import * as certificationReportRepository from '../../../shared/infrastructure/repositories/certification-report-repository.js';
-import * as competenceForScoringRepository from '../../../../../src/certification/scoring/infrastructure/repositories/competence-for-scoring-repository.js';
 import * as complementaryCertificationRepository from '../../../../../lib/infrastructure/repositories/complementary-certification-repository.js';
 import * as certificateRepository from '../../../course/infrastructure/repositories/certificate-repository.js';
 import * as challengeRepository from '../../../../shared/infrastructure/repositories/challenge-repository.js';
@@ -69,7 +68,6 @@ import { injectDependencies } from '../../../../shared/infrastructure/utils/depe
  * @typedef {certificationOfficerRepository} CertificationOfficerRepository
  * @typedef {competenceMarkRepository} CompetenceMarkRepository
  * @typedef {competenceRepository} CompetenceRepository
- * @typedef {competenceForScoringRepository} CompetenceForScoringRepository
  * @typedef {complementaryCertificationRepository} ComplementaryCertificationRepository
  * @typedef {cpfExportRepository} CpfExportRepository
  * @typedef {finalizedSessionRepository} FinalizedSessionRepository
@@ -100,7 +98,6 @@ const dependencies = {
   certificationChallengeLiveAlertRepository,
   certificationCourseRepository,
   certificationCpfService,
-  competenceForScoringRepository,
   certificationIssueReportRepository,
   certificationOfficerRepository,
   certificationReportRepository,
@@ -149,9 +146,6 @@ const usecasesWithoutInjectedDependencies = {
   })),
   ...(await importNamedExportsFromDirectory({
     path: join(path, '../../../flash-certification/domain/usecases/'),
-  })),
-  ...(await importNamedExportsFromDirectory({
-    path: join(path, '../../../scoring/domain/usecases/'),
   })),
   ...(await importNamedExportsFromDirectory({
     path: join(path, '../../../course/domain/usecases/'),

--- a/api/tests/certification/scoring/integration/application/competence-for-scoring-configuration-controller_test.js
+++ b/api/tests/certification/scoring/integration/application/competence-for-scoring-configuration-controller_test.js
@@ -1,6 +1,6 @@
 import { competenceForScoringConfigurationController } from '../../../../../src/certification/scoring/application/competence-for-scoring-configuration-controller.js';
 import { sinon, expect, hFake } from '../../../../test-helper.js';
-import { usecases } from '../../../../../src/certification/shared/domain/usecases/index.js';
+import { usecases } from '../../../../../src/certification/scoring/domain/usecases/index.js';
 
 describe('Integration | Application | CompetenceForScoringConfigurationController', function () {
   describe('#saveCompetenceForScoringConfiguration', function () {


### PR DESCRIPTION
## :unicorn: Problème

- Le fichier api/src/certification/shared/domain/usecases/index.js importe des repositories qui viennent d’un peu partout
- Cela fait que des usecases dans un bounded context sont injectés avec des repositories d’autres bounded context
- Cela casse complètement l’intérêt et la stabilité des contextes
- Cela engendre des conflits et erreurs d’injection
- Il ne devrait injecter des dépendances que dans les usecases de son context
- Autrement dit : des usescases dans les bounded context ne doivent pas avoir une dépendance injecté par shared si ce repository est dans son context

## :robot: Proposition

- Enlever l'injection du context scoring de shared

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

* Une seule route concernée, `PATCH /api/certification-centers/{certificationCenterId}/certification-center-memberships/{id}`
* Sur Pix Certif, réaliser une modification des membres (être admin du centre), vérifier que cela fonctionne
