### PR TITLE
[TECH] :recycle: Déplacement du `logger` dans le répertoire `src`

### DIFF
--- a/api/db/batch-processing.js
+++ b/api/db/batch-processing.js
@@ -1,5 +1,5 @@
 const BATCH_SIZE = 10;
-import { logger } from '../lib/infrastructure/logger.js';
+import { logger } from '../src/shared/infrastructure/utils/logger.js';
 
 function batch(knex, elementsToUpdate, treatment) {
   function _innerTreatment(knex, remainingElementsToUpdate, countOfBatches, batchesDone) {

--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -4,7 +4,7 @@ const types = pg.types;
 import _ from 'lodash';
 
 const { get } = _;
-import { logger } from '../lib/infrastructure/logger.js';
+import { logger } from '../src/shared/infrastructure/utils/logger.js';
 import { monitoringTools } from '../lib/infrastructure/monitoring-tools.js';
 import { config } from '../lib/config.js';
 import perf_hooks from 'perf_hooks';

--- a/api/index.js
+++ b/api/index.js
@@ -6,7 +6,7 @@ import { validateEnvironmentVariables } from './lib/infrastructure/validate-envi
 validateEnvironmentVariables();
 
 import { createServer } from './server.js';
-import { logger } from './lib/infrastructure/logger.js';
+import { logger } from './src/shared/infrastructure/utils/logger.js';
 import { disconnect } from './db/knex-database-connection.js';
 import { learningContentCache } from './lib/infrastructure/caches/learning-content-cache.js';
 import { temporaryStorage } from './lib/infrastructure/temporary-storage/index.js';

--- a/api/lib/application/cache/cache-controller.js
+++ b/api/lib/application/cache/cache-controller.js
@@ -1,6 +1,6 @@
 import * as LearningContentDatasources from '../../infrastructure/datasources/learning-content/index.js';
 import * as learningContentDatasource from '../../infrastructure/datasources/learning-content/datasource.js';
-import { logger } from '../../infrastructure/logger.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import _ from 'lodash';
 
 const refreshCacheEntries = function (_, h, dependencies = { learningContentDatasource }) {

--- a/api/lib/application/lcms/lcms-controller.js
+++ b/api/lib/application/lcms/lcms-controller.js
@@ -1,5 +1,5 @@
 import { usecases } from '../../domain/usecases/index.js';
-import { logger } from '../../infrastructure/logger.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 
 const createRelease = async function (request, h) {
   usecases

--- a/api/lib/application/saml/saml-controller.js
+++ b/api/lib/application/saml/saml-controller.js
@@ -1,6 +1,6 @@
 import * as saml from '../../infrastructure/saml.js';
 import { usecases } from '../../domain/usecases/index.js';
-import { logger } from '../../infrastructure/logger.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import { tokenService } from '../../../src/shared/domain/services/token-service.js';
 import { config } from '../../config.js';
 

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -16,7 +16,7 @@ import { getSessionCertificationResultsCsv } from '../../infrastructure/utils/cs
 import { fillCandidatesImportSheet } from '../../infrastructure/files/candidates-import/fill-candidates-import-sheet.js';
 import lodash from 'lodash';
 import { UserLinkedToCertificationCandidate } from '../../domain/events/UserLinkedToCertificationCandidate.js';
-import { logger } from '../../infrastructure/logger.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 
 const { trim } = lodash;
 

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -39,7 +39,7 @@ import * as userRepository from '../../../src/shared/infrastructure/repositories
 import { participantResultsSharedRepository } from '../../infrastructure/repositories/participant-results-shared-repository.js';
 import * as juryCertificationSummaryRepository from '../../infrastructure/repositories/jury-certification-summary-repository.js';
 import * as finalizedSessionRepository from '../../../src/certification/session/infrastructure/repositories/finalized-session-repository.js';
-import { logger } from '../../infrastructure/logger.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import * as poleEmploiNotifier from '../../infrastructure/externals/pole-emploi/pole-emploi-notifier.js';
 import * as disabledPoleEmploiNotifier from '../../infrastructure/externals/pole-emploi/disabled-pole-emploi-notifier.js';
 import { handleAutoJury } from './handle-auto-jury.js';

--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -3,7 +3,7 @@ import jsonwebtoken from 'jsonwebtoken';
 import { randomUUID } from 'crypto';
 import { Issuer } from 'openid-client';
 
-import { logger } from '../../../infrastructure/logger.js';
+import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
 import { OidcMissingFieldsError } from '../../errors.js';
 import { AuthenticationMethod } from '../../models/AuthenticationMethod.js';
 import { AuthenticationSessionContent } from '../../models/AuthenticationSessionContent.js';

--- a/api/lib/domain/services/session-publication-service.js
+++ b/api/lib/domain/services/session-publication-service.js
@@ -15,7 +15,7 @@ import lodash from 'lodash';
 
 const { some, uniqBy } = lodash;
 
-import { logger } from '../../infrastructure/logger.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import { status } from '../../../src/shared/domain/models/AssessmentResult.js';
 
 /**

--- a/api/lib/domain/services/solution-service-qrocm-ind.js
+++ b/api/lib/domain/services/solution-service-qrocm-ind.js
@@ -1,7 +1,7 @@
 import jsYaml from 'js-yaml';
 import levenshtein from 'fast-levenshtein';
 import { _ } from '../../infrastructure/utils/lodash-utils.js';
-import { logger } from '../../infrastructure/logger.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import { applyPreTreatments, applyTreatments } from './validation-treatments.js';
 import { YamlParsingError } from '../../domain/errors.js';
 import { LEVENSHTEIN_DISTANCE_MAX_RATE } from '../../../src/shared/domain/constants.js';

--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -7,7 +7,7 @@ import {
 
 import { Examiner } from '../../../src/shared/domain/models/Examiner.js';
 import { KnowledgeElement } from '../models/KnowledgeElement.js';
-import { logger } from '../../infrastructure/logger.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import { ForbiddenAccess } from '../../../src/shared/domain/errors.js';
 
 const correctAnswerThenUpdateAssessment = async function ({

--- a/api/lib/domain/usecases/get-next-challenge-for-demo.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-demo.js
@@ -1,6 +1,6 @@
 import { AssessmentEndedError } from '../errors.js';
 import { _ } from '../../infrastructure/utils/lodash-utils.js';
-import { logger } from '../../infrastructure/logger.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 
 const getNextChallengeForDemo = function ({ assessment, answerRepository, challengeRepository, courseRepository }) {
   const courseId = assessment.courseId;

--- a/api/lib/domain/usecases/update-expired-password.js
+++ b/api/lib/domain/usecases/update-expired-password.js
@@ -4,7 +4,7 @@ const { get } = lodash;
 
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 import { UserNotFoundError } from '../../domain/errors.js';
-import { logger } from '../../../lib/infrastructure/logger.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import { ForbiddenAccess } from '../../../src/shared/domain/errors.js';
 
 const updateExpiredPassword = async function ({

--- a/api/lib/domain/usecases/update-last-question-state.js
+++ b/api/lib/domain/usecases/update-last-question-state.js
@@ -1,4 +1,4 @@
-import { logger } from '../../infrastructure/logger.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import { Assessment } from '../../../src/shared/domain/models/Assessment.js';
 
 const updateLastQuestionState = async function ({

--- a/api/lib/infrastructure/caches/RedisCache.js
+++ b/api/lib/infrastructure/caches/RedisCache.js
@@ -5,7 +5,7 @@ const { using } = bluebird;
 import Redlock from 'redlock';
 import { Cache } from './Cache.js';
 import { RedisClient } from '../utils/RedisClient.js';
-import { logger } from '../logger.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import { config } from '../../config.js';
 import { applyPatch } from './apply-patch.js';
 

--- a/api/lib/infrastructure/jobs/JobQueue.js
+++ b/api/lib/infrastructure/jobs/JobQueue.js
@@ -1,5 +1,5 @@
 import { MonitoredJobHandler } from './monitoring/MonitoredJobHandler.js';
-import { logger } from '../logger.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import { config } from '../../config.js';
 
 const { teamSize, teamConcurrency } = config.pgBoss;

--- a/api/lib/infrastructure/jobs/cpf-export/handlers/send-email.js
+++ b/api/lib/infrastructure/jobs/cpf-export/handlers/send-email.js
@@ -1,5 +1,5 @@
 import { config } from '../../../../config.js';
-import { logger } from '../../../logger.js';
+import { logger } from '../../../../../src/shared/infrastructure/utils/logger.js';
 
 const { cpf } = config;
 const sendEmail = async function ({ getPreSignedUrls, mailService }) {

--- a/api/lib/infrastructure/jobs/cpf-export/schedule-cpf-jobs.js
+++ b/api/lib/infrastructure/jobs/cpf-export/schedule-cpf-jobs.js
@@ -1,5 +1,5 @@
 import { cpfExport } from './index.js';
-import { logger } from '../../logger.js';
+import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
 import { config } from '../../../config.js';
 const { plannerJob, sendEmailJob } = config.cpf;
 

--- a/api/lib/infrastructure/jobs/monitoring/MonitoredJobQueue.js
+++ b/api/lib/infrastructure/jobs/monitoring/MonitoredJobQueue.js
@@ -1,5 +1,5 @@
 import { MonitoringJobExecutionTimeHandler } from './MonitoringJobExecutionTimeHandler.js';
-import { logger } from '../../logger.js';
+import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
 import { config } from '../../../config.js';
 
 const { teamSize, teamConcurrency } = config.pgBoss;

--- a/api/lib/infrastructure/lcms.js
+++ b/api/lib/infrastructure/lcms.js
@@ -1,6 +1,6 @@
 import { httpAgent } from './http/http-agent.js';
 import { config } from '../config.js';
-import { logger } from './logger.js';
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 
 const { lcms: lcmsConfig } = config;
 const getLatestRelease = async function () {

--- a/api/lib/infrastructure/logger.js
+++ b/api/lib/infrastructure/logger.js
@@ -1,2 +1,0 @@
-// FIXME this file should be deleted after migration
-export * from '../../src/shared/infrastructure/utils/logger.js';

--- a/api/lib/infrastructure/monitoring-tools.js
+++ b/api/lib/infrastructure/monitoring-tools.js
@@ -4,7 +4,7 @@ import { config } from '../config.js';
 import lodash from 'lodash';
 
 const { get, set, update, omit } = lodash;
-import { logger } from '../infrastructure/logger.js';
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 import * as requestResponseUtils from '../infrastructure/utils/request-response-utils.js';
 
 import async_hooks from 'async_hooks';

--- a/api/lib/infrastructure/plugins/pino.js
+++ b/api/lib/infrastructure/plugins/pino.js
@@ -2,7 +2,7 @@ import { stdSerializers } from 'pino';
 import crypto from 'crypto';
 import { config } from '../../config.js';
 import { monitoringTools } from '../monitoring-tools.js';
-import { logger } from '../logger.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 
 const serializersSym = Symbol.for('pino.serializers');
 

--- a/api/lib/infrastructure/saml.js
+++ b/api/lib/infrastructure/saml.js
@@ -4,7 +4,7 @@ samlify.setSchemaValidator({
     return true;
   },
 });
-import { logger } from './logger.js';
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 import { config } from '../config.js';
 
 const samlSettings = config.saml;

--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -1,4 +1,4 @@
-import { logger } from '../../logger.js';
+import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
 import { FileValidationError } from '../../../../lib/domain/errors.js';
 import { convertDateValue } from '../../../../src/shared/infrastructure/utils/date-utils.js';
 import { headers, emptySession, COMPLEMENTARY_CERTIFICATION_SUFFIX } from '../../utils/csv/sessions-import.js';

--- a/api/lib/infrastructure/utils/RedisClient.js
+++ b/api/lib/infrastructure/utils/RedisClient.js
@@ -1,7 +1,7 @@
 import Redis from 'ioredis';
 import Redlock from 'redlock';
 
-import { logger } from '../logger.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 
 class RedisClient {
   constructor(redisUrl, { name, prefix } = {}) {

--- a/api/scripts/_template.js
+++ b/api/scripts/_template.js
@@ -6,7 +6,7 @@ import * as url from 'url';
 
 const { performance } = perf_hooks;
 
-import { logger } from '../lib/infrastructure/logger.js';
+import { logger } from '../src/shared/infrastructure/utils/logger.js';
 import { learningContentCache as cache } from '../lib/infrastructure/caches/learning-content-cache.js';
 import { knex, disconnect } from '../db/knex-database-connection.js';
 

--- a/api/scripts/certification/fill-issue-report-category-id.js
+++ b/api/scripts/certification/fill-issue-report-category-id.js
@@ -1,4 +1,4 @@
-import { logger } from '../../lib/infrastructure/logger.js';
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 import { knex, disconnect } from '../../db/knex-database-connection.js';
 import bluebird from 'bluebird';
 import * as url from 'url';

--- a/api/scripts/certification/fill-last-assessment-result-certification-course-table.js
+++ b/api/scripts/certification/fill-last-assessment-result-certification-course-table.js
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv';
 
 dotenv.config();
-import { logger } from '../../lib/infrastructure/logger.js';
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 import { learningContentCache as cache } from '../../lib/infrastructure/caches/learning-content-cache.js';
 import { knex, disconnect } from '../../db/knex-database-connection.js';
 import bluebird from 'bluebird';

--- a/api/scripts/certification/fill-pix-certification-status-column-in-certification-courses-table.js
+++ b/api/scripts/certification/fill-pix-certification-status-column-in-certification-courses-table.js
@@ -5,7 +5,7 @@ import perf_hooks from 'perf_hooks';
 
 const { performance } = perf_hooks;
 
-import { logger } from '../../lib/infrastructure/logger.js';
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 import { learningContentCache as cache } from '../../lib/infrastructure/caches/learning-content-cache.js';
 import { knex, disconnect } from '../../db/knex-database-connection.js';
 import yargs from 'yargs';

--- a/api/scripts/certification/generate-certification-csv-results-by-session-ids.js
+++ b/api/scripts/certification/generate-certification-csv-results-by-session-ids.js
@@ -9,7 +9,7 @@ import fs from 'fs';
 import bluebird from 'bluebird';
 import lodash from 'lodash';
 const { isEmpty } = lodash;
-import { logger } from '../../lib/infrastructure/logger.js';
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 import { usecases } from '../../lib/domain/usecases/index.js';
 import { temporaryStorage } from '../../lib/infrastructure/temporary-storage/index.js';
 import { disconnect } from '../../db/knex-database-connection.js';

--- a/api/scripts/certification/get-user-certification-eligibility.js
+++ b/api/scripts/certification/get-user-certification-eligibility.js
@@ -5,7 +5,7 @@ import * as dotenv from 'dotenv';
 
 dotenv.config({ path: `${__dirname}/../.env` });
 
-import { logger } from '../../lib/infrastructure/logger.js';
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 import { usecases } from '../../lib/domain/usecases/index.js';
 import { learningContentCache as cache } from '../../lib/infrastructure/caches/learning-content-cache.js';
 import * as placementProfileService from '../../lib/domain/services/placement-profile-service.js';

--- a/api/scripts/certification/import-certification-cpf-cities.js
+++ b/api/scripts/certification/import-certification-cpf-cities.js
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv';
 
 dotenv.config();
-import { logger } from '../../lib/infrastructure/logger.js';
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 
 /**
  * Usage: node scripts/import-certification-cpf-cities path/file.csv

--- a/api/scripts/certification/launch-auto-jury-for-session.js
+++ b/api/scripts/certification/launch-auto-jury-for-session.js
@@ -9,7 +9,7 @@ import * as certificationIssueReportRepository from '../../src/certification/sha
 import * as certificationCourseRepository from '../../src/certification/shared/infrastructure/repositories/certification-course-repository.js';
 import { handleAutoJury } from '../../lib/domain/events/handle-auto-jury.js';
 import * as events from '../../lib/domain/events/index.js';
-import { logger } from '../../lib/infrastructure/logger.js';
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 import * as url from 'url';
 
 const modulePath = url.fileURLToPath(import.meta.url);

--- a/api/scripts/certification/next-gen/generate-flash-algorithm-configuration.js
+++ b/api/scripts/certification/next-gen/generate-flash-algorithm-configuration.js
@@ -1,4 +1,4 @@
-import { logger } from '../../../lib/infrastructure/logger.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import { disconnect } from '../../../db/knex-database-connection.js';
 import * as flashAlgorithmConfigurationRepository from '../../../src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js';
 import * as url from 'url';

--- a/api/scripts/certification/send-certification-result-emails.js
+++ b/api/scripts/certification/send-certification-result-emails.js
@@ -3,7 +3,7 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 import bluebird from 'bluebird';
-import { logger } from '../../lib/infrastructure/logger.js';
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 import * as sessionRepository from '../../src/certification/session/infrastructure/repositories/session-repository.js';
 import * as certificationCenterRepository from '../../src/certification/shared/infrastructure/repositories/certification-center-repository.js';
 import * as mailService from '../../lib/domain/services/mail-service.js';

--- a/api/scripts/certification/trigger-autojury-on-finalized-sessions.js
+++ b/api/scripts/certification/trigger-autojury-on-finalized-sessions.js
@@ -5,7 +5,7 @@ import * as certificationIssueReportRepository from '../../src/certification/sha
 import * as certificationAssessmentRepository from '../../src/certification/shared/infrastructure/repositories/certification-assessment-repository.js';
 import * as certificationCourseRepository from '../../src/certification/shared/infrastructure/repositories/certification-course-repository.js';
 import * as challengeRepository from '../../src/shared/infrastructure/repositories/challenge-repository.js';
-import { logger } from '../../lib/infrastructure/logger.js';
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 import { SessionFinalized } from '../../lib/domain/events/SessionFinalized.js';
 import { eventDispatcher } from '../../lib/domain/events/index.js';
 import * as url from 'url';

--- a/api/scripts/certification/update-certification-infos.js
+++ b/api/scripts/certification/update-certification-infos.js
@@ -9,7 +9,7 @@ import bluebird from 'bluebird';
 
 import { readFile } from 'fs/promises';
 
-import { logger } from '../../lib/infrastructure/logger.js';
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 // Usage: node scripts/update-certifications-infos path/data.csv path/sessionsId.csv
 // data.csv
 // #externalId,birthdate,birthINSEECode,birthPostalCode,birthCity,birthCountry

--- a/api/scripts/certification/validate-cpf-xml.js
+++ b/api/scripts/certification/validate-cpf-xml.js
@@ -2,7 +2,7 @@
 import { parseXml } from 'libxmljs2';
 import { readFile } from 'fs/promises';
 import * as url from 'url';
-import { logger } from '../../lib/infrastructure/logger.js';
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 

--- a/api/scripts/data-generation/generate-certif-cli.js
+++ b/api/scripts/data-generation/generate-certif-cli.js
@@ -11,7 +11,7 @@ import bluebird from 'bluebird';
 import lodash from 'lodash';
 
 const { maxBy } = lodash;
-import { logger } from '../../lib/infrastructure/logger.js';
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 import { getNewSessionCode } from '../../src/certification/session/domain/services/session-code-service.js';
 import { temporaryStorage } from '../../lib/infrastructure/temporary-storage/index.js';
 import {

--- a/api/scripts/data-generation/seeds/dump-target-profile-data-as-seeds.js
+++ b/api/scripts/data-generation/seeds/dump-target-profile-data-as-seeds.js
@@ -10,7 +10,7 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
 import { knex, disconnect } from '../../../db/knex-database-connection.js';
-import { logger } from '../../../lib/infrastructure/logger.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import { learningContentCache } from '../../../lib/infrastructure/caches/learning-content-cache.js';
 
 async function main() {

--- a/api/scripts/database/create-database.js
+++ b/api/scripts/database/create-database.js
@@ -1,6 +1,6 @@
 import dotenv from 'dotenv';
 dotenv.config();
-import { logger } from '../../lib/infrastructure/logger.js';
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 import { PgClient } from '../PgClient.js';
 import { PGSQL_DUPLICATE_DATABASE_ERROR } from '../../db/pgsql-errors.js';
 

--- a/api/scripts/database/drop-database.js
+++ b/api/scripts/database/drop-database.js
@@ -1,6 +1,6 @@
 import dotenv from 'dotenv';
 dotenv.config();
-import { logger } from '../../lib/infrastructure/logger.js';
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 import { PgClient } from '../PgClient.js';
 import { PGSQL_NON_EXISTENT_DATABASE_ERROR } from '../../db/pgsql-errors.js';
 

--- a/api/scripts/database/empty-database.js
+++ b/api/scripts/database/empty-database.js
@@ -1,5 +1,5 @@
 import { emptyAllTables, disconnect } from '../../db/knex-database-connection.js';
-import { logger } from '../../lib/infrastructure/logger.js';
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 
 const main = async () => {
   logger.info('Emptying all tables...');

--- a/api/scripts/database/pg-boss-migration.js
+++ b/api/scripts/database/pg-boss-migration.js
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv';
 dotenv.config();
 import PgBoss from 'pg-boss';
-import { logger } from '../../lib/infrastructure/logger.js';
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 import { disconnect } from '../../db/knex-database-connection.js';
 
 async function main() {

--- a/api/scripts/database/restore-dump/download-backup.js
+++ b/api/scripts/database/restore-dump/download-backup.js
@@ -5,7 +5,7 @@ dotenv.config({ path: '../../../.env' });
 import fs from 'fs';
 import Joi from 'joi';
 import { ScalingoClient } from './helpers/scalingo/scalingo-client.js';
-import { logger } from '../../../lib/infrastructure/logger.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import { disconnect } from '../../../db/knex-database-connection.js';
 
 const postgresDatabaseAddonProviderId = 'postgresql';

--- a/api/scripts/fill-in-assessment-method.js
+++ b/api/scripts/fill-in-assessment-method.js
@@ -2,7 +2,7 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 import { knex } from '../db/knex-database-connection.js';
-import { logger } from '../lib/infrastructure/logger.js';
+import { logger } from '../src/shared/infrastructure/utils/logger.js';
 
 async function fillInAssessmentMethod() {
   const chunkSize = 50000;

--- a/api/scripts/fill-target-profiles-with-default-image-url.js
+++ b/api/scripts/fill-target-profiles-with-default-image-url.js
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv';
 import perf_hooks from 'perf_hooks';
 import * as url from 'url';
-import { logger } from '../lib/infrastructure/logger.js';
+import { logger } from '../src/shared/infrastructure/utils/logger.js';
 import { disconnect, knex } from '../db/knex-database-connection.js';
 
 dotenv.config();

--- a/api/scripts/generate-api-documentation.js
+++ b/api/scripts/generate-api-documentation.js
@@ -2,7 +2,7 @@ import dotenv from 'dotenv';
 // eslint-disable-next-line n/no-unpublished-import
 import jsdocToMarkdown from 'jsdoc-to-markdown';
 import * as url from 'url';
-import { logger } from '../lib/infrastructure/logger.js';
+import { logger } from '../src/shared/infrastructure/utils/logger.js';
 
 dotenv.config();
 

--- a/api/scripts/prod/compute-badge-acquisitions.js
+++ b/api/scripts/prod/compute-badge-acquisitions.js
@@ -11,7 +11,7 @@ import yargs from 'yargs/yargs';
 import { hideBin } from 'yargs/helpers';
 import { knex, disconnect } from '../../db/knex-database-connection.js';
 import { CampaignParticipation } from '../../lib/domain/models/CampaignParticipation.js';
-import { logger } from '../../lib/infrastructure/logger.js';
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 import * as badgeAcquisitionRepository from '../../lib/infrastructure/repositories/badge-acquisition-repository.js';
 import * as badgeForCalculationRepository from '../../lib/infrastructure/repositories/badge-for-calculation-repository.js';
 import * as knowledgeElementRepository from '../../lib/infrastructure/repositories/knowledge-element-repository.js';

--- a/api/scripts/prod/target-profile-migrations/convert-target-profiles-into-new-format.js
+++ b/api/scripts/prod/target-profile-migrations/convert-target-profiles-into-new-format.js
@@ -3,7 +3,7 @@ import dotenv from 'dotenv';
 dotenv.config();
 import _ from 'lodash';
 import { knex, disconnect } from '../../../db/knex-database-connection.js';
-import { logger } from '../../../lib/infrastructure/logger.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import { learningContentCache } from '../../../lib/infrastructure/caches/learning-content-cache.js';
 import { autoMigrateTargetProfile } from './common.js';
 import * as url from 'url';

--- a/api/scripts/prod/target-profile-migrations/extract-need-stages-migration.js
+++ b/api/scripts/prod/target-profile-migrations/extract-need-stages-migration.js
@@ -5,7 +5,7 @@ import { readFile, writeFile } from 'fs/promises';
 import { performance } from 'perf_hooks';
 import { read as readXlsx, utils as xlsxUtils } from 'xlsx';
 
-import { logger } from '../../../lib/infrastructure/logger.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 

--- a/api/scripts/prod/target-profile-migrations/migrate-stages-to-level.js
+++ b/api/scripts/prod/target-profile-migrations/migrate-stages-to-level.js
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'url';
 import { utils as xlsxUtils, writeXLSX } from 'xlsx';
 import fp from 'lodash/fp.js';
 
-import { logger } from '../../../lib/infrastructure/logger.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import { learningContentCache as cache } from '../../../lib/infrastructure/caches/learning-content-cache.js';
 import { disconnect } from '../../../db/knex-database-connection.js';
 

--- a/api/scripts/prod/target-profile-migrations/parse-xls-files-for-target-profiles-migration.js
+++ b/api/scripts/prod/target-profile-migrations/parse-xls-files-for-target-profiles-migration.js
@@ -12,7 +12,7 @@ import perf_hooks from 'perf_hooks';
 const { performance } = perf_hooks;
 
 import XLSX from 'xlsx';
-import { logger } from '../../../lib/infrastructure/logger.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import { learningContentCache as cache } from '../../../lib/infrastructure/caches/learning-content-cache.js';
 import { knex, disconnect } from '../../../db/knex-database-connection.js';
 import { normalizeAndRemoveAccents } from '../../../lib/domain/services/validation-treatments.js';

--- a/api/scripts/prod/target-profile-migrations/revert-stages-to-threshold.js
+++ b/api/scripts/prod/target-profile-migrations/revert-stages-to-threshold.js
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'url';
 import { readFile, set_fs, utils as xlsxUtils } from 'xlsx';
 import fp from 'lodash/fp.js';
 
-import { logger } from '../../../lib/infrastructure/logger.js';
+import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import { learningContentCache as cache } from '../../../lib/infrastructure/caches/learning-content-cache.js';
 import { disconnect } from '../../../db/knex-database-connection.js';
 

--- a/api/scripts/refresh-cache.js
+++ b/api/scripts/refresh-cache.js
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv';
 
 dotenv.config();
-import { logger } from '../lib/infrastructure/logger.js';
+import { logger } from '../src/shared/infrastructure/utils/logger.js';
 import { learningContentCache } from '../lib/infrastructure/caches/learning-content-cache.js';
 
 import * as learningContentDatasource from '../lib/infrastructure/datasources/learning-content/datasource.js';

--- a/api/scripts/tooling/tooling.js
+++ b/api/scripts/tooling/tooling.js
@@ -4,7 +4,7 @@ import * as skillRepository from '../../lib/infrastructure/repositories/skill-re
 import * as competenceRepository from '../../src/shared/infrastructure/repositories/competence-repository.js';
 import * as challengeRepository from '../../src/shared/infrastructure/repositories/challenge-repository.js';
 import * as campaignRepository from '../../lib/infrastructure/repositories/campaign-repository.js';
-import { logger } from '../../lib/infrastructure/logger.js';
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 import { knex } from '../../db/knex-database-connection.js';
 import { ComplementaryCertificationKeys } from '../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 

--- a/api/scripts/update-audit-api-csv-file.js
+++ b/api/scripts/update-audit-api-csv-file.js
@@ -1,5 +1,5 @@
 import url from 'url';
-import { logger } from '../lib/infrastructure/logger.js';
+import { logger } from '../src/shared/infrastructure/utils/logger.js';
 import { parseCsvWithHeader } from '../lib/infrastructure/helpers/csv.js';
 const swaggerUrl = `https://app.pix.fr/api/swagger.json`;
 

--- a/api/src/certification/complementary-certification/domain/usecases/send-target-profile-notifications.js
+++ b/api/src/certification/complementary-certification/domain/usecases/send-target-profile-notifications.js
@@ -1,6 +1,6 @@
 import bluebird from 'bluebird';
 import { CONCURRENCY_HEAVY_OPERATIONS } from '../../../../shared/infrastructure/constants.js';
-import { logger } from '../../../../../lib/infrastructure/logger.js';
+import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 const EVENT_NAME = 'attach-target-profile-certif';
 
 export { sendTargetProfileNotifications };

--- a/api/src/certification/shared/infrastructure/repositories/certification-challenge-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-challenge-repository.js
@@ -1,5 +1,5 @@
 import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';
-import { logger } from '../../../../../lib/infrastructure/logger.js';
+import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 import { AssessmentEndedError } from '../../../../../lib/domain/errors.js';
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { CertificationChallenge } from '../../../../../lib/domain/models/CertificationChallenge.js';

--- a/api/src/devcomp/infrastructure/repositories/training-trigger-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/training-trigger-repository.js
@@ -9,7 +9,7 @@ import * as competenceRepository from '../../../shared/infrastructure/repositori
 import * as thematicRepository from '../../../../lib/infrastructure/repositories/thematic-repository.js';
 import * as tubeRepository from '../../../../lib/infrastructure/repositories/tube-repository.js';
 import { TrainingTrigger } from '../../domain/models/TrainingTrigger.js';
-import { logger } from '../../../../lib/infrastructure/logger.js';
+import { logger } from '../../../shared/infrastructure/utils/logger.js';
 
 const TABLE_NAME = 'training-triggers';
 

--- a/api/src/school/domain/services/algorithm-method.js
+++ b/api/src/school/domain/services/algorithm-method.js
@@ -1,5 +1,5 @@
 import { Activity } from '../models/Activity.js';
-import { logger } from '../../../../lib/infrastructure/logger.js';
+import { logger } from '../../../shared/infrastructure/utils/logger.js';
 
 export const pix1dService = { getNextActivityLevel };
 

--- a/api/src/school/infrastructure/repositories/challenge-repository.js
+++ b/api/src/school/infrastructure/repositories/challenge-repository.js
@@ -7,7 +7,7 @@ import {
   skillDatasource,
   tubeDatasource,
 } from '../../../../lib/infrastructure/datasources/learning-content/index.js';
-import { logger } from '../../../../lib/infrastructure/logger.js';
+import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { Activity } from '../../domain/models/Activity.js';
 import * as solutionAdapter from '../../../../src/shared/infrastructure/adapters/solution-adapter.js';
 

--- a/api/src/shared/application/assessments/assessment-controller.js
+++ b/api/src/shared/application/assessments/assessment-controller.js
@@ -5,7 +5,7 @@ import { usecases } from '../../../../lib/domain/usecases/index.js';
 import { usecases as devcompUsecases } from '../../../devcomp/domain/usecases/index.js';
 import { usecases as certificationUsecases } from '../../../certification/shared/domain/usecases/index.js';
 import * as events from '../../../../lib/domain/events/index.js';
-import { logger } from '../../../../lib/infrastructure/logger.js';
+import { logger } from '../../infrastructure/utils/logger.js';
 import * as assessmentRepository from '../../infrastructure/repositories/assessment-repository.js';
 import * as assessmentSerializer from '../../infrastructure/serializers/jsonapi/assessment-serializer.js';
 import * as challengeSerializer from '../../infrastructure/serializers/jsonapi/challenge-serializer.js';

--- a/api/src/shared/domain/models/Examiner.js
+++ b/api/src/shared/domain/models/Examiner.js
@@ -1,4 +1,4 @@
-import { logger } from '../../../../lib/infrastructure/logger.js';
+import { logger } from '../../infrastructure/utils/logger.js';
 import { Answer } from '../../../evaluation/domain/models/Answer.js';
 import { AnswerStatus } from './AnswerStatus.js';
 

--- a/api/src/shared/storage/infrastructure/providers/S3ObjectStorageProvider.js
+++ b/api/src/shared/storage/infrastructure/providers/S3ObjectStorageProvider.js
@@ -1,7 +1,7 @@
 import * as clientS3 from '@aws-sdk/client-s3';
 import * as libStorage from '@aws-sdk/lib-storage';
 import * as s3RequestPresigner from '@aws-sdk/s3-request-presigner';
-import { logger } from '../../../../../lib/infrastructure/logger.js';
+import { logger } from '../../../infrastructure/utils/logger.js';
 
 class S3ObjectStorageProvider {
   #dependencies;

--- a/api/tests/acceptance/scripts/certification/update-certification-infos_test.js
+++ b/api/tests/acceptance/scripts/certification/update-certification-infos_test.js
@@ -2,7 +2,7 @@ import { expect, databaseBuilder, knex, sinon } from '../../../test-helper.js';
 import { writeFile, rm } from 'fs/promises';
 import lodash from 'lodash';
 const { values } = lodash;
-import { logger } from '../../../../lib/infrastructure/logger.js';
+import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
 import { updateCertificationInfos, headers } from '../../../../scripts/certification/update-certification-infos.js';
 import * as url from 'url';
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));

--- a/api/tests/devcomp/integration/infrastructure/repositories/training-trigger-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/training-trigger-repository_test.js
@@ -14,7 +14,7 @@ import { TrainingTrigger, TrainingTriggerTube } from '../../../../../lib/domain/
 import { TrainingTriggerForAdmin } from '../../../../../src/devcomp/domain/read-models/TrainingTriggerForAdmin.js';
 import _ from 'lodash';
 import { NotFoundError } from '../../../../../lib/domain/errors.js';
-import { logger } from '../../../../../lib/infrastructure/logger.js';
+import { logger } from '../../../../../src/shared/infrastructure/utils/logger.js';
 
 describe('Integration | Repository | training-trigger-repository', function () {
   let learningContent;

--- a/api/tests/integration/scripts/prod/compute-badge-acquisitions_test.js
+++ b/api/tests/integration/scripts/prod/compute-badge-acquisitions_test.js
@@ -15,7 +15,7 @@ import {
 } from '../../../../scripts/prod/compute-badge-acquisitions.js';
 
 import { CampaignParticipation } from '../../../../lib/domain/models/CampaignParticipation.js';
-import { logger } from '../../../../lib/infrastructure/logger.js';
+import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
 import * as badgeAcquisitionRepository from '../../../../lib/infrastructure/repositories/badge-acquisition-repository.js';
 import * as badgeForCalculationRepository from '../../../../lib/infrastructure/repositories/badge-for-calculation-repository.js';
 import * as knowledgeElementRepository from '../../../../lib/infrastructure/repositories/knowledge-element-repository.js';

--- a/api/tests/unit/application/cache/cache-controller_test.js
+++ b/api/tests/unit/application/cache/cache-controller_test.js
@@ -1,7 +1,7 @@
 import { expect, sinon, hFake } from '../../../test-helper.js';
 import { cacheController } from '../../../../lib/application/cache/cache-controller.js';
 import * as learningContentDatasources from '../../../../lib/infrastructure/datasources/learning-content/index.js';
-import { logger } from '../../../../lib/infrastructure/logger.js';
+import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
 
 describe('Unit | Controller | cache-controller', function () {
   describe('#refreshCacheEntry', function () {

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -5,7 +5,7 @@ import { usecases as sessionUsecases } from '../../../../src/certification/sessi
 import { UserAlreadyLinkedToCertificationCandidate } from '../../../../lib/domain/events/UserAlreadyLinkedToCertificationCandidate.js';
 import { UserLinkedToCertificationCandidate } from '../../../../lib/domain/events/UserLinkedToCertificationCandidate.js';
 import { SessionPublicationBatchResult } from '../../../../lib/domain/models/index.js';
-import { logger } from '../../../../lib/infrastructure/logger.js';
+import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
 import { SessionPublicationBatchError } from '../../../../lib/application/http-errors.js';
 import * as queryParamsUtils from '../../../../lib/infrastructure/utils/query-params-utils.js';
 import { getI18n } from '../../../tooling/i18n/i18n.js';

--- a/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
@@ -13,7 +13,7 @@ import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTrans
 import { UserToCreate } from '../../../../../lib/domain/models/UserToCreate.js';
 import { AuthenticationMethod } from '../../../../../lib/domain/models/AuthenticationMethod.js';
 import * as OidcIdentityProviders from '../../../../../lib/domain/constants/oidc-identity-providers.js';
-import { logger } from '../../../../../lib/infrastructure/logger.js';
+import { logger } from '../../../../../src/shared/infrastructure/utils/logger.js';
 import { monitoringTools } from '../../../../../lib/infrastructure/monitoring-tools.js';
 import { OIDC_ERRORS } from '../../../../../lib/domain/constants.js';
 import { OidcError } from '../../../../../src/shared/domain/errors.js';

--- a/api/tests/unit/domain/services/course-service_test.js
+++ b/api/tests/unit/domain/services/course-service_test.js
@@ -1,5 +1,5 @@
 import * as courseService from '../../../../lib/domain/services/course-service.js';
-import { logger } from '../../../../lib/infrastructure/logger.js';
+import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
 import { expect, sinon, domainBuilder, catchErr } from '../../../test-helper.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
 

--- a/api/tests/unit/domain/usecases/update-expired-password_test.js
+++ b/api/tests/unit/domain/usecases/update-expired-password_test.js
@@ -2,7 +2,7 @@ import { sinon, expect, domainBuilder, catchErr } from '../../../test-helper.js'
 import { UserNotFoundError } from '../../../../lib/domain/errors.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 import { updateExpiredPassword } from '../../../../lib/domain/usecases/update-expired-password.js';
-import { logger } from '../../../../lib/infrastructure/logger.js';
+import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
 import { ForbiddenAccess } from '../../../../src/shared/domain/errors.js';
 
 describe('Unit | UseCase | update-expired-password', function () {

--- a/api/tests/unit/infrastructure/jobs/cpf-export/handlers/send-email_test.js
+++ b/api/tests/unit/infrastructure/jobs/cpf-export/handlers/send-email_test.js
@@ -1,6 +1,6 @@
 import { expect, sinon } from '../../../../../test-helper.js';
 import { sendEmail } from '../../../../../../lib/infrastructure/jobs/cpf-export/handlers/send-email.js';
-import { logger } from '../../../../../../lib/infrastructure/logger.js';
+import { logger } from '../../../../../../src/shared/infrastructure/utils/logger.js';
 
 describe('Unit | Infrastructure | jobs | cpf-export | send-email', function () {
   let getPreSignedUrls;

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -1,6 +1,6 @@
 import { expect, sinon, catchErr } from '../../../../test-helper.js';
 import * as csvSerializer from '../../../../../lib/infrastructure/serializers/csv/csv-serializer.js';
-import { logger } from '../../../../../lib/infrastructure/logger.js';
+import { logger } from '../../../../../src/shared/infrastructure/utils/logger.js';
 import _ from 'lodash';
 import { FileValidationError } from '../../../../../lib/domain/errors.js';
 import { emptySession } from '../../../../../lib/infrastructure/utils/csv/sessions-import.js';

--- a/api/worker.js
+++ b/api/worker.js
@@ -6,7 +6,7 @@ import PgBoss from 'pg-boss';
 import _ from 'lodash';
 
 import { config } from './lib/config.js';
-import { logger } from './lib/infrastructure/logger.js';
+import { logger } from './src/shared/infrastructure/utils/logger.js';
 import { JobQueue } from './lib/infrastructure/jobs/JobQueue.js';
 import { ParticipationResultCalculationJob } from './lib/infrastructure/jobs/campaign-result/ParticipationResultCalculationJob.js';
 import { SendSharedParticipationResultsToPoleEmploiJob } from './lib/infrastructure/jobs/campaign-result/SendSharedParticipationResultsToPoleEmploiJob.js';


### PR DESCRIPTION
## :unicorn: Problème

cf https://github.com/1024pix/pix/blob/dev/docs/adr/0051-nouvelle-arborescence-api.md

## :robot: Proposition

Déplacement du fichier logger dans le répertoire `src/shared/infrastructure/utils/`

## :rainbow: Remarques

Il y avait des sortes de fichiers intermédiaires que j'ai supprimés. Je ne sais pas si placer le logger dans un répertoire utils est une bonne idée :shrug: 

## :100: Pour tester

Tests vert 🟢 et rien de changer dans les diverses applications.