### PR TITLE
[FEATURE] Récupérer l'information des langues disponibles pour la certification (pix-11277)

### DIFF
--- a/api/lib/domain/models/User.js
+++ b/api/lib/domain/models/User.js
@@ -112,6 +112,10 @@ class User {
     }
   }
 
+  isLanguageAvailableForV3Certification() {
+    return this.dependencies.languageService.isLanguageAvailableForV3Certification(this.lang);
+  }
+
   isLinkedToOrganizations() {
     return this.memberships.length > 0;
   }

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -28,6 +28,7 @@ const retrieveLastOrCreateCertificationCourse = async function ({
   certificationCourseRepository,
   sessionRepository,
   certificationCenterRepository,
+  userRepository,
   certificationChallengesService,
   placementProfileService,
   certificationBadgesService,
@@ -68,6 +69,11 @@ const retrieveLastOrCreateCertificationCourse = async function ({
 
   const { version } = session;
 
+  if (version === CertificationVersion.V3) {
+    const user = await userRepository.get(userId);
+    _validateUserLanguage(user);
+  }
+
   return _startNewCertification({
     domainTransaction,
     sessionId,
@@ -87,6 +93,14 @@ const retrieveLastOrCreateCertificationCourse = async function ({
 };
 
 export { retrieveLastOrCreateCertificationCourse };
+
+function _validateUserLanguage(user) {
+  const isUserLanguageAvailableForCertification = user.isLanguageAvailableForV3Certification();
+
+  if (!isUserLanguageAvailableForCertification) {
+    return;
+  }
+}
 
 function _validateSessionAccess(session, accessCode) {
   if (session.accessCode !== accessCode) {

--- a/api/src/shared/domain/services/language-service.js
+++ b/api/src/shared/domain/services/language-service.js
@@ -7,6 +7,7 @@ const LANGUAGES_CODE = {
 };
 
 const AVAILABLE_LANGUAGES = Object.values(LANGUAGES_CODE);
+const V3_CERTIFICATION_AVAILABLE_LANGUAGES = [LANGUAGES_CODE.ENGLISH, LANGUAGES_CODE.FRENCH];
 
 function assertLanguageAvailability(languageCode) {
   if (!languageCode) return;
@@ -16,4 +17,10 @@ function assertLanguageAvailability(languageCode) {
   }
 }
 
-export { assertLanguageAvailability, AVAILABLE_LANGUAGES, LANGUAGES_CODE };
+function isLanguageAvailableForV3Certification(lang) {
+  if (!lang) return;
+
+  return V3_CERTIFICATION_AVAILABLE_LANGUAGES.includes(lang);
+}
+
+export { assertLanguageAvailability, AVAILABLE_LANGUAGES, isLanguageAvailableForV3Certification, LANGUAGES_CODE };

--- a/api/tests/shared/unit/domain/services/language-service_test.js
+++ b/api/tests/shared/unit/domain/services/language-service_test.js
@@ -32,4 +32,33 @@ describe('Unit | Shared | Domain | Services | Language Service', function () {
       });
     });
   });
+
+  describe('#isLanguageAvailableForV3Certification', function () {
+    context('when language is not provided', function () {
+      it('returns nothing', function () {
+        // then
+        expect(languageService.isLanguageAvailableForV3Certification()).to.be.undefined;
+      });
+    });
+
+    context('when given language is available', function () {
+      it('returns true', function () {
+        // given
+        const lang = 'fr';
+
+        // when & then
+        expect(languageService.isLanguageAvailableForV3Certification(lang)).to.be.true;
+      });
+    });
+
+    context('when given language is not available', function () {
+      it('returns false', function () {
+        // given
+        const lang = 'nl';
+
+        // when & then
+        expect(languageService.isLanguageAvailableForV3Certification(lang)).to.be.false;
+      });
+    });
+  });
 });

--- a/api/tests/unit/domain/models/User_test.js
+++ b/api/tests/unit/domain/models/User_test.js
@@ -122,6 +122,34 @@ describe('Unit | Domain | Models | User', function () {
     });
   });
 
+  describe('isLanguageAvailableForV3Certification', function () {
+    it('should be true if user language is available for certification', function () {
+      // given
+      const user = domainBuilder.buildUser({
+        lang: 'en',
+      });
+
+      // when
+      const isAvailable = user.isLanguageAvailableForV3Certification();
+
+      //then
+      expect(isAvailable).to.be.true;
+    });
+
+    it('should be false if user language is NOT available for certification', function () {
+      // given
+      const user = domainBuilder.buildUser({
+        lang: 'nl',
+      });
+
+      // when
+      const isAvailable = user.isLanguageAvailableForV3Certification();
+
+      //then
+      expect(isAvailable).to.be.false;
+    });
+  });
+
   describe('isLinkedToOrganizations', function () {
     it('should be true if user has a role in an organization', function () {
       // given

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -32,6 +32,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
   const certificationBadgesService = {};
   const placementProfileService = {};
   const verifyCertificateCodeService = {};
+  const userRepository = {};
 
   const injectables = {
     assessmentRepository,
@@ -45,6 +46,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
     certificationChallengesService,
     placementProfileService,
     verifyCertificateCodeService,
+    userRepository,
   };
 
   beforeEach(function () {
@@ -64,8 +66,8 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
     certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId = sinon.stub();
     certificationCourseRepository.save = sinon.stub();
     sessionRepository.get = sinon.stub();
+    userRepository.get = sinon.stub();
     placementProfileService.getPlacementProfile = sinon.stub();
-
     verifyCertificateCodeService.generateCertificateVerificationCode = sinon.stub().resolves(verificationCode);
     certificationCenterRepository.getBySessionId = sinon.stub();
   });
@@ -468,6 +470,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
               it('should create a v3 certification', async function () {
                 // given
+                const userId = 2;
                 const domainTransaction = Symbol('someDomainTransaction');
 
                 const foundSession = domainBuilder.buildSession.created({
@@ -504,8 +507,10 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                 certificationCenterRepository.getBySessionId.resolves(certificationCenter);
 
                 certificationBadgesService.findStillValidBadgeAcquisitions
-                  .withArgs({ userId: 2, domainTransaction })
+                  .withArgs({ userId, domainTransaction })
                   .resolves([]);
+
+                userRepository.get.withArgs(userId).resolves(domainBuilder.buildUser({ id: userId }));
 
                 // TODO: extraire jusqu'à la ligne 387 dans une fonction ?
                 const certificationCourseToSave = CertificationCourse.from({


### PR DESCRIPTION
Pour permettre de passer la certification dans une langue donnée, nous allons nous baser sur la langue du compte au lancement du test de certification par le candidat. Et si une langue n’est pas dispo pour la certif, on prévoit d’en informer le candidat.

## :unicorn: Problème
Il n’est pas possible actuellement d’identifier les langues disponibles pour la certif vs. celles qui ne le sont pas.

## :robot: Proposition
Identifier les langues disponibles pour la certification, aujourd’hui FR et EN.

## :rainbow: Remarques
- Les langues sont en dur dans le code, à voir s'il faut les mettre en DB

## :100: Pour tester

Vu que l'on n'utilise pas encore l'information de la langue, tests verts pour le moment ?
