### PR TITLE
[FEATURE] Eviter le CLS dû au chargement de l'illustration d'un Module (PIX-11302)

### DIFF
--- a/mon-pix/app/pods/components/module/details/styles.scss
+++ b/mon-pix/app/pods/components/module/details/styles.scss
@@ -23,6 +23,8 @@
 .module-details-image {
   &__illustration {
     display: block;
+    width: auto;
+    max-height: 100%;
     margin: 0 auto;
     padding-top: var(--pix-spacing-6x);
   }

--- a/mon-pix/app/pods/components/module/details/template.hbs
+++ b/mon-pix/app/pods/components/module/details/template.hbs
@@ -1,7 +1,7 @@
 {{page-title @module.title}}
 <main id="main" class="module-details" role="main">
   <div class="module-details__image">
-    <img alt="" class="module-details-image__illustration" src={{@module.details.image}} />
+    <img alt="" class="module-details-image__illustration" src={{@module.details.image}} height="150" />
   </div>
 
   <div class="module-details__content">


### PR DESCRIPTION
## :unicorn: Problème
Lors du chargement de la page de détails d'un module, l'image n'a pas encore eu le temps d'apparaître et aucun espace n'est réservé pour elle. On se retrouve donc avec un saut dans le contenu dans la page quand elle charge finalement : on parle de [Cumulative Layout Shift](https://web.dev/articles/cls).

![image](https://github.com/1024pix/pix/assets/5855339/f105aee4-9cf7-46bf-b529-0a29ce0d8af3)

## :robot: Proposition
Prévoir un espace pour afficher l'illustration. J'ai choisi une hauteur max, on pourra en rediscuter avec Quentin à son retour.

Vu qu'on manipule des images vectorielles on devrait être plutôt safe mais dans le doute j'ai ajouté 2 propriétés pour éviter d'étirer les illustrations.

## :rainbow: Remarques
RAS

## :100: Pour tester
- Vérifier en supprimant l'attribut `href` d'une image de la page de détails qu'un espace est bien réservé
- Constater que les illustrations actuelles des différents modules ne sont pas déformées
