### PR TITLE
[FEATURE] Enlever la barre de navigation sur la page /details de Modulix (PIX-11480).

### DIFF
--- a/mon-pix/app/pods/module/details/template.hbs
+++ b/mon-pix/app/pods/module/details/template.hbs
@@ -1,7 +1,15 @@
 <BetaBanner />
-<header>
-  <NavbarHeader />
-</header>
+<nav>
+  <ul>
+    <li>
+      <Skiplink @href="#main" @label={{t "common.skip-links.skip-to-content"}} />
+    </li>
+    <li>
+      <Skiplink @href="#footer" @label={{t "common.skip-links.skip-to-footer"}} />
+    </li>
+  </ul>
+</nav>
+
 <div class="modulix">
   <Module::Details @module={{@model}} />
 </div>

--- a/mon-pix/tests/acceptance/module/visit-module-details-page_test.js
+++ b/mon-pix/tests/acceptance/module/visit-module-details-page_test.js
@@ -3,12 +3,14 @@ import { setupApplicationTest } from 'ember-qunit';
 import { currentURL } from '@ember/test-helpers';
 import { visit } from '@1024pix/ember-testing-library';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import setupIntl from 'mon-pix/tests/helpers/setup-intl';
 
 module('Acceptance | Module | Routes | details', function (hooks) {
   setupApplicationTest(hooks);
+  setupIntl(hooks);
   setupMirage(hooks);
 
-  test('should visit and include the module title, header and footer', async function (assert) {
+  test('should visit and include the module title, skiplinks and footer', async function (assert) {
     // given
     const module = server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
@@ -31,7 +33,8 @@ module('Acceptance | Module | Routes | details', function (hooks) {
     assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/details');
     assert.ok(document.title.includes(module.title));
     assert.dom(screen.getByRole('alert')).exists();
-    assert.dom(screen.getByRole('banner')).exists();
+    assert.dom(screen.getByRole('link', { name: this.intl.t('common.skip-links.skip-to-content') })).exists();
+    assert.dom(screen.getByRole('link', { name: this.intl.t('common.skip-links.skip-to-footer') })).exists();
     assert.dom(screen.getByRole('contentinfo')).exists();
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Suite à [PIX-11422](https://1024pix.atlassian.net/browse/PIX-11422) le parcours utilisateur qui arrive sur Modulix non connecté et qui clique sur "Se connecter" est, une fois connecté, redirigé vers la page d'accueil de Pix, sans possibilité de revenir vers Modulix depuis le menu.

## :robot: Proposition
Enlever le header sur la page /details des modules, garder le footer et les liens d'évitements.

## :rainbow: Remarques
- Nous avons décidé de mettre les balises Skiplink dans une balise nav et une liste (ul/li) comme recommandé sur le site du gouvernement : https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/lien-d-evitement/
- Nous nous sommes posé la question d'enlever le lien "Aller au contenu" car il n'y a pas beaucoup d'étapes entre le lien d'évitement et l'ancre en question mais toujours sur le site du gouv sur les liens d'évitements, il est écrit :
> Le choix des liens à afficher dépend des éléments clés présents dans le site. Le lien minimum est “Accéder au contenu”, les autres liens doivent être choisis en fonction des fonctionnalité/zone clés.

Nous avons donc décidé de le garder.

## :100: Pour tester
- Aller sur la page [du module de didacticiel](https://app-pr8239.review.pix.fr/modules/didacticiel-modulix) par exemple
- Constater la présence des liens d'évitements uniquement à la place du header

[PIX-11422]: https://1024pix.atlassian.net/browse/PIX-11422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ