### PR TITLE
[FEATURE] Mise à jour du wording pour la page de verification du code de certificat (PIX-11384) 

### DIFF
--- a/mon-pix/tests/acceptance/fill-in-certificate-verification-code_test.js
+++ b/mon-pix/tests/acceptance/fill-in-certificate-verification-code_test.js
@@ -12,6 +12,23 @@ module('Acceptance | Certificate verification', function (hooks) {
   setupMirage(hooks);
   setupIntl(hooks);
 
+  test('display a verification section', async function (assert) {
+    // given & when
+    const screen = await visit('/verification-certificat');
+
+    // then
+    assert.dom(screen.getByRole('heading', { name: 'Vérifier un certificat Pix' })).exists();
+    assert
+      .dom(
+        screen.getByText(
+          'La certification Pix atteste d’un niveau de maîtrise des compétences numériques : saisissez ci-après le "code de vérification" du certificat Pix à vérifier.',
+        ),
+      )
+      .exists();
+    assert.dom(screen.getByRole('textbox', { name: 'Code de vérification (P-XXXXXXXX)' })).exists();
+    assert.dom(screen.getByRole('button', { name: 'Vérifier le certificat' })).exists();
+  });
+
   module('when certificate verification code is valid', function () {
     test('redirects to certificate details page', async function (assert) {
       // Given

--- a/mon-pix/tests/acceptance/fill-in-certificate-verification-code_test.js
+++ b/mon-pix/tests/acceptance/fill-in-certificate-verification-code_test.js
@@ -1,10 +1,9 @@
 import { visit } from '@1024pix/ember-testing-library';
-import { currentURL, fillIn } from '@ember/test-helpers';
+import { click, currentURL, fillIn } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-import { clickByLabel } from '../helpers/click-by-label';
 import setupIntl from '../helpers/setup-intl';
 
 module('Acceptance | Certificate verification', function (hooks) {
@@ -31,50 +30,50 @@ module('Acceptance | Certificate verification', function (hooks) {
 
   module('when certificate verification code is valid', function () {
     test('redirects to certificate details page', async function (assert) {
-      // Given
-      await visit('/verification-certificat');
-      await fillIn('#certificate-verification-code', 'P-123VALID');
+      // given
+      const screen = await visit('/verification-certificat');
+      await fillIn(screen.getByRole('textbox', { name: 'Code de vérification (P-XXXXXXXX)' }), 'P-123VALID');
 
-      // When
-      await clickByLabel(this.intl.t('pages.fill-in-certificate-verification-code.verify'));
+      // when
+      await click(screen.getByRole('button', { name: 'Vérifier le certificat' }));
 
-      // Then
+      // then
       assert.strictEqual(currentURL(), '/partage-certificat/200');
     });
   });
 
   module('when certificate verification code is wrong', function () {
     test('does not redirect to certificate details page', async function (assert) {
-      // Given
-      await visit('/verification-certificat');
-      await fillIn('#certificate-verification-code', 'P-12345678');
+      // given
+      const screen = await visit('/verification-certificat');
+      await fillIn(screen.getByRole('textbox', { name: 'Code de vérification (P-XXXXXXXX)' }), 'P-12345678');
 
-      // When
-      await clickByLabel(this.intl.t('pages.fill-in-certificate-verification-code.verify'));
+      // when
+      await click(screen.getByRole('button', { name: 'Vérifier le certificat' }));
 
-      // Then
+      // then
       assert.strictEqual(currentURL(), '/verification-certificat');
     });
 
     test('shows error message', async function (assert) {
-      // Given
-      await visit('/verification-certificat');
-      await fillIn('#certificate-verification-code', 'P-12345678');
+      // given
+      const screen = await visit('/verification-certificat');
+      await fillIn(screen.getByRole('textbox', { name: 'Code de vérification (P-XXXXXXXX)' }), 'P-12345678');
 
-      // When
-      await clickByLabel(this.intl.t('pages.fill-in-certificate-verification-code.verify'));
+      // when
+      await click(screen.getByRole('button', { name: 'Vérifier le certificat' }));
 
-      // Then
-      assert.dom('.form__error--not-found').exists();
+      // then
+      assert.dom(screen.getByText("Il n'y a pas de certificat Pix correspondant.")).exists();
     });
   });
 
   module('when user visits /partage-certificat/200 directly', function () {
     test('redirects to /verification-certificat', async function (assert) {
-      // When
+      // given & when
       await visit('/partage-certificat/200');
 
-      // Then
+      // then
       assert.strictEqual(currentURL(), '/verification-certificat');
     });
   });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -984,7 +984,7 @@
     },
     "fill-in-certificate-verification-code": {
       "title": "Verify the authenticity of a Pix Certificate",
-      "description": "The Pix Certification assesses digital literacy and is recognised throughout Europe and in the business world.",
+      "description": "The Pix Certification assesses digital proficiency: please enter the \"verification code\" of the Pix certificate you wish to check.",
       "errors": {
         "missing-code": "Please enter the verification code in this format: P-XXXXXXXX",
         "not-found": "There is no corresponding Pix Certificate.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -984,7 +984,7 @@
     },
     "fill-in-certificate-verification-code": {
       "title": "Vérifier un certificat Pix",
-      "description": "La certification Pix atteste d’un niveau de maitrise des compétences numériques, reconnu par l’État et le monde professionnel.",
+      "description": "La certification Pix atteste d’un niveau de maîtrise des compétences numériques : saisissez ci-après le \"code de vérification\" du certificat Pix à vérifier.",
       "errors": {
         "missing-code": "Merci de renseigner le code de vérification.",
         "not-found": "Il n'y a pas de certificat Pix correspondant.",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -984,7 +984,7 @@
     },
     "fill-in-certificate-verification-code": {
       "title": "Een Pix-certificaat controleren",
-      "description": "Een Pix-certificaat getuigt van een vaardigheidsniveau in digitale vaardigheden: voer hieronder de \\\"verificatiecode\\\" in voor het Pix-certificaat dat je wilt controleren.",
+      "description": "Een Pix-certificaat getuigt van een vaardigheidsniveau in digitale vaardigheden: voer hieronder de \"verificatiecode\" in voor het Pix-certificaat dat je wilt controleren.",
       "errors": {
         "missing-code": "Voer de verificatiecode in.",
         "not-found": "Er is geen bijbehorend Pix-certificaat.",


### PR DESCRIPTION
## :unicorn: Problème
Etant donné qu'il n'y a pas encore de reconnaissance officielle hors de France de la certification Pix, le wording actuel de la page de verification du certificat ne semble pas correspondre au contexte d’ouverture à l'international de Pix:

“La certification Pix atteste d’un niveau de maitrise des compétences numériques, reconnu par l’État et le monde professionnel.”

## :robot: Proposition
Modifier le wording de la page de vérification du certificat pour qu’il soit plus générique : 

vFR : “La certification Pix atteste d’un niveau de maîtrise des compétences numériques : saisissez ci-après le “code de vérification” du certificat Pix à vérifier.“

vEN : “The Pix Certification assesses digital proficiency: please enter the “verification code” of the Pix certificate you wish to check.”

## :rainbow: Remarques
~~NL à définir~~

## :100: Pour tester
Verifier la page sur mon-pix: `/verification-certificat` dans les differentes langues
