### PR TITLE
[TECH] récupère la liste des `OrganizationLearners` à partir d'une mission et d'une organisation (PIX-11493)

### DIFF
--- a/api/src/school/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/school/infrastructure/repositories/organization-learner-repository.js
@@ -18,4 +18,15 @@ const getById = async function (organizationLearnerId) {
   });
 };
 
-export { getStudentsByOrganizationId, getById };
+async function getAllFromMissionIdAndOrganizationId(missionId, organizationId) {
+  const rawOrganizationLearners = await knex('organization-learners')
+    .join('mission-assessments', 'mission-assessments.organizationLearnerId', 'organization-learners.id')
+    .where({ organizationId })
+    .andWhere({ missionId });
+
+  return rawOrganizationLearners.map((rawOrganizationLearner) => {
+    return new OrganizationLearner({ ...rawOrganizationLearner });
+  });
+}
+
+export { getStudentsByOrganizationId, getById, getAllFromMissionIdAndOrganizationId };

--- a/api/tests/school/integration/infrastructure/repositories/organization-learners-repository_test.js
+++ b/api/tests/school/integration/infrastructure/repositories/organization-learners-repository_test.js
@@ -60,4 +60,34 @@ describe('Integration | Repository | organizationLearner', function () {
       );
     });
   });
+  describe('#getAllFromMissionIdAndOrganizationId', function () {
+    it('returns the missionAssessment corresponding to the missionId', async function () {
+      const missionId = 'flute78';
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+      const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId,
+      });
+      databaseBuilder.factory.buildMissionAssessment({
+        missionId,
+        organizationLearnerId: organizationLearner.id,
+      });
+
+      const organizationLearnerFromOtherOrga = databaseBuilder.factory.buildOrganizationLearner();
+      databaseBuilder.factory.buildMissionAssessment({
+        missionId,
+        organizationLearnerId: organizationLearnerFromOtherOrga.id,
+      });
+      await databaseBuilder.commit();
+
+      const missionAssessments = await organizationLearnersRepository.getAllFromMissionIdAndOrganizationId(
+        missionId,
+        organizationId,
+      );
+
+      const expectedOrganizationLearner = new OrganizationLearner({ ...organizationLearner });
+
+      expect(missionAssessments).to.deep.equal([expectedOrganizationLearner]);
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème

- Nous n'affichons pas les classes ayant commencé les missions (ref https://1024pix.atlassian.net/jira/software/c/projects/PIX/boards/107?selectedIssue=PIX-11201)
- Nous n'affichons pas la liste des élèves ayant participé à une mission (ref https://1024pix.atlassian.net/jira/software/c/projects/PIX/boards/107?selectedIssue=PIX-11198)

## :robot: Proposition

Pour pouvoir afficher ces informations dans l'interface, nous avons besoin de récupérer la liste des élèves pour une organisation et une mission donnée.

## :rainbow: Remarques

Pour le moment, nous avons simplement ajouté une fonction dans le `OrganizationLearnersRepository` du domaine `school` pour faciliter la finalisation des deux tickets cité plus haut.

## :100: Pour tester

La CI est verte. 
