### PR TITLE
[TECH] :recycle: déplacement de `area-repository` vers le répertoire `src/shared`

### DIFF
--- a/api/lib/domain/services/scoring/scoring-certification-service.js
+++ b/api/lib/domain/services/scoring/scoring-certification-service.js
@@ -8,7 +8,7 @@ import { ReproducibilityRate } from '../../models/ReproducibilityRate.js';
 import { CompetenceMark } from '../../models/CompetenceMark.js';
 import { CertificationAssessmentScore } from '../../../../src/certification/scoring/domain/models/CertificationAssessmentScore.js';
 import { AnswerCollectionForScoring } from '../../models/AnswerCollectionForScoring.js';
-import * as areaRepository from '../../../infrastructure/repositories/area-repository.js';
+import * as areaRepository from '../../../../src/shared/infrastructure/repositories/area-repository.js';
 import { CertificationVersion } from '../../../../src/shared/domain/models/CertificationVersion.js';
 
 function _selectAnswersMatchingCertificationChallenges(answers, certificationChallenges) {

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -13,7 +13,7 @@ import * as activityAnswerRepository from '../../../src/school/infrastructure/re
 import * as adminMemberRepository from '../../../src/shared/infrastructure/repositories/admin-member-repository.js';
 import * as algorithmDataFetcherService from '../../domain/services/algorithm-methods/data-fetcher.js';
 import * as answerRepository from '../../../src/shared/infrastructure/repositories/answer-repository.js';
-import * as areaRepository from '../../infrastructure/repositories/area-repository.js';
+import * as areaRepository from '../../../src/shared/infrastructure/repositories/area-repository.js';
 import * as assessmentRepository from '../../../src/shared/infrastructure/repositories/assessment-repository.js';
 import * as assessmentResultRepository from '../../../src/shared/infrastructure/repositories/assessment-result-repository.js';
 import * as attachableTargetProfileRepository from '../../infrastructure/repositories/attachable-target-profiles-repository.js';

--- a/api/lib/infrastructure/repositories/campaign-participation-result-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-result-repository.js
@@ -2,7 +2,7 @@ import { CampaignParticipationResult } from '../../domain/models/CampaignPartici
 import * as campaignParticipationRepository from './campaign-participation-repository.js';
 import * as campaignRepository from './campaign-repository.js';
 import * as competenceRepository from '../../../src/shared/infrastructure/repositories/competence-repository.js';
-import * as areaRepository from './area-repository.js';
+import * as areaRepository from '../../../src/shared/infrastructure/repositories/area-repository.js';
 import * as assessmentRepository from '../../../src/shared/infrastructure/repositories/assessment-repository.js';
 import * as knowledgeElementRepository from './knowledge-element-repository.js';
 

--- a/api/lib/infrastructure/repositories/campaign-profile-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-profile-repository.js
@@ -3,7 +3,7 @@ import * as placementProfileService from '../../domain/services/placement-profil
 import { NotFoundError } from '../../../lib/domain/errors.js';
 import { knex } from '../../../db/knex-database-connection.js';
 import * as competenceRepository from '../../../src/shared/infrastructure/repositories/competence-repository.js';
-import * as areaRepository from './area-repository.js';
+import * as areaRepository from '../../../src/shared/infrastructure/repositories/area-repository.js';
 
 const findProfile = async function ({ campaignId, campaignParticipationId, locale }) {
   const profile = await _fetchCampaignProfileAttributesFromCampaignParticipation(campaignId, campaignParticipationId);

--- a/api/lib/infrastructure/repositories/competence-tree-repository.js
+++ b/api/lib/infrastructure/repositories/competence-tree-repository.js
@@ -1,4 +1,4 @@
-import * as areaRepository from './area-repository.js';
+import * as areaRepository from '../../../src/shared/infrastructure/repositories/area-repository.js';
 import { CompetenceTree } from '../../domain/models/CompetenceTree.js';
 
 const get = async function ({ locale, dependencies = { areaRepository } } = {}) {

--- a/api/lib/infrastructure/repositories/learning-content-repository.js
+++ b/api/lib/infrastructure/repositories/learning-content-repository.js
@@ -5,7 +5,7 @@ import * as tubeRepository from './tube-repository.js';
 import * as thematicRepository from './thematic-repository.js';
 import * as campaignRepository from './campaign-repository.js';
 import * as competenceRepository from '../../../src/shared/infrastructure/repositories/competence-repository.js';
-import * as areaRepository from './area-repository.js';
+import * as areaRepository from '../../../src/shared/infrastructure/repositories/area-repository.js';
 import * as frameworkRepository from './framework-repository.js';
 import * as skillRepository from './skill-repository.js';
 import { LearningContent } from '../../domain/models/LearningContent.js';

--- a/api/lib/infrastructure/repositories/participant-result-repository.js
+++ b/api/lib/infrastructure/repositories/participant-result-repository.js
@@ -5,7 +5,7 @@ import { AssessmentResult } from '../../domain/read-models/participant-results/A
 import * as competenceRepository from '../../../src/shared/infrastructure/repositories/competence-repository.js';
 import * as answerRepository from '../../../src/shared/infrastructure/repositories/answer-repository.js';
 import * as challengeRepository from '../../../src/shared/infrastructure/repositories/challenge-repository.js';
-import * as areaRepository from './area-repository.js';
+import * as areaRepository from '../../../src/shared/infrastructure/repositories/area-repository.js';
 import * as knowledgeElementRepository from './knowledge-element-repository.js';
 import * as flashAssessmentResultRepository from './flash-assessment-result-repository.js';
 import * as campaignRepository from './campaign-repository.js';

--- a/api/src/certification/scoring/infrastructure/repositories/competence-for-scoring-repository.js
+++ b/api/src/certification/scoring/infrastructure/repositories/competence-for-scoring-repository.js
@@ -1,5 +1,5 @@
 import * as competenceRepository from '../../../../shared/infrastructure/repositories/competence-repository.js';
-import * as areaRepository from '../../../../../lib/infrastructure/repositories/area-repository.js';
+import * as areaRepository from '../../../../shared/infrastructure/repositories/area-repository.js';
 import { CompetenceForScoring } from '../../domain/models/CompetenceForScoring.js';
 import { knex } from '../../../../../db/knex-database-connection.js';
 

--- a/api/src/devcomp/infrastructure/repositories/training-trigger-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/training-trigger-repository.js
@@ -4,7 +4,7 @@ import { NotFoundError } from '../../../../lib/domain/errors.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { TrainingTriggerForAdmin } from '../../domain/read-models/TrainingTriggerForAdmin.js';
 import { TrainingTriggerTube } from '../../domain/models/TrainingTriggerTube.js';
-import * as areaRepository from '../../../../lib/infrastructure/repositories/area-repository.js';
+import * as areaRepository from '../../../shared/infrastructure/repositories/area-repository.js';
 import * as competenceRepository from '../../../shared/infrastructure/repositories/competence-repository.js';
 import * as thematicRepository from '../../../../lib/infrastructure/repositories/thematic-repository.js';
 import * as tubeRepository from '../../../../lib/infrastructure/repositories/tube-repository.js';

--- a/api/src/evaluation/domain/usecases/index.js
+++ b/api/src/evaluation/domain/usecases/index.js
@@ -4,7 +4,7 @@ import { dirname, join } from 'node:path';
 import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import * as answerRepository from '../../../shared/infrastructure/repositories/answer-repository.js';
-import * as areaRepository from '../../../../lib/infrastructure/repositories/area-repository.js';
+import * as areaRepository from '../../../shared/infrastructure/repositories/area-repository.js';
 import * as assessmentRepository from '../../../shared/infrastructure/repositories/assessment-repository.js';
 import * as campaignRepository from '../../../../lib/infrastructure/repositories/campaign-repository.js';
 import * as campaignParticipationRepository from '../../../../lib/infrastructure/repositories/campaign-participation-repository.js';

--- a/api/src/school/domain/usecases/index.js
+++ b/api/src/school/domain/usecases/index.js
@@ -5,7 +5,7 @@ import { injectDependencies } from '../../../shared/infrastructure/utils/depende
 
 import * as activityAnswerRepository from '../../infrastructure/repositories/activity-answer-repository.js';
 import * as activityRepository from '../../infrastructure/repositories/activity-repository.js';
-import * as areaRepository from '../../../../lib/infrastructure/repositories/area-repository.js';
+import * as areaRepository from '../../../shared/infrastructure/repositories/area-repository.js';
 import * as assessmentRepository from '../../../shared/infrastructure/repositories/assessment-repository.js';
 import * as challengeRepository from '../../infrastructure/repositories/challenge-repository.js';
 import * as competenceRepository from '../../../shared/infrastructure/repositories/competence-repository.js';

--- a/api/src/shared/infrastructure/repositories/area-repository.js
+++ b/api/src/shared/infrastructure/repositories/area-repository.js
@@ -1,9 +1,9 @@
-import { Area } from '../../domain/models/Area.js';
-import { areaDatasource } from '../datasources/learning-content/area-datasource.js';
-import * as competenceRepository from '../../../src/shared/infrastructure/repositories/competence-repository.js';
-import { getTranslatedKey } from '../../../src/shared/domain/services/get-translated-text.js';
+import { Area } from '../../../../lib/domain/models/Area.js';
+import { areaDatasource } from '../../../../lib/infrastructure/datasources/learning-content/area-datasource.js';
+import * as competenceRepository from './competence-repository.js';
+import { getTranslatedKey } from '../../domain/services/get-translated-text.js';
 import _ from 'lodash';
-import { NotFoundError } from '../../domain/errors.js';
+import { NotFoundError } from '../../../../lib/domain/errors.js';
 
 function _toDomain({ areaData, locale }) {
   const translatedTitle = getTranslatedKey(areaData.title_i18n, locale);

--- a/api/src/shared/infrastructure/repositories/target-profile-for-admin-repository.js
+++ b/api/src/shared/infrastructure/repositories/target-profile-for-admin-repository.js
@@ -5,7 +5,7 @@ import { LOCALE } from '../../domain/constants.js';
 
 const { FRENCH_FRANCE } = LOCALE;
 
-import * as areaRepository from '../../../../lib/infrastructure/repositories/area-repository.js';
+import * as areaRepository from '../../../shared/infrastructure/repositories/area-repository.js';
 import * as competenceRepository from './competence-repository.js';
 import * as thematicRepository from '../../../../lib/infrastructure/repositories/thematic-repository.js';
 import * as tubeRepository from '../../../../lib/infrastructure/repositories/tube-repository.js';

--- a/api/tests/integration/infrastructure/repositories/area-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/area-repository_test.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { expect, domainBuilder, mockLearningContent, catchErr } from '../../../test-helper.js';
 import { Area } from '../../../../lib/domain/models/Area.js';
-import * as areaRepository from '../../../../lib/infrastructure/repositories/area-repository.js';
+import * as areaRepository from '../../../../src/shared/infrastructure/repositories/area-repository.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
 
 describe('Integration | Repository | area-repository', function () {

--- a/api/tests/school/integration/domain/usecases/get-mission_test.js
+++ b/api/tests/school/integration/domain/usecases/get-mission_test.js
@@ -3,7 +3,7 @@ import { expect, mockLearningContent } from '../../../../test-helper.js';
 import { getMission } from '../../../../../src/school/domain/usecases/get-mission.js';
 import * as missionRepository from '../../../../../src/school/infrastructure/repositories/mission-repository.js';
 import * as competenceRepository from '../../../../../src/shared/infrastructure/repositories/competence-repository.js';
-import * as areaRepository from '../../../../../lib/infrastructure/repositories/area-repository.js';
+import * as areaRepository from '../../../../../src/shared/infrastructure/repositories/area-repository.js';
 import * as learningContentBuilder from '../../../../tooling/learning-content-builder/index.js';
 describe('Integration | UseCase | getMission', function () {
   it('Should return a mission', async function () {


### PR DESCRIPTION
## :unicorn: Problème

cf https://github.com/1024pix/pix/blob/dev/docs/adr/0051-nouvelle-arborescence-api.md

## :robot: Proposition

Déplacement de `area-repository.js` vers `src/shared`

## :rainbow: Remarques


## :100: Pour tester

Tests verts 🟢 et rien de changé dans les diverses applications.
