### PR TITLE
[TECH] Utiliser la variable recommandée par l'hébergeur pour alimenter le header de version

### DIFF
--- a/1d/app/adapters/application.js
+++ b/1d/app/adapters/application.js
@@ -7,7 +7,7 @@ export default class Application extends JSONAPIAdapter {
 
   get headers() {
     return {
-      'X-App-Version': ENV.APP.version,
+      'X-App-Version': ENV.APP.APP_VERSION,
     };
   }
 }

--- a/1d/config/environment.js
+++ b/1d/config/environment.js
@@ -25,6 +25,7 @@ module.exports = function (environment) {
       EMBED_ALLOWED_ORIGINS: (
         process.env.EMBED_ALLOWED_ORIGINS || 'https://epreuves.pix.fr,https://1024pix.github.io'
       ).split(','),
+      APP_VERSION: process.env.SOURCE_VERSION || 'development',
     },
     'ember-cli-mirage': {
       usingProxy: true,

--- a/admin/app/adapters/application.js
+++ b/admin/app/adapters/application.js
@@ -14,7 +14,7 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
     if (this.session.isAuthenticated) {
       headers['Authorization'] = `Bearer ${this.session.data.authenticated.access_token}`;
     }
-    headers['X-App-Version'] = ENV.APP.version;
+    headers['X-App-Version'] = ENV.APP.APP_VERSION;
     return headers;
   }
 

--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -81,6 +81,7 @@ module.exports = function (environment) {
         defaultValue: 6,
         minValue: 6,
       }),
+      APP_VERSION: process.env.SOURCE_VERSION || 'development',
     },
 
     'ember-cli-notifications': {

--- a/api/lib/infrastructure/plugins/pino.js
+++ b/api/lib/infrastructure/plugins/pino.js
@@ -10,6 +10,8 @@ function requestSerializer(req) {
   const enhancedReq = {
     ...req,
     version: config.version,
+    clientVersion: req.headers['x-app-version'] || '-',
+    clientVersionMismatched: config.version !== req.headers['x-app-version'],
   };
 
   if (!config.hapi.enableRequestMonitoring) return enhancedReq;

--- a/certif/app/adapters/application.js
+++ b/certif/app/adapters/application.js
@@ -16,7 +16,7 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
       headers['Authorization'] = `Bearer ${this.session.data.authenticated.access_token}`;
     }
     headers['Accept-Language'] = this._locale;
-    headers['X-App-Version'] = ENV.APP.version;
+    headers['X-App-Version'] = ENV.APP.APP_VERSION;
 
     return headers;
   }

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -91,6 +91,7 @@ module.exports = function (environment) {
       }),
       sessionSupervisingPollingRate: process.env.SESSION_SUPERVISING_POLLING_RATE ?? 5000,
       COOKIE_LOCALE_LIFESPAN_IN_SECONDS: 31536000, // 1 year in seconds
+      APP_VERSION: process.env.SOURCE_VERSION || 'development',
     },
 
     matomo: {},

--- a/mon-pix/app/adapters/application.js
+++ b/mon-pix/app/adapters/application.js
@@ -21,7 +21,7 @@ export default class Application extends JSONAPIAdapter {
       headers['Authorization'] = `Bearer ${this.session.data.authenticated.access_token}`;
     }
     headers['Accept-Language'] = this._locale;
-    headers['X-App-Version'] = ENV.APP.version;
+    headers['X-App-Version'] = ENV.APP.APP_VERSION;
     return headers;
   }
 

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -101,6 +101,7 @@ module.exports = function (environment) {
       }),
       COOKIE_LOCALE_LIFESPAN_IN_SECONDS: 31536000, // 1 year in seconds
       AUTONOMOUS_COURSES_ORGANIZATION_ID: parseInt(process.env.AUTONOMOUS_COURSES_ORGANIZATION_ID, 10),
+      APP_VERSION: process.env.SOURCE_VERSION || 'development',
     },
 
     fontawesome: {

--- a/orga/app/adapters/application.js
+++ b/orga/app/adapters/application.js
@@ -21,7 +21,7 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
       headers['Authorization'] = `Bearer ${this.session.data.authenticated.access_token}`;
     }
     headers['Accept-Language'] = this._locale;
-    headers['X-App-Version'] = ENV.APP.version;
+    headers['X-App-Version'] = ENV.APP.APP_VERSION;
     return headers;
   }
 

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -93,6 +93,7 @@ module.exports = function (environment) {
         },
       },
       COOKIE_LOCALE_LIFESPAN_IN_SECONDS: 31536000, // 1 year in seconds
+      APP_VERSION: process.env.SOURCE_VERSION || 'development',
     },
 
     fontawesome: {


### PR DESCRIPTION
## :unicorn: Problème

La version indiquée par les fronts n'est pas identique à celle logguée par l'API, qui elle utilise une variable poussée par l'hébergeur : https://github.com/1024pix/pix/blob/2e0ce02e9a993940cc5ae2ab2b5d07df8261e88c/api/src/shared/config.js#L373 .

## :robot: Proposition

Utiliser la même information via la variable indiquée lors du build : https://doc.scalingo.com/platform/app/environment#build-environment-variables

## :100: Pour tester

Faire un déploiement manuel sur les RA avec une version spécifique, et vérifier que la version "labelisée" lors du déploiement est bien celle  indiquée dans les logs lors des appels : 

```
scalingo --region osc-fr1 --app pix-api-review-pr8258 deploy https://github.com/1024pix/pix/archive/use-same-input-for-app-version.tar.gz v42.1.2
scalingo --region osc-fr1 --app pix-front-review-pr8258 deploy https://github.com/1024pix/pix/archive/use-same-input-for-app-version.tar.gz v42.1.2
```

(J'ai seulement déployé mon-pix pour tester, du coup il faut accéder directement à la RA) 