### PR TITLE
[BUGFIX] Rétablir la création de RT d'un profil-cible (PIX-11508).

### DIFF
--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -279,19 +279,17 @@ const register = async function (server) {
                 title: Joi.string().required().allow('').allow(null),
                 'is-certifiable': Joi.boolean().required(),
                 'is-always-visible': Joi.boolean().required(),
-                'campaign-threshold': Joi.number().min(0).max(100),
-                'capped-tubes-criteria': Joi.array()
-                  .min(1)
-                  .items({
-                    name: Joi.string(),
-                    threshold: Joi.string().required(),
-                    cappedTubes: Joi.array()
-                      .min(1)
-                      .items({
-                        id: Joi.string(),
-                        level: Joi.number().min(0),
-                      }),
-                  }),
+                'campaign-threshold': Joi.number().min(0).max(100).allow(null),
+                'capped-tubes-criteria': Joi.array().items({
+                  name: Joi.string(),
+                  threshold: Joi.string().required(),
+                  cappedTubes: Joi.array()
+                    .min(1)
+                    .items({
+                      id: Joi.string(),
+                      level: Joi.number().min(0),
+                    }),
+                }),
               })
                 .or('campaign-threshold', 'capped-tubes-criteria')
                 .required(),


### PR DESCRIPTION
## :unicorn: Problème

En créant un profil cible avec un RT avec le critère d'attribution suivant :
- sur une sélection de sujets du profil cible
- taux de 70% réussite aux questions de niveau 3.
On obtient ce message : data.attributes.campaign-threshold" must be a number.

De la même façon, en choisissant uniquement un critère d'obtention sur l'ensemble du profil cible, une erreur apparaissait.

## :robot: Proposition

Modifier le modèle de validation JOI.

## :100: Pour tester

Sur admin en RA, créer des nouveaux RT correspondant aux 2 cas de bugs.
