### PR TITLE
[FEATURE][ADMIN] Permettre la création d'organisations avec un identifiant externe déjà présent en base de données (PIX-9785)

### DIFF
--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -61,7 +61,7 @@ const register = async function (server) {
           },
         },
         handler: organizationController.createInBatch,
-        tags: ['api', 'organizations'],
+        tags: ['api', 'admin', 'organizations'],
         notes: [
           "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
             '- Elle permet de créer de nouvelles organisations en masse.',

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -44,11 +44,7 @@ const register = async function (server) {
       config: {
         pre: [
           {
-            method: (request, h) =>
-              securityPreHandlers.hasAtLeastOneAccessOf([securityPreHandlers.checkAdminMemberHasRoleSuperAdmin])(
-                request,
-                h,
-              ),
+            method: securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
             assign: 'hasAuthorizationToAccessAdminScope',
           },
         ],

--- a/api/lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js
+++ b/api/lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js
@@ -15,22 +15,22 @@ import { OrganizationForAdmin } from '../models/index.js';
 import { Organization } from '../models/Organization.js';
 import { OrganizationTag } from '../models/OrganizationTag.js';
 
-const { isEmpty, uniqBy } = lodash;
-
 const SEPARATOR = '_';
+
+const { isEmpty, uniqBy } = lodash;
 
 const createOrganizationsWithTagsAndTargetProfiles = async function ({
   organizations,
   domainTransaction = DomainTransaction,
+  dataProtectionOfficerRepository,
+  organizationInvitationRepository,
   organizationRepository,
+  organizationTagRepository,
+  schoolRepository,
   tagRepository,
   targetProfileShareRepository,
-  organizationTagRepository,
-  organizationInvitationRepository,
-  dataProtectionOfficerRepository,
   organizationValidator,
   organizationInvitationService,
-  schoolRepository,
 }) {
   if (isEmpty(organizations)) {
     throw new ObjectValidationError('Les organisations ne sont pas renseignées.');

--- a/api/lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js
+++ b/api/lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js
@@ -98,7 +98,7 @@ function _transformOrganizationsCsvData(organizationsCsvData) {
         email: organizationCsvData.DPOEmail,
       },
       emailInvitations: organizationCsvData.emailInvitations,
-      tags: organizationCsvData.tags.split(SEPARATOR),
+      tags: isEmpty(organizationCsvData.tags) ? [] : organizationCsvData.tags.split(SEPARATOR),
       targetProfiles: isEmpty(organizationCsvData.targetProfiles)
         ? []
         : organizationCsvData.targetProfiles.split(SEPARATOR).filter((targetProfile) => !!targetProfile.trim()),

--- a/api/lib/domain/validators/organization-with-tags-and-target-profiles-script.js
+++ b/api/lib/domain/validators/organization-with-tags-and-target-profiles-script.js
@@ -21,11 +21,8 @@ const schema = Joi.object({
   name: Joi.string().required().messages({
     'string.empty': 'Le nom n’est pas renseigné.',
   }),
-  tags: Joi.string().required().messages({
-    'string.empty': 'Les tags ne sont pas renseignés.',
-  }),
+  tags: Joi.string().allow('').default(''),
   locale: Joi.string()
-    .required()
     .valid(...supportedLocales)
     .default('fr-fr')
     .messages({
@@ -33,8 +30,8 @@ const schema = Joi.object({
       'any.only': `La locale doit avoir l'une des valeurs suivantes : ${supportedLocales.join(', ')}`,
     }),
   identityProviderForCampaigns: Joi.string().allow(null),
-  provinceCode: Joi.string().required().allow('', null),
-  credit: Joi.number().required().messages({
+  provinceCode: Joi.string().allow('', null),
+  credit: Joi.number().default(0).messages({
     'number.base': 'Le crédit doit être un entier.',
   }),
   emailInvitations: Joi.string().email().allow('', null).messages({

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -104,6 +104,7 @@ const batchCreateOrganizations = async function (
         .returning('*');
 
       const enabledFeatures = _.keys(organization.features).filter((key) => organization.features[key] === true);
+
       for (const featureKey of enabledFeatures) {
         const feature = featuresByKey[featureKey];
         await knexConn('organization-features').insert({
@@ -111,7 +112,11 @@ const batchCreateOrganizations = async function (
           featureId: feature.id,
         });
       }
-      return createdOrganization;
+
+      return {
+        createdOrganization,
+        organizationToCreate: organization,
+      };
     },
     {
       concurrency: CONCURRENCY_HEAVY_OPERATIONS,

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -85,7 +85,8 @@ const batchCreateOrganizations = async function (
 
   return bluebird.map(
     organizations,
-    async (organization) => {
+    async (organizationCsvData) => {
+      const { organization } = organizationCsvData;
       const [createdOrganization] = await knexConn(ORGANIZATIONS_TABLE_NAME)
         .insert(
           _.pick(organization, [
@@ -115,7 +116,7 @@ const batchCreateOrganizations = async function (
 
       return {
         createdOrganization,
-        organizationToCreate: organization,
+        organizationToCreate: organizationCsvData,
       };
     },
     {

--- a/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
+++ b/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
@@ -281,80 +281,80 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
         ]);
       });
     });
-  });
 
-  describe('when one provided tag is not found in database', function () {
-    it('should rollback', async function () {
-      // given
-      databaseBuilder.factory.buildTargetProfile({ id: 123, ownerOrganizationId: null }).id;
-      await databaseBuilder.commit();
+    describe('when one provided tag is not found in database', function () {
+      it('should rollback', async function () {
+        // given
+        databaseBuilder.factory.buildTargetProfile({ id: 123, ownerOrganizationId: null }).id;
+        await databaseBuilder.commit();
 
-      const organizationsWithTagsNotExists = [
-        {
-          type: 'PRO',
-          externalId: 'b400',
-          name: 'Mathieu Bâtiment',
-          provinceCode: '567',
-          credit: 20,
-          emailInvitations: 'mathieu@example.net',
-          locale: 'fr-fr',
-          tags: 'TagNotFound_AnotherTagNotFound',
-          targetProfiles: '123',
-          createdBy: userId,
-          documentationUrl: 'http://www.pix.fr',
-          organizationInvitationRole: 'ADMIN',
-        },
-        {
-          type: 'PRO',
-          externalId: 'b200',
-          name: 'Youness et Fils',
-          provinceCode: '123',
-          credit: 0,
-          emailInvitations: 'youness@example.net',
-          locale: 'fr-fr',
-          tags: 'TagNotFound',
-          targetProfiles: '123',
-          createdBy: userId,
-          documentationUrl: 'http://www.pix.fr',
-          organizationInvitationRole: 'MEMBER',
-        },
-        {
-          type: 'PRO',
-          externalId: 'b300',
-          name: 'Andreia & Co',
-          provinceCode: '345',
-          credit: 10,
-          emailInvitations: 'andreia@example.net',
-          locale: 'fr-fr',
-          tags: 'AnotherTagNotFound',
-          targetProfiles: '123',
-          createdBy: userId,
-          documentationUrl: 'http://www.pix.fr',
-          organizationInvitationRole: 'ADMIN',
-        },
-      ];
+        const organizationsWithTagsNotExists = [
+          {
+            type: 'PRO',
+            externalId: 'b400',
+            name: 'Mathieu Bâtiment',
+            provinceCode: '567',
+            credit: 20,
+            emailInvitations: 'mathieu@example.net',
+            locale: 'fr-fr',
+            tags: 'TagNotFound_AnotherTagNotFound',
+            targetProfiles: '123',
+            createdBy: userId,
+            documentationUrl: 'http://www.pix.fr',
+            organizationInvitationRole: 'ADMIN',
+          },
+          {
+            type: 'PRO',
+            externalId: 'b200',
+            name: 'Youness et Fils',
+            provinceCode: '123',
+            credit: 0,
+            emailInvitations: 'youness@example.net',
+            locale: 'fr-fr',
+            tags: 'TagNotFound',
+            targetProfiles: '123',
+            createdBy: userId,
+            documentationUrl: 'http://www.pix.fr',
+            organizationInvitationRole: 'MEMBER',
+          },
+          {
+            type: 'PRO',
+            externalId: 'b300',
+            name: 'Andreia & Co',
+            provinceCode: '345',
+            credit: 10,
+            emailInvitations: 'andreia@example.net',
+            locale: 'fr-fr',
+            tags: 'AnotherTagNotFound',
+            targetProfiles: '123',
+            createdBy: userId,
+            documentationUrl: 'http://www.pix.fr',
+            organizationInvitationRole: 'ADMIN',
+          },
+        ];
 
-      // when
-      const error = await catchErr(createOrganizationsWithTagsAndTargetProfiles)({
-        domainTransaction,
-        organizations: organizationsWithTagsNotExists,
-        organizationRepository,
-        tagRepository,
-        targetProfileShareRepository,
-        organizationTagRepository,
-        organizationInvitationRepository,
-        dataProtectionOfficerRepository,
-        organizationValidator,
-        organizationInvitationService,
+        // when
+        const error = await catchErr(createOrganizationsWithTagsAndTargetProfiles)({
+          domainTransaction,
+          organizations: organizationsWithTagsNotExists,
+          organizationRepository,
+          tagRepository,
+          targetProfileShareRepository,
+          organizationTagRepository,
+          organizationInvitationRepository,
+          dataProtectionOfficerRepository,
+          organizationValidator,
+          organizationInvitationService,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(OrganizationTagNotFound);
+        expect(error.message).to.be.equal("Le tag TagNotFound de l'organisation Mathieu Bâtiment n'existe pas.");
+        const organizationsInDB = await knex('organizations').select();
+        expect(organizationsInDB.length).to.equal(0);
+        const organizationTagsInDB = await knex('organization-tags').select();
+        expect(organizationTagsInDB.length).to.equal(0);
       });
-
-      // then
-      expect(error).to.be.instanceOf(OrganizationTagNotFound);
-      expect(error.message).to.be.equal("Le tag TagNotFound de l'organisation Mathieu Bâtiment n'existe pas.");
-      const organizationsInDB = await knex('organizations').select();
-      expect(organizationsInDB.length).to.equal(0);
-      const organizationTagsInDB = await knex('organization-tags').select();
-      expect(organizationTagsInDB.length).to.equal(0);
     });
   });
 

--- a/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
+++ b/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
@@ -34,7 +34,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
     await databaseBuilder.commit();
   });
 
-  describe('validation error cases', function () {
+  describe('#errors', function () {
     context('when provided CSV file is empty', function () {
       it('throws an error', async function () {
         // given
@@ -700,7 +700,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
     });
   });
 
-  describe('when organization type id SCO-1D', function () {
+  describe('when organization type is SCO-1D', function () {
     it('should add mission management feature to organization', async function () {
       // given
       databaseBuilder.factory.buildTag({ name: 'TAG1' });

--- a/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
+++ b/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
@@ -113,10 +113,6 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
             message: 'Le nom n’est pas renseigné.',
           },
           {
-            attribute: 'tags',
-            message: 'Les tags ne sont pas renseignés.',
-          },
-          {
             attribute: 'locale',
             message: "La locale doit avoir l'une des valeurs suivantes : en, fr, fr-be, fr-fr, nl-be",
           },

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -983,6 +983,7 @@ describe('Integration | Repository | Organization', function () {
 
   describe('#batchCreateOrganizations', function () {
     let computeOrganizationLearnerCertificabilityId;
+
     beforeEach(async function () {
       computeOrganizationLearnerCertificabilityId = databaseBuilder.factory.buildFeature(
         ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY,
@@ -1029,6 +1030,43 @@ describe('Integration | Repository | Organization', function () {
       expect(foundOrganizations[0].provinceCode).to.equal(organization.provinceCode);
       expect(foundOrganizations[0].createdBy).to.equal(organization.createdBy);
       expect(foundOrganizations[0].documentationUrl).to.equal(organization.documentationUrl);
+    });
+
+    context('when organization is added', function () {
+      it('returns organization data to create and created organization', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const organizationsToCreate = [
+          domainBuilder.buildOrganizationForAdmin({
+            id: null,
+            externalId: '1237457A',
+            name: 'Orga 1',
+            createdBy: userId,
+          }),
+        ];
+
+        await databaseBuilder.commit();
+
+        // when
+        const createdOrganizations = await organizationRepository.batchCreateOrganizations(organizationsToCreate);
+
+        // then
+        expect(createdOrganizations).to.have.lengthOf(1);
+
+        const { createdOrganization, organizationToCreate } = createdOrganizations[0];
+        expect(organizationToCreate).to.include({
+          id: null,
+          externalId: '1237457A',
+          name: 'Orga 1',
+          createdBy: userId,
+        });
+        expect(createdOrganization).to.include({
+          id: createdOrganization.id,
+          externalId: '1237457A',
+          name: 'Orga 1',
+          createdBy: userId,
+        });
+      });
     });
 
     it('should enable compute organization learner certificability feature for sco organization managing students', async function () {

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -997,7 +997,10 @@ describe('Integration | Repository | Organization', function () {
       const organization2 = domainBuilder.buildOrganizationForAdmin();
 
       // when
-      await organizationRepository.batchCreateOrganizations([organization1, organization2]);
+      await organizationRepository.batchCreateOrganizations([
+        { organization: organization1 },
+        { organization: organization2 },
+      ]);
 
       // then
       const foundOrganizations = await knex('organizations').select();
@@ -1020,7 +1023,7 @@ describe('Integration | Repository | Organization', function () {
       });
 
       // when
-      await organizationRepository.batchCreateOrganizations([organization]);
+      await organizationRepository.batchCreateOrganizations([{ organization }]);
 
       // then
       const foundOrganizations = await knex('organizations').select();
@@ -1036,14 +1039,15 @@ describe('Integration | Repository | Organization', function () {
       it('returns organization data to create and created organization', async function () {
         // given
         const userId = databaseBuilder.factory.buildUser().id;
-        const organizationsToCreate = [
-          domainBuilder.buildOrganizationForAdmin({
+        const organizationFormattedCsvData = {
+          organization: domainBuilder.buildOrganizationForAdmin({
             id: null,
             externalId: '1237457A',
             name: 'Orga 1',
             createdBy: userId,
           }),
-        ];
+        };
+        const organizationsToCreate = [organizationFormattedCsvData];
 
         await databaseBuilder.commit();
 
@@ -1054,12 +1058,7 @@ describe('Integration | Repository | Organization', function () {
         expect(createdOrganizations).to.have.lengthOf(1);
 
         const { createdOrganization, organizationToCreate } = createdOrganizations[0];
-        expect(organizationToCreate).to.include({
-          id: null,
-          externalId: '1237457A',
-          name: 'Orga 1',
-          createdBy: userId,
-        });
+        expect(organizationToCreate).to.include(organizationFormattedCsvData);
         expect(createdOrganization).to.include({
           id: createdOrganization.id,
           externalId: '1237457A',
@@ -1090,7 +1089,14 @@ describe('Integration | Repository | Organization', function () {
         organizationScoManagingStudent.isManagingStudents;
 
       // when
-      await organizationRepository.batchCreateOrganizations([organizationScoManagingStudent, otherOrganization]);
+      await organizationRepository.batchCreateOrganizations([
+        {
+          organization: organizationScoManagingStudent,
+        },
+        {
+          organization: otherOrganization,
+        },
+      ]);
 
       const savedOrganizationFeatures = await knex('organization-features');
 
@@ -1117,7 +1123,7 @@ describe('Integration | Repository | Organization', function () {
       });
 
       // when
-      await organizationRepository.batchCreateOrganizations([organization]);
+      await organizationRepository.batchCreateOrganizations([{ organization }]);
 
       const savedOrganizationFeatures = await knex('organization-features');
       const savedOrganizations = await knex('organizations');

--- a/api/tests/unit/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
+++ b/api/tests/unit/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
@@ -97,8 +97,18 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
         organizationRepositoryStub.findByExternalIdsFetchingIdsOnly.resolves([]);
         tagRepositoryStub.findAll.resolves(allTags);
         organizationRepositoryStub.batchCreateOrganizations.resolves([
-          domainBuilder.buildOrganization(firstOrganization),
-          domainBuilder.buildOrganization(secondOrganization),
+          {
+            createdOrganization: domainBuilder.buildOrganization(firstOrganization),
+            organizationToCreate: {
+              ...firstOrganization,
+              tags: firstOrganization.tags?.split('_') ?? [],
+              targetProfiles: firstOrganization.targetProfiles?.split('_') ?? [],
+            },
+          },
+          {
+            createdOrganization: domainBuilder.buildOrganization(secondOrganization),
+            organizationToCreate: secondOrganization,
+          },
         ]);
 
         // when
@@ -122,20 +132,28 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
 
   it('validates organization data before trying to create organizations', async function () {
     // given
-    const organizations = [
-      {
-        name: '',
-        externalId: 'AB1234',
-        emailInvitations: 'fake@axample.net',
-        createdBy: 4,
-        tags: 'tag1_tag2',
-        targetProfiles: '123',
-      },
-    ];
+    const organization = {
+      name: '',
+      externalId: 'AB1234',
+      emailInvitations: 'fake@axample.net',
+      createdBy: 4,
+      tags: 'tag1_tag2',
+      targetProfiles: '123',
+    };
+    const organizations = [organization];
 
     // when
     tagRepositoryStub.findAll.resolves(allTags);
-    organizationRepositoryStub.batchCreateOrganizations.resolves(organizations);
+    organizationRepositoryStub.batchCreateOrganizations.resolves([
+      {
+        createdOrganization: domainBuilder.buildOrganization(organization),
+        organizationToCreate: {
+          ...organization,
+          tags: organization.tags?.split('_') ?? [],
+          targetProfiles: organization.targetProfiles?.split('_') ?? [],
+        },
+      },
+    ]);
 
     // when
     await createOrganizationsWithTagsAndTargetProfiles({
@@ -188,9 +206,53 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
       email: organizationSCO.emailForSCOActivation,
     });
 
-    const expectedProOrganizationToInsert = [organizationPROToCreate, organizationSCOToCreate];
+    const expectedProOrganizationToInsert = [
+      {
+        organization: organizationPROToCreate,
+        tags: organizationPRO.tags?.split('_') ?? [],
+        targetProfiles: organizationPRO.targetProfiles?.split('_') ?? [],
+        role: undefined,
+        dataProtectionOfficer: {
+          email: undefined,
+          firstName: undefined,
+          lastName: undefined,
+        },
+        emailInvitations: organizationPRO.emailInvitations,
+        locale: undefined,
+      },
+      {
+        organization: organizationSCOToCreate,
+        tags: organizationSCO.tags?.split('_') ?? [],
+        targetProfiles: organizationSCO.targetProfiles?.split('_') ?? [],
+        role: undefined,
+        dataProtectionOfficer: {
+          email: undefined,
+          firstName: undefined,
+          lastName: undefined,
+        },
+        emailInvitations: organizationSCO.emailInvitations,
+        locale: undefined,
+      },
+    ];
     tagRepositoryStub.findAll.resolves(allTags);
-    organizationRepositoryStub.batchCreateOrganizations.resolves([organizationPROToCreate, organizationSCOToCreate]);
+    organizationRepositoryStub.batchCreateOrganizations.resolves([
+      {
+        createdOrganization: organizationPROToCreate,
+        organizationToCreate: {
+          ...organizationPRO,
+          tags: organizationPRO.tags?.split('_') ?? [],
+          targetProfiles: organizationPRO.targetProfiles?.split('_') ?? [],
+        },
+      },
+      {
+        createdOrganization: organizationSCOToCreate,
+        organizationToCreate: {
+          ...organizationSCO,
+          tags: organizationSCO.tags?.split('_') ?? [],
+          targetProfiles: organizationSCO.targetProfiles?.split('_') ?? [],
+        },
+      },
+    ]);
 
     // when
     await createOrganizationsWithTagsAndTargetProfiles({
@@ -245,8 +307,22 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
     organizationRepositoryStub.findByExternalIdsFetchingIdsOnly.resolves([]);
     tagRepositoryStub.findAll.resolves(allTags);
     organizationRepositoryStub.batchCreateOrganizations.resolves([
-      domainBuilder.buildOrganization(firstOrganization),
-      domainBuilder.buildOrganization(secondOrganization),
+      {
+        createdOrganization: domainBuilder.buildOrganization(firstOrganization),
+        organizationToCreate: {
+          ...firstOrganization,
+          tags: firstOrganization.tags?.split('_') ?? [],
+          targetProfiles: firstOrganization.targetProfiles?.split('_') ?? [],
+        },
+      },
+      {
+        createdOrganization: domainBuilder.buildOrganization(secondOrganization),
+        organizationToCreate: {
+          ...secondOrganization,
+          tags: secondOrganization.tags?.split('_') ?? [],
+          targetProfiles: secondOrganization.targetProfiles?.split('_') ?? [],
+        },
+      },
     ]);
 
     // when
@@ -292,8 +368,22 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
     organizationRepositoryStub.findByExternalIdsFetchingIdsOnly.resolves([]);
     tagRepositoryStub.findAll.resolves(allTags);
     organizationRepositoryStub.batchCreateOrganizations.resolves([
-      domainBuilder.buildOrganization(firstOrganization),
-      domainBuilder.buildOrganization(secondOrganization),
+      {
+        createdOrganization: domainBuilder.buildOrganization(firstOrganization),
+        organizationToCreate: {
+          ...firstOrganization,
+          tags: firstOrganization.tags?.split('_') ?? [],
+          targetProfiles: firstOrganization.targetProfiles?.split('_') ?? [],
+        },
+      },
+      {
+        createdOrganization: domainBuilder.buildOrganization(secondOrganization),
+        organizationToCreate: {
+          ...secondOrganization,
+          tags: secondOrganization.tags?.split('_') ?? [],
+          targetProfiles: secondOrganization.targetProfiles?.split('_') ?? [],
+        },
+      },
     ]);
 
     // when
@@ -346,8 +436,27 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
     organizationRepositoryStub.findByExternalIdsFetchingIdsOnly.resolves([]);
     tagRepositoryStub.findAll.resolves(allTags);
     organizationRepositoryStub.batchCreateOrganizations.resolves([
-      domainBuilder.buildOrganization(firstOrganization),
-      domainBuilder.buildOrganization(secondOrganization),
+      {
+        createdOrganization: domainBuilder.buildOrganization(firstOrganization),
+        organizationToCreate: {
+          ...firstOrganization,
+          tags: firstOrganization.tags?.split('_') ?? [],
+          targetProfiles: firstOrganization.targetProfiles?.split('_') ?? [],
+          dataProtectionOfficer: {
+            email: firstOrganization.DPOEmail,
+            firstName: firstOrganization.DPOFirstName,
+            lastName: firstOrganization.DPOLastName,
+          },
+        },
+      },
+      {
+        createdOrganization: domainBuilder.buildOrganization(secondOrganization),
+        organizationToCreate: {
+          ...secondOrganization,
+          tags: secondOrganization.tags?.split('_') ?? [],
+          targetProfiles: secondOrganization.targetProfiles?.split('_') ?? [],
+        },
+      },
     ]);
 
     // when
@@ -398,8 +507,24 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
     organizationRepositoryStub.findByExternalIdsFetchingIdsOnly.resolves([]);
     tagRepositoryStub.findAll.resolves(allTags);
     organizationRepositoryStub.batchCreateOrganizations.resolves([
-      domainBuilder.buildOrganization(firstOrganizationWithAdminRole),
-      domainBuilder.buildOrganization(secondOrganizationWithMemberRole),
+      {
+        createdOrganization: domainBuilder.buildOrganization(firstOrganizationWithAdminRole),
+        organizationToCreate: {
+          ...firstOrganizationWithAdminRole,
+          tags: firstOrganizationWithAdminRole.tags?.split('_') ?? [],
+          targetProfiles: firstOrganizationWithAdminRole.targetProfiles?.split('_') ?? [],
+          role: firstOrganizationWithAdminRole.organizationInvitationRole,
+        },
+      },
+      {
+        createdOrganization: domainBuilder.buildOrganization(secondOrganizationWithMemberRole),
+        organizationToCreate: {
+          ...secondOrganizationWithMemberRole,
+          tags: secondOrganizationWithMemberRole.tags?.split('_') ?? [],
+          targetProfiles: secondOrganizationWithMemberRole.targetProfiles?.split('_') ?? [],
+          role: secondOrganizationWithMemberRole.organizationInvitationRole,
+        },
+      },
     ]);
 
     // when
@@ -454,7 +579,14 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
       organizationRepositoryStub.findByExternalIdsFetchingIdsOnly.resolves([]);
       tagRepositoryStub.findAll.resolves(allTags);
       organizationRepositoryStub.batchCreateOrganizations.resolves([
-        domainBuilder.buildOrganization(organizationWithoutEmail),
+        {
+          createdOrganization: domainBuilder.buildOrganization(organizationWithoutEmail),
+          organizationToCreate: {
+            ...organizationWithoutEmail,
+            tags: organizationWithoutEmail.tags?.split('_') ?? [],
+            targetProfiles: organizationWithoutEmail.targetProfiles?.split('_') ?? [],
+          },
+        },
       ]);
 
       // when

--- a/api/tests/unit/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
+++ b/api/tests/unit/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
@@ -4,6 +4,7 @@ import { Membership } from '../../../../lib/domain/models/Membership.js';
 import { OrganizationTag } from '../../../../lib/domain/models/OrganizationTag.js';
 import { createOrganizationsWithTagsAndTargetProfiles } from '../../../../lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js';
 import { DomainTransaction as domainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
+import { monitoringTools } from '../../../../lib/infrastructure/monitoring-tools.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';
 
 describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', function () {
@@ -53,6 +54,7 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
     };
 
     organizationInvitationService.createProOrganizationInvitation.resolves();
+    sinon.stub(monitoringTools, 'logErrorWithCorrelationIds');
   });
 
   context('#errors', function () {
@@ -126,6 +128,13 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
         // then
         expect(error).to.be.instanceOf(OrganizationTagNotFound);
         expect(error.message).to.be.equal("Le tag TagNotFound de l'organisation organization A n'existe pas.");
+        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith({
+          message: `Le tag TagNotFound de l'organisation organization A n'existe pas.`,
+          context: 'create-organizations-with-tags-and-target-profiles',
+          error: { name: 'OrganizationTagNotFound' },
+          event: 'add-organizations-tags',
+          team: 'acces',
+        });
       });
     });
   });

--- a/api/tests/unit/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
+++ b/api/tests/unit/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
@@ -1,9 +1,4 @@
-import {
-  ManyOrganizationsFoundError,
-  ObjectValidationError,
-  OrganizationAlreadyExistError,
-  OrganizationTagNotFound,
-} from '../../../../lib/domain/errors.js';
+import { ObjectValidationError, OrganizationTagNotFound } from '../../../../lib/domain/errors.js';
 import { OrganizationForAdmin } from '../../../../lib/domain/models/index.js';
 import { Membership } from '../../../../lib/domain/models/Membership.js';
 import { OrganizationTag } from '../../../../lib/domain/models/OrganizationTag.js';
@@ -70,17 +65,6 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
     // then
     expect(error).to.be.an.instanceOf(ObjectValidationError);
     expect(error.message).to.be.equals('Les organisations ne sont pas renseignées.');
-  });
-
-  it('should throw an error if the same organization appears twice', async function () {
-    // given
-    const organizations = [{ externalId: 'externalId' }, { externalId: 'externalId' }];
-
-    // when
-    const error = await catchErr(createOrganizationsWithTagsAndTargetProfiles)({ organizations });
-
-    // then
-    expect(error).to.be.an.instanceOf(ManyOrganizationsFoundError);
   });
 
   it('should validate organization data before trying to create organizations', async function () {
@@ -482,32 +466,5 @@ describe('Unit | UseCase | create-organizations-with-tags-and-target-profiles', 
 
     // then
     expect(organizationInvitationService.createProOrganizationInvitation).to.not.have.been.called;
-  });
-
-  context('when an organization already exists in database', function () {
-    it('should throw an error', async function () {
-      // given
-
-      const organizations = [
-        { externalId: 'Ab1234', name: 'fake', emailInvitations: 'fake@axample.net', createdBy: 4 },
-        { externalId: 'Cd456', name: 'fake', emailInvitations: 'fake@axample.net', createdBy: 4 },
-      ];
-      organizationRepositoryStub.findByExternalIdsFetchingIdsOnly.resolves([
-        { id: '1', externalId: 'Ab1234' },
-        { id: '2', externalId: 'Cd456' },
-      ]);
-
-      // when
-      const error = await catchErr(createOrganizationsWithTagsAndTargetProfiles)({
-        organizations,
-        organizationRepository: organizationRepositoryStub,
-        organizationValidator,
-        organizationInvitationService,
-      });
-
-      // then
-      expect(error).to.be.an.instanceOf(OrganizationAlreadyExistError);
-      expect(error.message).to.equal('Les organisations avec les externalIds suivants : Ab1234, Cd456 existent déjà.');
-    });
   });
 });

--- a/api/tests/unit/domain/validators/organization-with-tags-and-target-profiles-script_test.js
+++ b/api/tests/unit/domain/validators/organization-with-tags-and-target-profiles-script_test.js
@@ -1,11 +1,13 @@
+import { Organization } from '../../../../lib/domain/models/index.js';
 import { validate } from '../../../../lib/domain/validators/organization-with-tags-and-target-profiles-script.js';
 import { SUPPORTED_LOCALES } from '../../../../src/shared/domain/constants.js';
 import { EntityValidationError } from '../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../test-helper.js';
 
+const organizationTypes = [...Object.values(Organization.types)];
 const supportedLocales = SUPPORTED_LOCALES.map((supportedLocale) => supportedLocale.toLocaleLowerCase());
 
-describe('Unit | Domain | Validators | organization-with-tags-and-target-profiles-script', function () {
+describe('Unit | Domain | Validators | organization-with-tags-and-target-profiles-script.js', function () {
   const DEFAULT_ORGANIZATION = {
     createdBy: 1234,
     credit: 0,
@@ -36,9 +38,52 @@ describe('Unit | Domain | Validators | organization-with-tags-and-target-profile
         });
       });
     });
+
+    context('when all required properties are provided', function () {
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      organizationTypes.forEach((organizationType) => {
+        context(`when organization type is ${organizationType}`, function () {
+          it('returns "true"', function () {
+            // given
+            const organization = {
+              type: organizationType,
+              externalId: 'EXTERNAL_ID',
+              name: 'Organization Name',
+              createdBy: 0,
+            };
+
+            // when
+            const result = validate(organization);
+
+            // then
+            expect(result).to.be.true;
+          });
+        });
+      });
+    });
   });
 
   context('error', function () {
+    context('when one of or all required properties is not provided', function () {
+      it('returns an EntityValidation error', function () {
+        // given
+        const organization = {};
+
+        // when
+        const error = catchErrSync(validate)(organization);
+
+        // then
+        expect(error).to.be.instanceOf(EntityValidationError);
+        expect(error.message).to.equal(`Échec de validation de l'entité.`);
+        expect(error.invalidAttributes).to.have.deep.members([
+          { attribute: 'type', message: '"type" is required' },
+          { attribute: 'externalId', message: '"externalId" is required' },
+          { attribute: 'name', message: '"name" is required' },
+          { attribute: 'createdBy', message: "L'id du créateur est manquant" },
+        ]);
+      });
+    });
+
     context(`when locale is not supported`, function () {
       it('returns an EntityValidation error', function () {
         // given


### PR DESCRIPTION
## :unicorn: Problème

Il y a un besoin de créer plusieurs organisations avec le même identifiant externe, car il y a le besoin parfois de créer N orgas avec le même externalid (=SIRET). Mais pour le moment ce n'est pas possible avec Pix Admin OGA. Il existe une règle métier qui interdit la création de plusieurs organisations avec le même identifiant externe. Cette règle métier n'est validée que dans le usecase et pas comme contrainte en base de données.

Les agents qui doivent faire cette création malgré tout, doivent faire plusieurs manipulation pour y arriver :

1. ajouter une lettre ou un chiffre en plus pour rendre l'organisation unique
2. retirer cette lettre ou ce chiffre via metabase après création de l'organisation

## :robot: Proposition

Retirer la contrainte métier dans le usecase.

## :rainbow: Remarques

⚠️  Il faudrait vérifier que toutes les fonctionnalités dépendantes de l'identifiant externe (externalId) ne soient pas impactées par cette modification (ex: recherche avec un identifiant externe retournera potentiellement un tableau et plus un élément)

## :100: Pour tester

1. Se connecter sur **Pix Admin** (https://admin-pr8264.review.pix.fr/) avec un compte ayant le rôle **SUPER_ADMIN**
2. Cliquer sur l'onglet **Administration** (avant dernier élément du menu)
3. Cliquer sur le bouton **Importer un fichier CSV** du bloc **Création en masse d'organisations**
4. Importer un CSV contenant une organisation ayant le même identifiant externe (externalId) qu'une organisation existante en base de données. _Ne pas oublier d'ajouter l'id du compte sur lequel vous êtes connecté en tant que créateur de l'organisation (colonne createdBy)_.
5. Constater l'affichage d'une notification de succès
6. Effectuer l'étape 3 à 5 autant de fois que vous le souhaitez
7. Cliquer sur l'onglet **Organisations**
8. Filtrer la liste par **externalId** avec votre identifiant externe
9. Constater que les organisations que vous avez créé sont bien présentes

Voici un fichier CSV pour vos tests

```
type,externalId,name,provinceCode,credit,emailInvitations,emailForSCOActivation,organizationInvitationRole,locale,tags,createdBy,documentationUrl,targetProfiles,isManagingStudents,identityProviderForCampaigns,DPOFirstName,DPOLastName,DPOEmail
PRO,EXT_ID_DUP,PRO Orga 1,,,,,ADMIN,fr-fr,PUBLIC,90000,,,,,,,
PRO,EXT_ID_DUP,PRO Orga 2,,,,,ADMIN,fr-fr,PUBLIC,90000,,,,,,,
SCO,EXT_ID_DUP,SCO Orga 1,,,,,ADMIN,fr-fr,PUBLIC,90000,,,,,,,
SCO-1D,EXT_ID_DUP,SCO-1D Orga 1,,,,,ADMIN,fr-fr,PUBLIC,90000,,,,,,,
SCO-1D,EXT_ID_DUP,SCO-1D Orga 2,,,,,ADMIN,fr-fr,PUBLIC,90000,,,,,,,
```
