### PR TITLE
[FEATURE] Afficher un commentaire auto jury en cas de réponses insuffisantes pour la certification V3 (PIX-10530).

### DIFF
--- a/api/lib/domain/events/handle-auto-jury.js
+++ b/api/lib/domain/events/handle-auto-jury.js
@@ -158,7 +158,7 @@ async function _autoCompleteUnfinishedTest({
     certificationAssessment.skipUnansweredChallenges();
   }
 
-  if (certificationCourse.isAbortReasonCandidateUnrelated()) {
+  if (certificationCourse.isAbortReasonTechnical()) {
     certificationAssessment.neutralizeUnansweredChallenges();
   }
 

--- a/api/lib/domain/events/handle-certification-scoring.js
+++ b/api/lib/domain/events/handle-certification-scoring.js
@@ -53,7 +53,7 @@ async function handleCertificationScoring({
       });
     }
 
-    return _calculateCertificationScore({
+    return _handleV2CertificationScoring({
       certificationAssessment,
       assessmentResultRepository,
       certificationCourseRepository,
@@ -66,7 +66,7 @@ async function handleCertificationScoring({
   return null;
 }
 
-async function _calculateCertificationScore({
+async function _handleV2CertificationScoring({
   certificationAssessment,
   assessmentResultRepository,
   certificationCourseRepository,
@@ -80,7 +80,7 @@ async function _calculateCertificationScore({
     });
     const certificationCourse = await certificationCourseRepository.get(certificationAssessment.certificationCourseId);
     certificationCourse.complete({ now: new Date() });
-    await _saveResult({
+    await _saveV2Result({
       certificationAssessmentScore,
       certificationAssessment,
       assessmentResultRepository,
@@ -164,7 +164,13 @@ async function _handleV3CertificationScoring({
 
   await certificationAssessmentHistoryRepository.save(certificationAssessmentHistory);
 
-  await _saveResult({
+  const assessmentResult = await _createV3AssessmentResult({
+    certificationAssessment,
+    certificationAssessmentScore,
+  });
+
+  await _saveV3Result({
+    assessmentResult,
     certificationAssessment,
     certificationAssessmentScore,
     assessmentResultRepository,
@@ -187,7 +193,7 @@ function _shouldCancelV3Certification({ allAnswers, certificationCourse }) {
   );
 }
 
-async function _saveResult({
+async function _saveV2Result({
   certificationAssessment,
   certificationAssessmentScore,
   assessmentResultRepository,
@@ -195,7 +201,7 @@ async function _saveResult({
   certificationCourseRepository,
   competenceMarkRepository,
 }) {
-  const assessmentResult = await _createAssessmentResult({
+  const assessmentResult = await _createV2AssessmentResult({
     certificationAssessment,
     certificationAssessmentScore,
     assessmentResultRepository,
@@ -211,7 +217,31 @@ async function _saveResult({
   return certificationCourseRepository.update(certificationCourse);
 }
 
-function _createAssessmentResult({
+async function _saveV3Result({
+  assessmentResult,
+  certificationAssessment,
+  certificationAssessmentScore,
+  assessmentResultRepository,
+  certificationCourse,
+  certificationCourseRepository,
+  competenceMarkRepository,
+}) {
+  const newAssessmentResult = await assessmentResultRepository.save({
+    certificationCourseId: certificationAssessment.certificationCourseId,
+    assessmentResult,
+  });
+
+  await bluebird.mapSeries(certificationAssessmentScore.competenceMarks, (competenceMark) => {
+    const competenceMarkDomain = new CompetenceMark({
+      ...competenceMark,
+      assessmentResultId: newAssessmentResult.id,
+    });
+    return competenceMarkRepository.save(competenceMarkDomain);
+  });
+  return certificationCourseRepository.update(certificationCourse);
+}
+
+function _createV2AssessmentResult({
   certificationAssessment,
   certificationAssessmentScore,
   assessmentResultRepository,
@@ -226,6 +256,16 @@ function _createAssessmentResult({
   return assessmentResultRepository.save({
     certificationCourseId: certificationAssessment.certificationCourseId,
     assessmentResult,
+  });
+}
+
+function _createV3AssessmentResult({ certificationAssessment, certificationAssessmentScore }) {
+  return AssessmentResultFactory.buildStandardAssessmentResult({
+    pixScore: certificationAssessmentScore.nbPix,
+    reproducibilityRate: certificationAssessmentScore.getPercentageCorrectAnswers(),
+    status: certificationAssessmentScore.status,
+    assessmentId: certificationAssessment.id,
+    emitter: EMITTER,
   });
 }
 

--- a/api/lib/domain/models/CertificationCourse.js
+++ b/api/lib/domain/models/CertificationCourse.js
@@ -216,7 +216,7 @@ class CertificationCourse {
     return this._abortReason === ABORT_REASONS.CANDIDATE;
   }
 
-  isAbortReasonCandidateUnrelated() {
+  isAbortReasonTechnical() {
     return this._abortReason === ABORT_REASONS.TECHNICAL;
   }
 

--- a/api/lib/domain/models/CertificationResult.js
+++ b/api/lib/domain/models/CertificationResult.js
@@ -143,13 +143,6 @@ class CertificationResult {
     return this.status === status.STARTED;
   }
 
-  hasBeenRejectedAutomatically() {
-    return (
-      this.status === status.REJECTED &&
-      (this.emitter === emitters.PIX_ALGO || this.emitter === emitters.PIX_ALGO_AUTO_JURY)
-    );
-  }
-
   getUniqComplementaryCertificationCourseResultLabels() {
     return [
       ...new Set(

--- a/api/lib/infrastructure/utils/csv/certification-results/CertificationResultsCsvValues.js
+++ b/api/lib/infrastructure/utils/csv/certification-results/CertificationResultsCsvValues.js
@@ -84,11 +84,7 @@ class CertificationResultsCsvValues {
   }
 
   getCommentForOrganization(certificationResult) {
-    if (certificationResult.hasBeenRejectedAutomatically()) {
-      return this.getTranslation(CertificationResultsCsvValues.VALUES.REJECTED_AUTOMATICALLY_COMMENT);
-    }
-
-    return certificationResult.commentForOrganization.getComment(this.translate);
+    return certificationResult.commentForOrganization?.getComment(this.translate);
   }
 
   getComplementaryCertificationStatus({ certificationResult, sessionComplementaryCertificationsLabel }) {

--- a/api/src/certification/scoring/domain/models/factories/AssessmentResultFactory.js
+++ b/api/src/certification/scoring/domain/models/factories/AssessmentResultFactory.js
@@ -71,4 +71,28 @@ export class AssessmentResultFactory {
       competenceMarks,
     });
   }
+
+  static buildLackOfAnswers({ pixScore, reproducibilityRate, status, assessmentId, juryId, emitter, competenceMarks }) {
+    const commentForCandidate = new JuryComment({
+      context: JuryCommentContexts.CANDIDATE,
+      commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_LACK_OF_ANSWERS,
+    });
+
+    const commentForOrganization = new JuryComment({
+      context: JuryCommentContexts.ORGANIZATION,
+      commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_LACK_OF_ANSWERS,
+    });
+
+    return new AssessmentResult({
+      emitter,
+      pixScore,
+      reproducibilityRate,
+      status,
+      assessmentId,
+      juryId,
+      competenceMarks,
+      commentForCandidate,
+      commentForOrganization,
+    });
+  }
 }

--- a/api/src/certification/shared/domain/models/JuryComment.js
+++ b/api/src/certification/shared/domain/models/JuryComment.js
@@ -18,6 +18,7 @@ const JuryCommentContexts = Object.freeze({
 const AutoJuryCommentKeys = Object.freeze({
   FRAUD: 'FRAUD',
   CANCELLED_DUE_TO_NEUTRALIZATION: 'CANCELLED_DUE_TO_NEUTRALIZATION',
+  REJECTED_DUE_TO_LACK_OF_ANSWERS: 'REJECTED_DUE_TO_LACK_OF_ANSWERS',
 });
 
 class JuryComment {

--- a/api/tests/integration/infrastructure/repositories/certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-result-repository_test.js
@@ -84,7 +84,9 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
         sessionId,
         status: CertificationResult.status.REJECTED,
         pixScore: 0,
-        commentForOrganization: 'Un commentaire orga 2',
+        commentForOrganization: domainBuilder.certification.shared.buildJuryComment.organization({
+          fallbackComment: 'Un commentaire orga 2',
+        }),
         competencesWithMark: [],
         complementaryCertificationCourseResults: [],
       });
@@ -99,7 +101,9 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
         sessionId,
         status: CertificationResult.status.CANCELLED,
         pixScore: null,
-        commentForOrganization: null,
+        commentForOrganization: domainBuilder.certification.shared.buildJuryComment.organization({
+          fallbackComment: null,
+        }),
         competencesWithMark: [],
         complementaryCertificationCourseResults: [],
         emitter: null,
@@ -115,7 +119,9 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
         sessionId,
         status: CertificationResult.status.VALIDATED,
         pixScore: 123,
-        commentForOrganization: 'Un commentaire orga 1',
+        commentForOrganization: domainBuilder.certification.shared.buildJuryComment.organization({
+          fallbackComment: 'Un commentaire orga 1',
+        }),
         competencesWithMark: [
           domainBuilder.buildCompetenceMark({
             id: 123,
@@ -249,7 +255,9 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
           birthdate: '2001-05-21',
           birthplace: 'Paris',
           createdAt: new Date('2022-01-01T00:00:00Z'),
-          commentForOrganization: 'Some comment for organization',
+          commentForOrganization: domainBuilder.certification.shared.buildJuryComment.organization({
+            fallbackComment: 'Some comment for organization',
+          }),
           competencesWithMark: [
             domainBuilder.buildCompetenceMark({
               id: competenceMarkId,
@@ -282,7 +290,9 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
           birthdate: '2001-05-21',
           birthplace: 'Paris',
           createdAt: new Date('2022-01-01T00:00:00Z'),
-          commentForOrganization: 'Some comment for organization',
+          commentForOrganization: domainBuilder.certification.shared.buildJuryComment.organization({
+            fallbackComment: 'Some comment for organization',
+          }),
           competencesWithMark: [
             domainBuilder.buildCompetenceMark({
               id: otherCompetenceMarkId,
@@ -366,7 +376,9 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
           birthdate: '2001-05-21',
           birthplace: 'Paris',
           createdAt: new Date('2022-01-01T00:00:00Z'),
-          commentForOrganization: 'Some comment for organization',
+          commentForOrganization: domainBuilder.certification.shared.buildJuryComment.organization({
+            fallbackComment: 'Some comment for organization',
+          }),
           competencesWithMark: [
             domainBuilder.buildCompetenceMark({
               id: oneCompetenceMarkId,
@@ -585,7 +597,9 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
         sessionId,
         status: CertificationResult.status.REJECTED,
         pixScore: 0,
-        commentForOrganization: 'Un commentaire orga 2',
+        commentForOrganization: domainBuilder.certification.shared.buildJuryComment.organization({
+          fallbackComment: 'Un commentaire orga 2',
+        }),
         competencesWithMark: [],
         complementaryCertificationCourseResults: [],
       });
@@ -600,7 +614,9 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
         sessionId,
         status: CertificationResult.status.CANCELLED,
         pixScore: null,
-        commentForOrganization: null,
+        commentForOrganization: domainBuilder.certification.shared.buildJuryComment.organization({
+          fallbackComment: null,
+        }),
         competencesWithMark: [],
         complementaryCertificationCourseResults: [],
         emitter: null,
@@ -616,8 +632,10 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
         sessionId,
         status: CertificationResult.status.VALIDATED,
         pixScore: 123,
-        commentForOrganization: 'Un commentaire orga 1',
-        commentByAutoJury: AutoJuryCommentKeys.CANCELLED_DUE_TO_NEUTRALIZATION,
+        commentForOrganization: domainBuilder.certification.shared.buildJuryComment.organization({
+          fallbackComment: 'Un commentaire orga 1',
+          commentByAutoJury: AutoJuryCommentKeys.CANCELLED_DUE_TO_NEUTRALIZATION,
+        }),
         competencesWithMark: [
           domainBuilder.buildCompetenceMark({
             id: 123,
@@ -787,7 +805,9 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
           birthdate: '2001-05-21',
           birthplace: 'Paris',
           createdAt: new Date('2022-01-01T00:00:00Z'),
-          commentForOrganization: 'Some comment for organization',
+          commentForOrganization: domainBuilder.certification.shared.buildJuryComment.organization({
+            fallbackComment: 'Some comment for organization',
+          }),
           competencesWithMark: [
             domainBuilder.buildCompetenceMark({
               id: competenceMarkId,

--- a/api/tests/tooling/domain-builder/factory/build-certification-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-result.js
@@ -1,5 +1,4 @@
 import { CertificationResult } from '../../../../lib/domain/models/CertificationResult.js';
-import { JuryComment, JuryCommentContexts } from '../../../../src/certification/shared/domain/models/JuryComment.js';
 
 const buildCertificationResult = function ({
   id = 123,
@@ -13,17 +12,10 @@ const buildCertificationResult = function ({
   status = CertificationResult.status.REJECTED,
   pixScore = 0,
   emitter = 'PIX-ALGO',
-  commentForOrganization = 'comment organization',
-  commentByAutoJury,
+  commentForOrganization,
   competencesWithMark = [],
   complementaryCertificationCourseResults = [],
 } = {}) {
-  const juryCommentForOrganization = new JuryComment({
-    fallbackComment: commentForOrganization,
-    commentByAutoJury,
-    context: JuryCommentContexts.ORGANIZATION,
-  });
-
   return new CertificationResult({
     id,
     firstName,
@@ -36,7 +28,7 @@ const buildCertificationResult = function ({
     status,
     pixScore,
     emitter,
-    commentForOrganization: juryCommentForOrganization,
+    commentForOrganization,
     competencesWithMark,
     complementaryCertificationCourseResults,
   });
@@ -119,7 +111,6 @@ buildCertificationResult.cancelled = function ({
   sessionId,
   pixScore,
   emitter,
-  commentByAutoJury,
   commentForOrganization,
   competencesWithMark,
   complementaryCertificationCourseResults,
@@ -136,7 +127,6 @@ buildCertificationResult.cancelled = function ({
     status: CertificationResult.status.CANCELLED,
     pixScore,
     emitter,
-    commentByAutoJury,
     commentForOrganization,
     competencesWithMark,
     complementaryCertificationCourseResults,

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -7,6 +7,7 @@ import { ChallengeNeutralized } from '../../../../lib/domain/events/ChallengeNeu
 import { _forTestOnly } from '../../../../lib/domain/events/index.js';
 import { ABORT_REASONS } from '../../../../lib/domain/models/CertificationCourse.js';
 import { AssessmentResult, CertificationAssessment, CertificationResult } from '../../../../lib/domain/models/index.js';
+import { AutoJuryCommentKeys } from '../../../../src/certification/shared/domain/models/JuryComment.js';
 import { config } from '../../../../src/shared/config.js';
 import { CertificationVersion } from '../../../../src/shared/domain/models/CertificationVersion.js';
 import {
@@ -169,12 +170,18 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           const expectedResult = {
             certificationCourseId,
             assessmentResult: new AssessmentResult({
-              emitter: 'PIX-ALGO',
+              emitter: AssessmentResult.emitters.PIX_ALGO,
               pixScore: scoreForEstimatedLevel,
               reproducibilityRate: 100,
-              status: 'rejected',
+              status: AssessmentResult.status.REJECTED,
               competenceMarks: [],
               assessmentId: 123,
+              commentForCandidate: domainBuilder.certification.shared.buildJuryComment.candidate({
+                commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_LACK_OF_ANSWERS,
+              }),
+              commentForOrganization: domainBuilder.certification.shared.buildJuryComment.organization({
+                commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_LACK_OF_ANSWERS,
+              }),
             }),
           };
 
@@ -278,10 +285,10 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           const expectedResult = {
             certificationCourseId,
             assessmentResult: new AssessmentResult({
-              emitter: 'PIX-ALGO',
+              emitter: AssessmentResult.emitters.PIX_ALGO,
               pixScore: scoreForEstimatedLevel,
               reproducibilityRate: 100,
-              status: 'rejected',
+              status: AssessmentResult.status.REJECTED,
               competenceMarks: [],
               assessmentId: 123,
               commentForCandidate: domainBuilder.certification.shared.buildJuryComment.candidate({
@@ -407,10 +414,10 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           const expectedResult = {
             certificationCourseId,
             assessmentResult: new AssessmentResult({
-              emitter: 'PIX-ALGO',
+              emitter: AssessmentResult.emitters.PIX_ALGO,
               pixScore: rawScore,
               reproducibilityRate: 100,
-              status: 'validated',
+              status: AssessmentResult.status.VALIDATED,
               competenceMarks: [],
               assessmentId: 123,
             }),
@@ -518,10 +525,10 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           const expectedResult = {
             certificationCourseId,
             assessmentResult: new AssessmentResult({
-              emitter: 'PIX-ALGO',
+              emitter: AssessmentResult.emitters.PIX_ALGO,
               pixScore: degradedScore,
               reproducibilityRate: 100,
-              status: 'validated',
+              status: AssessmentResult.status.VALIDATED,
               competenceMarks: [],
               assessmentId: 123,
             }),
@@ -630,10 +637,10 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         const expectedResult = {
           certificationCourseId,
           assessmentResult: new AssessmentResult({
-            emitter: 'PIX-ALGO',
+            emitter: AssessmentResult.emitters.PIX_ALGO,
             pixScore: scoreForEstimatedLevel,
             reproducibilityRate: 100,
-            status: 'validated',
+            status: AssessmentResult.status.VALIDATED,
             competenceMarks: [],
             assessmentId: 123,
           }),
@@ -838,10 +845,10 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           const expectedResult = {
             certificationCourseId,
             assessmentResult: new AssessmentResult({
-              emitter: 'PIX-ALGO',
+              emitter: AssessmentResult.emitters.PIX_ALGO,
               pixScore: cappedScoreForEstimatedLevel,
               reproducibilityRate: 100,
-              status: 'validated',
+              status: AssessmentResult.status.VALIDATED,
               competenceMarks: [],
               assessmentId: 123,
             }),
@@ -1301,7 +1308,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         commentByJury: 'Oopsie',
         pixScore: 0,
         reproducibilityRate: 0,
-        status: 'error',
+        status: AssessmentResult.status.ERROR,
         assessmentId: 123,
         juryId: 7,
       });

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -5,6 +5,7 @@ import { _forTestOnly } from '../../../../lib/domain/events/index.js';
 import { ABORT_REASONS, CertificationCourse } from '../../../../lib/domain/models/CertificationCourse.js';
 import { CertificationChallengeForScoring } from '../../../../src/certification/scoring/domain/models/CertificationChallengeForScoring.js';
 import { AssessmentResultFactory } from '../../../../src/certification/scoring/domain/models/factories/AssessmentResultFactory.js';
+import { AutoJuryCommentKeys } from '../../../../src/certification/shared/domain/models/JuryComment.js';
 import { config } from '../../../../src/shared/config.js';
 import { AssessmentResult, status } from '../../../../src/shared/domain/models/AssessmentResult.js';
 import {
@@ -181,7 +182,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
           expect(AssessmentResultFactory.buildAlgoErrorResult).to.have.been.calledWithExactly({
             error: computeError,
             assessmentId: certificationAssessment.id,
-            emitter: 'PIX-ALGO',
+            emitter: AssessmentResult.emitters.PIX_ALGO,
           });
           expect(assessmentResultRepository.save).to.have.been.calledWithExactly({
             certificationCourseId: 1234,
@@ -246,7 +247,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
             reproducibilityRate: certificationAssessmentScore.percentageCorrectAnswers,
             status: certificationAssessmentScore.status,
             assessmentId: certificationAssessment.id,
-            emitter: 'PIX-ALGO',
+            emitter: AssessmentResult.emitters.PIX_ALGO,
           });
 
           expect(assessmentResultRepository.save).to.have.been.calledWithExactly({
@@ -334,7 +335,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
         );
       });
 
-      describe('when less than the minimum number of answers required by the config has been answered and the candidate abandoned', function () {
+      describe('when less than the minimum number of answers required by the config has been answered', function () {
         describe('when the candidate did not finish due to a lack of time', function () {
           it('should reject the certification', async function () {
             // given
@@ -424,7 +425,13 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
               reproducibilityRate: certificationAssessmentScore.getPercentageCorrectAnswers(),
               status: status.REJECTED,
               assessmentId: certificationAssessment.id,
-              emitter: 'PIX-ALGO',
+              emitter: AssessmentResult.emitters.PIX_ALGO,
+              commentForCandidate: domainBuilder.certification.shared.buildJuryComment.candidate({
+                commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_LACK_OF_ANSWERS,
+              }),
+              commentForOrganization: domainBuilder.certification.shared.buildJuryComment.organization({
+                commentByAutoJury: AutoJuryCommentKeys.REJECTED_DUE_TO_LACK_OF_ANSWERS,
+              }),
             });
 
             expect(assessmentResultRepository.save).to.have.been.calledWithExactly({
@@ -536,7 +543,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
               reproducibilityRate: certificationAssessmentScore.getPercentageCorrectAnswers(),
               status: status.REJECTED,
               assessmentId: certificationAssessment.id,
-              emitter: 'PIX-ALGO',
+              emitter: AssessmentResult.emitters.PIX_ALGO,
             });
 
             expect(assessmentResultRepository.save).to.have.been.calledWithExactly({
@@ -649,7 +656,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
               reproducibilityRate: certificationAssessmentScore.getPercentageCorrectAnswers(),
               status: status.VALIDATED,
               assessmentId: certificationAssessment.id,
-              emitter: 'PIX-ALGO',
+              emitter: AssessmentResult.emitters.PIX_ALGO,
             });
             expect(assessmentResultRepository.save).to.have.been.calledWithExactly({
               certificationCourseId: 1234,
@@ -757,7 +764,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
                 reproducibilityRate: certificationAssessmentScore.getPercentageCorrectAnswers(),
                 status: status.VALIDATED,
                 assessmentId: certificationAssessment.id,
-                emitter: 'PIX-ALGO',
+                emitter: AssessmentResult.emitters.PIX_ALGO,
               });
               expect(assessmentResultRepository.save).to.have.been.calledWithExactly({
                 certificationCourseId: 1234,
@@ -859,7 +866,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
                 reproducibilityRate: certificationAssessmentScore.getPercentageCorrectAnswers(),
                 status: status.VALIDATED,
                 assessmentId: certificationAssessment.id,
-                emitter: 'PIX-ALGO',
+                emitter: AssessmentResult.emitters.PIX_ALGO,
               });
               expect(assessmentResultRepository.save).to.have.been.calledWithExactly({
                 certificationCourseId: 1234,
@@ -965,7 +972,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
                 reproducibilityRate: certificationAssessmentScore.getPercentageCorrectAnswers(),
                 status: status.VALIDATED,
                 assessmentId: certificationAssessment.id,
-                emitter: 'PIX-ALGO',
+                emitter: AssessmentResult.emitters.PIX_ALGO,
               });
               expect(assessmentResultRepository.save).to.have.been.calledWithExactly({
                 certificationCourseId: 1234,

--- a/api/tests/unit/infrastructure/utils/csv/certification-results/CertificationResultsCsvValues_test.js
+++ b/api/tests/unit/infrastructure/utils/csv/certification-results/CertificationResultsCsvValues_test.js
@@ -299,7 +299,7 @@ describe('Unit | Infrastructure | Utils | Csv | CertificationResultsCsvValues', 
       externalId: 'LOLORD',
       createdAt: new Date('2020-01-01'),
       pixScore: 55,
-      commentForOrganization: 'RAS',
+      commentForOrganization: undefined,
       competencesWithMark: [],
       complementaryCertificationCourseResults: [],
     };
@@ -310,7 +310,9 @@ describe('Unit | Infrastructure | Utils | Csv | CertificationResultsCsvValues', 
         const certificationResult = domainBuilder.buildCertificationResult.cancelled({
           ...aCertificationResultData,
           emitter: CertificationResult.emitters.PIX_ALGO,
-          commentByAutoJury: AutoJuryCommentKeys.CANCELLED_DUE_TO_NEUTRALIZATION,
+          commentForOrganization: domainBuilder.certification.shared.buildJuryComment.organization({
+            commentByAutoJury: AutoJuryCommentKeys.CANCELLED_DUE_TO_NEUTRALIZATION,
+          }),
         });
 
         // when
@@ -327,7 +329,9 @@ describe('Unit | Infrastructure | Utils | Csv | CertificationResultsCsvValues', 
         const certificationResult = domainBuilder.buildCertificationResult.validated({
           ...aCertificationResultData,
           emitter: CertificationResult.emitters.PIX_ALGO,
-          commentForOrganization: 'MANUAL COMMENT',
+          commentForOrganization: domainBuilder.certification.shared.buildJuryComment.organization({
+            fallbackComment: 'MANUAL COMMENT',
+          }),
         });
 
         // when
@@ -338,25 +342,7 @@ describe('Unit | Infrastructure | Utils | Csv | CertificationResultsCsvValues', 
       });
     });
 
-    context('when complementary certification is rejected', function () {
-      it('should return that the certification has been automatically invalidated', function () {
-        // given
-        const certificationResult = domainBuilder.buildCertificationResult.rejected({
-          ...aCertificationResultData,
-          emitter: CertificationResult.emitters.PIX_ALGO,
-        });
-
-        // when
-        const result = new CertificationResultsCsvValues(i18n).getCommentForOrganization(certificationResult);
-
-        // then
-        expect(result).to.equal(
-          "Le candidat a répondu faux à plus de 50% des questions posées, cela a invalidé l'ensemble de sa certification, et a donc entraîné un score de 0 pix",
-        );
-      });
-    });
-
-    it('should return the comment', function () {
+    it('should no return a comment', function () {
       // given
       const certificationResult = domainBuilder.buildCertificationResult.validated(aCertificationResultData);
 
@@ -364,7 +350,7 @@ describe('Unit | Infrastructure | Utils | Csv | CertificationResultsCsvValues', 
       const result = new CertificationResultsCsvValues(i18n).getCommentForOrganization(certificationResult);
 
       // then
-      expect(result).to.equal('RAS');
+      expect(result).to.be.undefined;
     });
   });
 

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -311,6 +311,10 @@
       "FRAUD": {
         "candidate": "The Pix certification exam conditions have not been respected. Your certification exam has been reported for fraud and has consequently been invalidated.",
         "organization": "A fraud has been detected : after analysis, we have decided on rejecting this certification exam."
+      },
+      "REJECTED_DUE_TO_LACK_OF_ANSWERS": {
+        "candidate": "The number of questions answered during your certification exam is too low to allow us to deliver a Pix certification.",
+        "organization": "The number of questions answered by the candidate during their certification exam is too low to allow us to deliver a Pix certification."
       }
     }
   },

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -325,6 +325,10 @@
       "FRAUD": {
         "candidate": "Les conditions de passation du test de certification n'ayant pas été respectées et ayant fait l'objet d'un signalement pour fraude, votre certification a été invalidée en conséquence.",
         "organization": "Une situation de fraude a été détectée : après analyse, nous avons statué sur un rejet de la certification."
+      },
+      "REJECTED_DUE_TO_LACK_OF_ANSWERS": {
+        "candidate": "Le nombre de questions répondues pendant votre test de certification est insuffisant et ne nous permet pas de vous délivrer une certification Pix.",
+        "organization": "Le nombre de questions répondues par le candidat pendant son test de certification est insuffisant et ne nous permet pas de lui délivrer une certification Pix."
       }
     }
   },

--- a/api/translations/nl.json
+++ b/api/translations/nl.json
@@ -325,6 +325,10 @@
       "FRAUD": {
         "candidate": "The Pix certification exam conditions have not been respected. Your certification exam has been reported for fraud and has consequently been invalidated.",
         "organization": "A fraud has been detected : after analysis, we have decided on rejecting this certification exam."
+      },
+      "REJECTED_DUE_TO_LACK_OF_ANSWERS": {
+        "candidate": "The number of questions answered during your certification exam is too low to allow us to deliver a Pix certification.",
+        "organization": "The number of questions answered by the candidate during their certification exam is too low to allow us to deliver a Pix certification."
       }
     }
   },


### PR DESCRIPTION
## :unicorn: Problème

Pour les certifications v3, s’il n’y a pas assez de questions répondues par le candidat, la certification est automatiquement annulée (en présence d’un problème technique) ou rejetée (en l’absence de problème technique).

Un message automatique doit être adressé dans ce cas au candidat et à l’organisation pour les en informer.

## :robot: Proposition

Transformer le commentaire "non automatique" en automatique

## :rainbow: Remarques
* Sur le scoring (pas rescoring), j'ai dû splitter la partie V2 et V3 de fait (plus les mêmes règles métiers)
* ⚠️ Annulation = erreur technique, pas la faute du candidat
  * Rejet = pas d'erreur, et pas assez de réponses
  * ⚠️ une réponse "passée" = faux, et surtout si passé, c'est considéré comme répondue (donc pas dans la borne du minimum de réponses à fournir).

## :100: Pour tester

### Non régression - annulée problème technique

* Sur Pix Certif, avec `certifV3@example.net` créer une certification V3
* Inscrire un candidat, puis sur Pix App, avec `certif-success@example.net`, rentrer en certification, puis démarrer la surveillance
* Répondez à une seule question en tant que candidat
* Sur Pix Certif, terminer la surveillance en terminant le test, puis allez finaliser la session **en précisant "erreur technique" comme raison**
* Sur Pix Admin avec `superadmin@example.net`, retrouver votre session, vérifier que la certification est annulée et **ne contient pas** le texte de la nouvelle clé `REJECTED_DUE_TO_LACK_OF_ANSWERS`

### Scoring - rejetée, candidat n'a pas répondu à assez de questions

* Sur Pix Certif, avec `certifV3@example.net` créer une certification V3
* Inscrire un candidat en indiquant votre email pour le CSV des résultats, puis sur Pix App, avec `certif-success@example.net`, rentrer en certification, puis démarrer la surveillance
* Répondez à une seule question en tant que candidat, ne rien faire de plus (ne surtout pas passer)
* Sur Pix Certif, terminer la surveillance en terminant le test, puis allez finaliser la session **sans mettre de raison particulière**, c'est juste que la certification du candidat s'est arrêtée par manque de temps
* Sur Pix Admin avec `superadmin@example.net`, retrouver votre session, vérifier que le commentaire jury correspondent bien au texte de la nouvelle clé `REJECTED_DUE_TO_LACK_OF_ANSWERS`
