### PR TITLE
[TECH] Corriger le manque de contraste sur les textes dans certaines pages liées à la certification (PIX-11409).

### DIFF
--- a/certif/app/styles/pages/session-supervising-error.scss
+++ b/certif/app/styles/pages/session-supervising-error.scss
@@ -34,7 +34,7 @@
 
   &__subtitle {
     margin: 8px 0;
-    color: $pix-neutral-30;
+    color: var(--pix-neutral-500);
     font-weight: normal;
     font-size: 0.8rem;
     text-align: center;

--- a/mon-pix/app/styles/components/_certification-joiner.scss
+++ b/mon-pix/app/styles/components/_certification-joiner.scss
@@ -85,7 +85,7 @@
   p.certification-joiner__validation-error {
     margin-top: 6px;
     margin-bottom: 0;
-    color: $pix-warning-60;
+    color: var(--pix-error-500);
     font-size: 0.875rem;
   }
 
@@ -113,7 +113,7 @@
   .certification-course-page {
     &__errors {
       margin: 5px;
-      color: $pix-warning-60;
+      color: var(--pix-error-500);
       font-size: 0.875rem;
       text-align: start;
 
@@ -127,7 +127,7 @@
 
       a,
       a:visited {
-        color: $pix-warning-60;
+        color: var(--pix-error-500);
         text-decoration: underline;
       }
     }

--- a/mon-pix/app/styles/components/_congratulations-certification-banner.scss
+++ b/mon-pix/app/styles/components/_congratulations-certification-banner.scss
@@ -8,7 +8,7 @@
   height: fit-content;
   padding: 24px 16px;
   color: $pix-neutral-10;
-  background: $pix-content-dark;
+  background: var(--pix-certif-500);
   border-radius: 6px;
   text-rendering: optimizelegibility;
 
@@ -40,7 +40,7 @@
 }
 
 @mixin textBannerStyle {
-  color: $pix-neutral-10;
+  color: var(--pix-neutral-0);
   font-weight: $font-normal;
   font-family: $font-open-sans;
   line-height: 2rem;


### PR DESCRIPTION
## :unicorn: Problème
Actuellement certaines pages on été identifiés avec des textes ne respectant pas le contraste minimum entre leur couleur et la couleur du fond.

<img width="316" alt="Capture d’écran 2024-02-26 à 12 01 08" src="https://github.com/1024pix/pix/assets/58915422/0c05490a-6c42-42e4-a704-ce9e1c918087">
<img width="357" alt="Capture d’écran 2024-02-26 à 12 10 44" src="https://github.com/1024pix/pix/assets/58915422/ad8f3337-beed-44a1-8545-6ea478a57b6f">


## :robot: Proposition
Modifier les couleurs pour valider les critères de contraste.

## :rainbow: Remarques
Les couleurs utilisées proviennent du DS, visible sur Pix UI : https://ui.pix.fr/?path=/docs/utiliser-pix-ui-design-tokens-palette-de-couleurs--docs

## :100: Pour tester
- Aller sur la page d'erreur de l'espace surveillant : https://certif-pr8270.review.pix.fr/sessions/7406/surveiller
- Utiliser Wave ou le [WCAG color contrast](https://chromewebstore.google.com/detail/wcag-color-contrast-check/plnahcmalebffmaghcpcmpaciebdhgdf?pli=1) pour s'assurer que le contraste est bon 
<img width="326" alt="Capture d’écran 2024-03-05 à 10 55 19" src="https://github.com/1024pix/pix/assets/58915422/a1c713b1-736f-4393-a15f-ffba65ade816">

- Se connecter sur Pix App avec certif-success@example.net
- Aller sur Certifications
- Remplir le premier champ avec des lettres pour avoir le message d'erreur
- Valider le formulaire avec le reste des champs vides pour avoir un second message d'erreur près du bouton
- Utiliser Wave ou le [WCAG color contrast](https://chromewebstore.google.com/detail/wcag-color-contrast-check/plnahcmalebffmaghcpcmpaciebdhgdf?pli=1) pour s'assurer que le contraste est bon 

<img width="232" alt="Capture d’écran 2024-03-05 à 11 03 51" src="https://github.com/1024pix/pix/assets/58915422/f7772801-1036-4dd7-b185-e910a52e9d48">
<img width="232" alt="Capture d’écran 2024-03-05 à 11 06 04" src="https://github.com/1024pix/pix/assets/58915422/0df661df-45c7-4aaa-8ca9-031fd50e589c">
<img width="438" alt="Capture d’écran 2024-03-05 à 11 17 26" src="https://github.com/1024pix/pix/assets/58915422/416b4e90-6b50-45f5-9951-dd14d6f368d5">
