### PR TITLE
[TECH] :construction_worker: Détecte les branches suceptible d'être périmées

### DIFF
--- a/.github/workflows/stale-branches.yml
+++ b/.github/workflows/stale-branches.yml
@@ -1,0 +1,22 @@
+on:
+  schedule:
+    - cron: "0 12 * * *"
+
+jobs:
+  cleanup_branches:
+    name: "Branch Cleaner"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Manage Stale Branches"
+        id: branch_cleaner
+        uses: crazy-matt/manage-stale-branches@1.0.1
+        with:
+          gh_token: ${{ env.PIX_SERVICE_ACTIONS_TOKEN }}
+          stale_older_than: 60
+          suggestions_older_than: 30
+          dry_run: true
+          archive_stale: true
+          excluded_branches: |
+            origin/main
+            origin/master
+            origin/dev


### PR DESCRIPTION
## :unicorn: Problème

Nous sommes 50+ à travailler sur Pix tous les jours de la semaine. Parfois, nous explorons des solutions, des nouvelles fonctionnalités, des idées, des tentatives de correction... Et nous laissons la branche pendre, dépérir...

À ce jour, 189 branches dans le monorepo Pix.

![image](https://github.com/1024pix/pix/assets/42057/ba0665e8-2176-4c6e-a1ae-2d57fc2c92f1)


Donc les plus anciennes ont presque un an d'existence...

![image](https://github.com/1024pix/pix/assets/42057/73208db1-6bb0-496f-80a2-e3f845eedf05)


## :robot: Proposition

Mettre en place un script qui, a intervalle régulier, va taguer les branches les plus anciennes. Au moins dans un premier temps.

Il existe une action : [Manage Stale Branches](https://github.com/marketplace/actions/manage-stale-branches).

Dans cette PR, l'idée, c'est de laisser la configuration par défaut, c'est-à-dire 

- Au bout de 30 jours, la branche est marquée comme « stale »
- Au bout de 60 jours, la branche est déplacée dans une sous branche `archive/`

## :rainbow: Remarques


## :100: Pour tester

:shrug: Peut-être faut-il pouvoir faire tourner le script manuellement ? Puis supprimer les tags qui auraient été mis en place...
