### PR TITLE
[TECH] :recycle: Renvoie l'erreur reçue plutôt qu'une erreur maison générique

### DIFF
--- a/api/lib/application/http-errors.js
+++ b/api/lib/application/http-errors.js
@@ -131,14 +131,6 @@ class SessionPublicationBatchError extends BaseHttpError {
   }
 }
 
-class InternalServerError extends BaseHttpError {
-  constructor(message, title) {
-    super(message);
-    this.title = title || 'Internal Server Error';
-    this.status = 500;
-  }
-}
-
 class TooManyRequestsError extends BaseHttpError {
   constructor(message) {
     super(message);
@@ -164,7 +156,6 @@ const HttpErrors = {
   ConflictError,
   ForbiddenError,
   ImproveCompetenceEvaluationForbiddenError,
-  InternalServerError,
   MissingQueryParamError,
   NotFoundError,
   PasswordShouldChangeError,
@@ -185,7 +176,6 @@ export {
   ConflictError,
   ForbiddenError,
   ImproveCompetenceEvaluationForbiddenError,
-  InternalServerError,
   MissingQueryParamError,
   NotFoundError,
   PasswordShouldChangeError,

--- a/api/lib/domain/usecases/get-correction-for-answer.js
+++ b/api/lib/domain/usecases/get-correction-for-answer.js
@@ -1,6 +1,5 @@
 import { AssessmentNotCompletedError, NotFoundError } from '../errors.js';
 import { LearningContentResourceNotFound } from '../../../src/shared/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
-import { InternalServerError } from '../../application/http-errors.js';
 
 const getCorrectionForAnswer = async function ({
   assessmentRepository,
@@ -31,8 +30,9 @@ const getCorrectionForAnswer = async function ({
   } catch (error) {
     if (error instanceof LearningContentResourceNotFound) {
       throw new NotFoundError();
+    } else {
+      throw error;
     }
-    throw new InternalServerError();
   }
 
   return response;

--- a/api/src/shared/application/http-errors.js
+++ b/api/src/shared/application/http-errors.js
@@ -123,14 +123,6 @@ class SessionPublicationBatchError extends BaseHttpError {
   }
 }
 
-class InternalServerError extends BaseHttpError {
-  constructor(message, title) {
-    super(message);
-    this.title = title || 'Internal Server Error';
-    this.status = 500;
-  }
-}
-
 class TooManyRequestsError extends BaseHttpError {
   constructor(message) {
     super(message);
@@ -155,7 +147,6 @@ const HttpErrors = {
   BaseHttpError,
   ConflictError,
   ForbiddenError,
-  InternalServerError,
   MissingQueryParamError,
   NotFoundError,
   PasswordShouldChangeError,
@@ -175,7 +166,6 @@ export {
   BaseHttpError,
   ConflictError,
   ForbiddenError,
-  InternalServerError,
   MissingQueryParamError,
   NotFoundError,
   PasswordShouldChangeError,

--- a/api/tests/unit/domain/usecases/get-correction-for-answer_test.js
+++ b/api/tests/unit/domain/usecases/get-correction-for-answer_test.js
@@ -4,7 +4,8 @@ import { Answer } from '../../../../src/evaluation/domain/models/Answer.js';
 import { AssessmentNotCompletedError, NotFoundError } from '../../../../lib/domain/errors.js';
 import { expect, sinon, catchErr, domainBuilder } from '../../../test-helper.js';
 import { LearningContentResourceNotFound } from '../../../../src/shared/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
-import { InternalServerError } from '../../../../lib/application/http-errors.js';
+
+class OtherError extends Error {}
 
 describe('Unit | UseCase | getCorrectionForAnswer', function () {
   const assessmentRepository = { get: () => undefined };
@@ -166,7 +167,7 @@ describe('Unit | UseCase | getCorrectionForAnswer', function () {
 
         correctionRepository.getByChallengeId
           .withArgs({ challengeId, answerValue: answer.value, userId: assessment.userId, locale })
-          .rejects(new Error());
+          .rejects(new OtherError('A message'));
 
         // when
         const error = await catchErr(getCorrectionForAnswer)({
@@ -179,7 +180,9 @@ describe('Unit | UseCase | getCorrectionForAnswer', function () {
         });
 
         // then
-        expect(error).to.be.an.instanceOf(InternalServerError);
+        expect(error).to.be.an.instanceOf(OtherError);
+        expect(error.message).to.equal('A message');
+        expect(error.stack).to.not.be.empty;
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème

Nous avons détecté une erreur 500 dans les logs de production ce matin (https://1024pix.slack.com/archives/C6SGTNVUK/p1709630095510609). Le problème, c'est qu'il n'y a pas de message, ou pas vraiment, et surtout pas de trace d'appel ([stacktrace](https://fr.wikipedia.org/wiki/Trace_d%27appels)).

L'erreur 500 sur le même point d'arrivée (endpoint) a été détecté il y a quelques jours (https://1024pix.slack.com/archives/C6SGTNVUK/p1707301851041679?thread_ts=1707262281.381919&cid=C6SGTNVUK).

Nous avons détecté une gestion d'erreur assez surprenante, où l'on utilise une `InternalServerError` maison pour renvoyer une erreur 500, alors que la plupart des autres erreurs « métiers » sont en fait des erreurs 4xx.

La PR #7175 a introduit l'utilisation de cette erreur générique. L'objectif était de préciser le cas de l'erreur `LearningContentResourceNotFound`, mais les autres cas ont tous été transformés en cette erreur générique maison `InternalServerError`

## :robot: Proposition

Renvoyer l'erreur reçue si elle ne correspond pas à ce que nous voulions transformer. Et supprimer l'utilisation de cette erreur générique maison un peu étrange.

## :rainbow: Remarques

Ça n'explique pas vraiment pourquoi nous n'avons pas de stacktrace, mais peut-être que ça nous permettra d'avoir une erreur plus complète :shrug: 

## :100: Pour tester

Les épreuves doivent passer normalement, si on provoque une erreur sur un contenu (autre que `LearningContentNotFound`) nous devrions voir l'erreur en question et non plus une `InternalServerError` standard.
