### PR TITLE
[FEATURE] [API] Ajouter nl-BE dans SUPPORTED_LOCALES (PIX-11232)

### DIFF
--- a/api/src/shared/domain/constants.js
+++ b/api/src/shared/domain/constants.js
@@ -7,7 +7,7 @@ const LOCALE = {
   DUTCH_SPOKEN: 'nl',
 };
 
-const SUPPORTED_LOCALES = ['en', 'fr', 'fr-BE', 'fr-FR'];
+const SUPPORTED_LOCALES = ['en', 'fr', 'fr-BE', 'fr-FR', 'nl-BE'];
 
 const ORGANIZATION_FEATURE = {
   MISSIONS_MANAGEMENT: {


### PR DESCRIPTION
## :unicorn: Problème

Actuellement la locale `nl-BE` n'est pas présente dans `SUPPORTED_LOCALES`. Cette absence empêcherait l'enregistrement de la locale d'un utilisateur qui aurait choisi `Nederlands` lors de sa connexion à Pix App.

## :robot: Proposition

Ajouter `nl-BE` dans `SUPPORTED_LOCALES`.

## :rainbow: Remarques

RAS

## :100: Pour tester

* Vérifier que la CI s'exécute avec succès. On ne peut rien tester fonctionnellement tant que Pix App n'a pas été modifié avec la prise en charge publique du néerlandais.