### PR TITLE
[FEATURE] Fournir la passageId au formulaire de feedback à la fin d'un Module (PIX-11445) 

### DIFF
--- a/mon-pix/app/pods/components/module/recap/template.hbs
+++ b/mon-pix/app/pods/components/module/recap/template.hbs
@@ -15,7 +15,7 @@
       @shape="rounded"
       @size="big"
       target="_blank"
-      @href="https://form-eu.123formbuilder.com/71180/modulix-experimentation"
+      @href="https://form-eu.123formbuilder.com/71180/modulix-experimentation?2850087={{@passage.id}}"
     >
       {{t "pages.modulix.recap.goToForm"}}
     </PixButtonLink>

--- a/mon-pix/app/pods/module/details/route.js
+++ b/mon-pix/app/pods/module/details/route.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 
 export default class ModuleDetailsRoute extends Route {
-  async model() {
+  model() {
     return this.modelFor('module');
   }
 }

--- a/mon-pix/app/pods/module/recap/route.js
+++ b/mon-pix/app/pods/module/recap/route.js
@@ -1,3 +1,17 @@
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 
-export default class ModuleRecapRoute extends Route {}
+export default class ModuleRecapRoute extends Route {
+  @service store;
+  @service router;
+
+  beforeModel(transition) {
+    if (!transition.from) {
+      return this.router.replaceWith('module.details');
+    }
+  }
+
+  model() {
+    return this.modelFor('module.get');
+  }
+}

--- a/mon-pix/app/pods/module/recap/template.hbs
+++ b/mon-pix/app/pods/module/recap/template.hbs
@@ -1,5 +1,5 @@
 {{page-title (t "pages.modulix.recap.title")}}
 
 <div class="modulix">
-  <Module::Recap @module={{this.model}} />
+  <Module::Recap @module={{@model.module}} @passage={{@model.passage}}/>
 </div>

--- a/mon-pix/app/pods/module/recap/template.hbs
+++ b/mon-pix/app/pods/module/recap/template.hbs
@@ -1,5 +1,5 @@
 {{page-title (t "pages.modulix.recap.title")}}
 
 <div class="modulix">
-  <Module::Recap @module={{@model.module}} @passage={{@model.passage}}/>
+  <Module::Recap @module={{@model.module}} @passage={{@model.passage}} />
 </div>

--- a/mon-pix/app/pods/module/route.js
+++ b/mon-pix/app/pods/module/route.js
@@ -4,7 +4,7 @@ import { service } from '@ember/service';
 export default class ModuleRoute extends Route {
   @service store;
 
-  async model(params) {
-    return await this.store.findRecord('module', params.slug);
+  model(params) {
+    return this.store.findRecord('module', params.slug);
   }
 }

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
@@ -41,8 +41,13 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleRecap', function (ho
       const formLink = screen.getByRole('link', { name: this.intl.t('pages.modulix.recap.goToForm') });
 
       // then
+      const passage = server.schema.passages.all().models[0];
       assert.ok(formLink);
       assert.ok(screen.getByRole('link', { name: this.intl.t('pages.modulix.recap.backToModuleDetails') }));
+      assert.strictEqual(
+        formLink.getAttribute('href'),
+        `https://form-eu.123formbuilder.com/71180/modulix-experimentation?2850087=${passage.id}`,
+      );
     });
 
     test('should navigate to details page by clicking on back to module details button', async function (assert) {

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { visit } from '@1024pix/ember-testing-library';
+import { clickByName, visit } from '@1024pix/ember-testing-library';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { click, currentURL } from '@ember/test-helpers';
 import setupIntl from '../../helpers/setup-intl';
@@ -10,9 +10,9 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleRecap', function (ho
   setupMirage(hooks);
   setupIntl(hooks);
 
-  module('when user arrive on the module recap page', function () {
-    test('should display the links to details button and to form builder', async function (assert) {
-      // given
+  module('when user arrive on the module recap page', function (hooks) {
+    let screen;
+    hooks.beforeEach(async function () {
       server.create('module', {
         id: 'bien-ecrire-son-adresse-mail',
         title: 'Bien écrire son adresse mail',
@@ -26,36 +26,27 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleRecap', function (ho
         },
       });
 
+      screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+      await clickByName('Terminer');
+    });
+
+    test('should include the right page title', async function (assert) {
+      // then
+      assert.ok(document.title.includes(this.intl.t('pages.modulix.recap.title')));
+      assert.ok(screen.getByRole('heading', { level: 1, name: this.intl.t('pages.modulix.recap.title') }));
+    });
+
+    test('should display the links to details button and to form builder', async function (assert) {
       // when
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/recap');
       const formLink = screen.getByRole('link', { name: this.intl.t('pages.modulix.recap.goToForm') });
 
       // then
       assert.ok(formLink);
       assert.ok(screen.getByRole('link', { name: this.intl.t('pages.modulix.recap.backToModuleDetails') }));
-      assert.strictEqual(
-        formLink.getAttribute('href'),
-        'https://form-eu.123formbuilder.com/71180/modulix-experimentation',
-      );
     });
 
     test('should navigate to details page by clicking on back to module details button', async function (assert) {
-      // given
-      server.create('module', {
-        id: 'bien-ecrire-son-adresse-mail',
-        title: 'Bien écrire son adresse mail',
-        grains: [],
-        details: {
-          image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
-          description: 'Description',
-          duration: 'duration',
-          level: 'level',
-          objectives: ['Objectif #1'],
-        },
-      });
-
       // when
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/recap');
       await click(screen.getByRole('link', { name: this.intl.t('pages.modulix.recap.backToModuleDetails') }));
 
       // then

--- a/mon-pix/tests/acceptance/module/visit-module-recap-page_test.js
+++ b/mon-pix/tests/acceptance/module/visit-module-recap-page_test.js
@@ -10,7 +10,7 @@ module('Acceptance | Module | Routes | recap', function (hooks) {
   setupIntl(hooks);
   setupMirage(hooks);
 
-  test('can visit /modules/:slug/recap', async function (assert) {
+  test("can't visit /modules/:slug/recap", async function (assert) {
     // given
     server.create('module', {
       id: 'bien-ecrire-son-adresse-mail',
@@ -20,20 +20,6 @@ module('Acceptance | Module | Routes | recap', function (hooks) {
     await visit('/modules/bien-ecrire-son-adresse-mail/recap');
 
     // then
-    assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/recap');
-  });
-
-  test('should include the right page title', async function (assert) {
-    // given
-    server.create('module', {
-      id: 'bien-ecrire-son-adresse-mail',
-    });
-
-    // when
-    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/recap');
-
-    // then
-    assert.ok(document.title.includes(this.intl.t('pages.modulix.recap.title')));
-    assert.ok(screen.getByRole('heading', { level: 1, name: this.intl.t('pages.modulix.recap.title') }));
+    assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/details');
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
A present, il y n'a aucun moyen de relier le passage d'une personne à ses réponses au formulaire.

## :robot: Proposition
Nous fournissons le `passageId` via un query param qui va remplir un champ caché du formulaire 123FormBuilder.

## :rainbow: Remarques
On a empêché d'accéder à la page de fin, sans passer par le module.

## :100: Pour tester

### Test de passageId dans le formulaire 
- Sur Pix App, faire un module et à la fin du module cliquer sur remplir le formulaire
- Verifier que le formulaire contient un passageId

### Test du bouton retour page /recap
- Sur Pix App, faire un module et le terminer
- Cliquer sur "Retourner aux détails du module"
- Constater que la page s'affiche correctement

### Test pas d'accès direct à la page /recap
- Sur Pix App aller sur `/modules/bien-ecrire-son-adresse-mail/recap`
- Constater que la page finale est `/details`
- Constater que la page `/recap` n'est pas dans l'historique
