### PR TITLE
[TECH] :recycle: Déplacement de `entity-validator.js` vers `src`

### DIFF
--- a/api/lib/domain/events/UserAnonymized.js
+++ b/api/lib/domain/events/UserAnonymized.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 import { Event } from './Event.js';
-import { validateEntity } from '../validators/entity-validator.js';
+import { validateEntity } from '../../../src/shared/domain/validators/entity-validator.js';
 import { PIX_ADMIN } from '../../../src/authorization/domain/constants.js';
 
 const { ROLES } = PIX_ADMIN;

--- a/api/lib/domain/models/AuthenticationMethod.js
+++ b/api/lib/domain/models/AuthenticationMethod.js
@@ -1,7 +1,7 @@
 import BaseJoi from 'joi';
 import JoiDate from '@joi/date';
 const Joi = BaseJoi.extend(JoiDate);
-import { validateEntity } from '../validators/entity-validator.js';
+import { validateEntity } from '../../../src/shared/domain/validators/entity-validator.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 import { POLE_EMPLOI, CNAV, FWB, PAYSDELALOIRE } from '../constants/oidc-identity-providers.js';
 

--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -1,7 +1,7 @@
 import BaseJoi from 'joi';
 import JoiDate from '@joi/date';
 const Joi = BaseJoi.extend(JoiDate);
-import { validateEntity } from '../validators/entity-validator.js';
+import { validateEntity } from '../../../src/shared/domain/validators/entity-validator.js';
 import _ from 'lodash';
 
 import { ChallengeToBeNeutralizedNotFoundError, ChallengeToBeDeneutralizedNotFoundError } from '../errors.js';

--- a/api/lib/domain/models/CertificationCenterInvitation.js
+++ b/api/lib/domain/models/CertificationCenterInvitation.js
@@ -1,7 +1,7 @@
 import BaseJoi from 'joi';
 import JoiDate from '@joi/date';
 const Joi = BaseJoi.extend(JoiDate);
-import { validateEntity } from '../validators/entity-validator.js';
+import { validateEntity } from '../../../src/shared/domain/validators/entity-validator.js';
 import randomString from 'randomstring';
 
 const statuses = {

--- a/api/lib/domain/models/CompetenceMark.js
+++ b/api/lib/domain/models/CompetenceMark.js
@@ -1,5 +1,5 @@
 import Joi from 'joi';
-import { validateEntity } from '../validators/entity-validator.js';
+import { validateEntity } from '../../../src/shared/domain/validators/entity-validator.js';
 
 const schema = Joi.object({
   id: Joi.number().integer().optional(),

--- a/api/lib/domain/models/OrganizationInvitation.js
+++ b/api/lib/domain/models/OrganizationInvitation.js
@@ -1,7 +1,7 @@
 import BaseJoi from 'joi';
 import JoiDate from '@joi/date';
 const Joi = BaseJoi.extend(JoiDate);
-import { validateEntity } from '../validators/entity-validator.js';
+import { validateEntity } from '../../../src/shared/domain/validators/entity-validator.js';
 
 const statuses = {
   PENDING: 'pending',

--- a/api/lib/domain/models/PartnerCertificationScoring.js
+++ b/api/lib/domain/models/PartnerCertificationScoring.js
@@ -1,7 +1,7 @@
 import BaseJoi from 'joi';
 import JoiDate from '@joi/date';
 const Joi = BaseJoi.extend(JoiDate);
-import { validateEntity } from '../validators/entity-validator.js';
+import { validateEntity } from '../../../src/shared/domain/validators/entity-validator.js';
 import { NotImplementedError } from '../errors.js';
 
 const SOURCES = {

--- a/api/lib/domain/read-models/CampaignParticipationInfo.js
+++ b/api/lib/domain/read-models/CampaignParticipationInfo.js
@@ -1,7 +1,7 @@
 import BaseJoi from 'joi';
 import JoiDate from '@joi/date';
 const Joi = BaseJoi.extend(JoiDate);
-import { validateEntity } from '../validators/entity-validator.js';
+import { validateEntity } from '../../../src/shared/domain/validators/entity-validator.js';
 import _ from 'lodash';
 
 const validationSchema = Joi.object({

--- a/api/lib/domain/read-models/OrganizationLearnerForAdmin.js
+++ b/api/lib/domain/read-models/OrganizationLearnerForAdmin.js
@@ -1,7 +1,7 @@
 import BaseJoi from 'joi';
 import JoiDate from '@joi/date';
 const Joi = BaseJoi.extend(JoiDate);
-import { validateEntity } from '../validators/entity-validator.js';
+import { validateEntity } from '../../../src/shared/domain/validators/entity-validator.js';
 
 const validationSchema = Joi.object({
   id: Joi.number().integer().required(),

--- a/api/src/prescription/organization-place/domain/read-models/PlacesLot.js
+++ b/api/src/prescription/organization-place/domain/read-models/PlacesLot.js
@@ -1,7 +1,7 @@
 import BaseJoi from 'joi';
 import JoiDate from '@joi/date';
 const Joi = BaseJoi.extend(JoiDate);
-import { validateEntity } from '../../../../../lib/domain/validators/entity-validator.js';
+import { validateEntity } from '../../../../shared/domain/validators/entity-validator.js';
 
 const validationSchema = Joi.object({
   count: Joi.number().required().allow(null),

--- a/api/src/shared/application/models/domain-error-mapping-configuration.js
+++ b/api/src/shared/application/models/domain-error-mapping-configuration.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 
-import { validateEntity } from '../../../../lib/domain/validators/entity-validator.js';
+import { validateEntity } from '../../domain/validators/entity-validator.js';
 
 const schema = Joi.object({
   name: Joi.string().required(),

--- a/api/src/shared/domain/models/AdminMember.js
+++ b/api/src/shared/domain/models/AdminMember.js
@@ -1,7 +1,7 @@
 import BaseJoi from 'joi';
 import JoiDate from '@joi/date';
 const Joi = BaseJoi.extend(JoiDate);
-import { validateEntity } from '../../../../lib/domain/validators/entity-validator.js';
+import { validateEntity } from '../validators/entity-validator.js';
 import lodash from 'lodash';
 import { PIX_ADMIN } from '../../../authorization/domain/constants.js';
 

--- a/api/src/shared/domain/validators/entity-validator.js
+++ b/api/src/shared/domain/validators/entity-validator.js
@@ -1,4 +1,4 @@
-import { ObjectValidationError } from '../errors.js';
+import { ObjectValidationError } from '../../../../lib/domain/errors.js';
 
 const validateEntity = function (schema, entity) {
   const { error } = schema.validate(entity);

--- a/api/tests/unit/domain/validators/entity-validator_test.js
+++ b/api/tests/unit/domain/validators/entity-validator_test.js
@@ -1,7 +1,7 @@
 import { expect } from '../../../test-helper.js';
 import { ObjectValidationError } from '../../../../lib/domain/errors.js';
 import Joi from 'joi';
-import { validateEntity } from '../../../../lib/domain/validators/entity-validator.js';
+import { validateEntity } from '../../../../src/shared/domain/validators/entity-validator.js';
 
 describe('Unit | Domain | Validators | entity-validator', function () {
   describe('#validateEntity', function () {


### PR DESCRIPTION
## :unicorn: Problème

cf https://github.com/1024pix/pix/blob/dev/docs/adr/0051-nouvelle-arborescence-api.md

## :robot: Proposition

Déplacement du fichier `entity-validator.js` vers `src/shared`

## :rainbow: Remarques


## :100: Pour tester

Tests verts 🟢 et rien de changé dans les diverses applications.