### PR TITLE
[FEATURE][ADMIN] Ajouter la gestion de la langue nl et la locale nl-BE sur la page d'un utilisateur (PIX-11537)

### DIFF
--- a/admin/app/services/references.js
+++ b/admin/app/services/references.js
@@ -14,6 +14,7 @@ export default class ReferencesService extends Service {
       { value: 'fr', label: 'fr' },
       { value: 'fr-BE', label: 'fr-BE' },
       { value: 'fr-FR', label: 'fr-FR' },
+      { value: 'nl-BE', label: 'nl-BE' },
     ];
   }
 }

--- a/admin/app/services/references.js
+++ b/admin/app/services/references.js
@@ -5,6 +5,7 @@ export default class ReferencesService extends Service {
     return [
       { value: 'fr', label: 'Français' },
       { value: 'en', label: 'Anglais' },
+      { value: 'nl', label: 'Néerlandais' },
     ];
   }
 

--- a/admin/tests/integration/components/users/user-overview_test.js
+++ b/admin/tests/integration/components/users/user-overview_test.js
@@ -273,7 +273,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
         assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
       });
 
-      test('displays user’s language, locale, first name and last name in edit mode', async function (assert) {
+      test('displays user’s first name and last name with available languages and locales in edit mode', async function (assert) {
         // given
         this.set('user', user);
 

--- a/admin/tests/integration/components/users/user-overview_test.js
+++ b/admin/tests/integration/components/users/user-overview_test.js
@@ -70,7 +70,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
           lastName: 'Snow',
           email: 'john.snow@winterfell.got',
           username: 'kingofthenorth',
-          lang: 'fr',
+          lang: 'nl',
           locale: 'nl-BE',
         });
         this.set('user', user);
@@ -83,7 +83,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
         assert.dom(screen.getByText(`Nom : ${this.user.lastName}`)).exists();
         assert.dom(screen.getByText(`Adresse e-mail : ${this.user.email}`)).exists();
         assert.dom(screen.getByText(`Identifiant : ${this.user.username}`)).exists();
-        assert.dom(screen.getByText('Langue : fr')).exists();
+        assert.dom(screen.getByText('Langue : nl')).exists();
         assert.dom(screen.getByText('Locale : nl-BE')).exists();
         assert.dom(screen.getByText('Date de création :')).exists();
       });
@@ -289,6 +289,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
         await screen.findByRole('listbox');
         assert.dom(screen.getByRole('option', { name: 'Français' })).exists();
         assert.dom(screen.getByRole('option', { name: 'Anglais' })).exists();
+        assert.dom(screen.getByRole('option', { name: 'Néerlandais' })).exists();
 
         await clickByName('Locale :');
         await waitFor(async () => {

--- a/admin/tests/integration/components/users/user-overview_test.js
+++ b/admin/tests/integration/components/users/user-overview_test.js
@@ -71,7 +71,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
           email: 'john.snow@winterfell.got',
           username: 'kingofthenorth',
           lang: 'fr',
-          locale: 'fr-FR',
+          locale: 'nl-BE',
         });
         this.set('user', user);
 
@@ -84,7 +84,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
         assert.dom(screen.getByText(`Adresse e-mail : ${this.user.email}`)).exists();
         assert.dom(screen.getByText(`Identifiant : ${this.user.username}`)).exists();
         assert.dom(screen.getByText('Langue : fr')).exists();
-        assert.dom(screen.getByText('Locale : fr-FR')).exists();
+        assert.dom(screen.getByText('Locale : nl-BE')).exists();
         assert.dom(screen.getByText('Date de création :')).exists();
       });
 
@@ -273,7 +273,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
         assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
       });
 
-      test('displays user’s language, first name and last name in edit mode', async function (assert) {
+      test('displays user’s language, locale, first name and last name in edit mode', async function (assert) {
         // given
         this.set('user', user);
 
@@ -297,6 +297,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
           assert.dom(screen.getByRole('option', { name: 'fr' })).exists();
           assert.dom(screen.getByRole('option', { name: 'fr-BE' })).exists();
           assert.dom(screen.getByRole('option', { name: 'fr-FR' })).exists();
+          assert.dom(screen.getByRole('option', { name: 'nl-BE' })).exists();
         });
       });
 

--- a/admin/tests/integration/components/users/user-overview_test.js
+++ b/admin/tests/integration/components/users/user-overview_test.js
@@ -62,30 +62,39 @@ module('Integration | Component | users | user-overview', function (hooks) {
         assert.dom(screen.getByText('Date de création : 10/12/2021')).exists();
       });
 
-      test("displays user's information without creation date", async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const user = store.createRecord('user', {
-          firstName: 'John',
-          lastName: 'Snow',
-          email: 'john.snow@winterfell.got',
-          username: 'kingofthenorth',
-          lang: 'nl',
-          locale: 'nl-BE',
+      [
+        { locale: 'en', lang: 'en' },
+        { locale: 'fr', lang: 'fr' },
+        { locale: 'fr-BE', lang: 'fr' },
+        { locale: 'fr-FR', lang: 'fr' },
+        { locale: 'nl-BE', lang: 'nl' },
+      ].forEach((expected) => {
+        test("displays user's information without creation date", async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const user = store.createRecord('user', {
+            firstName: 'John',
+            lastName: 'Snow',
+            email: 'john.snow@winterfell.got',
+            username: 'kingofthenorth',
+            lang: expected.lang,
+            locale: expected.locale,
+          });
+          this.set('user', user);
+
+          // when
+          const screen = await render(hbs`<Users::UserOverview @user={{this.user}} />`);
+          // await this.pauseTest()
+
+          // then
+          assert.dom(screen.getByText(`Prénom : ${this.user.firstName}`)).exists();
+          assert.dom(screen.getByText(`Nom : ${this.user.lastName}`)).exists();
+          assert.dom(screen.getByText(`Adresse e-mail : ${this.user.email}`)).exists();
+          assert.dom(screen.getByText(`Identifiant : ${this.user.username}`)).exists();
+          assert.dom(screen.getByText(`Langue : ${expected.lang}`)).exists();
+          assert.dom(screen.getByText(`Locale : ${expected.locale}`)).exists();
+          assert.dom(screen.getByText('Date de création :')).exists();
         });
-        this.set('user', user);
-
-        // when
-        const screen = await render(hbs`<Users::UserOverview @user={{this.user}} />`);
-
-        // then
-        assert.dom(screen.getByText(`Prénom : ${this.user.firstName}`)).exists();
-        assert.dom(screen.getByText(`Nom : ${this.user.lastName}`)).exists();
-        assert.dom(screen.getByText(`Adresse e-mail : ${this.user.email}`)).exists();
-        assert.dom(screen.getByText(`Identifiant : ${this.user.username}`)).exists();
-        assert.dom(screen.getByText('Langue : nl')).exists();
-        assert.dom(screen.getByText('Locale : nl-BE')).exists();
-        assert.dom(screen.getByText('Date de création :')).exists();
       });
 
       module('terms of service', function () {

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -11,6 +11,7 @@ import { identifiersType } from '../../../src/shared/domain/types/identifiers-ty
 import * as OidcIdentityProviders from '../../domain/constants/oidc-identity-providers.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../domain/constants/identity-providers.js';
 import { AVAILABLE_LANGUAGES } from '../../../src/shared/domain/services/language-service.js';
+import { SUPPORTED_LOCALES } from '../../../src/shared/domain/constants.js';
 
 const reassignAuthenticationMethodJoiSchema = Joi.object({
   data: {
@@ -240,7 +241,10 @@ const register = async function (server) {
                 email: Joi.string().email().allow(null).optional(),
                 username: Joi.string().allow(null).optional(),
                 lang: Joi.string().valid(...AVAILABLE_LANGUAGES),
-                locale: Joi.string().allow(null).optional().valid('en', 'fr', 'fr-BE', 'fr-FR'),
+                locale: Joi.string()
+                  .allow(null)
+                  .optional()
+                  .valid(...SUPPORTED_LOCALES),
               },
             },
           }),


### PR DESCRIPTION
## :unicorn: Problème
Avec l'arrivée de la nouvelle locale `nl-BE` sur Pix nous avons besoin d'ajouter la gestion de cette locale sur Pix Admin.

## :robot: Proposition
Ajouter la locale `nl-BE` dans la méthode `availableLocales()` et la langue `nl` dans la méthode `availableLanguages()` du service `references`.

## :rainbow: Remarques
RAS.

## :100: Pour tester

1. Se connecter à Pix Admin
2. Se rendre sur la page d'un utilisateur (ex: `/users/106618`)
3. Dans la partie `Informations de l'utilisateur` cliquez sur le bouton `Modifier`
4. Cliquez sur le sélecteur `Langue` vous devez voir l'option `Néerlandais` dans  la liste, sélectionnez là
5. Puis, cliquez sur le sélecteur `Locale` vous devez voir l'option `nl-BE` dans  la liste, sélectionnez là
6. Cliquez sur le bouton `Modifier` pour valider les changements
7. Une notification de succès doit apparaitre
8. Vérifiez que la langue et la locale de l'utilisateur ont bien été mises à jour
