### PR TITLE
[FEATURE] Permettre des sous-titres vidéo vides sur Modulix (PIX-10997)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/module.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/module.json
@@ -454,7 +454,7 @@
               "type": "video",
               "title": "Vidéo de présentation de Pix",
               "url": "https://videos.pix.fr/modulix/didacticiel/presentation.mp4",
-              "subtitles": "-",
+              "subtitles": "",
               "transcription": "<p>Le numérique évolue en permanence, vos compétences aussi, pour travailler, communiquer et s'informer, se déplacer, réaliser des démarches, un enjeu tout au long de la vie.</p><p>Sur <a href=\"https://pix.fr\" target=\"blank\">pix.fr</a>, testez-vous et cultivez vos compétences numériques.</p><p>Les tests Pix sont personnalisés, les questions s'adaptent à votre niveau, réponse après réponse.</p><p>Évaluez vos connaissances et savoir-faire sur 16 compétences, dans 5 domaines, sur 5 niveaux de débutants à confirmer, avec des mises en situation ludiques, recherches en ligne, manipulation de fichiers et de données, culture numérique...</p><p>Allez à votre rythme, vous pouvez arrêter et reprendre quand vous le voulez.</p><p>Toutes les 5 questions, découvrez vos résultats et progressez grâce aux astuces et aux tutos.</p><p>En relevant les défis Pix, vous apprendrez de nouvelles choses et aurez envie d'aller plus loin.</p><p>Vous pensez pouvoir faire mieux ?</p><p>Retentez les tests et améliorez votre score.</p><p>Faites reconnaître officiellement votre niveau en passant la certification Pix, reconnue par l'État et le monde professionnel.</p><p>Pix : le service public en ligne pour évaluer, développer et certifier ses compétences numériques.</p>"
             }
           ]
@@ -2789,7 +2789,7 @@
               "type": "video",
               "title": "Discussion entre Elias et Léna (1 sur 2)",
               "url": "https://videos.pix.fr/modulix/sources-informations/chat-1.mp4",
-              "subtitles": "-",
+              "subtitles": "",
               "transcription": "<ul><li>Elias : Les Jeux Olympiques d’hiver de 2029 auront lieu dans le désert !</li><li>Léna : T’es sûr ? Comment tu le sais ?</li><li>Elias : C’est Sandy qui me l’a dit.</li></ul>"
             },
             {
@@ -2812,7 +2812,7 @@
               "type": "video",
               "title": "Discussion entre Elias et Léna (2 sur 2)",
               "url": "https://videos.pix.fr/modulix/sources-informations/chat-2.mp4",
-              "subtitles": "-",
+              "subtitles": "",
               "transcription": "<ul><li>Léna : Et c’est vrai du coup ?</li><li>Elias : Sandy l’a vu sur internet !</li><li>Léna : Tu peux m’envoyer le lien stp ?</li><li>Elias : Oui, c’est un article de FranceInfo</li><li>Elias : https://www.francetvinfo.fr/sports/l-arabie-saoudite-designee-pour-accueillir-les-jeux-asiatiques-d-hiver-en-2029_5396737.html</li></ul>"
             },
             {

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/video.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/video.js
@@ -6,7 +6,7 @@ const videoElementSchema = Joi.object({
   type: Joi.string().valid('video').required(),
   title: Joi.string().required(),
   url: Joi.string().uri().required(),
-  subtitles: Joi.string().required(),
+  subtitles: Joi.string().allow('').required(),
   transcription: htmlSchema.allow(''),
 }).required();
 

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/video.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/video.js
@@ -6,7 +6,7 @@ const videoElementSchema = Joi.object({
   type: Joi.string().valid('video').required(),
   title: Joi.string().required(),
   url: Joi.string().uri().required(),
-  subtitles: Joi.string().allow('').required(),
+  subtitles: Joi.string().uri().allow('').required(),
   transcription: htmlSchema.allow(''),
 }).required();
 

--- a/mon-pix/app/pods/components/module/video/component.js
+++ b/mon-pix/app/pods/components/module/video/component.js
@@ -9,6 +9,10 @@ export default class ModuleVideo extends Component {
   @tracked modalIsOpen = false;
   @service metrics;
 
+  get hasSubtitles() {
+    return this.args.video.subtitles.length > 0;
+  }
+
   get hasTranscription() {
     return this.args.video.transcription.length > 0;
   }

--- a/mon-pix/app/pods/components/module/video/template.hbs
+++ b/mon-pix/app/pods/components/module/video/template.hbs
@@ -1,5 +1,6 @@
 <div class="element-video">
   <div class="element-video__container">
+    {{! template-lint-disable require-media-caption }}
     <video
       {{did-insert this.launchPlyr}}
       id={{@video.id}}
@@ -10,7 +11,9 @@
       crossorigin
     >
       <source src={{@video.url}} type="video/mp4" />
-      <track kind="captions" label="Français" src={{@video.subtitles}} srclang="fr" default />
+      {{#if this.hasSubtitles}}
+        <track kind="captions" label="Français" src={{@video.subtitles}} srclang="fr" default />
+      {{/if}}
     </video>
   </div>
 

--- a/mon-pix/tests/integration/components/module/video_test.js
+++ b/mon-pix/tests/integration/components/module/video_test.js
@@ -9,7 +9,7 @@ module('Integration | Component | Module | Video', function (hooks) {
 
   test('should display a video', async function (assert) {
     // given
-    const url = 'https://videos.pix.fr/modulix/chat_animation_2.webm';
+    const url = 'https://videos.pix.fr/modulix/placeholder-video.mp4';
 
     const videoElement = {
       url,
@@ -31,7 +31,7 @@ module('Integration | Component | Module | Video', function (hooks) {
 
   test('should be able to use the modal for transcription', async function (assert) {
     // given
-    const url = 'https://videos.pix.fr/modulix/chat_animation_2.webm';
+    const url = 'https://videos.pix.fr/modulix/placeholder-video.mp4';
 
     const videoElement = {
       url,
@@ -53,7 +53,7 @@ module('Integration | Component | Module | Video', function (hooks) {
 
   test('should not be able to open the modal if there is no transcription', async function (assert) {
     // given
-    const url = 'https://videos.pix.fr/modulix/chat_animation_2.webm';
+    const url = 'https://videos.pix.fr/modulix/placeholder-video.mp4';
 
     const video = {
       url,

--- a/mon-pix/tests/integration/components/module/video_test.js
+++ b/mon-pix/tests/integration/components/module/video_test.js
@@ -29,6 +29,46 @@ module('Integration | Component | Module | Video', function (hooks) {
     assert.ok(document.getElementsByClassName('pix-video-player'));
   });
 
+  test('should be able to use the subtitles track when provided', async function (assert) {
+    // given
+    const url = 'https://videos.pix.fr/modulix/placeholder-video.mp4';
+
+    const videoElement = {
+      url,
+      title: 'title',
+      subtitles: 'https://videos.pix.fr/modulix/placeholder-video.vtt',
+      transcription: 'transcription',
+    };
+
+    this.set('video', videoElement);
+
+    //  when
+    await render(hbs`<Module::Video @video={{this.video}}/>`);
+
+    // then
+    assert.dom('video > track').exists();
+  });
+
+  test('should not be able to use the subtitles track when there is none', async function (assert) {
+    // given
+    const url = 'https://videos.pix.fr/modulix/placeholder-video.mp4';
+
+    const videoElement = {
+      url,
+      title: 'title',
+      subtitles: '',
+      transcription: 'transcription',
+    };
+
+    this.set('video', videoElement);
+
+    //  when
+    await render(hbs`<Module::Video @video={{this.video}}/>`);
+
+    // then
+    assert.dom('video > track').doesNotExist();
+  });
+
   test('should be able to use the modal for transcription', async function (assert) {
     // given
     const url = 'https://videos.pix.fr/modulix/placeholder-video.mp4';

--- a/mon-pix/tests/unit/components/module/video_test.js
+++ b/mon-pix/tests/unit/components/module/video_test.js
@@ -6,6 +6,38 @@ import sinon from 'sinon';
 module('Unit | Component | Module | Video', function (hooks) {
   setupTest(hooks);
 
+  module('#hasSubtitles', function () {
+    test('should return true if video has a transcription', function (assert) {
+      // given
+      const video = {
+        title: '',
+        url: '',
+        subtitles: 'hello',
+        transcription: '',
+      };
+
+      const component = createPodsComponent('module/video', { video });
+
+      // when & then
+      assert.true(component.hasSubtitles);
+    });
+
+    test('should return false if video has an empty transcription', function (assert) {
+      // given
+      const video = {
+        title: '',
+        url: '',
+        subtitles: '',
+        transcription: '',
+      };
+
+      const component = createPodsComponent('module/video', { video });
+
+      // when & then
+      assert.false(component.hasSubtitles);
+    });
+  });
+
   module(`#hasTranscription`, function () {
     test(`should return true if video has a transcription`, function (assert) {
       // given


### PR DESCRIPTION
## :unicorn: Problème
Les sous-titres de vidéos ne sont pas nécessaires si la vidéo les porte directement. Pour le moment l'utilisateur télécharge des fichiers de sous-titres inexistants à cette URL : `/modules/didacticiel-modulix/-` (requêtes inutiles donc).

Dans la même veine que #7972 et https://github.com/1024pix/pix-tutos/pull/251.

## :robot: Proposition
Ne pas donner accès aux sous-titres ni les télécharger si ils ne sont pas nécessaires.

Voir https://docs.google.com/document/d/1TayDDwmoA_XLUnIubTVLOGuJnaWTvkLzPv3XOVG3kqs/edit cc. @matthieu-octo 

Corriger les contenus sujets à ce soucis.

## :rainbow: Remarques
RAS

## :100: Pour tester
Constater que si les sous-titres sont utilisés ils sont bien accessibles (ex: `/modules/bien-ecrire-son-adresse-mail/passage`), et que si il n'y en a pas (ex: `/modules/didacticiel-modulix/passage`) il n'y a pas possibilité d'accès ni de requête inutile.
