### PR TITLE
[FEATURE] Afficher l'option Nederlands dans le sélecteur de langues (PIX-10685)

### DIFF
--- a/mon-pix/app/languages.js
+++ b/mon-pix/app/languages.js
@@ -9,6 +9,6 @@ export default {
   },
   nl: {
     value: 'Nederlands',
-    languageSwitcherDisplayed: false,
+    languageSwitcherDisplayed: true,
   },
 };

--- a/mon-pix/tests/integration/components/language-switcher_test.js
+++ b/mon-pix/tests/integration/components/language-switcher_test.js
@@ -33,7 +33,7 @@ module('Integration | Component | Language Switcher', function (hooks) {
         return option.innerText;
       });
 
-      assert.deepEqual(optionsInnerText, ['Français', 'English']);
+      assert.deepEqual(optionsInnerText, ['Français', 'English', 'Nederlands']);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Afin de préparer le lancement de Pix App en néerlandais, nous devons activer l'option `Nederlands` dans le sélecteur de langues pour que les utilisateurs néerlandophones puissent avoir accès à l'application dans leur langue.

## :robot: Proposition
Afficher l'option `Nederlands` dans le sélecteur de langues.

## :rainbow: Remarques
RAS.

## :100: Pour tester

1. Se rendre sur la **page d'inscription** de Pix App sur le domaine international ( en .org)
2. Cliquez sur le sélecteur de langues, vous devez voir l'option Nederlands dans la liste
3. Sélectionnez cette option, vérifiez que la page apparait bien en Néerlandais
4. Remplissez le formulaire et inscrivez-vous 
5. Vérifiez que l'application est bien en Néerlandais
6. Déconnectez-vous
7. Se rendre sur la **page de connexion** Pix App sur le domaine international (.org)
8. Cliquez sur le sélecteur de langues, vous devez voir l'option Nederlands dans la liste
7. Sélectionnez cette option, vérifiez que la page apparait bien en Néerlandais