### PR TITLE
[TECH] Ajoute le tracking d'accès aux Contenus Formatifs dans le code (PIX-11413)

### DIFF
--- a/mon-pix/app/components/training/card.hbs
+++ b/mon-pix/app/components/training/card.hbs
@@ -1,5 +1,5 @@
 <PixBlock class="training-card" @shadow="light">
-  <a class="training-card__content" href={{@training.link}} target="_blank">
+  <a class="training-card__content" href={{@training.link}} target="_blank" {{on "click" this.trackAccess}}>
     <h3 class="training-card-content__title">{{@training.title}}</h3>
     <div class="training-card-content__infos" title="{{this.tagTitle}}">
       <PixTag @compact={{true}} @color={{this.tagColor}} class="training-card-content-infos__tag">

--- a/mon-pix/app/components/training/card.js
+++ b/mon-pix/app/components/training/card.js
@@ -1,8 +1,11 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
+import { action } from '@ember/object';
 
 export default class Card extends Component {
   @service intl;
+  @service metrics;
+  @service router;
 
   get durationFormatted() {
     const days = this.args.training.duration.days ? `${this.args.training.duration.days}j ` : '';
@@ -66,5 +69,15 @@ export default class Card extends Component {
     const min = 1;
     const max = 3;
     return Math.floor(Math.random() * (max - min + 1) + min);
+  }
+
+  @action
+  trackAccess() {
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Accès Contenu Formatif',
+      'pix-event-action': `Click depuis : ${this.router.currentRouteName}`,
+      'pix-event-name': `Ouvre le cf : ${this.args.training.title}`,
+    });
   }
 }

--- a/mon-pix/tests/unit/components/training/card_test.js
+++ b/mon-pix/tests/unit/components/training/card_test.js
@@ -186,4 +186,30 @@ module('Unit | Component | Training | card', function (hooks) {
       assert.strictEqual(result, 'primary');
     });
   });
+
+  module('#trackAccess', function () {
+    test('should push event on click', function (assert) {
+      // given
+      const metrics = this.owner.lookup('service:metrics');
+      metrics.add = sinon.stub();
+      const trainingTitle = 'Mon super CF';
+      const component = createGlimmerComponent('training/card', {
+        training: { title: trainingTitle, link: 'https://exemple.net/' },
+      });
+      const currentRouteName = 'current.route.name';
+      component.router = { currentRouteName };
+
+      // when
+      component.trackAccess();
+
+      // then
+      sinon.assert.calledWithExactly(metrics.add, {
+        event: 'custom-event',
+        'pix-event-category': 'Accès Contenu Formatif',
+        'pix-event-action': `Click depuis : ${currentRouteName}`,
+        'pix-event-name': `Ouvre le cf : ${trainingTitle}`,
+      });
+      assert.ok(true);
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Le tracking d'accès aux CFs dépend de nos classes CSS qui peuvent évoluer sans qu'on s'en rende compte. C'est ce qui est arrivé sur #8180.

## :robot: Proposition
Rendre visible le tracking via une action dans le code JS du composant.

J'ai changé légèrement les noms catégories et noms d'événement pour faciliter la lecture. Il ne faudra pas oublier de nettoyer Matomo Tag Manager pour éviter les doublons.

## :rainbow: Remarques
Je ne sais pas correctement tester ce tracking : j'ai essayé avec un test d'intégration avec un "vrai" click (ce qui fonctionne) mais je n'ai pas envie qu'une nouvelle page s'ouvre pendant l'exécution des tests ^^".

## :100: Pour tester
Vérifier qu'un appel à Matomo est bien fait lors d'un clic sur un CF.
