### PR TITLE
[FEATURE] Stocke l'état de l'import FREGATA (PIX-11346) 

### DIFF
--- a/api/src/prescription/learner-management/application/sco-organization-management-controller.js
+++ b/api/src/prescription/learner-management/application/sco-organization-management-controller.js
@@ -23,6 +23,7 @@ const importOrganizationLearnersFromSIECLE = async function (
       });
     } else if (format === 'csv') {
       await usecases.importOrganizationLearnersFromSIECLECSVFormat({
+        userId: authenticatedUserId,
         organizationId,
         payload: request.payload,
         i18n: request.i18n,

--- a/api/src/prescription/learner-management/domain/usecases/import-organization-learners-from-siecle-csv-format.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-organization-learners-from-siecle-csv-format.js
@@ -2,63 +2,101 @@ import { SiecleXmlImportError } from '../errors.js';
 
 const { isEmpty, chunk } = lodash;
 import bluebird from 'bluebird';
+import { createReadStream } from 'fs';
 import lodash from 'lodash';
 
 import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';
 import { ORGANIZATION_LEARNER_CHUNK_SIZE } from '../../../../shared/infrastructure/constants.js';
 import { OrganizationLearnerParser } from '../../infrastructure/serializers/csv/organization-learner-parser.js';
+import { OrganizationImport } from '../models/OrganizationImport.js';
 
 const ERRORS = {
   EMPTY: 'EMPTY',
-  INVALID_FILE_EXTENSION: 'INVALID_FILE_EXTENSION',
 };
 
 const importOrganizationLearnersFromSIECLECSVFormat = async function ({
+  userId,
   organizationId,
   payload,
   organizationLearnerRepository,
   organizationRepository,
+  organizationImportRepository,
   importStorage,
   i18n,
+  dependencies = { createReadStream },
 }) {
   let organizationLearnerData = [];
-  const organization = await organizationRepository.get(organizationId);
 
-  const filename = await importStorage.sendFile({ filepath: payload.path });
+  const organization = await organizationRepository.get(organizationId);
+  let organizationImport = OrganizationImport.create({ organizationId, createdBy: userId });
+
+  let filename;
+  const errors = [];
+  let encoding;
   try {
+    filename = await importStorage.sendFile({ filepath: payload.path });
+    const readableStreamEncoding = dependencies.createReadStream(payload.path);
+    const bufferEncoding = await getDataBuffer(readableStreamEncoding);
+    const parserEncoding = OrganizationLearnerParser.buildParser(bufferEncoding, organization.id, i18n);
+    encoding = parserEncoding.getFileEncoding();
+  } catch (error) {
+    errors.push(error);
+    throw error;
+  } finally {
+    organizationImport.upload({ filename, encoding, errors });
+    await organizationImportRepository.save(organizationImport);
+  }
+
+  try {
+    organizationImport = await organizationImportRepository.getByOrganizationId(organizationId);
+
     const readableStream = await importStorage.readFile({ filename });
     const buffer = await getDataBuffer(readableStream);
     const parser = OrganizationLearnerParser.buildParser(buffer, organization.id, i18n);
-    const result = parser.parse(parser.getFileEncoding());
+    const result = parser.parse(organizationImport.encoding);
     organizationLearnerData = result.learners;
+    if (isEmpty(organizationLearnerData)) {
+      throw new SiecleXmlImportError(ERRORS.EMPTY);
+    }
+  } catch (error) {
+    errors.push(error);
+    throw error;
   } finally {
+    organizationImport.validate({ errors });
+    await organizationImportRepository.save(organizationImport);
     await importStorage.deleteFile({ filename });
   }
 
-  if (isEmpty(organizationLearnerData)) {
-    throw new SiecleXmlImportError(ERRORS.EMPTY);
-  }
-
-  const organizationLearnersChunks = chunk(organizationLearnerData, ORGANIZATION_LEARNER_CHUNK_SIZE);
-
-  const nationalStudentIdData = organizationLearnerData.map((learner) => learner.nationalStudentId, []);
-
   return DomainTransaction.execute(async (domainTransaction) => {
-    await organizationLearnerRepository.disableAllOrganizationLearnersInOrganization({
-      domainTransaction,
-      organizationId,
-      nationalStudentIds: nationalStudentIdData,
-    });
+    try {
+      organizationImport = await organizationImportRepository.getByOrganizationId(organizationId);
 
-    await bluebird.mapSeries(organizationLearnersChunks, (chunk) => {
-      return organizationLearnerRepository.addOrUpdateOrganizationOfOrganizationLearners(
-        chunk,
-        organizationId,
+      const organizationLearnersChunks = chunk(organizationLearnerData, ORGANIZATION_LEARNER_CHUNK_SIZE);
+      const nationalStudentIdData = organizationLearnerData.map((learner) => learner.nationalStudentId, []);
+
+      await organizationLearnerRepository.disableAllOrganizationLearnersInOrganization({
         domainTransaction,
-      );
-    });
+        organizationId,
+        nationalStudentIds: nationalStudentIdData,
+      });
+
+      await bluebird.mapSeries(organizationLearnersChunks, (chunk) => {
+        return organizationLearnerRepository.addOrUpdateOrganizationOfOrganizationLearners(
+          chunk,
+          organizationId,
+          domainTransaction,
+        );
+      });
+    } catch (error) {
+      errors.push(error);
+      throw error;
+    } finally {
+      organizationImport.process({ errors });
+      await organizationImportRepository.save(organizationImport);
+    }
   });
 };
+
 function getDataBuffer(readableStream) {
   return new Promise((resolve, reject) => {
     const chunks = [];
@@ -71,4 +109,5 @@ function getDataBuffer(readableStream) {
     });
   });
 }
+
 export { importOrganizationLearnersFromSIECLECSVFormat };

--- a/api/tests/prescription/learner-management/unit/domain/usecases/import-organization-learners-from-siecle-csv-format_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/import-organization-learners-from-siecle-csv-format_test.js
@@ -2,21 +2,24 @@ import iconv from 'iconv-lite';
 import { Readable } from 'stream';
 
 import { DomainTransaction } from '../../../../../../lib/infrastructure/DomainTransaction.js';
+import { OrganizationImport } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationImport.js';
 import { importOrganizationLearnersFromSIECLECSVFormat } from '../../../../../../src/prescription/learner-management/domain/usecases/import-organization-learners-from-siecle-csv-format.js';
 import { OrganizationLearnerImportHeader } from '../../../../../../src/prescription/learner-management/infrastructure/serializers/csv/organization-learner-import-header.js';
-import { expect, sinon } from '../../../../../test-helper.js';
+import { catchErr, expect, sinon } from '../../../../../test-helper.js';
 import { getI18n } from '../../../../../tooling/i18n/i18n.js';
 
 describe('Unit | UseCase | import-organization-learners-from-siecle-csv', function () {
   const organizationId = 1234;
   let organizationLearnerRepositoryStub;
   let organizationRepositoryStub;
+  let organizationImportRepositoryStub;
   let importStorageStub;
   let payload;
   let filename;
   let domainTransaction;
   let i18n;
   let csvHeaders;
+  let csv;
 
   beforeEach(function () {
     domainTransaction = Symbol();
@@ -41,8 +44,15 @@ describe('Unit | UseCase | import-organization-learners-from-siecle-csv', functi
       findByOrganizationId: sinon.stub(),
       disableAllOrganizationLearnersInOrganization: sinon.stub().resolves(),
     };
+    organizationImportRepositoryStub = {
+      getByOrganizationId: sinon.stub(),
+      save: sinon.stub(),
+    };
 
-    organizationRepositoryStub = { get: sinon.stub() };
+    organizationImportRepositoryStub.getByOrganizationId.callsFake(
+      () => new OrganizationImport({ organizationId, createdBy: 2, encoding: 'utf-8' }),
+    );
+    organizationRepositoryStub = { get: sinon.stub().resolves({ id: 123 }) };
   });
 
   context('when extracted organizationLearners informations can be imported', function () {
@@ -50,7 +60,7 @@ describe('Unit | UseCase | import-organization-learners-from-siecle-csv', functi
       importStorageStub.sendFile.withArgs({ filepath: payload.path }).resolves(filename);
       organizationRepositoryStub.get.withArgs(organizationId).resolves({ id: 123 });
 
-      const input = `${csvHeaders}
+      csv = `${csvHeaders}
       4581234567F;Léa;Jeannette;Klervi;Corse;Cottonmouth;Féminin;01/01/1990;2A214;;2A;99100;AP;MEF1;Division 2
       4581234567G;Léo;;;Corse;;Féminin;01/01/1990;;Plymouth;99;99132;ST;MEF1;Division 1
       `.trim();
@@ -58,7 +68,7 @@ describe('Unit | UseCase | import-organization-learners-from-siecle-csv', functi
       importStorageStub.readFile.withArgs({ filename }).resolves(
         new Readable({
           read() {
-            this.push(iconv.encode(input, 'utf8'));
+            this.push(iconv.encode(csv, 'utf8'));
             this.push(null);
           },
         }),
@@ -72,6 +82,17 @@ describe('Unit | UseCase | import-organization-learners-from-siecle-csv', functi
         organizationRepository: organizationRepositoryStub,
         organizationLearnerRepository: organizationLearnerRepositoryStub,
         importStorage: importStorageStub,
+        organizationImportRepository: organizationImportRepositoryStub,
+        dependencies: {
+          createReadStream: sinon.stub().returns(
+            new Readable({
+              read() {
+                this.push(iconv.encode(csv, 'utf8'));
+                this.push(null);
+              },
+            }),
+          ),
+        },
         i18n,
       });
 
@@ -85,9 +106,193 @@ describe('Unit | UseCase | import-organization-learners-from-siecle-csv', functi
         organizationRepository: organizationRepositoryStub,
         organizationLearnerRepository: organizationLearnerRepositoryStub,
         importStorage: importStorageStub,
+        organizationImportRepository: organizationImportRepositoryStub,
+        dependencies: {
+          createReadStream: sinon.stub().returns(
+            new Readable({
+              read() {
+                this.push(iconv.encode(csv, 'utf8'));
+                this.push(null);
+              },
+            }),
+          ),
+        },
         i18n,
       });
       expect(importStorageStub.deleteFile).to.have.been.called;
+    });
+  });
+  context('save import state in database', function () {
+    describe('success case', function () {
+      it('should save uploaded, validated and imported state each after each', async function () {
+        // given
+        importStorageStub.sendFile.withArgs({ filepath: payload.path }).resolves(filename);
+        organizationRepositoryStub.get.withArgs(organizationId).resolves({ id: 123 });
+
+        csv = `${csvHeaders}
+      4581234567F;Léa;Jeannette;Klervi;Corse;Cottonmouth;Féminin;01/01/1990;2A214;;2A;99100;AP;MEF1;Division 2
+      4581234567G;Léo;;;Corse;;Féminin;01/01/1990;;Plymouth;99;99132;ST;MEF1;Division 1
+      `.trim();
+
+        importStorageStub.readFile.withArgs({ filename }).resolves(
+          new Readable({
+            read() {
+              this.push(iconv.encode(csv, 'utf8'));
+              this.push(null);
+            },
+          }),
+        );
+
+        // when
+        await importOrganizationLearnersFromSIECLECSVFormat({
+          organizationId,
+          payload,
+          organizationRepository: organizationRepositoryStub,
+          organizationLearnerRepository: organizationLearnerRepositoryStub,
+          importStorage: importStorageStub,
+          organizationImportRepository: organizationImportRepositoryStub,
+          dependencies: {
+            createReadStream: sinon.stub().returns(
+              new Readable({
+                read() {
+                  this.push(iconv.encode(csv, 'utf8'));
+                  this.push(null);
+                },
+              }),
+            ),
+          },
+          i18n,
+        });
+
+        // then
+
+        const firstSaveCall = organizationImportRepositoryStub.save.getCall(0).args[0];
+        const secondSaveCall = organizationImportRepositoryStub.save.getCall(1).args[0];
+        const thirdSaveCall = organizationImportRepositoryStub.save.getCall(2).args[0];
+
+        expect(firstSaveCall.status).to.equal('UPLOADED');
+        expect(secondSaveCall.status).to.equal('VALIDATED');
+        expect(thirdSaveCall.status).to.equal('IMPORTED');
+      });
+    });
+    describe('errors case', function () {
+      describe('when there is an upload error', function () {
+        it('should save UPLOAD_ERROR status', async function () {
+          // given
+          importStorageStub.sendFile.rejects();
+
+          // when
+          await catchErr(importOrganizationLearnersFromSIECLECSVFormat)({
+            organizationId,
+            payload,
+            organizationRepository: organizationRepositoryStub,
+            organizationLearnerRepository: organizationLearnerRepositoryStub,
+            importStorage: importStorageStub,
+            organizationImportRepository: organizationImportRepositoryStub,
+            dependencies: {
+              createReadStream: sinon.stub().returns(
+                new Readable({
+                  read() {
+                    this.push(iconv.encode(csv, 'utf8'));
+                    this.push(null);
+                  },
+                }),
+              ),
+            },
+            i18n,
+          });
+
+          // then
+
+          expect(organizationImportRepositoryStub.save.getCall(0).args[0].status).to.equal('UPLOAD_ERROR');
+        });
+      });
+      describe('when there is an validation error', function () {
+        it('should save VALIDATION_ERROR status', async function () {
+          // given
+          importStorageStub.sendFile.withArgs({ filepath: payload.path }).resolves(filename);
+          csv = `${csvHeaders}`.trim();
+
+          importStorageStub.readFile.withArgs({ filename }).resolves(
+            new Readable({
+              read() {
+                this.push(iconv.encode(csv, 'utf8'));
+                this.push(null);
+              },
+            }),
+          );
+          // when
+          await catchErr(importOrganizationLearnersFromSIECLECSVFormat)({
+            organizationId,
+            payload,
+            organizationRepository: organizationRepositoryStub,
+            organizationLearnerRepository: organizationLearnerRepositoryStub,
+            importStorage: importStorageStub,
+            organizationImportRepository: organizationImportRepositoryStub,
+            dependencies: {
+              createReadStream: sinon.stub().returns(
+                new Readable({
+                  read() {
+                    this.push(iconv.encode(csv, 'utf8'));
+                    this.push(null);
+                  },
+                }),
+              ),
+            },
+            i18n,
+          });
+
+          // then
+          expect(organizationImportRepositoryStub.save.getCall(1).args[0].status).to.equal('VALIDATION_ERROR');
+        });
+      });
+      describe('when there is an import error', function () {
+        it('should save IMPORT_ERROR status', async function () {
+          // given
+          importStorageStub.sendFile.withArgs({ filepath: payload.path }).resolves(filename);
+          organizationRepositoryStub.get.withArgs(organizationId).resolves({ id: 123 });
+
+          csv = `${csvHeaders}
+      4581234567F;Léa;Jeannette;Klervi;Corse;Cottonmouth;Féminin;01/01/1990;2A214;;2A;99100;AP;MEF1;Division 2
+      4581234567G;Léo;;;Corse;;Féminin;01/01/1990;;Plymouth;99;99132;ST;MEF1;Division 1
+      `.trim();
+
+          importStorageStub.readFile.withArgs({ filename }).resolves(
+            new Readable({
+              read() {
+                this.push(iconv.encode(csv, 'utf8'));
+                this.push(null);
+              },
+            }),
+          );
+          organizationLearnerRepositoryStub.addOrUpdateOrganizationOfOrganizationLearners.rejects();
+
+          // when
+          await catchErr(importOrganizationLearnersFromSIECLECSVFormat)({
+            organizationId,
+            payload,
+            organizationRepository: organizationRepositoryStub,
+            organizationLearnerRepository: organizationLearnerRepositoryStub,
+            importStorage: importStorageStub,
+            organizationImportRepository: organizationImportRepositoryStub,
+            dependencies: {
+              createReadStream: sinon.stub().returns(
+                new Readable({
+                  read() {
+                    this.push(iconv.encode(csv, 'utf8'));
+                    this.push(null);
+                  },
+                }),
+              ),
+            },
+            i18n,
+          });
+
+          // then
+
+          expect(organizationImportRepositoryStub.save.getCall(2).args[0].status).to.equal('IMPORT_ERROR');
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Maintenant que nous stockons le fichier d'import dans un S3. On doit stocker l'état de l'import (FREGATA dans le cas de cette PR) dans la table organization-imports à chaque étape de l'import.

## :robot: Proposition
On ajoute le stockage du statut pour chaque étape de l'import, ainsi que les erreurs associées si il y en a.

## :rainbow: Remarques
Il existe 6 statuts différents possible : 
- UPLOADED : Cas nominal
- UPLOAD_ERROR : En cas de soucis lors de l'upload sur le S3
- VALIDATED : Cas nominal
- VALIDATION_ERROR : En cas de soucis lors de la validation du fichier 
- IMPORTED : Cas nominal
- IMPORT_ERROR : En cas de soucis lors de l'insertion en BDD (Une contrainte qui casse ... )


## :100: Pour tester
Cas nominal : 
Le plus simple étant en local .. Pour pouvoir stopper le code dans le usecase aux différents endroits avec des points d'arrêts
-> UPLOADED : Après l'upload MAIS avant la validation
-> VALIDATED : Après la validation MAIS avant l'insertion en BDD 
-> IMPORTED : A la fin de toutes les étapes


Pour les erreurs à tester : 
-> UPLOAD_ERROR : couper le docker du s3. Importer. Vérifier en BDD
-> VALIDATION_ERROR : Enlever un en-tete obligatoire dans le csv?. Importer. Vérifier en BDD
-> IMPORT_ERROR : Le plus embêtant à tester, possible de throw une erreur dans la méthode `addOrUpdateOrganizationOfOrganizationLearners` afin que l'insertion ne se passe pas bien. Importer. Vérifier en BDD

Après tout ça, une bonne pause est méritée ! 
🐈‍⬛ 