### PR TITLE
[FEATURE] Récupérer la config de niveau par compétence en fonction de la date du certification-course (PIX-11548).

### DIFF
--- a/api/db/database-builder/factory/build-flash-algorithm-configuration.js
+++ b/api/db/database-builder/factory/build-flash-algorithm-configuration.js
@@ -1,5 +1,5 @@
-import { databaseBuffer } from '../database-buffer.js';
 import { config } from '../../../src/shared/config.js';
+import { databaseBuffer } from '../database-buffer.js';
 
 const buildFlashAlgorithmConfiguration = function ({
   warmUpLength = null,

--- a/api/db/database-builder/factory/build-flash-algorithm-configuration.js
+++ b/api/db/database-builder/factory/build-flash-algorithm-configuration.js
@@ -1,9 +1,10 @@
 import { databaseBuffer } from '../database-buffer.js';
+import { config } from '../../../src/shared/config.js';
 
 const buildFlashAlgorithmConfiguration = function ({
   warmUpLength = null,
   forcedCompetences = [],
-  maximumAssessmentLength = null,
+  maximumAssessmentLength = config.v3Certification.numberOfChallengesPerCourse,
   challengesBetweenSameCompetence = null,
   minimumEstimatedSuccessRateRanges = [],
   limitToOneQuestionPerTube = null,

--- a/api/lib/domain/events/handle-certification-rescoring.js
+++ b/api/lib/domain/events/handle-certification-rescoring.js
@@ -107,7 +107,9 @@ async function _handleV3Certification({
     ? ABORT_REASONS.CANDIDATE
     : ABORT_REASONS.TECHNICAL;
 
-  const configuration = await flashAlgorithmConfigurationRepository.get();
+  const configuration = await flashAlgorithmConfigurationRepository.getMostRecentBeforeDate(
+    certificationCourse.getStartDate(),
+  );
 
   const algorithm = new FlashAssessmentAlgorithm({
     flashAlgorithmImplementation: flashAlgorithmService,

--- a/api/lib/domain/events/handle-certification-scoring.js
+++ b/api/lib/domain/events/handle-certification-scoring.js
@@ -138,7 +138,9 @@ async function _handleV3CertificationScoring({
     ? ABORT_REASONS.CANDIDATE
     : ABORT_REASONS.TECHNICAL;
 
-  const configuration = await flashAlgorithmConfigurationRepository.get();
+  const configuration = await flashAlgorithmConfigurationRepository.getMostRecentBeforeDate(
+    certificationCourse.getStartDate(),
+  );
 
   const algorithm = new FlashAssessmentAlgorithm({
     flashAlgorithmImplementation: flashAlgorithmService,

--- a/api/lib/domain/models/CertificationCourse.js
+++ b/api/lib/domain/models/CertificationCourse.js
@@ -244,6 +244,10 @@ class CertificationCourse {
     return this._maxReachableLevelOnCertificationDate;
   }
 
+  getStartDate() {
+    return this._createdAt;
+  }
+
   getNumberOfChallenges() {
     if (this.isV3()) {
       return this._numberOfChallenges;

--- a/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
@@ -25,7 +25,8 @@ const getNextChallengeForCampaignAssessment = async function ({
       locale,
     });
 
-    const configuration = (await flashAlgorithmConfigurationRepository.get()) ?? _createDefaultAlgorithmConfiguration();
+    const configuration =
+      (await flashAlgorithmConfigurationRepository.getMostRecent()) ?? _createDefaultAlgorithmConfiguration();
 
     const assessmentAlgorithm = new FlashAssessmentAlgorithm({
       flashAlgorithmImplementation: flashAlgorithmService,

--- a/api/src/certification/course/domain/usecases/get-next-challenge-for-certification.js
+++ b/api/src/certification/course/domain/usecases/get-next-challenge-for-certification.js
@@ -43,7 +43,9 @@ const getNextChallengeForCertification = async function ({
       challengeRepository.findActiveFlashCompatible({ locale }),
     ]);
 
-    const algorithmConfiguration = await flashAlgorithmConfigurationRepository.get();
+    const algorithmConfiguration = await flashAlgorithmConfigurationRepository.getMostRecentBeforeDate(
+      certificationCourse.getStartDate(),
+    );
 
     const assessmentAlgorithm = new FlashAssessmentAlgorithm({
       flashAlgorithmImplementation: flashAlgorithmService,

--- a/api/src/certification/flash-certification/domain/models/FlashAssessmentAlgorithmConfiguration.js
+++ b/api/src/certification/flash-certification/domain/models/FlashAssessmentAlgorithmConfiguration.js
@@ -25,6 +25,7 @@ export class FlashAssessmentAlgorithmConfiguration {
     doubleMeasuresUntil,
     variationPercent,
     variationPercentUntil,
+    createdAt,
   } = {}) {
     this.warmUpLength = warmUpLength;
     this.forcedCompetences = forcedCompetences;
@@ -36,6 +37,7 @@ export class FlashAssessmentAlgorithmConfiguration {
     this.doubleMeasuresUntil = doubleMeasuresUntil;
     this.variationPercent = variationPercent;
     this.variationPercentUntil = variationPercentUntil;
+    this.createdAt = createdAt;
   }
 
   toDTO() {
@@ -52,6 +54,7 @@ export class FlashAssessmentAlgorithmConfiguration {
       doubleMeasuresUntil: this.doubleMeasuresUntil,
       variationPercent: this.variationPercent,
       variationPercentUntil: this.variationPercentUntil,
+      createdAt: this.createdAt,
     };
   }
 
@@ -66,6 +69,7 @@ export class FlashAssessmentAlgorithmConfiguration {
     doubleMeasuresUntil,
     variationPercent,
     variationPercentUntil,
+    createdAt,
   }) {
     return new FlashAssessmentAlgorithmConfiguration({
       warmUpLength,
@@ -80,6 +84,7 @@ export class FlashAssessmentAlgorithmConfiguration {
       doubleMeasuresUntil,
       variationPercent,
       variationPercentUntil,
+      createdAt,
     });
   }
 }

--- a/api/src/certification/flash-certification/domain/usecases/get-active-flash-assessment-configuration.js
+++ b/api/src/certification/flash-certification/domain/usecases/get-active-flash-assessment-configuration.js
@@ -1,3 +1,3 @@
 export const getActiveFlashAssessmentConfiguration = async ({ flashAlgorithmConfigurationRepository }) => {
-  return flashAlgorithmConfigurationRepository.get();
+  return flashAlgorithmConfigurationRepository.getMostRecent();
 };

--- a/api/src/certification/flash-certification/domain/usecases/update-active-flash-assessment-configuration.js
+++ b/api/src/certification/flash-certification/domain/usecases/update-active-flash-assessment-configuration.js
@@ -9,6 +9,7 @@ export const updateActiveFlashAssessmentConfiguration = async ({
     new FlashAssessmentAlgorithmConfiguration({
       ...previousConfiguration,
       ...configuration,
+      createdAt: new Date(),
     }),
   );
 };

--- a/api/src/certification/flash-certification/domain/usecases/update-active-flash-assessment-configuration.js
+++ b/api/src/certification/flash-certification/domain/usecases/update-active-flash-assessment-configuration.js
@@ -4,7 +4,7 @@ export const updateActiveFlashAssessmentConfiguration = async ({
   flashAlgorithmConfigurationRepository,
   configuration,
 }) => {
-  const previousConfiguration = await flashAlgorithmConfigurationRepository.get();
+  const previousConfiguration = await flashAlgorithmConfigurationRepository.getMostRecent();
   await flashAlgorithmConfigurationRepository.save(
     new FlashAssessmentAlgorithmConfiguration({
       ...previousConfiguration,

--- a/api/src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js
+++ b/api/src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js
@@ -1,6 +1,6 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
-import { FlashAssessmentAlgorithmConfiguration } from '../../domain/models/FlashAssessmentAlgorithmConfiguration.js';
 import { NotFoundError } from '../../../../../lib/domain/errors.js';
+import { FlashAssessmentAlgorithmConfiguration } from '../../domain/models/FlashAssessmentAlgorithmConfiguration.js';
 
 const TABLE_NAME = 'flash-algorithm-configurations';
 
@@ -37,4 +37,4 @@ const getMostRecentBeforeDate = async (date) => {
   return FlashAssessmentAlgorithmConfiguration.fromDTO(firstFlashAlgoConfiguration);
 };
 
-export { save, getMostRecent, getMostRecentBeforeDate };
+export { getMostRecent, getMostRecentBeforeDate, save };

--- a/api/src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js
+++ b/api/src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js
@@ -1,5 +1,6 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { FlashAssessmentAlgorithmConfiguration } from '../../domain/models/FlashAssessmentAlgorithmConfiguration.js';
+import { NotFoundError } from '../../../../../lib/domain/errors.js';
 
 const TABLE_NAME = 'flash-algorithm-configurations';
 
@@ -17,4 +18,23 @@ const get = async function () {
   return FlashAssessmentAlgorithmConfiguration.fromDTO(flashAlgorithmConfiguration);
 };
 
-export { get, save };
+const getMostRecentBeforeDate = async (date) => {
+  const flashAlgorithmConfiguration = await knex(TABLE_NAME)
+    .where('createdAt', '<=', date)
+    .orderBy('createdAt', 'desc')
+    .first();
+
+  if (flashAlgorithmConfiguration) {
+    return FlashAssessmentAlgorithmConfiguration.fromDTO(flashAlgorithmConfiguration);
+  }
+
+  const firstFlashAlgoConfiguration = await knex(TABLE_NAME).orderBy('createdAt', 'asc').first();
+
+  if (!firstFlashAlgoConfiguration) {
+    throw new NotFoundError('Configuration not found');
+  }
+
+  return FlashAssessmentAlgorithmConfiguration.fromDTO(firstFlashAlgoConfiguration);
+};
+
+export { save, get, getMostRecentBeforeDate };

--- a/api/src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js
+++ b/api/src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js
@@ -8,7 +8,7 @@ const save = async function (flashAlgorithmConfiguration) {
   return knex(TABLE_NAME).insert(flashAlgorithmConfiguration.toDTO());
 };
 
-const get = async function () {
+const getMostRecent = async function () {
   const flashAlgorithmConfiguration = await knex(TABLE_NAME).orderBy('createdAt', 'desc').first();
 
   if (!flashAlgorithmConfiguration) {
@@ -37,4 +37,4 @@ const getMostRecentBeforeDate = async (date) => {
   return FlashAssessmentAlgorithmConfiguration.fromDTO(firstFlashAlgoConfiguration);
 };
 
-export { save, get, getMostRecentBeforeDate };
+export { save, getMostRecent, getMostRecentBeforeDate };

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -361,7 +361,7 @@ const configuration = (function () {
       redisUrl: process.env.REDIS_URL,
     },
     v3Certification: {
-      numberOfChallengesPerCourse: process.env.V3_CERTIFICATION_NUMBER_OF_CHALLENGES_PER_COURSE || 20,
+      numberOfChallengesPerCourse: parseInt(process.env.V3_CERTIFICATION_NUMBER_OF_CHALLENGES_PER_COURSE, 10) || 20,
       defaultProbabilityToPickChallenge: parseInt(process.env.DEFAULT_PROBABILITY_TO_PICK_CHALLENGE, 10) || 51,
       defaultCandidateCapacity: -3,
       challengesBetweenSameCompetence: 2,

--- a/api/tests/certification/course/acceptance/application/certification-course-route_test.js
+++ b/api/tests/certification/course/acceptance/application/certification-course-route_test.js
@@ -66,6 +66,7 @@ describe('Acceptance | Route | certification-course', function () {
       it('should create a new rejected AssessmentResult', async function () {
         // given
         const userId = (await insertUserWithRoleSuperAdmin()).id;
+        databaseBuilder.factory.buildFlashAlgorithmConfiguration();
 
         const session = databaseBuilder.factory.buildSession({
           publishedAt: new Date('2018-12-01T01:02:03Z'),

--- a/api/tests/certification/course/unit/domain/usecases/get-next-challenge-for-certification_test.js
+++ b/api/tests/certification/course/unit/domain/usecases/get-next-challenge-for-certification_test.js
@@ -79,9 +79,11 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
         flashAlgorithmService,
         flashAlgorithmConfigurationRepository;
 
+      let flashAlgorithmConfiguration;
+
       beforeEach(function () {
         flashAlgorithmConfigurationRepository = {
-          get: sinon.stub(),
+          getMostRecentBeforeDate: sinon.stub(),
         };
         answerRepository = {
           findByAssessment: sinon.stub(),
@@ -109,7 +111,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
           getEstimatedLevelAndErrorRate: sinon.stub(),
         };
 
-        flashAlgorithmConfigurationRepository.get.resolves(domainBuilder.buildFlashAlgorithmConfiguration({}));
+        flashAlgorithmConfiguration = domainBuilder.buildFlashAlgorithmConfiguration();
       });
       context('when there are challenges left to answer', function () {
         it('should save the returned next challenge', async function () {
@@ -120,6 +122,10 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
           });
           const assessment = domainBuilder.buildAssessment();
           const locale = 'fr-FR';
+
+          flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
+            .withArgs(v3CertificationCourse.getStartDate())
+            .resolves(flashAlgorithmConfiguration);
 
           answerRepository.findByAssessment.withArgs(assessment.id).resolves([]);
           certificationChallengeLiveAlertRepository.getLiveAlertValidatedChallengeIdsByAssessmentId
@@ -257,6 +263,10 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
             id: nonAnsweredCertificationChallenge.challengeId,
           });
 
+          flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
+            .withArgs(v3CertificationCourse.getStartDate())
+            .resolves(flashAlgorithmConfiguration);
+
           answerRepository.findByAssessment.withArgs(assessment.id).resolves([]);
           challengeRepository.findActiveFlashCompatible
             .withArgs({ locale })
@@ -349,6 +359,10 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
             skill: firstSkill,
           });
 
+          flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
+            .withArgs(v3CertificationCourse.getStartDate())
+            .resolves(flashAlgorithmConfiguration);
+
           answerRepository.findByAssessment.withArgs(assessment.id).resolves([]);
           challengeRepository.findActiveFlashCompatible
             .withArgs()
@@ -427,6 +441,10 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
             getPossibleNextChallenges: sinon.stub(),
             getEstimatedLevelAndErrorRate: sinon.stub(),
           };
+
+          flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
+            .withArgs(v3CertificationCourse.getStartDate())
+            .resolves(flashAlgorithmConfiguration);
 
           answerRepository.findByAssessment.withArgs(assessment.id).resolves([answer]);
           certificationChallengeLiveAlertRepository.getLiveAlertValidatedChallengeIdsByAssessmentId
@@ -512,13 +530,17 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-certification', fun
               const nextChallengeToAnswer = domainBuilder.buildChallenge({
                 competenceId,
               });
-              flashAlgorithmConfigurationRepository.get.reset();
-              const configuration = domainBuilder.buildFlashAlgorithmConfiguration(flashConfiguration);
-              flashAlgorithmConfigurationRepository.get.resolves(configuration);
 
               const v3CertificationCourse = domainBuilder.buildCertificationCourse({
                 version: CertificationVersion.V3,
               });
+
+              flashAlgorithmConfigurationRepository.getMostRecentBeforeDate.reset();
+              const configuration = domainBuilder.buildFlashAlgorithmConfiguration(flashConfiguration);
+              flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
+                .withArgs(v3CertificationCourse.getStartDate())
+                .resolves(configuration);
+
               const assessment = domainBuilder.buildAssessment();
               const locale = 'fr-FR';
 

--- a/api/tests/certification/flash-certification/integration/infrastructure/repositories/flash-algorithm-configuration-repository_test.js
+++ b/api/tests/certification/flash-certification/integration/infrastructure/repositories/flash-algorithm-configuration-repository_test.js
@@ -115,7 +115,7 @@ describe('Integration | Infrastructure | Repository | FlashAlgorithmConfiguratio
     });
   });
 
-  describe('#get', function () {
+  describe('#getMostRecent', function () {
     describe('when there is a saved configuration', function () {
       it('should return a flash algorithm configuration', async function () {
         // given
@@ -143,7 +143,7 @@ describe('Integration | Infrastructure | Repository | FlashAlgorithmConfiguratio
         await databaseBuilder.commit();
 
         // when
-        const configResult = await flashAlgorithmConfigurationRepository.get();
+        const configResult = await flashAlgorithmConfigurationRepository.getMostRecent();
 
         // then
         expect(configResult.toDTO()).to.deep.equal(expectedFlashAlgorithmConfiguration.toDTO());
@@ -196,7 +196,7 @@ describe('Integration | Infrastructure | Repository | FlashAlgorithmConfiguratio
         await databaseBuilder.commit();
 
         // when
-        const configResult = await flashAlgorithmConfigurationRepository.get();
+        const configResult = await flashAlgorithmConfigurationRepository.getMostRecent();
 
         // then
         expect(configResult.toDTO()).to.deep.equal(expectedFlashAlgorithmConfiguration.toDTO());
@@ -206,7 +206,7 @@ describe('Integration | Infrastructure | Repository | FlashAlgorithmConfiguratio
     describe('when there is no saved configuration', function () {
       it('should return default configuration', async function () {
         // when
-        const configResult = await flashAlgorithmConfigurationRepository.get();
+        const configResult = await flashAlgorithmConfigurationRepository.getMostRecent();
 
         // then
         expect(configResult).to.be.instanceOf(FlashAssessmentAlgorithmConfiguration);

--- a/api/tests/certification/flash-certification/integration/infrastructure/repositories/flash-algorithm-configuration-repository_test.js
+++ b/api/tests/certification/flash-certification/integration/infrastructure/repositories/flash-algorithm-configuration-repository_test.js
@@ -1,8 +1,9 @@
-import { catchErr, databaseBuilder, domainBuilder, expect, knex } from '../../../../../test-helper.js';
-import * as flashAlgorithmConfigurationRepository from '../../../../../../../api/src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js';
-import { FlashAssessmentAlgorithmConfiguration } from '../../../../../../src/certification/flash-certification/domain/models/FlashAssessmentAlgorithmConfiguration.js';
 import dayjs from 'dayjs';
+
+import * as flashAlgorithmConfigurationRepository from '../../../../../../../api/src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js';
 import { NotFoundError } from '../../../../../../lib/domain/errors.js';
+import { FlashAssessmentAlgorithmConfiguration } from '../../../../../../src/certification/flash-certification/domain/models/FlashAssessmentAlgorithmConfiguration.js';
+import { catchErr, databaseBuilder, domainBuilder, expect, knex } from '../../../../../test-helper.js';
 
 describe('Integration | Infrastructure | Repository | FlashAlgorithmConfigurationRepository', function () {
   describe('#save', function () {

--- a/api/tests/certification/flash-certification/unit/domain/usecases/get-active-flash-assessment-configuration_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/usecases/get-active-flash-assessment-configuration_test.js
@@ -5,12 +5,12 @@ describe('#getActiveFlashAssessmentConfiguration', function () {
   it('should return the last configuration', async function () {
     // given
     const flashAlgorithmConfigurationRepository = {
-      get: sinon.stub(),
+      getMostRecent: sinon.stub(),
     };
 
     const configuration = domainBuilder.buildFlashAlgorithmConfiguration();
 
-    flashAlgorithmConfigurationRepository.get.resolves(configuration);
+    flashAlgorithmConfigurationRepository.getMostRecent.resolves(configuration);
 
     // when
     const activeConfiguration = await getActiveFlashAssessmentConfiguration({ flashAlgorithmConfigurationRepository });

--- a/api/tests/certification/flash-certification/unit/domain/usecases/update-active-flash-assessment-configuration_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/usecases/update-active-flash-assessment-configuration_test.js
@@ -1,5 +1,6 @@
 import { updateActiveFlashAssessmentConfiguration } from '../../../../../../src/certification/flash-certification/domain/usecases/update-active-flash-assessment-configuration.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+import _ from 'lodash';
 
 describe('Unit | Domain | UseCases | update-active-flash-assessment-configuration', function () {
   it('should update the active flash assessment configuration', async function () {
@@ -32,6 +33,8 @@ describe('Unit | Domain | UseCases | update-active-flash-assessment-configuratio
       ...configuration,
     });
 
-    expect(flashAlgorithmConfigurationRepository.save).to.have.been.calledWith(expectedConfiguration);
+    expect(flashAlgorithmConfigurationRepository.save).to.have.been.calledWith(
+      sinon.match(_.omit(expectedConfiguration, 'createdAt')),
+    );
   });
 });

--- a/api/tests/certification/flash-certification/unit/domain/usecases/update-active-flash-assessment-configuration_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/usecases/update-active-flash-assessment-configuration_test.js
@@ -6,7 +6,7 @@ describe('Unit | Domain | UseCases | update-active-flash-assessment-configuratio
   it('should update the active flash assessment configuration', async function () {
     // given
     const flashAlgorithmConfigurationRepository = {
-      get: sinon.stub(),
+      getMostRecent: sinon.stub(),
       save: sinon.stub(),
     };
 
@@ -19,7 +19,7 @@ describe('Unit | Domain | UseCases | update-active-flash-assessment-configuratio
       variationPercent: 0.5,
     });
 
-    flashAlgorithmConfigurationRepository.get.resolves(previousConfiguration);
+    flashAlgorithmConfigurationRepository.getMostRecent.resolves(previousConfiguration);
 
     // when
     await updateActiveFlashAssessmentConfiguration({

--- a/api/tests/certification/flash-certification/unit/domain/usecases/update-active-flash-assessment-configuration_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/usecases/update-active-flash-assessment-configuration_test.js
@@ -1,6 +1,7 @@
+import _ from 'lodash';
+
 import { updateActiveFlashAssessmentConfiguration } from '../../../../../../src/certification/flash-certification/domain/usecases/update-active-flash-assessment-configuration.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
-import _ from 'lodash';
 
 describe('Unit | Domain | UseCases | update-active-flash-assessment-configuration', function () {
   it('should update the active flash assessment configuration', async function () {

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
@@ -417,6 +417,7 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
         },
       ],
     });
+    databaseBuilder.factory.buildFlashAlgorithmConfiguration();
 
     await databaseBuilder.commit();
 

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
@@ -89,6 +89,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
             certificationCenterId,
             version: CertificationVersion.V3,
           }).id;
+          databaseBuilder.factory.buildFlashAlgorithmConfiguration();
           const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
             isPublished: false,
             version: CertificationVersion.V3,

--- a/api/tests/tooling/domain-builder/factory/build-flash-algorithm-configuration.js
+++ b/api/tests/tooling/domain-builder/factory/build-flash-algorithm-configuration.js
@@ -12,6 +12,7 @@ export const buildFlashAlgorithmConfiguration = ({
   doubleMeasuresUntil,
   variationPercent,
   variationPercentUntil,
+  createdAt,
 } = {}) => {
   return new FlashAssessmentAlgorithmConfiguration({
     warmUpLength,
@@ -26,5 +27,6 @@ export const buildFlashAlgorithmConfiguration = ({
     doubleMeasuresUntil,
     variationPercent,
     variationPercentUntil,
+    createdAt,
   });
 };

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -52,7 +52,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
     competenceMarkRepository = { save: sinon.stub() };
     certificationChallengeForScoringRepository = { getByCertificationCourseId: sinon.stub() };
     answerRepository = { findByAssessment: sinon.stub() };
-    flashAlgorithmConfigurationRepository = { get: sinon.stub() };
+    flashAlgorithmConfigurationRepository = { getMostRecentBeforeDate: sinon.stub() };
     certificationAssessmentHistoryRepository = { save: sinon.stub() };
     baseFlashAlgorithmConfiguration = domainBuilder.buildFlashAlgorithmConfiguration({
       maximumAssessmentLength,
@@ -365,6 +365,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
     context('when certification is V3', function () {
       let certificationCourse;
       const assessmentResultId = 99;
+      const certificationCourseStartDate = new Date('2022-02-01');
 
       beforeEach(function () {
         event = new AssessmentCompleted({
@@ -382,6 +383,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
         certificationAssessmentRepository.get.withArgs(assessmentId).resolves(certificationAssessment);
         certificationCourse = domainBuilder.buildCertificationCourse({
           id: certificationCourseId,
+          createdAt: certificationCourseStartDate,
           completedAt: null,
         });
 
@@ -406,6 +408,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
             const scoreForEstimatedLevel = 592;
             const abortedCertificationCourse = domainBuilder.buildCertificationCourse({
               id: certificationCourseId,
+              createdAt: certificationCourseStartDate,
               abortReason: ABORT_REASONS.CANDIDATE,
             });
 
@@ -426,7 +429,9 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
 
             const answers = generateAnswersForChallenges({ challenges });
 
-            flashAlgorithmConfigurationRepository.get.resolves(baseFlashAlgorithmConfiguration);
+            flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
+              .withArgs(certificationCourseStartDate)
+              .resolves(baseFlashAlgorithmConfiguration);
 
             certificationChallengeForScoringRepository.getByCertificationCourseId
               .withArgs({ certificationCourseId })
@@ -522,6 +527,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
             const scoreForEstimatedLevel = 592;
             const abortedCertificationCourse = domainBuilder.buildCertificationCourse({
               id: certificationCourseId,
+              createdAt: certificationCourseStartDate,
               completedAt: null,
               abortReason,
             });
@@ -543,7 +549,9 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
 
             const answers = generateAnswersForChallenges({ challenges });
 
-            flashAlgorithmConfigurationRepository.get.resolves(baseFlashAlgorithmConfiguration);
+            flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
+              .withArgs(certificationCourseStartDate)
+              .resolves(baseFlashAlgorithmConfiguration);
 
             certificationChallengeForScoringRepository.getByCertificationCourseId
               .withArgs({ certificationCourseId })
@@ -663,7 +671,9 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
               .resolves(challenges);
             answerRepository.findByAssessment.withArgs(assessmentId).resolves(answers);
             certificationCourseRepository.get.withArgs(certificationCourseId).resolves(certificationCourse);
-            flashAlgorithmConfigurationRepository.get.resolves(baseFlashAlgorithmConfiguration);
+            flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
+              .withArgs(certificationCourseStartDate)
+              .resolves(baseFlashAlgorithmConfiguration);
             flashAlgorithmService.getEstimatedLevelAndErrorRate
               .withArgs({
                 challenges,
@@ -772,7 +782,9 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
                 .resolves(challenges);
               answerRepository.findByAssessment.withArgs(assessmentId).resolves(answers);
               certificationCourseRepository.get.withArgs(certificationCourseId).resolves(certificationCourse);
-              flashAlgorithmConfigurationRepository.get.resolves(baseFlashAlgorithmConfiguration);
+              flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
+                .withArgs(certificationCourseStartDate)
+                .resolves(baseFlashAlgorithmConfiguration);
               flashAlgorithmService.getEstimatedLevelAndErrorRate
                 .withArgs({
                   challenges,
@@ -853,6 +865,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
               const abortedCertificationCourse = domainBuilder.buildCertificationCourse({
                 id: certificationCourseId,
                 completedAt: null,
+                createdAt: certificationCourseStartDate,
                 abortReason,
               });
 
@@ -874,7 +887,9 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
                 .resolves(challenges);
               answerRepository.findByAssessment.withArgs(assessmentId).resolves(answers);
               certificationCourseRepository.get.withArgs(certificationCourseId).resolves(abortedCertificationCourse);
-              flashAlgorithmConfigurationRepository.get.resolves(baseFlashAlgorithmConfiguration);
+              flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
+                .withArgs(certificationCourseStartDate)
+                .resolves(baseFlashAlgorithmConfiguration);
               flashAlgorithmService.getEstimatedLevelAndErrorRate
                 .withArgs({
                   challenges,
@@ -959,6 +974,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
               const abortReason = ABORT_REASONS.CANDIDATE;
               const abortedCertificationCourse = domainBuilder.buildCertificationCourse({
                 id: certificationCourseId,
+                createdAt: certificationCourseStartDate,
                 completedAt: null,
                 abortReason,
               });
@@ -981,7 +997,9 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
                 .resolves(challenges);
               answerRepository.findByAssessment.withArgs(assessmentId).resolves(answers);
               certificationCourseRepository.get.withArgs(certificationCourseId).resolves(abortedCertificationCourse);
-              flashAlgorithmConfigurationRepository.get.resolves(baseFlashAlgorithmConfiguration);
+              flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
+                .withArgs(certificationCourseStartDate)
+                .resolves(baseFlashAlgorithmConfiguration);
               flashAlgorithmService.getEstimatedLevelAndErrorRate
                 .withArgs({
                   challenges,
@@ -1082,7 +1100,9 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
           .resolves(challenges);
         answerRepository.findByAssessment.withArgs(assessmentId).resolves(answers);
         certificationCourseRepository.get.withArgs(certificationCourseId).resolves(certificationCourse);
-        flashAlgorithmConfigurationRepository.get.resolves(baseFlashAlgorithmConfiguration);
+        flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
+          .withArgs(certificationCourseStartDate)
+          .resolves(baseFlashAlgorithmConfiguration);
 
         flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
           .withArgs({

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -24,7 +24,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
       assessment = domainBuilder.buildAssessment({ id: 1165 });
 
       answerRepository = { findByAssessment: sinon.stub() };
-      flashAlgorithmConfigurationRepository = { get: sinon.stub() };
+      flashAlgorithmConfigurationRepository = { getMostRecent: sinon.stub() };
       challengeRepository = { get: sinon.stub() };
       challengeRepository.get.withArgs('first_challenge').resolves(firstChallenge);
       challengeRepository.get.withArgs('second_challenge').resolves(secondChallenge);
@@ -117,7 +117,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
             limitToOneQuestionPerTube: false,
             enablePassageByAllCompetences: false,
           });
-          flashAlgorithmConfigurationRepository.get.resolves(configuration);
+          flashAlgorithmConfigurationRepository.getMostRecent.resolves(configuration);
 
           const algorithmDataFetcherServiceStub = {
             fetchForFlashCampaigns: sinon.stub(),
@@ -199,7 +199,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
             limitToOneQuestionPerTube: false,
             enablePassageByAllCompetences: false,
           });
-          flashAlgorithmConfigurationRepository.get.resolves(configuration);
+          flashAlgorithmConfigurationRepository.getMostRecent.resolves(configuration);
 
           algorithmDataFetcherServiceStub.fetchForFlashCampaigns
             .withArgs({
@@ -268,7 +268,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
           const configuration = domainBuilder.buildFlashAlgorithmConfiguration({
             maximumAssessmentLength: 1,
           });
-          flashAlgorithmConfigurationRepository.get.resolves(configuration);
+          flashAlgorithmConfigurationRepository.getMostRecent.resolves(configuration);
 
           algorithmDataFetcherServiceStub.fetchForFlashCampaigns
             .withArgs({


### PR DESCRIPTION
## :unicorn: Problème

Nous récupérons uniquement la dernière configuration de l'algo dans le code. Cela est problématique car un candidat peut voir sa certif rescorée et cela se baserait donc sur une config différente de celle avec laquelle il a passé son test.

## :robot: Proposition

Se baser sur la dernière configuration créée en amont de la création du certification course lié au candidat.
Si aucune configuration précédent la création du certification-course n'est trouvée, on se base sur la première configuration créée.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

✅ Lorsque la date de création du certification-course est plus récente que celle de la configuration de niveau par compétences:
- Créer une session V3
- Passer la certif et la terminer
- Finaliser la session
- Dans pix-admin, vérifier que le candidat dispose de niveaux par compétences qui correspondent à la dernière configuration créée en amont de la création du certification course

Lorsqu'une nouvelle configuration de niveaux par compétences est créée à posteriori d'un certification course non scoré:
- Créer une session V3
- Commencer une certif
- Créer une nouvelle configuration avec des niveaux différents de la configuration existante via un appel à l'endpoint nécessaire (voir https://github.com/1024pix/pix/pull/8092 pour savoir comment créer une configuration)
- Terminer la session
- Finaliser la session
- Dans pix-admin, vérifier que le candidat dispose de niveaux par compétences qui correspondent à la dernière configuration créée en amont de la création du certification course

Lorsqu'un certification course non terminée a été créé avant la moindre configuration de niveaux par compétence :
- Supprimer les configuration existantes en BDD
- Créer une session V3
- Commencer une certif
- Créer une nouvelle configuration avec des niveaux différents de la configuration existante via un appel à l'endpoint nécessaire
- Terminer la session
- Finaliser la session
- Dans pix-admin, vérifier que le candidat dispose de niveaux par compétences qui correspondent à la configuration créée

