### PR TITLE
[FEATURE] Ajouter les étapes de l'upload pour l'ajout/modification sur l'import SUP (PIX-11347)

### DIFF
--- a/api/src/prescription/learner-management/application/sup-organization-management-controller.js
+++ b/api/src/prescription/learner-management/application/sup-organization-management-controller.js
@@ -1,7 +1,6 @@
 import fs from 'fs';
 
 import { logErrorWithCorrelationIds } from '../../../../lib/infrastructure/monitoring-tools.js';
-import * as requestResponseUtils from '../../../../lib/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as supOrganizationLearnerWarningSerializer from '../infrastructure/serializers/jsonapi/sup-organization-learner-warnings-serializer.js';
 
@@ -15,7 +14,7 @@ const importSupOrganizationLearners = async function (
   },
 ) {
   const organizationId = request.params.id;
-
+  const authenticatedUserId = request.auth.credentials.userId;
   let warnings;
 
   try {
@@ -23,6 +22,7 @@ const importSupOrganizationLearners = async function (
       payload: request.payload,
       organizationId,
       i18n: request.i18n,
+      userId: authenticatedUserId,
     });
   } finally {
     try {
@@ -42,12 +42,11 @@ const replaceSupOrganizationLearners = async function (
   h,
   dependencies = {
     supOrganizationLearnerWarningSerializer,
-    requestResponseUtils,
     logErrorWithCorrelationIds,
     unlink: fs.unlink,
   },
 ) {
-  const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+  const userId = request.auth.credentials.userId;
   const organizationId = request.params.id;
 
   let warnings;

--- a/api/src/prescription/learner-management/domain/usecases/import-sup-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-sup-organization-learners.js
@@ -1,14 +1,41 @@
+import { createReadStream } from 'fs';
+
 import { SupOrganizationLearnerParser } from '../../infrastructure/serializers/csv/sup-organization-learner-parser.js';
+import { OrganizationImport } from '../models/OrganizationImport.js';
 
 const importSupOrganizationLearners = async function ({
   payload,
+  userId,
   organizationId,
   i18n,
   supOrganizationLearnerRepository,
+  organizationImportRepository,
   importStorage,
+  dependencies = { createReadStream },
 }) {
-  const filename = await importStorage.sendFile({ filepath: payload.path });
+  let organizationImport = OrganizationImport.create({ organizationId, createdBy: userId });
+  let filename;
+  let encoding;
+  const errors = [];
+  let learnersData, warningsData;
 
+  // Sending File
+  try {
+    filename = await importStorage.sendFile({ filepath: payload.path });
+
+    const readableStreamEncoding = dependencies.createReadStream(payload.path);
+    const bufferEncoding = await getDataBuffer(readableStreamEncoding);
+    const parserEncoding = SupOrganizationLearnerParser.create(bufferEncoding, organizationId, i18n);
+    encoding = parserEncoding.getFileEncoding();
+  } catch (error) {
+    errors.push(error);
+    throw error;
+  } finally {
+    organizationImport.upload({ filename, encoding, errors });
+    await organizationImportRepository.save(organizationImport);
+  }
+
+  // Reading File
   try {
     const readableStream = await importStorage.readFile({ filename });
 
@@ -17,11 +44,30 @@ const importSupOrganizationLearners = async function ({
 
     const { learners, warnings } = parser.parse(parser.getFileEncoding());
 
-    await supOrganizationLearnerRepository.addStudents(learners);
-
-    return warnings;
+    learnersData = learners;
+    warningsData = warnings;
+  } catch (error) {
+    errors.push(error);
+    throw error;
   } finally {
+    organizationImport = await organizationImportRepository.getByOrganizationId(organizationId);
+    organizationImport.validate({ errors, warnings: warningsData });
+    await organizationImportRepository.save(organizationImport);
     await importStorage.deleteFile({ filename });
+  }
+
+  // Insert Data
+  try {
+    await supOrganizationLearnerRepository.addStudents(learnersData);
+
+    return warningsData;
+  } catch (error) {
+    errors.push(error);
+    throw error;
+  } finally {
+    organizationImport = await organizationImportRepository.getByOrganizationId(organizationId);
+    organizationImport.process({ errors });
+    await organizationImportRepository.save(organizationImport);
   }
 };
 

--- a/api/tests/prescription/learner-management/unit/application/sup-organization-management-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/sup-organization-management-controller_test.js
@@ -14,7 +14,6 @@ describe('Unit | Controller | sup-organization-management-controller', function 
   let logErrorWithCorrelationIdsStub;
   let unlinkStub;
   let makeOrganizationLearnerParserStub;
-  let requestResponseUtilsStub;
 
   beforeEach(function () {
     organizationId = Symbol('organizationId');
@@ -29,19 +28,20 @@ describe('Unit | Controller | sup-organization-management-controller', function 
     supOrganizationLearnerWarningSerializerStub = { serialize: sinon.stub() };
     logErrorWithCorrelationIdsStub = sinon.stub();
     unlinkStub = sinon.stub();
-    requestResponseUtilsStub = { extractUserIdFromRequest: sinon.stub() };
   });
 
   context('#importSupOrganizationLearners', function () {
     it('should call importSupOrganizationLearners usecase and return 200', async function () {
       const params = { id: organizationId };
       const request = {
+        auth: { credentials: { userId } },
         payload: { path },
         params,
         i18n,
       };
       usecases.importSupOrganizationLearners
         .withArgs({
+          userId,
           payload: request.payload,
           organizationId,
           i18n,
@@ -69,12 +69,14 @@ describe('Unit | Controller | sup-organization-management-controller', function 
     it('should cleanup files on error', async function () {
       const params = { id: organizationId };
       const request = {
+        auth: { credentials: { userId } },
         payload: { path },
         params,
         i18n,
       };
       usecases.importSupOrganizationLearners
         .withArgs({
+          userId,
           payload: request.payload,
           organizationId,
           i18n,
@@ -94,6 +96,7 @@ describe('Unit | Controller | sup-organization-management-controller', function 
     it('should log an error if unlink fails', async function () {
       const params = { id: organizationId };
       const request = {
+        auth: { credentials: { userId } },
         payload: { path },
         params,
         i18n,
@@ -123,12 +126,11 @@ describe('Unit | Controller | sup-organization-management-controller', function 
     it('should call replaceSupOrganizationLearner usecase and return 200', async function () {
       const params = { id: organizationId };
       const request = {
+        auth: { credentials: { userId } },
         payload: { path },
         params,
         i18n,
       };
-
-      requestResponseUtilsStub.extractUserIdFromRequest.withArgs(request).returns(userId);
 
       usecases.replaceSupOrganizationLearners
         .withArgs({
@@ -145,7 +147,6 @@ describe('Unit | Controller | sup-organization-management-controller', function 
 
       // when
       const response = await supOrganizationManagementController.replaceSupOrganizationLearners(request, hFake, {
-        requestResponseUtils: requestResponseUtilsStub,
         supOrganizationLearnerWarningSerializer: supOrganizationLearnerWarningSerializerStub,
         logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub,
         unlink: unlinkStub,
@@ -161,12 +162,11 @@ describe('Unit | Controller | sup-organization-management-controller', function 
     it('should cleanup files on error', async function () {
       const params = { id: organizationId };
       const request = {
+        auth: { credentials: { userId } },
         payload: { path },
         params,
         i18n,
       };
-
-      requestResponseUtilsStub.extractUserIdFromRequest.withArgs(request).returns(userId);
 
       usecases.replaceSupOrganizationLearners
         .withArgs({
@@ -179,7 +179,6 @@ describe('Unit | Controller | sup-organization-management-controller', function 
 
       // when
       await catchErr(supOrganizationManagementController.replaceSupOrganizationLearners)(request, hFake, {
-        requestResponseUtils: requestResponseUtilsStub,
         makeOrganizationLearnerParser: makeOrganizationLearnerParserStub,
         supOrganizationLearnerWarningSerializer: supOrganizationLearnerWarningSerializerStub,
         logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub,
@@ -192,11 +191,11 @@ describe('Unit | Controller | sup-organization-management-controller', function 
     it('should log an error if unlink fails', async function () {
       const params = { id: organizationId };
       const request = {
+        auth: { credentials: { userId } },
         payload: { path },
         params,
         i18n,
       };
-      requestResponseUtilsStub.extractUserIdFromRequest.withArgs(request).returns(userId);
 
       usecases.replaceSupOrganizationLearners
         .withArgs({
@@ -216,7 +215,6 @@ describe('Unit | Controller | sup-organization-management-controller', function 
 
       // when
       const response = await supOrganizationManagementController.replaceSupOrganizationLearners(request, hFake, {
-        requestResponseUtils: requestResponseUtilsStub,
         supOrganizationLearnerWarningSerializer: supOrganizationLearnerWarningSerializerStub,
         logErrorWithCorrelationIds: logErrorWithCorrelationIdsStub,
         unlink: unlinkStub,


### PR DESCRIPTION
## :unicorn: Problème
Maintenant que nous stockons le fichier d'import dans un S3. On doit stocker l'état de l'import (SUP dans le cas de cette PR) dans la table organization-imports à chaque étape de l'import.

## :robot: Proposition
On ajoute le stockage du statut pour chaque étape de l'import, ainsi que les erreurs associées si il y en a.

## :rainbow: Remarques
Il existe 6 statuts différents possible : 
- UPLOADED : Cas nominal
- UPLOAD_ERROR : En cas de soucis lors de l'upload sur le S3
- VALIDATED : Cas nominal
- VALIDATION_ERROR : En cas de soucis lors de la validation du fichier 
- IMPORTED : Cas nominal
- IMPORT_ERROR : En cas de soucis lors de l'insertion en BDD (Une contrainte qui casse ... )


## :100: Pour tester
Cas nominal : 
Le plus simple étant en local .. Pour pouvoir stopper le code dans le usecase aux différents endroits avec des points d'arrêts
-> UPLOADED : Après l'upload MAIS avant la validation
-> VALIDATED : Après la validation MAIS avant l'insertion en BDD 
-> IMPORTED : A la fin de toutes les étapes


Pour les erreurs à tester : 
-> UPLOAD_ERROR : couper le docker du s3. Importer. Vérifier en BDD
-> VALIDATION_ERROR : Enlever un en-tete obligatoire dans le csv?. Importer. Vérifier en BDD
-> IMPORT_ERROR : Le plus embêtant à tester, possible de throw une erreur dans la méthode `addStudents` afin que l'insertion ne se passe pas bien. Importer. Vérifier en BDD

Après tout ça, un petit cocktail au bord de la mer 🍸 
