### PR TITLE
[FEATURE] Afficher les challenges Pix+ dans la page détail d'une certification (PIX-11585).

### DIFF
--- a/admin/app/models/certification-details.js
+++ b/admin/app/models/certification-details.js
@@ -6,6 +6,8 @@ import { memberAction } from 'ember-api-actions';
 import groupBy from 'lodash/groupBy';
 import sortBy from 'lodash/sortBy';
 
+const PIX_PLUS_INDEX = '';
+
 export default class CertificationDetails extends Model {
   @attr() competencesWithMark;
   @attr() totalScore;
@@ -35,6 +37,13 @@ export default class CertificationDetails extends Model {
         answers: answersByCompetence[competenceWithMark.index],
       };
     });
+    if (this.#includePixPlusCompetences(answersByCompetence)) {
+      competences.push({
+        index: PIX_PLUS_INDEX,
+        name: 'Pix +',
+        answers: answersByCompetence[PIX_PLUS_INDEX],
+      });
+    }
 
     return sortBy(competences, 'index');
   }
@@ -74,4 +83,8 @@ export default class CertificationDetails extends Model {
       };
     },
   });
+
+  #includePixPlusCompetences(answersByCompetence) {
+    return answersByCompetence[PIX_PLUS_INDEX];
+  }
 }

--- a/admin/tests/unit/models/certification-details_test.js
+++ b/admin/tests/unit/models/certification-details_test.js
@@ -27,33 +27,73 @@ module('Unit | Model | certification details', function (hooks) {
   });
 
   module('#get competences', function () {
-    test('returns competences', function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const listChallengesAndAnswers = [
-        { id: 'answerId1', competence: '1.1' },
-        { id: 'answerId2', competence: '1.1' },
-        { id: 'answerId3', competence: '1.2' },
-      ];
-      const competencesWithMark = [{ index: '1.1' }, { index: '1.2' }];
+    module('when there are Pix+ competences', function () {
+      test('returns all competences with Pix+ competences included', function (assert) {
+        // given
+        const PIX_PLUS_INDEX = '';
+        const store = this.owner.lookup('service:store');
+        const listChallengesAndAnswers = [
+          { id: 'answerIdPix+1', competence: PIX_PLUS_INDEX },
+          { id: 'answerIdPix+2', competence: PIX_PLUS_INDEX },
+          { id: 'answerId2', competence: '1.1' },
+          { id: 'answerId3', competence: '1.2' },
+        ];
+        const competencesWithMark = [{ index: '1.1' }, { index: '1.2' }];
 
-      // when
-      const certification = store.createRecord('certification-details', {
-        listChallengesAndAnswers,
-        competencesWithMark,
+        // when
+        const certification = store.createRecord('certification-details', {
+          listChallengesAndAnswers,
+          competencesWithMark,
+        });
+
+        // then
+        assert.deepEqual(certification.competences, [
+          {
+            index: PIX_PLUS_INDEX,
+            name: 'Pix +',
+            answers: [
+              { id: 'answerIdPix+1', competence: '', order: 1 },
+              { id: 'answerIdPix+2', competence: '', order: 2 },
+            ],
+          },
+          {
+            index: '1.1',
+            answers: [{ id: 'answerId2', competence: '1.1', order: 3 }],
+          },
+          { index: '1.2', answers: [{ id: 'answerId3', competence: '1.2', order: 4 }] },
+        ]);
       });
+    });
 
-      // then
-      assert.deepEqual(certification.competences, [
-        {
-          index: '1.1',
-          answers: [
-            { id: 'answerId1', competence: '1.1', order: 1 },
-            { id: 'answerId2', competence: '1.1', order: 2 },
-          ],
-        },
-        { index: '1.2', answers: [{ id: 'answerId3', competence: '1.2', order: 3 }] },
-      ]);
+    module('when there are only Pix core competences', function () {
+      test('returns competences', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const listChallengesAndAnswers = [
+          { id: 'answerId1', competence: '1.1' },
+          { id: 'answerId2', competence: '1.1' },
+          { id: 'answerId3', competence: '1.2' },
+        ];
+        const competencesWithMark = [{ index: '1.1' }, { index: '1.2' }];
+
+        // when
+        const certification = store.createRecord('certification-details', {
+          listChallengesAndAnswers,
+          competencesWithMark,
+        });
+
+        // then
+        assert.deepEqual(certification.competences, [
+          {
+            index: '1.1',
+            answers: [
+              { id: 'answerId1', competence: '1.1', order: 1 },
+              { id: 'answerId2', competence: '1.1', order: 2 },
+            ],
+          },
+          { index: '1.2', answers: [{ id: 'answerId3', competence: '1.2', order: 3 }] },
+        ]);
+      });
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Un candidat peut avoir des questions Pix ❤️ et Pix+
Dans la page admin détail d’une certification, on affiche les réponses triés par compétences.
Les réponses Pix+ ne sont pas affichés parce qu’il n’y a pas de competence-marks pour Pix+

## :robot: Proposition
Quickwin: On affiche tout les answers Pix+ dans un même bloc

## :rainbow: Remarques
Il faudra dans un 2nd temps générer les competence marks pour un affichage avec toutes les infos

## :100: Pour tester

- Trouver une certif PIX+ `select "certificationCourseId" from "complementary-certification-courses";`
- Aller sur le détail de la certification : https://admin-pr8341.review.pix.fr/certifications/143150/details
 - CléA => pas de difference
 - Droit/Edu => On a une "competence" Pix + qui contient tous les challenges
 
![Capture d’écran 2024-03-08 à 15 47 18](https://github.com/1024pix/pix/assets/103997660/9598fd26-413c-442a-a12e-ff9e88ba49a4)

