### PR TITLE
[FEATURE] Ajouter les étapes de l'import remplacer un étudiant dans PixOrga (PIX-11348)

### DIFF
--- a/api/src/prescription/learner-management/domain/usecases/replace-sup-organization-learner.js
+++ b/api/src/prescription/learner-management/domain/usecases/replace-sup-organization-learner.js
@@ -1,4 +1,7 @@
+import { createReadStream } from 'fs';
+
 import { SupOrganizationLearnerParser } from '../../infrastructure/serializers/csv/sup-organization-learner-parser.js';
+import { OrganizationImport } from '../models/OrganizationImport.js';
 
 const replaceSupOrganizationLearners = async function ({
   payload,
@@ -6,10 +9,32 @@ const replaceSupOrganizationLearners = async function ({
   i18n,
   userId,
   supOrganizationLearnerRepository,
+  organizationImportRepository,
   importStorage,
+  dependencies = { createReadStream },
 }) {
-  const filename = await importStorage.sendFile({ filepath: payload.path });
+  let organizationImport = OrganizationImport.create({ organizationId, createdBy: userId });
+  let filename, encoding;
+  const errors = [];
+  let warningsData, learnersData;
 
+  // Send File
+  try {
+    filename = await importStorage.sendFile({ filepath: payload.path });
+
+    const readableStreamEncoding = dependencies.createReadStream(payload.path);
+    const bufferEncoding = await getDataBuffer(readableStreamEncoding);
+    const parserEncoding = SupOrganizationLearnerParser.create(bufferEncoding, organizationId, i18n);
+    encoding = parserEncoding.getFileEncoding();
+  } catch (error) {
+    errors.push(error);
+    throw error;
+  } finally {
+    organizationImport.upload({ filename, encoding, errors });
+    await organizationImportRepository.save(organizationImport);
+  }
+
+  // Read File
   try {
     const readableStream = await importStorage.readFile({ filename });
     const buffer = await getDataBuffer(readableStream);
@@ -17,11 +42,30 @@ const replaceSupOrganizationLearners = async function ({
 
     const { learners, warnings } = parser.parse(parser.getFileEncoding());
 
-    await supOrganizationLearnerRepository.replaceStudents(organizationId, learners, userId);
-
-    return warnings;
+    learnersData = learners;
+    warningsData = warnings;
+  } catch (error) {
+    errors.push(error);
+    throw error;
   } finally {
+    organizationImport = await organizationImportRepository.getByOrganizationId(organizationId);
+    organizationImport.validate({ errors, warnings: warningsData });
+    await organizationImportRepository.save(organizationImport);
     await importStorage.deleteFile({ filename });
+  }
+
+  // Insert Data
+  try {
+    await supOrganizationLearnerRepository.replaceStudents(organizationId, learnersData, userId);
+
+    return warningsData;
+  } catch (error) {
+    errors.push(error);
+    throw error;
+  } finally {
+    organizationImport = await organizationImportRepository.getByOrganizationId(organizationId);
+    organizationImport.process({ errors });
+    await organizationImportRepository.save(organizationImport);
   }
 };
 

--- a/api/tests/prescription/learner-management/unit/domain/usecases/replace-sup-organization-learners_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/replace-sup-organization-learners_test.js
@@ -1,16 +1,21 @@
 import iconv from 'iconv-lite';
 import { Readable } from 'stream';
 
+import { OrganizationImport } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationImport.js';
 import { replaceSupOrganizationLearners } from '../../../../../../src/prescription/learner-management/domain/usecases/replace-sup-organization-learner.js';
 import { SupOrganizationLearnerImportHeader } from '../../../../../../src/prescription/learner-management/infrastructure/serializers/csv/sup-organization-learner-import-header.js';
-import { expect, sinon } from '../../../../../test-helper.js';
+import { catchErr, expect, sinon } from '../../../../../test-helper.js';
 import { getI18n } from '../../../../../tooling/i18n/i18n.js';
+
+const i18n = getI18n();
 
 describe('Unit | UseCase | ReplaceSupOrganizationLearner', function () {
   let filename,
     payload,
     importStorageStub,
+    supOrganizationLearnerImportHeader,
     supOrganizationLearnerRepositoryStub,
+    organizationImportRepositoryStub,
     csvStream,
     expectedLearners,
     expectedWarnings,
@@ -18,82 +23,9 @@ describe('Unit | UseCase | ReplaceSupOrganizationLearner', function () {
     organizationId;
 
   beforeEach(function () {
-    supOrganizationLearnerRepositoryStub = { replaceStudents: sinon.stub() };
-    supOrganizationLearnerRepositoryStub.replaceStudents.resolves();
-    csvStream = new Readable({
-      read() {
-        const supOrganizationLearnerImportHeader = new SupOrganizationLearnerImportHeader(getI18n()).columns
-          .map((column) => column.name)
-          .join(';');
-
-        const csvData = `${supOrganizationLearnerImportHeader}
-          Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;12346;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;
-          O-Ren;;;Ishii;Cottonmouth;01/01/1980;ishii@example.net;789;Assassination Squad;Bill;Deadly Viper Assassination Squad;DUT;;
-          `.trim();
-        this.push(iconv.encode(csvData, 'utf8'));
-        this.push(null);
-      },
-    });
-    expectedLearners = [
-      {
-        firstName: 'Beatrix',
-        middleName: 'The',
-        thirdName: 'Bride',
-        lastName: 'Kiddo',
-        preferredLastName: 'Black Mamba',
-        studentNumber: '12346',
-        email: 'thebride@example.net',
-        birthdate: '1970-01-01',
-        diploma: 'Non reconnu',
-        department: 'Assassination Squad',
-        educationalTeam: 'Hattori Hanzo',
-        group: 'Deadly Viper Assassination Squad',
-        studyScheme: 'Non reconnu',
-        organizationId: 1,
-      },
-      {
-        firstName: 'O-Ren',
-        middleName: undefined,
-        thirdName: undefined,
-        lastName: 'Ishii',
-        preferredLastName: 'Cottonmouth',
-        studentNumber: '789',
-        email: 'ishii@example.net',
-        birthdate: '1980-01-01',
-        diploma: 'Non reconnu',
-        department: 'Assassination Squad',
-        educationalTeam: 'Bill',
-        group: 'Deadly Viper Assassination Squad',
-        studyScheme: 'Non reconnu',
-        organizationId: 1,
-      },
-    ];
-    expectedWarnings = [
-      {
-        studentNumber: '12346',
-        field: 'study-scheme',
-        value: 'hello darkness my old friend',
-        code: 'unknown',
-      },
-      {
-        studentNumber: '12346',
-        field: 'diploma',
-        value: 'Master',
-        code: 'unknown',
-      },
-      {
-        studentNumber: '789',
-        field: 'study-scheme',
-        value: undefined,
-        code: 'unknown',
-      },
-      {
-        studentNumber: '789',
-        field: 'diploma',
-        value: 'DUT',
-        code: 'unknown',
-      },
-    ];
+    supOrganizationLearnerImportHeader = new SupOrganizationLearnerImportHeader(i18n).columns
+      .map((column) => column.name)
+      .join(';');
 
     userId = Symbol('userId');
     organizationId = 1;
@@ -102,53 +34,377 @@ describe('Unit | UseCase | ReplaceSupOrganizationLearner', function () {
 
     payload = { path: filename };
 
+    organizationImportRepositoryStub = {
+      getByOrganizationId: sinon.stub(),
+      save: sinon.stub(),
+    };
+
     importStorageStub = {
       sendFile: sinon.stub(),
       readFile: sinon.stub(),
       deleteFile: sinon.stub(),
     };
-    importStorageStub.sendFile.withArgs({ filepath: payload.path }).resolves(filename);
-    importStorageStub.readFile.withArgs({ filename }).resolves(csvStream);
-  });
 
-  it('parses the csv received and replace the SupOrganizationLearner', async function () {
-    await replaceSupOrganizationLearners({
-      payload,
-      organizationId,
-      userId,
-      i18n: getI18n(),
-      supOrganizationLearnerRepository: supOrganizationLearnerRepositoryStub,
-      importStorage: importStorageStub,
-    });
-
-    expect(supOrganizationLearnerRepositoryStub.replaceStudents).to.have.been.calledWithExactly(
-      organizationId,
-      expectedLearners,
-      userId,
+    organizationImportRepositoryStub.getByOrganizationId.callsFake(
+      () => new OrganizationImport({ organizationId, createdBy: 2, encoding: 'utf-8' }),
     );
   });
 
-  it('should return warnings about the import', async function () {
-    const warnings = await replaceSupOrganizationLearners({
-      payload,
-      organizationId,
-      userId,
-      i18n: getI18n(),
-      supOrganizationLearnerRepository: supOrganizationLearnerRepositoryStub,
-      importStorage: importStorageStub,
+  describe('when there is no errors', function () {
+    beforeEach(function () {
+      supOrganizationLearnerRepositoryStub = { replaceStudents: sinon.stub() };
+      supOrganizationLearnerRepositoryStub.replaceStudents.resolves();
+
+      expectedLearners = [
+        {
+          firstName: 'Beatrix',
+          middleName: 'The',
+          thirdName: 'Bride',
+          lastName: 'Kiddo',
+          preferredLastName: 'Black Mamba',
+          studentNumber: '12346',
+          email: 'thebride@example.net',
+          birthdate: '1970-01-01',
+          diploma: 'Non reconnu',
+          department: 'Assassination Squad',
+          educationalTeam: 'Hattori Hanzo',
+          group: 'Deadly Viper Assassination Squad',
+          studyScheme: 'Non reconnu',
+          organizationId: 1,
+        },
+        {
+          firstName: 'O-Ren',
+          middleName: undefined,
+          thirdName: undefined,
+          lastName: 'Ishii',
+          preferredLastName: 'Cottonmouth',
+          studentNumber: '789',
+          email: 'ishii@example.net',
+          birthdate: '1980-01-01',
+          diploma: 'Non reconnu',
+          department: 'Assassination Squad',
+          educationalTeam: 'Bill',
+          group: 'Deadly Viper Assassination Squad',
+          studyScheme: 'Non reconnu',
+          organizationId: 1,
+        },
+      ];
+      expectedWarnings = [
+        {
+          studentNumber: '12346',
+          field: 'study-scheme',
+          value: 'hello darkness my old friend',
+          code: 'unknown',
+        },
+        {
+          studentNumber: '12346',
+          field: 'diploma',
+          value: 'Master',
+          code: 'unknown',
+        },
+        {
+          studentNumber: '789',
+          field: 'study-scheme',
+          value: undefined,
+          code: 'unknown',
+        },
+        {
+          studentNumber: '789',
+          field: 'diploma',
+          value: 'DUT',
+          code: 'unknown',
+        },
+      ];
+
+      importStorageStub.sendFile.withArgs({ filepath: payload.path }).resolves(filename);
+      importStorageStub.readFile.withArgs({ filename }).resolves(csvStream);
     });
-    expect(warnings).to.deep.equals(expectedWarnings);
+
+    it('parses the csv received and replace the SupOrganizationLearner', async function () {
+      const input = `${supOrganizationLearnerImportHeader}
+          Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;12346;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;
+          O-Ren;;;Ishii;Cottonmouth;01/01/1980;ishii@example.net;789;Assassination Squad;Bill;Deadly Viper Assassination Squad;DUT;;
+      `.trim();
+
+      importStorageStub.readFile.withArgs({ filename }).resolves(
+        new Readable({
+          read() {
+            this.push(iconv.encode(input, 'utf8'));
+            this.push(null);
+          },
+        }),
+      );
+
+      await replaceSupOrganizationLearners({
+        payload,
+        organizationId,
+        userId,
+        i18n,
+        supOrganizationLearnerRepository: supOrganizationLearnerRepositoryStub,
+        organizationImportRepository: organizationImportRepositoryStub,
+        importStorage: importStorageStub,
+        dependencies: {
+          createReadStream: sinon.stub().returns(
+            new Readable({
+              read() {
+                this.push(iconv.encode(input, 'utf8'));
+                this.push(null);
+              },
+            }),
+          ),
+        },
+      });
+
+      expect(supOrganizationLearnerRepositoryStub.replaceStudents).to.have.been.calledWithExactly(
+        organizationId,
+        expectedLearners,
+        userId,
+      );
+    });
+
+    it('should return warnings about the import', async function () {
+      const input = `${supOrganizationLearnerImportHeader}
+          Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;12346;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;
+          O-Ren;;;Ishii;Cottonmouth;01/01/1980;ishii@example.net;789;Assassination Squad;Bill;Deadly Viper Assassination Squad;DUT;;
+      `.trim();
+
+      importStorageStub.readFile.withArgs({ filename }).resolves(
+        new Readable({
+          read() {
+            this.push(iconv.encode(input, 'utf8'));
+            this.push(null);
+          },
+        }),
+      );
+
+      const warnings = await replaceSupOrganizationLearners({
+        payload,
+        organizationId,
+        userId,
+        i18n,
+        supOrganizationLearnerRepository: supOrganizationLearnerRepositoryStub,
+        organizationImportRepository: organizationImportRepositoryStub,
+        importStorage: importStorageStub,
+        dependencies: {
+          createReadStream: sinon.stub().returns(
+            new Readable({
+              read() {
+                this.push(iconv.encode(input, 'utf8'));
+                this.push(null);
+              },
+            }),
+          ),
+        },
+      });
+      expect(warnings).to.deep.equals(expectedWarnings);
+    });
+
+    it('should delete file on s3', async function () {
+      const input = `${supOrganizationLearnerImportHeader}
+          Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;12346;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;
+          O-Ren;;;Ishii;Cottonmouth;01/01/1980;ishii@example.net;789;Assassination Squad;Bill;Deadly Viper Assassination Squad;DUT;;
+      `.trim();
+
+      importStorageStub.readFile.withArgs({ filename }).resolves(
+        new Readable({
+          read() {
+            this.push(iconv.encode(input, 'utf8'));
+            this.push(null);
+          },
+        }),
+      );
+
+      await replaceSupOrganizationLearners({
+        payload,
+        organizationId,
+        userId,
+        i18n,
+        supOrganizationLearnerRepository: supOrganizationLearnerRepositoryStub,
+        organizationImportRepository: organizationImportRepositoryStub,
+        importStorage: importStorageStub,
+        dependencies: {
+          createReadStream: sinon.stub().returns(
+            new Readable({
+              read() {
+                this.push(iconv.encode(input, 'utf8'));
+                this.push(null);
+              },
+            }),
+          ),
+        },
+      });
+      expect(importStorageStub.deleteFile).to.have.been.calledWithExactly({ filename: payload.path });
+    });
   });
 
-  it('should delete file on s3', async function () {
-    await replaceSupOrganizationLearners({
-      payload,
-      organizationId,
-      userId,
-      i18n: getI18n(),
-      supOrganizationLearnerRepository: supOrganizationLearnerRepositoryStub,
-      importStorage: importStorageStub,
+  context('save import state in database', function () {
+    describe('success case', function () {
+      it('should save uploaded, validated and imported state each after each', async function () {
+        // given
+        importStorageStub.sendFile.withArgs({ filepath: payload.path }).resolves(filename);
+
+        const csv = `${supOrganizationLearnerImportHeader}
+        Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;BAD;BAD;
+        `.trim();
+
+        importStorageStub.readFile.withArgs({ filename }).resolves(
+          new Readable({
+            read() {
+              this.push(iconv.encode(csv, 'utf8'));
+              this.push(null);
+            },
+          }),
+        );
+
+        // when
+        await replaceSupOrganizationLearners({
+          organizationId,
+          payload,
+          supOrganizationLearnerRepository: supOrganizationLearnerRepositoryStub,
+          importStorage: importStorageStub,
+          organizationImportRepository: organizationImportRepositoryStub,
+          dependencies: {
+            createReadStream: sinon.stub().returns(
+              new Readable({
+                read() {
+                  this.push(iconv.encode(csv, 'utf8'));
+                  this.push(null);
+                },
+              }),
+            ),
+          },
+          i18n,
+        });
+
+        // then
+
+        const firstSaveCall = organizationImportRepositoryStub.save.getCall(0).args[0];
+        const secondSaveCall = organizationImportRepositoryStub.save.getCall(1).args[0];
+        const thirdSaveCall = organizationImportRepositoryStub.save.getCall(2).args[0];
+
+        expect(firstSaveCall.status).to.equal('UPLOADED');
+        expect(secondSaveCall.status).to.equal('VALIDATED');
+        expect(thirdSaveCall.status).to.equal('IMPORTED');
+      });
     });
-    expect(importStorageStub.deleteFile).to.have.been.calledWithExactly({ filename: payload.path });
+
+    describe('errors case', function () {
+      describe('when there is an upload error', function () {
+        it('should save UPLOAD_ERROR status', async function () {
+          // given
+          const csv = `${supOrganizationLearnerImportHeader}`;
+          importStorageStub.sendFile.withArgs({ filepath: filename }).rejects();
+
+          // when
+          await catchErr(replaceSupOrganizationLearners)({
+            organizationId,
+            payload,
+            supOrganizationLearnerRepository: supOrganizationLearnerRepositoryStub,
+            importStorage: importStorageStub,
+            organizationImportRepository: organizationImportRepositoryStub,
+            dependencies: {
+              createReadStream: sinon.stub().returns(
+                new Readable({
+                  read() {
+                    this.push(iconv.encode(csv, 'utf8'));
+                    this.push(null);
+                  },
+                }),
+              ),
+            },
+            i18n,
+          });
+
+          // then
+
+          expect(organizationImportRepositoryStub.save.getCall(0).args[0].status).to.equal('UPLOAD_ERROR');
+        });
+      });
+      describe('when there is an validation error', function () {
+        it('should save VALIDATION_ERROR status', async function () {
+          // given
+          importStorageStub.sendFile.withArgs({ filepath: filename }).resolves(filename);
+          const csv = `${supOrganizationLearnerImportHeader}
+          Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;BAD;BAD;
+          Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;BAD;BAD;
+          `.trim();
+
+          importStorageStub.readFile.withArgs({ filename }).resolves(
+            new Readable({
+              read() {
+                this.push(iconv.encode(csv, 'utf8'));
+                this.push(null);
+              },
+            }),
+          );
+          // when
+          await catchErr(replaceSupOrganizationLearners)({
+            organizationId,
+            payload,
+            supOrganizationLearnerRepository: supOrganizationLearnerRepositoryStub,
+            importStorage: importStorageStub,
+            organizationImportRepository: organizationImportRepositoryStub,
+            dependencies: {
+              createReadStream: sinon.stub().returns(
+                new Readable({
+                  read() {
+                    this.push(iconv.encode(csv, 'utf8'));
+                    this.push(null);
+                  },
+                }),
+              ),
+            },
+            i18n,
+          });
+
+          // then
+          expect(organizationImportRepositoryStub.save.getCall(1).args[0].status).to.equal('VALIDATION_ERROR');
+        });
+      });
+      describe('when there is an import error', function () {
+        it('should save IMPORT_ERROR status', async function () {
+          // given
+          importStorageStub.sendFile.withArgs({ filepath: filename }).resolves(filename);
+
+          const csv = `${supOrganizationLearnerImportHeader}
+          Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;BAD;BAD;
+          `.trim();
+
+          importStorageStub.readFile.withArgs({ filename }).resolves(
+            new Readable({
+              read() {
+                this.push(iconv.encode(csv, 'utf8'));
+                this.push(null);
+              },
+            }),
+          );
+          supOrganizationLearnerRepositoryStub.replaceStudents.rejects('errors');
+
+          // when
+          await catchErr(replaceSupOrganizationLearners)({
+            organizationId,
+            payload,
+            supOrganizationLearnerRepository: supOrganizationLearnerRepositoryStub,
+            importStorage: importStorageStub,
+            organizationImportRepository: organizationImportRepositoryStub,
+            dependencies: {
+              createReadStream: sinon.stub().returns(
+                new Readable({
+                  read() {
+                    this.push(iconv.encode(csv, 'utf8'));
+                    this.push(null);
+                  },
+                }),
+              ),
+            },
+            i18n,
+          });
+
+          // then
+
+          expect(organizationImportRepositoryStub.save.getCall(2).args[0].status).to.equal('IMPORT_ERROR');
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Maintenant que nous stockons le fichier d'import dans un S3. On doit stocker l'état de l'import (SUP dans le cas de cette PR) dans la table organization-imports à chaque étape de l'import.

## :robot: Proposition
On ajoute le stockage du statut pour chaque étape de l'import, ainsi que les erreurs associées si il y en a.

## :rainbow: Remarques
Il existe 6 statuts différents possible : 
- UPLOADED : Cas nominal
- UPLOAD_ERROR : En cas de soucis lors de l'upload sur le S3
- VALIDATED : Cas nominal
- VALIDATION_ERROR : En cas de soucis lors de la validation du fichier 
- IMPORTED : Cas nominal
- IMPORT_ERROR : En cas de soucis lors de l'insertion en BDD (Une contrainte qui casse ... )


## :100: Pour tester
Cas nominal : 
Le plus simple étant en local .. Pour pouvoir stopper le code dans le usecase aux différents endroits avec des points d'arrêts
-> UPLOADED : Après l'upload MAIS avant la validation
-> VALIDATED : Après la validation MAIS avant l'insertion en BDD 
-> IMPORTED : A la fin de toutes les étapes


Pour les erreurs à tester : 
-> UPLOAD_ERROR : couper le docker du s3. Importer. Vérifier en BDD
-> VALIDATION_ERROR : Enlever un en-tete obligatoire dans le csv?. Importer. Vérifier en BDD
-> IMPORT_ERROR : Le plus embêtant à tester, possible de throw une erreur dans la méthode `replaceStudents` afin que l'insertion ne se passe pas bien. Importer. Vérifier en BDD

Après tout ça, un petit cocktail au bord de la mer 🍸 
