### PR TITLE
[TECH] Extract flash-certification cross-injection from shared (PIX-11471)

### DIFF
--- a/api/src/certification/flash-certification/application/flash-assessment-configuration-controller.js
+++ b/api/src/certification/flash-certification/application/flash-assessment-configuration-controller.js
@@ -1,4 +1,4 @@
-import { usecases } from '../../shared/domain/usecases/index.js';
+import { usecases } from '../domain/usecases/index.js';
 
 const getActiveFlashAssessmentConfiguration = async (req, h) => {
   const flashAssessmentConfiguration = await usecases.getActiveFlashAssessmentConfiguration();

--- a/api/src/certification/flash-certification/application/scenario-simulator-controller.js
+++ b/api/src/certification/flash-certification/application/scenario-simulator-controller.js
@@ -7,9 +7,9 @@ import { scenarioSimulatorBatchSerializer } from '../../../../lib/infrastructure
 import { random } from '../../../../lib/infrastructure/utils/random.js';
 import { extractLocaleFromRequest } from '../../../../lib/infrastructure/utils/request-response-utils.js';
 import { parseCsv } from '../../../../scripts/helpers/csvHelpers.js';
-import { usecases } from '../../shared/domain/usecases/index.js';
 import { FlashAssessmentSuccessRateHandler } from '../domain/models/FlashAssessmentSuccessRateHandler.js';
 import { pickChallengeService } from '../domain/services/pick-challenge-service.js';
+import { usecases } from '../domain/usecases/index.js';
 
 async function simulateFlashAssessmentScenario(
   request,

--- a/api/src/certification/flash-certification/domain/usecases/index.js
+++ b/api/src/certification/flash-certification/domain/usecases/index.js
@@ -1,0 +1,38 @@
+// eslint-disable import/no-restricted-paths
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import * as challengeRepository from '../../../../shared/infrastructure/repositories/challenge-repository.js';
+import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
+import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
+import * as flashAlgorithmConfigurationRepository from '../../infrastructure/repositories/flash-algorithm-configuration-repository.js';
+import * as flashAlgorithmService from '../services/algorithm-methods/flash.js';
+
+/**
+ * Using {@link https://jsdoc.app/tags-type "Closure Compiler's syntax"} to document injected dependencies
+ *
+ * @typedef {challengeRepository} ChallengeRepository
+ * @typedef {flashAlgorithmConfigurationRepository} FlashAlgorithmConfigurationRepository
+ * @typedef {flashAlgorithmService} FlashAlgorithmService
+ */
+const dependencies = {
+  challengeRepository,
+  flashAlgorithmConfigurationRepository,
+  flashAlgorithmService,
+};
+
+const path = dirname(fileURLToPath(import.meta.url));
+
+const usecasesWithoutInjectedDependencies = {
+  ...(await importNamedExportsFromDirectory({
+    path,
+    ignoredFileNames: ['index.js'],
+  })),
+};
+
+const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
+
+/**
+ * @typedef {dependencies} dependencies
+ */
+export { usecases };

--- a/api/src/certification/flash-certification/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
+++ b/api/src/certification/flash-certification/domain/usecases/simulate-flash-deterministic-assessment-scenario.js
@@ -5,14 +5,12 @@ import { FlashAssessmentAlgorithm } from '../models/FlashAssessmentAlgorithm.js'
 import { FlashAssessmentAlgorithmConfiguration } from '../models/FlashAssessmentAlgorithmConfiguration.js';
 
 export async function simulateFlashDeterministicAssessmentScenario({
-  challengeRepository,
   locale,
   pickChallenge,
   pickAnswerStatus,
   stopAtChallenge,
   initialCapacity,
   useObsoleteChallenges,
-  flashAlgorithmService,
   warmUpLength = 0,
   forcedCompetences = [],
   challengesBetweenSameCompetence = 0,
@@ -22,6 +20,8 @@ export async function simulateFlashDeterministicAssessmentScenario({
   doubleMeasuresUntil = 0,
   variationPercent,
   variationPercentUntil,
+  challengeRepository,
+  flashAlgorithmService,
 }) {
   const challenges = await challengeRepository.findFlashCompatible({ locale, useObsoleteChallenges });
 

--- a/api/src/certification/shared/domain/usecases/index.js
+++ b/api/src/certification/shared/domain/usecases/index.js
@@ -15,8 +15,6 @@ import { injectDependencies } from '../../../../shared/infrastructure/utils/depe
 import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as certificateRepository from '../../../course/infrastructure/repositories/certificate-repository.js';
 import * as v3CertificationCourseDetailsForAdministrationRepository from '../../../course/infrastructure/repositories/v3-certification-course-details-for-administration-repository.js';
-import * as flashAlgorithmService from '../../../flash-certification/domain/services/algorithm-methods/flash.js';
-import * as flashAlgorithmConfigurationRepository from '../../../flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js';
 import * as sessionCodeService from '../../../session/domain/services/session-code-service.js';
 import * as sessionsImportValidationService from '../../../session/domain/services/sessions-import-validation-service.js';
 import * as temporarySessionsStorageForMassImportService from '../../../session/domain/services/temporary-sessions-storage-for-mass-import-service.js';
@@ -71,7 +69,6 @@ import * as mailService from '../services/mail-service.js';
  * @typedef {complementaryCertificationRepository} ComplementaryCertificationRepository
  * @typedef {cpfExportRepository} CpfExportRepository
  * @typedef {finalizedSessionRepository} FinalizedSessionRepository
- * @typedef {flashAlgorithmService} FlashAlgorithmService
  * @typedef {issueReportCategoryRepository} IssueReportCategoryRepository
  * @typedef {jurySessionRepository} JurySessionRepository
  * @typedef {mailService} MailService
@@ -109,8 +106,6 @@ const dependencies = {
   competenceRepository,
   complementaryCertificationRepository,
   finalizedSessionRepository,
-  flashAlgorithmService,
-  flashAlgorithmConfigurationRepository,
   issueReportCategoryRepository,
   jurySessionRepository,
   mailService,
@@ -143,9 +138,6 @@ const usecasesWithoutInjectedDependencies = {
       'get-session-certification-candidates.js',
       'get-mass-import-template-information.js',
     ],
-  })),
-  ...(await importNamedExportsFromDirectory({
-    path: join(path, '../../../flash-certification/domain/usecases/'),
   })),
   ...(await importNamedExportsFromDirectory({
     path: join(path, '../../../course/domain/usecases/'),

--- a/api/tests/certification/flash-certification/integration/application/flash-assessment-configuration-controller_test.js
+++ b/api/tests/certification/flash-certification/integration/application/flash-assessment-configuration-controller_test.js
@@ -1,5 +1,5 @@
 import { flashAssessmentConfigurationController } from '../../../../../src/certification/flash-certification/application/flash-assessment-configuration-controller.js';
-import { usecases } from '../../../../../src/certification/shared/domain/usecases/index.js';
+import { usecases } from '../../../../../src/certification/flash-certification/domain/usecases/index.js';
 import { domainBuilder, expect, hFake, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Application | FlashAssessmentConfigurationController', function () {

--- a/api/tests/certification/flash-certification/integration/application/scenario-simulator-controller_test.js
+++ b/api/tests/certification/flash-certification/integration/application/scenario-simulator-controller_test.js
@@ -2,7 +2,7 @@ import { pickAnswerStatusService } from '../../../../../lib/domain/services/pick
 import { random } from '../../../../../lib/infrastructure/utils/random.js';
 import * as moduleUnderTest from '../../../../../src/certification/flash-certification/application/scenario-simulator-route.js';
 import { pickChallengeService } from '../../../../../src/certification/flash-certification/domain/services/pick-challenge-service.js';
-import { usecases } from '../../../../../src/certification/shared/domain/usecases/index.js';
+import { usecases } from '../../../../../src/certification/flash-certification/domain/usecases/index.js';
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { domainBuilder, expect, HttpTestServer, parseJsonStream, sinon } from '../../../../test-helper.js';
 


### PR DESCRIPTION
## :unicorn: Problème
Le fichier api/src/certification/shared/domain/usecases/index.js importe des repositories qui viennent d’un peu partout
Il ne devrait injecter des dépendances que dans les usecases de son context.
Notamment, le contexte flash-certification peut injecter ses propres dépendances.

## :robot: Proposition
Mettre en place un contexte d'injection propre au contexte flash-certification.
Utiliser ce contexte pour injecter les dépendances de flash-certification.
Retirer les dépendances injectées dans shared qui ne sont pas utiles.

## :rainbow: Remarques
nope

## :100: Pour tester
Les trois usecases sont des routes api sans front qui sont validées par les tests d'acceptance 💡 