### PR TITLE
[FEATURE] Retourner toutes les erreurs d'un import FREGATA (PIX-11114)

### DIFF
--- a/.vscode/sample.launch.json
+++ b/.vscode/sample.launch.json
@@ -46,6 +46,7 @@
         "LOG_ENABLED": "true",
         "LOG_LEVEL": "error"
       },
+      "envFile": "${workspaceFolder}/api/.env",
       "args": [
         "-ui",
         "bdd",
@@ -70,6 +71,7 @@
         "LOG_ENABLED": "true",
         "LOG_LEVEL": "error"
       },
+      "envFile": "${workspaceFolder}/api/.env",
       "program": "${workspaceRoot}/api/node_modules/mocha/bin/_mocha",
       "args": ["--no-timeouts", "${relativeFile}"],
       "cwd": "${workspaceRoot}",

--- a/api/src/prescription/learner-management/application/http-error-mapper-configuration.js
+++ b/api/src/prescription/learner-management/application/http-error-mapper-configuration.js
@@ -1,0 +1,13 @@
+import { HttpErrors } from '../../../shared/application/http-errors.js';
+import { AggregateImportError } from '../domain/errors.js';
+
+const learnerManagementDomainErrorMappingConfiguration = [
+  {
+    name: AggregateImportError.name,
+    httpErrorFn: (error) => {
+      return new HttpErrors.PreconditionFailedError(error.message, error.code, error.meta);
+    },
+  },
+];
+
+export { learnerManagementDomainErrorMappingConfiguration };

--- a/api/src/prescription/learner-management/domain/errors.js
+++ b/api/src/prescription/learner-management/domain/errors.js
@@ -20,4 +20,16 @@ class SiecleXmlImportError extends DomainError {
   }
 }
 
-export { OrganizationDoesNotHaveFeatureEnabledError, OrganizationLearnersCouldNotBeSavedError, SiecleXmlImportError };
+class AggregateImportError extends DomainError {
+  constructor(meta) {
+    super('An error occurred during import validation');
+    this.meta = meta;
+  }
+}
+
+export {
+  AggregateImportError,
+  OrganizationDoesNotHaveFeatureEnabledError,
+  OrganizationLearnersCouldNotBeSavedError,
+  SiecleXmlImportError,
+};

--- a/api/src/prescription/learner-management/domain/validators/organization-learner-validator.js
+++ b/api/src/prescription/learner-management/domain/validators/organization-learner-validator.js
@@ -5,7 +5,7 @@ import { EntityValidationError } from '../../../../shared/domain/errors.js';
 import { OrganizationLearner } from '../models/OrganizationLearner.js';
 
 const { STUDENT, APPRENTICE } = OrganizationLearner.STATUS;
-const validationConfiguration = { allowUnknown: true };
+const validationConfiguration = { allowUnknown: true, abortEarly: false };
 const MAX_LENGTH = 255;
 const CITY_CODE_LENGTH = 5;
 const PROVINCE_CODE_MIN_LENGTH = 2;
@@ -46,46 +46,53 @@ const validationSchema = Joi.object({
 });
 
 const checkValidation = function (organizationLearner) {
+  const errors = [];
   const { error } = validationSchema.validate(organizationLearner, validationConfiguration);
 
   if (error) {
-    const err = EntityValidationError.fromJoiErrors(error.details);
-    const { type, context } = error.details[0];
-    if (type === 'any.required') {
-      err.why = 'required';
-    }
-    if (type === 'string.max') {
-      err.why = 'max_length';
-      err.limit = context.limit;
-    }
-    if (type === 'string.length') {
-      err.why = 'length';
-      err.limit = context.limit;
-    }
-    if (type === 'string.min') {
-      err.why = 'min_length';
-      err.limit = context.limit;
-    }
-    if (type === 'string.pattern.base' && ['birthCountryCode', 'birthCityCode'].includes(context.key)) {
-      err.why = 'not_valid_insee_code';
-    }
-    if (type === 'date.format') {
-      err.why = 'not_a_date';
-    }
-    if (type === 'date.base') {
-      err.why = 'not_a_date';
-    }
-    if (type === 'any.only') {
-      err.why = 'bad_values';
-      err.valids = context.valids;
-    }
-    if (type === 'string.pattern.name') {
-      err.why = 'bad_pattern';
-      err.pattern = context.name;
-    }
-    err.key = context.key;
-    throw err;
+    error.details.forEach((error) => {
+      const err = EntityValidationError.fromJoiError(error);
+
+      const { type, context } = error;
+      if (type === 'any.required') {
+        err.why = 'required';
+      }
+      if (type === 'string.max') {
+        err.why = 'max_length';
+        err.limit = context.limit;
+      }
+      if (type === 'string.length') {
+        err.why = 'length';
+        err.limit = context.limit;
+      }
+      if (type === 'string.min') {
+        err.why = 'min_length';
+        err.limit = context.limit;
+      }
+      if (type === 'string.pattern.base' && ['birthCountryCode', 'birthCityCode'].includes(context.key)) {
+        err.why = 'not_valid_insee_code';
+      }
+      if (type === 'date.format') {
+        err.why = 'not_a_date';
+      }
+      if (type === 'date.base') {
+        err.why = 'not_a_date';
+      }
+      if (type === 'any.only') {
+        err.why = 'bad_values';
+        err.valids = context.valids;
+      }
+      if (type === 'string.pattern.name') {
+        err.why = 'bad_pattern';
+        err.pattern = context.name;
+      }
+      err.key = context.key;
+
+      errors.push(err);
+    });
   }
+
+  return errors;
 };
 
 export { checkValidation, FRANCE_COUNTRY_CODE };

--- a/api/src/prescription/learner-management/infrastructure/serializers/csv/sup-organization-learner-parser.js
+++ b/api/src/prescription/learner-management/infrastructure/serializers/csv/sup-organization-learner-parser.js
@@ -1,6 +1,6 @@
 import { CsvImportError } from '../../../../../shared/domain/errors.js';
 import { SupOrganizationLearnerSet } from '../../../domain/models/SupOrganizationLearnerSet.js';
-import { CsvOrganizationLearnerParser } from './csv-learner-parser.js';
+import { CsvOrganizationLearnerParser } from './csv-organization-learner-parser.js';
 import { SupOrganizationLearnerImportHeader } from './sup-organization-learner-import-header.js';
 
 const ERRORS = {
@@ -21,7 +21,7 @@ class SupOrganizationLearnerParser extends CsvOrganizationLearnerParser {
     super(input, organizationId, columns, LearnerSet);
   }
 
-  _handleError(err, index) {
+  _handleValidationError(err, index) {
     const column = this._columns.find((column) => column.property === err.key);
     const line = index + 2;
     const field = column.name;
@@ -31,7 +31,7 @@ class SupOrganizationLearnerParser extends CsvOrganizationLearnerParser {
     if (err.why === 'student_number_format') {
       throw new CsvImportError(ERRORS.STUDENT_NUMBER_FORMAT, { line, field });
     }
-    super._handleError(...arguments);
+    super._handleValidationError(...arguments);
   }
 }
 

--- a/api/src/prescription/shared/application/http-error-mapper-configuration.js
+++ b/api/src/prescription/shared/application/http-error-mapper-configuration.js
@@ -1,8 +1,10 @@
 import { DomainErrorMappingConfiguration } from '../../../shared/application/models/domain-error-mapping-configuration.js';
 import { campaignDomainErrorMappingConfiguration } from '../../campaign/application/http-error-mapper-configuration.js';
+import { learnerManagementDomainErrorMappingConfiguration } from '../../learner-management/application/http-error-mapper-configuration.js';
 
-const prescriptionDomainErrorMappingConfiguration = [...campaignDomainErrorMappingConfiguration].map(
-  (domainErrorMappingConfiguration) => new DomainErrorMappingConfiguration(domainErrorMappingConfiguration),
-);
+const prescriptionDomainErrorMappingConfiguration = []
+  .concat(campaignDomainErrorMappingConfiguration)
+  .concat(learnerManagementDomainErrorMappingConfiguration)
+  .map((domainErrorMappingConfiguration) => new DomainErrorMappingConfiguration(domainErrorMappingConfiguration));
 
 export { prescriptionDomainErrorMappingConfiguration };

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -6,7 +6,7 @@ import * as translations from '../../../translations/index.js';
 import { AdminMemberError } from '../../authorization/domain/errors.js';
 import { CsvWithNoSessionDataError, SessionStartedDeletionError } from '../../certification/session/domain/errors.js';
 import { ArchivedCampaignError } from '../../prescription/campaign/domain/errors.js';
-import { SiecleXmlImportError } from '../../prescription/learner-management/domain/errors.js';
+import { AggregateImportError, SiecleXmlImportError } from '../../prescription/learner-management/domain/errors.js';
 import { OrganizationCantGetPlacesStatisticsError } from '../../prescription/organization-place/domain/errors.js';
 import * as DomainErrors from '../domain/errors.js';
 import {
@@ -160,6 +160,13 @@ function handle(request, h, error) {
   }
 
   const httpError = domainErrorMapper.mapToHttpError(error) ?? _mapToHttpError(error);
+
+  if (error instanceof AggregateImportError) {
+    httpError.meta.forEach((error) => {
+      error.status = httpError.status;
+    });
+    return h.response(errorSerializer.serialize(httpError.meta)).code(httpError.status);
+  }
 
   return h.response(errorSerializer.serialize(httpError)).code(httpError.status);
 }

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -57,6 +57,12 @@ class EntityValidationError extends DomainError {
     this.invalidAttributes = invalidAttributes;
   }
 
+  static fromJoiError(joiError) {
+    const invalidAttributes = { attribute: joiError.context.key, message: joiError.message };
+
+    return new EntityValidationError({ invalidAttributes });
+  }
+
   static fromJoiErrors(joiErrors) {
     const invalidAttributes = joiErrors.map((error) => {
       return { attribute: error.context.key, message: error.message };

--- a/api/src/shared/infrastructure/serializers/jsonapi/error-serializer.js
+++ b/api/src/shared/infrastructure/serializers/jsonapi/error-serializer.js
@@ -3,13 +3,19 @@ import jsonapiSerializer from 'jsonapi-serializer';
 const { Error: JSONAPIError } = jsonapiSerializer;
 
 const serialize = function (infrastructureError) {
-  return JSONAPIError({
-    status: `${infrastructureError.status}`,
-    title: infrastructureError.title,
-    detail: infrastructureError.message,
-    code: infrastructureError.code,
-    meta: infrastructureError.meta,
-  });
+  if (!Array.isArray(infrastructureError)) infrastructureError = [infrastructureError];
+
+  return JSONAPIError(
+    infrastructureError.map((error) => {
+      return {
+        status: `${error.status}`,
+        title: error.title,
+        detail: error.message,
+        code: error.code,
+        meta: error.meta,
+      };
+    }),
+  );
 };
 
 export { serialize };

--- a/api/tests/prescription/learner-management/acceptance/application/organization-controller-import-sco-organization-learners_test.js
+++ b/api/tests/prescription/learner-management/acceptance/application/organization-controller-import-sco-organization-learners_test.js
@@ -966,6 +966,7 @@ describe('Acceptance | Application | organization-controller-import-sco-organiza
           const organizationLearners = await knex('organization-learners').where({ organizationId });
           expect(organizationLearners).to.have.lengthOf(0);
           expect(response.statusCode).to.equal(412);
+          expect(response.result.errors).lengthOf(1);
           expect(response.result.errors[0].code).to.equal('FIELD_REQUIRED');
           expect(response.result.errors[0].meta.field).to.equal('Nom de famille*');
         });

--- a/api/tests/unit/domain/validators/organization-learner-validator_test.js
+++ b/api/tests/unit/domain/validators/organization-learner-validator_test.js
@@ -2,7 +2,7 @@ import {
   checkValidation,
   FRANCE_COUNTRY_CODE,
 } from '../../../../src/prescription/learner-management/domain/validators/organization-learner-validator.js';
-import { catchErr, expect } from '../../../test-helper.js';
+import { expect } from '../../../test-helper.js';
 
 describe('Unit | Domain | Organization Learner validator', function () {
   context('#checkValidation', function () {
@@ -24,11 +24,9 @@ describe('Unit | Domain | Organization Learner validator', function () {
 
     context('when all required fields are presents', function () {
       it('is valid', async function () {
-        try {
-          checkValidation(validAttributes);
-        } catch (e) {
-          expect.fail('OrganizationLearner is valid when all required fields are present');
-        }
+        const errors = await checkValidation(validAttributes);
+
+        expect(errors).to.be.lengthOf(0);
       });
     });
 
@@ -48,10 +46,10 @@ describe('Unit | Domain | Organization Learner validator', function () {
         'organizationId',
       ].forEach((field) => {
         it(`throw an error when ${field} is missing`, async function () {
-          const error = await catchErr(checkValidation)({ ...validAttributes, [field]: undefined });
+          const error = await checkValidation({ ...validAttributes, [field]: undefined });
 
-          expect(error.key).to.equal(field);
-          expect(error.why).to.equal('required');
+          expect(error[0].key).to.equal(field);
+          expect(error[0].why).to.equal('required');
         });
       });
     });
@@ -70,28 +68,28 @@ describe('Unit | Domain | Organization Learner validator', function () {
         'division',
       ].forEach((field) => {
         it(`throw an error when ${field} has more than 255 characters`, async function () {
-          const error = await catchErr(checkValidation)({ ...validAttributes, [field]: '1'.repeat(256) });
+          const error = await checkValidation({ ...validAttributes, [field]: '1'.repeat(256) });
 
-          expect(error.key).to.equal(field);
-          expect(error.why).to.equal('max_length');
+          expect(error[0].key).to.equal(field);
+          expect(error[0].why).to.equal('max_length');
         });
       });
     });
 
     context('birthProvinceCode', function () {
       it('throw an error when birthProvinceCode has more than 3 characters', async function () {
-        const error = await catchErr(checkValidation)({ ...validAttributes, birthProvinceCode: '1234' });
+        const error = await checkValidation({ ...validAttributes, birthProvinceCode: '1234' });
 
-        expect(error.key).to.equal('birthProvinceCode');
-        expect(error.why).to.equal('max_length');
-        expect(error.limit).to.equal(3);
+        expect(error[0].key).to.equal('birthProvinceCode');
+        expect(error[0].why).to.equal('max_length');
+        expect(error[0].limit).to.equal(3);
       });
 
       it('throw an error when birthProvinceCode has lass than 2 characters', async function () {
-        const error = await catchErr(checkValidation)({ ...validAttributes, birthProvinceCode: '1' });
-        expect(error.key).to.equal('birthProvinceCode');
-        expect(error.why).to.equal('min_length');
-        expect(error.limit).to.equal(2);
+        const error = await checkValidation({ ...validAttributes, birthProvinceCode: '1' });
+        expect(error[0].key).to.equal('birthProvinceCode');
+        expect(error[0].why).to.equal('min_length');
+        expect(error[0].limit).to.equal(2);
       });
     });
 
@@ -107,52 +105,52 @@ describe('Unit | Domain | Organization Learner validator', function () {
       });
 
       it('throw an error when birthCountryCode before birthCityCode', async function () {
-        const error = await catchErr(checkValidation)({
+        const error = await checkValidation({
           ...validAttributes,
           birthCityCode: '',
           birthCountryCode: '12345',
         });
 
-        expect(error.key).to.equal('birthCountryCode');
-        expect(error.why).to.equal('not_valid_insee_code');
+        expect(error[0].key).to.equal('birthCountryCode');
+        expect(error[0].why).to.equal('not_valid_insee_code');
       });
 
       it('throw an error when birthCountryCode before birthCity', async function () {
-        const error = await catchErr(checkValidation)({ ...validAttributes, birthCity: '', birthCountryCode: '12345' });
+        const error = await checkValidation({ ...validAttributes, birthCity: '', birthCountryCode: '12345' });
 
-        expect(error.key).to.equal('birthCountryCode');
-        expect(error.why).to.equal('not_valid_insee_code');
+        expect(error[0].key).to.equal('birthCountryCode');
+        expect(error[0].why).to.equal('not_valid_insee_code');
       });
 
       it('throw an error when birthCountryCode has not 5 characters', async function () {
-        const error = await catchErr(checkValidation)({ ...validAttributes, birthCountryCode: '123456' });
+        const error = await checkValidation({ ...validAttributes, birthCountryCode: '123456' });
 
-        expect(error.key).to.equal('birthCountryCode');
-        expect(error.why).to.equal('length');
-        expect(error.limit).to.equal(5);
+        expect(error[0].key).to.equal('birthCountryCode');
+        expect(error[0].why).to.equal('length');
+        expect(error[0].limit).to.equal(5);
       });
 
       it('throw an error when birthCountryCode not start with 99', async function () {
-        const error = await catchErr(checkValidation)({ ...validAttributes, birthCountryCode: '88123' });
+        const error = await checkValidation({ ...validAttributes, birthCountryCode: '88123' });
 
-        expect(error.key).to.equal('birthCountryCode');
-        expect(error.why).to.equal('not_valid_insee_code');
+        expect(error[0].key).to.equal('birthCountryCode');
+        expect(error[0].why).to.equal('not_valid_insee_code');
       });
 
       it('throw an error when birthCountryCode contains letter', async function () {
-        const error = await catchErr(checkValidation)({ ...validAttributes, birthCountryCode: '2B122' });
+        const error = await checkValidation({ ...validAttributes, birthCountryCode: '2B122' });
 
-        expect(error.key).to.equal('birthCountryCode');
-        expect(error.why).to.equal('not_valid_insee_code');
+        expect(error[0].key).to.equal('birthCountryCode');
+        expect(error[0].why).to.equal('not_valid_insee_code');
       });
     });
 
     context('status', function () {
-      it("throw an error when status is not 'ST'", async function () {
-        const error = await catchErr(checkValidation)({ ...validAttributes, status: 'AA' });
+      it("throw an error when status is not 'ST' or 'AP'", async function () {
+        const error = await checkValidation({ ...validAttributes, status: 'AA' });
 
-        expect(error.key).to.equal('status');
-        expect(error.why).to.equal('bad_values');
+        expect(error[0].key).to.equal('status');
+        expect(error[0].why).to.equal('bad_values');
       });
 
       it("is valid when status is 'ST'", async function () {
@@ -174,10 +172,10 @@ describe('Unit | Domain | Organization Learner validator', function () {
 
     context('sex', function () {
       it("throw an error when status is not 'Féminin', 'féminin', 'Masculin' or 'masculin'", async function () {
-        const error = await catchErr(checkValidation)({ ...validAttributes, sex: 'AA' });
+        const error = await checkValidation({ ...validAttributes, sex: 'AA' });
 
-        expect(error.key).to.equal('sex');
-        expect(error.why).to.equal('bad_values');
+        expect(error[0].key).to.equal('sex');
+        expect(error[0].why).to.equal('bad_values');
       });
 
       it("is valid when status is 'Féminin'", async function () {
@@ -216,42 +214,42 @@ describe('Unit | Domain | Organization Learner validator', function () {
     context('birthdate', function () {
       context('when birthdate is not a date', function () {
         it('throws an error', async function () {
-          const error = await catchErr(checkValidation)({ ...validAttributes, birthdate: '123456' });
+          const error = await checkValidation({ ...validAttributes, birthdate: '123456' });
 
-          expect(error.key).to.equal('birthdate');
-          expect(error.why).to.equal('not_a_date');
+          expect(error[0].key).to.equal('birthdate');
+          expect(error[0].why).to.equal('not_a_date');
         });
       });
 
       context('when birthdate has not a valid format', function () {
         it('throws an error', async function () {
-          const error = await catchErr(checkValidation)({ ...validAttributes, birthdate: '2020/01/01' });
+          const error = await checkValidation({ ...validAttributes, birthdate: '2020/01/01' });
 
-          expect(error.key).to.equal('birthdate');
-          expect(error.why).to.equal('not_a_date');
+          expect(error[0].key).to.equal('birthdate');
+          expect(error[0].why).to.equal('not_a_date');
         });
       });
 
       context('when birthdate is null', function () {
         it('throws an error', async function () {
-          const error = await catchErr(checkValidation)({ ...validAttributes, birthdate: null });
+          const error = await checkValidation({ ...validAttributes, birthdate: null });
 
-          expect(error.key).to.equal('birthdate');
-          expect(error.why).to.equal('required');
+          expect(error[0].key).to.equal('birthdate');
+          expect(error[0].why).to.equal('required');
         });
       });
     });
 
     context('birthCity', function () {
       it('throw an error when birth country is not France and birthCity is undefined', async function () {
-        const error = await catchErr(checkValidation)({
+        const error = await checkValidation({
           ...validAttributes,
           birthCountryCode: '99125',
           birthCity: undefined,
         });
 
-        expect(error.key).to.equal('birthCity');
-        expect(error.why).to.equal('required');
+        expect(error[0].key).to.equal('birthCity');
+        expect(error[0].why).to.equal('required');
       });
 
       it('is valid when birthCity is undefined and birthCountry is France', async function () {
@@ -302,26 +300,26 @@ describe('Unit | Domain | Organization Learner validator', function () {
       context('is invalid', function () {
         context('when birthCountryCode is equal to France', function () {
           it('throw an error with a birthCityCode of 5 characters', async function () {
-            const error = await catchErr(checkValidation)({
+            const error = await checkValidation({
               ...validAttributes,
               birthCountryCode: FRANCE_COUNTRY_CODE,
               birthCityCode: '123456',
             });
 
-            expect(error.key).to.equal('birthCityCode');
-            expect(error.why).to.equal('length');
-            expect(error.limit).to.equal(5);
+            expect(error[0].key).to.equal('birthCityCode');
+            expect(error[0].why).to.equal('length');
+            expect(error[0].limit).to.equal(5);
           });
 
           it('throws an error with a birthCityCode which has a letter not in second character', async function () {
-            const error = await catchErr(checkValidation)({
+            const error = await checkValidation({
               ...validAttributes,
               birthCountryCode: FRANCE_COUNTRY_CODE,
               birthCityCode: '21B22',
             });
 
-            expect(error.key).to.equal('birthCityCode');
-            expect(error.why).to.equal('not_valid_insee_code');
+            expect(error[0].key).to.equal('birthCityCode');
+            expect(error[0].why).to.equal('not_valid_insee_code');
           });
         });
 
@@ -329,13 +327,21 @@ describe('Unit | Domain | Organization Learner validator', function () {
           it('throws an error with a birthCityCode of 256 characters', async function () {
             const stringOf256Char =
               'hZSJIp6WBhnZFxsnTxEQo1oSoWkRDSB8nQsbScrK9IfAmVGb1PFNdX333k6Tsn6YKHfebdRg2VryzQcY06GTm1sYIN9Y3B0uy1ZsZIFpZ3cQNLxnawaUfVQFylq1GFba9LNDowH7lISfn7HJbdf3hNawofdCbVNgRdw7ZAN8XdggDJUgyAs91GpQ6vCkrxa08AMYTI8QClkhUVazVGgwndtwN4EBG23K2AfayHKWVi6jSlPOgUrx4tgSAcxELxW2';
-            const error = await catchErr(checkValidation)({ ...validAttributes, birthCityCode: stringOf256Char });
+            const error = await checkValidation({ ...validAttributes, birthCityCode: stringOf256Char });
 
-            expect(error.key).to.equal('birthCityCode');
-            expect(error.why).to.equal('max_length');
-            expect(error.limit).to.equal(255);
+            expect(error[0].key).to.equal('birthCityCode');
+            expect(error[0].why).to.equal('max_length');
+            expect(error[0].limit).to.equal(255);
           });
         });
+      });
+    });
+
+    context('multiple error on the same line', function () {
+      it('throw an error with all bad element in the line', async function () {
+        const errors = await checkValidation({ ...validAttributes, sex: 'AA', status: 'AA' });
+
+        expect(errors).to.lengthOf(2);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement nous remontons les erreurs une à une.

## :robot: Proposition
Remonter les erreurs de manières groupé
 - Toutes les erreurs de header d'un coup
 - Toutes les erreurs de validation d'un coup
 
Et c'est déjà pas mal

## :rainbow: Remarques
RAS

## :100: Pour tester
TODO