### PR TITLE
[FEATURE][API] Mettre à jour les liens des emails pour langue Néerlandaise (PIX-11300)

### DIFF
--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -17,11 +17,13 @@ const PIX_CERTIF_NAME_FR = 'Pix Certif - Ne pas répondre';
 const PIX_CERTIF_NAME_EN = 'Pix Certif - Noreply';
 const HELPDESK_FRENCH_FRANCE = 'https://support.pix.fr';
 const HELPDESK_ENGLISH_SPOKEN = 'https://support.pix.org/en/support/home';
+const HELPDESK_DUTCH_SPOKEN = 'https://support.pix.org/en/support/home';
 const HELPDESK_FRENCH_SPOKEN = 'https://support.pix.org';
 const PIX_HOME_NAME_INTERNATIONAL = `pix${config.domain.tldOrg}`;
 const PIX_HOME_NAME_FRENCH_FRANCE = `pix${config.domain.tldFr}`;
 const PIX_HOME_URL_INTERNATIONAL_ENGLISH_SPOKEN = `${config.domain.pix + config.domain.tldOrg}/en-gb/`;
 const PIX_HOME_URL_INTERNATIONAL_FRENCH_SPOKEN = `${config.domain.pix + config.domain.tldOrg}/fr/`;
+const PIX_HOME_URL_INTERNATIONAL_DUTCH_SPOKEN = `${config.domain.pix + config.domain.tldOrg}/nl-be/`;
 const PIX_HOME_URL_FRENCH_FRANCE = `${config.domain.pix + config.domain.tldFr}`;
 
 const EMAIL_VERIFICATION_CODE_TAG = 'EMAIL_VERIFICATION_CODE';
@@ -59,9 +61,9 @@ function sendAccountCreationEmail(email, locale, redirectionUrl) {
   } else if (locale === DUTCH_SPOKEN) {
     variables = {
       homeName: PIX_HOME_NAME_INTERNATIONAL,
-      homeUrl: PIX_HOME_URL_INTERNATIONAL_ENGLISH_SPOKEN,
+      homeUrl: PIX_HOME_URL_INTERNATIONAL_DUTCH_SPOKEN,
       redirectionUrl: redirectionUrl || `${config.domain.pixApp + config.domain.tldOrg}/connexion/?lang=nl`,
-      helpdeskUrl: HELPDESK_ENGLISH_SPOKEN,
+      helpdeskUrl: HELPDESK_DUTCH_SPOKEN,
       displayNationalLogo: false,
       ...nlTranslations['pix-account-creation-email'].params,
     };

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -455,7 +455,7 @@ function sendVerificationCodeEmail({ code, email, locale, translate }) {
     options.variables = {
       code,
       homeName: PIX_HOME_NAME_INTERNATIONAL,
-      homeUrl: PIX_HOME_URL_INTERNATIONAL_ENGLISH_SPOKEN,
+      homeUrl: PIX_HOME_URL_INTERNATIONAL_DUTCH_SPOKEN,
       displayNationalLogo: false,
       ...nlTranslations['verification-code-email'].body,
     };

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -187,9 +187,9 @@ function sendResetPasswordDemandEmail({ email, locale, temporaryKey }) {
       locale: localeParam,
       ...nlTranslations['reset-password-demand-email'].params,
       homeName: PIX_HOME_NAME_INTERNATIONAL,
-      homeUrl: PIX_HOME_URL_INTERNATIONAL_ENGLISH_SPOKEN,
+      homeUrl: PIX_HOME_URL_INTERNATIONAL_DUTCH_SPOKEN,
       resetUrl: `${config.domain.pixApp + config.domain.tldOrg}/changer-mot-de-passe/${temporaryKey}/?lang=nl`,
-      helpdeskURL: HELPDESK_ENGLISH_SPOKEN,
+      helpdeskURL: HELPDESK_DUTCH_SPOKEN,
     };
 
     pixName = nlTranslations['email-sender-name']['pix-app'];

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -1,5 +1,6 @@
 import { config as settings } from '../../../../lib/config.js';
 import * as mailService from '../../../../lib/domain/services/mail-service.js';
+import { LOCALE } from '../../../../src/shared/domain/constants.js';
 import { tokenService } from '../../../../src/shared/domain/services/token-service.js';
 import { mailer } from '../../../../src/shared/mail/infrastructure/services/mailer.js';
 import en from '../../../../translations/en.json' assert { type: 'json' };
@@ -13,8 +14,6 @@ const mainTranslationsMapping = {
   en,
   nl,
 };
-
-import { LOCALE } from '../../../../src/shared/domain/constants.js';
 
 const { ENGLISH_SPOKEN, FRENCH_FRANCE, FRENCH_SPOKEN, DUTCH_SPOKEN } = LOCALE;
 
@@ -135,7 +134,7 @@ describe('Unit | Service | MailService', function () {
           expect(options.fromName).to.equal('PIX - Niet beantwoorden');
           expect(options.variables).to.include({
             homeName: 'pix.org',
-            homeUrl: 'https://pix.org/en-gb/',
+            homeUrl: 'https://pix.org/nl-be/',
             helpdeskUrl: 'https://support.pix.org/en/support/home',
             displayNationalLogo: false,
             redirectionUrl: 'https://app.pix.org/connexion/?lang=nl',

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -819,7 +819,7 @@ describe('Unit | Service | MailService', function () {
       expect(options.fromName).to.equal('PIX - Niet beantwoorden');
       expect(options.variables).to.include({
         homeName: 'pix.org',
-        homeUrl: 'https://pix.org/en-gb/',
+        homeUrl: 'https://pix.org/nl-be/',
         displayNationalLogo: false,
         code,
         ...mainTranslationsMapping.nl['verification-code-email'].body,

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -251,7 +251,7 @@ describe('Unit | Service | MailService', function () {
             locale: DUTCH_SPOKEN,
             ...mainTranslationsMapping.nl['reset-password-demand-email'].params,
             homeName: 'pix.org',
-            homeUrl: 'https://pix.org/en-gb/',
+            homeUrl: 'https://pix.org/nl-be/',
             resetUrl: `https://app.pix.org/changer-mot-de-passe/${temporaryKey}/?lang=nl`,
             helpdeskURL: 'https://support.pix.org/en/support/home',
           },
@@ -296,6 +296,7 @@ describe('Unit | Service | MailService', function () {
         // then
         expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);
       });
+
       it(`should call mailer with translated texts if locale is ${FRENCH_FRANCE}`, async function () {
         // given
         const expectedOptions = {
@@ -324,6 +325,7 @@ describe('Unit | Service | MailService', function () {
         // then
         expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);
       });
+
       it(`should call mailer with fr-fr translated texts if locale is undefined`, async function () {
         // given
         const expectedOptions = {


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, si une personne s'inscrit à Pix avec la langue Néerlandaise, cette personne recevra un email avec des liens qui pointent vers la langue Anglaise des différents sites.

## :robot: Proposition

Remplacer les liens qui étaient en Anglais pour le Néerlandais pour les emails suivants :

- Création de compte
- Réinitialisation de mot de passe
- Changement d'email

## :rainbow: Remarques

Le lien vers le site du support est resté le même et pointe toujours vers la version Anglaise car la version Néerlandaise n'est pas encore disponible.

## :100: Pour tester

⚠️ La variable `MAILING_ENABLED` doit avoir la valeur `true` avant de pouvoir recevoir un email. Modification à faire pour la RA.
En local, vous pouvez simplement désactiver cette variable et activer la suivante `DEBUG`.

#### Création de compte

1. Aller sur la page d'inscription sur le domaine .org (https://app-pr8351.review.pix.org/inscription)
2. Modifier la langue d'affichage vers le Néerlandais
3. S'inscrire
4. Vérifier la réception d'un email de **création de compte** en Néerlandais contenant les bons liens vers Pix Site et le site support
5. Vérifier dans l'email que le lien vers Twitter ne contient plus le paramètre `lang=fr`

#### Réinitialiser le mot de passe

1. Aller sur la page de connexion sur le domaine .org (https://app-pr8351.review.pix.org/connexion)
2. Changer la langue en Néerlandais
3. Cliquer sur le lien "Bent u uw wachtwoord vergeten?" (https://app-pr8351.review.pix.org/mot-de-passe-oublie)
4. Fournir une adresse email
5. Vérifier la réception d'un email de **réinitialisation de mot de passe** en Néerlandais contenant les bons liens vers Pix Site et le site support
6. Vérifier dans l'email que le lien vers Twitter ne contient plus le paramètre `lang=fr`

#### Changer l'email du compte

1. Se connecter à Pix App sur le domaine .org (ex: pixsupport@example.net)
2. Aller sur Mon Compte > Mes méthodes de connexion (https://app-pr8351.review.pix.org/mon-compte/methodes-de-connexion)
3. Cliquer sur le bouton Modifier
4. Fournir une nouvelle adresse email
5. Fournir son mot de passe
6. Cliquer sur le bouton Recevoir un code de vérification
7. Vérifier la réception d'un email de **changement d'email** en Néerlandais contenant les bons liens vers Pix Site et le site support, ainsi qu'un code
8. Vérifier dans l'email que le lien vers Twitter ne contient plus le paramètre `lang=fr`