### PR TITLE
[REFACTOR] Amélioration du style du lien du bloc de score sur le dashboard (PIX-10555).

### DIFF
--- a/mon-pix/app/components/dashboard/content.hbs
+++ b/mon-pix/app/components/dashboard/content.hbs
@@ -18,9 +18,9 @@
         @maxReachablePixScore={{this.maxReachablePixScore}}
         @maxReachableLevel={{this.maxReachableLevel}}
       />
-      <LinkTo @route="authenticated.profile" class="dashboard-content-score-wrapper__button">{{t
-          "pages.dashboard.score.profile-link"
-        }}</LinkTo>
+      <LinkTo @route="authenticated.profile" class="dashboard-content-score-wrapper__link">
+        {{t "pages.dashboard.score.profile-link"}}
+      </LinkTo>
     </div>
   </section>
 

--- a/mon-pix/app/styles/components/dashboard/_content.scss
+++ b/mon-pix/app/styles/components/dashboard/_content.scss
@@ -138,20 +138,24 @@
   }
 }
 
-.dashboard-content-score-wrapper {
-  &__button {
-    padding-top: 10px;
-    color: $pix-primary;
+.dashboard-content-score-wrapper__link {
+  margin-top: var(--pix-spacing-3x);
+  color: var(--pix-neutral-800);
+  font-weight: 500;
+  font-size: 0.875rem;
+  text-decoration: underline;
 
-    &:hover,
-    &:focus {
-      color: $pix-primary-70;
-      text-decoration: underline;
-    }
+  &:hover,
+  &:focus {
+    color: var(--pix-primary-500);
+  }
 
-    &:visited {
-      color: $pix-tertiary-70;
-    }
+  &:focus {
+    font-weight: 700;
+  }
+
+  &:active {
+    color: var(--pix-primary-900);
   }
 }
 


### PR DESCRIPTION
## :unicorn: Problème

Le texte du lien "Voir mes compétences" est en violet et peut faire penser à un lien déjà cliqué.

## :robot: Proposition

Lui donner le style du bouton "tertiary" (voir style [sur Figma](https://www.figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix?type=design&node-id=7790-2058&mode=design&t=1GSjng4938q24MOZ-4))

## :rainbow: Remarques

Ce style est écrit en dur pour l'instant, car il n'existe pas encore sur PixUI.

## :100: Pour tester

Se connecter à [PixApp en RA](https://app-pr8354.review.pix.fr/) et constater le changement de style du lien "Voir mes compétences" du bloc de score Pix.
