### PR TITLE
[REFACTOR] Amélioration du lien "détails" d'une carte de compétence (PIX-10556).

### DIFF
--- a/mon-pix/app/styles/components/_competence-card-default.scss
+++ b/mon-pix/app/styles/components/_competence-card-default.scss
@@ -183,10 +183,11 @@
     display: block;
     margin-top: 3px;
     margin-bottom: -4px;
-    color: $pix-neutral-30;
+    color: var(--pix-neutral-500);
     font-size: 0.625rem;
     letter-spacing: 0.5px;
     text-transform: uppercase;
+    text-decoration: underline;
     opacity: 0;
     transition: opacity 0.1s linear;
   }


### PR DESCRIPTION
## :unicorn: Problème

Sur une carte de compétence, pas assez de contraste pour le lien “détail” et affordance

## :robot: Proposition

Passer en neutral-500 et souligner le mot

## :100: Pour tester

Se connecter sur [PixApp en RA](https://app-pr8355.review.pix.fr/) et voir le changement de style sur le lien "détails" d'une carte de compétence.
