### PR TITLE
[FEATURE] Ajoute d'`alt` manquants sur Modulix

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -55,7 +55,7 @@
           "id": "8d7687c8-4a02-4d7e-bf6c-693a6d481c78",
           "type": "image",
           "url": "https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg",
-          "alt": "",
+          "alt": "Dessin détaillé dans l'alternative textuelle",
           "alternativeText": "Dessin d'un ordinateur dans un univers spatial."
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
@@ -243,7 +243,7 @@
           "id": "36b959d4-add7-403d-9e7f-aa4f0bf777b8",
           "type": "image",
           "url": "https://i.imgur.com/waJxYRr.jpeg",
-          "alt": "",
+          "alt": "Photo d'un connecteur avec un symbole représentant une flèche avec des ronds et des carrés",
           "alternativeText": ""
         },
         {


### PR DESCRIPTION
## :unicorn: Problème
Sur le module ports et connexions de modulix, il y a un image qui n'a pas un alt text. A cause de ca, l'image est pas accessible.

## :robot: Proposition
Ajoute un texte alternative sur l'image

## :rainbow: Remarques
RAS

## :100: Pour tester
Verifier que l'image avec le symbol usb a un alt text
