### PR TITLE
[FEATURE] Afficher la liste des élèves dans le détail d'une mission dans Pix Orga (PIX-11198)

### DIFF
--- a/api/src/school/application/mission-learner-controller.js
+++ b/api/src/school/application/mission-learner-controller.js
@@ -1,0 +1,13 @@
+import { extractParameters } from '../../shared/infrastructure/utils/query-params-utils.js';
+import { usecases } from '../domain/usecases/index.js';
+import * as missionLearnerSerializer from '../infrastructure/serializers/mission-learner-serializer.js';
+
+const findPaginatedMissionLearners = async function (request) {
+  const organizationId = request.params.id;
+  const { page } = extractParameters(request.query);
+  const result = await usecases.findPaginatedMissionLearners({ organizationId, page });
+  return missionLearnerSerializer.serialize(result);
+};
+
+const missionLearnerController = { findPaginatedMissionLearners };
+export { missionLearnerController };

--- a/api/src/school/application/mission-learner-route.js
+++ b/api/src/school/application/mission-learner-route.js
@@ -1,0 +1,38 @@
+import Joi from 'joi';
+
+import { securityPreHandlers } from '../../shared/application/security-pre-handlers.js';
+import { identifiersType } from '../../shared/domain/types/identifiers-type.js';
+import { missionLearnerController } from './mission-learner-controller.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/organizations/{id}/mission-learners',
+      config: {
+        pre: [
+          { method: securityPreHandlers.checkUserBelongsToOrganization },
+          { method: securityPreHandlers.checkPix1dActivated },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.organizationId,
+          }),
+          query: Joi.object({
+            'page[number]': Joi.number().integer().empty(''),
+            'page[size]': Joi.number().integer().empty(''),
+          }),
+        },
+        handler: missionLearnerController.findPaginatedMissionLearners,
+        tags: ['api', 'pix1d', 'mission-learners'],
+        notes: [
+          '- **Cette route est restreinte aux personnes authentifiées' +
+            "- Elle permet de récupérer tous les participants (organization-leaner) d'une orga",
+        ],
+      },
+    },
+  ]);
+};
+
+const name = 'mission-learners-api';
+export { name, register };

--- a/api/src/school/domain/models/MissionLearner.js
+++ b/api/src/school/domain/models/MissionLearner.js
@@ -1,0 +1,11 @@
+class MissionLearner {
+  constructor({ id, firstName, lastName, organizationId, division } = {}) {
+    this.id = id;
+    this.organizationId = organizationId;
+    this.lastName = lastName;
+    this.firstName = firstName;
+    this.division = division;
+  }
+}
+
+export { MissionLearner };

--- a/api/src/school/domain/usecases/get-all-mission-learners.js
+++ b/api/src/school/domain/usecases/get-all-mission-learners.js
@@ -1,0 +1,5 @@
+const findPaginatedMissionLearners = async function ({ missionLearnerRepository, organizationId, page } = {}) {
+  return await missionLearnerRepository.findPaginatedMissionLearners({ organizationId, page });
+};
+
+export { findPaginatedMissionLearners };

--- a/api/src/school/domain/usecases/index.js
+++ b/api/src/school/domain/usecases/index.js
@@ -11,6 +11,7 @@ import * as activityAnswerRepository from '../../infrastructure/repositories/act
 import * as activityRepository from '../../infrastructure/repositories/activity-repository.js';
 import * as challengeRepository from '../../infrastructure/repositories/challenge-repository.js';
 import * as missionAssessmentRepository from '../../infrastructure/repositories/mission-assessment-repository.js';
+import * as missionLearnerRepository from '../../infrastructure/repositories/mission-learner-repository.js';
 import * as missionRepository from '../../infrastructure/repositories/mission-repository.js';
 import * as organizationLearnerRepository from '../../infrastructure/repositories/organization-learner-repository.js';
 import * as schoolRepository from '../../infrastructure/repositories/school-repository.js';
@@ -24,6 +25,7 @@ const dependencies = {
   competenceRepository,
   missionAssessmentRepository,
   missionRepository,
+  missionLearnerRepository,
   organizationLearnerRepository,
   schoolRepository,
   sharedChallengeRepository,

--- a/api/src/school/infrastructure/repositories/mission-learner-repository.js
+++ b/api/src/school/infrastructure/repositories/mission-learner-repository.js
@@ -1,0 +1,15 @@
+import { knex } from '../../../../db/knex-database-connection.js';
+import { fetchPage } from '../../../../lib/infrastructure/utils/knex-utils.js';
+import { MissionLearner } from '../../domain/models/MissionLearner.js';
+
+const findPaginatedMissionLearners = async function ({ organizationId, page }) {
+  const { results, pagination } = await fetchPage(
+    knex('organization-learners').select('*').where({ organizationId: organizationId }),
+    page,
+  );
+
+  const missionLearners = results.map((missionLearner) => new MissionLearner({ ...missionLearner }));
+  return { missionLearners, pagination };
+};
+
+export { findPaginatedMissionLearners };

--- a/api/src/school/infrastructure/serializers/mission-learner-serializer.js
+++ b/api/src/school/infrastructure/serializers/mission-learner-serializer.js
@@ -1,0 +1,10 @@
+import { Serializer } from 'jsonapi-serializer';
+
+const serialize = function ({ missionLearners, pagination }) {
+  return new Serializer('mission-learner', {
+    attributes: ['firstName', 'lastName', 'division', 'organizationId'],
+    meta: pagination,
+  }).serialize(missionLearners);
+};
+
+export { serialize };

--- a/api/src/school/routes.js
+++ b/api/src/school/routes.js
@@ -1,9 +1,10 @@
 import * as activityAnswer from './application/activity-answer-route.js';
 import * as assessment from './application/assessment-route.js';
+import * as missionLearner from './application/mission-learner-route.js';
 import * as mission from './application/mission-route.js';
 import * as organizationLearner from './application/organization-learner-route.js';
 import * as school from './application/school-route.js';
 
-const schoolRoutes = [activityAnswer, assessment, mission, school, organizationLearner];
+const schoolRoutes = [activityAnswer, assessment, mission, school, organizationLearner, missionLearner];
 
 export { schoolRoutes };

--- a/api/tests/school/integration/application/mission-learner-controller_test.js
+++ b/api/tests/school/integration/application/mission-learner-controller_test.js
@@ -1,0 +1,77 @@
+import { missionLearnerController } from '../../../../src/school/application/mission-learner-controller.js';
+import { MissionLearner } from '../../../../src/school/domain/models/MissionLearner.js';
+import { usecases } from '../../../../src/school/domain/usecases/index.js';
+import { expect, hFake, sinon } from '../../../test-helper.js';
+
+describe('Integration | Controller | mission-learner-controller', function () {
+  describe('#findPaginatedMissionLearners', function () {
+    it('should return missionLearners', async function () {
+      const organizationId = 1;
+      const missionLearner = new MissionLearner({
+        id: 1,
+        firstName: 'TechnoMechanicus',
+        lastName: 'Musk',
+        organizationId,
+        division: 'CP',
+      });
+      const pagination = {
+        page: 1,
+        pageCount: 1,
+        pageSize: 50,
+        rowCount: 1,
+      };
+
+      sinon.stub(usecases, 'findPaginatedMissionLearners').resolves({ missionLearners: [missionLearner], pagination });
+
+      const result = await missionLearnerController.findPaginatedMissionLearners(
+        {
+          params: {
+            id: organizationId,
+          },
+          query: { 'page[size]': 50, 'page[number]': 1 },
+        },
+        hFake,
+      );
+
+      expect(result.data).to.deep.equal([
+        {
+          attributes: {
+            'first-name': missionLearner.firstName,
+            'last-name': missionLearner.lastName,
+            division: missionLearner.division,
+            'organization-id': missionLearner.organizationId,
+          },
+          id: missionLearner.id.toString(),
+          type: 'mission-learners',
+        },
+      ]);
+      expect(result.meta).to.deep.equal(pagination);
+    });
+
+    it('should return empty result when there is no mission learners', async function () {
+      const organizationId = 1;
+      const missionLearner = [];
+      const pagination = {
+        page: 1,
+        pageCount: 1,
+        pageSize: 50,
+        rowCount: 1,
+      };
+
+      sinon.stub(usecases, 'findPaginatedMissionLearners').resolves({ missionLearners: missionLearner, pagination });
+
+      const result = await missionLearnerController.findPaginatedMissionLearners(
+        {
+          params: {
+            id: organizationId,
+          },
+          query: { 'page[size]': 50, 'page[number]': 1 },
+        },
+        hFake,
+      );
+
+      expect(result.data).to.deep.equal([]);
+      expect(result.meta).to.deep.equal(pagination);
+    });
+  });
+});

--- a/api/tests/school/integration/infrastructure/repositories/mission-learners-repository_test.js
+++ b/api/tests/school/integration/infrastructure/repositories/mission-learners-repository_test.js
@@ -1,0 +1,48 @@
+import { MissionLearner } from '../../../../../src/school/domain/models/MissionLearner.js';
+import * as missionLearnersRepository from '../../../../../src/school/infrastructure/repositories/mission-learner-repository.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+describe('Integration | Repository | organizationLearner', function () {
+  describe('#findPaginatedMissionLearners', function () {
+    it('should return missionLearners corresponding to the organizationId', async function () {
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      const rawStudent = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+      const expectedMissionLearner = new MissionLearner(rawStudent);
+      databaseBuilder.factory.buildOrganizationLearner({ organizationId: otherOrganizationId });
+      await databaseBuilder.commit();
+
+      const customPagination = { number: 1, size: 100 };
+      const expectedPagination = {
+        page: 1,
+        pageCount: 1,
+        pageSize: 100,
+        rowCount: 1,
+      };
+      const missionLearners = await missionLearnersRepository.findPaginatedMissionLearners({
+        organizationId,
+        page: customPagination,
+      });
+
+      expect(missionLearners.missionLearners).to.deep.equal([expectedMissionLearner]);
+      expect(missionLearners.pagination).to.deep.equal(expectedPagination);
+    });
+
+    it('should return an empty array', async function () {
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      await databaseBuilder.commit();
+
+      const expectedPagination = {
+        page: 1,
+        pageCount: 0,
+        pageSize: 10,
+        rowCount: 0,
+      };
+      const missionLearners = await missionLearnersRepository.findPaginatedMissionLearners({ organizationId });
+
+      expect(missionLearners).to.deep.equal({
+        missionLearners: [],
+        pagination: expectedPagination,
+      });
+    });
+  });
+});

--- a/api/tests/school/unit/application/mission-learner-route_test.js
+++ b/api/tests/school/unit/application/mission-learner-route_test.js
@@ -1,0 +1,54 @@
+import { missionLearnerController } from '../../../../src/school/application/mission-learner-controller.js';
+import * as moduleUnderTest from '../../../../src/school/application/mission-learner-route.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
+import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
+
+describe('Unit | Route | mission-learner-route', function () {
+  describe('GET /api/organizations/{id}/mission-learners', function () {
+    it('should check user belongs to organization and pix1d is activated', async function () {
+      // given
+      const mock = sinon.mock(securityPreHandlers);
+      mock.expects('checkUserBelongsToOrganization').once().returns(true);
+      mock.expects('checkPix1dActivated').once().returns(true);
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      await httpTestServer.request('GET', '/api/organizations/4/mission-learners');
+
+      // then
+      mock.verify();
+    });
+
+    it('should return 200 if the mission is found', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserBelongsToOrganization').callsFake((request, h) => h.response(true));
+      sinon.stub(securityPreHandlers, 'checkPix1dActivated').callsFake((request, h) => h.response(true));
+      sinon.stub(missionLearnerController, 'findPaginatedMissionLearners').callsFake((request, h) => h.response('ok'));
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('GET', '/api/organizations/4/mission-learners');
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should return 400 when the organizationId is not a number', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserBelongsToOrganization').callsFake((request, h) => h.response(true));
+      sinon.stub(securityPreHandlers, 'checkPix1dActivated').callsFake((request, h) => h.response(true));
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('GET', '/api/organizations/AZRTY/mission-learners');
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+  });
+});

--- a/api/tests/school/unit/application/mission-route_test.js
+++ b/api/tests/school/unit/application/mission-route_test.js
@@ -3,8 +3,8 @@ import * as moduleUnderTest from '../../../../src/school/application/mission-rou
 import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
 
-describe('Unit | Router | mission-router', function () {
-  describe('GET /api/pix1d/missions/${missionId}', function () {
+describe('Unit | Router | mission-route', function () {
+  describe('GET /api/pix1d/missions/{missionId}', function () {
     it('should check pix1d activated', async function () {
       // given
       sinon.spy(securityPreHandlers, 'checkPix1dActivated');
@@ -34,7 +34,7 @@ describe('Unit | Router | mission-router', function () {
     });
   });
 
-  describe('GET /api/pix1d/missions/', function () {
+  describe('GET /api/pix1d/missions', function () {
     it('should check pix1d activated', async function () {
       // given
       sinon.spy(securityPreHandlers, 'checkPix1dActivated');
@@ -64,7 +64,7 @@ describe('Unit | Router | mission-router', function () {
     });
   });
 
-  describe('GET /api/organizations/{id}/missions/', function () {
+  describe('GET /api/organizations/{id}/missions', function () {
     it('should check user belongs to organization and pix1d is activated', async function () {
       // given
       const mock = sinon.mock(securityPreHandlers);
@@ -95,7 +95,7 @@ describe('Unit | Router | mission-router', function () {
       expect(response.statusCode).to.equal(200);
     });
   });
-  describe('GET /api/organizations/{id}/missions/${missionId}', function () {
+  describe('GET /api/organizations/{id}/missions/{missionId}', function () {
     it('should check user belongs to organization and pix1d is activated', async function () {
       // given
       const mock = sinon.mock(securityPreHandlers);

--- a/orga/app/adapters/mission-learner.js
+++ b/orga/app/adapters/mission-learner.js
@@ -1,0 +1,12 @@
+import ApplicationAdapter from './application';
+
+export default class MissionAdapter extends ApplicationAdapter {
+  urlForQuery(query) {
+    if (query.organizationId) {
+      const { organizationId } = query;
+      delete query.organizationId;
+      return `${this.host}/${this.namespace}/organizations/${organizationId}/mission-learners`;
+    }
+    return super.urlForQuery(...arguments);
+  }
+}

--- a/orga/app/components/mission/mission-information.hbs
+++ b/orga/app/components/mission/mission-information.hbs
@@ -7,7 +7,7 @@
 
       {{#each this.displayObjectives as |objective|}}
         <li>
-          <p>{{objective}}</p>
+          {{objective}}
         </li>
       {{/each}}
     </ul>

--- a/orga/app/controllers/authenticated/missions/details/learners.js
+++ b/orga/app/controllers/authenticated/missions/details/learners.js
@@ -1,0 +1,17 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+const DEFAULT_PAGE_NUMBER = 1;
+
+export default class MissionLearnersController extends Controller {
+  @service router;
+  @tracked pageNumber = DEFAULT_PAGE_NUMBER;
+  @tracked pageSize = 25;
+
+  @action
+  clearFilters() {
+    this.pageNumber = null;
+  }
+}

--- a/orga/app/models/mission-learner.js
+++ b/orga/app/models/mission-learner.js
@@ -1,0 +1,8 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class MissionLearner extends Model {
+  @attr('string') division;
+  @attr('string') firstName;
+  @attr('string') lastName;
+  @attr('string') organizationId;
+}

--- a/orga/app/router.js
+++ b/orga/app/router.js
@@ -81,7 +81,9 @@ Router.map(function () {
     this.route('places');
     this.route('missions', function () {
       this.route('list', { path: '/' });
-      this.route('details', { path: '/:mission_id' });
+      this.route('details', { path: '/:mission_id' }, function () {
+        this.route('learners', { path: '/' });
+      });
     });
   });
 

--- a/orga/app/routes/authenticated/missions/details/learners.js
+++ b/orga/app/routes/authenticated/missions/details/learners.js
@@ -1,0 +1,40 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class MissionLearnersRoute extends Route {
+  @service currentUser;
+  @service router;
+  @service store;
+
+  queryParams = {
+    pageNumber: {
+      refreshModel: true,
+    },
+    pageSize: {
+      refreshModel: true,
+    },
+  };
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.pageNumber = 1;
+      controller.pageSize = 25;
+    }
+  }
+  async model(params) {
+    const organizationId = this.currentUser.organization.id;
+    const mission = this.modelFor('authenticated.missions.details');
+    const missionLearners = this.store.query(
+      'mission-learner',
+      {
+        organizationId,
+        page: {
+          number: params.pageNumber,
+          size: params.pageSize,
+        },
+      },
+      { reload: true },
+    );
+    return { missionLearners, mission };
+  }
+}

--- a/orga/app/styles/pages/authenticated/mission.scss
+++ b/orga/app/styles/pages/authenticated/mission.scss
@@ -5,6 +5,7 @@
 }
 
 .mission-header {
+  margin-bottom:var(--pix-spacing-6x);
 
   &__banner {
     margin:var(--pix-spacing-4x) 0;
@@ -65,13 +66,18 @@
 }
 
 .mission-informations {
-  @extend %pix-body-m;
+  @extend %pix-body-l;
 
   color: var(--pix-neutral-500);
 
   &__objective-list {
     margin-top: var(--pix-spacing-2x);
     margin-left: var(--pix-spacing-6x);
+    list-style: disc;
   }
+}
+
+.learners-title {
+  margin-bottom:var(--pix-spacing-4x)
 }
 

--- a/orga/app/templates/authenticated/missions/details/learners.hbs
+++ b/orga/app/templates/authenticated/missions/details/learners.hbs
@@ -1,0 +1,39 @@
+<h2 class="learners-title">{{t "pages.missions.details.learners.title"}}</h2>
+{{#if @model.missionLearners}}
+  <div class="panel">
+    <table class="table content-text content-text--small participation-list__table">
+      <caption class="screen-reader-only">{{t
+          "pages.missions.details.learners.list.caption"
+          missionName=@model.mission.mission.name
+        }}</caption>
+      <thead>
+        <tr>
+          <Table::Header scope="col">{{t "pages.missions.details.learners.list.headers.first-name"}}</Table::Header>
+          <Table::Header scope="col">{{t "pages.missions.details.learners.list.headers.last-name"}}</Table::Header>
+          <Table::Header scope="col">{{t "pages.missions.details.learners.list.headers.division"}}</Table::Header>
+        </tr>
+      </thead>
+      <tbody>
+
+        {{#each this.model.missionLearners as |missionLearner|}}
+          <tr>
+            <td>
+              {{missionLearner.firstName}}
+            </td>
+            <td>
+              {{missionLearner.lastName}}
+            </td>
+            <td>
+              {{missionLearner.division}}
+            </td>
+          </tr>
+        {{/each}}
+      </tbody>
+    </table>
+  </div>
+  <Table::PaginationControl @pagination={{this.model.missionLearners.meta}} />
+{{else}}
+  <div class="table__empty content-text">
+    {{t "pages.missions.details.learners.no-data"}}
+  </div>
+{{/if}}

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -6,6 +6,7 @@ import { findFilteredPaginatedScoOrganizationParticipants } from './handlers/fin
 import { findFilteredPaginatedSupOrganizationParticipants } from './handlers/find-filtered-paginated-sup-organization-participants';
 import { findPaginatedAssessmentResults } from './handlers/find-paginated-assessment-results';
 import { findPaginatedCampaignProfilesCollectionParticipationSummaries } from './handlers/find-paginated-campaign-participation-summaries';
+import { findPaginatedMissionLearners } from './handlers/find-paginated-mission-learners';
 import { findPaginatedOrganizationMemberships } from './handlers/find-paginated-organization-memberships';
 
 const emptyData = {
@@ -524,6 +525,8 @@ function routes() {
     const missionId = request.params.mission_id;
     return schema.missions.find(missionId);
   });
+
+  this.get('/organizations/:organization_id/mission-learners', findPaginatedMissionLearners);
 
   this.get('/frameworks/for-target-profile-submission', (schema) => {
     return schema.frameworks.all();

--- a/orga/mirage/handlers/find-paginated-mission-learners.js
+++ b/orga/mirage/handlers/find-paginated-mission-learners.js
@@ -1,0 +1,20 @@
+import { applyPagination, getPaginationFromQueryParams } from './pagination-utils';
+
+export function findPaginatedMissionLearners(schema, request) {
+  const organizationId = request.params.organization_id;
+  const queryParams = request.queryParams;
+  const missionLearners = schema.missionLearners.where({ organizationId }).models;
+  const rowCount = missionLearners.length;
+  const pagination = getPaginationFromQueryParams(queryParams);
+  const paginatedMissionLearners = applyPagination(missionLearners, pagination);
+
+  const json = this.serialize({ modelName: 'missionLearners', models: paginatedMissionLearners }, 'membership');
+  json.meta = {
+    page: pagination.page,
+    pageSize: pagination.pageSize,
+    rowCount,
+    pageCount: Math.ceil(rowCount / pagination.pageSize),
+  };
+
+  return json;
+}

--- a/orga/mirage/serializers/mission-learner.js
+++ b/orga/mirage/serializers/mission-learner.js
@@ -1,0 +1,3 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({});

--- a/orga/tests/acceptance/missions-details_test.js
+++ b/orga/tests/acceptance/missions-details_test.js
@@ -32,4 +32,88 @@ module('Acceptance | Missions Detail', function (hooks) {
     assert.dom(screen.getByText('Super competence')).exists();
     assert.dom(screen.getByText('Super Objectif')).exists();
   });
+
+  module('when there is no mission learners', function () {
+    test('should display empty state', async function (assert) {
+      // given
+      const user = createUserWithMembershipAndTermsOfServiceAccepted();
+      const prescriber = createPrescriberByUser(user);
+      prescriber.features = { ...prescriber.features, MISSIONS_MANAGEMENT: true };
+      await authenticateSession(user.id);
+
+      server.create('mission', {
+        id: 1,
+        name: 'Super Mission',
+        competenceName: 'Super competence',
+        learningObjectives: 'Super Objectif',
+      });
+
+      const screen = await visit('/missions/1');
+
+      assert.dom(screen.getByText(this.intl.t('pages.missions.details.learners.no-data'))).exists();
+    });
+  });
+
+  module('when there are mission learners', function (hooks) {
+    hooks.beforeEach(async () => {
+      const user = createUserWithMembershipAndTermsOfServiceAccepted();
+      const prescriber = createPrescriberByUser(user);
+      prescriber.features = { ...prescriber.features, MISSIONS_MANAGEMENT: true };
+      await authenticateSession(user.id);
+
+      server.create('mission', {
+        id: 1,
+        name: 'Super Mission',
+        competenceName: 'Super competence',
+        learningObjectives: 'Super Objectif',
+      });
+
+      server.create('mission-learner', {
+        id: 1,
+        firstName: 'Mario',
+        lastName: 'Super',
+        division: 'CM2-A',
+        organizationId: 1,
+      });
+      server.create('mission-learner', {
+        id: 2,
+        firstName: 'Luigi',
+        lastName: 'SuperBros',
+        division: 'CM2-B',
+        organizationId: 1,
+      });
+    });
+
+    test('Should display learner informations', async function (assert) {
+      // given
+      const screen = await visit('/missions/1');
+
+      assert.strictEqual(screen.getAllByRole('row').length, 3, 'Table length header included');
+      assert.dom(screen.getByText('Super')).exists();
+      assert.dom(screen.getByText('Mario')).exists();
+      assert.dom(screen.getByText('SuperBros')).exists();
+      assert.dom(screen.getByText('Luigi')).exists();
+    });
+
+    test('Should display the pagination ', async function (assert) {
+      // given
+      const screen = await visit('/missions/1');
+
+      assert.ok(screen.getByText('Page 1 / 1'));
+      assert.dom(screen.getByLabelText(this.intl.t('common.pagination.action.select-page-size'))).hasText('25');
+    });
+
+    test('the table should have a caption', async function (assert) {
+      // given
+      const screen = await visit('/missions/1');
+
+      assert
+        .dom(
+          screen.getByText(
+            this.intl.t('pages.missions.details.learners.list.caption', { missionName: 'Super Mission' }),
+          ),
+        )
+        .exists({ count: 1 });
+    });
+  });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -761,6 +761,18 @@
         "competence": {
           "title": "Competence :"
         },
+        "learners": {
+          "title": "List of participants",
+          "list": {
+            "caption": "List of students with their result for the mission {missionName}",
+            "headers": {
+              "division": "Division",
+              "first-name": "First name",
+              "last-name": "Last name"
+            }
+          },
+          "no-data": "There is not any participants"
+        },
         "objective": {
           "title": "Objectives :"
         }

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -761,6 +761,18 @@
         "competence": {
           "title": "Compétence :"
         },
+        "learners": {
+          "title": "Liste des participations",
+          "list": {
+            "caption": "Tableau des élèves avec le résultat de leur participation à la mission {missionName}",
+            "headers": {
+              "division": "Classe",
+              "first-name": "Prénom",
+              "last-name": "Nom"
+            }
+          },
+          "no-data": "Il n'y a aucun participant"
+        },
         "objective": {
           "title": "Objectifs :"
         }


### PR DESCRIPTION
## :unicorn: Problème
La liste des élèves d'une école n'est visible nulle part.

## :robot: Proposition
Ajouter la liste des élèves de l'école dans le détail d'une mission dans l'optique de donner par la suite des données contextuelle à la mission (mission commencée, réussie, échouée...).

## :100: Pour tester
Depuis PixOrga, accéder au détail des différentes missions.
=> Tous les élèves sont affichés dans un tableau avec leur nom, prénom et leur classe.
