### PR TITLE
[TECH] Ne plus utiliser la rétrocompatibilité des éléments du grain dans Pix App (PIX-11359).

### DIFF
--- a/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
@@ -15,61 +15,7 @@ function serialize(module) {
             id: grain.id,
             title: grain.title,
             type: grain.type,
-            elements: grain.elements.map((element) => {
-              switch (element.type) {
-                case 'qcu':
-                  return {
-                    ...element,
-                    type: 'qcus',
-                  };
-                case 'qcm':
-                  return {
-                    ...element,
-                    type: 'qcms',
-                  };
-                case 'qrocm':
-                  return {
-                    ...element,
-                    proposals: element.proposals.map((proposal) => {
-                      switch (proposal.type) {
-                        case 'text':
-                          return {
-                            ...proposal,
-                            type: 'text',
-                          };
-                        case 'input': {
-                          return {
-                            ...proposal,
-                            type: 'input',
-                          };
-                        }
-                        case 'select': {
-                          return {
-                            ...proposal,
-                            type: 'select',
-                          };
-                        }
-                      }
-                    }),
-                    type: 'qrocms',
-                  };
-                case 'text':
-                  return {
-                    ...element,
-                    type: 'texts',
-                  };
-                case 'image':
-                  return {
-                    ...element,
-                    type: 'images',
-                  };
-                case 'video':
-                  return {
-                    ...element,
-                    type: 'videos',
-                  };
-              }
-            }),
+            elements: grain.elements,
             rawElements: grain.elements,
           };
         }),
@@ -80,28 +26,8 @@ function serialize(module) {
       ref: 'id',
       includes: true,
       attributes: ['title', 'type', 'elements', 'rawElements'],
-      elements: {
-        ref: 'id',
-        includes: true,
-        attributes: [
-          'content',
-          'instruction',
-          'proposals',
-          'type',
-          'url',
-          'alt',
-          'alternativeText',
-          'isAnswerable',
-          'subtitles',
-          'transcription',
-          'title',
-        ],
-      },
     },
-    typeForAttribute(attribute, { type }) {
-      if (attribute === 'elements') {
-        return type;
-      }
+    typeForAttribute(attribute) {
       if (attribute === 'grains') {
         return 'grains';
       }

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -186,125 +186,112 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
         included: [
           {
             attributes: {
-              content: 'toto',
-              'is-answerable': false,
-              type: 'texts',
-            },
-            id: '1',
-            type: 'texts',
-          },
-          {
-            attributes: {
-              instruction: 'hello',
-              'is-answerable': true,
-              proposals: [
-                {
-                  content: 'toto',
-                  id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
-                },
-              ],
-              type: 'qcus',
-            },
-            id: '2',
-            type: 'qcus',
-          },
-          {
-            attributes: {
-              instruction: 'hello',
-              'is-answerable': true,
-              proposals: [
+              title: 'Grain 1',
+              'raw-elements': [
                 {
                   content: 'toto',
                   id: '1',
-                },
-                {
-                  content: 'tata',
-                  id: '2',
-                },
-                {
-                  content: 'titi',
-                  id: '3',
-                },
-              ],
-              type: 'qcms',
-            },
-            id: '2000',
-            type: 'qcms',
-          },
-          {
-            attributes: {
-              instruction: '',
-              'is-answerable': true,
-              type: 'qrocms',
-              proposals: [
-                {
+                  isAnswerable: false,
                   type: 'text',
-                  content: '<p>Adresse mail de Naomi : ${email}</p>',
                 },
                 {
-                  type: 'input',
-                  input: 'email',
-                  inputType: 'text',
-                  size: 10,
-                  display: 'inline',
-                  placeholder: '',
-                  ariaLabel: 'Adresse mail de Naomi',
-                  defaultValue: '',
-                  solutions: ['naomizao@yahoo.com', 'naomizao@yahoo.fr'],
-                  tolerances: [],
-                },
-                {
-                  type: 'select',
-                  input: 'seconde-partie',
-                  display: 'inline',
-                  placeholder: '',
-                  ariaLabel: 'Réponse 3',
-                  defaultValue: '',
-                  options: [
+                  id: '2',
+                  instruction: 'hello',
+                  isAnswerable: true,
+                  locales: undefined,
+                  proposals: [
                     {
-                      id: '1',
-                      content: "l'identifiant",
-                    },
-                    {
-                      id: '2',
-                      content: "le fournisseur d'adresse mail",
+                      content: 'toto',
+                      id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
                     },
                   ],
-                  solutions: ['2'],
-                  tolerances: [],
+                  type: 'qcu',
+                },
+                {
+                  id: '2000',
+                  instruction: 'hello',
+                  isAnswerable: true,
+                  locales: undefined,
+                  proposals: [
+                    {
+                      content: 'toto',
+                      id: '1',
+                    },
+                    {
+                      content: 'tata',
+                      id: '2',
+                    },
+                    {
+                      content: 'titi',
+                      id: '3',
+                    },
+                  ],
+                  type: 'qcm',
+                },
+                {
+                  id: '100',
+                  instruction: '',
+                  isAnswerable: true,
+                  locales: ['fr-FR'],
+                  proposals: [
+                    {
+                      content: '<p>Adresse mail de Naomi : ${email}</p>',
+                      type: 'text',
+                    },
+                    {
+                      ariaLabel: 'Adresse mail de Naomi',
+                      defaultValue: '',
+                      display: 'inline',
+                      input: 'email',
+                      inputType: 'text',
+                      placeholder: '',
+                      size: 10,
+                      solutions: ['naomizao@yahoo.com', 'naomizao@yahoo.fr'],
+                      tolerances: [],
+                      type: 'input',
+                    },
+                    {
+                      ariaLabel: 'Réponse 3',
+                      defaultValue: '',
+                      display: 'inline',
+                      input: 'seconde-partie',
+                      options: [
+                        {
+                          content: "l'identifiant",
+                          id: '1',
+                        },
+                        {
+                          content: "le fournisseur d'adresse mail",
+                          id: '2',
+                        },
+                      ],
+                      placeholder: '',
+                      solutions: ['2'],
+                      tolerances: [],
+                      type: 'select',
+                    },
+                  ],
+                  type: 'qrocm',
+                },
+                {
+                  alt: 'alt',
+                  alternativeText: 'alternativeText',
+                  id: '3',
+                  isAnswerable: false,
+                  type: 'image',
+                  url: 'url',
+                },
+                {
+                  id: '4',
+                  isAnswerable: false,
+                  subtitles: 'subtitles',
+                  title: 'title',
+                  transcription: 'transcription',
+                  type: 'video',
+                  url: 'url',
                 },
               ],
-            },
-            id: '100',
-            type: 'qrocms',
-          },
-          {
-            attributes: {
-              url: 'url',
-              alt: 'alt',
-              'alternative-text': 'alternativeText',
-              type: 'images',
-              'is-answerable': false,
-            },
-            id: '3',
-            type: 'images',
-          },
-          {
-            attributes: {
-              'is-answerable': false,
-              subtitles: 'subtitles',
-              transcription: 'transcription',
-              title: 'title',
-              type: 'videos',
-              url: 'url',
-            },
-            id: '4',
-            type: 'videos',
-          },
-          {
-            attributes: {
-              title: 'Grain 1',
-              'raw-elements': [
+              elements: [
                 {
                   content: 'toto',
                   id: '1',
@@ -411,36 +398,6 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
               type: 'activity',
             },
             id: '1',
-            relationships: {
-              elements: {
-                data: [
-                  {
-                    id: '1',
-                    type: 'texts',
-                  },
-                  {
-                    id: '2',
-                    type: 'qcus',
-                  },
-                  {
-                    id: '2000',
-                    type: 'qcms',
-                  },
-                  {
-                    id: '100',
-                    type: 'qrocms',
-                  },
-                  {
-                    id: '3',
-                    type: 'images',
-                  },
-                  {
-                    id: '4',
-                    type: 'videos',
-                  },
-                ],
-              },
-            },
             type: 'grains',
           },
         ],

--- a/mon-pix/app/pods/components/module/grain/template.hbs
+++ b/mon-pix/app/pods/components/module/grain/template.hbs
@@ -13,7 +13,7 @@
   {{/if}}
 
   <div class="grain__content">
-    {{#each @grain.rawElements as |element|}}
+    {{#each @grain.elements as |element|}}
       <div class="grain-content__element">
         {{#if (eq element.type "text")}}
           <Module::Text @text={{element}} />

--- a/mon-pix/app/pods/grain/model.js
+++ b/mon-pix/app/pods/grain/model.js
@@ -2,16 +2,16 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class Grain extends Model {
   @attr('string') title;
-  @attr({ defaultValue: () => [] }) rawElements;
+  @attr({ defaultValue: () => [] }) elements;
 
   @belongsTo('module', { async: false, inverse: 'grains' }) module;
 
   get hasAnswerableElements() {
-    return this.rawElements.some((element) => element.isAnswerable);
+    return this.elements.some((element) => element.isAnswerable);
   }
 
   get answerableElements() {
-    return this.rawElements.filter((element) => {
+    return this.elements.filter((element) => {
       return element.isAnswerable;
     });
   }

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
@@ -98,7 +98,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
       const grain1 = server.create('grain', {
         id: 'grainId-1',
         title: 'title grain 1',
-        rawElements: [text1],
+        elements: [text1],
       });
       server.create('module', {
         id: 'bien-ecrire-son-adresse-mail',
@@ -141,17 +141,17 @@ function _createGrains(server) {
   const grain1 = server.create('grain', {
     id: 'grainId-1',
     title: 'title grain 1',
-    rawElements: [text1],
+    elements: [text1],
   });
   const grain2 = server.create('grain', {
     id: 'grainId-2',
     title: 'title grain 2',
-    rawElements: [text2],
+    elements: [text2],
   });
   const grain3 = server.create('grain', {
     id: 'grainId-3',
     title: 'title grain 3',
-    rawElements: [text3],
+    elements: [text3],
   });
 
   return [grain1, grain2, grain3];

--- a/mon-pix/tests/acceptance/module/retake_completed_module_test.js
+++ b/mon-pix/tests/acceptance/module/retake_completed_module_test.js
@@ -24,7 +24,7 @@ module('Acceptance | Module | Routes | retakeCompletedModule', function (hooks) 
     const grain1 = server.create('grain', {
       id: 'grainId1',
       title: 'title',
-      rawElements: [qcu],
+      elements: [qcu],
     });
 
     const text = {
@@ -37,7 +37,7 @@ module('Acceptance | Module | Routes | retakeCompletedModule', function (hooks) 
     const grain2 = server.create('grain', {
       id: 'grainId2',
       title: 'title',
-      rawElements: [text],
+      elements: [text],
     });
 
     server.create('module', {

--- a/mon-pix/tests/acceptance/module/verify-qcm_test.js
+++ b/mon-pix/tests/acceptance/module/verify-qcm_test.js
@@ -36,7 +36,7 @@ module('Acceptance | Module | Routes | verifyQcm', function (hooks) {
     const grain = server.create('grain', {
       id: 'grainId',
       title: 'title',
-      rawElements: [qcm1, qcm2],
+      elements: [qcm1, qcm2],
     });
 
     server.create('module', {

--- a/mon-pix/tests/acceptance/module/verify-qcu_test.js
+++ b/mon-pix/tests/acceptance/module/verify-qcu_test.js
@@ -32,7 +32,7 @@ module('Acceptance | Module | Routes | verifyQcu', function (hooks) {
     const grain = server.create('grain', {
       id: 'grainId',
       title: 'title',
-      rawElements: [qcu1, qcu2],
+      elements: [qcu1, qcu2],
     });
 
     server.create('module', {

--- a/mon-pix/tests/acceptance/module/verify-qrocm_test.js
+++ b/mon-pix/tests/acceptance/module/verify-qrocm_test.js
@@ -53,7 +53,7 @@ module('Acceptance | Module | Routes | verifyQrocm', function (hooks) {
     const grain = server.create('grain', {
       id: 'grainId',
       title: 'title',
-      rawElements: [qrocm1],
+      elements: [qrocm1],
     });
 
     server.create('module', {

--- a/mon-pix/tests/integration/components/module/grain_test.js
+++ b/mon-pix/tests/integration/components/module/grain_test.js
@@ -65,7 +65,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
         type: 'text',
         isAnswerable: false,
       };
-      const grain = store.createRecord('grain', { title: 'Grain title', rawElements: [textElement] });
+      const grain = store.createRecord('grain', { title: 'Grain title', elements: [textElement] });
       this.set('grain', grain);
 
       // when
@@ -87,7 +87,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
         type: 'qcu',
         isAnswerable: true,
       };
-      const grain = store.createRecord('grain', { title: 'Grain title', rawElements: [qcuElement] });
+      const grain = store.createRecord('grain', { title: 'Grain title', elements: [qcuElement] });
       this.set('grain', grain);
       const passage = store.createRecord('passage');
       this.set('passage', passage);
@@ -144,7 +144,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
         type: 'qrocm',
         isAnswerable: true,
       };
-      const grain = store.createRecord('grain', { title: 'Grain title', rawElements: [qrocmElement] });
+      const grain = store.createRecord('grain', { title: 'Grain title', elements: [qrocmElement] });
       this.set('grain', grain);
       const passage = store.createRecord('passage');
       this.set('passage', passage);
@@ -171,7 +171,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
         alternativeText: 'alternative instruction',
         type: 'image',
       };
-      const grain = store.createRecord('grain', { title: 'Grain title', rawElements: [imageElement] });
+      const grain = store.createRecord('grain', { title: 'Grain title', elements: [imageElement] });
       this.set('grain', grain);
 
       // when
@@ -188,7 +188,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
       const element = { type: 'qcu', isAnswerable: true };
-      const grain = store.createRecord('grain', { title: 'Grain title', rawElements: [element] });
+      const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
       this.set('grain', grain);
       const passage = store.createRecord('passage');
       this.set('passage', passage);
@@ -212,7 +212,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const element = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', { title: '1st Grain title', rawElements: [element] });
+        const grain = store.createRecord('grain', { title: '1st Grain title', elements: [element] });
         store.createRecord('module', { grains: [grain] });
         this.set('grain', grain);
         const passage = store.createRecord('passage');
@@ -235,7 +235,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const element = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', { title: '1st Grain title', rawElements: [element] });
+        const grain = store.createRecord('grain', { title: '1st Grain title', elements: [element] });
         store.createRecord('module', { grains: [grain] });
         this.set('grain', grain);
         const passage = store.createRecord('passage');
@@ -259,7 +259,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const element = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', { title: 'Grain title', rawElements: [element] });
+        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
         this.set('grain', grain);
         const passage = store.createRecord('passage');
         this.set('passage', passage);
@@ -278,7 +278,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const element = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', { title: '1st Grain title', rawElements: [element] });
+        const grain = store.createRecord('grain', { title: '1st Grain title', elements: [element] });
         store.createRecord('module', { grains: [grain] });
         this.set('grain', grain);
         const passage = store.createRecord('passage');
@@ -300,7 +300,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const element = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', { title: 'Grain title', rawElements: [element] });
+        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
         this.set('grain', grain);
         const passage = store.createRecord('passage');
         this.set('passage', passage);
@@ -319,7 +319,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const element = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', { title: 'Grain title', rawElements: [element] });
+        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
         store.createRecord('module', { grains: [grain] });
         this.set('grain', grain);
         const passage = store.createRecord('passage');
@@ -344,7 +344,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
       const element = { type: 'text', isAnswerable: false };
-      const grain = store.createRecord('grain', { title: '1st Grain title', rawElements: [element] });
+      const grain = store.createRecord('grain', { title: '1st Grain title', elements: [element] });
       store.createRecord('module', { id: 'module-id', grains: [grain] });
       this.set('grain', grain);
 
@@ -370,7 +370,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
       const element = { type: 'qcu', isAnswerable: true };
-      const grain = store.createRecord('grain', { title: 'Grain title', rawElements: [element] });
+      const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
       store.createRecord('module', { id: 'module-id', grains: [grain] });
       this.set('grain', grain);
       const passage = store.createRecord('passage');
@@ -400,7 +400,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
       const element = { type: 'text', isAnswerable: false };
-      const grain = store.createRecord('grain', { title: 'Grain title', rawElements: [element] });
+      const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
       this.set('grain', grain);
 
       // when
@@ -416,7 +416,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const element = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', { title: 'Grain title', rawElements: [element] });
+        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
         this.set('grain', grain);
         const passage = store.createRecord('passage');
         this.set('passage', passage);
@@ -444,7 +444,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
       // given
       const store = this.owner.lookup('service:store');
       const element = { type: 'text', isAnswerable: false };
-      const grain = store.createRecord('grain', { title: 'Grain title', rawElements: [element] });
+      const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
       this.set('grain', grain);
 
       // when

--- a/mon-pix/tests/integration/components/module/passage_test.js
+++ b/mon-pix/tests/integration/components/module/passage_test.js
@@ -13,7 +13,7 @@ module('Integration | Component | Module | Passage', function (hooks) {
     // given
     const store = this.owner.lookup('service:store');
     const textElement = { content: 'content', type: 'text' };
-    const grain = store.createRecord('grain', { id: 'grainId1', rawElements: [textElement] });
+    const grain = store.createRecord('grain', { id: 'grainId1', elements: [textElement] });
     const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
     this.set('module', module);
 
@@ -36,8 +36,8 @@ module('Integration | Component | Module | Passage', function (hooks) {
       proposals: ['radio1', 'radio2'],
       type: 'qcu',
     };
-    const rawElements = [textElement, qcuElement];
-    const grain = store.createRecord('grain', { id: 'grainId1', rawElements });
+    const elements = [textElement, qcuElement];
+    const grain = store.createRecord('grain', { id: 'grainId1', elements });
     const transitionTexts = [{ grainId: 'grainId1', content: 'transition text' }];
 
     const module = store.createRecord('module', { title: 'Module title', grains: [grain], transitionTexts });
@@ -67,8 +67,8 @@ module('Integration | Component | Module | Passage', function (hooks) {
       proposals: ['radio1', 'radio2'],
       type: 'qcu',
     };
-    const grain1 = store.createRecord('grain', { rawElements: [textElement] });
-    const grain2 = store.createRecord('grain', { rawElements: [qcuElement] });
+    const grain1 = store.createRecord('grain', { elements: [textElement] });
+    const grain2 = store.createRecord('grain', { elements: [qcuElement] });
 
     const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
     this.set('module', module);
@@ -98,8 +98,8 @@ module('Integration | Component | Module | Passage', function (hooks) {
         type: 'qcu',
         isAnswerable: true,
       };
-      const grain1 = store.createRecord('grain', { rawElements: [qcuElement] });
-      const grain2 = store.createRecord('grain', { rawElements: [textElement] });
+      const grain1 = store.createRecord('grain', { elements: [qcuElement] });
+      const grain2 = store.createRecord('grain', { elements: [textElement] });
 
       const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
       this.set('module', module);
@@ -128,8 +128,8 @@ module('Integration | Component | Module | Passage', function (hooks) {
         type: 'qcu',
         isAnswerable: true,
       };
-      const grain1 = store.createRecord('grain', { rawElements: [qcuElement] });
-      const grain2 = store.createRecord('grain', { rawElements: [textElement] });
+      const grain1 = store.createRecord('grain', { elements: [qcuElement] });
+      const grain2 = store.createRecord('grain', { elements: [textElement] });
 
       const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
       this.set('module', module);
@@ -167,8 +167,8 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const store = this.owner.lookup('service:store');
       const text1Element = { content: 'content', type: 'text' };
       const text2Element = { content: 'content 2', type: 'text' };
-      const grain1 = store.createRecord('grain', { rawElements: [text1Element] });
-      const grain2 = store.createRecord('grain', { rawElements: [text2Element] });
+      const grain1 = store.createRecord('grain', { elements: [text1Element] });
+      const grain2 = store.createRecord('grain', { elements: [text2Element] });
 
       const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
       this.set('module', module);
@@ -195,9 +195,9 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const text1Element = { content: 'content', type: 'text' };
       const text2Element = { content: 'content 2', type: 'text' };
       const text3Element = { content: 'content 3', type: 'text' };
-      const grain1 = store.createRecord('grain', { rawElements: [text1Element] });
-      const grain2 = store.createRecord('grain', { rawElements: [text2Element] });
-      const grain3 = store.createRecord('grain', { rawElements: [text3Element] });
+      const grain1 = store.createRecord('grain', { elements: [text1Element] });
+      const grain2 = store.createRecord('grain', { elements: [text2Element] });
+      const grain3 = store.createRecord('grain', { elements: [text3Element] });
 
       const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2, grain3] });
       this.set('module', module);
@@ -239,9 +239,9 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const text1Element = { content: 'content', type: 'text' };
       const text2Element = { content: 'content 2', type: 'text' };
       const text3Element = { content: 'content 3', type: 'text' };
-      const grain1 = store.createRecord('grain', { rawElements: [text1Element] });
-      const grain2 = store.createRecord('grain', { rawElements: [text2Element] });
-      const grain3 = store.createRecord('grain', { rawElements: [text3Element] });
+      const grain1 = store.createRecord('grain', { elements: [text1Element] });
+      const grain2 = store.createRecord('grain', { elements: [text2Element] });
+      const grain3 = store.createRecord('grain', { elements: [text3Element] });
 
       const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2, grain3] });
       this.set('module', module);
@@ -279,8 +279,8 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const store = this.owner.lookup('service:store');
       const text1Element = { content: 'content', type: 'text' };
       const text2Element = { content: 'content 2', type: 'text' };
-      const grain1 = store.createRecord('grain', { rawElements: [text1Element] });
-      const grain2 = store.createRecord('grain', { rawElements: [text2Element] });
+      const grain1 = store.createRecord('grain', { elements: [text1Element] });
+      const grain2 = store.createRecord('grain', { elements: [text2Element] });
 
       const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
       this.set('module', module);

--- a/mon-pix/tests/integration/components/module/qcm_test.js
+++ b/mon-pix/tests/integration/components/module/qcm_test.js
@@ -186,7 +186,7 @@ function prepareContextRecords(store, correctionResponse) {
     correction: correctionResponse,
     element: qcmElement,
   });
-  store.createRecord('grain', { id: 'id', rawElements: [qcmElement] });
+  store.createRecord('grain', { id: 'id', elements: [qcmElement] });
   store.createRecord('element-answer', {
     correction: correctionResponse,
     elementId: qcmElement.id,

--- a/mon-pix/tests/integration/components/module/qcu_test.js
+++ b/mon-pix/tests/integration/components/module/qcu_test.js
@@ -175,7 +175,7 @@ function prepareContextRecords(store, correctionResponse) {
     correction: correctionResponse,
     element: qcuElement,
   });
-  store.createRecord('grain', { id: 'id', rawElements: [qcuElement] });
+  store.createRecord('grain', { id: 'id', elements: [qcuElement] });
   store.createRecord('element-answer', {
     correction: correctionResponse,
     elementId: qcuElement.id,

--- a/mon-pix/tests/integration/components/module/qrocm_test.js
+++ b/mon-pix/tests/integration/components/module/qrocm_test.js
@@ -368,7 +368,7 @@ function prepareContextRecords(store, correctionResponse) {
     correction: correctionResponse,
     element: qrocm,
   });
-  store.createRecord('grain', { id: 'id', rawElements: [qrocm] });
+  store.createRecord('grain', { id: 'id', elements: [qrocm] });
   store.createRecord('element-answer', {
     correction: correctionResponse,
     elementId: qrocm.id,

--- a/mon-pix/tests/unit/models/modules/grain_test.js
+++ b/mon-pix/tests/unit/models/modules/grain_test.js
@@ -14,7 +14,7 @@ module('Unit | Model | Module | Grain', function (hooks) {
         const qrocm = { type: 'qrocm', isAnswerable: true };
         const text = { type: 'text', isAnswerable: false };
         const grain = store.createRecord('grain', {
-          rawElements: [qcu, qcm, qrocm, text],
+          elements: [qcu, qcm, qrocm, text],
         });
 
         // when
@@ -31,7 +31,7 @@ module('Unit | Model | Module | Grain', function (hooks) {
         const store = this.owner.lookup('service:store');
         const text = { type: 'text', isAnswerable: false };
         const grain = store.createRecord('grain', {
-          rawElements: [text],
+          elements: [text],
         });
 
         // when
@@ -53,7 +53,7 @@ module('Unit | Model | Module | Grain', function (hooks) {
         const qrocm = { type: 'qrocm', isAnswerable: true };
         const text = { type: 'text', isAnswerable: false };
         const grain = store.createRecord('grain', {
-          rawElements: [qcu, qcm, qrocm, text],
+          elements: [qcu, qcm, qrocm, text],
         });
 
         // when
@@ -71,7 +71,7 @@ module('Unit | Model | Module | Grain', function (hooks) {
         const store = this.owner.lookup('service:store');
         const text = { type: 'text' };
         const grain = store.createRecord('grain', {
-          rawElements: [text],
+          elements: [text],
         });
 
         // when
@@ -96,7 +96,7 @@ module('Unit | Model | Module | Grain', function (hooks) {
           elementAnswers: [elementAnswer],
         });
         const grain = store.createRecord('grain', {
-          rawElements: [qcu],
+          elements: [qcu],
         });
 
         // when
@@ -113,7 +113,7 @@ module('Unit | Model | Module | Grain', function (hooks) {
         const store = this.owner.lookup('service:store');
         const qcu = { type: 'qcu', isAnswerable: true };
         const grain = store.createRecord('grain', {
-          rawElements: [qcu],
+          elements: [qcu],
         });
         const passage = store.createRecord('passage');
 


### PR DESCRIPTION
## :unicorn: Problème
Lors de la PR #8129 Il était nécessaire de mettre en place un système assurant la rétrocompatibilité. 

Comme la version v4.106.0, n'est plus utilisé en production, nous pouvons retirer la rétrocompatibilité.

## :robot: Proposition
Dans un premier temps - CETTE PR 
Dans l'API :

- supprimer la serialization de elements en JSON:API
- laisser le champ elements en "raw JSON"
- laisser le champ rawElements

Dans le front :

- utiliser désormais elements
- supprimer tous les usages de rawElements

Dans un second temps - PAS CETTE PR 
Dans l'API
- supprimer rawElements

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- CI OK
- Sur Pix App faire un modules `/modules/didacticiel-modulix`