### PR TITLE
[TECH] Retirer le passage id du payload de /passages/{id}/answers (PIX-11312)

### DIFF
--- a/mon-pix/app/adapters/element-answer.js
+++ b/mon-pix/app/adapters/element-answer.js
@@ -1,8 +1,9 @@
 import ApplicationAdapter from './application';
 
 export default class ElementAnswer extends ApplicationAdapter {
-  urlForCreateRecord(modelName, { adapterOptions }) {
-    return `${this.host}/${this.namespace}/passages/${adapterOptions.passageId}/answers`;
+  urlForCreateRecord(modelName, snapshot) {
+    const passageId = snapshot.belongsTo('passage', { id: true });
+    return `${this.host}/${this.namespace}/passages/${passageId}/answers`;
   }
 
   createRecord(store, type, snapshot) {
@@ -14,7 +15,6 @@ export default class ElementAnswer extends ApplicationAdapter {
         data: {
           attributes: {
             'element-id': serializedSnapshot.data.attributes['element-id'],
-            'passage-id': serializedSnapshot.data.relationships.passage.data.id,
             'user-response': serializedSnapshot.data.attributes['user-response'],
           },
         },

--- a/mon-pix/tests/unit/adapters/element-answer_test.js
+++ b/mon-pix/tests/unit/adapters/element-answer_test.js
@@ -8,30 +8,32 @@ module('Unit | Adapter | Module | ElementAnswer', function (hooks) {
   module('#urlForCreateRecord', function () {
     test('should build url for create record', function (assert) {
       // given
+      const store = this.owner.lookup('service:store');
+      const passage = store.createRecord('passage', { id: '123' });
       const adapter = this.owner.lookup('adapter:element-answer');
       const option = {
-        adapterOptions: {
-          passageId: '12',
-        },
+        modelName: 'element-answer',
+        belongsTo: sinon.stub(),
       };
+      option.belongsTo.withArgs('passage', { id: true }).returns(passage.id);
       // when
+
       const url = adapter.urlForCreateRecord('element-answer', option);
 
       // then
-      assert.true(url.endsWith(`api/passages/${option.adapterOptions.passageId}/answers`));
+      assert.true(url.endsWith(`api/passages/${passage.id}/answers`));
     });
   });
 
   module('#createRecord', function () {
     test('should build the right payload', async function (assert) {
       // given
+      const store = this.owner.lookup('service:store');
+      const passageId = 12;
+      const passage = store.createRecord('passage', { id: passageId });
       const adapter = this.owner.lookup('adapter:element-answer');
       adapter.ajax = sinon.stub().resolves();
 
-      const passageId = 12;
-      const passage = {
-        id: passageId,
-      };
       const userResponse = [];
       const element = { id: 'element-id' };
 
@@ -43,23 +45,19 @@ module('Unit | Adapter | Module | ElementAnswer', function (hooks) {
             attributes: {
               'element-id': element.id,
               'user-response': userResponse,
-              'passage-id': passage.id,
             },
           },
         },
       };
       const snapshot = {
         record: { element, userResponse, passage },
-        adapterOptions: {
-          passageId,
-        },
+        belongsTo: sinon.stub(),
         serialize: function () {
           return {
             data: {
               attributes: {
                 'user-response': userResponse,
                 'element-id': element.id,
-                'passage-id': passage.id,
               },
               relationships: {
                 passage: { data: passage },
@@ -68,6 +66,7 @@ module('Unit | Adapter | Module | ElementAnswer', function (hooks) {
           };
         },
       };
+      snapshot.belongsTo.withArgs('passage', { id: true }).returns(passage.id);
 
       // when
       await adapter.createRecord(null, { modelName: 'passage' }, snapshot);


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, lorsque l'on vérifie la réponse d'une modalité, la route API `/passages/{id}/answers` est appelée avec le passage id dans le payload, ce qui n'est pas utile. Il faut donc le retirer.

## :robot: Proposition
Cette route est appelée lors du `Store.createRecord` du modèle `element-answer`.
Étant donné que ce modèle possède une relation avec le modèle `passage`, il n'y a plus besoin de passer l'id du passage dans l'`adapterOption`.
Au lieu de cela on peut retrouver le passage id en passant par l'`element-answer`.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
La CI passe.
Tester [un module](https://app-pr8372.review.pix.fr/modules/didacticiel-modulix) et vérifier que l'on peut toujours répondre aux éléments d'activité.
