### PR TITLE
[TECH] Remplacer les "contains" dans les tests par des méthodes de testingLibrary (PIX-11602)

### DIFF
--- a/orga/tests/acceptance/sco-organization-participant-list_test.js
+++ b/orga/tests/acceptance/sco-organization-participant-list_test.js
@@ -111,8 +111,8 @@ module('Acceptance | Sco Organization Participant List', function (hooks) {
 
           // then
           assert.strictEqual(currentURL(), '/eleves?connectionTypes=%5B%22email%22%5D');
-          assert.contains('Rambo');
-          assert.notContains('Norris');
+          assert.ok(screen.getByText('Rambo'));
+          assert.notOk(screen.queryByText('Norris'));
         });
 
         module('when user select "Sans Mediacentre" in connection type filter', function () {
@@ -159,19 +159,19 @@ module('Acceptance | Sco Organization Participant List', function (hooks) {
 
             // then
             assert.strictEqual(currentURL(), '/eleves?connectionTypes=%5B%22without_mediacentre%22%5D');
-            assert.contains('Mikasa');
-            assert.notContains('Eren');
-            assert.notContains('Armin');
+            assert.ok(screen.getByText('Mikasa'));
+            assert.notOk(screen.queryByText('Eren'));
+            assert.notOk(screen.queryByText('Armin'));
           });
         });
 
         test('it should paginate the students list', async function (assert) {
           // when
-          await visit('/eleves?pageSize=1&pageNumber=1');
+          const screen = await visit('/eleves?pageSize=1&pageNumber=1');
 
           // then
-          assert.contains('Norris');
-          assert.notContains('Rambo');
+          assert.ok(screen.getByText('Norris'));
+          assert.notOk(screen.queryByText('Rambo'));
         });
       });
 
@@ -207,7 +207,7 @@ module('Acceptance | Sco Organization Participant List', function (hooks) {
             await screen.findByRole('dialog');
 
             // then
-            assert.contains('Réinitialiser le mot de passe');
+            assert.ok(screen.getByRole('button', { name: 'Réinitialiser le mot de passe' }));
           });
 
           test('it should display unique password input when reset button is clicked', async function (assert) {
@@ -260,8 +260,8 @@ module('Acceptance | Sco Organization Participant List', function (hooks) {
             await screen.findByRole('dialog');
 
             // then
-            assert.contains('Médiacentre');
-            assert.contains('Ajouter une connexion avec un identifiant');
+            assert.ok(screen.getByText('Médiacentre'));
+            assert.ok(screen.getByText('Ajouter une connexion avec un identifiant'));
           });
 
           test('it should display username and unique password when add username button is clicked', async function (assert) {
@@ -276,9 +276,9 @@ module('Acceptance | Sco Organization Participant List', function (hooks) {
             await clickByName('Ajouter l’identifiant');
 
             // then
-            assert.contains('Médiacentre');
-            assert.contains('Identifiant');
-            assert.contains('Nouveau mot de passe à usage unique');
+            assert.ok(screen.getByText('Médiacentre'));
+            assert.ok(screen.getByLabelText('Identifiant'));
+            assert.ok(screen.getByRole('textbox', { name: 'Nouveau mot de passe à usage unique' }));
             assert.dom('#username').exist;
             assert.dom('#generated-password').exist;
           });
@@ -303,11 +303,11 @@ module('Acceptance | Sco Organization Participant List', function (hooks) {
 
             await screen.findByRole('dialog');
             // then
-            assert.contains('Médiacentre');
-            assert.contains('Identifiant');
+            assert.ok(screen.getByText('Médiacentre'));
+            assert.ok(screen.getByLabelText('Identifiant'));
           });
 
-          test('it should open pasword modal and display password reset button', async function (assert) {
+          test('it should open password modal and display password reset button', async function (assert) {
             // given
             const screen = await visit('/eleves');
 
@@ -317,7 +317,7 @@ module('Acceptance | Sco Organization Participant List', function (hooks) {
 
             await screen.findByRole('dialog');
             // then
-            assert.contains('Réinitialiser le mot de passe');
+            assert.ok(screen.getByRole('button', { name: 'Réinitialiser le mot de passe' }));
           });
 
           test('it should open password modal and display unique password when reset button is clicked', async function (assert) {
@@ -373,7 +373,7 @@ module('Acceptance | Sco Organization Participant List', function (hooks) {
               const successNotification = await screen.getByText(
                 this.intl.t('pages.sco-organization-participants.messages.password-reset-success'),
               );
-              assert.dom(successNotification).exists();
+              assert.ok(successNotification);
             });
           });
         });

--- a/orga/tests/acceptance/sup-organization-participant-list_test.js
+++ b/orga/tests/acceptance/sup-organization-participant-list_test.js
@@ -1,4 +1,4 @@
-import { clickByName, clickByText, fillByLabel, visit } from '@1024pix/ember-testing-library';
+import { clickByName, clickByText, fillByLabel, visit, within } from '@1024pix/ember-testing-library';
 import { click, currentURL } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupApplicationTest } from 'ember-qunit';
@@ -51,20 +51,20 @@ module('Acceptance | Sup Organization Participant List', function (hooks) {
     module('filters', function () {
       test('it filters students by group', async function (assert) {
         // given
-        const { getByPlaceholderText, findByRole } = await visit('/etudiants');
+        const screen = await visit('/etudiants');
 
         // when
 
-        const select = await getByPlaceholderText('Rechercher par groupe');
+        const select = await screen.getByRole('textbox', { name: 'Entrer un groupe' });
         await click(select);
 
-        await findByRole('menu');
+        await screen.findByRole('menu');
 
         await clickByName('L1');
 
         // then
-        assert.notContains('toto');
-        assert.contains('tata');
+        assert.notOk(screen.queryByText('toto'));
+        assert.ok(screen.getByText('tata'));
       });
 
       test('it filters by certificability', async function (assert) {
@@ -74,10 +74,12 @@ module('Acceptance | Sup Organization Participant List', function (hooks) {
         server.create('organization-participant', { organizationId, firstName: 'Jean', lastName: 'Charles' });
 
         await authenticateSession(user.id);
-        const { getByLabelText } = await visit('/etudiants');
+        const screen = await visit('/etudiants');
 
         // when
-        const select = getByLabelText(this.intl.t('pages.sup-organization-participants.filter.certificability.label'));
+        const select = screen.getByRole('textbox', {
+          name: this.intl.t('pages.sup-organization-participants.filter.certificability.label'),
+        });
         await click(select);
         await clickByText(this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.eligible'));
 
@@ -98,40 +100,40 @@ module('Acceptance | Sup Organization Participant List', function (hooks) {
     module('And edit the student number', function () {
       test('it should update the student number', async function (assert) {
         // given
-        const { getAllByRole, findByRole } = await visit('/etudiants');
+        const screen = await visit('/etudiants');
 
         // when
-        const actions = getAllByRole('button', { name: 'Afficher les actions' });
+        const actions = screen.getAllByRole('button', { name: 'Afficher les actions' });
 
         await click(actions[0]);
         await clickByName('Éditer le numéro étudiant');
 
-        await findByRole('dialog');
+        await screen.findByRole('dialog');
 
         await fillByLabel('Nouveau numéro étudiant', '1234');
         await clickByName('Mettre à jour');
 
         // then
-        assert.contains('1234');
+        assert.ok(screen.getByText('1234'));
       });
 
       test('it should not update the student number if exists', async function (assert) {
         // given
-        const { getAllByRole, findByRole } = await visit('/etudiants');
+        const screen = await visit('/etudiants');
 
         // when
-        const actions = getAllByRole('button', { name: 'Afficher les actions' });
+        const actions = screen.getAllByRole('button', { name: 'Afficher les actions' });
 
         await click(actions[0]);
         await clickByName('Éditer le numéro étudiant');
 
-        await findByRole('dialog');
+        const modal = await screen.findByRole('dialog');
 
         await fillByLabel('Nouveau numéro étudiant', '321');
         await clickByName('Mettre à jour');
 
         // then
-        assert.contains('123');
+        assert.ok(within(modal).getByText('123'));
       });
     });
   });

--- a/orga/tests/acceptance/switch-organization_test.js
+++ b/orga/tests/acceptance/switch-organization_test.js
@@ -1,5 +1,5 @@
-import { clickByName } from '@1024pix/ember-testing-library';
-import { currentURL, visit } from '@ember/test-helpers';
+import { clickByName, visit } from '@1024pix/ember-testing-library';
+import { currentURL } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -25,10 +25,10 @@ module('Acceptance | Switch Organization', function (hooks) {
 
     test('should display the main organization name and externalId in summary', async function (assert) {
       // when
-      await visit('/');
+      const screen = await visit('/');
 
       // then
-      assert.contains('BRO & Evil Associates (EXTBRO)');
+      assert.ok(screen.getByText('BRO & Evil Associates (EXTBRO)'));
     });
 
     test('should only have disconnect item in menu', async function (assert) {
@@ -50,12 +50,11 @@ module('Acceptance | Switch Organization', function (hooks) {
       createPrescriberByUser(user);
 
       await authenticateSession(user.id);
-
-      await visit('/');
     });
 
     test('should have an organization in menu', async function (assert) {
       // when
+      await visit('/');
       await clickByName('Ouvrir le menu utilisateur');
 
       // then
@@ -66,15 +65,19 @@ module('Acceptance | Switch Organization', function (hooks) {
     module('When prescriber click on an organization', function () {
       test('should change main organization in summary', async function (assert) {
         // when
+        const screen = await visit('/');
+
         await clickByName('Ouvrir le menu utilisateur');
         await clickByName('My Heaven Company (HEAVEN)');
 
         // then
-        assert.contains('My Heaven Company (HEAVEN)');
+        assert.ok(screen.getByText('My Heaven Company (HEAVEN)'));
       });
 
       test('should have the old main organization in the menu', async function (assert) {
         // when
+        await visit('/');
+
         await clickByName('Ouvrir le menu utilisateur');
         await clickByName('My Heaven Company (HEAVEN)');
         await clickByName('Ouvrir le menu utilisateur');
@@ -103,6 +106,8 @@ module('Acceptance | Switch Organization', function (hooks) {
         function () {
           test('it should display student menu item', async function (assert) {
             // when
+            await visit('/');
+
             await clickByName('Ouvrir le menu utilisateur');
             await clickByName('My Heaven Company (HEAVEN)');
 

--- a/orga/tests/acceptance/team-creation_test.js
+++ b/orga/tests/acceptance/team-creation_test.js
@@ -87,7 +87,7 @@ module('Acceptance | Team Creation', function (hooks) {
           pixOrgaTermsOfServiceAccepted: true,
         });
 
-        await visit('/equipe/creation');
+        const screen = await visit('/equipe/creation');
         await fillByLabel(inputLabel, email);
 
         // when
@@ -103,22 +103,22 @@ module('Acceptance | Team Creation', function (hooks) {
         assert.strictEqual(organizationInvitation.code, code);
 
         assert.strictEqual(currentURL(), '/equipe/invitations');
-        assert.contains(email);
-        assert.contains(this.intl.t('pages.team-new.success.invitation', { email }));
+        assert.ok(screen.getByText(email));
+        assert.ok(screen.getByText(this.intl.t('pages.team-new.success.invitation', { email })));
       });
 
       test('it should display other confirm invitation message when there is multiple invitations', async function (assert) {
         // given
         const emails = 'elisa.agnard@example.net,fred.durand@example.net';
 
-        await visit('/equipe/creation');
+        const screen = await visit('/equipe/creation');
         await fillByLabel(inputLabel, emails);
 
         // when
         await clickByName(inviteButton);
 
         // then
-        assert.contains(this.intl.t('pages.team-new.success.multiple-invitations'));
+        assert.ok(screen.getByText(this.intl.t('pages.team-new.success.multiple-invitations')));
       });
 
       test('it should not allow to invite a prescriber when an email is not given', async function (assert) {
@@ -136,7 +136,7 @@ module('Acceptance | Team Creation', function (hooks) {
 
       test('should display an empty input field after cancel and before add a team member', async function (assert) {
         // given
-        await visit('/equipe/creation');
+        const screen = await visit('/equipe/creation');
         await fillByLabel(inputLabel, email);
         await clickByName(cancelButton);
 
@@ -144,7 +144,7 @@ module('Acceptance | Team Creation', function (hooks) {
         await visit('/equipe/creation');
 
         // then
-        assert.contains('');
+        assert.ok(screen.getByDisplayValue(''));
       });
 
       test('should redirect to invitations list after cancelling on invite page', async function (assert) {
@@ -163,7 +163,7 @@ module('Acceptance | Team Creation', function (hooks) {
         // given
         const expectedErrorMessage = this.intl.t('pages.team-new.errors.status.500');
 
-        await visit('/equipe/creation');
+        const screen = await visit('/equipe/creation');
         server.post(
           `/organizations/${organizationId}/invitations`,
           {
@@ -185,14 +185,14 @@ module('Acceptance | Team Creation', function (hooks) {
         // then
 
         assert.strictEqual(currentURL(), '/equipe/creation');
-        assert.contains(expectedErrorMessage);
+        assert.ok(screen.getByText(expectedErrorMessage));
       });
 
       test('it should display error on global form when error 412 is returned from backend', async function (assert) {
         // given
         const expectedErrorMessage = this.intl.t('pages.team-new.errors.status.412');
 
-        await visit('/equipe/creation');
+        const screen = await visit('/equipe/creation');
         server.post(
           `/organizations/${organizationId}/invitations`,
           {
@@ -214,14 +214,14 @@ module('Acceptance | Team Creation', function (hooks) {
         // then
 
         assert.strictEqual(currentURL(), '/equipe/creation');
-        assert.contains(expectedErrorMessage);
+        assert.ok(screen.getByText(expectedErrorMessage));
       });
 
       test('it should display error on global form when error 404 is returned from backend', async function (assert) {
         // given
         const expectedErrorMessage = this.intl.t('pages.team-new.errors.status.404');
 
-        await visit('/equipe/creation');
+        const screen = await visit('/equipe/creation');
         server.post(
           `/organizations/${organizationId}/invitations`,
           {
@@ -243,14 +243,14 @@ module('Acceptance | Team Creation', function (hooks) {
         // then
 
         assert.strictEqual(currentURL(), '/equipe/creation');
-        assert.contains(expectedErrorMessage);
+        assert.ok(screen.getByText(expectedErrorMessage));
       });
 
       test('it should display error on global form when error 400 is returned from backend', async function (assert) {
         // given
         const expectedErrorMessage = this.intl.t('pages.team-new.errors.status.400');
 
-        await visit('/equipe/creation');
+        const screen = await visit('/equipe/creation');
         server.post(
           `/organizations/${organizationId}/invitations`,
           {
@@ -272,7 +272,7 @@ module('Acceptance | Team Creation', function (hooks) {
         // then
 
         assert.strictEqual(currentURL(), '/equipe/creation');
-        assert.contains(expectedErrorMessage);
+        assert.ok(screen.getByText(expectedErrorMessage));
       });
 
       module(
@@ -308,7 +308,7 @@ module('Acceptance | Team Creation', function (hooks) {
               errorMessage,
             });
             assert.strictEqual(currentURL(), '/equipe/creation');
-            assert.dom(screen.getByText(expectedErrorMessage)).exists();
+            assert.ok(screen.getByText(expectedErrorMessage));
           });
         },
       );

--- a/orga/tests/integration/components/auth/join-request-form_test.js
+++ b/orga/tests/integration/components/auth/join-request-form_test.js
@@ -15,28 +15,28 @@ module('Integration | Component | Auth::JoinRequestForm', function (hooks) {
     [{ stringFilledIn: '' }, { stringFilledIn: ' ' }].forEach(function ({ stringFilledIn }) {
       test(`it should display an error message on firstName field, when '${stringFilledIn}' is typed and focused out`, async function (assert) {
         // given
-        await render(hbs`<Auth::JoinRequestForm />`);
+        const screen = await render(hbs`<Auth::JoinRequestForm />`);
 
         // when
         await fillByLabel('Votre prénom', stringFilledIn);
         await triggerEvent('#firstName', 'focusout');
 
         // then
-        assert.contains(EMPTY_FIRSTNAME_ERROR_MESSAGE);
+        assert.ok(screen.getByText(EMPTY_FIRSTNAME_ERROR_MESSAGE));
       });
     });
 
     [{ stringFilledIn: '' }, { stringFilledIn: ' ' }].forEach(function ({ stringFilledIn }) {
       test(`it should display an error message on lastName field, when '${stringFilledIn}' is typed and focused out`, async function (assert) {
         // given
-        await render(hbs`<Auth::JoinRequestForm />`);
+        const screen = await render(hbs`<Auth::JoinRequestForm />`);
 
         // when
         await fillByLabel('Votre nom', stringFilledIn);
         await triggerEvent('#lastName', 'focusout');
 
         // then
-        assert.contains(EMPTY_LASTNAME_ERROR_MESSAGE);
+        assert.ok(screen.getByText(EMPTY_LASTNAME_ERROR_MESSAGE));
       });
     });
   });

--- a/orga/tests/integration/components/banner/communication_test.js
+++ b/orga/tests/integration/components/banner/communication_test.js
@@ -34,10 +34,10 @@ module('Integration | Component | Banner::Communication', function (hooks) {
     ENV.APP.BANNER_TYPE = 'information';
 
     // when
-    await render(hbs`<Banner::Communication />`);
+    const screen = await render(hbs`<Banner::Communication />`);
 
     // then
     assert.dom('.pix-banner--information').exists();
-    assert.contains('information banner text ...');
+    assert.ok(screen.getByText('information banner text ...'));
   });
 });

--- a/orga/tests/integration/components/campaign/activity/delete-participation-modal_test.js
+++ b/orga/tests/integration/components/campaign/activity/delete-participation-modal_test.js
@@ -41,24 +41,14 @@ module('Integration | Component | Campaign::Activity::DeleteParticipationModal',
   @deleteCampaignParticipation={{this.deleteCampaignParticipation}}
 />`);
 
-        const expectedText = this.intl.t('pages.campaign-activity.delete-participation-modal.title', {
-          firstName: 'Joe',
-          lastName: 'La frite',
-          htmlSafe: true,
-        });
-        assert
-          .dom(
-            screen.getByText((content, node) => {
-              const hasText = (node) => node.innerHTML.trim() === expectedText.__string;
-              const nodeHasText = hasText(node);
-              const childrenDontHaveText = Array.from(node.children).every((child) => !hasText(child));
-              return nodeHasText && childrenDontHaveText;
-            }),
-          )
-          .exists();
-        assert.contains(this.intl.t('pages.campaign-activity.delete-participation-modal.text'));
-        assert.contains(this.intl.t('pages.campaign-activity.delete-participation-modal.actions.cancel'));
-        assert.contains(this.intl.t('pages.campaign-activity.delete-participation-modal.actions.confirmation'));
+        assert.ok(screen.getByRole('heading', { name: 'Supprimer la participation de Joe La frite ?' }));
+        assert.ok(screen.getByText(this.intl.t('pages.campaign-activity.delete-participation-modal.text')));
+        assert.ok(screen.getByText(this.intl.t('pages.campaign-activity.delete-participation-modal.actions.cancel')));
+        assert.ok(
+          screen.getByRole('button', {
+            name: this.intl.t('pages.campaign-activity.delete-participation-modal.actions.confirmation'),
+          }),
+        );
       });
 
       module('When the user clicks on cancel button', function () {
@@ -97,7 +87,7 @@ module('Integration | Component | Campaign::Activity::DeleteParticipationModal',
           this.set('campaign.type', 'ASSESSMENT');
           this.set('participation.status', 'STARTED');
 
-          await render(hbs`<Campaign::Activity::DeleteParticipationModal
+          const screen = await render(hbs`<Campaign::Activity::DeleteParticipationModal
   @campaign={{this.campaign}}
   @participation={{this.participation}}
   @isModalOpen={{this.isModalOpen}}
@@ -105,9 +95,11 @@ module('Integration | Component | Campaign::Activity::DeleteParticipationModal',
   @deleteCampaignParticipation={{this.deleteCampaignParticipation}}
 />`);
 
-          assert.contains(
-            this.intl.t(
-              'pages.campaign-activity.delete-participation-modal.warning.assessment-campaign-participation.started-participation',
+          assert.ok(
+            screen.getByText(
+              this.intl.t(
+                'pages.campaign-activity.delete-participation-modal.warning.assessment-campaign-participation.started-participation',
+              ),
             ),
           );
         });
@@ -116,7 +108,7 @@ module('Integration | Component | Campaign::Activity::DeleteParticipationModal',
           this.set('campaign.type', 'ASSESSMENT');
           this.set('participation.status', 'TO_SHARE');
 
-          await render(hbs`<Campaign::Activity::DeleteParticipationModal
+          const screen = await render(hbs`<Campaign::Activity::DeleteParticipationModal
   @campaign={{this.campaign}}
   @participation={{this.participation}}
   @isModalOpen={{this.isModalOpen}}
@@ -124,9 +116,11 @@ module('Integration | Component | Campaign::Activity::DeleteParticipationModal',
   @deleteCampaignParticipation={{this.deleteCampaignParticipation}}
 />`);
 
-          assert.contains(
-            this.intl.t(
-              'pages.campaign-activity.delete-participation-modal.warning.assessment-campaign-participation.to-share-participation',
+          assert.ok(
+            screen.getByText(
+              this.intl.t(
+                'pages.campaign-activity.delete-participation-modal.warning.assessment-campaign-participation.to-share-participation',
+              ),
             ),
           );
         });
@@ -135,7 +129,7 @@ module('Integration | Component | Campaign::Activity::DeleteParticipationModal',
           this.set('campaign.type', 'ASSESSMENT');
           this.set('participation.status', 'SHARED');
 
-          await render(hbs`<Campaign::Activity::DeleteParticipationModal
+          const screen = await render(hbs`<Campaign::Activity::DeleteParticipationModal
   @campaign={{this.campaign}}
   @participation={{this.participation}}
   @isModalOpen={{this.isModalOpen}}
@@ -143,9 +137,11 @@ module('Integration | Component | Campaign::Activity::DeleteParticipationModal',
   @deleteCampaignParticipation={{this.deleteCampaignParticipation}}
 />`);
 
-          assert.contains(
-            this.intl.t(
-              'pages.campaign-activity.delete-participation-modal.warning.assessment-campaign-participation.shared-participation',
+          assert.ok(
+            screen.getByText(
+              this.intl.t(
+                'pages.campaign-activity.delete-participation-modal.warning.assessment-campaign-participation.shared-participation',
+              ),
             ),
           );
         });
@@ -154,7 +150,7 @@ module('Integration | Component | Campaign::Activity::DeleteParticipationModal',
           this.set('campaign.type', 'PROFILES_COLLECTION');
           this.set('participation.status', 'TO_SHARE');
 
-          await render(hbs`<Campaign::Activity::DeleteParticipationModal
+          const screen = await render(hbs`<Campaign::Activity::DeleteParticipationModal
   @campaign={{this.campaign}}
   @participation={{this.participation}}
   @isModalOpen={{this.isModalOpen}}
@@ -162,9 +158,11 @@ module('Integration | Component | Campaign::Activity::DeleteParticipationModal',
   @deleteCampaignParticipation={{this.deleteCampaignParticipation}}
 />`);
 
-          assert.contains(
-            this.intl.t(
-              'pages.campaign-activity.delete-participation-modal.warning.profiles-collection-campaign-participation.to-share-participation',
+          assert.ok(
+            screen.getByText(
+              this.intl.t(
+                'pages.campaign-activity.delete-participation-modal.warning.profiles-collection-campaign-participation.to-share-participation',
+              ),
             ),
           );
         });
@@ -173,7 +171,7 @@ module('Integration | Component | Campaign::Activity::DeleteParticipationModal',
           this.set('campaign.type', 'PROFILES_COLLECTION');
           this.set('participation.status', 'SHARED');
 
-          await render(hbs`<Campaign::Activity::DeleteParticipationModal
+          const screen = await render(hbs`<Campaign::Activity::DeleteParticipationModal
   @campaign={{this.campaign}}
   @participation={{this.participation}}
   @isModalOpen={{this.isModalOpen}}
@@ -181,9 +179,11 @@ module('Integration | Component | Campaign::Activity::DeleteParticipationModal',
   @deleteCampaignParticipation={{this.deleteCampaignParticipation}}
 />`);
 
-          assert.contains(
-            this.intl.t(
-              'pages.campaign-activity.delete-participation-modal.warning.profiles-collection-campaign-participation.shared-participation',
+          assert.ok(
+            screen.getByText(
+              this.intl.t(
+                'pages.campaign-activity.delete-participation-modal.warning.profiles-collection-campaign-participation.shared-participation',
+              ),
             ),
           );
         });

--- a/orga/tests/integration/components/campaign/activity/participants-list_test.js
+++ b/orga/tests/integration/components/campaign/activity/participants-list_test.js
@@ -34,7 +34,7 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
       },
     ]);
 
-    await render(
+    const screen = await render(
       hbs`<Campaign::Activity::ParticipantsList
   @campaign={{this.campaign}}
   @participations={{this.participations}}
@@ -43,10 +43,10 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
 />`,
     );
 
-    assert.contains('Joe');
-    assert.contains('La frite');
-    assert.contains('patate');
-    assert.contains("En attente d'envoi");
+    assert.ok(screen.getByText('Joe'));
+    assert.ok(screen.getByText('La frite'));
+    assert.ok(screen.getByText('patate'));
+    assert.ok(screen.getAllByText("En attente d'envoi"));
   });
 
   test('it should link to the last shared or current campaign participation details', async function (assert) {
@@ -110,8 +110,8 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
 />`,
     );
 
-    assert.dom(screen.getByText(this.intl.t('pages.campaign-activity.table.column.participationCount'))).exists();
-    assert.dom(screen.getByText('2')).exists();
+    assert.ok(screen.getByText(this.intl.t('pages.campaign-activity.table.column.participationCount')));
+    assert.ok(screen.getByText('2'));
   });
 
   test('it should hide participation column when showParticipationCount is false', async function (assert) {
@@ -165,13 +165,11 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
 />`,
     );
 
-    assert
-      .dom(
-        screen.getByLabelText(
-          this.intl.t('pages.campaign-activity.table.see-results', { firstName: 'Joe', lastName: 'La frite' }),
-        ),
-      )
-      .exists();
+    assert.ok(
+      screen.getByLabelText(
+        this.intl.t('pages.campaign-activity.table.see-results', { firstName: 'Joe', lastName: 'La frite' }),
+      ),
+    );
   });
 
   module('#deleteParticipation', function () {
@@ -192,14 +190,14 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
           },
         ];
 
-        await render(hbs`<Campaign::Activity::ParticipantsList
+        const screen = await render(hbs`<Campaign::Activity::ParticipantsList
   @campaign={{this.campaign}}
   @participations={{this.participations}}
   @onClickParticipant={{this.noop}}
   @onFilter={{this.noop}}
 />`);
 
-        assert.dom('[aria-label="Supprimer la participation"]').exists();
+        assert.ok(screen.getByRole('button', { name: 'Supprimer la participation' }));
       });
     });
 
@@ -221,14 +219,14 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
           },
         ];
 
-        await render(hbs`<Campaign::Activity::ParticipantsList
+        const screen = await render(hbs`<Campaign::Activity::ParticipantsList
   @campaign={{this.campaign}}
   @participations={{this.participations}}
   @onClickParticipant={{this.noop}}
   @onFilter={{this.noop}}
 />`);
 
-        assert.dom('[aria-label="Supprimer la participation"]').exists();
+        assert.ok(screen.getByRole('button', { name: 'Supprimer la participation' }));
       });
     });
 
@@ -250,14 +248,14 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
           },
         ];
 
-        await render(hbs`<Campaign::Activity::ParticipantsList
+        const screen = await render(hbs`<Campaign::Activity::ParticipantsList
   @campaign={{this.campaign}}
   @participations={{this.participations}}
   @onClickParticipant={{this.noop}}
   @onFilter={{this.noop}}
 />`);
 
-        assert.dom('[aria-label="Supprimer la participation"]').doesNotExist();
+        assert.notOk(screen.queryByRole('button', { name: 'Supprimer la participation' }));
       });
     });
   });

--- a/orga/tests/integration/components/campaign/analysis/recommendations_test.js
+++ b/orga/tests/integration/components/campaign/analysis/recommendations_test.js
@@ -85,7 +85,7 @@ module('Integration | Component | Campaign::Analysis::Recommendations', function
     });
 
     test('it should have a caption to describe the table', async function (assert) {
-      assert.contains(this.intl.t('pages.campaign-review.table.analysis.caption'));
+      assert.ok(screen.getByText(this.intl.t('pages.campaign-review.table.analysis.caption')));
     });
   });
 
@@ -93,11 +93,11 @@ module('Integration | Component | Campaign::Analysis::Recommendations', function
     test('it displays pending results', async function (assert) {
       this.campaignTubeRecommendations = [];
 
-      await render(hbs`<Campaign::Analysis::Recommendations
+      const screen = await render(hbs`<Campaign::Analysis::Recommendations
   @campaignTubeRecommendations={{this.campaignTubeRecommendations}}
   @displayAnalysis={{false}}
 />`);
-      assert.contains('En attente de résultats');
+      assert.ok(screen.getByText('En attente de résultats'));
     });
   });
 });

--- a/orga/tests/integration/components/campaign/analysis/tube-recommendation-row_test.js
+++ b/orga/tests/integration/components/campaign/analysis/tube-recommendation-row_test.js
@@ -53,7 +53,9 @@ module('Integration | Component | Campaign::Analysis::TubeRecommendationRow', fu
     // given
     this.tubeRecommendation.tutorials = [tutorial1];
 
-    await render(hbs`<Campaign::Analysis::TubeRecommendationRow @tubeRecommendation={{this.tubeRecommendation}} />`);
+    const screen = await render(
+      hbs`<Campaign::Analysis::TubeRecommendationRow @tubeRecommendation={{this.tubeRecommendation}} />`,
+    );
 
     // when
     await click('[data-icon="chevron-down"]');
@@ -64,21 +66,27 @@ module('Integration | Component | Campaign::Analysis::TubeRecommendationRow', fu
     assert.dom('[aria-label="Tutoriel"]:first-child').containsText('Vidéo');
     assert.dom('[aria-label="Tutoriel"]:first-child').containsText('10 minutes');
     assert.dom('[aria-label="Tutoriel"]:first-child').containsText('Par Youtube');
-    assert.dom('button[aria-expanded="true"]').exists();
-    assert.contains('Tube Desc A');
+    assert.ok(
+      screen.getByRole('button', { name: 'Afficher la liste des tutos' }).hasAttribute('aria-expanded', 'true'),
+    );
+    assert.ok(screen.getByText('Tube Desc A'));
   });
 
   test('it should hide element to screen reader', async function (assert) {
     // given
     this.tubeRecommendation.tutorials = [tutorial1];
 
-    await render(hbs`<Campaign::Analysis::TubeRecommendationRow @tubeRecommendation={{this.tubeRecommendation}} />`);
+    const screen = await render(
+      hbs`<Campaign::Analysis::TubeRecommendationRow @tubeRecommendation={{this.tubeRecommendation}} />`,
+    );
 
     // then
     assert.dom('tr[aria-hidden="true"]').containsText('1 tuto recommandé par la communauté Pix');
     assert.dom('a[tabindex="-1"]:first-child').containsText('tutorial1');
-    assert.dom('button[aria-expanded="false"]').exists();
-    assert.contains('Tube Desc A');
+    assert.ok(
+      screen.getByRole('button', { name: 'Afficher la liste des tutos' }).hasAttribute('aria-expanded', 'false'),
+    );
+    assert.ok(screen.getByText('Tube Desc A'));
   });
 
   test('it should expand and display 2 tutorials in the list', async function (assert) {
@@ -115,10 +123,12 @@ module('Integration | Component | Campaign::Analysis::TubeRecommendationRow', fu
       this.tubeRecommendation.tutorials = [tutorial1];
 
       //when
-      await render(hbs`<Campaign::Analysis::TubeRecommendationRow @tubeRecommendation={{this.tubeRecommendation}} />`);
+      const screen = await render(
+        hbs`<Campaign::Analysis::TubeRecommendationRow @tubeRecommendation={{this.tubeRecommendation}} />`,
+      );
 
       // then
-      assert.dom('[aria-label="Sujet"]').containsText('1 tuto');
+      assert.dom(screen.getByLabelText('Sujet')).containsText('1 tuto');
     });
 
     test('it should display "2 tutos" when there are two tutorials', async function (assert) {
@@ -126,10 +136,12 @@ module('Integration | Component | Campaign::Analysis::TubeRecommendationRow', fu
       this.tubeRecommendation.tutorials = [tutorial1, tutorial2];
 
       //when
-      await render(hbs`<Campaign::Analysis::TubeRecommendationRow @tubeRecommendation={{this.tubeRecommendation}} />`);
+      const screen = await render(
+        hbs`<Campaign::Analysis::TubeRecommendationRow @tubeRecommendation={{this.tubeRecommendation}} />`,
+      );
 
       // then
-      assert.dom('[aria-label="Sujet"]').containsText('2 tutos');
+      assert.dom(screen.getByLabelText('Sujet')).containsText('2 tutos');
     });
   });
 });

--- a/orga/tests/integration/components/campaign/badges_test.js
+++ b/orga/tests/integration/components/campaign/badges_test.js
@@ -1,4 +1,4 @@
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 
@@ -29,9 +29,9 @@ module('Integration | Component | Campaign::Badges', function (hooks) {
     this.badges = [{ title: 'badge1', imageUrl: 'img1', altMessage: 'alt-img1' }];
 
     // when
-    await render(hbs`<Campaign::Badges @badges={{this.badges}} />`);
+    const screen = await render(hbs`<Campaign::Badges @badges={{this.badges}} />`);
 
     // then
-    assert.contains('badge1');
+    assert.ok(screen.getByText('badge1'));
   });
 });

--- a/orga/tests/integration/components/campaign/charts/participants-by-day_test.js
+++ b/orga/tests/integration/components/campaign/charts/participants-by-day_test.js
@@ -31,13 +31,13 @@ module('Integration | Component | Campaign::Charts::ParticipantsByDay', function
     });
 
     // when
-    await render(
+    const screen = await render(
       hbs`<Campaign::Charts::ParticipantsByDay @campaignId={{this.campaignId}} @isTypeAssessment={{true}} />`,
     );
 
-    assert.contains('Date');
-    assert.contains('Total des participants');
-    assert.contains('Total des participants ayant envoyé leurs résultats');
+    assert.strictEqual(screen.getAllByText('Date').length, 2);
+    assert.ok(screen.getByText('Total des participants'));
+    assert.ok(screen.getByText('Total des participants ayant envoyé leurs résultats'));
   });
 
   test('it should display status for profile collection campaign', async function (assert) {
@@ -52,12 +52,12 @@ module('Integration | Component | Campaign::Charts::ParticipantsByDay', function
     });
 
     // when
-    await render(
+    const screen = await render(
       hbs`<Campaign::Charts::ParticipantsByDay @campaignId={{this.campaignId}} @isTypeAssessment={{false}} />`,
     );
 
-    assert.contains('Date');
-    assert.contains('Total des participants');
-    assert.contains('Total des participants ayant envoyé leurs profils');
+    assert.strictEqual(screen.getAllByText('Date').length, 2);
+    assert.ok(screen.getByText('Total des participants'));
+    assert.ok(screen.getByText('Total des participants ayant envoyé leurs profils'));
   });
 });

--- a/orga/tests/integration/components/campaign/charts/participants-by-stage_test.js
+++ b/orga/tests/integration/components/campaign/charts/participants-by-stage_test.js
@@ -47,33 +47,36 @@ module('Integration | Component | Campaign::Charts::ParticipantsByStage', functi
 
   test('it should display participants number', async function (assert) {
     // then
-    assert.contains('0 participant');
-    assert.contains('5 participants');
+    assert.ok(screen.getByText('0 participant'));
+    assert.ok(screen.getByText('5 participants'));
   });
 
   test('it should display participants percentage by stages', async function (assert) {
     // then
-    assert.contains('0 %');
-    assert.contains('100 %');
+    assert.ok(screen.getByText('0 %'));
+    assert.ok(screen.getByText('100 %'));
   });
 
   test('should render a screen reader message', async function (assert) {
     // then
-    assert.dom(screen.getByText('0 étoile sur 1')).exists();
-    assert.dom(screen.getByText('1 étoile sur 1')).exists();
+    assert.ok(screen.getByText('0 étoile sur 1'));
+    assert.ok(screen.getByText('1 étoile sur 1'));
   });
 
   test('it should not display empty tooltip', async function (assert) {
     // then
-    assert.dom('[role="tooltip"]').doesNotExist();
+    assert.notOk(screen.queryByRole('tooltip'));
   });
 
   test('it should call onSelectStage when user click on a bar', async function (assert) {
     // when
-    await click('[role=button]');
+
+    // click on the first stage bar
+    await click(screen.getAllByRole('button')[0]);
+
     // then
-    assert.dom('[role=button]').exists();
     sinon.assert.calledWith(onSelectStage, 100498);
+    assert.ok(true);
   });
 
   module('when there is tooltip info', function () {
@@ -92,16 +95,16 @@ module('Integration | Component | Campaign::Charts::ParticipantsByStage', functi
         });
 
         // when
-        await render(
+        const screen = await render(
           hbs`<Campaign::Charts::ParticipantsByStage @campaignId={{this.campaignId}} @onSelectStage={{this.onSelectStage}} />`,
         );
 
         // then
-        assert.dom('[role="tooltip"]').exists();
-        assert.contains('title1');
-        assert.contains('description1');
-        assert.contains('title2');
-        assert.contains('description2');
+        assert.ok(screen.getByText('title1'));
+        assert.ok(screen.getByText('description1'));
+
+        assert.ok(screen.getByText('title2'));
+        assert.ok(screen.getByText('description2'));
       });
     });
 
@@ -117,13 +120,13 @@ module('Integration | Component | Campaign::Charts::ParticipantsByStage', functi
         });
 
         // when
-        await render(
+        const screen = await render(
           hbs`<Campaign::Charts::ParticipantsByStage @campaignId={{this.campaignId}} @onSelectStage={{this.onSelectStage}} />`,
         );
 
         // then
         assert.dom('[role="tooltip"]').exists();
-        assert.contains('title1');
+        assert.ok(screen.getByText('title1'));
       });
     });
 
@@ -145,7 +148,7 @@ module('Integration | Component | Campaign::Charts::ParticipantsByStage', functi
 
         // then
         assert.dom('[role="tooltip"]').exists();
-        assert.contains('description1');
+        assert.ok(screen.getByText('description1'));
       });
     });
   });


### PR DESCRIPTION
## 🦄 Problème
Le contains et notContains a été créé en interne il y a plus de 3ans afin de répondre au besoin de vérification de textes dans les tests fronts.
Depuis ce temps nous avons la lib testing-library qui a des solutions plus précises comme getByText, queryByText, getByLabelText,... Qui répondent totalement à nos besoin et nous permette de supprimer nos contains et notContains

## 🤖 Proposition
Remplacer les utilisations de contains et notContains par des solutions de testing-library afin de pouvoir, par la suite, supprimer le développement de contains et notContains

## 🌈 Remarques
Ils sont partout partout alors je n'ai pas supprimé de tous les fichiers pour des soucis de taille de PR et de Review.

Réalisés :

- sco-organization-participant-list
- sup-organization-participant-list
- switch-organization-acceptance
- team-creation
- joinRequestForm
- communication banner
- campaign badge
- delete participation modal
- participants-list
- campaign analysis recommendation
- tube recommendation row
- Campaign Charts ParticipantsByDay


## 💯 Pour tester
Vérifier que tous les tests passent
