### PR TITLE
[FEATURE] Ajout du calcul du niveau par compétence lors du rescoring (PIX-11546).

### DIFF
--- a/api/lib/domain/events/handle-certification-rescoring.js
+++ b/api/lib/domain/events/handle-certification-rescoring.js
@@ -40,6 +40,7 @@ async function handleCertificationRescoring({
   flashAlgorithmConfigurationRepository,
   flashAlgorithmService,
   certificationAssessmentHistoryRepository,
+  competenceForScoringRepository,
 }) {
   checkEventTypes(event, eventTypes);
 
@@ -59,6 +60,8 @@ async function handleCertificationRescoring({
         flashAlgorithmConfigurationRepository,
         flashAlgorithmService,
         certificationAssessmentHistoryRepository,
+        competenceForScoringRepository,
+        locale: event.locale,
       });
     }
 
@@ -95,6 +98,8 @@ async function _handleV3Certification({
   flashAlgorithmConfigurationRepository,
   flashAlgorithmService,
   certificationAssessmentHistoryRepository,
+  competenceForScoringRepository,
+  locale,
 }) {
   const allAnswers = await answerRepository.findByAssessment(certificationAssessment.id);
   const certificationChallengesForScoring = await certificationChallengeForScoringRepository.getByCertificationCourseId(
@@ -116,12 +121,15 @@ async function _handleV3Certification({
     configuration,
   });
 
+  const competencesForScoring = await competenceForScoringRepository.listByLocale({ locale });
+
   const certificationAssessmentScore = CertificationAssessmentScoreV3.fromChallengesAndAnswers({
     algorithm,
     challenges: certificationChallengesForScoring,
     allAnswers,
     abortReason,
     maxReachableLevelOnCertificationDate: certificationCourse.getMaxReachableLevelOnCertificationDate(),
+    competencesForScoring,
   });
 
   let assessmentResult;

--- a/api/tests/certification/course/acceptance/application/certification-course-route_test.js
+++ b/api/tests/certification/course/acceptance/application/certification-course-route_test.js
@@ -73,6 +73,26 @@ describe('Acceptance | Route | certification-course', function () {
           version: 3,
         });
 
+        const configuration = [
+          {
+            competence: '1.1',
+            values: [
+              {
+                bounds: {
+                  max: -2.2,
+                  min: -9.8,
+                },
+                competenceLevel: 0,
+              },
+            ],
+          },
+        ];
+
+        databaseBuilder.factory.buildCompetenceScoringConfiguration({
+          configuration,
+          createdAt: new Date('2018-01-01T08:00:00Z'),
+        });
+
         const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
           sessionId: session.id,
           userId,

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -34,10 +34,11 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
       flashAlgorithmConfigurationRepository,
       flashAlgorithmService,
       certificationAssessmentHistoryRepository,
-      competenceForScoringRepository;
+      competenceForScoringRepository,
+      competenceMarkRepository;
 
     let baseFlashAlgorithmConfig;
-
+    let assessmentResult;
     let dependencies;
 
     beforeEach(function () {
@@ -73,6 +74,10 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         listByLocale: sinon.stub(),
       };
 
+      competenceMarkRepository = {
+        save: sinon.stub(),
+      };
+
       dependencies = {
         certificationAssessmentRepository,
         certificationChallengeForScoringRepository,
@@ -83,6 +88,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         flashAlgorithmService,
         certificationAssessmentHistoryRepository,
         competenceForScoringRepository,
+        competenceMarkRepository,
       };
 
       baseFlashAlgorithmConfig = domainBuilder.buildFlashAlgorithmConfiguration({
@@ -90,6 +96,10 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
       });
 
       competenceForScoringRepository.listByLocale.resolves([domainBuilder.buildCompetenceForScoring()]);
+
+      assessmentResult = domainBuilder.buildAssessmentResult();
+      assessmentResultRepository.save.resolves(assessmentResult);
+      competenceMarkRepository.save.resolves();
     });
 
     describe('when less than the minimum number of answers required by the config has been answered', function () {
@@ -692,6 +702,17 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         expect(result).to.deep.equal(expectedEvent);
         expect(certificationAssessmentHistoryRepository.save).to.have.been.calledWithExactly(
           certificationAssessmentHistory,
+        );
+        expect(competenceMarkRepository.save).to.have.been.calledWithExactly(
+          domainBuilder.buildCompetenceMark({
+            id: undefined,
+            assessmentResultId: assessmentResult.id,
+            area_code: '1',
+            competenceId: 'recCompetenceId',
+            competence_code: '1.1',
+            level: 2,
+            score: 0,
+          }),
         );
       });
 

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -33,7 +33,8 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
       certificationCourseRepository,
       flashAlgorithmConfigurationRepository,
       flashAlgorithmService,
-      certificationAssessmentHistoryRepository;
+      certificationAssessmentHistoryRepository,
+      competenceForScoringRepository;
 
     let baseFlashAlgorithmConfig;
 
@@ -68,6 +69,10 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         save: sinon.stub(),
       };
 
+      competenceForScoringRepository = {
+        listByLocale: sinon.stub(),
+      };
+
       dependencies = {
         certificationAssessmentRepository,
         certificationChallengeForScoringRepository,
@@ -77,11 +82,14 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         flashAlgorithmConfigurationRepository,
         flashAlgorithmService,
         certificationAssessmentHistoryRepository,
+        competenceForScoringRepository,
       };
 
       baseFlashAlgorithmConfig = domainBuilder.buildFlashAlgorithmConfiguration({
         maximumAssessmentLength,
       });
+
+      competenceForScoringRepository.listByLocale.resolves([domainBuilder.buildCompetenceForScoring()]);
     });
 
     describe('when less than the minimum number of answers required by the config has been answered', function () {

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -87,6 +87,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
     describe('when less than the minimum number of answers required by the config has been answered', function () {
       describe('when the certification was not finished due to a lack of time', function () {
         it('should save the score with a rejected status', async function () {
+          // given
           const certificationAssessment = domainBuilder.buildCertificationAssessment({
             version: CertificationVersion.V3,
           });
@@ -162,11 +163,13 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
             certificationCourseId,
           });
 
+          // when
           const result = await handleCertificationRescoring({
             ...dependencies,
             event,
           });
 
+          // then
           const expectedResult = {
             certificationCourseId,
             assessmentResult: new AssessmentResult({
@@ -202,6 +205,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
 
       describe('when the certification was not finished due to technical difficulties', function () {
         it('should save the score with a rejected status and cancel the certification course', async function () {
+          // given
           const certificationAssessment = domainBuilder.buildCertificationAssessment({
             version: CertificationVersion.V3,
           });
@@ -277,11 +281,13 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
             certificationCourseId,
           });
 
+          // when
           const result = await handleCertificationRescoring({
             ...dependencies,
             event,
           });
 
+          // then
           const expectedResult = {
             certificationCourseId,
             assessmentResult: new AssessmentResult({
@@ -329,6 +335,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
     describe('when not all questions were answered', function () {
       describe('when the candidate did not finish due to technical difficulties', function () {
         it('should save the raw score', async function () {
+          // given
           const certificationCourseStartDate = new Date('2022-01-01');
           const certificationAssessment = domainBuilder.buildCertificationAssessment({
             version: CertificationVersion.V3,
@@ -410,11 +417,13 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
             certificationCourseId,
           });
 
+          // when
           const result = await handleCertificationRescoring({
             ...dependencies,
             event,
           });
 
+          // then
           const expectedResult = {
             certificationCourseId,
             assessmentResult: new AssessmentResult({
@@ -445,6 +454,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
       describe('when the candidate did not finish in time', function () {
         it('should save the degraded score', async function () {
           const certificationCourseStartDate = new Date('2022-01-01');
+          // given
           const certificationAssessment = domainBuilder.buildCertificationAssessment({
             version: CertificationVersion.V3,
           });
@@ -525,11 +535,13 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
             certificationCourseId,
           });
 
+          // when
           const result = await handleCertificationRescoring({
             ...dependencies,
             event,
           });
 
+          // then
           const expectedResult = {
             certificationCourseId,
             assessmentResult: new AssessmentResult({
@@ -560,6 +572,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
 
     describe('when all the questions were answered', function () {
       it('should save the score', async function () {
+        // given
         const certificationCourseStartDate = new Date('2022-01-01');
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
           version: CertificationVersion.V3,
@@ -641,11 +654,13 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           certificationCourseId,
         });
 
+        // when
         const result = await handleCertificationRescoring({
           ...dependencies,
           event,
         });
 
+        // then
         const expectedResult = {
           certificationCourseId,
           assessmentResult: new AssessmentResult({
@@ -675,6 +690,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
       describe('when certification is rejected for fraud', function () {
         it('should save the score with rejected status', async function () {
           const certificationCourseStartDate = new Date('2022-01-01');
+          // given
           const certificationAssessment = domainBuilder.buildCertificationAssessment({
             version: CertificationVersion.V3,
           });
@@ -755,11 +771,13 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
             certificationCourseId,
           });
 
+          // when
           const result = await handleCertificationRescoring({
             ...dependencies,
             event,
           });
 
+          // then
           const assessmentResultToBeSaved = domainBuilder.certification.scoring.buildAssessmentResult.fraud({
             pixScore: scoreForEstimatedLevel,
             reproducibilityRate: 100,
@@ -787,6 +805,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
       describe('when the certification would reach a very high score', function () {
         it('should return the score capped based on the maximum available level when the certification was done', async function () {
           const certificationCourseStartDate = new Date('2022-01-01');
+          // given
           const certificationAssessment = domainBuilder.buildCertificationAssessment({
             version: CertificationVersion.V3,
           });
@@ -879,11 +898,13 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
             certificationCourseId,
           });
 
+          // when
           await handleCertificationRescoring({
             ...dependencies,
             event,
           });
 
+          // then
           expect(assessmentResultRepository.save).to.have.been.calledWith(expectedResult);
           expect(certificationAssessmentHistoryRepository.save).to.have.been.calledWithExactly(
             certificationAssessmentHistory,


### PR DESCRIPTION
## :unicorn: Problème

Le calcul du niveau par compétence n'a été implémenté que pour le scoring.
Il est également nécessaire de l'avoir lors du rescoring.

## :robot: Proposition

Rajout du calcul de niveau par compétence lors du rescoring

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

- Créer une session de certification V3 (`certifv3@example.net`)
- Ajouter un candidat 
- Démarrer et terminer la session (`certifiable-contenu-user@example.net`)
- Finaliser la session
- Vérifier dans pix-admin que le candidat a des niveaux par compétences
- Effectuer une action permettant de lancer un rescoring
- Vérifier que le candidat a toujours des niveaux par compétences après rescoring
