### PR TITLE
[TECH] Nettoyer le `solution-service-qrocm-ind` hérité de ./api/lib (PIX-10484)

### DIFF
--- a/api/src/devcomp/domain/services/solution-service-qrocm-ind.js
+++ b/api/src/devcomp/domain/services/solution-service-qrocm-ind.js
@@ -17,6 +17,11 @@ function match({ answerValue, solution }) {
     return { result: AnswerStatus.KO };
   }
 
+  // Sets comparison
+  if (!_areAnswersComparableToSolutions(answerValue, solutionValue)) {
+    throw new Error('An error occurred because there is no solution found for an answer.');
+  }
+
   // Treatments
   const treatedSolutions = _applyTreatmentsToSolutions(solutionValue, enabledTreatments, qrocBlocksTypes);
   const treatedAnswers = _applyTreatmentsToAnswers(answerValue, enabledTreatments, qrocBlocksTypes);
@@ -79,7 +84,7 @@ function _areApproximatelyEqualAccordingToLevenshteinDistanceRatio(answer, solut
   return ratio <= LEVENSHTEIN_DISTANCE_MAX_RATE;
 }
 
-function _compareAnswersAndSolutions(answers, solutions, enabledTreatments, qrocBlocksTypes = {}) {
+function _areAnswersComparableToSolutions(answers, solutions) {
   for (const answerKey in answers) {
     const solutionVariants = solutions[answerKey];
     if (!solutionVariants) {
@@ -88,10 +93,13 @@ function _compareAnswersAndSolutions(answers, solutions, enabledTreatments, qroc
           Object.keys(solutions)[0]
         }`,
       );
-      throw new Error('An error occurred because there is no solution found for an answer.');
+      return false;
     }
   }
+  return true;
+}
 
+function _compareAnswersAndSolutions(answers, solutions, enabledTreatments, qrocBlocksTypes = {}) {
   const results = {};
   for (const answerKey in answers) {
     const answer = answers[answerKey];
@@ -116,4 +124,11 @@ function _formatResult(resultDetails) {
   return AnswerStatus.OK;
 }
 
-export { _applyTreatmentsToAnswers, _applyTreatmentsToSolutions, _compareAnswersAndSolutions, _formatResult, match };
+export {
+  _applyTreatmentsToAnswers,
+  _applyTreatmentsToSolutions,
+  _areAnswersComparableToSolutions,
+  _compareAnswersAndSolutions,
+  _formatResult,
+  match,
+};

--- a/api/tests/devcomp/unit/domain/services/solution-service-qrocm-ind_test.js
+++ b/api/tests/devcomp/unit/domain/services/solution-service-qrocm-ind_test.js
@@ -43,6 +43,32 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
     });
   });
 
+  describe('#_areAnswersComparableToSolutions', function () {
+    it('should return false if there is no solutions for one input but answers', async function () {
+      // given
+      const answers = { phraseSansSolution: 'lasagne', phrase1: "Le silence est d'ours", phrase2: 'facebook' };
+      const solutions = { phrase1: ["Le silence est d'or"], phrase2: ['facebook'] };
+
+      // when
+      const actual = service._areAnswersComparableToSolutions(answers, solutions);
+
+      // then
+      expect(actual).to.be.false;
+    });
+
+    it('should return true if there is a corresponding solution for all answers', async function () {
+      // given
+      const answers = { phraseAvecSolution: 'lasagne', phrase1: "Le silence est d'ours", phrase2: 'facebook' };
+      const solutions = { phraseAvecSolution: ['lasagne'], phrase1: ["Le silence est d'or"], phrase2: ['facebook'] };
+
+      // when
+      const actual = service._areAnswersComparableToSolutions(answers, solutions);
+
+      // then
+      expect(actual).to.be.true;
+    });
+  });
+
   describe('#_compareAnswersAndSolutions', function () {
     it('should return results comparing answers and solutions strictly when T3 is disabled', function () {
       // given
@@ -70,20 +96,6 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
       // then
       const expected = { phrase1: true, phrase2: true, phrase3: false };
       expect(actual).to.deep.equal(expected);
-    });
-
-    it('should throw an error if there is no solutions for one input but answers', async function () {
-      // given
-      const answers = { phraseSansSolution: 'lasagne', phrase1: "Le silence est d'ours", phrase2: 'facebook' };
-      const solutions = { phrase1: ["Le silence est d'or"], phrase2: ['facebook'] };
-      const enabledTreatments = ['t3'];
-
-      // when
-      const error = await catchErr(service._compareAnswersAndSolutions)(answers, solutions, enabledTreatments);
-
-      // then
-      expect(error).to.be.an.instanceOf(Error);
-      expect(error.message).to.equal('An error occurred because there is no solution found for an answer.');
     });
   });
 
@@ -308,6 +320,20 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
           expect(service.match({ answerValue: testCase.answer, solution })).to.deep.equal(testCase.output);
         },
       );
+    });
+  });
+
+  describe('match, but the answers set do not match the solutions set', function () {
+    it('should throw an error', async function () {
+      const answer = { dossier1: 'a' };
+      const solutionValue = { dossier2: ['Eureka'] };
+      const enabledTreatments = ['t1', 't2', 't3'];
+      const solution = { value: solutionValue, enabledTreatments };
+
+      const error = await catchErr(service.match)({ answerValue: answer, solution });
+
+      expect(error).to.be.an.instanceOf(Error);
+      expect(error.message).to.equal('An error occurred because there is no solution found for an answer.');
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Le fichier `api/src/devcomp/domain/services/solution-service-qrocm-ind.js` a été copié en l'état de `/lib` vers notre BC **_devcomp_**.
La logique fonctionne très bien mais il y avait une ou deux petites améliorations à faire **(scout rule ?)**

## :robot: Proposition
Entre autre, faire le tour des `map` et des `forEach` pour s'assurer de leur bonne utilisation.

### Finalement
Nous avons opté pour une clarification des boucles qui permettent entre autres de formater les `answers` et les `solutions` en fonction des tolérances (`treatments`).
Il y aura de futures refacto à prévoir afin de mieux intégrer les _solution-service_ à notre BC.

## :rainbow: Remarques
J'ai aussi proposé un commit dédié à retirer _lodash_ du fichier. Je ne dis pas qu'il faut arrêter d'utiliser _lodash_ dans notre api, mais je questionne le fait d'utiliser une lib pour un besoin tech qui peut être adressé avec du js vanilla.

### Finalement
Nous avons opté pour conserver les fonctions utilitaires _lodash_ `isString` et `isEmpty`.

## :100: Pour tester
La CI passe.
