### PR TITLE
[REFACTOR] Améliorer le responsive du bloc d'actions des épreuves (PIX-9646).

### DIFF
--- a/mon-pix/app/components/challenge-actions.hbs
+++ b/mon-pix/app/components/challenge-actions.hbs
@@ -2,13 +2,13 @@
   <h2 class="sr-only">{{t "pages.challenge.parts.validation"}}</h2>
 
   {{#if @answer}}
-    <span class="challenge-actions__already-answered">
+    <PixMessage class="challenge-actions__already-answered" @withIcon="true">
       {{#if (eq @answer.result "timedout")}}
         {{t "pages.challenge.timed.cannot-answer"}}
       {{else}}
         {{t "pages.challenge.already-answered"}}
       {{/if}}
-    </span>
+    </PixMessage>
     <PixButton
       @triggerAction={{fn @resumeAssessment @assessment}}
       @backgroundColor="primary"

--- a/mon-pix/app/styles/components/_challenge-actions.scss
+++ b/mon-pix/app/styles/components/_challenge-actions.scss
@@ -1,48 +1,19 @@
-@mixin action-button() {
-  margin: 0 1px;
-
-  @include device-is('tablet') {
-    margin: 0 5px;
-  }
-
-  &-text {
-    font-size: 0.8rem;
-    letter-spacing: 0.03rem;
-    text-transform: uppercase;
-
-    @include device-is('tablet') {
-      font-size: 1rem;
-    }
-  }
-}
-
-.rounded-panel__row.challenge-actions {
-  padding: 16px 0;
-
-  @include device-is('tablet') {
-    padding: 16px;
-  }
-}
-
 .challenge-actions {
   display: flex;
   flex-direction: column;
+  gap: $pix-spacing-s;
   justify-content: center;
   margin: $pix-spacing-xxs;
   background-color: $pix-neutral-10;
 
-  &__group > p {
-    margin-top: 8px;
-    color: $pix-neutral-90;
-    font-size: 0.75rem;
-    line-height: 17px;
+  &__already-answered {
+    flex-grow: 1;
   }
 
   @include device-is('mobile') {
-    &__buttons {
-      display: flex;
-      flex-direction: column;
-      padding: 0 $pix-spacing-m;
+    &__buttons button {
+      width: min(100%, 20em);
+      margin-inline: auto;
     }
 
     &__action-validate {
@@ -58,21 +29,12 @@
     &__buttons {
       display: flex;
       flex-direction: row-reverse;
+      gap: $pix-spacing-s;
     }
 
     &__action-validate {
       min-width: 12.5em;
-      margin-left: $pix-spacing-s;
     }
-  }
-
-  &__already-answered {
-    margin-right: 20px;
-    color: $pix-neutral-70;
-    font-weight: $font-medium;
-    font-size: 1rem;
-    font-family: $font-roboto;
-    letter-spacing: 0.031rem;
   }
 
   &__alert-message {


### PR DESCRIPTION
## :unicorn: Problème

La marge de “vous avez déjà répondu à cette question” n'était pas bonne en version mobile

## :robot: Proposition

- Revoir le responsive
- Afficher le message "vous avez déjà répondu à cette question" dans un composant PixMessage de PixUI (vu avec le design)

## :100: Pour tester

Voir une page d'épreuve déjà faite en mode mobile
