### PR TITLE
[FEATURE][MON-PIX] Modifier les URLs des CGU et Politique Protection des données pour le Néerlandais (PIX-11620)

### DIFF
--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -3,6 +3,7 @@ import ENV from 'mon-pix/config/environment';
 
 const FRENCH_INTERNATIONAL_LOCALE = 'fr';
 const ENGLISH_INTERNATIONAL_LOCALE = 'en';
+const DUTCH_INTERNATIONAL_LOCALE = 'nl';
 
 export default class Url extends Service {
   @service currentDomain;
@@ -31,13 +32,19 @@ export default class Url extends Service {
 
   get dataProtectionPolicyUrl() {
     const currentLanguage = this.intl.primaryLocale;
+
     if (this.currentDomain.isFranceDomain) {
       return `https://pix.fr/politique-protection-donnees-personnelles-app`;
     }
 
-    return currentLanguage === FRENCH_INTERNATIONAL_LOCALE
-      ? 'https://pix.org/fr/politique-protection-donnees-personnelles-app'
-      : 'https://pix.org/en-gb/personal-data-protection-policy';
+    switch (currentLanguage) {
+      case ENGLISH_INTERNATIONAL_LOCALE:
+        return 'https://pix.org/en-gb/personal-data-protection-policy';
+      case DUTCH_INTERNATIONAL_LOCALE:
+        return 'https://pix.org/nl-be/beleid-inzake-de-bescherming-van-persoonsgegevens';
+      default:
+        return 'https://pix.org/fr/politique-protection-donnees-personnelles-app';
+    }
   }
 
   get _showcaseWebsiteUrl() {

--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -22,12 +22,19 @@ export default class Url extends Service {
 
   get cguUrl() {
     const currentLanguage = this.intl.primaryLocale;
+
     if (this.currentDomain.isFranceDomain) {
       return `https://pix.fr/conditions-generales-d-utilisation`;
     }
-    return currentLanguage === FRENCH_INTERNATIONAL_LOCALE
-      ? 'https://pix.org/fr/conditions-generales-d-utilisation'
-      : 'https://pix.org/en-gb/terms-and-conditions';
+
+    switch (currentLanguage) {
+      case ENGLISH_INTERNATIONAL_LOCALE:
+        return 'https://pix.org/en-gb/terms-and-conditions';
+      case DUTCH_INTERNATIONAL_LOCALE:
+        return 'https://pix.org/nl-be/algemene-gebruiksvoorwaarden';
+      default:
+        return 'https://pix.org/fr/conditions-generales-d-utilisation';
+    }
   }
 
   get dataProtectionPolicyUrl() {

--- a/mon-pix/tests/unit/services/url_test.js
+++ b/mon-pix/tests/unit/services/url_test.js
@@ -114,6 +114,22 @@ module('Unit | Service | url', function (hooks) {
           assert.strictEqual(cguUrl, expectedCguUrl);
         });
       });
+
+      module('when current language is "nl"', function () {
+        test('returns the French page URL', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.currentDomain = { isFranceDomain: true };
+          service.intl = { primaryLocale: DUTCH_INTERNATIONAL_LOCALE };
+          const expectedCguUrl = 'https://pix.fr/conditions-generales-d-utilisation';
+
+          // when
+          const cguUrl = service.cguUrl;
+
+          // then
+          assert.strictEqual(cguUrl, expectedCguUrl);
+        });
+      });
     });
 
     module('when website is pix.org', function () {
@@ -141,6 +157,23 @@ module('Unit | Service | url', function (hooks) {
           const expectedCguUrl = 'https://pix.org/en-gb/terms-and-conditions';
           service.currentDomain = { getExtension: sinon.stub().returns(INTERNATIONAL_TLD) };
           service.intl = { primaryLocale: ENGLISH_INTERNATIONAL_LOCALE };
+
+          // when
+          const cguUrl = service.cguUrl;
+
+          // then
+          assert.strictEqual(cguUrl, expectedCguUrl);
+        });
+      });
+
+      module('when current language is "nl"', function () {
+        test('returns the Nederland page URL', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.currentDomain = { isFranceDomain: false };
+          const expectedCguUrl = 'https://pix.org/nl-be/algemene-gebruiksvoorwaarden';
+          service.currentDomain = { getExtension: sinon.stub().returns(INTERNATIONAL_TLD) };
+          service.intl = { primaryLocale: DUTCH_INTERNATIONAL_LOCALE };
 
           // when
           const cguUrl = service.cguUrl;

--- a/mon-pix/tests/unit/services/url_test.js
+++ b/mon-pix/tests/unit/services/url_test.js
@@ -157,13 +157,13 @@ module('Unit | Service | url', function (hooks) {
         // given
         const service = this.owner.lookup('service:url');
         service.currentDomain = { isFranceDomain: true };
-        const expectedCguUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
+        const expectedDataProtectionPolicyUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
 
         // when
-        const cguUrl = service.dataProtectionPolicyUrl;
+        const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
 
         // then
-        assert.strictEqual(cguUrl, expectedCguUrl);
+        assert.strictEqual(dataProtectionPolicyUrl, expectedDataProtectionPolicyUrl);
       });
 
       module('when current language is "en"', function () {
@@ -172,13 +172,13 @@ module('Unit | Service | url', function (hooks) {
           const service = this.owner.lookup('service:url');
           service.currentDomain = { isFranceDomain: true };
           service.intl = { primaryLocale: ENGLISH_INTERNATIONAL_LOCALE };
-          const expectedCguUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
+          const expectedDataProtectionPolicyUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
 
           // when
-          const cguUrl = service.dataProtectionPolicyUrl;
+          const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
 
           // then
-          assert.strictEqual(cguUrl, expectedCguUrl);
+          assert.strictEqual(dataProtectionPolicyUrl, expectedDataProtectionPolicyUrl);
         });
       });
     });
@@ -190,13 +190,13 @@ module('Unit | Service | url', function (hooks) {
           const service = this.owner.lookup('service:url');
           service.currentDomain = { isFranceDomain: false };
           service.intl = { primaryLocale: FRENCH_INTERNATIONAL_LOCALE };
-          const expectedCguUrl = 'https://pix.org/fr/politique-protection-donnees-personnelles-app';
+          const expectedDataProtectionPolicyUrl = 'https://pix.org/fr/politique-protection-donnees-personnelles-app';
 
           // when
-          const cguUrl = service.dataProtectionPolicyUrl;
+          const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
 
           // then
-          assert.strictEqual(cguUrl, expectedCguUrl);
+          assert.strictEqual(dataProtectionPolicyUrl, expectedDataProtectionPolicyUrl);
         });
       });
 
@@ -206,13 +206,13 @@ module('Unit | Service | url', function (hooks) {
           const service = this.owner.lookup('service:url');
           service.currentDomain = { isFranceDomain: false };
           service.intl = { primaryLocale: ENGLISH_INTERNATIONAL_LOCALE };
-          const expectedCguUrl = 'https://pix.org/en-gb/personal-data-protection-policy';
+          const expectedDataProtectionPolicyUrl = 'https://pix.org/en-gb/personal-data-protection-policy';
 
           // when
-          const cguUrl = service.dataProtectionPolicyUrl;
+          const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
 
           // then
-          assert.strictEqual(cguUrl, expectedCguUrl);
+          assert.strictEqual(dataProtectionPolicyUrl, expectedDataProtectionPolicyUrl);
         });
       });
     });

--- a/mon-pix/tests/unit/services/url_test.js
+++ b/mon-pix/tests/unit/services/url_test.js
@@ -7,6 +7,7 @@ const INTERNATIONAL_TLD = 'org';
 
 const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 const FRENCH_INTERNATIONAL_LOCALE = 'fr';
+const DUTCH_INTERNATIONAL_LOCALE = 'nl';
 
 import setupIntl from 'mon-pix/tests/helpers/setup-intl';
 
@@ -181,6 +182,22 @@ module('Unit | Service | url', function (hooks) {
           assert.strictEqual(dataProtectionPolicyUrl, expectedDataProtectionPolicyUrl);
         });
       });
+
+      module('when current language is "nl"', function () {
+        test('returns the French page URL', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.currentDomain = { isFranceDomain: true };
+          service.intl = { primaryLocale: DUTCH_INTERNATIONAL_LOCALE };
+          const expectedDataProtectionPolicyUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
+
+          // when
+          const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
+
+          // then
+          assert.strictEqual(dataProtectionPolicyUrl, expectedDataProtectionPolicyUrl);
+        });
+      });
     });
 
     module('when website is pix.org', function () {
@@ -207,6 +224,23 @@ module('Unit | Service | url', function (hooks) {
           service.currentDomain = { isFranceDomain: false };
           service.intl = { primaryLocale: ENGLISH_INTERNATIONAL_LOCALE };
           const expectedDataProtectionPolicyUrl = 'https://pix.org/en-gb/personal-data-protection-policy';
+
+          // when
+          const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
+
+          // then
+          assert.strictEqual(dataProtectionPolicyUrl, expectedDataProtectionPolicyUrl);
+        });
+      });
+
+      module('when current language is "nl"', function () {
+        test('returns the Nederland page URL', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.currentDomain = { isFranceDomain: false };
+          service.intl = { primaryLocale: DUTCH_INTERNATIONAL_LOCALE };
+          const expectedDataProtectionPolicyUrl =
+            'https://pix.org/nl-be/beleid-inzake-de-bescherming-van-persoonsgegevens';
 
           // when
           const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;


### PR DESCRIPTION
## :unicorn: Problème

Actuellement les URLs des CGU et Politique Protection des données, lorsque la langue d'affichage est le néerlandais, pointent vers les versions anglaise.

## :robot: Proposition

Modifier les URLs des CGU et Politique Protection des données pour le Néerlandais.

## :rainbow: Remarques

RAS

## :100: Pour tester

1. Aller sur le page d'inscription du domaine .org de Pix App (https://app-pr8390.review.pix.org/inscription)
2. Modifier la langue d'affichage de la page en **Nederlands**
3. Ouvrir le lien des **CGU (gebruiksvoorwaarden)** se trouvant en bas du formulaire d'inscription dans un nouvel onglet de votre navigateur
4. Vérifier que le lien est bien [https:/pix.org/nl-be/algemene-gebruiksvoorwaarden](https:/pix.org/nl-be/algemene-gebruiksvoorwaarden)
5. Ouvrir le lien de la **Politique de Protection des données (privacybeleid)** se trouvant en bas du formulaire d'inscription dans un nouvel onglet de votre navigateur
6. Vérifier que le lien est bien [https://pix.org/nl-be/beleid-inzake-de-bescherming-van-persoonsgegevens](https://pix.org/nl-be/beleid-inzake-de-bescherming-van-persoonsgegevens)
