### PR TITLE
[REFACTOR] Améliorer le contraste du bloc de signalement d'épreuve (PIX-9644).

### DIFF
--- a/mon-pix/app/components/feedback-panel.hbs
+++ b/mon-pix/app/components/feedback-panel.hbs
@@ -87,9 +87,8 @@
                 {{/if}}
                 <PixButton
                   @triggerAction={{this.toggleModalVisibility}}
-                  @backgroundColor="neutral"
-                  aria-label={{t "pages.challenge.feedback-panel.form.actions.submit-aria-label"}}
                   @isDisabled={{this.isSendButtonDisabled}}
+                  aria-label={{t "pages.challenge.feedback-panel.form.actions.submit-aria-label"}}
                 >
                   {{t "pages.challenge.feedback-panel.form.actions.submit"}}
                 </PixButton>

--- a/mon-pix/app/styles/components/_feedback-panel.scss
+++ b/mon-pix/app/styles/components/_feedback-panel.scss
@@ -1,7 +1,7 @@
 .feedback-panel {
   z-index: 1;
   padding: 0 $pix-spacing-s;
-  color: $pix-neutral-60;
+  color: $pix-neutral-70;
   font-size: 0.938rem;
 }
 
@@ -35,7 +35,7 @@
 .feedback-panel__open-button:hover,
 .feedback-panel__open-button:focus-visible,
 .feedback-panel__open-button:active {
-  color: $pix-primary;
+  color: var(--pix-warning-700);
 }
 
 /* "Form" view


### PR DESCRIPTION
## :unicorn: Problème

Manque de contraste :
- au survol du bouton "Signaler un problème avec la question"
- du bouton de submit

## :robot: Proposition

- Comme sur la maquette, la couleur du survol de "Signaler un problème avec la question" est maintenant doré
- Le bouton est maintenant primary

## :100: Pour tester

Aller sur une épreuve en RA et constater des changements
