### PR TITLE
[TECH] Migration de l'oidc-authentication-service dans src (PIX-11623)

### DIFF
--- a/api/lib/domain/services/authentication/cnav-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/cnav-oidc-authentication-service.js
@@ -1,6 +1,6 @@
+import { OidcAuthenticationService } from '../../../../src/authentication/domain/services/oidc-authentication-service.js';
 import { config } from '../../../config.js';
 import { CNAV } from '../../constants/oidc-identity-providers.js';
-import { OidcAuthenticationService } from './oidc-authentication-service.js';
 
 const configKey = CNAV.configKey;
 

--- a/api/lib/domain/services/authentication/fwb-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/fwb-oidc-authentication-service.js
@@ -1,9 +1,9 @@
 import { randomUUID } from 'crypto';
 
+import { OidcAuthenticationService } from '../../../../src/authentication/domain/services/oidc-authentication-service.js';
 import { config } from '../../../config.js';
 import { temporaryStorage } from '../../../infrastructure/temporary-storage/index.js';
 import { FWB } from '../../constants/oidc-identity-providers.js';
-import { OidcAuthenticationService } from './oidc-authentication-service.js';
 
 const configKey = FWB.configKey;
 const logoutUrlTemporaryStorage = temporaryStorage.withPrefix('logout-url:');

--- a/api/lib/domain/services/authentication/google-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/google-oidc-authentication-service.js
@@ -1,6 +1,6 @@
+import { OidcAuthenticationService } from '../../../../src/authentication/domain/services/oidc-authentication-service.js';
 import { config } from '../../../config.js';
 import { GOOGLE } from '../../constants/oidc-identity-providers.js';
-import { OidcAuthenticationService } from './oidc-authentication-service.js';
 
 const configKey = GOOGLE.configKey;
 

--- a/api/lib/domain/services/authentication/paysdelaloire-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/paysdelaloire-oidc-authentication-service.js
@@ -1,6 +1,6 @@
+import { OidcAuthenticationService } from '../../../../src/authentication/domain/services/oidc-authentication-service.js';
 import { config } from '../../../../src/shared/config.js';
 import { PAYSDELALOIRE } from '../../constants/oidc-identity-providers.js';
-import { OidcAuthenticationService } from './oidc-authentication-service.js';
 
 const configKey = PAYSDELALOIRE.configKey;
 

--- a/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
@@ -1,12 +1,12 @@
 import { randomUUID } from 'crypto';
 import dayjs from 'dayjs';
 
+import { OidcAuthenticationService } from '../../../../src/authentication/domain/services/oidc-authentication-service.js';
 import { config } from '../../../config.js';
 import { DomainTransaction } from '../../../infrastructure/DomainTransaction.js';
 import { temporaryStorage } from '../../../infrastructure/temporary-storage/index.js';
 import { POLE_EMPLOI } from '../../constants/oidc-identity-providers.js';
-import { AuthenticationMethod } from '../../models/AuthenticationMethod.js';
-import { OidcAuthenticationService } from './oidc-authentication-service.js';
+import { AuthenticationMethod } from '../../models/index.js';
 
 const configKey = POLE_EMPLOI.configKey;
 const logoutUrlTemporaryStorage = temporaryStorage.withPrefix('logout-url:');

--- a/api/src/authentication/domain/services/oidc-authentication-service.js
+++ b/api/src/authentication/domain/services/oidc-authentication-service.js
@@ -3,16 +3,15 @@ import jsonwebtoken from 'jsonwebtoken';
 import lodash from 'lodash';
 import { Issuer } from 'openid-client';
 
-import { config } from '../../../../src/shared/config.js';
-import { OidcError } from '../../../../src/shared/domain/errors.js';
-import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
-import { DomainTransaction } from '../../../infrastructure/DomainTransaction.js';
-import { monitoringTools } from '../../../infrastructure/monitoring-tools.js';
-import { temporaryStorage } from '../../../infrastructure/temporary-storage/index.js';
-import { OIDC_ERRORS } from '../../constants.js';
-import { OidcMissingFieldsError } from '../../errors.js';
-import { AuthenticationMethod } from '../../models/AuthenticationMethod.js';
-import { AuthenticationSessionContent } from '../../models/AuthenticationSessionContent.js';
+import { OIDC_ERRORS } from '../../../../lib/domain/constants.js';
+import { OidcMissingFieldsError } from '../../../../lib/domain/errors.js';
+import { AuthenticationMethod, AuthenticationSessionContent } from '../../../../lib/domain/models/index.js';
+import { monitoringTools } from '../../../../lib/infrastructure/monitoring-tools.js';
+import { temporaryStorage } from '../../../../lib/infrastructure/temporary-storage/index.js';
+import { config } from '../../../shared/config.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { OidcError } from '../../../shared/domain/errors.js';
+import { logger } from '../../../shared/infrastructure/utils/logger.js';
 
 const DEFAULT_REQUIRED_PROPERTIES = ['clientId', 'clientSecret', 'redirectUri', 'openidConfigurationUrl'];
 const DEFAULT_SCOPE = 'openid profile';

--- a/api/tests/authentication/unit/domain/services/oidc-authentication-service_test.js
+++ b/api/tests/authentication/unit/domain/services/oidc-authentication-service_test.js
@@ -185,11 +185,12 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       // given
       const userId = 42;
       const accessToken = Symbol('valid access token');
-      settings.authentication.secret = 'a secret';
       const payload = { user_id: userId };
-      const secret = 'a secret';
       const jwtOptions = { expiresIn: 1 };
-      sinon.stub(jsonwebtoken, 'sign').withArgs(payload, secret, jwtOptions).returns(accessToken);
+      sinon
+        .stub(jsonwebtoken, 'sign')
+        .withArgs(payload, settings.authentication.secret, jwtOptions)
+        .returns(accessToken);
 
       const oidcAuthenticationService = new OidcAuthenticationService({ jwtOptions });
 
@@ -743,9 +744,9 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
 
     beforeEach(function () {
       domainTransaction = Symbol();
-      DomainTransaction.execute = (lambda) => {
+      sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => {
         return lambda(domainTransaction);
-      };
+      });
 
       userToCreateRepository = {
         create: sinon.stub(),

--- a/api/tests/authentication/unit/domain/services/oidc-authentication-service_test.js
+++ b/api/tests/authentication/unit/domain/services/oidc-authentication-service_test.js
@@ -5,12 +5,14 @@ import { config as settings } from '../../../../../lib/config.js';
 import { OIDC_ERRORS } from '../../../../../lib/domain/constants.js';
 import * as OidcIdentityProviders from '../../../../../lib/domain/constants/oidc-identity-providers.js';
 import { OidcMissingFieldsError } from '../../../../../lib/domain/errors.js';
-import { AuthenticationMethod } from '../../../../../lib/domain/models/AuthenticationMethod.js';
-import { AuthenticationSessionContent } from '../../../../../lib/domain/models/AuthenticationSessionContent.js';
-import { UserToCreate } from '../../../../../lib/domain/models/UserToCreate.js';
-import { OidcAuthenticationService } from '../../../../../lib/domain/services/authentication/oidc-authentication-service.js';
-import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';
+import {
+  AuthenticationMethod,
+  AuthenticationSessionContent,
+  UserToCreate,
+} from '../../../../../lib/domain/models/index.js';
 import { monitoringTools } from '../../../../../lib/infrastructure/monitoring-tools.js';
+import { OidcAuthenticationService } from '../../../../../src/authentication/domain/services/oidc-authentication-service.js';
+import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
 import { OidcError } from '../../../../../src/shared/domain/errors.js';
 import { logger } from '../../../../../src/shared/infrastructure/utils/logger.js';
 import { catchErr, catchErrSync, expect, sinon } from '../../../../test-helper.js';

--- a/api/tests/tooling/server/hapi-server-with-test-oidc-provider.js
+++ b/api/tests/tooling/server/hapi-server-with-test-oidc-provider.js
@@ -1,7 +1,7 @@
 import nock from 'nock';
 
-import { OidcAuthenticationService } from '../../../lib/domain/services/authentication/oidc-authentication-service.js';
 import { createServer } from '../../../server.js';
+import { OidcAuthenticationService } from '../../../src/authentication/domain/services/oidc-authentication-service.js';
 
 const openIdConfigurationResponse = {
   token_endpoint: 'https://oidc.example.net/ea5ac20c-5076-4806-860a-b0aeb01645d4/oauth2/v2.0/token',

--- a/api/tests/unit/setup-oidc-authentication-service-registry_test.js
+++ b/api/tests/unit/setup-oidc-authentication-service-registry_test.js
@@ -1,6 +1,6 @@
 import { setupOidcAuthenticationServiceRegistry } from '../../config/setup-oidc-authentication-service-registry.js';
 import { oidcAuthenticationServiceRegistry } from '../../lib/domain/services/authentication/authentication-service-registry.js';
-import { OidcAuthenticationService } from '../../lib/domain/services/authentication/oidc-authentication-service.js';
+import { OidcAuthenticationService } from '../../src/authentication/domain/services/oidc-authentication-service.js';
 import { expect, sinon } from '../test-helper.js';
 
 describe('Unit | Config | setup-oidc-authentication-service-registry', function () {


### PR DESCRIPTION
## :unicorn: Problème

L'oidc-authentication-service se trouve encore dans `lib/` et c'est un bon candidat pour migration vers `src/authentication`.

## :robot: Proposition

Déplacer oidc-authentication-service et ses tests unitaires de `lib/` vers `src/authentication`.

## :rainbow: Remarques

En réalisant cette migration nous nous sommes rendus compte que des tests effectuaient des modifications provoquant des effets de bord. Cela a été corrigé dans le 2ème commit. Et il serait bon de propager ces corrections salutaires dans le reste du code.

## :100: Pour tester

Vérifier que la CI passe.