### PR TITLE
[TECH] Supprime le champ title et description du tube

### DIFF
--- a/api/lib/domain/models/Tube.js
+++ b/api/lib/domain/models/Tube.js
@@ -4,8 +4,6 @@ class Tube {
   constructor({
     id,
     name,
-    title,
-    description,
     practicalTitle,
     practicalDescription,
     isMobileCompliant,
@@ -16,8 +14,6 @@ class Tube {
     skillIds,
   }) {
     this.id = id;
-    this.title = title;
-    this.description = description;
     this.practicalTitle = practicalTitle;
     this.practicalDescription = practicalDescription;
     this.isMobileCompliant = isMobileCompliant;

--- a/api/lib/infrastructure/repositories/tube-repository.js
+++ b/api/lib/infrastructure/repositories/tube-repository.js
@@ -13,8 +13,6 @@ function _toDomain({ tubeData, locale }) {
   return new Tube({
     id: tubeData.id,
     name: tubeData.name,
-    title: tubeData.title,
-    description: tubeData.description,
     practicalTitle: translatedPracticalTitle,
     practicalDescription: translatedPracticalDescription,
     isMobileCompliant: tubeData.isMobileCompliant,

--- a/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
@@ -85,8 +85,6 @@ describe('Integration | Repository | training-repository', function () {
       tube = domainBuilder.buildTube({
         id: 'recTube0',
         name: 'tubeName',
-        title: 'tubeTitle',
-        description: 'tubeDescription',
         practicalTitle: 'translatedPracticalTitle',
         practicalDescription: 'translatedPracticalDescription',
         isMobileCompliant: true,
@@ -369,8 +367,6 @@ describe('Integration | Repository | training-repository', function () {
       tube = domainBuilder.buildTube({
         id: 'recTube0',
         name: 'tubeName',
-        title: 'tubeTitle',
-        description: 'tubeDescription',
         practicalTitle: 'translatedPracticalTitle',
         practicalDescription: 'translatedPracticalDescription',
         isMobileCompliant: true,

--- a/api/tests/devcomp/integration/infrastructure/repositories/training-trigger-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/training-trigger-repository_test.js
@@ -26,8 +26,6 @@ describe('Integration | Repository | training-trigger-repository', function () {
     tube = domainBuilder.buildTube({
       id: 'recTube0',
       name: 'tubeName',
-      title: 'tubeTitle',
-      description: 'tubeDescription',
       practicalTitle: 'translatedPracticalTitle',
       practicalDescription: 'translatedPracticalDescription',
       isMobileCompliant: true,
@@ -40,8 +38,6 @@ describe('Integration | Repository | training-trigger-repository', function () {
     tube1 = domainBuilder.buildTube({
       id: 'recTube1',
       name: 'tubeName1',
-      title: 'tubeTitle1',
-      description: 'tubeDescription1',
       practicalTitle: 'translatedPracticalTitle',
       practicalDescription: 'translatedPracticalDescription',
       isMobileCompliant: true,
@@ -54,8 +50,6 @@ describe('Integration | Repository | training-trigger-repository', function () {
     tube2 = domainBuilder.buildTube({
       id: 'recTube2',
       name: 'tubeName2',
-      title: 'tubeTitle2',
-      description: 'tubeDescription2',
       practicalTitle: 'translatedPracticalTitle',
       practicalDescription: 'translatedPracticalDescription',
       isMobileCompliant: true,

--- a/api/tests/integration/infrastructure/repositories/tube-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tube-repository_test.js
@@ -8,8 +8,6 @@ describe('Integration | Repository | tube-repository', function () {
       const expectedTube = domainBuilder.buildTube({
         id: 'recTube0',
         name: 'tubeName',
-        title: 'tubeTitle',
-        description: 'tubeDescription',
         practicalTitle: 'translatedPracticalTitle',
         practicalDescription: 'translatedPracticalDescription',
         isMobileCompliant: true,
@@ -56,8 +54,6 @@ describe('Integration | Repository | tube-repository', function () {
       const tube0 = domainBuilder.buildTube({
         id: 'recTube0',
         name: 'tubeName0',
-        title: 'tubeTitle0',
-        description: 'tubeDescription0',
         practicalTitle: 'translatedPracticalTitle0',
         practicalDescription: 'translatedPracticalDescription0',
         isMobileCompliant: true,
@@ -70,8 +66,6 @@ describe('Integration | Repository | tube-repository', function () {
       const tube1 = domainBuilder.buildTube({
         id: 'recTube1',
         name: 'tubeName1',
-        title: 'tubeTitle1',
-        description: 'tubeDescription1',
         practicalTitle: 'translatedPracticalTitle1',
         practicalDescription: 'translatedPracticalDescription1',
         isMobileCompliant: false,
@@ -84,8 +78,6 @@ describe('Integration | Repository | tube-repository', function () {
       const learningContentTube0 = {
         id: 'recTube0',
         name: 'tubeName0',
-        title: 'tubeTitle0',
-        description: 'tubeDescription0',
         practicalTitle_i18n: {
           fr: 'translatedPracticalTitle0',
         },
@@ -102,8 +94,6 @@ describe('Integration | Repository | tube-repository', function () {
       const learningContentTube1 = {
         id: 'recTube1',
         name: 'tubeName1',
-        title: 'tubeTitle1',
-        description: 'tubeDescription1',
         practicalTitle_i18n: {
           fr: 'translatedPracticalTitle1',
         },
@@ -134,8 +124,6 @@ describe('Integration | Repository | tube-repository', function () {
       const tube0 = domainBuilder.buildTube({
         id: 'recTube0',
         name: 'tubeName0',
-        title: 'tubeTitle0',
-        description: 'tubeDescription0',
         practicalTitle: 'translatedPracticalTitle0',
         practicalDescription: 'translatedPracticalDescription0',
         isMobileCompliant: true,
@@ -149,8 +137,6 @@ describe('Integration | Repository | tube-repository', function () {
       const tube1 = domainBuilder.buildTube({
         id: 'recTube1',
         name: 'tubeName1',
-        title: 'tubeTitle1',
-        description: 'tubeDescription1',
         practicalTitle: 'translatedPracticalTitle1',
         practicalDescription: 'translatedPracticalDescription1',
         isMobileCompliant: false,
@@ -164,8 +150,6 @@ describe('Integration | Repository | tube-repository', function () {
       const learningContentTube0 = {
         id: 'recTube0',
         name: 'tubeName0',
-        title: 'tubeTitle0',
-        description: 'tubeDescription0',
         practicalTitle_i18n: {
           fr: 'translatedPracticalTitle0',
         },
@@ -182,8 +166,6 @@ describe('Integration | Repository | tube-repository', function () {
       const learningContentTube1 = {
         id: 'recTube1',
         name: 'tubeName1',
-        title: 'tubeTitle1',
-        description: 'tubeDescription1',
         practicalTitle_i18n: {
           fr: 'translatedPracticalTitle1',
         },
@@ -212,8 +194,6 @@ describe('Integration | Repository | tube-repository', function () {
         const expectedTube = domainBuilder.buildTube({
           id: 'recTube0',
           name: 'tubeName',
-          title: 'tubeTitle',
-          description: 'tubeDescription',
           practicalTitle: 'translatedPracticalTitle',
           practicalDescription: 'translatedPracticalDescription',
           isMobileCompliant: true,
@@ -228,8 +208,6 @@ describe('Integration | Repository | tube-repository', function () {
             {
               id: 'recTube0',
               name: 'tubeName',
-              title: 'tubeTitle',
-              description: 'tubeDescription',
               practicalTitle_i18n: {
                 fr: 'translatedPracticalTitle',
               },
@@ -261,8 +239,6 @@ describe('Integration | Repository | tube-repository', function () {
         const expectedTube = domainBuilder.buildTube({
           id: 'recTube0',
           name: 'tubeName',
-          title: 'tubeTitle',
-          description: 'tubeDescription',
           practicalTitle: 'translatedPracticalTitleEnUs',
           practicalDescription: 'translatedPracticalDescriptionEnUs',
           isMobileCompliant: true,
@@ -277,8 +253,6 @@ describe('Integration | Repository | tube-repository', function () {
             {
               id: 'recTube0',
               name: 'tubeName',
-              title: 'tubeTitle',
-              description: 'tubeDescription',
               practicalTitle_i18n: {
                 fr: 'translatedPracticalTitle',
                 en: 'translatedPracticalTitleEnUs',
@@ -313,8 +287,6 @@ describe('Integration | Repository | tube-repository', function () {
       const learningContentTube0 = {
         id: 'recTube0',
         name: 'tubeName0',
-        title: 'tubeTitle0',
-        description: 'tubeDescription0',
         practicalTitle_i18n: {
           fr: 'practicalTitreFR0',
           en: 'practicalTitreEN0',
@@ -332,8 +304,6 @@ describe('Integration | Repository | tube-repository', function () {
       const learningContentTube1 = {
         id: 'recTube1',
         name: 'tubeName1',
-        title: 'tubeTitle1',
-        description: 'tubeDescription1',
         practicalTitle_i18n: {
           fr: 'practicalTitreFR1',
           en: 'practicalTitreEN1',
@@ -351,8 +321,6 @@ describe('Integration | Repository | tube-repository', function () {
       const learningContentTube2 = {
         id: 'recTube2',
         name: 'tubeName2',
-        title: 'tubeTitle2',
-        description: 'tubeDescription2',
         practicalTitle_i18n: {
           fr: 'practicalTitreFR2',
           en: 'practicalTitreEN2',
@@ -389,8 +357,6 @@ describe('Integration | Repository | tube-repository', function () {
       const tube1 = domainBuilder.buildTube({
         id: 'recTube1',
         name: 'tubeName1',
-        title: 'tubeTitle1',
-        description: 'tubeDescription1',
         practicalTitle: 'practicalTitreFR1',
         practicalDescription: 'practicalDescriptionFR1',
         isMobileCompliant: false,
@@ -403,8 +369,6 @@ describe('Integration | Repository | tube-repository', function () {
       const tube2 = domainBuilder.buildTube({
         id: 'recTube2',
         name: 'tubeName2',
-        title: 'tubeTitle2',
-        description: 'tubeDescription2',
         practicalTitle: 'practicalTitreFR2',
         practicalDescription: 'practicalDescriptionFR2',
         isMobileCompliant: true,
@@ -427,8 +391,6 @@ describe('Integration | Repository | tube-repository', function () {
       const tube1 = domainBuilder.buildTube({
         id: 'recTube1',
         name: 'tubeName1',
-        title: 'tubeTitle1',
-        description: 'tubeDescription1',
         practicalTitle: 'practicalTitreEN1',
         practicalDescription: 'practicalDescriptionEN1',
         isMobileCompliant: false,
@@ -441,8 +403,6 @@ describe('Integration | Repository | tube-repository', function () {
       const tube2 = domainBuilder.buildTube({
         id: 'recTube2',
         name: 'tubeName2',
-        title: 'tubeTitle2',
-        description: 'tubeDescription2',
         practicalTitle: 'practicalTitreEN2',
         practicalDescription: 'practicalDescriptionEN2',
         isMobileCompliant: true,
@@ -467,8 +427,6 @@ describe('Integration | Repository | tube-repository', function () {
       const tube1 = domainBuilder.buildTube({
         id: 'recTube1',
         name: 'tubeName1',
-        title: 'tubeTitle1',
-        description: 'tubeDescription1',
         practicalTitle: 'translatedPracticalTitle1',
         practicalDescription: 'translatedPracticalDescription1',
         isMobileCompliant: true,
@@ -482,8 +440,6 @@ describe('Integration | Repository | tube-repository', function () {
       const learningContentTube0 = {
         id: 'recTube0',
         name: 'tubeName0',
-        title: 'tubeTitle0',
-        description: 'tubeDescription0',
         practicalTitle_i18n: {
           fr: 'translatedPracticalTitle0',
         },
@@ -500,8 +456,6 @@ describe('Integration | Repository | tube-repository', function () {
       const learningContentTube1 = {
         id: 'recTube1',
         name: 'tubeName1',
-        title: 'tubeTitle1',
-        description: 'tubeDescription1',
         practicalTitle_i18n: {
           fr: 'translatedPracticalTitle1',
         },
@@ -518,8 +472,6 @@ describe('Integration | Repository | tube-repository', function () {
       const learningContentTube2 = {
         id: 'recTube2',
         name: 'tubeName2',
-        title: 'tubeTitle2',
-        description: 'tubeDescription2',
         practicalTitle_i18n: {
           fr: 'translatedPracticalTitle2',
         },
@@ -565,8 +517,6 @@ describe('Integration | Repository | tube-repository', function () {
       const tube1 = domainBuilder.buildTube({
         id: 'recTube1',
         name: 'tubeName1',
-        title: 'tubeTitle1',
-        description: 'tubeDescription1',
         practicalTitle: 'translatedPracticalTitle1EnUs',
         practicalDescription: 'translatedPracticalDescription1EnUs',
         isMobileCompliant: true,
@@ -580,8 +530,6 @@ describe('Integration | Repository | tube-repository', function () {
       const learningContentTube0 = {
         id: 'recTube0',
         name: 'tubeName0',
-        title: 'tubeTitle0',
-        description: 'tubeDescription0',
         practicalTitle_i18n: {
           fr: 'translatedPracticalTitle0',
           en: 'translatedPracticalTitle0EnUs',
@@ -600,8 +548,6 @@ describe('Integration | Repository | tube-repository', function () {
       const learningContentTube1 = {
         id: 'recTube1',
         name: 'tubeName1',
-        title: 'tubeTitle1',
-        description: 'tubeDescription1',
         practicalTitle_i18n: {
           fr: 'translatedPracticalTitle1',
           en: 'translatedPracticalTitle1EnUs',
@@ -620,8 +566,6 @@ describe('Integration | Repository | tube-repository', function () {
       const learningContentTube2 = {
         id: 'recTube2',
         name: 'tubeName2',
-        title: 'tubeTitle2',
-        description: 'tubeDescription2',
         practicalTitle_i18n: {
           fr: 'translatedPracticalTitle2',
           en: 'translatedPracticalTitle2EnUs',

--- a/api/tests/tooling/domain-builder/factory/build-tube.js
+++ b/api/tests/tooling/domain-builder/factory/build-tube.js
@@ -4,8 +4,6 @@ import { BuildSkillCollection as buildSkillCollection } from './build-skill-coll
 const buildTube = function ({
   id = 'recTube123',
   name = '@tubeName',
-  title = 'titre',
-  description = 'description',
   practicalTitle = 'titre pratique',
   practicalDescription = 'description pratique',
   isMobileCompliant = false,
@@ -18,8 +16,6 @@ const buildTube = function ({
   return new Tube({
     id,
     name,
-    title,
-    description,
     practicalTitle,
     practicalDescription,
     isMobileCompliant,

--- a/api/tests/tooling/learning-content-builder/build-tube.js
+++ b/api/tests/tooling/learning-content-builder/build-tube.js
@@ -1,8 +1,6 @@
 const buildTube = function ({
   id = 'recTube123',
   name = '@tubeName',
-  title = 'titre',
-  description = 'description',
   practicalTitle_i18n = {
     fr: 'titre pratique',
   },
@@ -18,8 +16,6 @@ const buildTube = function ({
   return {
     id,
     name,
-    title,
-    description,
     practicalTitle_i18n,
     practicalDescription_i18n,
     isMobileCompliant,


### PR DESCRIPTION
## :unicorn: Problème
Les champs title et description du Tube ne doivent plus être utilisés.

## :robot: Proposition
Les supprimer.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- Tests verts
- Pix admin: création d'un profil cible
- Orga: la page de création du json de profil cible