### PR TITLE
[BUGFIX] Éviter les 2 écrans intermédiaires en fin de parcours (PIX-11203).

### DIFF
--- a/mon-pix/app/components/checkpoint-continue.js
+++ b/mon-pix/app/components/checkpoint-continue.js
@@ -3,7 +3,6 @@ import Component from '@glimmer/component';
 export default class CheckpointContinue extends Component {
   get query() {
     return {
-      assessmentHasNoMoreQuestions: this.args.finalCheckpoint,
       hasSeenCheckpoint: true,
     };
   }

--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -55,14 +55,6 @@ export default class ChallengeRoute extends Route {
     });
   }
 
-  async redirect(model) {
-    if (!model.challenge) {
-      return this.router.replaceWith('assessments.resume', model.assessment.id, {
-        queryParams: { assessmentHasNoMoreQuestions: true },
-      });
-    }
-  }
-
   serialize(model) {
     return {
       assessment_id: model.assessment.id,

--- a/mon-pix/app/routes/authenticated/competences/resume.js
+++ b/mon-pix/app/routes/authenticated/competences/resume.js
@@ -12,7 +12,7 @@ export default class ResumeRoute extends Route {
     return this.store.queryRecord('competenceEvaluation', { competenceId, startOrResume: true });
   }
 
-  async afterModel(competenceEvaluation) {
+  async redirect(competenceEvaluation) {
     const assessment = await competenceEvaluation.assessment;
     return this.router.replaceWith('assessments.resume', assessment.id);
   }

--- a/mon-pix/app/routes/courses/start.js
+++ b/mon-pix/app/routes/courses/start.js
@@ -9,7 +9,7 @@ export default class CreateAssessmentRoute extends Route {
     return this.store.findRecord('course', params.course_id);
   }
 
-  async afterModel(course) {
+  async redirect(course) {
     const assessment = await this.store.createRecord('assessment', { course, type: 'DEMO' }).save();
     return this.router.replaceWith('assessments.resume', assessment.id);
   }

--- a/mon-pix/tests/unit/routes/authenticated/competences/resume_test.js
+++ b/mon-pix/tests/unit/routes/authenticated/competences/resume_test.js
@@ -43,14 +43,14 @@ module('Unit | Route | Competence | Resume', function (hooks) {
     });
   });
 
-  module('#afterModel', function () {
+  module('#redirect', function () {
     test('should transition to assessments.resume', async function (assert) {
       // given
       route.router.replaceWith.returns();
       const competenceEvaluation = EmberObject.create({ competenceId, assessment: { id: 'assessmentId' } });
 
       // when
-      await route.afterModel(competenceEvaluation);
+      await route.redirect(competenceEvaluation);
 
       // then
       sinon.assert.calledOnce(route.router.replaceWith);

--- a/mon-pix/tests/unit/routes/courses/start_test.js
+++ b/mon-pix/tests/unit/routes/courses/start_test.js
@@ -25,10 +25,10 @@ module('Unit | Route | Courses | Start', function (hooks) {
     route.router = { replaceWith: sinon.stub() };
   });
 
-  module('#afterModel', function () {
+  module('#redirect', function () {
     test('should call the creation of a new assessment', async function (assert) {
       // when
-      await route.afterModel(course);
+      await route.redirect(course);
 
       // then
       sinon.assert.calledWith(createRecordStub, 'assessment', { course, type: course.type });
@@ -37,7 +37,7 @@ module('Unit | Route | Courses | Start', function (hooks) {
 
     test('should redirect to resume assessment route', async function (assert) {
       // when
-      await route.afterModel(course);
+      await route.redirect(course);
 
       // then
       sinon.assert.calledWith(route.router.replaceWith, 'assessments.resume', createdAssessment.id);


### PR DESCRIPTION
## :unicorn: Problème

L'écran intermédiaire apparait 2 fois dans certains cas en fin de parcours (ex: ABCDiag).

## :robot: Proposition

Checker s'il y a encore une épreuve à proposer avant d'arriver dans la page de checkpoint.

## :100: Pour tester

En RA, passer toutes les épreuves de la compétence "Gérer des données" et constater qu'il n'y a eu qu'un seul checkpoint à la fin (après la 15e épreuve passée).
