### PR TITLE
[FEATURE][ADMIN] Permettre la création d'organisations en masse avec toutes les locales gérées (PIX-11550)

### DIFF
--- a/api/lib/domain/validators/organization-with-tags-and-target-profiles-script.js
+++ b/api/lib/domain/validators/organization-with-tags-and-target-profiles-script.js
@@ -1,8 +1,11 @@
 import Joi from 'joi';
 
+import { SUPPORTED_LOCALES } from '../../../src/shared/domain/constants.js';
 import { EntityValidationError } from '../../../src/shared/domain/errors.js';
 import { Membership } from '../models/Membership.js';
 import { Organization } from '../models/Organization.js';
+
+const supportedLocales = SUPPORTED_LOCALES.map((supportedLocale) => supportedLocale.toLocaleLowerCase());
 
 const schema = Joi.object({
   type: Joi.string()
@@ -21,10 +24,14 @@ const schema = Joi.object({
   tags: Joi.string().required().messages({
     'string.empty': 'Les tags ne sont pas renseignés.',
   }),
-  locale: Joi.string().required().valid('fr-fr', 'fr', 'en').default('fr-fr').messages({
-    'string.empty': "La locale n'est pas renseignée.",
-    'any.only': "La locale doit avoir l'une des valeurs suivantes : fr-fr, fr ou en",
-  }),
+  locale: Joi.string()
+    .required()
+    .valid(...supportedLocales)
+    .default('fr-fr')
+    .messages({
+      'string.empty': "La locale n'est pas renseignée.",
+      'any.only': `La locale doit avoir l'une des valeurs suivantes : ${supportedLocales.join(', ')}`,
+    }),
   identityProviderForCampaigns: Joi.string().allow(null),
   provinceCode: Joi.string().required().allow('', null),
   credit: Joi.number().required().messages({

--- a/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
+++ b/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
@@ -259,7 +259,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           },
           {
             attribute: 'locale',
-            message: "La locale doit avoir l'une des valeurs suivantes : fr-fr, fr ou en",
+            message: "La locale doit avoir l'une des valeurs suivantes : en, fr, fr-be, fr-fr, nl-be",
           },
           {
             attribute: 'locale',

--- a/api/tests/unit/domain/validators/organization-with-tags-and-target-profiles-script_test.js
+++ b/api/tests/unit/domain/validators/organization-with-tags-and-target-profiles-script_test.js
@@ -1,0 +1,63 @@
+import { validate } from '../../../../lib/domain/validators/organization-with-tags-and-target-profiles-script.js';
+import { SUPPORTED_LOCALES } from '../../../../src/shared/domain/constants.js';
+import { EntityValidationError } from '../../../../src/shared/domain/errors.js';
+import { catchErrSync, expect } from '../../../test-helper.js';
+
+const supportedLocales = SUPPORTED_LOCALES.map((supportedLocale) => supportedLocale.toLocaleLowerCase());
+
+describe('Unit | Domain | Validators | organization-with-tags-and-target-profiles-script', function () {
+  const DEFAULT_ORGANIZATION = {
+    createdBy: 1234,
+    credit: 0,
+    externalId: 'EXT_ID_123',
+    locale: 'fr-fr',
+    name: 'Orga Name',
+    provinceCode: '123',
+    tags: 'TAG1',
+    type: 'SCO',
+  };
+
+  context('success', function () {
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    supportedLocales.forEach((locale) => {
+      context(`when locale is ${locale}`, function () {
+        it('returns true', function () {
+          // given
+          const organization = {
+            ...DEFAULT_ORGANIZATION,
+            locale,
+          };
+
+          // when
+          const result = validate(organization);
+
+          // then
+          expect(result).to.be.true;
+        });
+      });
+    });
+  });
+
+  context('error', function () {
+    context(`when locale is not supported`, function () {
+      it('returns an EntityValidation error', function () {
+        // given
+        const organization = {
+          ...DEFAULT_ORGANIZATION,
+          locale: 'pt-br',
+        };
+
+        // when
+        const error = catchErrSync(validate)(organization);
+
+        // then
+        expect(error).to.be.instanceOf(EntityValidationError);
+        expect(error.message).to.equal(`Échec de validation de l'entité.`);
+        expect(error.invalidAttributes).to.deep.include({
+          attribute: 'locale',
+          message: `La locale doit avoir l'une des valeurs suivantes : en, fr, fr-be, fr-fr, nl-be`,
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, il n'est pas possible de créer en masse des organisations avec une locale différente de la liste suivante : `fr-fr`, `fr`, `en`. Or, nous supportons également les locales suivantes : `fr-be`, `nl-be`.

## :robot: Proposition

Modifier le schéma Joi pour prendre en compte **toutes** les locales gérées.

## :rainbow: Remarques

RAS

## :100: Pour tester

1. Se connecter sur **Pix Admin** (https://admin-pr8397.review.pix.fr/) avec un compte ayant le rôle **SUPER_ADMIN** (superadmin@example.net)
2. Cliquer sur l'onglet **Administration**
3. Cliquer sur le bouton **Importer un fichier CSV** du bloc **Création en masse d'organisations**
4. Importer un CSV contenant une organisation ayant une locale supportée. Ne pas oublier d'ajouter l'id du compte sur lequel vous êtes connecté en tant que créateur de l'organisation (colonne createdBy).
5. Constater l'affichage d'une notification de succès

Voici un fichier CSV pour vos tests

```csv
type,externalId,name,provinceCode,credit,emailInvitations,emailForSCOActivation,organizationInvitationRole,locale,tags,createdBy,documentationUrl,targetProfiles,isManagingStudents,identityProviderForCampaigns,DPOFirstName,DPOLastName,DPOEmail
PRO,EXT_ID_1,PRO Orga 1,,,,,ADMIN,fr-fr,PUBLIC,90000,,,,,,,
PRO,EXT_ID_12,PRO Orga 2,,,,,ADMIN,fr-be,PUBLIC_AEFE_MEDNUM,90000,,,,,,,
SCO,EXT_ID_123,SCO Orga 1,,,,,ADMIN,en,PUBLIC_CFA,90000,,,,,,,
SCO-1D,EXT_ID_1234,SCO-1D Orga 1,,,,,ADMIN,nl-be,PUBLIC_AEFE_MEDNUM,90000,,,,,,,
SCO-1D,EXT_ID_1235,SCO-1D Orga 2,,,,,ADMIN,fr,PUBLIC_CFA,90000,,,,,,,
```