### PR TITLE
[BUGFIX] Correction d'une référence de grain dans une transition

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
@@ -32,7 +32,7 @@
     },
     {
       "content": "<p>Vérifions que vous avez compris l'essentiel avec quelques exemples.</p>",
-      "grainId": "27c3d4e9-cdee-452f-8c63-f780b890776e"
+      "grainId": "65e80d85-4590-4662-8765-f1b3d995f21a"
     },
     {
       "content": "<p>En plus des règles que vous venez de voir, voici aussi quelques astuces pour vous aider à créer vos mots de passe.&nbsp;<span aria-hidden=\"true\">💡</span></p>",


### PR DESCRIPTION
## :unicorn: Problème
Depuis  #8356, Un texte de transition référence un grain inexistant.

## :robot: Proposition
Corriger l'identifiant de grain référencé.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que l'accès au module [`mots-de-passe-securises`](https://app-pr8406.review.pix.fr/) est corrigé.
