### PR TITLE
[FEATURE] Retourner une erreur lorsque les données du référentiel Modulix ne sont pas cohérentes

### DIFF
--- a/api/src/devcomp/application/http-error-mapper-configuration.js
+++ b/api/src/devcomp/application/http-error-mapper-configuration.js
@@ -1,12 +1,23 @@
 import { HttpErrors } from '../../shared/application/http-errors.js';
 import { DomainErrorMappingConfiguration } from '../../shared/application/models/domain-error-mapping-configuration.js';
-import { ModuleDoesNotExistError, PassageDoesNotExistError, PassageTerminatedError } from '../domain/errors.js';
+import {
+  ModuleDoesNotExistError,
+  ModuleInstantiationError,
+  PassageDoesNotExistError,
+  PassageTerminatedError,
+} from '../domain/errors.js';
 
 const devcompDomainErrorMappingConfiguration = [
   {
     name: ModuleDoesNotExistError.name,
     httpErrorFn: (error) => {
       return new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta);
+    },
+  },
+  {
+    name: ModuleInstantiationError.name,
+    httpErrorFn: (error) => {
+      return new HttpErrors.BadGatewayError(error.message, error.code, error.meta);
     },
   },
   {

--- a/api/src/devcomp/domain/errors.js
+++ b/api/src/devcomp/domain/errors.js
@@ -6,6 +6,12 @@ class ModuleDoesNotExistError extends DomainError {
   }
 }
 
+class ModuleInstantiationError extends DomainError {
+  constructor(message = 'The module can not be instantiated due to incoherent data') {
+    super(message);
+  }
+}
+
 class PassageDoesNotExistError extends DomainError {
   constructor(message = 'The passage does not exist') {
     super(message);
@@ -24,4 +30,10 @@ class UserNotAuthorizedToFindTrainings extends DomainError {
   }
 }
 
-export { ModuleDoesNotExistError, PassageDoesNotExistError, PassageTerminatedError, UserNotAuthorizedToFindTrainings };
+export {
+  ModuleDoesNotExistError,
+  ModuleInstantiationError,
+  PassageDoesNotExistError,
+  PassageTerminatedError,
+  UserNotAuthorizedToFindTrainings,
+};

--- a/api/src/devcomp/domain/models/module/Module.js
+++ b/api/src/devcomp/domain/models/module/Module.js
@@ -1,6 +1,7 @@
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
+import { ModuleInstantiationError } from '../../errors.js';
 import { BlockInput } from '../block/BlockInput.js';
 import { BlockSelect } from '../block/BlockSelect.js';
 import { BlockSelectOption } from '../block/BlockSelectOption.js';
@@ -39,85 +40,93 @@ class Module {
   }
 
   static toDomain(moduleData) {
-    return new Module({
-      id: moduleData.id,
-      slug: moduleData.slug,
-      title: moduleData.title,
-      transitionTexts: moduleData.transitionTexts?.map((transitionText) => new TransitionText(transitionText)) ?? [],
-      details: new Details(moduleData.details),
-      grains: moduleData.grains.map((grain) => {
-        return new Grain({
-          id: grain.id,
-          title: grain.title,
-          type: grain.type,
-          elements: grain.elements
-            .map((element) => {
-              switch (element.type) {
-                case 'image':
-                  return Module.#toImageDomain(element);
-                case 'text':
-                  return Module.#toTextDomain(element);
-                case 'qcm':
-                  return Module.#toQCMDomain(element);
-                case 'qcu':
-                  return Module.#toQCUDomain(element);
-                case 'qrocm':
-                  return Module.#toQROCMDomain(element);
-                case 'video':
-                  return Module.#toVideoDomain(element);
-                default:
-                  logger.warn({
-                    event: 'module_element_type_unknown',
-                    message: `Element inconnu: ${element.type}`,
-                  });
-                  return undefined;
-              }
-            })
-            .filter((element) => element !== undefined),
-        });
-      }),
-    });
+    try {
+      return new Module({
+        id: moduleData.id,
+        slug: moduleData.slug,
+        title: moduleData.title,
+        transitionTexts: moduleData.transitionTexts?.map((transitionText) => new TransitionText(transitionText)) ?? [],
+        details: new Details(moduleData.details),
+        grains: moduleData.grains.map((grain) => {
+          return new Grain({
+            id: grain.id,
+            title: grain.title,
+            type: grain.type,
+            elements: grain.elements
+              .map((element) => {
+                switch (element.type) {
+                  case 'image':
+                    return Module.#toImageDomain(element);
+                  case 'text':
+                    return Module.#toTextDomain(element);
+                  case 'qcm':
+                    return Module.#toQCMDomain(element);
+                  case 'qcu':
+                    return Module.#toQCUDomain(element);
+                  case 'qrocm':
+                    return Module.#toQROCMDomain(element);
+                  case 'video':
+                    return Module.#toVideoDomain(element);
+                  default:
+                    logger.warn({
+                      event: 'module_element_type_unknown',
+                      message: `Element inconnu: ${element.type}`,
+                    });
+                    return undefined;
+                }
+              })
+              .filter((element) => element !== undefined),
+          });
+        }),
+      });
+    } catch (e) {
+      throw new ModuleInstantiationError(e.message);
+    }
   }
 
   static toDomainForVerification(moduleData) {
-    return new Module({
-      id: moduleData.id,
-      slug: moduleData.slug,
-      title: moduleData.title,
-      details: new Details(moduleData.details),
-      transitionTexts: moduleData.transitionTexts?.map((transitionText) => new TransitionText(transitionText)) ?? [],
-      grains: moduleData.grains.map((grain) => {
-        return new Grain({
-          id: grain.id,
-          title: grain.title,
-          type: grain.type,
-          elements: grain.elements
-            .map((element) => {
-              switch (element.type) {
-                case 'image':
-                  return Module.#toImageDomain(element);
-                case 'text':
-                  return Module.#toTextDomain(element);
-                case 'qcu':
-                  return Module.#toQCUForAnswerVerificationDomain(element);
-                case 'qcm':
-                  return Module.#toQCMForAnswerVerificationDomain(element);
-                case 'qrocm':
-                  return Module.#toQROCMForAnswerVerificationDomain(element);
-                case 'video':
-                  return Module.#toVideoDomain(element);
-                default:
-                  logger.warn({
-                    event: 'module_element_type_unknown',
-                    message: `Element inconnu: ${element.type}`,
-                  });
-                  return undefined;
-              }
-            })
-            .filter((element) => element !== undefined),
-        });
-      }),
-    });
+    try {
+      return new Module({
+        id: moduleData.id,
+        slug: moduleData.slug,
+        title: moduleData.title,
+        details: new Details(moduleData.details),
+        transitionTexts: moduleData.transitionTexts?.map((transitionText) => new TransitionText(transitionText)) ?? [],
+        grains: moduleData.grains.map((grain) => {
+          return new Grain({
+            id: grain.id,
+            title: grain.title,
+            type: grain.type,
+            elements: grain.elements
+              .map((element) => {
+                switch (element.type) {
+                  case 'image':
+                    return Module.#toImageDomain(element);
+                  case 'text':
+                    return Module.#toTextDomain(element);
+                  case 'qcu':
+                    return Module.#toQCUForAnswerVerificationDomain(element);
+                  case 'qcm':
+                    return Module.#toQCMForAnswerVerificationDomain(element);
+                  case 'qrocm':
+                    return Module.#toQROCMForAnswerVerificationDomain(element);
+                  case 'video':
+                    return Module.#toVideoDomain(element);
+                  default:
+                    logger.warn({
+                      event: 'module_element_type_unknown',
+                      message: `Element inconnu: ${element.type}`,
+                    });
+                    return undefined;
+                }
+              })
+              .filter((element) => element !== undefined),
+          });
+        }),
+      });
+    } catch (e) {
+      throw new ModuleInstantiationError(e.message);
+    }
   }
 
   #assertTransitionTextsLinkedToGrain(transitionTexts, grains) {

--- a/api/src/devcomp/domain/models/module/Module.js
+++ b/api/src/devcomp/domain/models/module/Module.js
@@ -1,5 +1,24 @@
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { logger } from '../../../../shared/infrastructure/utils/logger.js';
+import { BlockInput } from '../block/BlockInput.js';
+import { BlockSelect } from '../block/BlockSelect.js';
+import { BlockSelectOption } from '../block/BlockSelectOption.js';
+import { BlockText } from '../block/BlockText.js';
+import { Image } from '../element/Image.js';
+import { QCM } from '../element/QCM.js';
+import { QCMForAnswerVerification } from '../element/QCM-for-answer-verification.js';
+import { QCU } from '../element/QCU.js';
+import { QCUForAnswerVerification } from '../element/QCU-for-answer-verification.js';
+import { QROCM } from '../element/QROCM.js';
+import { QROCMForAnswerVerification } from '../element/QROCM-for-answer-verification.js';
+import { Text } from '../element/Text.js';
+import { Video } from '../element/Video.js';
+import { Grain } from '../Grain.js';
+import { QcmProposal } from '../QcmProposal.js';
+import { QcuProposal } from '../QcuProposal.js';
+import { TransitionText } from '../TransitionText.js';
+import { Details } from './Details.js';
 
 class Module {
   constructor({ id, slug, title, grains, details, transitionTexts = [] }) {
@@ -17,6 +36,88 @@ class Module {
     this.grains = grains;
     this.transitionTexts = transitionTexts;
     this.details = details;
+  }
+
+  static toDomain(moduleData) {
+    return new Module({
+      id: moduleData.id,
+      slug: moduleData.slug,
+      title: moduleData.title,
+      transitionTexts: moduleData.transitionTexts?.map((transitionText) => new TransitionText(transitionText)) ?? [],
+      details: new Details(moduleData.details),
+      grains: moduleData.grains.map((grain) => {
+        return new Grain({
+          id: grain.id,
+          title: grain.title,
+          type: grain.type,
+          elements: grain.elements
+            .map((element) => {
+              switch (element.type) {
+                case 'image':
+                  return Module.#toImageDomain(element);
+                case 'text':
+                  return Module.#toTextDomain(element);
+                case 'qcm':
+                  return Module.#toQCMDomain(element);
+                case 'qcu':
+                  return Module.#toQCUDomain(element);
+                case 'qrocm':
+                  return Module.#toQROCMDomain(element);
+                case 'video':
+                  return Module.#toVideoDomain(element);
+                default:
+                  logger.warn({
+                    event: 'module_element_type_unknown',
+                    message: `Element inconnu: ${element.type}`,
+                  });
+                  return undefined;
+              }
+            })
+            .filter((element) => element !== undefined),
+        });
+      }),
+    });
+  }
+
+  static toDomainForVerification(moduleData) {
+    return new Module({
+      id: moduleData.id,
+      slug: moduleData.slug,
+      title: moduleData.title,
+      details: new Details(moduleData.details),
+      transitionTexts: moduleData.transitionTexts?.map((transitionText) => new TransitionText(transitionText)) ?? [],
+      grains: moduleData.grains.map((grain) => {
+        return new Grain({
+          id: grain.id,
+          title: grain.title,
+          type: grain.type,
+          elements: grain.elements
+            .map((element) => {
+              switch (element.type) {
+                case 'image':
+                  return Module.#toImageDomain(element);
+                case 'text':
+                  return Module.#toTextDomain(element);
+                case 'qcu':
+                  return Module.#toQCUForAnswerVerificationDomain(element);
+                case 'qcm':
+                  return Module.#toQCMForAnswerVerificationDomain(element);
+                case 'qrocm':
+                  return Module.#toQROCMForAnswerVerificationDomain(element);
+                case 'video':
+                  return Module.#toVideoDomain(element);
+                default:
+                  logger.warn({
+                    event: 'module_element_type_unknown',
+                    message: `Element inconnu: ${element.type}`,
+                  });
+                  return undefined;
+              }
+            })
+            .filter((element) => element !== undefined),
+        });
+      }),
+    });
   }
 
   #assertTransitionTextsLinkedToGrain(transitionTexts, grains) {
@@ -46,6 +147,125 @@ class Module {
     }
 
     return foundGrain;
+  }
+
+  static #toTextDomain(element) {
+    return new Text({
+      id: element.id,
+      content: element.content,
+    });
+  }
+
+  static #toImageDomain(element) {
+    return new Image({
+      id: element.id,
+      url: element.url,
+      alt: element.alt,
+      alternativeText: element.alternativeText,
+    });
+  }
+
+  static #toVideoDomain(element) {
+    return new Video({
+      id: element.id,
+      title: element.title,
+      url: element.url,
+      subtitles: element.subtitles,
+      transcription: element.transcription,
+    });
+  }
+
+  static #toQCUDomain(element) {
+    return new QCU({
+      id: element.id,
+      instruction: element.instruction,
+      locales: element.locales,
+      proposals: element.proposals.map((proposal) => {
+        return new QcuProposal({
+          id: proposal.id,
+          content: proposal.content,
+        });
+      }),
+    });
+  }
+
+  static #toQCMDomain(element) {
+    return new QCM({
+      id: element.id,
+      instruction: element.instruction,
+      locales: element.locales,
+      proposals: element.proposals.map((proposal) => {
+        return new QcmProposal({
+          id: proposal.id,
+          content: proposal.content,
+        });
+      }),
+    });
+  }
+
+  static #toQROCMDomain(element) {
+    return new QROCM({
+      id: element.id,
+      instruction: element.instruction,
+      locales: element.locales,
+      proposals: element.proposals.map((proposal) => {
+        switch (proposal.type) {
+          case 'text':
+            return new BlockText(proposal);
+          case 'input':
+            return new BlockInput(proposal);
+          case 'select':
+            return new BlockSelect({
+              ...proposal,
+              options: proposal.options.map((option) => new BlockSelectOption(option)),
+            });
+          default:
+            logger.warn(`Type de proposal inconnu: ${proposal.type}`);
+        }
+      }),
+    });
+  }
+
+  static #toQCUForAnswerVerificationDomain(element) {
+    return new QCUForAnswerVerification({
+      id: element.id,
+      instruction: element.instruction,
+      locales: element.locales,
+      proposals: element.proposals.map((proposal) => {
+        return new QcuProposal({
+          id: proposal.id,
+          content: proposal.content,
+        });
+      }),
+      feedbacks: element.feedbacks,
+      solution: element.solution,
+    });
+  }
+
+  static #toQCMForAnswerVerificationDomain(element) {
+    return new QCMForAnswerVerification({
+      id: element.id,
+      instruction: element.instruction,
+      locales: element.locales,
+      proposals: element.proposals.map((proposal) => {
+        return new QcmProposal({
+          id: proposal.id,
+          content: proposal.content,
+        });
+      }),
+      feedbacks: element.feedbacks,
+      solutions: element.solutions,
+    });
+  }
+
+  static #toQROCMForAnswerVerificationDomain(element) {
+    return new QROCMForAnswerVerification({
+      id: element.id,
+      instruction: element.instruction,
+      locales: element.locales,
+      proposals: element.proposals,
+      feedbacks: element.feedbacks,
+    });
   }
 }
 

--- a/api/src/devcomp/infrastructure/repositories/module-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/module-repository.js
@@ -1,31 +1,12 @@
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { LearningContentResourceNotFound } from '../../../shared/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
-import { logger } from '../../../shared/infrastructure/utils/logger.js';
-import { BlockInput } from '../../domain/models/block/BlockInput.js';
-import { BlockSelect } from '../../domain/models/block/BlockSelect.js';
-import { BlockSelectOption } from '../../domain/models/block/BlockSelectOption.js';
-import { BlockText } from '../../domain/models/block/BlockText.js';
-import { Image } from '../../domain/models/element/Image.js';
-import { QCM } from '../../domain/models/element/QCM.js';
-import { QCMForAnswerVerification } from '../../domain/models/element/QCM-for-answer-verification.js';
-import { QCU } from '../../domain/models/element/QCU.js';
-import { QCUForAnswerVerification } from '../../domain/models/element/QCU-for-answer-verification.js';
-import { QROCM } from '../../domain/models/element/QROCM.js';
-import { QROCMForAnswerVerification } from '../../domain/models/element/QROCM-for-answer-verification.js';
-import { Text } from '../../domain/models/element/Text.js';
-import { Video } from '../../domain/models/element/Video.js';
-import { Grain } from '../../domain/models/Grain.js';
-import { Details } from '../../domain/models/module/Details.js';
 import { Module } from '../../domain/models/module/Module.js';
-import { QcmProposal } from '../../domain/models/QcmProposal.js';
-import { QcuProposal } from '../../domain/models/QcuProposal.js';
-import { TransitionText } from '../../domain/models/TransitionText.js';
 
 async function getBySlug({ slug, moduleDatasource }) {
   try {
     const moduleData = await moduleDatasource.getBySlug(slug);
 
-    return _toDomain(moduleData);
+    return Module.toDomain(moduleData);
   } catch (e) {
     if (e instanceof LearningContentResourceNotFound) {
       throw new NotFoundError();
@@ -38,214 +19,13 @@ async function getBySlugForVerification({ slug, moduleDatasource }) {
   try {
     const moduleData = await moduleDatasource.getBySlug(slug);
 
-    return _toDomainForVerification(moduleData);
+    return Module.toDomainForVerification(moduleData);
   } catch (e) {
     if (e instanceof LearningContentResourceNotFound) {
       throw new NotFoundError();
     }
     throw e;
   }
-}
-
-function _toDomain(moduleData) {
-  return new Module({
-    id: moduleData.id,
-    slug: moduleData.slug,
-    title: moduleData.title,
-    transitionTexts: moduleData.transitionTexts?.map((transitionText) => new TransitionText(transitionText)) ?? [],
-    details: new Details(moduleData.details),
-    grains: moduleData.grains.map((grain) => {
-      return new Grain({
-        id: grain.id,
-        title: grain.title,
-        type: grain.type,
-        elements: grain.elements
-          .map((element) => {
-            switch (element.type) {
-              case 'image':
-                return _toImageDomain(element);
-              case 'text':
-                return _toTextDomain(element);
-              case 'qcm':
-                return _toQCMDomain(element);
-              case 'qcu':
-                return _toQCUDomain(element);
-              case 'qrocm':
-                return _toQROCMDomain(element);
-              case 'video':
-                return _toVideoDomain(element);
-              default:
-                logger.warn({
-                  event: 'module_element_type_unknown',
-                  message: `Element inconnu: ${element.type}`,
-                });
-                return undefined;
-            }
-          })
-          .filter((element) => element !== undefined),
-      });
-    }),
-  });
-}
-
-function _toDomainForVerification(moduleData) {
-  return new Module({
-    id: moduleData.id,
-    slug: moduleData.slug,
-    title: moduleData.title,
-    details: new Details(moduleData.details),
-    transitionTexts: moduleData.transitionTexts?.map((transitionText) => new TransitionText(transitionText)) ?? [],
-    grains: moduleData.grains.map((grain) => {
-      return new Grain({
-        id: grain.id,
-        title: grain.title,
-        type: grain.type,
-        elements: grain.elements
-          .map((element) => {
-            switch (element.type) {
-              case 'image':
-                return _toImageDomain(element);
-              case 'text':
-                return _toTextDomain(element);
-              case 'qcu':
-                return _toQCUForAnswerVerificationDomain(element);
-              case 'qcm':
-                return _toQCMForAnswerVerificationDomain(element);
-              case 'qrocm':
-                return _toQROCMForAnswerVerificationDomain(element);
-              case 'video':
-                return _toVideoDomain(element);
-              default:
-                logger.warn({
-                  event: 'module_element_type_unknown',
-                  message: `Element inconnu: ${element.type}`,
-                });
-                return undefined;
-            }
-          })
-          .filter((element) => element !== undefined),
-      });
-    }),
-  });
-}
-
-function _toTextDomain(element) {
-  return new Text({
-    id: element.id,
-    content: element.content,
-  });
-}
-
-function _toImageDomain(element) {
-  return new Image({
-    id: element.id,
-    url: element.url,
-    alt: element.alt,
-    alternativeText: element.alternativeText,
-  });
-}
-
-function _toVideoDomain(element) {
-  return new Video({
-    id: element.id,
-    title: element.title,
-    url: element.url,
-    subtitles: element.subtitles,
-    transcription: element.transcription,
-  });
-}
-
-function _toQCUForAnswerVerificationDomain(element) {
-  return new QCUForAnswerVerification({
-    id: element.id,
-    instruction: element.instruction,
-    locales: element.locales,
-    proposals: element.proposals.map((proposal) => {
-      return new QcuProposal({
-        id: proposal.id,
-        content: proposal.content,
-      });
-    }),
-    feedbacks: element.feedbacks,
-    solution: element.solution,
-  });
-}
-
-function _toQCUDomain(element) {
-  return new QCU({
-    id: element.id,
-    instruction: element.instruction,
-    locales: element.locales,
-    proposals: element.proposals.map((proposal) => {
-      return new QcuProposal({
-        id: proposal.id,
-        content: proposal.content,
-      });
-    }),
-  });
-}
-
-function _toQCMDomain(element) {
-  return new QCM({
-    id: element.id,
-    instruction: element.instruction,
-    locales: element.locales,
-    proposals: element.proposals.map((proposal) => {
-      return new QcmProposal({
-        id: proposal.id,
-        content: proposal.content,
-      });
-    }),
-  });
-}
-
-function _toQCMForAnswerVerificationDomain(element) {
-  return new QCMForAnswerVerification({
-    id: element.id,
-    instruction: element.instruction,
-    locales: element.locales,
-    proposals: element.proposals.map((proposal) => {
-      return new QcmProposal({
-        id: proposal.id,
-        content: proposal.content,
-      });
-    }),
-    feedbacks: element.feedbacks,
-    solutions: element.solutions,
-  });
-}
-
-function _toQROCMForAnswerVerificationDomain(element) {
-  return new QROCMForAnswerVerification({
-    id: element.id,
-    instruction: element.instruction,
-    locales: element.locales,
-    proposals: element.proposals,
-    feedbacks: element.feedbacks,
-  });
-}
-
-function _toQROCMDomain(element) {
-  return new QROCM({
-    id: element.id,
-    instruction: element.instruction,
-    locales: element.locales,
-    proposals: element.proposals.map((proposal) => {
-      switch (proposal.type) {
-        case 'text':
-          return new BlockText(proposal);
-        case 'input':
-          return new BlockInput(proposal);
-        case 'select':
-          return new BlockSelect({
-            ...proposal,
-            options: proposal.options.map((option) => new BlockSelectOption(option)),
-          });
-        default:
-          logger.warn(`Type de proposal inconnu: ${proposal.type}`);
-      }
-    }),
-  });
 }
 
 export { getBySlug, getBySlugForVerification };

--- a/api/src/shared/application/http-errors.js
+++ b/api/src/shared/application/http-errors.js
@@ -95,6 +95,14 @@ class ServiceUnavailableError extends BaseHttpError {
   }
 }
 
+class BadGatewayError extends BaseHttpError {
+  constructor(message) {
+    super(message);
+    this.title = 'BadGateway';
+    this.status = 502;
+  }
+}
+
 class BadRequestError extends BaseHttpError {
   constructor(message, code, meta) {
     super(message);
@@ -143,6 +151,7 @@ function sendJsonApiError(httpError, h) {
 }
 
 const HttpErrors = {
+  BadGatewayError,
   BadRequestError,
   BaseHttpError,
   ConflictError,
@@ -161,6 +170,7 @@ const HttpErrors = {
 };
 
 export {
+  BadGatewayError,
   BadRequestError,
   BaseHttpError,
   ConflictError,

--- a/api/tests/devcomp/unit/application/modules/controller_test.js
+++ b/api/tests/devcomp/unit/application/modules/controller_test.js
@@ -1,5 +1,7 @@
 import { modulesController } from '../../../../../src/devcomp/application/modules/controller.js';
-import { expect, sinon } from '../../../../test-helper.js';
+import * as moduleUnderTest from '../../../../../src/devcomp/application/modules/index.js';
+import { ModuleInstantiationError } from '../../../../../src/devcomp/domain/errors.js';
+import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Devcomp | Application | Modules | Module Controller', function () {
   describe('#getBySlug', function () {
@@ -19,6 +21,17 @@ describe('Unit | Devcomp | Application | Modules | Module Controller', function 
       const result = await modulesController.getBySlug({ params: { slug } }, null, { moduleSerializer, usecases });
 
       expect(result).to.equal(serializedModule);
+    });
+    it('should throw an error if referential data is incorrect', async function () {
+      // given
+      sinon.stub(modulesController, 'getBySlug').throws(new ModuleInstantiationError());
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('GET', '/api/modules/slug');
+
+      expect(response.statusCode).to.equal(502);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, lorsque les données du référentiel Modulix sont incohérentes (par exemple, lorsqu'un texte de transition est lié à un id de grain qui n'existe pas dans le module), nos modèles métiers retournent des erreurs non gérées par l'API (code **500**).

## :robot: Proposition
Implémenter une erreur `ModuleInstantiationError` héritant de `DomainError`, que l'on mappera en erreur qui fasse sens.
Nous avons opté pour l'erreur **502** _Bad Gateway ou Proxy Error_, car même si elle ne correspond pas exactement au cas présent, elle spécifie que notre serveur a reçu une réponse invalide depuis le serveur distant. Ce qui est relativement proche de notre situation.

Étant donné qu'il s'agit d'une erreur remontée par le _domain_, nous avons déplacé la tâche de mapping du `ModuleRepository` vers le modèle `Module`, via une méthode _static_.
L'implémentation de cette méthode est _wrappée_ dans un `try catch` qui _throw_ notre `ModuleInstantiationError` dans le cas où le `Module` ou un des modèles de sa grappe rencontre un soucis d'instanciation.

## :rainbow: Remarques
Durant le mapping initial, le `ModuleRepository` utilisait le _logger_ dans certains cas.
Dans cette PR, nous n'avons pas creusé le sujet pour savoir comment utiliser proprement le _logger_ sans polluer notre _domain_, donc vous trouverez l'import du _logger_ dans la class `Module` 😬  Mais nous sommes ouverts à toute suggestion pour éviter de mettre de l'infra dans notre _domain_.

Dans cette PR, nous avons désormais un `Module` qui s'occupe de faire les `toDomain` de tous les modèles de sa grappe. Pour renforcer la réutilisabilité, nous proposons de pousser le _pattern_ jusqu'au bout et d'implémenter la méthode `toDomain` pour le modèle `Grain` et pour chaque modèle d'`Element`.
Ce qui donnerait au niveau du `Module` ce genre de résultat:
```javascript
static toDomain(moduleData) {
    return new Module({
      id: moduleData.id,
      slug: moduleData.slug,
      title: moduleData.title,
      transitionTexts: moduleData.transitionTexts?.map((transitionText) => new TransitionText(transitionText)) ?? [],
      details: new Details(moduleData.details),
      grains: moduleData.grains.map((grain) => Grain.toDomain(grain)),
    });
  }
```

Qu'en dites-vous ?

## :100: Pour tester
La CI passe.
Les modules fonctionnent toujours ([celui-ci par exemple](https://app-pr8408.review.pix.fr/modules/didacticiel-modulix))
