### PR TITLE
[FEATURE] Prévenir le mauvais formattage de Module.

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -168,6 +168,7 @@
     "test:api:bail": "npm run test:api:unit -- --bail && npm run test:api:integration -- --bail && npm run test:api:acceptance -- --bail",
     "test:lint": "npm test && npm run lint",
     "monitoring:arborescence": "node scripts/arborescence-monitoring/arborescence-monitoring.js",
-    "monitoring:metrics": "node scripts/arborescence-monitoring/add-metrics-to-gist.js"
+    "monitoring:metrics": "node scripts/arborescence-monitoring/add-metrics-to-gist.js",
+    "modulix:test": "npm run test:api:path -- 'tests/devcomp/**/*test.js'"
   }
 }

--- a/api/tests/devcomp/acceptance/module-instantiation_test.js
+++ b/api/tests/devcomp/acceptance/module-instantiation_test.js
@@ -1,0 +1,20 @@
+import { Module } from '../../../src/devcomp/domain/models/module/Module.js';
+import moduleDatasource from '../../../src/devcomp/infrastructure/datasources/learning-content/module-datasource.js';
+import { expect } from '../../test-helper.js';
+
+const modules = await moduleDatasource.list();
+
+describe('Acceptance | Modules', function () {
+  describe('Verify modules', function () {
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    modules.forEach((module) => {
+      it(`module ${module.slug} should respect the correct structure`, function () {
+        try {
+          Module.toDomainForVerification(module);
+        } catch (e) {
+          expect.fail(e.message);
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le métier n'a pas de boucle de feedback rapide quand il créé un Module.

## :robot: Proposition
Comme nos constructeurs ont toutes les règles de gestion, nous créons un test qui vérifie que tous les modules sont instanciables.

Pour avoir une boucle rapide en local pour nos contributeurs, un `script` npm a aussi été ajouté pour lancer tous les tests liés au scope devcomp.

```shell
npm run modulix:test
```

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- Récuperer le code
- Changer quelques dans un module (exemple: un grainId d'une transition)
- Lancer les tests et constater que le test échoue