### PR TITLE
[FEATURE] Ajoute le nombre de participations partagées dans les résultats d'une campagne (PIX-11630)

### DIFF
--- a/api/db/seeds/data/common/organization-builder.js
+++ b/api/db/seeds/data/common/organization-builder.js
@@ -27,7 +27,7 @@ async function _createScoOrganization(databaseBuilder) {
     externalId: 'SCO_MANAGING',
     adminIds: [SCO_ORGANIZATION_USER_ID],
     memberIds: [ALL_ORGANIZATION_USER_ID],
-    featureIds: [FEATURE_COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY_ID],
+    featureIds: [FEATURE_COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY_ID, FEATURE_MULTIPLE_SENDING_ASSESSMENT_ID],
   });
 
   await organization.createOrganization({
@@ -66,6 +66,7 @@ async function _createSupOrganization(databaseBuilder) {
     externalId: 'SUP_MANAGING',
     adminIds: [SUP_ORGANIZATION_USER_ID],
     memberIds: [ALL_ORGANIZATION_USER_ID],
+    featureIds: [FEATURE_MULTIPLE_SENDING_ASSESSMENT_ID],
   });
 
   await organization.createOrganization({

--- a/api/db/seeds/data/team-prescription/build-campaigns.js
+++ b/api/db/seeds/data/team-prescription/build-campaigns.js
@@ -1,5 +1,7 @@
 import dayjs from 'dayjs';
 
+import { CampaignParticipationStatuses } from '../../../../src/prescription/shared/domain/constants.js';
+import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
 import {
   PRO_ORGANIZATION_ID,
   PRO_ORGANIZATION_USER_ID,
@@ -19,6 +21,26 @@ async function _createScoCampaigns(databaseBuilder) {
     ownerId: SCO_ORGANIZATION_USER_ID,
     name: "Campagne d'évaluation SCO",
     code: 'SCOASSIMP',
+    createdAt: dayjs().subtract(30, 'days').toDate(),
+    configCampaign: {
+      participantCount: 10,
+      completionDistribution: {
+        started: 1,
+        to_share: 2,
+        shared_one_validated_skill: 1,
+        shared_perfect: 1,
+      },
+    },
+  });
+
+  await createAssessmentCampaign({
+    databaseBuilder,
+    targetProfileId: TARGET_PROFILE_BADGES_STAGES_ID,
+    organizationId: SCO_MANAGING_ORGANIZATION_ID,
+    ownerId: SCO_ORGANIZATION_USER_ID,
+    name: "Campagne d'évaluation SCO envoi multiple",
+    code: 'SCOASSMUL',
+    multipleSendings: true,
     createdAt: dayjs().subtract(30, 'days').toDate(),
     configCampaign: {
       participantCount: 10,
@@ -64,6 +86,26 @@ async function _createSupCampaigns(databaseBuilder) {
     },
   });
 
+  await createAssessmentCampaign({
+    databaseBuilder,
+    targetProfileId: TARGET_PROFILE_NO_BADGES_NO_STAGES_ID,
+    organizationId: SUP_MANAGING_ORGANIZATION_ID,
+    ownerId: SUP_ORGANIZATION_USER_ID,
+    name: "Campagne d'évaluation SUP envoi multiple",
+    code: 'SUPASSMUL',
+    multipleSendings: true,
+    createdAt: dayjs().subtract(30, 'days').toDate(),
+    configCampaign: {
+      participantCount: 10,
+      completionDistribution: {
+        started: 1,
+        to_share: 2,
+        shared_one_validated_skill: 1,
+        shared_perfect: 1,
+      },
+    },
+  });
+
   await createProfilesCollectionCampaign({
     databaseBuilder,
     organizationId: SUP_MANAGING_ORGANIZATION_ID,
@@ -95,6 +137,98 @@ async function _createProCampaigns(databaseBuilder) {
         shared_perfect: 1,
       },
     },
+  });
+
+  const { campaignId } = await createAssessmentCampaign({
+    databaseBuilder,
+    targetProfileId: TARGET_PROFILE_NO_BADGES_NO_STAGES_ID,
+    organizationId: PRO_ORGANIZATION_ID,
+    ownerId: PRO_ORGANIZATION_USER_ID,
+    name: "Campagne d'évaluation PRO envoi multiple",
+    code: 'PROASSMUL',
+    multipleSendings: true,
+    createdAt: dayjs().subtract(30, 'days').toDate(),
+    configCampaign: {
+      participantCount: 10,
+      completionDistribution: {
+        started: 1,
+        to_share: 2,
+        shared_one_validated_skill: 1,
+        shared_perfect: 1,
+      },
+    },
+  });
+
+  const { id: userId } = await databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Alex',
+    lastName: 'Terieur',
+    email: 'alex-terieur@example.net',
+    cgu: true,
+    lang: 'fr',
+  });
+
+  const { id: organizationLearnerId } = await databaseBuilder.factory.buildOrganizationLearner({
+    firstName: 'Alex',
+    lastName: 'Terieur',
+    userId,
+    organizationId: PRO_ORGANIZATION_ID,
+  });
+  const { id: firstCampaignParticipationId, createdAt } = await databaseBuilder.factory.buildCampaignParticipation({
+    campaignId,
+    organizationLearnerId,
+    userId,
+    isImproved: true,
+  });
+  await databaseBuilder.factory.buildAssessment({
+    userId,
+    type: Assessment.types.CAMPAIGN,
+    createdAt,
+    state: Assessment.states.COMPLETED,
+    isImproving: true,
+    lastQuestionDate: new Date(),
+    lastQuestionState: Assessment.statesOfLastQuestion.ASKED,
+    competenceId: null,
+    campaignParticipationId: firstCampaignParticipationId,
+  });
+
+  const { id: secondCampaignParticipationId } = await databaseBuilder.factory.buildCampaignParticipation({
+    organizationLearnerId,
+    userId,
+    campaignId,
+    isImproved: true,
+  });
+
+  await databaseBuilder.factory.buildAssessment({
+    userId,
+    type: Assessment.types.CAMPAIGN,
+    createdAt,
+    state: Assessment.states.COMPLETED,
+    isImproving: true,
+    lastQuestionDate: new Date(),
+    lastQuestionState: Assessment.statesOfLastQuestion.ASKED,
+    competenceId: null,
+    campaignParticipationId: secondCampaignParticipationId,
+  });
+
+  const { id: thirdCampaignParticipationId } = await databaseBuilder.factory.buildCampaignParticipation({
+    organizationLearnerId,
+    userId,
+    campaignId,
+    isImproved: false,
+    status: CampaignParticipationStatuses.TO_SHARE,
+    sharedAt: null,
+  });
+
+  await databaseBuilder.factory.buildAssessment({
+    userId,
+    type: Assessment.types.CAMPAIGN,
+    createdAt,
+    state: Assessment.states.COMPLETED,
+    isImproving: true,
+    lastQuestionDate: new Date(),
+    lastQuestionState: Assessment.statesOfLastQuestion.ASKED,
+    competenceId: null,
+    campaignParticipationId: thirdCampaignParticipationId,
   });
 
   await createProfilesCollectionCampaign({

--- a/api/src/prescription/campaign/domain/read-models/CampaignAssessmentParticipationResultMinimal.js
+++ b/api/src/prescription/campaign/domain/read-models/CampaignAssessmentParticipationResultMinimal.js
@@ -11,6 +11,7 @@ class CampaignAssessmentParticipationResultMinimal {
     totalStage,
     prescriberTitle,
     prescriberDescription,
+    sharedResultCount,
     badges = [],
   }) {
     this.campaignParticipationId = campaignParticipationId;
@@ -25,6 +26,7 @@ class CampaignAssessmentParticipationResultMinimal {
     this.prescriberDescription = prescriberDescription;
     //TODO REMOVE WHEN https://1024pix.atlassian.net/browse/PIX-6849 IS DONE
     this.badges = _.uniqBy(badges, 'id');
+    this.sharedResultCount = sharedResultCount;
   }
 }
 

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-assessment-participation-result-list-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-assessment-participation-result-list-repository.js
@@ -13,7 +13,6 @@ async function findPaginatedByCampaignId({ page = {}, campaignId, filters = {} }
 
   const { results, pagination } = await _getResultListPaginated(campaignId, stageCollection, filters, page);
   const participations = await _buildCampaignAssessmentParticipationResultList(results, stageCollection);
-
   return {
     participations,
     pagination,
@@ -42,6 +41,13 @@ function _getParticipations(qb, campaignId, stageCollection, filters) {
     'campaign-participations.validatedSkillsCount',
     'campaign-participations.id AS campaignParticipationId',
     'campaign-participations.userId',
+    knex('campaign-participations')
+      .count()
+      .whereRaw('"organizationLearnerId" = "view-active-organization-learners".id')
+      .where('campaign-participations.campaignId', campaignId)
+      .where('campaign-participations.status', SHARED)
+      .whereNull('campaign-participations.deletedAt')
+      .as('sharedResultCount'),
   )
     .distinctOn('campaign-participations.organizationLearnerId')
     .from('campaign-participations')

--- a/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-assessment-result-minimal-serializer.js
+++ b/api/src/prescription/campaign/infrastructure/serializers/jsonapi/campaign-assessment-result-minimal-serializer.js
@@ -15,6 +15,7 @@ const serialize = function ({ participations, pagination }) {
       'prescriberTitle',
       'prescriberDescription',
       'badges',
+      'sharedResultCount',
     ],
     badges: {
       ref: 'id',

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-assessment-participation-result-list-repository_test.js
@@ -154,6 +154,39 @@ describe('Integration | Repository | Campaign Assessment Participation Result Li
         expect(participations).to.have.lengthOf(1);
         expect(participations[0].participantExternalId).to.equal('My first');
       });
+
+      it('should return count of shared participation for given campaign', async function () {
+        // given
+        databaseBuilder.factory.buildCampaignParticipation({
+          participantExternalId: 'Second Participation Shared',
+          campaignId: campaign.id,
+          isImproved: true,
+          organizationLearnerId: learner.id,
+          userId,
+          createdAt: new Date(2022, 10, 2),
+          sharedAt: new Date(2022, 10, 3),
+        });
+        // given
+        databaseBuilder.factory.buildCampaignParticipation({
+          participantExternalId: 'third Participation not shared',
+          campaignId: campaign.id,
+          isImproved: false,
+          organizationLearnerId: learner.id,
+          status: CampaignParticipationStatuses.STARTED,
+          userId,
+          createdAt: new Date(2022, 10, 4),
+          sharedAt: new Date(2022, 10, 5),
+        });
+
+        await databaseBuilder.commit();
+
+        //when
+        const { participations } = await campaignAssessmentParticipationResultListRepository.findPaginatedByCampaignId({
+          campaignId: campaign.id,
+        });
+        // then
+        expect(participations[0].sharedResultCount).to.equal(2);
+      });
     });
 
     context('when there is an organization learner', function () {

--- a/api/tests/prescription/campaign/unit/domain/read-models/CampaignAssessmentParticipationResultMinimal_test.js
+++ b/api/tests/prescription/campaign/unit/domain/read-models/CampaignAssessmentParticipationResultMinimal_test.js
@@ -14,6 +14,7 @@ describe('Unit | Domain | Read-Models | CampaignResults | CampaignAssessmentPart
         totalStage: 6,
         prescriberTitle: 'titre prescripteur',
         prescriberDescription: 'description prescripteur',
+        sharedResultCount: 3,
       });
 
       expect(campaignAssessmentParticipationResultMinimal).to.deep.equal({
@@ -27,6 +28,7 @@ describe('Unit | Domain | Read-Models | CampaignResults | CampaignAssessmentPart
         totalStage: 6,
         prescriberTitle: 'titre prescripteur',
         prescriberDescription: 'description prescripteur',
+        sharedResultCount: 3,
       });
     });
   });

--- a/api/tests/prescription/campaign/unit/infrastrucutre/serializers/jsonapi/campaign-assessment-result-minimal-serializer_test.js
+++ b/api/tests/prescription/campaign/unit/infrastrucutre/serializers/jsonapi/campaign-assessment-result-minimal-serializer_test.js
@@ -16,6 +16,7 @@ describe('Unit | Serializer | JSONAPI | campaign-assessment-result-minimal-seria
           totalStage: 6,
           prescriberTitle: 'titre prescripteur 1',
           prescriberDescription: 'description prescripteur 1',
+          sharedResultCount: 0,
         },
         {
           campaignParticipationId: '2',
@@ -28,6 +29,7 @@ describe('Unit | Serializer | JSONAPI | campaign-assessment-result-minimal-seria
           prescriberTitle: null,
           prescriberDescription: null,
           badges: [domainBuilder.buildBadge({ id: 1, title: 'b1', imageUrl: 'http://toto.svg', altMessage: 'alt' })],
+          sharedResultCount: 0,
         },
       ];
       const pagination = {
@@ -53,6 +55,7 @@ describe('Unit | Serializer | JSONAPI | campaign-assessment-result-minimal-seria
               'total-stage': 6,
               'prescriber-title': 'titre prescripteur 1',
               'prescriber-description': 'description prescripteur 1',
+              'shared-result-count': 0,
             },
           },
           {
@@ -67,6 +70,7 @@ describe('Unit | Serializer | JSONAPI | campaign-assessment-result-minimal-seria
               'total-stage': null,
               'prescriber-title': null,
               'prescriber-description': null,
+              'shared-result-count': 0,
             },
             relationships: {
               badges: {

--- a/orga/app/components/campaign/results/assessment-list.hbs
+++ b/orga/app/components/campaign/results/assessment-list.hbs
@@ -38,6 +38,9 @@
           {{#if @campaign.hasBadges}}
             <Table::Header>{{t "pages.campaign-results.table.column.badges"}}</Table::Header>
           {{/if}}
+          <Table::Header aria-label={{t "pages.campaign-results.table.column.ariaSharedResultCount"}}>
+            {{t "pages.campaign-results.table.column.sharedResultCount"}}
+          </Table::Header>
         </tr>
       </thead>
 

--- a/orga/app/components/campaign/results/assessment-row.hbs
+++ b/orga/app/components/campaign/results/assessment-row.hbs
@@ -23,6 +23,9 @@
       @isTableDisplay={{true}}
     />
   </td>
+  <td class="table__column--small">
+    {{@participation.sharedResultCount}}
+  </td>
   {{#if @hasBadges}}
     <td class="participant-list__badges">
       <Campaign::Badges @badges={{@participation.badges}} />

--- a/orga/app/models/campaign-assessment-result-minimal.js
+++ b/orga/app/models/campaign-assessment-result-minimal.js
@@ -9,6 +9,7 @@ export default class CampaignAssessmentResultMinimal extends Model {
   @attr('number') totalStage;
   @attr('string') prescriberTitle;
   @attr('string') prescriberDescription;
+  @attr('number') sharedResultCount;
 
   @hasMany('Badge', { async: true, inverse: null }) badges;
 }

--- a/orga/tests/integration/components/campaign/results/assessment-list_test.js
+++ b/orga/tests/integration/components/campaign/results/assessment-list_test.js
@@ -68,6 +68,7 @@ module('Integration | Component | Campaign::Results::AssessmentList', function (
           lastName: 'Doe',
           masteryRate: 0.8,
           isShared: true,
+          sharedResultCount: 3,
         },
       ];
       participations.meta = {
@@ -78,7 +79,7 @@ module('Integration | Component | Campaign::Results::AssessmentList', function (
       this.set('participations', participations);
 
       // when
-      await render(
+      const screen = await render(
         hbs`<Campaign::Results::AssessmentList
   @campaign={{this.campaign}}
   @participations={{this.participations}}
@@ -92,10 +93,11 @@ module('Integration | Component | Campaign::Results::AssessmentList', function (
       );
 
       // then
-      assert.notContains('Aucun participant');
-      assert.contains('Doe');
-      assert.contains('John');
-      assert.contains('80 %');
+      assert.notOk(screen.queryByText(this.intl.t('pages.campaign-results.table.empty')));
+      assert.ok(screen.getByText('Doe'));
+      assert.ok(screen.getByText('John'));
+      assert.ok(screen.getByText('80 %'));
+      assert.ok(screen.getByText('3'));
     });
 
     test('it should display badge and tooltip', async function (assert) {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -508,6 +508,7 @@
       "table": {
         "title": "List of submitted results",
         "column": {
+          "ariaSharedResultCount": "Number of sent results",
           "badges": "Thematic results",
           "first-name": "First name",
           "last-name": "Last name",
@@ -515,7 +516,8 @@
             "label": "Success rate",
             "on-hold": "Pending",
             "under-test": "Test in progress"
-          }
+          },
+          "sharedResultCount": "No of sent results"
         },
         "empty": "No participants",
         "row-title": "Participant"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -508,6 +508,7 @@
       "table": {
         "title": "Liste des résultats reçus",
         "column": {
+          "ariaSharedResultCount": "Nombre  de résultats envoyés",
           "badges": "Résultats Thématiques",
           "first-name": "Prénom",
           "last-name": "Nom",
@@ -515,7 +516,8 @@
             "label": "Résultats",
             "on-hold": " En attente d'envoi",
             "under-test": "En cours de test"
-          }
+          },
+          "sharedResultCount": "Nb résultats envoyés"
         },
         "empty": "Aucune participation",
         "row-title": "Participant"


### PR DESCRIPTION
## :unicorn: Problème
Nous avons permis de voir le nombre de participations d’un participant à une campagne à envoi multiple et de conserver le dernier résultat partagé. 
Nous souhaitons également informer le prescripteur sur le nombre de participations déjà partagées dans l’onglet “résultats” de la campagne d'évaluation. 

## :robot: Proposition
Ajouter une colonne “Nb résultats envoyés” dans le tableau dans l’onglet “résultats” de la campagne.

## :rainbow: Remarques
On profite de cette pr pour ajouter une seed d'un learner ('Alex Terieur', `alex-terieur@example.net`) qui a partagé plusieurs fois ses résultats dans une campagne d'éval à envoi multiple
⚠️  TODO (Ajouté en dette tech) : Revoir la méthode de création de résultats de participations, car actuellement elle ne permet pas d'ajuster "finement" les besoins ... (Comme justement, ajouter plusieurs participations partagés ou non pour le même learner à une même campagne)

## :100: Pour tester
- Se connecter à Pix Orga avec `pro-orga@example.net`
- allez sur la campagne d'eval envoi multiple (PROASSMUL)
- afficher l'onglet résultats
- voir les nombre de resultats partagés pour le learner "Alex Terieur" -> 2 normalement,
- Aller sur Pix App,
- Se connecter avec `alex-terieur@example.net`
- Aller sur la campagne en attente d'envoi et la partager
- Retourner vérifier sur Pix Orga que cette fois le nb de résultats partagés pour ce learner est de 3
- 🐈‍⬛ 