### PR TITLE
[BUGFIX] Corriger des soucis d'accessibilité côté Modulix (PIX-11646).

### DIFF
--- a/mon-pix/app/pods/components/module/details/template.hbs
+++ b/mon-pix/app/pods/components/module/details/template.hbs
@@ -26,7 +26,7 @@
             "pages.modulix.details.duration"
           }}
         </div>
-        <p>{{t "pages.modulix.details.durationValue" duration=@module.details.duration}}</p>
+        <p>{{t "pages.modulix.details.durationValue" htmlSafe=true duration=@module.details.duration}}</p>
       </div>
       <div class="module-details-infos-indications__category">
         <div class="module-details-infos-indications-category__title">

--- a/mon-pix/app/pods/components/module/grain/style.scss
+++ b/mon-pix/app/pods/components/module/grain/style.scss
@@ -3,6 +3,7 @@
 
   &--active {
     min-height: calc(100vh - var(--grain-scroll-offset));
+    outline: none;
 
     @supports (min-height: 100dvh) {
       min-height: calc(100dvh - var(--grain-scroll-offset));
@@ -19,48 +20,40 @@
     font-weight: var(--pix-font-medium);
   }
 
+  &__card {
+    border-radius: var(--pix-spacing-4x);
+  }
+}
+
+.grain-card {
   &__content {
     padding: var(--pix-spacing-6x);
-    border-top-left-radius: var(--pix-spacing-4x);
-    border-top-right-radius: var(--pix-spacing-4x);
-
-    &:last-child {
-      border-bottom-right-radius: var(--pix-spacing-4x);
-      border-bottom-left-radius: var(--pix-spacing-4x);
-    }
   }
 
   &__footer {
     padding: var(--pix-spacing-6x);
-    border-bottom-right-radius: var(--pix-spacing-4x);
-    border-bottom-left-radius: var(--pix-spacing-4x);
+    border-top: 1px solid var(--pix-neutral-100);
+  }
+
+  &--lesson {
+    background: var(--pix-info-50);
+  }
+
+  &--activity {
+    background: var(--pix-neutral-20);
   }
 }
 
-.grain-content {
+.grain-card-content {
   &__element:not(:last-child) {
     margin-bottom: var(--pix-spacing-8x);
   }
 }
 
-.grain--lesson {
-  .grain__content {
-    background: var(--pix-info-50);
-  }
-
-  .grain__footer {
-    background: var(--pix-info-50);
-    border-top: 1px solid var(--pix-neutral-100);
-  }
-}
-
-.grain--activity {
-  .grain__content {
-    background: var(--pix-neutral-20);
-  }
-
-  .grain__footer {
-    background: var(--pix-info-50);
-    border-top: 1px solid var(--pix-neutral-500);
+// stylelint-disable-next-line no-duplicate-selectors
+.grain--active:focus-visible {
+  .grain__card {
+    outline: 2px solid var(--pix-neutral-500);
+    outline-offset: -2px;
   }
 }

--- a/mon-pix/app/pods/components/module/grain/template.hbs
+++ b/mon-pix/app/pods/components/module/grain/template.hbs
@@ -1,5 +1,5 @@
 <article
-  class="grain grain--lesson {{if @hasJustAppeared 'grain--active'}}"
+  class="grain {{if @hasJustAppeared 'grain--active'}}"
   aria-live={{this.ariaLiveGrainValue}}
   tabindex="-1"
   {{did-insert this.focusAndScroll}}
@@ -12,64 +12,66 @@
     </header>
   {{/if}}
 
-  <div class="grain__content">
-    {{#each @grain.elements as |element|}}
-      <div class="grain-content__element">
-        {{#if (eq element.type "text")}}
-          <Module::Text @text={{element}} />
-        {{else if (eq element.type "image")}}
-          <Module::Image @image={{element}} @moduleId={{@grain.module.id}} />
-        {{else if (eq element.type "video")}}
-          <Module::Video @video={{element}} @moduleId={{@grain.module.id}} />
-        {{else if (eq element.type "qcu")}}
-          <Module::Qcu
-            @qcu={{element}}
-            @submitAnswer={{@submitAnswer}}
-            @correction={{this.getLastCorrectionForElement element}}
-          />
-        {{else if (eq element.type "qcm")}}
-          <Module::Qcm
-            @qcm={{element}}
-            @submitAnswer={{@submitAnswer}}
-            @correction={{this.getLastCorrectionForElement element}}
-          />
-        {{else if (eq element.type "qrocm")}}
-          <Module::Qrocm
-            @qrocm={{element}}
-            @submitAnswer={{@submitAnswer}}
-            @correction={{this.getLastCorrectionForElement element}}
-          />
-        {{/if}}
-      </div>
-    {{/each}}
+  <div class="grain__card grain-card--lesson">
+    <div class="grain-card__content">
+      {{#each @grain.elements as |element|}}
+        <div class="grain-card-content__element">
+          {{#if (eq element.type "text")}}
+            <Module::Text @text={{element}} />
+          {{else if (eq element.type "image")}}
+            <Module::Image @image={{element}} @moduleId={{@grain.module.id}} />
+          {{else if (eq element.type "video")}}
+            <Module::Video @video={{element}} @moduleId={{@grain.module.id}} />
+          {{else if (eq element.type "qcu")}}
+            <Module::Qcu
+              @qcu={{element}}
+              @submitAnswer={{@submitAnswer}}
+              @correction={{this.getLastCorrectionForElement element}}
+            />
+          {{else if (eq element.type "qcm")}}
+            <Module::Qcm
+              @qcm={{element}}
+              @submitAnswer={{@submitAnswer}}
+              @correction={{this.getLastCorrectionForElement element}}
+            />
+          {{else if (eq element.type "qrocm")}}
+            <Module::Qrocm
+              @qrocm={{element}}
+              @submitAnswer={{@submitAnswer}}
+              @correction={{this.getLastCorrectionForElement element}}
+            />
+          {{/if}}
+        </div>
+      {{/each}}
+    </div>
+
+    {{#if this.shouldDisplaySkipButton}}
+      <footer class="grain-card__footer">
+        <PixButton
+          @backgroundColor="transparent-light"
+          @isBorderVisible={{true}}
+          @shape="rounded"
+          @triggerAction={{@skipAction}}
+        >
+          {{t "pages.modulix.buttons.grain.skip"}}
+        </PixButton>
+      </footer>
+    {{/if}}
+
+    {{#if this.shouldDisplayContinueButton}}
+      <footer class="grain-card__footer">
+        <PixButton @backgroundColor="primary" @shape="rounded" @triggerAction={{@continueAction}}>
+          {{t "pages.modulix.buttons.grain.continue"}}
+        </PixButton>
+      </footer>
+    {{/if}}
+
+    {{#if @shouldDisplayTerminateButton}}
+      <footer class="grain-card__footer">
+        <PixButton @backgroundColor="primary" @shape="rounded" @triggerAction={{@terminateAction}}>
+          {{t "pages.modulix.buttons.grain.terminate"}}
+        </PixButton>
+      </footer>
+    {{/if}}
   </div>
-
-  {{#if this.shouldDisplaySkipButton}}
-    <footer class="grain__footer">
-      <PixButton
-        @backgroundColor="transparent-light"
-        @isBorderVisible={{true}}
-        @shape="rounded"
-        @triggerAction={{@skipAction}}
-      >
-        {{t "pages.modulix.buttons.grain.skip"}}
-      </PixButton>
-    </footer>
-  {{/if}}
-
-  {{#if this.shouldDisplayContinueButton}}
-    <footer class="grain__footer">
-      <PixButton @backgroundColor="primary" @shape="rounded" @triggerAction={{@continueAction}}>
-        {{t "pages.modulix.buttons.grain.continue"}}
-      </PixButton>
-    </footer>
-  {{/if}}
-
-  {{#if @shouldDisplayTerminateButton}}
-    <footer class="grain__footer">
-      <PixButton @backgroundColor="primary" @shape="rounded" @triggerAction={{@terminateAction}}>
-        {{t "pages.modulix.buttons.grain.terminate"}}
-      </PixButton>
-    </footer>
-  {{/if}}
 </article>

--- a/mon-pix/app/pods/components/module/qcm/styles.scss
+++ b/mon-pix/app/pods/components/module/qcm/styles.scss
@@ -1,4 +1,9 @@
 .element-qcm {
+  &__header {
+    display: flex;
+    flex-direction: column-reverse;
+  }
+
   &__proposals {
     margin-bottom: var(--pix-spacing-4x);
   }
@@ -9,16 +14,16 @@
 }
 
 .element-qcm-header {
-  &__instruction {
-    margin-bottom: var(--pix-spacing-2x);
-    font-weight: var(--pix-font-medium);
-  }
-
   &__direction {
     @extend %pix-body-s;
 
     margin-bottom: var(--pix-spacing-4x);
     color: var(--pix-neutral-500);
+  }
+
+  &__instruction {
+    margin-bottom: var(--pix-spacing-2x);
+    font-weight: var(--pix-font-medium);
   }
 }
 

--- a/mon-pix/app/pods/components/module/qcm/template.hbs
+++ b/mon-pix/app/pods/components/module/qcm/template.hbs
@@ -1,13 +1,13 @@
 <form class="element-qcm">
   <fieldset disabled={{this.disableInput}}>
     <div class="element-qcm__header">
-      <div class="element-qcm-header__instruction">
-        {{html-unsafe @qcm.instruction}}
-      </div>
-
       <legend class="element-qcm-header__direction">
         {{t "pages.modulix.qcm.direction"}}
       </legend>
+
+      <div class="element-qcm-header__instruction">
+        {{html-unsafe @qcm.instruction}}
+      </div>
     </div>
 
     <div class="element-qcm__proposals">

--- a/mon-pix/app/pods/components/module/qcu/styles.scss
+++ b/mon-pix/app/pods/components/module/qcu/styles.scss
@@ -1,4 +1,9 @@
 .element-qcu {
+  &__header {
+    display: flex;
+    flex-direction: column-reverse;
+  }
+
   &__proposals {
     margin-bottom: var(--pix-spacing-4x);
   }
@@ -9,16 +14,16 @@
 }
 
 .element-qcu-header {
-  &__instruction {
-    margin-bottom: var(--pix-spacing-2x);
-    font-weight: var(--pix-font-medium);
-  }
-
   &__direction {
     @extend %pix-body-s;
 
     margin-bottom: var(--pix-spacing-4x);
     color: var(--pix-neutral-500);
+  }
+
+  &__instruction {
+    margin-bottom: var(--pix-spacing-2x);
+    font-weight: var(--pix-font-medium);
   }
 }
 

--- a/mon-pix/app/pods/components/module/qcu/template.hbs
+++ b/mon-pix/app/pods/components/module/qcu/template.hbs
@@ -1,13 +1,13 @@
 <form class="element-qcu">
   <fieldset disabled={{this.disableInput}}>
     <div class="element-qcu__header">
-      <div class="element-qcu-header__instruction">
-        {{html-unsafe @qcu.instruction}}
-      </div>
-
       <legend class="element-qcu-header__direction">
         {{t "pages.modulix.qcu.direction"}}
       </legend>
+
+      <div class="element-qcu-header__instruction">
+        {{html-unsafe @qcu.instruction}}
+      </div>
     </div>
 
     <div class="element-qcu__proposals">

--- a/mon-pix/app/pods/components/module/qrocm/component.js
+++ b/mon-pix/app/pods/components/module/qrocm/component.js
@@ -21,7 +21,7 @@ export default class ModuleQrocm extends Component {
   }
 
   get nbOfProposals() {
-    return this.qrocm.proposals.length;
+    return this.qrocm.proposals.filter(({ type }) => type !== 'text').length;
   }
 
   @action

--- a/mon-pix/app/pods/components/module/qrocm/styles.scss
+++ b/mon-pix/app/pods/components/module/qrocm/styles.scss
@@ -1,4 +1,9 @@
 .element-qrocm {
+  &__header {
+    display: flex;
+    flex-direction: column-reverse;
+  }
+
   &__proposals {
     margin-bottom: var(--pix-spacing-4x);
   }
@@ -9,16 +14,16 @@
 }
 
 .element-qrocm-header {
-  &__instruction {
-    margin-bottom: var(--pix-spacing-3x);
-    font-weight: var(--pix-font-medium);
-  }
-
   &__direction {
     @extend %pix-body-s;
 
     margin-bottom: var(--pix-spacing-4x);
     color: var(--pix-neutral-500);
+  }
+
+  &__instruction {
+    margin-bottom: var(--pix-spacing-2x);
+    font-weight: var(--pix-font-medium);
   }
 }
 

--- a/mon-pix/app/pods/components/module/qrocm/template.hbs
+++ b/mon-pix/app/pods/components/module/qrocm/template.hbs
@@ -1,13 +1,13 @@
 <form class="element-qrocm" autocapitalize="off" autocomplete="nope" autocorrect="off" spellcheck="false">
   <fieldset disabled={{this.disableInput}}>
     <div class="element-qrocm__header">
-      <div class="element-qrocm-header__instruction">
-        {{html-unsafe @qrocm.instruction}}
-      </div>
-
       <legend class="element-qrocm-header__direction">
         {{t "pages.modulix.qrocm.direction" count=this.nbOfProposals}}
       </legend>
+
+      <div class="element-qrocm-header__instruction">
+        {{html-unsafe @qrocm.instruction}}
+      </div>
     </div>
 
     <div class="element-qrocm__proposals">

--- a/mon-pix/tests/integration/components/module/details_test.js
+++ b/mon-pix/tests/integration/components/module/details_test.js
@@ -28,7 +28,7 @@ module('Integration | Component | Module | Details', function (hooks) {
     assert.ok(screen.getByRole('heading', { name: module.title, level: 1 }));
     assert.ok(screen.getByRole('img').hasAttribute('src', module.details.image));
     assert.ok(screen.getByText(module.details.description));
-    assert.ok(screen.getByText(`≈${module.details.duration} min`));
+    assert.ok(screen.getByText(`${module.details.duration} min`));
     assert.ok(screen.getByText(module.details.level));
     assert.ok(screen.getByText(module.details.objectives[0]));
     assert.ok(screen.getByRole('heading', { name: this.intl.t('pages.modulix.details.explanationTitle'), level: 2 }));

--- a/mon-pix/tests/integration/components/module/qrocm_test.js
+++ b/mon-pix/tests/integration/components/module/qrocm_test.js
@@ -56,7 +56,9 @@ module('Integration | Component | Module | QROCM', function (hooks) {
     assert.dom(screen.getByText('Mon instruction')).exists({ count: 1 });
     assert.ok(
       screen.getByRole('group', {
-        legend: this.intl.t('pages.modulix.qrocm.direction', { count: qrocm.proposals.length }),
+        legend: this.intl.t('pages.modulix.qrocm.direction', {
+          count: qrocm.proposals.filter(({ type }) => type !== 'text').length,
+        }),
       }),
     );
     assert.dom(screen.getByText('Ma première proposition')).exists({ count: 1 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1201,7 +1201,7 @@
       },
       "details": {
         "duration": "Duration",
-        "durationValue": "≈{duration} min",
+        "durationValue": "'<span aria-hidden=\"true\">'≈'</span><span class=\"screen-reader-only\">'About '</span>'{duration} min",
         "explanationText1": "The Pix training modules are comprised of lessons and activities to practice and develop your digital skills. The lessons take the form of videos, audios, images and texts. The activities allow you to practice and verify your answers directly. Each module takes around 10 minutes to complete on a particular subject with a level of difficulty from beginner to expert.",
         "explanationText2": "These training modules are actually in beta test phase. You can send us your suggestions for improvement in the questionnaire at the end of each module.",
         "explanationTitle": "What is a module?",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1201,7 +1201,7 @@
       },
       "details": {
         "duration": "Durée",
-        "durationValue": "≈{duration} min",
+        "durationValue": "'<span aria-hidden=\"true\">'≈'</span><span class=\"screen-reader-only\">'Environ '</span>'{duration} min",
         "explanationText1": "Les modules de formation Pix sont composés de leçons et d’activités pour vous exercer et développer vos compétences numériques. Les leçons prennent la forme de vidéos, d'audios, d'images et de textes. Les activités vous permettent de vous entraîner et de vérifier directement vos réponses. Un module dure environ 10 minutes, sur un sujet précis, avec un niveau de difficulté allant de débutant à expert.",
         "explanationText2": "Ces modules de formation sont actuellement en phase de bêta-test. Vous pouvez nous envoyer toutes vos suggestions d’amélioration dans le questionnaire de fin de module.",
         "explanationTitle": "C'est quoi un module ?",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1201,7 +1201,7 @@
       },
       "details": {
         "duration": "Duur",
-        "durationValue": "≈{duration} min",
+        "durationValue": "'<span aria-hidden=\"true\">'≈'</span><span class=\"screen-reader-only\">'Ongeveer '</span>'{duration} min",
         "explanationText1": "Pix trainingsmodules bestaan uit lessen en activiteiten om je te helpen je digitale vaardigheden te oefenen en te ontwikkelen. De lessen bestaan uit video's, audio, afbeeldingen en tekst. Met de activiteiten kun je direct oefenen en je antwoorden controleren. Elke module duurt ongeveer 10 minuten, gaat over een specifiek onderwerp en heeft een moeilijkheidsgraad van beginner tot expert.",
         "explanationText2": "Deze trainingsmodules bevinden zich momenteel in de beta-testfase. Je kunt ons suggesties voor verbetering sturen via de vragenlijst aan het einde van elke module.",
         "explanationTitle": "Wat is een module?",


### PR DESCRIPTION
## :unicorn: Problème
Suite des retours utilisateurs chez INJA, ils ont remonté quelques soucis de lisabilité pour comprendre les consignes des QCU etc.

## :robot: Proposition
Nous avons visuellement garder le structure des `instructions` et `direction` mais, sémantiquement on les a inversé pour qu'il soit plus comprehensible avec un lecture l'ecran.

Nous avons aussi corrigé un probléme avec le plurialisation de champ `direction` de QROCM.

Pour le dernier grain qui s'affiche, nous avons retiré un indicateur visuel mal placé pour le remplacer par un indicateur sur la card.

Avant
![image](https://github.com/1024pix/pix/assets/5855339/30b41d2f-4aca-4a07-9230-b56dfcb34150)

Le caractère `≈` a été transcrit textuellement.

## :rainbow: Remarques
Nous avons ajouté la notion d'un `card` qui existait côté design mais pas encore côté code.

## :100: Pour tester
Aller sur [bien-ecrire-son-adresse-mail](https://app-pr8416.review.pix.fr/modules/bien-ecrire-son-adresse-mail)
Verifier que les instructions de QROCM sont bien pluralisées (singulier et pluriel) 
Verifier que le dernier grain qui s'affiche est bien mis en avance avec une bordure.
Verifier que l'ordre d'instruction et direction sont visuellement pas changé, mais avec un lecture d'écran ils sont lu en inverse.
