### PR TITLE
[FEATURE] Afficher uniquement les missions actives dans Pix 1d et Pix Orga (PIX-11313).

### DIFF
--- a/api/src/school/application/mission-controller.js
+++ b/api/src/school/application/mission-controller.js
@@ -7,11 +7,11 @@ const getById = async function (request, h, dependencies = { missionSerializer }
   return dependencies.missionSerializer.serialize(mission);
 };
 
-const findAll = async function (request, h, dependencies = { missionSerializer }) {
+const findAllActive = async function (request, h, dependencies = { missionSerializer }) {
   const { id: organizationId } = request.params;
-  const missions = await usecases.findAllMissions({ organizationId });
+  const missions = await usecases.findAllActiveMissions({ organizationId });
   return dependencies.missionSerializer.serialize(missions);
 };
 
-const missionController = { getById, findAll };
+const missionController = { getById, findAllActive };
 export { missionController };

--- a/api/src/school/application/mission-route.js
+++ b/api/src/school/application/mission-route.js
@@ -12,7 +12,7 @@ const register = async function (server) {
       config: {
         pre: [{ method: securityPreHandlers.checkPix1dActivated }],
         auth: false,
-        handler: missionController.findAll,
+        handler: missionController.findAllActive,
         tags: ['api', 'pix1d', 'mission'],
         notes: [
           '- **Cette route est restreinte aux utilisateurs de pix1d' +
@@ -28,7 +28,7 @@ const register = async function (server) {
           { method: securityPreHandlers.checkUserBelongsToOrganization },
           { method: securityPreHandlers.checkPix1dActivated },
         ],
-        handler: missionController.findAll,
+        handler: missionController.findAllActive,
         tags: ['api', 'pix1d', 'mission'],
         notes: [
           "- **Cette route est restreinte aux utilisateurs d'une organisation pix1d spécifique" +

--- a/api/src/school/domain/models/Mission.js
+++ b/api/src/school/domain/models/Mission.js
@@ -5,7 +5,6 @@ class Mission {
     competenceId,
     competenceName,
     thematicId,
-    status,
     learningObjectives,
     validatedObjectives,
     areaCode,
@@ -16,7 +15,6 @@ class Mission {
     this.competenceId = competenceId;
     this.competenceName = competenceName;
     this.thematicId = thematicId;
-    this.status = status;
     this.areaCode = areaCode;
     this.learningObjectives = learningObjectives;
     this.validatedObjectives = validatedObjectives;

--- a/api/src/school/domain/usecases/find-all-active-missions.js
+++ b/api/src/school/domain/usecases/find-all-active-missions.js
@@ -1,13 +1,13 @@
 import { injectComplementDataTo } from '../services/inject-complement-data-to-mission.js';
 
-async function findAllMissions({
+async function findAllActiveMissions({
   organizationId,
   missionRepository,
   areaRepository,
   competenceRepository,
   organizationLearnerRepository,
 }) {
-  const missions = await missionRepository.findAllMissions();
+  const missions = await missionRepository.findAllActiveMissions();
   return Promise.all(
     missions.map(async (mission) => {
       return await injectComplementDataTo({
@@ -21,4 +21,4 @@ async function findAllMissions({
   );
 }
 
-export { findAllMissions };
+export { findAllActiveMissions };

--- a/api/src/school/infrastructure/repositories/mission-repository.js
+++ b/api/src/school/infrastructure/repositories/mission-repository.js
@@ -17,13 +17,11 @@ function _toDomain(data, locale) {
     thematicId: data.thematicId,
     learningObjectives: translatedLearningObjectives,
     validatedObjectives: translatedValidatedObjectives,
-    status: data.status,
   });
 }
 
 async function get(id, locale = { locale: FRENCH_FRANCE }) {
   try {
-    // Les missions sont stockées en tant que thématiques dans PixEditor :)
     const missionData = await missionDatasource.get(id);
     return _toDomain(missionData, locale);
   } catch (error) {

--- a/api/src/school/infrastructure/repositories/mission-repository.js
+++ b/api/src/school/infrastructure/repositories/mission-repository.js
@@ -31,9 +31,10 @@ async function get(id, locale = { locale: FRENCH_FRANCE }) {
   }
 }
 
-async function findAllMissions(locale = { locale: FRENCH_FRANCE }) {
-  const missionDataList = await missionDatasource.list();
-  return missionDataList.map((missionData) => _toDomain(missionData, locale));
+async function findAllActiveMissions(locale = { locale: FRENCH_FRANCE }) {
+  const allMissions = await missionDatasource.list();
+  const allActiveMissions = allMissions.filter((mission) => mission.status === 'ACTIVE');
+  return allActiveMissions.map((missionData) => _toDomain(missionData, locale));
 }
 
-export { findAllMissions, get };
+export { findAllActiveMissions, get };

--- a/api/tests/school/integration/application/mission-controller_test.js
+++ b/api/tests/school/integration/application/mission-controller_test.js
@@ -48,14 +48,14 @@ describe('Integration | Controller | mission-controller', function () {
     });
   });
 
-  describe('#findAll', function () {
-    it('should find all missions', async function () {
+  describe('#findAllActive', function () {
+    it('should find all active missions', async function () {
       // given
       const mission = new Mission({ id: 1, name: 'TAG1', color: 'Green', startedBy: 'CM1' });
-      sinon.stub(usecases, 'findAllMissions').resolves([mission]);
+      sinon.stub(usecases, 'findAllActiveMissions').resolves([mission]);
 
       // when
-      const result = await missionController.findAll({ params: { id: 'organizationId' } }, hFake);
+      const result = await missionController.findAllActive({ params: { id: 'organizationId' } }, hFake);
 
       // then
       expect(result.data).to.deep.equal([

--- a/api/tests/school/integration/domain/usecases/find-all-active-missions_test.js
+++ b/api/tests/school/integration/domain/usecases/find-all-active-missions_test.js
@@ -3,7 +3,7 @@ import { usecases } from '../../../../../src/school/domain/usecases/index.js';
 import { databaseBuilder, expect, mockLearningContent } from '../../../../test-helper.js';
 import * as learningContentBuilder from '../../../../tooling/learning-content-builder/index.js';
 
-describe('Integration | UseCases | find-all-missions', function () {
+describe('Integration | UseCases | find-all-active-missions', function () {
   it('return empty array without missions from LCMS', async function () {
     const expectedMissions = [];
 
@@ -11,17 +11,27 @@ describe('Integration | UseCases | find-all-missions', function () {
       missions: [],
     });
 
-    const returnedMissions = await usecases.findAllMissions();
+    const returnedMissions = await usecases.findAllActiveMissions();
     expect(returnedMissions).to.deep.equal(expectedMissions);
   });
 
-  it('return missions from LCMS', async function () {
-    const mission = learningContentBuilder.buildMission({
+  it('return active missions from LCMS', async function () {
+    const activeMission = learningContentBuilder.buildMission({
       id: 12,
       name_i18n: { fr: 'truc' },
       competenceId: 'competenceId',
       thematicId: 'thematicId',
-      status: 'a status',
+      status: 'ACTIVE',
+      learningObjectives_i18n: { fr: 'Il était une fois' },
+      validatedObjectives_i18n: { fr: 'Bravo ! tu as réussi !' },
+    });
+
+    const inactiveMission = learningContentBuilder.buildMission({
+      id: 13,
+      name_i18n: { fr: 'truc' },
+      competenceId: 'competenceId',
+      thematicId: 'thematicId',
+      status: 'INACTIVE',
       learningObjectives_i18n: { fr: 'Il était une fois' },
       validatedObjectives_i18n: { fr: 'Bravo ! tu as réussi !' },
     });
@@ -42,7 +52,7 @@ describe('Integration | UseCases | find-all-missions', function () {
     };
 
     mockLearningContent({
-      missions: [mission],
+      missions: [activeMission, inactiveMission],
       areas: [area],
       competences: [competence],
     });
@@ -53,14 +63,14 @@ describe('Integration | UseCases | find-all-missions', function () {
       competenceId: 'competenceId',
       thematicId: 'thematicId',
       competenceName: '4.5 Competence',
-      status: 'a status',
+      status: 'ACTIVE',
       areaCode: 3,
       learningObjectives: 'Il était une fois',
       validatedObjectives: 'Bravo ! tu as réussi !',
       startedBy: '',
     });
     const expectedMissions = [expectedMission];
-    const returnedMissions = await usecases.findAllMissions({ organizationId });
+    const returnedMissions = await usecases.findAllActiveMissions({ organizationId });
 
     expect(returnedMissions).to.deep.equal(expectedMissions);
   });

--- a/api/tests/school/unit/application/mission-route_test.js
+++ b/api/tests/school/unit/application/mission-route_test.js
@@ -38,7 +38,7 @@ describe('Unit | Router | mission-route', function () {
     it('should check pix1d activated', async function () {
       // given
       sinon.spy(securityPreHandlers, 'checkPix1dActivated');
-      sinon.stub(missionController, 'findAll').callsFake((request, h) => h.response('ok'));
+      sinon.stub(missionController, 'findAllActive').callsFake((request, h) => h.response('ok'));
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 
@@ -52,7 +52,7 @@ describe('Unit | Router | mission-route', function () {
     it('should return 200', async function () {
       // given
       sinon.stub(securityPreHandlers, 'checkPix1dActivated').callsFake((request, h) => h.response());
-      sinon.stub(missionController, 'findAll').callsFake((request, h) => h.response('ok'));
+      sinon.stub(missionController, 'findAllActive').callsFake((request, h) => h.response('ok'));
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 
@@ -84,7 +84,7 @@ describe('Unit | Router | mission-route', function () {
       // given
       sinon.stub(securityPreHandlers, 'checkUserBelongsToOrganization').resolves(true);
       sinon.stub(securityPreHandlers, 'checkPix1dActivated').resolves(true);
-      sinon.stub(missionController, 'findAll').callsFake((request, h) => h.response('ok'));
+      sinon.stub(missionController, 'findAllActive').callsFake((request, h) => h.response('ok'));
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 


### PR DESCRIPTION
## :unicorn: Problème
L'utilisateur pouvait voir les missions inactives, à la fois dans pix-orga et pix-1d.

## :robot: Proposition
Limiter la liste des missions retournées par l'API et affichées à l'utilisateur, en filtrant sur le statut de la missions.

## :100: Pour tester
1- Se connecter à Pix editor et vérifier la présence d'une mission inactive dans le pool de missions.
2- Se connecter à pix-1d et pix-orga et vérifier que la mission inactive n'est pas visible