### PR TITLE
[FEATURE][MON-PIX] Modifier les liens du footer pour la langue néerlandaise (PIX-11596)

### DIFF
--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -54,19 +54,6 @@ export default class Url extends Service {
     }
   }
 
-  get _showcaseWebsiteUrl() {
-    const currentLanguage = this.intl.primaryLocale;
-
-    if (currentLanguage === ENGLISH_INTERNATIONAL_LOCALE) {
-      return `https://pix.${this.currentDomain.getExtension()}/en-gb`;
-    }
-    return `https://pix.${this.currentDomain.getExtension()}`;
-  }
-
-  get _showcaseWebsiteLinkText() {
-    return this.intl.t('navigation.showcase-homepage', { tld: this.currentDomain.getExtension() });
-  }
-
   get accessibilityUrl() {
     const currentLanguage = this.intl.primaryLocale;
     if (this.currentDomain.isFranceDomain) {
@@ -101,5 +88,18 @@ export default class Url extends Service {
       return 'https://pix.org/en/news/discover-level-7-on-pix';
     }
     return 'https://pix.fr/actualites/decouvrez-le-niveau-7-des-maintenant-sur-pix';
+  }
+
+  get _showcaseWebsiteUrl() {
+    const currentLanguage = this.intl.primaryLocale;
+
+    if (currentLanguage === ENGLISH_INTERNATIONAL_LOCALE) {
+      return `https://pix.${this.currentDomain.getExtension()}/en-gb`;
+    }
+    return `https://pix.${this.currentDomain.getExtension()}`;
+  }
+
+  get _showcaseWebsiteLinkText() {
+    return this.intl.t('navigation.showcase-homepage', { tld: this.currentDomain.getExtension() });
   }
 }

--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -82,10 +82,16 @@ export default class Url extends Service {
   get supportHomeUrl() {
     const currentLanguage = this.intl.primaryLocale;
 
-    if (currentLanguage === ENGLISH_INTERNATIONAL_LOCALE) {
-      return 'https://support.pix.org/en/support/home';
+    if (this.currentDomain.isFranceDomain) {
+      return 'https://support.pix.org/fr/support/home';
     }
-    return 'https://support.pix.org/fr/support/home';
+
+    switch (currentLanguage) {
+      case ENGLISH_INTERNATIONAL_LOCALE:
+        return 'https://support.pix.org/en/support/home';
+      default:
+        return 'https://support.pix.org/fr/support/home';
+    }
   }
 
   get levelSevenNewsUrl() {

--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -1,7 +1,6 @@
 import Service, { inject as service } from '@ember/service';
 import ENV from 'mon-pix/config/environment';
 
-const FRENCH_INTERNATIONAL_LOCALE = 'fr';
 const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 const DUTCH_INTERNATIONAL_LOCALE = 'nl';
 
@@ -89,6 +88,8 @@ export default class Url extends Service {
     switch (currentLanguage) {
       case ENGLISH_INTERNATIONAL_LOCALE:
         return 'https://support.pix.org/en/support/home';
+      case DUTCH_INTERNATIONAL_LOCALE:
+        return 'https://pix.org/nl-be/support';
       default:
         return 'https://support.pix.org/fr/support/home';
     }

--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -56,12 +56,19 @@ export default class Url extends Service {
 
   get accessibilityUrl() {
     const currentLanguage = this.intl.primaryLocale;
+
     if (this.currentDomain.isFranceDomain) {
       return `https://pix.fr/accessibilite`;
     }
-    return currentLanguage === FRENCH_INTERNATIONAL_LOCALE
-      ? `https://pix.org/fr/accessibilite`
-      : `https://pix.org/en-gb/accessibility`;
+
+    switch (currentLanguage) {
+      case ENGLISH_INTERNATIONAL_LOCALE:
+        return 'https://pix.org/en-gb/accessibility';
+      case DUTCH_INTERNATIONAL_LOCALE:
+        return 'https://pix.org/nl-be/toegankelijkheid';
+      default:
+        return 'https://pix.org/fr/accessibilite';
+    }
   }
 
   get accessibilityHelpUrl() {

--- a/mon-pix/tests/unit/services/url_test.js
+++ b/mon-pix/tests/unit/services/url_test.js
@@ -316,6 +316,22 @@ module('Unit | Service | url', function (hooks) {
           assert.strictEqual(accessibilityUrl, expectedAccessibilityUrl);
         });
       });
+
+      module('when current language is "nl"', function () {
+        test('returns the French page URL', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.currentDomain = { isFranceDomain: true };
+          service.intl = { primaryLocale: DUTCH_INTERNATIONAL_LOCALE };
+          const expectedAccessibilityUrl = 'https://pix.fr/accessibilite';
+
+          // when
+          const accessibilityUrl = service.accessibilityUrl;
+
+          // then
+          assert.strictEqual(accessibilityUrl, expectedAccessibilityUrl);
+        });
+      });
     });
 
     module('when website is pix.org', function () {
@@ -342,6 +358,22 @@ module('Unit | Service | url', function (hooks) {
           service.currentDomain = { isFranceDomain: false };
           service.intl = { primaryLocale: ENGLISH_INTERNATIONAL_LOCALE };
           const expectedAccessibilityUrl = 'https://pix.org/en-gb/accessibility';
+
+          // when
+          const accessibilityUrl = service.accessibilityUrl;
+
+          // then
+          assert.strictEqual(accessibilityUrl, expectedAccessibilityUrl);
+        });
+      });
+
+      module('when current language is "nl"', function () {
+        test('returns the Nederland page URL', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.currentDomain = { isFranceDomain: false };
+          service.intl = { primaryLocale: DUTCH_INTERNATIONAL_LOCALE };
+          const expectedAccessibilityUrl = 'https://pix.org/nl-be/toegankelijkheid';
 
           // when
           const accessibilityUrl = service.accessibilityUrl;

--- a/mon-pix/tests/unit/services/url_test.js
+++ b/mon-pix/tests/unit/services/url_test.js
@@ -448,6 +448,22 @@ module('Unit | Service | url', function (hooks) {
           assert.strictEqual(supportHomeUrl, expectedSupportHomeUrl);
         });
       });
+
+      module('when current language is "nl"', function () {
+        test('returns the French page URL', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.currentDomain = { isFranceDomain: true };
+          service.intl = { primaryLocale: DUTCH_INTERNATIONAL_LOCALE };
+          const expectedSupportHomeUrl = 'https://support.pix.org/fr/support/home';
+
+          // when
+          const supportHomeUrl = service.supportHomeUrl;
+
+          // then
+          assert.strictEqual(supportHomeUrl, expectedSupportHomeUrl);
+        });
+      });
     });
 
     module('when website is pix.org', function () {
@@ -474,6 +490,22 @@ module('Unit | Service | url', function (hooks) {
           service.currentDomain = { isFranceDomain: false };
           service.intl = { primaryLocale: ENGLISH_INTERNATIONAL_LOCALE };
           const expectedSupportHomeUrl = 'https://support.pix.org/en/support/home';
+
+          // when
+          const supportHomeUrl = service.supportHomeUrl;
+
+          // then
+          assert.strictEqual(supportHomeUrl, expectedSupportHomeUrl);
+        });
+      });
+
+      module('when current language is "nl"', function () {
+        test('returns the Nederland page URL', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.currentDomain = { isFranceDomain: false };
+          service.intl = { primaryLocale: DUTCH_INTERNATIONAL_LOCALE };
+          const expectedSupportHomeUrl = 'https://pix.org/nl-be/support';
 
           // when
           const supportHomeUrl = service.supportHomeUrl;

--- a/mon-pix/tests/unit/services/url_test.js
+++ b/mon-pix/tests/unit/services/url_test.js
@@ -416,4 +416,72 @@ module('Unit | Service | url', function (hooks) {
       });
     });
   });
+
+  module('#supportHomeUrl', function () {
+    module('when website is pix.fr', function () {
+      test('returns the French page URL', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url');
+        service.currentDomain = { isFranceDomain: true };
+        service.intl = { primaryLocale: FRENCH_INTERNATIONAL_LOCALE };
+        const expectedSupportHomeUrl = 'https://support.pix.org/fr/support/home';
+
+        // when
+        const supportHomeUrl = service.supportHomeUrl;
+
+        // then
+        assert.strictEqual(supportHomeUrl, expectedSupportHomeUrl);
+      });
+
+      module('when current language is "en"', function () {
+        test('returns the French page URL', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.currentDomain = { isFranceDomain: true };
+          service.intl = { primaryLocale: ENGLISH_INTERNATIONAL_LOCALE };
+          const expectedSupportHomeUrl = 'https://support.pix.org/fr/support/home';
+
+          // when
+          const supportHomeUrl = service.supportHomeUrl;
+
+          // then
+          assert.strictEqual(supportHomeUrl, expectedSupportHomeUrl);
+        });
+      });
+    });
+
+    module('when website is pix.org', function () {
+      module('when current language is "fr"', function () {
+        test('returns the French page URL', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.currentDomain = { isFranceDomain: false };
+          service.intl = { primaryLocale: FRENCH_INTERNATIONAL_LOCALE };
+          const expectedSupportHomeUrl = 'https://support.pix.org/fr/support/home';
+
+          // when
+          const supportHomeUrl = service.supportHomeUrl;
+
+          // then
+          assert.strictEqual(supportHomeUrl, expectedSupportHomeUrl);
+        });
+      });
+
+      module('when current language is "en"', function () {
+        test('returns the English page URL', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.currentDomain = { isFranceDomain: false };
+          service.intl = { primaryLocale: ENGLISH_INTERNATIONAL_LOCALE };
+          const expectedSupportHomeUrl = 'https://support.pix.org/en/support/home';
+
+          // when
+          const supportHomeUrl = service.supportHomeUrl;
+
+          // then
+          assert.strictEqual(supportHomeUrl, expectedSupportHomeUrl);
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème

Certains liens du footer, une fois connecté sur Pix App pour la langue néerlandaise, ne sont pas corrects. Ces liens pointent vers la version française ou anglaise des documents.

## :robot: Proposition

Modifier les liens pour pointer vers la version néerlandaise du document.

## :rainbow: Remarques

RAS

## :100: Pour tester

1. Se connecter à Pix App (compte d'exemple: superadmin@example.net)
2. Aller sur la page Mon Compte dans l'onglet Choisir ma langue
3. Choisir la langue Nederlands
4. Vérifier en bas de page
    - Helpcentrum -- https://pix.org/nl-be/support
    - Toegankelijkheid: gedeeltelijk conform -- https://pix.org/nl-be/toegankelijkheid
    - UGC -- https://pix.org/nl-be/algemene-gebruiksvoorwaarden 
    - Gegevensbeschermingsbeleid -- https://pix.org/nl-be/beleid-inzake-de-bescherming-van-persoonsgegevens 
