### PR TITLE
[FEATURE] Ajoute l'information sur la remontée auto dans la page de détail d'une organisation (PIX-9904)

### DIFF
--- a/admin/app/components/organizations/information-section-edit.hbs
+++ b/admin/app/components/organizations/information-section-edit.hbs
@@ -198,9 +198,9 @@
 
     <div class="form-field organization-edit-form__checkbox">
       <PixCheckbox
-        @id="enableMultipleSendingAssessement"
+        @id="isMultipleSendingAssessmentEnabled"
         {{on "change" this.onChangeMultipleSendingAssessment}}
-        @checked={{this.form.enableMultipleSendingAssessment}}
+        @checked={{this.form.isMultipleSendingAssessmentEnabled}}
         @class="form-field__label"
       >
         Activer l'envoi multiple pour les campagnes de type évaluation
@@ -208,9 +208,9 @@
     </div>
     <div class="form-field organization-edit-form__checkbox">
       <PixCheckbox
-        @id="enablePlacesManagement"
+        @id="isPlacesManagementEnabled"
         {{on "change" this.onChangePlacesManagement}}
-        @checked={{this.form.enablePlacesManagement}}
+        @checked={{this.form.isPlacesManagementEnabled}}
         @class="form-field__label"
       >
         Activer la page Places sur PixOrga

--- a/admin/app/components/organizations/information-section-edit.js
+++ b/admin/app/components/organizations/information-section-edit.js
@@ -40,12 +40,12 @@ export default class OrganizationInformationSectionEditionMode extends Component
 
   @action
   onChangeMultipleSendingAssessment() {
-    this.form.enableMultipleSendingAssessment = !this.form.enableMultipleSendingAssessment;
+    this.form.isMultipleSendingAssessmentEnabled = !this.form.isMultipleSendingAssessmentEnabled;
   }
 
   @action
   onChangePlacesManagement() {
-    this.form.enablePlacesManagement = !this.form.enablePlacesManagement;
+    this.form.isPlacesManagementEnabled = !this.form.isPlacesManagementEnabled;
   }
 
   @action
@@ -73,8 +73,8 @@ export default class OrganizationInformationSectionEditionMode extends Component
     this.args.organization.set('documentationUrl', this.form.documentationUrl);
     this.args.organization.set('showSkills', this.form.showSkills);
     this.args.organization.set('identityProviderForCampaigns', this.form.identityProviderForCampaigns);
-    this.args.organization.set('enableMultipleSendingAssessment', this.form.enableMultipleSendingAssessment);
-    this.args.organization.set('enablePlacesManagement', this.form.enablePlacesManagement);
+    this.args.organization.set('isMultipleSendingAssessmentEnabled', this.form.isMultipleSendingAssessmentEnabled);
+    this.args.organization.set('isPlacesManagementEnabled', this.form.isPlacesManagementEnabled);
 
     this.closeAndResetForm();
     return this.args.onSubmit();
@@ -92,8 +92,8 @@ export default class OrganizationInformationSectionEditionMode extends Component
     this.form.isManagingStudents = this.args.organization.isManagingStudents;
     this.form.documentationUrl = this.args.organization.documentationUrl;
     this.form.showSkills = this.args.organization.showSkills;
-    this.form.enableMultipleSendingAssessment = this.args.organization.enableMultipleSendingAssessment;
-    this.form.enablePlacesManagement = this.args.organization.enablePlacesManagement;
+    this.form.isMultipleSendingAssessmentEnabled = this.args.organization.isMultipleSendingAssessmentEnabled;
+    this.form.isPlacesManagementEnabled = this.args.organization.isPlacesManagementEnabled;
     this.form.identityProviderForCampaigns =
       this.args.organization.identityProviderForCampaigns ?? this.noIdentityProviderOption.value;
   }

--- a/admin/app/components/organizations/information-section-view.hbs
+++ b/admin/app/components/organizations/information-section-view.hbs
@@ -104,9 +104,9 @@
           <li>Gestion d’élèves/étudiants : {{if @organization.isManagingStudents "Oui" "Non"}}</li>
         {{/if}}
         <li>Activer l'envoi multiple sur les campagnes d'évaluation :
-          {{if @organization.enableMultipleSendingAssessment "Oui" "Non"}}</li>
+          {{if @organization.isMultipleSendingAssessmentEnabled "Oui" "Non"}}</li>
         <li>Activer la page Places sur PixOrga :
-          {{if @organization.enablePlacesManagement "Oui" "Non"}}</li>
+          {{if @organization.isPlacesManagementEnabled "Oui" "Non"}}</li>
         {{#if @organization.code}}
           <br />
           <li>Code : {{@organization.code}}</li>

--- a/admin/app/components/organizations/information-section-view.hbs
+++ b/admin/app/components/organizations/information-section-view.hbs
@@ -76,15 +76,11 @@
             Non spécifié
           {{/if}}
         </li>
-        <li>Affichage des acquis dans l'export de résultats : {{if @organization.showSkills "Oui" "Non"}}</li>
         <li>SSO : {{this.identityProviderName}}</li>
 
         <br />
 
         <li>Adresse e-mail d'activation SCO : {{@organization.email}}</li>
-        {{#if (or @organization.isOrganizationSCO @organization.isOrganizationSUP)}}
-          <li>Gestion d’élèves/étudiants : {{if @organization.isManagingStudents "Oui" "Non"}}</li>
-        {{/if}}
 
         <br />
 
@@ -100,6 +96,13 @@
           {{/if}}
         </li>
         <li>Affichage du Net Promoter Score : {{if @organization.showNPS "Oui" "Non"}}</li>
+      </ul>
+      <h3 class="page-section__title page-section__title--sub">Fonctionnalités disponibles : </h3>
+      <ul class="organization-information-section__details__list">
+        <li>Affichage des acquis dans l'export de résultats : {{if @organization.showSkills "Oui" "Non"}}</li>
+        {{#if (or @organization.isOrganizationSCO @organization.isOrganizationSUP)}}
+          <li>Gestion d’élèves/étudiants : {{if @organization.isManagingStudents "Oui" "Non"}}</li>
+        {{/if}}
         <li>Activer l'envoi multiple sur les campagnes d'évaluation :
           {{if @organization.enableMultipleSendingAssessment "Oui" "Non"}}</li>
         <li>Activer la page Places sur PixOrga :
@@ -107,6 +110,9 @@
         {{#if @organization.code}}
           <br />
           <li>Code : {{@organization.code}}</li>
+        {{/if}}
+        {{#if @organization.isComputeCertificabilityEnabled}}
+          <li>Certificabilité automatique activée</li>
         {{/if}}
       </ul>
       {{#if this.accessControl.hasAccessToOrganizationActionsScope}}

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -51,24 +51,24 @@ export default class Organization extends Model {
     return this.features[Organization.featureList.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY];
   }
 
-  get enableMultipleSendingAssessment() {
+  get isMultipleSendingAssessmentEnabled() {
     if (!this.features) return false;
     return this.features[Organization.featureList.MULTIPLE_SENDING_ASSESSMENT];
   }
 
-  set enableMultipleSendingAssessment(value) {
+  set isMultipleSendingAssessmentEnabled(value) {
     if (!this.features) {
       this.features = {};
     }
     this.features[Organization.featureList.MULTIPLE_SENDING_ASSESSMENT] = value;
   }
 
-  get enablePlacesManagement() {
+  get isPlacesManagementEnabled() {
     if (!this.features) return false;
     return this.features[Organization.featureList.PLACES_MANAGEMENT];
   }
 
-  set enablePlacesManagement(value) {
+  set isPlacesManagementEnabled(value) {
     if (!this.features) {
       this.features = {};
     }

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -42,7 +42,13 @@ export default class Organization extends Model {
     return {
       MULTIPLE_SENDING_ASSESSMENT: 'MULTIPLE_SENDING_ASSESSMENT',
       PLACES_MANAGEMENT: 'PLACES_MANAGEMENT',
+      COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY: 'COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY',
     };
+  }
+
+  get isComputeCertificabilityEnabled() {
+    if (!this.features) return false;
+    return this.features[Organization.featureList.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY];
   }
 
   get enableMultipleSendingAssessment() {

--- a/admin/tests/integration/components/organizations/information-section-view_test.js
+++ b/admin/tests/integration/components/organizations/information-section-view_test.js
@@ -329,6 +329,41 @@ module('Integration | Component | organizations/information-section-view', funct
         assert.dom(screen.queryByRole('checkbox', { name: 'Gestion d’élèves/étudiants' })).doesNotExist();
       });
     });
+
+    module('Features', function () {
+      module('when compute certificability is true', function () {
+        test('should display this information', async function (assert) {
+          // given
+          const organization = EmberObject.create({
+            isComputeCertificabilityEnabled: true,
+          });
+          this.set('organization', organization);
+
+          // when
+          const screen = await render(
+            hbs`<Organizations::InformationSectionView @organization={{this.organization}} />`,
+          );
+          // then
+          assert.ok(screen.getByText('Certificabilité automatique activée'));
+        });
+      });
+      module('when compute certificability is false', function () {
+        test('should not display this information', async function (assert) {
+          // given
+          const organization = EmberObject.create({
+            isComputeCertificabilityEnabled: false,
+          });
+          this.set('organization', organization);
+
+          // when
+          const screen = await render(
+            hbs`<Organizations::InformationSectionView @organization={{this.organization}} />`,
+          );
+          // then
+          assert.notOk(screen.queryByText('Certificabilité automatique activée'));
+        });
+      });
+    });
   });
 
   module('when user does not have access', function () {

--- a/admin/tests/unit/models/organization_test.js
+++ b/admin/tests/unit/models/organization_test.js
@@ -4,6 +4,50 @@ import { module, test } from 'qunit';
 module('Unit | Model | organization', function (hooks) {
   setupTest(hooks);
 
+  module('#isComputeCertificabilityEnabled', function () {
+    module('#get', function () {
+      test('it returns true when feature is enabled', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const model = store.createRecord('organization', {
+          features: { ['COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY']: true },
+        });
+
+        // when
+        const isComputeCertificabilityEnabled = model.isComputeCertificabilityEnabled;
+
+        // then
+        assert.true(isComputeCertificabilityEnabled);
+      });
+
+      test('it returns false when feature is disabled', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const model = store.createRecord('organization', {
+          features: { ['COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY']: false },
+        });
+
+        // when
+        const isComputeCertificabilityEnabled = model.isComputeCertificabilityEnabled;
+
+        // then
+        assert.false(isComputeCertificabilityEnabled);
+      });
+
+      test('it returns false when no features are provided', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const model = store.createRecord('organization', {});
+
+        // when
+        const isComputeCertificabilityEnabled = model.isComputeCertificabilityEnabled;
+
+        // then
+        assert.false(isComputeCertificabilityEnabled);
+      });
+    });
+  });
+
   module('#enablePlacesManagement', function () {
     module('#get', function () {
       test('it returns true when feature is enabled', function (assert) {

--- a/admin/tests/unit/models/organization_test.js
+++ b/admin/tests/unit/models/organization_test.js
@@ -48,7 +48,7 @@ module('Unit | Model | organization', function (hooks) {
     });
   });
 
-  module('#enablePlacesManagement', function () {
+  module('#isPlacesManagementEnabled', function () {
     module('#get', function () {
       test('it returns true when feature is enabled', function (assert) {
         // given
@@ -58,10 +58,10 @@ module('Unit | Model | organization', function (hooks) {
         });
 
         // when
-        const enablePlacesManagement = model.enablePlacesManagement;
+        const isPlacesManagementEnabled = model.isPlacesManagementEnabled;
 
         // then
-        assert.true(enablePlacesManagement);
+        assert.true(isPlacesManagementEnabled);
       });
       test('it returns false when feature is disabled', function (assert) {
         // given
@@ -71,10 +71,10 @@ module('Unit | Model | organization', function (hooks) {
         });
 
         // when
-        const enablePlacesManagement = model.enablePlacesManagement;
+        const isPlacesManagementEnabled = model.isPlacesManagementEnabled;
 
         // then
-        assert.false(enablePlacesManagement);
+        assert.false(isPlacesManagementEnabled);
       });
       test('it returns false when no features are provided', function (assert) {
         // given
@@ -82,10 +82,10 @@ module('Unit | Model | organization', function (hooks) {
         const model = store.createRecord('organization', {});
 
         // when
-        const enablePlacesManagement = model.enablePlacesManagement;
+        const isPlacesManagementEnabled = model.isPlacesManagementEnabled;
 
         // then
-        assert.false(enablePlacesManagement);
+        assert.false(isPlacesManagementEnabled);
       });
     });
 
@@ -98,11 +98,11 @@ module('Unit | Model | organization', function (hooks) {
         });
 
         // when
-        model.enablePlacesManagement = true;
+        model.isPlacesManagementEnabled = true;
 
         // then
-        const enablePlacesManagement = model.enablePlacesManagement;
-        assert.true(enablePlacesManagement);
+        const isPlacesManagementEnabled = model.isPlacesManagementEnabled;
+        assert.true(isPlacesManagementEnabled);
       });
       test('it disable feature', function (assert) {
         // given
@@ -111,11 +111,11 @@ module('Unit | Model | organization', function (hooks) {
           features: { ['PLACES_MANAGEMENT']: true },
         });
         // when
-        model.enablePlacesManagement = false;
+        model.isPlacesManagementEnabled = false;
 
         // then
-        const enablePlacesManagement = model.enablePlacesManagement;
-        assert.false(enablePlacesManagement);
+        const isPlacesManagementEnabled = model.isPlacesManagementEnabled;
+        assert.false(isPlacesManagementEnabled);
       });
       test('it handles having no features yet', function (assert) {
         // given
@@ -123,16 +123,16 @@ module('Unit | Model | organization', function (hooks) {
         const model = store.createRecord('organization', {});
 
         // when
-        model.enablePlacesManagement = true;
+        model.isPlacesManagementEnabled = true;
 
         // then
-        const enablePlacesManagement = model.enablePlacesManagement;
-        assert.true(enablePlacesManagement);
+        const isPlacesManagementEnabled = model.isPlacesManagementEnabled;
+        assert.true(isPlacesManagementEnabled);
       });
     });
   });
 
-  module('#enableMultipleSendingAssessment', function () {
+  module('#isMultipleSendingAssessmentEnabled', function () {
     module('#get', function () {
       test('it returns true when feature is enabled', function (assert) {
         // given
@@ -142,10 +142,10 @@ module('Unit | Model | organization', function (hooks) {
         });
 
         // when
-        const enableMultipleSendingAssessment = model.enableMultipleSendingAssessment;
+        const isMultipleSendingAssessmentEnabled = model.isMultipleSendingAssessmentEnabled;
 
         // then
-        assert.true(enableMultipleSendingAssessment);
+        assert.true(isMultipleSendingAssessmentEnabled);
       });
       test('it returns false when feature is disabled', function (assert) {
         // given
@@ -155,10 +155,10 @@ module('Unit | Model | organization', function (hooks) {
         });
 
         // when
-        const enableMultipleSendingAssessment = model.enableMultipleSendingAssessment;
+        const isMultipleSendingAssessmentEnabled = model.isMultipleSendingAssessmentEnabled;
 
         // then
-        assert.false(enableMultipleSendingAssessment);
+        assert.false(isMultipleSendingAssessmentEnabled);
       });
       test('it returns false when no features are provided', function (assert) {
         // given
@@ -166,10 +166,10 @@ module('Unit | Model | organization', function (hooks) {
         const model = store.createRecord('organization', {});
 
         // when
-        const enableMultipleSendingAssessment = model.enableMultipleSendingAssessment;
+        const isMultipleSendingAssessmentEnabled = model.isMultipleSendingAssessmentEnabled;
 
         // then
-        assert.false(enableMultipleSendingAssessment);
+        assert.false(isMultipleSendingAssessmentEnabled);
       });
     });
 
@@ -182,11 +182,11 @@ module('Unit | Model | organization', function (hooks) {
         });
 
         // when
-        model.enableMultipleSendingAssessment = true;
+        model.isMultipleSendingAssessmentEnabled = true;
 
         // then
-        const enableMultipleSendingAssessment = model.enableMultipleSendingAssessment;
-        assert.true(enableMultipleSendingAssessment);
+        const isMultipleSendingAssessmentEnabled = model.isMultipleSendingAssessmentEnabled;
+        assert.true(isMultipleSendingAssessmentEnabled);
       });
       test('it disable feature', function (assert) {
         // given
@@ -195,11 +195,11 @@ module('Unit | Model | organization', function (hooks) {
           features: { ['MULTIPLE_SENDING_ASSESSMENT']: true },
         });
         // when
-        model.enableMultipleSendingAssessment = false;
+        model.isMultipleSendingAssessmentEnabled = false;
 
         // then
-        const enableMultipleSendingAssessment = model.enableMultipleSendingAssessment;
-        assert.false(enableMultipleSendingAssessment);
+        const isMultipleSendingAssessmentEnabled = model.isMultipleSendingAssessmentEnabled;
+        assert.false(isMultipleSendingAssessmentEnabled);
       });
       test('it handles having no features yet', function (assert) {
         // given
@@ -207,11 +207,11 @@ module('Unit | Model | organization', function (hooks) {
         const model = store.createRecord('organization', {});
 
         // when
-        model.enableMultipleSendingAssessment = true;
+        model.isMultipleSendingAssessmentEnabled = true;
 
         // then
-        const enableMultipleSendingAssessment = model.enableMultipleSendingAssessment;
-        assert.true(enableMultipleSendingAssessment);
+        const isMultipleSendingAssessmentEnabled = model.isMultipleSendingAssessmentEnabled;
+        assert.true(isMultipleSendingAssessmentEnabled);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Nous avons activé la fonctionnalité "remontée automatique de la certificabilité" pour toutes les orgas SCO MEN, AGRI et AEFE. 
Actuellement, l’info n’est pas visible dans PixAdmin au niveau des orgas. 
Cela pourrait être compliqué si on ouvre la fonctionnalité à d’autres orgas ou pour les personnes n’ayant pas l’historique sur le sujet. 

## :robot: Proposition
Afficher “Certificabilité auto activée” pour les orgas concernée dans PixAdmin au niveau de l’encadré rouge : 

## :rainbow: Remarques
On a ajouté un sous titre pour les features dispo sur une orga afin que ce soit plus lisible

## :100: Pour tester
- Se connecter à Pix Admin
- Aller sur la page de l'organisation 'Sco - Managing Student' 
- Vérifier que l'information "Certificabilité automatique activée" est bien affichée
- Aller sur la page d'une autre orga (Sup, Pro ou Sco not managing)
- Vérifier que cette fois l'information n'apparait pas
- 🐈‍⬛ 
