### PR TITLE
[BUGFIX] Correction typographique : ajout des espaces fines et espaces mots insécables dans tous les modules

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
@@ -35,7 +35,7 @@
       "grainId": "09304128-193f-4ea8-bda7-edffd72b1bf2"
     },
     {
-      "content": "<p>Vous l’avez sûrement remarqué, nous parlons depuis le début de ce module d’adresses IP publiques.<br>Il existe un autre type d’adresse IP : les adresses IP privées, aussi appelées IP locales.</p>",
+      "content": "<p>Vous l’avez sûrement remarqué, nous parlons depuis le début de ce module d’adresses IP publiques.<br>Il existe un autre type d’adresse IP&nbsp;: les adresses IP privées, aussi appelées IP locales.</p>",
       "grainId": "45d507ce-f822-4a06-aa6e-f2a1b0aeada3"
     },
     {
@@ -59,7 +59,7 @@
           "type": "image",
           "url": "https://images.pix.fr/modulix/adresse-ip-publique-et-vous/intro.jpg",
           "alt": "Image décrite dans l'alternative textuelle",
-          "alternativeText": "<p>Recherche \"recettes de cuisine végétariennes\" SOSCuisine Lien vers soscuisine.com categorie vegetarienne Recette végétarienne Recettes végétariennes • Critères de recherche actifs • Affiner la recherche: • Résultats de recherche : 906 résultats trouvés • Zucchini à la menthe • Yogourt ... © CuisinePop.com Lien vers cuisinepop.com Recettes végétariennes faciles à préparer. Des nouvelles ... Plus de résultats v France • Toulouse - D'après votre adresse IP - Mettre à jour ma position</p>"
+          "alternativeText": "<p>Recherche \"recettes de cuisine végétariennes\" SOSCuisine Lien vers soscuisine.com categorie vegetarienne Recette végétarienne Recettes végétariennes • Critères de recherche actifs • Affiner la recherche: • Résultats de recherche&nbsp;: 906 résultats trouvés • Zucchini à la menthe • Yogourt ... © CuisinePop.com Lien vers cuisinepop.com Recettes végétariennes faciles à préparer. Des nouvelles ... Plus de résultats v France • Toulouse - D'après votre adresse IP - Mettre à jour ma position</p>"
         },
         {
           "id": "ff75255c-18e0-4cd9-8fd1-83a9ab6994fb",
@@ -298,7 +298,7 @@
         {
           "id": "0856af53-1060-478f-8416-ddbc5ed3940c",
           "type": "text",
-          "content": "<h3>Indice n°1 :</h3><p>Faites une recherche en ligne. Des sites internet existent pour cela.</p><h3>Indice n°2 :</h3><p>Pour votre recherche, utilisez les mots-clés \"localisation\" et \"adresse IP\".</p>"
+          "content": "<h3>Indice n°1&nbsp;:</h3><p>Faites une recherche en ligne. Des sites internet existent pour cela.</p><h3>Indice n°2&nbsp;:</h3><p>Pour votre recherche, utilisez les mots-clés \"localisation\" et \"adresse IP\".</p>"
         }
       ]
     },
@@ -436,7 +436,7 @@
         {
           "id": "83c57d2b-c2d8-46fe-9b1c-051a58dcf890",
           "type": "text",
-          "content": "<h3>Indice n°1 :</h3><p>Faites une recherche en ligne. Des sites internet existent pour cela.</p><h3>Indice n°2 :</h3><p>Pour votre recherche, utilisez les mots-clés \"trouver\" et \"mon adresse IP\".</p>"
+          "content": "<h3>Indice n°1&nbsp;:</h3><p>Faites une recherche en ligne. Des sites internet existent pour cela.</p><h3>Indice n°2&nbsp;:</h3><p>Pour votre recherche, utilisez les mots-clés \"trouver\" et \"mon adresse IP\".</p>"
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
@@ -244,7 +244,7 @@
           ],
           "feedbacks": {
             "valid": "<p>Correct. Au mieux, avec une adresse IP publique, on peut connaître votre pays ou votre ville. Si besoin, les autorités peuvent cependant accéder à plus d'informations dans un cadre prévu par la loi.</p>",
-            "invalid": "<p>Incorrect. Une adresse IP publique permet d'identifier un pays, voire une ville de connexion, mais difficile d’en savoir plus !</p>"
+            "invalid": "<p>Incorrect. Une adresse IP publique permet d'identifier un pays, voire une ville de connexion, mais difficile d’en savoir plus&#8239;!</p>"
           },
           "solution": "2"
         }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
@@ -27,7 +27,7 @@
       "grainId": "eba0b676-c0c4-4b32-b5e4-dd94d13766a5"
     },
     {
-      "content": "<p>Lorsque vous êtes en ligne, votre adresse IP publique est partagée et utilisée. Mais savez-vous quelles informations cette adresse donne sur vous&#8239;? <span aria-hidden=\"true\">👁️‍🗨️</span>️</p>",
+      "content": "<p>Lorsque vous êtes en ligne, votre adresse IP publique est partagée et utilisée. Mais savez-vous quelles informations cette adresse donne sur vous&#8239;?&nbsp;<span aria-hidden=\"true\">👁️‍🗨️</span>️</p>",
       "grainId": "96cdedc1-2d31-40c2-ac02-d3fd83f26e30"
     },
     {
@@ -258,7 +258,7 @@
         {
           "id": "27fc867a-7258-4f85-b8cc-bdd1ab2d26a5",
           "type": "text",
-          "content": "<h3>Ce qu'il faut retenir <span aria-hidden=\"true\">🎓</span>️</h3><ul><li>L’adresse IP publique donne une information sur la zone géographique de la connexion.</li><li>Votre adresse IP publique est celle de votre box internet.</li><li>Les personnes connectées à la même box internet ont la même adresse IP publique.</li><li>À partir d'une adresse IP publique, on peut seulement identifier un pays, voire une ville de connexion.</li></ul>"
+          "content": "<h3>Ce qu'il faut retenir&nbsp;<span aria-hidden=\"true\">🎓</span>️</h3><ul><li>L’adresse IP publique donne une information sur la zone géographique de la connexion.</li><li>Votre adresse IP publique est celle de votre box internet.</li><li>Les personnes connectées à la même box internet ont la même adresse IP publique.</li><li>À partir d'une adresse IP publique, on peut seulement identifier un pays, voire une ville de connexion.</li></ul>"
         }
       ]
     },
@@ -286,7 +286,7 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Correct. <span aria-hidden=\"true\">🎉</span></p>",
+            "valid": "<p>Correct.&nbsp;<span aria-hidden=\"true\">🎉</span></p>",
             "invalid": "<p>Incorrect. Pour réussir, utilisez un site internet dédié. Pour le trouver, faites une recherche sur internet avec les mots-clés \"localisation adresse IP\".</p>"
           }
         },
@@ -346,7 +346,7 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Correct. <span aria-hidden=\"true\">🎉</span></p>",
+            "valid": "<p>Correct.&nbsp;<span aria-hidden=\"true\">🎉</span></p>",
             "invalid": "<p>Incorrect. L'adresse IP privée (locale) est visible uniquement par les appareils du réseau local.</p>"
           },
           "solution": "1"
@@ -371,7 +371,7 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Correct. <span aria-hidden=\"true\">🎉</span></p>",
+            "valid": "<p>Correct.&nbsp;<span aria-hidden=\"true\">🎉</span></p>",
             "invalid": "<p>Incorrect. L'adresse IP publique permet les échanges entre une box internet et les sites visités.</p>"
           },
           "solution": "2"
@@ -396,7 +396,7 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Correct. <span aria-hidden=\"true\">🎉</span></p>",
+            "valid": "<p>Correct.&nbsp;<span aria-hidden=\"true\">🎉</span></p>",
             "invalid": "<p>Incorrect. L'adresse IP publique est spécifique à la box internet, pas aux appareils qui y sont connectés.</p>"
           },
           "solution": "2"

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
@@ -15,7 +15,7 @@
   },
   "transitionTexts": [
     {
-      "content": "<p>En naviguant sur internet, il arrive qu'un site sache où vous vous trouvez alors que vous ne lui avez pas partagé votre localisation.<span aria-hidden=\"true\">📍</span>️<br>Mystère ? Pas vraiment. On vous explique tout dans ce module.</p>",
+      "content": "<p>En naviguant sur internet, il arrive qu'un site sache où vous vous trouvez alors que vous ne lui avez pas partagé votre localisation.<span aria-hidden=\"true\">📍</span>️<br>Mystère&#8239;? Pas vraiment. On vous explique tout dans ce module.</p>",
       "grainId": "1d516eb9-e7b7-48a3-a3b5-7971ad171d6f"
     },
     {
@@ -27,7 +27,7 @@
       "grainId": "eba0b676-c0c4-4b32-b5e4-dd94d13766a5"
     },
     {
-      "content": "<p>Lorsque vous êtes en ligne, votre adresse IP publique est partagée et utilisée. Mais savez-vous quelles informations cette adresse donne sur vous ? <span aria-hidden=\"true\">👁️‍🗨️</span>️</p>",
+      "content": "<p>Lorsque vous êtes en ligne, votre adresse IP publique est partagée et utilisée. Mais savez-vous quelles informations cette adresse donne sur vous&#8239;? <span aria-hidden=\"true\">👁️‍🗨️</span>️</p>",
       "grainId": "96cdedc1-2d31-40c2-ac02-d3fd83f26e30"
     },
     {
@@ -64,7 +64,7 @@
         {
           "id": "ff75255c-18e0-4cd9-8fd1-83a9ab6994fb",
           "type": "qcu",
-          "instruction": "<p>Quelle information ce moteur de recherche a-t-il utilisée pour déterminer la localisation de cet utilisateur ?</p>",
+          "instruction": "<p>Quelle information ce moteur de recherche a-t-il utilisée pour déterminer la localisation de cet utilisateur&#8239;?</p>",
           "proposals": [
             {
               "id": "1",
@@ -115,7 +115,7 @@
         {
           "id": "06f8ac75-44e6-4001-9822-8d44fdfe7741",
           "type": "qcu",
-          "instruction": "<p>Quelle définition peut-on donner de l'adresse IP publique ?</p>",
+          "instruction": "<p>Quelle définition peut-on donner de l'adresse IP publique&#8239;?</p>",
           "proposals": [
             {
               "id": "1",
@@ -411,7 +411,7 @@
         {
           "id": "eed9177c-4bc9-401c-928f-13585df010f7",
           "type": "qcu",
-          "instruction": "<p>Pour finir ce module, cherchez votre adresse IP publique actuelle.<span aria-hidden=\"true\">🕵️‍♂️</span>️<span aria-hidden=\"true\">🕵🏽‍♀️</span>️</p><p>Pensez-vous avoir réussi à la trouver ?</p>",
+          "instruction": "<p>Pour finir ce module, cherchez votre adresse IP publique actuelle.<span aria-hidden=\"true\">🕵️‍♂️</span>️<span aria-hidden=\"true\">🕵🏽‍♀️</span>️</p><p>Pensez-vous avoir réussi à la trouver&#8239;?</p>",
           "proposals": [
             {
               "id": "1",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -50,7 +50,7 @@
     {
       "id": "af860b1e-0566-4b06-bcb4-a68a5151d621",
       "type": "lesson",
-      "title": "Explications&nbsp;: les parties d’une adresse mail",
+      "title": "Explications : les parties d’une adresse mail",
       "elements": [
         {
           "id": "d4bf1c51-b113-440a-949a-f21c1e001daa",
@@ -120,7 +120,7 @@
     {
       "id": "edd7fec3-a649-425b-b8e3-65b13c6c47ea",
       "type": "activity",
-      "title": "Les parties d’une adresse mail&nbsp;: applications",
+      "title": "Les parties d’une adresse mail : applications",
       "elements": [
         {
           "id": "fd702cb8-9ad2-41aa-b21d-449f1342ef03",
@@ -330,7 +330,7 @@
     {
       "id": "d54142a3-43df-4bde-b1a3-8a795384f428",
       "type": "lesson",
-      "title": "Diversité des identifiants et des fournisseurs d’adresse mail&nbsp;: synthèse",
+      "title": "Diversité des identifiants et des fournisseurs d’adresse mail : synthèse",
       "elements": [
         {
           "id": "b0fcb950-b5b1-4384-886e-79fb852d5bb7",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -19,7 +19,7 @@
       "grainId": "34d225e8-5d52-4ebd-9acd-8bde8438cfc9"
     },
     {
-      "content": "<p>Et oui ! Naomi le sait&nbsp;: les adresses mails respectent un certain format.</p><p>Étudions en détails l’adresse mail de Mickaël. <span aria-hidden=\"true\">👨‍🏫👩‍🏫</span></p>",
+      "content": "<p>Et oui&#8239;! Naomi le sait&nbsp;: les adresses mails respectent un certain format.</p><p>Étudions en détails l’adresse mail de Mickaël. <span aria-hidden=\"true\">👨‍🏫👩‍🏫</span></p>",
       "grainId": "af860b1e-0566-4b06-bcb4-a68a5151d621"
     },
     {
@@ -43,7 +43,7 @@
           "title": "Le format des adresses mail",
           "url": "https://videos.pix.fr/modulix/bien-ecrire-adresse-mail/chat_animation.mp4",
           "subtitles": "https://videos.pix.fr/modulix/bien-ecrire-adresse-mail/chat_animation.vtt",
-          "transcription": "<ul><li>Naomi&nbsp;: Salut, tu peux me redonner ton adresse mail stp&#8239;? <span aria-hidden=\"true\">😇</span></li> <li>Mickaël&nbsp;: Oui, c’est mickael.aubert123#laposte.net</li><li>Naomi&nbsp;: T’es sûr&#8239;? <span aria-hidden=\"true\">😬</span></li><li>Naomi&nbsp;: Tu veux dire mickael.aubert123@laposte.net</li><li>Mickaël&nbsp;: Ah oui désolé ! <span aria-hidden=\"true\">😣</span></li><li>Mickaël&nbsp;: comment tu as su&#8239;? </li><li>Naomi&nbsp;: …</li></ul>"
+          "transcription": "<ul><li>Naomi&nbsp;: Salut, tu peux me redonner ton adresse mail stp&#8239;? <span aria-hidden=\"true\">😇</span></li> <li>Mickaël&nbsp;: Oui, c’est mickael.aubert123#laposte.net</li><li>Naomi&nbsp;: T’es sûr&#8239;? <span aria-hidden=\"true\">😬</span></li><li>Naomi&nbsp;: Tu veux dire mickael.aubert123@laposte.net</li><li>Mickaël&nbsp;: Ah oui désolé&#8239;! <span aria-hidden=\"true\">😣</span></li><li>Mickaël&nbsp;: comment tu as su&#8239;? </li><li>Naomi&nbsp;: …</li></ul>"
         }
       ]
     },
@@ -79,7 +79,7 @@
         {
           "id": "c1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d",
           "type": "text",
-          "content": "<h3 class=\"screen-reader-only\">L'identifiant</h3><h4>Partie n°1&nbsp;: l’identifiant choisi par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque, même avec des majuscules !</p><p><span aria-hidden=\"true\">✅</span> Par exemple&nbsp;: mika671 ou G3oDu671</p><p class=\"pix-list-inline\"><span aria-hidden=\"true\">❌</span> Mais certains caractères sont interdits&nbsp;:</p><ul><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>"
+          "content": "<h3 class=\"screen-reader-only\">L'identifiant</h3><h4>Partie n°1&nbsp;: l’identifiant choisi par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque, même avec des majuscules&#8239;!</p><p><span aria-hidden=\"true\">✅</span> Par exemple&nbsp;: mika671 ou G3oDu671</p><p class=\"pix-list-inline\"><span aria-hidden=\"true\">❌</span> Mais certains caractères sont interdits&nbsp;:</p><ul><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>"
         },
         {
           "id": "8137ddf4-f689-4297-8beb-a8de0c64b14d",
@@ -209,8 +209,8 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Correct ! <span aria-hidden=\"true\">🎉</span>&nbsp;Vous avez retrouvé le bon format d’une adresse mail.</p>",
-            "invalid": "<p>Incorrect ! Pour avoir de l’aide, revenez en arrière. <span aria-hidden=\"true\">⬆️</span></p>"
+            "valid": "<p>Correct&#8239;! <span aria-hidden=\"true\">🎉</span>&nbsp;Vous avez retrouvé le bon format d’une adresse mail.</p>",
+            "invalid": "<p>Incorrect&#8239;! Pour avoir de l’aide, revenez en arrière. <span aria-hidden=\"true\">⬆️</span></p>"
           }
         }
       ]
@@ -245,8 +245,8 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p class=\"pix-list-inline\">Oui, aucun problème ! Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>",
-            "invalid": "<p class=\"pix-list-inline\">Et si ! Les chiffres sont autorisés dans l’identifiant d’une adresse mail. Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>"
+            "valid": "<p class=\"pix-list-inline\">Oui, aucun problème&#8239;! Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>",
+            "invalid": "<p class=\"pix-list-inline\">Et si&#8239;! Les chiffres sont autorisés dans l’identifiant d’une adresse mail. Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>"
           },
           "solution": "1"
         },
@@ -270,8 +270,8 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Et oui ! Cette adresse est correctement écrite. On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>",
-            "invalid": "<p>Et si ! Cette adresse est correctement écrite. On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>"
+            "valid": "<p>Et oui&#8239;! Cette adresse est correctement écrite. On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>",
+            "invalid": "<p>Et si&#8239;! Cette adresse est correctement écrite. On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>"
           },
           "solution": "1"
         },
@@ -320,7 +320,7 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Bien vu ! Google n’est effectivement pas le seul fournisseur d’adresse mail. Il y en énormément, vous avez peut-être déjà vu des adresses de chez</p><ul><li>Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>La Poste (laposte.net).</li></ul>",
+            "valid": "<p>Bien vu&#8239;! Google n’est effectivement pas le seul fournisseur d’adresse mail. Il y en énormément, vous avez peut-être déjà vu des adresses de chez</p><ul><li>Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>La Poste (laposte.net).</li></ul>",
             "invalid": "<p>Il y a d’autres fournisseurs d’adresses mails que Google (gmail.com).</p><p>Il y en a énormément, vous avez peut-être déjà vu des adresses de chez</p><ul><li>Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>La Poste (laposte.net).</li></ul>"
           },
           "solution": "2"

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -19,7 +19,7 @@
       "grainId": "34d225e8-5d52-4ebd-9acd-8bde8438cfc9"
     },
     {
-      "content": "<p>Et oui ! Naomi le sait : les adresses mails respectent un certain format.</p><p>Étudions en détails l’adresse mail de Mickaël. <span aria-hidden=\"true\">👨‍🏫👩‍🏫</span></p>",
+      "content": "<p>Et oui ! Naomi le sait&nbsp;: les adresses mails respectent un certain format.</p><p>Étudions en détails l’adresse mail de Mickaël. <span aria-hidden=\"true\">👨‍🏫👩‍🏫</span></p>",
       "grainId": "af860b1e-0566-4b06-bcb4-a68a5151d621"
     },
     {
@@ -43,14 +43,14 @@
           "title": "Le format des adresses mail",
           "url": "https://videos.pix.fr/modulix/bien-ecrire-adresse-mail/chat_animation.mp4",
           "subtitles": "https://videos.pix.fr/modulix/bien-ecrire-adresse-mail/chat_animation.vtt",
-          "transcription": "<ul><li>Naomi : Salut, tu peux me redonner ton adresse mail stp ? <span aria-hidden=\"true\">😇</span></li> <li>Mickaël : Oui, c’est mickael.aubert123#laposte.net</li><li>Naomi : T’es sûr ? <span aria-hidden=\"true\">😬</span></li><li>Naomi : Tu veux dire mickael.aubert123@laposte.net</li><li>Mickaël : Ah oui désolé ! <span aria-hidden=\"true\">😣</span></li><li>Mickaël : comment tu as su ? </li><li>Naomi : …</li></ul>"
+          "transcription": "<ul><li>Naomi&nbsp;: Salut, tu peux me redonner ton adresse mail stp ? <span aria-hidden=\"true\">😇</span></li> <li>Mickaël&nbsp;: Oui, c’est mickael.aubert123#laposte.net</li><li>Naomi&nbsp;: T’es sûr ? <span aria-hidden=\"true\">😬</span></li><li>Naomi&nbsp;: Tu veux dire mickael.aubert123@laposte.net</li><li>Mickaël&nbsp;: Ah oui désolé ! <span aria-hidden=\"true\">😣</span></li><li>Mickaël&nbsp;: comment tu as su ? </li><li>Naomi&nbsp;: …</li></ul>"
         }
       ]
     },
     {
       "id": "af860b1e-0566-4b06-bcb4-a68a5151d621",
       "type": "lesson",
-      "title": "Explications : les parties d’une adresse mail",
+      "title": "Explications&nbsp;: les parties d’une adresse mail",
       "elements": [
         {
           "id": "d4bf1c51-b113-440a-949a-f21c1e001daa",
@@ -79,7 +79,7 @@
         {
           "id": "c1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d",
           "type": "text",
-          "content": "<h3 class=\"screen-reader-only\">L'identifiant</h3><h4>Partie n°1 : l’identifiant choisi par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque, même avec des majuscules !</p><p><span aria-hidden=\"true\">✅</span> Par exemple : mika671 ou G3oDu671</p><p class=\"pix-list-inline\"><span aria-hidden=\"true\">❌</span> Mais certains caractères sont interdits :</p><ul><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>"
+          "content": "<h3 class=\"screen-reader-only\">L'identifiant</h3><h4>Partie n°1&nbsp;: l’identifiant choisi par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque, même avec des majuscules !</p><p><span aria-hidden=\"true\">✅</span> Par exemple&nbsp;: mika671 ou G3oDu671</p><p class=\"pix-list-inline\"><span aria-hidden=\"true\">❌</span> Mais certains caractères sont interdits&nbsp;:</p><ul><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>"
         },
         {
           "id": "8137ddf4-f689-4297-8beb-a8de0c64b14d",
@@ -96,7 +96,7 @@
         {
           "id": "ad8ad08a-3ff7-4228-8233-6cd5ce0f4812",
           "type": "text",
-          "content": "<h3 class=\"screen-reader-only\">L'arobase</h3><h4>Au centre : l’arobase qui sépare l’identifiant du fournisseur d’adresse mail.</h4><p><span aria-hidden=\"true\">🇬🇧</span> En anglais, ce symbole se lit <i lang=\"en\">“at”</i> et veut dire “chez”.</p><p><span aria-hidden=\"true\">🤔</span> Le saviez-vous&nbsp;? L'arobase est un symbole qui était utilisé bien avant l’informatique, pour compter des quantités par exemple.</p>"
+          "content": "<h3 class=\"screen-reader-only\">L'arobase</h3><h4>Au centre&nbsp;: l’arobase qui sépare l’identifiant du fournisseur d’adresse mail.</h4><p><span aria-hidden=\"true\">🇬🇧</span> En anglais, ce symbole se lit <i lang=\"en\">“at”</i> et veut dire “chez”.</p><p><span aria-hidden=\"true\">🤔</span> Le saviez-vous&nbsp;? L'arobase est un symbole qui était utilisé bien avant l’informatique, pour compter des quantités par exemple.</p>"
         },
         {
           "id": "887ad2ce-26e0-4277-a0b0-45d51a1b7a12",
@@ -113,14 +113,14 @@
         {
           "id": "1fd829f8-1799-4779-a28d-5d26fba31b8b",
           "type": "text",
-          "content": "<h3 class=\"screen-reader-only\">Le fournisseur d’adresse mail</h3><h4>Partie n°2 : le fournisseur d’adresse mail. Cette partie de l’adresse est donnée par le fournisseur.</h4><p><span aria-hidden=\"true\">✅</span> Voici des exemples de fournisseurs d’adresses mail&nbsp;: </p><ul><li>La Poste (laposte.net)</li><li>Google (gmail.com)</li><li>Yahoo (yahoo.com)</li><li>Microsoft (hotmail.com, live.fr)</li></ul>"
+          "content": "<h3 class=\"screen-reader-only\">Le fournisseur d’adresse mail</h3><h4>Partie n°2&nbsp;: le fournisseur d’adresse mail. Cette partie de l’adresse est donnée par le fournisseur.</h4><p><span aria-hidden=\"true\">✅</span> Voici des exemples de fournisseurs d’adresses mail&nbsp;: </p><ul><li>La Poste (laposte.net)</li><li>Google (gmail.com)</li><li>Yahoo (yahoo.com)</li><li>Microsoft (hotmail.com, live.fr)</li></ul>"
         }
       ]
     },
     {
       "id": "edd7fec3-a649-425b-b8e3-65b13c6c47ea",
       "type": "activity",
-      "title": "Les parties d’une adresse mail : applications",
+      "title": "Les parties d’une adresse mail&nbsp;: applications",
       "elements": [
         {
           "id": "fd702cb8-9ad2-41aa-b21d-449f1342ef03",
@@ -129,7 +129,7 @@
           "proposals": [
             {
               "type": "text",
-              "content": "<p>Symbole :</p>"
+              "content": "<p>Symbole&nbsp;:</p>"
             },
             {
               "input": "symbole",
@@ -330,12 +330,12 @@
     {
       "id": "d54142a3-43df-4bde-b1a3-8a795384f428",
       "type": "lesson",
-      "title": "Diversité des identifiants et des fournisseurs d’adresse mail : synthèse",
+      "title": "Diversité des identifiants et des fournisseurs d’adresse mail&nbsp;: synthèse",
       "elements": [
         {
           "id": "b0fcb950-b5b1-4384-886e-79fb852d5bb7",
           "type": "text",
-          "content": "<h3>Ce qu’il faut retenir :</h3><ul><li>Il peut y avoir des chiffres dans l’identifiant d’une adresse mail. Ils peuvent être n’importe où dans l’identifiant. <br></li><li>Il y a une seule @ (arobase) dans une adresse mail. Elle permet de séparer l’identifiant du fournisseur d’adresse mail.</li><li>Les adresses mails se terminent de différentes manières après l'@, selon le fournisseur d’adresse mail.<br><span aria-hidden=\"true\">✅</span> Exemples&nbsp;: laposte.net, free.fr, gmail.com, yahoo.com, etc.</li></ul>"
+          "content": "<h3>Ce qu’il faut retenir&nbsp;:</h3><ul><li>Il peut y avoir des chiffres dans l’identifiant d’une adresse mail. Ils peuvent être n’importe où dans l’identifiant. <br></li><li>Il y a une seule @ (arobase) dans une adresse mail. Elle permet de séparer l’identifiant du fournisseur d’adresse mail.</li><li>Les adresses mails se terminent de différentes manières après l'@, selon le fournisseur d’adresse mail.<br><span aria-hidden=\"true\">✅</span> Exemples&nbsp;: laposte.net, free.fr, gmail.com, yahoo.com, etc.</li></ul>"
         }
       ]
     },
@@ -347,7 +347,7 @@
         {
           "id": "8709ad92-093e-447a-a7b6-3223e6171196",
           "type": "qrocm",
-          "instruction": "<p>Écrivez l'adresse mail de Naomi à partir des informations suivantes :</p><ul><li>Son identifiant est <code>naomizao457</code></li><li>Son fournisseur d’adresse mail est Yahoo</li></ul>",
+          "instruction": "<p>Écrivez l'adresse mail de Naomi à partir des informations suivantes&nbsp;:</p><ul><li>Son identifiant est <code>naomizao457</code></li><li>Son fournisseur d’adresse mail est Yahoo</li></ul>",
           "proposals": [
             {
               "type": "text",
@@ -367,7 +367,7 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Correct. <span aria-hidden=\"true\">🎉</span> Tout est dans l'ordre : l'identifiant, l'arobase puis le fournisseur d'adresse mail</p>",
+            "valid": "<p>Correct. <span aria-hidden=\"true\">🎉</span> Tout est dans l'ordre&nbsp;: l'identifiant, l'arobase puis le fournisseur d'adresse mail</p>",
             "invalid": "<p> Incorrect. Pour réussir la prochaine fois, lisez les indices ci-dessous <span aria-hidden=\"true\">👇</span> </p>"
           }
         },
@@ -379,7 +379,7 @@
         {
           "id": "0856af53-1060-478f-8416-ddbc5ed3940c",
           "type": "text",
-          "content": "<h3>Indice n°1 :</h3><p>L'ordre à suivre est : l'identifiant, l'arobase puis le fournisseur d'adresse mail.</p><h3>Indice n°2 :</h3><p>Les adresses mails fournies par Yahoo se terminent par yahoo.com.</p>"
+          "content": "<h3>Indice n°1&nbsp;:</h3><p>L'ordre à suivre est&nbsp;: l'identifiant, l'arobase puis le fournisseur d'adresse mail.</p><h3>Indice n°2&nbsp;:</h3><p>Les adresses mails fournies par Yahoo se terminent par yahoo.com.</p>"
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -15,11 +15,11 @@
   },
   "transitionTexts": [
     {
-      "content": "<p>Naomi a perdu l’adresse mail de son ami Mickaël. Elle n’arrive pas à la retrouver. <span aria-hidden=\"true\">🤷‍♀</span>️<br> Elle en a besoin pour envoyer un document à son ami. Naomi lui demande donc par SMS de lui redonner son adresse mail. <br> Lancez la vidéo pour voir leur discussion. <span aria-hidden=\"true\">▶️</span></p>",
+      "content": "<p>Naomi a perdu l’adresse mail de son ami Mickaël. Elle n’arrive pas à la retrouver.&nbsp;<span aria-hidden=\"true\">🤷‍♀</span>️<br> Elle en a besoin pour envoyer un document à son ami. Naomi lui demande donc par SMS de lui redonner son adresse mail. <br> Lancez la vidéo pour voir leur discussion.&nbsp;<span aria-hidden=\"true\">▶️</span></p>",
       "grainId": "34d225e8-5d52-4ebd-9acd-8bde8438cfc9"
     },
     {
-      "content": "<p>Et oui&#8239;! Naomi le sait&nbsp;: les adresses mails respectent un certain format.</p><p>Étudions en détails l’adresse mail de Mickaël. <span aria-hidden=\"true\">👨‍🏫👩‍🏫</span></p>",
+      "content": "<p>Et oui&#8239;! Naomi le sait&nbsp;: les adresses mails respectent un certain format.</p><p>Étudions en détails l’adresse mail de Mickaël.&nbsp;<span aria-hidden=\"true\">👨‍🏫👩‍🏫</span></p>",
       "grainId": "af860b1e-0566-4b06-bcb4-a68a5151d621"
     },
     {
@@ -43,7 +43,7 @@
           "title": "Le format des adresses mail",
           "url": "https://videos.pix.fr/modulix/bien-ecrire-adresse-mail/chat_animation.mp4",
           "subtitles": "https://videos.pix.fr/modulix/bien-ecrire-adresse-mail/chat_animation.vtt",
-          "transcription": "<ul><li>Naomi&nbsp;: Salut, tu peux me redonner ton adresse mail stp&#8239;? <span aria-hidden=\"true\">😇</span></li> <li>Mickaël&nbsp;: Oui, c’est mickael.aubert123#laposte.net</li><li>Naomi&nbsp;: T’es sûr&#8239;? <span aria-hidden=\"true\">😬</span></li><li>Naomi&nbsp;: Tu veux dire mickael.aubert123@laposte.net</li><li>Mickaël&nbsp;: Ah oui désolé&#8239;! <span aria-hidden=\"true\">😣</span></li><li>Mickaël&nbsp;: comment tu as su&#8239;? </li><li>Naomi&nbsp;: …</li></ul>"
+          "transcription": "<ul><li>Naomi&nbsp;: Salut, tu peux me redonner ton adresse mail stp&#8239;?&nbsp;<span aria-hidden=\"true\">😇</span></li> <li>Mickaël&nbsp;: Oui, c’est mickael.aubert123#laposte.net</li><li>Naomi&nbsp;: T’es sûr&#8239;?&nbsp;<span aria-hidden=\"true\">😬</span></li><li>Naomi&nbsp;: Tu veux dire mickael.aubert123@laposte.net</li><li>Mickaël&nbsp;: Ah oui désolé&#8239;!&nbsp;<span aria-hidden=\"true\">😣</span></li><li>Mickaël&nbsp;: comment tu as su&#8239;? </li><li>Naomi&nbsp;: …</li></ul>"
         }
       ]
     },
@@ -145,7 +145,7 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Correct. <span aria-hidden=\"true\">🎉</span></p>",
+            "valid": "<p>Correct.&nbsp;<span aria-hidden=\"true\">🎉</span></p>",
             "invalid": "<p>Incorrect. Cherchez le symbole @ sur votre clavier pour pouvoir l'écrire.</p>"
           }
         },
@@ -209,8 +209,8 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Correct&#8239;! <span aria-hidden=\"true\">🎉</span>&nbsp;Vous avez retrouvé le bon format d’une adresse mail.</p>",
-            "invalid": "<p>Incorrect&#8239;! Pour avoir de l’aide, revenez en arrière. <span aria-hidden=\"true\">⬆️</span></p>"
+            "valid": "<p>Correct&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span>&nbsp;Vous avez retrouvé le bon format d’une adresse mail.</p>",
+            "invalid": "<p>Incorrect&#8239;! Pour avoir de l’aide, revenez en arrière.&nbsp;<span aria-hidden=\"true\">⬆️</span></p>"
           }
         }
       ]
@@ -367,8 +367,8 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Correct. <span aria-hidden=\"true\">🎉</span> Tout est dans l'ordre&nbsp;: l'identifiant, l'arobase puis le fournisseur d'adresse mail</p>",
-            "invalid": "<p> Incorrect. Pour réussir la prochaine fois, lisez les indices ci-dessous <span aria-hidden=\"true\">👇</span> </p>"
+            "valid": "<p>Correct.&nbsp;<span aria-hidden=\"true\">🎉</span> Tout est dans l'ordre&nbsp;: l'identifiant, l'arobase puis le fournisseur d'adresse mail</p>",
+            "invalid": "<p> Incorrect. Pour réussir la prochaine fois, lisez les indices ci-dessous&nbsp;<span aria-hidden=\"true\">👇</span> </p>"
           }
         },
         {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -43,7 +43,7 @@
           "title": "Le format des adresses mail",
           "url": "https://videos.pix.fr/modulix/bien-ecrire-adresse-mail/chat_animation.mp4",
           "subtitles": "https://videos.pix.fr/modulix/bien-ecrire-adresse-mail/chat_animation.vtt",
-          "transcription": "<ul><li>Naomi&nbsp;: Salut, tu peux me redonner ton adresse mail stp ? <span aria-hidden=\"true\">😇</span></li> <li>Mickaël&nbsp;: Oui, c’est mickael.aubert123#laposte.net</li><li>Naomi&nbsp;: T’es sûr ? <span aria-hidden=\"true\">😬</span></li><li>Naomi&nbsp;: Tu veux dire mickael.aubert123@laposte.net</li><li>Mickaël&nbsp;: Ah oui désolé ! <span aria-hidden=\"true\">😣</span></li><li>Mickaël&nbsp;: comment tu as su ? </li><li>Naomi&nbsp;: …</li></ul>"
+          "transcription": "<ul><li>Naomi&nbsp;: Salut, tu peux me redonner ton adresse mail stp&#8239;? <span aria-hidden=\"true\">😇</span></li> <li>Mickaël&nbsp;: Oui, c’est mickael.aubert123#laposte.net</li><li>Naomi&nbsp;: T’es sûr&#8239;? <span aria-hidden=\"true\">😬</span></li><li>Naomi&nbsp;: Tu veux dire mickael.aubert123@laposte.net</li><li>Mickaël&nbsp;: Ah oui désolé ! <span aria-hidden=\"true\">😣</span></li><li>Mickaël&nbsp;: comment tu as su&#8239;? </li><li>Naomi&nbsp;: …</li></ul>"
         }
       ]
     },
@@ -125,7 +125,7 @@
         {
           "id": "fd702cb8-9ad2-41aa-b21d-449f1342ef03",
           "type": "qrocm",
-          "instruction": "<p>Quel symbole permet de séparer les deux parties d'une adresse mail ?</p>",
+          "instruction": "<p>Quel symbole permet de séparer les deux parties d'une adresse mail&#8239;?</p>",
           "proposals": [
             {
               "type": "text",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -4,14 +4,14 @@
   "title": "Didacticiel Modulix",
   "details": {
     "image": "https://images.pix.fr/modulix/placeholder-details.svg",
-    "description": "Découvrez avec ce didacticiel comment fonctionne Modulix !",
+    "description": "Découvrez avec ce didacticiel comment fonctionne Modulix&#8239;!",
     "duration": 5,
     "level": "Débutant",
     "objectives": ["Naviguer dans Modulix", "Découvrir les leçons et les activités"]
   },
   "transitionTexts": [
     {
-      "content": "<p>Bonjour et bienvenue dans ce didacticiel Modulix. Vous allez pouvoir facilement découvrir comment fonctionne ce nouveau produit Pix.<br>C'est partix !</p>",
+      "content": "<p>Bonjour et bienvenue dans ce didacticiel Modulix. Vous allez pouvoir facilement découvrir comment fonctionne ce nouveau produit Pix.<br>C'est partix&#8239;!</p>",
       "grainId": "f312c33d-e7c9-4a69-9ba0-913957b8f7dd"
     },
     {
@@ -23,7 +23,7 @@
       "grainId": "533c69b8-a836-41be-8ffc-8d4636e31224"
     },
     {
-      "content": "<p>Vous l’aurez compris, on aime varier les plaisirs et proposer différents types d’activité, après le questionnaire à choix unique on vous laisse découvrir le QCM !</p>",
+      "content": "<p>Vous l’aurez compris, on aime varier les plaisirs et proposer différents types d’activité, après le questionnaire à choix unique on vous laisse découvrir le QCM&#8239;!</p>",
       "grainId": "0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c"
     },
     {
@@ -31,7 +31,7 @@
       "grainId": "2a77a10f-19a3-4544-80f9-8012dad6506a"
     },
     {
-      "content": "<p>Vous arrivez à la fin de ce didacticiel. Une dernière activité et vous serez prêt à explorer tous les modules que vous souhaitez !<span aria-hidden=\"true\">🌟</span>️ </p>",
+      "content": "<p>Vous arrivez à la fin de ce didacticiel. Une dernière activité et vous serez prêt à explorer tous les modules que vous souhaitez&#8239;!<span aria-hidden=\"true\">🌟</span>️ </p>",
       "grainId": "7cf75e70-8749-4392-8081-f2c02badb0fb"
     }
   ],
@@ -49,7 +49,7 @@
         {
           "id": "a2372bf4-86a4-4ecc-a188-b51f4f98bca2",
           "type": "text",
-          "content": "<p>Voici un texte de leçon. Parfois, il y a des émojis pour aider à la lecture <span aria-hidden=\"true\">📚</span>️.<br>Et là, voici une image !</p>"
+          "content": "<p>Voici un texte de leçon. Parfois, il y a des émojis pour aider à la lecture <span aria-hidden=\"true\">📚</span>️.<br>Et là, voici une image&#8239;!</p>"
         },
         {
           "id": "8d7687c8-4a02-4d7e-bf6c-693a6d481c78",
@@ -100,7 +100,7 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Correct ! Ces 16 compétences sont rangées dans 5 domaines.</p>",
+            "valid": "<p>Correct&#8239;! Ces 16 compétences sont rangées dans 5 domaines.</p>",
             "invalid": "<p>Incorrect. Retourner voir la vidéo si besoin <span aria-hidden=\"true\">⬆️</span>️!</p>"
           },
           "solution": "1"
@@ -139,8 +139,8 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Correct ! Vous nous avez bien cernés&nbsp;:)</p>",
-            "invalid": "<p>Et non ! Pix sert à évaluer, certifier et développer ses compétences numériques.</p>"
+            "valid": "<p>Correct&#8239;! Vous nous avez bien cernés&nbsp;:)</p>",
+            "invalid": "<p>Et non&#8239;! Pix sert à évaluer, certifier et développer ses compétences numériques.</p>"
           },
           "solutions": ["1", "3", "4"]
         }
@@ -170,8 +170,8 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Correct ! Vous avez bien remonté la page</p>",
-            "invalid": "<p>Incorrect. Remonter la page pour retrouver le premier mot !</p>"
+            "valid": "<p>Correct&#8239;! Vous avez bien remonté la page</p>",
+            "invalid": "<p>Incorrect. Remonter la page pour retrouver le premier mot&#8239;!</p>"
           },
           "solution": "2"
         }
@@ -201,8 +201,8 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Correct ! vous êtes prêt à explorer <span aria-hidden=\"true\">🎉</span></p>",
-            "invalid": "<p>Incorrect ! vous y arriverez la prochaine fois !</p>"
+            "valid": "<p>Correct&#8239;! vous êtes prêt à explorer <span aria-hidden=\"true\">🎉</span></p>",
+            "invalid": "<p>Incorrect&#8239;! vous y arriverez la prochaine fois&#8239;!</p>"
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -15,11 +15,11 @@
       "grainId": "f312c33d-e7c9-4a69-9ba0-913957b8f7dd"
     },
     {
-      "content": "<p>Chaque leçon a un objectif pédagogique précis.</p><p>Dans la prochaine leçon, nous vous proposons de découvrir Pix avec une courte vidéo <span aria-hidden=\"true\">▶️</span></p>",
+      "content": "<p>Chaque leçon a un objectif pédagogique précis.</p><p>Dans la prochaine leçon, nous vous proposons de découvrir Pix avec une courte vidéo&nbsp;<span aria-hidden=\"true\">▶️</span></p>",
       "grainId": "73ac3644-7637-4cee-86d4-1a75f53f0b9c"
     },
     {
-      "content": "<p>Vous allez faire votre première activité. Les activités servent à vérifier que vous avez compris l'essentiel des leçons.<br>Dans les activités Modulix, vous avez votre résultat immédiatement. À vous de jouer <span aria-hidden=\"true\">🚀</span></p>",
+      "content": "<p>Vous allez faire votre première activité. Les activités servent à vérifier que vous avez compris l'essentiel des leçons.<br>Dans les activités Modulix, vous avez votre résultat immédiatement. À vous de jouer&nbsp;<span aria-hidden=\"true\">🚀</span></p>",
       "grainId": "533c69b8-a836-41be-8ffc-8d4636e31224"
     },
     {
@@ -27,7 +27,7 @@
       "grainId": "0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c"
     },
     {
-      "content": "<p>Vous l'avez peut-être remarqué&nbsp;: dans un module, vous pouvez voir tous les contenus en remontant la page <span aria-hidden=\"true\">⬆️</span>️</p>",
+      "content": "<p>Vous l'avez peut-être remarqué&nbsp;: dans un module, vous pouvez voir tous les contenus en remontant la page&nbsp;<span aria-hidden=\"true\">⬆️</span>️</p>",
       "grainId": "2a77a10f-19a3-4544-80f9-8012dad6506a"
     },
     {
@@ -49,7 +49,7 @@
         {
           "id": "a2372bf4-86a4-4ecc-a188-b51f4f98bca2",
           "type": "text",
-          "content": "<p>Voici un texte de leçon. Parfois, il y a des émojis pour aider à la lecture <span aria-hidden=\"true\">📚</span>️.<br>Et là, voici une image&#8239;!</p>"
+          "content": "<p>Voici un texte de leçon. Parfois, il y a des émojis pour aider à la lecture&nbsp;<span aria-hidden=\"true\">📚</span>️.<br>Et là, voici une image&#8239;!</p>"
         },
         {
           "id": "8d7687c8-4a02-4d7e-bf6c-693a6d481c78",
@@ -101,7 +101,7 @@
           ],
           "feedbacks": {
             "valid": "<p>Correct&#8239;! Ces 16 compétences sont rangées dans 5 domaines.</p>",
-            "invalid": "<p>Incorrect. Retourner voir la vidéo si besoin <span aria-hidden=\"true\">⬆️</span>️!</p>"
+            "invalid": "<p>Incorrect. Retourner voir la vidéo si besoin&nbsp;<span aria-hidden=\"true\">⬆️</span>️!</p>"
           },
           "solution": "1"
         }
@@ -201,7 +201,7 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Correct&#8239;! vous êtes prêt à explorer <span aria-hidden=\"true\">🎉</span></p>",
+            "valid": "<p>Correct&#8239;! vous êtes prêt à explorer&nbsp;<span aria-hidden=\"true\">🎉</span></p>",
             "invalid": "<p>Incorrect&#8239;! vous y arriverez la prochaine fois&#8239;!</p>"
           }
         }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -4,7 +4,7 @@
   "title": "Didacticiel Modulix",
   "details": {
     "image": "https://images.pix.fr/modulix/placeholder-details.svg",
-    "description": "Découvrez avec ce didacticiel comment fonctionne Modulix&#8239;!",
+    "description": "Découvrez avec ce didacticiel comment fonctionne Modulix !",
     "duration": 5,
     "level": "Débutant",
     "objectives": ["Naviguer dans Modulix", "Découvrir les leçons et les activités"]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -76,7 +76,7 @@
           "title": "Vidéo de présentation de Pix",
           "url": "https://videos.pix.fr/modulix/didacticiel/presentation.mp4",
           "subtitles": "",
-          "transcription": "<p>Le numérique évolue en permanence, vos compétences aussi, pour travailler, communiquer et s'informer, se déplacer, réaliser des démarches, un enjeu tout au long de la vie.</p><p>Sur <a href=\"https://pix.fr\" target=\"blank\">pix.fr</a>, testez-vous et cultivez vos compétences numériques.</p><p>Les tests Pix sont personnalisés, les questions s'adaptent à votre niveau, réponse après réponse.</p><p>Évaluez vos connaissances et savoir-faire sur 16 compétences, dans 5 domaines, sur 5 niveaux de débutants à confirmer, avec des mises en situation ludiques, recherches en ligne, manipulation de fichiers et de données, culture numérique...</p><p>Allez à votre rythme, vous pouvez arrêter et reprendre quand vous le voulez.</p><p>Toutes les 5 questions, découvrez vos résultats et progressez grâce aux astuces et aux tutos.</p><p>En relevant les défis Pix, vous apprendrez de nouvelles choses et aurez envie d'aller plus loin.</p><p>Vous pensez pouvoir faire mieux ?</p><p>Retentez les tests et améliorez votre score.</p><p>Faites reconnaître officiellement votre niveau en passant la certification Pix, reconnue par l'État et le monde professionnel.</p><p>Pix&nbsp;: le service public en ligne pour évaluer, développer et certifier ses compétences numériques.</p>"
+          "transcription": "<p>Le numérique évolue en permanence, vos compétences aussi, pour travailler, communiquer et s'informer, se déplacer, réaliser des démarches, un enjeu tout au long de la vie.</p><p>Sur <a href=\"https://pix.fr\" target=\"blank\">pix.fr</a>, testez-vous et cultivez vos compétences numériques.</p><p>Les tests Pix sont personnalisés, les questions s'adaptent à votre niveau, réponse après réponse.</p><p>Évaluez vos connaissances et savoir-faire sur 16 compétences, dans 5 domaines, sur 5 niveaux de débutants à confirmer, avec des mises en situation ludiques, recherches en ligne, manipulation de fichiers et de données, culture numérique...</p><p>Allez à votre rythme, vous pouvez arrêter et reprendre quand vous le voulez.</p><p>Toutes les 5 questions, découvrez vos résultats et progressez grâce aux astuces et aux tutos.</p><p>En relevant les défis Pix, vous apprendrez de nouvelles choses et aurez envie d'aller plus loin.</p><p>Vous pensez pouvoir faire mieux&#8239;?</p><p>Retentez les tests et améliorez votre score.</p><p>Faites reconnaître officiellement votre niveau en passant la certification Pix, reconnue par l'État et le monde professionnel.</p><p>Pix&nbsp;: le service public en ligne pour évaluer, développer et certifier ses compétences numériques.</p>"
         }
       ]
     },
@@ -115,7 +115,7 @@
         {
           "id": "30701e93-1b4d-4da4-b018-fa756c07d53f",
           "type": "qcm",
-          "instruction": "<p>Quels sont les 3 piliers de Pix ?</p>",
+          "instruction": "<p>Quels sont les 3 piliers de Pix&#8239;?</p>",
           "proposals": [
             {
               "id": "1",
@@ -154,7 +154,7 @@
         {
           "id": "0a5e77e8-1c8e-4cb6-a41d-cf6ad7935447",
           "type": "qcu",
-          "instruction": "<p>Remontez la page pour trouver le premier mot de ce module.<br>Quel est ce mot ?</p>",
+          "instruction": "<p>Remontez la page pour trouver le premier mot de ce module.<br>Quel est ce mot&#8239;?</p>",
           "proposals": [
             {
               "id": "1",
@@ -185,7 +185,7 @@
         {
           "id": "98c51fa7-03b7-49b1-8c5e-49341d35909c",
           "type": "qrocm",
-          "instruction": "<p>Quel est le nom de ce nouveau produit Pix ?</p>",
+          "instruction": "<p>Quel est le nom de ce nouveau produit Pix&#8239;?</p>",
           "proposals": [
             {
               "input": "nom-produit",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -27,7 +27,7 @@
       "grainId": "0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c"
     },
     {
-      "content": "<p>Vous l'avez peut-être remarqué : dans un module, vous pouvez voir tous les contenus en remontant la page <span aria-hidden=\"true\">⬆️</span>️</p>",
+      "content": "<p>Vous l'avez peut-être remarqué&nbsp;: dans un module, vous pouvez voir tous les contenus en remontant la page <span aria-hidden=\"true\">⬆️</span>️</p>",
       "grainId": "2a77a10f-19a3-4544-80f9-8012dad6506a"
     },
     {
@@ -76,7 +76,7 @@
           "title": "Vidéo de présentation de Pix",
           "url": "https://videos.pix.fr/modulix/didacticiel/presentation.mp4",
           "subtitles": "",
-          "transcription": "<p>Le numérique évolue en permanence, vos compétences aussi, pour travailler, communiquer et s'informer, se déplacer, réaliser des démarches, un enjeu tout au long de la vie.</p><p>Sur <a href=\"https://pix.fr\" target=\"blank\">pix.fr</a>, testez-vous et cultivez vos compétences numériques.</p><p>Les tests Pix sont personnalisés, les questions s'adaptent à votre niveau, réponse après réponse.</p><p>Évaluez vos connaissances et savoir-faire sur 16 compétences, dans 5 domaines, sur 5 niveaux de débutants à confirmer, avec des mises en situation ludiques, recherches en ligne, manipulation de fichiers et de données, culture numérique...</p><p>Allez à votre rythme, vous pouvez arrêter et reprendre quand vous le voulez.</p><p>Toutes les 5 questions, découvrez vos résultats et progressez grâce aux astuces et aux tutos.</p><p>En relevant les défis Pix, vous apprendrez de nouvelles choses et aurez envie d'aller plus loin.</p><p>Vous pensez pouvoir faire mieux ?</p><p>Retentez les tests et améliorez votre score.</p><p>Faites reconnaître officiellement votre niveau en passant la certification Pix, reconnue par l'État et le monde professionnel.</p><p>Pix : le service public en ligne pour évaluer, développer et certifier ses compétences numériques.</p>"
+          "transcription": "<p>Le numérique évolue en permanence, vos compétences aussi, pour travailler, communiquer et s'informer, se déplacer, réaliser des démarches, un enjeu tout au long de la vie.</p><p>Sur <a href=\"https://pix.fr\" target=\"blank\">pix.fr</a>, testez-vous et cultivez vos compétences numériques.</p><p>Les tests Pix sont personnalisés, les questions s'adaptent à votre niveau, réponse après réponse.</p><p>Évaluez vos connaissances et savoir-faire sur 16 compétences, dans 5 domaines, sur 5 niveaux de débutants à confirmer, avec des mises en situation ludiques, recherches en ligne, manipulation de fichiers et de données, culture numérique...</p><p>Allez à votre rythme, vous pouvez arrêter et reprendre quand vous le voulez.</p><p>Toutes les 5 questions, découvrez vos résultats et progressez grâce aux astuces et aux tutos.</p><p>En relevant les défis Pix, vous apprendrez de nouvelles choses et aurez envie d'aller plus loin.</p><p>Vous pensez pouvoir faire mieux ?</p><p>Retentez les tests et améliorez votre score.</p><p>Faites reconnaître officiellement votre niveau en passant la certification Pix, reconnue par l'État et le monde professionnel.</p><p>Pix&nbsp;: le service public en ligne pour évaluer, développer et certifier ses compétences numériques.</p>"
         }
       ]
     },
@@ -139,7 +139,7 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Correct ! Vous nous avez bien cernés :)</p>",
+            "valid": "<p>Correct ! Vous nous avez bien cernés&nbsp;:)</p>",
             "invalid": "<p>Et non ! Pix sert à évaluer, certifier et développer ses compétences numériques.</p>"
           },
           "solutions": ["1", "3", "4"]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
@@ -15,15 +15,15 @@
   },
   "transitionTexts": [
     {
-      "content": "<p>Commençons par un jeu. <span aria-hidden=\"true\">🎮</span>️<br>Sans chercher sur internet, essayez de deviner si chaque information proposée dans ces articles de journaux est plutôt vraie ou plutôt fausse. Bonne chance&#8239;!</p>",
+      "content": "<p>Commençons par un jeu.&nbsp;<span aria-hidden=\"true\">🎮</span>️<br>Sans chercher sur internet, essayez de deviner si chaque information proposée dans ces articles de journaux est plutôt vraie ou plutôt fausse. Bonne chance&#8239;!</p>",
       "grainId": "f242e81e-b182-44a1-a668-557f26b5ff8b"
     },
     {
-      "content": "<p>Vous l'avez remarqué, en lisant seulement le titre d’un article, c’est presque impossible de savoir si une information est vraie ou fausse. <span aria-hidden=\"true\">🤔</span>️<br>Parfois, ce ne sont même pas des informations mais par exemple des opinions. <span aria-hidden=\"true\">📚</span>️ Vous allez découvrir la différence dans la vidéo suivante.</p>",
+      "content": "<p>Vous l'avez remarqué, en lisant seulement le titre d’un article, c’est presque impossible de savoir si une information est vraie ou fausse.&nbsp;<span aria-hidden=\"true\">🤔</span>️<br>Parfois, ce ne sont même pas des informations mais par exemple des opinions.&nbsp;<span aria-hidden=\"true\">📚</span>️ Vous allez découvrir la différence dans la vidéo suivante.</p>",
       "grainId": "eb83569f-2e37-49ed-aa6f-31c420b673b9"
     },
     {
-      "content": "<p>Vous savez maintenant mieux repérer une information. Mais une information peut être fausse ...<br>Voyons ensemble des questions à se poser pour vérifier une information. <span aria-hidden=\"true\">🗒️</span>️</p>",
+      "content": "<p>Vous savez maintenant mieux repérer une information. Mais une information peut être fausse ...<br>Voyons ensemble des questions à se poser pour vérifier une information.&nbsp;<span aria-hidden=\"true\">🗒️</span>️</p>",
       "grainId": "ed22ab38-ec6d-47df-88ea-4894f1cd6c8a"
     },
     {
@@ -39,7 +39,7 @@
       "grainId": "428ea826-6e21-4c56-a5a2-f97373f1e833"
     },
     {
-      "content": "<p>Maintenant, à vous d’étudier une nouvelle situation. <span aria-hidden=\"true\">🕵️</span>️<span aria-hidden=\"true\">🕵🏿‍♀️</span>️</p>",
+      "content": "<p>Maintenant, à vous d’étudier une nouvelle situation.&nbsp;<span aria-hidden=\"true\">🕵️</span>️<span aria-hidden=\"true\">🕵🏿‍♀️</span>️</p>",
       "grainId": "9f56f75e-3e2d-4a6e-8623-9b74747b236d"
     }
   ],
@@ -264,7 +264,7 @@
         {
           "id": "332d9e96-d12e-4809-9d25-173a57ed93be",
           "type": "text",
-          "content": "<h3>Question n°1&nbsp;: qui est l’auteur de cette information&#8239;? <span aria-hidden=\"true\">🖋️</span>️</h3><p>En vous posant cette question, vous pourrez mieux évaluer l’information.<br>Par exemple, si vous connaissez ou non l’auteur, si l’auteur est reconnu ou encore si l’auteur a un intérêt particulier à ce que cette information circule.</p>"
+          "content": "<h3>Question n°1&nbsp;: qui est l’auteur de cette information&#8239;?&nbsp;<span aria-hidden=\"true\">🖋️</span>️</h3><p>En vous posant cette question, vous pourrez mieux évaluer l’information.<br>Par exemple, si vous connaissez ou non l’auteur, si l’auteur est reconnu ou encore si l’auteur a un intérêt particulier à ce que cette information circule.</p>"
         },
         {
           "id": "42276690-f134-4b88-ac0f-c26ad62370ec",
@@ -274,7 +274,7 @@
         {
           "id": "8aa4a733-4a92-4007-897d-ab884a7add85",
           "type": "text",
-          "content": "<h3>Question n°2&nbsp;: quelle est la date de l’information&#8239;? <span aria-hidden=\"true\">📅</span>️</h3><p>C’est simple à vérifier et très important&#8239;! Des informations vraies un jour peuvent être fausses le lendemain. <br>Par exemple, une alerte inondation ou une promotion dans un magasin.</p>"
+          "content": "<h3>Question n°2&nbsp;: quelle est la date de l’information&#8239;?&nbsp;<span aria-hidden=\"true\">📅</span>️</h3><p>C’est simple à vérifier et très important&#8239;! Des informations vraies un jour peuvent être fausses le lendemain. <br>Par exemple, une alerte inondation ou une promotion dans un magasin.</p>"
         },
         {
           "id": "056ef18b-2f2f-4518-acca-93bb59b2d151",
@@ -284,7 +284,7 @@
         {
           "id": "36577421-d9d0-4f49-ac43-b4e804ba5635",
           "type": "text",
-          "content": "<h3>Question n°3&nbsp;: d’où provient cette information&#8239;? <span aria-hidden=\"true\">ℹ️</span>️</h3><p>C'est-à-dire, son origine, sa source. Cherchez à savoir si c’est une observation, un témoignage, un résultat d’expérience, etc.<br>Regardez également si vous pouvez vérifier cette information par vous-même et si l’auteur a partagé ses sources.</p>"
+          "content": "<h3>Question n°3&nbsp;: d’où provient cette information&#8239;?&nbsp;<span aria-hidden=\"true\">ℹ️</span>️</h3><p>C'est-à-dire, son origine, sa source. Cherchez à savoir si c’est une observation, un témoignage, un résultat d’expérience, etc.<br>Regardez également si vous pouvez vérifier cette information par vous-même et si l’auteur a partagé ses sources.</p>"
         }
       ]
     },
@@ -321,7 +321,7 @@
           ],
           "feedbacks": {
             "valid": "<p>Correct. Tous ces éléments permettent de vérifier une information. </p>",
-            "invalid": "<p>Incorrect. Retournez voir la leçon ci-dessus si besoin <span aria-hidden=\"true\">⬆</span>️!</p>"
+            "invalid": "<p>Incorrect. Retournez voir la leçon ci-dessus si besoin&nbsp;<span aria-hidden=\"true\">⬆</span>️!</p>"
           },
           "solutions": ["2", "3", "5"]
         }
@@ -474,7 +474,7 @@
         {
           "id": "eb90d3ea-797f-4e4a-9675-e679b9f5bf3c",
           "type": "text",
-          "content": "<p>Stéphane n'arrive pas à faire pousser sa nouvelle plante verte d’intérieur <span aria-hidden=\"true\">🪴</span>️. Il cherche des astuces sur les réseaux sociaux.<br>Il trouve les informations suivantes, publiées le 28 août 2023, par SuperJardinier&nbsp;:</p>"
+          "content": "<p>Stéphane n'arrive pas à faire pousser sa nouvelle plante verte d’intérieur&nbsp;<span aria-hidden=\"true\">🪴</span>️. Il cherche des astuces sur les réseaux sociaux.<br>Il trouve les informations suivantes, publiées le 28 août 2023, par SuperJardinier&nbsp;:</p>"
         },
         {
           "id": "2c525ab3-23bf-4b43-867d-ea1fac54efad",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
@@ -35,7 +35,7 @@
       "grainId": "c624de0b-658a-47e7-b780-c579a1033aba"
     },
     {
-      "content": "<p>Même si on a vérifié le “qui ? quand ? d'où ?”, il faut rester vigilant.<br>D'autres indices peuvent aider à détecter de fausses informations.&nbsp;👣 <br>Plus ils s’accumulent, plus l’information a des chances d’être fausse.</p>",
+      "content": "<p>Même si on a vérifié le “qui&#8239;? quand&#8239;? d'où&#8239;?”, il faut rester vigilant.<br>D'autres indices peuvent aider à détecter de fausses informations.&nbsp;👣 <br>Plus ils s’accumulent, plus l’information a des chances d’être fausse.</p>",
       "grainId": "428ea826-6e21-4c56-a5a2-f97373f1e833"
     },
     {
@@ -264,7 +264,7 @@
         {
           "id": "332d9e96-d12e-4809-9d25-173a57ed93be",
           "type": "text",
-          "content": "<h3>Question n°1&nbsp;: qui est l’auteur de cette information ? <span aria-hidden=\"true\">🖋️</span>️</h3><p>En vous posant cette question, vous pourrez mieux évaluer l’information.<br>Par exemple, si vous connaissez ou non l’auteur, si l’auteur est reconnu ou encore si l’auteur a un intérêt particulier à ce que cette information circule.</p>"
+          "content": "<h3>Question n°1&nbsp;: qui est l’auteur de cette information&#8239;? <span aria-hidden=\"true\">🖋️</span>️</h3><p>En vous posant cette question, vous pourrez mieux évaluer l’information.<br>Par exemple, si vous connaissez ou non l’auteur, si l’auteur est reconnu ou encore si l’auteur a un intérêt particulier à ce que cette information circule.</p>"
         },
         {
           "id": "42276690-f134-4b88-ac0f-c26ad62370ec",
@@ -274,7 +274,7 @@
         {
           "id": "8aa4a733-4a92-4007-897d-ab884a7add85",
           "type": "text",
-          "content": "<h3>Question n°2&nbsp;: quelle est la date de l’information ? <span aria-hidden=\"true\">📅</span>️</h3><p>C’est simple à vérifier et très important ! Des informations vraies un jour peuvent être fausses le lendemain. <br>Par exemple, une alerte inondation ou une promotion dans un magasin.</p>"
+          "content": "<h3>Question n°2&nbsp;: quelle est la date de l’information&#8239;? <span aria-hidden=\"true\">📅</span>️</h3><p>C’est simple à vérifier et très important ! Des informations vraies un jour peuvent être fausses le lendemain. <br>Par exemple, une alerte inondation ou une promotion dans un magasin.</p>"
         },
         {
           "id": "056ef18b-2f2f-4518-acca-93bb59b2d151",
@@ -284,7 +284,7 @@
         {
           "id": "36577421-d9d0-4f49-ac43-b4e804ba5635",
           "type": "text",
-          "content": "<h3>Question n°3&nbsp;: d’où provient cette information ? <span aria-hidden=\"true\">ℹ️</span>️</h3><p>C'est-à-dire, son origine, sa source. Cherchez à savoir si c’est une observation, un témoignage, un résultat d’expérience, etc.<br>Regardez également si vous pouvez vérifier cette information par vous-même et si l’auteur a partagé ses sources.</p>"
+          "content": "<h3>Question n°3&nbsp;: d’où provient cette information&#8239;? <span aria-hidden=\"true\">ℹ️</span>️</h3><p>C'est-à-dire, son origine, sa source. Cherchez à savoir si c’est une observation, un témoignage, un résultat d’expérience, etc.<br>Regardez également si vous pouvez vérifier cette information par vous-même et si l’auteur a partagé ses sources.</p>"
         }
       ]
     },
@@ -296,7 +296,7 @@
         {
           "id": "1c39f509-cdc2-4d3e-85f8-7731739a793f",
           "type": "qcm",
-          "instruction": "<p>Parmi les éléments suivants, lesquels permettent de vérifier une information ?</p>",
+          "instruction": "<p>Parmi les éléments suivants, lesquels permettent de vérifier une information&#8239;?</p>",
           "proposals": [
             {
               "id": "1",
@@ -481,12 +481,12 @@
           "type": "image",
           "url": "https://i.imgur.com/Scxdcfm.png",
           "alt": "",
-          "alternativeText": "Vos plantes vertes ne poussent pas ? Voici 2 super astuces dont vous ne pourrez plus vous passer.<br> Astuce 1&nbsp;: Privilégier la lumière directe. Un grand bain de soleil, ça fait toujours du bien ! Votre plante va adorer.<br> Astuce 2&nbsp;: Mettez de la spiruline dans la terre. Vous trouverez d’ailleurs un lien en description avec le code promo JARDINIER3000."
+          "alternativeText": "Vos plantes vertes ne poussent pas&#8239;? Voici 2 super astuces dont vous ne pourrez plus vous passer.<br> Astuce 1&nbsp;: Privilégier la lumière directe. Un grand bain de soleil, ça fait toujours du bien ! Votre plante va adorer.<br> Astuce 2&nbsp;: Mettez de la spiruline dans la terre. Vous trouverez d’ailleurs un lien en description avec le code promo JARDINIER3000."
         },
         {
           "id": "2a308355-f39f-498e-aef6-f1c0830f5b1f",
           "type": "qcm",
-          "instruction": "<p>Quels sont les conseils à donner à Stéphane ?</p>",
+          "instruction": "<p>Quels sont les conseils à donner à Stéphane&#8239;?</p>",
           "proposals": [
             {
               "id": "1",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
@@ -15,7 +15,7 @@
   },
   "transitionTexts": [
     {
-      "content": "<p>Commençons par un jeu. <span aria-hidden=\"true\">🎮</span>️<br>Sans chercher sur internet, essayez de deviner si chaque information proposée dans ces articles de journaux est plutôt vraie ou plutôt fausse. Bonne chance !</p>",
+      "content": "<p>Commençons par un jeu. <span aria-hidden=\"true\">🎮</span>️<br>Sans chercher sur internet, essayez de deviner si chaque information proposée dans ces articles de journaux est plutôt vraie ou plutôt fausse. Bonne chance&#8239;!</p>",
       "grainId": "f242e81e-b182-44a1-a668-557f26b5ff8b"
     },
     {
@@ -71,8 +71,8 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Bien vu ! C'est le titre d'un <a href=\"https://www.sciencesetavenir.fr/sante/cerveau-et-psy/a-huit-mois-un-bebe-comprend-deja-la-notion-d-outil-y-compris-les-nouvelles-technologies_176388\" target=\"_blank\">article du magazine Sciences et Avenir</a>.</p>",
-            "invalid": "<p>Et pourtant, c'est vrai ! C'est le titre d'un <a href=\"https://www.sciencesetavenir.fr/sante/cerveau-et-psy/a-huit-mois-un-bebe-comprend-deja-la-notion-d-outil-y-compris-les-nouvelles-technologies_176388\" target=\"_blank\">article du magazine Sciences et Avenir</a>.</p>"
+            "valid": "<p>Bien vu&#8239;! C'est le titre d'un <a href=\"https://www.sciencesetavenir.fr/sante/cerveau-et-psy/a-huit-mois-un-bebe-comprend-deja-la-notion-d-outil-y-compris-les-nouvelles-technologies_176388\" target=\"_blank\">article du magazine Sciences et Avenir</a>.</p>",
+            "invalid": "<p>Et pourtant, c'est vrai&#8239;! C'est le titre d'un <a href=\"https://www.sciencesetavenir.fr/sante/cerveau-et-psy/a-huit-mois-un-bebe-comprend-deja-la-notion-d-outil-y-compris-les-nouvelles-technologies_176388\" target=\"_blank\">article du magazine Sciences et Avenir</a>.</p>"
           },
           "solution": "1"
         },
@@ -103,8 +103,8 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Bravo ! C'est le titre d'un <a href=\"https://www.slate.fr/story/252022/san-francisco-navettes-sans-conducteurs-autonomes\" target=\"_blank\">article de Slate</a>.</p>",
-            "invalid": "<p>Et pourtant, c'est vrai ! C'est le titre d'un <a href=\"https://www.slate.fr/story/252022/san-francisco-navettes-sans-conducteurs-autonomes\" target=\"_blank\">article de Slate</a>.</p>"
+            "valid": "<p>Bravo&#8239;! C'est le titre d'un <a href=\"https://www.slate.fr/story/252022/san-francisco-navettes-sans-conducteurs-autonomes\" target=\"_blank\">article de Slate</a>.</p>",
+            "invalid": "<p>Et pourtant, c'est vrai&#8239;! C'est le titre d'un <a href=\"https://www.slate.fr/story/252022/san-francisco-navettes-sans-conducteurs-autonomes\" target=\"_blank\">article de Slate</a>.</p>"
           },
           "solution": "1"
         },
@@ -135,8 +135,8 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Oui, c'est une fake news ! C'est le titre d'un <a href=\"https://www.legorafi.fr/2017/03/27/le-professeur-de-techno-forcait-ses-eleves-a-construire-des-porte-cles-lumineux-quil-revendait-sur-les-marches/\" target=\"_blank\">article <strong>parodique</strong> du Gorafi</a>.</p>",
-            "invalid": "<p>Attention, c'est une fake news ! C'est le titre d'un <a href=\"https://www.legorafi.fr/2017/03/27/le-professeur-de-techno-forcait-ses-eleves-a-construire-des-porte-cles-lumineux-quil-revendait-sur-les-marches/\" target=\"_blank\">article <strong>parodique</strong> du Gorafi</a>.</p>"
+            "valid": "<p>Oui, c'est une fake news&#8239;! C'est le titre d'un <a href=\"https://www.legorafi.fr/2017/03/27/le-professeur-de-techno-forcait-ses-eleves-a-construire-des-porte-cles-lumineux-quil-revendait-sur-les-marches/\" target=\"_blank\">article <strong>parodique</strong> du Gorafi</a>.</p>",
+            "invalid": "<p>Attention, c'est une fake news&#8239;! C'est le titre d'un <a href=\"https://www.legorafi.fr/2017/03/27/le-professeur-de-techno-forcait-ses-eleves-a-construire-des-porte-cles-lumineux-quil-revendait-sur-les-marches/\" target=\"_blank\">article <strong>parodique</strong> du Gorafi</a>.</p>"
           },
           "solution": "2"
         }
@@ -274,7 +274,7 @@
         {
           "id": "8aa4a733-4a92-4007-897d-ab884a7add85",
           "type": "text",
-          "content": "<h3>Question n°2&nbsp;: quelle est la date de l’information&#8239;? <span aria-hidden=\"true\">📅</span>️</h3><p>C’est simple à vérifier et très important ! Des informations vraies un jour peuvent être fausses le lendemain. <br>Par exemple, une alerte inondation ou une promotion dans un magasin.</p>"
+          "content": "<h3>Question n°2&nbsp;: quelle est la date de l’information&#8239;? <span aria-hidden=\"true\">📅</span>️</h3><p>C’est simple à vérifier et très important&#8239;! Des informations vraies un jour peuvent être fausses le lendemain. <br>Par exemple, une alerte inondation ou une promotion dans un magasin.</p>"
         },
         {
           "id": "056ef18b-2f2f-4518-acca-93bb59b2d151",
@@ -337,7 +337,7 @@
           "type": "image",
           "url": "https://images.pix.fr/modulix/distinguer-vrai-faux-sur-internet/tweet6.jpg",
           "alt": "",
-          "alternativeText": "Fan Du Real Madrid&nbsp;: ENFIN ! Kylian Mbappé va quitter le PSG pour rejoindre le Real Madrid. Tu es un vrai 10 !! <a href=\"https://www.goal.com/fr/news/le-psg-tente-un-dernier-coup-avec-kylian-mbappe/bltcba9cc42978c4f80\" target=\"_blank\">https://www.goal.com/fr/news/le-psg-tente-un-dernier-coup-avec-kylian-mbappe/bltcba9cc42978c4f80</a>"
+          "alternativeText": "Fan Du Real Madrid&nbsp;: ENFIN&#8239;! Kylian Mbappé va quitter le PSG pour rejoindre le Real Madrid. Tu es un vrai 10&#8239;!! <a href=\"https://www.goal.com/fr/news/le-psg-tente-un-dernier-coup-avec-kylian-mbappe/bltcba9cc42978c4f80\" target=\"_blank\">https://www.goal.com/fr/news/le-psg-tente-un-dernier-coup-avec-kylian-mbappe/bltcba9cc42978c4f80</a>"
         },
         {
           "id": "7e2cda57-9383-4a9b-ab46-b6d96317d6ac",
@@ -363,7 +363,7 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Correct. FanDuRealMadrid annonce la venue de Mbappé dans son club favori alors que l’article utilisé comme source ne l’annonce pas du tout !</p>",
+            "valid": "<p>Correct. FanDuRealMadrid annonce la venue de Mbappé dans son club favori alors que l’article utilisé comme source ne l’annonce pas du tout&#8239;!</p>",
             "invalid": "<p>Incorrect. L’article utilisé comme source n’annonce pas du tout la venue de Mbappé. Ce fan a sûrement été influencé par ses envies.</p>"
           },
           "solution": "1"
@@ -378,7 +378,7 @@
           "type": "image",
           "url": "https://i.imgur.com/5BMW9i7.png",
           "alt": "",
-          "alternativeText": "Jean-Eude Coulignant&nbsp;: Scoop ! Grâce aux nouvelles technologies, il y a de plus en plus de visiteurs dans les musées"
+          "alternativeText": "Jean-Eude Coulignant&nbsp;: Scoop&#8239;! Grâce aux nouvelles technologies, il y a de plus en plus de visiteurs dans les musées"
         },
         {
           "id": "81943b07-ecf0-408b-877c-55e1943df1fc",
@@ -481,7 +481,7 @@
           "type": "image",
           "url": "https://i.imgur.com/Scxdcfm.png",
           "alt": "",
-          "alternativeText": "Vos plantes vertes ne poussent pas&#8239;? Voici 2 super astuces dont vous ne pourrez plus vous passer.<br> Astuce 1&nbsp;: Privilégier la lumière directe. Un grand bain de soleil, ça fait toujours du bien ! Votre plante va adorer.<br> Astuce 2&nbsp;: Mettez de la spiruline dans la terre. Vous trouverez d’ailleurs un lien en description avec le code promo JARDINIER3000."
+          "alternativeText": "Vos plantes vertes ne poussent pas&#8239;? Voici 2 super astuces dont vous ne pourrez plus vous passer.<br> Astuce 1&nbsp;: Privilégier la lumière directe. Un grand bain de soleil, ça fait toujours du bien&#8239;! Votre plante va adorer.<br> Astuce 2&nbsp;: Mettez de la spiruline dans la terre. Vous trouverez d’ailleurs un lien en description avec le code promo JARDINIER3000."
         },
         {
           "id": "2a308355-f39f-498e-aef6-f1c0830f5b1f",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
@@ -150,7 +150,7 @@
         {
           "id": "342183f7-af51-4e4e-ab4c-ebed1e195063",
           "type": "text",
-          "content": "<p>À la fin de cette vidéo, des questions vous seront posées sur des mots de vocabulaire : \"une anecdote\", \"une rumeur\", \"une opinion\".</p>"
+          "content": "<p>À la fin de cette vidéo, des questions vous seront posées sur des mots de vocabulaire&nbsp;: \"une anecdote\", \"une rumeur\", \"une opinion\".</p>"
         },
         {
           "id": "3a9f2269-99ba-4631-b6fd-6802c88d5c26",
@@ -264,7 +264,7 @@
         {
           "id": "332d9e96-d12e-4809-9d25-173a57ed93be",
           "type": "text",
-          "content": "<h3>Question n°1 : qui est l’auteur de cette information ? <span aria-hidden=\"true\">🖋️</span>️</h3><p>En vous posant cette question, vous pourrez mieux évaluer l’information.<br>Par exemple, si vous connaissez ou non l’auteur, si l’auteur est reconnu ou encore si l’auteur a un intérêt particulier à ce que cette information circule.</p>"
+          "content": "<h3>Question n°1&nbsp;: qui est l’auteur de cette information ? <span aria-hidden=\"true\">🖋️</span>️</h3><p>En vous posant cette question, vous pourrez mieux évaluer l’information.<br>Par exemple, si vous connaissez ou non l’auteur, si l’auteur est reconnu ou encore si l’auteur a un intérêt particulier à ce que cette information circule.</p>"
         },
         {
           "id": "42276690-f134-4b88-ac0f-c26ad62370ec",
@@ -274,7 +274,7 @@
         {
           "id": "8aa4a733-4a92-4007-897d-ab884a7add85",
           "type": "text",
-          "content": "<h3>Question n°2 : quelle est la date de l’information ? <span aria-hidden=\"true\">📅</span>️</h3><p>C’est simple à vérifier et très important ! Des informations vraies un jour peuvent être fausses le lendemain. <br>Par exemple, une alerte inondation ou une promotion dans un magasin.</p>"
+          "content": "<h3>Question n°2&nbsp;: quelle est la date de l’information ? <span aria-hidden=\"true\">📅</span>️</h3><p>C’est simple à vérifier et très important ! Des informations vraies un jour peuvent être fausses le lendemain. <br>Par exemple, une alerte inondation ou une promotion dans un magasin.</p>"
         },
         {
           "id": "056ef18b-2f2f-4518-acca-93bb59b2d151",
@@ -284,7 +284,7 @@
         {
           "id": "36577421-d9d0-4f49-ac43-b4e804ba5635",
           "type": "text",
-          "content": "<h3>Question n°3 : d’où provient cette information ? <span aria-hidden=\"true\">ℹ️</span>️</h3><p>C'est-à-dire, son origine, sa source. Cherchez à savoir si c’est une observation, un témoignage, un résultat d’expérience, etc.<br>Regardez également si vous pouvez vérifier cette information par vous-même et si l’auteur a partagé ses sources.</p>"
+          "content": "<h3>Question n°3&nbsp;: d’où provient cette information ? <span aria-hidden=\"true\">ℹ️</span>️</h3><p>C'est-à-dire, son origine, sa source. Cherchez à savoir si c’est une observation, un témoignage, un résultat d’expérience, etc.<br>Regardez également si vous pouvez vérifier cette information par vous-même et si l’auteur a partagé ses sources.</p>"
         }
       ]
     },
@@ -337,7 +337,7 @@
           "type": "image",
           "url": "https://images.pix.fr/modulix/distinguer-vrai-faux-sur-internet/tweet6.jpg",
           "alt": "",
-          "alternativeText": "Fan Du Real Madrid : ENFIN ! Kylian Mbappé va quitter le PSG pour rejoindre le Real Madrid. Tu es un vrai 10 !! <a href=\"https://www.goal.com/fr/news/le-psg-tente-un-dernier-coup-avec-kylian-mbappe/bltcba9cc42978c4f80\" target=\"_blank\">https://www.goal.com/fr/news/le-psg-tente-un-dernier-coup-avec-kylian-mbappe/bltcba9cc42978c4f80</a>"
+          "alternativeText": "Fan Du Real Madrid&nbsp;: ENFIN ! Kylian Mbappé va quitter le PSG pour rejoindre le Real Madrid. Tu es un vrai 10 !! <a href=\"https://www.goal.com/fr/news/le-psg-tente-un-dernier-coup-avec-kylian-mbappe/bltcba9cc42978c4f80\" target=\"_blank\">https://www.goal.com/fr/news/le-psg-tente-un-dernier-coup-avec-kylian-mbappe/bltcba9cc42978c4f80</a>"
         },
         {
           "id": "7e2cda57-9383-4a9b-ab46-b6d96317d6ac",
@@ -378,7 +378,7 @@
           "type": "image",
           "url": "https://i.imgur.com/5BMW9i7.png",
           "alt": "",
-          "alternativeText": "Jean-Eude Coulignant : Scoop ! Grâce aux nouvelles technologies, il y a de plus en plus de visiteurs dans les musées"
+          "alternativeText": "Jean-Eude Coulignant&nbsp;: Scoop ! Grâce aux nouvelles technologies, il y a de plus en plus de visiteurs dans les musées"
         },
         {
           "id": "81943b07-ecf0-408b-877c-55e1943df1fc",
@@ -414,7 +414,7 @@
           "type": "image",
           "url": "https://images.pix.fr/modulix/distinguer-vrai-faux-sur-internet/tweet7.jpg",
           "alt": "",
-          "alternativeText": "Stéphanie Attelage : Allez vite au supermarché, il n'y aura bientôt plus de pâtes. Pour plus d'infos : <a href=\"https://www.zayactu.org/2021/08/la-france-bientot-confrontee-a-une-penurie-de-pates-alimentaires\" target=\"_blank\">https://www.zayactu.org/2021/08/la-france-bientot-confrontee-a-une-penurie-de-pates-alimentaires</a>!"
+          "alternativeText": "Stéphanie Attelage&nbsp;: Allez vite au supermarché, il n'y aura bientôt plus de pâtes. Pour plus d'infos&nbsp;: <a href=\"https://www.zayactu.org/2021/08/la-france-bientot-confrontee-a-une-penurie-de-pates-alimentaires\" target=\"_blank\">https://www.zayactu.org/2021/08/la-france-bientot-confrontee-a-une-penurie-de-pates-alimentaires</a>!"
         },
         {
           "id": "4f002984-f136-4962-8f9a-b5f69d2995af",
@@ -462,7 +462,7 @@
           "type": "image",
           "url": "https://i.imgur.com/QS0xFIn.png",
           "alt": "",
-          "alternativeText": "Indice 1 : Un ton alarmiste, qui veut faire ressentir un sentiment d’urgence, doit amener à une posture de prudence.<br>Indice 2 : La demande explicite de partager une information est un indice que l’auteur cherche à rendre son contenu viral et “faire le buzz”.<br>Indice 3 : L’utilisation de majuscules et d’émojis angoissant sont utilisés pour interpeller. Cette manière d’écrire peut indiquer l’envie pour l’auteur d’être lu à tout prix. Les fautes d’orthographe indique que le contenu a été rédigé sans attention particulière."
+          "alternativeText": "Indice 1&nbsp;: Un ton alarmiste, qui veut faire ressentir un sentiment d’urgence, doit amener à une posture de prudence.<br>Indice 2&nbsp;: La demande explicite de partager une information est un indice que l’auteur cherche à rendre son contenu viral et “faire le buzz”.<br>Indice 3&nbsp;: L’utilisation de majuscules et d’émojis angoissant sont utilisés pour interpeller. Cette manière d’écrire peut indiquer l’envie pour l’auteur d’être lu à tout prix. Les fautes d’orthographe indique que le contenu a été rédigé sans attention particulière."
         }
       ]
     },
@@ -474,14 +474,14 @@
         {
           "id": "eb90d3ea-797f-4e4a-9675-e679b9f5bf3c",
           "type": "text",
-          "content": "<p>Stéphane n'arrive pas à faire pousser sa nouvelle plante verte d’intérieur <span aria-hidden=\"true\">🪴</span>️. Il cherche des astuces sur les réseaux sociaux.<br>Il trouve les informations suivantes, publiées le 28 août 2023, par SuperJardinier :</p>"
+          "content": "<p>Stéphane n'arrive pas à faire pousser sa nouvelle plante verte d’intérieur <span aria-hidden=\"true\">🪴</span>️. Il cherche des astuces sur les réseaux sociaux.<br>Il trouve les informations suivantes, publiées le 28 août 2023, par SuperJardinier&nbsp;:</p>"
         },
         {
           "id": "2c525ab3-23bf-4b43-867d-ea1fac54efad",
           "type": "image",
           "url": "https://i.imgur.com/Scxdcfm.png",
           "alt": "",
-          "alternativeText": "Vos plantes vertes ne poussent pas ? Voici 2 super astuces dont vous ne pourrez plus vous passer.<br> Astuce 1 : Privilégier la lumière directe. Un grand bain de soleil, ça fait toujours du bien ! Votre plante va adorer.<br> Astuce 2 : Mettez de la spiruline dans la terre. Vous trouverez d’ailleurs un lien en description avec le code promo JARDINIER3000."
+          "alternativeText": "Vos plantes vertes ne poussent pas ? Voici 2 super astuces dont vous ne pourrez plus vous passer.<br> Astuce 1&nbsp;: Privilégier la lumière directe. Un grand bain de soleil, ça fait toujours du bien ! Votre plante va adorer.<br> Astuce 2&nbsp;: Mettez de la spiruline dans la terre. Vous trouverez d’ailleurs un lien en description avec le code promo JARDINIER3000."
         },
         {
           "id": "2a308355-f39f-498e-aef6-f1c0830f5b1f",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
@@ -68,7 +68,32 @@
               "ariaLabel": "Mot de passe",
               "defaultValue": "",
               "tolerances": ["t1"],
-              "solutions": ["123456", "123456789", "azerty", "admin", "1234561", "azertyuiop", "loulou", "000000", "doudou", "password", "marseille", "motdepasse", "12345678", "chouchou", "soleil", "cheval", "12345", "Password", "bonjour", "1234567891", "1234", "0000", "toto", "azerty123"]
+              "solutions": [
+                "123456",
+                "123456789",
+                "azerty",
+                "admin",
+                "1234561",
+                "azertyuiop",
+                "loulou",
+                "000000",
+                "doudou",
+                "password",
+                "marseille",
+                "motdepasse",
+                "12345678",
+                "chouchou",
+                "soleil",
+                "cheval",
+                "12345",
+                "Password",
+                "bonjour",
+                "1234567891",
+                "1234",
+                "0000",
+                "toto",
+                "azerty123"
+              ]
             }
           ],
           "feedbacks": {
@@ -125,7 +150,56 @@
               "ariaLabel": "Mot de passe d'Austin",
               "defaultValue": "",
               "tolerances": ["t1"],
-              "solutions": ["Bill15111984", "15111984Bill", "Bill151184", "151184Bill", "bill15111984", "15111984bill", "bill151184", "151184bill", "Bill15novembre1984", "15novembre1984Bill", "Bill15novembre84", "15novembre84Bill", "bill15novembre1984", "15novembre1984bill", "bill15novembre84", "15novembre84bill","Bill15/11/1984", "15/11/1984Bill", "Bill15/11/84", "15/11/84Bill", "bill15/11/1984", "15/11/1984bill", "bill15/11/84", "15/11/84bill", "Bill151119", "151119Bill", "Bill1511", "1511Bill", "bill1511", "1511bill", "bill1511", "1511bill", "Bill15novembre", "15novembreBill", "Bill15novembre", "15novembreBill", "bill15novembre", "15novembrebill", "bill15novembre", "15novembrebill","Bill15/11", "15/11Bill", "Bill15/11", "15/11Bill", "bill15/11", "15/11bill", "bill15/11", "15/11bill"]
+              "solutions": [
+                "Bill15111984",
+                "15111984Bill",
+                "Bill151184",
+                "151184Bill",
+                "bill15111984",
+                "15111984bill",
+                "bill151184",
+                "151184bill",
+                "Bill15novembre1984",
+                "15novembre1984Bill",
+                "Bill15novembre84",
+                "15novembre84Bill",
+                "bill15novembre1984",
+                "15novembre1984bill",
+                "bill15novembre84",
+                "15novembre84bill",
+                "Bill15/11/1984",
+                "15/11/1984Bill",
+                "Bill15/11/84",
+                "15/11/84Bill",
+                "bill15/11/1984",
+                "15/11/1984bill",
+                "bill15/11/84",
+                "15/11/84bill",
+                "Bill151119",
+                "151119Bill",
+                "Bill1511",
+                "1511Bill",
+                "bill1511",
+                "1511bill",
+                "bill1511",
+                "1511bill",
+                "Bill15novembre",
+                "15novembreBill",
+                "Bill15novembre",
+                "15novembreBill",
+                "bill15novembre",
+                "15novembrebill",
+                "bill15novembre",
+                "15novembrebill",
+                "Bill15/11",
+                "15/11Bill",
+                "Bill15/11",
+                "15/11Bill",
+                "bill15/11",
+                "15/11bill",
+                "bill15/11",
+                "15/11bill"
+              ]
             }
           ],
           "feedbacks": {
@@ -312,10 +386,7 @@
             "valid": "<p>Correct. Un mot de passe long est plus solide. Se servir d'une phrase permet de mieux s'en souvenir. </p>",
             "invalid": "<p>Incorrect. Un mot de passe long est plus solide. Se servir d'une phrase permet de mieux s'en souvenir.</p>"
           },
-          "solutions": [
-            "1",
-            "4"
-          ]
+          "solutions": ["1", "4"]
         }
       ]
     },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
@@ -72,8 +72,8 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Bien vu&#8239;! Voici la liste des 5 mots de passe les plus utilisés&nbsp;: 123456 ; 123456789 ; azerty ; 1234561 ; qwerty.<br>Ce sont donc de mauvais mots de passe.</p>",
-            "invalid": "<p>Dommage&#8239;! Voici la liste des 5 mots de passe les plus utilisés&nbsp;: 123456 ; 123456789 ; azerty ; 1234561 ; qwerty.<br>Ce sont donc de mauvais mots de passe.</p>"
+            "valid": "<p>Bien vu&#8239;! Voici la liste des 5 mots de passe les plus utilisés&nbsp;: 123456&#8239;; 123456789&#8239;; azerty&#8239;; 1234561&#8239;; qwerty.<br>Ce sont donc de mauvais mots de passe.</p>",
+            "invalid": "<p>Dommage&#8239;! Voici la liste des 5 mots de passe les plus utilisés&nbsp;: 123456&#8239;; 123456789&#8239;; azerty&#8239;; 1234561&#8239;; qwerty.<br>Ce sont donc de mauvais mots de passe.</p>"
           }
         }
       ]
@@ -153,7 +153,7 @@
         {
           "id": "52f4050d-7ab9-41da-987b-d9172d5b3cb0",
           "type": "text",
-          "content": "<h3>Règle n°2&nbsp;: variez les caractères utilisés.&nbsp;<span aria-hidden=\"true\">🔣</span></h3><p>Un bon mot de passe contient différents caractères ; ce qui augmente le nombre de combinaisons possibles. On peut utiliser des minuscules, des majuscules, des chiffres, des caractères spéciaux&nbsp;: <code>=</code> <code>@</code> <code>$</code> <code>#</code> <code>!</code> <code>?</code>.</p>"
+          "content": "<h3>Règle n°2&nbsp;: variez les caractères utilisés.&nbsp;<span aria-hidden=\"true\">🔣</span></h3><p>Un bon mot de passe contient différents caractères&#8239;; ce qui augmente le nombre de combinaisons possibles. On peut utiliser des minuscules, des majuscules, des chiffres, des caractères spéciaux&nbsp;: <code>=</code> <code>@</code> <code>$</code> <code>#</code> <code>!</code> <code>?</code>.</p>"
         },
         {
           "id": "2895432c-72a3-44be-ae0e-52041f5b847e",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
@@ -23,7 +23,7 @@
       "grainId": "831fd61c-54ae-4b21-bd3f-61f40887a869"
     },
     {
-      "content": "<p>Un exemple : Austin a utilisé des informations personnelles pour créer son mot de passe. Vous allez pouvoir le deviner facilement. À vous de jouer.&nbsp;<span aria-hidden=\"true\">🕵🏻‍♂️</span>&nbsp;<span aria-hidden=\"true\">🕵🏿‍♀️</span></p>",
+      "content": "<p>Un exemple&nbsp;: Austin a utilisé des informations personnelles pour créer son mot de passe. Vous allez pouvoir le deviner facilement. À vous de jouer.&nbsp;<span aria-hidden=\"true\">🕵🏻‍♂️</span>&nbsp;<span aria-hidden=\"true\">🕵🏿‍♀️</span></p>",
       "grainId": "1cda400f-008c-49db-b46b-6f783ccbc273"
     },
     {
@@ -72,8 +72,8 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Bien vu ! Voici la liste des 5 mots de passe les plus utilisés : 123456 ; 123456789 ; azerty ; 1234561 ; qwerty.<br>Ce sont donc de mauvais mots de passe.</p>",
-            "invalid": "<p>Dommage ! Voici la liste des 5 mots de passe les plus utilisés : 123456 ; 123456789 ; azerty ; 1234561 ; qwerty.<br>Ce sont donc de mauvais mots de passe.</p>"
+            "valid": "<p>Bien vu ! Voici la liste des 5 mots de passe les plus utilisés&nbsp;: 123456 ; 123456789 ; azerty ; 1234561 ; qwerty.<br>Ce sont donc de mauvais mots de passe.</p>",
+            "invalid": "<p>Dommage ! Voici la liste des 5 mots de passe les plus utilisés&nbsp;: 123456 ; 123456789 ; azerty ; 1234561 ; qwerty.<br>Ce sont donc de mauvais mots de passe.</p>"
           }
         }
       ]
@@ -143,7 +143,7 @@
         {
           "id": "02bb0017-a74d-4c78-8502-3c57d9f12209",
           "type": "text",
-          "content": "<h3>Règle n°1 : créez un mot de passe long.&nbsp;<span aria-hidden=\"true\">📝</span></h3><p>Un mot de passe long sera dur à deviner ou à pirater. Mais gardez une longueur raisonnable : à partir de 12 caractères, le mot de passe est assez long.</p>"
+          "content": "<h3>Règle n°1&nbsp;: créez un mot de passe long.&nbsp;<span aria-hidden=\"true\">📝</span></h3><p>Un mot de passe long sera dur à deviner ou à pirater. Mais gardez une longueur raisonnable&nbsp;: à partir de 12 caractères, le mot de passe est assez long.</p>"
         },
         {
           "id": "7f89a519-a5ce-4484-9952-eb6869b94291",
@@ -153,7 +153,7 @@
         {
           "id": "52f4050d-7ab9-41da-987b-d9172d5b3cb0",
           "type": "text",
-          "content": "<h3>Règle n°2 : variez les caractères utilisés.&nbsp;<span aria-hidden=\"true\">🔣</span></h3><p>Un bon mot de passe contient différents caractères ; ce qui augmente le nombre de combinaisons possibles. On peut utiliser des minuscules, des majuscules, des chiffres, des caractères spéciaux : <code>=</code> <code>@</code> <code>$</code> <code>#</code> <code>!</code> <code>?</code>.</p>"
+          "content": "<h3>Règle n°2&nbsp;: variez les caractères utilisés.&nbsp;<span aria-hidden=\"true\">🔣</span></h3><p>Un bon mot de passe contient différents caractères ; ce qui augmente le nombre de combinaisons possibles. On peut utiliser des minuscules, des majuscules, des chiffres, des caractères spéciaux&nbsp;: <code>=</code> <code>@</code> <code>$</code> <code>#</code> <code>!</code> <code>?</code>.</p>"
         },
         {
           "id": "2895432c-72a3-44be-ae0e-52041f5b847e",
@@ -163,7 +163,7 @@
         {
           "id": "c4505a09-864c-48f8-8077-013fae2db291",
           "type": "text",
-          "content": "<h3>Règle n°3 : n'utilisez pas d’informations personnelles.&nbsp;<span aria-hidden=\"true\">🤫</span></h3><p>De cette manière, il y a moins de chance que quelqu'un le devine. N'utilisez donc pas de dates de naissance et de numéros de téléphone. Un mot de passe doit être secret !</p>"
+          "content": "<h3>Règle n°3&nbsp;: n'utilisez pas d’informations personnelles.&nbsp;<span aria-hidden=\"true\">🤫</span></h3><p>De cette manière, il y a moins de chance que quelqu'un le devine. N'utilisez donc pas de dates de naissance et de numéros de téléphone. Un mot de passe doit être secret !</p>"
         }
       ]
     },
@@ -257,7 +257,7 @@
         {
           "id": "6eda6d92-1147-4c19-a7e5-f61a2228e33c",
           "type": "text",
-          "content": "<h3>Astuce n°1 : n'utilisez pas le même mot de passe partout !</h3><p>Utiliser toujours le même mot de passe est risqué. C'est comme utiliser la même clé pour toutes ses portes. C'est très pratique, mais si votre mot de passe est piraté, toutes les portes sont ouvertes !&nbsp;<span aria-hidden=\"true\">☠️</span></p>"
+          "content": "<h3>Astuce n°1&nbsp;: n'utilisez pas le même mot de passe partout !</h3><p>Utiliser toujours le même mot de passe est risqué. C'est comme utiliser la même clé pour toutes ses portes. C'est très pratique, mais si votre mot de passe est piraté, toutes les portes sont ouvertes !&nbsp;<span aria-hidden=\"true\">☠️</span></p>"
         },
         {
           "id": "b8bc3e1e-bf21-4b3b-8dce-0a0213aefb1b",
@@ -267,7 +267,7 @@
         {
           "id": "f6edeae6-fbfb-4dce-b556-1bb7928d5ff5",
           "type": "text",
-          "content": "<h3>Astuce n°2 : utilisez une phrase qui vous plaît et gardez certains caractères. </h3><p>Par exemple : la phrase \"<strong>J'a</strong>i <strong>2 c</strong>hats<strong>, 3 p</strong>oissons <strong>e</strong>xotiques <strong>e</strong>t <strong>j'a</strong>dore <strong>l</strong>a <strong>p</strong>longée <strong>!</strong>\" vous donne le mot de passe : <strong>Ja2c3peejalp!</strong></p>"
+          "content": "<h3>Astuce n°2&nbsp;: utilisez une phrase qui vous plaît et gardez certains caractères. </h3><p>Par exemple&nbsp;: la phrase \"<strong>J'a</strong>i <strong>2 c</strong>hats<strong>, 3 p</strong>oissons <strong>e</strong>xotiques <strong>e</strong>t <strong>j'a</strong>dore <strong>l</strong>a <strong>p</strong>longée <strong>!</strong>\" vous donne le mot de passe&nbsp;: <strong>Ja2c3peejalp!</strong></p>"
         },
         {
           "id": "95098e06-e113-46ba-afa0-b7890d5cf467",
@@ -277,7 +277,7 @@
         {
           "id": "dadd152e-350c-4710-8609-af5f92e69b2c",
           "type": "text",
-          "content": "<h3>Astuce n°3 : créez un nouveau mot de passe si vous l'avez oublié.</h3><p>Oublier son mot de passe, ce n'est pas grave. Au moment de votre connexion, les sites internet permettent de changer votre mot de passe si vous l'avez oublié.<br>Tous les mots de passe ne sont pas égaux. Par exemple, mémorisez bien celui de votre boîte mail car il permet de changer tous les autres.&nbsp;<span aria-hidden=\"true\">💡</span></p>"
+          "content": "<h3>Astuce n°3&nbsp;: créez un nouveau mot de passe si vous l'avez oublié.</h3><p>Oublier son mot de passe, ce n'est pas grave. Au moment de votre connexion, les sites internet permettent de changer votre mot de passe si vous l'avez oublié.<br>Tous les mots de passe ne sont pas égaux. Par exemple, mémorisez bien celui de votre boîte mail car il permet de changer tous les autres.&nbsp;<span aria-hidden=\"true\">💡</span></p>"
         }
       ]
     },
@@ -322,12 +322,12 @@
     {
       "id": "1ed4223a-2b8f-4c2c-8dcb-3d0567b562b0",
       "type": "lesson",
-      "title": "Sécuriser ses mots de passe : synthèse",
+      "title": "Sécuriser ses mots de passe&nbsp;: synthèse",
       "elements": [
         {
           "id": "2e695244-52c5-4277-8414-d18777d0d242",
           "type": "text",
-          "content": "<h3>Ce qu’il faut retenir</h3><ul><li>Tous les mots de passe ne sont pas égaux : l'accès à votre boîte mail permet de contrôler de nombreux autres services. Ce mot de passe est donc très important.&nbsp;<span aria-hidden=\"true\">🚨</span></li><li>Un mot de passe solide est unique, long et composé de différents caractères. Il ne contient pas d'informations personnelles et doit rester secret.&nbsp;<span aria-hidden=\"true\">🎯</span></li><li>Pour avoir un mot de passe solide et facile à retenir, on peut choisir une phrase et garder certains caractères.&nbsp;<span aria-hidden=\"true\">💡</span></li></ul>"
+          "content": "<h3>Ce qu’il faut retenir</h3><ul><li>Tous les mots de passe ne sont pas égaux&nbsp;: l'accès à votre boîte mail permet de contrôler de nombreux autres services. Ce mot de passe est donc très important.&nbsp;<span aria-hidden=\"true\">🚨</span></li><li>Un mot de passe solide est unique, long et composé de différents caractères. Il ne contient pas d'informations personnelles et doit rester secret.&nbsp;<span aria-hidden=\"true\">🎯</span></li><li>Pour avoir un mot de passe solide et facile à retenir, on peut choisir une phrase et garder certains caractères.&nbsp;<span aria-hidden=\"true\">💡</span></li></ul>"
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
@@ -322,7 +322,7 @@
     {
       "id": "1ed4223a-2b8f-4c2c-8dcb-3d0567b562b0",
       "type": "lesson",
-      "title": "Sécuriser ses mots de passe&nbsp;: synthèse",
+      "title": "Sécuriser ses mots de passe : synthèse",
       "elements": [
         {
           "id": "2e695244-52c5-4277-8414-d18777d0d242",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
@@ -27,7 +27,7 @@
       "grainId": "1cda400f-008c-49db-b46b-6f783ccbc273"
     },
     {
-      "content": "<p>Pour créer un mot de passe solide, il y a certaines règles à suivre. Regardons de plus près !</p>",
+      "content": "<p>Pour créer un mot de passe solide, il y a certaines règles à suivre. Regardons de plus près&#8239;!</p>",
       "grainId": "1564f763-5ba5-48ef-b752-dac463319899"
     },
     {
@@ -72,8 +72,8 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Bien vu ! Voici la liste des 5 mots de passe les plus utilisés&nbsp;: 123456 ; 123456789 ; azerty ; 1234561 ; qwerty.<br>Ce sont donc de mauvais mots de passe.</p>",
-            "invalid": "<p>Dommage ! Voici la liste des 5 mots de passe les plus utilisés&nbsp;: 123456 ; 123456789 ; azerty ; 1234561 ; qwerty.<br>Ce sont donc de mauvais mots de passe.</p>"
+            "valid": "<p>Bien vu&#8239;! Voici la liste des 5 mots de passe les plus utilisés&nbsp;: 123456 ; 123456789 ; azerty ; 1234561 ; qwerty.<br>Ce sont donc de mauvais mots de passe.</p>",
+            "invalid": "<p>Dommage&#8239;! Voici la liste des 5 mots de passe les plus utilisés&nbsp;: 123456 ; 123456789 ; azerty ; 1234561 ; qwerty.<br>Ce sont donc de mauvais mots de passe.</p>"
           }
         }
       ]
@@ -163,7 +163,7 @@
         {
           "id": "c4505a09-864c-48f8-8077-013fae2db291",
           "type": "text",
-          "content": "<h3>Règle n°3&nbsp;: n'utilisez pas d’informations personnelles.&nbsp;<span aria-hidden=\"true\">🤫</span></h3><p>De cette manière, il y a moins de chance que quelqu'un le devine. N'utilisez donc pas de dates de naissance et de numéros de téléphone. Un mot de passe doit être secret !</p>"
+          "content": "<h3>Règle n°3&nbsp;: n'utilisez pas d’informations personnelles.&nbsp;<span aria-hidden=\"true\">🤫</span></h3><p>De cette manière, il y a moins de chance que quelqu'un le devine. N'utilisez donc pas de dates de naissance et de numéros de téléphone. Un mot de passe doit être secret&#8239;!</p>"
         }
       ]
     },
@@ -192,8 +192,8 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Correct !&nbsp;<span aria-hidden=\"true\">🎉</span> </p>",
-            "invalid": "<p>Incorrect !</p>"
+            "valid": "<p>Correct&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span> </p>",
+            "invalid": "<p>Incorrect&#8239;!</p>"
           },
           "solution": "1"
         },
@@ -217,8 +217,8 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Correct !&nbsp;<span aria-hidden=\"true\">🎉</span> </p>",
-            "invalid": "<p>Incorrect !</p>"
+            "valid": "<p>Correct&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span> </p>",
+            "invalid": "<p>Incorrect&#8239;!</p>"
           },
           "solution": "2"
         },
@@ -242,8 +242,8 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Correct !&nbsp;<span aria-hidden=\"true\">🎉</span> </p>",
-            "invalid": "<p>Incorrect !</p>"
+            "valid": "<p>Correct&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span> </p>",
+            "invalid": "<p>Incorrect&#8239;!</p>"
           },
           "solution": "1"
         }
@@ -257,7 +257,7 @@
         {
           "id": "6eda6d92-1147-4c19-a7e5-f61a2228e33c",
           "type": "text",
-          "content": "<h3>Astuce n°1&nbsp;: n'utilisez pas le même mot de passe partout !</h3><p>Utiliser toujours le même mot de passe est risqué. C'est comme utiliser la même clé pour toutes ses portes. C'est très pratique, mais si votre mot de passe est piraté, toutes les portes sont ouvertes !&nbsp;<span aria-hidden=\"true\">☠️</span></p>"
+          "content": "<h3>Astuce n°1&nbsp;: n'utilisez pas le même mot de passe partout&#8239;!</h3><p>Utiliser toujours le même mot de passe est risqué. C'est comme utiliser la même clé pour toutes ses portes. C'est très pratique, mais si votre mot de passe est piraté, toutes les portes sont ouvertes&#8239;!&nbsp;<span aria-hidden=\"true\">☠️</span></p>"
         },
         {
           "id": "b8bc3e1e-bf21-4b3b-8dce-0a0213aefb1b",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
@@ -56,7 +56,7 @@
         {
           "id": "d8d3f524-10c7-4190-986b-f1e309efb124",
           "type": "qrocm",
-          "instruction": "<p>Certains mots de passe sont très utilisés et donc faciles à deviner. <br>À votre avis, quel est le mot de passe le plus utilisé en France ?</p>",
+          "instruction": "<p>Certains mots de passe sont très utilisés et donc faciles à deviner. <br>À votre avis, quel est le mot de passe le plus utilisé en France&#8239;?</p>",
           "proposals": [
             {
               "input": "mot-de-passe",
@@ -113,7 +113,7 @@
         {
           "id": "2695bb89-112c-49d1-80b2-469d824af58f",
           "type": "qrocm",
-          "instruction": "<p>À votre avis, quel peut être le mot de passe d'Austin ?</p>",
+          "instruction": "<p>À votre avis, quel peut être le mot de passe d'Austin&#8239;?</p>",
           "proposals": [
             {
               "input": "mot-de-passe",
@@ -130,7 +130,7 @@
           ],
           "feedbacks": {
             "valid": "<p>Correct. C’est un <strong>mot de passe faible</strong>, c’est-à-dire  facile à trouver.</p>",
-            "invalid": "<p>Incorrect. Plusieurs réponses sont possibles. Avez-vous utilisé la date de naissance d’Austin, par exemple 151184 ? Et utilisé le prénom de son fils Bill ?</p>"
+            "invalid": "<p>Incorrect. Plusieurs réponses sont possibles. Avez-vous utilisé la date de naissance d’Austin, par exemple 151184&#8239;? Et utilisé le prénom de son fils Bill&#8239;?</p>"
           }
         }
       ]
@@ -289,7 +289,7 @@
         {
           "id": "5db8677e-2c9e-4f36-b932-4989459af149",
           "type": "qcm",
-          "instruction": "<p>Quels conseils pouvez-vous donner à Austin pour créer un mot de passe solide ?</p>",
+          "instruction": "<p>Quels conseils pouvez-vous donner à Austin pour créer un mot de passe solide&#8239;?</p>",
           "proposals": [
             {
               "id": "1",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
@@ -14,7 +14,7 @@
   },
   "transitionTexts": [
     {
-      "content": "<p>Sur un ordinateur, on peut souvent brancher des appareils, comme une souris ou un clavier.<br>On peut aussi brancher une clé USB, même si ce n’est pas toujours facile à faire. <span aria-hidden=\"true\">🤯</span></p>",
+      "content": "<p>Sur un ordinateur, on peut souvent brancher des appareils, comme une souris ou un clavier.<br>On peut aussi brancher une clé USB, même si ce n’est pas toujours facile à faire.&nbsp;<span aria-hidden=\"true\">🤯</span></p>",
       "grainId": "8bb146db-104c-41e2-aa79-14f7a06e0930"
     },
     {
@@ -26,11 +26,11 @@
       "grainId": "e7aa8e1d-c88a-42ff-bf58-fe4371a1ce6a"
     },
     {
-      "content": "<p>Le port USB n’est pas le seul port présent sur un ordinateur. Voici des exemples de ports de connexion. <span aria-hidden=\"true\">👇</span></p>",
+      "content": "<p>Le port USB n’est pas le seul port présent sur un ordinateur. Voici des exemples de ports de connexion.&nbsp;<span aria-hidden=\"true\">👇</span></p>",
       "grainId": "3b26ddd0-8d3b-4f84-bee3-58cbe4073798"
     },
     {
-      "content": "<p>Maintenant que vous en savez plus sur les ports de connexion, vous allez peut-être pouvoir aider Maxime. <span aria-hidden=\"true\">👨🏽</span><br>Maxime veut équiper son ordinateur. Il a reçu un nouveau clavier pour son anniversaire. <span aria-hidden=\"true\">🎂</span></p>",
+      "content": "<p>Maintenant que vous en savez plus sur les ports de connexion, vous allez peut-être pouvoir aider Maxime.&nbsp;<span aria-hidden=\"true\">👨🏽</span><br>Maxime veut équiper son ordinateur. Il a reçu un nouveau clavier pour son anniversaire.&nbsp;<span aria-hidden=\"true\">🎂</span></p>",
       "grainId": "259bb2d0-8815-4bab-885a-a54f7d6d9606"
     },
     {
@@ -66,8 +66,8 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>C'est le cas de nombreuses personnes&#8239;! <span aria-hidden=\"true\">🏅</span></p>",
-            "invalid": "<p>Toujours&#8239;?! On ne vous croit pas... <span aria-hidden=\"true\">😉</span></p>"
+            "valid": "<p>C'est le cas de nombreuses personnes&#8239;!&nbsp;<span aria-hidden=\"true\">🏅</span></p>",
+            "invalid": "<p>Toujours&#8239;?! On ne vous croit pas...&nbsp;<span aria-hidden=\"true\">😉</span></p>"
           },
           "solution": "2"
         }
@@ -173,7 +173,7 @@
         {
           "id": "270b0408-be92-484a-b9b2-5d302f01eecf",
           "type": "text",
-          "content": "<h4>Pour chaque affirmation ci-dessous, choisissez si elle est vraie <span aria-hidden=\"true\">✅</span> ou fausse. <span aria-hidden=\"true\">❌</span></h4>"
+          "content": "<h4>Pour chaque affirmation ci-dessous, choisissez si elle est vraie&nbsp;<span aria-hidden=\"true\">✅</span> ou fausse.&nbsp;<span aria-hidden=\"true\">❌</span></h4>"
         },
         {
           "id": "6f276b50-a00c-49f7-b22c-23dbef0c2bf2",
@@ -300,7 +300,7 @@
         {
           "id": "df4b59c7-b4d8-450c-985a-dc9bc9735f26",
           "type": "text",
-          "content": "<p>Ce port est un <strong>port d’alimentation électrique</strong>.<br> Il sert à recharger un ordinateur ou à le connecter au réseau électrique. <span aria-hidden=\"true\">🔌</span> Sur les ordinateurs portables, il existe de nombreuses variantes. Sur un ordinateur fixe, ce port est plus gros.</p>"
+          "content": "<p>Ce port est un <strong>port d’alimentation électrique</strong>.<br> Il sert à recharger un ordinateur ou à le connecter au réseau électrique.&nbsp;<span aria-hidden=\"true\">🔌</span> Sur les ordinateurs portables, il existe de nombreuses variantes. Sur un ordinateur fixe, ce port est plus gros.</p>"
         },
         {
           "id": "02e82529-bcbc-4d0d-b9ad-e50d28bec4f3",
@@ -317,7 +317,7 @@
         {
           "id": "466f1f93-de01-4c1e-9624-2783a875fcf2",
           "type": "text",
-          "content": "<p>Ce port est un <strong>port VGA</strong>.<br> On le reconnaît grâce à sa forme et ses petits pointillés. Il sert à connecter un écran ou un vidéo-projecteur à l’ordinateur. <span aria-hidden=\"true\">📽️</span> De nos jours, il est de moins en moins utilisé.</p>"
+          "content": "<p>Ce port est un <strong>port VGA</strong>.<br> On le reconnaît grâce à sa forme et ses petits pointillés. Il sert à connecter un écran ou un vidéo-projecteur à l’ordinateur.&nbsp;<span aria-hidden=\"true\">📽️</span> De nos jours, il est de moins en moins utilisé.</p>"
         },
         {
           "id": "3a445423-faac-460b-b407-c8d80dfeb5d3",
@@ -334,7 +334,7 @@
         {
           "id": "86851d7d-0ce8-48a3-b8ac-433da8134dec",
           "type": "text",
-          "content": "<p>Ce port est un <strong>port HDMI</strong>.<br> On peut le reconnaître grâce à sa forme. Il porte souvent l'inscription \"HDMI\" juste à côté. Ce port sert principalement à connecter un écran ou un vidéo-projecteur à l’ordinateur, comme le port VGA. <span aria-hidden=\"true\">📽️</span></p>"
+          "content": "<p>Ce port est un <strong>port HDMI</strong>.<br> On peut le reconnaître grâce à sa forme. Il porte souvent l'inscription \"HDMI\" juste à côté. Ce port sert principalement à connecter un écran ou un vidéo-projecteur à l’ordinateur, comme le port VGA.&nbsp;<span aria-hidden=\"true\">📽️</span></p>"
         },
         {
           "id": "4ad6f499-244f-4f74-9112-feaebdd62305",
@@ -351,7 +351,7 @@
         {
           "id": "706f1c55-3009-4cff-affe-6548076d65ac",
           "type": "text",
-          "content": "<p>Ce port est un <strong>port USB</strong>.<br> Il sert à connecter différents appareils externes à l’ordinateur. <span aria-hidden=\"true\">🖱️</span> <span aria-hidden=\"true\">🎮</span></p>"
+          "content": "<p>Ce port est un <strong>port USB</strong>.<br> Il sert à connecter différents appareils externes à l’ordinateur.&nbsp;<span aria-hidden=\"true\">🖱️</span>&nbsp;<span aria-hidden=\"true\">🎮</span></p>"
         },
         {
           "id": "aa3f93df-8348-47f2-bb3c-2c32c114fcd0",
@@ -368,7 +368,7 @@
         {
           "id": "be359a9d-19d2-49a7-8699-8921156e554c",
           "type": "text",
-          "content": "<p>Ce port est un <strong>port Ethernet</strong>. On l'appelle aussi RJ45. <br> Il est utilisé pour connecter l’ordinateur à la box internet grâce à un câble Ethernet. <span aria-hidden=\"true\">🌐</span></p>"
+          "content": "<p>Ce port est un <strong>port Ethernet</strong>. On l'appelle aussi RJ45. <br> Il est utilisé pour connecter l’ordinateur à la box internet grâce à un câble Ethernet.&nbsp;<span aria-hidden=\"true\">🌐</span></p>"
         },
         {
           "id": "53eca1dc-8f9f-46bc-a132-1c1e65fadb70",
@@ -385,7 +385,7 @@
         {
           "id": "12ac3b9a-286c-4587-9a0d-6dc56e13caf9",
           "type": "text",
-          "content": "<p>Ce port est un <strong>port jack</strong> ou <strong>mini-jack</strong>.<br> Il est petit et rond. Il est souvent accompagné d’une image de casque. <span aria-hidden=\"true\">🎧</span> Il sert à connecter des appareils audios à l’ordinateur&nbsp;: des écouteurs, un casque, un micro, etc.</p>"
+          "content": "<p>Ce port est un <strong>port jack</strong> ou <strong>mini-jack</strong>.<br> Il est petit et rond. Il est souvent accompagné d’une image de casque.&nbsp;<span aria-hidden=\"true\">🎧</span> Il sert à connecter des appareils audios à l’ordinateur&nbsp;: des écouteurs, un casque, un micro, etc.</p>"
         }
       ]
     },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
@@ -81,7 +81,7 @@
         {
           "id": "0eb7bcc7-a552-45f0-823b-599f1b9e8bf1",
           "type": "text",
-          "content": "<p>Le port USB permet de brancher à son ordinateur des appareils avec des fonctionnalités très différentes.<br>Voici ci-dessous quelques exemples :</p>"
+          "content": "<p>Le port USB permet de brancher à son ordinateur des appareils avec des fonctionnalités très différentes.<br>Voici ci-dessous quelques exemples&nbsp;:</p>"
         },
         {
           "id": "5fc1c1c4-a3a7-481c-a586-71cfd1ccd59b",
@@ -154,7 +154,7 @@
         {
           "id": "a4414cd9-2071-4bad-b805-a7516a04e83d",
           "type": "text",
-          "content": "<p><span aria-hidden=\"true\">💡</span> Voici une astuce qui pourra vous aider : les appareils qui se branchent via USB ont souvent un symbole bien particulier, une flèche avec des ronds et des carrés. Ce symbole permet de reconnaître ces appareils.</p>"
+          "content": "<p><span aria-hidden=\"true\">💡</span> Voici une astuce qui pourra vous aider&nbsp;: les appareils qui se branchent via USB ont souvent un symbole bien particulier, une flèche avec des ronds et des carrés. Ce symbole permet de reconnaître ces appareils.</p>"
         },
         {
           "id": "7a55d4a9-3bff-4604-9fa9-0898b7d109dc",
@@ -385,7 +385,7 @@
         {
           "id": "12ac3b9a-286c-4587-9a0d-6dc56e13caf9",
           "type": "text",
-          "content": "<p>Ce port est un <strong>port jack</strong> ou <strong>mini-jack</strong>.<br> Il est petit et rond. Il est souvent accompagné d’une image de casque. <span aria-hidden=\"true\">🎧</span> Il sert à connecter des appareils audios à l’ordinateur : des écouteurs, un casque, un micro, etc.</p>"
+          "content": "<p>Ce port est un <strong>port jack</strong> ou <strong>mini-jack</strong>.<br> Il est petit et rond. Il est souvent accompagné d’une image de casque. <span aria-hidden=\"true\">🎧</span> Il sert à connecter des appareils audios à l’ordinateur&nbsp;: des écouteurs, un casque, un micro, etc.</p>"
         }
       ]
     },
@@ -397,7 +397,7 @@
         {
           "id": "efda82dc-1a96-488c-9d8d-a1bd5a8f1241",
           "type": "text",
-          "content": "<p>Voici ci-dessous l'ordinateur de Maxime :</p>"
+          "content": "<p>Voici ci-dessous l'ordinateur de Maxime&nbsp;:</p>"
         },
         {
           "id": "0f6485ad-1db7-4154-8c9c-b4432f51234f",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
@@ -58,7 +58,7 @@
           "proposals": [
             {
               "id": "1",
-              "content": "J'arrive toujours la brancher une clé USB du premier coup !"
+              "content": "J'arrive toujours la brancher une clé USB du premier coup&#8239;!"
             },
             {
               "id": "2",
@@ -66,7 +66,7 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>C'est le cas de nombreuses personnes ! <span aria-hidden=\"true\">🏅</span></p>",
+            "valid": "<p>C'est le cas de nombreuses personnes&#8239;! <span aria-hidden=\"true\">🏅</span></p>",
             "invalid": "<p>Toujours&#8239;?! On ne vous croit pas... <span aria-hidden=\"true\">😉</span></p>"
           },
           "solution": "2"
@@ -197,8 +197,8 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Oui ! cette souris filaire se branche à un port USB.</p>",
-            "invalid": "<p>Attention ! Regardez bien l’extrémité du fil de cette souris. Elle se branche à un port USB.</p>"
+            "valid": "<p>Oui&#8239;! cette souris filaire se branche à un port USB.</p>",
+            "invalid": "<p>Attention&#8239;! Regardez bien l’extrémité du fil de cette souris. Elle se branche à un port USB.</p>"
           },
           "solution": "1"
         },
@@ -229,8 +229,8 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Correct ! Ce casque audio ne se branche pas à un port USB. Il se branche à un port jack.</p>",
-            "invalid": "<p>Attention ! Regardez bien l’extrémité du fil de ce casque audio. Il ne se branche pas en USB.</p>"
+            "valid": "<p>Correct&#8239;! Ce casque audio ne se branche pas à un port USB. Il se branche à un port jack.</p>",
+            "invalid": "<p>Attention&#8239;! Regardez bien l’extrémité du fil de ce casque audio. Il ne se branche pas en USB.</p>"
           },
           "solution": "2"
         },
@@ -261,8 +261,8 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Bien vu ! Ce symbole peut changer un peu sur des ports USB plus récents.</p>",
-            "invalid": "<p>Et si ! Retenez ce symbole, il vous aidera à trouver les branchements USB.</p>"
+            "valid": "<p>Bien vu&#8239;! Ce symbole peut changer un peu sur des ports USB plus récents.</p>",
+            "invalid": "<p>Et si&#8239;! Retenez ce symbole, il vous aidera à trouver les branchements USB.</p>"
           },
           "solution": "1"
         }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
@@ -54,7 +54,7 @@
         {
           "id": "fda3b31f-4f97-44fb-80b7-3698df48c79a",
           "type": "qcu",
-          "instruction": "<p>Vous avez sûrement déjà branché une clé USB.<br> Quel type de personne êtes-vous ?</p>",
+          "instruction": "<p>Vous avez sûrement déjà branché une clé USB.<br> Quel type de personne êtes-vous&#8239;?</p>",
           "proposals": [
             {
               "id": "1",
@@ -67,7 +67,7 @@
           ],
           "feedbacks": {
             "valid": "<p>C'est le cas de nombreuses personnes ! <span aria-hidden=\"true\">🏅</span></p>",
-            "invalid": "<p>Toujours ?! On ne vous croit pas... <span aria-hidden=\"true\">😉</span></p>"
+            "invalid": "<p>Toujours&#8239;?! On ne vous croit pas... <span aria-hidden=\"true\">😉</span></p>"
           },
           "solution": "2"
         }
@@ -409,7 +409,7 @@
         {
           "id": "9548df1b-3bb4-4d7f-93ce-965de364797e",
           "type": "qcu",
-          "instruction": "<p>Sur quel port Maxime peut-il brancher son <strong>clavier USB</strong> ?</p>",
+          "instruction": "<p>Sur quel port Maxime peut-il brancher son <strong>clavier USB</strong>&#8239;?</p>",
           "proposals": [
             {
               "id": "1",
@@ -453,7 +453,7 @@
         {
           "id": "e6c1fdff-e2a3-4108-a1f8-245dc7e3668f",
           "type": "qcu",
-          "instruction": "<p>Pensez-vous avoir réussi à les trouver ?</p>",
+          "instruction": "<p>Pensez-vous avoir réussi à les trouver&#8239;?</p>",
           "proposals": [
             {
               "id": "1",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
@@ -27,7 +27,7 @@
       "grainId": "9a3926dd-750c-4b89-b1d0-9a286fe2d9e4"
     },
     {
-      "content": "<p>Des personnes du monde entier utilisent Wikipédia et y contribuent. De cette manière, les articles sont fréquemment disponibles dans plusieurs langues.<br>Un petit jeu : saurez-vous dans combien de langues ?</p>",
+      "content": "<p>Des personnes du monde entier utilisent Wikipédia et y contribuent. De cette manière, les articles sont fréquemment disponibles dans plusieurs langues.<br>Un petit jeu&nbsp;: saurez-vous dans combien de langues ?</p>",
       "grainId": "5f048ad8-d008-4956-840b-37e84138b433"
     },
     {
@@ -65,7 +65,7 @@
         {
           "id": "d5acb701-fd9c-40d4-b59d-fb2fd8f6b3fe",
           "type": "qcm",
-          "instruction": "<p>Une devinette : selon vous, quelles sont les <strong>deux</strong> phrases qui décrivent le mieux la signification du logo actuel de Wikipédia ?</p>",
+          "instruction": "<p>Une devinette&nbsp;: selon vous, quelles sont les <strong>deux</strong> phrases qui décrivent le mieux la signification du logo actuel de Wikipédia ?</p>",
           "proposals": [
             {
               "id": "1",
@@ -211,8 +211,8 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Correct. Il y a une représentation inégale entre ces langues : on compte environ 7 millions d’articles en anglais, 2 millions en français et 7 000 en tibétain.</p>",
-            "invalid": "<p>Incorrect. La réponse est 250.<br>Il y a une représentation inégale entre ces langues : on compte environ 7 millions d’articles en anglais, 2 millions en français et 7 000 en tibétain.</p>"
+            "valid": "<p>Correct. Il y a une représentation inégale entre ces langues&nbsp;: on compte environ 7 millions d’articles en anglais, 2 millions en français et 7 000 en tibétain.</p>",
+            "invalid": "<p>Incorrect. La réponse est 250.<br>Il y a une représentation inégale entre ces langues&nbsp;: on compte environ 7 millions d’articles en anglais, 2 millions en français et 7 000 en tibétain.</p>"
           },
           "solution": "2"
         }
@@ -291,7 +291,7 @@
           "proposals": [
             {
               "type": "text",
-              "content": "<p>Nom de la cinquième section :</p>"
+              "content": "<p>Nom de la cinquième section&nbsp;:</p>"
             },
             {
               "input": "cinquieme-section",
@@ -355,7 +355,7 @@
           "proposals": [
             {
               "type": "text",
-              "content": "<p>Niveau de qualité estimé :</p>"
+              "content": "<p>Niveau de qualité estimé&nbsp;:</p>"
             },
             {
               "input": "quality-wiki",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
@@ -15,7 +15,7 @@
   },
   "transitionTexts": [
     {
-      "content": "<p>Vous avez probablement déjà utilisé Wikipédia. Mais connaissez-vous la signification de son logo ? <span aria-hidden=\"true\">🌎</span>️ <span aria-hidden=\"true\">🧩</span>️</p>",
+      "content": "<p>Vous avez probablement déjà utilisé Wikipédia. Mais connaissez-vous la signification de son logo&#8239;? <span aria-hidden=\"true\">🌎</span>️ <span aria-hidden=\"true\">🧩</span>️</p>",
       "grainId": "da95d2bc-e597-4366-a095-21f7ab0f4845"
     },
     {
@@ -27,7 +27,7 @@
       "grainId": "9a3926dd-750c-4b89-b1d0-9a286fe2d9e4"
     },
     {
-      "content": "<p>Des personnes du monde entier utilisent Wikipédia et y contribuent. De cette manière, les articles sont fréquemment disponibles dans plusieurs langues.<br>Un petit jeu&nbsp;: saurez-vous dans combien de langues ?</p>",
+      "content": "<p>Des personnes du monde entier utilisent Wikipédia et y contribuent. De cette manière, les articles sont fréquemment disponibles dans plusieurs langues.<br>Un petit jeu&nbsp;: saurez-vous dans combien de langues&#8239;?</p>",
       "grainId": "5f048ad8-d008-4956-840b-37e84138b433"
     },
     {
@@ -65,7 +65,7 @@
         {
           "id": "d5acb701-fd9c-40d4-b59d-fb2fd8f6b3fe",
           "type": "qcm",
-          "instruction": "<p>Une devinette&nbsp;: selon vous, quelles sont les <strong>deux</strong> phrases qui décrivent le mieux la signification du logo actuel de Wikipédia ?</p>",
+          "instruction": "<p>Une devinette&nbsp;: selon vous, quelles sont les <strong>deux</strong> phrases qui décrivent le mieux la signification du logo actuel de Wikipédia&#8239;?</p>",
           "proposals": [
             {
               "id": "1",
@@ -191,7 +191,7 @@
         {
           "id": "c99efced-e183-4f4f-aec7-07a5da13294a",
           "type": "qcu",
-          "instruction": "<p>Dans le monde, il existe environ 7000 langues.<br>Selon vous, dans combien de langues environ Wikipédia existe-t-il ?</p>",
+          "instruction": "<p>Dans le monde, il existe environ 7000 langues.<br>Selon vous, dans combien de langues environ Wikipédia existe-t-il&#8239;?</p>",
           "proposals": [
             {
               "id": "1",
@@ -226,7 +226,7 @@
         {
           "id": "46dec681-51e7-44f8-9422-9ccd77125f8b",
           "type": "qcu",
-          "instruction": "<p>Selon vous, par quel moyen Wikipédia est-il financé ?</p>",
+          "instruction": "<p>Selon vous, par quel moyen Wikipédia est-il financé&#8239;?</p>",
           "proposals": [
             {
               "id": "1",
@@ -287,7 +287,7 @@
         {
           "id": "ea12a08f-fa0b-4693-a1fd-8a5baf27f494",
           "type": "qrocm",
-          "instruction": "<p>Dans le sommaire de cet article, trouvez la section <strong>Début</strong>. Quel est le nom de la cinquième section ?</p>",
+          "instruction": "<p>Dans le sommaire de cet article, trouvez la section <strong>Début</strong>. Quel est le nom de la cinquième section&#8239;?</p>",
           "proposals": [
             {
               "type": "text",
@@ -319,7 +319,7 @@
         {
           "id": "649c29ee-0b22-4da3-ba2a-036bb3016425",
           "type": "qrocm",
-          "instruction": "<p>Dans cet article, combien y a-t-il de Notes et références ? </p>",
+          "instruction": "<p>Dans cet article, combien y a-t-il de Notes et références&#8239;? </p>",
           "proposals": [
             {
               "type": "text",
@@ -351,7 +351,7 @@
         {
           "id": "be1ba37e-0588-42ed-8fab-f47bf118953a",
           "type": "qrocm",
-          "instruction": "<p>Quel est le niveau de qualité estimé de cet article ?</p>",
+          "instruction": "<p>Quel est le niveau de qualité estimé de cet article&#8239;?</p>",
           "proposals": [
             {
               "type": "text",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
@@ -15,7 +15,7 @@
   },
   "transitionTexts": [
     {
-      "content": "<p>Vous avez probablement déjà utilisé Wikipédia. Mais connaissez-vous la signification de son logo&#8239;? <span aria-hidden=\"true\">🌎</span>️ <span aria-hidden=\"true\">🧩</span>️</p>",
+      "content": "<p>Vous avez probablement déjà utilisé Wikipédia. Mais connaissez-vous la signification de son logo&#8239;?&nbsp;<span aria-hidden=\"true\">🌎</span>️&nbsp;<span aria-hidden=\"true\">🧩</span>️</p>",
       "grainId": "da95d2bc-e597-4366-a095-21f7ab0f4845"
     },
     {
@@ -31,7 +31,7 @@
       "grainId": "5f048ad8-d008-4956-840b-37e84138b433"
     },
     {
-      "content": "<p>Comme tout site internet, Wikipédia a besoin d’argent pour fonctionner. <span aria-hidden=\"true\">💰</span>️</p>",
+      "content": "<p>Comme tout site internet, Wikipédia a besoin d’argent pour fonctionner.&nbsp;<span aria-hidden=\"true\">💰</span>️</p>",
       "grainId": "09b21f5f-b7e7-4c7a-9059-bdb2a2be246d"
     },
     {
@@ -177,7 +177,7 @@
           ],
           "feedbacks": {
             "valid": "<p>Correct. Vous avez bien identifié les principes de Wikipédia. </p>",
-            "invalid": "<p>Incorrect. Remonter la page pour relire la leçon. <span aria-hidden=\"true\">⬆</span>️</p>"
+            "invalid": "<p>Incorrect. Remonter la page pour relire la leçon.&nbsp;<span aria-hidden=\"true\">⬆</span>️</p>"
           },
           "solutions": ["1", "3", "4"]
         }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
@@ -85,7 +85,7 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Correct !</p>",
+            "valid": "<p>Correct&#8239;!</p>",
             "invalid": "<p>Incorrect. La construction permanente et les différentes langues de Wikipédia sont symbolisées prioritairement à travers ce logo.</p>"
           },
           "solutions": ["1", "4"]
@@ -130,7 +130,7 @@
         {
           "id": "df11aa2c-1ebf-4a60-99a3-533dfc06756d",
           "type": "text",
-          "content": "<h4>4 - Wikipédia est un projet collaboratif.&nbsp;<span aria-hidden=\"true\">🙋🏽‍♂️</span>️<span aria-hidden=\"true\">🙋🏻‍♀️</span>️<span aria-hidden=\"true\">🙋🏿‍♀️</span>️<span aria-hidden=\"true\">🙋‍♂️</span>️</h4><p>C’est probablement sa caractéristique la plus remarquable. Tout le monde peut améliorer les contenus de Wikipédia ! Des règles claires de savoir-vivre sont à respecter.</p>"
+          "content": "<h4>4 - Wikipédia est un projet collaboratif.&nbsp;<span aria-hidden=\"true\">🙋🏽‍♂️</span>️<span aria-hidden=\"true\">🙋🏻‍♀️</span>️<span aria-hidden=\"true\">🙋🏿‍♀️</span>️<span aria-hidden=\"true\">🙋‍♂️</span>️</h4><p>C’est probablement sa caractéristique la plus remarquable. Tout le monde peut améliorer les contenus de Wikipédia&#8239;! Des règles claires de savoir-vivre sont à respecter.</p>"
         },
         {
           "id": "1edb38ba-7542-4198-a5de-c260ef6b95ea",
@@ -307,7 +307,7 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Correct !</p>",
+            "valid": "<p>Correct&#8239;!</p>",
             "invalid": "<p>Incorrect.</p>"
           }
         },
@@ -339,7 +339,7 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Correct !</p>",
+            "valid": "<p>Correct&#8239;!</p>",
             "invalid": "<p>Incorrect.</p>"
           }
         },
@@ -383,7 +383,7 @@
             }
           ],
           "feedbacks": {
-            "valid": "<p>Correct !</p>",
+            "valid": "<p>Correct&#8239;!</p>",
             "invalid": "<p>Incorrect.</p>"
           }
         }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
@@ -19,11 +19,11 @@
       "grainId": "652a469a-36b8-41ae-8cc5-1853b35d08ef"
     },
     {
-      "content": "<p>Léna a posé plusieurs questions à Elias pour trouver l’origine de l’information. C’est ce qu’on appelle la <strong>source d’une information. </strong> <span aria-hidden=\"true\">ℹ️</span>️<br>On vous explique tout dans la leçon suivante.</p>",
+      "content": "<p>Léna a posé plusieurs questions à Elias pour trouver l’origine de l’information. C’est ce qu’on appelle la <strong>source d’une information. </strong>&nbsp;<span aria-hidden=\"true\">ℹ️</span>️<br>On vous explique tout dans la leçon suivante.</p>",
       "grainId": "54cc6a3f-9603-4863-9ba4-052210425be2"
     },
     {
-      "content": "<p>Vous en savez maintenant plus sur ce qu'est une source d'information. Vérifions que vous avez compris l'essentiel. <span aria-hidden=\"true\">🎯</span>️</p>",
+      "content": "<p>Vous en savez maintenant plus sur ce qu'est une source d'information. Vérifions que vous avez compris l'essentiel.&nbsp;<span aria-hidden=\"true\">🎯</span>️</p>",
       "grainId": "42e4007c-9123-4aff-806a-6d7a8de3fd0a"
     },
     {
@@ -174,7 +174,7 @@
         {
           "id": "96cf39cd-88df-4104-a155-0fff0b40ac31",
           "type": "text",
-          "content": "<p>Une radio a publié une interview pour expliquer l’origine de la soucoupe volante vue par Madame Sarah. <span aria-hidden=\"true\">👽</span>️ <span aria-hidden=\"true\">🛸</span>️<br>Vous devrez par la suite choisir qui est la source d'information dans cette interview.</p>"
+          "content": "<p>Une radio a publié une interview pour expliquer l’origine de la soucoupe volante vue par Madame Sarah.&nbsp;<span aria-hidden=\"true\">👽</span>️&nbsp;<span aria-hidden=\"true\">🛸</span>️<br>Vous devrez par la suite choisir qui est la source d'information dans cette interview.</p>"
         },
         {
           "id": "edbeb7c0-52cc-45b8-b3b9-d8cdac00536f",
@@ -233,7 +233,7 @@
         {
           "id": "9723333b-6378-4dbd-84a2-92a8fc1cc41a",
           "type": "text",
-          "content": "<h3>Certaines sources d'information sont <strong>fiables</strong>. <span aria-hidden=\"true\">👍</span>️</h3><p>Le but de ces sources est d'informer et de partager des informations vérifiées, qui ont donc beaucoup de chances d'être vraies.</p>"
+          "content": "<h3>Certaines sources d'information sont <strong>fiables</strong>.&nbsp;<span aria-hidden=\"true\">👍</span>️</h3><p>Le but de ces sources est d'informer et de partager des informations vérifiées, qui ont donc beaucoup de chances d'être vraies.</p>"
         },
         {
           "id": "2fe6bf3f-c77c-4e21-a57e-8be804171e00",
@@ -243,7 +243,7 @@
         {
           "id": "0c5bf4bb-989c-4c60-a54c-ae1f842bc8fe",
           "type": "text",
-          "content": "<h3>Certaines sources d'information sont <strong>humoristiques</strong>. <span aria-hidden=\"true\">🤹</span>️</h3><p>Le but de ces sources est de faire rire et de partager des informations qui ont beaucoup de chances d'être fausses.</p>"
+          "content": "<h3>Certaines sources d'information sont <strong>humoristiques</strong>.&nbsp;<span aria-hidden=\"true\">🤹</span>️</h3><p>Le but de ces sources est de faire rire et de partager des informations qui ont beaucoup de chances d'être fausses.</p>"
         },
         {
           "id": "783421ea-d3eb-437d-9eac-7b51bade7fdb",
@@ -253,7 +253,7 @@
         {
           "id": "e22b6b68-a154-4b5a-a896-5b36eb6127a3",
           "type": "text",
-          "content": "<h3>Certaines sources d'information sont <strong>contestables</strong>. <span aria-hidden=\"true\">🤨</span>️</h3><p>Le but de ces sources est d'influencer ou de manipuler les gens. Mais le partage de ces informations a pour principal objectif de gagner de l'argent ou du pouvoir. Ces informations peuvent donc être remises en question.</p>"
+          "content": "<h3>Certaines sources d'information sont <strong>contestables</strong>.&nbsp;<span aria-hidden=\"true\">🤨</span>️</h3><p>Le but de ces sources est d'influencer ou de manipuler les gens. Mais le partage de ces informations a pour principal objectif de gagner de l'argent ou du pouvoir. Ces informations peuvent donc être remises en question.</p>"
         }
       ]
     },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
@@ -56,7 +56,7 @@
           "title": "Discussion entre Elias et Léna (1 sur 2)",
           "url": "https://videos.pix.fr/modulix/sources-informations/chat-1.mp4",
           "subtitles": "",
-          "transcription": "<ul><li>Elias : Les Jeux Olympiques d’hiver de 2029 auront lieu dans le désert !</li><li>Léna : T’es sûr ? Comment tu le sais ?</li><li>Elias : C’est Sandy qui me l’a dit.</li></ul>"
+          "transcription": "<ul><li>Elias&nbsp;: Les Jeux Olympiques d’hiver de 2029 auront lieu dans le désert !</li><li>Léna&nbsp;: T’es sûr ? Comment tu le sais ?</li><li>Elias&nbsp;: C’est Sandy qui me l’a dit.</li></ul>"
         },
         {
           "id": "a2f57d43-a8a1-4659-8730-f5cd39c350e0",
@@ -79,7 +79,7 @@
           "title": "Discussion entre Elias et Léna (2 sur 2)",
           "url": "https://videos.pix.fr/modulix/sources-informations/chat-2.mp4",
           "subtitles": "",
-          "transcription": "<ul><li>Léna : Et c’est vrai du coup ?</li><li>Elias : Sandy l’a vu sur internet !</li><li>Léna : Tu peux m’envoyer le lien stp ?</li><li>Elias : Oui, c’est un article de FranceInfo</li><li>Elias : https://www.francetvinfo.fr/sports/l-arabie-saoudite-designee-pour-accueillir-les-jeux-asiatiques-d-hiver-en-2029_5396737.html</li></ul>"
+          "transcription": "<ul><li>Léna&nbsp;: Et c’est vrai du coup ?</li><li>Elias&nbsp;: Sandy l’a vu sur internet !</li><li>Léna&nbsp;: Tu peux m’envoyer le lien stp ?</li><li>Elias&nbsp;: Oui, c’est un article de FranceInfo</li><li>Elias&nbsp;: https://www.francetvinfo.fr/sports/l-arabie-saoudite-designee-pour-accueillir-les-jeux-asiatiques-d-hiver-en-2029_5396737.html</li></ul>"
         },
         {
           "id": "8aca8852-a771-4ee2-b686-a2fb6b4f57c5",
@@ -121,7 +121,7 @@
         {
           "id": "81f2c1af-aeef-4d68-93a9-f4dd3cf1f8bc",
           "type": "text",
-          "content": "<h3>C'est quoi une source d'information ?</h3><p><span aria-hidden=\"true\">👉</span>️ La source est l’origine de l’information. C’est quelqu’un qui donne des détails sur une information.</p><p><span aria-hidden=\"true\">✅</span>️ Exemple : si ma voisine Madame Sarah me dit qu'il y a une soucoupe volante dans le ciel, c'est elle la source de cette information.</p>"
+          "content": "<h3>C'est quoi une source d'information ?</h3><p><span aria-hidden=\"true\">👉</span>️ La source est l’origine de l’information. C’est quelqu’un qui donne des détails sur une information.</p><p><span aria-hidden=\"true\">✅</span>️ Exemple&nbsp;: si ma voisine Madame Sarah me dit qu'il y a une soucoupe volante dans le ciel, c'est elle la source de cette information.</p>"
         },
         {
           "id": "a91f12e7-a297-4dc0-9f81-2a0ccbaba3f8",
@@ -131,7 +131,7 @@
         {
           "id": "e3ebd36a-c8b9-4990-af63-061329824708",
           "type": "text",
-          "content": "<h3>Comment savoir si on peut croire une source ?</h3><span aria-hidden=\"true\">👉</span>️ Il faut se poser quelques questions sur cette source : <ul><li>la source est-elle experte du sujet ?</li><li>la source est-elle influencée par ses émotions ou ses intérêts ?</li></ul><p><span aria-hidden=\"true\">✅</span>️ Exemple : Madame Sarah a l'impression d'avoir vu une soucoupe dans le ciel. Elle a interprété ce qu'elle a vu. Ce n'est peut-être pas une source fiable.</p>"
+          "content": "<h3>Comment savoir si on peut croire une source ?</h3><span aria-hidden=\"true\">👉</span>️ Il faut se poser quelques questions sur cette source&nbsp;: <ul><li>la source est-elle experte du sujet ?</li><li>la source est-elle influencée par ses émotions ou ses intérêts ?</li></ul><p><span aria-hidden=\"true\">✅</span>️ Exemple&nbsp;: Madame Sarah a l'impression d'avoir vu une soucoupe dans le ciel. Elle a interprété ce qu'elle a vu. Ce n'est peut-être pas une source fiable.</p>"
         }
       ]
     },
@@ -182,7 +182,7 @@
           "title": "Une vidéo",
           "url": "https://videos.pix.fr/modulix/sources-informations/itw-saturne.mp4",
           "subtitles": "https://videos.pix.fr/modulix/sources-informations/itw-saturne.vtt",
-          "transcription": "<ul><li> <strong>Journaliste Dupont</strong> : Flash info, bonjour ! ici le journaliste Dupont pour la radio d'à côté Lundi dernier, aux alentours de vingt et une heures, Mme. Sarah a vu une soucoupe volante dans le ciel. Croyance ou réalité ? <br>Je suis aujourd'hui avec la professeur Saturne, experte en astrophysique, auteur du livre Les soucoupes volantes existent-elles. Bonjour professeur, merci d'être avec nous.</li> <li><strong>Professeur Saturne</strong> : Bonjour, merci pour votre invitation. Alors, ce que Madame Sarah a vu, c'est pas une soucoupe, c'est une aurore boréale. Mon équipe et moi l'avons observé au télescope de l'université. Nous étudions les aurores boréales depuis plusieurs années maintenant et il arrive souvent que les gens confondent.</li><li><strong>Journaliste Dupont</strong> : Merci professeur Saturne pour votre témoignage. Merci aux auditeurs fidèles qui suivent notre émission à vous les studios.</li></ul>"
+          "transcription": "<ul><li> <strong>Journaliste Dupont</strong>&nbsp;: Flash info, bonjour ! ici le journaliste Dupont pour la radio d'à côté Lundi dernier, aux alentours de vingt et une heures, Mme. Sarah a vu une soucoupe volante dans le ciel. Croyance ou réalité ? <br>Je suis aujourd'hui avec la professeur Saturne, experte en astrophysique, auteur du livre Les soucoupes volantes existent-elles. Bonjour professeur, merci d'être avec nous.</li> <li><strong>Professeur Saturne</strong>&nbsp;: Bonjour, merci pour votre invitation. Alors, ce que Madame Sarah a vu, c'est pas une soucoupe, c'est une aurore boréale. Mon équipe et moi l'avons observé au télescope de l'université. Nous étudions les aurores boréales depuis plusieurs années maintenant et il arrive souvent que les gens confondent.</li><li><strong>Journaliste Dupont</strong>&nbsp;: Merci professeur Saturne pour votre témoignage. Merci aux auditeurs fidèles qui suivent notre émission à vous les studios.</li></ul>"
         },
         {
           "id": "fa0b94f1-5139-4c55-a8bb-c7a4257c1a40",
@@ -277,7 +277,7 @@
           "type": "image",
           "url": "https://i.imgur.com/R4Duhiy.png",
           "alt": "",
-          "alternativeText": "Auteur : franceinfo. Publication : Dans un Ehpad du Bas-Rhin, des chiens s'entraînent à détecter le Covid-19. Retrouvez cet article et l'association Handi'Chiens sur notre site. Date : 6 février 2023."
+          "alternativeText": "Auteur&nbsp;: franceinfo. Publication&nbsp;: Dans un Ehpad du Bas-Rhin, des chiens s'entraînent à détecter le Covid-19. Retrouvez cet article et l'association Handi'Chiens sur notre site. Date&nbsp;: 6 février 2023."
         },
         {
           "id": "69460323-29ca-4859-9581-fd67bc4cc84b",
@@ -313,7 +313,7 @@
           "type": "image",
           "url": "https://i.imgur.com/6RtSHW0.png",
           "alt": "",
-          "alternativeText": "Auteur : JournalDeBlagues. Publication : Reportage : cet élève avait fait ses devoirs mais son chien les a vraiment mangé. La maîtresse le met au coin pendant 72 heures sans nourriture. Date : 6 octobre 2023"
+          "alternativeText": "Auteur&nbsp;: JournalDeBlagues. Publication&nbsp;: Reportage&nbsp;: cet élève avait fait ses devoirs mais son chien les a vraiment mangé. La maîtresse le met au coin pendant 72 heures sans nourriture. Date&nbsp;: 6 octobre 2023"
         },
         {
           "id": "ff187918-225d-49de-99dd-2a316ccd09bf",
@@ -349,7 +349,7 @@
           "type": "image",
           "url": "https://i.imgur.com/9nQlmC6.png",
           "alt": "",
-          "alternativeText": "Auteur : Association des vendeurs de poissons rouges. Publication : Avoir un poisson rouge comme animal de compagnie augmente le bien-être de 38% selon nos études. Améliorez votre humeur et foncez en magasin ! Date : 8 juin 2023"
+          "alternativeText": "Auteur&nbsp;: Association des vendeurs de poissons rouges. Publication&nbsp;: Avoir un poisson rouge comme animal de compagnie augmente le bien-être de 38% selon nos études. Améliorez votre humeur et foncez en magasin ! Date&nbsp;: 8 juin 2023"
         },
         {
           "id": "9e252501-ecb0-46dc-ae3e-f5646e7cc252",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
@@ -56,7 +56,7 @@
           "title": "Discussion entre Elias et Léna (1 sur 2)",
           "url": "https://videos.pix.fr/modulix/sources-informations/chat-1.mp4",
           "subtitles": "",
-          "transcription": "<ul><li>Elias&nbsp;: Les Jeux Olympiques d’hiver de 2029 auront lieu dans le désert !</li><li>Léna&nbsp;: T’es sûr ? Comment tu le sais ?</li><li>Elias&nbsp;: C’est Sandy qui me l’a dit.</li></ul>"
+          "transcription": "<ul><li>Elias&nbsp;: Les Jeux Olympiques d’hiver de 2029 auront lieu dans le désert !</li><li>Léna&nbsp;: T’es sûr&#8239;? Comment tu le sais&#8239;?</li><li>Elias&nbsp;: C’est Sandy qui me l’a dit.</li></ul>"
         },
         {
           "id": "a2f57d43-a8a1-4659-8730-f5cd39c350e0",
@@ -79,12 +79,12 @@
           "title": "Discussion entre Elias et Léna (2 sur 2)",
           "url": "https://videos.pix.fr/modulix/sources-informations/chat-2.mp4",
           "subtitles": "",
-          "transcription": "<ul><li>Léna&nbsp;: Et c’est vrai du coup ?</li><li>Elias&nbsp;: Sandy l’a vu sur internet !</li><li>Léna&nbsp;: Tu peux m’envoyer le lien stp ?</li><li>Elias&nbsp;: Oui, c’est un article de FranceInfo</li><li>Elias&nbsp;: https://www.francetvinfo.fr/sports/l-arabie-saoudite-designee-pour-accueillir-les-jeux-asiatiques-d-hiver-en-2029_5396737.html</li></ul>"
+          "transcription": "<ul><li>Léna&nbsp;: Et c’est vrai du coup&#8239;?</li><li>Elias&nbsp;: Sandy l’a vu sur internet !</li><li>Léna&nbsp;: Tu peux m’envoyer le lien stp&#8239;?</li><li>Elias&nbsp;: Oui, c’est un article de FranceInfo</li><li>Elias&nbsp;: https://www.francetvinfo.fr/sports/l-arabie-saoudite-designee-pour-accueillir-les-jeux-asiatiques-d-hiver-en-2029_5396737.html</li></ul>"
         },
         {
           "id": "8aca8852-a771-4ee2-b686-a2fb6b4f57c5",
           "type": "qcu",
-          "instruction": "<p>Maintenant, est-ce que l'information donnée par Elias semble vraie ?</p>",
+          "instruction": "<p>Maintenant, est-ce que l'information donnée par Elias semble vraie&#8239;?</p>",
           "proposals": [
             {
               "id": "1",
@@ -121,7 +121,7 @@
         {
           "id": "81f2c1af-aeef-4d68-93a9-f4dd3cf1f8bc",
           "type": "text",
-          "content": "<h3>C'est quoi une source d'information ?</h3><p><span aria-hidden=\"true\">👉</span>️ La source est l’origine de l’information. C’est quelqu’un qui donne des détails sur une information.</p><p><span aria-hidden=\"true\">✅</span>️ Exemple&nbsp;: si ma voisine Madame Sarah me dit qu'il y a une soucoupe volante dans le ciel, c'est elle la source de cette information.</p>"
+          "content": "<h3>C'est quoi une source d'information&#8239;?</h3><p><span aria-hidden=\"true\">👉</span>️ La source est l’origine de l’information. C’est quelqu’un qui donne des détails sur une information.</p><p><span aria-hidden=\"true\">✅</span>️ Exemple&nbsp;: si ma voisine Madame Sarah me dit qu'il y a une soucoupe volante dans le ciel, c'est elle la source de cette information.</p>"
         },
         {
           "id": "a91f12e7-a297-4dc0-9f81-2a0ccbaba3f8",
@@ -131,7 +131,7 @@
         {
           "id": "e3ebd36a-c8b9-4990-af63-061329824708",
           "type": "text",
-          "content": "<h3>Comment savoir si on peut croire une source ?</h3><span aria-hidden=\"true\">👉</span>️ Il faut se poser quelques questions sur cette source&nbsp;: <ul><li>la source est-elle experte du sujet ?</li><li>la source est-elle influencée par ses émotions ou ses intérêts ?</li></ul><p><span aria-hidden=\"true\">✅</span>️ Exemple&nbsp;: Madame Sarah a l'impression d'avoir vu une soucoupe dans le ciel. Elle a interprété ce qu'elle a vu. Ce n'est peut-être pas une source fiable.</p>"
+          "content": "<h3>Comment savoir si on peut croire une source&#8239;?</h3><span aria-hidden=\"true\">👉</span>️ Il faut se poser quelques questions sur cette source&nbsp;: <ul><li>la source est-elle experte du sujet&#8239;?</li><li>la source est-elle influencée par ses émotions ou ses intérêts&#8239;?</li></ul><p><span aria-hidden=\"true\">✅</span>️ Exemple&nbsp;: Madame Sarah a l'impression d'avoir vu une soucoupe dans le ciel. Elle a interprété ce qu'elle a vu. Ce n'est peut-être pas une source fiable.</p>"
         }
       ]
     },
@@ -143,7 +143,7 @@
         {
           "id": "6ffc239b-2d88-4bed-bdd9-f1ecf215ad11",
           "type": "qcu",
-          "instruction": "<p>Quelle définition peut-on donner d'une source d'information ?</p>",
+          "instruction": "<p>Quelle définition peut-on donner d'une source d'information&#8239;?</p>",
           "proposals": [
             {
               "id": "1",
@@ -182,7 +182,7 @@
           "title": "Une vidéo",
           "url": "https://videos.pix.fr/modulix/sources-informations/itw-saturne.mp4",
           "subtitles": "https://videos.pix.fr/modulix/sources-informations/itw-saturne.vtt",
-          "transcription": "<ul><li> <strong>Journaliste Dupont</strong>&nbsp;: Flash info, bonjour ! ici le journaliste Dupont pour la radio d'à côté Lundi dernier, aux alentours de vingt et une heures, Mme. Sarah a vu une soucoupe volante dans le ciel. Croyance ou réalité ? <br>Je suis aujourd'hui avec la professeur Saturne, experte en astrophysique, auteur du livre Les soucoupes volantes existent-elles. Bonjour professeur, merci d'être avec nous.</li> <li><strong>Professeur Saturne</strong>&nbsp;: Bonjour, merci pour votre invitation. Alors, ce que Madame Sarah a vu, c'est pas une soucoupe, c'est une aurore boréale. Mon équipe et moi l'avons observé au télescope de l'université. Nous étudions les aurores boréales depuis plusieurs années maintenant et il arrive souvent que les gens confondent.</li><li><strong>Journaliste Dupont</strong>&nbsp;: Merci professeur Saturne pour votre témoignage. Merci aux auditeurs fidèles qui suivent notre émission à vous les studios.</li></ul>"
+          "transcription": "<ul><li> <strong>Journaliste Dupont</strong>&nbsp;: Flash info, bonjour ! ici le journaliste Dupont pour la radio d'à côté Lundi dernier, aux alentours de vingt et une heures, Mme. Sarah a vu une soucoupe volante dans le ciel. Croyance ou réalité&#8239;? <br>Je suis aujourd'hui avec la professeur Saturne, experte en astrophysique, auteur du livre Les soucoupes volantes existent-elles. Bonjour professeur, merci d'être avec nous.</li> <li><strong>Professeur Saturne</strong>&nbsp;: Bonjour, merci pour votre invitation. Alors, ce que Madame Sarah a vu, c'est pas une soucoupe, c'est une aurore boréale. Mon équipe et moi l'avons observé au télescope de l'université. Nous étudions les aurores boréales depuis plusieurs années maintenant et il arrive souvent que les gens confondent.</li><li><strong>Journaliste Dupont</strong>&nbsp;: Merci professeur Saturne pour votre témoignage. Merci aux auditeurs fidèles qui suivent notre émission à vous les studios.</li></ul>"
         },
         {
           "id": "fa0b94f1-5139-4c55-a8bb-c7a4257c1a40",
@@ -192,7 +192,7 @@
         {
           "id": "921f42c0-b47b-44b7-8bde-328c40e03e44",
           "type": "qcu",
-          "instruction": "<p>Dans l'interview, on entend que Madame Sarah a sûrement vu une aurore boréale et non une soucoupe volante.<br>Qui est la source de cette information ?</p>",
+          "instruction": "<p>Dans l'interview, on entend que Madame Sarah a sûrement vu une aurore boréale et non une soucoupe volante.<br>Qui est la source de cette information&#8239;?</p>",
           "proposals": [
             {
               "id": "1",
@@ -282,7 +282,7 @@
         {
           "id": "69460323-29ca-4859-9581-fd67bc4cc84b",
           "type": "qcu",
-          "instruction": "<p>Quel mot décrit le mieux cette source ?</p>",
+          "instruction": "<p>Quel mot décrit le mieux cette source&#8239;?</p>",
           "proposals": [
             {
               "id": "1",
@@ -318,7 +318,7 @@
         {
           "id": "ff187918-225d-49de-99dd-2a316ccd09bf",
           "type": "qcu",
-          "instruction": "<p>Quel mot décrit le mieux cette source ?</p>",
+          "instruction": "<p>Quel mot décrit le mieux cette source&#8239;?</p>",
           "proposals": [
             {
               "id": "1",
@@ -354,7 +354,7 @@
         {
           "id": "9e252501-ecb0-46dc-ae3e-f5646e7cc252",
           "type": "qcu",
-          "instruction": "<p>Quel mot décrit le mieux cette source ?</p>",
+          "instruction": "<p>Quel mot décrit le mieux cette source&#8239;?</p>",
           "proposals": [
             {
               "id": "1",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
@@ -56,7 +56,7 @@
           "title": "Discussion entre Elias et Léna (1 sur 2)",
           "url": "https://videos.pix.fr/modulix/sources-informations/chat-1.mp4",
           "subtitles": "",
-          "transcription": "<ul><li>Elias&nbsp;: Les Jeux Olympiques d’hiver de 2029 auront lieu dans le désert !</li><li>Léna&nbsp;: T’es sûr&#8239;? Comment tu le sais&#8239;?</li><li>Elias&nbsp;: C’est Sandy qui me l’a dit.</li></ul>"
+          "transcription": "<ul><li>Elias&nbsp;: Les Jeux Olympiques d’hiver de 2029 auront lieu dans le désert&#8239;!</li><li>Léna&nbsp;: T’es sûr&#8239;? Comment tu le sais&#8239;?</li><li>Elias&nbsp;: C’est Sandy qui me l’a dit.</li></ul>"
         },
         {
           "id": "a2f57d43-a8a1-4659-8730-f5cd39c350e0",
@@ -79,7 +79,7 @@
           "title": "Discussion entre Elias et Léna (2 sur 2)",
           "url": "https://videos.pix.fr/modulix/sources-informations/chat-2.mp4",
           "subtitles": "",
-          "transcription": "<ul><li>Léna&nbsp;: Et c’est vrai du coup&#8239;?</li><li>Elias&nbsp;: Sandy l’a vu sur internet !</li><li>Léna&nbsp;: Tu peux m’envoyer le lien stp&#8239;?</li><li>Elias&nbsp;: Oui, c’est un article de FranceInfo</li><li>Elias&nbsp;: https://www.francetvinfo.fr/sports/l-arabie-saoudite-designee-pour-accueillir-les-jeux-asiatiques-d-hiver-en-2029_5396737.html</li></ul>"
+          "transcription": "<ul><li>Léna&nbsp;: Et c’est vrai du coup&#8239;?</li><li>Elias&nbsp;: Sandy l’a vu sur internet&#8239;!</li><li>Léna&nbsp;: Tu peux m’envoyer le lien stp&#8239;?</li><li>Elias&nbsp;: Oui, c’est un article de FranceInfo</li><li>Elias&nbsp;: https://www.francetvinfo.fr/sports/l-arabie-saoudite-designee-pour-accueillir-les-jeux-asiatiques-d-hiver-en-2029_5396737.html</li></ul>"
         },
         {
           "id": "8aca8852-a771-4ee2-b686-a2fb6b4f57c5",
@@ -182,7 +182,7 @@
           "title": "Une vidéo",
           "url": "https://videos.pix.fr/modulix/sources-informations/itw-saturne.mp4",
           "subtitles": "https://videos.pix.fr/modulix/sources-informations/itw-saturne.vtt",
-          "transcription": "<ul><li> <strong>Journaliste Dupont</strong>&nbsp;: Flash info, bonjour ! ici le journaliste Dupont pour la radio d'à côté Lundi dernier, aux alentours de vingt et une heures, Mme. Sarah a vu une soucoupe volante dans le ciel. Croyance ou réalité&#8239;? <br>Je suis aujourd'hui avec la professeur Saturne, experte en astrophysique, auteur du livre Les soucoupes volantes existent-elles. Bonjour professeur, merci d'être avec nous.</li> <li><strong>Professeur Saturne</strong>&nbsp;: Bonjour, merci pour votre invitation. Alors, ce que Madame Sarah a vu, c'est pas une soucoupe, c'est une aurore boréale. Mon équipe et moi l'avons observé au télescope de l'université. Nous étudions les aurores boréales depuis plusieurs années maintenant et il arrive souvent que les gens confondent.</li><li><strong>Journaliste Dupont</strong>&nbsp;: Merci professeur Saturne pour votre témoignage. Merci aux auditeurs fidèles qui suivent notre émission à vous les studios.</li></ul>"
+          "transcription": "<ul><li> <strong>Journaliste Dupont</strong>&nbsp;: Flash info, bonjour&#8239;! ici le journaliste Dupont pour la radio d'à côté Lundi dernier, aux alentours de vingt et une heures, Mme. Sarah a vu une soucoupe volante dans le ciel. Croyance ou réalité&#8239;? <br>Je suis aujourd'hui avec la professeur Saturne, experte en astrophysique, auteur du livre Les soucoupes volantes existent-elles. Bonjour professeur, merci d'être avec nous.</li> <li><strong>Professeur Saturne</strong>&nbsp;: Bonjour, merci pour votre invitation. Alors, ce que Madame Sarah a vu, c'est pas une soucoupe, c'est une aurore boréale. Mon équipe et moi l'avons observé au télescope de l'université. Nous étudions les aurores boréales depuis plusieurs années maintenant et il arrive souvent que les gens confondent.</li><li><strong>Journaliste Dupont</strong>&nbsp;: Merci professeur Saturne pour votre témoignage. Merci aux auditeurs fidèles qui suivent notre émission à vous les studios.</li></ul>"
         },
         {
           "id": "fa0b94f1-5139-4c55-a8bb-c7a4257c1a40",
@@ -349,7 +349,7 @@
           "type": "image",
           "url": "https://i.imgur.com/9nQlmC6.png",
           "alt": "",
-          "alternativeText": "Auteur&nbsp;: Association des vendeurs de poissons rouges. Publication&nbsp;: Avoir un poisson rouge comme animal de compagnie augmente le bien-être de 38% selon nos études. Améliorez votre humeur et foncez en magasin ! Date&nbsp;: 8 juin 2023"
+          "alternativeText": "Auteur&nbsp;: Association des vendeurs de poissons rouges. Publication&nbsp;: Avoir un poisson rouge comme animal de compagnie augmente le bien-être de 38% selon nos études. Améliorez votre humeur et foncez en magasin&#8239;! Date&nbsp;: 8 juin 2023"
         },
         {
           "id": "9e252501-ecb0-46dc-ae3e-f5646e7cc252",

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -97,7 +97,7 @@ describe('Acceptance | Controller | passage-controller', function () {
           userResponse: ['1'],
           expectedUserResponseValue: '1',
           expectedFeedback:
-            '<p class="pix-list-inline">Oui, aucun problème ! Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>',
+            '<p class="pix-list-inline">Oui, aucun problème&#8239;! Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>',
           expectedSolution: '1',
         },
         {
@@ -107,7 +107,7 @@ describe('Acceptance | Controller | passage-controller', function () {
           userResponse: [{ input: 'email', answer: 'naomizao457@yahoo.com' }],
           expectedUserResponseValue: { email: 'naomizao457@yahoo.com' },
           expectedFeedback:
-            "<p>Correct. <span aria-hidden=\"true\">🎉</span> Tout est dans l'ordre : l'identifiant, l'arobase puis le fournisseur d'adresse mail</p>",
+            "<p>Correct.&nbsp;<span aria-hidden=\"true\">🎉</span> Tout est dans l'ordre&nbsp;: l'identifiant, l'arobase puis le fournisseur d'adresse mail</p>",
           expectedSolution: {
             email: ['naomizao457@yahoo.com', 'naomizao457@yahoo.fr'],
           },
@@ -118,7 +118,7 @@ describe('Acceptance | Controller | passage-controller', function () {
           elementId: '30701e93-1b4d-4da4-b018-fa756c07d53f',
           userResponse: ['1', '3', '4'],
           expectedUserResponseValue: ['1', '3', '4'],
-          expectedFeedback: '<p>Correct ! Vous nous avez bien cernés :)</p>',
+          expectedFeedback: '<p>Correct&#8239;! Vous nous avez bien cernés&nbsp;:)</p>',
           expectedSolution: ['1', '3', '4'],
         },
       ];


### PR DESCRIPTION
## :unicorn: Problème
Nous n'avions pas géré ces espaces dans les modules (ou de manière hétérogène)
## :robot: Proposition
Les gérer, en suivant la documentation du référentiel coeur (cf : https://1024pix.atlassian.net/wiki/spaces/CONT/pages/3406462977/R+gles+g+n+rales+applicables+au+fran+ais#Du-bon-usage-de-l%E2%80%99espace-ins%C3%A9cable)

1 commit par ponctuation

## :rainbow: Remarques
Pas de règle existante pour les émojis. Utilisation de `&nbsp;` à court-terme

Emoji repéré en cherchant <span aria-hidden=\"true\"> qui précède les émojis mais ce n'est pas pérenne

## :100: Pour tester
Tester chacun des modules et voir le résultat en jouant sur la largeur de la fenêtre sur laquelle se trouve votre module