### PR TITLE
[TECH] Ajouter la colonne attributes à la table organization-learners (Pix-11662)

### DIFF
--- a/api/db/migrations/20240318140110_add-attributes-to-organization-learner.js
+++ b/api/db/migrations/20240318140110_add-attributes-to-organization-learner.js
@@ -1,0 +1,25 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/DEV/pages/2153512965/Cr+er+une+migration
+
+// If your migrations target `answers` or `knowledge-elements`
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+const TABLE_NAME = 'organization-learners';
+const COLUMN_NAME = 'attributes';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.jsonb(COLUMN_NAME).defaultTo(null);
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## :unicorn: Problème
Dans un avenir, on souhaite avoir un import générique qui ne soit plus dépendant du type d'orga. Pour être moins dépendant aux différents attributs importés via les fichiers d'imports, on souhaite stocker les attributs dans un jsonb. 

## :robot: Proposition
Ajouter la colonne `attributes` à la table `organization-learners` 

## :rainbow: Remarques
RAS

## :100: Pour tester
Voir que la migration est passée 😺 