### PR TITLE
[BUGFIX] Corriger la disponibilité du bouton de publication de session sur Pix Admin (PIX-11481).

### DIFF
--- a/admin/app/controllers/authenticated/sessions/session/certifications.js
+++ b/admin/app/controllers/authenticated/sessions/session/certifications.js
@@ -1,9 +1,7 @@
 import Controller from '@ember/controller';
-// eslint-disable-next-line ember/no-computed-properties-in-native-classes
-import { action, computed } from '@ember/object';
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import some from 'lodash/some';
 
 const DEFAULT_PAGE_NUMBER = 1;
 export default class ListController extends Controller {
@@ -17,10 +15,14 @@ export default class ListController extends Controller {
   @tracked displayConfirm = false;
   @tracked confirmMessage = null;
 
-  @computed('model.juryCertificationSummaries.@each.status')
   get canPublish() {
-    return !some(this.model.juryCertificationSummaries.toArray(), (certif) =>
-      ['error', 'started'].includes(certif.status),
+    const juryCertificationSummaries = this.model.juryCertificationSummaries.toArray();
+    const session = this.model;
+
+    return (
+      !juryCertificationSummaries.some(
+        (certification) => certification.status === 'error' && !certification.isCancelled,
+      ) && session.isFinalized
     );
   }
 
@@ -36,9 +38,9 @@ export default class ListController extends Controller {
 
     if (!this.canPublish && !sessionIsPublished) return;
 
-    const text = sessionIsPublished ? 'Souhaitez-vous dépublier la session ?' : 'Souhaitez-vous publier la session ?';
-
-    this.confirmMessage = text;
+    this.confirmMessage = sessionIsPublished
+      ? 'Souhaitez-vous dépublier la session ?'
+      : 'Souhaitez-vous publier la session ?';
     this.displayConfirm = true;
   }
 

--- a/admin/app/templates/authenticated/sessions/session/certifications.hbs
+++ b/admin/app/templates/authenticated/sessions/session/certifications.hbs
@@ -25,8 +25,10 @@
                     Publier la session
                   </PixButton>
                 </:triggerElement>
-                <:tooltip>Vous ne pouvez pas publier la session tant qu'il reste des certifications en 'error' ou
-                  'started'.</:tooltip>
+                <:tooltip>
+                  Vous ne pouvez pas publier la session tant qu'elle n'est pas finalisée ou qu'il reste des
+                  certifications en erreur.
+                </:tooltip>
               </PixTooltip>
             {{/if}}
 


### PR DESCRIPTION
## :unicorn: Problème

Actuellement sur Pix Admin, lorsqu’on souhaite publier une session alors qu’elle n’a pas été finalisé, une pop-up nous indique ceci : `"Vous ne pouvez pas publier la session tant qu'il reste des certifications en 'error' ou 'started'."`

Pourtant, lorsqu’on finalise la session AVEC une certification en erreur, le bouton est disponible et c’est l’API qui nous jette car on ne peut publier une session avec ce cas de figure.

Autre cas de figure, si le métier définalise la session, le bouton de publication était également disponible alors qu'il faut finaliser la session avant publication.

## :robot: Proposition
- Ne plus se baser sur le statut `started` mais sur la finalisation de la session
- Etre plus clair sur le wording dans la pop-up
- maintenir le bouton `disabled` : en cas de session finalisée avec certification en erreur ou session non finalisée

## :100: Pour tester

- Se connecter sur Pix Admin 
- Aller sur cette certif démarré : https://admin-pr8440.review.pix.fr/sessions/7409/certifications
- Constater qu'on ne peut pas publier puisque non finalisée
<img width="1687" alt="Capture d’écran 2024-03-18 à 17 08 36" src="https://github.com/1024pix/pix/assets/58915422/7bafbea4-127a-4808-9581-ab09621eef7b">


- Aller sur cette certif : https://admin-pr8440.review.pix.org/sessions/7408/certifications
- Constater qu'on ne peut pas publier car une certification est en erreur
<img width="1547" alt="Capture d’écran 2024-03-18 à 14 04 12" src="https://github.com/1024pix/pix/assets/58915422/179c5858-7a27-47ae-bda5-c33417c9897f">

- Aller dans la page de détails de la certif en erreur et annuler la certification (on permet de publier une certification en erreur uniquement si annulée)
- Constater que le bouton est désormais dispo !
- Définaliser cette session (préalablement dépublié par mes soins) https://admin-pr8440.review.pix.fr/sessions/7401
- Constater que le bouton de publication est indisponible  