### PR TITLE
[TECH] Remplacer les notions de `treatment` par `tolerance` (PIX-11679)

### DIFF
--- a/api/src/devcomp/domain/models/Solution.js
+++ b/api/src/devcomp/domain/models/Solution.js
@@ -13,7 +13,7 @@ class Solution {
    * @param type: type de l'épreuve
    * @param value: Bonne réponse attendue.
    *
-   * Les traitements T1, T2 et T3 sont les traitements qu'il est possible d'utiliser pour valider une réponse.
+   * Les tolérances T1, T2 et T3 sont les tolérances qu'il est possible d'utiliser pour valider une réponse.
    * Pour plus d'informations, ne pas hésiter à se reporter aux explications présentes dans pix-editor.
    */
   constructor({
@@ -34,29 +34,29 @@ class Solution {
     this.qrocBlocksTypes = qrocBlocksTypes;
   }
 
-  get enabledTreatments() {
-    const enabledTreatments = [];
+  get enabledTolerances() {
+    const enabledTolerances = [];
     if (this.isT1Enabled) {
-      enabledTreatments.push('t1');
+      enabledTolerances.push('t1');
     }
     if (this.isT2Enabled) {
-      enabledTreatments.push('t2');
+      enabledTolerances.push('t2');
     }
     if (this.isT3Enabled) {
-      enabledTreatments.push('t3');
+      enabledTolerances.push('t3');
     }
-    return enabledTreatments;
+    return enabledTolerances;
   }
 
   // TODO: delete when deactivation object is correctly deleted everywhere
   /**
-   * @deprecated use the enabledTreatments property
+   * @deprecated use the enabledTolerances property
    */
   get deactivations() {
     return {
-      t1: !this.enabledTreatments.includes('t1'),
-      t2: !this.enabledTreatments.includes('t2'),
-      t3: !this.enabledTreatments.includes('t3'),
+      t1: !this.enabledTolerances.includes('t1'),
+      t2: !this.enabledTolerances.includes('t2'),
+      t3: !this.enabledTolerances.includes('t3'),
     };
   }
 }

--- a/api/src/devcomp/domain/models/element/QROCM-for-answer-verification.js
+++ b/api/src/devcomp/domain/models/element/QROCM-for-answer-verification.js
@@ -28,7 +28,7 @@ class QROCMForAnswerVerification extends QROCM {
       this.validator = new ValidatorQROCMInd({
         solution: {
           value: this.solutionValues,
-          enabledTreatments: this.solutionTolerances,
+          enabledTolerances: this.solutionTolerances,
         },
       });
     }

--- a/api/src/devcomp/domain/services/services-utils.js
+++ b/api/src/devcomp/domain/services/services-utils.js
@@ -1,13 +1,13 @@
 import { _ } from '../../../shared/infrastructure/utils/lodash-utils.js';
 
-const ALL_TREATMENTS = ['t1', 't2', 't3'];
+const ALL_TOLERANCES = ['t1', 't2', 't3'];
 
-function getEnabledTreatments(shouldApplyTreatments, deactivations) {
-  return shouldApplyTreatments ? ALL_TREATMENTS.filter((treatment) => !deactivations[treatment]) : [];
+function getEnabledTolerances(shouldApplyTolerances, deactivations) {
+  return shouldApplyTolerances ? ALL_TOLERANCES.filter((tolerance) => !deactivations[tolerance]) : [];
 }
 
-function useLevenshteinRatio(enabledTreatments) {
-  return _.includes(enabledTreatments, 't3');
+function useLevenshteinRatio(enabledTolerances) {
+  return _.includes(enabledTolerances, 't3');
 }
 
-export { getEnabledTreatments, useLevenshteinRatio };
+export { getEnabledTolerances, useLevenshteinRatio };

--- a/api/src/devcomp/domain/services/validation-tolerances.js
+++ b/api/src/devcomp/domain/services/validation-tolerances.js
@@ -19,30 +19,36 @@ function removeSpecialCharacters(value) {
     .replace(/\s\s+/g, ' ');
 }
 
-function applyPreTreatments(value) {
+function applyPreTreatmentForTolerance(value) {
   return value
     .toString()
     .normalize('NFC')
     .replace(/\u00A0/g, ' ');
 }
 
-const treatments = {
+const tolerances = {
   t1: normalizeAndRemoveAccents,
   t2: removeSpecialCharacters,
 };
 
-function applyTreatments(string, enabledTreatments) {
+function applyTolerances(string, enabledTolerances) {
   let result = string.toString();
-  if (_.isEmpty(enabledTreatments)) {
+  if (_.isEmpty(enabledTolerances)) {
     return result;
   }
-  _(enabledTreatments)
+  _(enabledTolerances)
     .sort()
-    .each((treatment) => {
-      const treatmentFunction = _.get(treatments, treatment);
-      result = treatmentFunction ? treatmentFunction(result) : result;
+    .each((tolerance) => {
+      const toleranceFunction = _.get(tolerances, tolerance);
+      result = toleranceFunction ? toleranceFunction(result) : result;
     });
   return result;
 }
 
-export { applyPreTreatments, applyTreatments, normalizeAndRemoveAccents, removeSpecialCharacters, treatments };
+export {
+  applyPreTreatmentForTolerance,
+  applyTolerances,
+  normalizeAndRemoveAccents,
+  removeSpecialCharacters,
+  tolerances,
+};

--- a/api/tests/devcomp/unit/domain/models/Solution_test.js
+++ b/api/tests/devcomp/unit/domain/models/Solution_test.js
@@ -2,16 +2,16 @@ import { Solution } from '../../../../../src/devcomp/domain/models/Solution.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Domain | Models | Solution', function () {
-  describe('#enabledTreatments', function () {
-    it('should contain nothing, when no treatments are set', function () {
+  describe('#enabledTolerances', function () {
+    it('should contain nothing, when no tolerances are set', function () {
       // given
       const solution = new Solution({ id: 'id' });
 
       // when
-      const enabledTreatments = solution.enabledTreatments;
+      const enabledTolerances = solution.enabledTolerances;
 
       // then
-      expect(enabledTreatments).to.be.empty;
+      expect(enabledTolerances).to.be.empty;
     });
 
     it('should contain t1, when isT1Enabled is true', function () {
@@ -19,10 +19,10 @@ describe('Unit | Domain | Models | Solution', function () {
       const solution = new Solution({ id: 'id', isT1Enabled: true });
 
       // when
-      const enabledTreatments = solution.enabledTreatments;
+      const enabledTolerances = solution.enabledTolerances;
 
       // then
-      expect(enabledTreatments).to.deep.equal(['t1']);
+      expect(enabledTolerances).to.deep.equal(['t1']);
     });
 
     it('should contain t2, when isT2Enabled is true', function () {
@@ -30,10 +30,10 @@ describe('Unit | Domain | Models | Solution', function () {
       const solution = new Solution({ id: 'id', isT2Enabled: true });
 
       // when
-      const enabledTreatments = solution.enabledTreatments;
+      const enabledTolerances = solution.enabledTolerances;
 
       // then
-      expect(enabledTreatments).to.deep.equal(['t2']);
+      expect(enabledTolerances).to.deep.equal(['t2']);
     });
 
     it('should contain t3, when isT3Enabled is true', function () {
@@ -41,10 +41,10 @@ describe('Unit | Domain | Models | Solution', function () {
       const solution = new Solution({ id: 'id', isT3Enabled: true });
 
       // when
-      const enabledTreatments = solution.enabledTreatments;
+      const enabledTolerances = solution.enabledTolerances;
 
       // then
-      expect(enabledTreatments).to.deep.equal(['t3']);
+      expect(enabledTolerances).to.deep.equal(['t3']);
     });
 
     it('should contain t1, t2, t3, when isT1Enabled, isT2Enabled, isT3Enabled is true', function () {
@@ -52,10 +52,10 @@ describe('Unit | Domain | Models | Solution', function () {
       const solution = new Solution({ id: 'id', isT1Enabled: true, isT2Enabled: true, isT3Enabled: true });
 
       // when
-      const enabledTreatments = solution.enabledTreatments;
+      const enabledTolerances = solution.enabledTolerances;
 
       // then
-      expect(enabledTreatments).to.deep.equal(['t1', 't2', 't3']);
+      expect(enabledTolerances).to.deep.equal(['t1', 't2', 't3']);
     });
   });
 

--- a/api/tests/devcomp/unit/domain/services/services-utils_test.js
+++ b/api/tests/devcomp/unit/domain/services/services-utils_test.js
@@ -1,58 +1,58 @@
 import {
-  getEnabledTreatments,
+  getEnabledTolerances,
   useLevenshteinRatio,
 } from '../../../../../src/devcomp/domain/services/services-utils.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Services | services-utils', function () {
-  describe('#getEnabledTreatments', function () {
-    describe('When we should apply the treatments', function () {
-      it('should return treatments which are not deactivated', function () {
+  describe('#getEnabledTolerances', function () {
+    describe('When we should apply the tolerances', function () {
+      it('should return tolerances which are not deactivated', function () {
         // given
-        const shouldApplyTreatments = true;
+        const shouldApplyTolerances = true;
         const deactivations = {
           t1: true,
           t2: false,
           t3: false,
         };
         // when
-        const enabledTreatments = getEnabledTreatments(shouldApplyTreatments, deactivations);
+        const enabledTolerances = getEnabledTolerances(shouldApplyTolerances, deactivations);
 
         // then
-        expect(enabledTreatments).to.deep.equal(['t2', 't3']);
+        expect(enabledTolerances).to.deep.equal(['t2', 't3']);
       });
     });
 
-    describe('When we should not apply the treatments', function () {
+    describe('When we should not apply the tolerances', function () {
       it('should return an empty list', function () {
         // given
-        const shouldApplyTreatments = false;
+        const shouldApplyTolerances = false;
         const deactivations = Symbol('deactivations');
         // when
-        const enabledTreatments = getEnabledTreatments(shouldApplyTreatments, deactivations);
+        const enabledTolerances = getEnabledTolerances(shouldApplyTolerances, deactivations);
 
         // then
-        expect(enabledTreatments).to.deep.equal([]);
+        expect(enabledTolerances).to.deep.equal([]);
       });
     });
   });
 
   describe('#useLevenshteinRatio', function () {
-    it('should return true if treatment #3 exists in enabled treatments list', function () {
+    it('should return true if tolerance #3 exists in enabled tolerances list', function () {
       // given
-      const enabledTreatments = ['t1', 't3'];
+      const enabledTolerances = ['t1', 't3'];
       // when
-      const isExist = useLevenshteinRatio(enabledTreatments);
+      const isExist = useLevenshteinRatio(enabledTolerances);
 
       // then
       expect(isExist).to.be.true;
     });
 
-    it('should return false if treatment #3 does not exist in enabled treatments list', function () {
+    it('should return false if tolerance #3 does not exist in enabled tolerances list', function () {
       // given
-      const enabledTreatments = ['t1', 't2'];
+      const enabledTolerances = ['t1', 't2'];
       // when
-      const isExist = useLevenshteinRatio(enabledTreatments);
+      const isExist = useLevenshteinRatio(enabledTolerances);
 
       // then
       expect(isExist).to.be.false;

--- a/api/tests/devcomp/unit/domain/services/solution-service-qrocm-ind_test.js
+++ b/api/tests/devcomp/unit/domain/services/solution-service-qrocm-ind_test.js
@@ -6,27 +6,27 @@ const ANSWER_OK = AnswerStatus.OK;
 const ANSWER_KO = AnswerStatus.KO;
 
 describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', function () {
-  describe('#_applyTreatmentsToSolutions(solutions, enabledTreatments)', function () {
+  describe('#_applyTolerancesToSolutions(solutions, enabledTolerances)', function () {
     it('t1 and t2 should be executed (lowerCase, trim, breaking space)', function () {
       // given
       const solutions = { '3lettres': ['OUI', 'NON   '], '4lettres': ['Good', 'Bad'] };
       const expected = { '3lettres': ['oui', 'non'], '4lettres': ['good', 'bad'] };
-      const enabledTreatments = ['t1', 't2'];
+      const enabledTolerances = ['t1', 't2'];
       // when
-      const actual = service._applyTreatmentsToSolutions(solutions, enabledTreatments);
+      const actual = service._applyTolerancesToSolutions(solutions, enabledTolerances);
       // then
       expect(actual).to.deep.equal(expected);
     });
   });
 
-  describe('#_applyTreatmentsToAnswers(answers, enabledTreatments)', function () {
+  describe('#_applyTolerancesToAnswers(answers, enabledTolerances)', function () {
     it('should be transformed in string', function () {
       // given
       const answers = { Num1: 1, Num2: 2 };
       const expected = { Num1: '1', Num2: '2' };
-      const enabledTreatments = ['t1', 't2'];
+      const enabledTolerances = ['t1', 't2'];
       // when
-      const actual = service._applyTreatmentsToAnswers(answers, enabledTreatments);
+      const actual = service._applyTolerancesToAnswers(answers, enabledTolerances);
       // then
       expect(actual).to.deep.equal(expected);
     });
@@ -35,9 +35,9 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
       // given
       const answers = { Num1: 1, Num2: 2 };
       const expected = { Num1: '1', Num2: '2' };
-      const enabledTreatments = [];
+      const enabledTolerances = [];
       // when
-      const actual = service._applyTreatmentsToAnswers(answers, enabledTreatments);
+      const actual = service._applyTolerancesToAnswers(answers, enabledTolerances);
       // then
       expect(actual).to.deep.equal(expected);
     });
@@ -74,10 +74,10 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
       // given
       const answers = { Num1: '1', Num2: '3' };
       const solutions = { Num1: ['1', 'un', '01'], Num2: ['2', 'deux', '02'] };
-      const allTreatmentsDisabled = [];
+      const allTolerancesDisabled = [];
 
       // when
-      const actual = service._compareAnswersAndSolutions(answers, solutions, allTreatmentsDisabled);
+      const actual = service._compareAnswersAndSolutions(answers, solutions, allTolerancesDisabled);
 
       // then
       const expected = { Num1: true, Num2: false };
@@ -88,10 +88,10 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
       // given
       const answers = { phrase1: "Le silence est d'ours", phrase2: 'faceboo', phrase3: 'lasagne' };
       const solutions = { phrase1: ["Le silence est d'or"], phrase2: ['facebook'], phrase3: ['engasal'] };
-      const t3TreatmentEnabled = ['t3'];
+      const t3ToleranceEnabled = ['t3'];
 
       // when
-      const actual = service._compareAnswersAndSolutions(answers, solutions, t3TreatmentEnabled);
+      const actual = service._compareAnswersAndSolutions(answers, solutions, t3ToleranceEnabled);
 
       // then
       const expected = { phrase1: true, phrase2: true, phrase3: false };
@@ -129,112 +129,112 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'tomate' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
         case: 'solution contains numbers',
         output: { result: ANSWER_OK, resultDetails: { num1: true, num2: true } },
         answer: { num1: '888', num2: '64' },
         solution: { num1: ['888'], num2: ['64'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
         case: 'solution contains decimal numbers with a comma',
         output: { result: ANSWER_OK, resultDetails: { num1: true, num2: true } },
         answer: { num1: '888,00', num2: '64' },
         solution: { num1: ['888,00'], num2: ['64'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
         case: 'solution contains decimal numbers with a dot',
         output: { result: ANSWER_OK, resultDetails: { num1: true, num2: true } },
         answer: { num1: '888.00', num2: '64' },
         solution: { num1: ['888.00'], num2: ['64'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
         case: 'leading/trailing spaces in solution',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'c o u r g e t t e', '6lettres': 't o m a t e' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
         case: 'uppercases and leading/trailing spaces in solution',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'c o u r g e t t e', '6lettres': 't o m a t e' },
         solution: { '9lettres': ['COUrgETTE'], '6lettres': ['TOmaTE', 'CHICON', 'LEGUME'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
         case: 'spaces in answer',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'c o u r g e t t e', '6lettres': 't o m a t e' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
         case: 'answer with levenshtein distance below 0.25',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'ourgette', '6lettres': 'tomae' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
         case: 'answer with uppercases',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'COURGETTE', '6lettres': 'TOMATE' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
         case: 'answer with uppercases and spaces',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'C O U R G E T T E', '6lettres': 'T O M A T E' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
         case: 'answer with uppercases spaces, and levenshtein > 0 but <= 0.25',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'C O U G E T T E', '6lettres': ' O M A T E' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
         case: 'answer with uppercases spaces, and levenshtein > 0 but <= 0.25, and accents',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'ç O u -- ;" ;--- _ \' grè TTÊ', '6lettres': ' O M A T E' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
         case: 'unbreakable spaces in answer',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'c o u r g e t t e', '6lettres': ' t o m a t e' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
         case: 'Solution has spaces in-between',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'abcdefg', '6lettres': 'ghjkl' },
         solution: { '9lettres': ['a b c d e f g'], '6lettres': ['ghjklm', 'ghjklp', 'ghjklz'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
         case: '(nominal case) Each answer strictly respect another corresponding solution',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'patate', '6lettres': 'legume' },
         solution: { '9lettres': ['courgette ', 'patate'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
         case: 'Each answer correctly match its solution, with worst levenshtein distance below or equal to 0.25',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'abcd', '6lettres': 'ghjkl' },
         solution: { '9lettres': ['abcde'], '6lettres': ['ghjklm', 'ghjklp', 'ghjklz'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
     ];
     // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
@@ -248,7 +248,7 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
           escape(testCase.solution) +
           '"',
         function () {
-          const solution = { value: testCase.solution, enabledTreatments: testCase.enabledTreatments };
+          const solution = { value: testCase.solution, enabledTolerances: testCase.enabledTolerances };
           expect(service.match({ answerValue: testCase.answer, solution })).to.deep.equal(testCase.output);
         },
       );
@@ -259,35 +259,35 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
         case: 'solution do not exists',
         output: { result: ANSWER_KO },
         answer: 'any answer',
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
         case: 'solution is empty',
         output: { result: ANSWER_KO },
         answer: '',
         solution: '',
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
         case: 'answer is not a valid object',
         output: { result: ANSWER_KO },
         answer: new Date(),
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
         case: 'solution is not a valid object',
         output: { result: ANSWER_KO },
         answer: { '9lettres': 'tomate', '6lettres': 'courgette' },
         solution: new Date(),
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
         case: 'Each answer points to the solution of another question',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': false, '6lettres': false } },
         answer: { '9lettres': 'tomate', '6lettres': 'courgette' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
         case: 'One of the levenshtein distance is above 0.25',
@@ -295,14 +295,14 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
         answer: { '9lettres': 'abcde', '6lettres': 'ghjkl' },
         //abcdefg below creates a levenshtein distance above 0.25
         solution: { '9lettres': ['abcdefg'], '6lettres': ['ghjklm', 'ghjklp', 'ghjklz'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
         case: 'All of the levenshtein distances are above 0.25',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': false, '6lettres': false } },
         answer: { '9lettres': 'abcde', '6lettres': 'ghjklpE11!!' },
         solution: { '9lettres': ['abcdefg'], '6lettres': ['ghjklm', 'ghjklp', 'ghjklz'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
     ];
     // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
@@ -316,7 +316,7 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
           escape(testCase.solution) +
           '"',
         function () {
-          const solution = { value: testCase.solution, enabledTreatments: testCase.enabledTreatments };
+          const solution = { value: testCase.solution, enabledTolerances: testCase.enabledTolerances };
           expect(service.match({ answerValue: testCase.answer, solution })).to.deep.equal(testCase.output);
         },
       );
@@ -327,8 +327,8 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
     it('should throw an error', async function () {
       const answer = { dossier1: 'a' };
       const solutionValue = { dossier2: ['Eureka'] };
-      const enabledTreatments = ['t1', 't2', 't3'];
-      const solution = { value: solutionValue, enabledTreatments };
+      const enabledTolerances = ['t1', 't2', 't3'];
+      const solution = { value: solutionValue, enabledTolerances };
 
       const error = await catchErr(service.match)({ answerValue: answer, solution });
 
@@ -337,14 +337,14 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
     });
   });
 
-  describe('match, strong focus on treatments', function () {
+  describe('match, strong focus on tolerances', function () {
     // it('when solution value is not an array, should throw an error', async function () {
     //   const answer = { dossier1: 'a' };
     //   const solutionValue = {
     //     dossier1: 'Eureka',
     //   };
-    //   const enabledTreatments = ['t1', 't2', 't3'];
-    //   const solution = { value: solutionValue, enabledTreatments };
+    //   const enabledTolerances = ['t1', 't2', 't3'];
+    //   const solution = { value: solutionValue, enabledTolerances };
     //
     //   const error = await catchErr(service.match)({ answerValue: answer, solution });
     //
@@ -358,91 +358,91 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'chicon' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
-        when: 'spaces treatment focus',
+        when: 'spaces tolerance focus',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'c h i c o n' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
-        when: 'spaces treatment focus on the solution',
+        when: 'spaces tolerance focus on the solution',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'chicon' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'c h i c o n', 'legume'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
-        when: 'uppercase treatment focus',
+        when: 'uppercase tolerance focus',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'CHICON' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
-        when: 'uppercase treatment focus on the solution',
+        when: 'uppercase tolerance focus on the solution',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'chicon' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'CHICON', 'legume'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
-        when: 'accent treatment focus',
+        when: 'accent tolerance focus',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'îàéùô' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'iaeuo', 'legume'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
-        when: 'accent treatment focus on the solution',
+        when: 'accent tolerance focus on the solution',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'iaeuo' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'îàéùô', 'legume'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
-        when: 'diacritic treatment focus',
+        when: 'diacritic tolerance focus',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'ççççç' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'ccccc', 'legume'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
-        when: 'diacritic treatment focus on the solution',
+        when: 'diacritic tolerance focus on the solution',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'ccccc' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'ççççç', 'legume'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
-        when: 'punctuation treatment focus',
+        when: 'punctuation tolerance focus',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': '.!p-u-n-c-t' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'punct', 'legume'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
-        when: 'punctuation treatment focus on the solution',
+        when: 'punctuation tolerance focus on the solution',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'punct' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', '.!p-u-n-c-t', 'legume'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
-        when: 'levenshtein treatment focus',
+        when: 'levenshtein tolerance focus',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': '0123456789' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', '123456789', 'legume'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
       {
-        when: 'levenshtein treatment focus on the solution',
+        when: 'levenshtein tolerance focus on the solution',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': '123456789' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', '0123456789', 'legume'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
       },
     ];
 
@@ -458,7 +458,7 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
           JSON.stringify(testCase.solution) +
           '"',
         function () {
-          const solution = { value: testCase.solution, enabledTreatments: testCase.enabledTreatments };
+          const solution = { value: testCase.solution, enabledTolerances: testCase.enabledTolerances };
           expect(service.match({ answerValue: testCase.answer, solution })).to.deep.equal(testCase.output);
         },
       );
@@ -472,91 +472,91 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'chicon' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t2', 't3'],
+        enabledTolerances: ['t2', 't3'],
       },
       {
-        when: 'spaces treatment focus',
+        when: 'spaces tolerance focus',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'c h i c o n' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t2', 't3'],
+        enabledTolerances: ['t2', 't3'],
       },
       {
-        when: 'spaces treatment focus on the solution',
+        when: 'spaces tolerance focus on the solution',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'chicon' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'c h i c o n', 'legume'] },
-        enabledTreatments: ['t2', 't3'],
+        enabledTolerances: ['t2', 't3'],
       },
       {
-        when: 'uppercase treatment focus',
+        when: 'uppercase tolerance focus',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'CHICON' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t2', 't3'],
+        enabledTolerances: ['t2', 't3'],
       },
       {
-        when: 'uppercase treatment focus on the solution',
+        when: 'uppercase tolerance focus on the solution',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'chicon' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'CHICON', 'legume'] },
-        enabledTreatments: ['t2', 't3'],
+        enabledTolerances: ['t2', 't3'],
       },
       {
-        when: 'accent treatment focus',
+        when: 'accent tolerance focus',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'îàéùô' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'iaeuo', 'legume'] },
-        enabledTreatments: ['t2', 't3'],
+        enabledTolerances: ['t2', 't3'],
       },
       {
-        when: 'accent treatment focus on the solution',
+        when: 'accent tolerance focus on the solution',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'iaeuo' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'îàéùô', 'legume'] },
-        enabledTreatments: ['t2', 't3'],
+        enabledTolerances: ['t2', 't3'],
       },
       {
-        when: 'diacritic treatment focus',
+        when: 'diacritic tolerance focus',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'ççççç' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'ccccc', 'legume'] },
-        enabledTreatments: ['t2', 't3'],
+        enabledTolerances: ['t2', 't3'],
       },
       {
-        when: 'diacritic treatment focus on the solution',
+        when: 'diacritic tolerance focus on the solution',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'ccccc' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'ççççç', 'legume'] },
-        enabledTreatments: ['t2', 't3'],
+        enabledTolerances: ['t2', 't3'],
       },
       {
-        when: 'punctuation treatment focus',
+        when: 'punctuation tolerance focus',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': '.!p-u-n-c-t' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'punct', 'legume'] },
-        enabledTreatments: ['t2', 't3'],
+        enabledTolerances: ['t2', 't3'],
       },
       {
-        when: 'punctuation treatment focus on the solution',
+        when: 'punctuation tolerance focus on the solution',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'punct' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', '.!p-u-n-c-t', 'legume'] },
-        enabledTreatments: ['t2', 't3'],
+        enabledTolerances: ['t2', 't3'],
       },
       {
-        when: 'levenshtein treatment focus',
+        when: 'levenshtein tolerance focus',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': '0123456789' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', '123456789', 'legume'] },
-        enabledTreatments: ['t2', 't3'],
+        enabledTolerances: ['t2', 't3'],
       },
       {
-        when: 'levenshtein treatment focus on the solution',
+        when: 'levenshtein tolerance focus on the solution',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': '123456789' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', '0123456789', 'legume'] },
-        enabledTreatments: ['t2', 't3'],
+        enabledTolerances: ['t2', 't3'],
       },
     ];
 
@@ -572,7 +572,7 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
           JSON.stringify(testCase.solution) +
           '"',
         function () {
-          const solution = { value: testCase.solution, enabledTreatments: testCase.enabledTreatments };
+          const solution = { value: testCase.solution, enabledTolerances: testCase.enabledTolerances };
           expect(service.match({ answerValue: testCase.answer, solution })).to.deep.equal(testCase.output);
         },
       );
@@ -586,91 +586,91 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'chicon' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t1', 't3'],
+        enabledTolerances: ['t1', 't3'],
       },
       {
-        when: 'spaces treatment focus',
+        when: 'spaces tolerance focus',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'c h i c o n' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t1', 't3'],
+        enabledTolerances: ['t1', 't3'],
       },
       {
-        when: 'spaces treatment focus on the solution',
+        when: 'spaces tolerance focus on the solution',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'chicon' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'c h i c o n', 'legume'] },
-        enabledTreatments: ['t1', 't3'],
+        enabledTolerances: ['t1', 't3'],
       },
       {
-        when: 'uppercase treatment focus',
+        when: 'uppercase tolerance focus',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'CHICON' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t1', 't3'],
+        enabledTolerances: ['t1', 't3'],
       },
       {
-        when: 'uppercase treatment focus on the solution',
+        when: 'uppercase tolerance focus on the solution',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'chicon' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'CHICON', 'legume'] },
-        enabledTreatments: ['t1', 't3'],
+        enabledTolerances: ['t1', 't3'],
       },
       {
-        when: 'accent treatment focus',
+        when: 'accent tolerance focus',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'îàéùô' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'iaeuo', 'legume'] },
-        enabledTreatments: ['t1', 't3'],
+        enabledTolerances: ['t1', 't3'],
       },
       {
-        when: 'accent treatment focus on the solution',
+        when: 'accent tolerance focus on the solution',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'iaeuo' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'îàéùô', 'legume'] },
-        enabledTreatments: ['t1', 't3'],
+        enabledTolerances: ['t1', 't3'],
       },
       {
-        when: 'diacritic treatment focus',
+        when: 'diacritic tolerance focus',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'ççççç' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'ccccc', 'legume'] },
-        enabledTreatments: ['t1', 't3'],
+        enabledTolerances: ['t1', 't3'],
       },
       {
-        when: 'diacritic treatment focus on the solution',
+        when: 'diacritic tolerance focus on the solution',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'ccccc' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'ççççç', 'legume'] },
-        enabledTreatments: ['t1', 't3'],
+        enabledTolerances: ['t1', 't3'],
       },
       {
-        when: 'punctuation treatment focus',
+        when: 'punctuation tolerance focus',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': '.!p-u-n-c-t' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'punct', 'legume'] },
-        enabledTreatments: ['t1', 't3'],
+        enabledTolerances: ['t1', 't3'],
       },
       {
-        when: 'punctuation treatment focus on the solution',
+        when: 'punctuation tolerance focus on the solution',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'punct' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', '.!p-u-n-c-t', 'legume'] },
-        enabledTreatments: ['t1', 't3'],
+        enabledTolerances: ['t1', 't3'],
       },
       {
-        when: 'levenshtein treatment focus',
+        when: 'levenshtein tolerance focus',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': '0123456789' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', '123456789', 'legume'] },
-        enabledTreatments: ['t1', 't3'],
+        enabledTolerances: ['t1', 't3'],
       },
       {
-        when: 'levenshtein treatment focus on the solution',
+        when: 'levenshtein tolerance focus on the solution',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': '123456789' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', '0123456789', 'legume'] },
-        enabledTreatments: ['t1', 't3'],
+        enabledTolerances: ['t1', 't3'],
       },
     ];
 
@@ -686,7 +686,7 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
           JSON.stringify(testCase.solution) +
           '"',
         function () {
-          const solution = { value: testCase.solution, enabledTreatments: testCase.enabledTreatments };
+          const solution = { value: testCase.solution, enabledTolerances: testCase.enabledTolerances };
           expect(service.match({ answerValue: testCase.answer, solution })).to.deep.equal(testCase.output);
         },
       );
@@ -700,91 +700,91 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'chicon' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t1', 't2'],
+        enabledTolerances: ['t1', 't2'],
       },
       {
-        when: 'spaces treatment focus',
+        when: 'spaces tolerance focus',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'c h i c o n' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t1', 't2'],
+        enabledTolerances: ['t1', 't2'],
       },
       {
-        when: 'spaces treatment focus on the solution',
+        when: 'spaces tolerance focus on the solution',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'chicon' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'c h i c o n', 'legume'] },
-        enabledTreatments: ['t1', 't2'],
+        enabledTolerances: ['t1', 't2'],
       },
       {
-        when: 'uppercase treatment focus',
+        when: 'uppercase tolerance focus',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'CHICON' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t1', 't2'],
+        enabledTolerances: ['t1', 't2'],
       },
       {
-        when: 'uppercase treatment focus on the solution',
+        when: 'uppercase tolerance focus on the solution',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'chicon' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'CHICON', 'legume'] },
-        enabledTreatments: ['t1', 't2'],
+        enabledTolerances: ['t1', 't2'],
       },
       {
-        when: 'accent treatment focus',
+        when: 'accent tolerance focus',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'îàéùô' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'iaeuo', 'legume'] },
-        enabledTreatments: ['t1', 't2'],
+        enabledTolerances: ['t1', 't2'],
       },
       {
-        when: 'accent treatment focus on the solution',
+        when: 'accent tolerance focus on the solution',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'iaeuo' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'îàéùô', 'legume'] },
-        enabledTreatments: ['t1', 't2'],
+        enabledTolerances: ['t1', 't2'],
       },
       {
-        when: 'diacritic treatment focus',
+        when: 'diacritic tolerance focus',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'ççççç' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'ccccc', 'legume'] },
-        enabledTreatments: ['t1', 't2'],
+        enabledTolerances: ['t1', 't2'],
       },
       {
-        when: 'diacritic treatment focus on the solution',
+        when: 'diacritic tolerance focus on the solution',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'ccccc' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'ççççç', 'legume'] },
-        enabledTreatments: ['t1', 't2'],
+        enabledTolerances: ['t1', 't2'],
       },
       {
-        when: 'punctuation treatment focus',
+        when: 'punctuation tolerance focus',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': '.!p-u-n-c-t' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'punct', 'legume'] },
-        enabledTreatments: ['t1', 't2'],
+        enabledTolerances: ['t1', 't2'],
       },
       {
-        when: 'punctuation treatment focus on the solution',
+        when: 'punctuation tolerance focus on the solution',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'punct' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', '.!p-u-n-c-t', 'legume'] },
-        enabledTreatments: ['t1', 't2'],
+        enabledTolerances: ['t1', 't2'],
       },
       {
-        when: 'levenshtein treatment focus',
+        when: 'levenshtein tolerance focus',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': '0123456789' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', '123456789', 'legume'] },
-        enabledTreatments: ['t1', 't2'],
+        enabledTolerances: ['t1', 't2'],
       },
       {
-        when: 'levenshtein treatment focus on the solution',
+        when: 'levenshtein tolerance focus on the solution',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': '123456789' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', '0123456789', 'legume'] },
-        enabledTreatments: ['t1', 't2'],
+        enabledTolerances: ['t1', 't2'],
       },
     ];
 
@@ -800,7 +800,7 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
           JSON.stringify(testCase.solution) +
           '"',
         function () {
-          const solution = { value: testCase.solution, enabledTreatments: testCase.enabledTreatments };
+          const solution = { value: testCase.solution, enabledTolerances: testCase.enabledTolerances };
           expect(service.match({ answerValue: testCase.answer, solution })).to.deep.equal(testCase.output);
         },
       );
@@ -814,91 +814,91 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'chicon' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t3'],
+        enabledTolerances: ['t3'],
       },
       {
-        when: 'spaces treatment focus',
+        when: 'spaces tolerance focus',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'c h i c o n' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t3'],
+        enabledTolerances: ['t3'],
       },
       {
-        when: 'spaces treatment focus on the solution',
+        when: 'spaces tolerance focus on the solution',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'chicon' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'c h i c o n', 'legume'] },
-        enabledTreatments: ['t3'],
+        enabledTolerances: ['t3'],
       },
       {
-        when: 'uppercase treatment focus',
+        when: 'uppercase tolerance focus',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'CHICON' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t3'],
+        enabledTolerances: ['t3'],
       },
       {
-        when: 'uppercase treatment focus on the solution',
+        when: 'uppercase tolerance focus on the solution',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'chicon' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'CHICON', 'legume'] },
-        enabledTreatments: ['t3'],
+        enabledTolerances: ['t3'],
       },
       {
-        when: 'accent treatment focus',
+        when: 'accent tolerance focus',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'îàéùô' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'iaeuo', 'legume'] },
-        enabledTreatments: ['t3'],
+        enabledTolerances: ['t3'],
       },
       {
-        when: 'accent treatment focus on the solution',
+        when: 'accent tolerance focus on the solution',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'iaeuo' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'îàéùô', 'legume'] },
-        enabledTreatments: ['t3'],
+        enabledTolerances: ['t3'],
       },
       {
-        when: 'diacritic treatment focus',
+        when: 'diacritic tolerance focus',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'ççççç' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'ccccc', 'legume'] },
-        enabledTreatments: ['t3'],
+        enabledTolerances: ['t3'],
       },
       {
-        when: 'diacritic treatment focus on the solution',
+        when: 'diacritic tolerance focus on the solution',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'ccccc' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'ççççç', 'legume'] },
-        enabledTreatments: ['t3'],
+        enabledTolerances: ['t3'],
       },
       {
-        when: 'punctuation treatment focus',
+        when: 'punctuation tolerance focus',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': '.!p-u-n-c-t' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'punct', 'legume'] },
-        enabledTreatments: ['t3'],
+        enabledTolerances: ['t3'],
       },
       {
-        when: 'punctuation treatment focus on the solution',
+        when: 'punctuation tolerance focus on the solution',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'punct' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', '.!p-u-n-c-t', 'legume'] },
-        enabledTreatments: ['t3'],
+        enabledTolerances: ['t3'],
       },
       {
-        when: 'levenshtein treatment focus',
+        when: 'levenshtein tolerance focus',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': '0123456789' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', '123456789', 'legume'] },
-        enabledTreatments: ['t3'],
+        enabledTolerances: ['t3'],
       },
       {
-        when: 'levenshtein treatment focus on the solution',
+        when: 'levenshtein tolerance focus on the solution',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': '123456789' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', '0123456789', 'legume'] },
-        enabledTreatments: ['t3'],
+        enabledTolerances: ['t3'],
       },
     ];
 
@@ -914,7 +914,7 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
           JSON.stringify(testCase.solution) +
           '"',
         function () {
-          const solution = { value: testCase.solution, enabledTreatments: testCase.enabledTreatments };
+          const solution = { value: testCase.solution, enabledTolerances: testCase.enabledTolerances };
           expect(service.match({ answerValue: testCase.answer, solution })).to.deep.equal(testCase.output);
         },
       );
@@ -928,91 +928,91 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'chicon' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t2'],
+        enabledTolerances: ['t2'],
       },
       {
-        when: 'spaces treatment focus',
+        when: 'spaces tolerance focus',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'c h i c o n' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t2'],
+        enabledTolerances: ['t2'],
       },
       {
-        when: 'spaces treatment focus on the solution',
+        when: 'spaces tolerance focus on the solution',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'chicon' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'c h i c o n', 'legume'] },
-        enabledTreatments: ['t2'],
+        enabledTolerances: ['t2'],
       },
       {
-        when: 'uppercase treatment focus',
+        when: 'uppercase tolerance focus',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'CHICON' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t2'],
+        enabledTolerances: ['t2'],
       },
       {
-        when: 'uppercase treatment focus on the solution',
+        when: 'uppercase tolerance focus on the solution',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'chicon' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'CHICON', 'legume'] },
-        enabledTreatments: ['t2'],
+        enabledTolerances: ['t2'],
       },
       {
-        when: 'accent treatment focus',
+        when: 'accent tolerance focus',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'îàéùô' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'iaeuo', 'legume'] },
-        enabledTreatments: ['t2'],
+        enabledTolerances: ['t2'],
       },
       {
-        when: 'accent treatment focus on the solution',
+        when: 'accent tolerance focus on the solution',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'iaeuo' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'îàéùô', 'legume'] },
-        enabledTreatments: ['t2'],
+        enabledTolerances: ['t2'],
       },
       {
-        when: 'diacritic treatment focus',
+        when: 'diacritic tolerance focus',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'ççççç' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'ccccc', 'legume'] },
-        enabledTreatments: ['t2'],
+        enabledTolerances: ['t2'],
       },
       {
-        when: 'diacritic treatment focus on the solution',
+        when: 'diacritic tolerance focus on the solution',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'ccccc' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'ççççç', 'legume'] },
-        enabledTreatments: ['t2'],
+        enabledTolerances: ['t2'],
       },
       {
-        when: 'punctuation treatment focus',
+        when: 'punctuation tolerance focus',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': '.!p-u-n-c-t' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'punct', 'legume'] },
-        enabledTreatments: ['t2'],
+        enabledTolerances: ['t2'],
       },
       {
-        when: 'punctuation treatment focus on the solution',
+        when: 'punctuation tolerance focus on the solution',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'punct' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', '.!p-u-n-c-t', 'legume'] },
-        enabledTreatments: ['t2'],
+        enabledTolerances: ['t2'],
       },
       {
-        when: 'levenshtein treatment focus',
+        when: 'levenshtein tolerance focus',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': '0123456789' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', '123456789', 'legume'] },
-        enabledTreatments: ['t2'],
+        enabledTolerances: ['t2'],
       },
       {
-        when: 'levenshtein treatment focus on the solution',
+        when: 'levenshtein tolerance focus on the solution',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': '123456789' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', '0123456789', 'legume'] },
-        enabledTreatments: ['t2'],
+        enabledTolerances: ['t2'],
       },
     ];
 
@@ -1028,7 +1028,7 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
           JSON.stringify(testCase.solution) +
           '"',
         function () {
-          const solution = { value: testCase.solution, enabledTreatments: testCase.enabledTreatments };
+          const solution = { value: testCase.solution, enabledTolerances: testCase.enabledTolerances };
           expect(service.match({ answerValue: testCase.answer, solution })).to.deep.equal(testCase.output);
         },
       );
@@ -1042,91 +1042,91 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'chicon' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t1'],
+        enabledTolerances: ['t1'],
       },
       {
-        when: 'spaces treatment focus',
+        when: 'spaces tolerance focus',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'c h i c o n' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t1'],
+        enabledTolerances: ['t1'],
       },
       {
-        when: 'spaces treatment focus on the solution',
+        when: 'spaces tolerance focus on the solution',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'chicon' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'c h i c o n', 'legume'] },
-        enabledTreatments: ['t1'],
+        enabledTolerances: ['t1'],
       },
       {
-        when: 'uppercase treatment focus',
+        when: 'uppercase tolerance focus',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'CHICON' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t1'],
+        enabledTolerances: ['t1'],
       },
       {
-        when: 'uppercase treatment focus on the solution',
+        when: 'uppercase tolerance focus on the solution',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'chicon' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'CHICON', 'legume'] },
-        enabledTreatments: ['t1'],
+        enabledTolerances: ['t1'],
       },
       {
-        when: 'accent treatment focus',
+        when: 'accent tolerance focus',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'îàéùô' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'iaeuo', 'legume'] },
-        enabledTreatments: ['t1'],
+        enabledTolerances: ['t1'],
       },
       {
-        when: 'accent treatment focus on the solution',
+        when: 'accent tolerance focus on the solution',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'iaeuo' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'îàéùô', 'legume'] },
-        enabledTreatments: ['t1'],
+        enabledTolerances: ['t1'],
       },
       {
-        when: 'diacritic treatment focus',
+        when: 'diacritic tolerance focus',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'ççççç' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'ccccc', 'legume'] },
-        enabledTreatments: ['t1'],
+        enabledTolerances: ['t1'],
       },
       {
-        when: 'diacritic treatment focus on the solution',
+        when: 'diacritic tolerance focus on the solution',
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'ccccc' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'ççççç', 'legume'] },
-        enabledTreatments: ['t1'],
+        enabledTolerances: ['t1'],
       },
       {
-        when: 'punctuation treatment focus',
+        when: 'punctuation tolerance focus',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': '.!p-u-n-c-t' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'punct', 'legume'] },
-        enabledTreatments: ['t1'],
+        enabledTolerances: ['t1'],
       },
       {
-        when: 'punctuation treatment focus on the solution',
+        when: 'punctuation tolerance focus on the solution',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'punct' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', '.!p-u-n-c-t', 'legume'] },
-        enabledTreatments: ['t1'],
+        enabledTolerances: ['t1'],
       },
       {
-        when: 'levenshtein treatment focus',
+        when: 'levenshtein tolerance focus',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': '0123456789' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', '123456789', 'legume'] },
-        enabledTreatments: ['t1'],
+        enabledTolerances: ['t1'],
       },
       {
-        when: 'levenshtein treatment focus on the solution',
+        when: 'levenshtein tolerance focus on the solution',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': '123456789' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', '0123456789', 'legume'] },
-        enabledTreatments: ['t1'],
+        enabledTolerances: ['t1'],
       },
     ];
 
@@ -1142,7 +1142,7 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
           JSON.stringify(testCase.solution) +
           '"',
         function () {
-          const solution = { value: testCase.solution, enabledTreatments: testCase.enabledTreatments };
+          const solution = { value: testCase.solution, enabledTolerances: testCase.enabledTolerances };
           expect(service.match({ answerValue: testCase.answer, solution })).to.deep.equal(testCase.output);
         },
       );
@@ -1156,91 +1156,91 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'chicon' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: [],
+        enabledTolerances: [],
       },
       {
-        when: 'spaces treatment focus',
+        when: 'spaces tolerance focus',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'c h i c o n' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: [],
+        enabledTolerances: [],
       },
       {
-        when: 'spaces treatment focus on the solution',
+        when: 'spaces tolerance focus on the solution',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'chicon' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'c h i c o n', 'legume'] },
-        enabledTreatments: [],
+        enabledTolerances: [],
       },
       {
-        when: 'uppercase treatment focus',
+        when: 'uppercase tolerance focus',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'CHICON' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: [],
+        enabledTolerances: [],
       },
       {
-        when: 'uppercase treatment focus on the solution',
+        when: 'uppercase tolerance focus on the solution',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'chicon' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'CHICON', 'legume'] },
-        enabledTreatments: [],
+        enabledTolerances: [],
       },
       {
-        when: 'accent treatment focus',
+        when: 'accent tolerance focus',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'îàéùô' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'iaeuo', 'legume'] },
-        enabledTreatments: [],
+        enabledTolerances: [],
       },
       {
-        when: 'accent treatment focus on the solution',
+        when: 'accent tolerance focus on the solution',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'iaeuo' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'îàéùô', 'legume'] },
-        enabledTreatments: [],
+        enabledTolerances: [],
       },
       {
-        when: 'diacritic treatment focus',
+        when: 'diacritic tolerance focus',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'ççççç' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'ccccc', 'legume'] },
-        enabledTreatments: [],
+        enabledTolerances: [],
       },
       {
-        when: 'diacritic treatment focus on the solution',
+        when: 'diacritic tolerance focus on the solution',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'ccccc' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'ççççç', 'legume'] },
-        enabledTreatments: [],
+        enabledTolerances: [],
       },
       {
-        when: 'punctuation treatment focus',
+        when: 'punctuation tolerance focus',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': '.!p-u-n-c-t' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'punct', 'legume'] },
-        enabledTreatments: [],
+        enabledTolerances: [],
       },
       {
-        when: 'punctuation treatment focus on the solution',
+        when: 'punctuation tolerance focus on the solution',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': 'punct' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', '.!p-u-n-c-t', 'legume'] },
-        enabledTreatments: [],
+        enabledTolerances: [],
       },
       {
-        when: 'levenshtein treatment focus',
+        when: 'levenshtein tolerance focus',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': '0123456789' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', '123456789', 'legume'] },
-        enabledTreatments: [],
+        enabledTolerances: [],
       },
       {
-        when: 'levenshtein treatment focus on the solution',
+        when: 'levenshtein tolerance focus on the solution',
         output: { result: ANSWER_KO, resultDetails: { '9lettres': true, '6lettres': false } },
         answer: { '9lettres': 'courgette', '6lettres': '123456789' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', '0123456789', 'legume'] },
-        enabledTreatments: [],
+        enabledTolerances: [],
       },
     ];
 
@@ -1256,7 +1256,7 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
           JSON.stringify(testCase.solution) +
           '"',
         function () {
-          const solution = { value: testCase.solution, enabledTreatments: testCase.enabledTreatments };
+          const solution = { value: testCase.solution, enabledTolerances: testCase.enabledTolerances };
           expect(service.match({ answerValue: testCase.answer, solution })).to.deep.equal(testCase.output);
         },
       );
@@ -1271,7 +1271,7 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
         output: { result: ANSWER_KO, resultDetails: { '9lettres': false, '6lettres': true } },
         answer: { '9lettres': 'courgetta', '6lettres': 'tomato' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t3'],
+        enabledTolerances: ['t3'],
         qrocBlocksTypes: { '9lettres': 'select', '6lettres': 'text' },
       },
       {
@@ -1279,7 +1279,7 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
         output: { result: ANSWER_KO, resultDetails: { '9lettres': false, '6lettres': true } },
         answer: { '9lettres': 'COURGETTE', '6lettres': 'TOMATE' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t1'],
+        enabledTolerances: ['t1'],
         qrocBlocksTypes: { '9lettres': 'select', '6lettres': 'text' },
       },
       {
@@ -1287,7 +1287,7 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
         output: { result: ANSWER_KO, resultDetails: { '9lettres': false, '6lettres': true } },
         answer: { '9lettres': 'courgette&&&', '6lettres': 'tomate&&&' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t2'],
+        enabledTolerances: ['t2'],
         qrocBlocksTypes: { '9lettres': 'select', '6lettres': 'text' },
       },
       {
@@ -1295,7 +1295,7 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'courgette', '6lettres': 'TOMATO&&' },
         solution: { '9lettres': ['courgette'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
         qrocBlocksTypes: { '9lettres': 'select', '6lettres': 'text' },
       },
       {
@@ -1303,7 +1303,7 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
         output: { result: ANSWER_OK, resultDetails: { '9lettres': true, '6lettres': true } },
         answer: { '9lettres': 'Courgette&**', '6lettres': 'TOMATO&&' },
         solution: { '9lettres': ['Courgette&**'], '6lettres': ['tomate', 'chicon', 'legume'] },
-        enabledTreatments: ['t1', 't2', 't3'],
+        enabledTolerances: ['t1', 't2', 't3'],
         qrocBlocksTypes: { '9lettres': 'select', '6lettres': 'text' },
       },
     ].forEach(function (testCase) {
@@ -1319,7 +1319,7 @@ describe('Unit | Devcomp | Domain | Service | SolutionServiceQROCM-ind ', functi
         function () {
           const solution = {
             value: testCase.solution,
-            enabledTreatments: testCase.enabledTreatments,
+            enabledTolerances: testCase.enabledTolerances,
             qrocBlocksTypes: testCase.qrocBlocksTypes,
           };
           expect(service.match({ answerValue: testCase.answer, solution })).to.deep.equal(testCase.output);

--- a/api/tests/devcomp/unit/domain/services/validation-tolerances_test.js
+++ b/api/tests/devcomp/unit/domain/services/validation-tolerances_test.js
@@ -1,12 +1,12 @@
 import {
-  applyPreTreatments,
-  applyTreatments,
+  applyPreTreatmentForTolerance,
+  applyTolerances,
   normalizeAndRemoveAccents,
   removeSpecialCharacters,
-} from '../../../../../src/devcomp/domain/services/validation-treatments.js';
+} from '../../../../../src/devcomp/domain/services/validation-tolerances.js';
 import { expect } from '../../../../test-helper.js';
 
-describe('Unit | Devcomp | Domain | Services | Validation Treatments', function () {
+describe('Unit | Devcomp | Domain | Services | Validation Tolerances', function () {
   describe('#normalizeAndRemoveAccents', function () {
     // Rule disabled to allow dynamic generated tests. See https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md#disallow-setup-in-describe-blocks-mochano-setup-in-describe
     // eslint-disable-next-line mocha/no-setup-in-describe
@@ -57,14 +57,14 @@ describe('Unit | Devcomp | Domain | Services | Validation Treatments', function 
     });
   });
 
-  describe('#applyPreTreatments', function () {
+  describe('#applyPreTreatmentForTolerance', function () {
     it('should return a copy of the given string with utf8 nfc normaliztion. \u0065\u0301 -> \u00e9', function () {
       // given
       const unnormalizedStr = '\u0065\u0301';
       const normalizedStr = '\u00e9';
 
       // when
-      const actual = applyPreTreatments(unnormalizedStr);
+      const actual = applyPreTreatmentForTolerance(unnormalizedStr);
 
       // then
       expect(actual).to.equal(normalizedStr);
@@ -76,34 +76,34 @@ describe('Unit | Devcomp | Domain | Services | Validation Treatments', function 
       const sameStringWithNormalSpaces = ' Shi Foo-Bar ';
 
       // when
-      const actual = applyPreTreatments(stringWithUnbreakableSpaces);
+      const actual = applyPreTreatmentForTolerance(stringWithUnbreakableSpaces);
 
       // then
       expect(actual).to.equal(sameStringWithNormalSpaces);
     });
   });
 
-  describe('#applyTreatments with enabled Treatments', function () {
+  describe('#applyTolerances with enabled Tolerances', function () {
     const input = ' Shi Foo-Bar ';
 
-    it('should return the given string without applying any treatment when the enabled treatments array is not defined', function () {
-      expect(applyTreatments(input)).to.equal(input);
+    it('should return the given string without applying any tolerance when the enabled tolerances array is not defined', function () {
+      expect(applyTolerances(input)).to.equal(input);
     });
 
-    it('should return the given string without applying any treatment when the enabled treatments array is empty', function () {
-      expect(applyTreatments(input, [])).to.equal(input);
+    it('should return the given string without applying any tolerance when the enabled tolerances array is empty', function () {
+      expect(applyTolerances(input, [])).to.equal(input);
     });
 
-    it('should return the given string without applying any treatment when the enabled treatments array does not contain "t1" nor "t2"', function () {
-      expect(applyTreatments(input, ['t1000'])).to.equal(input);
+    it('should return the given string without applying any tolerance when the enabled tolerances array does not contain "t1" nor "t2"', function () {
+      expect(applyTolerances(input, ['t1000'])).to.equal(input);
     });
 
-    it('should return a string with "t1" applied if it is set as enabled treatment', function () {
-      expect(applyTreatments(input, ['t1'])).to.equal('shifoo-bar');
+    it('should return a string with "t1" applied if it is set as enabled tolerance', function () {
+      expect(applyTolerances(input, ['t1'])).to.equal('shifoo-bar');
     });
 
-    it('should return a string with "t2" applied if it is set as enabled treatment', function () {
-      expect(applyTreatments(input, ['t2'])).to.equal(' Shi FooBar ');
+    it('should return a string with "t2" applied if it is set as enabled tolerance', function () {
+      expect(applyTolerances(input, ['t2'])).to.equal(' Shi FooBar ');
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Jusqu'ici, le langage de notre BC parle de `tolerance` mais le code récupéré dans _./lib_ pour valider les QROCM parle de `treatment`.

## :robot: Proposition
Nous avons donc remplacé les notions de `treatment` par `tolerance`.

## :rainbow: Remarques
Nous avons choisi de renommer la méthode `applyPreTreatments` en `applyPreTreatmentForTolerance` car il s'agit du pré-traitement d'une valeur pour pouvoir la gérer avec les tolérances.

Il y a ce [PR](https://github.com/1024pix/pix/pull/5231#issue-1450153541) qui parle les differences entre les T1/ T2 et T3 comme traitement / tolerances. A rediscuter pour voir si le nommage de `treatment` est toujours le mieux.

## :100: Pour tester
La CI passe.
