### PR TITLE
[FEATURE] expose l'état du dernier import d'un organization (PIX-11256)

### DIFF
--- a/api/src/prescription/learner-management/application/organization-import-controller.js
+++ b/api/src/prescription/learner-management/application/organization-import-controller.js
@@ -1,0 +1,15 @@
+import { usecases } from '../domain/usecases/index.js';
+import * as organizationImportSerializer from '../infrastructure/serializers/jsonapi/organization-import-serializer.js';
+
+const getOrganizationImportStatus = async function (request, h, dependencies = { organizationImportSerializer }) {
+  const organizationId = request.params.id;
+  const organizationImport = await usecases.getOrganizationImportStatus({
+    organizationId,
+  });
+
+  return h.response(dependencies.organizationImportSerializer.serialize(organizationImport)).code(200);
+};
+
+const organizationImportController = { getOrganizationImportStatus };
+
+export { organizationImportController };

--- a/api/src/prescription/learner-management/application/organization-import-route.js
+++ b/api/src/prescription/learner-management/application/organization-import-route.js
@@ -1,0 +1,41 @@
+import Joi from 'joi';
+
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
+import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { organizationImportController } from './organization-import-controller.js';
+
+const register = async (server) => {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/organizations/{id}/import-information',
+      config: {
+        pre: [
+          {
+            method: async (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkUserIsAdminInSCOOrganizationManagingStudents,
+                securityPreHandlers.checkUserIsAdminInSUPOrganizationManagingStudents,
+              ])(request, h),
+            assign: 'isAdminInOrganizationManagingStudents',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.organizationId,
+          }),
+        },
+        handler: organizationImportController.getOrganizationImportStatus,
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés et responsables d'une organisation avec import**\n" +
+            "- Elle permet de récupérer l'état du dernier réalisé pour l'organization",
+        ],
+        tags: ['api', 'organization-imports'],
+      },
+    },
+  ]);
+};
+
+const name = 'organization-import-api';
+
+export { name, register };

--- a/api/src/prescription/learner-management/domain/usecases/get-organization-import-status.js
+++ b/api/src/prescription/learner-management/domain/usecases/get-organization-import-status.js
@@ -1,5 +1,5 @@
 const getOrganizationImportStatus = async function ({ organizationId, organizationImportRepository }) {
-  return organizationImportRepository.getByOrganizationId(organizationId);
+  return organizationImportRepository.getLastByOrganizationId(organizationId);
 };
 
 export { getOrganizationImportStatus };

--- a/api/src/prescription/learner-management/domain/usecases/get-organization-import-status.js
+++ b/api/src/prescription/learner-management/domain/usecases/get-organization-import-status.js
@@ -1,0 +1,5 @@
+const getOrganizationImportStatus = async function ({ organizationId, organizationImportRepository }) {
+  return organizationImportRepository.getByOrganizationId(organizationId);
+};
+
+export { getOrganizationImportStatus };

--- a/api/src/prescription/learner-management/domain/usecases/import-organization-learners-from-siecle-csv-format.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-organization-learners-from-siecle-csv-format.js
@@ -48,7 +48,7 @@ const importOrganizationLearnersFromSIECLECSVFormat = async function ({
   }
 
   try {
-    organizationImport = await organizationImportRepository.getByOrganizationId(organizationId);
+    organizationImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
 
     const readableStream = await importStorage.readFile({ filename });
     const buffer = await getDataBuffer(readableStream);
@@ -69,7 +69,7 @@ const importOrganizationLearnersFromSIECLECSVFormat = async function ({
 
   return DomainTransaction.execute(async (domainTransaction) => {
     try {
-      organizationImport = await organizationImportRepository.getByOrganizationId(organizationId);
+      organizationImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
 
       const organizationLearnersChunks = chunk(organizationLearnerData, ORGANIZATION_LEARNER_CHUNK_SIZE);
       const nationalStudentIdData = organizationLearnerData.map((learner) => learner.nationalStudentId, []);

--- a/api/src/prescription/learner-management/domain/usecases/import-organization-learners-from-siecle-xml-format.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-organization-learners-from-siecle-xml-format.js
@@ -75,7 +75,7 @@ const importOrganizationLearnersFromSIECLEXMLFormat = async function ({
     errors.push(error);
     throw error;
   } finally {
-    organizationImport = await organizationImportRepository.getByOrganizationId(organizationId);
+    organizationImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
     organizationImport.validate({ errors });
     await organizationImportRepository.save(organizationImport);
     await importStorage.deleteFile({ filename });
@@ -104,7 +104,7 @@ const importOrganizationLearnersFromSIECLEXMLFormat = async function ({
       errors.push(error);
       throw error;
     } finally {
-      organizationImport = await organizationImportRepository.getByOrganizationId(organizationId);
+      organizationImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
       organizationImport.process({ errors });
       await organizationImportRepository.save(organizationImport);
     }

--- a/api/src/prescription/learner-management/domain/usecases/import-sup-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-sup-organization-learners.js
@@ -50,7 +50,7 @@ const importSupOrganizationLearners = async function ({
     errors.push(error);
     throw error;
   } finally {
-    organizationImport = await organizationImportRepository.getByOrganizationId(organizationId);
+    organizationImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
     organizationImport.validate({ errors, warnings: warningsData });
     await organizationImportRepository.save(organizationImport);
     await importStorage.deleteFile({ filename });
@@ -65,7 +65,7 @@ const importSupOrganizationLearners = async function ({
     errors.push(error);
     throw error;
   } finally {
-    organizationImport = await organizationImportRepository.getByOrganizationId(organizationId);
+    organizationImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
     organizationImport.process({ errors });
     await organizationImportRepository.save(organizationImport);
   }

--- a/api/src/prescription/learner-management/domain/usecases/replace-sup-organization-learner.js
+++ b/api/src/prescription/learner-management/domain/usecases/replace-sup-organization-learner.js
@@ -48,7 +48,7 @@ const replaceSupOrganizationLearners = async function ({
     errors.push(error);
     throw error;
   } finally {
-    organizationImport = await organizationImportRepository.getByOrganizationId(organizationId);
+    organizationImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
     organizationImport.validate({ errors, warnings: warningsData });
     await organizationImportRepository.save(organizationImport);
     await importStorage.deleteFile({ filename });
@@ -63,7 +63,7 @@ const replaceSupOrganizationLearners = async function ({
     errors.push(error);
     throw error;
   } finally {
-    organizationImport = await organizationImportRepository.getByOrganizationId(organizationId);
+    organizationImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
     organizationImport.process({ errors });
     await organizationImportRepository.save(organizationImport);
   }

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-import-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-import-repository.js
@@ -5,7 +5,7 @@ function _toDomain(data) {
   return new OrganizationImport(data);
 }
 
-const getByOrganizationId = async function (organizationId) {
+const getLastByOrganizationId = async function (organizationId) {
   const result = await knex('organization-imports').where({ organizationId }).orderBy('createdAt', 'desc').first();
 
   if (!result) return null;
@@ -40,4 +40,4 @@ const save = async function (organizationImport) {
   }
 };
 
-export { get, getByOrganizationId, save };
+export { get, getLastByOrganizationId, save };

--- a/api/src/prescription/learner-management/infrastructure/serializers/jsonapi/organization-import-serializer.js
+++ b/api/src/prescription/learner-management/infrastructure/serializers/jsonapi/organization-import-serializer.js
@@ -1,0 +1,12 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (organizationImport, meta) {
+  return new Serializer('organization-import', {
+    attributes: ['id', 'status', 'errors', 'createdAt', 'createdBy', 'updatedAt'],
+    meta,
+  }).serialize(organizationImport);
+};
+
+export { serialize };

--- a/api/src/prescription/learner-management/routes.js
+++ b/api/src/prescription/learner-management/routes.js
@@ -1,7 +1,13 @@
+import * as organizationImport from './application/organization-import-route.js';
 import * as organizationLearners from './application/organization-learners-route.js';
 import * as scoOrganizationManangement from './application/sco-organization-management-route.js';
 import * as supOrganizationManangement from './application/sup-organization-management-route.js';
 
-const learnerManagementRoutes = [supOrganizationManangement, scoOrganizationManangement, organizationLearners];
+const learnerManagementRoutes = [
+  supOrganizationManangement,
+  scoOrganizationManangement,
+  organizationLearners,
+  organizationImport,
+];
 
 export { learnerManagementRoutes };

--- a/api/tests/prescription/learner-management/acceptance/application/organization-import-route_test.js
+++ b/api/tests/prescription/learner-management/acceptance/application/organization-import-route_test.js
@@ -1,0 +1,89 @@
+import { Membership } from '../../../../../lib/domain/models/Membership.js';
+import { CsvImportError } from '../../../../../src/shared/domain/errors.js';
+import {
+  createServer,
+  databaseBuilder,
+  expect,
+  generateValidRequestAuthorizationHeader,
+} from '../../../../test-helper.js';
+
+describe('Acceptance | Application | organization-import', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('GET /organizations/{id}/import-information', function () {
+    let options, connectedUser;
+
+    beforeEach(async function () {
+      connectedUser = databaseBuilder.factory.buildUser();
+      await databaseBuilder.commit();
+    });
+
+    it('should return the last organization import status for a sup organization with an error', async function () {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization({ type: 'SUP', isManagingStudents: true });
+
+      databaseBuilder.factory.buildMembership({
+        organizationId: organization.id,
+        userId: connectedUser.id,
+        organizationRole: Membership.roles.ADMIN,
+      });
+
+      databaseBuilder.factory.buildOrganizationImport({
+        organizationId: organization.id,
+        createdBy: connectedUser.id,
+        // we destructure error to mimic getOwnPropertyNames / reducde
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#description
+        errors: JSON.stringify([{ ...new CsvImportError('header_error', { line: 3 }) }]),
+      });
+      await databaseBuilder.commit();
+
+      options = {
+        method: 'GET',
+        url: `/api/organizations/${organization.id}/import-information`,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(connectedUser.id),
+        },
+      };
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+    it('should return the last organization import status for a sco organization with no error', async function () {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
+
+      databaseBuilder.factory.buildMembership({
+        organizationId: organization.id,
+        userId: connectedUser.id,
+        organizationRole: Membership.roles.ADMIN,
+      });
+
+      databaseBuilder.factory.buildOrganizationImport({
+        organizationId: organization.id,
+        createdBy: connectedUser.id,
+        errors: JSON.stringify([]),
+      });
+
+      await databaseBuilder.commit();
+
+      options = {
+        method: 'GET',
+        url: `/api/organizations/${organization.id}/import-information`,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(connectedUser.id),
+        },
+      };
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+});

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-import-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-import-repository_test.js
@@ -15,7 +15,7 @@ describe('Integration | Repository | Organization Learner Management | Organizat
 
       await organizationImportRepository.save(organizationImport);
 
-      const savedImport = await organizationImportRepository.getByOrganizationId(organizationId);
+      const savedImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
       expect(savedImport.createdBy).to.equal(userId);
     });
 
@@ -33,7 +33,7 @@ describe('Integration | Repository | Organization Learner Management | Organizat
 
       await organizationImportRepository.save(organizationImport);
 
-      const savedImport = await organizationImportRepository.getByOrganizationId(organizationId);
+      const savedImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
       expect(savedImport.errors[0].message).to.equal('Something went wrong');
     });
 
@@ -41,12 +41,12 @@ describe('Integration | Repository | Organization Learner Management | Organizat
       const organizationId = databaseBuilder.factory.buildOrganizationImport().organizationId;
       await databaseBuilder.commit();
 
-      const organizationImport = await organizationImportRepository.getByOrganizationId(organizationId);
+      const organizationImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
       organizationImport.process({ errors: undefined });
 
       await organizationImportRepository.save(organizationImport);
 
-      const savedImport = await organizationImportRepository.getByOrganizationId(organizationId);
+      const savedImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
       expect(savedImport.status).to.equal(IMPORT_STATUSES.IMPORTED);
     });
 
@@ -85,7 +85,7 @@ describe('Integration | Repository | Organization Learner Management | Organizat
       const expectedResult = databaseBuilder.factory.buildOrganizationImport();
       await databaseBuilder.commit();
 
-      const result = await organizationImportRepository.getByOrganizationId(expectedResult.organizationId);
+      const result = await organizationImportRepository.getLastByOrganizationId(expectedResult.organizationId);
 
       expect(result).to.be.deep.equal({ ...expectedResult, errors: null });
     });
@@ -99,13 +99,13 @@ describe('Integration | Repository | Organization Learner Management | Organizat
       });
       await databaseBuilder.commit();
 
-      const result = await organizationImportRepository.getByOrganizationId(expectedResult.organizationId);
+      const result = await organizationImportRepository.getLastByOrganizationId(expectedResult.organizationId);
 
       expect(result).to.be.deep.equal({ ...expectedResult, errors: null });
     });
 
     it('should return null if nothing was found', async function () {
-      const result = await organizationImportRepository.getByOrganizationId(1);
+      const result = await organizationImportRepository.getLastByOrganizationId(1);
 
       expect(result).to.equal(null);
     });

--- a/api/tests/prescription/learner-management/unit/application/organization-import-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/organization-import-controller_test.js
@@ -1,0 +1,28 @@
+import { organizationImportController } from '../../../../../src/prescription/learner-management/application/organization-import-controller.js';
+import { usecases } from '../../../../../src/prescription/learner-management/domain/usecases/index.js';
+import { expect, hFake, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Application | Learner Management | organization-import-controller', function () {
+  let dependencies, serializeStub, usecaseResultSymbol;
+  const organizationId = 123;
+  const request = {
+    params: { id: organizationId },
+  };
+
+  beforeEach(function () {
+    sinon.stub(usecases, 'getOrganizationImportStatus');
+    usecaseResultSymbol = Symbol();
+    usecases.getOrganizationImportStatus.resolves(usecaseResultSymbol);
+    serializeStub = sinon.stub();
+    dependencies = { organizationImportSerializer: { serialize: serializeStub } };
+  });
+
+  it('should get last organization import', async function () {
+    hFake.request = {
+      path: `/api/organizations/${organizationId}/import-information`,
+    };
+    await organizationImportController.getOrganizationImportStatus(request, hFake, dependencies);
+    expect(usecases.getOrganizationImportStatus).to.have.been.calledOnceWithExactly({ organizationId });
+    expect(serializeStub).to.have.been.calledOnceWithExactly(usecaseResultSymbol);
+  });
+});

--- a/api/tests/prescription/learner-management/unit/application/organization-import-route_test.js
+++ b/api/tests/prescription/learner-management/unit/application/organization-import-route_test.js
@@ -1,0 +1,102 @@
+import { organizationImportController } from '../../../../../src/prescription/learner-management/application/organization-import-controller.js';
+import * as moduleUnderTest from '../../../../../src/prescription/learner-management/application/organization-import-route.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
+import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Router | organization-import-router', function () {
+  beforeEach(function () {
+    sinon.stub(securityPreHandlers, 'checkUserIsAdminInSUPOrganizationManagingStudents');
+    sinon.stub(securityPreHandlers, 'checkUserIsAdminInSCOOrganizationManagingStudents');
+  });
+
+  describe('GET /api/organizations/{organizationId}/import-information', function () {
+    it('should throw an error when id is invalid', async function () {
+      // given
+      const method = 'GET';
+      const url = '/api/organizations/wrongId/import-information';
+      const payload = {};
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+    context(
+      'when the user is an admin for the organization and the organization is SUP and manages students',
+      function () {
+        it('responds 200', async function () {
+          // given
+          const method = 'GET';
+          const url = '/api/organizations/1/import-information';
+          const payload = {};
+
+          securityPreHandlers.checkUserIsAdminInSCOOrganizationManagingStudents.callsFake((request, h) =>
+            h.response().code(403).takeover(),
+          );
+          securityPreHandlers.checkUserIsAdminInSUPOrganizationManagingStudents.resolves(true);
+
+          sinon
+            .stub(organizationImportController, 'getOrganizationImportStatus')
+            .callsFake((request, h) => h.response('ok').code(200));
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          // when
+          const response = await httpTestServer.request(method, url, payload);
+
+          // then
+          expect(organizationImportController.getOrganizationImportStatus).to.have.been.calledOnce;
+          expect(response.statusCode).to.equal(200);
+        });
+      },
+    );
+    context(
+      'when the user is an admin for the organization and the organization is SCO and manages students',
+      function () {
+        it('responds 200', async function () {
+          // given
+          const method = 'GET';
+          const url = '/api/organizations/1/import-information';
+          const payload = {};
+
+          securityPreHandlers.checkUserIsAdminInSUPOrganizationManagingStudents.callsFake((request, h) =>
+            h.response().code(403).takeover(),
+          );
+          securityPreHandlers.checkUserIsAdminInSCOOrganizationManagingStudents.resolves(true);
+
+          sinon
+            .stub(organizationImportController, 'getOrganizationImportStatus')
+            .callsFake((request, h) => h.response('ok').code(200));
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          // when
+          const response = await httpTestServer.request(method, url, payload);
+
+          // then
+          expect(organizationImportController.getOrganizationImportStatus).to.have.been.calledOnce;
+          expect(response.statusCode).to.equal(200);
+        });
+      },
+    );
+  });
+  context('when the user is not admin for the SUP organization nor SCO organizations', function () {
+    it('responds 403', async function () {
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf');
+      securityPreHandlers.hasAtLeastOneAccessOf.returns((request, h) => h.response().code(403).takeover());
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const method = 'GET';
+      const url = '/api/organizations/1/import-information';
+
+      const response = await httpTestServer.request(method, url);
+
+      expect(response.statusCode).to.equal(403);
+    });
+  });
+});

--- a/api/tests/prescription/learner-management/unit/domain/usecases/get-organization-import-status_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/get-organization-import-status_test.js
@@ -7,7 +7,7 @@ describe('Unit | UseCase | Organization Learners Management | Get Organization I
   beforeEach(function () {
     resultSymbol = Symbol('result');
     organizationImportRepository = {
-      getByOrganizationId: sinon.stub().resolves(resultSymbol),
+      getLastByOrganizationId: sinon.stub().resolves(resultSymbol),
     };
   });
 
@@ -22,7 +22,7 @@ describe('Unit | UseCase | Organization Learners Management | Get Organization I
     });
 
     // then
-    expect(organizationImportRepository.getByOrganizationId).to.have.been.calledWithExactly(organizationId);
+    expect(organizationImportRepository.getLastByOrganizationId).to.have.been.calledWithExactly(organizationId);
     expect(result).to.eq(resultSymbol);
   });
 });

--- a/api/tests/prescription/learner-management/unit/domain/usecases/get-organization-import-status_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/get-organization-import-status_test.js
@@ -1,0 +1,28 @@
+import { getOrganizationImportStatus } from '../../../../../../src/prescription/learner-management/domain/usecases/get-organization-import-status.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | UseCase | Organization Learners Management | Get Organization Import status', function () {
+  let organizationImportRepository, resultSymbol;
+
+  beforeEach(function () {
+    resultSymbol = Symbol('result');
+    organizationImportRepository = {
+      getByOrganizationId: sinon.stub().resolves(resultSymbol),
+    };
+  });
+
+  it('should return an OrganizationImport ', async function () {
+    // given
+    const organizationId = Symbol('orga_id');
+
+    // when
+    const result = await getOrganizationImportStatus({
+      organizationId,
+      organizationImportRepository,
+    });
+
+    // then
+    expect(organizationImportRepository.getByOrganizationId).to.have.been.calledWithExactly(organizationId);
+    expect(result).to.eq(resultSymbol);
+  });
+});

--- a/api/tests/prescription/learner-management/unit/domain/usecases/import-organization-learners-from-siecle-csv-format_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/import-organization-learners-from-siecle-csv-format_test.js
@@ -45,11 +45,11 @@ describe('Unit | UseCase | import-organization-learners-from-siecle-csv', functi
       disableAllOrganizationLearnersInOrganization: sinon.stub().resolves(),
     };
     organizationImportRepositoryStub = {
-      getByOrganizationId: sinon.stub(),
+      getLastByOrganizationId: sinon.stub(),
       save: sinon.stub(),
     };
 
-    organizationImportRepositoryStub.getByOrganizationId.callsFake(
+    organizationImportRepositoryStub.getLastByOrganizationId.callsFake(
       () => new OrganizationImport({ organizationId, createdBy: 2, encoding: 'utf-8' }),
     );
     organizationRepositoryStub = { get: sinon.stub().resolves({ id: 123 }) };

--- a/api/tests/prescription/learner-management/unit/domain/usecases/import-organization-learners-from-siecle-xml-format_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/import-organization-learners-from-siecle-xml-format_test.js
@@ -33,11 +33,11 @@ describe('Unit | UseCase | import-organization-learners-from-siecle-xml', functi
 
     organizationImportRepositoryStub = {
       get: sinon.stub(),
-      getByOrganizationId: sinon.stub(),
+      getLastByOrganizationId: sinon.stub(),
       save: sinon.stub(),
     };
 
-    organizationImportRepositoryStub.getByOrganizationId.callsFake(() =>
+    organizationImportRepositoryStub.getLastByOrganizationId.callsFake(() =>
       OrganizationImport.create({ organizationId, createdBy: 2 }),
     );
 

--- a/api/tests/prescription/learner-management/unit/domain/usecases/import-sup-organization-learners_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/import-sup-organization-learners_test.js
@@ -29,11 +29,11 @@ describe('Unit | UseCase | ImportSupOrganizationLearner', function () {
     };
 
     organizationImportRepositoryStub = {
-      getByOrganizationId: sinon.stub(),
+      getLastByOrganizationId: sinon.stub(),
       save: sinon.stub(),
     };
 
-    organizationImportRepositoryStub.getByOrganizationId.callsFake(
+    organizationImportRepositoryStub.getLastByOrganizationId.callsFake(
       () => new OrganizationImport({ organizationId, createdBy: 2, encoding: 'utf-8' }),
     );
   });

--- a/api/tests/prescription/learner-management/unit/domain/usecases/replace-sup-organization-learners_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/replace-sup-organization-learners_test.js
@@ -35,7 +35,7 @@ describe('Unit | UseCase | ReplaceSupOrganizationLearner', function () {
     payload = { path: filename };
 
     organizationImportRepositoryStub = {
-      getByOrganizationId: sinon.stub(),
+      getLastByOrganizationId: sinon.stub(),
       save: sinon.stub(),
     };
 
@@ -45,7 +45,7 @@ describe('Unit | UseCase | ReplaceSupOrganizationLearner', function () {
       deleteFile: sinon.stub(),
     };
 
-    organizationImportRepositoryStub.getByOrganizationId.callsFake(
+    organizationImportRepositoryStub.getLastByOrganizationId.callsFake(
       () => new OrganizationImport({ organizationId, createdBy: 2, encoding: 'utf-8' }),
     );
   });

--- a/api/tests/prescription/learner-management/unit/infrastructure/serializers/jsonapi/organization-import-serializer_test.js
+++ b/api/tests/prescription/learner-management/unit/infrastructure/serializers/jsonapi/organization-import-serializer_test.js
@@ -1,0 +1,40 @@
+import { IMPORT_STATUSES } from '../../../../../../../src/prescription/learner-management/domain/constants.js';
+import { OrganizationImport } from '../../../../../../../src/prescription/learner-management/domain/models/OrganizationImport.js';
+import { serialize } from '../../../../../../../src/prescription/learner-management/infrastructure/serializers/jsonapi/organization-import-serializer.js';
+import { CsvImportError } from '../../../../../../../src/shared/domain/errors.js';
+import { expect } from '../../../../../../test-helper.js';
+describe('Unit | Serializer | JSONAPI | organization-import-serializer', function () {
+  describe('#serialize', function () {
+    it('should convert an organizationInport model object into JSON API data', function () {
+      // given
+      const createdAt = new Date();
+      const updatedAt = new Date();
+      const organizationImport = new OrganizationImport({
+        id: 1,
+        status: IMPORT_STATUSES.VALIDATION_ERROR,
+        createdAt,
+        createdBy: 123,
+        encoding: 'utf-8',
+        // use object spread to mimic what is saved in db
+        errors: [{ ...new CsvImportError('header', { line: 3 }) }],
+        filename: 'filename',
+        organizationId: 456,
+        updatedAt,
+      });
+      expect(serialize(organizationImport)).to.eql({
+        data: {
+          id: '1',
+          type: 'organization-imports',
+          attributes: {
+            id: 1,
+            status: IMPORT_STATUSES.VALIDATION_ERROR,
+            'created-at': createdAt,
+            'updated-at': updatedAt,
+            'created-by': 123,
+            errors: [{ code: 'header', name: 'CsvImportError', meta: { line: 3 } }],
+          },
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre du travail sur l'import asynchrone, nous avons besoin de pouvoir récupérer l'état du dernier import pour une organisation afin de pouvoir quitter la page et revenir dessus par la suite.

## :robot: Proposition
On ajoute un endpoint pour récupérer l'etat du dernier import d'une organization

## :rainbow: Remarques
- documentation de la table a review aussi https://1024pix.atlassian.net/wiki/spaces/PROD/pages/4151705601/Data+-+table+organization-imports
J'ai renommé la propriété getByOrganizationId en getLastByOrganizationId pour refléter le comportement de la méthode 

## :100: Pour tester
Des tests au verts

