### PR TITLE
[FEATURE] Créer une nouvelle table oidc-providers (PIX-10030)

### DIFF
--- a/api/db/migrations/20240319110619_create-table-oidc-providers.js
+++ b/api/db/migrations/20240319110619_create-table-oidc-providers.js
@@ -1,0 +1,31 @@
+const TABLE_NAME = 'oidc-providers';
+
+export function up(knex) {
+  return knex.schema.createTable(TABLE_NAME, (table) => {
+    table.increments('id').primary();
+    table.string('accessTokenLifespan').notNullable();
+    table.string('claimsToStore ');
+    table.string('clientId').notNullable();
+    table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    table.jsonb('customProperties');
+    table.boolean('enabled').notNullable().defaultTo(false);
+    table.string('encryptedClientSecret').notNullable();
+    table.jsonb('extraAuthorizationUrlParameters');
+    table.string('identityProvider').notNullable();
+    table.string('idTokenLifespan').notNullable();
+    table.binary('logo');
+    table.jsonb('openidClientExtraMetadata');
+    table.string('openidConfigurationUrl').notNullable();
+    table.string('organizationName').notNullable();
+    table.string('postLogoutRedirectUri');
+    table.string('redirectUri').notNullable();
+    table.string('scope').notNullable();
+    table.string('slug').notNullable();
+    table.string('source').notNullable();
+    table.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
+  });
+}
+
+export function down(knex) {
+  return knex.schema.dropTable(TABLE_NAME);
+}


### PR DESCRIPTION
## :unicorn: Problème

Il y a le besoin d'avoir une nouvelle table SQL pour stocker les configurations de tous les OIDC Providers, de manière : 
* à pouvoir les gérer à la chaine, de manière industrielle
* à assurer la confidentialité des OIDC Providers utilisés par Pix

## :robot: Proposition

Ajouter une table `oidc-providers` dédiée. Cette table reprend quasiment toutes les propriétés utilisées précédemment dans le fichier `config.js` et dans les classes spécifiques héritant de `OidcAuthenticationService`. Les évolutions notables sont : 
* l'ajout de la possibilité de stocker directement un logo pour ne plus avoir à ajouter un fichier séparé dans le code source
* l'utilisation de certaines colonnes en `jsonb` pour pouvoir stocker toutes les informations « extra/custom » qui sont sans schéma par définition

## :rainbow: Remarques

RAS

## :100: Pour tester

- Exécuter la commande `npm run db:migrate` en local
- Vérifier que la table `oidc-providers` a bien été créée
- Exécuter la commande `npm run db:rollback:latest`et vérifier que la table `oidc-providers` n'existe plus
