### PR TITLE
[FEATURE] Rendre l'affichage de certains messages d'erreur plus claire lors de la création en masse d'organisations (PIX-11685)

### DIFF
--- a/api/lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js
+++ b/api/lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js
@@ -1,14 +1,14 @@
 import bluebird from 'bluebird';
 import lodash from 'lodash';
 
+import { PGSQL_FOREIGN_KEY_VIOLATION_ERROR } from '../../../db/pgsql-errors.js';
+import { InvalidInputDataError } from '../../../src/shared/domain/errors.js';
 import * as codeGenerator from '../../../src/shared/domain/services/code-generator.js';
 import { CONCURRENCY_HEAVY_OPERATIONS } from '../../infrastructure/constants.js';
 import { DomainTransaction } from '../../infrastructure/DomainTransaction.js';
 import { monitoringTools } from '../../infrastructure/monitoring-tools.js';
 import { ObjectValidationError, OrganizationTagNotFound, TargetProfileInvalidError } from '../errors.js';
-import { OrganizationForAdmin } from '../models/index.js';
-import { Organization } from '../models/Organization.js';
-import { OrganizationTag } from '../models/OrganizationTag.js';
+import { Organization, OrganizationForAdmin, OrganizationTag } from '../models/index.js';
 
 const SEPARATOR = '_';
 
@@ -44,10 +44,11 @@ const createOrganizationsWithTagsAndTargetProfiles = async function ({
   await domainTransaction.execute(async (domainTransaction) => {
     const transformedOrganizationsData = _transformOrganizationsCsvData(organizations);
 
-    createdOrganizations = await organizationRepository.batchCreateOrganizations(
-      transformedOrganizationsData,
+    createdOrganizations = await _createOrganizations({
       domainTransaction,
-    );
+      organizationRepository,
+      transformedOrganizationsData,
+    });
 
     await _addDataProtectionOfficers({
       createdOrganizations,
@@ -83,6 +84,25 @@ const createOrganizationsWithTagsAndTargetProfiles = async function ({
 
 export { createOrganizationsWithTagsAndTargetProfiles };
 
+async function _createOrganizations({ transformedOrganizationsData, domainTransaction, organizationRepository }) {
+  try {
+    const createdOrganizations = await organizationRepository.batchCreateOrganizations(
+      transformedOrganizationsData,
+      domainTransaction,
+    );
+    return createdOrganizations;
+  } catch (error) {
+    _monitorError(error.message, { error, event: 'create-organizations' });
+
+    if (error.code === PGSQL_FOREIGN_KEY_VIOLATION_ERROR) {
+      const createdByUserId = error.detail.match(/\d+/g);
+      throw new InvalidInputDataError({ message: `User with ID "${createdByUserId}" does not exist` });
+    }
+
+    throw error;
+  }
+}
+
 function _transformOrganizationsCsvData(organizationsCsvData) {
   const organizations = organizationsCsvData.map((organizationCsvData) => {
     const email =
@@ -106,6 +126,7 @@ function _transformOrganizationsCsvData(organizationsCsvData) {
       locale: organizationCsvData.locale,
     };
   });
+
   return organizations;
 }
 
@@ -129,6 +150,7 @@ async function _updateSchoolsWithCodes({ createdOrganizations, domainTransaction
     );
   } catch (error) {
     _monitorError(error.message, { error, event: 'add-school-organizations-codes' });
+
     throw error;
   }
 }
@@ -158,6 +180,7 @@ async function _addDataProtectionOfficers({
     );
   } catch (error) {
     _monitorError(error.message, { error, event: 'add-organizations-data-protection-officers' });
+
     throw error;
   }
 }
@@ -181,6 +204,7 @@ async function _addTags({ allTags, createdOrganizations, domainTransaction, orga
     await organizationTagRepository.batchCreate(organizationsTags, domainTransaction);
   } catch (error) {
     _monitorError(error.message, { error, event: 'add-organizations-tags' });
+
     throw error;
   }
 }
@@ -243,6 +267,7 @@ async function _sendInvitationEmails({
     );
   } catch (error) {
     _monitorError(error.message, { error, event: 'send-organizations-invitation-emails' });
+
     throw error;
   }
 }

--- a/api/lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js
+++ b/api/lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js
@@ -7,7 +7,7 @@ import * as codeGenerator from '../../../src/shared/domain/services/code-generat
 import { CONCURRENCY_HEAVY_OPERATIONS } from '../../infrastructure/constants.js';
 import { DomainTransaction } from '../../infrastructure/DomainTransaction.js';
 import { monitoringTools } from '../../infrastructure/monitoring-tools.js';
-import { ObjectValidationError, OrganizationTagNotFound, TargetProfileInvalidError } from '../errors.js';
+import { DomainError, ObjectValidationError, OrganizationTagNotFound, TargetProfileInvalidError } from '../errors.js';
 import { Organization, OrganizationForAdmin, OrganizationTag } from '../models/index.js';
 
 const SEPARATOR = '_';
@@ -99,7 +99,11 @@ async function _createOrganizations({ transformedOrganizationsData, domainTransa
       throw new InvalidInputDataError({ message: `User with ID "${createdByUserId}" does not exist` });
     }
 
-    throw error;
+    if (error instanceof DomainError) {
+      throw error;
+    }
+
+    throw new DomainError(error.message);
   }
 }
 
@@ -151,7 +155,11 @@ async function _updateSchoolsWithCodes({ createdOrganizations, domainTransaction
   } catch (error) {
     _monitorError(error.message, { error, event: 'add-school-organizations-codes' });
 
-    throw error;
+    if (error instanceof DomainError) {
+      throw error;
+    }
+
+    throw new DomainError(error.message);
   }
 }
 
@@ -181,7 +189,11 @@ async function _addDataProtectionOfficers({
   } catch (error) {
     _monitorError(error.message, { error, event: 'add-organizations-data-protection-officers' });
 
-    throw error;
+    if (error instanceof DomainError) {
+      throw error;
+    }
+
+    throw new DomainError(error.message);
   }
 }
 
@@ -205,7 +217,11 @@ async function _addTags({ allTags, createdOrganizations, domainTransaction, orga
   } catch (error) {
     _monitorError(error.message, { error, event: 'add-organizations-tags' });
 
-    throw error;
+    if (error instanceof DomainError) {
+      throw error;
+    }
+
+    throw new DomainError(error.message);
   }
 }
 
@@ -232,7 +248,11 @@ async function _addTargetProfiles({ createdOrganizations, domainTransaction, tar
       throw new TargetProfileInvalidError(`Le profil cible ${targetProfileId} n'existe pas.`);
     }
 
-    throw error;
+    if (error instanceof DomainError) {
+      throw error;
+    }
+
+    throw new DomainError(error.message);
   }
 }
 
@@ -268,7 +288,11 @@ async function _sendInvitationEmails({
   } catch (error) {
     _monitorError(error.message, { error, event: 'send-organizations-invitation-emails' });
 
-    throw error;
+    if (error instanceof DomainError) {
+      throw error;
+    }
+
+    throw new DomainError(error.message);
   }
 }
 

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -146,6 +146,10 @@ function _mapToHttpError(error) {
     return new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta);
   }
 
+  if (error instanceof DomainErrors.InvalidInputDataError) {
+    return new HttpErrors.PreconditionFailedError(error.message, error.code, error.meta);
+  }
+
   return new HttpErrors.BaseHttpError(error.message);
 }
 

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -86,6 +86,15 @@ class ForbiddenAccess extends DomainError {
   }
 }
 
+class InvalidInputDataError extends DomainError {
+  constructor({ code = 'INVALID_INPUT_DATA', message = 'Provided input data is invalid', meta } = {}) {
+    super(message);
+
+    this.code = code;
+    if (meta) this.meta = meta;
+  }
+}
+
 class InvalidExternalUserTokenError extends DomainError {
   constructor(message = 'L’idToken de l’utilisateur externe est invalide.') {
     super(message);
@@ -197,6 +206,7 @@ export {
   EntityValidationError,
   ForbiddenAccess,
   InvalidExternalUserTokenError,
+  InvalidInputDataError,
   InvalidResultRecipientTokenError,
   InvalidSessionResultTokenError,
   InvalidTemporaryKeyError,

--- a/api/tests/shared/unit/application/error-manager_test.js
+++ b/api/tests/shared/unit/application/error-manager_test.js
@@ -10,6 +10,7 @@ import { HttpErrors, UnauthorizedError } from '../../../../src/shared/applicatio
 import {
   CertificationAttestationGenerationError,
   EntityValidationError,
+  InvalidInputDataError,
   LocaleFormatError,
   LocaleNotSupportedError,
   NoCertificationAttestationForDivisionError,
@@ -303,6 +304,25 @@ describe('Shared | Unit | Application | ErrorManager', function () {
 
       // then
       expect(HttpErrors.UnprocessableEntityError).to.have.been.calledWithExactly(error.message, error.code);
+    });
+
+    context('when handling InvalidInputDataError', function () {
+      it('maps to PreconditionFailedError', async function () {
+        // given
+        const error = new InvalidInputDataError();
+        sinon.stub(HttpErrors, 'PreconditionFailedError');
+        const params = { request: {}, h: hFake, error };
+
+        // when
+        await handle(params.request, params.h, params.error);
+
+        // then
+        expect(HttpErrors.PreconditionFailedError).to.have.been.calledWithExactly(
+          error.message,
+          error.code,
+          error.meta,
+        );
+      });
     });
   });
 });

--- a/api/tests/shared/unit/domain/errors_test.js
+++ b/api/tests/shared/unit/domain/errors_test.js
@@ -37,4 +37,20 @@ describe('Unit | Shared | Domain | Errors', function () {
       });
     });
   });
+
+  describe('#InvalidInputDataError', function () {
+    it('exports InvalidInputDataError', function () {
+      // then
+      expect(errors.InvalidInputDataError).to.exist;
+    });
+
+    it('has default error message and code', function () {
+      // when
+      const error = new errors.InvalidInputDataError();
+
+      // then
+      expect(error.message).to.equal('Provided input data is invalid');
+      expect(error.code).to.equal('INVALID_INPUT_DATA');
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème

Lorsqu’une erreur n’est pas transformée en erreur du domaine, le contenu de la réponse qui sera émise n’est pas au format JSON Api ce qui entraine l’affichage d’une notification avec le message suivant : **[object Object]**.

## :robot: Proposition

Transformer les erreurs non gérées en erreur du domaine pour permettre un meilleur affichage du message au niveau de l’application front.

## :rainbow: Remarques

RAS

## :100: Pour tester

1. Se connecter sur **Pix Admin** (https://admin-pr8451.review.pix.fr/) avec un compte ayant le rôle **SUPER_ADMIN**
2. Cliquer sur l'onglet **Administration** (avant dernier élément du menu)
3. Cliquer sur le bouton **Importer un fichier CSV** du bloc **Création en masse d'organisations**
4. Importer un CSV contenant une organisation ayant le même identifiant externe (externalId) qu'une organisation existante en base de données. _Ne pas oublier d'ajouter l'id du compte sur lequel vous êtes connecté en tant que créateur de l'organisation (colonne createdBy)_.
5. Constater l'affichage d'une notification d'erreur bien formatée

Voici un fichier CSV pour vos tests. L'identifiant **990000** n'existe pas, et donc doit générer une erreur.

```
type,externalId,name,provinceCode,credit,emailInvitations,emailForSCOActivation,organizationInvitationRole,locale,tags,createdBy,documentationUrl,targetProfiles,isManagingStudents,identityProviderForCampaigns,DPOFirstName,DPOLastName,DPOEmail
PRO,EXT_ID_DUP,PRO Orga 1,,,,,ADMIN,fr-fr,PUBLIC,990000,,,,,,,
PRO,EXT_ID_DUP,PRO Orga 2,,,,,ADMIN,fr-fr,PUBLIC,90000,,,,,,,
SCO,EXT_ID_DUP,SCO Orga 1,,,,,ADMIN,fr-fr,PUBLIC,90000,,,,,,,
SCO-1D,EXT_ID_DUP,SCO-1D Orga 1,,,,,ADMIN,fr-fr,PUBLIC,90000,,,,,,,
SCO-1D,EXT_ID_DUP,SCO-1D Orga 2,,,,,ADMIN,fr-fr,PUBLIC,90000,,,,,,,
```
