### PR TITLE
[FEATURE] Utiliser les composants Pix UI dans la modale d'ajout de candidat à une session sur Pix Certif (PIX-11588).

### DIFF
--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -52,27 +52,22 @@
             {{t "common.labels.candidate.gender.title"}}
           </legend>
           <div class="radio-button-container">
-            <input
-              type="radio"
-              id="female"
-              value="F"
+            <PixRadioButton
+              @value="F"
               name="sex"
               required
-              {{on "click" (fn @updateCandidateData @candidateData "sex")}}
-            />
-            <label class="radio-button-label" for="female">
+              {{on "change" (fn @updateCandidateData @candidateData "sex")}}
+            >
               {{t "common.labels.candidate.gender.woman"}}
-            </label>
-            <input
-              type="radio"
-              id="male"
-              value="M"
+            </PixRadioButton>
+            <PixRadioButton
+              @value="M"
               name="sex"
-              {{on "click" (fn @updateCandidateData @candidateData "sex")}}
-            />
-            <label class="radio-button-label" for="male">
+              required
+              {{on "change" (fn @updateCandidateData @candidateData "sex")}}
+            >
               {{t "common.labels.candidate.gender.man"}}
-            </label>
+            </PixRadioButton>
           </div>
         </fieldset>
       </div>
@@ -122,28 +117,23 @@
               {{t "common.labels.candidate.birth-geographical-code"}}
             </legend>
             <div class="radio-button-container">
-              <input
-                type="radio"
-                id="insee-code-choice"
+              <PixRadioButton
                 name="birth-geo-code-option"
-                value="insee"
+                @value="insee"
                 checked="checked"
-                {{on "click" (fn this.selectBirthGeoCodeOption "insee")}}
+                {{on "change" (fn this.selectBirthGeoCodeOption "insee")}}
                 required
-              />
-              <label class="radio-button-label" for="insee-code-choice">
+              >
                 {{t "common.labels.candidate.insee-code"}}
-              </label>
-              <input
-                type="radio"
-                id="postal-code-choice"
+              </PixRadioButton>
+              <PixRadioButton
                 name="birth-geo-code-option"
-                value="postal"
-                {{on "click" (fn this.selectBirthGeoCodeOption "postal")}}
-              />
-              <label class="radio-button-label" for="postal-code-choice">
+                @value="postal"
+                {{on "change" (fn this.selectBirthGeoCodeOption "postal")}}
+                required
+              >
                 {{t "common.labels.candidate.postcode"}}
-              </label>
+              </PixRadioButton>
             </div>
           </fieldset>
         </div>
@@ -315,34 +305,22 @@
 
       {{#if this.complementaryCertificationsHabilitations.length}}
         <div class="new-certification-candidate-modal__form__field">
-          <span class="label">
-            {{t "common.forms.certification-labels.additional-certification"}}
-          </span>
-          <div class="complementary-certifications-checkbox-list">
-            <fieldset id="complementary-certifications">
-              <label for="no-complementaryCertification">
-                <input
-                  type="radio"
-                  name="complementary-certifications"
-                  id={{concat "no-complementaryCertification"}}
-                  checked="checked"
-                  {{on "input" this.updateComplementaryCertification}}
-                />
-                {{t "common.labels.candidate.none"}}
-              </label>
-              {{#each this.complementaryCertificationsHabilitations as |complementaryCertificationHabilitation index|}}
-                <label for={{concat "complementaryCertification_" index}}>
-                  <input
-                    type="radio"
-                    name="complementary-certifications"
-                    id={{concat "complementaryCertification_" index}}
-                    {{on "input" (fn this.updateComplementaryCertification complementaryCertificationHabilitation)}}
-                  />
-                  {{complementaryCertificationHabilitation.label}}
-                </label>
-              {{/each}}
-            </fieldset>
-          </div>
+          <fieldset id="complementary-certifications">
+            <legend class="label">
+              {{t "common.forms.certification-labels.additional-certification"}}
+            </legend>
+            <PixRadioButton name="complementary-certifications" {{on "change" this.updateComplementaryCertification}}>
+              {{t "common.labels.candidate.none"}}
+            </PixRadioButton>
+            {{#each this.complementaryCertificationsHabilitations as |complementaryCertificationHabilitation|}}
+              <PixRadioButton
+                name="complementary-certifications"
+                {{on "change" (fn this.updateComplementaryCertification complementaryCertificationHabilitation)}}
+              >
+                {{complementaryCertificationHabilitation.label}}
+              </PixRadioButton>
+            {{/each}}
+          </fieldset>
         </div>
       {{/if}}
     </form>

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -11,41 +11,32 @@
       {{on "submit" this.onFormSubmit}}
     >
 
-      <p class="new-certification-candidate-modal__form__required-fields-mention">
+      <p class="new-certification-candidate-modal-form__required-fields-mention">
         {{t "common.forms.mandatory-fields" htmlSafe=true}}
       </p>
 
-      <div class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double">
-        <label for="last-name" class="label">
-          <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
-          {{t "common.labels.candidate.birth-name"}}
-        </label>
-        <Input
-          id="last-name"
-          @type="text"
-          class="input"
-          @value={{@candidateData.lastName}}
+      <div class="new-certification-candidate-modal-form__field">
+        <PixInput
+          @id="last-name"
+          @label={{t "common.labels.candidate.birth-name"}}
           {{on "input" (fn @updateCandidateData @candidateData "lastName")}}
           required
+          aria-required={{true}}
+          autocomplete="off"
+          @requiredLabel={{t "common.forms.required"}}
         />
-      </div>
-
-      <div class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double">
-        <label for="first-name" class="label">
-          <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
-          {{t "common.labels.candidate.firstname"}}
-        </label>
-        <Input
-          id="first-name"
-          @type="text"
-          class="input"
-          @value={{@candidateData.firstName}}
+        <PixInput
+          @id="first-name"
+          @label={{t "common.labels.candidate.firstname"}}
           {{on "input" (fn @updateCandidateData @candidateData "firstName")}}
           required
+          aria-required={{true}}
+          autocomplete="off"
+          @requiredLabel={{t "common.forms.required"}}
         />
       </div>
 
-      <div class="new-certification-candidate-modal__form__field">
+      <div class="new-certification-candidate-modal-form__field">
         <fieldset>
           <legend class="label">
             <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
@@ -72,13 +63,11 @@
         </fieldset>
       </div>
 
-      <div class="new-certification-candidate-modal__form__field">
-        <label for="birthdate" class="label">
-          <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
-          {{t "common.labels.candidate.birth-date"}}
-        </label>
-        <Input
-          id="birthdate"
+      <div class="new-certification-candidate-modal-form__field">
+        <PixInput
+          @id="birth-name"
+          @label={{t "common.labels.candidate.birth-date"}}
+          placeholder={{t "common.labels.candidate.birth-date-example"}}
           class="ember-text-field ember-view input"
           {{on "change" this.updateBirthdate}}
           {{inputmask
@@ -88,29 +77,28 @@
             placeholder="_"
             registerAPI=this.saveApi
           }}
-          placeholder={{t "common.labels.candidate.birth-date-example"}}
           required
+          aria-required={{true}}
+          autocomplete="off"
+          @requiredLabel={{t "common.forms.required"}}
         />
       </div>
 
-      <div class="new-certification-candidate-modal__form__field">
-        <label for="birth-country" class="label">
-          <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
-          {{t "common.labels.candidate.birth-country"}}
-        </label>
+      <div class="new-certification-candidate-modal-form__field">
         <PixSelect
           @id="birth-country"
-          class="birth-country-selector"
           @options={{this.countryOptions}}
           @onChange={{this.selectBirthCountry}}
           @value={{this.selectedCountryInseeCode}}
           @hideDefaultOption={{true}}
+          @requiredText={{t "common.forms.required"}}
+          @label={{t "common.labels.candidate.birth-country"}}
           required
         />
       </div>
 
       {{#if this.isBirthGeoCodeRequired}}
-        <div class="new-certification-candidate-modal__form__field">
+        <div class="new-certification-candidate-modal-form__field">
           <fieldset>
             <legend class="label">
               <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
@@ -140,171 +128,134 @@
       {{/if}}
 
       {{#if this.isBirthInseeCodeRequired}}
-        <div class="new-certification-candidate-modal__form__field">
-          <label for="birth-insee-code" class="label">
-            <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
-            {{t "common.labels.candidate.birth-city-insee-code"}}
-          </label>
-          <Input
-            id="birth-insee-code"
-            @type="text"
-            maxlength="5"
-            class="input"
-            @value={{@candidateData.birthInseeCode}}
-            required
+        <div class="new-certification-candidate-modal-form__field">
+          <PixInput
+            @id="birth-insee-code"
+            @label={{t "common.labels.candidate.birth-city-insee-code"}}
             {{on "input" (fn @updateCandidateData @candidateData "birthInseeCode")}}
+            required
+            aria-required={{true}}
+            autocomplete="off"
+            maxlength="5"
+            @requiredLabel={{t "common.forms.required"}}
           />
         </div>
       {{/if}}
 
       {{#if this.isBirthPostalCodeRequired}}
-        <div
-          class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
-        >
-          <label for="birth-postal-code" class="label">
-            <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
-            {{t "common.labels.candidate.birth-city-postcode"}}
-          </label>
-          <Input
-            id="birth-postal-code"
-            @type="text"
-            maxlength="5"
-            class="input"
-            @value={{@candidateData.birthPostalCode}}
-            required
+        <div class="new-certification-candidate-modal-form__field">
+          <PixInput
+            @id="birth-postal-code"
+            @label={{t "common.labels.candidate.birth-city-postcode"}}
             {{on "input" (fn @updateCandidateData @candidateData "birthPostalCode")}}
+            required
+            aria-required={{true}}
+            autocomplete="off"
+            maxlength="5"
+            @requiredLabel={{t "common.forms.required"}}
           />
         </div>
       {{/if}}
 
       {{#if this.isBirthCityRequired}}
-        <div
-          class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
-        >
-          <label for="birth-city" class="label">
-            <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
-            {{t "common.labels.candidate.birth-city"}}
-          </label>
-          <Input
-            id="birth-city"
-            @type="text"
-            class="input"
-            @value={{@candidateData.birthCity}}
-            required
+        <div class="new-certification-candidate-modal-form__field">
+          <PixInput
+            @id="birth-city"
+            @label={{t "common.labels.candidate.birth-city"}}
             {{on "input" (fn @updateCandidateData @candidateData "birthCity")}}
+            required
+            aria-required={{true}}
+            autocomplete="off"
+            @requiredLabel={{t "common.forms.required"}}
           />
         </div>
       {{/if}}
 
-      <div class="new-certification-candidate-modal__form__field">
-        <label for="external-id" class="label">{{t "common.forms.certification-labels.external-id"}}</label>
-        <Input
-          id="external-id"
-          @type="text"
-          class="input"
-          @value={{@candidateData.externalId}}
+      <div class="new-certification-candidate-modal-form__field">
+        <PixInput
+          @id="external-id"
+          @label={{t "common.forms.certification-labels.external-id"}}
           {{on "input" (fn @updateCandidateData @candidateData "externalId")}}
+          autocomplete="off"
         />
       </div>
 
-      <div class="new-certification-candidate-modal__form__field">
-        <label for="extra-time-percentage" class="label">
-          {{t "common.forms.certification-labels.extratime-percentage"}}
-        </label>
-        <Input
-          id="extra-time-percentage"
-          @type="number"
+      <div class="new-certification-candidate-modal-form__field">
+        <PixInput
+          @id="extra-time-percentage"
+          @label={{t "common.forms.certification-labels.extratime-percentage"}}
           class="input {{if this.validation.email.hasError 'input--error'}}"
-          @value={{@candidateData.extraTimePercentage}}
           {{on "input" (fn @updateCandidateData @candidateData "extraTimePercentage")}}
+          autocomplete="off"
         />
       </div>
 
-      <div id="recipient-email-container" class="new-certification-candidate-modal__form__field">
-        <label for="result-recipient-email" class="label">
-          {{t "common.forms.certification-labels.email-results"}}
-        </label>
-        <Input
-          id="result-recipient-email"
-          @type="email"
-          class="input"
-          @value={{@candidateData.resultRecipientEmail}}
+      <div class="new-certification-candidate-modal-form__field">
+        <PixInput
+          @id="result-recipient-email"
+          @label={{t "common.forms.certification-labels.email-results"}}
           {{on "input" (fn @updateCandidateData @candidateData "resultRecipientEmail")}}
+          autocomplete="off"
         />
-        <PixMessage class="new-certification-candidate-modal__form__field__info-panel" @withIcon={{true}}>
-          {{t "pages.sessions.detail.candidates.add-modal.info-panel" htmlSafe=true}}
-        </PixMessage>
       </div>
 
-      <div id="email-container" class="new-certification-candidate-modal__form__field">
-        <label for="email" class="label">
-          {{t "common.forms.certification-labels.email-convocation"}}
-        </label>
-        <Input
-          id="email"
+      <PixMessage class="new-certification-candidate-modal-form__info-panel" @withIcon={{true}}>
+        {{t "pages.sessions.detail.candidates.add-modal.info-panel" htmlSafe=true}}
+      </PixMessage>
+
+      <div class="new-certification-candidate-modal-form__field">
+        <PixInput
+          @id="email"
           @type="email"
-          class="input"
-          @value={{@candidateData.email}}
-          {{on "input" (fn @updateCandidateData @candidateData "email")}}
+          @label={{t "common.forms.certification-labels.email-convocation"}}
+          {{on "input" (fn @updateCandidateData @candidateData "resultRecipientEmail")}}
+          autocomplete="off"
         />
       </div>
 
       {{#if @shouldDisplayPaymentOptions}}
-        <div
-          class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double new-certification-candidate-modal__form__field__fix-alert"
-        >
-          <label for="billing-mode" class="label">
-            <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
-            {{t "common.forms.certification-labels.pricing"}}
-          </label>
-          {{! template-lint-disable require-input-label }}
-          <input
-            class="new-certification-candidate-modal__form__field__fix-alert__input"
-            required
-            value={{@candidateData.billingMode}}
-            type="text"
-          />
+        <div class="new-certification-candidate-modal-form__field">
           <PixSelect
             @id="billing-mode"
-            class="birth-country-selector"
             @options={{this.billingModeOptions}}
             @onChange={{fn @updateCandidateDataFromValue @candidateData "billingMode"}}
             @value={{@candidateData.billingMode}}
             @placeholder={{this.billingMenuPlaceholder}}
             @hideDefaultOption={{true}}
+            @requiredText={{t "common.forms.required"}}
+            @label={{t "common.forms.certification-labels.pricing"}}
           />
-        </div>
-        <div
-          class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double new-certification-candidate-modal__form__field__tooltip"
-        >
-          <label for="prepayment-code" class="label">
-            {{t "common.forms.certification-labels.prepayment-code"}}
-          </label>
-          <PixTooltip @id="tooltip-prepayment-code" @position="left">
-            <:triggerElement>
-              <FaIcon
-                @icon="info-circle"
-                tabindex="0"
-                aria-describedby="tooltip-prepayment-code"
-                aria-label={{t "pages.sessions.detail.candidates.add-modal.prepayment-information"}}
-              />
-            </:triggerElement>
-            <:tooltip>
-              {{t "pages.sessions.detail.candidates.add-modal.prepayment-tooltip" htmlSafe=true}}
-            </:tooltip>
-          </PixTooltip>
-          <Input
-            id="prepayment-code"
-            @type="text"
-            class="input"
-            @value={{@candidateData.prepaymentCode}}
-            {{on "input" (fn @updateCandidateData @candidateData "prepaymentCode")}}
-          />
+
+          <div class="new-certification-candidate-modal-form__tooltip">
+            <label for="prepayment-code" class="label">
+              {{t "common.forms.certification-labels.prepayment-code"}}
+            </label>
+            <PixTooltip @id="tooltip-prepayment-code" @position="left">
+              <:triggerElement>
+                <FaIcon
+                  @icon="info-circle"
+                  tabindex="0"
+                  aria-describedby="tooltip-prepayment-code"
+                  aria-label={{t "pages.sessions.detail.candidates.add-modal.prepayment-information"}}
+                />
+              </:triggerElement>
+              <:tooltip>
+                {{t "pages.sessions.detail.candidates.add-modal.prepayment-tooltip" htmlSafe=true}}
+              </:tooltip>
+            </PixTooltip>
+            <Input
+              id="prepayment-code"
+              @type="text"
+              class="input"
+              @value={{@candidateData.prepaymentCode}}
+              {{on "input" (fn @updateCandidateData @candidateData "prepaymentCode")}}
+            />
+          </div>
         </div>
       {{/if}}
 
       {{#if this.complementaryCertificationsHabilitations.length}}
-        <div class="new-certification-candidate-modal__form__field">
+        <div class="new-certification-candidate-modal-form__field">
           <fieldset id="complementary-certifications">
             <legend class="label">
               {{t "common.forms.certification-labels.additional-certification"}}

--- a/certif/app/styles/components/new-certification-candidate-modal.scss
+++ b/certif/app/styles/components/new-certification-candidate-modal.scss
@@ -1,5 +1,3 @@
-/* stylelint-disable no-descending-specificity */
-
 .new-certification-candidate-modal {
   min-width: 576px;
   max-width: 576px;
@@ -9,84 +7,55 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
+  }
 
-    &__required-fields-mention {
-      width: 100%;
+  .radio-button-container {
+    display: flex;
+    gap: var(--pix-spacing-4x);
+    align-items: center;
+
+    > div {
+      margin-top: 0;
     }
+  }
+}
 
-    &__field {
-      width: 100%;
-      margin: 12px 0;
+.new-certification-candidate-modal-form {
+  &__info-panel {
+    margin-top: 8px;
+  }
 
-      &__fix-alert {
-        position:relative;
+  &__required-fields-mention {
+    width: 100%;
+  }
 
-        &__input {
-          position: absolute;
-          bottom: 0;
-          left: 0;
-        }
-      }
+  &__field {
+    display: flex;
+    gap: var(--pix-spacing-4x);
+    width: 100%;
+    margin: 12px 0;
 
-
-      label {
-        display: block;
-      }
-
-      .pix-select {
-        width: 248px;
-        height: 36px;
-      }
-
-      .birth-country-selector {
-        width: 248px;
-        height: 36px;
-      }
-
-      .radio-button-container {
-        display: flex;
-        align-items: center;
-        gap: var(--pix-spacing-4x);
-
-        > div {
-          margin-top: 0;
-        }
-      }
-
-      &-double {
-        width: 248px;
-      }
-
-      &__tooltip {
-        display: flex;
-        flex-wrap: wrap;
-
-        .pix-tooltip {
-          padding-left: 5px;
-          cursor: help;
-        }
-
-        .pix-tooltip__content--wide {
-          width: 600px;
-        }
-      }
-
-      &__info-panel {
-        margin-top: 8px;
-      }
+    .pix-input__container, button {
+      width: 248px;
     }
   }
 
-  &__actions {
+  /* prepayment custom field can be modified with the version 45 of pix UI */
+  &__tooltip {
     display: flex;
-    justify-content: flex-end;
-    width: 100%;
-    padding: 16px 0;
-    background-color: var(--pix-neutral-20);
-    border-radius: 0 0 5px 5px;
+    flex-wrap: wrap;
 
-    .pix-button {
-      margin-left: 16px;
+    .pix-tooltip {
+      padding-left: 5px;
+      cursor: help;
+    }
+
+    .pix-tooltip__content--wide {
+      width: 600px;
+    }
+
+    > input {
+      width: 248px;
     }
   }
 }

--- a/certif/app/styles/components/new-certification-candidate-modal.scss
+++ b/certif/app/styles/components/new-certification-candidate-modal.scss
@@ -5,13 +5,6 @@
   max-width: 576px;
   margin: 100px auto;
 
-  /* to fix in pix UI */
-  fieldset {
-    margin: 0;
-    padding: 0;
-    border: 0;
-  }
-
   &__form {
     display: flex;
     flex-wrap: wrap;
@@ -38,17 +31,6 @@
 
       label {
         display: block;
-
-        &.radio-button-label {
-          display: inline-block;
-          margin: 0 16px 0 8px;
-        }
-      }
-
-      input {
-        box-sizing: border-box;
-        width: 248px;
-        height: 36px;
       }
 
       .pix-select {
@@ -61,14 +43,14 @@
         height: 36px;
       }
 
-      input[type='radio'] {
-        width: 20px;
-        height: 20px;
-      }
-
       .radio-button-container {
         display: flex;
         align-items: center;
+        gap: var(--pix-spacing-4x);
+
+        > div {
+          margin-top: 0;
+        }
       }
 
       &-double {
@@ -91,27 +73,6 @@
 
       &__info-panel {
         margin-top: 8px;
-      }
-
-      .complementary-certifications-checkbox-list {
-        display: flex;
-
-        ul {
-          margin: 8px;
-          padding: 0;
-          list-style-type: none;
-        }
-
-        label {
-          display: flex;
-          align-items: center;
-          height: 30px;
-        }
-
-        input {
-          width: 20px;
-          margin-right: 10px;
-        }
       }
     }
   }

--- a/certif/app/styles/globals/forms.scss
+++ b/certif/app/styles/globals/forms.scss
@@ -1,10 +1,10 @@
 .label {
   display: inline-block;
+  margin-bottom: var(--pix-spacing-1x);
   margin-left: 1px;
-  padding-bottom: 5px;
-  color: var(--pix-neutral-800);
-  font-weight: 500;
-  font-size: 0.94rem;
+  color: var(--pix-neutral-900);
+  font-weight: var(--pix-font-medium);
+  font-size: 1rem;
 }
 
 .input {

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -415,6 +415,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
             // when
             const screen = await visit(`/sessions/${session.id}/candidats`);
             await click(screen.getByRole('button', { name: 'Inscrire un candidat' }));
+            await screen.findByRole('dialog');
             await _fillFormWithCorrectData(screen);
             await click(screen.getByRole('button', { name: 'Inscrire le candidat' }));
             await settled();
@@ -456,6 +457,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
               // when
               const screen = await visit(`/sessions/${session.id}/candidats`);
               await click(screen.getByRole('button', { name: 'Inscrire un candidat' }));
+              await screen.findByRole('dialog');
               await _fillFormWithCorrectData(screen);
               await click(screen.getByRole('button', { name: 'Inscrire le candidat' }));
 
@@ -477,24 +479,35 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
             // when
             const screen = await visit(`/sessions/${session.id}/candidats`);
             await click(screen.getByRole('button', { name: 'Inscrire un candidat' }));
+            await screen.findByRole('dialog');
             await _fillFormWithCorrectData(screen);
             await click(screen.getByRole('button', { name: 'Inscrire le candidat' }));
             await settled();
 
             // then
-            assert.dom('[data-test-notification-message="success"]').hasText('Le candidat a été inscrit avec succès.');
+            assert.dom(screen.getByText('Le candidat a été inscrit avec succès.')).exists();
           });
 
           test('it should add a new candidate', async function (assert) {
             // when
             const screen = await visit(`/sessions/${session.id}/candidats`);
             await click(screen.getByRole('button', { name: 'Inscrire un candidat' }));
+            await screen.findByRole('dialog');
             await _fillFormWithCorrectData(screen);
             await click(screen.getByRole('button', { name: 'Inscrire le candidat' }));
             await settled();
 
             // then
-            assert.dom('table tbody tr').exists({ count: 1 });
+            const table = screen.getByRole('table', {
+              name: 'Liste des candidats inscrits à la session, triée par nom de naissance, avec un lien pour voir les détails du candidat et la possibilité de supprimer un candidat dans la dernière colonne.',
+            });
+            const rows = await within(table).findAllByRole('row');
+            assert.dom(within(rows[1]).getByRole('cell', { name: 'Guybrush' })).exists();
+            assert.dom(within(rows[1]).getByRole('cell', { name: 'Threepwood' })).exists();
+            assert.dom(within(rows[1]).getByRole('cell', { name: '28/04/2019' })).exists();
+            assert.dom(within(rows[1]).getByRole('cell', { name: '20 %' })).exists();
+            assert.dom(within(rows[1]).getByRole('cell', { name: 'Gratuite' })).exists();
+            assert.dom(within(rows[1]).getByRole('cell', { name: 'roooooar@example.net' })).exists();
           });
 
           module('when shouldDisplayPaymentOptions is true', function () {
@@ -535,26 +548,26 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
   });
 
   async function _fillFormWithCorrectData(screen) {
-    await fillIn(screen.getByLabelText('* Prénom'), 'Guybrush');
-    await fillIn(screen.getByLabelText('* Nom de naissance'), 'Threepwood');
-    await fillIn(screen.getByLabelText('* Date de naissance'), '28/04/2019');
-    await click(screen.getByLabelText('Homme'));
-    await fillIn(screen.getByLabelText('* Pays de naissance'), '99100');
-    await click(screen.getByLabelText('Code INSEE'));
-    await fillIn(screen.getByLabelText('Identifiant externe'), '44AA3355');
-    await fillIn(screen.getByLabelText('* Code INSEE de naissance'), '75100');
-    await fillIn(screen.getByLabelText('Temps majoré (%)'), '20');
-    await click(screen.getByLabelText('* Tarification part Pix'));
+    await fillIn(screen.getByRole('textbox', { name: 'Obligatoire Prénom' }), 'Guybrush');
+    await fillIn(screen.getByRole('textbox', { name: 'Obligatoire Nom de naissance' }), 'Threepwood');
+    await fillIn(screen.getByRole('textbox', { name: 'Obligatoire Date de naissance' }), '28/04/2019');
+    await click(screen.getByRole('radio', { name: 'Homme' }));
+    await fillIn(screen.getByRole('button', { name: 'Obligatoire Pays de naissance' }), '99100');
+    await click(screen.getByRole('radio', { name: 'Code INSEE' }));
+    await fillIn(screen.getByRole('textbox', { name: 'Identifiant externe' }), '44AA3355');
+    await fillIn(screen.getByRole('textbox', { name: 'Obligatoire Code INSEE de naissance' }), '75100');
+    await fillIn(screen.getByRole('textbox', { name: 'Temps majoré (%)' }), '20');
+    await click(screen.getByRole('button', { name: 'Obligatoire Tarification part Pix' }));
     await click(
       await screen.findByRole('option', {
         name: 'Gratuite',
       }),
     );
     await fillIn(
-      screen.getByLabelText('E-mail du destinataire des résultats (formateur, enseignant...)'),
+      screen.getByRole('textbox', { name: 'E-mail du destinataire des résultats (formateur, enseignant...)' }),
       'guybrush.threepwood@example.net',
     );
-    await fillIn(screen.getByLabelText('E-mail de convocation'), 'roooooar@example.net');
+    await fillIn(screen.getByRole('textbox', { name: 'E-mail de convocation' }), 'roooooar@example.net');
   }
 });
 /* eslint-enable ember/no-settled-after-test-helper */

--- a/certif/tests/integration/components/new-certification-candidate-modal_test.js
+++ b/certif/tests/integration/components/new-certification-candidate-modal_test.js
@@ -62,29 +62,30 @@ module('Integration | Component | new-certification-candidate-modal', function (
     `);
 
     // then
-    assert.dom(screen.getByLabelText('* Nom de naissance')).exists();
-    assert.dom(screen.getByLabelText('* Prénom')).exists();
-    assert.dom(screen.getByLabelText('Homme')).exists();
-    assert.dom(screen.getByLabelText('Femme')).exists();
-    assert.dom(screen.getByLabelText('* Date de naissance')).exists();
-    assert.dom(screen.getByLabelText('* Pays de naissance')).exists();
-    assert.dom(screen.getByLabelText('Code INSEE')).exists();
-    assert.dom(screen.getByLabelText('Code postal')).exists();
-    assert.dom(screen.getByLabelText('* Code INSEE de naissance')).exists();
-    assert.dom(screen.getByLabelText('Identifiant externe')).exists();
-    assert.dom(screen.getByLabelText('Temps majoré (%)')).exists();
-    assert.dom(screen.getByLabelText('E-mail du destinataire des résultats (formateur, enseignant...)')).exists();
+    assert.dom(screen.getByRole('textbox', { name: 'Obligatoire Nom de naissance' })).exists();
+    assert.dom(screen.getByRole('textbox', { name: 'Obligatoire Prénom' })).exists();
+    assert.dom(screen.getByRole('radio', { name: 'Homme' })).exists();
+    assert.dom(screen.getByRole('radio', { name: 'Femme' })).exists();
+    assert.dom(screen.getByRole('textbox', { name: 'Obligatoire Date de naissance' })).exists();
+    assert.dom(screen.getByRole('button', { name: 'Obligatoire Pays de naissance' })).exists();
+    assert.dom(screen.getByRole('radio', { name: 'Code INSEE' })).exists();
+    assert.dom(screen.getByRole('radio', { name: 'Code postal' })).exists();
+    assert.dom(screen.getByRole('textbox', { name: 'Obligatoire Code INSEE de naissance' })).exists();
+    assert.dom(screen.getByRole('textbox', { name: 'Identifiant externe' })).exists();
+    assert.dom(screen.getByRole('textbox', { name: 'Temps majoré (%)' })).exists();
+    assert
+      .dom(screen.getByRole('textbox', { name: 'E-mail du destinataire des résultats (formateur, enseignant...)' }))
+      .exists();
     assert
       .dom(
         screen.getByText(
           'Si le champ n’est pas renseigné, les résultats ne seront pas transmis par mail pour le/les candidats concernés.Le candidat verra ses résultats affichés directement sur son compte Pix.',
-          { exact: false },
         ),
       )
       .exists();
-    assert.dom(screen.getByLabelText('E-mail de convocation')).exists();
-    assert.dom(screen.getByLabelText('Certif complémentaire 1')).exists();
-    assert.dom(screen.getByLabelText('Certif complémentaire 2')).exists();
+    assert.dom(screen.getByRole('textbox', { name: 'E-mail de convocation' })).exists();
+    assert.dom(screen.getByRole('radio', { name: 'Certif complémentaire 1' })).exists();
+    assert.dom(screen.getByRole('radio', { name: 'Certif complémentaire 2' })).exists();
   });
 
   test('it should have some inputs required', async function (assert) {
@@ -109,11 +110,11 @@ module('Integration | Component | new-certification-candidate-modal', function (
     `);
 
     // then
-    assert.dom(screen.getByRole('textbox', { name: 'Nom de naissance' })).hasAttribute('required');
-    assert.dom(screen.getByRole('textbox', { name: 'Prénom' })).hasAttribute('required');
-    assert.dom(screen.getByRole('textbox', { name: 'Date de naissance' })).hasAttribute('required');
+    assert.dom(screen.getByRole('textbox', { name: 'Obligatoire Nom de naissance' })).hasAttribute('required');
+    assert.dom(screen.getByRole('textbox', { name: 'Obligatoire Prénom' })).hasAttribute('required');
+    assert.dom(screen.getByRole('textbox', { name: 'Obligatoire Date de naissance' })).hasAttribute('required');
     assert.dom(screen.getByRole('radio', { name: 'Femme' })).hasAttribute('required');
-    assert.dom(screen.getByRole('textbox', { name: 'Code INSEE de naissance' })).hasAttribute('required');
+    assert.dom(screen.getByRole('textbox', { name: 'Obligatoire Code INSEE de naissance' })).hasAttribute('required');
   });
 
   module('when shouldDisplayPaymentOptions is true', function () {
@@ -162,31 +163,8 @@ module('Integration | Component | new-certification-candidate-modal', function (
       `);
 
       // then
-      assert.dom(screen.getByLabelText('* Nom de naissance')).exists();
-      assert.dom(screen.getByLabelText('* Prénom')).exists();
-      assert.dom(screen.getByLabelText('Homme')).exists();
-      assert.dom(screen.getByLabelText('Femme')).exists();
-      assert.dom(screen.getByLabelText('* Date de naissance')).exists();
-      assert.dom(screen.getByLabelText('* Pays de naissance')).exists();
-      assert.dom(screen.getByLabelText('Code INSEE')).exists();
-      assert.dom(screen.getByLabelText('Code postal')).exists();
-      assert.dom(screen.getByLabelText('* Code INSEE de naissance')).exists();
-      assert.dom(screen.getByLabelText('Identifiant externe')).exists();
-      assert.dom(screen.getByLabelText('Temps majoré (%)')).exists();
-      assert.dom(screen.getByLabelText('E-mail du destinataire des résultats (formateur, enseignant...)')).exists();
-      assert
-        .dom(
-          screen.getByText(
-            'Si le champ n’est pas renseigné, les résultats ne seront pas transmis par mail pour le/les candidats concernés.Le candidat verra ses résultats affichés directement sur son compte Pix.',
-            { exact: false },
-          ),
-        )
-        .exists();
-      assert.dom(screen.getByLabelText('E-mail de convocation')).exists();
-      assert.dom(screen.getByLabelText('Certif complémentaire 1')).exists();
-      assert.dom(screen.getByLabelText('Certif complémentaire 2')).exists();
-      assert.dom(screen.getByLabelText('* Tarification part Pix')).exists();
-      assert.dom(screen.getByLabelText('Code de prépaiement')).exists();
+      assert.dom(screen.getByRole('button', { name: 'Obligatoire Tarification part Pix' })).exists();
+      assert.dom(screen.getByRole('textbox', { name: 'Code de prépaiement' })).exists();
       assert.dom(screen.getByLabelText('Information du code de prépaiement')).exists();
     });
   });
@@ -232,7 +210,7 @@ module('Integration | Component | new-certification-candidate-modal', function (
     `);
 
     // then
-    assert.dom(screen.getByRole('button', { name: 'Pays de naissance' })).includesText('France');
+    assert.dom(screen.getByRole('button', { name: 'Obligatoire Pays de naissance' })).includesText('France');
   });
 
   module('when close button cross icon is clicked', () => {
@@ -359,7 +337,7 @@ module('Integration | Component | new-certification-candidate-modal', function (
         />
       `);
 
-      await click(screen.getByLabelText('* Pays de naissance'));
+      await click(screen.getByRole('button', { name: 'Obligatoire Pays de naissance' }));
       await click(
         await screen.findByRole('option', {
           name: 'Borduristan',

--- a/certif/tests/integration/components/new-certification-candidate-modal_test.js
+++ b/certif/tests/integration/components/new-certification-candidate-modal_test.js
@@ -1,6 +1,6 @@
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
-import { click, fillIn } from '@ember/test-helpers';
+import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -459,92 +459,6 @@ module('Integration | Component | new-certification-candidate-modal', function (
       assert.dom(screen.queryByLabelText('* Code INSEE de naissance')).isNotVisible();
       assert.dom(screen.queryByLabelText('* Code postal de naissance')).isVisible();
       assert.dom(screen.getByLabelText('* Commune de naissance')).isVisible();
-    });
-  });
-
-  module('when the form is filled', () => {
-    test('it should submit a student', async function (assert) {
-      const closeModalStub = sinon.stub();
-      const updateCandidateFromValueStub = sinon.stub();
-      updateCandidateFromValueStub.callsFake((object, key, value) => (object[key] = value));
-
-      const updateCandidateFromEventStub = sinon.stub();
-      const saveCandidateStub = sinon.stub();
-
-      this.set('closeModal', closeModalStub);
-      this.set('updateCandidateFromValueStub', updateCandidateFromValueStub);
-      this.set('updateCandidateFromEventStub', updateCandidateFromEventStub);
-      this.set('countries', [{ code: '99123', name: 'Borduristan' }]);
-      this.set('saveCandidate', saveCandidateStub);
-      this.set('candidateData', {
-        firstName: '',
-        lastName: '',
-        birthdate: '',
-        birthCity: '',
-        birthCountry: '',
-        email: '',
-        externalId: '',
-        resultRecipientEmail: '',
-        birthPostalCode: '',
-        birthInseeCode: '',
-        sex: '',
-        extraTimePercentage: '',
-      });
-      this.set('countries', [{ code: '99100', name: 'FRANCE' }]);
-
-      // when
-      const screen = await renderScreen(hbs`
-        <NewCertificationCandidateModal
-          @showModal={{true}}
-          @closeModal={{this.closeModal}}
-          @countries={{this.countries}}
-          @updateCandidateData={{this.updateCandidateFromEventStub}}
-          @updateCandidateDataFromValue={{this.updateCandidateFromValueStub}}
-          @candidateData={{this.candidateData}}
-          @saveCandidate={{this.saveCandidate}}
-          />
-      `);
-      await fillIn(screen.getByLabelText('* Prénom'), 'Guybrush');
-      await fillIn(screen.getByLabelText('* Nom de naissance'), 'Threepwood');
-      await fillIn(screen.getByLabelText('* Date de naissance'), '28/04/2019');
-      await click(screen.getByRole('radio', { name: 'Homme' }));
-      await click(screen.getByLabelText('* Pays de naissance'));
-      await click(
-        await screen.findByRole('option', {
-          name: 'FRANCE',
-        }),
-      );
-      await click(screen.getByRole('radio', { name: 'Code INSEE' }));
-      await click(screen.getByRole('radio', { name: 'Certif complémentaire 1' }));
-      await fillIn(screen.getByLabelText('Identifiant externe'), '44AA3355');
-      await fillIn(screen.getByLabelText('* Code INSEE de naissance'), '75100');
-      await fillIn(screen.getByLabelText('Temps majoré (%)'), '20');
-      await fillIn(
-        screen.getByLabelText('E-mail du destinataire des résultats (formateur, enseignant...)'),
-        'guybrush.threepwood@example.net',
-      );
-      await fillIn(screen.getByLabelText('E-mail de convocation'), 'roooooar@example.net');
-
-      await click(screen.getByRole('button', { name: 'Inscrire le candidat' }));
-
-      // then
-      assert.strictEqual(updateCandidateFromValueStub.callCount, 7);
-      assert.strictEqual(updateCandidateFromEventStub.callCount, 8);
-      sinon.assert.calledOnceWithExactly(saveCandidateStub, {
-        firstName: 'Guybrush',
-        lastName: 'Threepwood',
-        birthdate: '2019-04-28',
-        birthCity: '',
-        birthCountry: 'FRANCE',
-        email: 'roooooar@example.net',
-        externalId: '44AA3355',
-        resultRecipientEmail: 'guybrush.threepwood@example.net',
-        birthPostalCode: '',
-        birthInseeCode: '75100',
-        sex: '',
-        extraTimePercentage: '20',
-        complementaryCertification: { id: 0, label: 'Certif complémentaire 1', key: 'COMP_1' },
-      });
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement Pix Certif possède une dette concernant l'usage des composants Pix UI. Notamment la modale d'ajout de candidat à une session.

## :robot: Proposition
Utiliser les composants Pix UI : `PixRadioButton`, `PixInput`

https://ui.pix.fr/?path=/docs/form-inputs-input--docs

## :rainbow: Remarques
Seul le champ de Prépaiement n'est pas un composant Pix UI car il y a un tooltip dans son label et le composant ne gère pas ça à l'heure actuelle. Mais une PR est actuellement en cours pour rendre ça possible.
Ce sera dans la v45 !

Comme les fichiers bougent pas mal, la lecture peut être compliqué sur Github, ne pas hésiter à récupérer la branche et regarder ça dans son IDE.

## :100: Pour tester

- Se connecter avec certif-pro@example.net
- Aller sur une session existante
- Onglet candidats
- Inscrire un candidat
- Comparer la modale avec l'environnement d'intégration/recette/autre RA pour la non-régression (design des champs, disposition...)
- Enregistrer plusieurs candidats pour tester la non régression ( Cas avec juste les champs obligatoire, cas avec un code INSEE, cas avec un code postal, avec certif complémentaire, sans certification complémentaire etc)
