### PR TITLE
[TECH] :recycle: Modification de l'appel du token d'authentification pour l'action de « tri » des vieilles branches

### DIFF
--- a/.github/workflows/stale-branches.yml
+++ b/.github/workflows/stale-branches.yml
@@ -1,3 +1,5 @@
+name: Stale branches
+
 on:
   schedule:
     - cron: "0 12 * * *"
@@ -11,7 +13,7 @@ jobs:
         id: branch_cleaner
         uses: crazy-matt/manage-stale-branches@1.1.0
         with:
-          gh_token: ${{ env.PIX_SERVICE_ACTIONS_TOKEN }}
+          gh_token: ${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}
           stale_older_than: 60
           suggestions_older_than: 30
           dry_run: true


### PR DESCRIPTION
## :unicorn: Problème

L'action github mise en place pour « trier » les vieilles branches ne fonctionne pas : il y a un problème d'authentification.

## :robot: Proposition

Le token d'authentification est mis en place dans les « secrets » du repo, c'est donc un prefix `secrets` qu'il faut utilise et non `env`

## :rainbow: Remarques

L'action est toujours en dry-run, donc aucun risque.

## :100: Pour tester

Déployer sûr dev.
