### PR TITLE
[TECH] Déplace la logique validation de code dans le model Campaign (PIX-11691)

### DIFF
--- a/api/src/prescription/campaign/domain/models/Campaign.js
+++ b/api/src/prescription/campaign/domain/models/Campaign.js
@@ -1,5 +1,5 @@
 import { CampaignTypes } from '../../../shared/domain/constants.js';
-import { IsForAbsoluteNoviceUpdateError, MultipleSendingsUpdateError } from '../errors.js';
+import { CampaignCodeFormatError, IsForAbsoluteNoviceUpdateError, MultipleSendingsUpdateError } from '../errors.js';
 
 class Campaign {
   constructor({
@@ -65,7 +65,15 @@ class Campaign {
     return Boolean(this.archivedAt);
   }
 
+  #validateCode(code) {
+    return /^[A-Z0-9]{9}$/.test(code);
+  }
+
   updateFields(fields, isAuthorizedToUpdateIsForAbsoluteNovice) {
+    if (fields.code !== undefined && fields.code !== this.code && !this.#validateCode(fields.code)) {
+      throw new CampaignCodeFormatError();
+    }
+
     if (
       fields.multipleSendings !== undefined &&
       fields.multipleSendings !== this.multipleSendings &&

--- a/api/src/prescription/campaign/domain/usecases/update-campaign-code.js
+++ b/api/src/prescription/campaign/domain/usecases/update-campaign-code.js
@@ -1,18 +1,13 @@
-import { CampaignCodeFormatError, CampaignUniqueCodeError, UnknownCampaignId } from './../errors.js';
+import { CampaignUniqueCodeError, UnknownCampaignId } from './../errors.js';
 
-const updateCampaignCode = async function ({
-  campaignId,
-  campaignCode,
-  campaignAdministrationRepository,
-  codeGenerator,
-}) {
+const updateCampaignCode = async function ({ campaignId, campaignCode, campaignAdministrationRepository }) {
   const campaign = await campaignAdministrationRepository.get(campaignId);
   if (!campaign) {
     throw new UnknownCampaignId();
   }
-  if (!codeGenerator.validate(campaignCode)) {
-    throw new CampaignCodeFormatError();
-  }
+
+  campaign.updateFields({ code: campaignCode });
+
   const isCodeAvailable = await campaignAdministrationRepository.isCodeAvailable(campaignCode);
   if (!isCodeAvailable) {
     throw new CampaignUniqueCodeError();

--- a/api/src/prescription/campaign/domain/usecases/update-campaign-code.js
+++ b/api/src/prescription/campaign/domain/usecases/update-campaign-code.js
@@ -12,7 +12,8 @@ const updateCampaignCode = async function ({ campaignId, campaignCode, campaignA
   if (!isCodeAvailable) {
     throw new CampaignUniqueCodeError();
   }
-  await campaignAdministrationRepository.update({ campaignId, campaignAttributes: { code: campaignCode } });
+
+  await campaignAdministrationRepository.update(campaign);
 };
 
 export { updateCampaignCode };

--- a/api/src/prescription/campaign/domain/usecases/update-campaign-details.js
+++ b/api/src/prescription/campaign/domain/usecases/update-campaign-details.js
@@ -30,18 +30,7 @@ const updateCampaignDetails = async function ({
 
   campaignUpdateValidator.validate(campaign);
 
-  const campaignAttributes = {
-    name: campaign.name,
-    title: campaign.title,
-    customLandingPageText: campaign.customLandingPageText,
-    customResultPageText: campaign.customResultPageText,
-    customResultPageButtonText: campaign.customResultPageButtonText,
-    customResultPageButtonUrl: campaign.customResultPageButtonUrl,
-    multipleSendings: campaign.multipleSendings,
-    isForAbsoluteNovice: campaign.isForAbsoluteNovice,
-  };
-
-  return campaignAdministrationRepository.update({ campaignId, campaignAttributes });
+  return campaignAdministrationRepository.update(campaign);
 };
 
 export { updateCampaignDetails };

--- a/api/src/prescription/campaign/domain/usecases/update-campaign.js
+++ b/api/src/prescription/campaign/domain/usecases/update-campaign.js
@@ -38,14 +38,7 @@ const updateCampaign = async function ({
 
   campaignUpdateValidator.validate(campaign);
 
-  const campaignAttributes = {
-    name: campaign.name,
-    title: campaign.title,
-    customLandingPageText: campaign.customLandingPageText,
-    ownerId: campaign.ownerId,
-  };
-
-  return campaignAdministrationRepository.update({ campaignId: campaign.id, campaignAttributes });
+  return campaignAdministrationRepository.update(campaign);
 };
 
 export { updateCampaign };

--- a/api/src/shared/domain/services/code-generator.js
+++ b/api/src/shared/domain/services/code-generator.js
@@ -23,8 +23,4 @@ function generate(repository, pendingList = []) {
   });
 }
 
-function validate(code) {
-  return /^[A-Z0-9]{9}$/.test(code);
-}
-
-export { generate, validate };
+export { generate };

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-administration-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-administration-repository_test.js
@@ -468,17 +468,17 @@ describe('Integration | Repository | Campaign Administration', function () {
     let campaign;
 
     beforeEach(function () {
-      campaign = databaseBuilder.factory.buildCampaign();
+      campaign = new Campaign(databaseBuilder.factory.buildCampaign());
 
       return databaseBuilder.commit();
     });
 
     it('should return a Campaign domain object', async function () {
+      // given
+      campaign.updateFields({ title: 'Title' });
+
       // when
-      const campaignSaved = await campaignAdministrationRepository.update({
-        campaignId: campaign.id,
-        campaignAttributes: { title: 'Title' },
-      });
+      const campaignSaved = await campaignAdministrationRepository.update(campaign);
 
       // then
       expect(campaignSaved).to.be.an.instanceof(Campaign);
@@ -486,28 +486,25 @@ describe('Integration | Repository | Campaign Administration', function () {
 
     it('should update the correct campaign', async function () {
       // given
-      const campaignId = databaseBuilder.factory.buildCampaign({ title: 'MASH' }).id;
+      const expectedCampaign = new Campaign(databaseBuilder.factory.buildCampaign({ title: 'MASH' }));
       await databaseBuilder.commit();
+      campaign.updateFields({ title: 'Title' });
 
       // when
-      await campaignAdministrationRepository.update({
-        campaignId: campaign.id,
-        campaignAttributes: { title: 'Title' },
-      });
-      const row = await knex.from('campaigns').where({ id: campaignId }).first();
+      await campaignAdministrationRepository.update(campaign);
 
       // then
+      const row = await knex.from('campaigns').where({ id: expectedCampaign.id }).first();
       expect(row.title).to.equal('MASH');
     });
 
     it('should not add row in table "campaigns"', async function () {
       // given
       const rowsCountBeforeUpdate = await knex.select('id').from('campaigns');
+      campaign.updateFields({ title: 'Title' });
+
       // when
-      await campaignAdministrationRepository.update({
-        campaignId: campaign.id,
-        campaignAttributes: { title: 'Title' },
-      });
+      await campaignAdministrationRepository.update(campaign);
 
       // then
       const rowCountAfterUpdate = await knex.select('id').from('campaigns');
@@ -518,17 +515,15 @@ describe('Integration | Repository | Campaign Administration', function () {
       // given
       const newOwnerId = databaseBuilder.factory.buildUser().id;
       await databaseBuilder.commit();
+      campaign.updateFields({
+        title: 'New title',
+        name: 'New name',
+        customLandingPageText: 'New text',
+        ownerId: newOwnerId,
+      });
 
       // when
-      const campaignSaved = await campaignAdministrationRepository.update({
-        campaignId: campaign.id,
-        campaignAttributes: {
-          title: 'New title',
-          name: 'New name',
-          customLandingPageText: 'New text',
-          ownerId: newOwnerId,
-        },
-      });
+      const campaignSaved = await campaignAdministrationRepository.update(campaign);
 
       // then
       expect(campaignSaved.id).to.equal(campaign.id);

--- a/api/tests/prescription/campaign/unit/domain/models/Campaign_test.js
+++ b/api/tests/prescription/campaign/unit/domain/models/Campaign_test.js
@@ -1,22 +1,70 @@
+import { CampaignCodeFormatError } from '../../../../../../src/prescription/campaign/domain/errors.js';
 import { Campaign } from '../../../../../../src/prescription/campaign/domain/models/Campaign.js';
-import { expect } from '../../../../../test-helper.js';
+import { catchErr, expect } from '../../../../../test-helper.js';
 
 describe('Campaign', function () {
+  let campaign;
+
+  beforeEach(function () {
+    campaign = new Campaign({
+      id: 1,
+      code: 'RIGHTCODE',
+      name: 'Assessment101',
+      title: 'Minus One',
+      multipleSendings: true,
+    });
+  });
+
   describe('#updateFields', function () {
     it('update only field existing on model', function () {
-      const campaign = new Campaign({
-        id: 1,
-        name: 'Assessment101',
-        title: 'Minus One',
-        multipleSendings: true,
-      });
-
       campaign.updateFields({ name: 'GodZilla', toto: 'toto', multipleSendings: undefined });
 
       expect(campaign.name).to.be.equal('GodZilla');
       expect(campaign.title).to.be.equal('Minus One');
       expect(campaign.multipleSendings).to.be.true;
       expect(campaign.toto).to.be.undefined;
+    });
+
+    describe('#code', function () {
+      it('should throw an error if the code format is not respected', async function () {
+        const error = await catchErr(campaign.updateFields, campaign)({ code: 'WRONG' });
+
+        expect(error).to.be.instanceOf(CampaignCodeFormatError);
+      });
+
+      it('should not update code if not provided', async function () {
+        const originalCode = campaign.code;
+
+        campaign.updateFields({ name: 'Something' });
+
+        expect(campaign.code).to.equal(originalCode);
+      });
+
+      it('should return false if code is less than 9 char', async function () {
+        const error = await catchErr(campaign.updateFields, campaign)({ code: 'ABC123' });
+
+        expect(error).to.be.ok;
+      });
+
+      it('should return false if code is more than 9 char', async function () {
+        const error = await catchErr(campaign.updateFields, campaign)({ code: 'ABC123ABC123' });
+
+        expect(error).to.be.ok;
+      });
+
+      it('should return false if code contains char other than uppercase Alphanumeric or numbers', async function () {
+        const error = await catchErr(campaign.updateFields, campaign)({ code: 'abc abc @' });
+
+        expect(error).to.be.instanceOf(CampaignCodeFormatError);
+      });
+
+      it('should return true if code contains only uppercase alphanumeric chars', function () {
+        const expectedCode = '123ABDCDE';
+
+        campaign.updateFields({ code: expectedCode });
+
+        expect(campaign.code).to.equal(expectedCode);
+      });
     });
   });
 });

--- a/api/tests/prescription/campaign/unit/domain/usecases/update-campaign-code_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/update-campaign-code_test.js
@@ -1,5 +1,4 @@
 import {
-  CampaignCodeFormatError,
   CampaignUniqueCodeError,
   UnknownCampaignId,
 } from '../../../../../../src/prescription/campaign/domain/errors.js';
@@ -7,11 +6,12 @@ import { updateCampaignCode } from '../../../../../../src/prescription/campaign/
 import { catchErr, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | update-campaign-code', function () {
-  let campaignAdministrationRepository, codeGenerator;
+  let campaignAdministrationRepository, codeGenerator, campaignStub;
 
   beforeEach(function () {
     campaignAdministrationRepository = { get: sinon.stub(), isCodeAvailable: sinon.stub(), update: sinon.stub() };
     codeGenerator = { validate: sinon.stub() };
+    campaignStub = { updateFields: sinon.stub() };
   });
 
   it('should update campaign code', async function () {
@@ -20,7 +20,7 @@ describe('Unit | UseCase | update-campaign-code', function () {
     const campaignCode = Symbol('campaign-code');
 
     codeGenerator.validate.withArgs(campaignCode).returns(true);
-    campaignAdministrationRepository.get.withArgs(campaignId).resolves(Symbol('campaign'));
+    campaignAdministrationRepository.get.withArgs(campaignId).resolves(campaignStub);
     campaignAdministrationRepository.isCodeAvailable.withArgs(campaignCode).resolves(true);
 
     // when
@@ -32,6 +32,7 @@ describe('Unit | UseCase | update-campaign-code', function () {
       campaignAttributes: { code: campaignCode },
     });
   });
+
   context('when campaignId not match a campaign', function () {
     it('should throw an UnknonwCampaignId', async function () {
       // given
@@ -46,31 +47,12 @@ describe('Unit | UseCase | update-campaign-code', function () {
     });
   });
 
-  context("when campaign's code has a wrong format", function () {
-    it('should throw a CampaignCodeFormatError', async function () {
-      // given
-      const campaignId = Symbol('campaign-id');
-      const campaignCode = Symbol('campaign-code');
-      campaignAdministrationRepository.get.withArgs(campaignId).resolves(Symbol('campaign'));
-      codeGenerator.validate.withArgs(campaignCode).returns(false);
-      // when
-      const error = await catchErr(updateCampaignCode)({
-        campaignId,
-        campaignCode,
-        campaignAdministrationRepository,
-        codeGenerator,
-      });
-
-      expect(error).to.be.an.instanceOf(CampaignCodeFormatError);
-    });
-  });
-
   context("when campaign's code already exists", function () {
     it('should throw a CampaignUniqueCodeError', async function () {
       // given
       const campaignId = Symbol('campaign-id');
       const campaignCode = Symbol('campaign-code');
-      campaignAdministrationRepository.get.withArgs(campaignId).resolves(Symbol('campaign'));
+      campaignAdministrationRepository.get.withArgs(campaignId).resolves(campaignStub);
       codeGenerator.validate.withArgs(campaignCode).returns(true);
       campaignAdministrationRepository.isCodeAvailable.withArgs(campaignCode).resolves(false);
       // when

--- a/api/tests/prescription/campaign/unit/domain/usecases/update-campaign-code_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/update-campaign-code_test.js
@@ -27,10 +27,7 @@ describe('Unit | UseCase | update-campaign-code', function () {
     await updateCampaignCode({ campaignId, campaignCode, campaignAdministrationRepository, codeGenerator });
 
     // then
-    expect(campaignAdministrationRepository.update).to.have.been.calledOnceWithExactly({
-      campaignId,
-      campaignAttributes: { code: campaignCode },
-    });
+    expect(campaignAdministrationRepository.update).to.have.been.calledOnceWithExactly(campaignStub);
   });
 
   context('when campaignId not match a campaign', function () {

--- a/api/tests/prescription/campaign/unit/domain/usecases/update-campaign-details_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/update-campaign-details_test.js
@@ -38,10 +38,7 @@ describe('Unit | UseCase | update-campaign-details', function () {
       campaignUpdateValidator,
     });
 
-    expect(campaignAdministrationRepository.update).to.have.been.calledOnceWith({
-      campaignId,
-      campaignAttributes,
-    });
+    expect(campaignAdministrationRepository.update).to.have.been.calledOnceWith(campaign);
   });
 
   context('when you update campaign but validation is wrong', function () {

--- a/api/tests/prescription/campaign/unit/domain/usecases/update-campaign_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/update-campaign_test.js
@@ -48,189 +48,38 @@ describe('Unit | UseCase | update-campaign', function () {
         .resolves([ownerwithMembership]);
     });
 
-    it('should update the campaign title only', async function () {
+    it('should update the campaign', async function () {
       // given
-      const updatedCampaign = domainBuilder.prescription.campaign.buildCampaign.ofTypeAssessment({
+      const campaign = domainBuilder.prescription.campaign.buildCampaign.ofTypeAssessment({
         ...originalCampaign,
-        title: 'New title',
       });
-      campaignAdministrationRepository.update.resolves(updatedCampaign);
-
-      // when
-      const resultCampaign = await usecases.updateCampaign({
-        userId: userWithMembership.id,
-        campaignId: updatedCampaign.id,
-        title: updatedCampaign.title,
-        ownerId,
-        membershipRepository,
-        campaignAdministrationRepository,
-      });
-
-      // then
-      expect(campaignAdministrationRepository.update).to.have.been.calledWithExactly({
-        campaignId: updatedCampaign.id,
-        campaignAttributes: {
-          name: updatedCampaign.name,
-          title: updatedCampaign.title,
-          customLandingPageText: updatedCampaign.customLandingPageText,
-          ownerId: updatedCampaign.ownerId,
-        },
-      });
-      expect(resultCampaign.title).to.equal(updatedCampaign.title);
-      expect(resultCampaign.customLandingPageText).to.equal(originalCampaign.customLandingPageText);
-    });
-
-    it('should update the campaign page text only', async function () {
-      // given
-      const updatedCampaign = domainBuilder.prescription.campaign.buildCampaign({
-        ...originalCampaign,
-        customLandingPageText: 'New text',
-      });
-      campaignAdministrationRepository.update.resolves(updatedCampaign);
-
-      // when
-      const resultCampaign = await usecases.updateCampaign({
-        userId: userWithMembership.id,
-        campaignId: updatedCampaign.id,
-        ownerId,
-        customLandingPageText: updatedCampaign.customLandingPageText,
-        campaignAdministrationRepository,
-        membershipRepository,
-      });
-
-      // then
-      expect(campaignAdministrationRepository.update).to.have.been.calledWithExactly({
-        campaignId: updatedCampaign.id,
-        campaignAttributes: {
-          name: updatedCampaign.name,
-          title: updatedCampaign.title,
-          customLandingPageText: updatedCampaign.customLandingPageText,
-          ownerId: updatedCampaign.ownerId,
-        },
-      });
-      expect(resultCampaign.title).to.equal(originalCampaign.title);
-      expect(resultCampaign.customLandingPageText).to.equal(updatedCampaign.customLandingPageText);
-    });
-
-    it('should update the campaign archive date only', async function () {
-      // given
-      const updatedCampaign = domainBuilder.prescription.campaign.buildCampaign({ ...originalCampaign });
-      campaignAdministrationRepository.update.resolves(updatedCampaign);
-
-      // when
-      const resultCampaign = await usecases.updateCampaign({
-        userId: userWithMembership.id,
-        campaignId: updatedCampaign.id,
-        ownerId,
-        campaignAdministrationRepository,
-        membershipRepository,
-      });
-
-      // then
-      expect(campaignAdministrationRepository.update).to.have.been.calledWithExactly({
-        campaignId: updatedCampaign.id,
-        campaignAttributes: {
-          name: updatedCampaign.name,
-          title: updatedCampaign.title,
-          customLandingPageText: updatedCampaign.customLandingPageText,
-          ownerId: updatedCampaign.ownerId,
-        },
-      });
-      expect(resultCampaign.title).to.equal(originalCampaign.title);
-      expect(resultCampaign.customLandingPageText).to.equal(originalCampaign.customLandingPageText);
-    });
-
-    it('should update the campaign name only', async function () {
-      // given
-      const updatedCampaign = domainBuilder.prescription.campaign.buildCampaign({
-        ...originalCampaign,
+      const expectedResult = Symbol('updatedCampaign');
+      sinon.stub(campaign, 'updateFields');
+      campaignAdministrationRepository.get.withArgs(campaign.id).resolves(campaign);
+      campaignAdministrationRepository.update.withArgs(campaign).resolves(expectedResult);
+      membershipRepository.findByUserIdAndOrganizationId
+        .withArgs({ userId: userWithMembership.id, organizationId: campaign.organizationId })
+        .resolves([Symbol('membership')]);
+      const attributesToUpdate = {
+        title: 'New Title',
         name: 'New Name',
-      });
-      campaignAdministrationRepository.update.resolves(updatedCampaign);
+        customLandingPageText: 'New Custom Landing Page Text',
+        ownerId: 1,
+      };
 
       // when
       const resultCampaign = await usecases.updateCampaign({
         userId: userWithMembership.id,
-        campaignId: updatedCampaign.id,
-        name: updatedCampaign.name,
-        title: originalCampaign.title,
+        campaignId: campaign.id,
         ownerId,
-        campaignAdministrationRepository,
         membershipRepository,
+        campaignAdministrationRepository,
+        ...attributesToUpdate,
       });
 
       // then
-      expect(campaignAdministrationRepository.update).to.have.been.calledWithExactly({
-        campaignId: updatedCampaign.id,
-        campaignAttributes: {
-          name: updatedCampaign.name,
-          title: updatedCampaign.title,
-          customLandingPageText: updatedCampaign.customLandingPageText,
-          ownerId: updatedCampaign.ownerId,
-        },
-      });
-      expect(resultCampaign.name).to.equal(updatedCampaign.name);
-      expect(resultCampaign.customLandingPageText).to.equal(originalCampaign.customLandingPageText);
-    });
-
-    it('should update the campaign ownerId only', async function () {
-      // given
-      const newOwner = domainBuilder.buildUser({ id: 50 });
-      const newOwnerWithMembership = domainBuilder.buildMembership({
-        user: newOwner,
-        organization: { id: organizationId },
-      });
-      const updatedCampaign = domainBuilder.prescription.campaign.buildCampaign({
-        ...originalCampaign,
-        ownerId: newOwner.id,
-      });
-      campaignAdministrationRepository.update.resolves(updatedCampaign);
-      membershipRepository.findByUserIdAndOrganizationId.resolves([newOwnerWithMembership]);
-
-      // when
-      const resultCampaign = await usecases.updateCampaign({
-        userId: userWithMembership.id,
-        campaignId: updatedCampaign.id,
-        name: originalCampaign.name,
-        title: originalCampaign.title,
-        ownerId: updatedCampaign.ownerId,
-
-        campaignAdministrationRepository,
-        membershipRepository,
-      });
-
-      // then
-      expect(resultCampaign.ownerId).to.equal(updatedCampaign.ownerId);
-    });
-
-    it('should not update the campaign name if campaign name is undefined', async function () {
-      // given
-      const updatedCampaign = domainBuilder.prescription.campaign.buildCampaign({ ...originalCampaign });
-      campaignAdministrationRepository.update.resolves(updatedCampaign);
-
-      // when
-      const resultCampaign = await usecases.updateCampaign({
-        userId: userWithMembership.id,
-        campaignId: updatedCampaign.id,
-        name: undefined,
-        title: originalCampaign.title,
-        ownerId,
-        campaignAdministrationRepository,
-        membershipRepository,
-      });
-
-      // then
-      expect(campaignAdministrationRepository.update).to.have.been.calledWithExactly({
-        campaignId: updatedCampaign.id,
-        campaignAttributes: {
-          name: updatedCampaign.name,
-          title: updatedCampaign.title,
-          customLandingPageText: updatedCampaign.customLandingPageText,
-          ownerId: updatedCampaign.ownerId,
-        },
-      });
-      expect(resultCampaign.name).to.equal(originalCampaign.name);
-      expect(resultCampaign.customLandingPageText).to.equal(originalCampaign.customLandingPageText);
+      expect(campaign.updateFields).to.have.been.calledWithMatch(attributesToUpdate);
+      expect(resultCampaign).to.equal(expectedResult);
     });
   });
 

--- a/api/tests/unit/domain/services/code-generator_test.js
+++ b/api/tests/unit/domain/services/code-generator_test.js
@@ -114,18 +114,4 @@ describe('Unit | Domain | Services | code generator', function () {
       });
     });
   });
-  describe('#validate', function () {
-    it('should return false if code is less than 9 char', function () {
-      expect(codeGenerator.validate('ABC123')).to.be.false;
-    });
-    it('should return false if code is more than 9 char', function () {
-      expect(codeGenerator.validate('ABC123ABC123')).to.be.false;
-    });
-    it('should return false if code contains char other than uppercase Alphanumeric or numbers', function () {
-      expect(codeGenerator.validate('abc abc @')).to.be.false;
-    });
-    it('should return true if code contains only uppercase alphanumeric chars', function () {
-      expect(codeGenerator.validate('123ABDCDE')).to.be.true;
-    });
-  });
 });


### PR DESCRIPTION
## :unicorn: Problème
La logique de validation d'un code de campagne a été mis dans le service de génération de code.

## :robot: Proposition
Ré-intégrer la logique de validation de code dans le model Campaign.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
Les tests sont verts ✅ 
