### PR TITLE
[BUGFIX] Ne pas afficher de grain vide (PIX-11296)

### DIFF
--- a/mon-pix/app/pods/components/module/grain/component.js
+++ b/mon-pix/app/pods/components/module/grain/component.js
@@ -16,11 +16,27 @@ export default class ModuleGrain extends Component {
   }
 
   get shouldDisplaySkipButton() {
-    return this.args.canMoveToNextGrain && this.grain.hasAnswerableElements && !this.allElementsAreAnswered;
+    return this.args.canMoveToNextGrain && this.hasAnswerableElements && !this.allElementsAreAnswered;
+  }
+
+  get displayableElements() {
+    return this.args.grain.supportedElements;
+  }
+
+  get hasAnswerableElements() {
+    return this.displayableElements.some((element) => element.isAnswerable);
+  }
+
+  get answerableElements() {
+    return this.displayableElements.filter((element) => {
+      return element.isAnswerable;
+    });
   }
 
   get allElementsAreAnswered() {
-    return this.grain.allElementsAreAnsweredForPassage(this.args.passage);
+    return this.answerableElements.every((element) => {
+      return !!this.args.passage.getLastCorrectionForElement(element);
+    });
   }
 
   get ariaLiveGrainValue() {

--- a/mon-pix/app/pods/components/module/grain/template.hbs
+++ b/mon-pix/app/pods/components/module/grain/template.hbs
@@ -17,7 +17,7 @@
   </div>
   <div class="grain__card grain-card--{{@grain.type}}">
     <div class="grain-card__content">
-      {{#each @grain.elements as |element|}}
+      {{#each this.displayableElements as |element|}}
         <div class="grain-card-content__element">
           {{#if (eq element.type "text")}}
             <Module::Text @text={{element}} />

--- a/mon-pix/app/pods/components/module/passage/component.js
+++ b/mon-pix/app/pods/components/module/passage/component.js
@@ -6,7 +6,9 @@ import { tracked } from '@glimmer/tracking';
 export default class ModulePassage extends Component {
   @service router;
   @service metrics;
-  @tracked grainsToDisplay = [this.args.module.grains[0]];
+  displayableGrains = this.args.module.grains.filter((grain) => grain.supportedElements.length > 0);
+  @tracked grainsToDisplay = this.displayableGrains.length > 0 ? [this.displayableGrains[0]] : [];
+
   static SCROLL_OFFSET_PX = 70;
 
   @action
@@ -15,7 +17,7 @@ export default class ModulePassage extends Component {
   }
 
   get hasNextGrain() {
-    return this.grainsToDisplay.length < this.args.module.grains.length;
+    return this.grainsToDisplay.length < this.displayableGrains.length;
   }
 
   get lastIndex() {
@@ -24,7 +26,7 @@ export default class ModulePassage extends Component {
 
   @action
   skipToNextGrain() {
-    const lastGrain = this.args.module.grains[this.lastIndex];
+    const lastGrain = this.displayableGrains[this.lastIndex];
 
     this.addNextGrainToDisplay();
 
@@ -38,7 +40,7 @@ export default class ModulePassage extends Component {
 
   @action
   continueToNextGrain() {
-    const lastGrain = this.args.module.grains[this.lastIndex];
+    const lastGrain = this.displayableGrains[this.lastIndex];
 
     this.addNextGrainToDisplay();
 
@@ -55,7 +57,7 @@ export default class ModulePassage extends Component {
       return;
     }
 
-    const nextGrain = this.args.module.grains[this.lastIndex + 1];
+    const nextGrain = this.displayableGrains[this.lastIndex + 1];
     this.grainsToDisplay = [...this.grainsToDisplay, nextGrain];
   }
 

--- a/mon-pix/app/pods/grain/model.js
+++ b/mon-pix/app/pods/grain/model.js
@@ -1,5 +1,7 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
+const AVAILABLE_ELEMENT_TYPES = ['text', 'image', 'video', 'qcu', 'qcm', 'qrocm'];
+
 export default class Grain extends Model {
   @attr('string') title;
   @attr({ defaultValue: () => [] }) elements;
@@ -7,19 +9,7 @@ export default class Grain extends Model {
 
   @belongsTo('module', { async: false, inverse: 'grains' }) module;
 
-  get hasAnswerableElements() {
-    return this.elements.some((element) => element.isAnswerable);
-  }
-
-  get answerableElements() {
-    return this.elements.filter((element) => {
-      return element.isAnswerable;
-    });
-  }
-
-  allElementsAreAnsweredForPassage(passage) {
-    return this.answerableElements.every((element) => {
-      return !!passage.getLastCorrectionForElement(element);
-    });
+  get supportedElements() {
+    return this.elements.filter((element) => AVAILABLE_ELEMENT_TYPES.includes(element.type));
   }
 }

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
@@ -92,7 +92,7 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
       // given
       const text1 = {
         id: 'elementId-1',
-        type: 'texts',
+        type: 'text',
         content: 'content-1',
       };
       const grain1 = server.create('grain', {
@@ -124,17 +124,17 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
 function _createGrains(server) {
   const text1 = {
     id: 'elementId-1',
-    type: 'texts',
+    type: 'text',
     content: 'content-1',
   };
   const text2 = {
     id: 'elementId-2',
-    type: 'texts',
+    type: 'text',
     content: 'content-2',
   };
   const text3 = {
     id: 'elementId-3',
-    type: 'texts',
+    type: 'text',
     content: 'content-3',
   };
 

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
@@ -14,10 +14,14 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleRecap', function (ho
   module('when user arrive on the module recap page', function (hooks) {
     let screen;
     hooks.beforeEach(async function () {
+      const grain = server.create('grain', {
+        id: 'grain1',
+        elements: [{ type: 'text' }],
+      });
       server.create('module', {
         id: 'bien-ecrire-son-adresse-mail',
         title: 'Bien écrire son adresse mail',
-        grains: [],
+        grains: [grain],
         details: {
           image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
           description: 'Description',

--- a/mon-pix/tests/acceptance/module/retake_completed_module_test.js
+++ b/mon-pix/tests/acceptance/module/retake_completed_module_test.js
@@ -29,7 +29,7 @@ module('Acceptance | Module | Routes | retakeCompletedModule', function (hooks) 
 
     const text = {
       id: 'elementId-1',
-      type: 'texts',
+      type: 'text',
       content: 'content-1',
       isAnswerable: false,
     };

--- a/mon-pix/tests/integration/components/module/grain_test.js
+++ b/mon-pix/tests/integration/components/module/grain_test.js
@@ -227,7 +227,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       const correction = store.createRecord('correction-response');
       store.createRecord('element-answer', { element, correction, passage });
-      assert.true(grain.allElementsAreAnsweredForPassage(passage));
 
       // when
       const screen = await render(hbs`
@@ -252,7 +251,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
         const correction = store.createRecord('correction-response');
         store.createRecord('element-answer', { element, correction, passage });
-        assert.true(grain.allElementsAreAnsweredForPassage(passage));
 
         // when
         const screen = await render(hbs`
@@ -272,8 +270,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
         this.set('grain', grain);
         const passage = store.createRecord('passage');
         this.set('passage', passage);
-
-        assert.false(grain.allElementsAreAnsweredForPassage(passage));
 
         // when
         const screen = await render(hbs`
@@ -296,8 +292,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
         const passage = store.createRecord('passage');
         this.set('passage', passage);
 
-        assert.false(grain.allElementsAreAnsweredForPassage(passage));
-
         // when
         const screen = await render(hbs`
             <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
@@ -315,8 +309,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
         this.set('grain', grain);
         const passage = store.createRecord('passage');
         this.set('passage', passage);
-
-        assert.false(grain.allElementsAreAnsweredForPassage(passage));
 
         // when
         const screen = await render(hbs`
@@ -337,8 +329,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
         const passage = store.createRecord('passage');
         this.set('passage', passage);
 
-        assert.false(grain.allElementsAreAnsweredForPassage(passage));
-
         // when
         const screen = await render(hbs`
             <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
@@ -356,8 +346,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
         this.set('grain', grain);
         const passage = store.createRecord('passage');
         this.set('passage', passage);
-
-        assert.false(grain.allElementsAreAnsweredForPassage(passage));
 
         // when
         const screen = await render(hbs`

--- a/mon-pix/tests/integration/components/module/passage_test.js
+++ b/mon-pix/tests/integration/components/module/passage_test.js
@@ -306,4 +306,52 @@ module('Integration | Component | Module | Passage', function (hooks) {
       assert.ok(true);
     });
   });
+
+  module('When a grain contains non existing elements', function () {
+    test('should not display the grain if it contains only non existing elements', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const nonExistingElement1 = { type: 'non-existing-element-type' };
+      const nonExistingElement2 = {
+        type: 'non-existing-element-type',
+      };
+      const elements = [nonExistingElement1, nonExistingElement2];
+      const grain = store.createRecord('grain', { id: 'grainId1', elements });
+
+      const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
+      this.set('module', module);
+
+      const passage = store.createRecord('passage');
+      this.set('passage', passage);
+
+      // when
+      const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
+      // then
+      assert.strictEqual(screen.queryAllByRole('article').length, 0);
+    });
+
+    test('should not display the non existing elements but display the existing ones', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const existingElement = { content: '<h3>existing element content</h3>', type: 'text' };
+      const nonExistingElement1 = { type: 'non-existing-element-type' };
+      const nonExistingElement2 = {
+        type: 'non-existing-element-type',
+      };
+      const elements = [nonExistingElement1, nonExistingElement2, existingElement];
+      const grain = store.createRecord('grain', { id: 'grainId1', elements });
+
+      const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
+      this.set('module', module);
+
+      const passage = store.createRecord('passage');
+      this.set('passage', passage);
+
+      // when
+      const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
+      // then
+      assert.ok(screen.queryByRole('heading', { name: 'existing element content', level: 3 }));
+      assert.dom('.grain-card-content__element').exists({ count: 1 });
+    });
+  });
 });

--- a/mon-pix/tests/unit/components/module/grain_test.js
+++ b/mon-pix/tests/unit/components/module/grain_test.js
@@ -1,0 +1,137 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import createPodsComponent from '../../../helpers/create-pods-component';
+
+module('Unit | Component | Module | Grain', function (hooks) {
+  setupTest(hooks);
+
+  module('#hasAnswerableElements', function () {
+    module('when there are answerable elements in grain', function () {
+      test('should return true', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const qcu = { type: 'qcu', isAnswerable: true };
+        const qcm = { type: 'qcm', isAnswerable: true };
+        const qrocm = { type: 'qrocm', isAnswerable: true };
+        const text = { type: 'text', isAnswerable: false };
+        const grain = store.createRecord('grain', {
+          elements: [qcu, qcm, qrocm, text],
+        });
+        const component = createPodsComponent('module/grain', { grain });
+
+        // when
+        const hasAnswerableElements = component.hasAnswerableElements;
+
+        // then
+        assert.true(hasAnswerableElements);
+      });
+    });
+
+    module('when there are no answerable element in grain', function () {
+      test('should return false', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const text = { type: 'text', isAnswerable: false };
+        const grain = store.createRecord('grain', {
+          elements: [text],
+        });
+        const component = createPodsComponent('module/grain', { grain });
+
+        // when
+        const hasAnswerableElements = component.hasAnswerableElements;
+
+        // then
+        assert.false(hasAnswerableElements);
+      });
+    });
+  });
+
+  module('#answerableElements', function () {
+    module('when there are answerable elements in elements', function () {
+      test('should return only answerable elements', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const qcu = { type: 'qcu', isAnswerable: true };
+        const qcm = { type: 'qcm', isAnswerable: true };
+        const qrocm = { type: 'qrocm', isAnswerable: true };
+        const text = { type: 'text', isAnswerable: false };
+        const grain = store.createRecord('grain', {
+          elements: [qcu, qcm, qrocm, text],
+        });
+        const component = createPodsComponent('module/grain', { grain });
+
+        // when
+        const answerableElements = component.answerableElements;
+
+        // then
+        assert.strictEqual(answerableElements.length, 3);
+        assert.deepEqual(answerableElements, [qcu, qcm, qrocm]);
+      });
+    });
+
+    module('when there are no answerable elements in elements', function () {
+      test('should return an empty array', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const text = { type: 'text' };
+        const grain = store.createRecord('grain', {
+          elements: [text],
+        });
+        const component = createPodsComponent('module/grain', { grain });
+
+        // when
+        const answerableElements = component.answerableElements;
+
+        // then
+        assert.strictEqual(answerableElements.length, 0);
+      });
+    });
+  });
+
+  module('#allElementsAreAnswered', function () {
+    module('when all answerable elements are answered', function () {
+      test('should return true', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const qcu = { id: 'qcu-id-1', type: 'qcu' };
+        const elementAnswer = store.createRecord('element-answer', {
+          elementId: qcu.id,
+        });
+        const passage = store.createRecord('passage', {
+          elementAnswers: [elementAnswer],
+        });
+        const grain = store.createRecord('grain', {
+          elements: [qcu],
+        });
+
+        const component = createPodsComponent('module/grain', { grain, passage });
+
+        // when
+        const allElementsAreAnswered = component.allElementsAreAnswered;
+
+        // then
+        assert.true(allElementsAreAnswered);
+      });
+    });
+
+    module('when all answerable elements are not answered', function () {
+      test('should return false', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const qcu = { type: 'qcu', isAnswerable: true };
+        const grain = store.createRecord('grain', {
+          elements: [qcu],
+        });
+        const passage = store.createRecord('passage');
+        const component = createPodsComponent('module/grain', { grain, passage });
+
+        // when
+        const allElementsAreAnswered = component.allElementsAreAnswered;
+
+        // then
+        assert.false(allElementsAreAnswered);
+      });
+    });
+  });
+});

--- a/mon-pix/tests/unit/models/modules/grain_test.js
+++ b/mon-pix/tests/unit/models/modules/grain_test.js
@@ -4,125 +4,25 @@ import { module, test } from 'qunit';
 module('Unit | Model | Module | Grain', function (hooks) {
   setupTest(hooks);
 
-  module('#hasAnswerableElements', function () {
-    module('when there are answerable elements in grain', function () {
-      test('should return true', function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const qcu = { type: 'qcu', isAnswerable: true };
-        const qcm = { type: 'qcm', isAnswerable: true };
-        const qrocm = { type: 'qrocm', isAnswerable: true };
-        const text = { type: 'text', isAnswerable: false };
-        const grain = store.createRecord('grain', {
-          elements: [qcu, qcm, qrocm, text],
-        });
+  module('#supportedElements', function () {
+    test('should filter out not supported elements', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const qcu = { type: 'qcu', isAnswerable: true };
+      const qcm = { type: 'qcm', isAnswerable: true };
+      const qrocm = { type: 'qrocm', isAnswerable: true };
+      const unknown = { type: 'unknown', isAnswerable: false };
+      const text = { type: 'text', isAnswerable: false };
+      const video = { type: 'video', isAnswerable: false };
+      const image = { type: 'image', isAnswerable: false };
+      const expectedSupportedElements = [qcu, qcm, qrocm, text, video, image];
+      const grain = store.createRecord('grain', { elements: [...expectedSupportedElements, unknown] });
 
-        // when
-        const hasAnswerableElements = grain.hasAnswerableElements;
+      // when
+      const supportedElements = grain.supportedElements;
 
-        // then
-        assert.true(hasAnswerableElements);
-      });
-    });
-
-    module('when there are no answerable element in grain', function () {
-      test('should return false', function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const text = { type: 'text', isAnswerable: false };
-        const grain = store.createRecord('grain', {
-          elements: [text],
-        });
-
-        // when
-        const hasAnswerableElements = grain.hasAnswerableElements;
-
-        // then
-        assert.false(hasAnswerableElements);
-      });
-    });
-  });
-
-  module('#answerableElements', function () {
-    module('when there are answerable elements in elements', function () {
-      test('should return only answerable elements', function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const qcu = { type: 'qcu', isAnswerable: true };
-        const qcm = { type: 'qcm', isAnswerable: true };
-        const qrocm = { type: 'qrocm', isAnswerable: true };
-        const text = { type: 'text', isAnswerable: false };
-        const grain = store.createRecord('grain', {
-          elements: [qcu, qcm, qrocm, text],
-        });
-
-        // when
-        const answerableElements = grain.answerableElements;
-
-        // then
-        assert.strictEqual(answerableElements.length, 3);
-        assert.deepEqual(answerableElements, [qcu, qcm, qrocm]);
-      });
-    });
-
-    module('when there are no answerable elements in elements', function () {
-      test('should return an empty array', function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const text = { type: 'text' };
-        const grain = store.createRecord('grain', {
-          elements: [text],
-        });
-
-        // when
-        const answerableElements = grain.answerableElements;
-
-        // then
-        assert.strictEqual(answerableElements.length, 0);
-      });
-    });
-  });
-
-  module('#allElementsAreAnsweredForPassage', function () {
-    module('when all answerable elements are answered', function () {
-      test('should return true', function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const qcu = { id: 'qcu-id-1', type: 'qcu' };
-        const elementAnswer = store.createRecord('element-answer', {
-          elementId: qcu.id,
-        });
-        const passage = store.createRecord('passage', {
-          elementAnswers: [elementAnswer],
-        });
-        const grain = store.createRecord('grain', {
-          elements: [qcu],
-        });
-
-        // when
-        const allElementsAreAnswered = grain.allElementsAreAnsweredForPassage(passage);
-
-        // then
-        assert.true(allElementsAreAnswered);
-      });
-    });
-
-    module('when all answerable elements are not answered', function () {
-      test('should return false', function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const qcu = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', {
-          elements: [qcu],
-        });
-        const passage = store.createRecord('passage');
-
-        // when
-        const allElementsAreAnswered = grain.allElementsAreAnsweredForPassage(passage);
-
-        // then
-        assert.false(allElementsAreAnswered);
-      });
+      // then
+      assert.strictEqual(supportedElements.length, expectedSupportedElements.length);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Le problème survient lorsque l'API permet de renvoyer des grains avec de nouveaux types d'éléments.
Comme le front ne les gère pas encore, dans le cas où un grain ne contient que des éléments de types non pris en charge, nous verrons à l'écran un grain vide.
De même, si le grain comporte un élément pris en charge et un autre non pris en charge, le front affichera une `div` vide à la place de l'élément non pris en charge.

## :robot: Proposition
Ajouter un _getter_ `supportedElements` dans le modèle `Grain` du front qui retourne le tableau d'`Element` filtrés qui ne contient que les éléments pris en charge par le front.
De fait, le composant `Passage` ne prend en compte que les grains possédant au moins un élément affichable via le _getter_ du `Grain`.

## :rainbow: Remarques

## :100: Pour tester
En local:

1. via le plugin d'Ember, assigner un type non pris en charge pour un des éléments du module courant
2. terminer le module
3. revenir au détail en utilisant le CTA "Revenir aux détails du module"
4. relancer le passage en utilisant le CTA "Commencer le module"
5. constater que l'élément modifié n'apparaît pas
