### PR TITLE
[TECH] Supprimer la configuration des endpoints trouvés automatiquement par OpenID Configuration (PIX-11106)

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -512,6 +512,13 @@ AUTH_SECRET=the-password-must-be-at-least-32-characters-long
 # type: string
 # sample: POLE_EMPLOI_CLIENT_SECRET=
 
+# Token URL
+# Refer to https://pole-emploi.io/data/api/pole-emploi-connect
+#
+# presence: required for POLE EMPLOI authentication, optional otherwise
+# type: URL
+# sample: POLE_EMPLOI_TOKEN_URL=
+
 # Logout URL
 # Refer to https://pole-emploi.io/data/api/pole-emploi-connect
 #

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -312,7 +312,6 @@ const configuration = (function () {
     poleEmploi: {
       accessTokenLifespanMs: ms(process.env.POLE_EMPLOI_ACCESS_TOKEN_LIFESPAN || '7d'),
       afterLogoutUrl: process.env.POLE_EMPLOI_OIDC_AFTER_LOGOUT_URL,
-      authenticationUrl: process.env.POLE_EMPLOI_OIDC_AUTHENTICATION_URL,
       clientId: process.env.POLE_EMPLOI_CLIENT_ID,
       clientSecret: process.env.POLE_EMPLOI_CLIENT_SECRET,
       isEnabled: isFeatureEnabled(process.env.POLE_EMPLOI_ENABLED),
@@ -325,7 +324,6 @@ const configuration = (function () {
       sendingUrl: process.env.POLE_EMPLOI_SENDING_URL,
       tokenUrl: process.env.POLE_EMPLOI_TOKEN_URL,
       temporaryStorage: { idTokenLifespanMs: ms(process.env.POLE_EMPLOI_ID_TOKEN_LIFESPAN || '7d') },
-      userInfoUrl: process.env.POLE_EMPLOI_OIDC_USER_INFO_URL,
     },
     port: parseInt(process.env.PORT, 10) || 3000,
     rootPath: path.normalize(__dirname + '/..'),

--- a/api/tests/authentication/unit/domain/services/oidc-authentication-service_test.js
+++ b/api/tests/authentication/unit/domain/services/oidc-authentication-service_test.js
@@ -573,13 +573,12 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
           );
         }
 
-        const userInfoUrl = 'infoUrl';
         const idToken = generateIdToken({
           nonce: 'bb041272-d6e6-457c-99fb-ff1aa02217fd',
           sub: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
         });
 
-        const oidcAuthenticationService = new OidcAuthenticationService({ userInfoUrl });
+        const oidcAuthenticationService = new OidcAuthenticationService({});
         sinon.stub(oidcAuthenticationService, '_getUserInfoFromEndpoint').resolves({});
 
         // when

--- a/docker/sample.env
+++ b/docker/sample.env
@@ -519,13 +519,6 @@ AUTH_SECRET=the-password-must-be-at-least-32-characters-long
 # type: URL
 # sample: POLE_EMPLOI_TOKEN_URL=
 
-# Authentication URL
-# Refer to https://pole-emploi.io/data/api/pole-emploi-connect
-#
-# presence: required for POLE EMPLOI authentication, optional otherwise
-# type: URL
-# sample: POLE_EMPLOI_OIDC_AUTHENTICATION_URL=
-
 # Logout URL
 # Refer to https://pole-emploi.io/data/api/pole-emploi-connect
 #
@@ -539,13 +532,6 @@ AUTH_SECRET=the-password-must-be-at-least-32-characters-long
 # presence: required for POLE EMPLOI logout, optional otherwise
 # type: URL
 # sample: POLE_EMPLOI_OIDC_AFTER_LOGOUT_URL=
-
-# User info URL
-# Refer to https://pole-emploi.io/data/documentation/comprendre-dispositif-pole-emploi-connect/open-id-connect/requeter-api
-#
-# presence: required for POLE EMPLOI authentication, optional otherwise
-# type: URL
-# sample: POLE_EMPLOI_OIDC_USER_INFO_URL=
 
 # Access Token lifespan
 #
@@ -574,6 +560,13 @@ AUTH_SECRET=the-password-must-be-at-least-32-characters-long
 # default: true
 # sample: PUSH_DATA_TO_POLE_EMPLOI_ENABLED=true
 
+# presence: required
+# type: URL
+# sample: POLE_EMPLOI_REDIRECT_URI=
+
+# presence: required
+# type: URL
+# sample: POLE_EMPLOI_OPENID_CONFIGURATION_URL=
 
 # ===================
 # CNAV CONFIGURATION
@@ -598,24 +591,6 @@ AUTH_SECRET=the-password-must-be-at-least-32-characters-long
 # type: string
 # sample: CNAV_CLIENT_SECRET=
 
-# Token URL
-#
-# presence: required for CNAV authentication, optional otherwise
-# type: URL
-# sample: CNAV_TOKEN_URL=
-
-# Authentication URL
-#
-# presence: required for CNAV authentication, optional otherwise
-# type: URL
-# sample: CNAV_AUTHENTICATION_URL=
-
-# User info URL
-#
-# presence: required for CNAV authentication, optional otherwise
-# type: URL
-# sample: CNAV_OIDC_USER_INFO_URL=
-
 # Access Token lifespan
 #
 # presence: optional
@@ -623,6 +598,13 @@ AUTH_SECRET=the-password-must-be-at-least-32-characters-long
 # default: 7d
 # sample: CNAV_ACCESS_TOKEN_LIFESPAN=7d
 
+# presence: required
+# type: URL
+# sample: CNAV_REDIRECT_URI=
+
+# presence: required
+# type: URL
+# sample: CNAV_OPENID_CONFIGURATION_URL=
 
 # ===================
 # FWB CONFIGURATION
@@ -646,24 +628,6 @@ AUTH_SECRET=the-password-must-be-at-least-32-characters-long
 # presence: required for FWB authentication, optional otherwise
 # type: string
 # sample: FWB_CLIENT_SECRET=
-
-# Token URL
-#
-# presence: required for FWB authentication, optional otherwise
-# type: URL
-# sample: FWB_TOKEN_URL=
-
-# Authentication URL
-#
-# presence: required for FWB authentication, optional otherwise
-# type: URL
-# sample: FWB_AUTHENTICATION_URL=
-
-# User info URL
-#
-# presence: required for FWB authentication, optional otherwise
-# type: URL
-# sample: FWB_USER_INFO_URL=
 
 # Logout URL
 #
@@ -691,6 +655,14 @@ AUTH_SECRET=the-password-must-be-at-least-32-characters-long
 # default: 7d
 # sample: FWB_ID_TOKEN_LIFESPAN=7d
 
+# presence: required
+# type: URL
+# sample: FWB_REDIRECT_URI=
+
+# presence: required
+# type: URL
+# sample: FWB_OPENID_CONFIGURATION_URL=
+
 # ==============================
 # PAYS DE LA LOIRE CONFIGURATION
 # ==============================
@@ -713,24 +685,6 @@ AUTH_SECRET=the-password-must-be-at-least-32-characters-long
 # presence: required for PAYS DE LA LOIRE authentication, optional otherwise
 # type: string
 # sample: PAYSDELALOIRE_CLIENT_SECRET=
-
-# Token URL
-#
-# presence: required for PAYS DE LA LOIRE authentication, optional otherwise
-# type: URL
-# sample: PAYSDELALOIRE_TOKEN_URL=
-
-# Authentication URL
-#
-# presence: required for PAYS DE LA LOIRE authentication, optional otherwise
-# type: URL
-# sample: PAYSDELALOIRE_AUTHENTICATION_URL=
-
-# UserInfo URL
-#
-# presence: required for PAYS DE LA LOIRE authentication, optional otherwise
-# type: URL
-# sample: PAYSDELALOIRE_USER_INFO_URL=
 
 # End session URL
 #
@@ -756,6 +710,13 @@ AUTH_SECRET=the-password-must-be-at-least-32-characters-long
 # default: 7d
 # sample: POLE_EMPLOI_ID_TOKEN_LIFESPAN=7d
 
+# presence: required
+# type: URL
+# sample: PAYSDELALOIRE_REDIRECT_URI=
+
+# presence: required
+# type: URL
+# sample: PAYSDELALOIRE_OPENID_CONFIGURATION_URL=
 
 # ===================
 # GOOGLE CONFIGURATION
@@ -787,30 +748,20 @@ AUTH_SECRET=the-password-must-be-at-least-32-characters-long
 # type: string
 # sample: GOOGLE_CLIENT_SECRET=
 
-# Token URL
-#
-# presence: required for GOOGLE authentication, optional otherwise
-# type: URL
-# sample: GOOGLE_TOKEN_URL=
-
-# Authentication URL
-#
-# presence: required for GOOGLE authentication, optional otherwise
-# type: URL
-# sample: GOOGLE_AUTHENTICATION_URL=
-
-# User info URL
-#
-# presence: required for GOOGLE authentication, optional otherwise
-# type: URL
-# sample: GOOGLE_USER_INFO_URL=
-
 # Temporary storage idToken expiration delay in milliseconds
 #
 # presence: optional
 # type: Integer
 # default: 7d
 # sample: GOOGLE_ACCESS_TOKEN_LIFESPAN=
+
+# presence: required
+# type: URL
+# GOOGLE_REDIRECT_URI=
+
+# presence: required
+# type: URL
+GOOGLE_OPENID_CONFIGURATION_URL=https://accounts.google.com/.well-known/openid-configuration
 
 # ===================
 # AUTHENTICATION SESSION CONFIGURATION


### PR DESCRIPTION
## :unicorn: Contexte

Avec l'ajout de la librairie _openid-client_ avec #8028, nous n'avons plus besoin des variables d'environnement `${SSO}_OIDC_AUTHENTICATION_URL` et `${SSO}_OIDC_USER_INFO_URL`.

Un nettoyage avait déjà été fait précédemment avec #8136, et pour cause d'une régression la restauration de certaines propriétés avait été faite avec #8214.

## :robot: Proposition

Supprimer les dernières utilisations de ces variables dans le code mais en laissant `config.poleEmploi.tokenUrl` en place, car utilisée par Prescription.

## :rainbow: Remarques

Vérifier avec l'équipe Prescription qu'il n'y a pas d'impact !

## :100: Pour tester
- (Non régression) Vérifier que la connexion à France Travail fonctionne bien
