### PR TITLE
[FEATURE][MON-PIX] Supprimer le lien politique de protection des données des élèves dans le footer sur le domaine .org (PIX-11650)

### DIFF
--- a/mon-pix/app/components/footer.hbs
+++ b/mon-pix/app/components/footer.hbs
@@ -47,16 +47,18 @@
             </a>
           </li>
 
-          <li>
-            <a
-              href="{{t 'navigation.footer.student-data-protection-policy-url'}}"
-              target="_blank"
-              class="footer-navigation__item"
-              rel="noopener noreferrer"
-            >
-              {{t "navigation.footer.student-data-protection-policy"}}
-            </a>
-          </li>
+          {{#if this.shouldDisplayStudentDataProtectionPolicyLink}}
+            <li>
+              <a
+                href="{{t 'navigation.footer.student-data-protection-policy-url'}}"
+                target="_blank"
+                class="footer-navigation__item"
+                rel="noopener noreferrer"
+              >
+                {{t "navigation.footer.student-data-protection-policy"}}
+              </a>
+            </li>
+          {{/if}}
           <li>
             <LinkTo
               @route="authenticated.sitemap"

--- a/mon-pix/app/components/footer.js
+++ b/mon-pix/app/components/footer.js
@@ -10,6 +10,10 @@ export default class Footer extends Component {
     return this.currentDomain.isFranceDomain;
   }
 
+  get shouldDisplayStudentDataProtectionPolicyLink() {
+    return this.currentDomain.isFranceDomain;
+  }
+
   get currentYear() {
     const date = new Date();
     return date.getFullYear().toString();

--- a/mon-pix/tests/integration/components/footer_test.js
+++ b/mon-pix/tests/integration/components/footer_test.js
@@ -8,7 +8,7 @@ import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 module('Integration | Component | Footer', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('should display the Pix logo', async function (assert) {
+  test('displays the Pix logo', async function (assert) {
     // when
     const screen = await render(hbs`<Footer />}`);
 
@@ -16,7 +16,7 @@ module('Integration | Component | Footer', function (hooks) {
     assert.ok(screen.getByAltText(this.intl.t('navigation.homepage')));
   });
 
-  test('should display the navigation menu with expected elements', async function (assert) {
+  test('displays the navigation menu with expected elements', async function (assert) {
     // when
     const screen = await render(hbs`<Footer />}`);
 
@@ -29,7 +29,7 @@ module('Integration | Component | Footer', function (hooks) {
     assert.ok(screen.getByRole('link', { name: this.intl.t('navigation.footer.sitemap') }));
   });
 
-  test('should not display marianne logo when url does not have frenchDomainExtension', async function (assert) {
+  test('does not display marianne logo when url does not have frenchDomainExtension', async function (assert) {
     // given
     class CurrentDomainServiceStub extends Service {
       get isFranceDomain() {
@@ -45,7 +45,7 @@ module('Integration | Component | Footer', function (hooks) {
     assert.notOk(screen.queryByAltText(this.intl.t('common.french-republic')));
   });
 
-  test('should display marianne logo when url does have frenchDomainExtension', async function (assert) {
+  test('displays marianne logo when url does have frenchDomainExtension', async function (assert) {
     // given
     class CurrentDomainServiceStub extends Service {
       get isFranceDomain() {
@@ -61,7 +61,7 @@ module('Integration | Component | Footer', function (hooks) {
     assert.ok(screen.getByAltText(this.intl.t('common.french-republic')));
   });
 
-  test('should display the student data policy', async function (assert) {
+  test('displays the student data policy', async function (assert) {
     // given & when
     const screen = await render(hbs`<Footer />}`);
 

--- a/mon-pix/tests/integration/components/footer_test.js
+++ b/mon-pix/tests/integration/components/footer_test.js
@@ -29,36 +29,44 @@ module('Integration | Component | Footer', function (hooks) {
     assert.ok(screen.getByRole('link', { name: this.intl.t('navigation.footer.sitemap') }));
   });
 
-  test('does not display marianne logo when url does not have frenchDomainExtension', async function (assert) {
-    // given
-    class CurrentDomainServiceStub extends Service {
-      get isFranceDomain() {
-        return false;
+  module('when url does not have frenchDomainExtension', function (hooks) {
+    hooks.beforeEach(function () {
+      class CurrentDomainServiceStub extends Service {
+        get isFranceDomain() {
+          return false;
+        }
       }
-    }
-    this.owner.register('service:currentDomain', CurrentDomainServiceStub);
 
-    // when
-    const screen = await render(hbs`<Footer />`);
+      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+    });
 
-    // then
-    assert.notOk(screen.queryByAltText(this.intl.t('common.french-republic')));
+    test('does not display marianne logo', async function (assert) {
+      // when
+      const screen = await render(hbs`<Footer />`);
+
+      // then
+      assert.dom(screen.queryByAltText('République française. Liberté, égalité, fraternité.')).doesNotExist();
+    });
   });
 
-  test('displays marianne logo when url does have frenchDomainExtension', async function (assert) {
-    // given
-    class CurrentDomainServiceStub extends Service {
-      get isFranceDomain() {
-        return true;
+  module('when url does have frenchDomainExtension', function (hooks) {
+    hooks.beforeEach(function () {
+      class CurrentDomainServiceStub extends Service {
+        get isFranceDomain() {
+          return true;
+        }
       }
-    }
-    this.owner.register('service:currentDomain', CurrentDomainServiceStub);
 
-    // when
-    const screen = await render(hbs`<Footer />`);
+      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+    });
 
-    // then
-    assert.ok(screen.getByAltText(this.intl.t('common.french-republic')));
+    test('displays marianne logo', async function (assert) {
+      // when
+      const screen = await render(hbs`<Footer />`);
+
+      // then
+      assert.dom(screen.getByAltText('République française. Liberté, égalité, fraternité.')).exists();
+    });
   });
 
   test('displays the student data policy', async function (assert) {

--- a/mon-pix/tests/integration/components/footer_test.js
+++ b/mon-pix/tests/integration/components/footer_test.js
@@ -23,7 +23,6 @@ module('Integration | Component | Footer', function (hooks) {
     // then
     assert.ok(screen.getByRole('link', { name: this.intl.t('navigation.footer.a11y') }));
     assert.ok(screen.getByRole('link', { name: this.intl.t('navigation.footer.data-protection-policy') }));
-    assert.ok(screen.getByRole('link', { name: this.intl.t('navigation.footer.student-data-protection-policy') }));
     assert.ok(screen.getByRole('link', { name: this.intl.t('navigation.footer.eula') }));
     assert.ok(screen.getByRole('link', { name: this.intl.t('navigation.footer.help-center') }));
     assert.ok(screen.getByRole('link', { name: this.intl.t('navigation.footer.sitemap') }));
@@ -47,6 +46,14 @@ module('Integration | Component | Footer', function (hooks) {
       // then
       assert.dom(screen.queryByAltText('République française. Liberté, égalité, fraternité.')).doesNotExist();
     });
+
+    test('does not display the student data policy', async function (assert) {
+      // when
+      const screen = await render(hbs`<Footer />}`);
+
+      // then
+      assert.dom(screen.queryByRole('link', { name: 'Politique de protection des données des élèves' })).doesNotExist();
+    });
   });
 
   module('when url does have frenchDomainExtension', function (hooks) {
@@ -67,13 +74,13 @@ module('Integration | Component | Footer', function (hooks) {
       // then
       assert.dom(screen.getByAltText('République française. Liberté, égalité, fraternité.')).exists();
     });
-  });
 
-  test('displays the student data policy', async function (assert) {
-    // given & when
-    const screen = await render(hbs`<Footer />}`);
+    test('displays the student data policy', async function (assert) {
+      // when
+      const screen = await render(hbs`<Footer />}`);
 
-    // then
-    assert.ok(screen.getByRole('link', { name: this.intl.t('navigation.footer.student-data-protection-policy') }));
+      // then
+      assert.dom(screen.getByRole('link', { name: 'Politique de protection des données des élèves' })).exists();
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Le lien [Politique de protection des données des élèves](https://cloud.pix.fr/s/nqgBodTkbtsGb39) présent dans le footer de Pix App, ne concerne que les utilisateurs du domaine .fr

## :robot: Proposition
Supprimer ce lien lorsqu'on est sur le domaine .org.

## :rainbow: Remarques
RAS

## :100: Pour tester
### Test de non régression sur le domaine .fr
- Se connecter sur la RA Pix App (.fr) https://app-pr8460.review.pix.fr/ avec un compte déjà existant (ex: superadmin@example.net)
- Vérifier, dans le footer, que le lien `Politique de protection des données des élèves` est toujours présent

### Test sur le domaine .org
- Se connecter sur la RA Pix App (.org) https://app-pr8460.review.pix.org/ avec un compte déjà existant (ex: superadmin@example.net)
- Vérifier, dans le footer, que le lien `Politique de protection des données des élèves` n'est plus affiché.