### PR TITLE
[BUGFIX] Remonter la dernière participation d'un élève à une certification sur le CSV des résultats (PIX-11647)

### DIFF
--- a/api/src/certification/course/infrastructure/repositories/sco-certification-candidate-repository.js
+++ b/api/src/certification/course/infrastructure/repositories/sco-certification-candidate-repository.js
@@ -4,9 +4,9 @@ import { knex } from '../../../../../db/knex-database-connection.js';
  * @param {Object} params
  * @param {number} params.organizationId
  * @param {string} params.division
- * @returns {Array<number>} candidates identifiers of active students participants to certification sessions within given division
+ * @returns {Promise<Array<number>>} candidates identifiers of active students participants to certification sessions within given division
  */
-const findIdsByOrganizationIdAndDivision = async function ({ organizationId, division }) {
+const findIdsByOrganizationIdAndDivision = function ({ organizationId, division }) {
   const uniqLastCandidatesByOrganizationLearners = knex
     .select(
       'certification-candidates.id',

--- a/api/src/certification/course/infrastructure/repositories/sco-certification-candidate-repository.js
+++ b/api/src/certification/course/infrastructure/repositories/sco-certification-candidate-repository.js
@@ -11,7 +11,10 @@ const findIdsByOrganizationIdAndDivision = async function ({ organizationId, div
     .select(
       'certification-candidates.id',
       knex.raw(
-        'row_number() OVER (PARTITION BY "certification-candidates"."organizationLearnerId" ORDER BY "sessions"."publishedAt" DESC NULLS LAST) as session_number',
+        `row_number() OVER (
+          PARTITION BY "certification-candidates"."organizationLearnerId"
+          ORDER BY "certification-courses"."createdAt" DESC
+        ) as session_number`,
       ),
     )
     .from('certification-candidates')


### PR DESCRIPTION
## :unicorn: Problème
Une élève a rejoint une première certification mais celle-ci a été annulée car le surveillant a cliqué sur “Terminer le test” au lieu de “Autoriser à reprendre” lors de la première question de la candidate.
Elle a donc été réinscrite dans la foulée à une autre session et a pu passer sa certification le même jour.

C'est le résultat de la session annulée qui remonte dans le CSV des résultats de la classe à laquelle elle appartient.

## :robot: Proposition
Plutôt que de remonter le résultat de la dernière session publiée, nous remontons le résultat de la dernière participation à une certification dont la session a été publiée.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
Voici le setup que j'ai fait:
- J'ai pris l'élève first-name0 last-name0 de 1ère A (learneremail7200_0@example.net / pix123)
- Je l'ai accepté en session 7400 (crée et qui inclue cet élève dans les seeds).
- J'ai répondu à une question via le compte pix de l'élève
- En tant que surveillant, j'ai terminé le test de cet élève.
- J'ai créé une nouvelle session 7409 avec ce même élève.
- J'ai complété un certification course à 100% sur cette session (accepté en session + log sur Firefox de l'élève et magic button).
- En tant que surveillant j'ai finalisé les deux sessions (en indiquant problème technique pour la session 7400
- Sur pix admin, j'ai publié les deux sessions en même temps.

Ce qui nous donne [sur orga](https://orga-pr8464.review.pix.fr/certifications) (orga-sco-managing-students@example.net / pix123)
- Sélectionner la classe de 1ère A
- click sur exporter les résultats
- Ce qui nous donne un export avec le résultat de la deuxième entrée en certif (via la session 7409) pour l'élève first-name0 last-name0 🎉 
<img width="1331" alt="image" src="https://github.com/1024pix/pix/assets/3033624/8d4522a4-0d2e-49c9-ac72-9bc6a9a1f5cc">
