### PR TITLE
[FEATURE] Afficher Pix Certif et Pix Orga en anglais lorsque la langue de l'utilisateur n'est pas supportée (PIX-11633)

### DIFF
--- a/certif/app/components/banner/language-availability.hbs
+++ b/certif/app/components/banner/language-availability.hbs
@@ -1,0 +1,5 @@
+{{#if this.shouldDisplayBanner}}
+  <PixBanner @type="information" @canCloseBanner="true" @onCloseBannerTriggerAction={{this.closeBanner}}>
+    {{t "banners.language-availability.message"}}
+  </PixBanner>
+{{/if}}

--- a/certif/app/components/banner/language-availability.js
+++ b/certif/app/components/banner/language-availability.js
@@ -1,0 +1,17 @@
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+
+export default class LanguageAvailabilityBanner extends Component {
+  @service session;
+
+  get shouldDisplayBanner() {
+    const localeNotSupported = this.session?.data?.localeNotSupported;
+    const localeNotSupportedBannerClosed = this.session?.data?.localeNotSupportedBannerClosed;
+
+    return localeNotSupported && !localeNotSupportedBannerClosed;
+  }
+
+  @action
+  closeBanner() {}
+}

--- a/certif/app/components/banner/language-availability.js
+++ b/certif/app/components/banner/language-availability.js
@@ -13,5 +13,7 @@ export default class LanguageAvailabilityBanner extends Component {
   }
 
   @action
-  closeBanner() {}
+  closeBanner() {
+    this.session.updateDataAttribute('localeNotSupportedBannerClosed', true);
+  }
 }

--- a/certif/app/services/locale.js
+++ b/certif/app/services/locale.js
@@ -6,8 +6,8 @@ export const FRENCH_INTERNATIONAL_LOCALE = 'fr';
 export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 export const FRENCH_FRANCE_LOCALE = 'fr-FR';
 export const DEFAULT_LOCALE = FRENCH_INTERNATIONAL_LOCALE;
+export const SUPPORTED_LANGUAGES = Object.keys(languages);
 
-const SUPPORTED_LANGUAGES = Object.keys(languages);
 const { COOKIE_LOCALE_LIFESPAN_IN_SECONDS } = config.APP;
 
 export default class LocaleService extends Service {

--- a/certif/app/services/session.js
+++ b/certif/app/services/session.js
@@ -54,6 +54,8 @@ export default class CurrentSessionService extends SessionService {
     }
 
     const localeNotSupported = userLocale && !SUPPORTED_LANGUAGES.includes(userLocale);
+
+    this.data.localeNotSupported = localeNotSupported;
     const locale = localeNotSupported ? ENGLISH_INTERNATIONAL_LOCALE : userLocale || FRENCH_INTERNATIONAL_LOCALE;
 
     this.locale.setLocale(locale);

--- a/certif/app/services/session.js
+++ b/certif/app/services/session.js
@@ -66,4 +66,8 @@ export default class CurrentSessionService extends SessionService {
       runTask(this, resolve, millisecondsToWait);
     });
   }
+
+  updateDataAttribute(attribute, value) {
+    this.data[attribute] = value;
+  }
 }

--- a/certif/app/services/session.js
+++ b/certif/app/services/session.js
@@ -1,7 +1,12 @@
 import { service } from '@ember/service';
 import { runTask } from 'ember-lifeline';
 import SessionService from 'ember-simple-auth/services/session';
-import { FRENCH_FRANCE_LOCALE, FRENCH_INTERNATIONAL_LOCALE } from 'pix-certif/services/locale';
+import {
+  ENGLISH_INTERNATIONAL_LOCALE,
+  FRENCH_FRANCE_LOCALE,
+  FRENCH_INTERNATIONAL_LOCALE,
+  SUPPORTED_LANGUAGES,
+} from 'pix-certif/services/locale';
 
 export default class CurrentSessionService extends SessionService {
   @service currentDomain;
@@ -48,7 +53,9 @@ export default class CurrentSessionService extends SessionService {
       return;
     }
 
-    const locale = userLocale || FRENCH_INTERNATIONAL_LOCALE;
+    const localeNotSupported = userLocale && !SUPPORTED_LANGUAGES.includes(userLocale);
+    const locale = localeNotSupported ? ENGLISH_INTERNATIONAL_LOCALE : userLocale || FRENCH_INTERNATIONAL_LOCALE;
+
     this.locale.setLocale(locale);
   }
 

--- a/certif/app/services/session.js
+++ b/certif/app/services/session.js
@@ -30,6 +30,7 @@ export default class CurrentSessionService extends SessionService {
   }
 
   handleInvalidation() {
+    this.store.clear();
     super.handleInvalidation('/connexion');
   }
 

--- a/certif/app/templates/authenticated.hbs
+++ b/certif/app/templates/authenticated.hbs
@@ -83,6 +83,8 @@
       </PixBanner>
     {{/if}}
 
+    <Banner::LanguageAvailability />
+
     <div class="page">
       {{outlet}}
     </div>

--- a/certif/tests/integration/components/banner/language-availability_test.js
+++ b/certif/tests/integration/components/banner/language-availability_test.js
@@ -1,0 +1,67 @@
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Banner::LanguageAvailability', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  let session;
+
+  hooks.beforeEach(function () {
+    session = this.owner.lookup('service:session');
+  });
+
+  module('when user language is available', function () {
+    test('does not display the language availability banner', async function (assert) {
+      // given
+      session.data.localeNotSupported = false;
+      session.data.localeNotSupportedBannerClosed = false;
+
+      // when
+      const screen = await render(hbs`<Banner::LanguageAvailability />`);
+
+      // then
+      assert.dom(screen.queryByRole('alert')).doesNotExist();
+    });
+  });
+
+  module('when user language is not available', function (hooks) {
+    hooks.beforeEach(function () {
+      session.data.localeNotSupported = true;
+    });
+
+    module('when the user has not closed the banner', function () {
+      test('displays the language availability banner', async function (assert) {
+        // given
+        session.data.localeNotSupportedBannerClosed = false;
+
+        // when
+        const screen = await render(hbs`<Banner::LanguageAvailability />`);
+
+        // then
+        assert
+          .dom(
+            screen.getByText(
+              `Votre langue n'est pas encore disponible sur Pix Certif. Pour votre confort, l'application sera présentée en anglais. Toute l'équipe de Pix travaille à l'ajout de votre langue.`,
+            ),
+          )
+          .exists();
+      });
+    });
+
+    module('when the user has closed the banner', function () {
+      test('does not display the language availability banner', async function (assert) {
+        // given
+        session.data.localeNotSupportedBannerClosed = true;
+
+        // when
+        const screen = await render(hbs`<Banner::LanguageAvailability />`);
+
+        // then
+        assert.dom(screen.queryByRole('alert')).doesNotExist();
+      });
+    });
+  });
+});

--- a/certif/tests/integration/components/banner/language-availability_test.js
+++ b/certif/tests/integration/components/banner/language-availability_test.js
@@ -1,4 +1,4 @@
-import { render } from '@1024pix/ember-testing-library';
+import { clickByName, render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 
@@ -48,6 +48,20 @@ module('Integration | Component | Banner::LanguageAvailability', function (hooks
             ),
           )
           .exists();
+      });
+
+      module('when user close the language availability banner', function () {
+        test('closes the language availability banner', async function (assert) {
+          // given
+          session.data.localeNotSupportedBannerClosed = false;
+          const screen = await render(hbs`<Banner::LanguageAvailability />`);
+
+          // when
+          await clickByName('Fermer');
+
+          // then
+          assert.dom(screen.queryByRole('alert')).doesNotExist();
+        });
       });
     });
 

--- a/certif/tests/unit/components/banner/language-availability_test.js
+++ b/certif/tests/unit/components/banner/language-availability_test.js
@@ -1,0 +1,30 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+
+module('Unit | Component | Banner::LanguageAvailability', function (hooks) {
+  setupTest(hooks);
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
+  module('#closeBanner', function () {
+    test('calls session service method updateDataAttribute', async function (assert) {
+      // given
+      const sessionService = this.owner.lookup('service:session');
+      const component = await createGlimmerComponent('component:banner/language-availability');
+
+      component.session = sessionService;
+      sinon.stub(sessionService, 'updateDataAttribute');
+
+      // when
+      component.closeBanner();
+
+      // then
+      assert.true(sessionService.updateDataAttribute.calledWithExactly('localeNotSupportedBannerClosed', true));
+    });
+  });
+});

--- a/certif/tests/unit/services/session_test.js
+++ b/certif/tests/unit/services/session_test.js
@@ -57,6 +57,24 @@ module('Unit | Service | session', function (hooks) {
     });
   });
 
+  module('#handleInvalidation', function () {
+    test('overrides handleInvalidation method', function (assert) {
+      // then
+      assert.true(service.handleInvalidation instanceof Function);
+    });
+
+    test('calls clear method from session store', function (assert) {
+      // given
+      sinon.stub(service.store, 'clear');
+
+      // when
+      service.handleInvalidation();
+
+      // then
+      assert.true(service.store.clear.calledOnce);
+    });
+  });
+
   module('#handleLocale', function () {
     module('when domain is .fr', function () {
       module('when there is no cookie locale', function () {

--- a/certif/tests/unit/services/session_test.js
+++ b/certif/tests/unit/services/session_test.js
@@ -304,4 +304,18 @@ module('Unit | Service | session', function (hooks) {
       });
     });
   });
+
+  module('#updateDataAttribute', function () {
+    test('updates session data attribute value', function (assert) {
+      // when
+      service.updateDataAttribute('message', 'This is a message!');
+      service.updateDataAttribute('isItUsed', true);
+      service.updateDataAttribute('notDisplayed', false);
+
+      // then
+      assert.strictEqual(service.data.message, 'This is a message!');
+      assert.true(service.data.isItUsed);
+      assert.false(service.data.notDisplayed);
+    });
+  });
 });

--- a/certif/tests/unit/services/session_test.js
+++ b/certif/tests/unit/services/session_test.js
@@ -196,6 +196,21 @@ module('Unit | Service | session', function (hooks) {
         });
 
         module('when user is loaded', function () {
+          module('when user language is not available', function () {
+            test('sets the locale to English international', function (assert) {
+              // given
+              const isFranceDomain = false;
+              const localeFromQueryParam = undefined;
+              const userLocale = 'my-new-language-code-here';
+
+              // when
+              service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+              // then
+              assert.true(localeService.setLocale.calledWith(ENGLISH_INTERNATIONAL_LOCALE));
+            });
+          });
+
           test('sets the locale to the user’s lang', function (assert) {
             // given
             const isFranceDomain = false;

--- a/certif/tests/unit/services/session_test.js
+++ b/certif/tests/unit/services/session_test.js
@@ -208,6 +208,8 @@ module('Unit | Service | session', function (hooks) {
 
               // then
               assert.true(localeService.setLocale.calledWith(ENGLISH_INTERNATIONAL_LOCALE));
+              assert.true(service.data.localeNotSupported);
+              assert.strictEqual(service.data.localeNotSupportedBannerClosed, undefined);
             });
           });
 

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -1,4 +1,9 @@
 {
+  "banners": {
+    "language-availability": {
+      "message": "Your language is not yet available on Pix Orga. For your convenience, the application will be presented in English. The entire Pix team is working to add your language."
+    }
+  },
   "common": {
     "actions": {
       "add": "Add",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -1,4 +1,9 @@
 {
+  "banners": {
+    "language-availability": {
+      "message": "Votre langue n'est pas encore disponible sur Pix Certif. Pour votre confort, l'application sera présentée en anglais. Toute l'équipe de Pix travaille à l'ajout de votre langue."
+    }
+  },
   "common": {
     "actions": {
       "add": "Ajouter",

--- a/orga/app/components/banner/language-availability.hbs
+++ b/orga/app/components/banner/language-availability.hbs
@@ -1,0 +1,5 @@
+{{#if this.shouldDisplayBanner}}
+  <PixBanner @type="information" @canCloseBanner="true" @onCloseBannerTriggerAction={{this.closeBanner}}>
+    {{t "banners.language-availability.message"}}
+  </PixBanner>
+{{/if}}

--- a/orga/app/components/banner/language-availability.js
+++ b/orga/app/components/banner/language-availability.js
@@ -1,0 +1,17 @@
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+
+export default class LanguageAvailabilityBanner extends Component {
+  @service session;
+
+  get shouldDisplayBanner() {
+    const localeNotSupported = this.session?.data?.localeNotSupported;
+    const localeNotSupportedBannerClosed = this.session?.data?.localeNotSupportedBannerClosed;
+
+    return localeNotSupported && !localeNotSupportedBannerClosed;
+  }
+
+  @action
+  closeBanner() {}
+}

--- a/orga/app/components/banner/language-availability.js
+++ b/orga/app/components/banner/language-availability.js
@@ -13,5 +13,7 @@ export default class LanguageAvailabilityBanner extends Component {
   }
 
   @action
-  closeBanner() {}
+  closeBanner() {
+    this.session.updateDataAttribute('localeNotSupportedBannerClosed', true);
+  }
 }

--- a/orga/app/services/locale.js
+++ b/orga/app/services/locale.js
@@ -6,7 +6,7 @@ export const FRENCH_INTERNATIONAL_LOCALE = 'fr';
 export const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 export const FRENCH_FRANCE_LOCALE = 'fr-FR';
 export const DEFAULT_LOCALE = FRENCH_INTERNATIONAL_LOCALE;
-const SUPPORTED_LANGUAGES = Object.keys(languages);
+export const SUPPORTED_LANGUAGES = Object.keys(languages);
 
 const { COOKIE_LOCALE_LIFESPAN_IN_SECONDS } = config.APP;
 

--- a/orga/app/services/session.js
+++ b/orga/app/services/session.js
@@ -28,6 +28,7 @@ export default class CurrentSessionService extends SessionService {
   }
 
   async handleInvalidation() {
+    this.store.clear();
     const routeAfterInvalidation = this._getRouteAfterInvalidation();
     await super.handleInvalidation(routeAfterInvalidation);
   }

--- a/orga/app/services/session.js
+++ b/orga/app/services/session.js
@@ -64,6 +64,10 @@ export default class CurrentSessionService extends SessionService {
     });
   }
 
+  updateDataAttribute(attribute, value) {
+    this.data[attribute] = value;
+  }
+
   _getRouteAfterInvalidation() {
     const alternativeRootURL = this.alternativeRootURL;
     this.alternativeRootURL = null;

--- a/orga/app/services/session.js
+++ b/orga/app/services/session.js
@@ -51,6 +51,8 @@ export default class CurrentSessionService extends SessionService {
     }
 
     const localeNotSupported = userLocale && !SUPPORTED_LANGUAGES.includes(userLocale);
+
+    this.data.localeNotSupported = localeNotSupported;
     const locale = localeNotSupported ? ENGLISH_INTERNATIONAL_LOCALE : userLocale || FRENCH_INTERNATIONAL_LOCALE;
 
     this.locale.setLocale(locale);

--- a/orga/app/services/session.js
+++ b/orga/app/services/session.js
@@ -1,6 +1,11 @@
 import { service } from '@ember/service';
 import SessionService from 'ember-simple-auth/services/session';
-import { FRENCH_FRANCE_LOCALE, FRENCH_INTERNATIONAL_LOCALE } from 'pix-orga/services/locale';
+import {
+  ENGLISH_INTERNATIONAL_LOCALE,
+  FRENCH_FRANCE_LOCALE,
+  FRENCH_INTERNATIONAL_LOCALE,
+  SUPPORTED_LANGUAGES,
+} from 'pix-orga/services/locale';
 
 export default class CurrentSessionService extends SessionService {
   @service currentDomain;
@@ -45,7 +50,9 @@ export default class CurrentSessionService extends SessionService {
       return;
     }
 
-    const locale = userLocale || FRENCH_INTERNATIONAL_LOCALE;
+    const localeNotSupported = userLocale && !SUPPORTED_LANGUAGES.includes(userLocale);
+    const locale = localeNotSupported ? ENGLISH_INTERNATIONAL_LOCALE : userLocale || FRENCH_INTERNATIONAL_LOCALE;
+
     this.locale.setLocale(locale);
   }
 

--- a/orga/app/templates/authenticated.hbs
+++ b/orga/app/templates/authenticated.hbs
@@ -8,6 +8,7 @@
 
     <main class="main-content__body page">
       <Banner::Information />
+      <Banner::LanguageAvailability />
       {{outlet}}
     </main>
 

--- a/orga/tests/integration/components/banner/language-availability_test.js
+++ b/orga/tests/integration/components/banner/language-availability_test.js
@@ -1,0 +1,67 @@
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Banner::LanguageAvailability', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  let session;
+
+  hooks.beforeEach(function () {
+    session = this.owner.lookup('service:session');
+  });
+
+  module('when user language is available', function () {
+    test('does not display the language availability banner', async function (assert) {
+      // given
+      session.data.localeNotSupported = false;
+      session.data.localeNotSupportedBannerClosed = false;
+
+      // when
+      const screen = await render(hbs`<Banner::LanguageAvailability />`);
+
+      // then
+      assert.dom(screen.queryByRole('alert')).doesNotExist();
+    });
+  });
+
+  module('when user language is not available', function (hooks) {
+    hooks.beforeEach(function () {
+      session.data.localeNotSupported = true;
+    });
+
+    module('when the user has not closed the banner', function () {
+      test('displays the language availability banner', async function (assert) {
+        // given
+        session.data.localeNotSupportedBannerClosed = false;
+
+        // when
+        const screen = await render(hbs`<Banner::LanguageAvailability />`);
+
+        // then
+        assert
+          .dom(
+            screen.getByText(
+              `Votre langue n'est pas encore disponible sur Pix Orga. Pour votre confort, l'application sera présentée en anglais. Toute l'équipe de Pix travaille à l'ajout de votre langue.`,
+            ),
+          )
+          .exists();
+      });
+    });
+
+    module('when the user has closed the banner', function () {
+      test('does not display the language availability banner', async function (assert) {
+        // given
+        session.data.localeNotSupportedBannerClosed = true;
+
+        // when
+        const screen = await render(hbs`<Banner::LanguageAvailability />`);
+
+        // then
+        assert.dom(screen.queryByRole('alert')).doesNotExist();
+      });
+    });
+  });
+});

--- a/orga/tests/integration/components/banner/language-availability_test.js
+++ b/orga/tests/integration/components/banner/language-availability_test.js
@@ -1,4 +1,4 @@
-import { render } from '@1024pix/ember-testing-library';
+import { clickByName, render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 
@@ -48,6 +48,20 @@ module('Integration | Component | Banner::LanguageAvailability', function (hooks
             ),
           )
           .exists();
+      });
+
+      module('when user close the language availability banner', function () {
+        test('closes the language availability banner', async function (assert) {
+          // given
+          session.data.localeNotSupportedBannerClosed = false;
+          const screen = await render(hbs`<Banner::LanguageAvailability />`);
+
+          // when
+          await clickByName('Fermer');
+
+          // then
+          assert.dom(screen.queryByRole('alert')).doesNotExist();
+        });
       });
     });
 

--- a/orga/tests/unit/components/banner/language-availability_test.js
+++ b/orga/tests/unit/components/banner/language-availability_test.js
@@ -1,0 +1,30 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+
+module('Unit | Component | Banner::LanguageAvailability', function (hooks) {
+  setupTest(hooks);
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
+  module('#closeBanner', function () {
+    test('calls session service method updateDataAttribute', async function (assert) {
+      // given
+      const sessionService = this.owner.lookup('service:session');
+      const component = await createGlimmerComponent('component:banner/language-availability');
+
+      component.session = sessionService;
+      sinon.stub(sessionService, 'updateDataAttribute');
+
+      // when
+      component.closeBanner();
+
+      // then
+      assert.true(sessionService.updateDataAttribute.calledWithExactly('localeNotSupportedBannerClosed', true));
+    });
+  });
+});

--- a/orga/tests/unit/services/session_test.js
+++ b/orga/tests/unit/services/session_test.js
@@ -357,4 +357,18 @@ module('Unit | Service | session', function (hooks) {
       });
     });
   });
+
+  module('#updateDataAttribute', function () {
+    test('updates session data attribute value', function (assert) {
+      // when
+      service.updateDataAttribute('message', 'This is a message!');
+      service.updateDataAttribute('isItUsed', true);
+      service.updateDataAttribute('notDisplayed', false);
+
+      // then
+      assert.strictEqual(service.data.message, 'This is a message!');
+      assert.true(service.data.isItUsed);
+      assert.false(service.data.notDisplayed);
+    });
+  });
 });

--- a/orga/tests/unit/services/session_test.js
+++ b/orga/tests/unit/services/session_test.js
@@ -225,6 +225,21 @@ module('Unit | Service | session', function (hooks) {
         });
 
         module('when user is loaded', function () {
+          module('when user language is not available', function () {
+            test('sets the locale to English international', function (assert) {
+              // given
+              const isFranceDomain = false;
+              const localeFromQueryParam = undefined;
+              const userLocale = 'my-new-language-code-here';
+
+              // when
+              service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+              // then
+              assert.true(localeService.setLocale.calledWith(ENGLISH_INTERNATIONAL_LOCALE));
+            });
+          });
+
           test('sets the locale to the user’s lang', function (assert) {
             // given
             service.currentUser = {

--- a/orga/tests/unit/services/session_test.js
+++ b/orga/tests/unit/services/session_test.js
@@ -52,9 +52,20 @@ module('Unit | Service | session', function (hooks) {
   });
 
   module('#handleInvalidation', function () {
-    test('should override handleInvalidation method', function (assert) {
-      // when & then
-      assert.ok(service.handleInvalidation instanceof Function);
+    test('overrides handleInvalidation method', function (assert) {
+      // then
+      assert.true(service.handleInvalidation instanceof Function);
+    });
+
+    test('calls clear method from session store', function (assert) {
+      // given
+      sinon.stub(service.store, 'clear');
+
+      // when
+      service.handleInvalidation();
+
+      // then
+      assert.true(service.store.clear.calledOnce);
     });
   });
 

--- a/orga/tests/unit/services/session_test.js
+++ b/orga/tests/unit/services/session_test.js
@@ -237,6 +237,8 @@ module('Unit | Service | session', function (hooks) {
 
               // then
               assert.true(localeService.setLocale.calledWith(ENGLISH_INTERNATIONAL_LOCALE));
+              assert.true(service.data.localeNotSupported);
+              assert.strictEqual(service.data.localeNotSupportedBannerClosed, undefined);
             });
           });
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -59,6 +59,9 @@
     },
     "import": {
       "message": "The administrator can download certification results and '<'a href=\"/import-participants\" class=\"{linkClasses}\"'>'import'</a>' the students database to create back-to-school campaigns by year level. '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'Learn more'</a>'"
+    },
+    "language-availability": {
+      "message": "Your language is not yet available on Pix Orga. For your convenience, the application will be presented in English. The entire Pix team is working to add your language."
     }
   },
   "cards": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -59,6 +59,9 @@
     },
     "import": {
       "message": "L'administrateur peut télécharger les résultats de certification et '<'a href=\"/import-participants\" class=\"{linkClasses}\"'>'importer'</a>' la base élèves, afin de créer les campagnes de rentrée par niveau. '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'Plus d’info'</a>'"
+    },
+    "language-availability": {
+      "message": "Votre langue n'est pas encore disponible sur Pix Orga. Pour votre confort, l'application sera présentée en anglais. Toute l'équipe de Pix travaille à l'ajout de votre langue."
     }
   },
   "cards": {


### PR DESCRIPTION
## :unicorn: Problème

Lorsqu'un.e utilisateur.trice se connecte sur Pix Orga ou Pix Certif avec une langue qui n'est pas supportée par ces applications, l'application s'affiche avec des clés de traductions.

![Screenshot 2024-03-21 at 10 57 44](https://github.com/1024pix/pix/assets/6919604/9b9c84ee-5813-45c7-9e7b-2b0d29f35f05)


## :robot: Proposition

- Si la langue de l’utilisateur n’est pas gérée dans Pix Orga / Pix Certif alors afficher le contenu en langue anglaise par défaut.
- Ajouter une bannière pour indiquer à l’utilisateur que la langue affichée n’est pas pas langue car elle n’est pas encore implémentée sur Pix Orga / Pix Certif.
  - Comportement d’affichage : 
    - S’affiche lorsqu’il se connecte
    - L’utilisateur peut fermer. S’il ferme la bannière alors la bannière ne s’affiche plus durant toute la session.
  - Type de bannière : info
  - Message de la bannière "Your language is not yet available on (Pix Orga | Pix Certif). For your convenience, the application will be presented in English. The entire Pix team is working to add your language.”

## :rainbow: Remarques

- Lors de la déconnexion, il est nécessaire de faire appel à la méthode `clear` sur le store de la session pour retirer les données ajoutées par notre code. ESA (Ember Simple Auth) va uniquement retirer les données dont il a connaissance.

## :100: Pour tester

### Pix Orga

1. Se connecter sur Pix App du domaine .org avec le compte allorga@example.net
2. Changer la langue du compte en Nederlands
3. Se déconnecter
4. Se connecter sur Pix Orga du domaine .org avec le compte allorga@example.net
5. Constater l'affichage de l'application en anglais
6. Constater l'affichage d'une bannière avec le message "Your language is not yet available on Pix Orga. For your convenience, the application will be presented in English. The entire Pix team is working to add your language.”
7. Fermer la bannière
8. Parcourir l'application
9. Constater que la bannière ne s'affiche plus
10. Se déconnecter
11. Se connecter à nouveau à Pix Orga avec le compte allorga@example.net
12. Constater l'affichage, de nouveau, de la bannière avec le message "Your language is not yet available on Pix Orga. For your convenience, the application will be presented in English. The entire Pix team is working to add your language.”

### Pix Certif

1. Se connecter sur Pix App du domaine .org avec le compte james-paledroits@example.net
2. Changer la langue du compte en Nederlands
3. Se déconnecter
4. Se connecter sur Pix Certif du domaine .org avec le compte james-paledroits@example.net
5. Constater l'affichage de l'application en anglais
6. Constater l'affichage d'une bannière avec le message "Your language is not yet available on Pix Certif. For your convenience, the application will be presented in English. The entire Pix team is working to add your language.”
7. Fermer la bannière
8. Parcourir l'application
9. Constater que la bannière ne s'affiche plus
10. Se déconnecter
11. Se connecter à nouveau à Pix Certif avec le compte james-paledroits@example.net
12. Constater l'affichage, de nouveau, de la bannière avec le message "Your language is not yet available on Pix Certif. For your convenience, the application will be presented in English. The entire Pix team is working to add your language.”