### PR TITLE
[BUGFIX] Permettre de mettre à jour les code pays (cpf) via le script (PIX-11727)

### DIFF
--- a/api/scripts/certification/import-certification-cpf-cities.js
+++ b/api/scripts/certification/import-certification-cpf-cities.js
@@ -6,7 +6,7 @@ import lodash from 'lodash';
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 /**
- * Usage: node scripts/import-certification-cpf-cities path/file.csv
+ * Usage: node scripts/certification/import-certification-cpf-cities.js path/file.csv
  * File is semi-colon separated values, headers being:
  * code_commune_insee;nom_de_la_commune;code_postal;ligne_5
  * ligne_5 is used for potential alternative city name

--- a/api/scripts/certification/import-certification-cpf-countries.js
+++ b/api/scripts/certification/import-certification-cpf-countries.js
@@ -1,4 +1,4 @@
-// Usage: node import-certification-cpf-countries.js path/file.csv
+// Usage: node script/certification/import-certification-cpf-countries.js path/file.csv
 // File Millésime 2021 : Liste des pays et territoires étrangers au 01/01/2021
 // downloaded from https://www.data.gouv.fr/fr/datasets/code-officiel-geographique-cog/
 
@@ -82,7 +82,7 @@ async function main(filePath) {
   const trx = await knex.transaction();
 
   try {
-    console.log('Reading and parsing csv data file... ');
+    console.log(`Reading and parsing csv data file ${filePath}... `);
     const csvData = await parseCsv(filePath, { header: true, delimiter: ',', skipEmptyLines: true });
     console.log('ok');
 
@@ -105,13 +105,15 @@ async function main(filePath) {
     if (trx) {
       trx.rollback();
     }
+    throw error;
   }
 }
 
 (async () => {
   if (isLaunchedFromCommandLine) {
     try {
-      await main();
+      const filePath = process.argv[2];
+      await main(filePath);
     } catch (error) {
       console.error(error);
       process.exitCode = 1;

--- a/api/scripts/certification/import-certifications-from-csv.js
+++ b/api/scripts/certification/import-certifications-from-csv.js
@@ -122,7 +122,7 @@ const modulePath = url.fileURLToPath(import.meta.url);
 const isLaunchedFromCommandLine = process.argv[1] === modulePath;
 
 /**
- * Usage: node import-certifications-from-csv.js http://localhost:3000 jwt.access.token my_file.csv
+ * Usage: node scripts/certification/import-certifications-from-csv.js http://localhost:3000 jwt.access.token my_file.csv
  */
 function main() {
   console.log("Début du script d'import");

--- a/api/scripts/certification/update-certification-infos.js
+++ b/api/scripts/certification/update-certification-infos.js
@@ -11,7 +11,7 @@ import lodash from 'lodash';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 import { logger } from '../../src/shared/infrastructure/utils/logger.js';
-// Usage: node scripts/update-certifications-infos path/data.csv path/sessionsId.csv
+// Usage: node scripts/certification/update-certifications-infos path/data.csv path/sessionsId.csv
 // data.csv
 // #externalId,birthdate,birthINSEECode,birthPostalCode,birthCity,birthCountry
 // #EXTERNAL_ID,2000-01-01,NULL,75550, paris,FRANCE

--- a/api/scripts/certification/validate-cpf-xml.js
+++ b/api/scripts/certification/validate-cpf-xml.js
@@ -7,9 +7,7 @@ import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
-async function main() {
-  const xmlPath = process.argv[2];
-
+async function main(xmlPath) {
   logger.info('Starting script validate-cpf-xml');
 
   logger.trace(`Checking data file...`);
@@ -35,8 +33,8 @@ async function main() {
 
 (async () => {
   try {
-    await main();
-    logger.s;
+    const xmlPath = process.argv[2];
+    await main(xmlPath);
   } catch (error) {
     logger.error(error);
     process.exitCode = 1;


### PR DESCRIPTION
## :unicorn: Problème
Le script  import-certification-cpf-countries.js ne prends plus en compte le parametre (chemin du fichier à importer)

## :robot: Proposition
Remettre la lecture du parametre

## :rainbow: Remarques
Mise à jour des commentaires pour les scripts certif

## :100: Pour tester
Telecharger le fichier https://www.data.gouv.fr/fr/datasets/r/e31e4f85-635e-4ec9-8d88-c4d6c0c586bb
lancer le script: 
`scalingo -a pix-api-review-pr8468 run -file v_pays_territoire_2024.csv node scripts/certification/import-certification-cpf-countries.js /tmp/uploads/v_pays_territoire_2024.csv`
Verifier que les pays sont bien à jour dans la table:
`select * from "certification-cpf-countries";`