### PR TITLE
[BUGFIX] Corrige la validation d'une épreuve en preview en local (PIX-11709).

### DIFF
--- a/api/src/school/domain/usecases/correct-preview-answer.js
+++ b/api/src/school/domain/usecases/correct-preview-answer.js
@@ -7,10 +7,14 @@ const correctPreviewAnswer = async function ({
 } = {}) {
   const challenge = await sharedChallengeRepository.get(activityAnswer.challengeId);
   const examiner = injectedExaminer ?? new Examiner({ validator: challenge.validator });
-  return examiner.evaluate({
+  const correctedAnswer = examiner.evaluate({
     answer: activityAnswer,
     challengeFormat: challenge.format,
   });
+  return {
+    ...correctedAnswer,
+    id: 'preview-id',
+  };
 };
 
 export { correctPreviewAnswer };

--- a/api/tests/school/acceptance/application/assessments/activity-answer-controller_test.js
+++ b/api/tests/school/acceptance/application/assessments/activity-answer-controller_test.js
@@ -65,7 +65,7 @@ describe('Acceptance | Controller | activity-answer-controller', function () {
     });
 
     context('when isPreview', function () {
-      it('should return a 200 HTTP status code', async function () {
+      it('should return a 200 HTTP status code and an activity answer', async function () {
         // given
         const challenge = learningContentBuilder.buildChallenge();
         const skill = learningContentBuilder.buildSkill({ id: challenge.skillId });
@@ -102,11 +102,30 @@ describe('Acceptance | Controller | activity-answer-controller', function () {
           payload,
         };
 
+        const expectedBody = {
+          attributes: {
+            result: 'ko',
+            'result-details': null,
+            value: '',
+          },
+          relationships: {
+            challenge: {
+              data: {
+                id: 'recCHAL1',
+                type: 'challenges',
+              },
+            },
+          },
+          id: 'preview-id',
+          type: 'activity-answers',
+        };
+
         // when
         const response = await server.inject(options);
 
         // then
         expect(response.statusCode).to.equal(200);
+        expect(response.result.data).to.deep.equal(expectedBody);
       });
     });
   });

--- a/api/tests/school/integration/domain/usecases/correct-preview-answer_test.js
+++ b/api/tests/school/integration/domain/usecases/correct-preview-answer_test.js
@@ -34,6 +34,7 @@ describe('Integration | UseCases | correct-preview-answer', function () {
 
     // then
     expect(activityAnswersCount.count).to.equal(0);
+    expect(correctedAnswer.id).to.equal('preview-id');
     expect(correctedAnswer.result).to.deep.equal(AnswerStatus.OK);
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Lors de la validation d'une épreuve en preview, uniquement en local, il ne semble rien se passer.
Après investigation, `ember-data` attend un `id` dans l'objet de retour de la création d'une `activity-answer`.
Cette validation n'existe que en mode `DEBUG` (donc pas sur les environnements de production).
cf https://github.com/emberjs/data/blob/630ed2678b1259a1b2468280f183c548dd427da1/packages/json-api/src/-private/cache.ts#L877

## :robot: Proposition

On retourne un id toujours valorisé à `preview-id` lors de la validation d'une épreuve de preview.

## :rainbow: Remarques

C'était beaucoup de fun.

## :100: Pour tester

En local uniquement, se rendre sur http://localhost:4205/challenges/recdAv9GNMwO8LKWt/preview
Saisir une réponse.
Cliquer que `Je vérifie`.
Vérifier que la bulle de feedback est affichée (mauvaise réponse ou bonne réponse).