### PR TITLE
[TECH] Ne pas linter les fichiers de traductions générés par Phrase (PIX-11733)

### DIFF
--- a/1d/.eslintignore
+++ b/1d/.eslintignore
@@ -25,3 +25,8 @@
 /yarn.lock.ember-try
 
 /mirage/mirage
+
+# Phrase generated translation files
+/translations/*.json
+!/translations/en.json
+!/translations/fr.json

--- a/admin/.eslintignore
+++ b/admin/.eslintignore
@@ -23,3 +23,8 @@
 /.node_modules.ember-try/
 /bower.json.ember-try
 /package.json.ember-try
+
+# Phrase generated translation files
+/translations/*.json
+!/translations/en.json
+!/translations/fr.json

--- a/api/.eslintignore
+++ b/api/.eslintignore
@@ -1,3 +1,8 @@
 # https://eslint.org/docs/user-guide/configuring#eslintignore
 # .file are implicitly ignored, unless explicitly specified here
 node_modules/
+
+# Phrase generated translation files
+/translations/*.json
+!/translations/en.json
+!/translations/fr.json

--- a/certif/.eslintignore
+++ b/certif/.eslintignore
@@ -24,3 +24,8 @@
 /package.json.ember-try
 /package-lock.json.ember-try
 /yarn.lock.ember-try
+
+# Phrase generated translation files
+/translations/*.json
+!/translations/en.json
+!/translations/fr.json

--- a/mon-pix/.eslintignore
+++ b/mon-pix/.eslintignore
@@ -19,3 +19,8 @@
 /.node_modules.ember-try/
 /bower.json.ember-try
 /package.json.ember-try
+
+# Phrase generated translation files
+/translations/*.json
+!/translations/en.json
+!/translations/fr.json

--- a/orga/.eslintignore
+++ b/orga/.eslintignore
@@ -24,3 +24,8 @@
 /package.json.ember-try
 /package-lock.json.ember-try
 /yarn.lock.ember-try
+
+# Phrase generated translation files
+/translations/*.json
+!/translations/en.json
+!/translations/fr.json


### PR DESCRIPTION
## :unicorn: Problème
Phrase génère des fichiers de traductions qui ne passent pas le lint (clé pas rangées dans l'ordre alphabétique).

## :robot: Proposition
Ignorer ces fichiers.

## :rainbow: Remarques
N/A

## :100: Pour tester
 - Intervertir 2 clés dans `/mon-pix/translations/nl.json` et vérifier que `npm run lint:translations` ne renvoie pas d'erreur
 - Intervertir 2 clés dans `/mon-pix/translations/en.json` et vérifier que `npm run lint:translations` renvoie une erreur
 - Intervertir 2 clés dans `/mon-pix/translations/fr.json` et vérifier que `npm run lint:translations` renvoie une erreur