### PR TITLE
[TECH] Refactoriser l'algorithme de sélection d'épreuve (PIX-11595).

### DIFF
--- a/api/lib/domain/services/algorithm-methods/cat-algorithm.js
+++ b/api/lib/domain/services/algorithm-methods/cat-algorithm.js
@@ -1,26 +1,44 @@
-import _ from 'lodash';
-import fp from 'lodash/fp.js';
-
 import { KnowledgeElement } from '../../models/KnowledgeElement.js';
 
-const { pipe } = fp;
 export { findMaxRewardingSkills, getPredictedLevel };
 
-function getPredictedLevel(knowledgeElements, skills) {
-  return _.maxBy(_enumerateCatLevels(), (level) =>
-    _probabilityThatUserHasSpecificLevel(level, knowledgeElements, skills),
-  );
-}
+const findMaxRewardingSkills = ({ availableSkills, predictedLevel, tubes, knowledgeElements }) => {
+  const maxRewardingSkills = getMaxRewardingSkills({ availableSkills, predictedLevel, tubes, knowledgeElements });
+  return clearSkillsIfNotRewarding(maxRewardingSkills);
+};
 
-function _enumerateCatLevels() {
+const getPredictedLevel = (knowledgeElements, skills) => {
+  const catLevels = enumerateCatLevels();
+  const eachLevelWithProbability = catLevels.map((level) => ({
+    level,
+    probability: probabilityThatUserHasSpecificLevel(level, knowledgeElements, skills),
+  }));
+  const maximumProbabilityThatUserHasSpecificLevel = Math.max(
+    ...eachLevelWithProbability.map(({ probability }) => probability),
+  );
+
+  return eachLevelWithProbability.find(({ probability }) => probability === maximumProbabilityThatUserHasSpecificLevel)
+    .level;
+};
+
+const enumerateCatLevels = () => {
   const firstLevel = 0.5;
   const lastLevel = 8; // The upper boundary is not included in the range
   const levelStep = 0.5;
-  return _.range(firstLevel, lastLevel, levelStep);
-}
+  const numberOfSteps = (lastLevel - firstLevel) / levelStep;
 
-function _probabilityThatUserHasSpecificLevel(level, knowledgeElements, skills) {
-  const directKnowledgeElements = _.filter(knowledgeElements, (ke) => ke.source === 'direct');
+  return Array.from({ length: numberOfSteps }, (_, index) => firstLevel + index * levelStep);
+};
+
+// The probability P(gap) of giving the correct answer is given by the "logistic function"
+// https://en.wikipedia.org/wiki/Logistic_function
+const probaOfCorrectAnswer = (userEstimatedLevel, challengeDifficulty) =>
+  1 / (1 + Math.exp(-(userEstimatedLevel - challengeDifficulty)));
+
+const probabilityThatUserHasSpecificLevel = (level, knowledgeElements, skills) => {
+  const directKnowledgeElements = knowledgeElements.filter(
+    (knowledgeElement) => knowledgeElement.source === KnowledgeElement.SourceType.DIRECT,
+  );
   const extraAnswers = directKnowledgeElements.map((ke) => {
     const skill = skills.find((skill) => skill.id === ke.skillId);
     const maxDifficulty = skill.difficulty || 2;
@@ -33,21 +51,44 @@ function _probabilityThatUserHasSpecificLevel(level, knowledgeElements, skills) 
   extraAnswers.push(answerThatAnyoneCanSolve, answerThatNobodyCanSolve);
 
   const diffBetweenResultAndProbaToResolve = extraAnswers.map(
-    (answer) => answer.binaryOutcome - _probaOfCorrectAnswer(level, answer.maxDifficulty),
+    (answer) => answer.binaryOutcome - probaOfCorrectAnswer(level, answer.maxDifficulty),
   );
 
   return -Math.abs(diffBetweenResultAndProbaToResolve.reduce((a, b) => a + b));
-}
+};
 
-function findMaxRewardingSkills(...args) {
-  return pipe(_getMaxRewardingSkills, _clearSkillsIfNotRewarding)(...args);
-}
+const findTubeByName = (tubes, tubeName) => tubes.find((tube) => tube.name === tubeName);
 
-function _getMaxRewardingSkills({ availableSkills, predictedLevel, tubes, knowledgeElements }) {
-  return _.reduce(
-    availableSkills,
+const skillNotTestedYet = (knowledgeElements) => (skill) => {
+  const skillsAlreadyTested = knowledgeElements.map(({ skillId }) => skillId);
+  return !skillsAlreadyTested.includes(skill.id);
+};
+
+const getNewSkillsInfoIfSkillSolved = (testedSkills, tubes, knowledgeElements) =>
+  findTubeByName(tubes, testedSkills.tubeNameWithoutPrefix)
+    .getEasierThan(testedSkills)
+    .filter(skillNotTestedYet(knowledgeElements));
+
+// Skills that won't bring anymore information on the user is a termination condition of the CAT algorithm
+const clearSkillsIfNotRewarding = (skills) => skills.filter((skill) => skill.reward !== 0);
+
+const getNewSkillsInfoIfSkillUnsolved = (testedSkills, tubes, knowledgeElements) =>
+  findTubeByName(tubes, testedSkills.tubeNameWithoutPrefix)
+    .getHarderThan(testedSkills)
+    .filter(skillNotTestedYet(knowledgeElements));
+
+const computeReward = ({ skill, predictedLevel, tubes, knowledgeElements }) => {
+  const proba = probaOfCorrectAnswer(predictedLevel, skill.difficulty);
+  const extraSkillsIfSolvedCount = getNewSkillsInfoIfSkillSolved(skill, tubes, knowledgeElements).length;
+  const failedSkillsIfUnsolvedCount = getNewSkillsInfoIfSkillUnsolved(skill, tubes, knowledgeElements).length;
+
+  return proba * extraSkillsIfSolvedCount + (1 - proba) * failedSkillsIfUnsolvedCount;
+};
+
+const getMaxRewardingSkills = ({ availableSkills, predictedLevel, tubes, knowledgeElements }) =>
+  availableSkills.reduce(
     (acc, skill) => {
-      const skillReward = _computeReward({ skill, predictedLevel, tubes, knowledgeElements });
+      const skillReward = computeReward({ skill, predictedLevel, tubes, knowledgeElements });
       if (skillReward > acc.maxReward) {
         acc.maxReward = skillReward;
         acc.maxRewardingSkills = [skill];
@@ -58,56 +99,3 @@ function _getMaxRewardingSkills({ availableSkills, predictedLevel, tubes, knowle
     },
     { maxRewardingSkills: [], maxReward: -Infinity },
   ).maxRewardingSkills;
-}
-
-// Skills that won't bring anymore information on the user is a termination condition of the CAT algorithm
-function _clearSkillsIfNotRewarding(skills) {
-  return _.filter(skills, (skill) => skill.reward !== 0);
-}
-
-function _computeReward({ skill, predictedLevel, tubes, knowledgeElements }) {
-  const proba = _probaOfCorrectAnswer(predictedLevel, skill.difficulty);
-  const extraSkillsIfSolvedCount = _getNewSkillsInfoIfSkillSolved(skill, tubes, knowledgeElements).length;
-  const failedSkillsIfUnsolvedCount = _getNewSkillsInfoIfSkillUnsolved(skill, tubes, knowledgeElements).length;
-
-  return proba * extraSkillsIfSolvedCount + (1 - proba) * failedSkillsIfUnsolvedCount;
-}
-
-// The probability P(gap) of giving the correct answer is given by the "logistic function"
-// https://en.wikipedia.org/wiki/Logistic_function
-function _probaOfCorrectAnswer(userEstimatedLevel, challengeDifficulty) {
-  return 1 / (1 + Math.exp(-(userEstimatedLevel - challengeDifficulty)));
-}
-
-function _getNewSkillsInfoIfSkillSolved(skillTested, tubes, knowledgeElements) {
-  let extraValidatedSkills = _findTubeByName(tubes, skillTested.tubeNameWithoutPrefix)
-    .getEasierThan(skillTested)
-    .filter(_skillNotTestedYet(knowledgeElements));
-
-  if (!_.isEmpty(skillTested.linkedSkills)) {
-    extraValidatedSkills = _.concat(extraValidatedSkills, skillTested.linkedSkills);
-  }
-  return _.uniqBy(extraValidatedSkills, 'id');
-}
-
-function _getNewSkillsInfoIfSkillUnsolved(skillTested, tubes, knowledgeElements) {
-  let extraFailedSkills = _findTubeByName(tubes, skillTested.tubeNameWithoutPrefix)
-    .getHarderThan(skillTested)
-    .filter(_skillNotTestedYet(knowledgeElements));
-
-  if (!_.isEmpty(skillTested.linkedSkills)) {
-    extraFailedSkills = _.concat(extraFailedSkills, skillTested.linkedSkills);
-  }
-  return _.uniqBy(extraFailedSkills, 'id');
-}
-
-function _findTubeByName(tubes, tubeName) {
-  return tubes.find((tube) => tube.name === tubeName);
-}
-
-function _skillNotTestedYet(knowledgeElements) {
-  return (skill) => {
-    const skillsAlreadyTested = _.map(knowledgeElements, 'skillId');
-    return !skillsAlreadyTested.includes(skill.id);
-  };
-}

--- a/api/lib/domain/services/algorithm-methods/cat-algorithm.js
+++ b/api/lib/domain/services/algorithm-methods/cat-algorithm.js
@@ -22,12 +22,8 @@ const getPredictedLevel = (knowledgeElements, skills) => {
 };
 
 const enumerateCatLevels = () => {
-  const firstLevel = 0.5;
-  const lastLevel = 8; // The upper boundary is not included in the range
-  const levelStep = 0.5;
-  const numberOfSteps = (lastLevel - firstLevel) / levelStep;
-
-  return Array.from({ length: numberOfSteps }, (_, index) => firstLevel + index * levelStep);
+  const catLevelsFromFirstToLastExcludingUpperBoundary = [0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 5.5, 6, 6.5, 7, 7.5];
+  return catLevelsFromFirstToLastExcludingUpperBoundary;
 };
 
 // The probability P(gap) of giving the correct answer is given by the "logistic function"

--- a/api/lib/domain/services/algorithm-methods/skills-filter.js
+++ b/api/lib/domain/services/algorithm-methods/skills-filter.js
@@ -4,12 +4,14 @@ import {
   MAX_LEVEL_TO_BE_AN_EASY_TUBE,
 } from '../../constants.js';
 
-const getPlayableSkill = (skills) => skills.filter(({ isPlayable }) => isPlayable);
-const skillNotAlreadyTested = (knowledgeElements) => (skill) => {
+const getPlayableSkills = (skills) => skills.filter(({ isPlayable }) => isPlayable);
+
+const notAlreadyTestedSkill = (knowledgeElements) => (skill) => {
   const alreadyTestedSkillIds = knowledgeElements.map(({ skillId }) => skillId);
   return !alreadyTestedSkillIds.includes(skill.id);
 };
-const getUntestedSkills = (knowledgeElements, skills) => skills.filter(skillNotAlreadyTested(knowledgeElements));
+
+const getUntestedSkills = (knowledgeElements, skills) => skills.filter(notAlreadyTestedSkill(knowledgeElements));
 
 const keepSkillsFromEasyTubes = (tubes, targetSkills) => {
   const skillsFromEasyTubes = getPrioritySkills(tubes);
@@ -40,24 +42,24 @@ const remapDifficulty = (difficulty) =>
   Number(difficulty) === DEFAULT_LEVEL_FOR_FIRST_CHALLENGE ? Number.MIN_VALUE : Number(difficulty);
 
 const focusOnDefaultLevel = (targetSkills) =>
-  targetSkills.reduce((skillsWithDefaultLevel, skill) => {
-    if (skillsWithDefaultLevel.length === 0) {
-      skillsWithDefaultLevel.push(skill);
-      return skillsWithDefaultLevel;
+  targetSkills.reduce((defaultLevelSkills, skill) => {
+    if (defaultLevelSkills.length === 0) {
+      defaultLevelSkills.push(skill);
+      return defaultLevelSkills;
     }
 
     const currentSkillRemappedDifficulty = remapDifficulty(skill.difficulty);
-    const accumulatorFirstSkillRemappedDifficulty = remapDifficulty(skillsWithDefaultLevel[0].difficulty);
+    const accumulatorFirstSkillRemappedDifficulty = remapDifficulty(defaultLevelSkills[0].difficulty);
 
     if (currentSkillRemappedDifficulty < accumulatorFirstSkillRemappedDifficulty) {
-      skillsWithDefaultLevel = [skill];
+      defaultLevelSkills = [skill];
     }
 
     if (currentSkillRemappedDifficulty === accumulatorFirstSkillRemappedDifficulty) {
-      skillsWithDefaultLevel.push(skill);
+      defaultLevelSkills.push(skill);
     }
 
-    return skillsWithDefaultLevel;
+    return defaultLevelSkills;
   }, []);
 
 const isSkillTooHard = (skill, predictedLevel) =>
@@ -67,7 +69,7 @@ const removeTooDifficultSkills = (predictedLevel, targetSkills) =>
   targetSkills.filter((skill) => !isSkillTooHard(skill, predictedLevel));
 
 const getFilteredSkillsForFirstChallenge = ({ knowledgeElements, tubes, targetSkills }) => {
-  const playableSkills = getPlayableSkill(targetSkills);
+  const playableSkills = getPlayableSkills(targetSkills);
   const untestedSkills = getUntestedSkills(knowledgeElements, playableSkills);
   const skillsFromEasyTubes = keepSkillsFromEasyTubes(tubes, untestedSkills);
   const skillsWithoutTimedSkills = removeTimedSkillsIfNeeded(true, skillsFromEasyTubes);
@@ -81,11 +83,11 @@ const getFilteredSkillsForNextChallenge = ({
   isLastChallengeTimed,
   targetSkills,
 }) => {
-  const playableSkills = getPlayableSkill(targetSkills);
+  const playableSkills = getPlayableSkills(targetSkills);
   const untestedSkills = getUntestedSkills(knowledgeElements, playableSkills);
   const skillsFromEasyTubes = keepSkillsFromEasyTubes(tubes, untestedSkills);
   const skillsWithoutTimedSkills = removeTimedSkillsIfNeeded(isLastChallengeTimed, skillsFromEasyTubes);
   return removeTooDifficultSkills(predictedLevel, skillsWithoutTimedSkills);
 };
 
-export { getFilteredSkillsForFirstChallenge, getFilteredSkillsForNextChallenge };
+export { focusOnDefaultLevel, getFilteredSkillsForFirstChallenge, getFilteredSkillsForNextChallenge };

--- a/api/lib/domain/services/algorithm-methods/smart-random.js
+++ b/api/lib/domain/services/algorithm-methods/smart-random.js
@@ -1,32 +1,30 @@
-import _ from 'lodash';
-
 import { computeTubesFromSkills } from './../tube-service.js';
 import * as catAlgorithm from './cat-algorithm.js';
 import { getFilteredSkillsForFirstChallenge, getFilteredSkillsForNextChallenge } from './skills-filter.js';
 
 export { getPossibleSkillsForNextChallenge };
 
-function getPossibleSkillsForNextChallenge({
+const getPossibleSkillsForNextChallenge = ({
   knowledgeElements,
   challenges,
   targetSkills,
   lastAnswer,
   allAnswers,
   locale,
-} = {}) {
+} = {}) => {
   const isUserStartingTheTest = !lastAnswer;
-  const isLastChallengeTimed = _wasLastChallengeTimed(lastAnswer);
-  const tubes = _findTubes(targetSkills, challenges);
+  const isLastChallengeTimed = lastAnswer ? wasLastChallengeTimed(lastAnswer) : false;
+  const tubes = findTubes(targetSkills, challenges);
   const knowledgeElementsOfTargetSkills = knowledgeElements.filter((ke) => {
     return targetSkills.find((skill) => skill.id === ke.skillId);
   });
-  const filteredChallenges = _removeChallengesWithAnswer({ challenges, allAnswers });
-  targetSkills = _getSkillsWithAddedInformations({ targetSkills, filteredChallenges, locale });
+  const filteredChallenges = removeChallengesWithAnswer({ challenges, allAnswers });
+  targetSkills = getSkillsWithAddedInformations({ targetSkills, filteredChallenges, locale });
 
   // First challenge has specific rules
   const { possibleSkillsForNextChallenge, levelEstimated } = isUserStartingTheTest
-    ? _findFirstChallenge({ knowledgeElements: knowledgeElementsOfTargetSkills, targetSkills, tubes })
-    : _findAnyChallenge({
+    ? findFirstChallenge({ knowledgeElements: knowledgeElementsOfTargetSkills, targetSkills, tubes })
+    : findAnyChallenge({
         knowledgeElements: knowledgeElementsOfTargetSkills,
         targetSkills,
         tubes,
@@ -37,25 +35,23 @@ function getPossibleSkillsForNextChallenge({
   return possibleSkillsForNextChallenge.length > 0
     ? { hasAssessmentEnded: false, possibleSkillsForNextChallenge, levelEstimated }
     : { hasAssessmentEnded: true, possibleSkillsForNextChallenge, levelEstimated };
-}
+};
 
-function _wasLastChallengeTimed(lastAnswer) {
-  return _.get(lastAnswer, 'timeout') === null ? false : true;
-}
+const wasLastChallengeTimed = (lastAnswer) => Boolean(lastAnswer.timeout);
 
-function _findTubes(skills, challenges) {
-  const listSkillsWithChallenges = _filterSkillsByChallenges(skills, challenges);
+const findTubes = (skills, challenges) => {
+  const listSkillsWithChallenges = filterSkillsByChallenges(skills, challenges);
   return computeTubesFromSkills(listSkillsWithChallenges);
-}
+};
 
-function _filterSkillsByChallenges(skills, challenges) {
+const filterSkillsByChallenges = (skills, challenges) => {
   const skillsWithChallenges = skills.filter((skill) => {
     return challenges.find((challenge) => challenge.skill.name === skill.name);
   });
   return skillsWithChallenges;
-}
+};
 
-function _findAnyChallenge({ knowledgeElements, targetSkills, tubes, isLastChallengeTimed }) {
+const findAnyChallenge = ({ knowledgeElements, targetSkills, tubes, isLastChallengeTimed }) => {
   const predictedLevel = catAlgorithm.getPredictedLevel(knowledgeElements, targetSkills);
   const availableSkills = getFilteredSkillsForNextChallenge({
     knowledgeElements,
@@ -71,35 +67,32 @@ function _findAnyChallenge({ knowledgeElements, targetSkills, tubes, isLastChall
     knowledgeElements,
   });
   return { possibleSkillsForNextChallenge: maxRewardingSkills, levelEstimated: predictedLevel };
-}
+};
 
-function _findFirstChallenge({ knowledgeElements, targetSkills, tubes }) {
+const findFirstChallenge = ({ knowledgeElements, targetSkills, tubes }) => {
   const filteredSkillsForFirstChallenge = getFilteredSkillsForFirstChallenge({
     knowledgeElements,
     tubes,
     targetSkills,
   });
   return { possibleSkillsForNextChallenge: filteredSkillsForFirstChallenge, levelEstimated: 2 };
-}
+};
 
-function _getSkillsWithAddedInformations({ targetSkills, filteredChallenges, locale }) {
-  return _.map(targetSkills, (skill) => {
-    const challenges = _.filter(
-      filteredChallenges,
+const getSkillsWithAddedInformations = ({ targetSkills, filteredChallenges, locale }) =>
+  targetSkills.map((skill) => {
+    const challenges = filteredChallenges.filter(
       (challenge) => challenge.skill.id === skill.id && challenge.locales.includes(locale),
     );
     const [firstChallenge] = challenges;
     const skillCopy = Object.create(skill);
     return Object.assign(skillCopy, {
       challenges,
-      linkedSkills: firstChallenge ? _.reject(firstChallenge.skills, { id: skill.id }) : [],
       timed: firstChallenge ? firstChallenge.isTimed() : false,
       isPlayable: !!firstChallenge,
     });
   });
-}
 
-function _removeChallengesWithAnswer({ challenges, allAnswers }) {
+const removeChallengesWithAnswer = ({ challenges, allAnswers }) => {
   const challengeIdsWithAnswer = allAnswers.map((answer) => answer.challengeId);
-  return challenges.filter((challenge) => !_.includes(challengeIdsWithAnswer, challenge.id));
-}
+  return challenges.filter((challenge) => !challengeIdsWithAnswer.includes(challenge.id));
+};

--- a/api/src/certification/flash-certification/domain/services/pick-challenge-service.js
+++ b/api/src/certification/flash-certification/domain/services/pick-challenge-service.js
@@ -1,12 +1,11 @@
 import hashInt from 'hash-int';
-import _ from 'lodash';
 
 import { config } from '../../../../../lib/config.js';
 import { random } from '../../../../../lib/infrastructure/utils/random.js';
 const NON_EXISTING_ITEM = null;
 const VALIDATED_STATUS = 'validé';
 
-const pickChallenge = function ({ skills, randomSeed, locale }) {
+const pickChallenge = ({ skills, randomSeed, locale }) => {
   if (skills.length === 0) {
     return NON_EXISTING_ITEM;
   }
@@ -14,32 +13,28 @@ const pickChallenge = function ({ skills, randomSeed, locale }) {
   const keyForChallenge = Math.abs(hashInt(randomSeed + 1));
   const chosenSkill = skills[keyForSkill % skills.length];
 
-  return _pickLocaleChallengeAtIndex(chosenSkill.challenges, locale, keyForChallenge);
+  return pickLocaleChallengeAtIndex(chosenSkill.challenges, locale, keyForChallenge);
 };
 
-const chooseNextChallenge = function (
-  probabilityToPickChallenge = config.v3Certification.defaultProbabilityToPickChallenge,
-) {
-  return function ({ possibleChallenges }) {
+const chooseNextChallenge =
+  (probabilityToPickChallenge = config.v3Certification.defaultProbabilityToPickChallenge) =>
+  ({ possibleChallenges }) => {
     const challengeIndex = random.binaryTreeRandom(probabilityToPickChallenge, possibleChallenges.length);
 
     return possibleChallenges[challengeIndex];
   };
-};
 
 export const pickChallengeService = { pickChallenge, chooseNextChallenge };
 
-function _pickLocaleChallengeAtIndex(challenges, locale, index) {
-  const localeChallenges = _.filter(challenges, (challenge) => _.includes(challenge.locales, locale));
-  const possibleChallenges = _findPreferablyValidatedChallenges(localeChallenges);
-  return _.isEmpty(possibleChallenges) ? null : _pickChallengeAtIndex(possibleChallenges, index);
-}
+const pickLocaleChallengeAtIndex = (challenges, locale, index) => {
+  const localeChallenges = challenges.filter((challenge) => challenge.locales.includes(locale));
+  const possibleChallenges = findPreferablyValidatedChallenges(localeChallenges);
+  return possibleChallenges.length ? pickChallengeAtIndex(possibleChallenges, index) : null;
+};
 
-function _pickChallengeAtIndex(challenges, index) {
-  return challenges[index % challenges.length];
-}
+const pickChallengeAtIndex = (challenges, index) => challenges[index % challenges.length];
 
-function _findPreferablyValidatedChallenges(localeChallenges) {
-  const validatedChallenges = _.filter(localeChallenges, (challenge) => challenge.status === VALIDATED_STATUS);
+const findPreferablyValidatedChallenges = (localeChallenges) => {
+  const validatedChallenges = localeChallenges.filter((challenge) => challenge.status === VALIDATED_STATUS);
   return validatedChallenges.length > 0 ? validatedChallenges : localeChallenges;
-}
+};

--- a/api/tests/unit/domain/services/algorithm-methods/cat-algorithm_test.js
+++ b/api/tests/unit/domain/services/algorithm-methods/cat-algorithm_test.js
@@ -12,7 +12,9 @@ describe('Unit | Domain | services | cat-algorithm', function () {
   let skills;
   let tubes;
 
+  // data used for the following tests have been extracted from production to recreate genuine simulation results
   before(function () {
+    predictedLevel = 6.5;
     knowledgeElements = [
       {
         id: 167869,
@@ -984,7 +986,6 @@ describe('Unit | Domain | services | cat-algorithm', function () {
         name: 'utiliserVisio',
       },
     ].map(buildTube);
-    predictedLevel = 6.5;
   });
 
   describe('#getPredictedLevel', function () {

--- a/api/tests/unit/domain/services/algorithm-methods/cat-algorithm_test.js
+++ b/api/tests/unit/domain/services/algorithm-methods/cat-algorithm_test.js
@@ -1,0 +1,1028 @@
+import { assert } from 'chai';
+
+import {
+  findMaxRewardingSkills,
+  getPredictedLevel,
+} from '../../../../../lib/domain/services/algorithm-methods/cat-algorithm.js';
+import { buildKnowledgeElement, buildSkill, buildTube } from '../../../../tooling/domain-builder/factory/index.js';
+
+describe('Unit | Domain | services | cat-algorithm', function () {
+  let knowledgeElements;
+  let predictedLevel;
+  let skills;
+  let tubes;
+
+  before(function () {
+    knowledgeElements = [
+      {
+        id: 167869,
+        source: 'direct',
+        status: 'invalidated',
+        skillId: 'skill1nwDxoR0x0SCZW',
+      },
+      {
+        id: 167870,
+        source: 'inferred',
+        status: 'invalidated',
+        skillId: 'skill1MjpSjffZZXvh0',
+      },
+      {
+        id: 165695,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'rec1TZRdq2lKyLEaR',
+      },
+      {
+        id: 165703,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'rec8PgJLouOSZ17FG',
+      },
+      {
+        id: 165715,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'recfktfO0ROu1OifX',
+      },
+      {
+        id: 165727,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'reciF9dxvDfMUuFcb',
+      },
+      {
+        id: 165739,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'recyCbjLUApUp06rk',
+      },
+      {
+        id: 165751,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'skill1aa9GlPzDG3GUP',
+      },
+      {
+        id: 165763,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'skill1rXqGtiKi8JLdk',
+      },
+      {
+        id: 165775,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'skill1xkz0CTTsal6uL',
+      },
+      {
+        id: 165787,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'skill2fj31Yqxlb7jk6',
+      },
+      {
+        id: 165799,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'skill15XF9tWHkxNWPm',
+      },
+      {
+        id: 165811,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'skill135DNPBBKppVeo',
+      },
+      {
+        id: 165307,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'rec5JQfWV9brlT8hO',
+      },
+      {
+        id: 165319,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'recPG9ftlGZLiF0O6',
+      },
+      {
+        id: 165331,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'recPGDVdX0LSOWQQC',
+      },
+      {
+        id: 165343,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'recUDrhjEYqmfahRX',
+      },
+      {
+        id: 165355,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'recZ6RUx2zcIaRAIC',
+      },
+      {
+        id: 165367,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'skill1ekYIy8gFHyxCV',
+      },
+      {
+        id: 165379,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'skill1ENXr2MZ0XZhWj',
+      },
+      {
+        id: 165391,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'skill1urblOxjUEbinI',
+      },
+      {
+        id: 165403,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'skill2b3kerzZhjyp0A',
+      },
+      {
+        id: 165415,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'rec4973AsptLwKr5f',
+      },
+      {
+        id: 165427,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'recdnFCH9mBrDW06P',
+      },
+      {
+        id: 165439,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'recH1pcEWLBUCqXTm',
+      },
+      {
+        id: 165451,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'recTR73NgMRmrKRhT',
+      },
+      {
+        id: 165463,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'skill1DbWfXibjwaM1w',
+      },
+      {
+        id: 165475,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'skill1xQQ7zYfFzbmaH',
+      },
+      {
+        id: 165487,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'skill2BxFQALqARP441',
+      },
+      {
+        id: 165499,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'skill2rfU7dxfMwkMcr',
+      },
+      {
+        id: 165511,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'skill2x1YhidbkYp2Pg',
+      },
+      {
+        id: 165523,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'skill22ugx0qpvW2twf',
+      },
+      {
+        id: 165535,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'skill29qYgQv0UPtZzI',
+      },
+      {
+        id: 165547,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'rec9hCuo78BNiz94h',
+      },
+      {
+        id: 165559,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'recdwoJE9Po9zdf0A',
+      },
+      {
+        id: 165571,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'recIDXphXbneOrbux',
+      },
+      {
+        id: 165583,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'recl2LAo6vB6BOgUd',
+      },
+      {
+        id: 165595,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'recmoanUlDOyXexPF',
+      },
+      {
+        id: 165607,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'recuiCzBk96GLsysI',
+      },
+      {
+        id: 165619,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'recZQw6nVvfYg0uyB',
+      },
+      {
+        id: 165631,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'skill1iR2MVxDLqEIVO',
+      },
+      {
+        id: 165643,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'skill1TjG4RSc2Kt7uF',
+      },
+      {
+        id: 165655,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'skill1xsn4sAgpuxhuB',
+      },
+      {
+        id: 165667,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'skill18ySWKxgaUtP6y',
+      },
+      {
+        id: 165679,
+        source: 'direct',
+        status: 'validated',
+        skillId: 'skillO9IBV1NC2tNmd',
+      },
+    ].map(buildKnowledgeElement);
+    skills = [
+      {
+        id: 'rec1TZRdq2lKyLEaR',
+        name: '@répondreMail4',
+        difficulty: 4,
+      },
+      {
+        id: 'rec5JQfWV9brlT8hO',
+        name: '@adresseElect1',
+        difficulty: 1,
+      },
+      {
+        id: 'rec8PgJLouOSZ17FG',
+        name: '@spam4',
+        difficulty: 4,
+      },
+      {
+        id: 'rec9hCuo78BNiz94h',
+        name: '@spam3',
+        difficulty: 3,
+      },
+      {
+        id: 'rec20khhumencjHqt',
+        name: '@gestionMails5',
+        difficulty: 5,
+      },
+      {
+        id: 'rec4973AsptLwKr5f',
+        name: '@communicationAsynchrone2',
+        difficulty: 2,
+      },
+      {
+        id: 'recdnFCH9mBrDW06P',
+        name: '@spam2',
+        difficulty: 2,
+      },
+      {
+        id: 'recdwoJE9Po9zdf0A',
+        name: '@outilsMsgélectronique3',
+        difficulty: 3,
+      },
+      {
+        id: 'recfktfO0ROu1OifX',
+        name: '@netiquette4',
+        difficulty: 4,
+      },
+      {
+        id: 'recH1pcEWLBUCqXTm',
+        name: '@champsCourriel2',
+        difficulty: 2,
+      },
+      {
+        id: 'recIDXphXbneOrbux',
+        name: '@champsCourriel3',
+        difficulty: 3,
+      },
+      {
+        id: 'reciF9dxvDfMUuFcb',
+        name: '@champsCourriel4',
+        difficulty: 4,
+      },
+      {
+        id: 'recl2LAo6vB6BOgUd',
+        name: '@répondreMail3',
+        difficulty: 3,
+      },
+      {
+        id: 'recmoanUlDOyXexPF',
+        name: '@gestionMails3',
+        difficulty: 3,
+      },
+      {
+        id: 'recPG9ftlGZLiF0O6',
+        name: '@champsCourriel1',
+        difficulty: 1,
+      },
+      {
+        id: 'recPGDVdX0LSOWQQC',
+        name: '@gestionMails1',
+        difficulty: 1,
+      },
+      {
+        id: 'recTR73NgMRmrKRhT',
+        name: '@répondreMail2',
+        difficulty: 2,
+      },
+      {
+        id: 'recUaEq1tk16x66T',
+        name: '@gestionMails6',
+        difficulty: 6,
+      },
+      {
+        id: 'recUDrhjEYqmfahRX',
+        name: '@répondreMail1',
+        difficulty: 1,
+      },
+      {
+        id: 'recuiCzBk96GLsysI',
+        name: '@adresseElect3',
+        difficulty: 3,
+      },
+      {
+        id: 'recWTGXrt4fLP2QOL',
+        name: '@spam5',
+        difficulty: 5,
+      },
+      {
+        id: 'recwucYj3gElngpyL',
+        name: '@netiquette6',
+        difficulty: 6,
+      },
+      {
+        id: 'recyCbjLUApUp06rk',
+        name: '@gestionMails4',
+        difficulty: 4,
+      },
+      {
+        id: 'recZ6RUx2zcIaRAIC',
+        name: '@outilsMsgélectronique1',
+        difficulty: 1,
+      },
+      {
+        id: 'recZQw6nVvfYg0uyB',
+        name: '@communicationAsynchrone3',
+        difficulty: 3,
+      },
+      {
+        id: 'skill1aa9GlPzDG3GUP',
+        name: '@conversation4',
+        difficulty: 4,
+      },
+      {
+        id: 'skill1DbWfXibjwaM1w',
+        name: '@conversation2',
+        difficulty: 2,
+      },
+      {
+        id: 'skill1ekYIy8gFHyxCV',
+        name: '@canal1',
+        difficulty: 1,
+      },
+      {
+        id: 'skill1ENXr2MZ0XZhWj',
+        name: '@conversation1',
+        difficulty: 1,
+      },
+      {
+        id: 'skill1F8u92iXfUwcM6',
+        name: '@outilsMsgélectronique6',
+        difficulty: 6,
+      },
+      {
+        id: 'skill1GkELRn1T8WDxM',
+        name: '@PJ5',
+        difficulty: 5,
+      },
+      {
+        id: 'skill1iR2MVxDLqEIVO',
+        name: '@canal3',
+        difficulty: 3,
+      },
+      {
+        id: 'skill1j39bcoIGvlADN',
+        name: '@champsCourriel6',
+        difficulty: 6,
+      },
+      {
+        id: 'skill1kvO3wW1sZuryD',
+        name: '@communicationAsynchrone7',
+        difficulty: 7,
+      },
+      {
+        id: 'skill1lFqczMT6lqm5Y',
+        name: '@communicationAsynchrone5',
+        difficulty: 5,
+      },
+      {
+        id: 'skill1Ma8u52WmJfxIf',
+        name: '@champsCourriel5',
+        difficulty: 5,
+      },
+      {
+        id: 'skill1MjpSjffZZXvh0',
+        name: '@contacts7',
+        difficulty: 7,
+      },
+      {
+        id: 'skill1nwDxoR0x0SCZW',
+        name: '@contacts5',
+        difficulty: 5,
+      },
+      {
+        id: 'skill1qaJ2VnTFJ5GJf',
+        name: '@spam6',
+        difficulty: 6,
+      },
+      {
+        id: 'skill1rXqGtiKi8JLdk',
+        name: '@outilsMsgélectronique4',
+        difficulty: 4,
+      },
+      {
+        id: 'skill1TjG4RSc2Kt7uF',
+        name: '@outilsVisio3',
+        difficulty: 3,
+      },
+      {
+        id: 'skill1urblOxjUEbinI',
+        name: '@outilsVisio1',
+        difficulty: 1,
+      },
+      {
+        id: 'skill1xkz0CTTsal6uL',
+        name: '@outilsMessagerie4',
+        difficulty: 4,
+      },
+      {
+        id: 'skill1xQQ7zYfFzbmaH',
+        name: '@outilsMessagerie2',
+        difficulty: 2,
+      },
+      {
+        id: 'skill1xsn4sAgpuxhuB',
+        name: '@conversation3',
+        difficulty: 3,
+      },
+      {
+        id: 'skill1z5pb57z8oW19r',
+        name: '@outilsMsgélectronique5',
+        difficulty: 5,
+      },
+      {
+        id: 'skill2A1myNkqAxiyKT',
+        name: '@conversation5',
+        difficulty: 5,
+      },
+      {
+        id: 'skill2b3kerzZhjyp0A',
+        name: '@contacts1',
+        difficulty: 1,
+      },
+      {
+        id: 'skill2BxFQALqARP441',
+        name: '@adresseElect2',
+        difficulty: 2,
+      },
+      {
+        id: 'skill2fj31Yqxlb7jk6',
+        name: '@canal4',
+        difficulty: 4,
+      },
+      {
+        id: 'skill2ieQwFlW3Ne9Nt',
+        name: '@communicationAsynchrone6',
+        difficulty: 6,
+      },
+      {
+        id: 'skill2rfU7dxfMwkMcr',
+        name: '@outilsVisio2',
+        difficulty: 2,
+      },
+      {
+        id: 'skill2x1YhidbkYp2Pg',
+        name: '@canal2',
+        difficulty: 2,
+      },
+      {
+        id: 'skill12LsYS7w71E0rF',
+        name: '@outilsVisio6',
+        difficulty: 6,
+      },
+      {
+        id: 'skill15XF9tWHkxNWPm',
+        name: '@PJ4',
+        difficulty: 4,
+      },
+      {
+        id: 'skill18ySWKxgaUtP6y',
+        name: '@PJ3',
+        difficulty: 3,
+      },
+      {
+        id: 'skill22ugx0qpvW2twf',
+        name: '@PJ2',
+        difficulty: 2,
+      },
+      {
+        id: 'skill28p87p3Ot90Umv',
+        name: '@répondreMail5',
+        difficulty: 5,
+      },
+      {
+        id: 'skill29qYgQv0UPtZzI',
+        name: '@utiliserVisio2',
+        difficulty: 2,
+      },
+      {
+        id: 'skill135DNPBBKppVeo',
+        name: '@utiliserVisio4',
+        difficulty: 4,
+      },
+      {
+        id: 'skillO9IBV1NC2tNmd',
+        name: '@utiliserVisio3',
+        difficulty: 3,
+      },
+      {
+        id: 'skillQV0P5GuLMeYW7',
+        name: '@spam7',
+        difficulty: 7,
+      },
+    ].map(buildSkill);
+    tubes = [
+      {
+        skills: [
+          {
+            id: 'recUDrhjEYqmfahRX',
+            name: '@répondreMail1',
+            difficulty: 1,
+          },
+          {
+            id: 'recTR73NgMRmrKRhT',
+            name: '@répondreMail2',
+            difficulty: 2,
+          },
+          {
+            id: 'recl2LAo6vB6BOgUd',
+            name: '@répondreMail3',
+            difficulty: 3,
+          },
+          {
+            id: 'rec1TZRdq2lKyLEaR',
+            name: '@répondreMail4',
+            difficulty: 4,
+          },
+          {
+            id: 'skill28p87p3Ot90Umv',
+            name: '@répondreMail5',
+            difficulty: 5,
+          },
+        ],
+        name: 'répondreMail',
+      },
+      {
+        skills: [
+          {
+            id: 'rec5JQfWV9brlT8hO',
+            name: '@adresseElect1',
+            difficulty: 1,
+          },
+          {
+            id: 'skill2BxFQALqARP441',
+            name: '@adresseElect2',
+            difficulty: 2,
+          },
+          {
+            id: 'recuiCzBk96GLsysI',
+            name: '@adresseElect3',
+            difficulty: 3,
+          },
+        ],
+        name: 'adresseElect',
+      },
+      {
+        skills: [
+          {
+            id: 'recdnFCH9mBrDW06P',
+            name: '@spam2',
+            difficulty: 2,
+          },
+          {
+            id: 'rec9hCuo78BNiz94h',
+            name: '@spam3',
+            difficulty: 3,
+          },
+          {
+            id: 'rec8PgJLouOSZ17FG',
+            name: '@spam4',
+            difficulty: 4,
+          },
+          {
+            id: 'recWTGXrt4fLP2QOL',
+            name: '@spam5',
+            difficulty: 5,
+          },
+          {
+            id: 'skill1qaJ2VnTFJ5GJf',
+            name: '@spam6',
+            difficulty: 6,
+          },
+          {
+            id: 'skillQV0P5GuLMeYW7',
+            name: '@spam7',
+            difficulty: 7,
+          },
+        ],
+        name: 'spam',
+      },
+      {
+        skills: [
+          {
+            id: 'recPGDVdX0LSOWQQC',
+            name: '@gestionMails1',
+            difficulty: 1,
+          },
+          {
+            id: 'recmoanUlDOyXexPF',
+            name: '@gestionMails3',
+            difficulty: 3,
+          },
+          {
+            id: 'recyCbjLUApUp06rk',
+            name: '@gestionMails4',
+            difficulty: 4,
+          },
+          {
+            id: 'rec20khhumencjHqt',
+            name: '@gestionMails5',
+            difficulty: 5,
+          },
+          {
+            id: 'recUaEq1tk16x66T',
+            name: '@gestionMails6',
+            difficulty: 6,
+          },
+        ],
+        name: 'gestionMails',
+      },
+      {
+        skills: [
+          {
+            id: 'rec4973AsptLwKr5f',
+            name: '@communicationAsynchrone2',
+            difficulty: 2,
+          },
+          {
+            id: 'recZQw6nVvfYg0uyB',
+            name: '@communicationAsynchrone3',
+            difficulty: 3,
+          },
+          {
+            id: 'skill1lFqczMT6lqm5Y',
+            name: '@communicationAsynchrone5',
+            difficulty: 5,
+          },
+          {
+            id: 'skill2ieQwFlW3Ne9Nt',
+            name: '@communicationAsynchrone6',
+            difficulty: 6,
+          },
+          {
+            id: 'skill1kvO3wW1sZuryD',
+            name: '@communicationAsynchrone7',
+            difficulty: 7,
+          },
+        ],
+        name: 'communicationAsynchrone',
+      },
+      {
+        skills: [
+          {
+            id: 'recZ6RUx2zcIaRAIC',
+            name: '@outilsMsgélectronique1',
+            difficulty: 1,
+          },
+          {
+            id: 'recdwoJE9Po9zdf0A',
+            name: '@outilsMsgélectronique3',
+            difficulty: 3,
+          },
+          {
+            id: 'skill1rXqGtiKi8JLdk',
+            name: '@outilsMsgélectronique4',
+            difficulty: 4,
+          },
+          {
+            id: 'skill1z5pb57z8oW19r',
+            name: '@outilsMsgélectronique5',
+            difficulty: 5,
+          },
+          {
+            id: 'skill1F8u92iXfUwcM6',
+            name: '@outilsMsgélectronique6',
+            difficulty: 6,
+          },
+        ],
+        name: 'outilsMsgélectronique',
+      },
+      {
+        skills: [
+          {
+            id: 'recfktfO0ROu1OifX',
+            name: '@netiquette4',
+            difficulty: 4,
+          },
+          {
+            id: 'recwucYj3gElngpyL',
+            name: '@netiquette6',
+            difficulty: 6,
+          },
+        ],
+        name: 'netiquette',
+      },
+      {
+        skills: [
+          {
+            id: 'recPG9ftlGZLiF0O6',
+            name: '@champsCourriel1',
+            difficulty: 1,
+          },
+          {
+            id: 'recH1pcEWLBUCqXTm',
+            name: '@champsCourriel2',
+            difficulty: 2,
+          },
+          {
+            id: 'recIDXphXbneOrbux',
+            name: '@champsCourriel3',
+            difficulty: 3,
+          },
+          {
+            id: 'reciF9dxvDfMUuFcb',
+            name: '@champsCourriel4',
+            difficulty: 4,
+          },
+          {
+            id: 'skill1Ma8u52WmJfxIf',
+            name: '@champsCourriel5',
+            difficulty: 5,
+          },
+          {
+            id: 'skill1j39bcoIGvlADN',
+            name: '@champsCourriel6',
+            difficulty: 6,
+          },
+        ],
+        name: 'champsCourriel',
+      },
+      {
+        skills: [
+          {
+            id: 'skill1ENXr2MZ0XZhWj',
+            name: '@conversation1',
+            difficulty: 1,
+          },
+          {
+            id: 'skill1DbWfXibjwaM1w',
+            name: '@conversation2',
+            difficulty: 2,
+          },
+          {
+            id: 'skill1xsn4sAgpuxhuB',
+            name: '@conversation3',
+            difficulty: 3,
+          },
+          {
+            id: 'skill1aa9GlPzDG3GUP',
+            name: '@conversation4',
+            difficulty: 4,
+          },
+          {
+            id: 'skill2A1myNkqAxiyKT',
+            name: '@conversation5',
+            difficulty: 5,
+          },
+        ],
+        name: 'conversation',
+      },
+      {
+        skills: [
+          {
+            id: 'skill1ekYIy8gFHyxCV',
+            name: '@canal1',
+            difficulty: 1,
+          },
+          {
+            id: 'skill2x1YhidbkYp2Pg',
+            name: '@canal2',
+            difficulty: 2,
+          },
+          {
+            id: 'skill1iR2MVxDLqEIVO',
+            name: '@canal3',
+            difficulty: 3,
+          },
+          {
+            id: 'skill2fj31Yqxlb7jk6',
+            name: '@canal4',
+            difficulty: 4,
+          },
+        ],
+        name: 'canal',
+      },
+      {
+        skills: [
+          {
+            id: 'skill22ugx0qpvW2twf',
+            name: '@PJ2',
+            difficulty: 2,
+          },
+          {
+            id: 'skill18ySWKxgaUtP6y',
+            name: '@PJ3',
+            difficulty: 3,
+          },
+          {
+            id: 'skill15XF9tWHkxNWPm',
+            name: '@PJ4',
+            difficulty: 4,
+          },
+          {
+            id: 'skill1GkELRn1T8WDxM',
+            name: '@PJ5',
+            difficulty: 5,
+          },
+        ],
+        name: 'PJ',
+      },
+      {
+        skills: [
+          {
+            id: 'skill2b3kerzZhjyp0A',
+            name: '@contacts1',
+            difficulty: 1,
+          },
+          {
+            id: 'skill1nwDxoR0x0SCZW',
+            name: '@contacts5',
+            difficulty: 5,
+          },
+          {
+            id: 'skill1MjpSjffZZXvh0',
+            name: '@contacts7',
+            difficulty: 7,
+          },
+        ],
+        name: 'contacts',
+      },
+      {
+        skills: [
+          {
+            id: 'skill1urblOxjUEbinI',
+            name: '@outilsVisio1',
+            difficulty: 1,
+          },
+          {
+            id: 'skill2rfU7dxfMwkMcr',
+            name: '@outilsVisio2',
+            difficulty: 2,
+          },
+          {
+            id: 'skill1TjG4RSc2Kt7uF',
+            name: '@outilsVisio3',
+            difficulty: 3,
+          },
+          {
+            id: 'skill12LsYS7w71E0rF',
+            name: '@outilsVisio6',
+            difficulty: 6,
+          },
+        ],
+        name: 'outilsVisio',
+      },
+      {
+        skills: [
+          {
+            id: 'skill1xQQ7zYfFzbmaH',
+            name: '@outilsMessagerie2',
+            difficulty: 2,
+          },
+          {
+            id: 'skill1xkz0CTTsal6uL',
+            name: '@outilsMessagerie4',
+            difficulty: 4,
+          },
+        ],
+        name: 'outilsMessagerie',
+      },
+      {
+        skills: [
+          {
+            id: 'skill29qYgQv0UPtZzI',
+            name: '@utiliserVisio2',
+            difficulty: 2,
+          },
+          {
+            id: 'skillO9IBV1NC2tNmd',
+            name: '@utiliserVisio3',
+            difficulty: 3,
+          },
+          {
+            id: 'skill135DNPBBKppVeo',
+            name: '@utiliserVisio4',
+            difficulty: 4,
+          },
+        ],
+        name: 'utiliserVisio',
+      },
+    ].map(buildTube);
+    predictedLevel = 6.5;
+  });
+
+  describe('#getPredictedLevel', function () {
+    it('should return expected predicted level ', async function () {
+      // when
+      const predictedLevel = getPredictedLevel(knowledgeElements, skills);
+
+      // then
+      assert.equal(predictedLevel, 6.5);
+    });
+  });
+
+  describe('#findMaxRewardingSkills', function () {
+    it('should return expected max rewarding skills', async function () {
+      // given
+      const expectedMaxRewardingSkills = [
+        {
+          id: 'skill1qaJ2VnTFJ5GJf',
+          name: '@spam6',
+          difficulty: 6,
+        },
+        {
+          id: 'skill2ieQwFlW3Ne9Nt',
+          name: '@communicationAsynchrone6',
+          difficulty: 6,
+        },
+      ].map(buildSkill);
+
+      // when / then
+      assert.deepEqual(
+        findMaxRewardingSkills({
+          predictedLevel,
+          availableSkills: skills,
+          tubes,
+          knowledgeElements,
+        }),
+        expectedMaxRewardingSkills,
+      );
+    });
+  });
+});

--- a/api/tests/unit/domain/services/smart-random/skills-filter_test.js
+++ b/api/tests/unit/domain/services/smart-random/skills-filter_test.js
@@ -1,6 +1,8 @@
 import { Tube } from '../../../../../lib/domain/models/Tube.js';
 import * as skillsFilter from '../../../../../lib/domain/services/algorithm-methods/skills-filter.js';
+import { focusOnDefaultLevel } from '../../../../../lib/domain/services/algorithm-methods/skills-filter.js';
 import { domainBuilder, expect } from '../../../../test-helper.js';
+import { buildSkill } from '../../../../tooling/domain-builder/factory/index.js';
 
 const KNOWLEDGE_ELEMENT_STATUS = {
   VALIDATED: 'validated',
@@ -378,6 +380,48 @@ describe('Unit | Domain | services | smart-random | skillsFilter', function () {
 
         // then
         expect(result).to.deep.equal([playableSkill]);
+      });
+    });
+  });
+
+  describe('#focusOnDefaultLevel', function () {
+    describe("when some skill's difficulty are equal to 2", function () {
+      it('should only return difficulty 2 skills', function () {
+        // given
+        const skills = [
+          { id: 1, difficulty: 2 },
+          { id: 2, difficulty: 1 },
+          { id: 3, difficulty: 3 },
+          { id: 4, difficulty: 2 },
+        ].map(buildSkill);
+
+        // when
+        const difficultyTwoSkills = focusOnDefaultLevel(skills);
+
+        // then
+        expect(difficultyTwoSkills.length).to.equal(2);
+        expect(difficultyTwoSkills[0].id).to.equal(1);
+        expect(difficultyTwoSkills[1].id).to.equal(4);
+      });
+    });
+
+    describe('when there is no difficulty 2 skills', function () {
+      it('should return the lowest difficulty skills', function () {
+        // given
+        const skills = [
+          { id: 4, difficulty: 6 },
+          { id: 1, difficulty: 1 },
+          { id: 2, difficulty: 1 },
+          { id: 3, difficulty: 4 },
+        ].map(buildSkill);
+
+        // when
+        const lowestDifficultySkills = focusOnDefaultLevel(skills);
+
+        // then
+        expect(lowestDifficultySkills.length).to.equal(2);
+        expect(lowestDifficultySkills[0].id).to.equal(1);
+        expect(lowestDifficultySkills[1].id).to.equal(2);
       });
     });
   });

--- a/api/tests/unit/domain/services/smart-random/skills-filter_test.js
+++ b/api/tests/unit/domain/services/smart-random/skills-filter_test.js
@@ -15,7 +15,7 @@ function setPlayableSkills(skills) {
 
 describe('Unit | Domain | services | smart-random | skillsFilter', function () {
   describe('#getFilteredSkillsForFirstChallenge', function () {
-    it('should return a first skill possible', function () {
+    it('should return the first possible skill', function () {
       // given
       const skill1 = domainBuilder.buildSkill({ name: '@web3', difficulty: 3 });
       const skills = [skill1];
@@ -53,7 +53,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', function () {
       expect(result).to.deep.equal([skill1]);
     });
 
-    it('should return a skill valid from a tubes with max level at 3 (HAPPY PATH)', function () {
+    it('should return a valid skill from a tube which only contains skill levels inferior or equal to 3', function () {
       // given
       const skillTube1Level2 = domainBuilder.buildSkill({ id: 'rec1', name: '@web2', difficulty: 2 });
       const skillTube1Level4 = domainBuilder.buildSkill({ id: 'rec2', name: '@web4', difficulty: 4 });
@@ -179,7 +179,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', function () {
       });
     });
 
-    describe('Verify rules : Not skill with timed challenge after timed challenge', function () {
+    describe('Verify rules : No successive timed challenges', function () {
       it('should return a skill without timed challenge if last one was timed', function () {
         // given
         const skill1 = domainBuilder.buildSkill({ id: 'rec1', name: '@test2', difficulty: 2 });


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la réappropriation de l'algorithme par l'équipe XP d'éval et de la mise en place d'un simulateur, on souhaite retravailler le code existant pour en faciliter la lecture et l'usage dans les PR à venir.

## :robot: Proposition
- Supprimer l'utilisation de Lodash 
- Déclarer les fonctions avant leur usage dans les fichiers
- Tester des comportements et fonctions qui ne le sont pas
- Rendre plus claires des étapes de l'algorithme en préparation de l'usage qui en sera fait dans les PRs à venir

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
Pix doit toujours fonctionner. Vaste programme. 
