### PR TITLE
[FEATURE] utiliser la table `organization-imports` pour afficher les infos du dernier import (Pix-11670)

### DIFF
--- a/api/src/prescription/learner-management/domain/usecases/handle-payload-too-large-error.js
+++ b/api/src/prescription/learner-management/domain/usecases/handle-payload-too-large-error.js
@@ -1,0 +1,21 @@
+import { PayloadTooLargeError } from '../../../../../lib/application/http-errors.js';
+import { OrganizationImport } from '../models/OrganizationImport.js';
+const ERRORS = {
+  PAYLOAD_TOO_LARGE: 'PAYLOAD_TOO_LARGE',
+};
+const handlePayloadTooLargeError = async ({ organizationId, userId, organizationImportRepository }) => {
+  const organizationImport = OrganizationImport.create({ organizationId, createdBy: userId });
+  const organizationImportError = new PayloadTooLargeError(
+    'An error occurred, payload is too large',
+    ERRORS.PAYLOAD_TOO_LARGE,
+    {
+      maxSize: '20',
+    },
+  );
+  organizationImport.upload({ errors: [organizationImportError] });
+  await organizationImportRepository.save(organizationImport);
+
+  throw organizationImportError;
+};
+
+export { handlePayloadTooLargeError };

--- a/api/src/prescription/learner-management/domain/usecases/import-organization-learners-from-siecle-csv-format.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-organization-learners-from-siecle-csv-format.js
@@ -1,4 +1,4 @@
-import { SiecleXmlImportError } from '../errors.js';
+import { AggregateImportError, SiecleXmlImportError } from '../errors.js';
 
 const { isEmpty, chunk } = lodash;
 import bluebird from 'bluebird';
@@ -59,7 +59,11 @@ const importOrganizationLearnersFromSIECLECSVFormat = async function ({
       throw new SiecleXmlImportError(ERRORS.EMPTY);
     }
   } catch (error) {
-    errors.push(error);
+    if (error instanceof AggregateImportError) {
+      errors.push(...error.meta);
+    } else {
+      errors.push(error);
+    }
     throw error;
   } finally {
     organizationImport.validate({ errors });

--- a/api/src/prescription/learner-management/domain/usecases/import-organization-learners-from-siecle-xml-format.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-organization-learners-from-siecle-xml-format.js
@@ -1,6 +1,6 @@
 import fs from 'fs/promises';
 
-import { SiecleXmlImportError } from '../errors.js';
+import { AggregateImportError, SiecleXmlImportError } from '../errors.js';
 
 const { isEmpty, chunk } = lodash;
 
@@ -72,7 +72,11 @@ const importOrganizationLearnersFromSIECLEXMLFormat = async function ({
       throw new SiecleXmlImportError(ERRORS.EMPTY);
     }
   } catch (error) {
-    errors.push(error);
+    if (error instanceof AggregateImportError) {
+      errors.push(...error.meta);
+    } else {
+      errors.push(error);
+    }
     throw error;
   } finally {
     organizationImport = await organizationImportRepository.getLastByOrganizationId(organizationId);

--- a/api/src/prescription/learner-management/domain/usecases/import-organization-learners-from-siecle-xml-format.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-organization-learners-from-siecle-xml-format.js
@@ -40,12 +40,11 @@ const importOrganizationLearnersFromSIECLEXMLFormat = async function ({
   const organization = await organizationRepository.get(organizationId);
   const path = payload.path;
 
-  const { file: filePath, directory } = await siecleService.unzip(path);
-  const encoding = await siecleService.detectEncoding(filePath);
-
-  let filename;
+  let filename, encoding;
   const errors = [];
   try {
+    const { file: filePath, directory } = await siecleService.unzip(path);
+    encoding = await siecleService.detectEncoding(filePath);
     filename = await importStorage.sendFile({ filepath: filePath });
     if (directory) {
       await fs.rm(directory, { recursive: true });

--- a/api/src/prescription/learner-management/domain/usecases/import-sup-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-sup-organization-learners.js
@@ -1,6 +1,7 @@
 import { createReadStream } from 'fs';
 
 import { SupOrganizationLearnerParser } from '../../infrastructure/serializers/csv/sup-organization-learner-parser.js';
+import { AggregateImportError } from '../errors.js';
 import { OrganizationImport } from '../models/OrganizationImport.js';
 
 const importSupOrganizationLearners = async function ({
@@ -47,7 +48,11 @@ const importSupOrganizationLearners = async function ({
     learnersData = learners;
     warningsData = warnings;
   } catch (error) {
-    errors.push(error);
+    if (error instanceof AggregateImportError) {
+      errors.push(...error.meta);
+    } else {
+      errors.push(error);
+    }
     throw error;
   } finally {
     organizationImport = await organizationImportRepository.getLastByOrganizationId(organizationId);

--- a/api/src/prescription/learner-management/domain/usecases/replace-sup-organization-learner.js
+++ b/api/src/prescription/learner-management/domain/usecases/replace-sup-organization-learner.js
@@ -1,6 +1,7 @@
 import { createReadStream } from 'fs';
 
 import { SupOrganizationLearnerParser } from '../../infrastructure/serializers/csv/sup-organization-learner-parser.js';
+import { AggregateImportError } from '../errors.js';
 import { OrganizationImport } from '../models/OrganizationImport.js';
 
 const replaceSupOrganizationLearners = async function ({
@@ -45,7 +46,11 @@ const replaceSupOrganizationLearners = async function ({
     learnersData = learners;
     warningsData = warnings;
   } catch (error) {
-    errors.push(error);
+    if (error instanceof AggregateImportError) {
+      errors.push(...error.meta);
+    } else {
+      errors.push(error);
+    }
     throw error;
   } finally {
     organizationImport = await organizationImportRepository.getLastByOrganizationId(organizationId);

--- a/api/tests/prescription/learner-management/unit/domain/usecases/handle-payload-too-large-error_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/handle-payload-too-large-error_test.js
@@ -1,0 +1,33 @@
+import { PayloadTooLargeError } from '../../../../../../lib/application/http-errors.js';
+import { OrganizationImport } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationImport.js';
+import { handlePayloadTooLargeError } from '../../../../../../src/prescription/learner-management/domain/usecases/handle-payload-too-large-error.js';
+import { catchErr, expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | UseCase | Organization Learners Management | Handle Payload Too Large Error', function () {
+  let organizationImportRepository;
+
+  beforeEach(function () {
+    organizationImportRepository = {
+      save: sinon.stub(),
+    };
+    sinon.stub(OrganizationImport, 'create');
+  });
+
+  it('should save payload too large error and throw it', async function () {
+    // given
+    const userId = 777;
+    const organizationId = 111;
+    const organizationImportStub = { upload: sinon.stub() };
+    OrganizationImport.create.returns(organizationImportStub);
+    // when
+    const error = await catchErr(handlePayloadTooLargeError)({
+      organizationId,
+      userId,
+      organizationImportRepository,
+    });
+
+    // then
+    expect(organizationImportRepository.save).to.have.been.calledWithExactly(organizationImportStub);
+    expect(error).to.be.an.instanceof(PayloadTooLargeError);
+  });
+});

--- a/api/tests/prescription/learner-management/unit/domain/usecases/import-organization-learners-from-siecle-xml-format_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/import-organization-learners-from-siecle-xml-format_test.js
@@ -271,8 +271,26 @@ describe('Unit | UseCase | import-organization-learners-from-siecle-xml', functi
           //then
           expect(organizationImportRepositoryStub.save.getCall(0).args[0].status).to.equal('UPLOAD_ERROR');
         });
-      });
+        it('should save UPLOAD_ERROR status if zip is invalid', async function () {
+          //given
+          siecleServiceStub.unzip.rejects();
 
+          // when
+          await catchErr(importOrganizationLearnersFromSIECLEXMLFormat)({
+            organizationId,
+            payload,
+            format,
+            organizationRepository: organizationRepositoryStub,
+            organizationImportRepository: organizationImportRepositoryStub,
+            organizationLearnerRepository: organizationLearnerRepositoryStub,
+            siecleService: siecleServiceStub,
+            importStorage: importStorageStub,
+          });
+
+          //then
+          expect(organizationImportRepositoryStub.save.getCall(0).args[0].status).to.equal('UPLOAD_ERROR');
+        });
+      });
       describe('when there is a validation error', function () {
         it('should save VALIDATION_ERROR status', async function () {
           //given

--- a/orga/app/adapters/organization-import.js
+++ b/orga/app/adapters/organization-import.js
@@ -1,0 +1,9 @@
+import ApplicationAdapter from './application';
+
+export default class OrganizationImportAdapter extends ApplicationAdapter {
+  urlForQueryRecord(query) {
+    const { organizationId } = query;
+    delete query.organizationId;
+    return `${this.host}/${this.namespace}/organizations/${organizationId}/import-information`;
+  }
+}

--- a/orga/app/components/import.hbs
+++ b/orga/app/components/import.hbs
@@ -38,7 +38,7 @@
     </div>
   {{/unless}}
 
-  {{#if this.displayErrorImportPanel}}
+  {{#if this.displayImportMessagePanel}}
     <section class={{this.panelClasses}} aria-live="assertive">
       <h2 class="screen-reader-only">{{t "pages.organization-participants-import.error-panel.title"}}</h2>
 

--- a/orga/app/components/import.js
+++ b/orga/app/components/import.js
@@ -1,33 +1,32 @@
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import groupBy from 'lodash/groupBy';
+import uniq from 'lodash/uniq';
 
 export default class Import extends Component {
   @service currentUser;
   @service session;
+  @service errorMessages;
   @service intl;
 
-  get displayErrorImportPanel() {
-    return Boolean(this.args.errors) || this.hasWarnings;
-  }
-
-  get hasWarnings() {
-    return Boolean(this.args.warnings);
+  get displayImportMessagePanel() {
+    return this.args.organizationImport?.hasError || this.args.organizationImport?.hasWarning;
   }
 
   get displayBanner() {
-    return this.args.isLoading || Boolean(this.args.warningBanner);
+    return this.args.isLoading || this.args.organizationImport?.hasWarning;
   }
 
   get panelClasses() {
     const classes = ['import-students-page__error-panel'];
 
-    if (this.hasWarnings) classes.push('import-students-page__error-panel--warning');
+    if (this.args.organizationImport?.hasWarning) classes.push('import-students-page__error-panel--warning');
 
-    return classes.join(' ');
+    return classes.join(' ').trim();
   }
 
   get bannerType() {
-    if (this.hasWarnings) {
+    if (this.args.organizationImport?.hasWarning) {
       return 'warning';
     } else {
       return 'information';
@@ -35,13 +34,29 @@ export default class Import extends Component {
   }
 
   get bannerMessage() {
-    if (this.hasWarnings) return this.args.warningBanner;
-
+    if (this.args.organizationImport?.hasWarning) {
+      return this.intl.t('pages.organization-participants-import.warning-banner', { htmlSafe: true });
+    }
     return this.intl.t('pages.organization-participants-import.information');
   }
 
   get errorDetailList() {
-    return this.args.errors || this.args.warnings;
+    if (this.args.organizationImport?.hasWarning) {
+      const warnings = [];
+      const warningsByFields = groupBy(this.args.organizationImport?.errors, 'field');
+      if (warningsByFields.diploma) {
+        const diplomas = uniq(warningsByFields.diploma.map((warning) => warning.value)).join(', ');
+        warnings.push(this.intl.t('pages.organization-participants-import.warnings.diploma', { diplomas }));
+      }
+      if (warningsByFields['study-scheme']) {
+        const studySchemes = uniq(warningsByFields['study-scheme'].map((warning) => warning.value)).join(', ');
+        warnings.push(this.intl.t('pages.organization-participants-import.warnings.study-scheme', { studySchemes }));
+      }
+      return warnings;
+    }
+    return this.args.organizationImport?.errors.map((error) =>
+      this.errorMessages.getErrorMessage(error.code, error.meta),
+    );
   }
 
   get supportedFormats() {

--- a/orga/app/models/organization-import.js
+++ b/orga/app/models/organization-import.js
@@ -1,0 +1,20 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class OrganizationImport extends Model {
+  @attr('string') status;
+  @attr('date') createdAt;
+  @attr('date') updatedAt;
+  @attr() errors;
+
+  get hasError() {
+    return /ERROR/.test(this.status) && this.errors?.length > 0;
+  }
+
+  get hasWarning() {
+    return this.isDone && this.errors?.length > 0;
+  }
+
+  get isDone() {
+    return this.status === 'IMPORTED';
+  }
+}

--- a/orga/app/routes/authenticated/import-organization-participants.js
+++ b/orga/app/routes/authenticated/import-organization-participants.js
@@ -5,12 +5,24 @@ import { service } from '@ember/service';
 export default class ImportOrganizationParticipantsRoute extends Route {
   @service currentUser;
   @service router;
+  @service store;
 
   beforeModel() {
     super.beforeModel(...arguments);
 
     if (!this.currentUser.shouldAccessImportPage) {
       return this.router.replaceWith('application');
+    }
+  }
+
+  async model() {
+    try {
+      return await this.store.queryRecord('organization-import', {
+        organizationId: this.currentUser.organization.id,
+      });
+    } catch (error) {
+      console.log({ error });
+      this.router.replaceWith('application');
     }
   }
 
@@ -28,5 +40,9 @@ export default class ImportOrganizationParticipantsRoute extends Route {
   @action
   async refreshGroups() {
     await this.currentUser.organization.hasMany('groups').reload();
+  }
+  @action
+  refreshModel() {
+    this.refresh();
   }
 }

--- a/orga/app/routes/authenticated/import-organization-participants.js
+++ b/orga/app/routes/authenticated/import-organization-participants.js
@@ -21,7 +21,6 @@ export default class ImportOrganizationParticipantsRoute extends Route {
         organizationId: this.currentUser.organization.id,
       });
     } catch (error) {
-      console.log({ error });
       this.router.replaceWith('application');
     }
   }

--- a/orga/app/templates/authenticated/import-organization-participants.hbs
+++ b/orga/app/templates/authenticated/import-organization-participants.hbs
@@ -9,7 +9,5 @@
   @onImportSupStudents={{this.importSupStudents}}
   @onReplaceStudents={{this.replaceStudents}}
   @isLoading={{this.isLoading}}
-  @errors={{this.errors}}
-  @warnings={{this.warnings}}
-  @warningBanner={{this.warningBanner}}
+  @organizationImport={{@model}}
 />

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -99,7 +99,9 @@ function routes() {
   });
 
   this.patch('/memberships/:id');
-
+  this.get('/organizations/:id/import-information', () => {
+    return { data: null };
+  });
   this.get('/organizations/:id/campaigns', (schema, request) => {
     const {
       'filter[ownerName]': ownerName,

--- a/orga/tests/acceptance/import-organization-participants_test.js
+++ b/orga/tests/acceptance/import-organization-participants_test.js
@@ -29,7 +29,7 @@ module('Acceptance | Student Import', function (hooks) {
     });
 
     module('have access to upload file', function () {
-      test('it should display success message and reload students', async function (assert) {
+      test('navigate to import page', async function (assert) {
         // given
         const screen = await visit('/etudiants');
 

--- a/orga/tests/integration/components/import_test.js
+++ b/orga/tests/integration/components/import_test.js
@@ -9,7 +9,7 @@ import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | OrganizationParticipantImport', function (hooks) {
   setupIntlRenderingTest(hooks);
-
+  let organizationImport;
   hooks.beforeEach(function () {
     this.set('onImportSupStudents', sinon.stub());
     this.set('onImportScoStudents', sinon.stub());
@@ -24,24 +24,29 @@ module('Integration | Component | OrganizationParticipantImport', function (hook
       }
 
       this.owner.register('service:current-user', CurrentUserStub);
+
+      const store = this.owner.lookup('service:store');
+      organizationImport = store.createRecord('organization-import', {
+        status: 'VALIDATION_ERROR',
+        errors: [{ code: 'UAI_MISMATCHED', meta: {} }],
+      });
     });
 
     test('display error heading information', async function (assert) {
-      this.set('errors', []);
-      this.set('warnings', null);
+      this.set('organizationImport', organizationImport);
       const screen = await render(
         hbs`<Import
   @onImportSupStudents={{this.onImportSupStudents}}
   @onImportScoStudents={{this.onImportScoStudents}}
   @onReplaceStudents={{this.onReplaceStudents}}
-  @errors={{this.errors}}
-  @warnings={{this.warnings}}
+  @organizationImport={{this.organizationImport}}
 />`,
       );
 
       assert.ok(
         screen.getByRole('heading', { name: this.intl.t('pages.organization-participants-import.error-panel.title') }),
       );
+      assert.strictEqual(screen.getAllByRole('listitem').length, 1);
     });
   });
 
@@ -66,6 +71,7 @@ module('Integration | Component | OrganizationParticipantImport', function (hook
   @onImportScoStudents={{this.onImportScoStudents}}
   @onReplaceStudents={{this.onReplaceStudents}}
   @isLoading={{this.isLoading}}
+  @organizatioImport={{null}}
 />`,
       );
 
@@ -96,6 +102,7 @@ module('Integration | Component | OrganizationParticipantImport', function (hook
   @onImportScoStudents={{this.onImportScoStudents}}
   @onReplaceStudents={{this.onReplaceStudents}}
   @isLoading={{this.isLoading}}
+  @organizatioImport={{null}}
 />`,
       );
 
@@ -115,6 +122,7 @@ module('Integration | Component | OrganizationParticipantImport', function (hook
   @onImportScoStudents={{this.onImportScoStudents}}
   @onReplaceStudents={{this.onReplaceStudents}}
   @isLoading={{this.isLoading}}
+  @organizatioImport={{null}}
 />`,
         );
 
@@ -144,6 +152,7 @@ module('Integration | Component | OrganizationParticipantImport', function (hook
   @onImportScoStudents={{this.onImportScoStudents}}
   @onReplaceStudents={{this.onReplaceStudents}}
   @isLoading={{this.isLoading}}
+  @organizatioImport={{null}}
 />`,
         );
 
@@ -179,6 +188,7 @@ module('Integration | Component | OrganizationParticipantImport', function (hook
   @onImportScoStudents={{this.onImportScoStudents}}
   @onReplaceStudents={{this.onReplaceStudents}}
   @isLoading={{this.isLoading}}
+  @organizatioImport={{null}}
 />`,
         );
 
@@ -218,6 +228,7 @@ module('Integration | Component | OrganizationParticipantImport', function (hook
   @onImportScoStudents={{this.onImportScoStudents}}
   @onReplaceStudents={{this.onReplaceStudents}}
   @isLoading={{this.isLoading}}
+  @organizatioImport={{null}}
 />`,
       );
 
@@ -243,6 +254,7 @@ module('Integration | Component | OrganizationParticipantImport', function (hook
   @onImportScoStudents={{this.onImportScoStudents}}
   @onReplaceStudents={{this.onReplaceStudents}}
   @isLoading={{this.isLoading}}
+  @organizatioImport={{null}}
 />`,
       );
 
@@ -265,6 +277,7 @@ module('Integration | Component | OrganizationParticipantImport', function (hook
   @onImportScoStudents={{this.onImportScoStudents}}
   @onReplaceStudents={{this.onReplaceStudents}}
   @isLoading={{this.isLoading}}
+  @organizatioImport={{null}}
 />`,
       );
 
@@ -281,6 +294,7 @@ module('Integration | Component | OrganizationParticipantImport', function (hook
   @onImportScoStudents={{this.onImportScoStudents}}
   @onReplaceStudents={{this.onReplaceStudents}}
   @isLoading={{this.isLoading}}
+  @organizatioImport={{null}}
 />`,
       );
 
@@ -300,6 +314,7 @@ module('Integration | Component | OrganizationParticipantImport', function (hook
   @onImportScoStudents={{this.onImportScoStudents}}
   @onReplaceStudents={{this.onReplaceStudents}}
   @isLoading={{this.isLoading}}
+  @organizatioImport={{null}}
 />`,
       );
       assert.ok(await screen.findByText(this.intl.t('pages.organization-participants-import.information')));
@@ -325,6 +340,7 @@ module('Integration | Component | OrganizationParticipantImport', function (hook
   @onImportScoStudents={{this.onImportScoStudents}}
   @onReplaceStudents={{this.onReplaceStudents}}
   @isLoading={{this.isLoading}}
+  @organizatioImport={{null}}
 />`,
       );
 
@@ -340,6 +356,7 @@ module('Integration | Component | OrganizationParticipantImport', function (hook
   @onImportScoStudents={{this.onImportScoStudents}}
   @onReplaceStudents={{this.onReplaceStudents}}
   @isLoading={{this.isLoading}}
+  @organizatioImport={{null}}
 />`,
       );
 
@@ -359,6 +376,7 @@ module('Integration | Component | OrganizationParticipantImport', function (hook
   @onImportScoStudents={{this.onImportScoStudents}}
   @onReplaceStudents={{this.onReplaceStudents}}
   @isLoading={{this.isLoading}}
+  @organizatioImport={{null}}
 />`,
       );
       assert.ok(await screen.findByText(this.intl.t('pages.organization-participants-import.information')));
@@ -372,6 +390,7 @@ module('Integration | Component | OrganizationParticipantImport', function (hook
   @onImportScoStudents={{this.onImportScoStudents}}
   @onReplaceStudents={{this.onReplaceStudents}}
   @isLoading={{this.isLoading}}
+  @organizatioImport={{null}}
 />`,
       );
 

--- a/orga/tests/unit/controllers/authenticated/import-organization-participants_test.js
+++ b/orga/tests/unit/controllers/authenticated/import-organization-participants_test.js
@@ -18,7 +18,6 @@ module('Unit | Controller | authenticated/import-organization-participant', func
     controller = this.owner.lookup('controller:authenticated/import-organization-participants');
     controller.send = sinon.stub();
     controller.currentUser = currentUser;
-    controller.notifications = { sendError: sinon.stub(), sendSuccess: sinon.stub(), clearAll: sinon.stub() };
 
     const store = this.owner.lookup('service:store');
     const adapter = store.adapterFor('students-import');
@@ -33,67 +32,23 @@ module('Unit | Controller | authenticated/import-organization-participant', func
 
       assert.ok(addStudentsCsvStub.calledWith(1, files));
     });
-
+    test('should refresh the model', async (assert) => {
+      await controller.importSupStudents(files);
+      assert.ok(controller.send.calledWithExactly('refreshModel'));
+    });
     module('refresh groups', () => {
       test('should refresh current groups', async (assert) => {
         await controller.importSupStudents(files);
         assert.ok(controller.send.calledWithExactly('refreshGroups'));
       });
     });
-
-    module('manage CSV import errors', function (hooks) {
-      hooks.beforeEach(function () {
-        controller.notifications.sendError = sinon.spy();
-      });
-
-      test('notify a global error message if error not handled', async function (assert) {
-        addStudentsCsvStub.rejects({ errors: [{ status: '401' }] });
-
-        // when
-        await controller.importSupStudents(files);
-
-        // then
-        const notificationMessage = controller.notifications.sendError.firstCall.firstArg.toString();
-
-        assert.strictEqual(
-          notificationMessage,
-          this.intl.t('pages.organization-participants-import.error-panel.error-wrapper'),
-        );
-      });
-
-      test('notify a detailed error message if 412 error', async function (assert) {
-        addStudentsCsvStub.rejects({ errors: [{ status: '412', detail: 'Error message' }] });
-
-        // when
-        await controller.importSupStudents(files);
-
-        // then
-        const notificationMessage = controller.notifications.sendError.firstCall.firstArg.toString();
-
-        assert.strictEqual(
-          notificationMessage,
-          this.intl.t('pages.organization-participants-import.error-panel.error-wrapper'),
-        );
-      });
-
-      test('notify a detailed error message if 413 error', async function (assert) {
-        addStudentsCsvStub.rejects({ errors: [{ status: '413', detail: 'Error message' }] });
-
-        // when
-        await controller.importSupStudents(files);
-
-        // then
-        const notificationMessage = controller.notifications.sendError.firstCall.firstArg.toString();
-
-        assert.strictEqual(
-          notificationMessage,
-          this.intl.t('pages.organization-participants-import.error-panel.error-wrapper'),
-        );
-      });
-    });
   });
 
   module('#importScoStudents', function () {
+    test('should refresh the model', async (assert) => {
+      await controller.importScoStudents(files);
+      assert.ok(controller.send.calledWithExactly('refreshModel'));
+    });
     module('refresh divisions', () => {
       test('should refresh current divisions', async (assert) => {
         await controller.importScoStudents(files);
@@ -118,93 +73,6 @@ module('Unit | Controller | authenticated/import-organization-participant', func
         await controller.importScoStudents(files);
 
         assert.ok(importScoStudentStub.calledWith(1, files, 'xml'));
-        assert.ok(controller.notifications.sendSuccess.calledOnce);
-        assert.ok(controller.notifications.sendError.notCalled);
-        assert.strictEqual(controller.warningBanner, null);
-      });
-    });
-
-    module('manage import errors', function (hooks) {
-      hooks.beforeEach(function () {
-        controller.notifications.sendError = sinon.spy();
-      });
-
-      test('notify a global error message if error not handled', async function (assert) {
-        importScoStudentStub.rejects({ errors: [{ status: '401' }] });
-
-        // when
-        await controller.importScoStudents(files);
-
-        // then
-        const notificationMessage = controller.notifications.sendError.firstCall.firstArg.toString();
-
-        assert.strictEqual(
-          notificationMessage,
-          this.intl.t('pages.organization-participants-import.error-panel.error-wrapper'),
-        );
-      });
-
-      test('notify a detailed error message if 412 error', async function (assert) {
-        importScoStudentStub.rejects({ errors: [{ status: '412', detail: 'Error message' }] });
-
-        // when
-        await controller.importScoStudents(files);
-
-        // then
-        const notificationMessage = controller.notifications.sendError.firstCall.firstArg.toString();
-
-        assert.strictEqual(
-          notificationMessage,
-          this.intl.t('pages.organization-participants-import.error-panel.error-wrapper'),
-        );
-      });
-
-      test('notify a detailed error message if 413 error', async function (assert) {
-        importScoStudentStub.rejects({ errors: [{ status: '413', detail: 'Error message' }] });
-
-        // when
-        await controller.importScoStudents(files);
-
-        // then
-        const notificationMessage = controller.notifications.sendError.firstCall.firstArg.toString();
-
-        assert.strictEqual(
-          notificationMessage,
-          this.intl.t('pages.organization-participants-import.error-panel.error-wrapper'),
-        );
-      });
-
-      test('notify a detailed error message if 422 error', async function (assert) {
-        importScoStudentStub.rejects({ errors: [{ status: '422', detail: 'Error message' }] });
-
-        // when
-        await controller.importScoStudents(files);
-
-        // then
-        const notificationMessage = controller.notifications.sendError.firstCall.firstArg.toString();
-
-        assert.strictEqual(
-          notificationMessage,
-          this.intl.t('pages.organization-participants-import.error-panel.error-wrapper'),
-        );
-      });
-
-      test('should use error code and meta if provided', async function (assert) {
-        importScoStudentStub.rejects({
-          errors: [{ status: '422', code: 'SEX_CODE_REQUIRED', meta: { nationalStudentId: '1234' } }],
-        });
-
-        // when
-        await controller.importScoStudents(files);
-
-        // then
-        const errorMessages = controller.errors;
-
-        assert.true(
-          errorMessages.includes(
-            this.intl.t('api-error-messages.student-xml-import.sex-code-required', { nationalStudentId: '1234' }),
-          ),
-        );
       });
     });
   });
@@ -215,61 +83,14 @@ module('Unit | Controller | authenticated/import-organization-participant', func
 
       assert.ok(replaceStudentsCsvStub.calledWith(1, files));
     });
+    test('should refresh the model', async (assert) => {
+      await controller.replaceStudents(files);
+      assert.ok(controller.send.calledWithExactly('refreshModel'));
+    });
     module('refresh groups', () => {
       test('should refresh current groups', async (assert) => {
         await controller.replaceStudents(files);
         assert.ok(controller.send.calledWithExactly('refreshGroups'));
-      });
-    });
-
-    module('manage CSV import errors', function (hooks) {
-      hooks.beforeEach(function () {
-        controller.notifications.sendError = sinon.spy();
-      });
-
-      test('notify a global error message if error not handled when replacing registrations', async function (assert) {
-        replaceStudentsCsvStub.rejects({ errors: [{ status: '401' }] });
-
-        // when
-        await controller.replaceStudents(files);
-
-        // then
-        const notificationMessage = controller.notifications.sendError.firstCall.firstArg.toString();
-
-        assert.strictEqual(
-          notificationMessage,
-          this.intl.t('pages.organization-participants-import.error-panel.error-wrapper'),
-        );
-      });
-
-      test('notify a detailed error message if 412 error when replacing registrations', async function (assert) {
-        replaceStudentsCsvStub.rejects({ errors: [{ status: '412', detail: 'Error message' }] });
-
-        // when
-        await controller.replaceStudents(files);
-
-        // then
-        const notificationMessage = controller.notifications.sendError.firstCall.firstArg.toString();
-
-        assert.strictEqual(
-          notificationMessage,
-          this.intl.t('pages.organization-participants-import.error-panel.error-wrapper'),
-        );
-      });
-
-      test('notify a detailed error message if 413 error when replacing registrations when replacing registrations', async function (assert) {
-        replaceStudentsCsvStub.rejects({ errors: [{ status: '413', detail: 'Error message' }] });
-
-        // when
-        await controller.replaceStudents(files);
-
-        // then
-        const notificationMessage = controller.notifications.sendError.firstCall.firstArg.toString();
-
-        assert.strictEqual(
-          notificationMessage,
-          this.intl.t('pages.organization-participants-import.error-panel.error-wrapper'),
-        );
       });
     });
   });

--- a/orga/tests/unit/models/organization-import_test.js
+++ b/orga/tests/unit/models/organization-import_test.js
@@ -1,0 +1,62 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Model | organization-import', function (hooks) {
+  setupTest(hooks);
+  module('#hasError', function () {
+    ['UPLOAD_ERROR', 'VALIDATION_ERROR', 'IMPORT_ERROR'].forEach((status) => {
+      test('it should return true', function (assert) {
+        const store = this.owner.lookup('service:store');
+        const model = store.createRecord('organization-import', {
+          status,
+          errors: [Symbol('error')],
+        });
+        assert.ok(model.hasError);
+      });
+    });
+    ['UPLOADED', 'VALIDATED', 'IMPORTED'].forEach((status) => {
+      test('it should return false', function (assert) {
+        const store = this.owner.lookup('service:store');
+        const model = store.createRecord('organization-import', {
+          status,
+        });
+        assert.notOk(model.hasError);
+      });
+    });
+  });
+  module('#hasWarning', function () {
+    test('it should return true', function (assert) {
+      const store = this.owner.lookup('service:store');
+      const model = store.createRecord('organization-import', {
+        status: 'IMPORTED',
+        errors: [Symbol('warning')],
+      });
+      assert.ok(model.hasWarning);
+    });
+    test('it should return false', function (assert) {
+      const store = this.owner.lookup('service:store');
+      const model = store.createRecord('organization-import', {
+        status: 'IMPORTED',
+      });
+      assert.notOk(model.hasWarning);
+    });
+  });
+  module('#isDone', function () {
+    test('it should return true', function (assert) {
+      const store = this.owner.lookup('service:store');
+      const model = store.createRecord('organization-import', {
+        status: 'IMPORTED',
+      });
+      assert.ok(model.isDone);
+    });
+    ['UPLOADED', 'VALIDATED', 'UPLOAD_ERROR', 'VALIDATION_ERROR', 'IMPORT_ERROR'].forEach((status) => {
+      test('it should return false', function (assert) {
+        const store = this.owner.lookup('service:store');
+        const model = store.createRecord('organization-import', {
+          status,
+        });
+        assert.notOk(model.isDone);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la refonte de l'import pour le rendre asynchrone, nous stockons les infos de traitement de l'import dans une table. On souhaite utiliser ces infos plutôt que celle renvoyées par le endpoint

## :robot: Proposition
On affiche les erreurs de validité et de traitement du fichier depuis le endpoint d'import

## :rainbow: Remarques
on modifie la manière d'enregistrer les `AggregateImportError` en base pour n'avoir plus que les erreurs ou les warning lié à la validation

## :100: Pour tester
réaliser des import sco / sup / agri  et tester à chaque fois fichier ok et un fichier erreur