### PR TITLE
[FEATURE] Ajout de l'ID d'answer dans la table `certification-challenge-capacities` (PIX-11688)

### DIFF
--- a/api/db/database-builder/factory/build-certification-challenge-capacity.js
+++ b/api/db/database-builder/factory/build-certification-challenge-capacity.js
@@ -1,11 +1,12 @@
 import { databaseBuffer } from '../database-buffer.js';
 
-export const buildCertificationChallengeCapacity = ({ certificationChallengeId, capacity, createdAt }) => {
+export const buildCertificationChallengeCapacity = ({ answerId, capacity, certificationChallengeId, createdAt }) => {
   return databaseBuffer.pushInsertable({
     tableName: 'certification-challenge-capacities',
     values: {
-      certificationChallengeId,
+      answerId,
       capacity,
+      certificationChallengeId,
       createdAt,
     },
   });

--- a/api/db/migrations/20240321142333_add-answer-id-in-certification-challenge-capacities.js
+++ b/api/db/migrations/20240321142333_add-answer-id-in-certification-challenge-capacities.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'certification-challenge-capacities';
+const COLUMN_NAME = 'answerId';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.bigInteger(COLUMN_NAME).nullable().references('answers.id');
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/src/certification/flash-certification/domain/services/algorithm-methods/flash.js
+++ b/api/src/certification/flash-certification/domain/services/algorithm-methods/flash.js
@@ -74,14 +74,15 @@ function getEstimatedLevelAndErrorRateHistory({
   let likelihood = samples.map(() => DEFAULT_PROBABILITY_TO_ANSWER);
   let normalizedPosteriori;
   let answerIndex = 0;
+  let answer;
 
   const estimatedLevelHistory = [];
 
   while (answerIndex < allAnswers.length) {
+    answer = allAnswers[answerIndex];
     const variationPercentForCurrentAnswer = variationPercentUntil >= answerIndex ? variationPercent : undefined;
 
     if (!_shouldUseDoubleMeasure({ doubleMeasuresUntil, answerIndex, answersLength: allAnswers.length })) {
-      const answer = allAnswers[answerIndex];
       ({ latestEstimatedLevel, likelihood, normalizedPosteriori } = _singleMeasure({
         challenges,
         answer,
@@ -93,11 +94,11 @@ function getEstimatedLevelAndErrorRateHistory({
 
       answerIndex++;
     } else {
-      const answer1 = allAnswers[answerIndex];
+      answer = allAnswers[answerIndex];
       const answer2 = allAnswers[answerIndex + 1];
       ({ latestEstimatedLevel, likelihood, normalizedPosteriori } = _doubleMeasure({
         challenges,
-        answers: [answer1, answer2],
+        answers: [answer, answer2],
         latestEstimatedLevel,
         likelihood,
         normalizedPosteriori,
@@ -108,6 +109,7 @@ function getEstimatedLevelAndErrorRateHistory({
     }
 
     estimatedLevelHistory.push({
+      answerId: answer.id,
       estimatedLevel: latestEstimatedLevel,
       errorRate: _computeCorrectedErrorRate(latestEstimatedLevel, normalizedPosteriori),
     });

--- a/api/src/certification/scoring/domain/models/CertificationAssessmentHistory.js
+++ b/api/src/certification/scoring/domain/models/CertificationAssessmentHistory.js
@@ -10,8 +10,9 @@ export class CertificationAssessmentHistory {
       challenges,
     });
 
-    const capacityHistory = estimatedLevelAndErrorRateHistory.map(({ estimatedLevel }, index) =>
+    const capacityHistory = estimatedLevelAndErrorRateHistory.map(({ answerId, estimatedLevel }, index) =>
       CertificationChallengeCapacity.create({
+        answerId,
         certificationChallengeId: challenges[index].certificationChallengeId,
         capacity: estimatedLevel,
       }),

--- a/api/src/certification/scoring/domain/models/CertificationChallengeCapacity.js
+++ b/api/src/certification/scoring/domain/models/CertificationChallengeCapacity.js
@@ -1,12 +1,14 @@
 export class CertificationChallengeCapacity {
-  constructor({ certificationChallengeId, capacity, createdAt }) {
+  constructor({ answerId, certificationChallengeId, capacity, createdAt }) {
+    this.answerId = answerId;
     this.certificationChallengeId = certificationChallengeId;
     this.capacity = capacity;
     this.createdAt = createdAt;
   }
 
-  static create({ certificationChallengeId, capacity }) {
+  static create({ answerId, certificationChallengeId, capacity }) {
     return new CertificationChallengeCapacity({
+      answerId,
       certificationChallengeId,
       capacity,
     });

--- a/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
@@ -556,6 +556,29 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         expect(results[1].estimatedLevel).to.be.closeTo(1.802340122865396, 0.00000000001);
         expect(results[1].errorRate).to.be.closeTo(0.8549014053951466, 0.00000000001);
       });
+
+      it('should return the answer id when there is at least one answer', function () {
+        // given
+        const challenges = [
+          domainBuilder.buildChallenge({
+            id: 'ChallengeFirstAnswer',
+            discriminant: 1.86350005965093,
+            difficulty: 0.194712138508747,
+          }),
+        ];
+
+        const answerId = 1969;
+
+        const allAnswers = [
+          domainBuilder.buildAnswer({ id: answerId, result: AnswerStatus.OK, challengeId: challenges[0].id }),
+        ];
+
+        // when
+        const results = flash.getEstimatedLevelAndErrorRateHistory({ allAnswers, challenges });
+
+        // then
+        expect(results[0].answerId).to.equal(answerId);
+      });
     });
   });
 

--- a/api/tests/certification/scoring/integration/infrastructure/repositories/certification-assessment-history-repository_test.js
+++ b/api/tests/certification/scoring/integration/infrastructure/repositories/certification-assessment-history-repository_test.js
@@ -9,15 +9,19 @@ describe('Integration | Infrastructure | Repository | CertificationChallengeCapa
     describe('when there is no certification challenge capacity', function () {
       it('should save the certification challenge capacities', async function () {
         // given
+        const answerId1 = databaseBuilder.factory.buildAnswer().id;
+        const answerId2 = databaseBuilder.factory.buildAnswer().id;
         const certificationChallenge1 = databaseBuilder.factory.buildCertificationChallenge();
         const certificationChallenge2 = databaseBuilder.factory.buildCertificationChallenge();
 
         const capacityHistory = [
           domainBuilder.buildCertificationChallengeCapacity({
+            answerId: answerId1,
             certificationChallengeId: certificationChallenge1.id,
             capacity: 10,
           }),
           domainBuilder.buildCertificationChallengeCapacity({
+            answerId: answerId2,
             certificationChallengeId: certificationChallenge2.id,
             capacity: 20,
           }),
@@ -36,10 +40,12 @@ describe('Integration | Infrastructure | Repository | CertificationChallengeCapa
         const capacities = await knex('certification-challenge-capacities').select();
         expect(capacities).to.have.lengthOf(2);
         expect(_.omit(capacities[0], 'createdAt')).to.deep.equal({
+          answerId: answerId1,
           certificationChallengeId: certificationChallenge1.id,
           capacity: 10,
         });
         expect(_.omit(capacities[1], 'createdAt')).to.deep.equal({
+          answerId: answerId2,
           certificationChallengeId: certificationChallenge2.id,
           capacity: 20,
         });
@@ -48,6 +54,9 @@ describe('Integration | Infrastructure | Repository | CertificationChallengeCapa
 
     describe('when a certification challenge capacity already exists', function () {
       it('should update the preexisting certification challenge capacity', async function () {
+        // given
+        const answerId1 = databaseBuilder.factory.buildAnswer().id;
+        const answerId2 = databaseBuilder.factory.buildAnswer().id;
         const certificationChallenge1 = databaseBuilder.factory.buildCertificationChallenge();
         const certificationChallenge2 = databaseBuilder.factory.buildCertificationChallenge();
 
@@ -60,10 +69,12 @@ describe('Integration | Infrastructure | Repository | CertificationChallengeCapa
 
         const capacityHistory = [
           domainBuilder.buildCertificationChallengeCapacity({
+            answerId: answerId1,
             certificationChallengeId: certificationChallenge1.id,
             capacity: 10,
           }),
           domainBuilder.buildCertificationChallengeCapacity({
+            answerId: answerId2,
             certificationChallengeId: certificationChallenge2.id,
             capacity: 20,
           }),
@@ -80,10 +91,12 @@ describe('Integration | Infrastructure | Repository | CertificationChallengeCapa
         const capacities = await knex('certification-challenge-capacities').select();
         expect(capacities).to.have.lengthOf(2);
         expect(_.omit(capacities[0], 'createdAt')).to.deep.equal({
+          answerId: answerId1,
           certificationChallengeId: certificationChallenge1.id,
           capacity: 10,
         });
         expect(_.omit(capacities[1], 'createdAt')).to.deep.equal({
+          answerId: answerId2,
           certificationChallengeId: certificationChallenge2.id,
           capacity: 20,
         });

--- a/api/tests/certification/scoring/unit/domain/models/CertificationAssessmentHistory_test.js
+++ b/api/tests/certification/scoring/unit/domain/models/CertificationAssessmentHistory_test.js
@@ -8,6 +8,9 @@ describe('Unit | Domain | Models | CertificationAssessmentHistory', function () 
       const algorithm = {
         getEstimatedLevelAndErrorRateHistory: sinon.stub(),
       };
+      const firstAnswerId = 123;
+      const secondAnswerId = 456;
+      const thirdAnswerId = 789;
 
       const challenges = [
         domainBuilder.buildCertificationChallengeForScoring({
@@ -24,9 +27,9 @@ describe('Unit | Domain | Models | CertificationAssessmentHistory', function () 
         }),
       ];
       const allAnswers = [
-        domainBuilder.buildAnswer({ challengeId: 'challenge1', value: 'answer1' }),
-        domainBuilder.buildAnswer({ challengeId: 'challenge2', value: 'answer1' }),
-        domainBuilder.buildAnswer({ challengeId: 'challenge3', value: 'answer1' }),
+        domainBuilder.buildAnswer({ id: firstAnswerId, challengeId: 'challenge1', value: 'answer1' }),
+        domainBuilder.buildAnswer({ id: secondAnswerId, challengeId: 'challenge2', value: 'answer1' }),
+        domainBuilder.buildAnswer({ id: thirdAnswerId, challengeId: 'challenge3', value: 'answer1' }),
       ];
 
       algorithm.getEstimatedLevelAndErrorRateHistory
@@ -34,7 +37,11 @@ describe('Unit | Domain | Models | CertificationAssessmentHistory', function () 
           allAnswers,
           challenges,
         })
-        .returns([{ estimatedLevel: 1 }, { estimatedLevel: 2 }, { estimatedLevel: 3 }]);
+        .returns([
+          { answerId: firstAnswerId, estimatedLevel: 1 },
+          { answerId: secondAnswerId, estimatedLevel: 2 },
+          { answerId: thirdAnswerId, estimatedLevel: 3 },
+        ]);
 
       // when
       const certificationAssessmentHistory = CertificationAssessmentHistory.fromChallengesAndAnswers({
@@ -46,14 +53,17 @@ describe('Unit | Domain | Models | CertificationAssessmentHistory', function () 
       // then
       const expectedCapacityHistory = [
         domainBuilder.buildCertificationChallengeCapacity({
+          answerId: firstAnswerId,
           certificationChallengeId: 'certificationChallengeId1',
           capacity: 1,
         }),
         domainBuilder.buildCertificationChallengeCapacity({
+          answerId: secondAnswerId,
           certificationChallengeId: 'certificationChallengeId2',
           capacity: 2,
         }),
         domainBuilder.buildCertificationChallengeCapacity({
+          answerId: thirdAnswerId,
           certificationChallengeId: 'certificationChallengeId3',
           capacity: 3,
         }),

--- a/api/tests/tooling/domain-builder/factory/certification/scoring/build-certification-challenge-capacity.js
+++ b/api/tests/tooling/domain-builder/factory/certification/scoring/build-certification-challenge-capacity.js
@@ -1,7 +1,8 @@
 import { CertificationChallengeCapacity } from '../../../../../../src/certification/scoring/domain/models/CertificationChallengeCapacity.js';
 
-export const buildCertificationChallengeCapacity = ({ certificationChallengeId, capacity, createdAt }) => {
+export const buildCertificationChallengeCapacity = ({ answerId, certificationChallengeId, capacity, createdAt }) => {
   return new CertificationChallengeCapacity({
+    answerId,
     certificationChallengeId,
     capacity,
     createdAt,


### PR DESCRIPTION
## :unicorn: Problème

Donnée demandée par l'équipe Data afin de ne pas avoir à réaliser de jointures en passant par la table `assessments`, qui ralentit fortement les requêtes dans le cadre de leurs travaux.

## :robot: Proposition
Ajout d'un `answer id` dans la table `certification-challenge-capacities`

## :100: Pour tester
- Créer une session de certification V3 (certifv3@example.net)
- Ajouter un candidat
- Démarrer et terminer la session (certifiable-contenu-user@example.net)
- Vérifier dans la BDD que la table `certification-challenge-capacities` contient les nouveaux challenges avec un `answerID`