### PR TITLE
[TECH] Remplacer les "contains" dans les tests par des méthodes de testingLibrary (PIX-11714)

### DIFF
--- a/orga/tests/integration/components/campaign/filter/participation-filters_test.js
+++ b/orga/tests/integration/components/campaign/filter/participation-filters_test.js
@@ -28,7 +28,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
       this.set('rowCount', rowCount);
 
       // when
-      await render(
+      const screen = await render(
         hbs`<Campaign::Filter::ParticipationFilters
   @campaign={{this.campaign}}
   @rowCount={{this.rowCount}}
@@ -41,10 +41,10 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
       );
 
       // then
-      assert.contains('1 participant');
+      assert.ok(screen.getByText('1 participant'));
     });
 
-    test('it should display many filtered participant', async function (assert) {
+    test('it should display many filtered participants', async function (assert) {
       // given
       const badge = store.createRecord('badge');
       const campaign = store.createRecord('campaign', {
@@ -58,7 +58,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
       this.set('details', rowCount);
 
       // when
-      await render(
+      const screen = await render(
         hbs`<Campaign::Filter::ParticipationFilters
   @campaign={{this.campaign}}
   @rowCount={{this.details}}
@@ -71,7 +71,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
       );
 
       // then
-      assert.contains('2 participants');
+      assert.ok(screen.getByText('2 participants'));
     });
 
     module('Filter button', function () {
@@ -146,7 +146,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
           );
 
           //then
-          assert.dom(screen.getByRole('button', { name: 'Effacer les filtres', hidden: true })).exists();
+          assert.ok(screen.getByRole('button', { name: 'Effacer les filtres', hidden: true }));
         });
       });
 
@@ -173,7 +173,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
           );
 
           //then
-          assert.dom(screen.getByRole('button', { name: 'Effacer les filtres', hidden: true })).exists();
+          assert.ok(screen.getByRole('button', { name: 'Effacer les filtres', hidden: true }));
         });
       });
     });
@@ -192,7 +192,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         this.set('campaign', campaign);
 
         // when
-        await render(
+        const screen = await render(
           hbs`<Campaign::Filter::ParticipationFilters
   @campaign={{this.campaign}}
   @onFilter={{this.noop}}
@@ -204,7 +204,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         );
 
         // then
-        assert.notContains('Paliers');
+        assert.notOk(screen.queryByRole('button', { name: 'Paliers' }));
       });
     });
 
@@ -221,7 +221,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         this.set('campaign', campaign);
 
         // when
-        await render(
+        const screen = await render(
           hbs`<Campaign::Filter::ParticipationFilters
   @campaign={{this.campaign}}
   @onFilter={{this.noop}}
@@ -233,7 +233,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         );
 
         // then
-        assert.notContains('Paliers');
+        assert.notOk(screen.queryByRole('button', { name: 'Paliers' }));
       });
     });
 
@@ -251,7 +251,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         this.set('selectedStages', []);
 
         // when
-        await render(
+        const screen = await render(
           hbs`<Campaign::Filter::ParticipationFilters
   @campaign={{this.campaign}}
   @onFilter={{this.noop}}
@@ -264,7 +264,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         );
 
         // then
-        assert.contains('Paliers');
+        assert.ok(screen.getByRole('button', { name: 'Paliers' }));
       });
 
       test('it should not display the stage filter when it specified', async function (assert) {
@@ -279,7 +279,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         this.set('campaign', campaign);
 
         // when
-        await render(
+        const screen = await render(
           hbs`<Campaign::Filter::ParticipationFilters
   @campaign={{this.campaign}}
   @onFilter={{this.noop}}
@@ -291,7 +291,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         );
 
         // then
-        assert.notContains('Paliers');
+        assert.notOk(screen.queryByRole('button', { name: 'Paliers' }));
       });
 
       test('it triggers the filter when a stage is selected', async function (assert) {
@@ -346,7 +346,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         this.set('selectedBadges', []);
 
         // when
-        await render(
+        const screen = await render(
           hbs`<Campaign::Filter::ParticipationFilters
   @campaign={{this.campaign}}
   @onFilter={{this.noop}}
@@ -359,8 +359,8 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         );
 
         // then
-        assert.contains('Thématiques');
-        assert.contains('Les bases');
+        assert.ok(screen.getByRole('button', { name: 'Thématiques' }));
+        assert.ok(screen.getByLabelText('Les bases'));
       });
 
       test('it should not displays the badge filter when it specified', async function (assert) {
@@ -375,7 +375,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         this.set('campaign', campaign);
 
         // when
-        await render(
+        const screen = await render(
           hbs`<Campaign::Filter::ParticipationFilters
   @campaign={{this.campaign}}
   @onFilter={{this.noop}}
@@ -388,8 +388,8 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         );
 
         // then
-        assert.notContains('Thématiques');
-        assert.notContains('Les bases');
+        assert.notOk(screen.queryByRole('button', { name: 'Thématiques' }));
+        assert.notOk(screen.queryByLabelText('Les bases'));
       });
 
       test('it triggers the filter when a badge is selected', async function (assert) {
@@ -439,12 +439,12 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         this.set('campaign', campaign);
 
         // when
-        await render(
+        const screen = await render(
           hbs`<Campaign::Filter::ParticipationFilters @campaign={{this.campaign}} @onFilter={{this.noop}} />`,
         );
 
         // then
-        assert.notContains('Thématiques');
+        assert.notOk(screen.queryByRole('button', { name: 'Thématiques' }));
       });
     });
 
@@ -461,12 +461,12 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         this.set('campaign', campaign);
 
         // when
-        await render(
+        const screen = await render(
           hbs`<Campaign::Filter::ParticipationFilters @campaign={{this.campaign}} @onFilter={{this.noop}} />`,
         );
 
         // then
-        assert.notContains('Thématiques');
+        assert.notOk(screen.queryByRole('button', { name: 'Thématiques' }));
       });
     });
   });
@@ -666,7 +666,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
       );
 
       // then
-      assert.dom(screen.getByLabelText('Rechercher par certificabilité')).exists();
+      assert.ok(screen.getByLabelText('Rechercher par certificabilité'));
     });
 
     test('hide certificability filter on assessment campaign', async function (assert) {
@@ -691,7 +691,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
       );
 
       // then
-      assert.dom(screen.queryByLabelText('Rechercher par certificabilité')).doesNotExist();
+      assert.notOk(screen.queryByLabelText('Rechercher par certificabilité'));
     });
 
     test('it triggers the filter when a certificability is selected', async function (assert) {
@@ -743,7 +743,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
 
       test('it displays the division filter', async function (assert) {
         // when
-        await render(
+        const screen = await render(
           hbs`<Campaign::Filter::ParticipationFilters
   @campaign={{this.campaign}}
   @onFilter={{this.noop}}
@@ -755,8 +755,8 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
 />`,
         );
         // then
-        assert.contains('Classes');
-        assert.contains('d1');
+        assert.ok(screen.getByRole('textbox', { name: 'Rechercher par classes' }));
+        assert.ok(screen.getByLabelText('d1'));
       });
 
       test('it display disabled button', async function (assert) {
@@ -781,7 +781,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         );
 
         //then
-        assert.dom(screen.getByRole('button', { name: 'Effacer les filtres', hidden: true })).exists();
+        assert.ok(screen.getByRole('button', { name: 'Effacer les filtres', hidden: true }));
       });
 
       test('it triggers the filter when a division is selected', async function (assert) {
@@ -815,7 +815,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
       this.campaign = store.createRecord('campaign', { id: 1 });
       this.set('selectedDivisions', []);
       // when
-      await render(hbs`<Campaign::Filter::ParticipationFilters
+      const screen = await render(hbs`<Campaign::Filter::ParticipationFilters
   @campaign={{this.campaign}}
   @onFilter={{this.noop}}
   @isHiddenStages={{true}}
@@ -825,7 +825,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
 />`);
 
       // then
-      assert.notContains('Groupes');
+      assert.notOk(screen.queryByRole('button', { name: 'Groupes' }));
     });
   });
 
@@ -864,12 +864,12 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
         );
 
         //then
-        assert.dom(screen.getByRole('button', { name: 'Effacer les filtres', hidden: true })).exists();
+        assert.ok(screen.getByRole('button', { name: 'Effacer les filtres', hidden: true }));
       });
 
       test('it displays the group filter', async function (assert) {
         // when
-        await render(
+        const screen = await render(
           hbs`<Campaign::Filter::ParticipationFilters
   @campaign={{this.campaign}}
   @onFilter={{this.noop}}
@@ -879,8 +879,8 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
 />`,
         );
         // then
-        assert.contains('Groupes');
-        assert.contains('d1');
+        assert.ok(screen.getByRole('textbox', { name: 'Groupes' }));
+        assert.ok(screen.getByLabelText('d1'));
       });
 
       test('it triggers the filter when a group is selected', async function (assert) {
@@ -927,7 +927,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
       });
 
       // when
-      await render(
+      const screen = await render(
         hbs`<Campaign::Filter::ParticipationFilters
   @campaign={{this.campaign}}
   @onFilter={{this.noop}}
@@ -938,8 +938,8 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
       );
 
       // then
-      assert.notContains('Classes');
-      assert.notContains('d2');
+      assert.notOk(screen.queryByRole('textbox', { name: 'Rechercher par classes' }));
+      assert.notOk(screen.queryByLabelText('d2'));
     });
   });
 });

--- a/orga/tests/integration/components/campaign/results/profile-list_test.js
+++ b/orga/tests/integration/components/campaign/results/profile-list_test.js
@@ -33,7 +33,7 @@ module('Integration | Component | Campaign::Results::ProfileList', function (hoo
           sharedAt: new Date(2020, 1, 1),
         },
         {
-          firstName: 'John',
+          firstName: 'Patrick',
           lastName: 'Doe2',
           participantExternalId: '1234',
           sharedAt: null,
@@ -42,7 +42,7 @@ module('Integration | Component | Campaign::Results::ProfileList', function (hoo
       this.profiles.meta = { rowCount: 2 };
 
       // when
-      await render(
+      const screen = await render(
         hbs`<Campaign::Results::ProfileList
   @campaign={{this.campaign}}
   @profiles={{this.profiles}}
@@ -54,11 +54,13 @@ module('Integration | Component | Campaign::Results::ProfileList', function (hoo
       );
 
       // then
-      assert.notContains('En attente de profils');
-      assert.contains('Doe');
-      assert.contains('Doe2');
-      assert.contains('John');
-      assert.contains("En attente d'envoi");
+      assert.notOk(screen.queryByText('En attente de profils'));
+      assert.ok(screen.getByRole('cell', { name: 'Doe' }));
+      assert.ok(screen.getByRole('cell', { name: 'Doe2' }));
+      assert.ok(screen.getByRole('cell', { name: 'John' }));
+      assert.ok(screen.getByRole('cell', { name: 'Patrick' }));
+      assert.ok(screen.getByRole('cell', { name: "En attente d'envoi" }));
+      assert.ok(screen.getByRole('cell', { name: '01/02/2020' }));
     });
 
     test('it should display the profile list with external id', async function (assert) {
@@ -73,7 +75,7 @@ module('Integration | Component | Campaign::Results::ProfileList', function (hoo
       this.profiles.meta = { rowCount: 1 };
 
       // when
-      await render(
+      const screen = await render(
         hbs`<Campaign::Results::ProfileList
   @campaign={{this.campaign}}
   @profiles={{this.profiles}}
@@ -85,8 +87,8 @@ module('Integration | Component | Campaign::Results::ProfileList', function (hoo
       );
 
       // then
-      assert.contains('identifiant externe');
-      assert.contains('123');
+      assert.ok(screen.getByRole('columnheader', { name: 'identifiant externe' }));
+      assert.ok(screen.getByRole('cell', { name: '123' }));
     });
 
     test('it should display participant certification profile info when shared', async function (assert) {
@@ -110,7 +112,7 @@ module('Integration | Component | Campaign::Results::ProfileList', function (hoo
       this.profiles.meta = { rowCount: 1 };
 
       // when
-      await render(
+      const screen = await render(
         hbs`<Campaign::Results::ProfileList
   @campaign={{this.campaign}}
   @profiles={{this.profiles}}
@@ -122,10 +124,10 @@ module('Integration | Component | Campaign::Results::ProfileList', function (hoo
       );
 
       // then
-      assert.contains('01/02/2020');
-      assert.contains('10');
-      assert.contains('Certifiable');
-      assert.contains('5');
+      assert.ok(screen.getByRole('cell', { name: '01/02/2020' }));
+      assert.ok(screen.getByRole('cell', { name: '10' }));
+      assert.ok(screen.getByRole('cell', { name: 'Certifiable' }));
+      assert.ok(screen.getByRole('cell', { name: '5' }));
     });
 
     test('it should display a link to access participant profile', async function (assert) {
@@ -146,7 +148,7 @@ module('Integration | Component | Campaign::Results::ProfileList', function (hoo
       ];
 
       // when
-      await render(
+      const screen = await render(
         hbs`<Campaign::Results::ProfileList
   @campaign={{this.campaign}}
   @profiles={{this.profiles}}
@@ -158,7 +160,7 @@ module('Integration | Component | Campaign::Results::ProfileList', function (hoo
       );
 
       // then
-      assert.dom('a[href="/campagnes/1/profils/7"]').exists();
+      assert.ok(screen.getByRole('link', { href: '/campagnes/1/profils/7' }));
     });
   });
 
@@ -174,7 +176,7 @@ module('Integration | Component | Campaign::Results::ProfileList', function (hoo
       this.profiles.meta = { rowCount: 0 };
 
       // when
-      await render(
+      const screen = await render(
         hbs`<Campaign::Results::ProfileList
   @campaign={{this.campaign}}
   @profiles={{this.profiles}}
@@ -186,7 +188,7 @@ module('Integration | Component | Campaign::Results::ProfileList', function (hoo
       );
 
       // then
-      assert.contains('En attente de profils');
+      assert.ok(screen.getByText('En attente de profils'));
     });
   });
 });

--- a/orga/tests/integration/components/dropdown/icon-trigger_test.js
+++ b/orga/tests/integration/components/dropdown/icon-trigger_test.js
@@ -9,28 +9,32 @@ module('Integration | Component | Dropdown | icon-trigger', function (hooks) {
 
   test('should display actions menu', async function (assert) {
     // when
-    await render(hbs`<Dropdown::IconTrigger @ariaLabel='Afficher les actions' />`);
+    const screen = await render(hbs`<Dropdown::IconTrigger @ariaLabel='Afficher les actions' />`);
 
     // then
-    assert.dom('[aria-label="Afficher les actions"]').exists();
+    assert.ok(screen.getByLabelText('Afficher les actions'));
   });
 
   test('should display actions on click', async function (assert) {
     // when
-    await render(hbs`<Dropdown::IconTrigger @ariaLabel='Afficher les actions'>Something</Dropdown::IconTrigger>`);
+    const screen = await render(
+      hbs`<Dropdown::IconTrigger @ariaLabel='Afficher les actions'>Something</Dropdown::IconTrigger>`,
+    );
     await clickByName('Afficher les actions');
 
     // then
-    assert.contains('Something');
+    assert.ok(screen.getByText('Something'));
   });
 
   test('should hide actions on click again', async function (assert) {
     // when
-    await render(hbs`<Dropdown::IconTrigger @ariaLabel='Afficher les actions'>Something</Dropdown::IconTrigger>`);
+    const screen = await render(
+      hbs`<Dropdown::IconTrigger @ariaLabel='Afficher les actions'>Something</Dropdown::IconTrigger>`,
+    );
     await clickByName('Afficher les actions');
     await clickByName('Afficher les actions');
 
     // then
-    assert.notContains('Something');
+    assert.notOk(screen.queryByText('Something'));
   });
 });

--- a/orga/tests/integration/components/layout/organization-credit-info_test.js
+++ b/orga/tests/integration/components/layout/organization-credit-info_test.js
@@ -23,19 +23,22 @@ module('Integration | Component | Layout::OrganizationCreditInfo', function (hoo
 
   test('should display organization credit info', async function (assert) {
     // when
-    await render(hbs`<Layout::OrganizationCreditInfo />`);
+    const screen = await render(hbs`<Layout::OrganizationCreditInfo />`);
 
     // then
-    assert.contains('10 000 crédits');
+    assert.ok(screen.getByText('10 000 crédits'));
   });
 
   test('should display tooltip info', async function (assert) {
     // when
-    await render(hbs`<Layout::OrganizationCreditInfo />`);
+    const screen = await render(hbs`<Layout::OrganizationCreditInfo />`);
 
     // then
-    assert.contains(
-      'Le nombre de crédits affichés correspond au nombre de crédits acquis par l’organisation et en cours de validité (indépendamment de leur activation).',
+    assert.ok(
+      screen.getByText(
+        'Le nombre de crédits affichés correspond au nombre de crédits acquis par l’organisation et en cours de validité (indépendamment de leur activation).',
+        { exact: false },
+      ),
     );
   });
 
@@ -44,10 +47,10 @@ module('Integration | Component | Layout::OrganizationCreditInfo', function (hoo
     currentUserStub.organization.credit = 1;
 
     // when
-    await render(hbs`<Layout::OrganizationCreditInfo />`);
+    const screen = await render(hbs`<Layout::OrganizationCreditInfo />`);
 
     // then
-    assert.contains('1 crédit');
+    assert.ok(screen.getByText('1 crédit'));
   });
 
   test('should be hidden when credit is less than 1', async function (assert) {
@@ -55,10 +58,10 @@ module('Integration | Component | Layout::OrganizationCreditInfo', function (hoo
     currentUserStub.organization.credit = 0;
 
     // when
-    await render(hbs`<Layout::OrganizationCreditInfo />`);
+    const screen = await render(hbs`<Layout::OrganizationCreditInfo />`);
 
     // then
-    assert.notContains('crédit');
+    assert.notOk(screen.queryByText('crédit'));
   });
 
   test('should hiden when the prescriber is not ADMIN', async function (assert) {
@@ -66,10 +69,10 @@ module('Integration | Component | Layout::OrganizationCreditInfo', function (hoo
     currentUserStub.isAdminInOrganization = false;
 
     // when
-    await render(hbs`<Layout::OrganizationCreditInfo />`);
+    const screen = await render(hbs`<Layout::OrganizationCreditInfo />`);
 
     // then
-    assert.notContains('crédit');
-    assert.notContains('crédits');
+    assert.notOk(screen.queryByText('crédit'));
+    assert.notOk(screen.queryByText('crédits'));
   });
 });

--- a/orga/tests/integration/components/layout/user-logged-menu_test.js
+++ b/orga/tests/integration/components/layout/user-logged-menu_test.js
@@ -34,18 +34,18 @@ module('Integration | Component | Layout::UserLoggedMenu', function (hooks) {
 
   test("should display user's firstName and lastName", async function (assert) {
     // when
-    await render(hbs`<Layout::UserLoggedMenu />`);
+    const screen = await render(hbs`<Layout::UserLoggedMenu />`);
 
     // then
-    assert.contains(`${prescriber.firstName} ${prescriber.lastName}`);
+    assert.ok(screen.getByText(`${prescriber.firstName} ${prescriber.lastName}`));
   });
 
   test('should display the user current organization name and externalId', async function (assert) {
     // when
-    await render(hbs`<Layout::UserLoggedMenu />`);
+    const screen = await render(hbs`<Layout::UserLoggedMenu />`);
 
     // then
-    assert.contains(`${organization.name} (${organization.externalId})`);
+    assert.ok(screen.getByText(`${organization.name} (${organization.externalId})`));
   });
 
   test('should display the chevron-down icon when menu is close', async function (assert) {
@@ -69,22 +69,20 @@ module('Integration | Component | Layout::UserLoggedMenu', function (hooks) {
 
   test('should display the disconnect link when menu is open', async function (assert) {
     // when
-    await render(hbs`<Layout::UserLoggedMenu />`);
+    const screen = await render(hbs`<Layout::UserLoggedMenu />`);
     await clickByName('Ouvrir le menu utilisateur');
 
     // then
-    assert.contains('Se déconnecter');
+    assert.ok(screen.getByRole('link', { name: 'Se déconnecter' }));
   });
 
   test('should display the organizations name and externalId when menu is open', async function (assert) {
     // when
-    await render(hbs`<Layout::UserLoggedMenu />`);
+    const screen = await render(hbs`<Layout::UserLoggedMenu />`);
     await clickByName('Ouvrir le menu utilisateur');
 
     // then
-    assert.contains(organization2.name);
-    assert.contains(`(${organization2.externalId})`);
-    assert.contains(organization3.name);
-    assert.contains(`(${organization3.externalId})`);
+    assert.ok(screen.getByRole('button', { name: `${organization2.name} (${organization2.externalId})` }));
+    assert.ok(screen.getByRole('button', { name: `${organization3.name} (${organization3.externalId})` }));
   });
 });

--- a/orga/tests/integration/components/organization-participant/list_test.js
+++ b/orga/tests/integration/components/organization-participant/list_test.js
@@ -28,7 +28,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     this.set('certificabilityFilter', []);
     this.set('fullNameFilter', null);
     // when
-    await render(
+    const screen = await render(
       hbs`<OrganizationParticipant::List
   @participants={{this.participants}}
   @triggerFiltering={{this.noop}}
@@ -39,10 +39,10 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     );
 
     // then
-    assert.contains('Nom');
-    assert.contains('Prénom');
-    assert.contains('Nombre de participations');
-    assert.contains('Dernière participation');
+    assert.ok(screen.getByRole('columnheader', { name: 'Nom' }));
+    assert.ok(screen.getByRole('columnheader', { name: 'Prénom' }));
+    assert.ok(screen.getByRole('columnheader', { name: 'Nombre de participations' }));
+    assert.ok(screen.getByRole('columnheader', { name: 'Dernière participation' }));
   });
 
   test('it should have a caption to describe the table ', async function (assert) {
@@ -56,8 +56,9 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     ]);
     this.set('certificabilityFilter', []);
     this.set('fullNameFilter', null);
+
     // when
-    await render(
+    const screen = await render(
       hbs`<OrganizationParticipant::List
   @participants={{this.participants}}
   @triggerFiltering={{this.noop}}
@@ -68,7 +69,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     );
 
     // then
-    assert.contains(this.intl.t('pages.organization-participants.table.description'));
+    assert.ok(screen.getByRole('table', { name: this.intl.t('pages.organization-participants.table.description') }));
   });
 
   test('it should display a list of participants', async function (assert) {
@@ -89,7 +90,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     this.set('certificabilityFilter', []);
     this.set('fullNameFilter', null);
     // when
-    await render(
+    const screen = await render(
       hbs`<OrganizationParticipant::List
   @participants={{this.participants}}
   @triggerFiltering={{this.noop}}
@@ -100,8 +101,8 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     );
 
     // then
-    assert.contains('La Terreur');
-    assert.contains("L'asticot");
+    assert.ok(screen.getByRole('cell', { name: 'La Terreur' }));
+    assert.ok(screen.getByRole('cell', { name: "L'asticot" }));
   });
 
   test('it should display a link to access participant detail', async function (assert) {
@@ -152,7 +153,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     this.set('fullNameFilter', null);
 
     // when
-    await render(
+    const screen = await render(
       hbs`<OrganizationParticipant::List
   @participants={{this.participants}}
   @triggerFiltering={{this.noop}}
@@ -163,8 +164,8 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     );
 
     // then
-    assert.contains('La Terreur');
-    assert.contains('Gigi');
+    assert.ok(screen.getByRole('cell', { name: 'La Terreur' }));
+    assert.ok(screen.getByRole('cell', { name: 'Gigi' }));
   });
 
   test('it should display the number of participations for each participant', async function (assert) {
@@ -267,7 +268,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     this.set('fullNameFilter', null);
 
     // when
-    await render(
+    const screen = await render(
       hbs`<OrganizationParticipant::List
   @participants={{this.participants}}
   @triggerFiltering={{this.noop}}
@@ -278,8 +279,11 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     );
 
     // then
-    assert.contains(this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.eligible'));
-    assert.contains('02/01/2022');
+    assert.ok(
+      screen.getByRole('cell', {
+        name: `${this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.eligible')} 02/01/2022`,
+      }),
+    );
   });
 
   module('filtering cases', function () {
@@ -301,7 +305,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
       );
 
       // then
-      assert.dom(screen.getByLabelText('Recherche sur le nom et prénom')).exists();
+      assert.ok(screen.getByLabelText('Recherche sur le nom et prénom'));
     });
 
     test('it should trigger filtering with fullName search', async function (assert) {
@@ -775,7 +779,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     this.triggerFiltering = sinon.stub();
 
     // when
-    await render(
+    const screen = await render(
       hbs`<OrganizationParticipant::List
   @participants={{this.participants}}
   @triggerFiltering={{this.triggerFiltering}}
@@ -786,7 +790,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     );
 
     // then
-    assert.contains(this.intl.t('pages.organization-participants.table.empty'));
+    assert.ok(screen.getByText(this.intl.t('pages.organization-participants.table.empty')));
   });
 
   test('it should display the certificability tooltip', async function (assert) {
@@ -863,8 +867,8 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
       });
 
       //then
-      assert.dom(mainCheckbox).exists();
-      assert.dom(learnerCheckbox).exists();
+      assert.ok(mainCheckbox);
+      assert.ok(learnerCheckbox);
     });
 
     test('it should disable the main checkbox when participants list is empty', async function (assert) {
@@ -1062,9 +1066,9 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
         await click(firstLearnerToDelete);
 
         //then
-        assert
-          .dom(screen.getByText(this.intl.t('pages.organization-participants.action-bar.information', { count: 1 })))
-          .exists();
+        assert.ok(
+          screen.getByText(this.intl.t('pages.organization-participants.action-bar.information', { count: 1 })),
+        );
       });
 
       test('it should open the deletion modale', async function (assert) {
@@ -1106,7 +1110,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
         });
 
         //then
-        assert.dom(confirmationButton).exists();
+        assert.ok(confirmationButton);
       });
 
       test('it should delete participants', async function (assert) {


### PR DESCRIPTION
## 🦄 Problème
Le contains et notContains a été créé en interne il y a plus de 3ans afin de répondre au besoin de vérification de textes dans les tests fronts.
Depuis ce temps nous avons la lib testing-library qui a des solutions plus précises comme getByText, queryByText, getByLabelText,... Qui répondent totalement à nos besoin et nous permette de supprimer nos contains et notContains

## 🤖 Proposition
Remplacer les utilisations de contains et notContains par des solutions de testing-library afin de pouvoir, par la suite, supprimer le développement de contains et notContains

## 🌈 Remarques
Ils sont partout partout alors je n'ai pas supprimé de tous les fichiers pour des soucis de taille de PR et de Review.

Réalisés :
- participation-filter
- assessment-list
- profile-list
-  icon-trigger
- organization-credit-info
-  user-logged-menu
- organization-participants list

## 💯 Pour tester
Vérifier que tous les tests passent