### PR TITLE
[BUGFIX] Corriger la gestion d'exception de checkUserBelongsToScoOrganizationAndManagesStudents (PIX-11814)

### DIFF
--- a/api/src/shared/application/security-pre-handlers.js
+++ b/api/src/shared/application/security-pre-handlers.js
@@ -25,11 +25,10 @@ import * as checkUserIsAdminOfCertificationCenterUsecase from '../../../lib/appl
 import * as checkUserIsMemberOfCertificationCenterUsecase from '../../../lib/application/usecases/checkUserIsMemberOfCertificationCenter.js';
 import * as checkUserIsMemberOfCertificationCenterSessionUsecase from '../../../lib/application/usecases/checkUserIsMemberOfCertificationCenterSession.js';
 import * as checkUserOwnsCertificationCourseUseCase from '../../../lib/application/usecases/checkUserOwnsCertificationCourse.js';
-import { NotFoundError } from '../../../lib/domain/errors.js';
 import { Organization } from '../../../lib/domain/models/index.js';
 import { PIX_ADMIN } from '../../authorization/domain/constants.js';
 import * as certificationIssueReportRepository from '../../certification/shared/infrastructure/repositories/certification-issue-report-repository.js';
-import { ForbiddenAccess } from '../domain/errors.js';
+import { ForbiddenAccess, NotFoundError } from '../domain/errors.js';
 import * as organizationRepository from '../infrastructure/repositories/organization-repository.js';
 import * as checkOrganizationHasFeatureUseCase from './usecases/checkOrganizationHasFeature.js';
 import * as checkUserIsMemberOfAnOrganizationUseCase from './validator/checkUserIsMemberOfAnOrganization.js';


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'on passe par le pre-handler `checkUserBelongsToScoOrganizationAndManagesStudents` pour un centre non lié à une orga, on tombe sur une erreur 500.
On compare l'instance d'un NotFoundError qui n'est pas le même que celui créé (lib vs. src)

## :robot: Proposition
Importer le bon not found error

## :rainbow: Remarques
Ajout d'un test de non regression

## :100: Pour tester
Aller sur certif sur un centre avec une orga qui ne manage pas des etudiants. 
Telecharger le model vierge de l'import en masse
constater que le fichier se telecharge correctement
