### PR TITLE
[TECH] Ajout du userId créant une configuration de niveau par compétence (PIX-11721).

### DIFF
--- a/api/db/database-builder/factory/build-competence-scoring-configuration.js
+++ b/api/db/database-builder/factory/build-competence-scoring-configuration.js
@@ -4,6 +4,7 @@ export const buildCompetenceScoringConfiguration = function ({
   id = databaseBuffer.getNextId(),
   configuration,
   createdAt = new Date('2020-01-01'),
+  createdByUserId,
 }) {
   return databaseBuffer.pushInsertable({
     tableName: 'competence-scoring-configurations',
@@ -11,6 +12,7 @@ export const buildCompetenceScoringConfiguration = function ({
       id,
       configuration: JSON.stringify(configuration),
       createdAt,
+      createdByUserId,
     },
   });
 };

--- a/api/db/migrations/20240322103611_add-user-id-in-competence-scoring-configurations-table.js
+++ b/api/db/migrations/20240322103611_add-user-id-in-competence-scoring-configurations-table.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'competence-scoring-configurations';
+const COLUMN_NAME = 'createdByUserId';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.bigInteger(COLUMN_NAME).defaultTo(null).references('users.id');
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/db/seeds/data/team-certification/create-competence-scoring-configuration.js
+++ b/api/db/seeds/data/team-certification/create-competence-scoring-configuration.js
@@ -1,3 +1,5 @@
+import { REAL_PIX_SUPER_ADMIN_ID } from '../common/common-builder.js';
+
 const configuration = [
   {
     competence: '1.1',
@@ -980,5 +982,6 @@ const configuration = [
 export const createCompetenceScoringConfiguration = ({ databaseBuilder }) => {
   databaseBuilder.factory.buildCompetenceScoringConfiguration({
     configuration,
+    createdByUserId: REAL_PIX_SUPER_ADMIN_ID,
   });
 };

--- a/api/src/certification/scoring/application/scoring-configuration-controller.js
+++ b/api/src/certification/scoring/application/scoring-configuration-controller.js
@@ -2,7 +2,8 @@ import { usecases } from '../domain/usecases/index.js';
 
 const saveCompetenceForScoringConfiguration = async (request, h) => {
   const data = request.payload;
-  await usecases.saveCompetenceForScoringConfiguration({ data });
+  const userId = request.auth.credentials.userId;
+  await usecases.saveCompetenceForScoringConfiguration({ data, userId });
   return h.response().code(201);
 };
 

--- a/api/src/certification/scoring/application/scoring-configuration-route.js
+++ b/api/src/certification/scoring/application/scoring-configuration-route.js
@@ -34,7 +34,7 @@ const register = async (server) => {
             .required(),
         },
         handler: scoringConfigurationController.saveCompetenceForScoringConfiguration,
-        tags: ['api', 'scoring-configuration'],
+        tags: ['api', 'admin', 'scoring-configuration'],
         notes: [
           '**Cette route est restreinte aux super-administrateurs** \n' +
             "Création d'une nouvelle configuration de niveau par compétence pour la certification v3",

--- a/api/src/certification/scoring/domain/usecases/save-competence-for-scoring-configuration.js
+++ b/api/src/certification/scoring/domain/usecases/save-competence-for-scoring-configuration.js
@@ -6,8 +6,8 @@
  * @param {Object} params
  * @param {ScoringConfigurationRepository} params.scoringConfigurationRepository
  */
-const saveCompetenceForScoringConfiguration = async ({ data, scoringConfigurationRepository }) => {
-  await scoringConfigurationRepository.saveCompetenceForScoringConfiguration(data);
+const saveCompetenceForScoringConfiguration = async ({ data, userId, scoringConfigurationRepository }) => {
+  await scoringConfigurationRepository.saveCompetenceForScoringConfiguration({ configuration: data, userId });
 };
 
 export { saveCompetenceForScoringConfiguration };

--- a/api/src/certification/scoring/infrastructure/repositories/scoring-configuration-repository.js
+++ b/api/src/certification/scoring/infrastructure/repositories/scoring-configuration-repository.js
@@ -27,9 +27,10 @@ export const getLatestByDateAndLocale = async ({ locale, date }) => {
   });
 };
 
-export const saveCompetenceForScoringConfiguration = async (configuration) => {
+export const saveCompetenceForScoringConfiguration = async ({ configuration, userId }) => {
   const data = {
     configuration: JSON.stringify(configuration),
+    createdByUserId: userId,
   };
   await knex('competence-scoring-configurations').insert(data);
 };

--- a/api/tests/certification/course/acceptance/application/certification-course-route_test.js
+++ b/api/tests/certification/course/acceptance/application/certification-course-route_test.js
@@ -96,6 +96,7 @@ describe('Acceptance | Route | certification-course', function () {
         databaseBuilder.factory.buildCompetenceScoringConfiguration({
           configuration,
           createdAt: new Date('2018-01-01T08:00:00Z'),
+          createdByUserId: userId,
         });
 
         const certificationCourse = databaseBuilder.factory.buildCertificationCourse({

--- a/api/tests/certification/scoring/integration/application/scoring-configuration-controller_test.js
+++ b/api/tests/certification/scoring/integration/application/scoring-configuration-controller_test.js
@@ -6,12 +6,18 @@ describe('Integration | Application | ScoringConfigurationController', function 
   describe('#saveCompetenceForScoringConfiguration', function () {
     it('should save the competence for scoring configuration', async function () {
       // given
+      const userId = 123;
       sinon.stub(usecases, 'saveCompetenceForScoringConfiguration');
 
       const request = {
+        auth: {
+          credentials: {
+            userId,
+          },
+        },
         payload: {
           data: {
-            warmUpLength: 12,
+            someData: 12,
           },
         },
       };
@@ -23,6 +29,7 @@ describe('Integration | Application | ScoringConfigurationController', function 
       expect(response.statusCode).to.equal(201);
       expect(usecases.saveCompetenceForScoringConfiguration).to.have.been.calledWith({
         data: request.payload,
+        userId,
       });
     });
   });

--- a/api/tests/certification/scoring/integration/infrastructure/repositories/scoring-configuration-repository_test.js
+++ b/api/tests/certification/scoring/integration/infrastructure/repositories/scoring-configuration-repository_test.js
@@ -11,7 +11,7 @@ import { databaseBuilder, expect, mockLearningContent } from '../../../../../tes
 import { buildArea, buildCompetence, buildFramework } from '../../../../../tooling/domain-builder/factory/index.js';
 import { buildLearningContent } from '../../../../../tooling/learning-content-builder/index.js';
 
-describe('Unit | Repository | scoring-configuration-repository', function () {
+describe('Integration | Repository | scoring-configuration-repository', function () {
   describe('#getLatestByDateAndLocale', function () {
     it('should return a list of competences for scoring', async function () {
       // given
@@ -83,6 +83,7 @@ describe('Unit | Repository | scoring-configuration-repository', function () {
       databaseBuilder.factory.buildCompetenceScoringConfiguration({
         configuration: competenceScoringConfiguration,
         createdAt: firstConfigurationDate,
+        createdByUserId: userId,
       });
       databaseBuilder.factory.buildScoringConfiguration({
         configuration: certificationScoringConfiguration,
@@ -93,6 +94,7 @@ describe('Unit | Repository | scoring-configuration-repository', function () {
       databaseBuilder.factory.buildCompetenceScoringConfiguration({
         configuration: secondCompetenceScoringConfiguration,
         createdAt: secondConfigurationDate,
+        createdByUserId: userId,
       });
       databaseBuilder.factory.buildScoringConfiguration({
         configuration: secondCertificationScoringConfiguration,
@@ -103,6 +105,7 @@ describe('Unit | Repository | scoring-configuration-repository', function () {
       databaseBuilder.factory.buildCompetenceScoringConfiguration({
         configuration: competenceScoringConfiguration,
         createdAt: thirdConfigurationDate,
+        createdByUserId: userId,
       });
       databaseBuilder.factory.buildScoringConfiguration({
         configuration: certificationScoringConfiguration,
@@ -125,15 +128,19 @@ describe('Unit | Repository | scoring-configuration-repository', function () {
   describe('#saveCompetenceForScoringConfiguration', function () {
     it('should save a configuration for competence scoring', async function () {
       // given
-      const data = { some: 'data' };
+      const userId = 1000;
+      databaseBuilder.factory.buildUser({ id: userId });
+      const configuration = { some: 'data' };
+      await databaseBuilder.commit();
 
       // when
-      await saveCompetenceForScoringConfiguration(data);
+      await saveCompetenceForScoringConfiguration({ configuration, userId });
 
       // then
       const configurations = await knex('competence-scoring-configurations');
       expect(configurations.length).to.equal(1);
       expect(configurations[0].configuration).to.deep.equal({ some: 'data' });
+      expect(configurations[0].createdByUserId).to.equal(userId);
     });
   });
 

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
@@ -396,6 +396,7 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
     });
 
     databaseBuilder.factory.buildCompetenceScoringConfiguration({
+      createdByUserId: configurationCreatorId,
       configuration: [
         {
           competence: '1.1',


### PR DESCRIPTION
## :unicorn: Problème

Dans un souci d'historisation, nous souhaitons conserver l'id de l'utilisateur(-rice) sur Pix-Admin ayant créé une nouvelle configuration de niveau par compétence.

## :robot: Proposition

Ajout du userId en BDD dans la table `competence-scoring-configurations`

## :rainbow: Remarques

La colonne a été nommée `createdByUserId` de manière à être raccord avec la colonne disponible dans `certification-scoring-configurations` mais ces colonnes sont bien évidemment renommables. (`user` ? `userId` ?)

## :100: Pour tester

Sur pix-admin, se connecter avec le compte `superadmin@example.net`
Aller sur `/certifications/configuration`
Ajouter une nouvelle configuration de niveau par compétence (voir ci-dessous)
Vérifer la présence de l'id du compte `superadmin@example.net` dans la table `competence-scoring-configurations`

```
[
  {
    "competence": "1.1",
    "values": [
      {
        "bounds": {
          "max": -2.123,
          "min": -6.789
        },
        "competenceLevel": 0
      },
      {
        "bounds": {
          "max": -1.234,
          "min": -5.678
        },
        "competenceLevel": 1
      }
    ]
  }
]
```