### PR TITLE
[BUGFIX] Inverser les en-têtes de deux colonnes et conditionne un des affichages (PIX-11752)

### DIFF
--- a/orga/app/components/campaign/results/assessment-list.hbs
+++ b/orga/app/components/campaign/results/assessment-list.hbs
@@ -35,12 +35,12 @@
             <Table::Header>{{@campaign.idPixLabel}}</Table::Header>
           {{/if}}
           <Table::Header>{{t "pages.campaign-results.table.column.results.label"}}</Table::Header>
-          {{#if @campaign.hasBadges}}
-            <Table::Header>{{t "pages.campaign-results.table.column.badges"}}</Table::Header>
-          {{/if}}
           <Table::Header aria-label={{t "pages.campaign-results.table.column.ariaSharedResultCount"}}>
             {{t "pages.campaign-results.table.column.sharedResultCount"}}
           </Table::Header>
+          {{#if @campaign.hasBadges}}
+            <Table::Header>{{t "pages.campaign-results.table.column.badges"}}</Table::Header>
+          {{/if}}
         </tr>
       </thead>
 

--- a/orga/app/components/campaign/results/assessment-list.hbs
+++ b/orga/app/components/campaign/results/assessment-list.hbs
@@ -35,9 +35,11 @@
             <Table::Header>{{@campaign.idPixLabel}}</Table::Header>
           {{/if}}
           <Table::Header>{{t "pages.campaign-results.table.column.results.label"}}</Table::Header>
-          <Table::Header aria-label={{t "pages.campaign-results.table.column.ariaSharedResultCount"}}>
-            {{t "pages.campaign-results.table.column.sharedResultCount"}}
-          </Table::Header>
+          {{#if this.displayParticipationCount}}
+            <Table::Header aria-label={{t "pages.campaign-results.table.column.ariaSharedResultCount"}}>
+              {{t "pages.campaign-results.table.column.sharedResultCount"}}
+            </Table::Header>
+          {{/if}}
           {{#if @campaign.hasBadges}}
             <Table::Header>{{t "pages.campaign-results.table.column.badges"}}</Table::Header>
           {{/if}}
@@ -55,6 +57,7 @@
               @campaignId={{@campaign.id}}
               @stages={{@campaign.stages}}
               @onClickParticipant={{@onClickParticipant}}
+              @displayParticipationCount={{this.displayParticipationCount}}
             />
           {{/each}}
         </tbody>

--- a/orga/app/components/campaign/results/assessment-list.js
+++ b/orga/app/components/campaign/results/assessment-list.js
@@ -1,0 +1,6 @@
+import Component from '@glimmer/component';
+export default class AssessmentList extends Component {
+  get displayParticipationCount() {
+    return this.args.campaign.multipleSendings;
+  }
+}

--- a/orga/app/components/campaign/results/assessment-row.hbs
+++ b/orga/app/components/campaign/results/assessment-row.hbs
@@ -23,9 +23,11 @@
       @isTableDisplay={{true}}
     />
   </td>
-  <td class="table__column--small">
-    {{@participation.sharedResultCount}}
-  </td>
+  {{#if @displayParticipationCount}}
+    <td class="table__column--small">
+      {{@participation.sharedResultCount}}
+    </td>
+  {{/if}}
   {{#if @hasBadges}}
     <td class="participant-list__badges">
       <Campaign::Badges @badges={{@participation.badges}} />

--- a/orga/tests/integration/components/campaign/results/assessment-list_test.js
+++ b/orga/tests/integration/components/campaign/results/assessment-list_test.js
@@ -68,7 +68,6 @@ module('Integration | Component | Campaign::Results::AssessmentList', function (
           lastName: 'Doe',
           masteryRate: 0.8,
           isShared: true,
-          sharedResultCount: 3,
         },
       ];
       participations.meta = {
@@ -133,6 +132,64 @@ module('Integration | Component | Campaign::Results::AssessmentList', function (
 
       // then
       assert.ok(screen.getByRole('img', { src: 'url-badge', description: 'je suis un badge' }));
+    });
+
+    module('campaign has multiple sending enabled', function () {
+      test('it should display shared result count header', async function (assert) {
+        // given
+        const campaign = store.createRecord('campaign', {
+          multipleSendings: true,
+        });
+
+        this.set('campaign', campaign);
+        this.set('participations', []);
+
+        // when
+        const screen = await render(
+          hbs`<Campaign::Results::AssessmentList
+  @campaign={{this.campaign}}
+  @participations={{this.participations}}
+  @onClickParticipant={{this.noop}}
+  @onFilter={{this.noop}}
+  @selectedDivisions={{this.divisions}}
+  @selectedGroups={{this.groups}}
+  @selectedBadges={{this.badges}}
+  @selectedStages={{this.stages}}
+/>`,
+        );
+        // then
+        assert.ok(screen.getByText(this.intl.t('pages.campaign-results.table.column.sharedResultCount')));
+        assert.ok(screen.getByLabelText(this.intl.t('pages.campaign-results.table.column.ariaSharedResultCount')));
+      });
+    });
+
+    module('campaign has multiple sending not enabled', function () {
+      test('it should display shared result count header', async function (assert) {
+        // given
+        const campaign = store.createRecord('campaign', {
+          multipleSendings: false,
+        });
+
+        this.set('campaign', campaign);
+        this.set('participations', []);
+
+        // when
+        const screen = await render(
+          hbs`<Campaign::Results::AssessmentList
+  @campaign={{this.campaign}}
+  @participations={{this.participations}}
+  @onClickParticipant={{this.noop}}
+  @onFilter={{this.noop}}
+  @selectedDivisions={{this.divisions}}
+  @selectedGroups={{this.groups}}
+  @selectedBadges={{this.badges}}
+  @selectedStages={{this.stages}}
+/>`,
+        );
+        // then
+        assert.notOk(screen.queryByText(this.intl.t('pages.campaign-results.table.column.sharedResultCount')));
+        assert.notOk(screen.queryByLabelText(this.intl.t('pages.campaign-results.table.column.ariaSharedResultCount')));
+      });
     });
   });
 

--- a/orga/tests/integration/components/campaign/results/assessment-row_test.js
+++ b/orga/tests/integration/components/campaign/results/assessment-row_test.js
@@ -1,0 +1,68 @@
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Campaign::Results::AssessmentRow', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.set('noop', sinon.stub());
+  });
+
+  module('when the campaign has multiple sending enabled', function () {
+    test('it should display shared result count', async function (assert) {
+      // given
+      const participation = { sharedResultCount: 10 };
+
+      this.set('displayParticipationCount', true);
+      this.set('campaign', {});
+      this.set('participation', participation);
+
+      // when
+      const screen = await render(
+        hbs`<Campaign::Results::AssessmentRow
+  @hasStages={{this.campaign.hasStages}}
+  @hasBadges={{this.campaign.hasBadges}}
+  @hasExternalId={{this.campaign.hasExternalId}}
+  @participation={{this.participation}}
+  @campaignId={{this.campaign.id}}
+  @stages={{this.campaign.stages}}
+  @onClickParticipant={{this.noop}}
+  @displayParticipationCount={{this.displayParticipationCount}}
+/>`,
+      );
+      // then
+      assert.ok(screen.getByText('10'));
+    });
+  });
+
+  module('when the campaign has multiple sending not enabled', function () {
+    test('it should not display shared result count', async function (assert) {
+      // given
+      const participation = { sharedResultCount: 10 };
+
+      this.set('displayParticipationCount', false);
+      this.set('campaign', {});
+      this.set('participation', participation);
+
+      // when
+      const screen = await render(
+        hbs`<Campaign::Results::AssessmentRow
+  @hasStages={{this.campaign.hasStages}}
+  @hasBadges={{this.campaign.hasBadges}}
+  @hasExternalId={{this.campaign.hasExternalId}}
+  @participation={{this.participation}}
+  @campaignId={{this.campaign.id}}
+  @stages={{this.campaign.stages}}
+  @onClickParticipant={{this.noop}}
+  @displayParticipationCount={{this.displayParticipationCount}}
+/>`,
+      );
+      // then
+      assert.notOk(screen.queryByText('10'));
+    });
+  });
+});

--- a/orga/tests/unit/components/campaign/results/assessment-list_test.js
+++ b/orga/tests/unit/components/campaign/results/assessment-list_test.js
@@ -1,0 +1,32 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import createGlimmerComponent from '../../../../helpers/create-glimmer-component';
+
+module('Unit | Component | AssessmentList', (hooks) => {
+  setupTest(hooks);
+
+  let component;
+
+  hooks.beforeEach(function () {
+    component = createGlimmerComponent('component:campaign/results/assessment-list');
+  });
+
+  module('get displayParticipationCount', () => {
+    test('should return true when campaign has multiple sending enabled', function (assert) {
+      //when
+      component.args.campaign = { multipleSendings: true };
+
+      // then
+      assert.true(component.displayParticipationCount);
+    });
+
+    test('should return false when campaign has multiple sending not enabled', function (assert) {
+      //when
+      component.args.campaign = { multipleSendings: false };
+
+      // then
+      assert.false(component.displayParticipationCount);
+    });
+  });
+});

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -510,7 +510,7 @@
       "table": {
         "title": "Liste des résultats reçus",
         "column": {
-          "ariaSharedResultCount": "Nombre  de résultats envoyés",
+          "ariaSharedResultCount": "Nombre de résultats envoyés",
           "badges": "Résultats Thématiques",
           "first-name": "Prénom",
           "last-name": "Nom",


### PR DESCRIPTION
## :unicorn: Problème
On a introduit un bug avec la PR : 
- https://github.com/1024pix/pix/pull/8413

Les en-têtes et le contenu ne correspondent pas dans l’onglet “Résultats” des campagnes sur des PC avec RT
Le contenu des colonnes est ok mais les en-têtes sont inversés. 
On a aussi oublié de conditionner l’affichage de la colonne au fait que la campagne soit à envoi multiple.

## :robot: Proposition
Inverser les en-têtes “Résultats Thématiques” et “Nb de résultats envoyés” 
Afficher la colonne “Nb de résultats envoyés” si la campagne est à envoi multiple 

## :rainbow: Remarques
J'en ai profité pour créer le premier test d'integration du composant AssessmentRow. Il est seulement testé via son parent. Mais si on l'utilise dans un autre contexte, il ne sera pas du tout testé.
Je rajoute dans notre dette technique de rajouter tous les tests etant fait dans le parent dans celui ci dorénavant. 

## :100: Pour tester

- Aller sur Pix Orga
- Se connecter avec pro-orga@example.net
- Aller sur une campagne de collecte de profil **AVEC** envoi multiple -> Vérifier que la colonne Nb de résultats envoyés apparait bien ( et qu'elle est bien à sa place et plus au dessus des RT ) 
- Aller sur une campagne de collecte de profil **SANS** envoi multiple -> Vérifier que la colonne n'est plus présente
-  Aller sur une campagne d'évaluation **AVEC** envoi multiple -> Vérifier la même chose que pour la collecte AVEC
- Aller sur une campagne d'évaluation **SANS** envoi multiple -> Vérifier la même chose que pour la collecte SANS
- 🐈‍⬛ 
