### PR TITLE
[TECH] Renommer flash estimatedLevel en capacity (PIX-11379)

### DIFF
--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -118,11 +118,11 @@ const correctAnswerThenUpdateAssessment = async function ({
       locale,
     });
 
-    const { estimatedLevel, errorRate } = flashAlgorithmService.getEstimatedLevelAndErrorRate(flashData);
+    const { capacity, errorRate } = flashAlgorithmService.getEstimatedLevelAndErrorRate(flashData);
 
     await flashAssessmentResultRepository.save({
       answerId: answerSaved.id,
-      estimatedLevel,
+      capacity,
       errorRate,
       assessmentId: assessment.id,
     });

--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -118,7 +118,7 @@ const correctAnswerThenUpdateAssessment = async function ({
       locale,
     });
 
-    const { capacity, errorRate } = flashAlgorithmService.getEstimatedLevelAndErrorRate(flashData);
+    const { capacity, errorRate } = flashAlgorithmService.getCapacityAndErrorRate(flashData);
 
     await flashAssessmentResultRepository.save({
       answerId: answerSaved.id,

--- a/api/lib/infrastructure/repositories/participant-result-repository.js
+++ b/api/lib/infrastructure/repositories/participant-result-repository.js
@@ -114,7 +114,7 @@ async function _getFlashScoringResults(assessmentId, locale) {
   const { pixScore, pixScoreByCompetence } = flash.calculateTotalPixScoreAndScoreByCompetence({
     allAnswers,
     challenges,
-    estimatedLevel,
+    capacity: estimatedLevel,
   });
 
   const competences = await competenceRepository.findByRecordIds({

--- a/api/src/certification/flash-certification/domain/models/AssessmentSimulatorDoubleMeasureStrategy.js
+++ b/api/src/certification/flash-certification/domain/models/AssessmentSimulatorDoubleMeasureStrategy.js
@@ -43,7 +43,7 @@ export class AssessmentSimulatorDoubleMeasureStrategy {
       }
 
       const reward = this.algorithm.getReward({
-        estimatedLevel: estimatedLevelBefore,
+        capacity: estimatedLevelBefore,
         difficulty: nextChallenge.difficulty,
         discriminant: nextChallenge.discriminant,
       });

--- a/api/src/certification/flash-certification/domain/models/AssessmentSimulatorDoubleMeasureStrategy.js
+++ b/api/src/certification/flash-certification/domain/models/AssessmentSimulatorDoubleMeasureStrategy.js
@@ -27,7 +27,7 @@ export class AssessmentSimulatorDoubleMeasureStrategy {
         assessmentAnswers: [...challengesAnswers, ...newAnswers],
         challenges: this.challenges,
         initialCapacity: this.initialCapacity,
-        answersForComputingEstimatedLevel: challengesAnswers,
+        answersForComputingCapacity: challengesAnswers,
       });
 
       const availableChallenges = possibleChallenges.filter(({ id }) => {

--- a/api/src/certification/flash-certification/domain/models/AssessmentSimulatorDoubleMeasureStrategy.js
+++ b/api/src/certification/flash-certification/domain/models/AssessmentSimulatorDoubleMeasureStrategy.js
@@ -15,7 +15,7 @@ export class AssessmentSimulatorDoubleMeasureStrategy {
     const results = [];
     const newAnswers = [];
 
-    const { capacity: estimatedLevelBefore } = this.algorithm.getEstimatedLevelAndErrorRate({
+    const { capacity: capacityBefore } = this.algorithm.getCapacityAndErrorRate({
       allAnswers: challengesAnswers,
       challenges: this.challenges,
       initialCapacity: this.initialCapacity,
@@ -43,7 +43,7 @@ export class AssessmentSimulatorDoubleMeasureStrategy {
       }
 
       const reward = this.algorithm.getReward({
-        capacity: estimatedLevelBefore,
+        capacity: capacityBefore,
         difficulty: nextChallenge.difficulty,
         discriminant: nextChallenge.discriminant,
       });
@@ -57,7 +57,7 @@ export class AssessmentSimulatorDoubleMeasureStrategy {
       newAnswers.push(answer);
     }
 
-    const { capacity } = this.algorithm.getEstimatedLevelAndErrorRate({
+    const { capacity } = this.algorithm.getCapacityAndErrorRate({
       allAnswers: [...challengesAnswers, ...newAnswers],
       challenges: this.challenges,
       initialCapacity: this.initialCapacity,

--- a/api/src/certification/flash-certification/domain/models/AssessmentSimulatorDoubleMeasureStrategy.js
+++ b/api/src/certification/flash-certification/domain/models/AssessmentSimulatorDoubleMeasureStrategy.js
@@ -15,7 +15,7 @@ export class AssessmentSimulatorDoubleMeasureStrategy {
     const results = [];
     const newAnswers = [];
 
-    const { estimatedLevel: estimatedLevelBefore } = this.algorithm.getEstimatedLevelAndErrorRate({
+    const { capacity: estimatedLevelBefore } = this.algorithm.getEstimatedLevelAndErrorRate({
       allAnswers: challengesAnswers,
       challenges: this.challenges,
       initialCapacity: this.initialCapacity,
@@ -57,7 +57,7 @@ export class AssessmentSimulatorDoubleMeasureStrategy {
       newAnswers.push(answer);
     }
 
-    const { estimatedLevel } = this.algorithm.getEstimatedLevelAndErrorRate({
+    const { capacity } = this.algorithm.getEstimatedLevelAndErrorRate({
       allAnswers: [...challengesAnswers, ...newAnswers],
       challenges: this.challenges,
       initialCapacity: this.initialCapacity,
@@ -65,7 +65,7 @@ export class AssessmentSimulatorDoubleMeasureStrategy {
     });
 
     return {
-      results: results.map((result) => ({ ...result, estimatedLevel })),
+      results: results.map((result) => ({ ...result, capacity })),
       challengeAnswers: newAnswers,
       nextStepIndex: stepIndex + NUMBER_OF_MEASURES,
     };

--- a/api/src/certification/flash-certification/domain/models/AssessmentSimulatorSingleMeasureStrategy.js
+++ b/api/src/certification/flash-certification/domain/models/AssessmentSimulatorSingleMeasureStrategy.js
@@ -33,11 +33,11 @@ export class AssessmentSimulatorSingleMeasureStrategy {
       allAnswers: challengesAnswers,
       challenges: this.challenges,
       initialCapacity: this.initialCapacity,
-    }).estimatedLevel;
+    }).capacity;
 
     const newAnswer = new Answer({ result: answerStatus, challengeId: nextChallenge.id });
 
-    const { estimatedLevel, errorRate } = this.algorithm.getEstimatedLevelAndErrorRate({
+    const { capacity, errorRate } = this.algorithm.getEstimatedLevelAndErrorRate({
       allAnswers: [...challengesAnswers, newAnswer],
       challenges: this.challenges,
       initialCapacity: this.initialCapacity,
@@ -55,7 +55,7 @@ export class AssessmentSimulatorSingleMeasureStrategy {
         {
           challenge: nextChallenge,
           errorRate,
-          estimatedLevel,
+          capacity,
           reward,
           answerStatus,
         },

--- a/api/src/certification/flash-certification/domain/models/AssessmentSimulatorSingleMeasureStrategy.js
+++ b/api/src/certification/flash-certification/domain/models/AssessmentSimulatorSingleMeasureStrategy.js
@@ -44,7 +44,7 @@ export class AssessmentSimulatorSingleMeasureStrategy {
     });
 
     const reward = this.algorithm.getReward({
-      estimatedLevel: estimatedLevelBeforeAnswering,
+      capacity: estimatedLevelBeforeAnswering,
       difficulty: nextChallenge.difficulty,
       discriminant: nextChallenge.discriminant,
     });

--- a/api/src/certification/flash-certification/domain/models/AssessmentSimulatorSingleMeasureStrategy.js
+++ b/api/src/certification/flash-certification/domain/models/AssessmentSimulatorSingleMeasureStrategy.js
@@ -29,7 +29,7 @@ export class AssessmentSimulatorSingleMeasureStrategy {
       return null;
     }
 
-    const estimatedLevelBeforeAnswering = this.algorithm.getEstimatedLevelAndErrorRate({
+    const capacityBeforeAnswering = this.algorithm.getCapacityAndErrorRate({
       allAnswers: challengesAnswers,
       challenges: this.challenges,
       initialCapacity: this.initialCapacity,
@@ -37,14 +37,14 @@ export class AssessmentSimulatorSingleMeasureStrategy {
 
     const newAnswer = new Answer({ result: answerStatus, challengeId: nextChallenge.id });
 
-    const { capacity, errorRate } = this.algorithm.getEstimatedLevelAndErrorRate({
+    const { capacity, errorRate } = this.algorithm.getCapacityAndErrorRate({
       allAnswers: [...challengesAnswers, newAnswer],
       challenges: this.challenges,
       initialCapacity: this.initialCapacity,
     });
 
     const reward = this.algorithm.getReward({
-      capacity: estimatedLevelBeforeAnswering,
+      capacity: capacityBeforeAnswering,
       difficulty: nextChallenge.difficulty,
       discriminant: nextChallenge.discriminant,
     });

--- a/api/src/certification/flash-certification/domain/models/FlashAssessmentAlgorithm.js
+++ b/api/src/certification/flash-certification/domain/models/FlashAssessmentAlgorithm.js
@@ -60,7 +60,7 @@ class FlashAssessmentAlgorithm {
 
     return this.flashAlgorithmImplementation.getPossibleNextChallenges({
       availableChallenges: challengesAfterRulesApplication,
-      estimatedLevel,
+      capacity: estimatedLevel,
       options: {
         challengesBetweenSameCompetence: this._configuration.challengesBetweenSameCompetence,
         minimalSuccessRate,

--- a/api/src/certification/flash-certification/domain/models/FlashAssessmentAlgorithm.js
+++ b/api/src/certification/flash-certification/domain/models/FlashAssessmentAlgorithm.js
@@ -44,7 +44,7 @@ class FlashAssessmentAlgorithm {
       throw new AssessmentEndedError();
     }
 
-    const { capacity } = this.getEstimatedLevelAndErrorRate({
+    const { capacity } = this.getCapacityAndErrorRate({
       allAnswers: answersForComputingEstimatedLevel ?? assessmentAnswers,
       challenges,
       initialCapacity,
@@ -91,12 +91,12 @@ class FlashAssessmentAlgorithm {
     );
   }
 
-  getEstimatedLevelAndErrorRate({
+  getCapacityAndErrorRate({
     allAnswers,
     challenges,
     initialCapacity = config.v3Certification.defaultCandidateCapacity,
   }) {
-    return this.flashAlgorithmImplementation.getEstimatedLevelAndErrorRate({
+    return this.flashAlgorithmImplementation.getCapacityAndErrorRate({
       allAnswers,
       challenges,
       capacity: initialCapacity,

--- a/api/src/certification/flash-certification/domain/models/FlashAssessmentAlgorithm.js
+++ b/api/src/certification/flash-certification/domain/models/FlashAssessmentAlgorithm.js
@@ -38,14 +38,14 @@ class FlashAssessmentAlgorithm {
     assessmentAnswers,
     challenges,
     initialCapacity = config.v3Certification.defaultCandidateCapacity,
-    answersForComputingEstimatedLevel,
+    answersForComputingCapacity,
   }) {
     if (assessmentAnswers.length >= this._configuration.maximumAssessmentLength) {
       throw new AssessmentEndedError();
     }
 
     const { capacity } = this.getCapacityAndErrorRate({
-      allAnswers: answersForComputingEstimatedLevel ?? assessmentAnswers,
+      allAnswers: answersForComputingCapacity ?? assessmentAnswers,
       challenges,
       initialCapacity,
     });

--- a/api/src/certification/flash-certification/domain/models/FlashAssessmentAlgorithm.js
+++ b/api/src/certification/flash-certification/domain/models/FlashAssessmentAlgorithm.js
@@ -106,12 +106,12 @@ class FlashAssessmentAlgorithm {
     });
   }
 
-  getEstimatedLevelAndErrorRateHistory({
+  getCapacityAndErrorRateHistory({
     allAnswers,
     challenges,
     initialCapacity = config.v3Certification.defaultCandidateCapacity,
   }) {
-    return this.flashAlgorithmImplementation.getEstimatedLevelAndErrorRateHistory({
+    return this.flashAlgorithmImplementation.getCapacityAndErrorRateHistory({
       allAnswers,
       challenges,
       capacity: initialCapacity,

--- a/api/src/certification/flash-certification/domain/models/FlashAssessmentAlgorithm.js
+++ b/api/src/certification/flash-certification/domain/models/FlashAssessmentAlgorithm.js
@@ -121,8 +121,8 @@ class FlashAssessmentAlgorithm {
     });
   }
 
-  getReward({ estimatedLevel, discriminant, difficulty }) {
-    return this.flashAlgorithmImplementation.getReward({ estimatedLevel, discriminant, difficulty });
+  getReward({ capacity, discriminant, difficulty }) {
+    return this.flashAlgorithmImplementation.getReward({ capacity, discriminant, difficulty });
   }
 
   getConfiguration() {

--- a/api/src/certification/flash-certification/domain/models/FlashAssessmentAlgorithm.js
+++ b/api/src/certification/flash-certification/domain/models/FlashAssessmentAlgorithm.js
@@ -44,7 +44,7 @@ class FlashAssessmentAlgorithm {
       throw new AssessmentEndedError();
     }
 
-    const { estimatedLevel } = this.getEstimatedLevelAndErrorRate({
+    const { capacity } = this.getEstimatedLevelAndErrorRate({
       allAnswers: answersForComputingEstimatedLevel ?? assessmentAnswers,
       challenges,
       initialCapacity,
@@ -60,7 +60,7 @@ class FlashAssessmentAlgorithm {
 
     return this.flashAlgorithmImplementation.getPossibleNextChallenges({
       availableChallenges: challengesAfterRulesApplication,
-      capacity: estimatedLevel,
+      capacity,
       options: {
         challengesBetweenSameCompetence: this._configuration.challengesBetweenSameCompetence,
         minimalSuccessRate,
@@ -99,7 +99,7 @@ class FlashAssessmentAlgorithm {
     return this.flashAlgorithmImplementation.getEstimatedLevelAndErrorRate({
       allAnswers,
       challenges,
-      estimatedLevel: initialCapacity,
+      capacity: initialCapacity,
       variationPercent: this._configuration.variationPercent,
       variationPercentUntil: this._configuration.variationPercentUntil,
       doubleMeasuresUntil: this._configuration.doubleMeasuresUntil,
@@ -114,7 +114,7 @@ class FlashAssessmentAlgorithm {
     return this.flashAlgorithmImplementation.getEstimatedLevelAndErrorRateHistory({
       allAnswers,
       challenges,
-      estimatedLevel: initialCapacity,
+      capacity: initialCapacity,
       variationPercent: this._configuration.variationPercent,
       variationPercentUntil: this._configuration.variationPercentUntil,
       doubleMeasuresUntil: this._configuration.doubleMeasuresUntil,

--- a/api/src/certification/flash-certification/domain/services/algorithm-methods/flash.js
+++ b/api/src/certification/flash-certification/domain/services/algorithm-methods/flash.js
@@ -230,20 +230,15 @@ function getChallengesForNonAnsweredSkills({ allAnswers, challenges }) {
   return challengesForNonAnsweredSkills;
 }
 
-function calculateTotalPixScoreAndScoreByCompetence({ allAnswers, challenges, estimatedLevel }) {
+function calculateTotalPixScoreAndScoreByCompetence({ allAnswers, challenges, capacity }) {
   const succeededChallenges = _getDirectSucceededChallenges({ allAnswers, challenges });
 
   const inferredChallenges = _getInferredChallenges({
     challenges: getChallengesForNonAnsweredSkills({ allAnswers, challenges }),
-    estimatedLevel,
+    capacity,
   });
 
-  const pixScoreAndScoreByCompetence = _sumPixScoreAndScoreByCompetence([
-    ...succeededChallenges,
-    ...inferredChallenges,
-  ]);
-
-  return pixScoreAndScoreByCompetence;
+  return _sumPixScoreAndScoreByCompetence([...succeededChallenges, ...inferredChallenges]);
 }
 
 function _limitEstimatedLevelVariation(previousEstimatedLevel, nextEstimatedLevel, variationPercent) {
@@ -280,9 +275,9 @@ function _getDirectSucceededChallenges({ allAnswers, challenges }) {
   return correctAnswers.map((answer) => _findChallengeForAnswer(challenges, answer));
 }
 
-function _getInferredChallenges({ challenges, estimatedLevel }) {
+function _getInferredChallenges({ challenges, capacity }) {
   const challengesForInferrence = _findChallengesForInferrence(challenges);
-  return challengesForInferrence.filter((challenge) => estimatedLevel >= challenge.minimumCapability);
+  return challengesForInferrence.filter((challenge) => capacity >= challenge.minimumCapability);
 }
 
 /**

--- a/api/src/certification/flash-certification/domain/services/algorithm-methods/flash.js
+++ b/api/src/certification/flash-certification/domain/services/algorithm-methods/flash.js
@@ -15,9 +15,9 @@ const MAX_NUMBER_OF_RETURNED_CHALLENGES = 5;
 
 export {
   calculateTotalPixScoreAndScoreByCompetence,
-  getChallengesForNonAnsweredSkills,
-  getEstimatedLevelAndErrorRate,
+  getCapacityAndErrorRate,
   getCapacityAndErrorRateHistory,
+  getChallengesForNonAnsweredSkills,
   getPossibleNextChallenges,
   getReward,
 };
@@ -41,7 +41,7 @@ function getPossibleNextChallenges({
   return _findBestPossibleChallenges(challengesWithReward, minimalSuccessRate, capacity);
 }
 
-function getEstimatedLevelAndErrorRate({
+function getCapacityAndErrorRate({
   allAnswers,
   challenges,
   capacity = DEFAULT_CAPACITY,

--- a/api/src/certification/flash-certification/domain/services/algorithm-methods/flash.js
+++ b/api/src/certification/flash-certification/domain/services/algorithm-methods/flash.js
@@ -31,7 +31,7 @@ function getPossibleNextChallenges({
     return {
       challenge,
       reward: getReward({
-        estimatedLevel: capacity,
+        capacity,
         discriminant: challenge.discriminant,
         difficulty: challenge.difficulty,
       }),
@@ -339,8 +339,8 @@ function _sumPixScoreAndScoreByCompetence(challenges) {
   return { pixScore, pixScoreByCompetence };
 }
 
-function getReward({ estimatedLevel, discriminant, difficulty }) {
-  const probability = _getProbability(estimatedLevel, discriminant, difficulty);
+function getReward({ capacity, discriminant, difficulty }) {
+  const probability = _getProbability(capacity, discriminant, difficulty);
   return probability * (1 - probability) * Math.pow(discriminant, 2);
 }
 

--- a/api/src/certification/flash-certification/domain/services/algorithm-methods/flash.js
+++ b/api/src/certification/flash-certification/domain/services/algorithm-methods/flash.js
@@ -44,19 +44,19 @@ function getPossibleNextChallenges({
 function getEstimatedLevelAndErrorRate({
   allAnswers,
   challenges,
-  estimatedLevel = DEFAULT_CAPACITY,
+  capacity = DEFAULT_CAPACITY,
   doubleMeasuresUntil = 0,
   variationPercent,
   variationPercentUntil,
 }) {
   if (allAnswers.length === 0) {
-    return { estimatedLevel, errorRate: DEFAULT_ERROR_RATE };
+    return { capacity, errorRate: DEFAULT_ERROR_RATE };
   }
 
   const estimatedLevelHistory = getEstimatedLevelAndErrorRateHistory({
     allAnswers,
     challenges,
-    estimatedLevel,
+    capacity,
     doubleMeasuresUntil,
     variationPercent,
     variationPercentUntil,
@@ -68,12 +68,12 @@ function getEstimatedLevelAndErrorRate({
 function getEstimatedLevelAndErrorRateHistory({
   allAnswers,
   challenges,
-  estimatedLevel = DEFAULT_CAPACITY,
+  capacity = DEFAULT_CAPACITY,
   doubleMeasuresUntil = 0,
   variationPercent,
   variationPercentUntil,
 }) {
-  let latestEstimatedLevel = estimatedLevel;
+  let latestEstimatedLevel = capacity;
 
   let likelihood = samples.map(() => DEFAULT_PROBABILITY_TO_ANSWER);
   let normalizedPosteriori;
@@ -114,7 +114,7 @@ function getEstimatedLevelAndErrorRateHistory({
 
     estimatedLevelHistory.push({
       answerId: answer.id,
-      estimatedLevel: latestEstimatedLevel,
+      capacity: latestEstimatedLevel,
       errorRate: _computeCorrectedErrorRate(latestEstimatedLevel, normalizedPosteriori),
     });
   }

--- a/api/src/certification/flash-certification/domain/services/algorithm-methods/flash.js
+++ b/api/src/certification/flash-certification/domain/services/algorithm-methods/flash.js
@@ -2,7 +2,7 @@ import lodash from 'lodash';
 
 const { orderBy, range, sortBy, sortedUniqBy } = lodash;
 
-const DEFAULT_ESTIMATED_LEVEL = 0;
+const DEFAULT_CAPACITY = 0;
 const START_OF_SAMPLES = -9;
 const STEP_OF_SAMPLES = 18 / 80;
 const END_OF_SAMPLES = 9 + STEP_OF_SAMPLES;
@@ -24,23 +24,27 @@ export {
 
 function getPossibleNextChallenges({
   availableChallenges,
-  estimatedLevel = DEFAULT_ESTIMATED_LEVEL,
+  capacity = DEFAULT_CAPACITY,
   options: { minimalSuccessRate = 0 } = {},
 } = {}) {
   const challengesWithReward = availableChallenges.map((challenge) => {
     return {
       challenge,
-      reward: getReward({ estimatedLevel, discriminant: challenge.discriminant, difficulty: challenge.difficulty }),
+      reward: getReward({
+        estimatedLevel: capacity,
+        discriminant: challenge.discriminant,
+        difficulty: challenge.difficulty,
+      }),
     };
   });
 
-  return _findBestPossibleChallenges(challengesWithReward, minimalSuccessRate, estimatedLevel);
+  return _findBestPossibleChallenges(challengesWithReward, minimalSuccessRate, capacity);
 }
 
 function getEstimatedLevelAndErrorRate({
   allAnswers,
   challenges,
-  estimatedLevel = DEFAULT_ESTIMATED_LEVEL,
+  estimatedLevel = DEFAULT_CAPACITY,
   doubleMeasuresUntil = 0,
   variationPercent,
   variationPercentUntil,
@@ -64,7 +68,7 @@ function getEstimatedLevelAndErrorRate({
 function getEstimatedLevelAndErrorRateHistory({
   allAnswers,
   challenges,
-  estimatedLevel = DEFAULT_ESTIMATED_LEVEL,
+  estimatedLevel = DEFAULT_CAPACITY,
   doubleMeasuresUntil = 0,
   variationPercent,
   variationPercentUntil,
@@ -253,9 +257,9 @@ function _limitEstimatedLevelVariation(previousEstimatedLevel, nextEstimatedLeve
     : Math.max(nextEstimatedLevel, previousEstimatedLevel - gap);
 }
 
-function _findBestPossibleChallenges(challengesWithReward, minimumSuccessRate, estimatedLevel) {
+function _findBestPossibleChallenges(challengesWithReward, minimumSuccessRate, capacity) {
   const hasMinimumSuccessRate = ({ challenge }) => {
-    const successProbability = _getProbability(estimatedLevel, challenge.discriminant, challenge.difficulty);
+    const successProbability = _getProbability(capacity, challenge.discriminant, challenge.difficulty);
 
     return successProbability >= minimumSuccessRate;
   };
@@ -343,8 +347,8 @@ function getReward({ estimatedLevel, discriminant, difficulty }) {
 // Parameters are not wrapped inside an object for performance reasons
 // It avoids creating an object before each call which will trigger lots of
 // garbage collection, especially when running simulators
-function _getProbability(estimatedLevel, discriminant, difficulty) {
-  return 1 / (1 + Math.exp(discriminant * (difficulty - estimatedLevel)));
+function _getProbability(capacity, discriminant, difficulty) {
+  return 1 / (1 + Math.exp(discriminant * (difficulty - capacity)));
 }
 
 function _getGaussianValue({ gaussianMean, value }) {

--- a/api/src/certification/flash-certification/domain/services/algorithm-methods/flash.js
+++ b/api/src/certification/flash-certification/domain/services/algorithm-methods/flash.js
@@ -17,7 +17,7 @@ export {
   calculateTotalPixScoreAndScoreByCompetence,
   getChallengesForNonAnsweredSkills,
   getEstimatedLevelAndErrorRate,
-  getEstimatedLevelAndErrorRateHistory,
+  getCapacityAndErrorRateHistory,
   getPossibleNextChallenges,
   getReward,
 };
@@ -53,7 +53,7 @@ function getEstimatedLevelAndErrorRate({
     return { capacity, errorRate: DEFAULT_ERROR_RATE };
   }
 
-  const estimatedLevelHistory = getEstimatedLevelAndErrorRateHistory({
+  const estimatedLevelHistory = getCapacityAndErrorRateHistory({
     allAnswers,
     challenges,
     capacity,
@@ -65,7 +65,7 @@ function getEstimatedLevelAndErrorRate({
   return estimatedLevelHistory.at(-1);
 }
 
-function getEstimatedLevelAndErrorRateHistory({
+function getCapacityAndErrorRateHistory({
   allAnswers,
   challenges,
   capacity = DEFAULT_CAPACITY,

--- a/api/src/certification/scoring/domain/models/CertificationAssessmentHistory.js
+++ b/api/src/certification/scoring/domain/models/CertificationAssessmentHistory.js
@@ -10,11 +10,11 @@ export class CertificationAssessmentHistory {
       challenges,
     });
 
-    const capacityHistory = estimatedLevelAndErrorRateHistory.map(({ answerId, estimatedLevel }, index) =>
+    const capacityHistory = estimatedLevelAndErrorRateHistory.map(({ answerId, capacity }, index) =>
       CertificationChallengeCapacity.create({
         answerId,
         certificationChallengeId: challenges[index].certificationChallengeId,
-        capacity: estimatedLevel,
+        capacity,
       }),
     );
 

--- a/api/src/certification/scoring/domain/models/CertificationAssessmentHistory.js
+++ b/api/src/certification/scoring/domain/models/CertificationAssessmentHistory.js
@@ -5,12 +5,12 @@ export class CertificationAssessmentHistory {
     this.capacityHistory = capacityHistory;
   }
   static fromChallengesAndAnswers({ algorithm, challenges, allAnswers }) {
-    const estimatedLevelAndErrorRateHistory = algorithm.getEstimatedLevelAndErrorRateHistory({
+    const capacityAndErrorRateHistory = algorithm.getCapacityAndErrorRateHistory({
       allAnswers,
       challenges,
     });
 
-    const capacityHistory = estimatedLevelAndErrorRateHistory.map(({ answerId, capacity }, index) =>
+    const capacityHistory = capacityAndErrorRateHistory.map(({ answerId, capacity }, index) =>
       CertificationChallengeCapacity.create({
         answerId,
         certificationChallengeId: challenges[index].certificationChallengeId,

--- a/api/src/certification/scoring/domain/models/CertificationAssessmentScoreV3.js
+++ b/api/src/certification/scoring/domain/models/CertificationAssessmentScoreV3.js
@@ -73,25 +73,25 @@ const _computeScore = ({
   certificationScoringIntervals,
   intervalHeight,
 }) => {
-  let normalizedEstimatedLevel = capacity;
-  const minimumEstimatedLevel = certificationScoringIntervals[0].bounds.min;
-  const maximumEstimatedLevel = certificationScoringIntervals.at(-1).bounds.max;
+  let normalizedCapacity = capacity;
+  const minimumCapacity = certificationScoringIntervals[0].bounds.min;
+  const maximumCapacity = certificationScoringIntervals.at(-1).bounds.max;
 
-  if (normalizedEstimatedLevel < minimumEstimatedLevel) {
-    normalizedEstimatedLevel = minimumEstimatedLevel;
+  if (normalizedCapacity < minimumCapacity) {
+    normalizedCapacity = minimumCapacity;
   }
-  if (normalizedEstimatedLevel > maximumEstimatedLevel) {
-    normalizedEstimatedLevel = maximumEstimatedLevel;
+  if (normalizedCapacity > maximumCapacity) {
+    normalizedCapacity = maximumCapacity;
   }
 
-  const intervalIndex = _findIntervalIndex(normalizedEstimatedLevel, certificationScoringIntervals);
+  const intervalIndex = _findIntervalIndex(normalizedCapacity, certificationScoringIntervals);
 
   const intervalMaxValue = certificationScoringIntervals[intervalIndex].bounds.max;
   const intervalWidth =
     certificationScoringIntervals[intervalIndex].bounds.max - certificationScoringIntervals[intervalIndex].bounds.min;
 
   // Formula is defined here : https://1024pix.atlassian.net/wiki/spaces/DD/pages/3835133953/Vulgarisation+score+2023#Le-score
-  const score = intervalHeight * (intervalIndex + 1 + (normalizedEstimatedLevel - intervalMaxValue) / intervalWidth);
+  const score = intervalHeight * (intervalIndex + 1 + (normalizedCapacity - intervalMaxValue) / intervalWidth);
 
   const maximumReachableScore = maxReachableLevelOnCertificationDate * NUMBER_OF_COMPETENCES * PIX_PER_LEVEL;
 

--- a/api/src/certification/scoring/domain/models/CertificationAssessmentScoreV3.js
+++ b/api/src/certification/scoring/domain/models/CertificationAssessmentScoreV3.js
@@ -25,20 +25,20 @@ class CertificationAssessmentScoreV3 {
     const numberOfIntervals = v3CertificationScoring.getNumberOfIntervals();
     const intervalHeight = MAX_PIX_SCORE / numberOfIntervals;
 
-    const { estimatedLevel } = algorithm.getEstimatedLevelAndErrorRate({
+    const { capacity } = algorithm.getEstimatedLevelAndErrorRate({
       challenges,
       allAnswers,
     });
 
     const nbPix = _computeScore({
-      estimatedLevel,
+      capacity,
       maxReachableLevelOnCertificationDate,
       certificationScoringIntervals,
       numberOfIntervals,
       intervalHeight,
     });
 
-    const competenceMarks = v3CertificationScoring.getCompetencesScore(estimatedLevel);
+    const competenceMarks = v3CertificationScoring.getCompetencesScore(capacity);
 
     const status = _isCertificationRejected({ answers: allAnswers, abortReason })
       ? CertificationStatus.REJECTED
@@ -64,16 +64,16 @@ class CertificationAssessmentScoreV3 {
   }
 }
 
-const _findIntervalIndex = (estimatedLevel, certificationScoringIntervals) =>
-  certificationScoringIntervals.findIndex(({ bounds }) => estimatedLevel <= bounds.max && estimatedLevel >= bounds.min);
+const _findIntervalIndex = (capacity, certificationScoringIntervals) =>
+  certificationScoringIntervals.findIndex(({ bounds }) => capacity <= bounds.max && capacity >= bounds.min);
 
 const _computeScore = ({
-  estimatedLevel,
+  capacity,
   maxReachableLevelOnCertificationDate,
   certificationScoringIntervals,
   intervalHeight,
 }) => {
-  let normalizedEstimatedLevel = estimatedLevel;
+  let normalizedEstimatedLevel = capacity;
   const minimumEstimatedLevel = certificationScoringIntervals[0].bounds.min;
   const maximumEstimatedLevel = certificationScoringIntervals.at(-1).bounds.max;
 

--- a/api/src/certification/scoring/domain/models/CertificationAssessmentScoreV3.js
+++ b/api/src/certification/scoring/domain/models/CertificationAssessmentScoreV3.js
@@ -25,7 +25,7 @@ class CertificationAssessmentScoreV3 {
     const numberOfIntervals = v3CertificationScoring.getNumberOfIntervals();
     const intervalHeight = MAX_PIX_SCORE / numberOfIntervals;
 
-    const { capacity } = algorithm.getEstimatedLevelAndErrorRate({
+    const { capacity } = algorithm.getCapacityAndErrorRate({
       challenges,
       allAnswers,
     });

--- a/api/src/certification/scoring/domain/models/V3CertificationScoring.js
+++ b/api/src/certification/scoring/domain/models/V3CertificationScoring.js
@@ -6,10 +6,8 @@ export class V3CertificationScoring {
     this._certificationScoringConfiguration = certificationScoringConfiguration;
   }
 
-  getCompetencesScore(estimatedLevel) {
-    return this._competencesForScoring.map((competenceForScoring) =>
-      competenceForScoring.getCompetenceMark(estimatedLevel),
-    );
+  getCompetencesScore(capacity) {
+    return this._competencesForScoring.map((competenceForScoring) => competenceForScoring.getCompetenceMark(capacity));
   }
 
   getNumberOfIntervals() {

--- a/api/tests/certification/course/unit/domain/usecases/get-next-challenge-for-v3-certification_test.js
+++ b/api/tests/certification/course/unit/domain/usecases/get-next-challenge-for-v3-certification_test.js
@@ -83,12 +83,12 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-v3-certification', 
           .withArgs({
             allAnswers: [],
             challenges: [nextChallengeToAnswer],
-            estimatedLevel: config.v3Certification.defaultCandidateCapacity,
+            capacity: config.v3Certification.defaultCandidateCapacity,
             variationPercent: undefined,
             variationPercentUntil: undefined,
             doubleMeasuresUntil: undefined,
           })
-          .returns({ estimatedLevel: 0 });
+          .returns({ capacity: 0 });
 
         flashAlgorithmService.getPossibleNextChallenges
           .withArgs({
@@ -211,12 +211,12 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-v3-certification', 
           .withArgs({
             allAnswers: [],
             challenges: [nextChallenge],
-            estimatedLevel: config.v3Certification.defaultCandidateCapacity,
+            capacity: config.v3Certification.defaultCandidateCapacity,
             variationPercent: undefined,
             variationPercentUntil: undefined,
             doubleMeasuresUntil: undefined,
           })
-          .returns({ estimatedLevel: 0 });
+          .returns({ capacity: 0 });
 
         flashAlgorithmService.getPossibleNextChallenges
           .withArgs({
@@ -308,12 +308,12 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-v3-certification', 
           .withArgs({
             allAnswers: [],
             challenges: [challengeWithOtherSkill],
-            estimatedLevel: config.v3Certification.defaultCandidateCapacity,
+            capacity: config.v3Certification.defaultCandidateCapacity,
             variationPercent: undefined,
             variationPercentUntil: undefined,
             doubleMeasuresUntil: undefined,
           })
-          .returns({ estimatedLevel: 0 });
+          .returns({ capacity: 0 });
 
         flashAlgorithmService.getPossibleNextChallenges
           .withArgs({
@@ -403,13 +403,13 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-v3-certification', 
           .withArgs({
             allAnswers: [answer],
             challenges: [answeredChallenge],
-            estimatedLevel: config.v3Certification.defaultCandidateCapacity,
+            capacity: config.v3Certification.defaultCandidateCapacity,
             variationPercent: undefined,
             variationPercentUntil: undefined,
             doubleMeasuresUntil: undefined,
           })
           .returns({
-            estimatedLevel: 2,
+            capacity: 2,
           });
 
         flashAlgorithmService.getPossibleNextChallenges
@@ -503,12 +503,12 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-v3-certification', 
               .withArgs({
                 allAnswers: [],
                 challenges: [nextChallengeToAnswer],
-                estimatedLevel: config.v3Certification.defaultCandidateCapacity,
+                capacity: config.v3Certification.defaultCandidateCapacity,
                 variationPercent: configuration.variationPercent,
                 variationPercentUntil: undefined,
                 doubleMeasuresUntil: undefined,
               })
-              .returns({ estimatedLevel: 0 });
+              .returns({ capacity: 0 });
 
             flashAlgorithmService.getPossibleNextChallenges
               .withArgs({

--- a/api/tests/certification/course/unit/domain/usecases/get-next-challenge-for-v3-certification_test.js
+++ b/api/tests/certification/course/unit/domain/usecases/get-next-challenge-for-v3-certification_test.js
@@ -43,7 +43,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-v3-certification', 
       };
       flashAlgorithmService = {
         getPossibleNextChallenges: sinon.stub(),
-        getEstimatedLevelAndErrorRate: sinon.stub(),
+        getCapacityAndErrorRate: sinon.stub(),
       };
 
       flashAlgorithmConfiguration = domainBuilder.buildFlashAlgorithmConfiguration();
@@ -79,7 +79,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-v3-certification', 
         answerRepository.findByAssessment.withArgs(assessment.id).resolves([]);
         challengeRepository.findActiveFlashCompatible.withArgs({ locale }).resolves([nextChallengeToAnswer]);
 
-        flashAlgorithmService.getEstimatedLevelAndErrorRate
+        flashAlgorithmService.getCapacityAndErrorRate
           .withArgs({
             allAnswers: [],
             challenges: [nextChallengeToAnswer],
@@ -207,7 +207,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-v3-certification', 
         answerRepository.findByAssessment.withArgs(assessment.id).resolves([]);
         challengeRepository.findActiveFlashCompatible.withArgs({ locale }).resolves([nextChallenge, lastSeenChallenge]);
 
-        flashAlgorithmService.getEstimatedLevelAndErrorRate
+        flashAlgorithmService.getCapacityAndErrorRate
           .withArgs({
             allAnswers: [],
             challenges: [nextChallenge],
@@ -304,7 +304,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-v3-certification', 
           .withArgs()
           .resolves([challengeWithLiveAlert, challengeWithOtherSkill, challengeWithLiveAlertedSkill]);
 
-        flashAlgorithmService.getEstimatedLevelAndErrorRate
+        flashAlgorithmService.getCapacityAndErrorRate
           .withArgs({
             allAnswers: [],
             challenges: [challengeWithOtherSkill],
@@ -376,7 +376,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-v3-certification', 
 
         const flashAlgorithmService = {
           getPossibleNextChallenges: sinon.stub(),
-          getEstimatedLevelAndErrorRate: sinon.stub(),
+          getCapacityAndErrorRate: sinon.stub(),
         };
 
         flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
@@ -399,7 +399,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-v3-certification', 
         answerRepository.findByAssessment.withArgs(assessment.id).resolves([answer]);
         challengeRepository.findActiveFlashCompatible.withArgs({ locale }).resolves([answeredChallenge]);
 
-        flashAlgorithmService.getEstimatedLevelAndErrorRate
+        flashAlgorithmService.getCapacityAndErrorRate
           .withArgs({
             allAnswers: [answer],
             challenges: [answeredChallenge],
@@ -499,7 +499,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-v3-certification', 
             answerRepository.findByAssessment.withArgs(assessment.id).resolves([]);
             challengeRepository.findActiveFlashCompatible.withArgs({ locale }).resolves([nextChallengeToAnswer]);
 
-            flashAlgorithmService.getEstimatedLevelAndErrorRate
+            flashAlgorithmService.getCapacityAndErrorRate
               .withArgs({
                 allAnswers: [],
                 challenges: [nextChallengeToAnswer],

--- a/api/tests/certification/course/unit/domain/usecases/get-next-challenge-for-v3-certification_test.js
+++ b/api/tests/certification/course/unit/domain/usecases/get-next-challenge-for-v3-certification_test.js
@@ -48,6 +48,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-v3-certification', 
 
       flashAlgorithmConfiguration = domainBuilder.buildFlashAlgorithmConfiguration();
     });
+
     context('when there are challenges left to answer', function () {
       it('should save the returned next challenge', async function () {
         // given
@@ -92,7 +93,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-v3-certification', 
         flashAlgorithmService.getPossibleNextChallenges
           .withArgs({
             availableChallenges: [nextChallengeToAnswer],
-            estimatedLevel: 0,
+            capacity: 0,
             options: sinon.match.any,
           })
           .returns([nextChallengeToAnswer]);
@@ -220,7 +221,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-v3-certification', 
         flashAlgorithmService.getPossibleNextChallenges
           .withArgs({
             availableChallenges: [nextChallenge],
-            estimatedLevel: 0,
+            capacity: 0,
             options: sinon.match.any,
           })
           .returns([nextChallenge]);
@@ -317,7 +318,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-v3-certification', 
         flashAlgorithmService.getPossibleNextChallenges
           .withArgs({
             availableChallenges: [challengeWithOtherSkill],
-            estimatedLevel: 0,
+            capacity: 0,
             options: sinon.match.any,
           })
           .returns([challengeWithOtherSkill]);
@@ -414,7 +415,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-v3-certification', 
         flashAlgorithmService.getPossibleNextChallenges
           .withArgs({
             availableChallenges: [],
-            estimatedLevel: 2,
+            capacity: 2,
             options: sinon.match.any,
           })
           .returns({
@@ -512,7 +513,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-v3-certification', 
             flashAlgorithmService.getPossibleNextChallenges
               .withArgs({
                 availableChallenges: [nextChallengeToAnswer],
-                estimatedLevel: 0,
+                capacity: 0,
                 options: sinon.match.any,
               })
               .returns([nextChallengeToAnswer]);

--- a/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorDoubleMeasureStrategy_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorDoubleMeasureStrategy_test.js
@@ -14,13 +14,13 @@ describe('Unit | Domain | Models | AssessmentSimulatorDoubleMeasureStrategy', fu
         const doubleMeasuresUntil = 2;
         const algorithm = {
           getPossibleNextChallenges: sinon.stub(),
-          getEstimatedLevelAndErrorRate: sinon.stub(),
+          getCapacityAndErrorRate: sinon.stub(),
           getReward: sinon.stub(),
         };
         const pickChallenge = sinon.stub();
         const pickAnswerStatus = sinon.stub();
 
-        algorithm.getEstimatedLevelAndErrorRate
+        algorithm.getCapacityAndErrorRate
           .withArgs({
             allAnswers: [],
             challenges: allChallenges,
@@ -77,7 +77,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorDoubleMeasureStrategy', fu
         const initialCapacity = 0;
         const algorithm = {
           getPossibleNextChallenges: sinon.stub(),
-          getEstimatedLevelAndErrorRate: sinon.stub(),
+          getCapacityAndErrorRate: sinon.stub(),
           getReward: sinon.stub(),
         };
         const pickChallenge = sinon.stub();
@@ -99,7 +99,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorDoubleMeasureStrategy', fu
           })
           .returns([challenge1]);
 
-        algorithm.getEstimatedLevelAndErrorRate
+        algorithm.getCapacityAndErrorRate
           .withArgs({
             allAnswers: [],
             challenges: allChallenges,

--- a/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorDoubleMeasureStrategy_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorDoubleMeasureStrategy_test.js
@@ -72,7 +72,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorDoubleMeasureStrategy', fu
         const answerStatusForSimulator2 = AnswerStatus.OK;
         const newAnswer1 = new Answer({ challengeId: challenge1.id, result: answerStatusForSimulator1 });
         const newAnswer2 = new Answer({ challengeId: challenge2.id, result: answerStatusForSimulator2 });
-        const estimatedLevelBeforeAnswering = -0.5;
+        const capacityBeforeAnswering = -0.5;
         const expectedEstimatedLevel = 0.4;
         const initialCapacity = 0;
         const algorithm = {
@@ -107,7 +107,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorDoubleMeasureStrategy', fu
             doubleMeasuresUntil: 2,
           })
           .returns({
-            estimatedLevel: estimatedLevelBeforeAnswering,
+            estimatedLevel: capacityBeforeAnswering,
           })
           .withArgs({
             allAnswers: [sinon.match(newAnswer2), sinon.match(newAnswer1)],
@@ -121,13 +121,13 @@ describe('Unit | Domain | Models | AssessmentSimulatorDoubleMeasureStrategy', fu
 
         algorithm.getReward
           .withArgs({
-            estimatedLevel: estimatedLevelBeforeAnswering,
+            capacity: capacityBeforeAnswering,
             difficulty: challenge1.difficulty,
             discriminant: challenge1.discriminant,
           })
           .returns(challenge1Reward)
           .withArgs({
-            estimatedLevel: estimatedLevelBeforeAnswering,
+            capacity: capacityBeforeAnswering,
             difficulty: challenge2.difficulty,
             discriminant: challenge2.discriminant,
           })

--- a/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorDoubleMeasureStrategy_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorDoubleMeasureStrategy_test.js
@@ -36,7 +36,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorDoubleMeasureStrategy', fu
             assessmentAnswers: [],
             challenges: allChallenges,
             initialCapacity,
-            answersForComputingEstimatedLevel: [],
+            answersForComputingCapacity: [],
           })
           .returns([challenge2, challenge1]);
 
@@ -88,14 +88,14 @@ describe('Unit | Domain | Models | AssessmentSimulatorDoubleMeasureStrategy', fu
             assessmentAnswers: [],
             challenges: allChallenges,
             initialCapacity,
-            answersForComputingEstimatedLevel: [],
+            answersForComputingCapacity: [],
           })
           .returns([challenge2, challenge1])
           .withArgs({
             assessmentAnswers: [newAnswer2],
             challenges: allChallenges,
             initialCapacity,
-            answersForComputingEstimatedLevel: [],
+            answersForComputingCapacity: [],
           })
           .returns([challenge1]);
 

--- a/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorDoubleMeasureStrategy_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorDoubleMeasureStrategy_test.js
@@ -28,7 +28,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorDoubleMeasureStrategy', fu
             doubleMeasuresUntil,
           })
           .returns({
-            estimatedLevel: initialCapacity,
+            capacity: initialCapacity,
           });
 
         algorithm.getPossibleNextChallenges
@@ -73,7 +73,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorDoubleMeasureStrategy', fu
         const newAnswer1 = new Answer({ challengeId: challenge1.id, result: answerStatusForSimulator1 });
         const newAnswer2 = new Answer({ challengeId: challenge2.id, result: answerStatusForSimulator2 });
         const capacityBeforeAnswering = -0.5;
-        const expectedEstimatedLevel = 0.4;
+        const expectedCapacity = 0.4;
         const initialCapacity = 0;
         const algorithm = {
           getPossibleNextChallenges: sinon.stub(),
@@ -107,7 +107,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorDoubleMeasureStrategy', fu
             doubleMeasuresUntil: 2,
           })
           .returns({
-            estimatedLevel: capacityBeforeAnswering,
+            capacity: capacityBeforeAnswering,
           })
           .withArgs({
             allAnswers: [sinon.match(newAnswer2), sinon.match(newAnswer1)],
@@ -116,7 +116,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorDoubleMeasureStrategy', fu
             doubleMeasuresUntil: 2,
           })
           .returns({
-            estimatedLevel: expectedEstimatedLevel,
+            capacity: expectedCapacity,
           });
 
         algorithm.getReward
@@ -150,13 +150,13 @@ describe('Unit | Domain | Models | AssessmentSimulatorDoubleMeasureStrategy', fu
           results: [
             {
               challenge: challenge2,
-              estimatedLevel: expectedEstimatedLevel,
+              capacity: expectedCapacity,
               answerStatus: answerStatusForSimulator2.status,
               reward: challenge2Reward,
             },
             {
               challenge: challenge1,
-              estimatedLevel: expectedEstimatedLevel,
+              capacity: expectedCapacity,
               answerStatus: answerStatusForSimulator1.status,
               reward: challenge1Reward,
             },

--- a/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorSingleMeasureStrategy_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorSingleMeasureStrategy_test.js
@@ -14,7 +14,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorSingleMeasureStrategy', fu
           const initialCapacity = 0;
           const algorithm = {
             getPossibleNextChallenges: sinon.stub(),
-            getEstimatedLevelAndErrorRate: sinon.stub(),
+            getCapacityAndErrorRate: sinon.stub(),
             getReward: sinon.stub(),
           };
           const pickChallenge = sinon.stub();
@@ -61,13 +61,13 @@ describe('Unit | Domain | Models | AssessmentSimulatorSingleMeasureStrategy', fu
           const expectedReward = 5;
           const algorithm = {
             getPossibleNextChallenges: sinon.stub(),
-            getEstimatedLevelAndErrorRate: sinon.stub(),
+            getCapacityAndErrorRate: sinon.stub(),
             getReward: sinon.stub(),
           };
           const pickChallenge = sinon.stub();
           const pickAnswerStatus = sinon.stub();
 
-          algorithm.getEstimatedLevelAndErrorRate
+          algorithm.getCapacityAndErrorRate
             .withArgs({
               allAnswers: [],
               challenges: allChallenges,
@@ -147,7 +147,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorSingleMeasureStrategy', fu
           const capacityAfterFirstChallenge = 1.2;
           const algorithm = {
             getPossibleNextChallenges: sinon.stub(),
-            getEstimatedLevelAndErrorRate: sinon.stub(),
+            getCapacityAndErrorRate: sinon.stub(),
             getReward: sinon.stub(),
           };
           const challengeAnswer = domainBuilder.buildAnswer({ challengeId: challenge1.id });
@@ -196,14 +196,14 @@ describe('Unit | Domain | Models | AssessmentSimulatorSingleMeasureStrategy', fu
           const expectedReward = 5;
           const algorithm = {
             getPossibleNextChallenges: sinon.stub(),
-            getEstimatedLevelAndErrorRate: sinon.stub(),
+            getCapacityAndErrorRate: sinon.stub(),
             getReward: sinon.stub(),
           };
           const challengeAnswer = domainBuilder.buildAnswer({ challengeId: challenge1.id });
           const pickChallenge = sinon.stub();
           const pickAnswerStatus = sinon.stub();
 
-          algorithm.getEstimatedLevelAndErrorRate
+          algorithm.getCapacityAndErrorRate
             .withArgs({
               allAnswers: [challengeAnswer],
               challenges: allChallenges,

--- a/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorSingleMeasureStrategy_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorSingleMeasureStrategy_test.js
@@ -56,7 +56,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorSingleMeasureStrategy', fu
           const answerForSimulator = AnswerStatus.OK;
           const answer1 = { challengeId: challenge2.id, result: answerForSimulator };
           const initialCapacity = 0;
-          const expectedEstimatedLevel = 0.4;
+          const expectedCapacity = 0.4;
           const expectedErrorRate = 0.2;
           const expectedReward = 5;
           const algorithm = {
@@ -74,14 +74,14 @@ describe('Unit | Domain | Models | AssessmentSimulatorSingleMeasureStrategy', fu
               initialCapacity,
             })
             .returns({
-              estimatedLevel: initialCapacity,
+              capacity: initialCapacity,
             })
             .withArgs({
               allAnswers: [sinon.match(answer1)],
               challenges: allChallenges,
               initialCapacity,
             })
-            .returns({ estimatedLevel: expectedEstimatedLevel, errorRate: expectedErrorRate });
+            .returns({ capacity: expectedCapacity, errorRate: expectedErrorRate });
 
           algorithm.getPossibleNextChallenges
             .withArgs({
@@ -107,7 +107,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorSingleMeasureStrategy', fu
             results: [
               {
                 challenge: challenge2,
-                estimatedLevel: expectedEstimatedLevel,
+                capacity: expectedCapacity,
                 errorRate: expectedErrorRate,
                 reward: expectedReward,
                 answerStatus: answerForSimulator,
@@ -191,7 +191,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorSingleMeasureStrategy', fu
           const answerForSimulator = AnswerStatus.OK;
           const answer1 = { challengeId: challenge2.id, result: answerForSimulator };
           const capacityAfterFirstChallenge = 1.2;
-          const expectedEstimatedLevel = 0.4;
+          const expectedCapacity = 0.4;
           const expectedErrorRate = 0.2;
           const expectedReward = 5;
           const algorithm = {
@@ -210,14 +210,14 @@ describe('Unit | Domain | Models | AssessmentSimulatorSingleMeasureStrategy', fu
               initialCapacity: capacityAfterFirstChallenge,
             })
             .returns({
-              estimatedLevel: capacityAfterFirstChallenge,
+              capacity: capacityAfterFirstChallenge,
             })
             .withArgs({
               allAnswers: [challengeAnswer, sinon.match(answer1)],
               challenges: allChallenges,
               initialCapacity: capacityAfterFirstChallenge,
             })
-            .returns({ estimatedLevel: expectedEstimatedLevel, errorRate: expectedErrorRate });
+            .returns({ capacity: expectedCapacity, errorRate: expectedErrorRate });
 
           algorithm.getPossibleNextChallenges
             .withArgs({
@@ -244,7 +244,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorSingleMeasureStrategy', fu
             results: [
               {
                 challenge: challenge2,
-                estimatedLevel: expectedEstimatedLevel,
+                capacity: expectedCapacity,
                 errorRate: expectedErrorRate,
                 reward: expectedReward,
                 answerStatus: answerForSimulator,

--- a/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorSingleMeasureStrategy_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/AssessmentSimulatorSingleMeasureStrategy_test.js
@@ -96,7 +96,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorSingleMeasureStrategy', fu
 
           algorithm.getReward
             .withArgs({
-              estimatedLevel: initialCapacity,
+              capacity: initialCapacity,
               difficulty: challenge1.difficulty,
               discriminant: challenge1.discriminant,
             })
@@ -233,7 +233,7 @@ describe('Unit | Domain | Models | AssessmentSimulatorSingleMeasureStrategy', fu
 
           algorithm.getReward
             .withArgs({
-              estimatedLevel: capacityAfterFirstChallenge,
+              capacity: capacityAfterFirstChallenge,
               difficulty: challenge1.difficulty,
               discriminant: challenge1.discriminant,
             })

--- a/api/tests/certification/flash-certification/unit/domain/models/FlashAssessmentAlgorithm_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/FlashAssessmentAlgorithm_test.js
@@ -110,11 +110,11 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
               _getEstimatedLevelAndErrorRateParams({
                 allAnswers: assessmentAnswers,
                 challenges,
-                estimatedLevel: initialCapacity,
+                capacity: initialCapacity,
               }),
             )
             .returns({
-              estimatedLevel: computedEstimatedLevel,
+              capacity: computedEstimatedLevel,
             });
 
           const expectedChallenges = [unansweredChallengeTube2];
@@ -187,11 +187,11 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
               _getEstimatedLevelAndErrorRateParams({
                 allAnswers: assessmentAnswers,
                 challenges,
-                estimatedLevel: initialCapacity,
+                capacity: initialCapacity,
               }),
             )
             .returns({
-              estimatedLevel: computedEstimatedLevel,
+              capacity: computedEstimatedLevel,
             });
 
           const expectedChallenges = [unansweredChallengeTube1, unansweredChallengeTube2];
@@ -257,11 +257,11 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
             _getEstimatedLevelAndErrorRateParams({
               allAnswers: answersForComputingEstimatedLevel,
               challenges,
-              estimatedLevel: initialCapacity,
+              capacity: initialCapacity,
             }),
           )
           .returns({
-            estimatedLevel: 0,
+            capacity: 0,
           });
 
         flashAlgorithmImplementation.getPossibleNextChallenges
@@ -333,7 +333,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
           });
 
           flashAlgorithmImplementation.getEstimatedLevelAndErrorRate.returns({
-            estimatedLevel: 0,
+            capacity: 0,
           });
           flashAlgorithmImplementation.getPossibleNextChallenges
             .withArgs({
@@ -419,7 +419,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
 
           const expectedChallenges = [easyChallenge, hardChallenge2];
           flashAlgorithmImplementation.getEstimatedLevelAndErrorRate.returns({
-            estimatedLevel: 0,
+            capacity: 0,
           });
           flashAlgorithmImplementation.getPossibleNextChallenges
             .withArgs({

--- a/api/tests/certification/flash-certification/unit/domain/models/FlashAssessmentAlgorithm_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/FlashAssessmentAlgorithm_test.js
@@ -24,7 +24,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
   beforeEach(function () {
     flashAlgorithmImplementation = {
       getPossibleNextChallenges: sinon.stub(),
-      getEstimatedLevelAndErrorRate: sinon.stub(),
+      getCapacityAndErrorRate: sinon.stub(),
     };
   });
 
@@ -105,7 +105,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
 
           const challenges = [answeredChallengeTube1, unansweredChallengeTube1, unansweredChallengeTube2];
 
-          flashAlgorithmImplementation.getEstimatedLevelAndErrorRate
+          flashAlgorithmImplementation.getCapacityAndErrorRate
             .withArgs(
               _getEstimatedLevelAndErrorRateParams({
                 allAnswers: assessmentAnswers,
@@ -182,7 +182,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
 
           const challenges = [answeredChallengeTube1, unansweredChallengeTube1, unansweredChallengeTube2];
 
-          flashAlgorithmImplementation.getEstimatedLevelAndErrorRate
+          flashAlgorithmImplementation.getCapacityAndErrorRate
             .withArgs(
               _getEstimatedLevelAndErrorRateParams({
                 allAnswers: assessmentAnswers,
@@ -252,7 +252,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
           configuration: _getAlgorithmConfig(),
         });
 
-        flashAlgorithmImplementation.getEstimatedLevelAndErrorRate
+        flashAlgorithmImplementation.getCapacityAndErrorRate
           .withArgs(
             _getEstimatedLevelAndErrorRateParams({
               allAnswers: answersForComputingEstimatedLevel,
@@ -332,7 +332,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
             }),
           });
 
-          flashAlgorithmImplementation.getEstimatedLevelAndErrorRate.returns({
+          flashAlgorithmImplementation.getCapacityAndErrorRate.returns({
             capacity: 0,
           });
           flashAlgorithmImplementation.getPossibleNextChallenges
@@ -418,7 +418,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
           });
 
           const expectedChallenges = [easyChallenge, hardChallenge2];
-          flashAlgorithmImplementation.getEstimatedLevelAndErrorRate.returns({
+          flashAlgorithmImplementation.getCapacityAndErrorRate.returns({
             capacity: 0,
           });
           flashAlgorithmImplementation.getPossibleNextChallenges

--- a/api/tests/certification/flash-certification/unit/domain/models/FlashAssessmentAlgorithm_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/FlashAssessmentAlgorithm_test.js
@@ -244,7 +244,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
 
         const challenges = [hardChallenge, easyChallenge];
         const assessmentAnswers = [answer1];
-        const answersForComputingEstimatedLevel = [];
+        const answersForComputingCapacity = [];
 
         // when
         const algorithm = new FlashAssessmentAlgorithm({
@@ -255,7 +255,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
         flashAlgorithmImplementation.getCapacityAndErrorRate
           .withArgs(
             _getEstimatedLevelAndErrorRateParams({
-              allAnswers: answersForComputingEstimatedLevel,
+              allAnswers: answersForComputingCapacity,
               challenges,
               capacity: initialCapacity,
             }),
@@ -278,7 +278,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
           assessmentAnswers,
           challenges,
           initialCapacity,
-          answersForComputingEstimatedLevel,
+          answersForComputingCapacity,
         });
 
         expect(nextChallenges).to.deep.equal([hardChallenge]);

--- a/api/tests/certification/flash-certification/unit/domain/models/FlashAssessmentAlgorithm_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/FlashAssessmentAlgorithm_test.js
@@ -62,7 +62,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
           const alreadyAnsweredChallengesCount = 10;
           const remainingAnswersToGive = 1;
           const initialCapacity = config.v3Certification.defaultCandidateCapacity;
-          const computedEstimatedLevel = 2;
+          const computedCapacity = 2;
           config.features.numberOfChallengesForFlashMethod = 20;
           const algorithm = new FlashAssessmentAlgorithm({
             flashAlgorithmImplementation,
@@ -107,21 +107,21 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
 
           flashAlgorithmImplementation.getCapacityAndErrorRate
             .withArgs(
-              _getEstimatedLevelAndErrorRateParams({
+              _getCapacityAndErrorRateParams({
                 allAnswers: assessmentAnswers,
                 challenges,
                 capacity: initialCapacity,
               }),
             )
             .returns({
-              capacity: computedEstimatedLevel,
+              capacity: computedCapacity,
             });
 
           const expectedChallenges = [unansweredChallengeTube2];
           flashAlgorithmImplementation.getPossibleNextChallenges
             .withArgs({
               availableChallenges: expectedChallenges,
-              capacity: computedEstimatedLevel,
+              capacity: computedCapacity,
               options: baseGetNextChallengeOptions,
             })
             .returns(expectedChallenges);
@@ -137,7 +137,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
           const alreadyAnsweredChallengesCount = 10;
           const remainingAnswersToGive = 1;
           const initialCapacity = config.v3Certification.defaultCandidateCapacity;
-          const computedEstimatedLevel = 2;
+          const computedCapacity = 2;
           config.features.numberOfChallengesForFlashMethod = 20;
           const algorithm = new FlashAssessmentAlgorithm({
             flashAlgorithmImplementation,
@@ -184,21 +184,21 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
 
           flashAlgorithmImplementation.getCapacityAndErrorRate
             .withArgs(
-              _getEstimatedLevelAndErrorRateParams({
+              _getCapacityAndErrorRateParams({
                 allAnswers: assessmentAnswers,
                 challenges,
                 capacity: initialCapacity,
               }),
             )
             .returns({
-              capacity: computedEstimatedLevel,
+              capacity: computedCapacity,
             });
 
           const expectedChallenges = [unansweredChallengeTube1, unansweredChallengeTube2];
           flashAlgorithmImplementation.getPossibleNextChallenges
             .withArgs({
               availableChallenges: expectedChallenges,
-              capacity: computedEstimatedLevel,
+              capacity: computedCapacity,
               options: baseGetNextChallengeOptions,
             })
             .returns(expectedChallenges);
@@ -254,7 +254,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
 
         flashAlgorithmImplementation.getCapacityAndErrorRate
           .withArgs(
-            _getEstimatedLevelAndErrorRateParams({
+            _getCapacityAndErrorRateParams({
               allAnswers: answersForComputingCapacity,
               challenges,
               capacity: initialCapacity,
@@ -453,7 +453,7 @@ const _getAlgorithmConfig = (options) => {
   });
 };
 
-const _getEstimatedLevelAndErrorRateParams = (params) => ({
+const _getCapacityAndErrorRateParams = (params) => ({
   variationPercent: undefined,
   variationPercentUntil: undefined,
   doubleMeasuresUntil: undefined,

--- a/api/tests/certification/flash-certification/unit/domain/models/FlashAssessmentAlgorithm_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/models/FlashAssessmentAlgorithm_test.js
@@ -38,7 +38,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
           domainBuilder.buildChallenge({ id: assessmentAnswers[0].challengeId, skill: skill1 }),
           domainBuilder.buildChallenge({ competenceId: 'comp2', skill: skill2 }),
         ];
-        const estimatedLevel = 0;
+        const capacity = 0;
         const algorithm = new FlashAssessmentAlgorithm({
           flashAlgorithmImplementation,
           configuration: _getAlgorithmConfig({
@@ -50,7 +50,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
           algorithm.getPossibleNextChallenges({
             assessmentAnswers,
             challenges,
-            estimatedLevel,
+            capacity,
           }),
         ).to.throw(AssessmentEndedError);
       });
@@ -121,7 +121,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
           flashAlgorithmImplementation.getPossibleNextChallenges
             .withArgs({
               availableChallenges: expectedChallenges,
-              estimatedLevel: computedEstimatedLevel,
+              capacity: computedEstimatedLevel,
               options: baseGetNextChallengeOptions,
             })
             .returns(expectedChallenges);
@@ -198,7 +198,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
           flashAlgorithmImplementation.getPossibleNextChallenges
             .withArgs({
               availableChallenges: expectedChallenges,
-              estimatedLevel: computedEstimatedLevel,
+              capacity: computedEstimatedLevel,
               options: baseGetNextChallengeOptions,
             })
             .returns(expectedChallenges);
@@ -267,7 +267,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
         flashAlgorithmImplementation.getPossibleNextChallenges
           .withArgs({
             availableChallenges: [hardChallenge],
-            estimatedLevel: 0,
+            capacity: 0,
             options: {
               ...baseGetNextChallengeOptions,
             },
@@ -338,7 +338,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
           flashAlgorithmImplementation.getPossibleNextChallenges
             .withArgs({
               availableChallenges: challenges,
-              estimatedLevel: 0,
+              capacity: 0,
               options: {
                 ...baseGetNextChallengeOptions,
                 minimalSuccessRate: 0.8,
@@ -424,7 +424,7 @@ describe('Unit | Domain | Models | FlashAssessmentAlgorithm | FlashAssessmentAlg
           flashAlgorithmImplementation.getPossibleNextChallenges
             .withArgs({
               availableChallenges: expectedChallenges,
-              estimatedLevel: 0,
+              capacity: 0,
               options: {
                 ...baseGetNextChallengeOptions,
                 // Due to JS having troubles with float numbers, we must use a matcher.

--- a/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
@@ -704,12 +704,12 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
 
         const challenges = [...inferredChallenges, ...notInferredChallenges];
 
-        const estimatedLevel = 2;
+        const capacity = 2;
 
         const allAnswers = [];
 
         // when
-        const result = flash.calculateTotalPixScoreAndScoreByCompetence({ allAnswers, challenges, estimatedLevel });
+        const result = flash.calculateTotalPixScoreAndScoreByCompetence({ allAnswers, challenges, capacity });
 
         // then
         expect(result).to.deep.equal({
@@ -818,10 +818,10 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
           domainBuilder.buildAnswer({ result: AnswerStatus.SKIPPED, challengeId: challenges[3].id }),
         ];
 
-        const estimatedLevel = 2;
+        const capacity = 2;
 
         // when
-        const result = flash.calculateTotalPixScoreAndScoreByCompetence({ allAnswers, challenges, estimatedLevel });
+        const result = flash.calculateTotalPixScoreAndScoreByCompetence({ allAnswers, challenges, capacity });
 
         // then
         expect(result).to.deep.equal({
@@ -911,7 +911,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
 
         const challenges = [...succeededChallenges, ...inferredChallenges, ...notInferredChallenges];
 
-        const estimatedLevel = 2;
+        const capacity = 2;
 
         const allAnswers = [
           domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: succeededChallenges[0].id }),
@@ -919,7 +919,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         ];
 
         // when
-        const result = flash.calculateTotalPixScoreAndScoreByCompetence({ allAnswers, challenges, estimatedLevel });
+        const result = flash.calculateTotalPixScoreAndScoreByCompetence({ allAnswers, challenges, capacity });
 
         // then
         expect(result).to.deep.equal({
@@ -962,12 +962,12 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
           }), // minimumCapability: 2.1295639109084643
         ];
 
-        const estimatedLevel = 2;
+        const capacity = 2;
 
         const allAnswers = [];
 
         // when
-        const result = flash.calculateTotalPixScoreAndScoreByCompetence({ allAnswers, challenges, estimatedLevel });
+        const result = flash.calculateTotalPixScoreAndScoreByCompetence({ allAnswers, challenges, capacity });
 
         // then
         expect(result).to.deep.equal({

--- a/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
@@ -17,7 +17,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
           allChallenges,
           availableChallenges,
           allAnswers,
-          estimatedLevel: 0,
+          capacity: 0,
         });
 
         // then
@@ -81,7 +81,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
           allChallenges,
           availableChallenges,
           allAnswers,
-          estimatedLevel: 0,
+          capacity: 0,
         });
 
         // then

--- a/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
@@ -90,14 +90,14 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
     });
   });
 
-  describe('#getEstimatedLevelAndErrorRate', function () {
+  describe('#getCapacityAndErrorRate', function () {
     context('when single measure', function () {
       it('should return 0 when there is no answers', function () {
         // given
         const allAnswers = [];
 
         // when
-        const result = flash.getEstimatedLevelAndErrorRate({ allAnswers });
+        const result = flash.getCapacityAndErrorRate({ allAnswers });
 
         // then
         expect(result).to.deep.equal({
@@ -118,7 +118,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         const allAnswers = [domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id })];
 
         // when
-        const { capacity, errorRate } = flash.getEstimatedLevelAndErrorRate({ allAnswers, challenges });
+        const { capacity, errorRate } = flash.getCapacityAndErrorRate({ allAnswers, challenges });
 
         // then
         expect(capacity).to.be.closeTo(0.859419960298745, 0.00000000001);
@@ -146,7 +146,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         ];
 
         // when
-        const { capacity, errorRate } = flash.getEstimatedLevelAndErrorRate({ allAnswers, challenges });
+        const { capacity, errorRate } = flash.getCapacityAndErrorRate({ allAnswers, challenges });
 
         // then
         expect(capacity).to.be.closeTo(1.802340122865396, 0.00000000001);
@@ -180,7 +180,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         ];
 
         // when
-        const { capacity, errorRate } = flash.getEstimatedLevelAndErrorRate({ allAnswers, challenges });
+        const { capacity, errorRate } = flash.getCapacityAndErrorRate({ allAnswers, challenges });
 
         // then
         expect(capacity).to.be.closeTo(2.851063556136754, 0.00000000001);
@@ -346,7 +346,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
           let result;
 
           for (let i = 0; i < answers.length; i++) {
-            result = flash.getEstimatedLevelAndErrorRate({ challenges: listChallenges, allAnswers });
+            result = flash.getCapacityAndErrorRate({ challenges: listChallenges, allAnswers });
 
             // then
             expect(result.capacity).to.be.closeTo(expectedCapacity[i], 0.000000001);
@@ -374,7 +374,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
             const variationPercentUntil = 1;
 
             // when
-            const { capacity } = flash.getEstimatedLevelAndErrorRate({
+            const { capacity } = flash.getCapacityAndErrorRate({
               allAnswers,
               challenges,
               variationPercent,
@@ -402,7 +402,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
             const variationPercentUntil = 1;
 
             // when
-            const { capacity } = flash.getEstimatedLevelAndErrorRate({
+            const { capacity } = flash.getCapacityAndErrorRate({
               allAnswers,
               challenges,
               variationPercent,
@@ -444,7 +444,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         ];
 
         // when
-        const { capacity } = flash.getEstimatedLevelAndErrorRate({
+        const { capacity } = flash.getCapacityAndErrorRate({
           allAnswers,
           challenges,
           doubleMeasuresUntil: 2,
@@ -482,7 +482,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
           ];
 
           // when
-          const { capacity } = flash.getEstimatedLevelAndErrorRate({
+          const { capacity } = flash.getCapacityAndErrorRate({
             allAnswers,
             challenges,
             doubleMeasuresUntil: 4,

--- a/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
@@ -101,12 +101,12 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
 
         // then
         expect(result).to.deep.equal({
-          estimatedLevel: 0,
+          capacity: 0,
           errorRate: 5,
         });
       });
 
-      it('should return the correct estimatedLevel when there is one answer', function () {
+      it('should return the correct capacity when there is one answer', function () {
         // given
         const challenges = [
           domainBuilder.buildChallenge({
@@ -118,14 +118,14 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         const allAnswers = [domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id })];
 
         // when
-        const { estimatedLevel, errorRate } = flash.getEstimatedLevelAndErrorRate({ allAnswers, challenges });
+        const { capacity, errorRate } = flash.getEstimatedLevelAndErrorRate({ allAnswers, challenges });
 
         // then
-        expect(estimatedLevel).to.be.closeTo(0.859419960298745, 0.00000000001);
+        expect(capacity).to.be.closeTo(0.859419960298745, 0.00000000001);
         expect(errorRate).to.be.closeTo(0.9327454634914153, 0.00000000001);
       });
 
-      it('should return the correct estimatedLevel when there is two answers', function () {
+      it('should return the correct capacity when there is two answers', function () {
         // given
         const challenges = [
           domainBuilder.buildChallenge({
@@ -146,14 +146,14 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         ];
 
         // when
-        const { estimatedLevel, errorRate } = flash.getEstimatedLevelAndErrorRate({ allAnswers, challenges });
+        const { capacity, errorRate } = flash.getEstimatedLevelAndErrorRate({ allAnswers, challenges });
 
         // then
-        expect(estimatedLevel).to.be.closeTo(1.802340122865396, 0.00000000001);
+        expect(capacity).to.be.closeTo(1.802340122865396, 0.00000000001);
         expect(errorRate).to.be.closeTo(0.8549014053951466, 0.00000000001);
       });
 
-      it('should return the correct estimatedLevel when there is three answers', function () {
+      it('should return the correct capacity when there is three answers', function () {
         // given
         const challenges = [
           domainBuilder.buildChallenge({
@@ -180,10 +180,10 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         ];
 
         // when
-        const { estimatedLevel, errorRate } = flash.getEstimatedLevelAndErrorRate({ allAnswers, challenges });
+        const { capacity, errorRate } = flash.getEstimatedLevelAndErrorRate({ allAnswers, challenges });
 
         // then
-        expect(estimatedLevel).to.be.closeTo(2.851063556136754, 0.00000000001);
+        expect(capacity).to.be.closeTo(2.851063556136754, 0.00000000001);
         expect(errorRate).to.be.closeTo(0.9271693210547304, 0.00000000001);
       });
 
@@ -332,7 +332,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
             domainBuilder.buildAnswer({ challengeId: 'recA', result: AnswerStatus.OK }),
             domainBuilder.buildAnswer({ challengeId: 'recQ', result: AnswerStatus.OK }),
           ];
-          const expectedEstimatedLevel = [
+          const expectedCapacity = [
             0, -0.6086049191210775, -0.6653800198379971, -1.7794873733366134, -1.8036203882448785, -1.557864373635504,
             -1.3925555729766932,
           ];
@@ -349,7 +349,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
             result = flash.getEstimatedLevelAndErrorRate({ challenges: listChallenges, allAnswers });
 
             // then
-            expect(result.estimatedLevel).to.be.closeTo(expectedEstimatedLevel[i], 0.000000001);
+            expect(result.capacity).to.be.closeTo(expectedCapacity[i], 0.000000001);
             expect(result.errorRate).to.be.closeTo(expectedErrorRate[i], 0.000000001);
 
             allAnswers.push(answers[i]);
@@ -374,7 +374,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
             const variationPercentUntil = 1;
 
             // when
-            const { estimatedLevel } = flash.getEstimatedLevelAndErrorRate({
+            const { capacity } = flash.getEstimatedLevelAndErrorRate({
               allAnswers,
               challenges,
               variationPercent,
@@ -382,7 +382,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
             });
 
             // then
-            expect(estimatedLevel).to.be.closeTo(0.5, 0.00000000001);
+            expect(capacity).to.be.closeTo(0.5, 0.00000000001);
           });
         });
 
@@ -402,7 +402,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
             const variationPercentUntil = 1;
 
             // when
-            const { estimatedLevel } = flash.getEstimatedLevelAndErrorRate({
+            const { capacity } = flash.getEstimatedLevelAndErrorRate({
               allAnswers,
               challenges,
               variationPercent,
@@ -410,14 +410,14 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
             });
 
             // then
-            expect(estimatedLevel).to.be.closeTo(-0.5, 0.00000000001);
+            expect(capacity).to.be.closeTo(-0.5, 0.00000000001);
           });
         });
       });
     });
 
     context('when double measure', function () {
-      it('should return the correct estimatedLevel when there is three answers', function () {
+      it('should return the correct capacity when there is three answers', function () {
         // given
         const challenges = [
           domainBuilder.buildChallenge({
@@ -444,18 +444,18 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         ];
 
         // when
-        const { estimatedLevel } = flash.getEstimatedLevelAndErrorRate({
+        const { capacity } = flash.getEstimatedLevelAndErrorRate({
           allAnswers,
           challenges,
           doubleMeasuresUntil: 2,
         });
 
         // then
-        expect(estimatedLevel).to.be.closeTo(1.663469355503838, 0.00000000001);
+        expect(capacity).to.be.closeTo(1.663469355503838, 0.00000000001);
       });
 
       context('when double measure is active with an odd number of challenges', function () {
-        it('should return the correct estimatedLevel when there is three answers', function () {
+        it('should return the correct capacity when there is three answers', function () {
           // given
           const challenges = [
             domainBuilder.buildChallenge({
@@ -482,14 +482,14 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
           ];
 
           // when
-          const { estimatedLevel } = flash.getEstimatedLevelAndErrorRate({
+          const { capacity } = flash.getEstimatedLevelAndErrorRate({
             allAnswers,
             challenges,
             doubleMeasuresUntil: 4,
           });
 
           // then
-          expect(estimatedLevel).to.be.closeTo(1.663469355503838, 0.00000000001);
+          expect(capacity).to.be.closeTo(1.663469355503838, 0.00000000001);
         });
       });
     });
@@ -520,10 +520,10 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         const allAnswers = [domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id })];
 
         // when
-        const [{ estimatedLevel, errorRate }] = flash.getEstimatedLevelAndErrorRateHistory({ allAnswers, challenges });
+        const [{ capacity, errorRate }] = flash.getEstimatedLevelAndErrorRateHistory({ allAnswers, challenges });
 
         // then
-        expect(estimatedLevel).to.be.closeTo(0.859419960298745, 0.00000000001);
+        expect(capacity).to.be.closeTo(0.859419960298745, 0.00000000001);
         expect(errorRate).to.be.closeTo(0.9327454634914153, 0.00000000001);
       });
 
@@ -551,9 +551,9 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         const results = flash.getEstimatedLevelAndErrorRateHistory({ allAnswers, challenges });
 
         // then
-        expect(results[0].estimatedLevel).to.be.closeTo(0.859419960298745, 0.00000000001);
+        expect(results[0].capacity).to.be.closeTo(0.859419960298745, 0.00000000001);
         expect(results[0].errorRate).to.be.closeTo(0.9327454634914153, 0.00000000001);
-        expect(results[1].estimatedLevel).to.be.closeTo(1.802340122865396, 0.00000000001);
+        expect(results[1].capacity).to.be.closeTo(1.802340122865396, 0.00000000001);
         expect(results[1].errorRate).to.be.closeTo(0.8549014053951466, 0.00000000001);
       });
 

--- a/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
@@ -495,20 +495,20 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
     });
   });
 
-  describe('#getEstimatedLevelAndErrorRateHistory', function () {
+  describe('#getCapacityAndErrorRateHistory', function () {
     context('when single measure', function () {
       it('should return 0 when there is no answers', function () {
         // given
         const allAnswers = [];
 
         // when
-        const result = flash.getEstimatedLevelAndErrorRateHistory({ allAnswers });
+        const result = flash.getCapacityAndErrorRateHistory({ allAnswers });
 
         // then
         expect(result).to.deep.equal([]);
       });
 
-      it('should return the correct estimatedLevel when there is one answer', function () {
+      it('should return the correct capacity when there is one answer', function () {
         // given
         const challenges = [
           domainBuilder.buildChallenge({
@@ -520,14 +520,14 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         const allAnswers = [domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id })];
 
         // when
-        const [{ capacity, errorRate }] = flash.getEstimatedLevelAndErrorRateHistory({ allAnswers, challenges });
+        const [{ capacity, errorRate }] = flash.getCapacityAndErrorRateHistory({ allAnswers, challenges });
 
         // then
         expect(capacity).to.be.closeTo(0.859419960298745, 0.00000000001);
         expect(errorRate).to.be.closeTo(0.9327454634914153, 0.00000000001);
       });
 
-      it('should return the correct estimatedLevel when there are two answers', function () {
+      it('should return the correct capacity when there are two answers', function () {
         // given
         const challenges = [
           domainBuilder.buildChallenge({
@@ -548,7 +548,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         ];
 
         // when
-        const results = flash.getEstimatedLevelAndErrorRateHistory({ allAnswers, challenges });
+        const results = flash.getCapacityAndErrorRateHistory({ allAnswers, challenges });
 
         // then
         expect(results[0].capacity).to.be.closeTo(0.859419960298745, 0.00000000001);

--- a/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
@@ -574,7 +574,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         ];
 
         // when
-        const results = flash.getEstimatedLevelAndErrorRateHistory({ allAnswers, challenges });
+        const results = flash.getCapacityAndErrorRateHistory({ allAnswers, challenges });
 
         // then
         expect(results[0].answerId).to.equal(answerId);

--- a/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/certification/flash-certification/unit/domain/services/algorithm-methods/flash_test.js
@@ -188,7 +188,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
       });
 
       context('when the user answers a lot of challenges', function () {
-        it('should return the correct estimatedLevel and errorRate', function () {
+        it('should return the correct capacity and errorRate', function () {
           const listSkills = {
             url5: domainBuilder.buildSkill({ id: 'url5' }),
             web3: domainBuilder.buildSkill({ id: 'web3' }),
@@ -359,7 +359,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
 
       context('when limiting the estimated level variation to a given number of challenges', function () {
         context('when giving a right answer', function () {
-          it('should return the limited estimatedLevel for the correct number of challenges', function () {
+          it('should return the limited capacity for the correct number of challenges', function () {
             // given
             const challenges = [
               domainBuilder.buildChallenge({
@@ -387,7 +387,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         });
 
         context('when giving a wrong answer', function () {
-          it('should return the limited estimatedLevel', function () {
+          it('should return the limited capacity', function () {
             // given
             const challenges = [
               domainBuilder.buildChallenge({

--- a/api/tests/certification/scoring/unit/domain/models/CertificationAssessmentHistory_test.js
+++ b/api/tests/certification/scoring/unit/domain/models/CertificationAssessmentHistory_test.js
@@ -38,9 +38,9 @@ describe('Unit | Domain | Models | CertificationAssessmentHistory', function () 
           challenges,
         })
         .returns([
-          { answerId: firstAnswerId, estimatedLevel: 1 },
-          { answerId: secondAnswerId, estimatedLevel: 2 },
-          { answerId: thirdAnswerId, estimatedLevel: 3 },
+          { answerId: firstAnswerId, capacity: 1 },
+          { answerId: secondAnswerId, capacity: 2 },
+          { answerId: thirdAnswerId, capacity: 3 },
         ]);
 
       // when

--- a/api/tests/certification/scoring/unit/domain/models/CertificationAssessmentHistory_test.js
+++ b/api/tests/certification/scoring/unit/domain/models/CertificationAssessmentHistory_test.js
@@ -6,7 +6,7 @@ describe('Unit | Domain | Models | CertificationAssessmentHistory', function () 
     it('should return a CertificationAssessmentHistory with the capacity history', function () {
       // given
       const algorithm = {
-        getEstimatedLevelAndErrorRateHistory: sinon.stub(),
+        getCapacityAndErrorRateHistory: sinon.stub(),
       };
       const firstAnswerId = 123;
       const secondAnswerId = 456;
@@ -32,7 +32,7 @@ describe('Unit | Domain | Models | CertificationAssessmentHistory', function () 
         domainBuilder.buildAnswer({ id: thirdAnswerId, challengeId: 'challenge3', value: 'answer1' }),
       ];
 
-      algorithm.getEstimatedLevelAndErrorRateHistory
+      algorithm.getCapacityAndErrorRateHistory
         .withArgs({
           allAnswers,
           challenges,

--- a/api/tests/certification/scoring/unit/domain/models/CertificationAssessmentScoreV3_test.js
+++ b/api/tests/certification/scoring/unit/domain/models/CertificationAssessmentScoreV3_test.js
@@ -84,7 +84,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
 
   describe('when the candidate finished the test', function () {
     it('should return the full score', async function () {
-      const expectedEstimatedLevel = 2;
+      const expectedCapacity = 2;
       const expectedScoreForEstimatedLevel = 640;
 
       const numberOfQuestions = 32;
@@ -100,7 +100,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
           allAnswers,
         })
         .returns({
-          estimatedLevel: expectedEstimatedLevel,
+          capacity: expectedCapacity,
         });
 
       algorithm.getConfiguration.returns(
@@ -121,7 +121,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
     });
 
     it('should return the competence marks', async function () {
-      const expectedEstimatedLevel = 2;
+      const expectedCapacity = 2;
 
       const numberOfQuestions = 32;
 
@@ -136,7 +136,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
           allAnswers,
         })
         .returns({
-          estimatedLevel: expectedEstimatedLevel,
+          capacity: expectedCapacity,
         });
 
       algorithm.getConfiguration.returns(
@@ -168,7 +168,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
   describe('when the candidate did not finish the test', function () {
     describe('when the abort reason is technical difficulties', function () {
       it('should return the raw score', async function () {
-        const expectedEstimatedLevel = 2;
+        const expectedCapacity = 2;
         const expectedScoreForEstimatedLevel = 640;
 
         const numberOfAnsweredQuestions = 20;
@@ -186,7 +186,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
             allAnswers,
           })
           .returns({
-            estimatedLevel: expectedEstimatedLevel,
+            capacity: expectedCapacity,
           });
 
         algorithm.getConfiguration.returns(
@@ -208,7 +208,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
       });
 
       it('should return the competence marks', async function () {
-        const expectedEstimatedLevel = 2;
+        const expectedCapacity = 2;
 
         const numberOfAnsweredQuestions = 20;
         const numberCertificationQuestions = 32;
@@ -225,7 +225,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
             allAnswers,
           })
           .returns({
-            estimatedLevel: expectedEstimatedLevel,
+            capacity: expectedCapacity,
           });
 
         algorithm.getConfiguration.returns(
@@ -257,7 +257,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
 
     describe('when the abort reason is that the candidate did not finish', function () {
       it('should return the competence marks', async function () {
-        const expectedEstimatedLevel = 2;
+        const expectedCapacity = 2;
 
         const numberOfAnsweredQuestions = 20;
         const numberCertificationQuestions = 32;
@@ -274,7 +274,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
             allAnswers,
           })
           .returns({
-            estimatedLevel: expectedEstimatedLevel,
+            capacity: expectedCapacity,
           });
 
         algorithm.getConfiguration.returns(
@@ -320,7 +320,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
           allAnswers,
         })
         .returns({
-          estimatedLevel: veryLowEstimatedLevel,
+          capacity: veryLowEstimatedLevel,
         });
       algorithm.getConfiguration.returns(domainBuilder.buildFlashAlgorithmConfiguration());
 
@@ -351,7 +351,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
           allAnswers,
         })
         .returns({
-          estimatedLevel: veryLowEstimatedLevel,
+          capacity: veryLowEstimatedLevel,
         });
       algorithm.getConfiguration.returns(domainBuilder.buildFlashAlgorithmConfiguration());
 
@@ -392,7 +392,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
           allAnswers,
         })
         .returns({
-          estimatedLevel: veryHighEstimatedLevel,
+          capacity: veryHighEstimatedLevel,
         });
       algorithm.getConfiguration.returns(domainBuilder.buildFlashAlgorithmConfiguration());
 
@@ -423,7 +423,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
           allAnswers,
         })
         .returns({
-          estimatedLevel: veryHighEstimatedLevel,
+          capacity: veryHighEstimatedLevel,
         });
       algorithm.getConfiguration.returns(domainBuilder.buildFlashAlgorithmConfiguration());
 
@@ -463,7 +463,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
             allAnswers,
           })
           .returns({
-            estimatedLevel: 0,
+            capacity: 0,
           });
 
         algorithm.getConfiguration.returns(domainBuilder.buildFlashAlgorithmConfiguration());
@@ -493,7 +493,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
               allAnswers,
             })
             .returns({
-              estimatedLevel: 0,
+              capacity: 0,
             });
 
           algorithm.getConfiguration.returns(domainBuilder.buildFlashAlgorithmConfiguration());
@@ -523,7 +523,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
               allAnswers,
             })
             .returns({
-              estimatedLevel: 0,
+              capacity: 0,
             });
 
           algorithm.getConfiguration.returns(domainBuilder.buildFlashAlgorithmConfiguration());
@@ -555,7 +555,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
             allAnswers,
           })
           .returns({
-            estimatedLevel: 0,
+            capacity: 0,
           });
 
         algorithm.getConfiguration.returns(domainBuilder.buildFlashAlgorithmConfiguration());

--- a/api/tests/certification/scoring/unit/domain/models/CertificationAssessmentScoreV3_test.js
+++ b/api/tests/certification/scoring/unit/domain/models/CertificationAssessmentScoreV3_test.js
@@ -85,7 +85,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
   describe('when the candidate finished the test', function () {
     it('should return the full score', async function () {
       const expectedCapacity = 2;
-      const expectedScoreForEstimatedLevel = 640;
+      const expectedScoreForCapacity = 640;
 
       const numberOfQuestions = 32;
 
@@ -117,7 +117,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
         v3CertificationScoring,
       });
 
-      expect(score.nbPix).to.equal(expectedScoreForEstimatedLevel);
+      expect(score.nbPix).to.equal(expectedScoreForCapacity);
     });
 
     it('should return the competence marks', async function () {
@@ -169,7 +169,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
     describe('when the abort reason is technical difficulties', function () {
       it('should return the raw score', async function () {
         const expectedCapacity = 2;
-        const expectedScoreForEstimatedLevel = 640;
+        const expectedScoreForCapacity = 640;
 
         const numberOfAnsweredQuestions = 20;
         const numberCertificationQuestions = 32;
@@ -204,7 +204,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
           v3CertificationScoring,
         });
 
-        expect(score.nbPix).to.equal(expectedScoreForEstimatedLevel);
+        expect(score.nbPix).to.equal(expectedScoreForCapacity);
       });
 
       it('should return the competence marks', async function () {
@@ -308,7 +308,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
   describe('when we reach an estimated level below the MINIMUM', function () {
     it('the score should be 0', function () {
       // given
-      const veryLowEstimatedLevel = -9;
+      const veryLowCapacity = -9;
       const veryEasyDifficulty = -8;
       const numberOfChallenges = 32;
       const challenges = _buildChallenges(veryEasyDifficulty, numberOfChallenges);
@@ -320,7 +320,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
           allAnswers,
         })
         .returns({
-          capacity: veryLowEstimatedLevel,
+          capacity: veryLowCapacity,
         });
       algorithm.getConfiguration.returns(domainBuilder.buildFlashAlgorithmConfiguration());
 
@@ -339,7 +339,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
 
     it('should return the competence marks', function () {
       // given
-      const veryLowEstimatedLevel = -9;
+      const veryLowCapacity = -9;
       const veryEasyDifficulty = -8;
       const numberOfChallenges = 32;
       const challenges = _buildChallenges(veryEasyDifficulty, numberOfChallenges);
@@ -351,7 +351,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
           allAnswers,
         })
         .returns({
-          capacity: veryLowEstimatedLevel,
+          capacity: veryLowCapacity,
         });
       algorithm.getConfiguration.returns(domainBuilder.buildFlashAlgorithmConfiguration());
 
@@ -380,7 +380,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
   describe('when we reach an estimated level above the MAXIMUM', function () {
     it('the score should be 896', function () {
       // given
-      const veryHighEstimatedLevel = 1200;
+      const veryHighCapacity = 1200;
       const veryHardDifficulty = 8;
       const numberOfChallenges = 32;
       const challenges = _buildChallenges(veryHardDifficulty, numberOfChallenges);
@@ -392,7 +392,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
           allAnswers,
         })
         .returns({
-          capacity: veryHighEstimatedLevel,
+          capacity: veryHighCapacity,
         });
       algorithm.getConfiguration.returns(domainBuilder.buildFlashAlgorithmConfiguration());
 
@@ -411,7 +411,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
 
     it('should return the competence marks', function () {
       // given
-      const veryHighEstimatedLevel = 1200;
+      const veryHighCapacity = 1200;
       const veryHardDifficulty = 8;
       const numberOfChallenges = 32;
       const challenges = _buildChallenges(veryHardDifficulty, numberOfChallenges);
@@ -423,7 +423,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
           allAnswers,
         })
         .returns({
-          capacity: veryHighEstimatedLevel,
+          capacity: veryHighCapacity,
         });
       algorithm.getConfiguration.returns(domainBuilder.buildFlashAlgorithmConfiguration());
 

--- a/api/tests/certification/scoring/unit/domain/models/CertificationAssessmentScoreV3_test.js
+++ b/api/tests/certification/scoring/unit/domain/models/CertificationAssessmentScoreV3_test.js
@@ -32,7 +32,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
       findFlashCompatible: sinon.stub(),
     };
     algorithm = {
-      getEstimatedLevelAndErrorRate: sinon.stub(),
+      getCapacityAndErrorRate: sinon.stub(),
       getConfiguration: sinon.stub(),
     };
 
@@ -94,7 +94,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
 
       answerRepository.findByAssessment.withArgs(assessmentId).resolves(baseAnswers);
       challengeRepository.findFlashCompatible.withArgs().resolves(baseChallenges);
-      algorithm.getEstimatedLevelAndErrorRate
+      algorithm.getCapacityAndErrorRate
         .withArgs({
           challenges,
           allAnswers,
@@ -130,7 +130,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
 
       answerRepository.findByAssessment.withArgs(assessmentId).resolves(baseAnswers);
       challengeRepository.findFlashCompatible.withArgs().resolves(baseChallenges);
-      algorithm.getEstimatedLevelAndErrorRate
+      algorithm.getCapacityAndErrorRate
         .withArgs({
           challenges,
           allAnswers,
@@ -180,7 +180,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
 
         answerRepository.findByAssessment.withArgs(assessmentId).resolves(baseAnswers);
         challengeRepository.findFlashCompatible.withArgs().resolves(baseChallenges);
-        algorithm.getEstimatedLevelAndErrorRate
+        algorithm.getCapacityAndErrorRate
           .withArgs({
             challenges,
             allAnswers,
@@ -219,7 +219,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
 
         answerRepository.findByAssessment.withArgs(assessmentId).resolves(baseAnswers);
         challengeRepository.findFlashCompatible.withArgs().resolves(baseChallenges);
-        algorithm.getEstimatedLevelAndErrorRate
+        algorithm.getCapacityAndErrorRate
           .withArgs({
             challenges,
             allAnswers,
@@ -268,7 +268,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
 
         answerRepository.findByAssessment.withArgs(assessmentId).resolves(baseAnswers);
         challengeRepository.findFlashCompatible.withArgs().resolves(baseChallenges);
-        algorithm.getEstimatedLevelAndErrorRate
+        algorithm.getCapacityAndErrorRate
           .withArgs({
             challenges,
             allAnswers,
@@ -314,7 +314,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
       const challenges = _buildChallenges(veryEasyDifficulty, numberOfChallenges);
       const allAnswers = _buildAnswersForChallenges(challenges, AnswerStatus.KO);
 
-      algorithm.getEstimatedLevelAndErrorRate
+      algorithm.getCapacityAndErrorRate
         .withArgs({
           challenges,
           allAnswers,
@@ -345,7 +345,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
       const challenges = _buildChallenges(veryEasyDifficulty, numberOfChallenges);
       const allAnswers = _buildAnswersForChallenges(challenges, AnswerStatus.KO);
 
-      algorithm.getEstimatedLevelAndErrorRate
+      algorithm.getCapacityAndErrorRate
         .withArgs({
           challenges,
           allAnswers,
@@ -386,7 +386,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
       const challenges = _buildChallenges(veryHardDifficulty, numberOfChallenges);
       const allAnswers = _buildAnswersForChallenges(challenges, AnswerStatus.OK);
 
-      algorithm.getEstimatedLevelAndErrorRate
+      algorithm.getCapacityAndErrorRate
         .withArgs({
           challenges,
           allAnswers,
@@ -417,7 +417,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
       const challenges = _buildChallenges(veryHardDifficulty, numberOfChallenges);
       const allAnswers = _buildAnswersForChallenges(challenges, AnswerStatus.OK);
 
-      algorithm.getEstimatedLevelAndErrorRate
+      algorithm.getCapacityAndErrorRate
         .withArgs({
           challenges,
           allAnswers,
@@ -457,7 +457,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
         const challenges = _buildChallenges(difficulty, numberOfChallenges);
         const allAnswers = _buildAnswersForChallenges(challenges, AnswerStatus.OK);
 
-        algorithm.getEstimatedLevelAndErrorRate
+        algorithm.getCapacityAndErrorRate
           .withArgs({
             challenges,
             allAnswers,
@@ -487,7 +487,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
           const numberOfChallenges = config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification - 1;
           const challenges = _buildChallenges(difficulty, numberOfChallenges);
           const allAnswers = _buildAnswersForChallenges(challenges, AnswerStatus.OK);
-          algorithm.getEstimatedLevelAndErrorRate
+          algorithm.getCapacityAndErrorRate
             .withArgs({
               challenges,
               allAnswers,
@@ -517,7 +517,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
           const numberOfChallenges = config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification - 1;
           const challenges = _buildChallenges(difficulty, numberOfChallenges);
           const allAnswers = _buildAnswersForChallenges(challenges, AnswerStatus.OK);
-          algorithm.getEstimatedLevelAndErrorRate
+          algorithm.getCapacityAndErrorRate
             .withArgs({
               challenges,
               allAnswers,
@@ -549,7 +549,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
         const numberOfChallenges = config.v3Certification.scoring.minimumAnswersRequiredToValidateACertification - 1;
         const challenges = _buildChallenges(difficulty, numberOfChallenges);
         const allAnswers = _buildAnswersForChallenges(challenges, AnswerStatus.OK);
-        algorithm.getEstimatedLevelAndErrorRate
+        algorithm.getCapacityAndErrorRate
           .withArgs({
             challenges,
             allAnswers,

--- a/api/tests/certification/scoring/unit/domain/models/V3CertificationScoring_test.js
+++ b/api/tests/certification/scoring/unit/domain/models/V3CertificationScoring_test.js
@@ -5,7 +5,7 @@ describe('Unit | Certification | V3CertificationScoring', function () {
   describe('#getCompetencesScore', function () {
     it('should return the competences score', function () {
       // Given
-      const estimatedLevel = 3;
+      const capacity = 3;
       const competence1Score = 1;
       const competence2Score = 2;
       const competenceForScoring1 = {
@@ -18,8 +18,8 @@ describe('Unit | Certification | V3CertificationScoring', function () {
       const competence1Mark = domainBuilder.buildCompetenceMark({ score: competence1Score });
       const competence2Mark = domainBuilder.buildCompetenceMark({ score: competence2Score });
 
-      competenceForScoring1.getCompetenceMark.withArgs(estimatedLevel).returns(competence1Mark);
-      competenceForScoring2.getCompetenceMark.withArgs(estimatedLevel).returns(competence2Mark);
+      competenceForScoring1.getCompetenceMark.withArgs(capacity).returns(competence1Mark);
+      competenceForScoring2.getCompetenceMark.withArgs(capacity).returns(competence2Mark);
       const competencesForScoring = [competenceForScoring1, competenceForScoring2];
       const certificationScoringConfiguration = {};
 
@@ -29,7 +29,7 @@ describe('Unit | Certification | V3CertificationScoring', function () {
       });
 
       // When
-      const competencesScore = v3CertificationScoring.getCompetencesScore(estimatedLevel);
+      const competencesScore = v3CertificationScoring.getCompetencesScore(capacity);
 
       // Then
       expect(competencesScore).to.deep.equal([competence1Mark, competence2Mark]);

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -63,7 +63,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
       };
       flashAlgorithmService = {
         getEstimatedLevelAndErrorRate: sinon.stub(),
-        getEstimatedLevelAndErrorRateHistory: sinon.stub(),
+        getCapacityAndErrorRateHistory: sinon.stub(),
       };
 
       certificationAssessmentHistoryRepository = {
@@ -166,7 +166,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
               capacity: expectedCapacity,
             });
 
-          flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
+          flashAlgorithmService.getCapacityAndErrorRateHistory
             .withArgs({
               challenges: certificationChallengesForScoring,
               allAnswers: answers,
@@ -284,7 +284,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
               capacity: expectedCapacity,
             });
 
-          flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
+          flashAlgorithmService.getCapacityAndErrorRateHistory
             .withArgs({
               challenges: certificationChallengesForScoring,
               allAnswers: answers,
@@ -420,7 +420,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
               capacity: expectedCapacity,
             });
 
-          flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
+          flashAlgorithmService.getCapacityAndErrorRateHistory
             .withArgs({
               challenges: certificationChallengesForScoring,
               allAnswers: answers,
@@ -539,7 +539,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
             capacity: expectedCapacity,
           });
 
-        flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
+        flashAlgorithmService.getCapacityAndErrorRateHistory
           .withArgs({
             challenges: certificationChallengesForScoring,
             allAnswers: answers,
@@ -667,7 +667,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
               capacity: expectedCapacity,
             });
 
-          flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
+          flashAlgorithmService.getCapacityAndErrorRateHistory
             .withArgs({
               challenges: certificationChallengesForScoring,
               allAnswers: answers,
@@ -782,7 +782,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
               capacity: expectedCapacity,
             });
 
-          flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
+          flashAlgorithmService.getCapacityAndErrorRateHistory
             .withArgs({
               challenges: certificationChallengesForScoring,
               allAnswers: answers,

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -62,7 +62,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         getMostRecentBeforeDate: sinon.stub(),
       };
       flashAlgorithmService = {
-        getEstimatedLevelAndErrorRate: sinon.stub(),
+        getCapacityAndErrorRate: sinon.stub(),
         getCapacityAndErrorRateHistory: sinon.stub(),
       };
 
@@ -153,7 +153,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
             .withArgs({ id: certificationAssessment.certificationCourseId })
             .resolves(abortedCertificationCourse);
 
-          flashAlgorithmService.getEstimatedLevelAndErrorRate
+          flashAlgorithmService.getCapacityAndErrorRate
             .withArgs({
               challenges: certificationChallengesForScoring,
               allAnswers: answers,
@@ -271,7 +271,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
             .withArgs({ id: certificationAssessment.certificationCourseId })
             .resolves(abortedCertificationCourse);
 
-          flashAlgorithmService.getEstimatedLevelAndErrorRate
+          flashAlgorithmService.getCapacityAndErrorRate
             .withArgs({
               challenges: certificationChallengesForScoring,
               allAnswers: answers,
@@ -407,7 +407,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
             .withArgs(abortedCertificationCourse.getStartDate())
             .resolves(baseFlashAlgorithmConfig);
 
-          flashAlgorithmService.getEstimatedLevelAndErrorRate
+          flashAlgorithmService.getCapacityAndErrorRate
             .withArgs({
               challenges: certificationChallengesForScoring,
               allAnswers: answers,
@@ -526,7 +526,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           .withArgs({ id: certificationAssessment.certificationCourseId })
           .resolves(abortedCertificationCourse);
 
-        flashAlgorithmService.getEstimatedLevelAndErrorRate
+        flashAlgorithmService.getCapacityAndErrorRate
           .withArgs({
             challenges: certificationChallengesForScoring,
             allAnswers: answers,
@@ -654,7 +654,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
             .withArgs({ id: certificationAssessment.certificationCourseId })
             .resolves(abortedCertificationCourse);
 
-          flashAlgorithmService.getEstimatedLevelAndErrorRate
+          flashAlgorithmService.getCapacityAndErrorRate
             .withArgs({
               challenges: certificationChallengesForScoring,
               allAnswers: answers,
@@ -769,7 +769,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
             .withArgs({ id: certificationAssessment.certificationCourseId })
             .resolves(abortedCertificationCourse);
 
-          flashAlgorithmService.getEstimatedLevelAndErrorRate
+          flashAlgorithmService.getCapacityAndErrorRate
             .withArgs({
               challenges: certificationChallengesForScoring,
               allAnswers: answers,

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -124,14 +124,14 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           );
           const answers = generateAnswersForChallenges({ challenges });
 
-          const expectedEstimatedLevel = 2;
+          const expectedCapacity = 2;
           const scoreForEstimatedLevel = 640;
           const { certificationCourseId } = certificationAssessment;
 
           const capacityHistory = [
             domainBuilder.buildCertificationChallengeCapacity({
               certificationChallengeId: certificationChallengesForScoring[0].certificationChallengeId,
-              capacity: expectedEstimatedLevel,
+              capacity: expectedCapacity,
             }),
           ];
 
@@ -157,27 +157,27 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
             .withArgs({
               challenges: certificationChallengesForScoring,
               allAnswers: answers,
-              estimatedLevel: sinon.match.number,
+              capacity: sinon.match.number,
               variationPercent: undefined,
               variationPercentUntil: undefined,
               doubleMeasuresUntil: undefined,
             })
             .returns({
-              estimatedLevel: expectedEstimatedLevel,
+              capacity: expectedCapacity,
             });
 
           flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
             .withArgs({
               challenges: certificationChallengesForScoring,
               allAnswers: answers,
-              estimatedLevel: sinon.match.number,
+              capacity: sinon.match.number,
               variationPercent: undefined,
               variationPercentUntil: undefined,
               doubleMeasuresUntil: undefined,
             })
             .returns([
               {
-                estimatedLevel: expectedEstimatedLevel,
+                capacity: expectedCapacity,
               },
             ]);
 
@@ -242,14 +242,14 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           );
           const answers = generateAnswersForChallenges({ challenges });
 
-          const expectedEstimatedLevel = 2;
+          const expectedCapacity = 2;
           const scoreForEstimatedLevel = 640;
           const { certificationCourseId } = certificationAssessment;
 
           const capacityHistory = [
             domainBuilder.buildCertificationChallengeCapacity({
               certificationChallengeId: certificationChallengesForScoring[0].certificationChallengeId,
-              capacity: expectedEstimatedLevel,
+              capacity: expectedCapacity,
             }),
           ];
 
@@ -275,27 +275,27 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
             .withArgs({
               challenges: certificationChallengesForScoring,
               allAnswers: answers,
-              estimatedLevel: sinon.match.number,
+              capacity: sinon.match.number,
               variationPercent: undefined,
               variationPercentUntil: undefined,
               doubleMeasuresUntil: undefined,
             })
             .returns({
-              estimatedLevel: expectedEstimatedLevel,
+              capacity: expectedCapacity,
             });
 
           flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
             .withArgs({
               challenges: certificationChallengesForScoring,
               allAnswers: answers,
-              estimatedLevel: sinon.match.number,
+              capacity: sinon.match.number,
               variationPercent: undefined,
               variationPercentUntil: undefined,
               doubleMeasuresUntil: undefined,
             })
             .returns([
               {
-                estimatedLevel: expectedEstimatedLevel,
+                capacity: expectedCapacity,
               },
             ]);
 
@@ -374,14 +374,14 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           );
           const answers = generateAnswersForChallenges({ challenges });
 
-          const expectedEstimatedLevel = 2;
+          const expectedCapacity = 2;
           const rawScore = 640;
           const { certificationCourseId } = certificationAssessment;
 
           const capacityHistory = [
             domainBuilder.buildCertificationChallengeCapacity({
               certificationChallengeId: certificationChallengesForScoring[0].certificationChallengeId,
-              capacity: expectedEstimatedLevel,
+              capacity: expectedCapacity,
             }),
           ];
 
@@ -411,27 +411,27 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
             .withArgs({
               challenges: certificationChallengesForScoring,
               allAnswers: answers,
-              estimatedLevel: sinon.match.number,
+              capacity: sinon.match.number,
               variationPercent: undefined,
               variationPercentUntil: undefined,
               doubleMeasuresUntil: undefined,
             })
             .returns({
-              estimatedLevel: expectedEstimatedLevel,
+              capacity: expectedCapacity,
             });
 
           flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
             .withArgs({
               challenges: certificationChallengesForScoring,
               allAnswers: answers,
-              estimatedLevel: sinon.match.number,
+              capacity: sinon.match.number,
               variationPercent: undefined,
               variationPercentUntil: undefined,
               doubleMeasuresUntil: undefined,
             })
             .returns([
               {
-                estimatedLevel: expectedEstimatedLevel,
+                capacity: expectedCapacity,
               },
             ]);
 
@@ -493,14 +493,14 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         );
         const answers = generateAnswersForChallenges({ challenges });
 
-        const expectedEstimatedLevel = 2;
+        const expectedCapacity = 2;
         const scoreForEstimatedLevel = 640;
         const { certificationCourseId } = certificationAssessment;
 
         const capacityHistory = [
           domainBuilder.buildCertificationChallengeCapacity({
             certificationChallengeId: certificationChallengesForScoring[0].certificationChallengeId,
-            capacity: expectedEstimatedLevel,
+            capacity: expectedCapacity,
           }),
         ];
 
@@ -530,27 +530,27 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           .withArgs({
             challenges: certificationChallengesForScoring,
             allAnswers: answers,
-            estimatedLevel: sinon.match.number,
+            capacity: sinon.match.number,
             variationPercent: undefined,
             variationPercentUntil: undefined,
             doubleMeasuresUntil: undefined,
           })
           .returns({
-            estimatedLevel: expectedEstimatedLevel,
+            capacity: expectedCapacity,
           });
 
         flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
           .withArgs({
             challenges: certificationChallengesForScoring,
             allAnswers: answers,
-            estimatedLevel: sinon.match.number,
+            capacity: sinon.match.number,
             variationPercent: undefined,
             variationPercentUntil: undefined,
             doubleMeasuresUntil: undefined,
           })
           .returns([
             {
-              estimatedLevel: expectedEstimatedLevel,
+              capacity: expectedCapacity,
             },
           ]);
 
@@ -621,14 +621,14 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           );
           const answers = generateAnswersForChallenges({ challenges });
 
-          const expectedEstimatedLevel = 2;
+          const expectedCapacity = 2;
           const scoreForEstimatedLevel = 640;
           const { certificationCourseId } = certificationAssessment;
 
           const capacityHistory = [
             domainBuilder.buildCertificationChallengeCapacity({
               certificationChallengeId: certificationChallengesForScoring[0].certificationChallengeId,
-              capacity: expectedEstimatedLevel,
+              capacity: expectedCapacity,
             }),
           ];
 
@@ -658,27 +658,27 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
             .withArgs({
               challenges: certificationChallengesForScoring,
               allAnswers: answers,
-              estimatedLevel: sinon.match.number,
+              capacity: sinon.match.number,
               variationPercent: undefined,
               variationPercentUntil: undefined,
               doubleMeasuresUntil: undefined,
             })
             .returns({
-              estimatedLevel: expectedEstimatedLevel,
+              capacity: expectedCapacity,
             });
 
           flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
             .withArgs({
               challenges: certificationChallengesForScoring,
               allAnswers: answers,
-              estimatedLevel: sinon.match.number,
+              capacity: sinon.match.number,
               variationPercent: undefined,
               variationPercentUntil: undefined,
               doubleMeasuresUntil: undefined,
             })
             .returns([
               {
-                estimatedLevel: expectedEstimatedLevel,
+                capacity: expectedCapacity,
               },
             ]);
 
@@ -736,14 +736,14 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
 
           const answers = generateAnswersForChallenges({ challenges });
 
-          const expectedEstimatedLevel = 8;
+          const expectedCapacity = 8;
           const cappedScoreForEstimatedLevel = 896;
           const { certificationCourseId } = certificationAssessment;
 
           const capacityHistory = [
             domainBuilder.buildCertificationChallengeCapacity({
               certificationChallengeId: certificationChallengesForScoring[0].certificationChallengeId,
-              capacity: expectedEstimatedLevel,
+              capacity: expectedCapacity,
             }),
           ];
 
@@ -773,27 +773,27 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
             .withArgs({
               challenges: certificationChallengesForScoring,
               allAnswers: answers,
-              estimatedLevel: sinon.match.number,
+              capacity: sinon.match.number,
               variationPercent: undefined,
               variationPercentUntil: undefined,
               doubleMeasuresUntil: undefined,
             })
             .returns({
-              estimatedLevel: expectedEstimatedLevel,
+              capacity: expectedCapacity,
             });
 
           flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
             .withArgs({
               challenges: certificationChallengesForScoring,
               allAnswers: answers,
-              estimatedLevel: sinon.match.number,
+              capacity: sinon.match.number,
               variationPercent: undefined,
               variationPercentUntil: undefined,
               doubleMeasuresUntil: undefined,
             })
             .returns([
               {
-                estimatedLevel: expectedEstimatedLevel,
+                capacity: expectedCapacity,
               },
             ]);
 

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -125,7 +125,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           const answers = generateAnswersForChallenges({ challenges });
 
           const expectedCapacity = 2;
-          const scoreForEstimatedLevel = 640;
+          const scoreForCapacity = 640;
           const { certificationCourseId } = certificationAssessment;
 
           const capacityHistory = [
@@ -196,7 +196,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
             certificationCourseId,
             assessmentResult: new AssessmentResult({
               emitter: AssessmentResult.emitters.PIX_ALGO,
-              pixScore: scoreForEstimatedLevel,
+              pixScore: scoreForCapacity,
               reproducibilityRate: 100,
               status: AssessmentResult.status.REJECTED,
               competenceMarks: [],
@@ -243,7 +243,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           const answers = generateAnswersForChallenges({ challenges });
 
           const expectedCapacity = 2;
-          const scoreForEstimatedLevel = 640;
+          const scoreForCapacity = 640;
           const { certificationCourseId } = certificationAssessment;
 
           const capacityHistory = [
@@ -314,7 +314,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
             certificationCourseId,
             assessmentResult: new AssessmentResult({
               emitter: AssessmentResult.emitters.PIX_ALGO,
-              pixScore: scoreForEstimatedLevel,
+              pixScore: scoreForCapacity,
               reproducibilityRate: 100,
               status: AssessmentResult.status.REJECTED,
               competenceMarks: [],
@@ -494,7 +494,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         const answers = generateAnswersForChallenges({ challenges });
 
         const expectedCapacity = 2;
-        const scoreForEstimatedLevel = 640;
+        const scoreForCapacity = 640;
         const { certificationCourseId } = certificationAssessment;
 
         const capacityHistory = [
@@ -569,7 +569,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           certificationCourseId,
           assessmentResult: new AssessmentResult({
             emitter: AssessmentResult.emitters.PIX_ALGO,
-            pixScore: scoreForEstimatedLevel,
+            pixScore: scoreForCapacity,
             reproducibilityRate: 100,
             status: AssessmentResult.status.VALIDATED,
             competenceMarks: [],
@@ -622,7 +622,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           const answers = generateAnswersForChallenges({ challenges });
 
           const expectedCapacity = 2;
-          const scoreForEstimatedLevel = 640;
+          const scoreForCapacity = 640;
           const { certificationCourseId } = certificationAssessment;
 
           const capacityHistory = [
@@ -694,7 +694,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
 
           // then
           const assessmentResultToBeSaved = domainBuilder.certification.scoring.buildAssessmentResult.fraud({
-            pixScore: scoreForEstimatedLevel,
+            pixScore: scoreForCapacity,
             reproducibilityRate: 100,
             assessmentId: 123,
           });
@@ -737,7 +737,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           const answers = generateAnswersForChallenges({ challenges });
 
           const expectedCapacity = 8;
-          const cappedScoreForEstimatedLevel = 896;
+          const cappedscoreForCapacity = 896;
           const { certificationCourseId } = certificationAssessment;
 
           const capacityHistory = [
@@ -801,7 +801,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
             certificationCourseId,
             assessmentResult: new AssessmentResult({
               emitter: AssessmentResult.emitters.PIX_ALGO,
-              pixScore: cappedScoreForEstimatedLevel,
+              pixScore: cappedscoreForCapacity,
               reproducibilityRate: 100,
               status: AssessmentResult.status.VALIDATED,
               competenceMarks: [],

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -841,7 +841,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
             it('should return the score capped based on the maximum available level when the certification was done', async function () {
               // given
               const expectedCapacity = 8;
-              const cappedscoreForCapacity = 896;
+              const cappedScoreForCapacity = 896;
               const challenges = _generateCertificationChallengeForScoringList({ length: maximumAssessmentLength });
 
               const answers = generateAnswersForChallenges({ challenges });
@@ -911,11 +911,11 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
 
               // then
               const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScoreV3({
-                nbPix: cappedscoreForCapacity,
+                nbPix: cappedScoreForCapacity,
                 status: status.VALIDATED,
               });
               const expectedAssessmentResult = new AssessmentResult({
-                pixScore: cappedscoreForCapacity,
+                pixScore: cappedScoreForCapacity,
                 reproducibilityRate: certificationAssessmentScore.getPercentageCorrectAnswers(),
                 status: status.VALIDATED,
                 assessmentId: certificationAssessment.id,

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -453,7 +453,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
         });
 
         flashAlgorithmService = {
-          getEstimatedLevelAndErrorRate: sinon.stub(),
+          getCapacityAndErrorRate: sinon.stub(),
           getCapacityAndErrorRateHistory: sinon.stub(),
         };
 
@@ -511,7 +511,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
               .withArgs({ id: certificationCourseId })
               .resolves(abortedCertificationCourse);
 
-            flashAlgorithmService.getEstimatedLevelAndErrorRate
+            flashAlgorithmService.getCapacityAndErrorRate
               .withArgs({
                 challenges,
                 allAnswers: answers,
@@ -634,7 +634,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
               .withArgs({ id: certificationCourseId })
               .resolves(abortedCertificationCourse);
 
-            flashAlgorithmService.getEstimatedLevelAndErrorRate
+            flashAlgorithmService.getCapacityAndErrorRate
               .withArgs({
                 challenges,
                 allAnswers: answers,
@@ -754,7 +754,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
             flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
               .withArgs(certificationCourseStartDate)
               .resolves(baseFlashAlgorithmConfiguration);
-            flashAlgorithmService.getEstimatedLevelAndErrorRate
+            flashAlgorithmService.getCapacityAndErrorRate
               .withArgs({
                 challenges,
                 allAnswers: answers,
@@ -865,7 +865,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
               flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
                 .withArgs(certificationCourseStartDate)
                 .resolves(baseFlashAlgorithmConfiguration);
-              flashAlgorithmService.getEstimatedLevelAndErrorRate
+              flashAlgorithmService.getCapacityAndErrorRate
                 .withArgs({
                   challenges,
                   allAnswers: answers,
@@ -972,7 +972,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
               flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
                 .withArgs(certificationCourseStartDate)
                 .resolves(baseFlashAlgorithmConfiguration);
-              flashAlgorithmService.getEstimatedLevelAndErrorRate
+              flashAlgorithmService.getCapacityAndErrorRate
                 .withArgs({
                   challenges,
                   allAnswers: answers,
@@ -1084,7 +1084,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
               flashAlgorithmConfigurationRepository.getMostRecentBeforeDate
                 .withArgs(certificationCourseStartDate)
                 .resolves(baseFlashAlgorithmConfiguration);
-              flashAlgorithmService.getEstimatedLevelAndErrorRate
+              flashAlgorithmService.getCapacityAndErrorRate
                 .withArgs({
                   challenges,
                   allAnswers: answers,
@@ -1203,7 +1203,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
             },
           ]);
 
-        flashAlgorithmService.getEstimatedLevelAndErrorRate
+        flashAlgorithmService.getCapacityAndErrorRate
           .withArgs({
             challenges,
             allAnswers: answers,

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -454,7 +454,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
 
         flashAlgorithmService = {
           getEstimatedLevelAndErrorRate: sinon.stub(),
-          getEstimatedLevelAndErrorRateHistory: sinon.stub(),
+          getCapacityAndErrorRateHistory: sinon.stub(),
         };
 
         const scoringConfiguration = domainBuilder.buildV3CertificationScoring({
@@ -524,7 +524,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
                 capacity: expectedCapacity,
               });
 
-            flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
+            flashAlgorithmService.getCapacityAndErrorRateHistory
               .withArgs({
                 challenges,
                 allAnswers: answers,
@@ -647,7 +647,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
                 capacity: expectedCapacity,
               });
 
-            flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
+            flashAlgorithmService.getCapacityAndErrorRateHistory
               .withArgs({
                 challenges,
                 allAnswers: answers,
@@ -768,7 +768,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
               });
             assessmentResultRepository.save.resolves(domainBuilder.buildAssessmentResult({ id: assessmentResultId }));
 
-            flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
+            flashAlgorithmService.getCapacityAndErrorRateHistory
               .withArgs({
                 challenges,
                 allAnswers: answers,
@@ -878,7 +878,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
                   capacity: expectedCapacity,
                 });
 
-              flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
+              flashAlgorithmService.getCapacityAndErrorRateHistory
                 .withArgs({
                   challenges,
                   allAnswers: answers,
@@ -985,7 +985,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
                   capacity: expectedCapacity,
                 });
 
-              flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
+              flashAlgorithmService.getCapacityAndErrorRateHistory
                 .withArgs({
                   challenges,
                   allAnswers: answers,
@@ -1096,7 +1096,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
                 .returns({
                   capacity: expectedCapacity,
                 });
-              flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
+              flashAlgorithmService.getCapacityAndErrorRateHistory
                 .withArgs({
                   challenges,
                   allAnswers: answers,
@@ -1188,7 +1188,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
           .withArgs(certificationCourseStartDate)
           .resolves(baseFlashAlgorithmConfiguration);
 
-        flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
+        flashAlgorithmService.getCapacityAndErrorRateHistory
           .withArgs({
             challenges,
             allAnswers: answers,
@@ -1216,7 +1216,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
             capacity: 2,
           });
 
-        flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
+        flashAlgorithmService.getCapacityAndErrorRateHistory
           .withArgs({
             challenges,
             allAnswers: answers,

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -474,7 +474,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
         describe('when the candidate did not finish due to a lack of time', function () {
           it('should reject the certification', async function () {
             // given
-            const expectedEstimatedLevel = 2;
+            const expectedCapacity = 2;
             const scoreForEstimatedLevel = 640;
             const abortedCertificationCourse = domainBuilder.buildCertificationCourse({
               id: certificationCourseId,
@@ -489,7 +489,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
             const capacityHistory = [
               domainBuilder.buildCertificationChallengeCapacity({
                 certificationChallengeId: challenges[0].certificationChallengeId,
-                capacity: expectedEstimatedLevel,
+                capacity: expectedCapacity,
               }),
             ];
 
@@ -515,27 +515,27 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
               .withArgs({
                 challenges,
                 allAnswers: answers,
-                estimatedLevel: sinon.match.number,
+                capacity: sinon.match.number,
                 variationPercent: undefined,
                 variationPercentUntil: undefined,
                 doubleMeasuresUntil: undefined,
               })
               .returns({
-                estimatedLevel: expectedEstimatedLevel,
+                capacity: expectedCapacity,
               });
 
             flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
               .withArgs({
                 challenges,
                 allAnswers: answers,
-                estimatedLevel: sinon.match.number,
+                capacity: sinon.match.number,
                 variationPercent: undefined,
                 variationPercentUntil: undefined,
                 doubleMeasuresUntil: undefined,
               })
               .returns([
                 {
-                  estimatedLevel: expectedEstimatedLevel,
+                  capacity: expectedCapacity,
                 },
               ]);
 
@@ -595,7 +595,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
           it('should cancel the certification and reject the assessment result', async function () {
             // given
             const abortReason = ABORT_REASONS.TECHNICAL;
-            const expectedEstimatedLevel = 2;
+            const expectedCapacity = 2;
             const scoreForEstimatedLevel = 640;
             const abortedCertificationCourse = domainBuilder.buildCertificationCourse({
               id: certificationCourseId,
@@ -611,7 +611,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
             const capacityHistory = [
               domainBuilder.buildCertificationChallengeCapacity({
                 certificationChallengeId: challenges[0].certificationChallengeId,
-                capacity: expectedEstimatedLevel,
+                capacity: expectedCapacity,
               }),
             ];
 
@@ -638,27 +638,27 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
               .withArgs({
                 challenges,
                 allAnswers: answers,
-                estimatedLevel: sinon.match.number,
+                capacity: sinon.match.number,
                 variationPercent: undefined,
                 variationPercentUntil: undefined,
                 doubleMeasuresUntil: undefined,
               })
               .returns({
-                estimatedLevel: expectedEstimatedLevel,
+                capacity: expectedCapacity,
               });
 
             flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
               .withArgs({
                 challenges,
                 allAnswers: answers,
-                estimatedLevel: sinon.match.number,
+                capacity: sinon.match.number,
                 variationPercent: undefined,
                 variationPercentUntil: undefined,
                 doubleMeasuresUntil: undefined,
               })
               .returns([
                 {
-                  estimatedLevel: expectedEstimatedLevel,
+                  capacity: expectedCapacity,
                 },
               ]);
 
@@ -729,7 +729,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
         describe('when the certification was completed', function () {
           it('should build and save an assessment result with a validated status', async function () {
             // given
-            const expectedEstimatedLevel = 2;
+            const expectedCapacity = 2;
             const scoreForEstimatedLevel = 640;
             const challenges = _generateCertificationChallengeForScoringList({ length: maximumAssessmentLength });
             const answers = generateAnswersForChallenges({ challenges });
@@ -738,7 +738,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
             const capacityHistory = [
               domainBuilder.buildCertificationChallengeCapacity({
                 certificationChallengeId: challenges[0].certificationChallengeId,
-                capacity: expectedEstimatedLevel,
+                capacity: expectedCapacity,
               }),
             ];
 
@@ -758,13 +758,13 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
               .withArgs({
                 challenges,
                 allAnswers: answers,
-                estimatedLevel: sinon.match.number,
+                capacity: sinon.match.number,
                 variationPercent: undefined,
                 variationPercentUntil: undefined,
                 doubleMeasuresUntil: undefined,
               })
               .returns({
-                estimatedLevel: expectedEstimatedLevel,
+                capacity: expectedCapacity,
               });
             assessmentResultRepository.save.resolves(domainBuilder.buildAssessmentResult({ id: assessmentResultId }));
 
@@ -772,14 +772,14 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
               .withArgs({
                 challenges,
                 allAnswers: answers,
-                estimatedLevel: sinon.match.number,
+                capacity: sinon.match.number,
                 variationPercent: undefined,
                 variationPercentUntil: undefined,
                 doubleMeasuresUntil: undefined,
               })
               .returns([
                 {
-                  estimatedLevel: expectedEstimatedLevel,
+                  capacity: expectedCapacity,
                 },
               ]);
 
@@ -840,7 +840,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
           describe('when the certification would reach a very high score', function () {
             it('should return the score capped based on the maximum available level when the certification was done', async function () {
               // given
-              const expectedEstimatedLevel = 8;
+              const expectedCapacity = 8;
               const cappedScoreForEstimatedLevel = 896;
               const challenges = _generateCertificationChallengeForScoringList({ length: maximumAssessmentLength });
 
@@ -849,7 +849,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
               const capacityHistory = [
                 domainBuilder.buildCertificationChallengeCapacity({
                   certificationChallengeId: challenges[0].certificationChallengeId,
-                  capacity: expectedEstimatedLevel,
+                  capacity: expectedCapacity,
                 }),
               ];
 
@@ -869,27 +869,27 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
                 .withArgs({
                   challenges,
                   allAnswers: answers,
-                  estimatedLevel: sinon.match.number,
+                  capacity: sinon.match.number,
                   variationPercent: undefined,
                   variationPercentUntil: undefined,
                   doubleMeasuresUntil: undefined,
                 })
                 .returns({
-                  estimatedLevel: expectedEstimatedLevel,
+                  capacity: expectedCapacity,
                 });
 
               flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
                 .withArgs({
                   challenges,
                   allAnswers: answers,
-                  estimatedLevel: sinon.match.number,
+                  capacity: sinon.match.number,
                   variationPercent: undefined,
                   variationPercentUntil: undefined,
                   doubleMeasuresUntil: undefined,
                 })
                 .returns([
                   {
-                    estimatedLevel: expectedEstimatedLevel,
+                    capacity: expectedCapacity,
                   },
                 ]);
 
@@ -936,7 +936,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
           describe('when the candidate did not finish due to technical difficulties', function () {
             it('should build and save an assessment result with a validated status with the raw score', async function () {
               // given
-              const expectedEstimatedLevel = 2;
+              const expectedCapacity = 2;
               const rawScore = 640;
               const challenges = _generateCertificationChallengeForScoringList({
                 length: minimumAnswersRequiredToValidateACertification,
@@ -954,7 +954,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
               const capacityHistory = [
                 domainBuilder.buildCertificationChallengeCapacity({
                   certificationChallengeId: challenges[0].certificationChallengeId,
-                  capacity: expectedEstimatedLevel,
+                  capacity: expectedCapacity,
                 }),
               ];
 
@@ -976,27 +976,27 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
                 .withArgs({
                   challenges,
                   allAnswers: answers,
-                  estimatedLevel: sinon.match.number,
+                  capacity: sinon.match.number,
                   variationPercent: undefined,
                   variationPercentUntil: undefined,
                   doubleMeasuresUntil: undefined,
                 })
                 .returns({
-                  estimatedLevel: expectedEstimatedLevel,
+                  capacity: expectedCapacity,
                 });
 
               flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
                 .withArgs({
                   challenges,
                   allAnswers: answers,
-                  estimatedLevel: sinon.match.number,
+                  capacity: sinon.match.number,
                   variationPercent: undefined,
                   variationPercentUntil: undefined,
                   doubleMeasuresUntil: undefined,
                 })
                 .returns([
                   {
-                    estimatedLevel: expectedEstimatedLevel,
+                    capacity: expectedCapacity,
                   },
                 ]);
 
@@ -1048,7 +1048,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
           describe('when the candidate did not finish in time', function () {
             it('should build and save an assessment result with a validated status', async function () {
               // given
-              const expectedEstimatedLevel = 2;
+              const expectedCapacity = 2;
               const pixScore = 640;
               const challenges = _generateCertificationChallengeForScoringList({
                 length: minimumAnswersRequiredToValidateACertification,
@@ -1066,7 +1066,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
               const capacityHistory = [
                 domainBuilder.buildCertificationChallengeCapacity({
                   certificationChallengeId: challenges[0].certificationChallengeId,
-                  capacity: expectedEstimatedLevel,
+                  capacity: expectedCapacity,
                 }),
               ];
 
@@ -1088,26 +1088,26 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
                 .withArgs({
                   challenges,
                   allAnswers: answers,
-                  estimatedLevel: sinon.match.number,
+                  capacity: sinon.match.number,
                   variationPercent: undefined,
                   variationPercentUntil: undefined,
                   doubleMeasuresUntil: undefined,
                 })
                 .returns({
-                  estimatedLevel: expectedEstimatedLevel,
+                  capacity: expectedCapacity,
                 });
               flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
                 .withArgs({
                   challenges,
                   allAnswers: answers,
-                  estimatedLevel: sinon.match.number,
+                  capacity: sinon.match.number,
                   variationPercent: undefined,
                   variationPercentUntil: undefined,
                   doubleMeasuresUntil: undefined,
                 })
                 .returns([
                   {
-                    estimatedLevel: expectedEstimatedLevel,
+                    capacity: expectedCapacity,
                   },
                 ]);
 
@@ -1160,7 +1160,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
 
       it('should return a CertificationScoringCompleted', async function () {
         // given
-        const expectedEstimatedLevel = 2;
+        const expectedCapacity = 2;
         const challenge1 = domainBuilder.buildCertificationChallengeForScoring();
         const challenge2 = domainBuilder.buildCertificationChallengeForScoring();
         const challenges = [challenge1, challenge2];
@@ -1171,7 +1171,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
         const capacityHistory = [
           domainBuilder.buildCertificationChallengeCapacity({
             certificationChallengeId: challenges[0].certificationChallengeId,
-            capacity: expectedEstimatedLevel,
+            capacity: expectedCapacity,
           }),
         ];
 
@@ -1192,14 +1192,14 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
           .withArgs({
             challenges,
             allAnswers: answers,
-            estimatedLevel: sinon.match.number,
+            capacity: sinon.match.number,
             variationPercent: undefined,
             variationPercentUntil: undefined,
             doubleMeasuresUntil: undefined,
           })
           .returns([
             {
-              estimatedLevel: expectedEstimatedLevel,
+              capacity: expectedCapacity,
             },
           ]);
 
@@ -1207,27 +1207,27 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
           .withArgs({
             challenges,
             allAnswers: answers,
-            estimatedLevel: sinon.match.number,
+            capacity: sinon.match.number,
             variationPercent: undefined,
             variationPercentUntil: undefined,
             doubleMeasuresUntil: undefined,
           })
           .returns({
-            estimatedLevel: 2,
+            capacity: 2,
           });
 
         flashAlgorithmService.getEstimatedLevelAndErrorRateHistory
           .withArgs({
             challenges,
             allAnswers: answers,
-            estimatedLevel: sinon.match.number,
+            capacity: sinon.match.number,
             variationPercent: undefined,
             variationPercentUntil: undefined,
             doubleMeasuresUntil: undefined,
           })
           .returns([
             {
-              estimatedLevel: expectedEstimatedLevel,
+              capacity: expectedCapacity,
             },
           ]);
 

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -475,7 +475,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
           it('should reject the certification', async function () {
             // given
             const expectedCapacity = 2;
-            const scoreForEstimatedLevel = 640;
+            const scoreForCapacity = 640;
             const abortedCertificationCourse = domainBuilder.buildCertificationCourse({
               id: certificationCourseId,
               createdAt: certificationCourseStartDate,
@@ -557,11 +557,11 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
 
             // then
             const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScoreV3({
-              nbPix: scoreForEstimatedLevel,
+              nbPix: scoreForCapacity,
               status: status.REJECTED,
             });
             const expectedAssessmentResult = new AssessmentResult({
-              pixScore: scoreForEstimatedLevel,
+              pixScore: scoreForCapacity,
               reproducibilityRate: certificationAssessmentScore.getPercentageCorrectAnswers(),
               status: status.REJECTED,
               assessmentId: certificationAssessment.id,
@@ -596,7 +596,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
             // given
             const abortReason = ABORT_REASONS.TECHNICAL;
             const expectedCapacity = 2;
-            const scoreForEstimatedLevel = 640;
+            const scoreForCapacity = 640;
             const abortedCertificationCourse = domainBuilder.buildCertificationCourse({
               id: certificationCourseId,
               createdAt: certificationCourseStartDate,
@@ -680,11 +680,11 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
 
             // then
             const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScoreV3({
-              nbPix: scoreForEstimatedLevel,
+              nbPix: scoreForCapacity,
               status: status.REJECTED,
             });
             const expectedAssessmentResult = new AssessmentResult({
-              pixScore: scoreForEstimatedLevel,
+              pixScore: scoreForCapacity,
               reproducibilityRate: certificationAssessmentScore.getPercentageCorrectAnswers(),
               status: status.REJECTED,
               assessmentId: certificationAssessment.id,
@@ -730,7 +730,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
           it('should build and save an assessment result with a validated status', async function () {
             // given
             const expectedCapacity = 2;
-            const scoreForEstimatedLevel = 640;
+            const scoreForCapacity = 640;
             const challenges = _generateCertificationChallengeForScoringList({ length: maximumAssessmentLength });
             const answers = generateAnswersForChallenges({ challenges });
             const assessmentResultId = 123;
@@ -801,11 +801,11 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
 
             // then
             const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScoreV3({
-              nbPix: scoreForEstimatedLevel,
+              nbPix: scoreForCapacity,
               status: status.VALIDATED,
             });
             const expectedAssessmentResult = new AssessmentResult({
-              pixScore: scoreForEstimatedLevel,
+              pixScore: scoreForCapacity,
               reproducibilityRate: certificationAssessmentScore.getPercentageCorrectAnswers(),
               status: status.VALIDATED,
               assessmentId: certificationAssessment.id,
@@ -841,7 +841,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
             it('should return the score capped based on the maximum available level when the certification was done', async function () {
               // given
               const expectedCapacity = 8;
-              const cappedScoreForEstimatedLevel = 896;
+              const cappedscoreForCapacity = 896;
               const challenges = _generateCertificationChallengeForScoringList({ length: maximumAssessmentLength });
 
               const answers = generateAnswersForChallenges({ challenges });
@@ -911,11 +911,11 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
 
               // then
               const certificationAssessmentScore = domainBuilder.buildCertificationAssessmentScoreV3({
-                nbPix: cappedScoreForEstimatedLevel,
+                nbPix: cappedscoreForCapacity,
                 status: status.VALIDATED,
               });
               const expectedAssessmentResult = new AssessmentResult({
-                pixScore: cappedScoreForEstimatedLevel,
+                pixScore: cappedscoreForCapacity,
                 reproducibilityRate: certificationAssessmentScore.getPercentageCorrectAnswers(),
                 status: status.VALIDATED,
                 assessmentId: certificationAssessment.id,

--- a/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
+++ b/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
@@ -55,7 +55,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
     scorecardService = { computeScorecard: sinon.stub() };
     knowledgeElementRepository = { findUniqByUserIdAndAssessmentId: sinon.stub() };
     certificationChallengeLiveAlertRepository = { getOngoingByChallengeIdAndAssessmentId: sinon.stub() };
-    flashAlgorithmService = { getEstimatedLevelAndErrorRate: sinon.stub() };
+    flashAlgorithmService = { getCapacityAndErrorRate: sinon.stub() };
     algorithmDataFetcherService = { fetchForFlashLevelEstimation: sinon.stub() };
     dateUtils = {
       getNowDate: sinon.stub(),
@@ -550,7 +550,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
 
         flashData = Symbol('flashData');
         algorithmDataFetcherService.fetchForFlashLevelEstimation.returns(flashData);
-        flashAlgorithmService.getEstimatedLevelAndErrorRate.returns({
+        flashAlgorithmService.getCapacityAndErrorRate.returns({
           capacity,
           errorRate,
         });
@@ -651,10 +651,10 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
           ...dependencies,
         });
 
-        expect(flashAlgorithmService.getEstimatedLevelAndErrorRate).to.have.been.calledWithExactly(flashData);
+        expect(flashAlgorithmService.getCapacityAndErrorRate).to.have.been.calledWithExactly(flashData);
       });
 
-      it('should call the flash assessment result repository to save estimatedLevel and errorRate', async function () {
+      it('should call the flash assessment result repository to save capacity and errorRate', async function () {
         // when
         const { id } = await correctAnswerThenUpdateAssessment({
           answer,

--- a/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
+++ b/api/tests/unit/domain/usecases/correct-answer-then-update-assessment_test.js
@@ -512,7 +512,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
       let scorecard, knowledgeElement, skills, challenge, skillAlreadyValidated, skillNotAlreadyValidated;
       let flashData;
       const locale = 'fr';
-      const estimatedLevel = 1.93274982;
+      const capacity = 1.93274982;
       const errorRate = 0.9127398127;
 
       beforeEach(function () {
@@ -551,7 +551,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
         flashData = Symbol('flashData');
         algorithmDataFetcherService.fetchForFlashLevelEstimation.returns(flashData);
         flashAlgorithmService.getEstimatedLevelAndErrorRate.returns({
-          estimatedLevel,
+          capacity,
           errorRate,
         });
       });
@@ -665,7 +665,7 @@ describe('Unit | Domain | Use Cases | correct-answer-then-update-assessment', fu
 
         expect(flashAssessmentResultRepository.save).to.have.been.calledWithExactly({
           answerId: id,
-          estimatedLevel,
+          capacity,
           errorRate,
           assessmentId: assessment.id,
         });

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -163,7 +163,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
           flashAlgorithmService.getPossibleNextChallenges
             .withArgs({
               availableChallenges: [secondChallenge],
-              estimatedLevel: 0,
+              capacity: 0,
               options: sinon.match.object,
             })
             .returns([secondChallenge]);
@@ -231,7 +231,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
           flashAlgorithmService.getPossibleNextChallenges
             .withArgs({
               availableChallenges: [],
-              estimatedLevel: 0,
+              capacity: 0,
               options: sinon.match.object,
             })
             .returns({
@@ -299,7 +299,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
           flashAlgorithmService.getPossibleNextChallenges
             .withArgs({
               challenges,
-              estimatedLevel: 0,
+              capacity: 0,
               options: sinon.match.object,
             })
             .returns({

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -31,7 +31,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
       flashAssessmentResultRepository = Symbol('flashAssessmentResultRepository');
       pickChallengeService = { pickChallenge: sinon.stub(), chooseNextChallenge: sinon.stub() };
       flashAlgorithmService = {
-        getEstimatedLevelAndErrorRate: sinon.stub(),
+        getCapacityAndErrorRate: sinon.stub(),
         getPossibleNextChallenges: sinon.stub(),
         getReward: sinon.stub(),
       };
@@ -146,7 +146,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
               challenges,
             });
 
-          flashAlgorithmService.getEstimatedLevelAndErrorRate
+          flashAlgorithmService.getCapacityAndErrorRate
             .withArgs({
               challenges,
               allAnswers,
@@ -214,7 +214,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
               challenges,
             });
 
-          flashAlgorithmService.getEstimatedLevelAndErrorRate
+          flashAlgorithmService.getCapacityAndErrorRate
             .withArgs({
               challenges,
               allAnswers,
@@ -283,7 +283,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
               challenges,
             });
 
-          flashAlgorithmService.getEstimatedLevelAndErrorRate
+          flashAlgorithmService.getCapacityAndErrorRate
             .withArgs({
               challenges,
               allAnswers,

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -150,13 +150,13 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
             .withArgs({
               challenges,
               allAnswers,
-              estimatedLevel: config.v3Certification.defaultCandidateCapacity,
+              capacity: config.v3Certification.defaultCandidateCapacity,
               variationPercent: undefined,
               variationPercentUntil: undefined,
               doubleMeasuresUntil: undefined,
             })
             .returns({
-              estimatedLevel: 0,
+              capacity: 0,
               errorRate: 0.5,
             });
 
@@ -218,13 +218,13 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
             .withArgs({
               challenges,
               allAnswers,
-              estimatedLevel: config.v3Certification.defaultCandidateCapacity,
+              capacity: config.v3Certification.defaultCandidateCapacity,
               variationPercent: undefined,
               variationPercentUntil: undefined,
               doubleMeasuresUntil: undefined,
             })
             .returns({
-              estimatedLevel: 0,
+              capacity: 0,
               errorRate: 0.5,
             });
 
@@ -287,12 +287,12 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
             .withArgs({
               challenges,
               allAnswers,
-              estimatedLevel: config.v3Certification.defaultCandidateCapacity,
+              capacity: config.v3Certification.defaultCandidateCapacity,
               variationPercent: undefined,
               doubleMeasuresUntil: undefined,
             })
             .returns({
-              estimatedLevel: 0,
+              capacity: 0,
               errorRate: 0.5,
             });
 

--- a/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
+++ b/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
@@ -54,7 +54,7 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
           .withArgs({
             difficulty: firstChallenge.difficulty,
             discriminant: firstChallenge.discriminant,
-            estimatedLevel: initialCapacity,
+            capacity: initialCapacity,
           })
           .returns(0.5);
 
@@ -384,19 +384,19 @@ function prepareStubs({
     .withArgs({
       difficulty: firstChallenge.difficulty,
       discriminant: firstChallenge.discriminant,
-      estimatedLevel: 0,
+      capacity: 0,
     })
     .returns(0.5)
     .withArgs({
       difficulty: secondChallenge.difficulty,
       discriminant: secondChallenge.discriminant,
-      estimatedLevel: 1,
+      capacity: 1,
     })
     .returns(1.5)
     .withArgs({
       difficulty: thirdChallenge.difficulty,
       discriminant: thirdChallenge.discriminant,
-      estimatedLevel: 2,
+      capacity: 2,
     })
     .returns(2.5);
 

--- a/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
+++ b/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
@@ -33,7 +33,7 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
         result.forEach((answer) => {
           expect(answer.challenge).not.to.be.undefined;
           expect(answer.errorRate).not.to.be.undefined;
-          expect(answer.estimatedLevel).not.to.be.undefined;
+          expect(answer.capacity).not.to.be.undefined;
           expect(answer.reward).not.to.be.undefined;
           expect(answer.answerStatus).not.to.be.undefined;
         });
@@ -75,7 +75,7 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
         result.forEach((answer) => {
           expect(answer.challenge).not.to.be.undefined;
           expect(answer.errorRate).not.to.be.undefined;
-          expect(answer.estimatedLevel).not.to.be.undefined;
+          expect(answer.capacity).not.to.be.undefined;
           expect(answer.reward).not.to.be.undefined;
           expect(answer.answerStatus).not.to.be.undefined;
         });
@@ -141,7 +141,7 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
         result.forEach((answer) => {
           expect(answer.challenge).not.to.be.undefined;
           expect(answer.errorRate).not.to.be.undefined;
-          expect(answer.estimatedLevel).not.to.be.undefined;
+          expect(answer.capacity).not.to.be.undefined;
           expect(answer.reward).not.to.be.undefined;
           expect(answer.answerStatus).not.to.be.undefined;
         });
@@ -182,7 +182,7 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
         result.forEach((answer) => {
           expect(answer.challenge).not.to.be.undefined;
           expect(answer.errorRate).not.to.be.undefined;
-          expect(answer.estimatedLevel).not.to.be.undefined;
+          expect(answer.capacity).not.to.be.undefined;
           expect(answer.reward).not.to.be.undefined;
           expect(answer.answerStatus).not.to.be.undefined;
         });
@@ -211,7 +211,7 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
         expect(result).to.have.lengthOf(3);
         result.forEach((answer) => {
           expect(answer.challenge).not.to.be.undefined;
-          expect(answer.estimatedLevel).not.to.be.undefined;
+          expect(answer.capacity).not.to.be.undefined;
         });
       });
     });
@@ -252,7 +252,7 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
         .returns([]);
 
       flashAlgorithmService.getEstimatedLevelAndErrorRate.returns({
-        estimatedLevel: 0,
+        capacity: 0,
         errorRate: 1,
       });
       flashAlgorithmService.getReward.returns(1);
@@ -282,7 +282,7 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
           answerStatus: AnswerStatus.OK,
           challenge,
           errorRate: sinon.match.number,
-          estimatedLevel: sinon.match.number,
+          capacity: sinon.match.number,
           reward: sinon.match.number,
         },
       ]);
@@ -346,39 +346,39 @@ function prepareStubs({
     .withArgs({
       allAnswers: [],
       challenges: sinon.match.any,
-      estimatedLevel: initialCapacity,
+      capacity: initialCapacity,
       variationPercent: undefined,
       variationPercentUntil: undefined,
       doubleMeasuresUntil,
     })
-    .returns({ estimatedLevel: 0, errorRate: 0.1 })
+    .returns({ capacity: 0, errorRate: 0.1 })
     .withArgs({
       allAnswers: [successAnswerMatcher],
       challenges: [firstChallenge, secondChallenge, thirdChallenge],
-      estimatedLevel: initialCapacity,
+      capacity: initialCapacity,
       variationPercent: undefined,
       variationPercentUntil: undefined,
       doubleMeasuresUntil,
     })
-    .returns({ estimatedLevel: 1, errorRate: 1.1 })
+    .returns({ capacity: 1, errorRate: 1.1 })
     .withArgs({
       allAnswers: [successAnswerMatcher, successAnswerMatcher],
       challenges: [firstChallenge, secondChallenge, thirdChallenge],
-      estimatedLevel: initialCapacity,
+      capacity: initialCapacity,
       variationPercent: undefined,
       variationPercentUntil: undefined,
       doubleMeasuresUntil,
     })
-    .returns({ estimatedLevel: 2, errorRate: 2.1 })
+    .returns({ capacity: 2, errorRate: 2.1 })
     .withArgs({
       allAnswers: [successAnswerMatcher, successAnswerMatcher, successAnswerMatcher],
       challenges: [firstChallenge, secondChallenge, thirdChallenge],
-      estimatedLevel: initialCapacity,
+      capacity: initialCapacity,
       variationPercent: undefined,
       variationPercentUntil: undefined,
       doubleMeasuresUntil,
     })
-    .returns({ estimatedLevel: 3, errorRate: 3.1 });
+    .returns({ capacity: 3, errorRate: 3.1 });
 
   flashAlgorithmService.getReward
     .withArgs({

--- a/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
+++ b/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
@@ -14,7 +14,7 @@ const successAnswerMatcher = sinon.match({
 describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', function () {
   context('when there are enough flash challenges left', function () {
     context('when no initial capacity is provided', function () {
-      it('should return an array of estimated level, challenge, reward and error rate for each answer', async function () {
+      it('should return an array of capacity, challenge, reward and error rate for each answer', async function () {
         // given
         const { challengeRepository, pickChallenge, pickAnswerStatus, flashAlgorithmService } = prepareStubs();
 
@@ -233,7 +233,7 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
 
       const flashAlgorithmService = {
         getPossibleNextChallenges: sinon.stub(),
-        getEstimatedLevelAndErrorRate: sinon.stub(),
+        getCapacityAndErrorRate: sinon.stub(),
         getReward: sinon.stub(),
       };
 
@@ -251,7 +251,7 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
         )
         .returns([]);
 
-      flashAlgorithmService.getEstimatedLevelAndErrorRate.returns({
+      flashAlgorithmService.getCapacityAndErrorRate.returns({
         capacity: 0,
         errorRate: 1,
       });
@@ -329,7 +329,7 @@ function prepareStubs({
   const pickAnswerStatus = sinon.stub();
   const flashAlgorithmService = {
     getPossibleNextChallenges: sinon.stub(),
-    getEstimatedLevelAndErrorRate: sinon.stub(),
+    getCapacityAndErrorRate: sinon.stub(),
     getReward: sinon.stub(),
   };
 
@@ -342,7 +342,7 @@ function prepareStubs({
     ),
   );
 
-  flashAlgorithmService.getEstimatedLevelAndErrorRate
+  flashAlgorithmService.getCapacityAndErrorRate
     .withArgs({
       allAnswers: [],
       challenges: sinon.match.any,

--- a/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
+++ b/api/tests/unit/domain/usecases/simulate-flash-deterministic-assessment-scenario_test.js
@@ -108,19 +108,19 @@ describe('Unit | UseCase | simulate-flash-deterministic-assessment-scenario', fu
         flashAlgorithmService.getPossibleNextChallenges
           .withArgs({
             availableChallenges: allChallenges,
-            estimatedLevel: 0,
+            capacity: 0,
             options: getNextChallengesOptionsMatcher,
           })
           .returns([firstChallenge, thirdChallenge, secondChallenge])
           .withArgs({
             availableChallenges: [secondChallenge, thirdChallenge],
-            estimatedLevel: 1,
+            capacity: 1,
             options: getNextChallengesOptionsMatcher,
           })
           .returns([thirdChallenge, secondChallenge])
           .withArgs({
             availableChallenges: [thirdChallenge],
-            estimatedLevel: 2,
+            capacity: 2,
             options: getNextChallengesOptionsMatcher,
           })
           .returns([thirdChallenge]);
@@ -403,13 +403,13 @@ function prepareStubs({
   flashAlgorithmService.getPossibleNextChallenges
     .withArgs({
       availableChallenges: allChallenges,
-      estimatedLevel: 0,
+      capacity: 0,
       options: getNextChallengesOptionsMatcher,
     })
     .returns([firstChallenge, thirdChallenge, secondChallenge])
     .withArgs({
       availableChallenges: [thirdChallenge],
-      estimatedLevel: 2,
+      capacity: 2,
       options: getNextChallengesOptionsMatcher,
     })
     .returns([thirdChallenge]);
@@ -418,7 +418,7 @@ function prepareStubs({
     flashAlgorithmService.getPossibleNextChallenges
       .withArgs({
         availableChallenges: [secondChallenge, thirdChallenge],
-        estimatedLevel: 0,
+        capacity: 0,
         options: getNextChallengesOptionsMatcher,
       })
       .returns([thirdChallenge, secondChallenge]);
@@ -426,7 +426,7 @@ function prepareStubs({
     flashAlgorithmService.getPossibleNextChallenges
       .withArgs({
         availableChallenges: [secondChallenge, thirdChallenge],
-        estimatedLevel: 1,
+        capacity: 1,
         options: getNextChallengesOptionsMatcher,
       })
       .returns([thirdChallenge, secondChallenge]);


### PR DESCRIPTION
## :unicorn: Problème
Le terme `estimatedLevel`, correspondant à la capacité de l'utilisateur lors de la certif v3, n'est pas correct. Par convention, on utilisera le terme `capacity`

## :robot: Proposition
Modifier `estimatedLevel` partout où il est utilisé pour v3

## :rainbow: Remarques
Je n'ai pas touché aux `flash-assessment-results`, qui nécessite un changement en DB, on verra dans une autre PR

## :100: Pour tester
Vérifier que le passage de certif est toujours OK, et que les bonnes infos s'affiche côté admin
