### PR TITLE
[FEATURE] Changer le lien 'Importer' dans la bannière de rentrée vers la nouvelle page d'import (PIX-11822)

### DIFF
--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -58,7 +58,7 @@
       "message": "'<strong>'Certifications :'</strong>' n’oubliez pas de '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'finaliser les sessions dans Pix Certif'</a>' puis de télécharger les attestations ici via l'onglet “Certifications” avant la rentrée 2023."
     },
     "import": {
-      "message": "The administrator can download certification results and '<'a href=\"/eleves\" class=\"{linkClasses}\"'>'import'</a>' the students database to create back-to-school campaigns by year level. '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'Learn more'</a>'"
+      "message": "The administrator can download certification results and '<'a href=\"/import-participants\" class=\"{linkClasses}\"'>'import'</a>' the students database to create back-to-school campaigns by year level. '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'Learn more'</a>'"
     }
   },
   "cards": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -58,7 +58,7 @@
       "message": "'<strong>'Certifications :'</strong>' n’oubliez pas de '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'finaliser les sessions dans Pix Certif'</a>' puis de télécharger les attestations ici via l'onglet “Certifications” avant la rentrée 2023."
     },
     "import": {
-      "message": "L'administrateur peut télécharger les résultats de certification et '<'a href=\"/eleves\" class=\"{linkClasses}\"'>'importer'</a>' la base élèves, afin de créer les campagnes de rentrée par niveau. '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'Plus d’info'</a>'"
+      "message": "L'administrateur peut télécharger les résultats de certification et '<'a href=\"/import-participants\" class=\"{linkClasses}\"'>'importer'</a>' la base élèves, afin de créer les campagnes de rentrée par niveau. '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'Plus d’info'</a>'"
     }
   },
   "cards": {


### PR DESCRIPTION
## :unicorn: Problème
Le lien 'importer' dans le screen ci dessous, redirige vers la page `/eleves` qui est l'ancienne page ou on pouvait importer directement.
![image](https://github.com/1024pix/pix/assets/101280231/1af64b1a-d5e9-4b58-8b55-54aa815c9056)

Maintenant qu'on à uniformiser la page d'import à tous les types d'organisation, il faut que ce lien redirige plutôt vers `/import-participants`

## :robot: Proposition
Changer le lien dans les clés de traductions fr & en

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

- Aller sur Pix Orga
- Se connecter avec sco-orga@example.net
- Aller sur l'orga 'SCO Orga - FREGATA'
- Vérifier la bonne redirection dans le lien du bandeau d'information
- 🐈‍⬛ 
