### PR TITLE
[BUGFIX] Réparer la gestion de l'import en masse de sessions avec certification complémentaire sur Pix Certif (PIX-11818).

### DIFF
--- a/api/src/certification/complementary-certification/application/api/complementary-certification-api.js
+++ b/api/src/certification/complementary-certification/application/api/complementary-certification-api.js
@@ -18,3 +18,18 @@ export const getById = async ({ id }) => {
   const complementaryCertification = await usecases.getById({ id });
   return new ComplementaryCertification(complementaryCertification);
 };
+
+/**
+ * @function
+ * @name getByLabel
+ *
+ * @param {object} params
+ * @param {number} params.label mandatory
+ *
+ * @returns {ComplementaryCertification}
+ * @throws {NotFoundError} Complementary certification does not exist
+ */
+export const getByLabel = async ({ label }) => {
+  const complementaryCertification = await usecases.getByLabel({ label });
+  return new ComplementaryCertification(complementaryCertification);
+};

--- a/api/src/certification/complementary-certification/domain/usecases/get-by-label.js
+++ b/api/src/certification/complementary-certification/domain/usecases/get-by-label.js
@@ -1,0 +1,12 @@
+/**
+ * @typedef {import ('../../domain/usecases/index.js').ComplementaryCertificationRepository} ComplementaryCertificationRepository
+ */
+
+/**
+ * @param {Object} params
+ * @param {string} params.label - complementary certification label
+ * @param {ComplementaryCertificationRepository} params.complementaryCertificationRepository
+ */
+export const getByLabel = async ({ label, complementaryCertificationRepository }) => {
+  return complementaryCertificationRepository.getByLabel({ label });
+};

--- a/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-repository.js
+++ b/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-repository.js
@@ -15,9 +15,13 @@ const findAll = async function () {
 };
 
 const getByLabel = async function ({ label }) {
-  const result = await knex.from('complementary-certifications').where({ label }).first();
+  const complementaryCertification = await knex.from('complementary-certifications').where({ label }).first();
 
-  return _toDomain(result);
+  if (!complementaryCertification) {
+    throw new NotFoundError('Complementary certification does not exist');
+  }
+
+  return _toDomain(complementaryCertification);
 };
 
 const getById = async function ({ id }) {

--- a/api/src/certification/session/infrastructure/repositories/complementary-certification-repository.js
+++ b/api/src/certification/session/infrastructure/repositories/complementary-certification-repository.js
@@ -17,7 +17,23 @@ const getById = async function ({ complementaryCertificationId, complementaryCer
   return _toDomain(complementaryCertification);
 };
 
-export { getById };
+/**
+ * @function
+ * @param {Object} params
+ * @param {number} params.label
+ * @param {ComplementaryCertificationApi} params.complementaryCertificationApi
+ *
+ * @returns {ComplementaryCertification}
+ * @throws {NotFoundError} Complementary certification does not exist
+ */
+const getByLabel = async function ({ label, complementaryCertificationApi }) {
+  const complementaryCertification = await complementaryCertificationApi.getByLabel({
+    label,
+  });
+  return _toDomain(complementaryCertification);
+};
+
+export { getById, getByLabel };
 
 function _toDomain(result) {
   return new ComplementaryCertification(result);

--- a/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-repository_test.js
+++ b/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-repository_test.js
@@ -73,6 +73,22 @@ describe('Integration | Certification | Repository | complementary-certification
   });
 
   describe('#getByLabel', function () {
+    context('when the complementary certification does not exist', function () {
+      it('should throw a NotFoundError', async function () {
+        // given
+        const unknownComplementaryCertificationLabel = 'a label';
+
+        // when
+        const error = await catchErr(complementaryCertificationRepository.getByLabel)({
+          label: unknownComplementaryCertificationLabel,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(NotFoundError);
+        expect(error.message).to.equal('Complementary certification does not exist');
+      });
+    });
+
     it('should return the complementary certification by its label', async function () {
       // given
       const label = 'Pix+ Édu 1er degré';
@@ -104,7 +120,7 @@ describe('Integration | Certification | Repository | complementary-certification
   });
 
   describe('#getById', function () {
-    context('when the complementary certification does not exists', function () {
+    context('when the complementary certification does not exist', function () {
       it('should throw a NotFoundError', async function () {
         // given
         const unknownComplementaryCertificationId = 1;

--- a/api/tests/certification/session/acceptance/application/session-mass-import-route_test.js
+++ b/api/tests/certification/session/acceptance/application/session-mass-import-route_test.js
@@ -42,12 +42,23 @@ describe('Acceptance | Controller | Session | session-mass-import-route', functi
           externalId: '1234AB',
         }).id;
         databaseBuilder.factory.buildOrganization({ externalId: '1234AB', isManagingStudents: false, type: 'SUP' });
-
+        databaseBuilder.factory.buildCertificationCpfCountry({
+          commonName: 'FRANCE',
+          matcher: 'ACEFNR',
+          code: '99100',
+        });
+        databaseBuilder.factory.buildCertificationCpfCity({
+          INSEECode: '75115',
+          name: 'Paris',
+          isActualName: true,
+        });
+        databaseBuilder.factory.buildComplementaryCertification({ id: 1, label: 'Pix+ Édu 2nd degré' });
+        databaseBuilder.factory.buildComplementaryCertificationBadge({ label: 'Pix+ Édu 2nd degré' });
         databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
         await databaseBuilder.commit();
 
-        const newBuffer = `Numéro de session préexistante;* Nom du site;* Nom de la salle;* Date de début (format: JJ/MM/AAAA);* Heure de début (heure locale format: HH:MM);* Surveillant(s);Observations (optionnel);* Nom de naissance;* Prénom;* Date de naissance (format: JJ/MM/AAAA);* Sexe (M ou F);Code INSEE de la commune de naissance;Code postal de la commune de naissance;Nom de la commune de naissance;* Pays de naissance;E-mail du destinataire des résultats (formateur, enseignant…);E-mail de convocation;Identifiant externe;Temps majoré ? (exemple format: 33%);* Tarification part Pix (Gratuite, Prépayée ou Payante);Code de prépaiement (si Tarification part Pix Prépayée)
-        ;site1;salle1;19/10/2023;12:00;surveillant;non;;;;;;;;;;;;;;`;
+        const newBuffer = `Numéro de session préexistante,* Nom du site,* Nom de la salle,* Date de début (format: JJ/MM/AAAA),* Heure de début (heure locale format: HH:MM),* Surveillant(s),Observations (optionnel),* Nom de naissance,* Prénom,* Date de naissance (format: JJ/MM/AAAA),* Sexe (M ou F),Code INSEE de la commune de naissance,Code postal de la commune de naissance,Nom de la commune de naissance,* Pays de naissance,"E-mail du destinataire des résultats (formateur, enseignant…)",E-mail de convocation,Identifiant externe,Temps majoré ? (exemple format: 33%),"* Tarification part Pix (Gratuite, Prépayée ou Payante)",Code de prépaiement (si Tarification part Pix Prépayée),CléA Numérique ('oui' ou laisser vide),Pix+ Droit ('oui' ou laisser vide),Pix+ Édu 1er degré ('oui' ou laisser vide),Pix+ Édu 2nd degré ('oui' ou laisser vide)
+        ,site,salle,10/10/2025,12:00,surveillant,,noel,jean,10/10/2000,M,75115,,,FRANCE,,,,,Gratuite,,,,,oui`;
 
         const options = {
           method: 'POST',
@@ -65,16 +76,10 @@ describe('Acceptance | Controller | Session | session-mass-import-route', functi
         expect(response.statusCode).to.equal(200);
         expect(_checkIfValidUUID(response.result.cachedValidatedSessionsKey)).to.be.true;
         expect(omit(response.result, 'cachedValidatedSessionsKey')).to.deep.equal({
-          candidatesCount: 0,
-          errorReports: [
-            {
-              code: 'EMPTY_SESSION',
-              line: 2,
-              isBlocking: false,
-            },
-          ],
+          candidatesCount: 1,
+          errorReports: [],
           sessionsCount: 1,
-          sessionsWithoutCandidatesCount: 1,
+          sessionsWithoutCandidatesCount: 0,
         });
       });
     });

--- a/api/tests/certification/session/integration/infrastructure/repositories/complementary-certification-repository_test.js
+++ b/api/tests/certification/session/integration/infrastructure/repositories/complementary-certification-repository_test.js
@@ -43,4 +43,43 @@ describe('Integration | Certification | Session | Repository | Complementary cer
       });
     });
   });
+
+  describe('#getByLabel', function () {
+    it('should fetch the complementary certification', async function () {
+      // given
+      const { label } = databaseBuilder.factory.buildComplementaryCertification({
+        id: 1,
+        label: 'UneSuperCertifComplémentaire',
+        key: ComplementaryCertificationKeys.CLEA,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const complementaryCertification = await sessionRepositories.complementaryCertificationRepository.getByLabel({
+        label,
+      });
+
+      // then
+      expect(complementaryCertification).to.deepEqualInstance(
+        new ComplementaryCertification({
+          id: 1,
+          label: 'UneSuperCertifComplémentaire',
+          key: ComplementaryCertificationKeys.CLEA,
+        }),
+      );
+    });
+
+    context('when there is no complementary certification for the given label', function () {
+      it('should return an error', async function () {
+        // when
+        const error = await catchErr(sessionRepositories.complementaryCertificationRepository.getByLabel)({
+          label: 'a label',
+        });
+
+        // then
+        expect(error).to.be.instanceOf(NotFoundError);
+        expect(error.message).to.deep.equal('Complementary certification does not exist');
+      });
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur Pix Certif, sur l'import en masse de sessions, lorsqu'on souhaite importer avec au moins un candidat inscrit à une certification complémentaire, on a un message d’erreur concernant une erreur interne. 

Lorsqu’on essaie la même création de session mais sans l’inscription à la certification complémentaire, l’opération se déroule comme convenu.

L'erreur technique est la suivante : `complementaryCertificationRepository.getByLabel is not a function`

## :robot: Proposition
Faire appel à une API interne pour communiquer avec le repository du contexte complementary certification.

## :rainbow: Remarques
La méthode getByLabel était appelé depuis le dossier session, or le repository existant dans session ne possède pas la méthode. Elle se trouve ailleurs, dans le contexte complementary certification.

## :100: Pour tester

Test de non régression : 
- se connecter sur certif avec certif-pro@example.net
- Cliquer sur l'import en masse des session
- Importer des sessions avec un candidat sans certification complémentaire et avec.