### PR TITLE
[TECH] Déplace la configuration du plugin yar dans son propre fichier

### DIFF
--- a/api/lib/infrastructure/plugins/index.js
+++ b/api/lib/infrastructure/plugins/index.js
@@ -1,25 +1,12 @@
 import Inert from '@hapi/inert';
 import Vision from '@hapi/vision';
-import Yar from '@hapi/yar';
 
 import { config } from '../../config.js';
 import * as i18n from './i18n.js';
 import * as pino from './pino.js';
 import * as sentry from './sentry.js';
+import * as serverSideCookieSession from './yar.js';
 
-const serverSideCookieSessionPlugin = {
-  options: {
-    cookieOptions: {
-      isHttpOnly: config.environment !== 'test',
-      isSameSite: 'Strict',
-      isSecure: config.environment !== 'test',
-      password: config.authentication.secret,
-    },
-    storeBlank: false,
-  },
-  plugin: Yar,
-};
-
-const plugins = [Inert, Vision, i18n, pino, serverSideCookieSessionPlugin, ...(config.sentry.enabled ? [sentry] : [])];
+const plugins = [Inert, Vision, i18n, pino, serverSideCookieSession, ...(config.sentry.enabled ? [sentry] : [])];
 
 export { plugins };

--- a/api/lib/infrastructure/plugins/yar.js
+++ b/api/lib/infrastructure/plugins/yar.js
@@ -1,0 +1,16 @@
+import Yar from '@hapi/yar';
+
+import { config } from '../../config.js';
+
+const plugin = Yar;
+const options = {
+  cookieOptions: {
+    isHttpOnly: config.environment !== 'test',
+    isSameSite: 'Strict',
+    isSecure: config.environment !== 'test',
+    password: config.authentication.secret,
+  },
+  storeBlank: false,
+};
+
+export { options, plugin };


### PR DESCRIPTION
## :unicorn: Problème
Les configurations de plugins sont dans leurs fichiers respectifs en théorie. Pas celle du plugin yar.

## :robot: Proposition
Déplacer la configuration dans sont fichier `yar.js`

## :100: Pour tester
Tests verts
