### PR TITLE
[TECH] Notifier les membres de l'équipe accès lors d'une modification d'un des domaines (PIX-11836)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,8 @@
 # @1024pix/devcomp owns any file in the `/api/src/devcomp/` directory in the root of your repository and any of its subdirectories.
 /api/src/devcomp/ @1024pix/team-devcomp
+
+
+# Directories owned by team Accès
+/api/src/authentication/ @1024pix/team-acces
+/api/src/authorization/ @1024pix/team-acces
+/api/src/organizational-entities/ @1024pix/team-acces


### PR DESCRIPTION
## :unicorn: Problème

Nous pouvons utiliser la fonctionnalité `codeowners` de GitHub pour notifier les membres de l'équipe Accès si une modification est faite sur nos domaines.

## :robot: Proposition

Ajouter l'équipe Accès en tant que `owner` des domaines suivants : **authentication**, **authorization** et **organizational-entities**.

## :rainbow: Remarques

RAS

## :100: Pour tester

Rien à tester, la CI doit être ✅ 
