### PR TITLE
[TECH] Utilise la version moderne ES6 de dotenv

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,6 +1,5 @@
-import * as dotenv from 'dotenv';
+import 'dotenv/config';
 
-dotenv.config();
 import { validateEnvironmentVariables } from './lib/infrastructure/validate-environment-variables.js';
 
 validateEnvironmentVariables();

--- a/api/scripts/_template.js
+++ b/api/scripts/_template.js
@@ -1,6 +1,5 @@
-import dotenv from 'dotenv';
+import 'dotenv/config';
 
-dotenv.config();
 import perf_hooks from 'perf_hooks';
 import * as url from 'url';
 

--- a/api/scripts/add-or-update-certification-centers-dpo-infos.js
+++ b/api/scripts/add-or-update-certification-centers-dpo-infos.js
@@ -1,6 +1,5 @@
-import dotenv from 'dotenv';
+import 'dotenv/config';
 
-dotenv.config();
 import bluebird from 'bluebird';
 import _ from 'lodash';
 import * as url from 'url';

--- a/api/scripts/add-or-update-organizations-dpo-infos.js
+++ b/api/scripts/add-or-update-organizations-dpo-infos.js
@@ -1,6 +1,4 @@
-import dotenv from 'dotenv';
-
-dotenv.config();
+import 'dotenv/config';
 
 import bluebird from 'bluebird';
 import _ from 'lodash';

--- a/api/scripts/add-tags-to-organizations.js
+++ b/api/scripts/add-tags-to-organizations.js
@@ -1,9 +1,8 @@
 // Usage: node add-tags-to-organizations.js path/file.csv
 // To use on file with columns |organizationId, tagName|
 
-import dotenv from 'dotenv';
+import 'dotenv/config';
 
-dotenv.config();
 import lodash from 'lodash';
 
 import { OrganizationTag } from '../lib/domain/models/OrganizationTag.js';

--- a/api/scripts/certification/fill-last-assessment-result-certification-course-table.js
+++ b/api/scripts/certification/fill-last-assessment-result-certification-course-table.js
@@ -1,6 +1,5 @@
-import dotenv from 'dotenv';
+import 'dotenv/config';
 
-dotenv.config();
 import bluebird from 'bluebird';
 import * as url from 'url';
 

--- a/api/scripts/certification/fill-pix-certification-status-column-in-certification-courses-table.js
+++ b/api/scripts/certification/fill-pix-certification-status-column-in-certification-courses-table.js
@@ -1,6 +1,5 @@
-import dotenv from 'dotenv';
+import 'dotenv/config';
 
-dotenv.config();
 import perf_hooks from 'perf_hooks';
 
 const { performance } = perf_hooks;

--- a/api/scripts/certification/generate-certificate-verification-code.js
+++ b/api/scripts/certification/generate-certificate-verification-code.js
@@ -1,7 +1,6 @@
 /* eslint no-console: ["off"] */
-import dotenv from 'dotenv';
+import 'dotenv/config';
 
-dotenv.config();
 import bluebird from 'bluebird';
 import * as url from 'url';
 import yargs from 'yargs';

--- a/api/scripts/certification/generate-certification-test-statistics.js
+++ b/api/scripts/certification/generate-certification-test-statistics.js
@@ -1,6 +1,4 @@
-import dotenv from 'dotenv';
-
-dotenv.config();
+import 'dotenv/config';
 
 import _ from 'lodash';
 import originalFp from 'lodash/fp.js';

--- a/api/scripts/certification/import-certification-cpf-cities.js
+++ b/api/scripts/certification/import-certification-cpf-cities.js
@@ -1,6 +1,5 @@
-import dotenv from 'dotenv';
+import 'dotenv/config';
 
-dotenv.config();
 import lodash from 'lodash';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';

--- a/api/scripts/certification/launch-auto-jury-for-session.js
+++ b/api/scripts/certification/launch-auto-jury-for-session.js
@@ -1,6 +1,5 @@
-import dotenv from 'dotenv';
+import 'dotenv/config';
 
-dotenv.config();
 import * as url from 'url';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';

--- a/api/scripts/certification/send-certification-result-emails.js
+++ b/api/scripts/certification/send-certification-result-emails.js
@@ -1,6 +1,4 @@
-import dotenv from 'dotenv';
-
-dotenv.config();
+import 'dotenv/config';
 
 import bluebird from 'bluebird';
 import i18n from 'i18n';

--- a/api/scripts/compare-pix-with-latest-release.js
+++ b/api/scripts/compare-pix-with-latest-release.js
@@ -1,8 +1,7 @@
-import dotenv from 'dotenv';
-import * as url from 'url';
+import 'dotenv/config';
 
-dotenv.config();
 import _ from 'lodash';
+import * as url from 'url';
 
 import { buildKnowledgeElement } from '../db/database-builder/factory/build-knowledge-element.js';
 import { disconnect } from '../db/knex-database-connection.js';

--- a/api/scripts/create-organizations-with-tags-and-target-profiles.js
+++ b/api/scripts/create-organizations-with-tags-and-target-profiles.js
@@ -1,9 +1,6 @@
 // Usage: node create-organizations-with-tags-and-target-profiles.js path/file.csv
 // To use on file with columns |type, externalId, name, provinceCode, credit, emailInvitations, emailForSCOActivation, organizationInvitationRole, locale, tags, createdBy, targetProfiles, isManagingStudents, identityProviderForCampaigns, DPOFirstName, DPOLastName, DPOEmail|
-
-import dotenv from 'dotenv';
-
-dotenv.config();
+import 'dotenv/config';
 
 import lodash from 'lodash';
 

--- a/api/scripts/database/create-database.js
+++ b/api/scripts/database/create-database.js
@@ -1,5 +1,5 @@
-import dotenv from 'dotenv';
-dotenv.config();
+import 'dotenv/config';
+
 import { PGSQL_DUPLICATE_DATABASE_ERROR } from '../../db/pgsql-errors.js';
 import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 import { PgClient } from '../PgClient.js';

--- a/api/scripts/database/drop-database.js
+++ b/api/scripts/database/drop-database.js
@@ -1,5 +1,5 @@
-import dotenv from 'dotenv';
-dotenv.config();
+import 'dotenv/config';
+
 import { PGSQL_NON_EXISTENT_DATABASE_ERROR } from '../../db/pgsql-errors.js';
 import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 import { PgClient } from '../PgClient.js';

--- a/api/scripts/database/pg-boss-migration.js
+++ b/api/scripts/database/pg-boss-migration.js
@@ -1,5 +1,5 @@
-import dotenv from 'dotenv';
-dotenv.config();
+import 'dotenv/config';
+
 import PgBoss from 'pg-boss';
 
 import { disconnect } from '../../db/knex-database-connection.js';

--- a/api/scripts/fill-in-assessment-method.js
+++ b/api/scripts/fill-in-assessment-method.js
@@ -1,5 +1,4 @@
-import dotenv from 'dotenv';
-dotenv.config();
+import 'dotenv/config';
 
 import { knex } from '../db/knex-database-connection.js';
 import { logger } from '../src/shared/infrastructure/utils/logger.js';

--- a/api/scripts/fill-skill-id-in-user-saved-tutorials.js
+++ b/api/scripts/fill-skill-id-in-user-saved-tutorials.js
@@ -1,6 +1,5 @@
-import dotenv from 'dotenv';
+import 'dotenv/config';
 
-dotenv.config();
 import lodash from 'lodash';
 const { groupBy } = lodash;
 import * as url from 'url';

--- a/api/scripts/fill-target-profiles-with-default-image-url.js
+++ b/api/scripts/fill-target-profiles-with-default-image-url.js
@@ -1,11 +1,10 @@
-import dotenv from 'dotenv';
+import 'dotenv/config';
+
 import perf_hooks from 'perf_hooks';
 import * as url from 'url';
 
 import { disconnect, knex } from '../db/knex-database-connection.js';
 import { logger } from '../src/shared/infrastructure/utils/logger.js';
-
-dotenv.config();
 
 const { performance } = perf_hooks;
 

--- a/api/scripts/generate-api-documentation.js
+++ b/api/scripts/generate-api-documentation.js
@@ -1,11 +1,10 @@
-import dotenv from 'dotenv';
+import 'dotenv/config';
+
 // eslint-disable-next-line n/no-unpublished-import
 import jsdocToMarkdown from 'jsdoc-to-markdown';
 import * as url from 'url';
 
 import { logger } from '../src/shared/infrastructure/utils/logger.js';
-
-dotenv.config();
 
 async function main(baseFolder) {
   const docs = await jsdocToMarkdown.render({ files: `${baseFolder}/**/application/api/*.js` });

--- a/api/scripts/get-difficulties-from-challenge-ids.js
+++ b/api/scripts/get-difficulties-from-challenge-ids.js
@@ -1,10 +1,9 @@
-import dotenv from 'dotenv';
+import 'dotenv/config';
+
 import { readFile } from 'fs/promises';
 import Redis from 'ioredis';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-
-dotenv.config();
 
 const { challengeIdsFile, redisUrl } = yargs(hideBin(process.argv)).argv;
 const rawChallengeIdsFile = await readFile(challengeIdsFile, 'utf-8');

--- a/api/scripts/prod/compute-badge-acquisitions.js
+++ b/api/scripts/prod/compute-badge-acquisitions.js
@@ -1,6 +1,5 @@
-import dotenv from 'dotenv';
+import 'dotenv/config';
 
-dotenv.config();
 import bluebird from 'bluebird';
 import _ from 'lodash';
 import perf_hooks from 'perf_hooks';

--- a/api/scripts/prod/select-category-for-target-profiles.js
+++ b/api/scripts/prod/select-category-for-target-profiles.js
@@ -1,6 +1,5 @@
-import dotenv from 'dotenv';
+import 'dotenv/config';
 
-dotenv.config();
 import bluebird from 'bluebird';
 import lodash from 'lodash';
 const { groupBy, sum, has, partition, negate } = lodash;

--- a/api/scripts/prod/target-profile-migrations/convert-target-profiles-into-new-format.js
+++ b/api/scripts/prod/target-profile-migrations/convert-target-profiles-into-new-format.js
@@ -1,6 +1,5 @@
-import dotenv from 'dotenv';
+import 'dotenv/config';
 
-dotenv.config();
 import _ from 'lodash';
 import * as url from 'url';
 

--- a/api/scripts/prod/target-profile-migrations/migrate-stages-to-level.js
+++ b/api/scripts/prod/target-profile-migrations/migrate-stages-to-level.js
@@ -1,5 +1,4 @@
-import dotenv from 'dotenv';
-dotenv.config();
+import 'dotenv/config';
 
 import { readFile, writeFile } from 'fs/promises';
 import fp from 'lodash/fp.js';

--- a/api/scripts/prod/target-profile-migrations/revert-stages-to-threshold.js
+++ b/api/scripts/prod/target-profile-migrations/revert-stages-to-threshold.js
@@ -1,5 +1,4 @@
-import dotenv from 'dotenv';
-dotenv.config();
+import 'dotenv/config';
 
 import * as fs from 'fs';
 import fp from 'lodash/fp.js';

--- a/api/scripts/refresh-cache.js
+++ b/api/scripts/refresh-cache.js
@@ -1,6 +1,5 @@
-import dotenv from 'dotenv';
+import 'dotenv/config';
 
-dotenv.config();
 import { learningContentCache } from '../lib/infrastructure/caches/learning-content-cache.js';
 import * as learningContentDatasource from '../src/shared/infrastructure/datasources/learning-content/datasource.js';
 import { logger } from '../src/shared/infrastructure/utils/logger.js';

--- a/api/scripts/switch-campaign-to-flash.js
+++ b/api/scripts/switch-campaign-to-flash.js
@@ -1,7 +1,6 @@
-import dotenv from 'dotenv';
-import _ from 'lodash';
+import 'dotenv/config';
 
-dotenv.config();
+import _ from 'lodash';
 import * as url from 'url';
 
 import { knex } from '../db/knex-database-connection.js';

--- a/api/src/certification/course/scripts/generate-certification-attestations-by-session-ids.js
+++ b/api/src/certification/course/scripts/generate-certification-attestations-by-session-ids.js
@@ -1,6 +1,4 @@
-import dotenv from 'dotenv';
-
-dotenv.config();
+import 'dotenv/config';
 
 import bluebird from 'bluebird';
 import fs from 'fs';

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -1,12 +1,11 @@
+import 'dotenv/config';
+
 import dayjs from 'dayjs';
-import * as dotenv from 'dotenv';
 import ms from 'ms';
 import path from 'path';
 import * as url from 'url';
 
 import { getArrayOfStrings, getArrayOfUpperStrings } from './infrastructure/utils/string-utils.js';
-
-dotenv.config();
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 

--- a/api/worker.js
+++ b/api/worker.js
@@ -1,8 +1,8 @@
-import * as dotenv from 'dotenv';
-import * as url from 'url';
-dotenv.config();
+import 'dotenv/config';
+
 import _ from 'lodash';
 import PgBoss from 'pg-boss';
+import * as url from 'url';
 
 import { config } from './lib/config.js';
 import { UserAnonymizedEventLoggingJob } from './lib/infrastructure/jobs/audit-log/UserAnonymizedEventLoggingJob.js';


### PR DESCRIPTION
## :unicorn: Problème
Depuis que nous sommes passé a ES6/ESM, la façon d'utiliser dotenv n'a pas changé comme indiqué dans la documentation de dotenv: https://github.com/motdotla/dotenv?tab=readme-ov-file#%EF%B8%8F-usage 

## :robot: Proposition
Changer `require('dotenv').config()` en `import 'dotenv/config'`.

## :rainbow: Remarques
Il reste quelques utilisations de `dotenv.config()` lorsque nous avons besoin de spécifier le chemin vers le fichier .env. Je ne sais pas si c'est très pertinent d'avoir besoin de faire ca, mais dans le doute je l'ai laissé.

## :100: Pour tester
Démarrer l'API en local avec son .env et vérifier que la configuration est bien prise en compte.
