### PR TITLE
[TECH] Supprime l'usage de current-lang

### DIFF
--- a/admin/app/services/url.js
+++ b/admin/app/services/url.js
@@ -13,7 +13,7 @@ export default class Url extends Service {
   }
 
   get forgottenPasswordUrl() {
-    const currentLanguage = this.intl.t('current-lang');
+    const currentLanguage = this.intl.primaryLocale;
     let url = `${this.pixAppUrlWithoutExtension}${this.currentDomain.getExtension()}/mot-de-passe-oublie`;
     if (currentLanguage === 'en') {
       url += '?lang=en';

--- a/api/lib/application/healthcheck/healthcheck-controller.js
+++ b/api/lib/application/healthcheck/healthcheck-controller.js
@@ -15,7 +15,7 @@ const get = function (request) {
     'container-version': process.env.CONTAINER_VERSION,
     // eslint-disable-next-line n/no-process-env
     'container-app-name': process.env.APP,
-    'current-lang': request.i18n.__('current-lang'),
+    'current-lang': request.i18n.getLocale(),
   };
 };
 

--- a/api/src/certification/session/infrastructure/utils/pdf/attendance-sheet-pdf.js
+++ b/api/src/certification/session/infrastructure/utils/pdf/attendance-sheet-pdf.js
@@ -27,7 +27,7 @@ async function getAttendanceSheetPdfBuffer({
   i18n,
 } = {}) {
   const translate = i18n.__;
-  const lang = i18n.__('current-lang');
+  const lang = i18n.getLocale();
 
   const templatePath = `${dirname}/files/attendance-sheet.pdf`;
   const templateBuffer = await readFile(templatePath);

--- a/api/tests/tooling/i18n/i18n_test.js
+++ b/api/tests/tooling/i18n/i18n_test.js
@@ -3,7 +3,7 @@ import { getI18n } from './i18n.js';
 
 describe('Unit | Tooling | i18n', function () {
   it('should translate by default to fr', function () {
-    const currentLang = getI18n().__('current-lang');
+    const currentLang = getI18n().getLocale();
     expect(currentLang).to.equal('fr');
   });
 });

--- a/api/tests/unit/application/healthcheck/healthcheck-controller_test.js
+++ b/api/tests/unit/application/healthcheck/healthcheck-controller_test.js
@@ -9,7 +9,7 @@ describe('Unit | Controller | healthcheckController', function () {
   describe('#get', function () {
     it('should reply with the API description', async function () {
       // given
-      const mockedRequest = { i18n: { __: sinon.stub() } };
+      const mockedRequest = { i18n: { getLocale: sinon.stub() } };
 
       // when
       const response = await healthcheckController.get(mockedRequest, hFake);

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -1,5 +1,4 @@
 {
-  "current-lang": "en",
   "attendance-sheet": {
     "certification-information": {
       "date": "Date:",

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -1,5 +1,4 @@
 {
-  "current-lang": "fr",
   "account-recovery-email": {
     "params": {
       "choosePassword": "Choisir un mot de passe",

--- a/api/translations/nl.json
+++ b/api/translations/nl.json
@@ -1,5 +1,4 @@
 {
-  "current-lang": "nl",
   "account-recovery-email": {
     "params": {
       "choosePassword": "Kies een wachtwoord",

--- a/orga/app/components/auth/login-form.js
+++ b/orga/app/components/auth/login-form.js
@@ -23,7 +23,7 @@ export default class LoginForm extends Component {
   @tracked emailValidationMessage = null;
 
   get displayRecoveryLink() {
-    if (this.intl.t('current-lang') === 'en' || !this.currentDomain.isFranceDomain) {
+    if (this.intl.primaryLocale === 'en' || !this.currentDomain.isFranceDomain) {
       return false;
     }
     return !this.args.isWithInvitation;


### PR DESCRIPTION
## :unicorn: Problème
Pour connaitre la langue actuelle de l'application, on utilise une clef de traduction current-lang avec la langue courante.
Cela nécessite de bien mettre la langue que l'on traduit dans cette propriété, cela ne semble pas hyper intuitif.

Suite de #7585, #7622 et de #7623

## :robot: Proposition
Utiliser la fonction getLocale de l'objet i18n dans l'API: https://www.npmjs.com/package/i18n#i18ngetlocale
Utiliser primaryLocale sur l'objet intl coté front: https://ember-intl.github.io/ember-intl/docs/guide/service-api#primarylocale-readonly

## :rainbow: Remarques
J'ai mis dans la même PR les restes oubliés de orga et admin.

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
