### PR TITLE
[TECH] Basculer sur la version publié de eslint-plugin-knex

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -92,7 +92,7 @@
         "eslint-plugin-chai-expect": "^3.0.0",
         "eslint-plugin-i18n-json": "^4.0.0",
         "eslint-plugin-import": "^2.27.5",
-        "eslint-plugin-knex": "https://github.com/1024pix/eslint-plugin-knex#master",
+        "eslint-plugin-knex": "v0.2.2",
         "eslint-plugin-mocha": "^10.0.5",
         "eslint-plugin-n": "^16.0.0",
         "eslint-plugin-prettier": "^5.0.0",
@@ -5938,8 +5938,9 @@
       }
     },
     "node_modules/eslint-plugin-knex": {
-      "version": "0.2.1",
-      "resolved": "git+ssh://git@github.com/1024pix/eslint-plugin-knex.git#48af579a29b194c7e061acc22548652dd32951ef",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-knex/-/eslint-plugin-knex-0.2.2.tgz",
+      "integrity": "sha512-9jtfQaD/6tQO9tY6gnc9CMJHyVm8iuiznBzOBvfMfY4kd1N/yf1i+JYdbI8Lqp+z2f+D+r91uTCn84bcS8/F4A==",
       "dev": true
     },
     "node_modules/eslint-plugin-mocha": {

--- a/api/package.json
+++ b/api/package.json
@@ -98,7 +98,7 @@
     "eslint-plugin-chai-expect": "^3.0.0",
     "eslint-plugin-i18n-json": "^4.0.0",
     "eslint-plugin-import": "^2.27.5",
-    "eslint-plugin-knex": "https://github.com/1024pix/eslint-plugin-knex#master",
+    "eslint-plugin-knex": "v0.2.2",
     "eslint-plugin-mocha": "^10.0.5",
     "eslint-plugin-n": "^16.0.0",
     "eslint-plugin-prettier": "^5.0.0",

--- a/audit-logger/package-lock.json
+++ b/audit-logger/package-lock.json
@@ -35,7 +35,7 @@
         "eslint-config-prettier": "^9.0.0",
         "eslint-config-standard-with-typescript": "^43.0.0",
         "eslint-plugin-import": "^2.28.0",
-        "eslint-plugin-knex": "git+https://github.com/1024pix/eslint-plugin-knex#master",
+        "eslint-plugin-knex": "v0.2.2",
         "eslint-plugin-n": "^16.0.1",
         "eslint-plugin-prettier": "^5.0.0",
         "eslint-plugin-promise": "^6.1.1",
@@ -3335,8 +3335,9 @@
       }
     },
     "node_modules/eslint-plugin-knex": {
-      "version": "0.2.1",
-      "resolved": "git+ssh://git@github.com/1024pix/eslint-plugin-knex.git#48af579a29b194c7e061acc22548652dd32951ef",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-knex/-/eslint-plugin-knex-0.2.2.tgz",
+      "integrity": "sha512-9jtfQaD/6tQO9tY6gnc9CMJHyVm8iuiznBzOBvfMfY4kd1N/yf1i+JYdbI8Lqp+z2f+D+r91uTCn84bcS8/F4A==",
       "dev": true
     },
     "node_modules/eslint-plugin-n": {

--- a/audit-logger/package.json
+++ b/audit-logger/package.json
@@ -51,7 +51,7 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-config-standard-with-typescript": "^43.0.0",
     "eslint-plugin-import": "^2.28.0",
-    "eslint-plugin-knex": "git+https://github.com/1024pix/eslint-plugin-knex#master",
+    "eslint-plugin-knex": "v0.2.2",
     "eslint-plugin-n": "^16.0.1",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-promise": "^6.1.1",


### PR DESCRIPTION
## :unicorn: Problème
Une nouvelle version de eslint-plugin-knex a été publiée avec nos patchs. Notre fork n'est donc plus utile.

## :robot: Proposition
Utiliser la version publiée.

## :100: Pour tester
Tests verts
