### PR TITLE
[TECH] Ajoute les tests d'acceptance manquant sur les routes liées aux `campaign-participations` (PIX-11742)

### DIFF
--- a/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-controller_test.js
+++ b/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-controller_test.js
@@ -232,4 +232,35 @@ describe('Acceptance | API | Campaign Participations', function () {
       expect(response.result).to.deep.equal(expectedCampaignParticipationAnalysis);
     });
   });
+
+  describe('GET /api/campaigns/{campaignId}/assessment-participations/{campaignParticipationId}', function () {
+    it('should return the assessment participation', async function () {
+      databaseBuilder.factory.buildMembership({ userId, organizationId });
+      const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+      const campaign = databaseBuilder.factory.buildCampaign({ organizationId });
+      const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+        participantExternalId: 'Maitre Yoda',
+        campaignId: campaign.id,
+        organizationLearnerId: organizationLearner.id,
+      });
+      databaseBuilder.factory.buildAssessment({
+        userId: organizationLearner.userId,
+        campaignParticipationId: campaignParticipation.id,
+      });
+
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: `/api/campaigns/${campaign.id}/assessment-participations/${campaignParticipation.id}`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      };
+
+      const response = await server.inject(options);
+
+      expect(response.statusCode).to.equal(200);
+      const assessmentParticipation = response.result.data.attributes;
+      expect(assessmentParticipation['participant-external-id']).to.equal('Maitre Yoda');
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
En déplaçant les routes de cette PR : 
- https://github.com/1024pix/pix/pull/8461  

On s’est rendus compte que tous les tests passaient, mais l’application ne fonctionnait pas correctement. L’API renvoyait des 500 à certains moments. Il manquait effectivement des injections de repository dans les usecases utilisés.
Un test e2e cassant, ainsi qu’une revue fonctionnelle complète a mis en avant qu’il manquait des tests d’acceptance pour les cas nominaux.

## :robot: Proposition
Ajouter les 3 tests d'acceptance manquant pour les cas nominaux

## :rainbow: Remarques

## :100: Pour tester
Les tests sont verts ✅ 
🐈‍⬛ 
