### PR TITLE
[BUGFIX] Déclarer un nombre de challenges par défaut si pas de configuration d'algo au moment de la session (PIX-11853).

### DIFF
--- a/api/src/certification/course/infrastructure/repositories/v3-certification-course-details-for-administration-repository.js
+++ b/api/src/certification/course/infrastructure/repositories/v3-certification-course-details-for-administration-repository.js
@@ -45,10 +45,7 @@ const getV3DetailsByCertificationCourseId = async function ({ certificationCours
     })
     .first();
 
-  const { maximumAssessmentLength: numberOfChallenges } = await knex('flash-algorithm-configurations')
-    .where('createdAt', '<=', certificationCourseDTO.createdAt)
-    .orderBy('createdAt', 'desc')
-    .first();
+  const numberOfChallenges = await _getNumberOfChallenges(certificationCourseDTO);
 
   const certificationChallengesDetailsDTO = await knex
     .select({
@@ -109,4 +106,14 @@ function _certificationChallengeLiveAlertToDomain({ liveAlertsDTO, certification
     id: certificationChallengeLiveAlert.id,
     issueReportSubcategory: certificationChallengeLiveAlert.issueReportSubcategory,
   });
+}
+
+async function _getNumberOfChallenges(certificationCourseDTO) {
+  const DEFAULT_NUMBER_OF_CHALLENGES = 32;
+  const flashAlgorithmConfiguration = await knex('flash-algorithm-configurations')
+    .where('createdAt', '<=', certificationCourseDTO.createdAt)
+    .orderBy('createdAt', 'desc')
+    .first();
+
+  return flashAlgorithmConfiguration?.maximumAssessmentLength ?? DEFAULT_NUMBER_OF_CHALLENGES;
 }


### PR DESCRIPTION
## :unicorn: Problème

Il est impossible d'accéder à la page de détails des certifications dont le certification-course a été créé avant l'enregistrement en base de la première configuration de l'algo dans `flash-algorithm-configurations`.

## :robot: Proposition

Nous renvoyons une valeur par défaut correspondant au nombre de questions posées aux candidats des sessions incriminées.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

• Créer une session de certification V3 avec `certifv3@example.net`
• Réaliser le test avec `certifiable-contenu-user@example.net`
• Finaliser la session
• En base, modifier le `createdAt` de la config dans `flash-algorithm-configurations` de façon à ce qu'elle soit postérieure à la date de création du test passé en amont.
• Dans pix-admin, aller sur la page de détails de cette certification
• Vérifier qu'il n'y a pas d'erreur dans l'affichage