### PR TITLE
[TECH] Dans les tests unitaires remplacer le monkey-patching de DomainTransaction.execute par l’utilisation de sinon

### DIFF
--- a/api/tests/prescription/campaign-participation/unit/application/campaign-participation-controller_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/campaign-participation-controller_test.js
@@ -178,9 +178,9 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
       };
       const domainTransaction = Symbol();
 
-      DomainTransaction.execute = (lambda) => {
+      sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => {
         return lambda(domainTransaction);
-      };
+      });
       sinon.stub(usecases, 'deleteCampaignParticipation');
       usecases.deleteCampaignParticipation.resolves();
 

--- a/api/tests/prescription/campaign-participation/unit/application/learner-participation-controller_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/learner-participation-controller_test.js
@@ -252,9 +252,9 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
       const domainTransaction = Symbol();
 
       sinon.stub(usecases, 'beginCampaignParticipationImprovement');
-      DomainTransaction.execute = (lambda) => {
+      sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => {
         return lambda(domainTransaction);
-      };
+      });
       usecases.beginCampaignParticipationImprovement.resolves();
 
       // when

--- a/api/tests/shared/unit/application/assessments/assessment-controller_test.js
+++ b/api/tests/shared/unit/application/assessments/assessment-controller_test.js
@@ -69,9 +69,9 @@ describe('Unit | Controller | assessment-controller', function () {
       assessmentCompletedEvent = new AssessmentCompleted();
       assessment = Symbol('completed-assessment');
       locale = 'fr-fr';
-      DomainTransaction.execute = (lambda) => {
+      sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => {
         return lambda(domainTransaction);
-      };
+      });
 
       sinon.stub(usecases, 'completeAssessment');
       sinon.stub(usecases, 'handleBadgeAcquisition');

--- a/api/tests/shared/unit/domain/usecases/delete-unassociated-badge_test.js
+++ b/api/tests/shared/unit/domain/usecases/delete-unassociated-badge_test.js
@@ -2,10 +2,12 @@ import {
   AcquiredBadgeForbiddenDeletionError,
   CertificationBadgeForbiddenDeletionError,
 } from '../../../../../lib/domain/errors.js';
+import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';
 import { deleteUnassociatedBadge } from '../../../../../src/shared/domain/usecases/delete-unassociated-badge.js';
 import { catchErr, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | UseCase | delete-unassociated-badge', function () {
+  let domainTransaction;
   let badgeId;
   let badgeRepository;
   let complementaryCertificationBadgeRepository;
@@ -17,6 +19,11 @@ describe('Unit | UseCase | delete-unassociated-badge', function () {
       remove: sinon.stub(),
     };
     complementaryCertificationBadgeRepository = { isRelatedToCertification: sinon.stub() };
+
+    domainTransaction = Symbol('domainTransaction');
+    sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => {
+      return lambda(domainTransaction);
+    });
   });
 
   context('When the badge is not associated to a badge acquisition', function () {

--- a/api/tests/unit/application/account-recovery/account-recovery-controller_test.js
+++ b/api/tests/unit/application/account-recovery/account-recovery-controller_test.js
@@ -106,9 +106,9 @@ describe('Unit | Controller | account-recovery-controller', function () {
       };
 
       sinon.stub(usecases, 'updateUserForAccountRecovery').resolves();
-      DomainTransaction.execute = (lambda) => {
+      sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => {
         return lambda(domainTransaction);
-      };
+      });
 
       // when
       const response = await accountRecoveryController.updateUserAccountFromRecoveryDemand(request, hFake);

--- a/api/tests/unit/domain/usecases/account-recovery/update-user-for-account-recovery_test.js
+++ b/api/tests/unit/domain/usecases/account-recovery/update-user-for-account-recovery_test.js
@@ -55,9 +55,9 @@ describe('Unit | Usecases | update-user-for-account-recovery', function () {
       scoAccountRecoveryService.retrieveAndValidateAccountRecoveryDemand.resolves({ userId: user.id });
       cryptoService.hashPassword.withArgs(password).resolves(hashedPassword);
       authenticationMethodRepository.hasIdentityProviderPIX.withArgs({ userId: user.id }).resolves(false);
-      DomainTransaction.execute = (lambda) => {
+      sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => {
         return lambda(domainTransaction);
-      };
+      });
 
       // when
       await updateUserForAccountRecovery({
@@ -104,9 +104,9 @@ describe('Unit | Usecases | update-user-for-account-recovery', function () {
       scoAccountRecoveryService.retrieveAndValidateAccountRecoveryDemand.resolves({ userId: user.id });
       cryptoService.hashPassword.withArgs(password).resolves(hashedPassword);
       authenticationMethodRepository.hasIdentityProviderPIX.withArgs({ userId: user.id }).resolves(true);
-      DomainTransaction.execute = (lambda) => {
+      sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => {
         return lambda(domainTransaction);
-      };
+      });
 
       // when
       await updateUserForAccountRecovery({
@@ -166,9 +166,9 @@ describe('Unit | Usecases | update-user-for-account-recovery', function () {
       .withArgs({ id: user.id, userAttributes, domainTransaction })
       .resolves(userUpdate);
 
-    DomainTransaction.execute = (lambda) => {
+    sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => {
       return lambda(domainTransaction);
-    };
+    });
 
     // when
     await updateUserForAccountRecovery({
@@ -215,9 +215,9 @@ describe('Unit | Usecases | update-user-for-account-recovery', function () {
     authenticationMethodRepository.hasIdentityProviderPIX.resolves(true);
     userRepository.updateWithEmailConfirmed.resolves(userUpdate);
 
-    DomainTransaction.execute = (lambda) => {
+    sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => {
       return lambda(domainTransaction);
-    };
+    });
 
     // when
     await updateUserForAccountRecovery({

--- a/api/tests/unit/domain/usecases/import-certification-candidates-from-candidates-import-sheet_test.js
+++ b/api/tests/unit/domain/usecases/import-certification-candidates-from-candidates-import-sheet_test.js
@@ -36,9 +36,9 @@ describe('Unit | UseCase | import-certification-candidates-from-attendance-sheet
     complementaryCertificationRepository = Symbol('complementaryCertificationRepository');
     certificationCenterRepository = Symbol('certificationCenterRepository');
     domainTransaction = Symbol('domainTransaction');
-    DomainTransaction.execute = (lambda) => {
+    sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => {
       return lambda(domainTransaction);
-    };
+    });
   });
 
   describe('#importCertificationCandidatesFromCandidatesImportSheet', function () {


### PR DESCRIPTION
## :unicorn: Problème

Dans les tests unitaires il y a du monkey-patching sur `DomainTransaction.execute` qui crée des effets de bord sur les autres tests.

## :robot: Proposition

Lorsqu'il y a besoin de modifier le comportement de `DomainTransaction.execute` utiliser `sinon`, car dans [api/tests/test-helper.js](https://github.com/1024pix/pix/blob/dev/api/tests/test-helper.js) il y a la fonction `afterEach` qui fait un `restore` sur tous les stubs de *sinon*, ce qui restaure un environnement vierge, à la fin de chaque test, pour le test suivant.

## :rainbow: Remarques

RAS

## :100: Pour tester

* Vérifier que la CI passe.
* Vérifier qu'il ne reste plus d’occurrence de code comme « `DomainTransaction.execute =` » dans les tests
