### PR TITLE
[FEATURE] Améliorer la gestion du choix de la langue d'affichage (PIX-11826)

### DIFF
--- a/certif/app/services/locale.js
+++ b/certif/app/services/locale.js
@@ -18,7 +18,11 @@ export default class LocaleService extends Service {
 
   handleUnsupportedLanguage(language) {
     if (!language) return;
-    return SUPPORTED_LANGUAGES.includes(language) ? language : DEFAULT_LOCALE;
+    return this.isLanguageSupported(language) ? language : DEFAULT_LOCALE;
+  }
+
+  isLanguageSupported(language) {
+    return SUPPORTED_LANGUAGES.includes(language);
   }
 
   hasLocaleCookie() {

--- a/certif/app/services/session.js
+++ b/certif/app/services/session.js
@@ -13,8 +13,6 @@ export default class CurrentSessionService extends SessionService {
   @service currentUser;
   @service locale;
 
-  _localeFromQueryParam;
-
   async handleAuthentication() {
     const isFranceDomain = this.currentDomain.isFranceDomain;
     await this.currentUser.load();
@@ -35,10 +33,6 @@ export default class CurrentSessionService extends SessionService {
   }
 
   handleLocale({ isFranceDomain, localeFromQueryParam, userLocale }) {
-    if (localeFromQueryParam) {
-      this._localeFromQueryParam = this.locale.handleUnsupportedLanguage(localeFromQueryParam);
-    }
-
     if (isFranceDomain) {
       this.locale.setLocale(FRENCH_INTERNATIONAL_LOCALE);
 
@@ -49,16 +43,20 @@ export default class CurrentSessionService extends SessionService {
       return;
     }
 
-    if (this._localeFromQueryParam) {
-      this.locale.setLocale(this._localeFromQueryParam);
+    if (localeFromQueryParam && this.locale.isLanguageSupported(localeFromQueryParam)) {
+      this.locale.setLocale(localeFromQueryParam);
       return;
     }
 
-    const localeNotSupported = userLocale && !SUPPORTED_LANGUAGES.includes(userLocale);
+    if (!userLocale) {
+      this.locale.setLocale(FRENCH_INTERNATIONAL_LOCALE);
+      return;
+    }
+
+    const localeNotSupported = !SUPPORTED_LANGUAGES.includes(userLocale);
+    const locale = localeNotSupported ? ENGLISH_INTERNATIONAL_LOCALE : userLocale;
 
     this.data.localeNotSupported = localeNotSupported;
-    const locale = localeNotSupported ? ENGLISH_INTERNATIONAL_LOCALE : userLocale || FRENCH_INTERNATIONAL_LOCALE;
-
     this.locale.setLocale(locale);
   }
 

--- a/certif/tests/acceptance/authentication_test.js
+++ b/certif/tests/acceptance/authentication_test.js
@@ -156,11 +156,10 @@ module('Acceptance | authentication', function (hooks) {
       test('sets and remembers the locale to the lang query param which wins over the user’s lang', async function (assert) {
         // given
         certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+        await authenticateSession(certificationPointOfContact.id);
 
         // when
-        await visit('/?lang=en');
-        await authenticateSession(certificationPointOfContact.id);
-        const screen = await visit('/');
+        const screen = await visit('/?lang=en');
 
         // then
         assert.dom(screen.getByRole('link', { name: 'Invigilator’s Portal' })).exists();

--- a/certif/tests/unit/services/locale_test.js
+++ b/certif/tests/unit/services/locale_test.js
@@ -97,6 +97,38 @@ module('Unit | Service | locale', function (hooks) {
     });
   });
 
+  module('#isLanguageSupported', function () {
+    module('when no language provided', function () {
+      test('returns "false"', function (assert) {
+        // when
+        const isLanguageSupported = localeService.isLanguageSupported();
+
+        // then
+        assert.false(isLanguageSupported);
+      });
+    });
+
+    module('when language is not supported', function () {
+      test('returns "false"', function (assert) {
+        // when
+        const isLanguageSupported = localeService.isLanguageSupported('not supported');
+
+        // then
+        assert.false(isLanguageSupported);
+      });
+    });
+
+    module('when language is supported', function () {
+      test('returns "true"', function (assert) {
+        // when
+        const isLanguageSupported = localeService.isLanguageSupported('fr');
+
+        // then
+        assert.true(isLanguageSupported);
+      });
+    });
+  });
+
   module('#hasLocaleCookie', function () {
     module('when there is no cookie locale', function () {
       test('returns "false"', function (assert) {

--- a/certif/tests/unit/services/session_test.js
+++ b/certif/tests/unit/services/session_test.js
@@ -264,16 +264,32 @@ module('Unit | Service | session', function (hooks) {
           });
 
           module('when user is loaded', function () {
-            test('sets the locale to the user’s lang', function (assert) {
-              // given
-              const localeFromQueryParam = 'an invalid locale';
-              const userLocale = ENGLISH_INTERNATIONAL_LOCALE;
+            module('when user profile language is supported', function () {
+              test(`sets the locale to the user's profile language`, function (assert) {
+                // given
+                const localeFromQueryParam = 'an invalid locale';
+                const userLocale = ENGLISH_INTERNATIONAL_LOCALE;
 
-              // when
-              service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+                // when
+                service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
-              // then
-              assert.true(localeService.setLocale.calledWith(ENGLISH_INTERNATIONAL_LOCALE));
+                // then
+                assert.true(localeService.setLocale.calledWith(ENGLISH_INTERNATIONAL_LOCALE));
+              });
+            });
+
+            module('when user profile language is not supported', function () {
+              test(`sets the locale to english`, function (assert) {
+                // given
+                const localeFromQueryParam = 'an invalid locale';
+                const userLocale = 'not supported locale';
+
+                // when
+                service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+                // then
+                assert.true(localeService.setLocale.calledWith(ENGLISH_INTERNATIONAL_LOCALE));
+              });
             });
           });
         });

--- a/certif/tests/unit/services/session_test.js
+++ b/certif/tests/unit/services/session_test.js
@@ -285,7 +285,9 @@ module('Unit | Service | session', function (hooks) {
               const localeFromQueryParam = ENGLISH_INTERNATIONAL_LOCALE;
               const userLocale = undefined;
 
-              localeService.handleUnsupportedLanguage.returns(ENGLISH_INTERNATIONAL_LOCALE);
+              localeService.handleUnsupportedLanguage
+                .withArgs(ENGLISH_INTERNATIONAL_LOCALE)
+                .returns(ENGLISH_INTERNATIONAL_LOCALE);
 
               // when
               service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
@@ -301,7 +303,9 @@ module('Unit | Service | session', function (hooks) {
               const localeFromQueryParam = ENGLISH_INTERNATIONAL_LOCALE;
               const userLocale = FRENCH_INTERNATIONAL_LOCALE;
 
-              localeService.handleUnsupportedLanguage.returns(ENGLISH_INTERNATIONAL_LOCALE);
+              localeService.handleUnsupportedLanguage
+                .withArgs(ENGLISH_INTERNATIONAL_LOCALE)
+                .returns(ENGLISH_INTERNATIONAL_LOCALE);
 
               // when
               service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });

--- a/certif/tests/unit/services/session_test.js
+++ b/certif/tests/unit/services/session_test.js
@@ -76,12 +76,17 @@ module('Unit | Service | session', function (hooks) {
   });
 
   module('#handleLocale', function () {
-    module('when domain is .fr', function () {
+    module('when domain is .fr', function (hooks) {
+      let isFranceDomain;
+
+      hooks.beforeEach(function () {
+        isFranceDomain = true;
+      });
+
       module('when there is no cookie locale', function () {
         test('adds a cookie locale with "fr-FR" as value', function (assert) {
           // given
           localeService.hasLocaleCookie.returns(false);
-          const isFranceDomain = true;
           const localeFromQueryParam = undefined;
           const userLocale = undefined;
 
@@ -98,7 +103,6 @@ module('Unit | Service | session', function (hooks) {
         test('does not update cookie locale', function (assert) {
           // given
           localeService.hasLocaleCookie.returns(true);
-          const isFranceDomain = true;
           const localeFromQueryParam = undefined;
           const userLocale = undefined;
 
@@ -115,7 +119,6 @@ module('Unit | Service | session', function (hooks) {
         module('when user is not loaded', function () {
           test('sets the locale to be French international in every case', function (assert) {
             // given
-            const isFranceDomain = true;
             const localeFromQueryParam = undefined;
             const userLocale = undefined;
 
@@ -131,7 +134,6 @@ module('Unit | Service | session', function (hooks) {
         module('when user is loaded', function () {
           test('sets the locale to be French international in every case', function (assert) {
             // given
-            const isFranceDomain = true;
             const localeFromQueryParam = undefined;
             const userLocale = 'user’s lang';
 
@@ -149,7 +151,6 @@ module('Unit | Service | session', function (hooks) {
         module('when user is not loaded', function () {
           test('sets the locale to be French international in every case', function (assert) {
             // given
-            const isFranceDomain = true;
             const localeFromQueryParam = ENGLISH_INTERNATIONAL_LOCALE;
             const userLocale = undefined;
 
@@ -165,7 +166,6 @@ module('Unit | Service | session', function (hooks) {
         module('when user is loaded', function () {
           test('sets the locale to be French international in every case', function (assert) {
             // given
-            const isFranceDomain = true;
             const localeFromQueryParam = ENGLISH_INTERNATIONAL_LOCALE;
             const userLocale = 'user’s lang';
 
@@ -180,11 +180,16 @@ module('Unit | Service | session', function (hooks) {
       });
     });
 
-    module('when domain is .org', function () {
+    module('when domain is .org', function (hooks) {
+      let isFranceDomain;
+
+      hooks.beforeEach(function () {
+        isFranceDomain = false;
+      });
+
       test('does not set the cookie locale', function (assert) {
         // given
         localeService.hasLocaleCookie.returns(false);
-        const isFranceDomain = false;
         const localeFromQueryParam = undefined;
         const userLocale = undefined;
 
@@ -200,7 +205,6 @@ module('Unit | Service | session', function (hooks) {
         module('when user is not loaded', function () {
           test('sets the default locale', function (assert) {
             // given
-            const isFranceDomain = false;
             const localeFromQueryParam = undefined;
             const userLocale = undefined;
 
@@ -217,7 +221,6 @@ module('Unit | Service | session', function (hooks) {
           module('when user language is not available', function () {
             test('sets the locale to English international', function (assert) {
               // given
-              const isFranceDomain = false;
               const localeFromQueryParam = undefined;
               const userLocale = 'my-new-language-code-here';
 
@@ -233,7 +236,6 @@ module('Unit | Service | session', function (hooks) {
 
           test('sets the locale to the user’s lang', function (assert) {
             // given
-            const isFranceDomain = false;
             const localeFromQueryParam = undefined;
             const userLocale = ENGLISH_INTERNATIONAL_LOCALE;
 
@@ -252,7 +254,6 @@ module('Unit | Service | session', function (hooks) {
           module('when user is not loaded', function () {
             test('sets the default locale', function (assert) {
               // given
-              const isFranceDomain = false;
               const localeFromQueryParam = 'an invalid locale';
               const userLocale = undefined;
 
@@ -268,7 +269,6 @@ module('Unit | Service | session', function (hooks) {
           module('when user is loaded', function () {
             test('sets the locale to the user’s lang', function (assert) {
               // given
-              const isFranceDomain = false;
               const localeFromQueryParam = 'an invalid locale';
               const userLocale = ENGLISH_INTERNATIONAL_LOCALE;
 
@@ -286,7 +286,6 @@ module('Unit | Service | session', function (hooks) {
           module('when user is not loaded', function () {
             test('sets the locale to the lang query param', function (assert) {
               // given
-              const isFranceDomain = false;
               const localeFromQueryParam = ENGLISH_INTERNATIONAL_LOCALE;
               const userLocale = undefined;
 
@@ -304,7 +303,6 @@ module('Unit | Service | session', function (hooks) {
           module('when user is loaded', function () {
             test('sets the locale to the lang query param which wins over', function (assert) {
               // given
-              const isFranceDomain = false;
               const localeFromQueryParam = ENGLISH_INTERNATIONAL_LOCALE;
               const userLocale = FRENCH_INTERNATIONAL_LOCALE;
 

--- a/certif/tests/unit/services/session_test.js
+++ b/certif/tests/unit/services/session_test.js
@@ -94,8 +94,7 @@ module('Unit | Service | session', function (hooks) {
           service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
           // then
-          sinon.assert.calledWith(localeService.setLocaleCookie, FRENCH_FRANCE_LOCALE);
-          assert.ok(true);
+          assert.true(localeService.setLocaleCookie.calledWith(FRENCH_FRANCE_LOCALE));
         });
       });
 
@@ -110,8 +109,7 @@ module('Unit | Service | session', function (hooks) {
           service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
           // then
-          sinon.assert.notCalled(localeService.setLocaleCookie);
-          assert.ok(true);
+          assert.true(localeService.setLocaleCookie.notCalled);
         });
       });
 
@@ -126,8 +124,7 @@ module('Unit | Service | session', function (hooks) {
             service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.calledWith(localeService.setLocale, FRENCH_INTERNATIONAL_LOCALE);
-            assert.ok(true);
+            assert.true(localeService.setLocale.calledWith(FRENCH_INTERNATIONAL_LOCALE));
           });
         });
 
@@ -141,8 +138,7 @@ module('Unit | Service | session', function (hooks) {
             service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.calledWith(localeService.setLocale, FRENCH_INTERNATIONAL_LOCALE);
-            assert.ok(true);
+            assert.true(localeService.setLocale.calledWith(FRENCH_INTERNATIONAL_LOCALE));
           });
         });
       });
@@ -158,8 +154,7 @@ module('Unit | Service | session', function (hooks) {
             service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.calledWith(localeService.setLocale, FRENCH_INTERNATIONAL_LOCALE);
-            assert.ok(true);
+            assert.true(localeService.setLocale.calledWith(FRENCH_INTERNATIONAL_LOCALE));
           });
         });
 
@@ -173,8 +168,7 @@ module('Unit | Service | session', function (hooks) {
             service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.calledWith(localeService.setLocale, FRENCH_INTERNATIONAL_LOCALE);
-            assert.ok(true);
+            assert.true(localeService.setLocale.calledWith(FRENCH_INTERNATIONAL_LOCALE));
           });
         });
       });
@@ -197,8 +191,7 @@ module('Unit | Service | session', function (hooks) {
         service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
         // then
-        sinon.assert.notCalled(localeService.setLocaleCookie);
-        assert.ok(true);
+        assert.true(localeService.setLocaleCookie.notCalled);
       });
 
       module('when no lang query param', function () {
@@ -212,8 +205,7 @@ module('Unit | Service | session', function (hooks) {
             service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.calledWith(localeService.setLocale, DEFAULT_LOCALE);
-            assert.ok(true);
+            assert.true(localeService.setLocale.calledWith(DEFAULT_LOCALE));
           });
         });
 
@@ -243,8 +235,7 @@ module('Unit | Service | session', function (hooks) {
             service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.calledWith(localeService.setLocale, ENGLISH_INTERNATIONAL_LOCALE);
-            assert.ok(true);
+            assert.true(localeService.setLocale.calledWith(ENGLISH_INTERNATIONAL_LOCALE));
           });
         });
       });
@@ -261,8 +252,7 @@ module('Unit | Service | session', function (hooks) {
               service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
-              sinon.assert.calledWith(localeService.setLocale, DEFAULT_LOCALE);
-              assert.ok(true);
+              assert.true(localeService.setLocale.calledWith(DEFAULT_LOCALE));
             });
           });
 
@@ -276,8 +266,7 @@ module('Unit | Service | session', function (hooks) {
               service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
-              sinon.assert.calledWith(localeService.setLocale, ENGLISH_INTERNATIONAL_LOCALE);
-              assert.ok(true);
+              assert.true(localeService.setLocale.calledWith(ENGLISH_INTERNATIONAL_LOCALE));
             });
           });
         });
@@ -295,8 +284,7 @@ module('Unit | Service | session', function (hooks) {
               service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
-              sinon.assert.calledWith(localeService.setLocale, ENGLISH_INTERNATIONAL_LOCALE);
-              assert.ok(true);
+              assert.true(localeService.setLocale.calledWith(ENGLISH_INTERNATIONAL_LOCALE));
             });
           });
 
@@ -312,8 +300,7 @@ module('Unit | Service | session', function (hooks) {
               service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
-              sinon.assert.calledWith(localeService.setLocale, ENGLISH_INTERNATIONAL_LOCALE);
-              assert.ok(true);
+              assert.true(localeService.setLocale.calledWith(ENGLISH_INTERNATIONAL_LOCALE));
             });
           });
         });

--- a/certif/tests/unit/services/session_test.js
+++ b/certif/tests/unit/services/session_test.js
@@ -248,7 +248,7 @@ module('Unit | Service | session', function (hooks) {
       });
 
       module('when a lang query param is present', function () {
-        module('when the lang query param is invalid', function () {
+        module('when the lang query param is not supported', function () {
           module('when user is not loaded', function () {
             test('sets the default locale', function (assert) {
               // given
@@ -282,7 +282,7 @@ module('Unit | Service | session', function (hooks) {
           });
         });
 
-        module('when the lang query param is valid', function () {
+        module('when the lang query param is supported', function () {
           module('when user is not loaded', function () {
             test('sets the locale to the lang query param', function (assert) {
               // given

--- a/certif/tests/unit/services/session_test.js
+++ b/certif/tests/unit/services/session_test.js
@@ -113,11 +113,16 @@ module('Unit | Service | session', function (hooks) {
         });
       });
 
-      module('when no lang query param', function () {
+      module('when no lang query param', function (hooks) {
+        let localeFromQueryParam;
+
+        hooks.beforeEach(function () {
+          localeFromQueryParam = undefined;
+        });
+
         module('when user is not loaded', function () {
           test('sets the locale to be French international in every case', function (assert) {
             // given
-            const localeFromQueryParam = undefined;
             const userLocale = undefined;
 
             // when
@@ -131,7 +136,6 @@ module('Unit | Service | session', function (hooks) {
         module('when user is loaded', function () {
           test('sets the locale to be French international in every case', function (assert) {
             // given
-            const localeFromQueryParam = undefined;
             const userLocale = 'user’s lang';
 
             // when
@@ -194,11 +198,16 @@ module('Unit | Service | session', function (hooks) {
         assert.true(localeService.setLocaleCookie.notCalled);
       });
 
-      module('when no lang query param', function () {
+      module('when no lang query param', function (hooks) {
+        let localeFromQueryParam;
+
+        hooks.beforeEach(function () {
+          localeFromQueryParam = undefined;
+        });
+
         module('when user is not loaded', function () {
           test('sets the default locale', function (assert) {
             // given
-            const localeFromQueryParam = undefined;
             const userLocale = undefined;
 
             // when
@@ -213,7 +222,6 @@ module('Unit | Service | session', function (hooks) {
           module('when user language is not available', function () {
             test('sets the locale to English international', function (assert) {
               // given
-              const localeFromQueryParam = undefined;
               const userLocale = 'my-new-language-code-here';
 
               // when
@@ -228,7 +236,6 @@ module('Unit | Service | session', function (hooks) {
 
           test('sets the locale to the user’s lang', function (assert) {
             // given
-            const localeFromQueryParam = undefined;
             const userLocale = ENGLISH_INTERNATIONAL_LOCALE;
 
             // when

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -1,7 +1,7 @@
 {
   "banners": {
     "language-availability": {
-      "message": "Your language is not yet available on Pix Orga. For your convenience, the application will be presented in English. The entire Pix team is working to add your language."
+      "message": "Your language is not yet available on Pix Certif. For your convenience, the application will be presented in English. The entire Pix team is working to add your language."
     }
   },
   "common": {

--- a/orga/app/services/locale.js
+++ b/orga/app/services/locale.js
@@ -18,7 +18,11 @@ export default class LocaleService extends Service {
 
   handleUnsupportedLanguage(language) {
     if (!language) return;
-    return SUPPORTED_LANGUAGES.includes(language) ? language : DEFAULT_LOCALE;
+    return this.isLanguageSupported(language) ? language : DEFAULT_LOCALE;
+  }
+
+  isLanguageSupported(language) {
+    return SUPPORTED_LANGUAGES.includes(language);
   }
 
   hasLocaleCookie() {

--- a/orga/app/services/session.js
+++ b/orga/app/services/session.js
@@ -15,8 +15,6 @@ export default class CurrentSessionService extends SessionService {
   @service dayjs;
   @service url;
 
-  _localeFromQueryParam;
-
   routeAfterAuthentication = 'authenticated';
 
   async handleAuthentication() {
@@ -34,8 +32,6 @@ export default class CurrentSessionService extends SessionService {
   }
 
   handleLocale({ isFranceDomain, localeFromQueryParam, userLocale }) {
-    this._localeFromQueryParam = this.locale.handleUnsupportedLanguage(localeFromQueryParam);
-
     if (isFranceDomain) {
       this.locale.setLocale(FRENCH_INTERNATIONAL_LOCALE);
 
@@ -46,16 +42,20 @@ export default class CurrentSessionService extends SessionService {
       return;
     }
 
-    if (this._localeFromQueryParam) {
-      this.locale.setLocale(this._localeFromQueryParam);
+    if (localeFromQueryParam && this.locale.isLanguageSupported(localeFromQueryParam)) {
+      this.locale.setLocale(localeFromQueryParam);
       return;
     }
 
-    const localeNotSupported = userLocale && !SUPPORTED_LANGUAGES.includes(userLocale);
+    if (!userLocale) {
+      this.locale.setLocale(FRENCH_INTERNATIONAL_LOCALE);
+      return;
+    }
+
+    const localeNotSupported = !SUPPORTED_LANGUAGES.includes(userLocale);
+    const locale = localeNotSupported ? ENGLISH_INTERNATIONAL_LOCALE : userLocale;
 
     this.data.localeNotSupported = localeNotSupported;
-    const locale = localeNotSupported ? ENGLISH_INTERNATIONAL_LOCALE : userLocale || FRENCH_INTERNATIONAL_LOCALE;
-
     this.locale.setLocale(locale);
   }
 

--- a/orga/tests/unit/services/locale_test.js
+++ b/orga/tests/unit/services/locale_test.js
@@ -78,6 +78,38 @@ module('Unit | Service | locale', function (hooks) {
     });
   });
 
+  module('#isLanguageSupported', function () {
+    module('when no language provided', function () {
+      test('returns "false"', function (assert) {
+        // when
+        const isLanguageSupported = localeService.isLanguageSupported();
+
+        // then
+        assert.false(isLanguageSupported);
+      });
+    });
+
+    module('when language is not supported', function () {
+      test('returns "false"', function (assert) {
+        // when
+        const isLanguageSupported = localeService.isLanguageSupported('not supported');
+
+        // then
+        assert.false(isLanguageSupported);
+      });
+    });
+
+    module('when language is supported', function () {
+      test('returns "true"', function (assert) {
+        // when
+        const isLanguageSupported = localeService.isLanguageSupported('fr');
+
+        // then
+        assert.true(isLanguageSupported);
+      });
+    });
+  });
+
   module('#setLocaleCookie', function () {
     test('saves the locale in cookie locale', function (assert) {
       // given

--- a/orga/tests/unit/services/session_test.js
+++ b/orga/tests/unit/services/session_test.js
@@ -284,16 +284,32 @@ module('Unit | Service | session', function (hooks) {
           });
 
           module('when user is loaded', function () {
-            test('sets the locale to the user’s lang', function (assert) {
-              // given
-              const localeFromQueryParam = 'an invalid locale';
-              const userLocale = ENGLISH_INTERNATIONAL_LOCALE;
+            module('when user profile language is supported', function () {
+              test(`sets the locale to the user's profile language`, function (assert) {
+                // given
+                const localeFromQueryParam = 'an invalid locale';
+                const userLocale = ENGLISH_INTERNATIONAL_LOCALE;
 
-              // when
-              service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+                // when
+                service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
-              // then
-              assert.true(localeService.setLocale.calledWith(ENGLISH_INTERNATIONAL_LOCALE));
+                // then
+                assert.true(localeService.setLocale.calledWith(ENGLISH_INTERNATIONAL_LOCALE));
+              });
+            });
+
+            module('when user profile language is not supported', function () {
+              test(`sets the locale to english`, function (assert) {
+                // given
+                const localeFromQueryParam = 'an invalid locale';
+                const userLocale = 'not supported locale';
+
+                // when
+                service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+                // then
+                assert.true(localeService.setLocale.calledWith(ENGLISH_INTERNATIONAL_LOCALE));
+              });
             });
           });
         });

--- a/orga/tests/unit/services/session_test.js
+++ b/orga/tests/unit/services/session_test.js
@@ -198,11 +198,16 @@ module('Unit | Service | session', function (hooks) {
       });
     });
 
-    module('when domain is .org', function () {
+    module('when domain is .org', function (hooks) {
+      let isFranceDomain;
+
+      hooks.beforeEach(function () {
+        isFranceDomain = false;
+      });
+
       test('does not set the cookie locale', function (assert) {
         // given
         localeService.hasLocaleCookie.returns(false);
-        const isFranceDomain = false;
         const localeFromQueryParam = undefined;
         const userLocale = undefined;
 
@@ -222,7 +227,6 @@ module('Unit | Service | session', function (hooks) {
               load: sinon.stub(),
               prescriber: null,
             };
-            const isFranceDomain = false;
             const localeFromQueryParam = undefined;
             const userLocale = undefined;
 
@@ -239,7 +243,6 @@ module('Unit | Service | session', function (hooks) {
           module('when user language is not available', function () {
             test('sets the locale to English international', function (assert) {
               // given
-              const isFranceDomain = false;
               const localeFromQueryParam = undefined;
               const userLocale = 'my-new-language-code-here';
 
@@ -262,7 +265,6 @@ module('Unit | Service | session', function (hooks) {
                 save: sinon.stub(),
               },
             };
-            const isFranceDomain = false;
             const localeFromQueryParam = undefined;
             const userLocale = ENGLISH_INTERNATIONAL_LOCALE;
 
@@ -286,7 +288,6 @@ module('Unit | Service | session', function (hooks) {
                 load: sinon.stub(),
                 prescriber: null,
               };
-              const isFranceDomain = false;
               const localeFromQueryParam = 'an invalid locale';
               const userLocale = undefined;
 
@@ -309,7 +310,6 @@ module('Unit | Service | session', function (hooks) {
                   save: sinon.stub(),
                 },
               };
-              const isFranceDomain = false;
               const localeFromQueryParam = 'an invalid locale';
               const userLocale = ENGLISH_INTERNATIONAL_LOCALE;
 
@@ -335,7 +335,6 @@ module('Unit | Service | session', function (hooks) {
               localeService.handleUnsupportedLanguage.returns(ENGLISH_INTERNATIONAL_LOCALE);
 
               // when
-              const isFranceDomain = false;
               const localeFromQueryParam = ENGLISH_INTERNATIONAL_LOCALE;
               const userLocale = undefined;
 
@@ -351,7 +350,6 @@ module('Unit | Service | session', function (hooks) {
           module('when user is loaded', function () {
             test('sets the locale to the lang query param which wins over', function (assert) {
               // given
-              const isFranceDomain = false;
               const localeFromQueryParam = ENGLISH_INTERNATIONAL_LOCALE;
               const userLocale = FRENCH_INTERNATIONAL_LOCALE;
               localeService.handleUnsupportedLanguage.returns(ENGLISH_INTERNATIONAL_LOCALE);

--- a/orga/tests/unit/services/session_test.js
+++ b/orga/tests/unit/services/session_test.js
@@ -218,11 +218,16 @@ module('Unit | Service | session', function (hooks) {
         assert.true(localeService.setLocaleCookie.notCalled);
       });
 
-      module('when no lang query param', function () {
+      module('when no lang query param', function (hooks) {
+        let localeFromQueryParam;
+
+        hooks.beforeEach(function () {
+          localeFromQueryParam = undefined;
+        });
+
         module('when user is not loaded', function () {
           test('sets the default locale', function (assert) {
             // given
-            const localeFromQueryParam = undefined;
             const userLocale = undefined;
 
             // when
@@ -237,7 +242,6 @@ module('Unit | Service | session', function (hooks) {
           module('when user language is not available', function () {
             test('sets the locale to English international', function (assert) {
               // given
-              const localeFromQueryParam = undefined;
               const userLocale = 'my-new-language-code-here';
 
               // when
@@ -252,7 +256,6 @@ module('Unit | Service | session', function (hooks) {
 
           test('sets the locale to the user’s lang', function (assert) {
             // given
-            const localeFromQueryParam = undefined;
             const userLocale = ENGLISH_INTERNATIONAL_LOCALE;
 
             // when

--- a/orga/tests/unit/services/session_test.js
+++ b/orga/tests/unit/services/session_test.js
@@ -215,8 +215,7 @@ module('Unit | Service | session', function (hooks) {
         service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
         // then
-        sinon.assert.notCalled(localeService.setLocaleCookie);
-        assert.ok(true);
+        assert.true(localeService.setLocaleCookie.notCalled);
       });
 
       module('when no lang query param', function () {
@@ -234,8 +233,7 @@ module('Unit | Service | session', function (hooks) {
             service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.calledWith(localeService.setLocale, DEFAULT_LOCALE);
-            assert.ok(true);
+            assert.true(localeService.setLocale.calledWith(DEFAULT_LOCALE));
           });
         });
 
@@ -272,9 +270,8 @@ module('Unit | Service | session', function (hooks) {
             service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.calledWith(localeService.setLocale, ENGLISH_INTERNATIONAL_LOCALE);
             sinon.assert.notCalled(service.currentUser.prescriber.save);
-            assert.ok(true);
+            assert.true(localeService.setLocale.calledWith(ENGLISH_INTERNATIONAL_LOCALE));
           });
         });
       });
@@ -295,8 +292,7 @@ module('Unit | Service | session', function (hooks) {
               service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
-              sinon.assert.calledWith(localeService.setLocale, DEFAULT_LOCALE);
-              assert.ok(true);
+              assert.true(localeService.setLocale.calledWith(DEFAULT_LOCALE));
             });
           });
 
@@ -317,9 +313,8 @@ module('Unit | Service | session', function (hooks) {
               service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
-              sinon.assert.calledWith(localeService.setLocale, ENGLISH_INTERNATIONAL_LOCALE);
               sinon.assert.notCalled(service.currentUser.prescriber.save);
-              assert.ok(true);
+              assert.true(localeService.setLocale.calledWith(ENGLISH_INTERNATIONAL_LOCALE));
             });
           });
         });
@@ -342,8 +337,7 @@ module('Unit | Service | session', function (hooks) {
               service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
-              sinon.assert.calledWith(localeService.setLocale, ENGLISH_INTERNATIONAL_LOCALE);
-              assert.ok(true);
+              assert.true(localeService.setLocale.calledWith(ENGLISH_INTERNATIONAL_LOCALE));
             });
           });
 
@@ -358,8 +352,7 @@ module('Unit | Service | session', function (hooks) {
               service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
-              sinon.assert.calledWith(localeService.setLocale, ENGLISH_INTERNATIONAL_LOCALE);
-              assert.ok(true);
+              assert.true(localeService.setLocale.calledWith(ENGLISH_INTERNATIONAL_LOCALE));
             });
           });
         });

--- a/orga/tests/unit/services/session_test.js
+++ b/orga/tests/unit/services/session_test.js
@@ -302,11 +302,11 @@ module('Unit | Service | session', function (hooks) {
           module('when user is not loaded', function () {
             test('sets the locale to the lang query param', function (assert) {
               // given
-              localeService.handleUnsupportedLanguage.returns(ENGLISH_INTERNATIONAL_LOCALE);
-
-              // when
               const localeFromQueryParam = ENGLISH_INTERNATIONAL_LOCALE;
               const userLocale = undefined;
+              localeService.handleUnsupportedLanguage
+                .withArgs(ENGLISH_INTERNATIONAL_LOCALE)
+                .returns(ENGLISH_INTERNATIONAL_LOCALE);
 
               // when
               service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
@@ -321,7 +321,9 @@ module('Unit | Service | session', function (hooks) {
               // given
               const localeFromQueryParam = ENGLISH_INTERNATIONAL_LOCALE;
               const userLocale = FRENCH_INTERNATIONAL_LOCALE;
-              localeService.handleUnsupportedLanguage.returns(ENGLISH_INTERNATIONAL_LOCALE);
+              localeService.handleUnsupportedLanguage
+                .withArgs(ENGLISH_INTERNATIONAL_LOCALE)
+                .returns(ENGLISH_INTERNATIONAL_LOCALE);
 
               // when
               service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });

--- a/orga/tests/unit/services/session_test.js
+++ b/orga/tests/unit/services/session_test.js
@@ -278,7 +278,7 @@ module('Unit | Service | session', function (hooks) {
       });
 
       module('when a lang query param is present', function () {
-        module('when the lang query param is invalid', function () {
+        module('when the lang query param is not supported', function () {
           module('when user is not loaded', function () {
             test('sets the default locale', function (assert) {
               // given
@@ -324,7 +324,7 @@ module('Unit | Service | session', function (hooks) {
           });
         });
 
-        module('when the lang query param is valid', function () {
+        module('when the lang query param is supported', function () {
           module('when user is not loaded', function () {
             test('sets the locale to the lang query param', function (assert) {
               // given

--- a/orga/tests/unit/services/session_test.js
+++ b/orga/tests/unit/services/session_test.js
@@ -222,10 +222,6 @@ module('Unit | Service | session', function (hooks) {
         module('when user is not loaded', function () {
           test('sets the default locale', function (assert) {
             // given
-            service.currentUser = {
-              load: sinon.stub(),
-              prescriber: null,
-            };
             const localeFromQueryParam = undefined;
             const userLocale = undefined;
 
@@ -256,13 +252,6 @@ module('Unit | Service | session', function (hooks) {
 
           test('sets the locale to the user’s lang', function (assert) {
             // given
-            service.currentUser = {
-              load: sinon.stub(),
-              prescriber: {
-                lang: ENGLISH_INTERNATIONAL_LOCALE,
-                save: sinon.stub(),
-              },
-            };
             const localeFromQueryParam = undefined;
             const userLocale = ENGLISH_INTERNATIONAL_LOCALE;
 
@@ -270,7 +259,6 @@ module('Unit | Service | session', function (hooks) {
             service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.notCalled(service.currentUser.prescriber.save);
             assert.true(localeService.setLocale.calledWith(ENGLISH_INTERNATIONAL_LOCALE));
           });
         });
@@ -281,10 +269,6 @@ module('Unit | Service | session', function (hooks) {
           module('when user is not loaded', function () {
             test('sets the default locale', function (assert) {
               // given
-              service.currentUser = {
-                load: sinon.stub(),
-                prescriber: null,
-              };
               const localeFromQueryParam = 'an invalid locale';
               const userLocale = undefined;
 
@@ -299,13 +283,6 @@ module('Unit | Service | session', function (hooks) {
           module('when user is loaded', function () {
             test('sets the locale to the user’s lang', function (assert) {
               // given
-              service.currentUser = {
-                load: sinon.stub(),
-                prescriber: {
-                  lang: ENGLISH_INTERNATIONAL_LOCALE,
-                  save: sinon.stub(),
-                },
-              };
               const localeFromQueryParam = 'an invalid locale';
               const userLocale = ENGLISH_INTERNATIONAL_LOCALE;
 
@@ -313,7 +290,6 @@ module('Unit | Service | session', function (hooks) {
               service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
-              sinon.assert.notCalled(service.currentUser.prescriber.save);
               assert.true(localeService.setLocale.calledWith(ENGLISH_INTERNATIONAL_LOCALE));
             });
           });
@@ -323,10 +299,6 @@ module('Unit | Service | session', function (hooks) {
           module('when user is not loaded', function () {
             test('sets the locale to the lang query param', function (assert) {
               // given
-              service.currentUser = {
-                load: sinon.stub(),
-                prescriber: null,
-              };
               localeService.handleUnsupportedLanguage.returns(ENGLISH_INTERNATIONAL_LOCALE);
 
               // when


### PR DESCRIPTION
## :unicorn: Problème

Si la langue de l’utilisateur n’est pas encore gérée dans Pix Orga sur le domaine .org, et que le paramètre `lang` est fourni et non supporté ou invalide, alors Pix Orga s’affiche en français.

Sur Pix Certif sur le domaine .org, le problème est similaire.

Suite à la modification de cette gestion par la PR #8467, nous devons adapter la gestion du paramètre `lang`

## :robot: Proposition

Utilisateur connecté :

- Si le paramètre d’URL lang est fourni et invalide ou non supporté, alors utilisé la langue de l’utilisateur.
- Si la langue de l’utilisateur n’est pas gérée dans Pix Orga / Pix Certif alors afficher le contenu en langue anglaise par défaut.

## :rainbow: Remarques

RAS

## :100: Pour tester

### Pix Orga

1. Se connecter sur Pix App du domaine .org avec le compte allorga@example.net
2. Changer la langue du compte en Nederlands
3. Se déconnecter
4. Se connecter sur Pix Orga du domaine .org avec le compte allorga@example.net
5. Constater l'affichage de l'application en anglais
6. Constater l'affichage d'une bannière avec le message "Your language is not yet available on Pix Orga. For your convenience, the application will be presented in English. The entire Pix team is working to add your language.”
7. Fermer la bannière
8. Parcourir l'application
9. Constater que la bannière ne s'affiche plus
10. Se déconnecter
11. Se connecter à nouveau à Pix Orga avec le compte allorga@example.net
12. Constater l'affichage, de nouveau, de la bannière avec le message "Your language is not yet available on Pix Orga. For your convenience, the application will be presented in English. The entire Pix team is working to add your language.”
13. Modifier l'URL en y ajoutant `?lang=nl`
14. Constater l'affichage de l'application en anglais
15. Constater l'affichage d'une bannière avec le message "Your language is not yet available on Pix Orga. For your convenience, the application will be presented in English. The entire Pix team is working to add your language.”
16. Modifier l'URL en y ajoutant `?lang=invalid`
17. Constater l'affichage de l'application en anglais
18. Constater l'affichage d'une bannière avec le message "Your language is not yet available on Pix Orga. For your convenience, the application will be presented in English. The entire Pix team is working to add your language.”
19. Modifier l'URL en y ajoutant `?lang=fr`
20. Constater l'affichage de l'application en français
21. Constater que la bannière ne s'affiche pas

### Pix Certif

1. Se connecter sur Pix App du domaine .org avec le compte james-paledroits@example.net
2. Changer la langue du compte en Nederlands
3. Se déconnecter
4. Se connecter sur Pix Certif du domaine .org avec le compte james-paledroits@example.net
5. Constater l'affichage de l'application en anglais
6. Constater l'affichage d'une bannière avec le message "Your language is not yet available on Pix Certif. For your convenience, the application will be presented in English. The entire Pix team is working to add your language.”
7. Fermer la bannière
8. Parcourir l'application
9. Constater que la bannière ne s'affiche plus
10. Se déconnecter
11. Se connecter à nouveau à Pix Certif avec le compte james-paledroits@example.net
12. Constater l'affichage, de nouveau, de la bannière avec le message "Your language is not yet available on Pix Certif. For your convenience, the application will be presented in English. The entire Pix team is working to add your language.”
13. Modifier l'URL en y ajoutant `?lang=nl`
14. Constater l'affichage de l'application en anglais
15. Constater l'affichage d'une bannière avec le message "Your language is not yet available on Pix Orga. For your convenience, the application will be presented in English. The entire Pix team is working to add your language.”
16. Modifier l'URL en y ajoutant `?lang=invalid`
17. Constater l'affichage de l'application en anglais
18. Constater l'affichage d'une bannière avec le message "Your language is not yet available on Pix Orga. For your convenience, the application will be presented in English. The entire Pix team is working to add your language.”
19. Modifier l'URL en y ajoutant `?lang=fr`
20. Constater l'affichage de l'application en français
21. Constater que la bannière ne s'affiche pas
