### PR TITLE
[REFACTOR] Améliorer l'affichage des critères d'obtention d'un résultat thématique (PIX-11870).

### DIFF
--- a/admin/app/components/badges/badge.hbs
+++ b/admin/app/components/badges/badge.hbs
@@ -122,20 +122,26 @@
     </div>
   </section>
 
-  <section class="page-section">
-    <div class="page-section__header">
-      <h1 class="page-section__title">Critères</h1>
-    </div>
-
-    <div class="page-section__details table-admin">
-      {{#each @badge.criteria as |criterion|}}
-        {{#if criterion.isCampaignScope}}
-          <Badges::CampaignCriterion @criterion={{criterion}} />
-        {{/if}}
-        {{#if criterion.isCappedTubesScope}}
-          <Badges::CappedTubesCriterion @criterion={{criterion}} @targetProfile={{@targetProfile}} />
-        {{/if}}
-      {{/each}}
+  <section class="badge__criteria main-admin-form">
+    <div class="admin-form__content">
+      {{#if this.campaignScopeCriterion}}
+        <h2 class="badge__criteria-title">Critère d'obtention basé sur l'ensemble du profil cible&nbsp;:</h2>
+        <div class="card">
+          <div class="card__content">
+            <Badges::CampaignCriterion @criterion={{this.campaignScopeCriterion}} />
+          </div>
+        </div>
+      {{/if}}
+      {{#if this.cappedTubesCriteria.length}}
+        <h2 class="badge__criteria-title">
+          Liste des critères d'obtention basés sur une sélection de sujets du profil cible&nbsp;:
+        </h2>
+        {{#each this.cappedTubesCriteria as |criterion|}}
+          <div class="card">
+            <Badges::CappedTubesCriterion @criterion={{criterion}} @targetProfile={{@targetProfile}} />
+          </div>
+        {{/each}}
+      {{/if}}
     </div>
   </section>
 </main>

--- a/admin/app/components/badges/badge.js
+++ b/admin/app/components/badges/badge.js
@@ -32,6 +32,14 @@ export default class Badge extends Component {
     return this.args.badge.imageUrl.slice(this.IMAGE_BASE_URL.length);
   }
 
+  get campaignScopeCriterion() {
+    return this.args.badge.criteria.find((criterion) => criterion.isCampaignScope) || null;
+  }
+
+  get cappedTubesCriteria() {
+    return this.args.badge.criteria.filter((criterion) => criterion.isCappedTubesScope);
+  }
+
   @action
   async updateBadge(event) {
     event.preventDefault();

--- a/admin/app/components/badges/capped-tubes-criterion.hbs
+++ b/admin/app/components/badges/capped-tubes-criterion.hbs
@@ -1,21 +1,33 @@
-<p data-testid="toujourstriste">
-  L'évalué doit obtenir
-  <strong>{{@criterion.threshold}}%</strong>
+<div class="card__title">
   {{#if @criterion.name}}
-    sur le groupe
     <strong>{{@criterion.name}}</strong>
-    possédant
   {{else}}
-    sur tous
+    Critère
   {{/if}}
-  les sujets plafonnés par niveau suivants :
-</p>
+</div>
 
-{{#each this.areasForView as |area|}}
-  <Common::TubesDetails::Area
-    @title={{area.title}}
-    @color={{area.color}}
-    @competences={{area.competences}}
-    @displayDeviceCompatibility={{true}}
-  />
-{{/each}}
+<div class="card__content">
+  <p class="capped-tubes-criterion__text" data-testid="toujourstriste">
+    L'évalué doit obtenir
+    <strong>{{@criterion.threshold}}%</strong>
+    {{#if @criterion.name}}
+      sur le groupe
+      <strong>{{@criterion.name}}</strong>
+      possédant
+    {{else}}
+      sur tous
+    {{/if}}
+    les sujets plafonnés par niveau suivants :
+  </p>
+
+  <div class="badge-form-criterion">
+    {{#each this.areasForView as |area|}}
+      <Common::TubesDetails::Area
+        @title={{area.title}}
+        @color={{area.color}}
+        @competences={{area.competences}}
+        @displayDeviceCompatibility={{true}}
+      />
+    {{/each}}
+  </div>
+</div>

--- a/admin/app/styles/components/badges/badge.scss
+++ b/admin/app/styles/components/badges/badge.scss
@@ -39,7 +39,6 @@
 }
 
 .badge-edit-form-field {
-
   &__label {
     width: 100%;
   }
@@ -47,4 +46,18 @@
 
 .skill-sets-table {
   margin: 20px 0;
+}
+
+.badge__criteria-title {
+  @extend %pix-title-xs;
+
+  &:not(:first-child) {
+    margin-top: var(--pix-spacing-2x);
+    padding-top: var(--pix-spacing-6x);
+    border-top: 1px dashed var(--pix-neutral-100);
+  }
+}
+
+.capped-tubes-criterion__text {
+  margin-block: var(--pix-spacing-2x) var(--pix-spacing-4x);
 }

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
@@ -650,10 +650,14 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         assert.dom(screen.getByText('Message alternatif : Je mets du png je fais ce que je veux')).exists();
         assert.dom(screen.getByText('Certifiable')).exists();
         assert.dom(screen.getByText('Lacunes')).exists();
+        assert.dom(screen.getByText("Critère d'obtention basé sur l'ensemble du profil cible :")).exists();
         assert.deepEqual(
           screen.getByTestId('triste').innerText,
           'L‘évalué doit obtenir 50% sur l‘ensemble des sujets du profil cible.',
         );
+        assert
+          .dom(screen.getByText("Liste des critères d'obtention basés sur une sélection de sujets du profil cible :"))
+          .exists();
         const labelsForCappedTubes = screen.getAllByTestId('toujourstriste');
         assert.deepEqual(
           labelsForCappedTubes[0].innerText,

--- a/admin/tests/unit/components/badges/badge_test.js
+++ b/admin/tests/unit/components/badges/badge_test.js
@@ -33,4 +33,63 @@ module('Unit | Component | Badges | badge', function (hooks) {
       assert.strictEqual(component.isAlwaysVisibleText, 'Lacunes');
     });
   });
+
+  module('campaignScopeCriterion', function () {
+    test('returns null if campaign scope criterion does not exist', function (assert) {
+      // given & when
+      const component = createComponent('component:badges/badge');
+      component.args = {
+        badge: {
+          criteria: [{ isCappedTubesScope: true }],
+        },
+      };
+
+      // then
+      assert.strictEqual(component.campaignScopeCriterion, null);
+    });
+
+    test('returns the badge criterion if it exists', function (assert) {
+      // given & when
+      const component = createComponent('component:badges/badge');
+      component.args = {
+        badge: {
+          criteria: [{ isCampaignScope: true }, { isCappedTubesScope: true }],
+        },
+      };
+
+      // then
+      assert.deepEqual(component.campaignScopeCriterion, component.args.badge.criteria[0]);
+    });
+  });
+
+  module('cappedTubesCriteria', function () {
+    test('returns an empty array if capped tubes criterion does not exist', function (assert) {
+      // given & when
+      const component = createComponent('component:badges/badge');
+      component.args = {
+        badge: {
+          criteria: [{ isCampaignScope: true }],
+        },
+      };
+
+      // then
+      assert.deepEqual(component.cappedTubesCriteria, []);
+    });
+
+    test('returns an array of cappedTubesCriteria if they exist', function (assert) {
+      // given & when
+      const component = createComponent('component:badges/badge');
+      component.args = {
+        badge: {
+          criteria: [{ isCappedTubesScope: true }, { isCappedTubesScope: true }, { isCampaignScope: true }],
+        },
+      };
+
+      // then
+      assert.deepEqual(component.cappedTubesCriteria, [
+        component.args.badge.criteria[0],
+        component.args.badge.criteria[1],
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème

L'écran des critères d'obtention d'un résultat thématique n'était pas des plus lisibles.

## :robot: Proposition

Améliorer le style du bloc des critères d'obtention d'un résultat thématique.

## :100: Pour tester

Exemples à check :
- https://admin-pr8527.review.pix.fr/target-profiles/56/badges/57
- https://admin-pr8527.review.pix.fr/target-profiles/59/badges/60
