### PR TITLE
[BUGFIX]Corrections de liens menant vers des pages de support NL (PIX-11551)

### DIFF
--- a/api/translations/nl.json
+++ b/api/translations/nl.json
@@ -292,7 +292,6 @@
     },
     "template-name": "importmodel"
   },
-  "current-lang": "en",
   "entity-validation-errors": {
     "ACCEPT_CGU": "Je moet de gebruiksvoorwaarden van Pix accepteren om een account aan te maken.",
     "ALREADY_REGISTERED_EMAIL": "Dit e-mailadres is al geregistreerd, log in.",
@@ -318,10 +317,6 @@
       "CANCELLED_DUE_TO_LACK_OF_ANSWERS_FOR_TECHNICAL_REASON": {
         "candidate": "Een of meer technische problemen die tijdens de certificeringssessie aan uw surveillant zijn gemeld, hebben de kwaliteit van de certificeringstest beïnvloed. Helaas zijn we door het grote aantal vragen dat u niet goed kon beantwoorden niet in staat om een betrouwbare score te berekenen en een certificaat uit te reiken. De certificering wordt geannuleerd en de voorschrijver van uw certificering (indien van toepassing) wordt hiervan op de hoogte gesteld.",
         "organization": "Een of meer technische problemen, gemeld door deze kandidaat aan de supervisor van de certificeringssessie, hebben het vlotte verloop van de certificeringstest beïnvloed. We kunnen de kandidaat niet certificeren en zijn/haar certificering is daarom geannuleerd. Deze informatie moet in aanmerking worden genomen en kan ertoe leiden dat u een nieuwe certificeringssessie voor deze kandidaat voorstelt."
-      },
-      "CANCELLED_DUE_TO_LACK_OF_ANSWERS": {
-        "candidate": "Het aantal vragen tijdens je certificeringsexamen is te laag om een Pix-certificering te kunnen afgeven.",
-        "organization": "Het aantal vragen dat de kandidaat beantwoordt tijdens het certificeringsexamen is te laag om een Pix-certificering af te leveren."
       },
       "CANCELLED_DUE_TO_NEUTRALIZATION": {
         "candidate": "Ten minste één technisch probleem, gemeld aan je surveillant tijdens de certificeringssessie, heeft de kwaliteit van het certificeringsexamen beïnvloed. Vanwege het aantal vragen dat u niet heeft kunnen beantwoorden, kunnen we geen certificering afgeven. Het is geannuleerd, de specificeerder van uw certificeringsexamen (indien van toepassing) is op de hoogte gesteld.",

--- a/api/translations/nl.json
+++ b/api/translations/nl.json
@@ -292,6 +292,9 @@
     },
     "template-name": "importmodel"
   },
+  "email-sender-name": {
+    "pix-app": "PIX - Niet beantwoorden"
+  },
   "entity-validation-errors": {
     "ACCEPT_CGU": "Je moet de gebruiksvoorwaarden van Pix accepteren om een account aan te maken.",
     "ALREADY_REGISTERED_EMAIL": "Dit e-mailadres is al geregistreerd, log in.",

--- a/api/translations/nl.json
+++ b/api/translations/nl.json
@@ -21,17 +21,16 @@
       "session": "De certificeringssessie"
     },
     "examiner-information": {
-      "title": "De supervisor(s)",
       "invigilated-by": "Bewaakt door :",
-      "signature": "Handtekening(en) :"
+      "signature": "Handtekening(en) :",
+      "title": "De supervisor(s)"
     },
     "file-name": "registratie-sessieblad-",
     "header": {
-      "title": "Aanwezigheidslijst",
-      "page": "Pagina"
+      "page": "Pagina",
+      "title": "Aanwezigheidslijst"
     },
     "table": {
-      "title": "Kandidatenlijst",
       "birth-name": "Geboortenaam",
       "date-of-birth": {
         "example": "(dd/mm/jjjj)",
@@ -40,7 +39,8 @@
       "division": "Klasse",
       "external-id": "Lokaal identificatiesymbool",
       "first-name": "Voornaam",
-      "signature": "Handtekening"
+      "signature": "Handtekening",
+      "title": "Kandidatenlijst"
     }
   },
   "campaign-export": {
@@ -156,7 +156,6 @@
   },
   "certification-center-invitation-email": {
     "params": {
-      "title": "Uitnodiging om deel te nemen aan de ruimte",
       "acceptInvitation": "Uitnodiging accepteren",
       "doNotAnswer": "Dit is een automatische e-mail, antwoord niet.",
       "here": "hier",
@@ -164,6 +163,7 @@
       "needHelp": "Hulp nodig? Neem contact met ons op",
       "oneTimeLink": "Deze link is voor eenmalig gebruik",
       "pixCertifPresentation": "De Pix Certif-ruimte is een hulpmiddel voor het organiseren van certificeringssessies.",
+      "title": "Uitnodiging om deel te nemen aan de ruimte",
       "yourCertificationCenter": "Uw certificeringscentrum"
     },
     "subject": "Uitnodiging voor Pix Certif"
@@ -176,7 +176,6 @@
     "max-reachable-level-indication": "* Op de datum waarop deze certificering werd behaald, was het maximaal haalbare aantal pix { maxReachableScore }, wat overeenkomt met het niveau { maxReachableLevelOnCertificationDate }."
   },
   "certification-result-email": {
-    "title": "Raadpleeg de resultaten van certificeringssessie nr. {sessionId} !",
     "params": {
       "doNotReply": "Dit is een automatische e-mail, antwoord niet.",
       "download": "Download de resultaten",
@@ -190,7 +189,8 @@
       "resultsAvailable": "De resultaten van de Pix-certificaten die je hebt voorgeschreven aan je doelgroepen zijn beschikbaar.",
       "subject": "[Pix] Certificeringssessie",
       "viewResultsInProfile": "Kandidaten kunnen hun resultaten bekijken in hun Pix-profiel."
-    }
+    },
+    "title": "Raadpleeg de resultaten van certificeringssessie nr. {sessionId} !"
   },
   "certification-results-csv": {
     "filenames": {
@@ -230,6 +230,7 @@
   "csv-import-values": {
     "sup-organization-learner": {
       "diplomas": {
+        "other": "Andere",
         "bts": "BTS onder staatscontrole",
         "classe-preparatoire": "Door de staat gecontroleerde voorbereidende klas",
         "dcg ": "Door de staat gecontroleerde DCG",
@@ -245,13 +246,12 @@
         "license-grade": "Door de staat gecontroleerde graad die de graad van licentie verleent",
         "master": "Door de staat gecontroleerd nationaal masterdiploma",
         "master-grade": "Door de staat gecontroleerde master",
-        "other": "Andere",
         "vise": "Staatsdiploma"
       },
       "study-schemes": {
+        "other": "Andere",
         "continuous-training": "Voortgezette opleiding",
         "initial-training": "Initiële opleiding exclusief stages",
-        "other": "Andere",
         "training": "Leren"
       },
       "unknown": "Niet erkend"
@@ -292,9 +292,7 @@
     },
     "template-name": "importmodel"
   },
-  "email-sender-name": {
-    "pix-app": "PIX - Niet beantwoorden"
-  },
+  "current-lang": "en",
   "entity-validation-errors": {
     "ACCEPT_CGU": "Je moet de gebruiksvoorwaarden van Pix accepteren om een account aan te maken.",
     "ALREADY_REGISTERED_EMAIL": "Dit e-mailadres is al geregistreerd, log in.",
@@ -317,6 +315,10 @@
   },
   "jury": {
     "comment": {
+      "CANCELLED_DUE_TO_LACK_OF_ANSWERS_FOR_TECHNICAL_REASON": {
+        "candidate": "Een of meer technische problemen die tijdens de certificeringssessie aan uw surveillant zijn gemeld, hebben de kwaliteit van de certificeringstest beïnvloed. Helaas zijn we door het grote aantal vragen dat u niet goed kon beantwoorden niet in staat om een betrouwbare score te berekenen en een certificaat uit te reiken. De certificering wordt geannuleerd en de voorschrijver van uw certificering (indien van toepassing) wordt hiervan op de hoogte gesteld.",
+        "organization": "Een of meer technische problemen, gemeld door deze kandidaat aan de supervisor van de certificeringssessie, hebben het vlotte verloop van de certificeringstest beïnvloed. We kunnen de kandidaat niet certificeren en zijn/haar certificering is daarom geannuleerd. Deze informatie moet in aanmerking worden genomen en kan ertoe leiden dat u een nieuwe certificeringssessie voor deze kandidaat voorstelt."
+      },
       "CANCELLED_DUE_TO_LACK_OF_ANSWERS": {
         "candidate": "Het aantal vragen tijdens je certificeringsexamen is te laag om een Pix-certificering te kunnen afgeven.",
         "organization": "Het aantal vragen dat de kandidaat beantwoordt tijdens het certificeringsexamen is te laag om een Pix-certificering af te leveren."
@@ -330,14 +332,13 @@
         "organization": "Er is fraude ontdekt: na analyse hebben we besloten om dit certificeringsexamen af te wijzen."
       },
       "REJECTED_DUE_TO_INSUFFICIENT_CORRECT_ANSWERS": {
-        "candidate": "Als je meer dan 50% van de gestelde vragen fout hebt beantwoord, is je hele certificering ongeldig en krijg je een score van 0 pix.",
-        "organization": "Als de kandidaat meer dan 50% van de gestelde vragen fout heeft beantwoord, is zijn hele certificering ongeldig en krijgt hij een score van 0 pix."
+        "candidate": "Je hebt meer dan 50% van de vragen fout beantwoord, waardoor je hele certificering ongeldig wordt en je een score van 0 pix krijgt.",
+        "organization": "De kandidaat beantwoordde meer dan 50% van de vragen fout, waardoor zijn hele certificering ongeldig werd en hij een score van 0 pix kreeg."
       }
     }
   },
   "organization-invitation-email": {
     "params": {
-      "title": "Je bent uitgenodigd om lid te worden van Pix Orga",
       "acceptInvitation": "Uitnodiging accepteren",
       "doNotAnswer": "Dit is een automatische e-mail, antwoord niet.",
       "here": "hier",
@@ -346,13 +347,13 @@
       "oneTimeLink": "Deze link is voor eenmalig gebruik",
       "pixPresentation": "Pix is de openbare online service voor het beoordelen, ontwikkelen en certificeren van je digitale vaardigheden.",
       "subtitle": "Met het Pix Orga platform kun je testcampagnes maken en beheren en de voortgang van je deelnemers volgen.",
+      "title": "Je bent uitgenodigd om lid te worden van Pix Orga",
       "yourOrganization": "Uw organisatie"
     },
     "subject": "Uitnodiging om lid te worden van Pix Orga"
   },
   "pix-account-creation-email": {
     "params": {
-      "title": "Je Pix-account is aangemaakt!",
       "askForHelp": "Hulp nodig? Neem contact met ons op",
       "disclaimer": "Als je de account niet hebt aangemaakt, kun je vragen om deze te verwijderen.",
       "doNotAnswer": "Dit is een automatische e-mail, antwoord niet.",
@@ -360,13 +361,13 @@
       "helpdeskLinkLabel": "hier",
       "moreOn": "Ontdek meer over",
       "pixPresentation": "Pix is de online overheidsdienst voor het beoordelen, ontwikkelen en certificeren van je digitale vaardigheden.",
-      "subtitle": "Je kunt nu beginnen met de tests."
+      "subtitle": "Je kunt nu beginnen met de tests.",
+      "title": "Je Pix-account is aangemaakt!"
     },
     "subject": "Je Pix-account is aangemaakt"
   },
   "reset-password-demand-email": {
     "params": {
-      "title": "Wachtwoord opnieuw instellen",
       "clickOnTheButton": "Klik op de knop hieronder om een nieuw wachtwoord te kiezen.",
       "contactUs": "neem hier contact met ons op",
       "doNotAnswer": "Dit is een automatische e-mail, antwoord niet. Hulp nodig?",
@@ -374,6 +375,7 @@
       "moreOn": "Ontdek meer over",
       "pixPresentation": "Pix is de online overheidsdienst voor het beoordelen, ontwikkelen en certificeren van je digitale vaardigheden.",
       "resetMyPassword": "Een nieuw wachtwoord instellen",
+      "title": "Wachtwoord opnieuw instellen",
       "weCannotSendYourPassword": "Hallo, om veiligheidsredenen sturen we jouw wachtwoord niet per e-mail."
     },
     "subject": "Verzoek instellen nieuw wachtwoord Pix"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -139,28 +139,27 @@
     },
     "pix": "Pix",
     "showcase-homepage": "Startpagina Pix.{ tld }",
+    "user-logged-menu": {
+      "details": "Mijn informatie bekijken"
+    },
     "user": {
       "account": "Mijn account",
       "certifications": "Mijn certificaten",
       "sign-out": "Log uit.",
       "tests": "Mijn carrièrepaden"
-    },
-    "user-logged-menu": {
-      "details": "Mijn informatie bekijken"
     }
   },
   "pages": {
     "account-recovery": {
       "errors": {
-        "title": "Oeps, er is een fout gemaakt!",
         "account-exists": "Er bestaat al een account met dit e-mailadres.",
         "key-expired": "De herstellink is verlopen,",
         "key-expired-renew-demand-link": "vernieuw uw aanvraag hier.",
         "key-invalid": "De herstelverbinding bestaat niet.",
-        "key-used": "Dit account is al teruggevonden."
+        "key-used": "Dit account is al teruggevonden.",
+        "title": "Oeps, er is een fout gemaakt!"
       },
       "find-sco-record": {
-        "title": "Mijn account herstellen",
         "backup-email-confirmation": {
           "ask-for-new-email-message": "of zorg voor een nieuwe",
           "email-already-exist-for-account-message": "Het onderstaande e-mailadres is al gekoppeld aan uw account:",
@@ -204,8 +203,8 @@
           "good-news": "Goed nieuws { firstName } !"
         },
         "conflict": {
-          "title": "Conflict",
           "found-you-but": "{ firstName }, we hebben je gevonden maar ...",
+          "title": "Conflict",
           "warning": "Uit voorzorg moeten we uw gegevens samen controleren."
         },
         "contact-support": {
@@ -213,13 +212,12 @@
           "link-url": "https://support.pix.org/fr/support/tickets/new"
         },
         "send-email-confirmation": {
-          "title": "Je Pix-account herstellen",
           "check-spam": "Als je deze e-mail niet ziet, controleer dan je spammap.",
           "return": "Terug",
-          "send-email": "We hebben je zojuist een e-mail gestuurd waarmee je een wachtwoord kunt kiezen. Je kunt nu je mailbox controleren."
+          "send-email": "We hebben je zojuist een e-mail gestuurd waarmee je een wachtwoord kunt kiezen. Je kunt nu je mailbox controleren.",
+          "title": "Je Pix-account herstellen"
         },
         "student-information": {
-          "title": "Je hebt het schoolsysteem verlaten en wilt opnieuw toegang tot Pix",
           "errors": {
             "empty-first-name": "Het veld voor de voornaam is verplicht.",
             "empty-ine-ina": "Het INE-veld is verplicht.",
@@ -249,8 +247,10 @@
           "subtitle": {
             "link": "Reset je wachtwoord hier.",
             "text": "Als je een account hebt met een geldig e-mailadres,"
-          }
-        }
+          },
+          "title": "Je hebt het schoolsysteem verlaten en wilt opnieuw toegang tot Pix"
+        },
+        "title": "Mijn account herstellen"
       },
       "support": {
         "recover": "voor assistentie.",
@@ -272,26 +272,26 @@
       }
     },
     "assessment-banner": {
-      "title": "Beoordelingstest :",
       "modal": {
-        "title": "Heb je een pauze nodig?",
         "actions": {
           "quit": {
             "extra-information": "De proefversie afsluiten en terugkeren naar de startpagina"
           }
         },
-        "content": "Al je vorderingen worden vastgelegd. Je kunt verder gaan waar je gebleven was."
-      }
+        "content": "Al je vorderingen worden vastgelegd. Je kunt verder gaan waar je gebleven was.",
+        "title": "Heb je een pauze nodig?"
+      },
+      "title": "Beoordelingstest :"
     },
     "assessment-results": {
-      "title": "Einde test",
       "actions": {
         "continue-pix-experience": "Mijn Pix-ervaring voortzetten",
         "return-to-homepage": "Terug naar de startpagina"
       },
       "answers": {
         "header": "Uw antwoorden"
-      }
+      },
+      "title": "Einde test"
     },
     "autonomous-course": {
       "landing-page": {
@@ -301,58 +301,45 @@
           "start-connected": "Ik begin"
         },
         "texts": {
-          "title": "Start de test:",
           "first-course": "Is dit je eerste Pix-test?",
-          "legal-informations": "Of je nu een Pix-account hebt of niet, de gegevens over je voortgang worden naar ons verstuurd.'<br>'Deze informatie wordt door Pix gebruikt om de service te verbeteren."
+          "legal-informations": "Of je nu een Pix-account hebt of niet, de gegevens over je voortgang worden naar ons verstuurd.'<br>'Deze informatie wordt door Pix gebruikt om de service te verbeteren.",
+          "title": "Start de test:"
         }
       }
     },
-    "campaign": {
-      "errors": {
-        "existing-participation": "De cursus is niet toegankelijk voor jou.",
-        "existing-participation-info": "Neem contact op met je docent om je deelname aan Pix Orga te laten verwijderen.",
-        "existing-participation-user-info": "Er is al een geassocieerde deelneming op naam van",
-        "no-longer-accessible": "Oeps, de door u opgevraagde pagina is niet langer toegankelijk.",
-        "not-accessible": "Oeps, de opgevraagde pagina is niet toegankelijk."
-      }
-    },
     "campaign-landing": {
-      "title": "Presentatie",
       "assessment": {
-        "title": "Begin je Pix-reis",
         "action": "Ik begin",
         "announcement": "Registreer of log in op het Pix-platform en start je test.",
         "certify": {
-          "title": "De antwoorden die je in deze cursus valideert, dragen bij aan je persoonlijke digitale vaardigheidsprofiel op Pix.",
-          "description": "Afhankelijk van je situatie en onder bepaalde voorwaarden kun je toegang krijgen tot de Pix-certificering, die door de professionele wereld wordt erkend en waarmee je je digitale vaardigheden kunt verbeteren. Neem voor meer informatie contact op met de cursusorganisator."
+          "description": "Afhankelijk van je situatie en onder bepaalde voorwaarden kun je toegang krijgen tot de Pix-certificering, die door de professionele wereld wordt erkend en waarmee je je digitale vaardigheden kunt verbeteren. Neem voor meer informatie contact op met de cursusorganisator.",
+          "title": "De antwoorden die je in deze cursus valideert, dragen bij aan je persoonlijke digitale vaardigheidsprofiel op Pix."
         },
         "details": "Tijdens deze cursus krijg je de kans om :",
         "develop": {
-          "title": "Ontdek je resultaten naarmate de test vordert en raadpleeg hints over hoe je je kunt verbeteren.",
-          "description": "Om de 5 vragen zie je de juiste antwoorden en krijg je advies en een persoonlijke aanbeveling van tutorials om je vaardigheden te ontwikkelen."
+          "description": "Om de 5 vragen zie je de juiste antwoorden en krijg je advies en een persoonlijke aanbeveling van tutorials om je vaardigheden te ontwikkelen.",
+          "title": "Ontdek je resultaten naarmate de test vordert en raadpleeg hints over hoe je je kunt verbeteren."
         },
         "evaluate": {
-          "title": "Meet je digitale vaardigheden met leuke leeruitdagingen die zich aanpassen aan je vaardigheidsniveau (met behulp van een adaptief algoritme).",
-          "description": "Je zult internetopzoekingen moeten doen, je digitale werkomgeving moeten gebruiken, je kennis moeten testen, enz."
+          "description": "Je zult internetopzoekingen moeten doen, je digitale werkomgeving moeten gebruiken, je kennis moeten testen, enz.",
+          "title": "Meet je digitale vaardigheden met leuke leeruitdagingen die zich aanpassen aan je vaardigheidsniveau (met behulp van een adaptief algoritme)."
         },
         "legal": "Door op \"Ik begin\" te klikken, wordt informatie over je voortgang tijdens de cursus naar de cursusorganisator gestuurd zodat zij je kunnen ondersteunen. Als je aan het einde van de cursus op de knop \"Stuur mijn resultaten\" klikt, worden je resultaten naar de organisator gestuurd.",
+        "title": "Begin je Pix-reis",
         "title-with-username": "'<span>'{userFirstName}'</span>','<br>' begin je test"
       },
       "profiles-collection": {
-        "title": "Stuur je profiel",
         "action": "Laten we gaan!",
         "announcement": "Registreer of log in op het Pix-platform en stuur je profiel naar de ontvangende organisatie.",
         "legal": "Informatie met betrekking tot je PIX-profiel wordt naar de organisator gestuurd, zodat hij of zij je kan begeleiden. Deze informatie wordt alleen doorgegeven met jouw toestemming.",
+        "title": "Stuur je profiel",
         "title-with-username": "'<span>'{userFirstName}'</span>','<br>' stuur je profiel"
       },
+      "title": "Presentatie",
       "warning-message": "Ben jij niet {firstName} {lastName }?",
       "warning-message-logout": "Log uit."
     },
-    "campaign-participation": {
-      "title": "Test"
-    },
     "campaign-participation-overview": {
-      "title": "Test",
       "card": {
         "finished-at": "Voltooid op {date}",
         "results": "{result, number, ::percent} succes",
@@ -371,23 +358,35 @@
           "started": "Actief"
         },
         "text-disabled": "Cursus gedeactiveerd door uw organisatie.'<br> 'U kunt uw resultaten niet langer verzenden."
+      },
+      "title": "Test"
+    },
+    "campaign-participation": {
+      "title": "Test"
+    },
+    "campaign": {
+      "errors": {
+        "existing-participation": "De cursus is niet toegankelijk voor jou.",
+        "existing-participation-info": "Neem contact op met je docent om je deelname aan Pix Orga te laten verwijderen.",
+        "existing-participation-user-info": "Er is al een geassocieerde deelneming op naam van",
+        "no-longer-accessible": "Oeps, de door u opgevraagde pagina is niet langer toegankelijk.",
+        "not-accessible": "Oeps, de opgevraagde pagina is niet toegankelijk."
       }
     },
     "certificate": {
-      "title": "Pix-certificaat",
       "attestation": "Mijn certificaat downloaden",
       "back-link": "Terug naar mijn certificaten",
       "candidate-birth": "Geboren op {birthdate}",
       "candidate-birth-complete": "Geboren op {birthdate} te {birthplace}.",
       "certification-center": "Certificeringscentrum :",
       "competences": {
-        "title": "Gecertificeerde vaardigheden",
         "information": "Je gecertificeerde score is berekend op basis van je antwoorden tijdens het certificeringsproces. Deze kan daarom afwijken van het aantal Pix dat wordt weergegeven in je profiel. Op de dag van je certificering was het mogelijk om het {maxReachableLevelOnCertificationDate} vaardigheidsniveau en {maxReachablePixCountOnCertificationDate} pix maximaal te behalen.",
-        "subtitle": "(niveaus op {maxReachableLevel})"
+        "subtitle": "(niveaus op {maxReachableLevel})",
+        "title": "Gecertificeerde vaardigheden"
       },
       "complementary": {
-        "title": "Andere behaalde certificering",
-        "alternative": "Aanvullende certificering"
+        "alternative": "Aanvullende certificering",
+        "title": "Andere behaalde certificering"
       },
       "exam-date": "Datum bezoek :",
       "hexagon-score": {
@@ -397,33 +396,33 @@
       "jury-info": "De opmerkingen van de jury worden niet gedeeld op de verificatiepagina van je certificaat.",
       "jury-title": "Commentaar van de jury",
       "professionalizing-warning": "Het Pix-certificaat wordt door France Compétences erkend als een professionele kwalificatie zodra een minimale score van 120 pix is behaald.",
+      "title": "Pix-certificaat",
       "verification-code": {
-        "title": "Verificatie code",
         "alt": "Kopieer",
         "copied": "Code gekopieerd!",
         "copy": "Kopieer de code",
         "info": "(?)",
+        "title": "Verificatie code",
         "tooltip": "Geef deze code om een derde partij de echtheid van je certificaat te laten controleren"
       }
     },
     "certification-ender": {
       "candidate": {
-        "title": "Test over!",
         "disconnect": "Afmelden bij mijn account",
         "disconnect-tip": "Als dit niet jouw computer is, vergeet dan niet uit te loggen.",
         "ended-by-supervisor": "Je surveillant heeft je certificeringstest beëindigd. Je kunt niet doorgaan met het beantwoorden van de vragen.",
         "ended-due-to-finalization": "De sessie is afgerond door uw certificeringscentrum. U kunt niet langer doorgaan met het beantwoorden van vragen.",
-        "remote-certification": "Als je je Pix-certificering op afstand doet, zorg er dan voor dat je de verbinding met de monitoring tool verbreekt zodra je klaar bent met je test."
+        "remote-certification": "Als je je Pix-certificering op afstand doet, zorg er dan voor dat je de verbinding met de monitoring tool verbreekt zodra je klaar bent met je test.",
+        "title": "Test over!"
       },
       "results": {
-        "title": "Mijn certificeringsresultaten raadplegen en delen?",
         "disclaimer": "Je resultaten, in afwachting van validatie door de Pix teams, zullen binnenkort beschikbaar zijn in je Pix account.",
         "step-1": "Je hoeft alleen maar in te loggen op je Pix-account en je kunt je resultaten vinden in je profiel, onder \"Mijn certificeringen\" (toegankelijk door op je voornaam te klikken in de rechterbovenhoek van het scherm).",
-        "step-2": "Je kunt je certificeringscertificaat downloaden en delen met anderen, of ons de verificatiecode sturen om te gebruiken op de Pix-website."
+        "step-2": "Je kunt je certificeringscertificaat downloaden en delen met anderen, of ons de verificatiecode sturen om te gebruiken op de Pix-website.",
+        "title": "Mijn certificeringsresultaten raadplegen en delen?"
       }
     },
     "certification-joiner": {
-      "title": "Doe mee aan een certificeringssessie",
       "congratulation-banner": {
         "complementary-certification": {
           "eligible": "Je komt ook in aanmerking { count, plural, =1 {à la certification complémentaire} other {aux certifications complémentaires} } :",
@@ -451,6 +450,9 @@
         "actions": {
           "submit": "Ga verder met"
         },
+        "fields-validation": {
+          "session-number-error": "Het sessienummer bestaat alleen uit getallen."
+        },
         "fields": {
           "birth-date": "Geboortedatum",
           "birth-day": "geboortedag (DD)",
@@ -460,34 +462,31 @@
           "first-name": "Voornaam",
           "session-number": "Sessienummer",
           "session-number-information": "Alleen meegedeeld door de surveillant aan het begin van de sessie"
-        },
-        "fields-validation": {
-          "session-number-error": "Het sessienummer bestaat alleen uit getallen."
         }
-      }
+      },
+      "title": "Doe mee aan een certificeringssessie"
     },
     "certification-not-certifiable": {
-      "title": "Je profiel is nog niet certificeerbaar.",
       "action": {
         "back": "Terug naar de homepage"
       },
-      "text": "Om je profiel te laten certificeren, moet je voor minstens 5 vaardigheden een niveau hoger dan 0 hebben bereikt."
+      "text": "Om je profiel te laten certificeren, moet je voor minstens 5 vaardigheden een niveau hoger dan 0 hebben bereikt.",
+      "title": "Je profiel is nog niet certificeerbaar."
     },
     "certification-results": {
-      "title": "Test voltooid",
       "action": {
         "confirm": "Ik bevestig",
         "logout": "Log uit."
       },
       "finished": {
-        "title": "Bravo, het is voorbij!",
         "description": "Je resultaten zijn binnenkort beschikbaar in je account.",
+        "title": "Bravo, het is voorbij!",
         "warning-text": "Als dit niet jouw computer is, vergeet dan niet uit te loggen."
       },
-      "flag-alt": "Vlag"
+      "flag-alt": "Vlag",
+      "title": "Test voltooid"
     },
     "certification-start": {
-      "title": "Doe mee aan een certificeringssessie",
       "access-code": "Toegangscode gegeven door de supervisor",
       "actions": {
         "submit": "Mijn test starten"
@@ -509,10 +508,10 @@
       "first-title": "Je staat op het punt om aan je certificeringstest te beginnen",
       "link-to-user-certification": "Bekijk mijn certificaten",
       "non-eligible-subscription": "Je komt niet in aanmerking voor {nonEligibleSubscriptionLabel}. Je kunt echter wel je Pix-certificering behalen.",
-      "subscription": "Je bent geregistreerd voor de volgende aanvullende certificering naast de Pix-certificering:"
+      "subscription": "Je bent geregistreerd voor de volgende aanvullende certificering naast de Pix-certificering:",
+      "title": "Doe mee aan een certificeringssessie"
     },
     "certifications-list": {
-      "title": "Mijn certificaten",
       "header": {
         "certification-center": "Certificeringscentrum",
         "date": "Datum",
@@ -527,25 +526,20 @@
           "title": "Certificering geannuleerd"
         },
         "fail": {
-          "title": "Certificaat niet behaald",
-          "action": "Details tonen"
+          "action": "Details tonen",
+          "title": "Certificaat niet behaald"
         },
         "not-published": {
           "title": "In afwachting van resultaten"
         },
         "success": {
-          "title": "Behaalde certificering",
-          "action": "bekijk de resultaten"
+          "action": "bekijk de resultaten",
+          "title": "Behaalde certificering"
         }
-      }
+      },
+      "title": "Mijn certificaten"
     },
     "challenge": {
-      "title": {
-        "default": "Vrije modus - Vraag {stepNumber} op {totalChallengeNumber}.",
-        "focused": "Focusmodus - Vraag {stepNumber} op {totalChallengeNumber}.",
-        "focused-out": "Niet geslaagd - Focusmodus - Vraag {stepNumber} op {totalChallengeNumber}.",
-        "timed-out": "Verstreken tijd - Vraag {stepNumber} van {totalChallengeNumber}"
-      },
       "actions": {
         "continue": "Ga verder naar",
         "continue-go-to-next": "Ik ga door naar de volgende vraag",
@@ -560,7 +554,6 @@
         "numbered-label": "Antwoord {number}"
       },
       "certification": {
-        "title": "Certificering {certificationNumber}",
         "banner": {
           "certification-number": "Certificeringsnummer"
         },
@@ -569,7 +562,8 @@
           "description": "Om een probleem te melden, bel je je supervisor en geef je hem de volgende informatie:",
           "problem": "het ondervonden probleem",
           "question-number": "het vraagnummer (rechtsboven in het scherm)"
-        }
+        },
+        "title": "Certificering {certificationNumber}"
       },
       "embed-simulator": {
         "actions": {
@@ -578,6 +572,18 @@
           "reset": "Reset"
         },
         "placeholder": "De huidige toepassing laden"
+      },
+      "feedback-panel-v3": {
+        "actions": {
+          "no-send-feedback": "Nee, ik kom terug op de test",
+          "open-close": "Een probleem met de vraag melden",
+          "refresh-page": "Pagina verversen",
+          "send-feedback": "Ja, ik weet het zeker"
+        },
+        "description": "Weet je zeker dat je een probleem wilt melden?",
+        "information": "Als je een probleem meldt, wordt je certificering gepauzeerd totdat de supervisor ingrijpt om je melding te valideren of ongeldig te verklaren.",
+        "problem-banner": "Vertel het je supervisor zodat hij of zij kan uitzoeken wat het probleem is.",
+        "waiting-information": "Wachten op de supervisor..."
       },
       "feedback-panel": {
         "actions": {
@@ -593,12 +599,12 @@
             "category-selection": {
               "label": "Ik heb een probleem met",
               "options": {
+                "other": "Overig",
                 "accessibility": "Toegankelijkheid van de test",
                 "answer": "Het antwoord",
                 "download": "Het te downloaden bestand",
                 "embed": "De simulator/toepassing",
                 "link": "De link in de vraag",
-                "other": "Overig",
                 "picture": "De afbeelding",
                 "question": "De vraag",
                 "tutorial": "De handleiding"
@@ -613,6 +619,7 @@
                 "answer-not-accepted": "Mijn antwoord is correct, maar niet gevalideerd",
                 "answer-not-agreed": "Ik ben het niet eens met het antwoord",
                 "download": {
+                  "other": "Ik heb een ander probleem met de",
                   "edit-failure": {
                     "label": "Ik kan de",
                     "solution": "Het bestand staat waarschijnlijk open in \"Alleen lezen\" of \"Beveiligde modus\". '<br>'Klik op \"Bewerken inschakelen\" of \"Document bewerken\" op de banner bovenaan het bestand als deze verschijnt. '<br>'Sla anders het bestand op onder een andere naam en open dit nieuwe bestand."
@@ -624,8 +631,7 @@
                   "open-failure": {
                     "label": "Ik kan het bestand niet openen op een computer",
                     "solution": "Om voor deze test te slagen, kun je de LibreOffice-suite gebruiken, die gratis is en beschikbaar voor pc's en Macs. Het bevat Libre Office Writer (gelijkwaardig aan Word) en Libre Office Calc (gelijkwaardig aan Excel).'<a href=\"https://fr.libreoffice.org/download/telecharger-libreoffice\">'Download Libre Office'</a>'"
-                  },
-                  "other": "Ik heb een ander probleem met de"
+                  }
                 },
                 "embed-displayed-on-desktop-with-problems": {
                   "label": "Op een computer wordt de simulator weergegeven, maar er is een probleem",
@@ -675,21 +681,9 @@
           "guidance": "'</p><p>'* Wees voorzichtig met wat je in dit gedeelte schrijft: blijf objectief en feitelijk ten behoeve van jezelf en anderen.'</p><p>'Voer met name geen informatie in over jezelf of derden met betrekking tot gezondheid, religie, politieke, vakbonds- of filosofische opvattingen, etnische afkomst, sancties en overtuigingen.'</p>'"
         },
         "modal": {
-          "title": "Bevestiging van waarschuwing",
-          "content": "'<p><strong>'Weet je zeker dat je dit probleem wilt melden?'</strong></p><p>'Bedankt voor je melding, die zorgvuldig zal worden bekeken door het Pix-team. We houden rekening met al je feedback om onze diensten en gebruikerservaring voortdurend te verbeteren. We kunnen je geen persoonlijk antwoord geven. Hartelijk dank voor je medewerking.'</p>'"
+          "content": "'<p><strong>'Weet je zeker dat je dit probleem wilt melden?'</strong></p><p>'Bedankt voor je melding, die zorgvuldig zal worden bekeken door het Pix-team. We houden rekening met al je feedback om onze diensten en gebruikerservaring voortdurend te verbeteren. We kunnen je geen persoonlijk antwoord geven. Hartelijk dank voor je medewerking.'</p>'",
+          "title": "Bevestiging van waarschuwing"
         }
-      },
-      "feedback-panel-v3": {
-        "actions": {
-          "no-send-feedback": "Nee, ik kom terug op de test",
-          "open-close": "Een probleem met de vraag melden",
-          "refresh-page": "Pagina verversen",
-          "send-feedback": "Ja, ik weet het zeker"
-        },
-        "description": "Weet je zeker dat je een probleem wilt melden?",
-        "information": "Als je een probleem meldt, wordt je certificering gepauzeerd totdat de supervisor ingrijpt om je melding te valideren of ongeldig te verklaren.",
-        "problem-banner": "Vertel het je supervisor zodat hij of zij kan uitzoeken wat het probleem is.",
-        "waiting-information": "Wachten op de supervisor..."
       },
       "has-focused-out-of-window": {
         "certification": "We hebben een paginawissel geconstateerd. Je antwoord wordt als fout gerekend.'<br>'Als je gedwongen werd om van pagina te wisselen, informeer dan je supervisor en beantwoord de vraag in zijn of haar aanwezigheid.",
@@ -701,8 +695,8 @@
       },
       "is-focused-challenge": {
         "info-alert": {
-          "title": "Beantwoord deze vraag zonder op internet te zoeken of software te gebruiken.",
-          "subtitle": "Bij certificering wordt je antwoord niet gevalideerd als je van pagina verandert."
+          "subtitle": "Bij certificering wordt je antwoord niet gevalideerd als je van pagina verandert.",
+          "title": "Beantwoord deze vraag zonder op internet te zoeken of software te gebruiken."
         }
       },
       "parts": {
@@ -742,7 +736,7 @@
           },
           "description": "Pix laat je kiezen welk bestandsformaat je wilt downloaden. Als je niet weet welke optie je moet kiezen, houd dan de standaardkeuze aan. Dit is het bestandsformaat dat door het grootste aantal softwaretoepassingen wordt ondersteund.",
           "file-type": "bestand .{fileExtension}",
-          "help": "Hulp nodig met '<a href=\"https://support.pix.org/fr/support/solutions/articles/15000036390\" class=\"challenge-statement__action-help--link\" target=\"_blank\" aria-label=\"open, wijzig of vind dit bestand (openen in nieuw venster)\">'open, wijzig of vind dit bestand'</a>'?"
+          "help": "Hulp nodig met '<a href=\"https://pix.org/nl-be/bijstand-gedownload-bestand-openen\" class=\"challenge-statement__action-help--link\" target=\"_blank\" aria-label=\"open, wijzig of vind dit bestand (openen in nieuw venster)\">'open, wijzig of vind dit bestand'</a>'?"
         },
         "sr-only": {
           "alternative-instruction": "Deze proefdruk bevat een illustratie met een tekstalternatief.",
@@ -752,24 +746,26 @@
           "aria-label": "Geef de indicatie op het bewijs weer.",
           "close": "Ik snap het.",
           "focused": {
-            "title": "Scherpstelmodus",
-            "content": "'<p class=\"tooltip-tag-information__title--focused\">'Blijf op deze pagina om te reageren!'</p>' Gebruik geen internet of een app om te reageren. Elke activiteit buiten de zone wordt gedetecteerd."
+            "content": "'<p class=\"tooltip-tag-information__title--focused\">'Blijf op deze pagina om te reageren!'</p>' Gebruik geen internet of een app om te reageren. Elke activiteit buiten de zone wordt gedetecteerd.",
+            "title": "Scherpstelmodus"
           },
           "other": {
-            "title": "Vrije modus",
-            "content": "Je bent vrij om het internet of applicaties te gebruiken om deze vraag te beantwoorden."
+            "content": "Je bent vrij om het internet of applicaties te gebruiken om deze vraag te beantwoorden.",
+            "title": "Vrije modus"
           }
         }
       },
       "timed": {
         "cannot-answer": "De tijdslimiet is verstreken. Je antwoord wordt niet gevalideerd."
+      },
+      "title": {
+        "default": "Vrije modus - Vraag {stepNumber} op {totalChallengeNumber}.",
+        "focused": "Focusmodus - Vraag {stepNumber} op {totalChallengeNumber}.",
+        "focused-out": "Niet geslaagd - Focusmodus - Vraag {stepNumber} op {totalChallengeNumber}.",
+        "timed-out": "Verstreken tijd - Vraag {stepNumber} van {totalChallengeNumber}"
       }
     },
     "checkpoint": {
-      "title": {
-        "assessment-progress": "Vooruitgang",
-        "end-of-assessment": "Einde van je beoordeling"
-      },
       "actions": {
         "next-page": {
           "continue": "Ga verder met",
@@ -786,6 +782,10 @@
       "completion-percentage": {
         "caption": "vooruitgang",
         "label": "'<p class=\"sr-only\">'Je hebt '</p>'{completionPercentage}%'<p class=\"sr-only\">' van je test voltooid.'</p>'"
+      },
+      "title": {
+        "assessment-progress": "Vooruitgang",
+        "end-of-assessment": "Einde van je beoordeling"
       }
     },
     "comparison-window": {
@@ -852,7 +852,6 @@
       "upcoming-tutorials": "Je zult hier snel handleidingen vinden om je te helpen slagen voor dit type test."
     },
     "competence-details": {
-      "title": "Bevoegdheid",
       "actions": {
         "continue": {
           "extra-information": "De competentie hervatten {competenceName}",
@@ -870,9 +869,9 @@
           "description": "Reset beschikbaar in { daysBeforeReset, plural, =0 {0 dag.} =1 {1 dag.} other {# dagen.} }",
           "label": "Op nul zetten",
           "modal": {
-            "title": "Vaardigheden resetten",
             "important-message": "Jouw { earnedPix } Pix wordt verwijderd uit de vaardigheid: { scoreCardName }.",
             "important-message-above-level-one": "Je { level } en { earnedPix } Pix worden verwijderd uit de vaardigheid: { scoreCardName }.",
+            "title": "Vaardigheden resetten",
             "warning": {
               "certification": "als je je profiel en je verschillende resultaten wilt laten certificeren, kan dit van invloed zijn op je certificering.",
               "header": "Voorzichtig:",
@@ -887,13 +886,13 @@
       },
       "for-competence": "de vaardigheid  {competence}",
       "next-level-info": "{ remainingPixToNextLevel } pix voordat de niveau { level }",
+      "title": "Bevoegdheid",
       "tutorials": {
-        "title": "Ontwikkel je vaardigheden",
-        "description": "Hier is een selectie van tutorials om je te helpen Pix te verdienen."
+        "description": "Hier is een selectie van tutorials om je te helpen Pix te verdienen.",
+        "title": "Ontwikkel je vaardigheden"
       }
     },
     "competence-result": {
-      "title": "Resultaten van je vaardigheid",
       "header": {
         "congratulations": "Gefeliciteerd!",
         "not-bad": "Niet slecht, maar niet geweldig!",
@@ -902,7 +901,8 @@
         "too-bad-subtitle": "Het is duidelijk niet jouw dag, maar je zult het de volgende keer beter doen.",
         "you-have-earned": "Je hebt",
         "you-have-reached-level": "U hebt bereikt"
-      }
+      },
+      "title": "Resultaten van je vaardigheid"
     },
     "course": {
       "errors": {
@@ -910,25 +910,24 @@
       }
     },
     "dashboard": {
-      "title": "Home",
       "campaigns": {
-        "title": "Test",
         "resume": {
           "action": "Ga verder met",
           "text": "<h2>Vergeet niet het indienen van je profiel te voltooien!</h2>"
         },
         "subtitle": "Ga door met uw huidige tests of stuur uw resultaten op",
-        "tests-link": "Al mijn carrièrepaden"
+        "tests-link": "Al mijn carrièrepaden",
+        "title": "Test"
       },
       "empty-dashboard": {
         "link-to-competences": "Bekijk mijn vaardigheden",
         "message": "<h2>Bravo, je hebt de aanbevolen vaardigheden voltooid! </h2> <p>Om verder te gaan, blijf oefenen door vaardigheden opnieuw te proberen. </p>"
       },
       "improvable-competences": {
-        "title": "Een vaardigheid opnieuw proberen",
         "extra-information": "Toegang tot alle vaardigheden om het opnieuw te proberen",
         "profile-link": "Alle vaardigheden",
-        "subtitle": "Klaar om je vaardigheden naar een hoger niveau te tillen?"
+        "subtitle": "Klaar om je vaardigheden naar een hoger niveau te tillen?",
+        "title": "Een vaardigheid opnieuw proberen"
       },
       "presentation": {
         "link": {
@@ -938,53 +937,53 @@
         "message": "<h2>Welkom bij Pix in het Nederlands!</h2><p>De vertaling van al onze vaardigheden is binnenkort beschikbaar.</p>"
       },
       "recommended-competences": {
-        "title": "Aanbevolen vaardigheden",
         "extra-information": "Toegang tot alle aanbevolen vaardigheden",
         "profile-link": "Alle vaardigheden",
-        "subtitle": "Verken de vaardigheden die voor jou aanbevolen worden."
+        "subtitle": "Verken de vaardigheden die voor jou aanbevolen worden.",
+        "title": "Aanbevolen vaardigheden"
       },
       "score": {
         "profile-link": "Bekijk mijn vaardigheden"
       },
       "started-competences": {
-        "title": "Een vaardigheid terugnemen",
-        "subtitle": "Ga door met je vaardigheidstests, vind de nieuwste hier."
-      }
+        "subtitle": "Ga door met je vaardigheidstests, vind de nieuwste hier.",
+        "title": "Een vaardigheid terugnemen"
+      },
+      "title": "Home"
     },
     "error": {
       "content-text": "'<p>'Laad deze pagina opnieuw of keer terug naar de startpagina.'</p><p>'Je kunt ook contact met ons opnemen via '<a href=\"https://support.pix.fr/support/tickets/new\">'het helpcentrumformulier'</a>' onder vermelding van de foutcode hieronder in de beschrijving.'</p><p>'Onze excuses voor het ongemak.'</p><p>'Het Pix-team.'</p>'",
       "first-title": "Oeps, er is een fout gemaakt!"
     },
     "fill-in-campaign-code": {
-      "title": "Ik heb een code",
       "description": "Deze code bestaat uit 9 cijfers en/of letters. Deze wordt verstuurd door je school/organisatie en wordt gebruikt om een cursus te starten of je profiel te versturen.",
       "errors": {
         "forbidden": "Oeps, we kunnen je niet vinden. Controleer je gegevens om verder te gaan of laat het de organisator weten.",
         "missing-code": "Voer een code in.",
         "not-found": "Je code is verkeerd, controleer de indeling (bijv. ABCDEF234) of neem contact op met de organisator."
       },
-      "explanation-link": "https://support.pix.org/fr/support/solutions/articles/15000029147-qu-est-ce-qu-un-code-parcours-et-comment-l-utiliser-",
+      "explanation-link": "https://pix.org/nl-be/wat-is-een-code-en-hoe-gebruik-je-die",
       "explanation-message": "Wat is een routecode en hoe gebruik je die?",
       "first-title-connected": "{ firstName }, voer uw code in",
       "first-title-not-connected": "Voer uw code in",
       "label": "Voer je code in om te beginnen.",
       "mediacentre-start-campaign-modal": {
-        "title": "Toegang tot de cursus via Mediacentre",
         "actions": {
           "continue": "Ga verder met",
           "quit": "Verlaat"
         },
         "message": "Om toegang te krijgen tot de cursus :",
         "message-footer": "Maak verbinding met Pix via je Mediacenter",
-        "organised-by": "voorgesteld door"
+        "organised-by": "voorgesteld door",
+        "title": "Toegang tot de cursus via Mediacentre"
       },
       "start": "Toegang tot de cursus",
+      "title": "Ik heb een code",
       "warning-message": "Ben jij niet {firstName} {lastName }?",
       "warning-message-logout": "Log uit."
     },
     "fill-in-certificate-verification-code": {
-      "title": "Een Pix-certificaat controleren",
-      "description": "Een Pix-certificaat getuigt van een vaardigheidsniveau in digitale vaardigheden: voer hieronder de \\\"verificatiecode\\\" in voor het Pix-certificaat dat je wilt controleren.",
+      "description": "Een Pix-certificaat getuigt van een vaardigheidsniveau in digitale vaardigheden: voer hieronder de \"verificatiecode\" in voor het Pix-certificaat dat je wilt controleren.",
       "errors": {
         "missing-code": "Voer de verificatiecode in.",
         "not-found": "Er is geen bijbehorend Pix-certificaat.",
@@ -993,10 +992,10 @@
       },
       "first-title": "Een Pix-certificaat controleren",
       "label": "Verificatiecode (P-XXXXXXXX)",
+      "title": "Een Pix-certificaat controleren",
       "verify": "Controleer het certificaat"
     },
     "fill-in-participant-external-id": {
-      "title": "Mijn login invoeren",
       "announcement": "De organisator heeft de volgende informatie nodig om je te kunnen begeleiden:",
       "buttons": {
         "cancel": "Annuleer",
@@ -1006,18 +1005,18 @@
         "max-length-id-pix-label": "Uw { idPixLabel } mag niet langer zijn dan 255 tekens.",
         "missing-id-pix-label": "Voer uw { idPixLabel } in."
       },
-      "first-title": "Voordat u begint"
+      "first-title": "Voordat u begint",
+      "title": "Mijn login invoeren"
     },
     "focused-certification-challenge-instructions": {
-      "title": "Scherpstelmodus",
       "action": "Ik ben er klaar voor",
-      "description": "Voor de volgende vraag of vragen mag je de pagina niet verlaten."
+      "description": "Voor de volgende vraag of vragen mag je de pagina niet verlaten.",
+      "title": "Scherpstelmodus"
     },
     "inscription": {
       "choose-language-aria-label": "Selecteer een taal"
     },
     "join": {
-      "title": "Word lid van",
       "button": "Laten we gaan!",
       "fields": {
         "birthdate": {
@@ -1055,7 +1054,6 @@
         "subtitle": "Vul de ontbrekende informatie in"
       },
       "sup": {
-        "title": "Registreer je Pix-account bij {organizationName}.",
         "error": "Controleer de gegevens die je hebt ingevoerd of log in als je al een Pix-account hebt.",
         "fields": {
           "student-number": {
@@ -1065,21 +1063,48 @@
             "not-existing": "Ik heb geen studentennummer"
           }
         },
-        "message": "Voer de gegevens in zoals ze op je studentenkaart staan om toegang te krijgen tot de test en de resultaten te versturen. Pix zal het de volgende keer onthouden."
-      }
+        "message": "Voer de gegevens in zoals ze op je studentenkaart staan om toegang te krijgen tot de test en de resultaten te versturen. Pix zal het de volgende keer onthouden.",
+        "title": "Registreer je Pix-account bij {organizationName}."
+      },
+      "title": "Word lid van"
     },
     "learning-more": {
-      "title": "Voor meer informatie",
-      "info": "Deze links naar tutorials zijn voorgesteld door Pix-gebruikers."
+      "info": "Deze links naar tutorials zijn voorgesteld door Pix-gebruikers.",
+      "title": "Voor meer informatie"
     },
     "levelup-notif": {
       "obtained-level": "Niveau {level} gewonnen!"
     },
+    "login-or-register-oidc": {
+      "error": {
+        "account-conflict": "Dit account is al gekoppeld aan deze organisatie. Log in met een ander account of neem contact op met support.",
+        "data-sharing-refused": "We informeren u dat de overdracht van uw gegevens, zoals gespecificeerd op de vorige pagina, essentieel is om toegang te krijgen tot de service en deze te gebruiken.",
+        "error-message": "Je moet de gebruiksvoorwaarden van Pix accepteren.",
+        "expired-authentication-key": "Uw verificatieverzoek is verlopen.",
+        "invalid-email": "Uw e-mailadres is ongeldig.",
+        "login-unauthorized-error": "Het ingevoerde e-mailadres en/of wachtwoord is onjuist."
+      },
+      "login-form": {
+        "button": "Ik ben online.",
+        "description": "Log in om je bestaande account te koppelen en je eerder beoordeelde vaardigheden op te halen",
+        "email": "E-mail adres",
+        "password": "Wachtwoord",
+        "title": "Ik heb al een Pix-account"
+      },
+      "register-form": {
+        "button": "Ik maak mijn account aan",
+        "description": "Er wordt een account aangemaakt met de informatie die door de organisatie is verstrekt.",
+        "information": {
+          "family-name": "Naam: {familyName}",
+          "given-name": "Voornaam : {givenName}"
+        },
+        "title": "Ik heb geen Pix-account"
+      },
+      "title": "Maak je Pix-account aan"
+    },
     "login-or-register": {
-      "title": "Verbinding maken met Pix",
       "invitation": "{ organizationName } nodigt je uit om je aan te sluiten bij Pix",
       "login-form": {
-        "title": "Ik heb al een Pix-account",
         "button": "Inloggen",
         "error": "Het e-mailadres of de ingevoerde gebruikersnaam en/of wachtwoord zijn onjuist",
         "fields": {
@@ -1096,10 +1121,10 @@
           "other-identity": "Een login: Neem contact op met uw docent om het opnieuw in te stellen",
           "reset-link": "Klik hier om het opnieuw in te stellen"
         },
+        "title": "Ik heb al een Pix-account",
         "unexpected-user-account-error": "Het e-mailadres of de gebruikersnaam is onjuist. Om verder te gaan, moet u inloggen op uw account, die in de vorm :"
       },
       "register-form": {
-        "title": "Ik wil me registreren bij Pix",
         "button": "Meld je nu aan",
         "button-form": "Ik wil graag registreren",
         "fields": {
@@ -1153,35 +1178,10 @@
         },
         "rgpd-legal-notice": "Als u wilt weten hoe uw gegevens worden verwerkt en wat uw rechten zijn, kunt u het volgende lezen",
         "rgpd-legal-notice-link": "Informatie.",
-        "rgpd-legal-notice-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39"
-      }
-    },
-    "login-or-register-oidc": {
-      "title": "Maak je Pix-account aan",
-      "error": {
-        "account-conflict": "Dit account is al gekoppeld aan deze organisatie. Log in met een ander account of neem contact op met support.",
-        "data-sharing-refused": "We informeren u dat de overdracht van uw gegevens, zoals gespecificeerd op de vorige pagina, essentieel is om toegang te krijgen tot de service en deze te gebruiken.",
-        "error-message": "Je moet de gebruiksvoorwaarden van Pix accepteren.",
-        "expired-authentication-key": "Uw verificatieverzoek is verlopen.",
-        "invalid-email": "Uw e-mailadres is ongeldig.",
-        "login-unauthorized-error": "Het ingevoerde e-mailadres en/of wachtwoord is onjuist."
+        "rgpd-legal-notice-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39",
+        "title": "Ik wil me registreren bij Pix"
       },
-      "login-form": {
-        "title": "Ik heb al een Pix-account",
-        "button": "Ik ben online.",
-        "description": "Log in om je bestaande account te koppelen en je eerder beoordeelde vaardigheden op te halen",
-        "email": "E-mail adres",
-        "password": "Wachtwoord"
-      },
-      "register-form": {
-        "title": "Ik heb geen Pix-account",
-        "button": "Ik maak mijn account aan",
-        "description": "Er wordt een account aangemaakt met de informatie die door de organisatie is verstrekt.",
-        "information": {
-          "family-name": "Naam: {familyName}",
-          "given-name": "Voornaam : {givenName}"
-        }
-      }
+      "title": "Verbinding maken met Pix"
     },
     "modulix": {
       "beta-banner": "Deze module is in bètaversie. Je kunt ons feedback sturen aan het einde van deze module om ons te helpen deze te verbeteren.",
@@ -1209,12 +1209,6 @@
         "objectives": "Doelstellingen",
         "startModule": "De module starten"
       },
-      "grain": {
-        "tag": {
-          "activity": "activiteit",
-          "lesson": "les"
-        }
-      },
       "modals": {
         "alternativeText": {
           "title": "Tekst alternatief"
@@ -1233,10 +1227,10 @@
         "direction": "Vul de lege velden in."
       },
       "recap": {
-        "title": "Gefeliciteerd! Module voltooid",
         "backToModuleDetails": "Terug naar moduledetails",
         "goToForm": "Beantwoord de vragenlijst",
-        "subtitle": "Je hebt de volgende doelen bereikt:"
+        "subtitle": "Je hebt de volgende doelen bereikt:",
+        "title": "Gefeliciteerd! Module voltooid"
       },
       "verification-precondition-failed-alert": {
         "qcm": "Selecteer ten minste twee antwoorden om te bevestigen.",
@@ -1245,11 +1239,10 @@
       }
     },
     "not-connected": {
-      "title": "Ontkoppeld",
-      "message": "Je bent er helemaal uit.'<br>'Dank je, tot ziens."
+      "message": "Je bent er helemaal uit.'<br>'Dank je, tot ziens.",
+      "title": "Ontkoppeld"
     },
     "oidc-reconciliation": {
-      "title": "Let op!",
       "authentication-method-to-add": "Verbinding toegevoegd :",
       "confirm": "Ga verder met",
       "current-authentication-methods": "Mijn huidige verbindingsmethoden:",
@@ -1260,10 +1253,10 @@
       "return": "Terug",
       "sub-title": "Er wordt binnenkort een nieuwe verbindingsmethode toegevoegd aan je Pix-account",
       "switch-account": "Account wijzigen",
+      "title": "Let op!",
       "username": "Inloggen"
     },
     "password-reset-demand": {
-      "title": "Bent u uw wachtwoord vergeten?",
       "actions": {
         "back-home": "Terug naar de homepage",
         "back-sign-in": "Terug naar de inlogpagina",
@@ -1283,10 +1276,22 @@
         "help": "Als je deze e-mail niet ontvangt, controleer dan je spamfolder.",
         "instructions": "Er is een e-mail met instructies voor het opnieuw instellen van uw wachtwoord\nverzonden naar het e-mailadres {email}.",
         "subtitle": "Wachtwoord opnieuw instellen"
-      }
+      },
+      "title": "Bent u uw wachtwoord vergeten?"
+    },
+    "profile-already-shared": {
+      "actions": {
+        "continue": "Zet je Pix-ervaring voort"
+      },
+      "explanation": "Je hebt het onderstaande profiel al verzonden naar de organisatie {organization}'<br>'op {date} om {hour,time,hhmm}",
+      "first-title": "Niet alles gaat volgens plan",
+      "retry": {
+        "button": "Mijn profiel opnieuw verzenden",
+        "message": "{organization} nodigt je uit om je profiel nog eens te sturen om je vooruitgang te meten."
+      },
+      "title": "Profiel al verzonden"
     },
     "profile": {
-      "title": "Vaardigheden",
       "accessibility": {
         "title": "Je Pix-profiel",
         "user-score": "Je aantal Pix",
@@ -1316,27 +1321,15 @@
         "reminder-send-campaign": "Vergeet niet je zending af te ronden!",
         "reminder-send-campaign-with-title": "{title}\" route voltooid. Vergeet niet je zending af te ronden!"
       },
+      "title": "Vaardigheden",
       "total-score-helper": {
-        "title": "Waarom 1024 pixels?",
         "explanation": "'<p>'Dit is het maximale aantal pix dat men kan bereiken wanneer alle 8 niveaus van het Pix-referentiesysteem beschikbaar zijn.'</p><p>'Vandaag is '<span class=\"hexagon-score-information__text--strong\">'het maximum {maxReachablePixScore} pix'</span>', wat overeenkomt met niveau {maxReachableLevel}.'</p>'",
         "icon": "Informatie over pix",
-        "label": "Tooltip openen"
-      }
-    },
-    "profile-already-shared": {
-      "title": "Profiel al verzonden",
-      "actions": {
-        "continue": "Zet je Pix-ervaring voort"
-      },
-      "explanation": "Je hebt het onderstaande profiel al verzonden naar de organisatie {organization}'<br>'op {date} om {hour,time,hhmm}",
-      "first-title": "Niet alles gaat volgens plan",
-      "retry": {
-        "button": "Mijn profiel opnieuw verzenden",
-        "message": "{organization} nodigt je uit om je profiel nog eens te sturen om je vooruitgang te meten."
+        "label": "Tooltip openen",
+        "title": "Waarom 1024 pixels?"
       }
     },
     "reset-password": {
-      "title": "Mijn wachtwoord wijzigen",
       "actions": {
         "sign-in": "Log in op",
         "submit": "Stuur naar"
@@ -1352,7 +1345,8 @@
         }
       },
       "instruction": "Voer uw nieuwe wachtwoord in",
-      "succeed": "Uw wachtwoord is gewijzigd."
+      "succeed": "Uw wachtwoord is gewijzigd.",
+      "title": "Mijn wachtwoord wijzigen"
     },
     "result-item": {
       "aband": "Geen antwoord",
@@ -1367,7 +1361,6 @@
       "timedout": "Time-out"
     },
     "send-profile": {
-      "title": "Stuur mijn profiel",
       "disabled-share": "Deze cursus is gedeactiveerd door de organisator. Het is niet langer mogelijk om resultaten te versturen.",
       "errors": {
         "archived": "Je kunt je profiel niet meer opsturen omdat de organisator de verzameling profielen heeft gearchiveerd."
@@ -1379,14 +1372,14 @@
         "send": "Ik stuur mijn profiel",
         "shared": "Bedankt, je profiel is verzonden!"
       },
-      "instructions": "Je gaat de score en vaardigheidsniveaus op je Pix-profiel zetten. '<br>' Eventuele wijzigingen aan je profiel nadat je deze informatie hebt verzonden zullen niet worden doorgestuurd.'<br>' Vergeet niet te controleren voor het verzenden!"
+      "instructions": "Je gaat de score en vaardigheidsniveaus op je Pix-profiel zetten. '<br>' Eventuele wijzigingen aan je profiel nadat je deze informatie hebt verzonden zullen niet worden doorgestuurd.'<br>' Vergeet niet te controleren voor het verzenden!",
+      "title": "Stuur mijn profiel"
     },
     "shared-certification": {
-      "title": "Delen van certificaten",
-      "back-link": "Terug naar het invoeren van de verificatiecode"
+      "back-link": "Terug naar het invoeren van de verificatiecode",
+      "title": "Delen van certificaten"
     },
     "sign-in": {
-      "title": "Verbinding",
       "actions": {
         "submit": "Ik ben online."
       },
@@ -1405,25 +1398,25 @@
       "first-title": "Log in op",
       "forgotten-password": "Bent u uw wachtwoord vergeten?",
       "fwb": {
-        "title": "Verbinding maken via het FWB",
         "link": {
           "img": "FWB verbinden"
-        }
+        },
+        "title": "Verbinding maken via het FWB"
       },
       "or": "OF",
       "pole-emploi": {
-        "title": "Contact maken met Pôle Emploi",
         "link": {
           "img": "pôle Emploi connect"
-        }
+        },
+        "title": "Contact maken met Pôle Emploi"
       },
       "subtitle": {
         "link": "Een account aanmaken",
         "text": "Heb je nog geen Pix-account?"
-      }
+      },
+      "title": "Verbinding"
     },
     "sign-up": {
-      "title": "Registratie",
       "actions": {
         "submit": "Ik wil graag registreren"
       },
@@ -1456,22 +1449,22 @@
       "instructions": "Velden gemarkeerd met '<abbr title=\"mandatory\" class=\"mandatory-mark\">'*'</abbr>' zijn verplicht.",
       "subtitle": {
         "link": "inloggen op uw account"
-      }
+      },
+      "title": "Registratie"
     },
     "sitemap": {
-      "title": "Kaart",
       "accessibility": {
-        "title": "Toegankelijkheid",
-        "help": "Hulp bij vragen over toegankelijkheid op Pix"
+        "help": "Hulp bij vragen over toegankelijkheid op Pix",
+        "title": "Toegankelijkheid"
       },
       "cgu": {
         "policy": "Gegevensbeschermingsbeleid",
         "subcontractors": "Lijst van onderaannemers"
       },
-      "resources": "Middelen"
+      "resources": "Middelen",
+      "title": "Kaart"
     },
     "skill-review": {
-      "title": "Resultaten",
       "abstract": "Je beheerst '<strong>'{rate, number, ::percent}'</strong><br>'van de getoetste vaardigheden.",
       "abstract-title": "Je resultaat voor deze route",
       "actions": {
@@ -1487,14 +1480,14 @@
       },
       "badges-title": "Je thematische resultaten",
       "details": {
-        "title": "Je resultaten per vaardigheid",
         "caption": "Details van je resultaten in percentages volgens vaardigheden",
         "flash-pix-score": "{score, number, ::.} Pix",
         "header-result": "Resultaten",
         "header-skill": "Geteste vaardigheden",
         "percentage": "{rate, number, ::percent}",
         "progress-bar-label": "Slagingspercentage voor de vaardigheid",
-        "result": "Algemeen resultaat"
+        "result": "Algemeen resultaat",
+        "title": "Je resultaten per vaardigheid"
       },
       "disabled-share": "Deze route is gedeactiveerd door de organisator.'<br>'Het is niet langer mogelijk om resultaten te versturen.",
       "error": "Oeps, er is een fout gemaakt!",
@@ -1504,17 +1497,17 @@
         "pixScore": "Je hebt {score, number, ::.} behaald. Pix"
       },
       "improve": {
-        "title": "Wil je je resultaten verbeteren?",
-        "description": "Je kunt sommige vragen opnieuw proberen"
+        "description": "Je kunt sommige vragen opnieuw proberen",
+        "title": "Wil je je resultaten verbeteren?"
       },
       "information": "Als je al een Pix-route hebt voltooid, krijg je dezelfde vragen niet nog een keer. De resultaten die hier worden getoond, houden echter rekening met al je antwoorden.",
       "net-promoter-score": {
-        "title": "Jouw mening telt!",
         "link": {
           "href": "https://pix.fr",
           "label": "Ik geef mijn mening"
         },
-        "text": "Neem een paar minuten de tijd om ons te vertellen wat je van deze test vond en help ons hem te verbeteren."
+        "text": "Neem een paar minuten de tijd om ons te vertellen wat je van deze test vond en help ons hem te verbeteren.",
+        "title": "Jouw mening telt!"
       },
       "not-finished": "Je kunt je resultaten nog niet opsturen, dus we hebben nog een paar vragen voor je.",
       "organization-message": "Bericht van uw organisatie",
@@ -1536,24 +1529,25 @@
       },
       "send-title": "Stuur ons uw resultaten",
       "stage": {
-        "title": "Vaardigheden",
         "caption": "Details van je resultaten in de vorm van percentages en sterren volgens vaardigheden",
         "masteryPercentage": "{rate, number, ::percent} succes",
-        "starsAcquired": "{acquired, plural, =0 {aucune étoile acquise} other {# étoile acquise}} op {total}"
+        "starsAcquired": "{acquired, plural, =0 {aucune étoile acquise} other {# étoile acquise}} op {total}",
+        "title": "Vaardigheden"
       },
+      "title": "Resultaten",
       "trainings": {
-        "title": "Wil je meer weten?",
-        "description": "Ontdek de aanbevolen trainingen op basis van je resultaten om je te helpen vooruitgang te boeken!"
+        "description": "Ontdek de aanbevolen trainingen op basis van je resultaten om je te helpen vooruitgang te boeken!",
+        "title": "Wil je meer weten?"
       }
     },
     "terms-of-service": {
-      "title": "Gebruiksvoorwaarden",
       "cgu": "Ik ga akkoord met de '<a href=\"https://pix.fr/conditions-generales-d-utilisation\" class=\"link\" target=\"_blank\">'gebruiksvoorwaarden van Pix'</a>'.",
       "form": {
         "button": "Ik ga verder",
         "error-message": "Je moet de gebruiksvoorwaarden van Pix accepteren."
       },
-      "message": "We hebben onze gebruiksvoorwaarden bijgewerkt. Accepteer ze om je Pix-ervaring voort te zetten."
+      "message": "We hebben onze gebruiksvoorwaarden bijgewerkt. Accepteer ze om je Pix-ervaring voort te zetten.",
+      "title": "Gebruiksvoorwaarden"
     },
     "timed-challenge-instructions": {
       "action": "De test starten",
@@ -1571,45 +1565,44 @@
         "webinaire": "Webinar"
       }
     },
+    "tutorial-panel": {
+      "info": "Deze links naar tutorials zijn voorgesteld door Pix-gebruikers.",
+      "title": "Om de volgende keer te slagen"
+    },
     "tutorial": {
-      "title": "Campagne handleiding",
       "next": "Volgende",
       "pages": {
         "page0": {
-          "title": "Je kunt op internet zoeken ...",
           "explanation": "Als je het antwoord niet weet, vind je het vast wel op\n.",
-          "icon": "icn-recherche.svg"
+          "icon": "icn-recherche.svg",
+          "title": "Je kunt op internet zoeken ..."
         },
         "page1": {
-          "title": "... behalve voor bepaalde vragen",
           "explanation": "Als deze afbeelding wordt weergegeven, gebruik dan alleen je eigen kennis!\nJe mag het internet of je software niet gebruiken.",
-          "icon": "icn-focus.svg"
+          "icon": "icn-focus.svg",
+          "title": "... behalve voor bepaalde vragen"
         },
         "page2": {
-          "title": "Geen tijdslimiet!",
           "explanation": "Neem zoveel tijd als je nodig hebt om de cursus te voltooien.\nAls een vraag een tijdslimiet heeft, wordt dit aangegeven.",
-          "icon": "icn-temps.svg"
+          "icon": "icn-temps.svg",
+          "title": "Geen tijdslimiet!"
         },
         "page3": {
-          "title": "Tutorials om te leren",
           "explanation": "Ga naar tutorials om meer te leren\nover elke vraag en boek vooruitgang.",
-          "icon": "icn-tutos.svg"
+          "icon": "icn-tutos.svg",
+          "title": "Tutorials om te leren"
         },
         "page4": {
-          "title": "De juiste moeilijkheidsgraad",
           "explanation": "Afhankelijk van je antwoorden past\nPix de moeilijkheidsgraad van de vragen aan.",
-          "icon": "icn-algo.svg"
+          "icon": "icn-algo.svg",
+          "title": "De juiste moeilijkheidsgraad"
         }
       },
       "pass": "Negeer",
-      "start": "Begin mijn reis"
-    },
-    "tutorial-panel": {
-      "title": "Om de volgende keer te slagen",
-      "info": "Deze links naar tutorials zijn voorgesteld door Pix-gebruikers."
+      "start": "Begin mijn reis",
+      "title": "Campagne handleiding"
     },
     "update-expired-password": {
-      "title": "Mijn wachtwoord wijzigen",
       "button": "Reset",
       "fields": {
         "error": "Je wachtwoord moet minstens 8 tekens lang zijn en minstens één hoofdletter, één kleine letter en één cijfer bevatten.",
@@ -1619,37 +1612,11 @@
       "first-title": "Wachtwoord resetten",
       "go-to-login": "Ik ben online.",
       "subtitle": "Kies een nieuw wachtwoord om verder te gaan",
+      "title": "Mijn wachtwoord wijzigen",
       "validation": "Je wachtwoord is bijgewerkt."
     },
     "user-account": {
-      "title": "Mijn account",
-      "account-update-email": {
-        "title": "Je e-mailadres wijzigen",
-        "email-information": "Dit e-mailadres moet geldig zijn voor het geval u uw wachtwoord vergeet. Dit wordt je nieuwe inlogadres.",
-        "fields": {
-          "errors": {
-            "empty-password": "Je wachtwoord mag niet leeg zijn.",
-            "invalid-password": "Het ingevoerde wachtwoord is ongeldig.",
-            "mismatching-email": "De twee e-mailadressen zijn niet identiek. Controleer uw inzending.",
-            "new-email-already-exist": "Dit e-mailadres is al in gebruik.",
-            "unknown-error": "Er is een fout opgetreden. Probeer het opnieuw of neem contact op met de klantenservice.",
-            "wrong-email-format": "Uw e-mailadres is ongeldig."
-          },
-          "new-email": {
-            "label": "Nieuw e-mailadres"
-          },
-          "new-email-confirmation": {
-            "label": "Bevestiging van e-mailadres"
-          },
-          "password": {
-            "label": "Wachtwoord"
-          }
-        },
-        "password-information": "Voer uw wachtwoord in om te bevestigen",
-        "save-button": "Bevestig"
-      },
       "account-update-email-with-validation": {
-        "title": "Je e-mailadres wijzigen",
         "fields": {
           "errors": {
             "empty-password": "Je wachtwoord mag niet leeg zijn.",
@@ -1665,7 +1632,33 @@
             "security-information": "De veiligheid van uw persoonlijke gegevens is van essentieel belang. Daarom controleren we of u de afzender bent van deze aanvraag. Voer je wachtwoord in om een verificatiecode te ontvangen."
           }
         },
-        "save-button": "Een verificatiecode ontvangen"
+        "save-button": "Een verificatiecode ontvangen",
+        "title": "Je e-mailadres wijzigen"
+      },
+      "account-update-email": {
+        "email-information": "Dit e-mailadres moet geldig zijn voor het geval u uw wachtwoord vergeet. Dit wordt je nieuwe inlogadres.",
+        "fields": {
+          "errors": {
+            "empty-password": "Je wachtwoord mag niet leeg zijn.",
+            "invalid-password": "Het ingevoerde wachtwoord is ongeldig.",
+            "mismatching-email": "De twee e-mailadressen zijn niet identiek. Controleer uw inzending.",
+            "new-email-already-exist": "Dit e-mailadres is al in gebruik.",
+            "unknown-error": "Er is een fout opgetreden. Probeer het opnieuw of neem contact op met de klantenservice.",
+            "wrong-email-format": "Uw e-mailadres is ongeldig."
+          },
+          "new-email-confirmation": {
+            "label": "Bevestiging van e-mailadres"
+          },
+          "new-email": {
+            "label": "Nieuw e-mailadres"
+          },
+          "password": {
+            "label": "Wachtwoord"
+          }
+        },
+        "password-information": "Voer uw wachtwoord in om te bevestigen",
+        "save-button": "Bevestig",
+        "title": "Je e-mailadres wijzigen"
       },
       "connexion-methods": {
         "authentication-methods": {
@@ -1679,7 +1672,6 @@
         "username": "Inloggen"
       },
       "email-verification": {
-        "title": "Je e-mailadres controleren",
         "code-explanation-of-use": "Om van veld naar veld te gaan, gebruik je tab of de pijlen naar links en rechts op het toetsenbord. Om een veld in te vullen, voer je getallen in van 1 tot 9 of gebruik je de pijlen omhoog en omlaag op het toetsenbord.",
         "code-label": "Veld",
         "code-legend": "Voer de verificatiecode in die per e-mail is verzonden",
@@ -1693,6 +1685,7 @@
           "unknown-error": "Er is een fout opgetreden. Probeer het opnieuw of neem contact op met de klantenservice."
         },
         "send-back-the-code": "stuur me de code",
+        "title": "Je e-mailadres controleren",
         "update-successful": "Je e-mailadres is gewijzigd!"
       },
       "language": {
@@ -1704,25 +1697,25 @@
         "first-name": "Voornaam",
         "last-name": "Achternaam",
         "menu-link-title": "Mijn persoonlijke gegevens"
-      }
+      },
+      "title": "Mijn account"
     },
     "user-tests": {
       "title": "Mijn carrièrepaden"
     },
     "user-trainings": {
-      "title": "Mijn trainingen",
-      "description": "Blijf vooruitgang boeken dankzij de trainingen die aan het einde van je assessment worden aanbevolen."
+      "description": "Blijf vooruitgang boeken dankzij de trainingen die aan het einde van je assessment worden aanbevolen.",
+      "title": "Mijn trainingen"
     },
     "user-tutorials": {
-      "title": "Mijn tutorials",
       "description": "Maak optimaal gebruik van de tutorials die worden voorgesteld door de community van Pix-gebruikers.",
       "empty-list-info": {
-        "title": "Je hebt nog niets geregistreerd",
         "description": {
           "part1": "Tijdens het uitvoeren van je tests worden tutorials aanbevolen: klik op het bladwijzerpictogram",
           "part2": "om degene die je hier wilt vinden te registreren!"
         },
-        "image-link": "images/illustrations/user-tutorials/illustration-fr.svg"
+        "image-link": "images/illustrations/user-tutorials/illustration-fr.svg",
+        "title": "Je hebt nog niets geregistreerd"
       },
       "filter": "Filter",
       "label": "handleidingen",
@@ -1746,20 +1739,21 @@
       },
       "recommended": "Aanbevolen",
       "recommended-empty": {
-        "title": "{firstName}, vind je favoriete tutorials hier",
         "description": "Om tutorials aan te bevelen die geschikt zijn voor jouw niveau, moet je beginnen met een vaardigheidstest.",
-        "link": "Ik begin"
+        "link": "Ik begin",
+        "title": "{firstName}, vind je favoriete tutorials hier"
       },
       "saved": "Geregistreerd",
       "saved-empty": {
-        "title": "Je hebt nog geen geregistreerde tutorials",
-        "description": "Je moet een aanbevolen zelfstudie registreren om deze hier te laten verschijnen."
+        "description": "Je moet een aanbevolen zelfstudie registreren om deze hier te laten verschijnen.",
+        "title": "Je hebt nog geen geregistreerde tutorials"
       },
       "sidebar": {
         "reset": "Reset",
         "reset-aria-label": "Alle filters resetten en deselecteren",
         "see-results": "Bekijk de resultaten"
-      }
+      },
+      "title": "Mijn tutorials"
     }
   }
 }

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1209,6 +1209,12 @@
         "objectives": "Doelstellingen",
         "startModule": "De module starten"
       },
+      "grain": {
+        "tag": {
+          "activity": "activiteit",
+          "lesson": "les"
+        }
+      },
       "modals": {
         "alternativeText": {
           "title": "Tekst alternatief"


### PR DESCRIPTION
Corrections des liens : 
- Lien “Wat is een routecode en hoe gebruik je die?” : qui menait sur la page FR“ [Utiliser Pix : Qu’est-ce qu’un parcours code et comment l’utiliser ?](https://support.pix.org/fr/support/solutions/articles/15000029147-qu-est-ce-qu-un-code-parcours-et-comment-l-utiliser-)” (clé concernée : pages.fill-in-campaign-code.explanation-link)
-  Le lien d’aide affiché sur la page d'une épreuve possédant un document à télécharger doit mener vers la page de support NL et non FR. (clé concernée : pages.challenge.statement.file-download.help)