### PR TITLE
[FEATURE] Afficher un commentaire auto jury lorsqu'un problème technique empêche le bon déroulement de la certification V2 (PIX-10535)

### DIFF
--- a/api/lib/domain/events/handle-certification-rescoring.js
+++ b/api/lib/domain/events/handle-certification-rescoring.js
@@ -340,14 +340,6 @@ function _createV2AssessmentResult({
       assessmentId: certificationAssessment.id,
       juryId: event.juryId,
     });
-  } else if (certificationAssessmentScore.hasInsufficientCorrectAnswers()) {
-    return AssessmentResultFactory.buildInsufficientCorrectAnswers({
-      emitter,
-      pixScore: certificationAssessmentScore.nbPix,
-      reproducibilityRate: certificationAssessmentScore.getPercentageCorrectAnswers(),
-      assessmentId: certificationAssessment.id,
-      juryId: event.juryId,
-    });
   } else if (!certificationAssessmentScore.hasEnoughNonNeutralizedChallengesToBeTrusted) {
     return AssessmentResultFactory.buildNotTrustableAssessmentResult({
       pixScore: certificationAssessmentScore.nbPix,
@@ -355,6 +347,14 @@ function _createV2AssessmentResult({
       status: certificationAssessmentScore.status,
       assessmentId: certificationAssessment.id,
       emitter,
+      juryId: event.juryId,
+    });
+  } else if (certificationAssessmentScore.hasInsufficientCorrectAnswers()) {
+    return AssessmentResultFactory.buildInsufficientCorrectAnswers({
+      emitter,
+      pixScore: certificationAssessmentScore.nbPix,
+      reproducibilityRate: certificationAssessmentScore.getPercentageCorrectAnswers(),
+      assessmentId: certificationAssessment.id,
       juryId: event.juryId,
     });
   } else {

--- a/api/tests/tooling/domain-builder/factory/certification/scoring/build-assessment-result.js
+++ b/api/tests/tooling/domain-builder/factory/certification/scoring/build-assessment-result.js
@@ -64,4 +64,24 @@ buildAssessmentResult.insufficientCorrectAnswers = function ({
   });
 };
 
+buildAssessmentResult.lackOfAnswersForTechnicalReason = function ({
+  pixScore,
+  reproducibilityRate,
+  status,
+  assessmentId,
+  juryId,
+  competenceMarks,
+  emitter,
+} = {}) {
+  return AssessmentResultFactory.buildLackOfAnswersForTechnicalReason({
+    pixScore,
+    reproducibilityRate,
+    status,
+    assessmentId,
+    juryId,
+    competenceMarks,
+    emitter,
+  });
+};
+
 export { buildAssessmentResult };

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -830,16 +830,25 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
   });
 
   describe('when handling a v2 certification', function () {
-    it('computes and persists the assessment result and competence marks when computation succeeds', async function () {
-      // given
-      const certificationCourseRepository = {
+    let certificationCourseRepository,
+      assessmentResultRepository,
+      certificationAssessmentRepository,
+      competenceMarkRepository,
+      scoringCertificationService;
+
+    beforeEach(function () {
+      certificationCourseRepository = {
         get: sinon.stub(),
         update: sinon.stub(),
       };
-      const assessmentResultRepository = { save: sinon.stub() };
-      const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
-      const competenceMarkRepository = { save: sinon.stub() };
-      const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
+      assessmentResultRepository = { save: sinon.stub() };
+      certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
+      competenceMarkRepository = { save: sinon.stub() };
+      scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
+    });
+
+    it('computes and persists the assessment result and competence marks when computation succeeds', async function () {
+      // given
       const certificationCourse = domainBuilder.buildCertificationCourse({
         isCancelled: false,
       });
@@ -925,14 +934,6 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
     context('when the certification has not enough non neutralized challenges to be trusted', function () {
       it('cancels the certification and save a not trustable assessment result', async function () {
         // given
-        const certificationCourseRepository = {
-          get: sinon.stub(),
-          update: sinon.stub(),
-        };
-        const assessmentResultRepository = { save: sinon.stub() };
-        const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
-        const competenceMarkRepository = { save: sinon.stub() };
-        const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
         const certificationCourse = domainBuilder.buildCertificationCourse({ id: 789 });
 
         const event = new ChallengeNeutralized({ certificationCourseId: 789, juryId: 7 });
@@ -1010,14 +1011,6 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
       context('when it has insufficient correct answers', function () {
         it('cancels the certification and save a not trustable assessment result', async function () {
           // given
-          const certificationCourseRepository = {
-            get: sinon.stub(),
-            update: sinon.stub(),
-          };
-          const assessmentResultRepository = { save: sinon.stub() };
-          const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
-          const competenceMarkRepository = { save: sinon.stub() };
-          const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
           const certificationCourse = domainBuilder.buildCertificationCourse({ id: 789 });
 
           const event = new ChallengeNeutralized({ certificationCourseId: 789, juryId: 7 });
@@ -1095,14 +1088,6 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
     context('when the certification has enough non neutralized challenges to be trusted', function () {
       it('uncancels the certification and save a standard assessment result', async function () {
         // given
-        const certificationCourseRepository = {
-          get: sinon.stub(),
-          update: sinon.stub(),
-        };
-        const assessmentResultRepository = { save: sinon.stub() };
-        const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
-        const competenceMarkRepository = { save: sinon.stub() };
-        const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
         const certificationCourse = domainBuilder.buildCertificationCourse({ id: 789, isCancelled: true });
 
         const event = new ChallengeNeutralized({ certificationCourseId: 789, juryId: 7 });
@@ -1181,14 +1166,6 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
       context('when it is rejected for fraud', function () {
         it('save a standard rejected assessment result ', async function () {
           // given
-          const certificationCourseRepository = {
-            get: sinon.stub(),
-            update: sinon.stub(),
-          };
-          const assessmentResultRepository = { save: sinon.stub() };
-          const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
-          const competenceMarkRepository = { save: sinon.stub() };
-          const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
           const certificationCourse = domainBuilder.buildCertificationCourse({
             id: 789,
             isRejectedForFraud: true,
@@ -1269,14 +1246,6 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
       context('when it is rejected for insufficient correct answers', function () {
         it('should create and save an insufficient correct answers assessment result', async function () {
           // given
-          const certificationCourseRepository = {
-            get: sinon.stub(),
-            update: sinon.stub(),
-          };
-          const assessmentResultRepository = { save: sinon.stub() };
-          const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
-          const competenceMarkRepository = { save: sinon.stub() };
-          const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
           const certificationCourse = domainBuilder.buildCertificationCourse({
             id: 789,
           });
@@ -1359,14 +1328,6 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         context('when the candidate encountered a technical issue during certification', function () {
           it('should cancel the certification and save an assessment result lacking answers for technical reason', async function () {
             // given
-            const certificationCourseRepository = {
-              get: sinon.stub(),
-              update: sinon.stub(),
-            };
-            const assessmentResultRepository = { save: sinon.stub() };
-            const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
-            const competenceMarkRepository = { save: sinon.stub() };
-            const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
             const certificationCourse = domainBuilder.buildCertificationCourse({
               id: 789,
               abortReason: ABORT_REASONS.TECHNICAL,
@@ -1446,14 +1407,6 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
 
       it('returns a CertificationRescoringCompleted event', async function () {
         // given
-        const certificationCourseRepository = {
-          get: sinon.stub(),
-          update: sinon.stub(),
-        };
-        const assessmentResultRepository = { save: sinon.stub() };
-        const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
-        const competenceMarkRepository = { save: sinon.stub() };
-        const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
         const certificationCourse = domainBuilder.buildCertificationCourse();
 
         const event = new ChallengeNeutralized({ certificationCourseId: certificationCourse.getId(), juryId: 7 });
@@ -1501,11 +1454,6 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
 
       it('computes and persists the assessment result in error when computation fails', async function () {
         // given
-        const assessmentResultRepository = { save: sinon.stub() };
-        const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
-        const competenceMarkRepository = { save: sinon.stub() };
-        const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
-
         const event = new ChallengeNeutralized({ certificationCourseId: 1, juryId: 7 });
         const certificationAssessment = new CertificationAssessment({
           id: 123,
@@ -1591,14 +1539,6 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         context(`when event is of type ${eventType}`, function () {
           it(`should save an assessment result with a ${emitter} emitter`, async function () {
             // given
-            const certificationCourseRepository = {
-              get: sinon.stub(),
-              update: sinon.stub(),
-            };
-            const assessmentResultRepository = { save: sinon.stub() };
-            const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
-            const competenceMarkRepository = { save: sinon.stub() };
-            const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
             const certificationCourse = domainBuilder.buildCertificationCourse({
               id: 789,
               isCancelled: false,


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, lorsqu'un candidat abandonne la certification pour problème technique et qu'il n'a pas suffisamment de bonne réponse, alors sa certification est refusée mais sans aucun commentaire.

## :robot: Proposition
Afficher un commentaire pour ce cas de figure et annuler la certification en plus du rejet.

## :rainbow: Remarques
Coté rescoring, on fix un bug en déplaçant la condition du cas de la neutralization avant la condition du manque de réponses.

## :100: Pour tester

**Non régression - annulée problème technique**

- Sur Pix Certif, avec certif-pro@example.net créer une certification V2
- Inscrire un candidat, puis sur Pix App, avec certif-success@example.net, rentrer en certification, puis démarrer la surveillance
- Répondez à une seule question en tant que candidat
- Sur Pix Certif, terminer la surveillance en terminant le test, puis allez finaliser la session en précisant "erreur technique" comme raison
- Sur Pix Admin avec superadmin@example.net, retrouver votre session, vérifier que la certification est annulée et contient le texte de la nouvelle clé `CANCELLED_DUE_TO_LACK_OF_ANSWERS_FOR_TECHNICAL_REASON`

      "CANCELLED_DUE_TO_LACK_OF_ANSWERS_FOR_TECHNICAL_REASON": {
        "candidate": "Un ou plusieurs problème(s) technique(s), signalé(s) à votre surveillant pendant la session de certification, a/ont affecté la qualité du test de certification. En raison du trop grand nombre de questions auxquelles vous n'avez pas pu répondre dans de bonnes conditions, nous ne sommes malheureusement pas en mesure de calculer un score fiable et de fournir un certificat. La certification est annulée, le prescripteur de votre certification (le cas échéant), en est informé.",
        "organization": "Un ou plusieurs problème(s) technique(s), signalés par ce(cette) candidate au surveillant de la session de certification, a/ont affecté le bon déroulement du test de certification. Nous sommes dans l'incapacité de le/la certifier, sa certification est donc annulée. Cette information est à prendre en compte et peut vous conduire à proposer une nouvelle session de certification pour ce(cette) candidat(e)."
      },
