### PR TITLE
[TECH] Créer un script pour charger les données des OIDC Providers (PIX-10033)

### DIFF
--- a/api/db/migrations/20240327174114_add-enabledForPixAdmin-to-table-oidc-providers.js
+++ b/api/db/migrations/20240327174114_add-enabledForPixAdmin-to-table-oidc-providers.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'oidc-providers';
+const COLUMN_NAME = 'enabledForPixAdmin';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.boolean(COLUMN_NAME).notNullable().defaultTo(false);
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/db/migrations/20240328154446_add-unicity-constraint-to-table-oidc-providers.js
+++ b/api/db/migrations/20240328154446_add-unicity-constraint-to-table-oidc-providers.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'oidc-providers';
+const COLUMN_NAME = 'identityProvider';
+
+const up = async function (knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.unique(COLUMN_NAME);
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropUnique(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/lib/domain/services/authentication/google-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/google-oidc-authentication-service.js
@@ -20,7 +20,6 @@ class GoogleOidcAuthenticationService extends OidcAuthenticationService {
       slug: 'google',
       source: 'google',
       scope: 'openid profile email',
-      shouldCloseSession: true,
     });
 
     this.temporaryStorage = config[configKey].temporaryStorage;

--- a/api/scripts/team-acces/load-oidc-providers-from-env-variables.js
+++ b/api/scripts/team-acces/load-oidc-providers-from-env-variables.js
@@ -1,0 +1,152 @@
+import Debug from 'debug';
+
+import { disconnect } from '../../db/knex-database-connection.js';
+import { learningContentCache as cache } from '../../lib/infrastructure/caches/learning-content-cache.js';
+import { temporaryStorage } from '../../lib/infrastructure/temporary-storage/index.js';
+import { usecases } from '../../src/authentication/domain/usecases/index.js';
+import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
+import * as cryptoService from '../../src/shared/domain/services/crypto-service.js';
+
+const debugOidcProvidersProperties = Debug('pix:oidc-providers:properties');
+
+const TIMER_NAME = 'load-oidc-providers-from-env-variables';
+
+const OIDC_PROVIDERS_POLE_EMPLOI = {
+  identityProvider: 'POLE_EMPLOI',
+  organizationName: 'France Travail',
+  scope: `application_${process.env.POLE_EMPLOI_CLIENT_ID} api_peconnect-individuv1 openid profile serviceDigitauxExposition api_peconnect-servicesdigitauxv1`,
+  slug: 'pole-emploi',
+  source: 'pole_emploi_connect',
+
+  clientId: process.env.POLE_EMPLOI_CLIENT_ID,
+  encryptedClientSecret: await cryptoService.encrypt(process.env.POLE_EMPLOI_CLIENT_SECRET),
+
+  accessTokenLifespan: process.env.POLE_EMPLOI_ACCESS_TOKEN_LIFESPAN || '7d',
+  enabled: Boolean(process.env.POLE_EMPLOI_ENABLED),
+  idTokenLifespan: process.env.POLE_EMPLOI_ID_TOKEN_LIFESPAN || '7d',
+  openidConfigurationUrl: process.env.POLE_EMPLOI_OPENID_CONFIGURATION_URL,
+  redirectUri: process.env.POLE_EMPLOI_REDIRECT_URI,
+  shouldCloseSession: true,
+
+  openidClientExtraMetadata: { token_endpoint_auth_method: 'client_secret_post' },
+
+  customProperties: {
+    logoutUrl: process.env.POLE_EMPLOI_OIDC_LOGOUT_URL,
+    afterLogoutUrl: process.env.POLE_EMPLOI_OIDC_AFTER_LOGOUT_URL,
+  },
+};
+const OIDC_PROVIDERS_FWB = {
+  identityProvider: 'FWB',
+  organizationName: 'Fédération Wallonie-Bruxelles',
+  scope: 'openid profile',
+  slug: 'fwb',
+  source: 'fwb',
+
+  clientId: process.env.FWB_CLIENT_ID,
+  encryptedClientSecret: await cryptoService.encrypt(process.env.FWB_CLIENT_SECRET),
+
+  accessTokenLifespan: process.env.FWB_ACCESS_TOKEN_LIFESPAN || '7d',
+  claimsToStore: process.env.FWB_CLAIMS_TO_STORE,
+  enabled: Boolean(process.env.FWB_ENABLED),
+  idTokenLifespan: process.env.FWB_ID_TOKEN_LIFESPAN || '7d',
+  openidConfigurationUrl: process.env.FWB_OPENID_CONFIGURATION_URL,
+  redirectUri: process.env.FWB_REDIRECT_URI,
+  shouldCloseSession: true,
+
+  customProperties: {
+    logoutUrl: process.env.FWB_OIDC_LOGOUT_URL,
+  },
+};
+const OIDC_PROVIDERS_CNAV = {
+  identityProvider: 'CNAV',
+  organizationName: 'CNAV',
+  scope: 'openid profile',
+  slug: 'cnav',
+  source: 'cnav',
+
+  clientId: process.env.CNAV_CLIENT_ID,
+  encryptedClientSecret: await cryptoService.encrypt(process.env.CNAV_CLIENT_SECRET),
+
+  accessTokenLifespan: process.env.CNAV_ACCESS_TOKEN_LIFESPAN || '7d',
+  enabled: Boolean(process.env.CNAV_ENABLED),
+  idTokenLifespan: process.env.CNAV_ID_TOKEN_LIFESPAN || '7d',
+  openidConfigurationUrl: process.env.CNAV_OPENID_CONFIGURATION_URL,
+  redirectUri: process.env.CNAV_REDIRECT_URI,
+
+  extraAuthorizationUrlParameters: { RedirectToIdentityProvider: 'AD+Authority' },
+};
+const OIDC_PROVIDERS_PAYSDELALOIRE = {
+  identityProvider: 'PAYSDELALOIRE',
+  organizationName: 'Pays de la Loire',
+  scope: 'openid profile',
+  slug: 'pays-de-la-loire',
+  source: 'paysdelaloire',
+
+  clientId: process.env.PAYSDELALOIRE_CLIENT_ID,
+  encryptedClientSecret: await cryptoService.encrypt(process.env.PAYSDELALOIRE_CLIENT_SECRET),
+
+  accessTokenLifespan: process.env.PAYSDELALOIRE_ACCESS_TOKEN_LIFESPAN || '7d',
+  enabled: Boolean(process.env.PAYSDELALOIRE_ENABLED),
+  idTokenLifespan: process.env.PAYSDELALOIRE_ID_TOKEN_LIFESPAN || '7d',
+  openidConfigurationUrl: process.env.PAYSDELALOIRE_OPENID_CONFIGURATION_URL,
+  postLogoutRedirectUri: process.env.PAYSDELALOIRE_POST_LOGOUT_REDIRECT_URI,
+  redirectUri: process.env.PAYSDELALOIRE_REDIRECT_URI,
+  shouldCloseSession: true,
+};
+const OIDC_PROVIDERS_GOOGLE = {
+  identityProvider: 'GOOGLE',
+  organizationName: 'Google',
+  scope: 'openid profile email',
+  slug: 'google',
+  source: 'google',
+
+  clientId: process.env.GOOGLE_CLIENT_ID,
+  encryptedClientSecret: await cryptoService.encrypt(process.env.GOOGLE_CLIENT_SECRET),
+
+  accessTokenLifespan: process.env.GOOGLE_ACCESS_TOKEN_LIFESPAN || '7d',
+  claimsToStore: process.env.GOOGLE_CLAIMS_TO_STORE,
+  enabled: Boolean(process.env.GOOGLE_ENABLED),
+  enabledForPixAdmin: Boolean(process.env.GOOGLE_ENABLED_FOR_PIX_ADMIN),
+  idTokenLifespan: process.env.GOOGLE_ID_TOKEN_LIFESPAN || '7d',
+  openidConfigurationUrl: process.env.GOOGLE_OPENID_CONFIGURATION_URL,
+  redirectUri: process.env.GOOGLE_REDIRECT_URI,
+};
+
+const OIDC_PROVIDERS = [
+  OIDC_PROVIDERS_POLE_EMPLOI,
+  OIDC_PROVIDERS_FWB,
+  OIDC_PROVIDERS_CNAV,
+  OIDC_PROVIDERS_PAYSDELALOIRE,
+  OIDC_PROVIDERS_GOOGLE,
+];
+
+try {
+  console.time(TIMER_NAME);
+  await main();
+  console.log('\noidc-providers table loaded with success\n');
+} catch (error) {
+  console.error(error.message);
+  process.exitCode = 1;
+} finally {
+  await disconnect();
+  await cache.quit();
+  await temporaryStorage.quit();
+  console.timeEnd(TIMER_NAME);
+}
+
+async function main() {
+  await DomainTransaction.execute(
+    async (domainTransaction) =>
+      await Promise.all(
+        OIDC_PROVIDERS.map(async (oidcProviderProperties) => {
+          console.log(
+            `Preparing to create configuration for OIDC Provider "${oidcProviderProperties.identityProvider}"…`,
+          );
+
+          debugOidcProvidersProperties(oidcProviderProperties);
+
+          return usecases.addOidcProvider({ ...oidcProviderProperties, domainTransaction });
+        }),
+      ),
+  );
+}

--- a/api/src/authentication/domain/usecases/add-oidc-provider.js
+++ b/api/src/authentication/domain/usecases/add-oidc-provider.js
@@ -1,0 +1,80 @@
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+/**
+ * @typedef {import ('../usecases/index.js').OidcProviderRepository} OidcProviderRepository
+ */
+
+/**
+ * @param {Object} params
+ * @param {string} params.accessTokenLifespan
+ * @param {string} params.claimsToStore
+ * @param {string} params.clientId
+ * @param {Object} params.customProperties
+ * @param {boolean} params.enabled
+ * @param {boolean} params.enabledForPixAdmin
+ * @param {string} params.encryptedClientSecret
+ * @param {Object} params.extraAuthorizationUrlParameters
+ * @param {string} params.identityProvider
+ * @param {string} params.idTokenLifespan
+ * @param {Object} params.openidClientExtraMetadata
+ * @param {string} params.openidConfigurationUrl
+ * @param {string} params.organizationName
+ * @param {string} params.postLogoutRedirectUri
+ * @param {string} params.redirectUri
+ * @param {string} params.scope
+ * @param {boolean} params.shouldCloseSession
+ * @param {string} params.slug
+ * @param {string} params.source
+ * @param {OidcProviderRepository} params.oidcProviderRepository
+ * @param {DomainTransaction} params.domainTransaction
+ * @returns {Promise<void>}
+ */
+const addOidcProvider = async function ({
+  accessTokenLifespan,
+  claimsToStore,
+  clientId,
+  customProperties,
+  enabled,
+  enabledForPixAdmin,
+  encryptedClientSecret,
+  extraAuthorizationUrlParameters,
+  identityProvider,
+  idTokenLifespan,
+  openidClientExtraMetadata,
+  openidConfigurationUrl,
+  organizationName,
+  postLogoutRedirectUri,
+  redirectUri,
+  scope,
+  shouldCloseSession,
+  slug,
+  source,
+  oidcProviderRepository,
+  domainTransaction = DomainTransaction.emptyTransaction(),
+}) {
+  await oidcProviderRepository.create(
+    {
+      accessTokenLifespan,
+      claimsToStore,
+      clientId,
+      customProperties,
+      enabled,
+      enabledForPixAdmin,
+      encryptedClientSecret,
+      extraAuthorizationUrlParameters,
+      identityProvider,
+      idTokenLifespan,
+      openidClientExtraMetadata,
+      openidConfigurationUrl,
+      organizationName,
+      postLogoutRedirectUri,
+      redirectUri,
+      scope,
+      shouldCloseSession,
+      slug,
+      source,
+    },
+    { domainTransaction },
+  );
+};
+
+export { addOidcProvider };

--- a/api/src/authentication/domain/usecases/index.js
+++ b/api/src/authentication/domain/usecases/index.js
@@ -7,6 +7,7 @@ import * as userLoginRepository from '../../../shared/infrastructure/repositorie
 import * as userRepository from '../../../shared/infrastructure/repositories/user-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
+import * as oidcProviderRepository from '../../infrastructure/repositories/oidc-provider-repository.js';
 import * as pixAuthenticationService from '../services/pix-authentication-service.js';
 import * as refreshTokenService from '../services/refresh-token-service.js';
 
@@ -19,6 +20,7 @@ const dependencies = {
   userRepository,
   userLoginRepository,
   adminMemberRepository,
+  oidcProviderRepository,
 };
 
 const usecasesWithoutInjectedDependencies = {

--- a/api/src/authentication/infrastructure/repositories/oidc-provider-repository.js
+++ b/api/src/authentication/infrastructure/repositories/oidc-provider-repository.js
@@ -1,0 +1,82 @@
+import { knex } from '../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+
+const OIDC_PROVIDERS_TABLE_NAME = 'oidc-providers';
+
+/**
+ * @param {Object} params
+ * @param {string} params.accessTokenLifespan
+ * @param {string} params.claimsToStore
+ * @param {string} params.clientId
+ * @param {Object} params.customProperties
+ * @param {boolean} params.enabled
+ * @param {boolean} params.enabledForPixAdmin
+ * @param {string} params.encryptedClientSecret
+ * @param {Object} params.extraAuthorizationUrlParameters
+ * @param {string} params.identityProvider
+ * @param {string} params.idTokenLifespan
+ * @param {Object} params.openidClientExtraMetadata
+ * @param {string} params.openidConfigurationUrl
+ * @param {string} params.organizationName
+ * @param {string} params.postLogoutRedirectUri
+ * @param {string} params.redirectUri
+ * @param {string} params.scope
+ * @param {boolean} params.shouldCloseSession
+ * @param {string} params.slug
+ * @param {string} params.source
+ * @param {Object} dependencies
+ * @param {DomainTransaction} dependencies.domainTransaction
+ * @returns {Promise<any[]>}
+ */
+const create = async function (
+  {
+    accessTokenLifespan,
+    claimsToStore,
+    clientId,
+    customProperties,
+    enabled,
+    enabledForPixAdmin,
+    encryptedClientSecret,
+    extraAuthorizationUrlParameters,
+    identityProvider,
+    idTokenLifespan,
+    openidClientExtraMetadata,
+    openidConfigurationUrl,
+    organizationName,
+    postLogoutRedirectUri,
+    redirectUri,
+    scope,
+    shouldCloseSession,
+    slug,
+    source,
+  },
+  dependencies = { domainTransaction: DomainTransaction.emptyTransaction() },
+) {
+  const knexConn = dependencies.domainTransaction.knexTransaction ?? knex;
+
+  const oidcProviderProperties = {
+    accessTokenLifespan,
+    claimsToStore,
+    clientId,
+    customProperties,
+    enabled,
+    enabledForPixAdmin,
+    encryptedClientSecret,
+    extraAuthorizationUrlParameters,
+    identityProvider,
+    idTokenLifespan,
+    openidClientExtraMetadata,
+    openidConfigurationUrl,
+    organizationName,
+    postLogoutRedirectUri,
+    redirectUri,
+    scope,
+    shouldCloseSession,
+    slug,
+    source,
+  };
+
+  return await knexConn(OIDC_PROVIDERS_TABLE_NAME).insert(oidcProviderProperties).returning('*');
+};
+
+export { create };

--- a/api/tests/authentication/integration/infrastructure/repositories/oidc-provider-repository_test.js
+++ b/api/tests/authentication/integration/infrastructure/repositories/oidc-provider-repository_test.js
@@ -1,0 +1,31 @@
+import * as oidcProviderRepository from '../../../../../src/authentication/infrastructure/repositories/oidc-provider-repository.js';
+import { expect, knex } from '../../../../test-helper.js';
+
+describe('Integration | Authentication | Infrastructure | Repositories | OidcProvider', function () {
+  describe('#create', function () {
+    it('stores an OIDC Provider in the database', async function () {
+      // given
+      const oidcProviderProperties = {
+        accessTokenLifespan: '7d',
+        idTokenLifespan: '7d',
+        clientId: 'client',
+        encryptedClientSecret: '#%@!!!!!!!!!!!!!',
+        shouldCloseSession: true,
+        identityProvider: 'OIDC_EXAMPLE_NET',
+        openidConfigurationUrl: 'https://oidc.example.net/.well-known/openid-configuration',
+        organizationName: 'OIDC Example',
+        redirectUri: 'https://app.dev.pix.org/connexion/oidc-example-net',
+        scope: 'openid profile',
+        slug: 'oidc-example-net',
+        source: 'oidcexamplenet',
+      };
+
+      // when
+      const savedOidcProvider = await oidcProviderRepository.create(oidcProviderProperties);
+
+      // then
+      const oidcProvider = await knex('oidc-providers').where({ identityProvider: 'OIDC_EXAMPLE_NET' }).first('id');
+      expect(oidcProvider.id).to.equal(savedOidcProvider[0].id);
+    });
+  });
+});

--- a/api/tests/authentication/unit/domain/usecases/add-oidc-provider_test.js
+++ b/api/tests/authentication/unit/domain/usecases/add-oidc-provider_test.js
@@ -1,0 +1,57 @@
+import { addOidcProvider } from '../../../../../src/authentication/domain/usecases/add-oidc-provider.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Authentication | Domain | UseCases | add-oidc-provider', function () {
+  it('creates an OIDC Provider in the oidc-provider-repository', async function () {
+    // given
+    const domainTransaction = {
+      knexTransaction: null,
+    };
+    const oidcProviderRepository = {
+      create: sinon.stub(),
+    };
+    const oidcProviderProperties = {
+      accessTokenLifespan: '7d',
+      idTokenLifespan: '7d',
+      clientId: 'client',
+      encryptedClientSecret: '#%@!!!!!!!!!!!!!',
+      shouldCloseSession: true,
+      identityProvider: 'OIDC_EXAMPLE_NET',
+      openidConfigurationUrl: 'https://oidc.example.net/.well-known/openid-configuration',
+      organizationName: 'OIDC Example',
+      redirectUri: 'https://app.dev.pix.org/connexion/oidc-example-net',
+      scope: 'openid profile',
+      slug: 'oidc-example-net',
+      source: 'oidcexamplenet',
+    };
+    const expectedOidcProviderProperties = {
+      accessTokenLifespan: '7d',
+      claimsToStore: undefined,
+      clientId: 'client',
+      customProperties: undefined,
+      enabled: undefined,
+      enabledForPixAdmin: undefined,
+      encryptedClientSecret: '#%@!!!!!!!!!!!!!',
+      extraAuthorizationUrlParameters: undefined,
+      identityProvider: 'OIDC_EXAMPLE_NET',
+      idTokenLifespan: '7d',
+      openidClientExtraMetadata: undefined,
+      openidConfigurationUrl: 'https://oidc.example.net/.well-known/openid-configuration',
+      organizationName: 'OIDC Example',
+      postLogoutRedirectUri: undefined,
+      redirectUri: 'https://app.dev.pix.org/connexion/oidc-example-net',
+      scope: 'openid profile',
+      shouldCloseSession: true,
+      slug: 'oidc-example-net',
+      source: 'oidcexamplenet',
+    };
+
+    // when
+    await addOidcProvider({ ...oidcProviderProperties, oidcProviderRepository, domainTransaction });
+
+    // then
+    expect(oidcProviderRepository.create).to.have.been.calledWithExactly(expectedOidcProviderProperties, {
+      domainTransaction,
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

En recette et en production on a besoin de charger la table `oidc-providers` de la base de données avec les variables d'environnement.

Il a également été demandé de changer la durée de vie par défaut des tokens de 7 jours à 48h.

## :robot: Proposition

* Dans la table `oidc-providers` ajouter la colonne `enabledForPixAdmin` qui avait été oubliée.
* Créer un script pour charger les données des OIDC Providers à partir des variables d'environnement.

Cette PR embarque également la modification pour `GoogleOidcAuthenticationService` de la propriété `shouldCloseSession` qui avait été initialisée à `true` par erreur lors de #8494, car on ne veut pas que la déconnexion de Pix Admin entraine la déconnexion du SSO Google.

Cette PR embarque enfin une contrainte d'unicité sur la propriété `identityProvider`.

## :rainbow: Remarques

RAS

## :100: Pour tester

1. Réaliser la validation de la migration additionnelle de la DB : 
   1. Exécuter la commande `npm run db:migrate` en local
   2. Vérifier que la table `oidc-providers` a bien été modifiée avec l'ajout d'une colonne `enabledForPixAdmin` et avec l'ajout de la contrainte d'unicité sur la colonne `identityProvider`.
   3. Exécuter 2 fois la commande `npm run db:rollback:latest` et vérifier que la table `oidc-providers` ne contient plus la nouvelle colonne `enabledForPixAdmin` ni la contrainte d'unicité sur la colonne `identityProvider`.
2. Vérifier dans le fichier `api/scripts/team-acces/load-oidc-providers-from-env-variables.js` la bonne définition de chacune des propriétés pour chaque OIDC Provider
3. Exécuter la commande `node scripts/team-acces/load-oidc-providers-from-env-variables.js` et vérifier que l'exécution du script ne produit aucune erreur et que la table `oidc-providers` contient  5 enregistrements remplis avec des données exactes.

:information_source: Bien exécuter le script depuis le répertoire `api/` avec la commande `node scripts/team-acces/load-oidc-providers-from-env-variables.js` et non pas depuis la racine du monorepo avec la commande `node api/scripts/team-acces/load-oidc-providers-from-env-variables.js`.

:information_source: Le développeur/la développeuse peut activer du debug pour voir les définitions des propriétés qui vont être insérées en base de données. Pour cela définir une variable `DEBUG` comme précisé ci-dessous. On a effet fait attention à ne pas mettre dans le code de `console.log` ou toute autre chose qui afficherait dans les logs de la production les `clientSecret` que nous protégeons.

```shell
export DEBUG="pix:oidc-providers:properties"
```