### PR TITLE
[FEATURE] désactive les boutons d'import si un import est en cours (PIX-11681)

### DIFF
--- a/orga/app/components/import.hbs
+++ b/orga/app/components/import.hbs
@@ -27,17 +27,20 @@
           @onImportStudents={{@onImportScoStudents}}
           @acceptedFileType={{this.acceptedFileType}}
           @supportedFormats={{this.supportedFormats}}
+          @disabled={{this.inProgress}}
         />
       {{else if this.currentUser.isSUPManagingStudents}}
         <SupOrganizationParticipant::ImportCards::Add
           @onAddStudents={{@onImportSupStudents}}
           @acceptedFileType={{this.acceptedFileType}}
           @supportedFormats={{this.supportedFormats}}
+          @disabled={{this.inProgress}}
         />
         <SupOrganizationParticipant::ImportCards::Replace
           @onReplaceStudents={{@onReplaceStudents}}
           @acceptedFileType={{this.acceptedFileType}}
           @supportedFormats={{this.supportedFormats}}
+          @disabled={{this.inProgress}}
         />
       {{/if}}
     </div>

--- a/orga/app/components/import.js
+++ b/orga/app/components/import.js
@@ -9,6 +9,10 @@ export default class Import extends Component {
   @service errorMessages;
   @service intl;
 
+  get inProgress() {
+    return this.args.organizationImportDetail?.inProgress;
+  }
+
   get displaySuccess() {
     return this.args.organizationImportDetail?.isDone;
   }

--- a/orga/app/components/sco-organization-participant/import-card.hbs
+++ b/orga/app/components/sco-organization-participant/import-card.hbs
@@ -16,16 +16,21 @@
   </div>
 
   <div class="import-card__footer">
-    <PixButtonUpload
-      @id="students-file-upload"
-      @size="small"
-      @onChange={{@onImportStudents}}
-      accept={{@supportedFormats}}
-      aria-describedby="accepted-files"
-    >
-      {{t "pages.organization-participants-import.actions.add-sco.label"}}
-    </PixButtonUpload>
-
+    {{#if @disabled}}
+      <PixButton @isDisabled={{@disabled}} @size="small" aria-describedby="accepted-files">
+        {{t "pages.organization-participants-import.actions.add-sco.label"}}
+      </PixButton>
+    {{else}}
+      <PixButtonUpload
+        @id="students-file-upload"
+        @size="small"
+        @onChange={{@onImportStudents}}
+        accept={{@supportedFormats}}
+        aria-describedby="accepted-files"
+      >
+        {{t "pages.organization-participants-import.actions.add-sco.label"}}
+      </PixButtonUpload>
+    {{/if}}
     <p class="import-card__accepted-files" id="accepted-files">
       {{@acceptedFileType}}
     </p>

--- a/orga/app/components/sup-organization-participant/import-cards/add.hbs
+++ b/orga/app/components/sup-organization-participant/import-cards/add.hbs
@@ -8,16 +8,21 @@
   </p>
 
   <div class="import-card__footer">
-    <PixButtonUpload
-      @id="students-file-upload-add"
-      @size="small"
-      @onChange={{@onAddStudents}}
-      accept={{@supportedFormats}}
-      aria-describedby="accepted-files-add"
-    >
-      {{t "pages.organization-participants-import.actions.add-sup.label"}}
-    </PixButtonUpload>
-
+    {{#if @disabled}}
+      <PixButton @isDisabled={{@disabled}} @size="small" aria-describedby="accepted-files-add">
+        {{t "pages.organization-participants-import.actions.add-sup.label"}}
+      </PixButton>
+    {{else}}
+      <PixButtonUpload
+        @id="students-file-upload-add"
+        @size="small"
+        @onChange={{@onAddStudents}}
+        accept={{@supportedFormats}}
+        aria-describedby="accepted-files-add"
+      >
+        {{t "pages.organization-participants-import.actions.add-sup.label"}}
+      </PixButtonUpload>
+    {{/if}}
     <p class="import-card__accepted-files" id="accepted-files-add">
       {{@acceptedFileType}}
     </p>

--- a/orga/app/components/sup-organization-participant/import-cards/replace.hbs
+++ b/orga/app/components/sup-organization-participant/import-cards/replace.hbs
@@ -7,7 +7,12 @@
   </p>
 
   <div class="import-card__footer">
-    <PixButton @triggerAction={{this.toggleModal}} @size="small" aria-describedby="accepted-files-replace">
+    <PixButton
+      @triggerAction={{this.toggleModal}}
+      @isDisabled={{@disabled}}
+      @size="small"
+      aria-describedby="accepted-files-replace"
+    >
       {{t "pages.organization-participants-import.actions.replace.label"}}
     </PixButton>
 

--- a/orga/app/models/organization-import-detail.js
+++ b/orga/app/models/organization-import-detail.js
@@ -17,4 +17,8 @@ export default class OrganizationImportDetail extends Model {
   get isDone() {
     return this.status === 'IMPORTED';
   }
+
+  get inProgress() {
+    return ['UPLOADED', 'VALIDATED'].includes(this.status);
+  }
 }

--- a/orga/tests/integration/components/sco-organization-participant/import-card_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/import-card_test.js
@@ -1,0 +1,33 @@
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | ScoOrganizationParticipant::ImportCard', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('upload button', () => {
+    test('should be disable', async function (assert) {
+      // when
+      const screen = await render(hbs`<ScoOrganizationParticipant::ImportCard @disabled={{true}} />`);
+
+      // then
+      const button = screen.getByRole('button', {
+        name: this.intl.t('pages.organization-participants-import.actions.add-sco.label'),
+      });
+      assert.ok(button.hasAttribute('disabled'));
+    });
+
+    test('should be enable', async function (assert) {
+      // when
+      const screen = await render(hbs`<ScoOrganizationParticipant::ImportCard @disabled={{false}} />`);
+
+      // then
+      const button = screen.getByRole('button', {
+        name: this.intl.t('pages.organization-participants-import.actions.add-sco.label'),
+      });
+      assert.notOk(button.hasAttribute('disabled'));
+    });
+  });
+});

--- a/orga/tests/integration/components/sup-organization-participant/import-cards/add_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/import-cards/add_test.js
@@ -1,0 +1,33 @@
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | SupOrganizationParticipant::ImportCards::Add', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('upload button', () => {
+    test('should be disable', async function (assert) {
+      // when
+      const screen = await render(hbs`<SupOrganizationParticipant::ImportCards::Add @disabled={{true}} />`);
+
+      // then
+      const button = screen.getByRole('button', {
+        name: this.intl.t('pages.organization-participants-import.actions.add-sup.label'),
+      });
+      assert.ok(button.hasAttribute('disabled'));
+    });
+
+    test('should be enable', async function (assert) {
+      // when
+      const screen = await render(hbs`<SupOrganizationParticipant::ImportCards::Add @disabled={{false}} />`);
+
+      // then
+      const button = screen.getByRole('button', {
+        name: this.intl.t('pages.organization-participants-import.actions.add-sup.label'),
+      });
+      assert.notOk(button.hasAttribute('disabled'));
+    });
+  });
+});

--- a/orga/tests/integration/components/sup-organization-participant/import-cards/replace_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/import-cards/replace_test.js
@@ -1,0 +1,33 @@
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | SupOrganizationParticipant::ImportCards::Replace', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('upload button', () => {
+    test('should be disable', async function (assert) {
+      // when
+      const screen = await render(hbs`<SupOrganizationParticipant::ImportCards::Replace @disabled={{true}} />`);
+
+      // then
+      const button = screen.getByRole('button', {
+        name: this.intl.t('pages.organization-participants-import.actions.replace.label'),
+      });
+      assert.ok(button.hasAttribute('disabled'));
+    });
+
+    test('should be enable', async function (assert) {
+      // when
+      const screen = await render(hbs`<SupOrganizationParticipant::ImportCards::Replace @disabled={{false}} />`);
+
+      // then
+      const button = screen.getByRole('button', {
+        name: this.intl.t('pages.organization-participants-import.actions.replace.label'),
+      });
+      assert.notOk(button.hasAttribute('disabled'));
+    });
+  });
+});

--- a/orga/tests/unit/models/organization-import_test.js
+++ b/orga/tests/unit/models/organization-import_test.js
@@ -59,4 +59,24 @@ module('Unit | Model | organization-import-detail', function (hooks) {
       });
     });
   });
+  module('inProgress', function () {
+    ['UPLOADED', 'VALIDATED'].forEach((status) => {
+      test('it should return true', function (assert) {
+        const store = this.owner.lookup('service:store');
+        const model = store.createRecord('organization-import-detail', {
+          status,
+        });
+        assert.ok(model.inProgress);
+      });
+    });
+    ['UPLOAD_ERROR', 'VALIDATION_ERROR', 'IMPORT_ERROR', 'IMPORTED'].forEach((status) => {
+      test('it should return false', function (assert) {
+        const store = this.owner.lookup('service:store');
+        const model = store.createRecord('organization-import-detail', {
+          status,
+        });
+        assert.notOk(model.inProgress);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Afin de limiter les ressources utilisées lors des imports, nous souhaitons empêcher l' utilisateur d’importer un nouveau fichier tant qu’un import est en cours.

## :robot: Proposition
On désactive les boutons si un import est en cours.

## :rainbow: Remarques
Les messages de statuts en cours ne sont pas encore gérés, on devrait mergé cette pr une fois les messages de statuts en place.

## :100: Pour tester
Sco
- Se rendre sur la page import de l'orga SCO_MANAGING
- vérifier que le bouton est désactivé
Sup
- Se rendre sur la page import de l'orga SCO_MANAGING
- vérifier que les boutons sont désactivés
Agri
- Réaliser un import avec l' orga sco fregata 
- Modifier l'état de l'import depuis scalingo (UPLOADED, VALIDATED)
- vérifier que le bouton est désactivé
