### PR TITLE
[BUGFIX] Màj tolérance d'un QROC du module bien-ecrire-son-adresse-mail

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -362,7 +362,7 @@
               "placeholder": "",
               "ariaLabel": "Adresse mail de Naomi",
               "defaultValue": "",
-              "tolerances": [],
+              "tolerances": ["t1"],
               "solutions": ["naomizao457@yahoo.com", "naomizao457@yahoo.fr"]
             }
           ],


### PR DESCRIPTION
## :unicorn: Problème
Tolérance mal renseignée sur la dernière activité du module
## :robot: Proposition
Ajouter une tolérance

## :rainbow: Remarques
RAS
## :100: Pour tester
Soumettre une réponse avec des majuscules sur le dernier grain et voir si la réponse est comptée comme juste. 
Lien module : https://app-pr8541.review.pix.fr/modules/bien-ecrire-son-adresse-mail