### PR TITLE
[FEATURE]: Retrait du bandeau d'information gestion des accès à Pix Certif pour PRO et SUP (PIX-11857)

### DIFF
--- a/certif/app/controllers/authenticated.js
+++ b/certif/app/controllers/authenticated.js
@@ -22,13 +22,6 @@ export default class AuthenticatedController extends Controller {
     );
   }
 
-  get displayRoleManagementBanner() {
-    return (
-      this.currentUser.currentAllowedCertificationCenterAccess.isPro ||
-      this.currentUser.currentAllowedCertificationCenterAccess.isSup
-    );
-  }
-
   get documentationLink() {
     if (this.currentUser.currentAllowedCertificationCenterAccess.isV3Pilot) {
       return LINK_V3_PILOT;

--- a/certif/app/templates/authenticated.hbs
+++ b/certif/app/templates/authenticated.hbs
@@ -73,16 +73,6 @@
       </PixBanner>
     {{/if}}
 
-    {{#if this.displayRoleManagementBanner}}
-      <PixBanner
-        @actionLabel={{t "pages.sup-and-pro.banner.url-label"}}
-        @actionUrl="https://cloud.pix.fr/s/xfPrK5n7K73kmbz"
-        @canCloseBanner="true"
-      >
-        {{t "pages.sup-and-pro.banner.information" htmlSafe=true}}
-      </PixBanner>
-    {{/if}}
-
     <Banner::LanguageAvailability />
 
     <div class="page">

--- a/certif/tests/acceptance/authenticated_test.js
+++ b/certif/tests/acceptance/authenticated_test.js
@@ -135,60 +135,6 @@ module('Acceptance | authenticated', function (hooks) {
         });
       });
     });
-
-    module('role management banner', function () {
-      module('when certification center is SCO', function () {
-        test('it should not display the banner', async function (assert) {
-          // given
-          const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted(
-            'SCO',
-            'Scoule',
-          );
-          await authenticateSession(certificationPointOfContact.id);
-
-          // when
-          const screen = await visitScreen('/sessions/liste');
-
-          // then
-          assert
-            .dom(
-              screen.queryByText(
-                'Nouveauté : Gestion des accès à Pix Certif, plus d’autonomie pour les centres ! Rendez-vous dans l’onglet Equipe pour découvrir les administrateurs et membres de votre espace Pix Certif. Les administrateurs peuvent dorénavant ajouter des membres dans Pix Certif sans avoir à contacter l’équipe Certification.',
-              ),
-            )
-            .doesNotExist();
-          assert.dom(screen.queryByRole('link', { name: 'Plus d’information ici' })).doesNotExist();
-        });
-      });
-
-      const nonSchoolCertificationCentersTypes = ['SUP', 'PRO'];
-
-      nonSchoolCertificationCentersTypes.forEach((type) => {
-        module(`when certification center is ${type}`, function () {
-          test('it should not display the banner', async function (assert) {
-            // given
-            const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted(
-              type,
-              'Soupère',
-            );
-            await authenticateSession(certificationPointOfContact.id);
-
-            // when
-            const screen = await visitScreen('/sessions/liste');
-
-            // then
-            assert
-              .dom(
-                screen.getByText(
-                  'Nouveauté : Gestion des accès à Pix Certif, plus d’autonomie pour les centres ! Rendez-vous dans l’onglet Equipe pour découvrir les administrateurs et membres de votre espace Pix Certif. Les administrateurs peuvent dorénavant ajouter des membres dans Pix Certif sans avoir à contacter l’équipe Certification.',
-                ),
-              )
-              .exists();
-            assert.dom(screen.getByRole('link', { name: 'Plus d’information ici' })).exists();
-          });
-        });
-      });
-    });
   });
 
   module('When user changes current certification center', function () {

--- a/certif/tests/unit/controllers/authenticated_test.js
+++ b/certif/tests/unit/controllers/authenticated_test.js
@@ -16,9 +16,11 @@ module('Unit | Controller | authenticated', function (hooks) {
         isRelatedToManagingStudentsOrganization: true,
         isV3Pilot: true,
       });
+
       class CurrentUserStub extends Service {
         currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
       }
+
       this.owner.register('service:current-user', CurrentUserStub);
       const controller = this.owner.lookup('controller:authenticated');
 
@@ -37,9 +39,11 @@ module('Unit | Controller | authenticated', function (hooks) {
         name: 'Sunnydale',
         type: 'NOT_SCO',
       });
+
       class CurrentUserStub extends Service {
         currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
       }
+
       this.owner.register('service:current-user', CurrentUserStub);
       const controller = this.owner.lookup('controller:authenticated');
 
@@ -59,9 +63,11 @@ module('Unit | Controller | authenticated', function (hooks) {
         type: 'SCO',
         isRelatedToManagingStudentsOrganization: true,
       });
+
       class CurrentUserStub extends Service {
         currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
       }
+
       this.owner.register('service:current-user', CurrentUserStub);
       const controller = this.owner.lookup('controller:authenticated');
 
@@ -86,12 +92,15 @@ module('Unit | Controller | authenticated', function (hooks) {
         isAccessBlockedAEFE: false,
         isAccessBlockedAgri: false,
       });
+
       class CurrentUserStub extends Service {
         currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
       }
+
       class RouterStub extends Service {
         currentRouteName = 'not.finalization-page';
       }
+
       this.owner.register('service:router', RouterStub);
       this.owner.register('service:current-user', CurrentUserStub);
       const controller = this.owner.lookup('controller:authenticated');
@@ -117,12 +126,15 @@ module('Unit | Controller | authenticated', function (hooks) {
         isAccessBlockedAEFE: false,
         isAccessBlockedAgri: false,
       });
+
       class CurrentUserStub extends Service {
         currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
       }
+
       class RouterStub extends Service {
         currentRouteName = 'not.finalization-page';
       }
+
       this.owner.register('service:router', RouterStub);
       this.owner.register('service:current-user', CurrentUserStub);
       const controller = this.owner.lookup('controller:authenticated');
@@ -148,12 +160,15 @@ module('Unit | Controller | authenticated', function (hooks) {
         isAccessBlockedAEFE: false,
         isAccessBlockedAgri: false,
       });
+
       class CurrentUserStub extends Service {
         currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
       }
+
       class RouterStub extends Service {
         currentRouteName = 'authenticated.sessions.finalize';
       }
+
       this.owner.register('service:router', RouterStub);
       this.owner.register('service:current-user', CurrentUserStub);
       const controller = this.owner.lookup('controller:authenticated');
@@ -179,12 +194,15 @@ module('Unit | Controller | authenticated', function (hooks) {
         isAccessBlockedAEFE: false,
         isAccessBlockedAgri: false,
       });
+
       class CurrentUserStub extends Service {
         currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
       }
+
       class RouterStub extends Service {
         currentRouteName = 'not.finalization-page';
       }
+
       this.owner.register('service:router', RouterStub);
       this.owner.register('service:current-user', CurrentUserStub);
       const controller = this.owner.lookup('controller:authenticated');
@@ -209,9 +227,11 @@ module('Unit | Controller | authenticated', function (hooks) {
         isAccessBlockedAEFE: false,
         isAccessBlockedAgri: false,
       });
+
       class CurrentUserStub extends Service {
         currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
       }
+
       this.owner.register('service:current-user', CurrentUserStub);
       const controller = this.owner.lookup('controller:authenticated');
 
@@ -232,9 +252,11 @@ module('Unit | Controller | authenticated', function (hooks) {
         isAccessBlockedAEFE: false,
         isAccessBlockedAgri: false,
       });
+
       class CurrentUserStub extends Service {
         currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
       }
+
       this.owner.register('service:current-user', CurrentUserStub);
       const controller = this.owner.lookup('controller:authenticated');
 
@@ -243,54 +265,6 @@ module('Unit | Controller | authenticated', function (hooks) {
 
       // then
       assert.true(showLinkToSessions);
-    });
-  });
-
-  module('#get displayRoleManagementBanner', function () {
-    module('when certif center is SCO', function () {
-      test('should not display banner', function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
-          id: 123,
-          name: 'Scoule',
-          type: 'SCO',
-        });
-        class CurrentUserStub extends Service {
-          currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
-        }
-        this.owner.register('service:current-user', CurrentUserStub);
-        const controller = this.owner.lookup('controller:authenticated');
-
-        // when
-        const displayBanner = controller.displayRoleManagementBanner;
-
-        // then
-        assert.false(displayBanner);
-      });
-    });
-
-    module('when certif center is SUP or PRO', function () {
-      test('should display banner', function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
-          id: 345,
-          name: 'Super',
-          type: 'SUP',
-        });
-        class CurrentUserStub extends Service {
-          currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
-        }
-        this.owner.register('service:current-user', CurrentUserStub);
-        const controller = this.owner.lookup('controller:authenticated');
-
-        // when
-        const displayBanner = controller.displayRoleManagementBanner;
-
-        // then
-        assert.true(displayBanner);
-      });
     });
   });
 });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -858,12 +858,6 @@
         }
       }
     },
-    "sup-and-pro": {
-      "banner": {
-        "information": "Nouveauté : Gestion des accès à Pix Certif, plus d’autonomie pour les centres ! '<br>' Rendez-vous dans l’onglet Equipe pour découvrir les administrateurs et membres de votre espace Pix Certif. Les administrateurs peuvent dorénavant ajouter des membres dans Pix Certif sans avoir à contacter l’équipe Certification. '<br>'",
-        "url-label": "Plus d’information ici"
-      }
-    },
     "team": {
       "title": "Team",
       "invite-button": "Invite a member",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -858,12 +858,6 @@
         }
       }
     },
-    "sup-and-pro": {
-      "banner": {
-        "information": "Nouveauté : Gestion des accès à Pix Certif, plus d’autonomie pour les centres ! '</br>' Rendez-vous dans l’onglet Equipe pour découvrir les administrateurs et membres de votre espace Pix Certif. Les administrateurs peuvent dorénavant ajouter des membres dans Pix Certif sans avoir à contacter l’équipe Certification. '<br>'",
-        "url-label": "Plus d’information ici"
-      }
-    },
     "team": {
       "title": "Équipe",
       "invite-button": "Inviter un membre",


### PR DESCRIPTION
## :unicorn: Problème
La nouveauté s’est estompée depuis décembre 2023, il est inutile pour l’utilisateur de continuer à afficher ce message.

## :robot: Proposition
Retirer le bandeau d'information des espaces Pix Certif PRO et SUP :

## :rainbow: Remarques
RAS

## :100: Pour tester

1. Se connecter sur Pix Certif (en SUP ou PRO)
2. Constater que le bandeau d'information n'est plus affiché (voir capture d'écran)
![Capture d’écran 2024-03-29 à 11 32 44](https://github.com/1024pix/pix/assets/152303583/95a84ca3-4cf0-4971-bb81-f6755c46d339)
