### PR TITLE
[FEATURE] Créer le repository permettant de sauvegarder les nouveaux format de learner (Pix-11615)

### DIFF
--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import { OrganizationLearnersCouldNotBeSavedError } from '../../../../../lib/domain/errors.js';
 import { OrganizationLearner } from '../../../../../lib/domain/models/index.js';
 import * as organizationLearnerRepository from '../../../../../lib/infrastructure/repositories/organization-learner-repository.js';
+import { ApplicationTransaction } from '../../../shared/infrastructure/ApplicationTransaction.js';
 
 const removeByIds = function ({ organizationLearnerIds, userId, domainTransaction }) {
   return domainTransaction
@@ -63,4 +64,19 @@ const addOrUpdateOrganizationOfOrganizationLearners = async function (
   }
 };
 
-export { addOrUpdateOrganizationOfOrganizationLearners, disableAllOrganizationLearnersInOrganization, removeByIds };
+const saveCommonOrganizationLearners = function (learners) {
+  const knex = ApplicationTransaction.getConnection();
+  return knex('organization-learners').insert(learners);
+};
+const disableCommonOrganizationLearnersFromOrganizationId = function (organizationId) {
+  const knex = ApplicationTransaction.getConnection();
+  return knex('organization-learners').where({ organizationId }).update({ isDisabled: true, updatedAt: new Date() });
+};
+
+export {
+  addOrUpdateOrganizationOfOrganizationLearners,
+  disableAllOrganizationLearnersInOrganization,
+  disableCommonOrganizationLearnersFromOrganizationId,
+  removeByIds,
+  saveCommonOrganizationLearners,
+};


### PR DESCRIPTION
## :unicorn: Problème
Dans la continuité de l'épix de la reforme des imports , on souhaite sauvegarder les infos des learners issus de l'import


## :robot: Proposition
Ajouter 2 méthodes un pour sauvegarder en bdd et l'autre pour désactiver les learners d'une organization

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- On ne peut pas tester pour l'instant, donc vérifier que les tests de l'api passent. 