### PR TITLE
[FEATURE] Récupérer le format d'import pour une organisation spécifique (PIX-11613)

### DIFF
--- a/api/db/database-builder/factory/build-organization-feature.js
+++ b/api/db/database-builder/factory/build-organization-feature.js
@@ -4,11 +4,13 @@ const buildOrganizationFeature = function buildOrganizationFeature({
   id = databaseBuffer.getNextId(),
   organizationId,
   featureId,
+  params,
 } = {}) {
   const values = {
     id,
     organizationId,
     featureId,
+    params,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/db/migrations/20240329142858_add-params-on-organization-features.js
+++ b/api/db/migrations/20240329142858_add-params-on-organization-features.js
@@ -1,0 +1,25 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/DEV/pages/2153512965/Cr+er+une+migration
+
+// If your migrations target `answers` or `knowledge-elements`
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+const TABLE_NAME = 'organization-features';
+const COLUMN_NAME = 'params';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.jsonb(COLUMN_NAME).defaultTo(null);
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/src/prescription/learner-management/domain/models/OrganizationLearnerImportFormat.js
+++ b/api/src/prescription/learner-management/domain/models/OrganizationLearnerImportFormat.js
@@ -1,0 +1,9 @@
+class OrganizationLearnerImportFormat {
+  constructor({ name, fileType, config } = {}) {
+    this.name = name;
+    this.fileType = fileType;
+    this.config = config;
+  }
+}
+
+export { OrganizationLearnerImportFormat };

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-import-format-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-import-format-repository.js
@@ -1,0 +1,34 @@
+import { ORGANIZATION_FEATURE } from '../../../../shared/domain/constants.js';
+import { ApplicationTransaction } from '../../../shared/infrastructure/ApplicationTransaction.js';
+import { OrganizationLearnerImportFormat } from '../../domain/models/OrganizationLearnerImportFormat.js';
+
+function _toDomain(data) {
+  return new OrganizationLearnerImportFormat(data);
+}
+
+const get = async function (organizationId) {
+  const knex = ApplicationTransaction.getConnection();
+
+  const configResult = await knex('organization-features')
+    .select('params')
+    .join('features', function () {
+      this.on('features.id', 'organization-features.featureId').onVal(
+        'features.key',
+        ORGANIZATION_FEATURE.LEARNER_IMPORT.key,
+      );
+    })
+    .where({ organizationId })
+    .first();
+
+  if (!configResult) return null;
+
+  const result = await knex('organization-learner-import-formats')
+    .where('id', configResult.params.organizationLearnerImportId)
+    .first();
+
+  if (!result) return null;
+
+  return _toDomain(result);
+};
+
+export { get };

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-import-format-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-import-format-repository_test.js
@@ -1,0 +1,59 @@
+import { OrganizationLearnerImportFormat } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationLearnerImportFormat.js';
+import * as organizationLearnerImportFormatRepository from '../../../../../../src/prescription/learner-management/infrastructure/repositories/organization-learner-import-format-repository.js';
+import { ORGANIZATION_FEATURE } from '../../../../../../src/shared/domain/constants.js';
+import { databaseBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Integration | Repository | Organization Learner Management | Organization Learner Import Format', function () {
+  describe('#get', function () {
+    it('should return import state', async function () {
+      // given
+      const importConfig = {
+        name: 'MY_TEST_EXPORT',
+        fileType: 'csv',
+        config: {
+          encoding: ['utf-8'],
+          validationRules: {
+            unicity: ['my_column1'],
+            formats: [
+              { name: 'my_column1', type: 'string' },
+              { name: 'my_column2', type: 'string' },
+            ],
+          },
+          headers: [
+            { name: 'my_column1', required: true, property: 'lastName' },
+            { name: 'my_column2', required: true, property: 'firstName' },
+          ],
+        },
+      };
+
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+      const featureId = databaseBuilder.factory.buildFeature({
+        key: ORGANIZATION_FEATURE.LEARNER_IMPORT.key,
+      }).id;
+
+      const organizationLearnerImportId = databaseBuilder.factory.buildOrganizationLearnerImportFormat(importConfig).id;
+
+      databaseBuilder.factory.buildOrganizationFeature({
+        organizationId,
+        featureId,
+        params: { organizationLearnerImportId },
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await organizationLearnerImportFormatRepository.get(organizationId);
+
+      // then
+      expect(result).to.be.an.instanceOf(OrganizationLearnerImportFormat);
+      expect(result).to.be.deep.equal(new OrganizationLearnerImportFormat(importConfig));
+    });
+
+    it('should return null if nothing was found', async function () {
+      const result = await organizationLearnerImportFormatRepository.get(1);
+
+      expect(result).to.equal(null);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Pour extraire les données d'un import générique, nous devons pouvoir récupérer la configuration associé à une organisation

## :robot: Proposition
Ajouter un nouveau repo qui repond à cette demande

## :rainbow: Remarques
RAS

## :100: Pour tester
CI ok
