### PR TITLE
[TECH] Deplacer isRelatedToCertification vers le repo approprié (PIX-11920)

### DIFF
--- a/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-badge-repository.js
+++ b/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-badge-repository.js
@@ -1,4 +1,5 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { Badge } from '../../../../shared/domain/models/Badge.js';
 import { ComplementaryCertificationBadge } from '../../domain/models/ComplementaryCertificationBadge.js';
@@ -73,8 +74,22 @@ const getAllWithSameTargetProfile = async function (complementaryCertificationBa
   return complementaryCertificationBadges.map(_toDomain);
 };
 
+const isRelatedToCertification = async function (badgeId, { knexTransaction } = DomainTransaction.emptyTransaction()) {
+  const complementaryCertificationBadge = await (knexTransaction ?? knex)('complementary-certification-badges')
+    .where({ badgeId })
+    .first();
+  return !!complementaryCertificationBadge;
+};
+
 function _toDomain(complementaryCertificationBadgeDTO) {
   return new ComplementaryCertificationBadge(complementaryCertificationBadgeDTO);
 }
 
-export { attach, detachByIds, findAttachableBadgesByIds, getAllIdsByTargetProfileId, getAllWithSameTargetProfile };
+export {
+  attach,
+  detachByIds,
+  findAttachableBadgesByIds,
+  getAllIdsByTargetProfileId,
+  getAllWithSameTargetProfile,
+  isRelatedToCertification,
+};

--- a/api/src/shared/domain/usecases/delete-unassociated-badge.js
+++ b/api/src/shared/domain/usecases/delete-unassociated-badge.js
@@ -4,10 +4,17 @@ import {
 } from '../../../../lib/domain/errors.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 
-const deleteUnassociatedBadge = async function ({ badgeId, badgeRepository }) {
+const deleteUnassociatedBadge = async function ({
+  badgeId,
+  badgeRepository,
+  complementaryCertificationBadgeRepository,
+}) {
   return DomainTransaction.execute(async (domainTransaction) => {
     const isAssociated = await badgeRepository.isAssociated(badgeId, domainTransaction);
-    const isRelatedToCertification = await badgeRepository.isRelatedToCertification(badgeId, domainTransaction);
+    const isRelatedToCertification = await complementaryCertificationBadgeRepository.isRelatedToCertification(
+      badgeId,
+      domainTransaction,
+    );
 
     if (isAssociated) {
       throw new AcquiredBadgeForbiddenDeletionError();

--- a/api/src/shared/domain/usecases/index.js
+++ b/api/src/shared/domain/usecases/index.js
@@ -2,6 +2,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import * as targetProfileRepository from '../../../../lib/infrastructure/repositories/target-profile-repository.js';
+import * as complementaryCertificationBadgeRepository from '../../../certification/complementary-certification/infrastructure/repositories/complementary-certification-badge-repository.js';
 import * as badgeCriteriaRepository from '../../../evaluation/infrastructure/repositories/badge-criteria-repository.js';
 import * as activityAnswerRepository from '../../../school/infrastructure/repositories/activity-answer-repository.js';
 import * as activityRepository from '../../../school/infrastructure/repositories/activity-repository.js';
@@ -18,6 +19,7 @@ const usecasesWithoutInjectedDependencies = {
 };
 
 const dependencies = {
+  complementaryCertificationBadgeRepository,
   activityAnswerRepository,
   activityRepository,
   assessmentRepository,

--- a/api/src/shared/infrastructure/repositories/badge-repository.js
+++ b/api/src/shared/infrastructure/repositories/badge-repository.js
@@ -22,13 +22,6 @@ const isAssociated = async function (badgeId, { knexTransaction } = DomainTransa
   return !!associatedBadge;
 };
 
-const isRelatedToCertification = async function (badgeId, { knexTransaction } = DomainTransaction.emptyTransaction()) {
-  const complementaryCertificationBadge = await (knexTransaction ?? knex)('complementary-certification-badges')
-    .where({ badgeId })
-    .first();
-  return !!complementaryCertificationBadge;
-};
-
 const get = async function (id) {
   const badge = await knex(TABLE_NAME).select('*').where({ id }).first();
   if (!badge) throw new NotFoundError('Badge not found');
@@ -76,17 +69,7 @@ const findAllByIds = async function ({ ids }) {
   });
 };
 
-export {
-  findAllByIds,
-  findByCampaignId,
-  get,
-  isAssociated,
-  isKeyAvailable,
-  isRelatedToCertification,
-  remove,
-  save,
-  update,
-};
+export { findAllByIds, findByCampaignId, get, isAssociated, isKeyAvailable, remove, save, update };
 
 function _adaptModelToDb(badge) {
   return omit(badge, ['id', 'badgeCriteria', 'complementaryCertificationBadge']);

--- a/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-badge-repository_test.js
+++ b/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-badge-repository_test.js
@@ -204,7 +204,9 @@ describe('Integration | Infrastructure | Repository | Certification | Complement
       await databaseBuilder.commit();
 
       // when
-      const results = await complementaryCertificationBadgeRepository.findAttachableBadgesByIds({ ids: [123] });
+      const results = await complementaryCertificationBadgeRepository.findAttachableBadgesByIds({
+        ids: [123],
+      });
 
       // then
       expect(results).to.deep.equal([
@@ -253,7 +255,9 @@ describe('Integration | Infrastructure | Repository | Certification | Complement
       await databaseBuilder.commit();
 
       // when
-      const results = await complementaryCertificationBadgeRepository.findAttachableBadgesByIds({ ids: [123] });
+      const results = await complementaryCertificationBadgeRepository.findAttachableBadgesByIds({
+        ids: [123],
+      });
 
       // then
       expect(results).to.be.empty;
@@ -327,6 +331,59 @@ describe('Integration | Infrastructure | Repository | Certification | Complement
 
         // then
         expect(error).to.be.instanceof(NotFoundError);
+      });
+    });
+  });
+
+  describe('#isRelatedToCertification', function () {
+    describe('when the badge is not acquired', function () {
+      it('should return false', async function () {
+        // given
+        const badgeId = databaseBuilder.factory.buildBadge({ id: 1 }).id;
+        await databaseBuilder.commit();
+
+        // when
+        const isRelatedToCertification =
+          await complementaryCertificationBadgeRepository.isRelatedToCertification(badgeId);
+
+        // then
+        expect(isRelatedToCertification).to.be.false;
+      });
+    });
+
+    describe('when the badge is present in complementary-certification-badges', function () {
+      it('should return true', async function () {
+        // given
+        const badge = databaseBuilder.factory.buildBadge();
+        const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification().id;
+        databaseBuilder.factory.buildComplementaryCertificationBadge({
+          badgeId: badge.id,
+          complementaryCertificationId,
+        }).id;
+        await databaseBuilder.commit();
+
+        // when
+        const isRelatedToCertification = await complementaryCertificationBadgeRepository.isRelatedToCertification(
+          badge.id,
+        );
+
+        // then
+        expect(isRelatedToCertification).to.be.true;
+      });
+    });
+
+    describe('when the badge is present in both complementary-certification-badges and complementary-certification-course-results', function () {
+      it('should return true', async function () {
+        // given
+        const badgeId = databaseBuilder.factory.buildBadge().id;
+        databaseBuilder.factory.buildComplementaryCertificationBadge({ complementaryCertificationId: null, badgeId });
+        await databaseBuilder.commit();
+
+        // when
+        const isNotAssociated = await complementaryCertificationBadgeRepository.isRelatedToCertification(badgeId);
+
+        // then
+        expect(isNotAssociated).to.be.true;
       });
     });
   });

--- a/api/tests/shared/integration/infrastructure/repositories/badge-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/badge-repository_test.js
@@ -279,56 +279,6 @@ describe('Integration | Repository | Badge', function () {
     });
   });
 
-  describe('#isRelatedToCertification', function () {
-    describe('when the badge is not acquired', function () {
-      it('should return false', async function () {
-        // given
-        const badgeId = databaseBuilder.factory.buildBadge({ id: 1 }).id;
-        await databaseBuilder.commit();
-
-        // when
-        const isRelatedToCertification = await badgeRepository.isRelatedToCertification(badgeId);
-
-        // then
-        expect(isRelatedToCertification).to.be.false;
-      });
-    });
-
-    describe('when the badge is present in complementary-certification-badges', function () {
-      it('should return true', async function () {
-        // given
-        const badge = databaseBuilder.factory.buildBadge();
-        const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification().id;
-        databaseBuilder.factory.buildComplementaryCertificationBadge({
-          badgeId: badge.id,
-          complementaryCertificationId,
-        }).id;
-        await databaseBuilder.commit();
-
-        // when
-        const isRelatedToCertification = await badgeRepository.isRelatedToCertification(badge.id);
-
-        // then
-        expect(isRelatedToCertification).to.be.true;
-      });
-    });
-
-    describe('when the badge is present in both complementary-certification-badges and complementary-certification-course-results', function () {
-      it('should return true', async function () {
-        // given
-        const badgeId = databaseBuilder.factory.buildBadge().id;
-        databaseBuilder.factory.buildComplementaryCertificationBadge({ complementaryCertificationId: null, badgeId });
-        await databaseBuilder.commit();
-
-        // when
-        const isNotAssociated = await badgeRepository.isRelatedToCertification(badgeId);
-
-        // then
-        expect(isNotAssociated).to.be.true;
-      });
-    });
-  });
-
   describe('#remove', function () {
     describe('when the record to delete is in the table', function () {
       it('should return true when deletion goes well', async function () {

--- a/api/tests/shared/unit/domain/usecases/delete-unassociated-badge_test.js
+++ b/api/tests/shared/unit/domain/usecases/delete-unassociated-badge_test.js
@@ -8,14 +8,15 @@ import { catchErr, expect, sinon } from '../../../../test-helper.js';
 describe('Unit | UseCase | delete-unassociated-badge', function () {
   let badgeId;
   let badgeRepository;
+  let complementaryCertificationBadgeRepository;
 
   beforeEach(async function () {
     badgeId = 'badgeId';
     badgeRepository = {
       isAssociated: sinon.stub(),
       remove: sinon.stub(),
-      isRelatedToCertification: sinon.stub(),
     };
+    complementaryCertificationBadgeRepository = { isRelatedToCertification: sinon.stub() };
   });
 
   context('When the badge is not associated to a badge acquisition', function () {
@@ -29,6 +30,7 @@ describe('Unit | UseCase | delete-unassociated-badge', function () {
       const response = await deleteUnassociatedBadge({
         badgeId,
         badgeRepository,
+        complementaryCertificationBadgeRepository,
       });
 
       // then
@@ -46,6 +48,7 @@ describe('Unit | UseCase | delete-unassociated-badge', function () {
       const err = await catchErr(deleteUnassociatedBadge)({
         badgeId,
         badgeRepository,
+        complementaryCertificationBadgeRepository,
       });
 
       // then
@@ -55,7 +58,7 @@ describe('Unit | UseCase | delete-unassociated-badge', function () {
 
   context('When the badge is related to a certification', function () {
     beforeEach(function () {
-      badgeRepository.isRelatedToCertification.withArgs(badgeId).resolves(true);
+      complementaryCertificationBadgeRepository.isRelatedToCertification.withArgs(badgeId).resolves(true);
       badgeRepository.remove.withArgs(badgeId).resolves(true);
     });
 
@@ -64,6 +67,7 @@ describe('Unit | UseCase | delete-unassociated-badge', function () {
       const error = await catchErr(deleteUnassociatedBadge)({
         badgeId,
         badgeRepository,
+        complementaryCertificationBadgeRepository,
       });
 
       // then
@@ -73,7 +77,7 @@ describe('Unit | UseCase | delete-unassociated-badge', function () {
 
   context('When the badge is not related to a certification', function () {
     beforeEach(function () {
-      badgeRepository.isRelatedToCertification.withArgs(badgeId).resolves(false);
+      complementaryCertificationBadgeRepository.isRelatedToCertification.withArgs(badgeId).resolves(false);
       badgeRepository.remove.withArgs(badgeId).resolves(true);
     });
 
@@ -82,6 +86,7 @@ describe('Unit | UseCase | delete-unassociated-badge', function () {
       const response = await deleteUnassociatedBadge({
         badgeId,
         badgeRepository,
+        complementaryCertificationBadgeRepository,
       });
 
       // then


### PR DESCRIPTION
## :unicorn: Problème
La methode `isRelatedToCertification` est dans le repo `badgeRepository` mais devrait etre dans `complementaryCertificationBadgeRepository`

## :robot: Proposition
La deplacer

## :rainbow: Remarques
Cela permettra de sortir `badgeRepository` de `shared`

## :100: Pour tester
Dans admin
- essayer de supprimer un badge "associé" a une certif complementaire ([exemple](https://admin-pr8548.review.pix.fr/target-profiles/56/insights)) et s'assurer qu'on est bloqué 
- essayer de supprimer un badge NON "associé" a une certif complementaire et s'assurer qu'on est PAS bloqué

