### PR TITLE
[REFACTOR] Migrer badge-criteria-repository dans le scope evaluation (PIX-11894).

### DIFF
--- a/api/lib/application/target-profiles/target-profile-controller.js
+++ b/api/lib/application/target-profiles/target-profile-controller.js
@@ -1,5 +1,6 @@
 import { usecases as devcompUsecases } from '../../../src/devcomp/domain/usecases/index.js';
 import * as trainingSummarySerializer from '../../../src/devcomp/infrastructure/serializers/jsonapi/training-summary-serializer.js';
+import { sharedUsecases } from '../../../src/shared/domain/usecases/index.js';
 import * as badgeSerializer from '../../../src/shared/infrastructure/serializers/jsonapi/badge-serializer.js';
 import * as queryParamsUtils from '../../../src/shared/infrastructure/utils/query-params-utils.js';
 import { usecases } from '../../domain/usecases/index.js';
@@ -116,7 +117,7 @@ const createBadge = async function (request, h) {
   const targetProfileId = request.params.id;
   const badgeCreation = await badgeCreationDeserializer.deserialize(request.payload);
 
-  const createdBadge = await usecases.createBadge({ targetProfileId, badgeCreation });
+  const createdBadge = await sharedUsecases.createBadge({ targetProfileId, badgeCreation });
 
   return h.response(badgeSerializer.serialize(createdBadge)).created();
 };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -92,7 +92,6 @@ import * as accountRecoveryDemandRepository from '../../infrastructure/repositor
 import * as attachableTargetProfileRepository from '../../infrastructure/repositories/attachable-target-profiles-repository.js';
 import * as authenticationMethodRepository from '../../infrastructure/repositories/authentication-method-repository.js';
 import * as badgeAcquisitionRepository from '../../infrastructure/repositories/badge-acquisition-repository.js';
-import * as badgeCriteriaRepository from '../../infrastructure/repositories/badge-criteria-repository.js';
 import * as badgeForCalculationRepository from '../../infrastructure/repositories/badge-for-calculation-repository.js';
 import * as campaignAnalysisRepository from '../../infrastructure/repositories/campaign-analysis-repository.js';
 import * as campaignCollectiveResultRepository from '../../infrastructure/repositories/campaign-collective-result-repository.js';
@@ -211,7 +210,6 @@ const dependencies = {
   authenticationServiceRegistry,
   authenticationSessionService,
   badgeAcquisitionRepository,
-  badgeCriteriaRepository,
   badgeForCalculationRepository,
   badgeRepository,
   campaignAdministrationRepository,

--- a/api/scripts/create-badge-criteria-for-specified-badge.js
+++ b/api/scripts/create-badge-criteria-for-specified-badge.js
@@ -7,7 +7,7 @@ import { disconnect } from '../db/knex-database-connection.js';
 import { NotFoundError } from '../lib/domain/errors.js';
 import { SCOPES } from '../lib/domain/models/BadgeDetails.js';
 import { DomainTransaction } from '../lib/infrastructure/DomainTransaction.js';
-import * as badgeCriteriaRepository from '../lib/infrastructure/repositories/badge-criteria-repository.js';
+import * as badgeCriteriaRepository from '../src/evaluation/infrastructure/repositories/badge-criteria-repository.js';
 import * as badgeRepository from '../src/shared/infrastructure/repositories/badge-repository.js';
 
 // Usage: node scripts/create-badge-criteria-for-specified-badge path/data.json

--- a/api/src/evaluation/infrastructure/repositories/badge-criteria-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/badge-criteria-repository.js
@@ -1,5 +1,5 @@
-import { knex } from '../../../db/knex-database-connection.js';
-import { DomainTransaction } from '../DomainTransaction.js';
+import { knex } from '../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
 
 const TABLE_NAME = 'badge-criteria';
 

--- a/api/src/evaluation/infrastructure/repositories/index.js
+++ b/api/src/evaluation/infrastructure/repositories/index.js
@@ -3,10 +3,12 @@ import * as targetProfileApi from '../../../prescription/target-profile/applicat
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import * as autonomousCourseRepository from './autonomous-course-repository.js';
 import * as autonomousCourseTargetProfileRepository from './autonomous-course-target-profile-repository.js';
+import * as badgeCriteriaRepository from './badge-criteria-repository.js';
 
 const repositoriesWithoutInjectedDependencies = {
   autonomousCourseRepository,
   autonomousCourseTargetProfileRepository,
+  badgeCriteriaRepository,
 };
 
 const dependencies = {

--- a/api/src/shared/domain/usecases/create-badge.js
+++ b/api/src/shared/domain/usecases/create-badge.js
@@ -1,5 +1,5 @@
-import { MissingBadgeCriterionError } from '../../../src/shared/domain/errors.js';
-import { DomainTransaction } from '../../infrastructure/DomainTransaction.js';
+import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
+import { MissingBadgeCriterionError } from '../errors.js';
 
 const createBadge = async function ({
   targetProfileId,

--- a/api/src/shared/domain/usecases/index.js
+++ b/api/src/shared/domain/usecases/index.js
@@ -1,6 +1,8 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import * as targetProfileRepository from '../../../../lib/infrastructure/repositories/target-profile-repository.js';
+import * as badgeCriteriaRepository from '../../../evaluation/infrastructure/repositories/badge-criteria-repository.js';
 import * as activityAnswerRepository from '../../../school/infrastructure/repositories/activity-answer-repository.js';
 import * as activityRepository from '../../../school/infrastructure/repositories/activity-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
@@ -19,8 +21,10 @@ const dependencies = {
   activityAnswerRepository,
   activityRepository,
   assessmentRepository,
-  challengeRepository,
   badgeRepository,
+  badgeCriteriaRepository,
+  challengeRepository,
+  targetProfileRepository,
 };
 
 const sharedUsecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/tests/evaluation/integration/infrastructure/repositories/badge-criteria-repository_test.js
+++ b/api/tests/evaluation/integration/infrastructure/repositories/badge-criteria-repository_test.js
@@ -1,5 +1,5 @@
-import * as badgeCriteriaRepository from '../../../../lib/infrastructure/repositories/badge-criteria-repository.js';
-import { databaseBuilder, expect, knex } from '../../../test-helper.js';
+import * as badgeCriteriaRepository from '../../../../../src/evaluation/infrastructure/repositories/badge-criteria-repository.js';
+import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
 
 describe('Integration | Repository | Badge Criteria Repository', function () {
   describe('#save', function () {

--- a/api/tests/shared/integration/domain/usecases/create-badge_test.js
+++ b/api/tests/shared/integration/domain/usecases/create-badge_test.js
@@ -1,16 +1,16 @@
 import _ from 'lodash';
 
-import { createBadge } from '../../../../lib/domain/usecases/create-badge.js';
-import * as badgeCriteriaRepository from '../../../../lib/infrastructure/repositories/badge-criteria-repository.js';
-import * as targetProfileRepository from '../../../../lib/infrastructure/repositories/target-profile-repository.js';
+import * as targetProfileRepository from '../../../../../lib/infrastructure/repositories/target-profile-repository.js';
+import * as badgeCriteriaRepository from '../../../../../src/evaluation/infrastructure/repositories/badge-criteria-repository.js';
 import {
   AlreadyExistingEntityError,
   MissingBadgeCriterionError,
   NotFoundError,
-} from '../../../../src/shared/domain/errors.js';
-import { Badge } from '../../../../src/shared/domain/models/Badge.js';
-import * as badgeRepository from '../../../../src/shared/infrastructure/repositories/badge-repository.js';
-import { catchErr, databaseBuilder, expect, knex, mockLearningContent, sinon } from '../../../test-helper.js';
+} from '../../../../../src/shared/domain/errors.js';
+import { Badge } from '../../../../../src/shared/domain/models/Badge.js';
+import { createBadge } from '../../../../../src/shared/domain/usecases/create-badge.js';
+import * as badgeRepository from '../../../../../src/shared/infrastructure/repositories/badge-repository.js';
+import { catchErr, databaseBuilder, expect, knex, mockLearningContent, sinon } from '../../../../test-helper.js';
 
 describe('Integration | UseCases | create-badge', function () {
   let targetProfileId;


### PR DESCRIPTION
## :unicorn: Problème

`badge-criteria-repository` était toujours dans le dossier `lib`

## :robot: Proposition

Le déplacer dans le dossier `src/evaluation`

## :100: Pour tester

Tests verts ✅
