### PR TITLE
[TECH] Charger les données de la table oidc-providers avec les seeds (PIX-10032)

### DIFF
--- a/api/db/database-builder/factory/build-oidc-provider.js
+++ b/api/db/database-builder/factory/build-oidc-provider.js
@@ -1,0 +1,57 @@
+import * as cryptoService from '../../../src/shared/domain/services/crypto-service.js';
+import { databaseBuffer } from '../database-buffer.js';
+
+const OIDC_PROVIDERS_TABLE_NAME = 'oidc-providers';
+
+export async function buildOidcProvider({
+  id = databaseBuffer.getNextId(),
+  accessTokenLifespan,
+  claimsToStore,
+  clientId,
+  clientSecret,
+  customProperties,
+  enabled,
+  enabledForPixAdmin,
+  extraAuthorizationUrlParameters,
+  identityProvider,
+  idTokenLifespan,
+  openidClientExtraMetadata,
+  openidConfigurationUrl,
+  organizationName,
+  postLogoutRedirectUri,
+  redirectUri,
+  scope,
+  shouldCloseSession,
+  slug,
+  source,
+}) {
+  const encryptedClientSecret = await cryptoService.encrypt(clientSecret);
+
+  const values = {
+    id,
+    accessTokenLifespan,
+    claimsToStore,
+    clientId,
+    customProperties,
+    enabled,
+    enabledForPixAdmin,
+    encryptedClientSecret,
+    extraAuthorizationUrlParameters,
+    identityProvider,
+    idTokenLifespan,
+    openidClientExtraMetadata,
+    openidConfigurationUrl,
+    organizationName,
+    postLogoutRedirectUri,
+    redirectUri,
+    scope,
+    shouldCloseSession,
+    slug,
+    source,
+  };
+
+  return databaseBuffer.pushInsertable({
+    tableName: OIDC_PROVIDERS_TABLE_NAME,
+    values,
+  });
+}

--- a/api/db/seeds/data/team-acces/build-oidc-providers.js
+++ b/api/db/seeds/data/team-acces/build-oidc-providers.js
@@ -1,0 +1,22 @@
+import Debug from 'debug';
+
+const debugOidcProvidersSeeds = Debug('pix:oidc-providers:seeds');
+
+export async function buildOidcProviders(databaseBuilder) {
+  const oidcProvidersJson = process.env.OIDC_PROVIDERS;
+  if (!oidcProvidersJson) {
+    debugOidcProvidersSeeds('No environment variable OIDC_PROVIDERS defined, no loading of "oidc-providers" table.');
+    return;
+  }
+
+  const oidcProviders = JSON.parse(oidcProvidersJson);
+  await Promise.all(
+    oidcProviders.map(async (oidcProviderPropertiesWithRawClientSecret) => {
+      debugOidcProvidersSeeds(
+        `Loading configuration for OIDC provider "${oidcProviderPropertiesWithRawClientSecret.identityProvider}"…`,
+      );
+
+      return databaseBuilder.factory.buildOidcProvider({ ...oidcProviderPropertiesWithRawClientSecret });
+    }),
+  );
+}

--- a/api/db/seeds/data/team-acces/data-builder.js
+++ b/api/db/seeds/data/team-acces/data-builder.js
@@ -1,6 +1,7 @@
 import { buildArchivedOrganizations } from './build-archived-organizations.js';
 import { buildBlockedUsers } from './build-blocked-users.js';
 import { buildCertificationCenters } from './build-certification-centers.js';
+import { buildOidcProviders } from './build-oidc-providers.js';
 import { buildOrganizationUsers } from './build-organization-users.js';
 import { buildPixAdminRoles } from './build-pix-admin-roles.js';
 import { buildResetPasswordUsers } from './build-reset-password-users.js';
@@ -20,6 +21,7 @@ async function teamAccesDataBuilder(databaseBuilder) {
   buildArchivedOrganizations(databaseBuilder);
   buildScoOrganizationLearners(databaseBuilder);
   await buildCertificationCenters(databaseBuilder);
+  await buildOidcProviders(databaseBuilder);
 }
 
 export { teamAccesDataBuilder };


### PR DESCRIPTION
## :unicorn: Problème

Actuellement le mécanisme de _databaseBuilder_ ne charge pas la table `oidc-providers` à chaque `npm run db:seed`. 

## :robot: Proposition

Utilisation du mécanisme de _databaseBuilder_ pour charger le contenu de la variable d'environnement `OIDC_PROVIDERS` dans la table `oidc-providers` à chaque `npm run db:seed`. 

La table `oidc-providers` sera vidée à chaque exécution de `npm run db:seed` et ne sera remplie que pour les devs ayant défini la variable d'environnement `OIDC_PROVIDERS`, en s'exécutant sans erreur pour les devs n'ayant pas la variable d'environnement `OIDC_PROVIDERS` définie.

## :rainbow: Remarques

RAS

## :100: Pour tester

1. Optionnellement activer le debug : 

   ```shell
   export DEBUG="pix:oidc-providers:*"
   ```

2. S'assurer que la variable d'environnement `OIDC_PROVIDERS` n'est pas définie : 

   ```shell
   unset OIDC_PROVIDERS
   ```

3. Exécuter la commande `npm run db:seed`.
4. Constater que la commande s'est exécutée sans erreur et que la table `oidc-providers` est vide.
5. Optionnellement récupérer ou écrire un fichier `OIDC_PROVIDERS.json` qui servira à remplir la variable d'environnement `OIDC_PROVIDERS`. En effet on ne peut pas mettre de retours à la ligne dans la définition d'une variable dans un fichier `.env`, alors disposer d'un tel fichier `OIDC_PROVIDERS.json` facilite la vie.

6. Définir la variable d'environnement `OIDC_PROVIDERS`, par exemple à partir d'un fichier `OIDC_PROVIDERS.json` : 

   ```shell
   export OIDC_PROVIDERS=$(cat OIDC_PROVIDERS.json)
   ```
7. Exécuter `npm run db:seed`.
8. Constater que la commande s'est exécutée sans erreur et que la table `oidc-providers` est remplie avec 5 enregistrements contenant les valeurs correctes.
