### PR TITLE
[FEATURE] Permettre la modif d'un critère d'obtention d'ensemble de PF d'un RT dans l'API (PIX-11880).

### DIFF
--- a/api/db/database-builder/factory/build-badge-criterion.js
+++ b/api/db/database-builder/factory/build-badge-criterion.js
@@ -1,12 +1,13 @@
 import { SCOPES } from '../../../lib/domain/models/BadgeDetails.js';
 import { databaseBuffer } from '../database-buffer.js';
+import { buildBadge } from './build-badge.js';
 
 const buildBadgeCriterion = function ({
   id = databaseBuffer.getNextId(),
   scope = SCOPES.CAMPAIGN_PARTICIPATION,
   threshold = 50,
-  badgeId,
-  cappedTubes,
+  badgeId = buildBadge().id,
+  cappedTubes = null,
   name = null,
 } = {}) {
   const values = {

--- a/api/db/database-builder/factory/build-badge-criterion.js
+++ b/api/db/database-builder/factory/build-badge-criterion.js
@@ -31,7 +31,7 @@ buildBadgeCriterion.scopeCampaignParticipation = function ({ id, threshold, badg
     threshold,
     badgeId,
     name,
-    cappedTubes: [],
+    cappedTubes: null,
   });
 };
 

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -1013,6 +1013,14 @@ class AcquiredBadgeForbiddenDeletionError extends DomainError {
   }
 }
 
+class AcquiredBadgeForbiddenUpdateError extends DomainError {
+  constructor(
+    message = "Il est interdit de modifier un critère d'un résultat thématique déjà acquis par un utilisateur.",
+  ) {
+    super(message);
+  }
+}
+
 class CertificationBadgeForbiddenDeletionError extends DomainError {
   constructor(message = 'Il est interdit de supprimer un résultat thématique lié à une certification.') {
     super(message);
@@ -1068,6 +1076,7 @@ export {
   AccountRecoveryDemandNotCreatedError,
   AccountRecoveryUserAlreadyConfirmEmail,
   AcquiredBadgeForbiddenDeletionError,
+  AcquiredBadgeForbiddenUpdateError,
   AlreadyAcceptedOrCancelledInvitationError,
   AlreadyExistingAdminMemberError,
   AlreadyExistingCampaignParticipationError,

--- a/api/src/evaluation/application/badge-criteria/badge-criteria-controller.js
+++ b/api/src/evaluation/application/badge-criteria/badge-criteria-controller.js
@@ -1,0 +1,16 @@
+import { evaluationUsecases as usecases } from '../../domain/usecases/index.js';
+import * as badgeCriterionSerializer from '../../infrastructure/serializers/jsonapi/badge-criterion-serializer.js';
+
+const updateCriterion = async (request, h, dependencies = { usecases, badgeCriterionSerializer }) => {
+  const badgeCriterionId = request.params.badgeCriterionId;
+  const { badgeId, ...attributesToUpdate } = await dependencies.badgeCriterionSerializer.deserialize(request.payload);
+  await dependencies.usecases.updateBadgeCriterion({
+    id: badgeCriterionId,
+    badgeId,
+    attributesToUpdate,
+  });
+  return h.response().code(204);
+};
+
+const badgeCriteriaController = { updateCriterion };
+export default badgeCriteriaController;

--- a/api/src/evaluation/application/badge-criteria/index.js
+++ b/api/src/evaluation/application/badge-criteria/index.js
@@ -1,0 +1,69 @@
+import Joi from 'joi';
+
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
+import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import badgeCriteriaController from './badge-criteria-controller.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'PATCH',
+      path: '/api/admin/badge-criteria/{badgeCriterionId}',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            badgeCriterionId: identifiersType.badgeCriterionId,
+          }),
+          payload: Joi.object({
+            data: {
+              type: Joi.string().valid('badge-criteria'),
+              attributes: Joi.object({
+                'capped-tubes': Joi.array()
+                  .items({
+                    id: Joi.string(),
+                    level: Joi.number().min(0),
+                  })
+                  .optional(),
+                name: Joi.string().optional(),
+                threshold: Joi.number().integer().min(0).max(100).optional(),
+              })
+                .or('capped-tubes', 'name', 'threshold')
+                .required(),
+              relationships: Joi.object()
+                .keys({
+                  badge: {
+                    data: {
+                      type: Joi.string().valid('badges').required(),
+                      id: identifiersType.badgeId,
+                    },
+                  },
+                })
+                .required(),
+            },
+          }),
+        },
+        handler: badgeCriteriaController.updateCriterion,
+        tags: ['api', 'admin', 'bagde-criteria'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
+            "- Elle permet de modifier un critère d'acquisition d'un résultat thématique",
+        ],
+      },
+    },
+  ]);
+};
+
+const name = 'badge-criteria-api';
+export { name, register };

--- a/api/src/evaluation/domain/models/BadgeCriterion.js
+++ b/api/src/evaluation/domain/models/BadgeCriterion.js
@@ -1,0 +1,19 @@
+export default class BadgeCriterion {
+  /**
+   *
+   * @param {number} id
+   * @param {number} badgeId
+   * @param {array<{id: string, level: number}>|null} cappedTubes
+   * @param {string|null} name
+   * @param {('CampaignParticipation'|'CappedTubes')} scope
+   * @param {number} threshold
+   */
+  constructor({ id, badgeId, cappedTubes, name, scope, threshold } = {}) {
+    this.id = id;
+    this.badgeId = badgeId;
+    this.cappedTubes = cappedTubes;
+    this.name = name;
+    this.scope = scope;
+    this.threshold = threshold;
+  }
+}

--- a/api/src/evaluation/domain/usecases/index.js
+++ b/api/src/evaluation/domain/usecases/index.js
@@ -11,11 +11,13 @@ import { pickChallengeService } from '../../../certification/flash-certification
 import * as answerRepository from '../../../shared/infrastructure/repositories/answer-repository.js';
 import * as areaRepository from '../../../shared/infrastructure/repositories/area-repository.js';
 import * as assessmentRepository from '../../../shared/infrastructure/repositories/assessment-repository.js';
+import * as badgeRepository from '../../../shared/infrastructure/repositories/badge-repository.js';
 import * as competenceRepository from '../../../shared/infrastructure/repositories/competence-repository.js';
 import * as skillRepository from '../../../shared/infrastructure/repositories/skill-repository.js';
 import * as targetProfileForAdminRepository from '../../../shared/infrastructure/repositories/target-profile-for-admin-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
+import * as badgeCriteriaRepository from '../../infrastructure/repositories/badge-criteria-repository.js';
 import * as competenceEvaluationRepository from '../../infrastructure/repositories/competence-evaluation-repository.js';
 import * as feedbackRepository from '../../infrastructure/repositories/feedback-repository.js';
 import { repositories } from '../../infrastructure/repositories/index.js';
@@ -37,6 +39,8 @@ const dependencies = {
   assessmentRepository,
   autonomousCourseRepository: repositories.autonomousCourseRepository,
   autonomousCourseTargetProfileRepository: repositories.autonomousCourseTargetProfileRepository,
+  badgeRepository,
+  badgeCriteriaRepository,
   campaignRepository,
   campaignParticipationRepository,
   competenceEvaluationRepository,

--- a/api/src/evaluation/domain/usecases/update-badge-criterion.js
+++ b/api/src/evaluation/domain/usecases/update-badge-criterion.js
@@ -1,0 +1,13 @@
+import { AcquiredBadgeForbiddenUpdateError } from '../../../../lib/domain/errors.js';
+
+const updateBadgeCriterion = async ({ id, badgeId, attributesToUpdate, badgeCriteriaRepository, badgeRepository }) => {
+  const isBadgeAlreadyAcquired = await badgeRepository.isAssociated(badgeId);
+
+  if (isBadgeAlreadyAcquired) {
+    throw new AcquiredBadgeForbiddenUpdateError();
+  }
+
+  return badgeCriteriaRepository.updateCriterion(id, attributesToUpdate);
+};
+
+export { updateBadgeCriterion };

--- a/api/src/evaluation/infrastructure/repositories/badge-criteria-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/badge-criteria-repository.js
@@ -1,5 +1,8 @@
 import { knex } from '../../../../db/knex-database-connection.js';
+import { BadRequestError } from '../../../../lib/application/http-errors.js';
 import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
+import { NotFoundError } from '../../../shared/domain/errors.js';
+import BadgeCriterion from '../../domain/models/BadgeCriterion.js';
 
 const TABLE_NAME = 'badge-criteria';
 
@@ -12,4 +15,18 @@ const save = async function ({ badgeCriterion }, { knexTransaction } = DomainTra
   await (knexTransaction ?? knex)(TABLE_NAME).insert(data);
 };
 
-export { save };
+const updateCriterion = async function (id, attributesToUpdate) {
+  if (Object.keys(attributesToUpdate).length === 0) {
+    throw new BadRequestError("Erreur, aucune propriété n'est à mettre à jour");
+  }
+
+  const [updatedCriterion] = await knex(TABLE_NAME).update(attributesToUpdate).where({ id }).returning('*');
+
+  if (!updatedCriterion) {
+    throw new NotFoundError('Erreur, critère de résultat thématique introuvable');
+  }
+
+  return new BadgeCriterion(updatedCriterion);
+};
+
+export { save, updateCriterion };

--- a/api/src/evaluation/infrastructure/serializers/jsonapi/badge-criterion-serializer.js
+++ b/api/src/evaluation/infrastructure/serializers/jsonapi/badge-criterion-serializer.js
@@ -1,0 +1,24 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+const { Deserializer } = jsonapiSerializer;
+
+import BadgeCriterion from '../../../domain/models/BadgeCriterion.js';
+
+const deserialize = async function (payload) {
+  const deserializedPayload = await new Deserializer({
+    keyForAttribute: 'camelCase',
+    badges: {
+      valueForRelationship: function (relationship) {
+        return relationship.id;
+      },
+    },
+    transform: function (record) {
+      record['badgeId'] = record['badge'];
+      delete record['badge'];
+      return record;
+    },
+  }).deserialize(payload);
+
+  return new BadgeCriterion({ ...deserializedPayload });
+};
+
+export { deserialize };

--- a/api/src/evaluation/routes.js
+++ b/api/src/evaluation/routes.js
@@ -1,5 +1,6 @@
 import * as answersRoutes from './application/answers/index.js';
 import * as autonomousCoursesRoutes from './application/autonomous-courses/index.js';
+import * as badgeCriteriaRoutes from './application/badge-criteria/index.js';
 import * as competenceEvaluationsRoutes from './application/competence-evaluations/index.js';
 import * as feedbacksRoutes from './application/feedbacks/index.js';
 import * as progressionsRoutes from './application/progressions/index.js';
@@ -12,6 +13,7 @@ const evaluationRoutes = [
   smartRandomSimulatorRoutes,
   answersRoutes,
   autonomousCoursesRoutes,
+  badgeCriteriaRoutes,
   competenceEvaluationsRoutes,
   stageCollectionRoutes,
   feedbacksRoutes,

--- a/api/tests/evaluation/acceptance/application/badge-criteria/badge-criteria-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/badge-criteria/badge-criteria-controller_test.js
@@ -1,0 +1,68 @@
+import {
+  createServer,
+  databaseBuilder,
+  expect,
+  generateValidRequestAuthorizationHeader,
+  insertUserWithRoleSuperAdmin,
+  knex,
+} from '../../../../test-helper.js';
+
+describe('Acceptance | API | Badge Criteria', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('PATCH /api/admin/badge-criteria/{badgeCriterionId}', function () {
+    it('should update the badge criterion', async function () {
+      // given
+      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const initialBadgeCriterion = databaseBuilder.factory.buildBadgeCriterion({
+        name: 'old name',
+        threshold: 10,
+      });
+      await databaseBuilder.commit();
+
+      const attributesToUpdate = {
+        name: 'brand new name',
+        threshold: 99,
+      };
+
+      const response = await server.inject({
+        method: 'PATCH',
+        url: `/api/admin/badge-criteria/${initialBadgeCriterion.id}`,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(superAdmin.id),
+        },
+        payload: {
+          data: {
+            type: 'badge-criteria',
+            attributes: attributesToUpdate,
+            relationships: {
+              badge: {
+                data: {
+                  type: 'badges',
+                  id: initialBadgeCriterion.badgeId,
+                },
+              },
+            },
+          },
+        },
+      });
+
+      // then
+      const updatedBadgeCriterion = await knex('badge-criteria')
+        .select('*')
+        .where({ id: initialBadgeCriterion.id })
+        .first();
+
+      expect(updatedBadgeCriterion).to.deep.equal({
+        ...initialBadgeCriterion,
+        ...attributesToUpdate,
+      });
+
+      expect(response.statusCode).to.equal(204);
+    });
+  });
+});

--- a/api/tests/evaluation/integration/infrastructure/repositories/badge-criteria-repository_test.js
+++ b/api/tests/evaluation/integration/infrastructure/repositories/badge-criteria-repository_test.js
@@ -1,5 +1,8 @@
+import { BadRequestError } from '../../../../../lib/application/http-errors.js';
+import BadgeCriterion from '../../../../../src/evaluation/domain/models/BadgeCriterion.js';
 import * as badgeCriteriaRepository from '../../../../../src/evaluation/infrastructure/repositories/badge-criteria-repository.js';
-import { databaseBuilder, expect, knex } from '../../../../test-helper.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
+import { catchErr, databaseBuilder, expect, knex } from '../../../../test-helper.js';
 
 describe('Integration | Repository | Badge Criteria Repository', function () {
   describe('#save', function () {
@@ -60,6 +63,71 @@ describe('Integration | Repository | Badge Criteria Repository', function () {
           { id: 'tubeABC', level: 2 },
           { id: 'tubeDEF', level: 8 },
         ],
+      });
+    });
+  });
+
+  describe('#update-criterion', function () {
+    context('when badge-criterion exists', function () {
+      it('should update CampaignParticipation badge-criterion', async function () {
+        // given
+        const badgeCriterion = databaseBuilder.factory.buildBadgeCriterion.scopeCampaignParticipation({
+          name: 'dummy criterion',
+          threshold: 10,
+        });
+        await databaseBuilder.commit();
+
+        const attributesToUpdate = {
+          name: 'updated name',
+          threshold: 99,
+        };
+
+        // when
+        const updatedBadgeCriterion = await badgeCriteriaRepository.updateCriterion(
+          badgeCriterion.id,
+          attributesToUpdate,
+        );
+
+        // then
+        expect(updatedBadgeCriterion).to.be.instanceOf(BadgeCriterion);
+        expect(updatedBadgeCriterion).to.deep.equal({
+          ...badgeCriterion,
+          ...attributesToUpdate,
+        });
+      });
+    });
+
+    context('when badge-criterion does not exist', function () {
+      it('should throw a not found message error', async function () {
+        // given
+        const notExistingBadgeCriterionId = 9999;
+
+        // when
+        const error = await catchErr(badgeCriteriaRepository.updateCriterion)(notExistingBadgeCriterionId, {
+          name: 'dummy ',
+        });
+
+        // then
+        expect(error).to.be.instanceOf(NotFoundError);
+      });
+    });
+
+    context('when no attributes are going to be updated', function () {
+      it('should throw a not found message error', async function () {
+        // given
+        const badgeCriterion = databaseBuilder.factory.buildBadgeCriterion.scopeCampaignParticipation({
+          name: 'dummy criterion',
+          threshold: 10,
+        });
+        await databaseBuilder.commit();
+
+        const attributesToUpdate = {};
+
+        // when
+        const error = await catchErr(badgeCriteriaRepository.updateCriterion)(badgeCriterion.id, attributesToUpdate);
+
+        // then
+        expect(error).to.be.instanceOf(BadRequestError);
       });
     });
   });

--- a/api/tests/evaluation/unit/application/badge-criteria/badge-criteria-controller_test.js
+++ b/api/tests/evaluation/unit/application/badge-criteria/badge-criteria-controller_test.js
@@ -1,0 +1,65 @@
+import badgeCriteriaController from '../../../../../src/evaluation/application/badge-criteria/badge-criteria-controller.js';
+import { evaluationUsecases } from '../../../../../src/evaluation/domain/usecases/index.js';
+import { expect, hFake, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Controller | badge-criteria-controller', function () {
+  describe('#updateCriterion', function () {
+    it('should call the appropriate usecase', async function () {
+      // given
+      const deserializedPayload = {
+        badgeId: 111,
+        name: 'Dummy name',
+        threshold: 10,
+      };
+
+      const badgeCriterionSerializer = {
+        deserialize: sinon.stub().returns(deserializedPayload),
+      };
+
+      const badgeCriterion = Symbol('badgeCriterion');
+      sinon.stub(evaluationUsecases, 'updateBadgeCriterion').resolves(badgeCriterion);
+
+      const dependencies = { usecases: evaluationUsecases, badgeCriterionSerializer };
+
+      // when
+      const response = await badgeCriteriaController.updateCriterion(
+        {
+          params: {
+            badgeCriterionId: 1,
+          },
+          payload: {
+            data: {
+              type: 'badge-criteria',
+              attributes: {
+                name: 'Dummy name',
+                threshold: 10,
+              },
+              relationships: {
+                badge: {
+                  data: {
+                    type: 'badges',
+                    id: 111,
+                  },
+                },
+              },
+            },
+          },
+        },
+        hFake,
+        dependencies,
+      );
+
+      // then
+      expect(badgeCriterionSerializer.deserialize).to.have.been.calledOnce;
+      expect(evaluationUsecases.updateBadgeCriterion).to.have.been.calledOnceWithExactly({
+        id: 1,
+        badgeId: deserializedPayload.badgeId,
+        attributesToUpdate: {
+          name: deserializedPayload.name,
+          threshold: deserializedPayload.threshold,
+        },
+      });
+      expect(response.statusCode).to.equal(204);
+    });
+  });
+});

--- a/api/tests/evaluation/unit/application/badge-criteria/index_test.js
+++ b/api/tests/evaluation/unit/application/badge-criteria/index_test.js
@@ -1,0 +1,116 @@
+import badgeCriteriaController from '../../../../../src/evaluation/application/badge-criteria/badge-criteria-controller.js';
+import * as badgeCriteriaRouter from '../../../../../src/evaluation/application/badge-criteria/index.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
+import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Application | Router | badge-criteria-router', function () {
+  describe('PATCH /api/admin/badge-criteria/{id}', function () {
+    let httpTestServer;
+
+    beforeEach(async function () {
+      sinon
+        .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
+        .withArgs([
+          securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+          securityPreHandlers.checkAdminMemberHasRoleSupport,
+          securityPreHandlers.checkAdminMemberHasRoleMetier,
+          securityPreHandlers.checkAdminMemberHasRoleCertif,
+        ])
+        .callsFake(() => (request, h) => h.response(true));
+
+      sinon.stub(badgeCriteriaController, 'updateCriterion').callsFake((request, h) => h.response('ok').code(204));
+      httpTestServer = new HttpTestServer();
+      await httpTestServer.register(badgeCriteriaRouter);
+    });
+
+    context('when payload is valid', function () {
+      it('should return 204', async function () {
+        // given
+        const method = 'PATCH';
+        const url = '/api/admin/badge-criteria/1';
+        const payload = {
+          data: {
+            type: 'badge-criteria',
+            attributes: {
+              name: 'Dummy name',
+              threshold: 10,
+            },
+            relationships: {
+              badge: {
+                data: {
+                  type: 'badges',
+                  id: 111,
+                },
+              },
+            },
+          },
+        };
+
+        // when
+        const response = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(response.statusCode).to.equal(204);
+      });
+    });
+
+    context('when payload attributes is empty', function () {
+      it('should return 400', async function () {
+        // given
+        const method = 'PATCH';
+        const url = '/api/admin/badge-criteria/1';
+        const payload = {
+          data: {
+            type: 'badge-criteria',
+            attributes: {},
+            relationships: {
+              badge: {
+                data: {
+                  type: 'badges',
+                  id: 111,
+                },
+              },
+            },
+          },
+        };
+
+        // when
+        const response = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+
+    context('when payload relationships is not valid', function () {
+      it('should return 400', async function () {
+        // given
+        const method = 'PATCH';
+        const url = '/api/admin/badge-criteria/1';
+        const payload = {
+          data: {
+            type: 'badge-criteria',
+            attributes: {
+              name: 'Dummy name',
+              threshold: 10,
+            },
+            relationships: {
+              badge: {
+                data: {
+                  type: 'not-badges',
+                  id: 1,
+                },
+              },
+            },
+          },
+        };
+
+        // when
+        const response = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+  });
+});

--- a/api/tests/evaluation/unit/domain/usecases/update-badge-criterion_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/update-badge-criterion_test.js
@@ -1,0 +1,54 @@
+import { AcquiredBadgeForbiddenUpdateError } from '../../../../../lib/domain/errors.js';
+import { updateBadgeCriterion } from '../../../../../src/evaluation/domain/usecases/update-badge-criterion.js';
+import { catchErr, expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Domain | Use Cases | update-badge-criterion', function () {
+  context('when badge is not already acquired', function () {
+    it('should call badgeCriteriaRepository #updateBadgeCriterion', async function () {
+      // given
+      const attributesToUpdate = Symbol('badgeCriterion');
+      const badgeCriteriaRepositoryStub = {
+        updateCriterion: sinon.stub().resolves(),
+      };
+      const badgeRepositoryStub = {
+        isAssociated: sinon.stub().returns(false),
+      };
+
+      // when
+      await updateBadgeCriterion({
+        id: 1,
+        attributesToUpdate,
+        badgeCriteriaRepository: badgeCriteriaRepositoryStub,
+        badgeRepository: badgeRepositoryStub,
+      });
+
+      // then
+      expect(badgeCriteriaRepositoryStub.updateCriterion).to.have.been.calledOnceWithExactly(1, attributesToUpdate);
+    });
+  });
+
+  context('when badge is already acquired', function () {
+    it('should throw an AcquiredBadgeForbiddenUpdateError', async function () {
+      // given
+      const attributesToUpdate = Symbol('badgeCriterion');
+      const badgeCriteriaRepositoryStub = {
+        updateCriterion: sinon.stub().resolves(),
+      };
+      const badgeRepositoryStub = {
+        isAssociated: sinon.stub().returns(true),
+      };
+
+      // when
+      const error = await catchErr(updateBadgeCriterion)({
+        id: 1,
+        attributesToUpdate,
+        badgeCriteriaRepository: badgeCriteriaRepositoryStub,
+        badgeRepository: badgeRepositoryStub,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(AcquiredBadgeForbiddenUpdateError);
+      expect(badgeCriteriaRepositoryStub.updateCriterion).to.not.have.been.called;
+    });
+  });
+});

--- a/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/badge-criterion-serializer_test.js
+++ b/api/tests/evaluation/unit/infrastructure/serializers/jsonapi/badge-criterion-serializer_test.js
@@ -1,0 +1,43 @@
+import * as serializer from '../../../../../../src/evaluation/infrastructure/serializers/jsonapi/badge-criterion-serializer.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | Serializer | JSONAPI | badge-criterion-serializer', function () {
+  describe('#deserialize', function () {
+    it('should convert JSON API data to BadgeCriterion model object', async function () {
+      // given
+      const jsonTraining = {
+        data: {
+          type: 'badge-criteria',
+          attributes: {
+            id: 1,
+            'capped-tubes': [{ id: 10, level: 2 }],
+            name: 'Criterion name',
+            scope: 'CAMPAIGN_PARTICIPATION',
+            threshold: 66,
+          },
+          relationships: {
+            badge: {
+              data: {
+                type: 'badges',
+                id: 111,
+              },
+            },
+          },
+        },
+      };
+
+      // when
+      const badgeCriterion = await serializer.deserialize(jsonTraining);
+
+      // then
+      expect(badgeCriterion).to.deep.equal({
+        id: 1,
+        badgeId: 111,
+        cappedTubes: [{ id: 10, level: 2 }],
+        name: 'Criterion name',
+        scope: 'CAMPAIGN_PARTICIPATION',
+        threshold: 66,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Il n'est pas encore possible de modifier le critère d'obtention par ensemble de profil cible d'un RT.

## :robot: Proposition

Ajouter la route pour la modification dans l'API.

➡️ Règle métier : la modification n'est pas permise si le profil-cible est relié à une campagne

### ℹ️ Remarques

Il manque un `@belongsTo('bagde')` dans le model Admin de badge-criterion https://github.com/1024pix/pix/blob/dev/admin/app/models/badge-criterion.js

## :100: Pour tester

Vérifier les tests et tests verts ✅
