### PR TITLE
[FEATURE] Sauvegarde de la langue du candidat au début d'une certif V3 (PIX-11279).

### DIFF
--- a/api/db/database-builder/factory/build-certification-course.js
+++ b/api/db/database-builder/factory/build-certification-course.js
@@ -30,6 +30,7 @@ const buildCertificationCourse = function ({
   isRejectedForFraud = false,
   abortReason = null,
   pixCertificationStatus = null,
+  lang = null,
 } = {}) {
   userId = _.isUndefined(userId) ? buildUser().id : userId;
   sessionId = _.isUndefined(sessionId) ? buildSession().id : sessionId;
@@ -59,6 +60,7 @@ const buildCertificationCourse = function ({
     isRejectedForFraud,
     abortReason,
     pixCertificationStatus,
+    lang,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'certification-courses',

--- a/api/db/migrations/20240402085912_add-lang-column-in-certification-courses-table.js
+++ b/api/db/migrations/20240402085912_add-lang-column-in-certification-courses-table.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'certification-courses';
+const COLUMN_NAME = 'lang';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).defaultTo(null);
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -72,7 +72,12 @@ const retrieveLastOrCreateCertificationCourse = async function ({
   let lang;
   if (version === CertificationVersion.V3) {
     const user = await userRepository.get(userId);
-    _validateUserLanguage(user);
+    const isUserLanguageValid = _validateUserLanguage(user);
+
+    if (!isUserLanguageValid) {
+      throw new Error(`Cant create a certification course in ${user.lang}`);
+    }
+
     lang = user.lang;
   }
 
@@ -98,11 +103,7 @@ const retrieveLastOrCreateCertificationCourse = async function ({
 export { retrieveLastOrCreateCertificationCourse };
 
 function _validateUserLanguage(user) {
-  const isUserLanguageAvailableForCertification = user.isLanguageAvailableForV3Certification();
-
-  if (!isUserLanguageAvailableForCertification) {
-    return;
-  }
+  return user.isLanguageAvailableForV3Certification();
 }
 
 function _validateSessionAccess(session, accessCode) {

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -69,9 +69,11 @@ const retrieveLastOrCreateCertificationCourse = async function ({
 
   const { version } = session;
 
+  let lang;
   if (version === CertificationVersion.V3) {
     const user = await userRepository.get(userId);
     _validateUserLanguage(user);
+    lang = user.lang;
   }
 
   return _startNewCertification({
@@ -89,6 +91,7 @@ const retrieveLastOrCreateCertificationCourse = async function ({
     verifyCertificateCodeService,
     certificationBadgesService,
     version,
+    lang,
   });
 };
 
@@ -152,6 +155,7 @@ async function _startNewCertification({
   certificationBadgesService,
   verifyCertificateCodeService,
   version,
+  lang,
 }) {
   const challengesForCertification = [];
 
@@ -233,6 +237,7 @@ async function _startNewCertification({
     verifyCertificateCodeService,
     complementaryCertificationCourseData,
     version,
+    lang,
   });
 }
 
@@ -259,6 +264,7 @@ async function _createCertificationCourse({
   complementaryCertificationCourseData,
   domainTransaction,
   version,
+  lang,
 }) {
   const verificationCode = await verifyCertificateCodeService.generateCertificateVerificationCode();
   const complementaryCertificationCourses = complementaryCertificationCourseData.map(
@@ -272,6 +278,7 @@ async function _createCertificationCourse({
     complementaryCertificationCourses,
     verificationCode,
     version,
+    lang,
   });
 
   const savedCertificationCourse = await certificationCourseRepository.save({

--- a/api/src/certification/shared/domain/models/CertificationCourse.js
+++ b/api/src/certification/shared/domain/models/CertificationCourse.js
@@ -39,6 +39,7 @@ class CertificationCourse {
     numberOfChallenges,
     version = CertificationVersion.V2,
     isRejectedForFraud = false,
+    lang,
   } = {}) {
     this._id = id;
     this._firstName = firstName;
@@ -67,6 +68,7 @@ class CertificationCourse {
     this._complementaryCertificationCourses = complementaryCertificationCourses;
     this._isRejectedForFraud = isRejectedForFraud;
     this._numberOfChallenges = numberOfChallenges;
+    this._lang = lang;
   }
 
   static from({
@@ -77,6 +79,7 @@ class CertificationCourse {
     complementaryCertificationCourses,
     numberOfChallenges,
     version,
+    lang,
   }) {
     return new CertificationCourse({
       userId: certificationCandidate.userId,
@@ -96,6 +99,7 @@ class CertificationCourse {
       maxReachableLevelOnCertificationDate,
       complementaryCertificationCourses,
       version,
+      lang,
     });
   }
 
@@ -240,6 +244,10 @@ class CertificationCourse {
     return this._version;
   }
 
+  getLanguage() {
+    return this._lang;
+  }
+
   getMaxReachableLevelOnCertificationDate() {
     return this._maxReachableLevelOnCertificationDate;
   }
@@ -289,6 +297,7 @@ class CertificationCourse {
       complementaryCertificationCourses: this._complementaryCertificationCourses,
       numberOfChallenges: this._numberOfChallenges,
       version: this._version,
+      lang: this._lang,
     };
   }
 }

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -49,6 +49,7 @@ describe('Integration | Repository | Certification Course', function () {
           'certificationIssueReports',
           'complementaryCertificationCourses',
           'maxReachableLevelOnCertificationDate',
+          'lang',
         ];
 
         expect(_.omit(retrievedCertificationCourse.toDTO(), fieldsToOmitInCertificationCourse)).to.deep.equal(
@@ -97,6 +98,7 @@ describe('Integration | Repository | Certification Course', function () {
           sessionId,
           complementaryCertificationCourses: [],
           version: 3,
+          lang: 'fr',
         });
 
         return databaseBuilder.commit();
@@ -111,6 +113,7 @@ describe('Integration | Repository | Certification Course', function () {
           id: savedCertificationCourse.getId(),
         });
         expect(retrievedCertificationCourse.getVersion()).to.equal(3);
+        expect(retrievedCertificationCourse.getLanguage()).to.equal('fr');
       });
 
       it('should return the saved certification course', async function () {

--- a/api/tests/tooling/domain-builder/factory/build-certification-course.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-course.js
@@ -32,6 +32,7 @@ function buildCertificationCourse({
   complementaryCertificationCourses = [],
   maxReachableLevelOnCertificationDate = 7,
   numberOfChallenges = 20,
+  lang,
 } = {}) {
   const certificationIssueReports = [];
   if (examinerComment && examinerComment !== '') {
@@ -74,6 +75,7 @@ function buildCertificationCourse({
     complementaryCertificationCourses,
     maxReachableLevelOnCertificationDate,
     numberOfChallenges,
+    lang,
   });
 }
 
@@ -103,6 +105,7 @@ buildCertificationCourse.unpersisted = function ({
   abortReason = null,
   complementaryCertificationCourses = [],
   maxReachableLevelOnCertificationDate = 7,
+  lang,
 } = {}) {
   return new CertificationCourse({
     firstName,
@@ -131,6 +134,7 @@ buildCertificationCourse.unpersisted = function ({
     abortReason,
     complementaryCertificationCourses,
     maxReachableLevelOnCertificationDate,
+    lang,
   });
 };
 

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -510,19 +510,22 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                   .withArgs({ userId, domainTransaction })
                   .resolves([]);
 
-                userRepository.get.withArgs(userId).resolves(domainBuilder.buildUser({ id: userId }));
+                const user = domainBuilder.buildUser({ id: userId });
+                userRepository.get.withArgs(userId).resolves(user);
 
-                // TODO: extraire jusqu'à la ligne 387 dans une fonction ?
                 const certificationCourseToSave = CertificationCourse.from({
                   certificationCandidate: foundCertificationCandidate,
                   challenges: [],
                   verificationCode,
                   maxReachableLevelOnCertificationDate: MAX_REACHABLE_LEVEL,
                   version: 3,
+                  lang: user.lang,
                 });
+
                 const savedCertificationCourse = domainBuilder.buildCertificationCourse(
                   certificationCourseToSave.toDTO(),
                 );
+
                 certificationCourseRepository.save
                   .withArgs({ certificationCourse: certificationCourseToSave, domainTransaction })
                   .resolves(savedCertificationCourse);
@@ -535,6 +538,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                   isImproving: false,
                   method: Assessment.methods.CERTIFICATION_DETERMINED,
                 });
+
                 const savedAssessment = domainBuilder.buildAssessment(assessmentToSave);
                 assessmentRepository.save
                   .withArgs({ assessment: assessmentToSave, domainTransaction })
@@ -558,6 +562,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                     assessment: savedAssessment,
                     challenges: [],
                     version: 3,
+                    lang: user.lang,
                   }),
                 });
               });


### PR DESCRIPTION
## :unicorn: Problème

Dans le cadre de la nouvelle certification Pix, et pour assurer la continuité avec la certification actuelle, nous allons permettre aux candidats de passer la certif en anglais.

Pour permettre de passer la certification dans une langue donnée, nous allons nous baser sur la langue du compte au lancement du test de certification par le candidat. 

La langue du compte au moment où le test est lancé par le candidat n’est pas une information que l’on stock aujourd’hui.

## :robot: Proposition

Sauvegarde la langue de l'utilisateur récupérée au lancement de la certif V3

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

• Créer une session de certification V3 (`certifv3@example.net`)
• Commencer le test (`certifiable-contenu-user@example.net`)
• Vérifier que la langue du candidat a été enregistrée en BDD (table `certification-courses`)

Pour aller plus loin : 

Refaire la même chose en changeant la langue du candidat pour de l'anglais avant et pendant le test (sur `.org`) et vérifier que la langue enregistrée correspond à celle utilisée avant le début du test.
