### PR TITLE
[BUGFIX][ORGA] Remettre la couleur de fond manquante (PIX-11877)

### DIFF
--- a/orga/app/styles/pages/join-request.scss
+++ b/orga/app/styles/pages/join-request.scss
@@ -5,7 +5,7 @@
   justify-content: center;
   width: 100%;
   min-height: 100%;
-  background: var(--pix-secondary-500)-orga-gradient;
+  background: $pix-secondary-orga-gradient;
 
   a {
     text-decoration: underline;

--- a/orga/app/styles/pages/join.scss
+++ b/orga/app/styles/pages/join.scss
@@ -5,5 +5,5 @@
   justify-content: center;
   width: 100%;
   min-height: 100vh;
-  background: var(--pix-secondary-500)-orga-gradient;
+  background: $pix-secondary-orga-gradient;
 }


### PR DESCRIPTION
## :unicorn: Problème
La couleur de fond sur les pages d'invitation et d'activation d'un espace Pix Orga a disparu. 
La variable couleur utilisée n'existe plus.

## :robot: Proposition
Utiliser la bonne variable du Design System pour la couleur de fond de ces pages.

## :rainbow: Remarques
⚠️ Il y a un soucis dans le nommage de la variable côté documentation Pix UI.
Dans le [code](https://github.com/1024pix/pix-ui/blob/dev/addon/styles/pix-design-tokens/_colors.scss) elle s’appelle `$pix-secondary-orga-gradient`, mais dans la [doc Pix UI](https://ui.pix.fr/?path=/docs/utiliser-pix-ui-design-tokens-palette-de-couleurs--docs), elle s’appelle `$pix-primary-secondary-gradient`.
Il faudra créer un ticket côté PixUI pour corriger ça.

## :100: Pour tester

1. Se rendre Pix Orga (domaine .fr)
2. Aller sur la page https://orga-pr8565.review.pix.fr/demande-administration-sco et vérifier que la couleur de fond est présente et que c'est la même que celle de la page de connexion.
3. Aller sur la page `/rejoindre?invitationId=4&code=ABCDEF123` et vérifier que la couleur de fond est présente et que c'est la même que celle de la page de connexion.
