### PR TITLE
[TECH] Unifier le fonctionnement des jobs de la CI (PIX-11947)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,15 @@ workflows:
           context: Pix
           requires:
             - api_install
-      - api_test:
+      - api_unit_test:
+          context: Pix
+          requires:
+            - api_install
+      - api_integration_test:
+          context: Pix
+          requires:
+            - api_install
+      - api_acceptance_test:
           context: Pix
           requires:
             - api_install
@@ -336,7 +344,7 @@ jobs:
             TEST_REDIS_URL: redis://localhost:6379
           when: always
 
-  api_test:
+  api_unit_test:
     executor:
       name: node-redis-postgres-s3-docker
     working_directory: ~/pix/api
@@ -345,9 +353,68 @@ jobs:
           at: ~/pix
       - run:
           name: Test
-          command: npm run test
+          command: npm run test:api:unit
           environment:
+            NODE_ENV: test
             TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci
+            TEST_REDIS_URL: redis://localhost:6379
+            TEST_IMPORT_STORAGE_ENDPOINT: http://localhost:9090
+            TEST_IMPORT_STORAGE_BUCKET_NAME: pix-import-test
+            MOCHA_FILE: /home/circleci/test-results/test-results.[hash].xml
+            MOCHA_REPORTER: mocha-junit-reporter
+          when: always
+      - store_test_results:
+          path: /home/circleci/test-results
+      - store_artifacts:
+          path: /home/circleci/test-results
+  api_integration_test:
+    executor:
+      name: node-redis-postgres-s3-docker
+    working_directory: ~/pix/api
+    steps:
+      - attach_workspace:
+          at: ~/pix
+      - run:
+          name: Prepare database
+          command: npm run db:prepare
+          environment:
+            NODE_ENV: test
+            TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci_integration
+      - run:
+          name: Test
+          command: npm run test:api:integration
+          environment:
+            NODE_ENV: test
+            TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci_integration
+            TEST_REDIS_URL: redis://localhost:6379
+            TEST_IMPORT_STORAGE_ENDPOINT: http://localhost:9090
+            TEST_IMPORT_STORAGE_BUCKET_NAME: pix-import-test
+            MOCHA_FILE: /home/circleci/test-results/test-results.[hash].xml
+            MOCHA_REPORTER: mocha-junit-reporter
+          when: always
+      - store_test_results:
+          path: /home/circleci/test-results
+      - store_artifacts:
+          path: /home/circleci/test-results
+  api_acceptance_test:
+    executor:
+      name: node-redis-postgres-s3-docker
+    working_directory: ~/pix/api
+    steps:
+      - attach_workspace:
+          at: ~/pix
+      - run:
+          name: Prepare database
+          command: npm run db:prepare
+          environment:
+            NODE_ENV: test
+            TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci_acceptance
+      - run:
+          name: Test
+          command: npm run test:api:acceptance
+          environment:
+            NODE_ENV: test
+            TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci_acceptance
             TEST_REDIS_URL: redis://localhost:6379
             TEST_IMPORT_STORAGE_ENDPOINT: http://localhost:9090
             TEST_IMPORT_STORAGE_BUCKET_NAME: pix-import-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,12 +106,10 @@ workflows:
           context: Pix
           requires:
             - checkout
-
       - api_lint:
           context: Pix
           requires:
             - api_install
-
       - api_test:
           context: Pix
           requires:
@@ -134,16 +132,18 @@ workflows:
           context: Pix
           requires:
             - checkout
-
       - mon_pix_lint:
           context: Pix
           requires:
             - mon_pix_install
-
       - mon_pix_test:
           context: Pix
           requires:
             - mon_pix_install
+      - e2e_test_mon_pix:
+          context: Pix
+          requires:
+            - checkout
 
       - orga_install:
           context: Pix
@@ -157,6 +157,10 @@ workflows:
           context: Pix
           requires:
             - orga_install
+      - e2e_test_orga:
+          context: Pix
+          requires:
+            - checkout
 
       - certif_install:
           context: Pix
@@ -170,10 +174,6 @@ workflows:
           context: Pix
           requires:
             - certif_install
-      - e2e_test_orga:
-          context: Pix
-          requires:
-            - checkout
 
       - admin_install:
           context: Pix
@@ -200,11 +200,6 @@ workflows:
           context: Pix
           requires:
             - pix1d_install
-
-      - e2e_test_app:
-          context: Pix
-          requires:
-            - checkout
 
 jobs:
   checkout:
@@ -681,7 +676,7 @@ jobs:
       - store_artifacts:
           path: /home/circleci/test-results/admin
 
-  e2e_test_app:
+  e2e_test_mon_pix:
     executor:
       name: node-browsers-redis-postgres-docker
     parallelism: 4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,10 +137,18 @@ workflows:
           requires:
             - mon_pix_install
 
-      - orga_build_and_test:
+      - orga_install:
           context: Pix
           requires:
             - checkout
+      - orga_lint:
+          context: Pix
+          requires:
+            - orga_install
+      - orga_test:
+          context: Pix
+          requires:
+            - orga_install
 
       - certif_build_and_test:
           context: Pix
@@ -411,12 +419,11 @@ jobs:
       - store_artifacts:
           path: /home/circleci/test-results/mon_pix
 
-  orga_build_and_test:
+  orga_install:
     executor:
-      name: node-browsers-docker
+      name: node-docker
     working_directory: ~/pix/orga
     steps:
-      - browser-tools/install-chrome
       - attach_workspace:
           at: ~/pix
       - run: cat package*.json > cachekey
@@ -428,14 +435,38 @@ jobs:
           key: v7-orga-npm-{{ checksum "cachekey" }}
           paths:
             - ~/.npm
+      - persist_to_workspace:
+          root: ~/pix
+          paths:
+            - orga
+
+  orga_lint:
+    executor:
+      name: node-docker
+    working_directory: ~/pix/orga
+    steps:
+      - attach_workspace:
+          at: ~/pix
       - run:
           name: Lint
           command: npm run lint
+          when: always
+
+  orga_test:
+    executor:
+      name: node-browsers-docker
+    working_directory: ~/pix/orga
+    parallelism: 3
+    steps:
+      - browser-tools/install-chrome
+      - attach_workspace:
+          at: ~/pix
       - run:
           environment:
             RESULTS_PATH: ../../test-results/orga
           name: Test
           command: npm run test:ci
+          when: always
       - store_test_results:
           path: /home/circleci/test-results/orga
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,10 +167,19 @@ workflows:
           requires:
             - checkout
 
-      - admin_build_and_test:
+      - admin_install:
           context: Pix
           requires:
             - checkout
+      - admin_lint:
+          context: Pix
+          requires:
+            - admin_install
+      - admin_test:
+          context: Pix
+          requires:
+            - admin_install
+
       - pix1d_build_and_test:
           context: Pix
           requires:
@@ -562,12 +571,11 @@ jobs:
       - store_artifacts:
           path: /home/circleci/test-results/certif
 
-  admin_build_and_test:
+  admin_install:
     executor:
-      name: node-browsers-docker
+      name: node-docker
     working_directory: ~/pix/admin
     steps:
-      - browser-tools/install-chrome
       - attach_workspace:
           at: ~/pix
       - run: cat package*.json > cachekey
@@ -579,14 +587,38 @@ jobs:
           key: v7-admin-npm-{{ checksum "cachekey" }}
           paths:
             - ~/.npm
+      - persist_to_workspace:
+          root: ~/pix
+          paths:
+            - admin
+
+  admin_lint:
+    executor:
+      name: node-docker
+    working_directory: ~/pix/admin
+    steps:
+      - attach_workspace:
+          at: ~/pix
       - run:
           name: Lint
           command: npm run lint
+          when: always
+
+  admin_test:
+    executor:
+      name: node-browsers-docker
+    working_directory: ~/pix/admin
+    parallelism: 3
+    steps:
+      - browser-tools/install-chrome
+      - attach_workspace:
+          at: ~/pix
       - run:
           environment:
             RESULTS_PATH: ../../test-results/admin
           name: Test
           command: npm run test:ci
+          when: always
       - store_test_results:
           path: /home/circleci/test-results/admin
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,7 +150,19 @@ workflows:
           requires:
             - orga_install
 
-      - certif_build_and_test:
+      - certif_install:
+          context: Pix
+          requires:
+            - checkout
+      - certif_lint:
+          context: Pix
+          requires:
+            - certif_install
+      - certif_test:
+          context: Pix
+          requires:
+            - certif_install
+      - e2e_test_orga:
           context: Pix
           requires:
             - checkout
@@ -165,11 +177,6 @@ workflows:
             - checkout
 
       - e2e_test_app:
-          context: Pix
-          requires:
-            - checkout
-
-      - e2e_test_orga:
           context: Pix
           requires:
             - checkout
@@ -502,12 +509,11 @@ jobs:
       - store_artifacts:
           path: /home/circleci/test-results/pix1d
 
-  certif_build_and_test:
+  certif_install:
     executor:
-      name: node-browsers-docker
+      name: node-docker
     working_directory: ~/pix/certif
     steps:
-      - browser-tools/install-chrome
       - attach_workspace:
           at: ~/pix
       - run: cat package*.json > cachekey
@@ -519,14 +525,38 @@ jobs:
           key: v7-certif-npm-{{ checksum "cachekey" }}
           paths:
             - ~/.npm
+      - persist_to_workspace:
+          root: ~/pix
+          paths:
+            - certif
+
+  certif_lint:
+    executor:
+      name: node-docker
+    working_directory: ~/pix/certif
+    steps:
+      - attach_workspace:
+          at: ~/pix
       - run:
           name: Lint
           command: npm run lint
+          when: always
+
+  certif_test:
+    executor:
+      name: node-browsers-docker
+    working_directory: ~/pix/certif
+    parallelism: 3
+    steps:
+      - browser-tools/install-chrome
+      - attach_workspace:
+          at: ~/pix
       - run:
           environment:
             RESULTS_PATH: ../../test-results/certif
           name: Test
           command: npm run test:ci
+          when: always
       - store_test_results:
           path: /home/circleci/test-results/certif
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,10 +117,18 @@ workflows:
           requires:
             - api_install
 
-      - audit_logger_build_and_test:
+      - audit_logger_install:
           context: Pix
           requires:
             - checkout
+      - audit_logger_lint:
+          context: Pix
+          requires:
+            - audit_logger_install
+      - audit_logger_test:
+          context: Pix
+          requires:
+            - audit_logger_install
 
       - mon_pix_install:
           context: Pix
@@ -356,9 +364,9 @@ jobs:
       - store_artifacts:
           path: /home/circleci/test-results
 
-  audit_logger_build_and_test:
+  audit_logger_install:
     executor:
-      name: node-postgres-docker
+      name: node-docker
     working_directory: ~/pix/audit-logger
     steps:
       - attach_workspace:
@@ -372,12 +380,30 @@ jobs:
           key: v7-audit-logger-npm-{{ checksum "cachekey" }}
           paths:
             - ~/.npm
+      - persist_to_workspace:
+          root: ~/pix
+          paths:
+            - audit-logger
+
+  audit_logger_lint:
+    executor:
+      name: node-postgres-docker
+    working_directory: ~/pix/audit-logger
+    steps:
+      - attach_workspace:
+          at: ~/pix
       - run:
           name: Lint
           command: npm run lint
-          environment:
-            TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci
           when: always
+
+  audit_logger_test:
+    executor:
+      name: node-postgres-docker
+    working_directory: ~/pix/audit-logger
+    steps:
+      - attach_workspace:
+          at: ~/pix
       - run:
           name: Test
           command: npm run test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,10 +180,18 @@ workflows:
           requires:
             - admin_install
 
-      - pix1d_build_and_test:
+      - pix1d_install:
           context: Pix
           requires:
             - checkout
+      - pix1d_lint:
+          context: Pix
+          requires:
+            - pix1d_install
+      - pix1d_test:
+          context: Pix
+          requires:
+            - pix1d_install
 
       - e2e_test_app:
           context: Pix
@@ -488,12 +496,11 @@ jobs:
       - store_artifacts:
           path: /home/circleci/test-results/orga
 
-  pix1d_build_and_test:
+  pix1d_install:
     executor:
-      name: node-browsers-docker
+      name: node-docker
     working_directory: ~/pix/1d
     steps:
-      - browser-tools/install-chrome
       - attach_workspace:
           at: ~/pix
       - run: cat package*.json > cachekey
@@ -505,14 +512,38 @@ jobs:
           key: v7-pix1d-npm-{{ checksum "cachekey" }}
           paths:
             - ~/.npm
+      - persist_to_workspace:
+          root: ~/pix
+          paths:
+            - 1d
+
+  pix1d_lint:
+    executor:
+      name: node-docker
+    working_directory: ~/pix/1d
+    steps:
+      - attach_workspace:
+          at: ~/pix
       - run:
           name: Lint
           command: npm run lint
+          when: always
+
+  pix1d_test:
+    executor:
+      name: node-browsers-docker
+    working_directory: ~/pix/1d
+    parallelism: 3
+    steps:
+      - browser-tools/install-chrome
+      - attach_workspace:
+          at: ~/pix
       - run:
           environment:
             RESULTS_PATH: ../../test-results/pix1d
           name: Test
           command: npm run test:ci
+          when: always
       - store_test_results:
           path: /home/circleci/test-results/pix1d
       - store_artifacts:


### PR DESCRIPTION
## :unicorn: Problème

Certains jobs de la CI sont séparés en 3 parties : `xxx_install`, `xxx_lint` et `xxx_test`. Pour d'autres, il n'y a qu'un seul job `xxx_build_and_test`.

## :robot: Proposition

Unifier cette séparation à tous les jobs qui ne le sont pas encore, et faire un split des tests unitaire, integration et acceptance pour l'API

## :rainbow: Remarques

RAS

## :100: Pour tester

Vérifier que la CI est ok ✅ 
