### PR TITLE
[BUGFIX] corrige la largeur des champ texte  lors de la creation de campagne (PIX-11904)

### DIFF
--- a/orga/app/styles/pages/authenticated/campaigns/new.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/new.scss
@@ -3,4 +3,8 @@
   flex-direction: column;
   flex-grow: 1;
   margin-top: var(--pix-spacing-4x);
+
+  .pix-input {
+    width: 100%;
+  }
 }


### PR DESCRIPTION
## :unicorn: Problème
Suite à la [montée de version pixUI sur PixOrga](https://github.com/1024pix/pix/pull/8507) , la largeur de l’input field “Nom de la campagne” sur le formulaire de création de campagne n’est plus ok. 

## :robot: Proposition
remettre la taille à 100%

## :rainbow: Remarques
(Les input  `* Libellé de l’identifiant`  et  `Titre du parcours ` étaient aussi impactés.
Ne sachant pas trop les impacts d'une surcharge de règle générale, j'ai préféré limité la surcharge à la page de création de campagne. 

## :100: Pour tester
- Aller sur la page de création de campagne.
- Vérifier que les input ont tous la même taille.
