### PR TITLE
[TECH] Extrait le traitement de données de l'import SIECLE dans un usecase (PIX-11945)

### DIFF
--- a/api/src/prescription/learner-management/application/sco-organization-management-controller.js
+++ b/api/src/prescription/learner-management/application/sco-organization-management-controller.js
@@ -21,6 +21,7 @@ const importOrganizationLearnersFromSIECLE = async function (
         organizationId,
         payload: request.payload,
       });
+      await usecases.addOrUpdateOrganizationLearners({ organizationId });
     } else if (format === 'csv') {
       await usecases.importOrganizationLearnersFromSIECLECSVFormat({
         userId: authenticatedUserId,

--- a/api/src/prescription/learner-management/domain/usecases/add-or-update-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/add-or-update-organization-learners.js
@@ -1,0 +1,57 @@
+import bluebird from 'bluebird';
+import lodash from 'lodash';
+
+import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';
+import { ORGANIZATION_LEARNER_CHUNK_SIZE } from '../../../../shared/infrastructure/constants.js';
+import { SiecleParser } from '../../infrastructure/serializers/xml/siecle-parser.js';
+import { SiecleFileStreamer } from '../../infrastructure/utils/xml/siecle-file-streamer.js';
+
+const { chunk } = lodash;
+
+async function addOrUpdateOrganizationLearners({
+  organizationId,
+  organizationLearnerRepository,
+  organizationImportRepository,
+  importStorage,
+  chunkSize = ORGANIZATION_LEARNER_CHUNK_SIZE,
+}) {
+  const errors = [];
+  const organizationImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
+
+  return DomainTransaction.execute(async (domainTransaction) => {
+    try {
+      const readableStream = await importStorage.readFile({ filename: organizationImport.filename });
+      const siecleFileStreamer = await SiecleFileStreamer.create(readableStream, organizationImport.encoding);
+      const parser = SiecleParser.create(siecleFileStreamer);
+
+      const organizationLearnerData = await parser.parse();
+
+      const organizationLearnersChunks = chunk(organizationLearnerData, chunkSize);
+
+      const nationalStudentIdData = organizationLearnerData.map((learner) => learner.nationalStudentId);
+
+      await organizationLearnerRepository.disableAllOrganizationLearnersInOrganization({
+        domainTransaction,
+        organizationId,
+        nationalStudentIds: nationalStudentIdData,
+      });
+
+      await bluebird.mapSeries(organizationLearnersChunks, (chunk) => {
+        return organizationLearnerRepository.addOrUpdateOrganizationOfOrganizationLearners(
+          chunk,
+          organizationId,
+          domainTransaction,
+        );
+      });
+    } catch (error) {
+      errors.push(error);
+      throw error;
+    } finally {
+      organizationImport.process({ errors });
+      await organizationImportRepository.save(organizationImport, domainTransaction);
+      await importStorage.deleteFile({ filename: organizationImport.filename });
+    }
+  });
+}
+
+export { addOrUpdateOrganizationLearners };

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-import-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-import-repository_test.js
@@ -1,6 +1,7 @@
 import { IMPORT_STATUSES } from '../../../../../../src/prescription/learner-management/domain/constants.js';
 import { OrganizationImport } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationImport.js';
 import * as organizationImportRepository from '../../../../../../src/prescription/learner-management/infrastructure/repositories/organization-import-repository.js';
+import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { catchErr, databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | Repository | Organization Learner Management | Organization Import', function () {
@@ -63,6 +64,25 @@ describe('Integration | Repository | Organization Learner Management | Organizat
 
       expect(error).to.be.ok;
     });
+
+    it('should use domainTransaction', async function () {
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const userId = databaseBuilder.factory.buildUser().id;
+      await databaseBuilder.commit();
+
+      const organizationImport = OrganizationImport.create({ organizationId, createdBy: userId });
+      organizationImport.upload({ filename: 'test.csv', encoding: 'utf8' });
+      try {
+        await DomainTransaction.execute(async (domainTransaction) => {
+          await organizationImportRepository.save(organizationImport, domainTransaction);
+          throw new Error();
+        });
+        // eslint-disable-next-line no-empty
+      } catch (e) {}
+
+      const savedImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
+      expect(savedImport).to.be.null;
+    });
   });
 
   describe('#get', function () {
@@ -82,7 +102,7 @@ describe('Integration | Repository | Organization Learner Management | Organizat
     });
   });
 
-  describe('#getByOrganizationId', function () {
+  describe('#getLastByOrganizationId', function () {
     it('should return import state', async function () {
       const expectedResult = databaseBuilder.factory.buildOrganizationImport();
       await databaseBuilder.commit();

--- a/api/tests/prescription/learner-management/unit/application/sco-organization-management-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/sco-organization-management-controller_test.js
@@ -23,6 +23,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
     beforeEach(function () {
       sinon.stub(fs, 'unlink').resolves();
       sinon.stub(usecases, 'importOrganizationLearnersFromSIECLEXMLFormat');
+      sinon.stub(usecases, 'addOrUpdateOrganizationLearners');
       sinon.stub(usecases, 'importOrganizationLearnersFromSIECLECSVFormat');
       usecases.importOrganizationLearnersFromSIECLEXMLFormat.resolves();
       dependencies = { logErrorWithCorrelationIds: sinon.stub() };
@@ -57,7 +58,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       expect(dependencies.logErrorWithCorrelationIds).to.have.been.calledWith(error);
     });
 
-    it('should call the usecase to import organizationLearners xml', async function () {
+    it('should call usecases to import organizationLearners xml', async function () {
       // given
       const userId = 1;
       request.auth = { credentials: { userId } };
@@ -73,6 +74,9 @@ describe('Unit | Application | Organizations | organization-controller', functio
         userId,
         organizationId,
         payload,
+      });
+      expect(usecases.addOrUpdateOrganizationLearners).to.have.been.calledWithExactly({
+        organizationId,
       });
     });
 

--- a/api/tests/prescription/learner-management/unit/domain/usecases/add-or-update-organization-learners_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/add-or-update-organization-learners_test.js
@@ -1,0 +1,111 @@
+import { DomainTransaction } from '../../../../../../lib/infrastructure/DomainTransaction.js';
+import { addOrUpdateOrganizationLearners } from '../../../../../../src/prescription/learner-management/domain/usecases/add-or-update-organization-learners.js';
+import { SiecleParser } from '../../../../../../src/prescription/learner-management/infrastructure/serializers/xml/siecle-parser.js';
+import { SiecleFileStreamer } from '../../../../../../src/prescription/learner-management/infrastructure/utils/xml/siecle-file-streamer.js';
+import { catchErr, expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | UseCase | add-or-update-organization-learners', function () {
+  const organizationId = 1234;
+  let organizationLearnerRepositoryStub;
+  let organizationImportRepositoryStub;
+  let importStorageStub;
+  let readableSymbol;
+  let parserStub;
+  let streamerSymbol;
+  let domainTransaction;
+  let organizationImportStub;
+
+  beforeEach(function () {
+    organizationImportRepositoryStub = {
+      getLastByOrganizationId: sinon.stub(),
+      save: sinon.stub(),
+    };
+    organizationImportStub = { filename: Symbol('filename'), encoding: Symbol('encoding'), process: sinon.stub() };
+    organizationImportRepositoryStub.getLastByOrganizationId.returns(organizationImportStub);
+
+    domainTransaction = Symbol();
+    sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
+      return callback(domainTransaction);
+    });
+    readableSymbol = Symbol('readable');
+    importStorageStub = {
+      readFile: sinon.stub().withArgs({ filename: organizationImportStub.filename }).resolves(readableSymbol),
+      deleteFile: sinon.stub(),
+    };
+    streamerSymbol = Symbol('streamer');
+    sinon
+      .stub(SiecleFileStreamer, 'create')
+      .withArgs(readableSymbol, organizationImportStub.encoding)
+      .resolves(streamerSymbol);
+    parserStub = {
+      parse: sinon.stub().resolves([
+        { lastName: 'Student1', nationalStudentId: 'INE1' },
+        { lastName: 'Student2', nationalStudentId: 'INE2' },
+        { lastName: 'Student3', nationalStudentId: 'INE3' },
+      ]),
+    };
+    sinon.stub(SiecleParser, 'create').withArgs(streamerSymbol).returns(parserStub);
+
+    organizationLearnerRepositoryStub = {
+      addOrUpdateOrganizationOfOrganizationLearners: sinon.stub(),
+      disableAllOrganizationLearnersInOrganization: sinon.stub().resolves(),
+    };
+  });
+
+  it('should save learners', async function () {
+    organizationLearnerRepositoryStub.addOrUpdateOrganizationOfOrganizationLearners.resolves();
+
+    await addOrUpdateOrganizationLearners({
+      organizationId,
+      importStorage: importStorageStub,
+      organizationImportRepository: organizationImportRepositoryStub,
+      organizationLearnerRepository: organizationLearnerRepositoryStub,
+      chunkSize: 2,
+    });
+
+    expect(organizationLearnerRepositoryStub.disableAllOrganizationLearnersInOrganization).to.have.been.calledWith({
+      domainTransaction,
+      organizationId,
+      nationalStudentIds: ['INE1', 'INE2', 'INE3'],
+    });
+    expect(organizationLearnerRepositoryStub.addOrUpdateOrganizationOfOrganizationLearners).to.have.been.calledTwice;
+    expect(
+      organizationLearnerRepositoryStub.addOrUpdateOrganizationOfOrganizationLearners.getCall(0).args,
+    ).to.deep.equal([
+      [
+        { lastName: 'Student1', nationalStudentId: 'INE1' },
+        { lastName: 'Student2', nationalStudentId: 'INE2' },
+      ],
+      organizationId,
+      domainTransaction,
+    ]);
+    expect(
+      organizationLearnerRepositoryStub.addOrUpdateOrganizationOfOrganizationLearners.getCall(1).args,
+    ).to.deep.equal([[{ lastName: 'Student3', nationalStudentId: 'INE3' }], organizationId, domainTransaction]);
+
+    expect(organizationImportStub.process).to.have.been.calledWith({ errors: [] });
+    expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(
+      organizationImportStub,
+      domainTransaction,
+    );
+
+    expect(importStorageStub.deleteFile).to.have.been.calledWithExactly({ filename: organizationImportStub.filename });
+  });
+
+  it('should handle errors', async function () {
+    const s3Error = new Error('s3 error');
+    importStorageStub.readFile.rejects(s3Error);
+    const error = await catchErr(addOrUpdateOrganizationLearners)({
+      organizationId,
+      importStorage: importStorageStub,
+      organizationImportRepository: organizationImportRepositoryStub,
+      organizationLearnerRepository: organizationLearnerRepositoryStub,
+      chunkSize: 2,
+    });
+    expect(error).to.equal(s3Error);
+    expect(organizationLearnerRepositoryStub.addOrUpdateOrganizationOfOrganizationLearners).to.have.been.not.called;
+    expect(organizationLearnerRepositoryStub.disableAllOrganizationLearnersInOrganization).to.have.been.not.called;
+    expect(organizationImportStub.process).to.have.been.called;
+    expect(organizationImportRepositoryStub.save).to.have.been.called;
+  });
+});

--- a/api/tests/prescription/learner-management/unit/domain/usecases/import-organization-learners-from-siecle-xml-format_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/import-organization-learners-from-siecle-xml-format_test.js
@@ -138,42 +138,8 @@ describe('Unit | UseCase | import-organization-learners-from-siecle-xml', functi
       });
 
       // then
-      const organizationLearners = [
-        { lastName: 'UpdatedStudent1', nationalStudentId: 'INE1' },
-        { lastName: 'UpdatedStudent2', nationalStudentId: 'INE2' },
-        { lastName: 'StudentToCreate', nationalStudentId: 'INE3' },
-      ];
 
       expect(SiecleParser.create).to.have.been.calledWithExactly(siecleFileStreamerSymbol);
-      expect(
-        organizationLearnerRepositoryStub.addOrUpdateOrganizationOfOrganizationLearners,
-      ).to.have.been.calledWithExactly(organizationLearners, organizationId, domainTransaction);
-      expect(organizationLearnerRepositoryStub.addOrUpdateOrganizationOfOrganizationLearners).to.not.throw();
-    });
-
-    it('should disable all previous organization learners', async function () {
-      // given
-      const extractedOrganizationLearnersInformations = [{ nationalStudentId: 'INE1' }];
-      organizationRepositoryStub.get.withArgs(organizationId).resolves({ externalId: organizationUAI });
-      parseStub.resolves(extractedOrganizationLearnersInformations);
-
-      organizationLearnerRepositoryStub.findByOrganizationId.resolves();
-
-      // when
-      await importOrganizationLearnersFromSIECLEXMLFormat({
-        organizationId,
-        payload,
-        organizationRepository: organizationRepositoryStub,
-        organizationImportRepository: organizationImportRepositoryStub,
-        organizationLearnerRepository: organizationLearnerRepositoryStub,
-        siecleService: siecleServiceStub,
-        importStorage: importStorageStub,
-      });
-
-      // then
-      expect(
-        organizationLearnerRepositoryStub.disableAllOrganizationLearnersInOrganization,
-      ).to.have.been.calledWithExactly({ domainTransaction, organizationId, nationalStudentIds: ['INE1'] });
     });
   });
 
@@ -211,7 +177,7 @@ describe('Unit | UseCase | import-organization-learners-from-siecle-xml', functi
 
   context('save import state in database', function () {
     describe('success case', function () {
-      it('should save uploaded, validated and imported state each after each', async function () {
+      it('should save uploaded, validated state each after each', async function () {
         // given
         const extractedOrganizationLearnersInformations = [
           { lastName: 'UpdatedStudent1', nationalStudentId: 'INE1' },
@@ -243,11 +209,9 @@ describe('Unit | UseCase | import-organization-learners-from-siecle-xml', functi
 
         const firstSaveCall = organizationImportRepositoryStub.save.getCall(0).args[0];
         const secondSaveCall = organizationImportRepositoryStub.save.getCall(1).args[0];
-        const thirdSaveCall = organizationImportRepositoryStub.save.getCall(2).args[0];
 
         expect(firstSaveCall.status).to.equal('UPLOADED');
         expect(secondSaveCall.status).to.equal('VALIDATED');
-        expect(thirdSaveCall.status).to.equal('IMPORTED');
       });
     });
     describe('errors case', function () {
@@ -312,35 +276,6 @@ describe('Unit | UseCase | import-organization-learners-from-siecle-xml', functi
 
           //then
           expect(organizationImportRepositoryStub.save.getCall(1).args[0].status).to.equal('VALIDATION_ERROR');
-        });
-      });
-
-      describe('when there is an import error', function () {
-        it('should save IMPORT_ERROR status', async function () {
-          //given
-          const extractedOrganizationLearnersInformations = [
-            { lastName: 'UpdatedStudent1', nationalStudentId: 'INE1' },
-            { lastName: 'UpdatedStudent2', nationalStudentId: 'INE2' },
-            { lastName: 'StudentToCreate', nationalStudentId: 'INE3' },
-          ];
-          organizationRepositoryStub.get.withArgs(organizationId).resolves({ externalId: organizationUAI });
-          parseStub.resolves(extractedOrganizationLearnersInformations);
-          organizationLearnerRepositoryStub.addOrUpdateOrganizationOfOrganizationLearners.rejects();
-
-          // when
-          await catchErr(importOrganizationLearnersFromSIECLEXMLFormat)({
-            organizationId,
-            payload,
-            format,
-            organizationRepository: organizationRepositoryStub,
-            organizationImportRepository: organizationImportRepositoryStub,
-            organizationLearnerRepository: organizationLearnerRepositoryStub,
-            siecleService: siecleServiceStub,
-            importStorage: importStorageStub,
-          });
-
-          //then
-          expect(organizationImportRepositoryStub.save.getCall(2).args[0].status).to.equal('IMPORT_ERROR');
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
En prévision de l'ajout de PGBoss pour la refonte de l'import, on veut commencer par découper le usecase initial, en 3 sous parties, qui partiront par la suite dans des handlers

## :robot: Proposition
On crée un nouveau usecase qui s'occupe de la 3eme partie de l'import. On enlève cette partie du usecase initial, et on appel celui ci à la suite dans le controller.

## :rainbow: Remarques
Partie Import SIECLE seulement ici.

## :100: Pour tester
Faire un import SIECLE
Vérifier que tout se passe bien
🐈‍⬛ 
