### PR TITLE
[TECH] met à jour le plugin update-prettier-plugin-ember-template-tag

### DIFF
--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -82,7 +82,7 @@
         "p-queue": "^8.0.0",
         "patternomaly": "^1.3.2",
         "prettier": "^3.2.5",
-        "prettier-plugin-ember-template-tag": "2.0.0",
+        "prettier-plugin-ember-template-tag": "^2.0.2",
         "query-string": "^9.0.0",
         "qunit": "^2.20.1",
         "qunit-dom": "^3.0.0",
@@ -44832,9 +44832,9 @@
       }
     },
     "node_modules/prettier-plugin-ember-template-tag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-ember-template-tag/-/prettier-plugin-ember-template-tag-2.0.0.tgz",
-      "integrity": "sha512-n2iIQedT5r/kvoTfhjThPECE1y0Ji3DupNpCtENP1Dm974M2NoKhaT5QynfBdn+WXlPhvFE4A/2uDSsZfx373A==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-ember-template-tag/-/prettier-plugin-ember-template-tag-2.0.2.tgz",
+      "integrity": "sha512-eSEnrxdD3NtMyIGwG2FxcTPOdpcbCK7VnBNhAufdaoeOIs+mNwmTsZdkWxr/LMhBdgtR1IUQB0l0YQhUQGz6kQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.23.6",

--- a/orga/package.json
+++ b/orga/package.json
@@ -114,7 +114,7 @@
     "p-queue": "^8.0.0",
     "patternomaly": "^1.3.2",
     "prettier": "^3.2.5",
-    "prettier-plugin-ember-template-tag": "2.0.0",
+    "prettier-plugin-ember-template-tag": "^2.0.2",
     "query-string": "^9.0.0",
     "qunit": "^2.20.1",
     "qunit-dom": "^3.0.0",


### PR DESCRIPTION
## :unicorn: Problème
Suite à l'ajout du support des fichier *.gjs dans orga, nous avions du basculer le plugin `update-prettier-plugin-ember-template-tag` en version `2.0.0` pour éviter un crash d'eslint sur la CI

## :robot: Proposition
maintenant que la PR qui corrige le pb a été mergée, nous pouvons rebasculer sur la dernière version du plugin 
  

## :rainbow: Remarques
https://github.com/gitKrystan/prettier-plugin-ember-template-tag/pull/259

## :100: Pour tester
la CI verte
