### PR TITLE
[FEATURE] Retourner les détails des étapes de Smart Random (PIX-11561).

### DIFF
--- a/admin/app/controllers/authenticated/smart-random-simulator/get-next-challenge.js
+++ b/admin/app/controllers/authenticated/smart-random-simulator/get-next-challenge.js
@@ -91,7 +91,8 @@ export default class SmartRandomSimulator extends Controller {
         break;
       }
       case 200: {
-        this.returnedChallenges = [...this.returnedChallenges, await apiResponse.json()];
+        const response = await apiResponse.json();
+        this.returnedChallenges = [...this.returnedChallenges, response.challenge];
         break;
       }
       default: {

--- a/admin/tests/unit/controllers/authenticated/smart-random-simulator/get-next-challenge-test.js
+++ b/admin/tests/unit/controllers/authenticated/smart-random-simulator/get-next-challenge-test.js
@@ -19,6 +19,11 @@ module('Unit | Controller | authenticated/smart-random-simulator/get-next-challe
     focused: false,
   };
 
+  const apiResponseBody = {
+    challenge: returnedChallenge,
+    smartRandomDetails: [],
+  };
+
   hooks.beforeEach(async function () {
     controller = this.owner.lookup('controller:authenticated.smart-random-simulator.get-next-challenge');
   });
@@ -26,7 +31,7 @@ module('Unit | Controller | authenticated/smart-random-simulator/get-next-challe
   module('#requestNextChallenge', function () {
     test('it should call window fetch function', async function (assert) {
       // given
-      const apiResponse = new Response(JSON.stringify(returnedChallenge), { status: 200 });
+      const apiResponse = new Response(JSON.stringify(apiResponseBody), { status: 200 });
       fetchStub.resolves(apiResponse);
 
       // when
@@ -39,7 +44,7 @@ module('Unit | Controller | authenticated/smart-random-simulator/get-next-challe
     module('when api answer is 200', function () {
       test('it should add returned challenge to current challenges', async function (assert) {
         // given
-        const apiResponse = new Response(JSON.stringify(returnedChallenge), { status: 200 });
+        const apiResponse = new Response(JSON.stringify(apiResponseBody), { status: 200 });
         fetchStub.resolves(apiResponse);
 
         // when

--- a/api/lib/domain/services/algorithm-methods/cat-algorithm.js
+++ b/api/lib/domain/services/algorithm-methods/cat-algorithm.js
@@ -2,14 +2,15 @@ import { KnowledgeElement } from '../../models/KnowledgeElement.js';
 
 export { findMaxRewardingSkills, getPredictedLevel };
 
+const CAT_LEVELS = [0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 5.5, 6, 6.5, 7, 7.5];
+
 const findMaxRewardingSkills = ({ availableSkills, predictedLevel, tubes, knowledgeElements }) => {
   const maxRewardingSkills = getMaxRewardingSkills({ availableSkills, predictedLevel, tubes, knowledgeElements });
   return clearSkillsIfNotRewarding(maxRewardingSkills);
 };
 
 const getPredictedLevel = (knowledgeElements, skills) => {
-  const catLevels = enumerateCatLevels();
-  const eachLevelWithProbability = catLevels.map((level) => ({
+  const eachLevelWithProbability = CAT_LEVELS.map((level) => ({
     level,
     probability: probabilityThatUserHasSpecificLevel(level, knowledgeElements, skills),
   }));
@@ -19,11 +20,6 @@ const getPredictedLevel = (knowledgeElements, skills) => {
 
   return eachLevelWithProbability.find(({ probability }) => probability === maximumProbabilityThatUserHasSpecificLevel)
     .level;
-};
-
-const enumerateCatLevels = () => {
-  const catLevelsFromFirstToLastExcludingUpperBoundary = [0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 5.5, 6, 6.5, 7, 7.5];
-  return catLevelsFromFirstToLastExcludingUpperBoundary;
 };
 
 // The probability P(gap) of giving the correct answer is given by the "logistic function"
@@ -83,15 +79,15 @@ const computeReward = ({ skill, predictedLevel, tubes, knowledgeElements }) => {
 
 const getMaxRewardingSkills = ({ availableSkills, predictedLevel, tubes, knowledgeElements }) =>
   availableSkills.reduce(
-    (acc, skill) => {
+    (maxRewardingSkills, skill) => {
       const skillReward = computeReward({ skill, predictedLevel, tubes, knowledgeElements });
-      if (skillReward > acc.maxReward) {
-        acc.maxReward = skillReward;
-        acc.maxRewardingSkills = [skill];
-      } else if (skillReward === acc.maxReward) {
-        acc.maxRewardingSkills.push(skill);
+      if (skillReward > maxRewardingSkills.maxReward) {
+        maxRewardingSkills.maxReward = skillReward;
+        maxRewardingSkills.maxRewardingSkills = [skill];
+      } else if (skillReward === maxRewardingSkills.maxReward) {
+        maxRewardingSkills.maxRewardingSkills.push(skill);
       }
-      return acc;
+      return maxRewardingSkills;
     },
     { maxRewardingSkills: [], maxReward: -Infinity },
   ).maxRewardingSkills;

--- a/api/src/evaluation/domain/models/SmartRandomDetails.js
+++ b/api/src/evaluation/domain/models/SmartRandomDetails.js
@@ -1,0 +1,23 @@
+import { SmartRandomStep } from './SmartRandomStep.js';
+
+class SmartRandomDetails {
+  /**
+   * @type {SmartRandomStep[]}
+   */
+  steps = [];
+
+  /**
+   * @type {number | null}
+   */
+  predictedLevel = null;
+
+  /**
+   * @param {string} stepName
+   * @param {[Skill]} outputSkills
+   */
+  addStep(stepName, outputSkills) {
+    this.steps.push(new SmartRandomStep(stepName, outputSkills));
+  }
+}
+
+export { SmartRandomDetails };

--- a/api/src/evaluation/domain/models/SmartRandomStep.js
+++ b/api/src/evaluation/domain/models/SmartRandomStep.js
@@ -1,0 +1,36 @@
+import { Skill } from '../../../../lib/domain/models/index.js';
+
+const STEPS_NAMES = {
+  DEFAULT_LEVEL: 'DEFAULT_LEVEL',
+  EASY_TUBES: 'EASY_TUBES',
+  MAX_REWARDING_SKILLS: 'MAX_REWARDING_SKILLS',
+  NO_CHALLENGE: 'NO_CHALLENGE',
+  RANDOM_PICK: 'RANDOM_PICK',
+  TIMED_SKILLS: 'TIMED_SKILLS',
+  TOO_DIFFICULT: 'TOO_DIFFICULT',
+  ALREADY_TESTED: 'UNTESTED',
+};
+
+class SmartRandomStep {
+  /**
+   * @type {string}
+   */
+  name;
+
+  /**
+   * @type {[Skill]}
+   */
+  outputSkills;
+
+  /**
+   * @param {string} name
+   * @param {[Skill]} outputSkills
+   */
+  constructor(name, outputSkills) {
+    this.name = name;
+    // This ensures that the returned skills are “pure” and that any added properties are removed
+    this.outputSkills = outputSkills.map((outputSkill) => new Skill(outputSkill));
+  }
+}
+
+export { SmartRandomStep, STEPS_NAMES };

--- a/api/src/evaluation/domain/usecases/get-next-challenge-for-simulator.js
+++ b/api/src/evaluation/domain/usecases/get-next-challenge-for-simulator.js
@@ -1,27 +1,37 @@
+import { STEPS_NAMES } from '../models/SmartRandomStep.js';
+
 /**
  * @param {simulationParameters: SimulationParameters} simulationParameters
  * @param pickChallengeService
  * @param smartRandomService
- * @returns {Promise<Challenge | null>}
+ * @returns {Promise<{challenge: Challenge, smartRandomDetails: SmartRandomDetails} | null>}
  */
 const getNextChallengeForSimulator = function ({ simulationParameters, pickChallengeService, smartRandomService }) {
-  const { possibleSkillsForNextChallenge, hasAssessmentEnded } = smartRandomService.getPossibleSkillsForNextChallenge({
-    knowledgeElements: simulationParameters.knowledgeElements,
-    challenges: simulationParameters.challenges,
-    locale: simulationParameters.locale,
-    targetSkills: simulationParameters.skills,
-    allAnswers: simulationParameters.answers,
-  });
+  const { possibleSkillsForNextChallenge, hasAssessmentEnded, smartRandomDetails } =
+    smartRandomService.getPossibleSkillsForNextChallenge({
+      knowledgeElements: simulationParameters.knowledgeElements,
+      challenges: simulationParameters.challenges,
+      locale: simulationParameters.locale,
+      targetSkills: simulationParameters.skills,
+      allAnswers: simulationParameters.answers,
+      lastAnswer: simulationParameters.answers.length
+        ? simulationParameters.answers[simulationParameters.answers.length - 1]
+        : null,
+    });
 
   if (hasAssessmentEnded) {
     return null;
   }
 
-  return pickChallengeService.pickChallenge({
+  const challenge = pickChallengeService.pickChallenge({
     skills: possibleSkillsForNextChallenge,
     randomSeed: simulationParameters.assessmentId,
     locale: simulationParameters.locale,
   });
+
+  smartRandomDetails.addStep(STEPS_NAMES.RANDOM_PICK, [challenge.skill]);
+
+  return { challenge, smartRandomDetails };
 };
 
 export { getNextChallengeForSimulator };

--- a/api/tests/evaluation/acceptance/application/smart-random-simulator/smart-random-simulator-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/smart-random-simulator/smart-random-simulator-controller_test.js
@@ -80,7 +80,10 @@ describe('Acceptance | API | Smart Random Simulator', function () {
           expect(response.statusCode).to.equal(200);
         });
         it('should return a challenge', async function () {
-          expect(JSON.parse(response.payload).id).to.equal('challengerec1234567');
+          expect(JSON.parse(response.payload).challenge.id).to.equal('challengerec1234567');
+        });
+        it('should return smart random details', async function () {
+          expect(JSON.parse(response.payload).smartRandomDetails).to.exist;
         });
       });
       context('when the route should not return a challenge', function () {

--- a/api/tests/evaluation/integration/domain/usecases/get-next-challenge-for-simulator_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/get-next-challenge-for-simulator_test.js
@@ -1,4 +1,5 @@
 import { SimulationParameters } from '../../../../../src/evaluation/domain/models/SimulationParameters.js';
+import { SmartRandomDetails } from '../../../../../src/evaluation/domain/models/SmartRandomDetails.js';
 import { evaluationUsecases } from '../../../../../src/evaluation/domain/usecases/index.js';
 import { Challenge } from '../../../../../src/shared/domain/models/Challenge.js';
 import { domainBuilder, expect } from '../../../../test-helper.js';
@@ -18,13 +19,34 @@ describe('Integration | Usecases | Get next challenge for simulator', function (
       });
 
       // when
-      const nextChallenge = await evaluationUsecases.getNextChallengeForSimulator({
+      const { challenge: nextChallenge } = await evaluationUsecases.getNextChallengeForSimulator({
         simulationParameters,
       });
 
       // then
       expect(nextChallenge).to.be.instanceOf(Challenge);
       expect(nextChallenge.skill.id).to.equal(skill.id);
+    });
+
+    it('should return smart random details', async function () {
+      // given
+      const skill = domainBuilder.buildSkill({ difficulty: 2 });
+      const challenge = domainBuilder.buildChallenge({ skill, locales: ['fr-fr'] });
+      const simulationParameters = new SimulationParameters({
+        skills: [skill],
+        challenges: [challenge],
+        answers: [],
+        knowledgeElements: [],
+        locale: 'fr-fr',
+      });
+
+      // when
+      const { smartRandomDetails } = await evaluationUsecases.getNextChallengeForSimulator({
+        simulationParameters,
+      });
+
+      // then
+      expect(smartRandomDetails).to.be.instanceOf(SmartRandomDetails);
     });
   });
 

--- a/api/tests/evaluation/unit/domain/usecases/get-next-challenge-for-simulator_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/get-next-challenge-for-simulator_test.js
@@ -1,3 +1,4 @@
+import { SmartRandomDetails } from '../../../../../src/evaluation/domain/models/SmartRandomDetails.js';
 import { getNextChallengeForSimulator } from '../../../../../src/evaluation/domain/usecases/get-next-challenge-for-simulator.js';
 import { expect, sinon } from '../../../../test-helper.js';
 
@@ -26,7 +27,9 @@ describe('Unit | UseCase | get-next-challenge-for-simulator', function () {
 
         // when
         const result = getNextChallengeForSimulator({
-          simulationParameters: {},
+          simulationParameters: {
+            answers: [],
+          },
           pickChallengeService,
           smartRandomService,
         });
@@ -43,14 +46,17 @@ describe('Unit | UseCase | get-next-challenge-for-simulator', function () {
         // given
         const possibleSkillsForNextChallenge = Symbol('possibleSkillsForNextChallenge');
         const pickChallengeServiceResult = Symbol('pickChallengeServiceResult');
+        const smartRandomDetails = new SmartRandomDetails();
         const simulationParameters = {
           assessmentId: Symbol('assessmentId'),
           locale: Symbol('locale'),
+          answers: [],
         };
 
         smartRandomService.getPossibleSkillsForNextChallenge.returns({
           hasAssessmentEnded: false,
           possibleSkillsForNextChallenge,
+          smartRandomDetails,
         });
 
         pickChallengeService.pickChallenge.returns(pickChallengeServiceResult);
@@ -69,7 +75,8 @@ describe('Unit | UseCase | get-next-challenge-for-simulator', function () {
           randomSeed: simulationParameters.assessmentId,
           locale: simulationParameters.locale,
         });
-        expect(result).to.equal(pickChallengeServiceResult);
+
+        expect(result.challenge).to.equal(pickChallengeServiceResult);
       });
     });
   });

--- a/api/tests/unit/domain/services/smart-random/skills-filter_test.js
+++ b/api/tests/unit/domain/services/smart-random/skills-filter_test.js
@@ -1,6 +1,10 @@
 import { Tube } from '../../../../../lib/domain/models/Tube.js';
-import * as skillsFilter from '../../../../../lib/domain/services/algorithm-methods/skills-filter.js';
-import { focusOnDefaultLevel } from '../../../../../lib/domain/services/algorithm-methods/skills-filter.js';
+import {
+  focusOnDefaultLevel,
+  getFilteredSkillsForFirstChallenge,
+  getFilteredSkillsForNextChallenge,
+} from '../../../../../lib/domain/services/algorithm-methods/skills-filter.js';
+import { SmartRandomDetails } from '../../../../../src/evaluation/domain/models/SmartRandomDetails.js';
 import { domainBuilder, expect } from '../../../../test-helper.js';
 import { buildSkill } from '../../../../tooling/domain-builder/factory/index.js';
 
@@ -26,14 +30,34 @@ describe('Unit | Domain | services | smart-random | skillsFilter', function () {
       setPlayableSkills(skills);
 
       // when
-      const result = skillsFilter.getFilteredSkillsForFirstChallenge({
+      const { availableSkills } = getFilteredSkillsForFirstChallenge({
         knowledgeElements,
         tubes,
         targetSkills: skills,
       });
 
       // then
-      expect(result).to.deep.equal([skill1]);
+      expect(availableSkills).to.deep.equal([skill1]);
+    });
+
+    it('should return algorithm selection details', function () {
+      // given
+      const skill1 = domainBuilder.buildSkill({ name: '@web3', difficulty: 3 });
+      const skills = [skill1];
+      const knowledgeElements = [];
+      const tubes = [new Tube({ skills: [skill1] })];
+      setPlayableSkills(skills);
+
+      // when
+      const { smartRandomDetails } = getFilteredSkillsForFirstChallenge({
+        knowledgeElements,
+        tubes,
+        targetSkills: skills,
+      });
+
+      // then
+      expect(smartRandomDetails).to.be.instanceof(SmartRandomDetails);
+      expect(smartRandomDetails.steps.length).to.equal(5);
     });
 
     it('should return a skill even if the only tube has a skill with difficulty > 3', function () {
@@ -45,14 +69,14 @@ describe('Unit | Domain | services | smart-random | skillsFilter', function () {
       setPlayableSkills(skills);
 
       // when
-      const result = skillsFilter.getFilteredSkillsForFirstChallenge({
+      const { availableSkills } = getFilteredSkillsForFirstChallenge({
         knowledgeElements,
         tubes,
         targetSkills: skills,
       });
 
       // then
-      expect(result).to.deep.equal([skill1]);
+      expect(availableSkills).to.deep.equal([skill1]);
     });
 
     it('should return a valid skill from a tube which only contains skill levels inferior or equal to 3', function () {
@@ -71,14 +95,14 @@ describe('Unit | Domain | services | smart-random | skillsFilter', function () {
       setPlayableSkills(skills);
 
       // when
-      const result = skillsFilter.getFilteredSkillsForFirstChallenge({
+      const { availableSkills } = getFilteredSkillsForFirstChallenge({
         knowledgeElements,
         tubes,
         targetSkills: skills,
       });
 
       // then
-      expect(result).to.deep.equal([skillFromEasyTubeLevel2]);
+      expect(availableSkills).to.deep.equal([skillFromEasyTubeLevel2]);
     });
 
     it('should return non timed skills', function () {
@@ -92,14 +116,14 @@ describe('Unit | Domain | services | smart-random | skillsFilter', function () {
       setPlayableSkills(skills);
 
       // when
-      const result = skillsFilter.getFilteredSkillsForFirstChallenge({
+      const { availableSkills } = getFilteredSkillsForFirstChallenge({
         knowledgeElements,
         tubes,
         targetSkills: skills,
       });
 
       // then
-      expect(result).to.deep.equal([skillTube2Level2]);
+      expect(availableSkills).to.deep.equal([skillTube2Level2]);
     });
 
     it('should return timed skills if there is only timed skills', function () {
@@ -114,14 +138,14 @@ describe('Unit | Domain | services | smart-random | skillsFilter', function () {
       setPlayableSkills(skills);
 
       // when
-      const result = skillsFilter.getFilteredSkillsForFirstChallenge({
+      const { availableSkills } = getFilteredSkillsForFirstChallenge({
         knowledgeElements,
         tubes,
         targetSkills: skills,
       });
 
       // then
-      expect(result).to.deep.equal([skillTube1Level2Timed, skillTube2Level2Timed]);
+      expect(availableSkills).to.deep.equal([skillTube1Level2Timed, skillTube2Level2Timed]);
     });
 
     it('should return only playable skills', function () {
@@ -135,18 +159,38 @@ describe('Unit | Domain | services | smart-random | skillsFilter', function () {
       notPlayableSkill.isPlayable = false;
 
       // when
-      const result = skillsFilter.getFilteredSkillsForFirstChallenge({
+      const { availableSkills } = getFilteredSkillsForFirstChallenge({
         knowledgeElements,
         tubes,
         targetSkills: skills,
       });
 
       // then
-      expect(result).to.deep.equal([playableSkill]);
+      expect(availableSkills).to.deep.equal([playableSkill]);
     });
   });
 
   describe('#getFilteredSkillsForNextChallenge', function () {
+    it('should return algorithm selection details', function () {
+      // given
+      const skill1 = domainBuilder.buildSkill({ name: '@web3', difficulty: 3 });
+      const skills = [skill1];
+      const knowledgeElements = [];
+      const tubes = [new Tube({ skills: [skill1] })];
+      setPlayableSkills(skills);
+
+      // when
+      const { smartRandomDetails } = getFilteredSkillsForNextChallenge({
+        knowledgeElements,
+        tubes,
+        targetSkills: skills,
+      });
+
+      // then
+      expect(smartRandomDetails).to.be.instanceof(SmartRandomDetails);
+      expect(smartRandomDetails.steps.length).to.equal(5);
+    });
+
     describe('Verify rules : Skills not already tested', function () {
       it('should not ask a question that targets a skill already assessed', function () {
         // given
@@ -169,7 +213,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', function () {
         setPlayableSkills(skills);
 
         // when
-        const result = skillsFilter.getFilteredSkillsForNextChallenge({
+        const { availableSkills } = getFilteredSkillsForNextChallenge({
           knowledgeElements,
           predictedLevel: 3,
           isLastChallengeTimed: false,
@@ -177,7 +221,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', function () {
         });
 
         // then
-        expect(result).to.deep.equal([skillNotAssessedLevel3]);
+        expect(availableSkills).to.deep.equal([skillNotAssessedLevel3]);
       });
     });
 
@@ -202,7 +246,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', function () {
         setPlayableSkills(skills);
 
         // when
-        const result = skillsFilter.getFilteredSkillsForNextChallenge({
+        const { availableSkills } = getFilteredSkillsForNextChallenge({
           isLastChallengeTimed,
           knowledgeElements,
           predictedLevel: 2,
@@ -210,7 +254,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', function () {
         });
 
         // then
-        expect(result).to.deep.equal([skillWithoutTimedChallenge]);
+        expect(availableSkills).to.deep.equal([skillWithoutTimedChallenge]);
       });
 
       it('should return a skill with timed challenges if last one was timed but we dont have not timed challenge', function () {
@@ -232,7 +276,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', function () {
         setPlayableSkills(skills);
 
         // when
-        const result = skillsFilter.getFilteredSkillsForNextChallenge({
+        const { availableSkills } = getFilteredSkillsForNextChallenge({
           knowledgeElements,
           predictedLevel: 2,
           targetSkills: skills,
@@ -240,7 +284,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', function () {
         });
 
         // then
-        expect(result).to.have.members([skill2]);
+        expect(availableSkills).to.have.members([skill2]);
       });
     });
 
@@ -269,7 +313,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', function () {
         setPlayableSkills(skills);
 
         // when
-        const result = skillsFilter.getFilteredSkillsForNextChallenge({
+        const { availableSkills } = getFilteredSkillsForNextChallenge({
           knowledgeElements,
           predictedLevel: 2,
           targetSkills: skills,
@@ -278,7 +322,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', function () {
         });
 
         // then
-        expect(result).to.deep.equal([skill3, skill4]);
+        expect(availableSkills).to.deep.equal([skill3, skill4]);
       });
     });
 
@@ -311,7 +355,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', function () {
         setPlayableSkills(skills);
 
         // when
-        const result = skillsFilter.getFilteredSkillsForNextChallenge({
+        const { availableSkills } = getFilteredSkillsForNextChallenge({
           knowledgeElements,
           predictedLevel: 5,
           targetSkills: skills,
@@ -320,7 +364,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', function () {
         });
 
         // then
-        expect(result).to.deep.equal([easyTubeSkill2, easyTubeSkill3]);
+        expect(availableSkills).to.deep.equal([easyTubeSkill2, easyTubeSkill3]);
       });
 
       it('should return skills from all tubes if there is not easy tubes', function () {
@@ -343,7 +387,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', function () {
         setPlayableSkills(skills);
 
         // when
-        const result = skillsFilter.getFilteredSkillsForNextChallenge({
+        const { availableSkills } = getFilteredSkillsForNextChallenge({
           knowledgeElements,
           predictedLevel: 5,
           targetSkills: skills,
@@ -352,7 +396,7 @@ describe('Unit | Domain | services | smart-random | skillsFilter', function () {
         });
 
         // then
-        expect(result).to.deep.equal([skill4, skill5, skill6]);
+        expect(availableSkills).to.deep.equal([skill4, skill5, skill6]);
       });
     });
 
@@ -372,14 +416,14 @@ describe('Unit | Domain | services | smart-random | skillsFilter', function () {
         playableSkill.isPlayable = true;
 
         // when
-        const result = skillsFilter.getFilteredSkillsForNextChallenge({
+        const { availableSkills } = getFilteredSkillsForNextChallenge({
           knowledgeElements,
           tubes,
           targetSkills: skills,
         });
 
         // then
-        expect(result).to.deep.equal([playableSkill]);
+        expect(availableSkills).to.deep.equal([playableSkill]);
       });
     });
   });

--- a/api/tests/unit/domain/services/smart-random/smart-random_test.js
+++ b/api/tests/unit/domain/services/smart-random/smart-random_test.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 
 import * as SmartRandom from '../../../../../lib/domain/services/algorithm-methods/smart-random.js';
+import { SmartRandomDetails } from '../../../../../src/evaluation/domain/models/SmartRandomDetails.js';
 import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
 import { domainBuilder, expect } from '../../../../test-helper.js';
 
@@ -111,6 +112,25 @@ describe('Integration | Domain | Algorithm-methods | SmartRandom', function () {
   });
 
   describe('#getPossibleSkillsForNextChallenge', function () {
+    it('should return smart random details', function () {
+      // given
+      targetSkills = [web1, url3, cnil1, cnil2];
+      challenges = [challengeWeb_1, challengeWeb_3, challengeCnil_1, challengeCnil_2];
+
+      // when
+      const { smartRandomDetails } = SmartRandom.getPossibleSkillsForNextChallenge({
+        targetSkills,
+        challenges,
+        knowledgeElements: [],
+        lastAnswer,
+        allAnswers,
+        locale,
+      });
+
+      // then
+      expect(smartRandomDetails).to.be.instanceof(SmartRandomDetails);
+    });
+
     context('when it is the first question only', function () {
       it('should ideally start with an untimed, default starting level skill', function () {
         // given


### PR DESCRIPTION
Cette PR s'inscrit dans le cadre de la création d'une interface pour visualiser les étapes de sélection des challenges.

## :unicorn: Problème
Nous avons ébauché une première version de l'interface mais celle-ci ne permet pas encore de visualiser les détails des étapes de sélection. 
Pour ce faire, nous avons préalablement besoin que l'API retourne ces informations.

## :robot: Proposition
Nous avons créé un objet qui permet de stocker les informations et détails de sélection d'une épreuve. Cet objet est retourné dans la route API du simulateur. Nous pourrons ensuite exploiter ces données pour en rendre compté à l'utilisateur.

## :rainbow: Remarques
Il y a eu une petite refacto violente aux lignes suivantes:
https://github.com/1024pix/pix/pull/8579/files#diff-0b9e3b6e1a0927e94a7df42da0fe6c50927eb6b6d111f1d3800841e9a24ce00fR89-R94
On dupliquait l'objet avant d'y insérer de nouvelles propriétés. 
C'était à mon sens superflu et engendre des soucis à cause de l'héritage de prototype pour transformer ces objets en réponse API.
La solution proposée n'est cependant pas parfaite puisque on vient rajouter des propriétés à un objet du domaine sur lequel ces propriétés n'ont pas été déclarées.
Ce problème sera adressé dans une PR ultérieure.

## :100: Pour tester
S'assurer que les campagnes et les parcours autonomes ne sont pas impactés.

Utiliser le simulateur dans l'admin, celui ci doit toujours être fonctionnel. 
Dans l'onglet "réseau", analyser la requête "/api/admin/smart-random-simulator/get-next-challenge" et confirmer que la réponse contient désormais une propriété "smartRandomDetails" qui contient les étapes de sélection.
