### PR TITLE
[FEATURE] Empêcher une valeur nulle ou vide dans la payload de réponse, sauf dans le cas d'un timeout (PIX-11905).

### DIFF
--- a/api/config/server-setup-error-handling.js
+++ b/api/config/server-setup-error-handling.js
@@ -4,6 +4,7 @@ import { courseDomainErrorMappingConfiguration } from '../src/certification/cour
 import { sessionDomainErrorMappingConfiguration } from '../src/certification/session/application/http-error-mapper-configuration.js';
 import { certificationDomainErrorMappingConfiguration } from '../src/certification/shared/application/http-error-mapper-configuration.js';
 import { devcompDomainErrorMappingConfiguration } from '../src/devcomp/application/http-error-mapper-configuration.js';
+import { evaluationDomainErrorMappingConfiguration } from '../src/evaluation/application/http-error-mapper-configuration.js';
 import { prescriptionDomainErrorMappingConfiguration } from '../src/prescription/shared/application/http-error-mapper-configuration.js';
 import { schoolDomainErrorMappingConfiguration } from '../src/school/application/http-error-mapper-configuration.js';
 import { domainErrorMapper } from '../src/shared/application/domain-error-mapper.js';
@@ -16,6 +17,7 @@ const setupErrorHandling = function (server) {
     ...sessionDomainErrorMappingConfiguration,
     ...certificationDomainErrorMappingConfiguration,
     ...devcompDomainErrorMappingConfiguration,
+    ...evaluationDomainErrorMappingConfiguration,
     ...prescriptionDomainErrorMappingConfiguration,
     ...schoolDomainErrorMappingConfiguration,
   ];

--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -1,3 +1,4 @@
+import { EmptyAnswerError } from '../../../src/evaluation/domain/errors.js';
 import { ForbiddenAccess } from '../../../src/shared/domain/errors.js';
 import { Examiner } from '../../../src/shared/domain/models/Examiner.js';
 import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
@@ -145,6 +146,9 @@ const correctAnswerThenUpdateAssessment = async function ({
   }
   if (assessment.lastChallengeId && assessment.lastChallengeId != answer.challengeId) {
     throw new ChallengeNotAskedError();
+  }
+  if (!answer.hasValue && !answer.hasTimedOut) {
+    throw new EmptyAnswerError();
   }
 
   const challenge = await challengeRepository.get(answer.challengeId);

--- a/api/src/evaluation/application/http-error-mapper-configuration.js
+++ b/api/src/evaluation/application/http-error-mapper-configuration.js
@@ -1,0 +1,14 @@
+import { HttpErrors } from '../../shared/application/http-errors.js';
+import { DomainErrorMappingConfiguration } from '../../shared/application/models/domain-error-mapping-configuration.js';
+import { EmptyAnswerError } from '../domain/errors.js';
+
+const evaluationDomainErrorMappingConfiguration = [
+  {
+    name: EmptyAnswerError.name,
+    httpErrorFn: (error) => {
+      return new HttpErrors.BadRequestError(error.message, error.code);
+    },
+  },
+].map((domainErrorMappingConfiguration) => new DomainErrorMappingConfiguration(domainErrorMappingConfiguration));
+
+export { evaluationDomainErrorMappingConfiguration };

--- a/api/src/evaluation/domain/errors.js
+++ b/api/src/evaluation/domain/errors.js
@@ -1,9 +1,4 @@
-class DomainError extends Error {
-  constructor(message) {
-    super(message);
-    this.name = this.constructor.name;
-  }
-}
+import { DomainError } from '../../shared/domain/errors.js';
 
 class StageWithLinkedCampaignError extends DomainError {
   constructor() {
@@ -17,4 +12,4 @@ class EmptyAnswerError extends DomainError {
   }
 }
 
-export { DomainError, EmptyAnswerError, StageWithLinkedCampaignError };
+export { EmptyAnswerError, StageWithLinkedCampaignError };

--- a/api/src/evaluation/domain/errors.js
+++ b/api/src/evaluation/domain/errors.js
@@ -11,4 +11,10 @@ class StageWithLinkedCampaignError extends DomainError {
   }
 }
 
-export { DomainError, StageWithLinkedCampaignError };
+class EmptyAnswerError extends DomainError {
+  constructor(message = 'The answer value cannot be empty', code = 'ANSWER_CANNOT_BE_EMPTY') {
+    super(message, code);
+  }
+}
+
+export { DomainError, EmptyAnswerError, StageWithLinkedCampaignError };

--- a/api/src/evaluation/domain/models/Answer.js
+++ b/api/src/evaluation/domain/models/Answer.js
@@ -60,6 +60,10 @@ class Answer {
     return _.isInteger(this.timeout) && this.timeout < 0;
   }
 
+  get hasValue() {
+    return Boolean(this.value);
+  }
+
   setTimeSpentFrom({ now, lastQuestionDate }) {
     this.timeSpent = Math.ceil((now.getTime() - lastQuestionDate.getTime()) / 1000);
   }

--- a/api/src/shared/application/assessments/assessment-controller.js
+++ b/api/src/shared/application/assessments/assessment-controller.js
@@ -12,6 +12,7 @@ import * as certificationVersionRepository from '../../../certification/course/i
 import { CertificationVersion } from '../../../certification/shared/domain/models/CertificationVersion.js';
 import * as certificationChallengeRepository from '../../../certification/shared/infrastructure/repositories/certification-challenge-repository.js';
 import { usecases as devcompUsecases } from '../../../devcomp/domain/usecases/index.js';
+import { Answer } from '../../../evaluation/domain/models/Answer.js';
 import * as competenceEvaluationSerializer from '../../../evaluation/infrastructure/serializers/jsonapi/competence-evaluation-serializer.js';
 import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { AssessmentEndedError } from '../../domain/errors.js';
@@ -133,11 +134,11 @@ const autoValidateNextChallenge = async function (request, h) {
   const locale = extractLocaleFromRequest(request);
   const assessment = await usecases.getAssessment({ assessmentId, locale });
   const userId = assessment.userId;
-  const fakeAnswer = {
+  const fakeAnswer = new Answer({
     assessmentId,
     challengeId: assessment.lastChallengeId,
     value: 'FAKE_ANSWER_WITH_AUTO_VALIDATE_NEXT_CHALLENGE',
-  };
+  });
   const validatorAlwaysOK = new ValidatorAlwaysOK();
   const alwaysTrueExaminer = new Examiner({ validator: validatorAlwaysOK });
   await usecases.correctAnswerThenUpdateAssessment({

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -5,6 +5,7 @@ import { extractLocaleFromRequest } from '../../../lib/infrastructure/utils/requ
 import * as translations from '../../../translations/index.js';
 import { AdminMemberError } from '../../authorization/domain/errors.js';
 import { CsvWithNoSessionDataError, SessionStartedDeletionError } from '../../certification/session/domain/errors.js';
+import { EmptyAnswerError } from '../../evaluation/domain/errors.js';
 import { ArchivedCampaignError } from '../../prescription/campaign/domain/errors.js';
 import { CampaignParticipationDeletedError } from '../../prescription/campaign-participation/domain/errors.js';
 import { AggregateImportError, SiecleXmlImportError } from '../../prescription/learner-management/domain/errors.js';
@@ -153,6 +154,10 @@ function _mapToHttpError(error) {
 
   if (error instanceof CampaignParticipationDeletedError) {
     return new HttpErrors.PreconditionFailedError(error.message);
+  }
+
+  if (error instanceof EmptyAnswerError) {
+    return new HttpErrors.BadRequestError(error.message, error.code);
   }
 
   return new HttpErrors.BaseHttpError(error.message);

--- a/api/tests/evaluation/acceptance/application/answers/answer-controller-save_test.js
+++ b/api/tests/evaluation/acceptance/application/answers/answer-controller-save_test.js
@@ -258,7 +258,7 @@ describe('Acceptance | Controller | answer-controller-save', function () {
       });
     });
 
-    context('when the answer is empty and timeout', function () {
+    context('when the answer is empty and has timed out', function () {
       beforeEach(function () {
         // given
         const learningContent = {
@@ -303,7 +303,7 @@ describe('Acceptance | Controller | answer-controller-save', function () {
               type: 'answers',
               attributes: {
                 value: '',
-                timeout: 25,
+                timeout: -1,
               },
               relationships: {
                 assessment: {
@@ -333,6 +333,83 @@ describe('Acceptance | Controller | answer-controller-save', function () {
 
         // then
         expect(response.statusCode).to.equal(201);
+      });
+    });
+
+    context('when the answer is empty but not in timeout', function () {
+      beforeEach(function () {
+        // given
+        const learningContent = {
+          areas: [{ id: 'recArea1', competenceIds: ['recCompetence'] }],
+          competences: [
+            {
+              id: 'recCompetence',
+              areaId: 'recArea1',
+              skillIds: ['recSkill1'],
+              origin: 'Pix',
+            },
+          ],
+          skills: [
+            {
+              id: 'recSkill1',
+              name: '@recArea1_Competence1_Tube1_Skill1',
+              status: 'actif',
+              competenceId: 'recCompetence',
+            },
+          ],
+          challenges: [
+            {
+              id: challengeId,
+              competenceId: 'recCompetence',
+              skillId: 'recSkill1',
+              status: 'validé',
+              solution: correctAnswer,
+              locales: ['fr-fr'],
+              proposals: '${a}',
+              type: 'QROC',
+            },
+          ],
+        };
+        mockLearningContent(learningContent);
+
+        postAnswersOptions = {
+          method: 'POST',
+          url: '/api/answers',
+          headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+          payload: {
+            data: {
+              type: 'answers',
+              attributes: {
+                value: '',
+              },
+              relationships: {
+                assessment: {
+                  data: {
+                    type: 'assessments',
+                    id: insertedAssessmentId,
+                  },
+                },
+                challenge: {
+                  data: {
+                    type: 'challenges',
+                    id: challengeId,
+                  },
+                },
+              },
+            },
+          },
+        };
+
+        // when
+        promise = server.inject(postAnswersOptions);
+      });
+
+      it('should return 400 HTTP status code', async function () {
+        // when
+        const response = await promise;
+
+        // then
+        expect(response.statusCode).to.equal(400);
       });
     });
   });

--- a/api/tests/evaluation/unit/application/answers/index_test.js
+++ b/api/tests/evaluation/unit/application/answers/index_test.js
@@ -1,9 +1,6 @@
-import { config } from '../../../../../lib/config.js';
 import { answerController } from '../../../../../src/evaluation/application/answers/answer-controller.js';
 import * as moduleUnderTest from '../../../../../src/evaluation/application/answers/index.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
-
-const { features } = config;
 
 describe('Unit | Application | Router | answer-router', function () {
   describe('POST /api/answers', function () {
@@ -33,35 +30,6 @@ describe('Unit | Application | Router | answer-router', function () {
 
       // then
       expect(response.statusCode).to.equal(201);
-    });
-
-    it('should return BAD_REQUEST with message if answer length is too long but does not (security issue)', async function () {
-      // given
-      sinon.stub(answerController, 'save').callsFake((request, h) => h.response().created());
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-      const value = 'X'.repeat(features.userAnswersMaxLength + 1);
-
-      const payload = {
-        data: {
-          attributes: {
-            value,
-            result: null,
-            'result-details': null,
-            timeout: null,
-          },
-          relationships: {},
-          assessment: {},
-          challenge: {},
-          type: 'answers',
-        },
-      };
-
-      // when
-      const response = await httpTestServer.request('POST', '/api/answers', payload);
-
-      // then
-      expect(response.statusCode).to.not.equal(400);
     });
   });
 

--- a/api/tests/evaluation/unit/domain/models/Answer_test.js
+++ b/api/tests/evaluation/unit/domain/models/Answer_test.js
@@ -170,6 +170,41 @@ describe('Unit | Domain | Models | Answer', function () {
     });
   });
 
+  describe('#hasValue', function () {
+    it('should return true if the answer has a value', function () {
+      // given
+      const answer = domainBuilder.buildAnswer({ value: 'super réponse' });
+
+      // when
+      const hasValue = answer.hasValue;
+
+      // then
+      expect(hasValue).to.be.true;
+    });
+
+    it('should return false if the answer has a null value', function () {
+      // given
+      const answer = domainBuilder.buildAnswer({ value: null });
+
+      // when
+      const hasValue = answer.hasValue;
+
+      // then
+      expect(hasValue).to.be.false;
+    });
+
+    it('should return false if the answer value is an empty string', function () {
+      // given
+      const answer = domainBuilder.buildAnswer({ value: '' });
+
+      // when
+      const hasValue = answer.hasValue;
+
+      // then
+      expect(hasValue).to.be.false;
+    });
+  });
+
   describe('#setTimeSpentFrom', function () {
     it('should return the computed time spent on a challenge', function () {
       // given


### PR DESCRIPTION
## :unicorn: Problème
Il est actuellement possible de soumettre des réponses avec des "value" vides, ce qui entraine des erreurs lors de la correction de la réponse. 
Il faut cependant prendre en compte le cas "time out" dans lequel il faut accepter une value vide.

## :robot: Proposition
Renvoyer une erreur 400 si la value est vide est que l'épreuve n'est pas "timed out"

## :rainbow: Remarques


## :100: Pour tester
Vérifier que le passage d'épreuves fonctionne toujours correctement

Tenter de soumettre une value vide avec Postman sur "POST/answers" sur une question qui n'est pas en timeout
Tenter de soumettre une value vide avec Postman sur "POST/answers" sur une questions en timeout (timeout -1)

Challenge avec timeout:
https://app-pr8582.review.pix.fr/challenges/recof7JBpSS8Y8FVa/preview
