### PR TITLE
[BUGFIX] Modifications modules expé : retours Lisa et bascule leçon <> activité

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
@@ -46,7 +46,7 @@
   "grains": [
     {
       "id": "1d516eb9-e7b7-48a3-a3b5-7971ad171d6f",
-      "type": "lesson",
+      "type": "activity",
       "title": "Étrange : ce site interne sait où je suis !",
       "elements": [
         {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -19,7 +19,7 @@
       "grainId": "34d225e8-5d52-4ebd-9acd-8bde8438cfc9"
     },
     {
-      "content": "<p>Et oui&#8239;! Naomi le sait&nbsp;: les adresses mails respectent un certain format.</p><p>Étudions en détails l’adresse mail de Mickaël.&nbsp;<span aria-hidden=\"true\">👨‍🏫👩‍🏫</span></p>",
+      "content": "<p>Et oui&#8239;! Naomi le sait&nbsp;: les adresses mails ont une forme particulière.</p><p>Étudions en détails l’adresse mail de Mickaël.&nbsp;<span aria-hidden=\"true\">👨‍🏫👩‍🏫</span></p>",
       "grainId": "af860b1e-0566-4b06-bcb4-a68a5151d621"
     },
     {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -15,7 +15,7 @@
   },
   "transitionTexts": [
     {
-      "content": "<p>Naomi a perdu l’adresse mail de son ami Mickaël. Elle n’arrive pas à la retrouver.&nbsp;<span aria-hidden=\"true\">🤷‍♀</span>️<br> Elle en a besoin pour envoyer un document à son ami. Naomi lui demande donc par SMS de lui redonner son adresse mail. <br> Lancez la vidéo pour voir leur discussion.&nbsp;<span aria-hidden=\"true\">📺</span></p>",
+      "content": "<p>Naomi a oublié l’adresse mail de son ami Mickaël.&nbsp;<span aria-hidden=\"true\">🤷‍♀</span>️<br> Elle en a besoin pour envoyer un document à son ami. Naomi lui demande donc par SMS de lui redonner son adresse mail. <br> Lancez la vidéo pour voir leur discussion.&nbsp;<span aria-hidden=\"true\">📺</span></p>",
       "grainId": "34d225e8-5d52-4ebd-9acd-8bde8438cfc9"
     },
     {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -113,7 +113,7 @@
         {
           "id": "1fd829f8-1799-4779-a28d-5d26fba31b8b",
           "type": "text",
-          "content": "<h3 class=\"screen-reader-only\">Le fournisseur d’adresse mail</h3><h4>Partie n°2&nbsp;: le fournisseur d’adresse mail. Cette partie de l’adresse est donnée par le fournisseur.</h4><p><span aria-hidden=\"true\">✅</span> Voici des exemples de fournisseurs d’adresses mail&nbsp;: </p><ul><li>La Poste (laposte.net)</li><li>Google (gmail.com)</li><li>Yahoo (yahoo.com)</li><li>Microsoft (hotmail.com, live.fr)</li></ul>"
+          "content": "<h3 class=\"screen-reader-only\">Le fournisseur d’adresse mail</h3><h4>Partie n°2&nbsp;: le fournisseur d’adresse mail. Cette partie de l’adresse est donnée par le fournisseur.</h4><p><span aria-hidden=\"true\">✅</span> Voici des exemples de fournisseurs d’adresses mail&nbsp;: </p><ul><li>La Poste (laposte.net)</li><li>Google (gmail.com)</li><li>Yahoo (yahoo.com, yahoo.fr)</li><li>Microsoft (hotmail.com, live.fr)</li></ul>"
         }
       ]
     },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
@@ -361,7 +361,7 @@
     },
     {
       "id": "6336bac0-c272-40cc-a002-ee724a5ec4c8",
-      "type": "lesson",
+      "type": "activity",
       "title": "Les conseils à donner à un ami",
       "elements": [
         {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
@@ -14,7 +14,7 @@
   },
   "transitionTexts": [
     {
-      "content": "<p>Sur un ordinateur, on peut souvent brancher des appareils, comme une souris ou un clavier.<br>On peut aussi brancher une clé USB, même si ce n’est pas toujours facile à faire.&nbsp;<span aria-hidden=\"true\">🤯</span></p>",
+      "content": "<p>Sur un ordinateur, on peut souvent brancher des appareils, comme une souris ou un clavier.Pour les brancher, il y a des prises de différentes formes : ce sont les ports de connexion.<br>On peut aussi brancher une clé USB, même si ce n’est pas toujours facile à faire.&nbsp;<span aria-hidden=\"true\">🤯</span></p>",
       "grainId": "8bb146db-104c-41e2-aa79-14f7a06e0930"
     },
     {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
@@ -34,7 +34,7 @@
       "grainId": "259bb2d0-8815-4bab-885a-a54f7d6d9606"
     },
     {
-      "content": "<p>Pour finir ce module, à vous de jouer en reconnaissant les ports de votre ordinateur.</p>",
+      "content": "<p>Pour finir ce module, vous allez devoir explorer les ports de connexion de votre propre ordinateur.À vous de jouer&#8239;!</p>",
       "grainId": "57cea880-a324-4a1b-8cfe-a7c8d1b0f5b1"
     }
   ],
@@ -448,7 +448,7 @@
         {
           "id": "e6730d81-c115-4821-a415-4f719a252746",
           "type": "text",
-          "content": "<h3>Trouvez et nommez tous les ports de connexion de votre ordinateur.</h3>"
+          "content": "<h3>Cherchez et nommez tous les ports de connexion de votre ordinateur.</h3>"
         },
         {
           "id": "e6c1fdff-e2a3-4108-a1f8-245dc7e3668f",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
@@ -178,7 +178,7 @@
         {
           "id": "6f276b50-a00c-49f7-b22c-23dbef0c2bf2",
           "type": "image",
-          "url": "https://i.imgur.com/gn9ppqZ.jpeg",
+          "url": "https://i.imgur.com/9VHmIUG.jpeg",
           "alt": "Une souris d'ordinateur",
           "alternativeText": ""
         },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
@@ -277,7 +277,7 @@
     },
     {
       "id": "cbf15e50-8f82-47a6-affd-8494c688b606",
-      "type": "lesson",
+      "type": "activity",
       "title": "Trouver efficacement des informations dans un article Wikipédia",
       "elements": [
         {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
@@ -46,7 +46,7 @@
   "grains": [
     {
       "id": "da95d2bc-e597-4366-a095-21f7ab0f4845",
-      "type": "lesson",
+      "type": "activity",
       "title": "Wikipédia : un site de référence !",
       "elements": [
         {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
@@ -265,7 +265,7 @@
         {
           "id": "714fd0bb-9252-4c53-a1a2-ce4168e76a1b",
           "type": "text",
-          "content": "<p>Pour chaque publication, choisissez si elle est fiable, humoristique ou parodique.</p>"
+          "content": "<p>Pour chaque publication, choisissez si elle est fiable, humoristique ou contestable.</p>"
         },
         {
           "id": "d1fa2ea9-1a79-440a-81e4-b2fbee429740",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
@@ -273,42 +273,6 @@
           "content": "<hr>"
         },
         {
-          "id": "966d5373-3bb5-434c-ae3f-04dfa16a7e4c",
-          "type": "image",
-          "url": "https://i.imgur.com/R4Duhiy.png",
-          "alt": "Publication de franceinfo (@franceinfo) sur X (Twitter) décrite dans l'alternative textuelle",
-          "alternativeText": "Publication de franceinfo (@franceinfo) sur X (Twitter) à 15h57 le 6 février 2023&nbsp;: &laquo;&nbsp;Dans un Ehpad du Bas-Rhin, des chiens s'entraînent à détecter le Covid-19. Retrouvez cet article et l'association Handi'Chiens sur notre site.&nbsp;&raquo;"
-        },
-        {
-          "id": "69460323-29ca-4859-9581-fd67bc4cc84b",
-          "type": "qcu",
-          "instruction": "<p>Quel mot décrit le mieux cette source&#8239;?</p>",
-          "proposals": [
-            {
-              "id": "1",
-              "content": "fiable"
-            },
-            {
-              "id": "2",
-              "content": "humoristique"
-            },
-            {
-              "id": "3",
-              "content": "contestable"
-            }
-          ],
-          "feedbacks": {
-            "valid": "<p>Correct. Ce journal est reconnu et vérifie les informations qu’il publie. Ces informations sont donc très souvent vraies.</p>",
-            "invalid": "<p>Incorrect. Ce journal est reconnu et vérifie les informations qu’il publie. Ces informations sont donc très souvent vraies.</p>"
-          },
-          "solution": "1"
-        },
-        {
-          "id": "a9bd5509-7aa0-4ad1-b3db-e83875bfacbe",
-          "type": "text",
-          "content": "<hr>"
-        },
-        {
           "id": "276594e5-b95b-4fa3-8b93-ba8138669d70",
           "type": "image",
           "url": "https://i.imgur.com/6RtSHW0.png",
@@ -338,6 +302,42 @@
             "invalid": "<p>Incorrect. Les publications de JournalDeBlagues ont pour objectif de faire rire.</p>"
           },
           "solution": "2"
+        },
+        {
+          "id": "a9bd5509-7aa0-4ad1-b3db-e83875bfacbe",
+          "type": "text",
+          "content": "<hr>"
+        },
+        {
+          "id": "966d5373-3bb5-434c-ae3f-04dfa16a7e4c",
+          "type": "image",
+          "url": "https://i.imgur.com/R4Duhiy.png",
+          "alt": "Publication de franceinfo (@franceinfo) sur X (Twitter) décrite dans l'alternative textuelle",
+          "alternativeText": "Publication de franceinfo (@franceinfo) sur X (Twitter) à 15h57 le 6 février 2023&nbsp;: &laquo;&nbsp;Dans un Ehpad du Bas-Rhin, des chiens s'entraînent à détecter le Covid-19. Retrouvez cet article et l'association Handi'Chiens sur notre site.&nbsp;&raquo;"
+        },
+        {
+          "id": "69460323-29ca-4859-9581-fd67bc4cc84b",
+          "type": "qcu",
+          "instruction": "<p>Quel mot décrit le mieux cette source&#8239;?</p>",
+          "proposals": [
+            {
+              "id": "1",
+              "content": "fiable"
+            },
+            {
+              "id": "2",
+              "content": "humoristique"
+            },
+            {
+              "id": "3",
+              "content": "contestable"
+            }
+          ],
+          "feedbacks": {
+            "valid": "<p>Correct. Ce journal est reconnu et vérifie les informations qu’il publie. Ces informations sont donc très souvent vraies.</p>",
+            "invalid": "<p>Incorrect. Ce journal est reconnu et vérifie les informations qu’il publie. Ces informations sont donc très souvent vraies.</p>"
+          },
+          "solution": "1"
         },
         {
           "id": "a9bd5509-7aa0-4ad1-b3db-e83875bfacbe",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
@@ -42,7 +42,7 @@
   "grains": [
     {
       "id": "652a469a-36b8-41ae-8cc5-1853b35d08ef",
-      "type": "lesson",
+      "type": "activity",
       "title": "Les JO d’hiver 2029 dans le désert : info ou rumeur ?",
       "elements": [
         {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
@@ -223,7 +223,7 @@
         {
           "id": "d0a2bb58-be8e-4f75-a626-8ac387771dfe",
           "type": "text",
-          "content": "<p>Après cette leçon, vous devrez classer des sources sur des exemples concrets.</p>"
+          "content": "<p>Après cette leçon, des publications vous seront présentées. Vous devrez choisir pour chaque publication le type de source correspondant.</p>"
         },
         {
           "id": "bb24db79-0624-4d43-b1bb-a5510ba12c40",


### PR DESCRIPTION
## :unicorn: Problème

- certains contenus devaient être améliorés, suite à la relecture de Lisa sur les modules bas niveaux (cf. https://docs.google.com/document/d/1IZk6T4U0ct8z4mRGtZvv0LYLzszPXeNcNwtJVZPsVI8/edit)

- par ailleurs, maintenant que le type de grains (leçon ou activité) est affiché à l'utilisateur, quelques modifications à faire sur des changements de statuts (coquilles ou choix : si au moins 1 réponse à donner dans le grain, c'est une activité) 

## :robot: Proposition
Passer les modifications

## :rainbow: Remarques
Certains retours de Lisa seront discutés par ailleurs car demande plus de travail
## :100: Pour tester
Suivre les liens vers les modules et constater les modifications
