### PR TITLE
[FEATURE] Informer le candidat si sa langue n'est pas disponible en certif V3 (PIX-11280).

### DIFF
--- a/api/lib/domain/models/User.js
+++ b/api/lib/domain/models/User.js
@@ -112,10 +112,6 @@ class User {
     }
   }
 
-  isLanguageAvailableForV3Certification() {
-    return this.dependencies.languageService.isLanguageAvailableForV3Certification(this.lang);
-  }
-
   isLinkedToOrganizations() {
     return this.memberships.length > 0;
   }

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -52,6 +52,7 @@ import * as missionRepository from '../../../src/school/infrastructure/repositor
 import * as schoolRepository from '../../../src/school/infrastructure/repositories/school-repository.js';
 import * as codeGenerator from '../../../src/shared/domain/services/code-generator.js';
 import * as cryptoService from '../../../src/shared/domain/services/crypto-service.js';
+import * as languageService from '../../../src/shared/domain/services/language-service.js';
 import { tokenService } from '../../../src/shared/domain/services/token-service.js';
 import * as adminMemberRepository from '../../../src/shared/infrastructure/repositories/admin-member-repository.js';
 import * as answerRepository from '../../../src/shared/infrastructure/repositories/answer-repository.js';
@@ -294,6 +295,7 @@ const dependencies = {
   learningContentConversionService,
   learningContentRepository,
   localeService,
+  languageService,
   mailService,
   membershipRepository,
   missionRepository,

--- a/api/lib/domain/usecases/link-user-to-session-certification-candidate.js
+++ b/api/lib/domain/usecases/link-user-to-session-certification-candidate.js
@@ -39,7 +39,7 @@ const linkUserToSessionCertificationCandidate = async function ({
     const isUserLanguageValid = _validateUserLanguage(languageService, user.lang);
 
     if (!isUserLanguageValid) {
-      throw new LanguageNotSupportedError();
+      throw new LanguageNotSupportedError(user.lang);
     }
   }
 

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -2,6 +2,7 @@ import bluebird from 'bluebird';
 
 import { CertificationCourse } from '../../../src/certification/shared/domain/models/CertificationCourse.js';
 import { CertificationVersion } from '../../../src/certification/shared/domain/models/CertificationVersion.js';
+import { LanguageNotSupportedError } from '../../../src/shared/domain/errors.js';
 import { Assessment } from '../../../src/shared/domain/models/Assessment.js';
 import { config } from '../../config.js';
 import {
@@ -76,7 +77,7 @@ const retrieveLastOrCreateCertificationCourse = async function ({
     const isUserLanguageValid = _validateUserLanguage(languageService, user.lang);
 
     if (!isUserLanguageValid) {
-      throw new Error(`Cant create a certification course in ${user.lang}`);
+      throw new LanguageNotSupportedError(user.lang);
     }
 
     lang = user.lang;

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -33,6 +33,7 @@ const retrieveLastOrCreateCertificationCourse = async function ({
   placementProfileService,
   certificationBadgesService,
   verifyCertificateCodeService,
+  languageService,
 }) {
   const session = await sessionRepository.get({ id: sessionId });
 
@@ -72,7 +73,7 @@ const retrieveLastOrCreateCertificationCourse = async function ({
   let lang;
   if (version === CertificationVersion.V3) {
     const user = await userRepository.get(userId);
-    const isUserLanguageValid = _validateUserLanguage(user);
+    const isUserLanguageValid = _validateUserLanguage(languageService, user.lang);
 
     if (!isUserLanguageValid) {
       throw new Error(`Cant create a certification course in ${user.lang}`);
@@ -102,8 +103,8 @@ const retrieveLastOrCreateCertificationCourse = async function ({
 
 export { retrieveLastOrCreateCertificationCourse };
 
-function _validateUserLanguage(user) {
-  return user.isLanguageAvailableForV3Certification();
+function _validateUserLanguage(languageService, userLanguage) {
+  return CertificationCourse.isLanguageAvailableForV3Certification(languageService, userLanguage);
 }
 
 function _validateSessionAccess(session, accessCode) {

--- a/api/src/certification/shared/domain/models/CertificationCourse.js
+++ b/api/src/certification/shared/domain/models/CertificationCourse.js
@@ -268,6 +268,10 @@ class CertificationCourse {
     return this._version === CertificationVersion.V3;
   }
 
+  static isLanguageAvailableForV3Certification(languageService, candidateLanguage) {
+    return languageService.isLanguageAvailableForV3Certification(candidateLanguage);
+  }
+
   toDTO() {
     return {
       id: this._id,

--- a/api/tests/certification/shared/unit/domain/models/CertificationCourse_test.js
+++ b/api/tests/certification/shared/unit/domain/models/CertificationCourse_test.js
@@ -1,5 +1,7 @@
+import { CertificationCourse } from '../../../../../../src/certification/shared/domain/models/CertificationCourse.js';
 import { CertificationVersion } from '../../../../../../src/certification/shared/domain/models/CertificationVersion.js';
 import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
+import * as languageService from '../../../../../../src/shared/domain/services/language-service.js';
 import { domainBuilder, expect } from '../../../../../test-helper.js';
 import { generateChallengeList } from '../../../fixtures/challenges.js';
 
@@ -353,6 +355,34 @@ describe('Unit | Domain | Models | CertificationCourse', function () {
         // then
         expect(computedNumberOfChallenges).to.equal(numberOfChallenges);
       });
+    });
+  });
+
+  describe('#isLanguageAvailableForV3Certification', function () {
+    it('should be true if user language is available for certification', function () {
+      // given
+      const user = domainBuilder.buildUser({
+        lang: 'en',
+      });
+
+      // when
+      const isAvailable = CertificationCourse.isLanguageAvailableForV3Certification(languageService, user.lang);
+
+      //then
+      expect(isAvailable).to.be.true;
+    });
+
+    it('should be false if user language is NOT available for certification', function () {
+      // given
+      const user = domainBuilder.buildUser({
+        lang: 'nl',
+      });
+
+      // when
+      const isAvailable = CertificationCourse.isLanguageAvailableForV3Certification(languageService, user.lang);
+
+      //then
+      expect(isAvailable).to.be.false;
     });
   });
 });

--- a/api/tests/unit/domain/models/User_test.js
+++ b/api/tests/unit/domain/models/User_test.js
@@ -122,34 +122,6 @@ describe('Unit | Domain | Models | User', function () {
     });
   });
 
-  describe('isLanguageAvailableForV3Certification', function () {
-    it('should be true if user language is available for certification', function () {
-      // given
-      const user = domainBuilder.buildUser({
-        lang: 'en',
-      });
-
-      // when
-      const isAvailable = user.isLanguageAvailableForV3Certification();
-
-      //then
-      expect(isAvailable).to.be.true;
-    });
-
-    it('should be false if user language is NOT available for certification', function () {
-      // given
-      const user = domainBuilder.buildUser({
-        lang: 'nl',
-      });
-
-      // when
-      const isAvailable = user.isLanguageAvailableForV3Certification();
-
-      //then
-      expect(isAvailable).to.be.false;
-    });
-  });
-
   describe('isLinkedToOrganizations', function () {
     it('should be true if user has a role in an organization', function () {
       // given

--- a/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
+++ b/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
@@ -9,6 +9,7 @@ import {
 import { UserAlreadyLinkedToCertificationCandidate } from '../../../../lib/domain/events/UserAlreadyLinkedToCertificationCandidate.js';
 import { UserLinkedToCertificationCandidate } from '../../../../lib/domain/events/UserLinkedToCertificationCandidate.js';
 import { linkUserToSessionCertificationCandidate } from '../../../../lib/domain/usecases/link-user-to-session-certification-candidate.js';
+import { LanguageNotSupportedError } from '../../../../src/shared/domain/errors.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';
 
 describe('Unit | Domain | Use Cases | link-user-to-session-certification-candidate', function () {
@@ -18,72 +19,41 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
   const lastName = 'Bideau';
   const birthdate = '2010-10-10';
 
-  context('when the session is not accessible', function () {
-    it('should throw a SessionNotAccessible error', async function () {
-      // given
-      const sessionRepository = {
-        get: sinon.stub(),
-      };
-      sessionRepository.get.withArgs({ id: 42 }).resolves(domainBuilder.buildSession.finalized());
+  context('when the session is V2 or V3 (common context)', function () {
+    context('when the session is not accessible', function () {
+      it('should throw a SessionNotAccessible error', async function () {
+        // given
+        const sessionRepository = {
+          get: sinon.stub(),
+        };
+        sessionRepository.get.withArgs({ id: 42 }).resolves(domainBuilder.buildSession.finalized());
 
-      // when
-      const err = await catchErr(linkUserToSessionCertificationCandidate)({
-        sessionId,
-        userId,
-        firstName,
-        lastName,
-        birthdate,
-        sessionRepository,
-      });
-
-      // then
-      expect(err).to.be.instanceOf(SessionNotAccessible);
-    });
-  });
-
-  context('when the session is accessible', function () {
-    const sessionRepository = { get: () => undefined };
-
-    beforeEach(function () {
-      sessionRepository.get = sinon.stub();
-      sessionRepository.get.withArgs({ id: 42 }).resolves(domainBuilder.buildSession.created());
-    });
-
-    context('when there is a problem with the personal info', function () {
-      context('when no certification candidates match with the provided personal info', function () {
-        it('should throw a CertificationCandidateByPersonalInfoNotFoundError', async function () {
-          // given
-          const certificationCandidateRepository =
-            _buildFakeCertificationCandidateRepository().withFindBySessionIdAndPersonalInfo({
-              args: {
-                sessionId,
-                firstName,
-                lastName,
-                birthdate,
-              },
-              resolves: [],
-            });
-
-          // when
-          const err = await catchErr(linkUserToSessionCertificationCandidate)({
-            sessionId,
-            userId,
-            firstName,
-            lastName,
-            birthdate,
-            sessionRepository,
-            certificationCandidateRepository,
-          });
-
-          // then
-          expect(err).to.be.instanceOf(CertificationCandidateByPersonalInfoNotFoundError);
+        // when
+        const err = await catchErr(linkUserToSessionCertificationCandidate)({
+          sessionId,
+          userId,
+          firstName,
+          lastName,
+          birthdate,
+          sessionRepository,
         });
+
+        // then
+        expect(err).to.be.instanceOf(SessionNotAccessible);
+      });
+    });
+
+    context('when the session is accessible', function () {
+      const sessionRepository = { get: () => undefined };
+
+      beforeEach(function () {
+        sessionRepository.get = sinon.stub();
+        sessionRepository.get.withArgs({ id: 42 }).resolves(domainBuilder.buildSession.created());
       });
 
-      context(
-        'when there are more than one certification candidates that match with the provided personal info',
-        function () {
-          it('should throw a CertificationCandidateByPersonalInfoTooManyMatchesError', async function () {
+      context('when there is a problem with the personal info', function () {
+        context('when no certification candidates match with the provided personal info', function () {
+          it('should throw a CertificationCandidateByPersonalInfoNotFoundError', async function () {
             // given
             const certificationCandidateRepository =
               _buildFakeCertificationCandidateRepository().withFindBySessionIdAndPersonalInfo({
@@ -93,7 +63,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
                   lastName,
                   birthdate,
                 },
-                resolves: ['candidate1', 'candidate2'],
+                resolves: [],
               });
 
             // when
@@ -108,145 +78,231 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
             });
 
             // then
-            expect(err).to.be.instanceOf(CertificationCandidateByPersonalInfoTooManyMatchesError);
+            expect(err).to.be.instanceOf(CertificationCandidateByPersonalInfoNotFoundError);
+          });
+        });
+
+        context(
+          'when there are more than one certification candidates that match with the provided personal info',
+          function () {
+            it('should throw a CertificationCandidateByPersonalInfoTooManyMatchesError', async function () {
+              // given
+              const certificationCandidateRepository =
+                _buildFakeCertificationCandidateRepository().withFindBySessionIdAndPersonalInfo({
+                  args: {
+                    sessionId,
+                    firstName,
+                    lastName,
+                    birthdate,
+                  },
+                  resolves: ['candidate1', 'candidate2'],
+                });
+
+              // when
+              const err = await catchErr(linkUserToSessionCertificationCandidate)({
+                sessionId,
+                userId,
+                firstName,
+                lastName,
+                birthdate,
+                sessionRepository,
+                certificationCandidateRepository,
+              });
+
+              // then
+              expect(err).to.be.instanceOf(CertificationCandidateByPersonalInfoTooManyMatchesError);
+            });
+          },
+        );
+      });
+
+      context(
+        'when there is exactly one certification candidate that matches with the provided personal info',
+        function () {
+          context('when the matching certification candidate is already linked to a user', function () {
+            context('when the linked user is the same as the user being linked', function () {
+              it('should not create a link and return the matching certification candidate', async function () {
+                // given
+                const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId });
+                const certificationCandidateRepository =
+                  _buildFakeCertificationCandidateRepository().withFindBySessionIdAndPersonalInfo({
+                    args: {
+                      sessionId,
+                      firstName,
+                      lastName,
+                      birthdate,
+                    },
+                    resolves: [certificationCandidate],
+                  });
+
+                const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SUP' });
+                const certificationCenterRepository = _buildFakeCertificationCenterRepository().withGetBySessionId({
+                  args: { sessionId },
+                  resolves: certificationCenter,
+                });
+
+                // when
+                const result = await linkUserToSessionCertificationCandidate({
+                  sessionId,
+                  userId,
+                  firstName,
+                  lastName,
+                  birthdate,
+                  sessionRepository,
+                  certificationCandidateRepository,
+                  certificationCenterRepository,
+                });
+
+                // then
+                expect(result).to.deep.equal(new UserAlreadyLinkedToCertificationCandidate());
+              });
+            });
+
+            context('when the linked user is not the same as the user being linked', function () {
+              it('should throw a CertificationCandidateAlreadyLinkedToUserError', async function () {
+                // given
+                const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId: 'otherUserId' });
+                const certificationCandidateRepository =
+                  _buildFakeCertificationCandidateRepository().withFindBySessionIdAndPersonalInfo({
+                    args: {
+                      sessionId,
+                      firstName,
+                      lastName,
+                      birthdate,
+                    },
+                    resolves: [certificationCandidate],
+                  });
+
+                const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SUP' });
+                const certificationCenterRepository = _buildFakeCertificationCenterRepository().withGetBySessionId({
+                  args: { sessionId },
+                  resolves: certificationCenter,
+                });
+
+                // when
+                const err = await catchErr(linkUserToSessionCertificationCandidate)({
+                  sessionId,
+                  userId,
+                  firstName,
+                  lastName,
+                  birthdate,
+                  sessionRepository,
+                  certificationCandidateRepository,
+                  certificationCenterRepository,
+                });
+
+                // then
+                expect(err).to.be.instanceOf(UnexpectedUserAccountError);
+              });
+            });
+          });
+
+          context('when the matching certification candidate has no link to any user', function () {
+            context('when the user is already linked to another candidate in the session', function () {
+              it('should throw a UserAlreadyLinkedToCandidateInSessionError', async function () {
+                // given
+                const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId: null });
+                const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
+                  .withFindBySessionIdAndPersonalInfo({
+                    args: {
+                      sessionId,
+                      firstName,
+                      lastName,
+                      birthdate,
+                    },
+                    resolves: [certificationCandidate],
+                  })
+                  .withFindOneBySessionIdAndUserId({
+                    args: { sessionId, userId },
+                    resolves: 'existingLinkedCandidateToUser',
+                  });
+
+                const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SUP' });
+                const certificationCenterRepository = _buildFakeCertificationCenterRepository().withGetBySessionId({
+                  args: { sessionId },
+                  resolves: certificationCenter,
+                });
+
+                // when
+                const err = await catchErr(linkUserToSessionCertificationCandidate)({
+                  sessionId,
+                  userId,
+                  firstName,
+                  lastName,
+                  birthdate,
+                  sessionRepository,
+                  certificationCandidateRepository,
+                  certificationCenterRepository,
+                });
+
+                // then
+                expect(err).to.be.instanceOf(UserAlreadyLinkedToCandidateInSessionError);
+              });
+            });
+
+            context('when the user is not linked to any candidate in this session', function () {
+              it('should create a link between the candidate and the user and return the linked certification candidate', async function () {
+                // given
+                const certificationCandidate = domainBuilder.buildCertificationCandidate({
+                  userId: null,
+                  id: 'candidateId',
+                });
+                const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
+                  .withFindBySessionIdAndPersonalInfo({
+                    args: {
+                      sessionId,
+                      firstName,
+                      lastName,
+                      birthdate,
+                    },
+                    resolves: [certificationCandidate],
+                  })
+                  .withFindOneBySessionIdAndUserId({ args: { sessionId, userId }, resolves: undefined })
+                  .withLinkToUser({});
+
+                const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SUP' });
+                const certificationCenterRepository = _buildFakeCertificationCenterRepository().withGetBySessionId({
+                  args: { sessionId },
+                  resolves: certificationCenter,
+                });
+
+                // when
+                const result = await linkUserToSessionCertificationCandidate({
+                  sessionId,
+                  userId,
+                  firstName,
+                  lastName,
+                  birthdate,
+                  sessionRepository,
+                  certificationCandidateRepository,
+                  certificationCenterRepository,
+                });
+
+                // then
+                expect(result).to.deep.equal(new UserAlreadyLinkedToCertificationCandidate());
+                sinon.assert.calledWith(certificationCandidateRepository.linkToUser, {
+                  id: certificationCandidate.id,
+                  userId,
+                });
+              });
+            });
           });
         },
       );
-    });
 
-    context(
-      'when there is exactly one certification candidate that matches with the provided personal info',
-      function () {
-        context('when the matching certification candidate is already linked to a user', function () {
-          context('when the linked user is the same as the user being linked', function () {
-            it('should not create a link and return the matching certification candidate', async function () {
-              // given
-              const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId });
-              const certificationCandidateRepository =
-                _buildFakeCertificationCandidateRepository().withFindBySessionIdAndPersonalInfo({
-                  args: {
-                    sessionId,
-                    firstName,
-                    lastName,
-                    birthdate,
-                  },
-                  resolves: [certificationCandidate],
-                });
-
-              const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SUP' });
-              const certificationCenterRepository = _buildFakeCertificationCenterRepository().withGetBySessionId({
-                args: { sessionId },
-                resolves: certificationCenter,
-              });
-
-              // when
-              const result = await linkUserToSessionCertificationCandidate({
-                sessionId,
-                userId,
-                firstName,
-                lastName,
-                birthdate,
-                sessionRepository,
-                certificationCandidateRepository,
-                certificationCenterRepository,
-              });
-
-              // then
-              expect(result).to.deep.equal(new UserAlreadyLinkedToCertificationCandidate());
-            });
-          });
-
-          context('when the linked user is not the same as the user being linked', function () {
-            it('should throw a CertificationCandidateAlreadyLinkedToUserError', async function () {
-              // given
-              const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId: 'otherUserId' });
-              const certificationCandidateRepository =
-                _buildFakeCertificationCandidateRepository().withFindBySessionIdAndPersonalInfo({
-                  args: {
-                    sessionId,
-                    firstName,
-                    lastName,
-                    birthdate,
-                  },
-                  resolves: [certificationCandidate],
-                });
-
-              const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SUP' });
-              const certificationCenterRepository = _buildFakeCertificationCenterRepository().withGetBySessionId({
-                args: { sessionId },
-                resolves: certificationCenter,
-              });
-
-              // when
-              const err = await catchErr(linkUserToSessionCertificationCandidate)({
-                sessionId,
-                userId,
-                firstName,
-                lastName,
-                birthdate,
-                sessionRepository,
-                certificationCandidateRepository,
-                certificationCenterRepository,
-              });
-
-              // then
-              expect(err).to.be.instanceOf(UnexpectedUserAccountError);
-            });
-          });
-        });
-
-        context('when the matching certification candidate has no link to any user', function () {
-          context('when the user is already linked to another candidate in the session', function () {
-            it('should throw a UserAlreadyLinkedToCandidateInSessionError', async function () {
-              // given
-              const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId: null });
-              const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
-                .withFindBySessionIdAndPersonalInfo({
-                  args: {
-                    sessionId,
-                    firstName,
-                    lastName,
-                    birthdate,
-                  },
-                  resolves: [certificationCandidate],
-                })
-                .withFindOneBySessionIdAndUserId({
-                  args: { sessionId, userId },
-                  resolves: 'existingLinkedCandidateToUser',
-                });
-
-              const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SUP' });
-              const certificationCenterRepository = _buildFakeCertificationCenterRepository().withGetBySessionId({
-                args: { sessionId },
-                resolves: certificationCenter,
-              });
-
-              // when
-              const err = await catchErr(linkUserToSessionCertificationCandidate)({
-                sessionId,
-                userId,
-                firstName,
-                lastName,
-                birthdate,
-                sessionRepository,
-                certificationCandidateRepository,
-                certificationCenterRepository,
-              });
-
-              // then
-              expect(err).to.be.instanceOf(UserAlreadyLinkedToCandidateInSessionError);
-            });
-          });
-
-          context('when the user is not linked to any candidate in this session', function () {
-            it('should create a link between the candidate and the user and return the linked certification candidate', async function () {
+      context('when the organization behind this session is of type SCO', function () {
+        context('when the organization is also managing students', function () {
+          context('when the user does not match with a session candidate and its organization learner', function () {
+            it('throws MatchingReconciledStudentNotFoundError', async function () {
               // given
               const certificationCandidate = domainBuilder.buildCertificationCandidate({
                 userId: null,
-                id: 'candidateId',
+                firstName,
+                lastName,
+                birthdate,
               });
-              const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
-                .withFindBySessionIdAndPersonalInfo({
+              const certificationCandidateRepository =
+                _buildFakeCertificationCandidateRepository().withFindBySessionIdAndPersonalInfo({
                   args: {
                     sessionId,
                     firstName,
@@ -254,18 +310,35 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
                     birthdate,
                   },
                   resolves: [certificationCandidate],
-                })
-                .withFindOneBySessionIdAndUserId({ args: { sessionId, userId }, resolves: undefined })
-                .withLinkToUser({});
+                });
 
-              const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SUP' });
+              const certificationCenter = domainBuilder.buildCertificationCenter({
+                sessionId,
+                type: 'SCO',
+                externalId: '123456',
+              });
               const certificationCenterRepository = _buildFakeCertificationCenterRepository().withGetBySessionId({
                 args: { sessionId },
                 resolves: certificationCenter,
               });
+              const organization = domainBuilder.buildOrganization({
+                type: 'SCO',
+                isManagingStudents: true,
+                externalId: '123456',
+              });
+              const organizationRepository = _buildFakeOrganizationRepository().withGetScoOrganizationByExternalId({
+                args: '123456',
+                resolves: organization,
+              });
+
+              const organizationLearnerRepository =
+                _buildFakeOrganizationLearnerRepository().withIsOrganizationLearnerIdLinkedToUserAndSCOOrganization({
+                  args: { userId, organizationLearnerId: certificationCandidate.organizationLearnerId },
+                  resolves: false,
+                });
 
               // when
-              const result = await linkUserToSessionCertificationCandidate({
+              const err = await catchErr(linkUserToSessionCertificationCandidate)({
                 sessionId,
                 userId,
                 firstName,
@@ -273,34 +346,184 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
                 birthdate,
                 sessionRepository,
                 certificationCandidateRepository,
+                organizationLearnerRepository,
                 certificationCenterRepository,
+                organizationRepository,
               });
 
               // then
-              expect(result).to.deep.equal(new UserAlreadyLinkedToCertificationCandidate());
-              sinon.assert.calledWith(certificationCandidateRepository.linkToUser, {
-                id: certificationCandidate.id,
-                userId,
+              expect(err).to.be.instanceOf(MatchingReconciledStudentNotFoundError);
+            });
+          });
+
+          context('when the user matches with a session candidate and its organization learner', function () {
+            context('when no other candidates is already linked to that user', function () {
+              it('should create a link between the candidate and the user and return an event to notify it, ', async function () {
+                // given
+                const organizationLearner = domainBuilder.buildOrganizationLearner();
+                const certificationCandidate = domainBuilder.buildCertificationCandidate({
+                  userId: null,
+                  firstName,
+                  lastName,
+                  birthdate,
+                  organizationLearnerId: organizationLearner.id,
+                });
+                const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
+                  .withFindBySessionIdAndPersonalInfo({
+                    args: {
+                      sessionId,
+                      firstName,
+                      lastName,
+                      birthdate,
+                    },
+                    resolves: [certificationCandidate],
+                  })
+                  .withFindOneBySessionIdAndUserId({
+                    args: {
+                      sessionId,
+                      userId,
+                    },
+                    resolves: null,
+                  });
+
+                const certificationCenter = domainBuilder.buildCertificationCenter({
+                  sessionId,
+                  type: 'SCO',
+                  externalId: '123456',
+                });
+                const certificationCenterRepository = _buildFakeCertificationCenterRepository().withGetBySessionId({
+                  args: { sessionId },
+                  resolves: certificationCenter,
+                });
+                const organization = domainBuilder.buildOrganization({
+                  type: 'SCO',
+                  isManagingStudents: true,
+                  externalId: '123456',
+                });
+                const organizationRepository = _buildFakeOrganizationRepository().withGetScoOrganizationByExternalId({
+                  args: '123456',
+                  resolves: organization,
+                });
+
+                const organizationLearnerRepository =
+                  _buildFakeOrganizationLearnerRepository().withIsOrganizationLearnerIdLinkedToUserAndSCOOrganization({
+                    args: { userId, organizationLearnerId: certificationCandidate.organizationLearnerId },
+                    resolves: true,
+                  });
+
+                // when
+                const event = await linkUserToSessionCertificationCandidate({
+                  sessionId,
+                  userId,
+                  firstName,
+                  lastName,
+                  birthdate,
+                  sessionRepository,
+                  certificationCandidateRepository,
+                  organizationLearnerRepository,
+                  certificationCenterRepository,
+                  organizationRepository,
+                });
+
+                // then
+                expect(certificationCandidateRepository.linkToUser).to.have.been.calledWithExactly({
+                  id: certificationCandidate.id,
+                  userId,
+                });
+                expect(
+                  organizationLearnerRepository.isOrganizationLearnerIdLinkedToUserAndSCOOrganization,
+                ).to.have.been.calledWithExactly({ userId, organizationLearnerId: organizationLearner.id });
+                expect(event).to.be.instanceOf(UserLinkedToCertificationCandidate);
+              });
+            });
+
+            context('when another candidates is already linked to that user', function () {
+              it('throws UserAlreadyLinkedToCandidateInSessionError', async function () {
+                // given
+                const organizationLearner = domainBuilder.buildOrganizationLearner();
+                const certificationCandidate = domainBuilder.buildCertificationCandidate({
+                  userId: null,
+                  firstName,
+                  lastName,
+                  birthdate,
+                  organizationLearnerId: organizationLearner.id,
+                });
+                const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
+                  .withFindBySessionIdAndPersonalInfo({
+                    args: {
+                      sessionId,
+                      firstName,
+                      lastName,
+                      birthdate,
+                    },
+                    resolves: [certificationCandidate],
+                  })
+                  .withFindOneBySessionIdAndUserId({
+                    args: {
+                      sessionId,
+                      userId,
+                    },
+                    resolves: domainBuilder.buildCertificationCandidate({ id: 'another candidate' }),
+                  });
+
+                const certificationCenter = domainBuilder.buildCertificationCenter({
+                  sessionId,
+                  type: 'SCO',
+                  externalId: '123456',
+                });
+                const certificationCenterRepository = _buildFakeCertificationCenterRepository().withGetBySessionId({
+                  args: { sessionId },
+                  resolves: certificationCenter,
+                });
+                const organization = domainBuilder.buildOrganization({
+                  type: 'SCO',
+                  isManagingStudents: true,
+                  externalId: '123456',
+                });
+                const organizationRepository = _buildFakeOrganizationRepository().withGetScoOrganizationByExternalId({
+                  args: '123456',
+                  resolves: organization,
+                });
+
+                const organizationLearnerRepository =
+                  _buildFakeOrganizationLearnerRepository().withIsOrganizationLearnerIdLinkedToUserAndSCOOrganization({
+                    args: { userId, organizationLearnerId: certificationCandidate.organizationLearnerId },
+                    resolves: true,
+                  });
+
+                // when
+                const error = await catchErr(linkUserToSessionCertificationCandidate)({
+                  sessionId,
+                  userId,
+                  firstName,
+                  lastName,
+                  birthdate,
+                  sessionRepository,
+                  certificationCandidateRepository,
+                  organizationLearnerRepository,
+                  certificationCenterRepository,
+                  organizationRepository,
+                });
+
+                // then
+                expect(
+                  organizationLearnerRepository.isOrganizationLearnerIdLinkedToUserAndSCOOrganization,
+                ).to.have.been.calledWithExactly({ userId, organizationLearnerId: organizationLearner.id });
+                expect(error).to.be.an.instanceof(UserAlreadyLinkedToCandidateInSessionError);
               });
             });
           });
         });
-      },
-    );
 
-    context('when the organization behind this session is of type SCO', function () {
-      context('when the organization is also managing students', function () {
-        context('when the user does not match with a session candidate and its organization learner', function () {
-          it('throws MatchingReconciledStudentNotFoundError', async function () {
+        context('when the organization is not managing students', function () {
+          it('should return the linked certification candidate', async function () {
             // given
             const certificationCandidate = domainBuilder.buildCertificationCandidate({
               userId: null,
-              firstName,
-              lastName,
-              birthdate,
+              id: 'candidateId',
             });
-            const certificationCandidateRepository =
-              _buildFakeCertificationCandidateRepository().withFindBySessionIdAndPersonalInfo({
+            const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
+              .withFindBySessionIdAndPersonalInfo({
                 args: {
                   sessionId,
                   firstName,
@@ -308,7 +531,9 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
                   birthdate,
                 },
                 resolves: [certificationCandidate],
-              });
+              })
+              .withFindOneBySessionIdAndUserId({ args: { sessionId, userId }, resolves: undefined })
+              .withLinkToUser({});
 
             const certificationCenter = domainBuilder.buildCertificationCenter({
               sessionId,
@@ -321,7 +546,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
             });
             const organization = domainBuilder.buildOrganization({
               type: 'SCO',
-              isManagingStudents: true,
+              isManagingStudents: false,
               externalId: '123456',
             });
             const organizationRepository = _buildFakeOrganizationRepository().withGetScoOrganizationByExternalId({
@@ -332,11 +557,11 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
             const organizationLearnerRepository =
               _buildFakeOrganizationLearnerRepository().withIsOrganizationLearnerIdLinkedToUserAndSCOOrganization({
                 args: { userId, organizationLearnerId: certificationCandidate.organizationLearnerId },
-                resolves: false,
+                resolves: true,
               });
 
             // when
-            const err = await catchErr(linkUserToSessionCertificationCandidate)({
+            const result = await linkUserToSessionCertificationCandidate({
               sessionId,
               userId,
               firstName,
@@ -344,235 +569,54 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
               birthdate,
               sessionRepository,
               certificationCandidateRepository,
-              organizationLearnerRepository,
               certificationCenterRepository,
               organizationRepository,
+              organizationLearnerRepository,
             });
 
             // then
-            expect(err).to.be.instanceOf(MatchingReconciledStudentNotFoundError);
-          });
-        });
-
-        context('when the user matches with a session candidate and its organization learner', function () {
-          context('when no other candidates is already linked to that user', function () {
-            it('should create a link between the candidate and the user and return an event to notify it, ', async function () {
-              // given
-              const organizationLearner = domainBuilder.buildOrganizationLearner();
-              const certificationCandidate = domainBuilder.buildCertificationCandidate({
-                userId: null,
-                firstName,
-                lastName,
-                birthdate,
-                organizationLearnerId: organizationLearner.id,
-              });
-              const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
-                .withFindBySessionIdAndPersonalInfo({
-                  args: {
-                    sessionId,
-                    firstName,
-                    lastName,
-                    birthdate,
-                  },
-                  resolves: [certificationCandidate],
-                })
-                .withFindOneBySessionIdAndUserId({
-                  args: {
-                    sessionId,
-                    userId,
-                  },
-                  resolves: null,
-                });
-
-              const certificationCenter = domainBuilder.buildCertificationCenter({
-                sessionId,
-                type: 'SCO',
-                externalId: '123456',
-              });
-              const certificationCenterRepository = _buildFakeCertificationCenterRepository().withGetBySessionId({
-                args: { sessionId },
-                resolves: certificationCenter,
-              });
-              const organization = domainBuilder.buildOrganization({
-                type: 'SCO',
-                isManagingStudents: true,
-                externalId: '123456',
-              });
-              const organizationRepository = _buildFakeOrganizationRepository().withGetScoOrganizationByExternalId({
-                args: '123456',
-                resolves: organization,
-              });
-
-              const organizationLearnerRepository =
-                _buildFakeOrganizationLearnerRepository().withIsOrganizationLearnerIdLinkedToUserAndSCOOrganization({
-                  args: { userId, organizationLearnerId: certificationCandidate.organizationLearnerId },
-                  resolves: true,
-                });
-
-              // when
-              const event = await linkUserToSessionCertificationCandidate({
-                sessionId,
-                userId,
-                firstName,
-                lastName,
-                birthdate,
-                sessionRepository,
-                certificationCandidateRepository,
-                organizationLearnerRepository,
-                certificationCenterRepository,
-                organizationRepository,
-              });
-
-              // then
-              expect(certificationCandidateRepository.linkToUser).to.have.been.calledWithExactly({
-                id: certificationCandidate.id,
-                userId,
-              });
-              expect(
-                organizationLearnerRepository.isOrganizationLearnerIdLinkedToUserAndSCOOrganization,
-              ).to.have.been.calledWithExactly({ userId, organizationLearnerId: organizationLearner.id });
-              expect(event).to.be.instanceOf(UserLinkedToCertificationCandidate);
-            });
-          });
-
-          context('when another candidates is already linked to that user', function () {
-            it('throws UserAlreadyLinkedToCandidateInSessionError', async function () {
-              // given
-              const organizationLearner = domainBuilder.buildOrganizationLearner();
-              const certificationCandidate = domainBuilder.buildCertificationCandidate({
-                userId: null,
-                firstName,
-                lastName,
-                birthdate,
-                organizationLearnerId: organizationLearner.id,
-              });
-              const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
-                .withFindBySessionIdAndPersonalInfo({
-                  args: {
-                    sessionId,
-                    firstName,
-                    lastName,
-                    birthdate,
-                  },
-                  resolves: [certificationCandidate],
-                })
-                .withFindOneBySessionIdAndUserId({
-                  args: {
-                    sessionId,
-                    userId,
-                  },
-                  resolves: domainBuilder.buildCertificationCandidate({ id: 'another candidate' }),
-                });
-
-              const certificationCenter = domainBuilder.buildCertificationCenter({
-                sessionId,
-                type: 'SCO',
-                externalId: '123456',
-              });
-              const certificationCenterRepository = _buildFakeCertificationCenterRepository().withGetBySessionId({
-                args: { sessionId },
-                resolves: certificationCenter,
-              });
-              const organization = domainBuilder.buildOrganization({
-                type: 'SCO',
-                isManagingStudents: true,
-                externalId: '123456',
-              });
-              const organizationRepository = _buildFakeOrganizationRepository().withGetScoOrganizationByExternalId({
-                args: '123456',
-                resolves: organization,
-              });
-
-              const organizationLearnerRepository =
-                _buildFakeOrganizationLearnerRepository().withIsOrganizationLearnerIdLinkedToUserAndSCOOrganization({
-                  args: { userId, organizationLearnerId: certificationCandidate.organizationLearnerId },
-                  resolves: true,
-                });
-
-              // when
-              const error = await catchErr(linkUserToSessionCertificationCandidate)({
-                sessionId,
-                userId,
-                firstName,
-                lastName,
-                birthdate,
-                sessionRepository,
-                certificationCandidateRepository,
-                organizationLearnerRepository,
-                certificationCenterRepository,
-                organizationRepository,
-              });
-
-              // then
-              expect(
-                organizationLearnerRepository.isOrganizationLearnerIdLinkedToUserAndSCOOrganization,
-              ).to.have.been.calledWithExactly({ userId, organizationLearnerId: organizationLearner.id });
-              expect(error).to.be.an.instanceof(UserAlreadyLinkedToCandidateInSessionError);
-            });
+            expect(organizationLearnerRepository.isOrganizationLearnerIdLinkedToUserAndSCOOrganization).to.be.not
+              .called;
+            expect(result).to.be.an.instanceof(UserLinkedToCertificationCandidate);
           });
         });
       });
+    });
+  });
 
-      context('when the organization is not managing students', function () {
-        it('should return the linked certification candidate', async function () {
-          // given
-          const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId: null, id: 'candidateId' });
-          const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
-            .withFindBySessionIdAndPersonalInfo({
-              args: {
-                sessionId,
-                firstName,
-                lastName,
-                birthdate,
-              },
-              resolves: [certificationCandidate],
-            })
-            .withFindOneBySessionIdAndUserId({ args: { sessionId, userId }, resolves: undefined })
-            .withLinkToUser({});
+  context('when the session is V3', function () {
+    context('when the user language is not available', function () {
+      it('should throw a language not supported error', async function () {
+        const sessionRepository = {
+          get: sinon.stub(),
+        };
+        sessionRepository.get.withArgs({ id: 42 }).resolves(domainBuilder.buildSession({ version: 3 }));
+        const userRepository = {
+          get: sinon.stub(),
+        };
+        const userId = '123';
+        const user = domainBuilder.buildUser({ id: userId, lang: 'nl' });
+        userRepository.get.withArgs(user.id).resolves(user);
 
-          const certificationCenter = domainBuilder.buildCertificationCenter({
-            sessionId,
-            type: 'SCO',
-            externalId: '123456',
-          });
-          const certificationCenterRepository = _buildFakeCertificationCenterRepository().withGetBySessionId({
-            args: { sessionId },
-            resolves: certificationCenter,
-          });
-          const organization = domainBuilder.buildOrganization({
-            type: 'SCO',
-            isManagingStudents: false,
-            externalId: '123456',
-          });
-          const organizationRepository = _buildFakeOrganizationRepository().withGetScoOrganizationByExternalId({
-            args: '123456',
-            resolves: organization,
-          });
+        const languageService = {
+          isLanguageAvailableForV3Certification: sinon.stub(),
+        };
+        languageService.isLanguageAvailableForV3Certification.withArgs(user.lang).returns(false);
 
-          const organizationLearnerRepository =
-            _buildFakeOrganizationLearnerRepository().withIsOrganizationLearnerIdLinkedToUserAndSCOOrganization({
-              args: { userId, organizationLearnerId: certificationCandidate.organizationLearnerId },
-              resolves: true,
-            });
-
-          // when
-          const result = await linkUserToSessionCertificationCandidate({
-            sessionId,
-            userId,
-            firstName,
-            lastName,
-            birthdate,
-            sessionRepository,
-            certificationCandidateRepository,
-            certificationCenterRepository,
-            organizationRepository,
-            organizationLearnerRepository,
-          });
-
-          // then
-          expect(organizationLearnerRepository.isOrganizationLearnerIdLinkedToUserAndSCOOrganization).to.be.not.called;
-          expect(result).to.be.an.instanceof(UserLinkedToCertificationCandidate);
+        // when
+        const err = await catchErr(linkUserToSessionCertificationCandidate)({
+          sessionId,
+          userId,
+          firstName,
+          lastName,
+          birthdate,
+          sessionRepository,
+          userRepository,
+          languageService,
         });
+
+        // then
+        expect(err).to.be.instanceOf(LanguageNotSupportedError);
       });
     });
   });

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -12,6 +12,7 @@ import {
 import { ComplementaryCertificationCourse } from '../../../../lib/domain/models/ComplementaryCertificationCourse.js';
 import { retrieveLastOrCreateCertificationCourse } from '../../../../lib/domain/usecases/retrieve-last-or-create-certification-course.js';
 import { CertificationCourse } from '../../../../src/certification/shared/domain/models/CertificationCourse.js';
+import { LanguageNotSupportedError } from '../../../../src/shared/domain/errors.js';
 import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';
 
@@ -521,7 +522,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
                     // then
                     expect(certificationCourseRepository.save).not.to.have.been.called;
-                    expect(error).to.be.instanceOf(Error);
+                    expect(error).to.be.instanceOf(LanguageNotSupportedError);
                   });
                 });
 

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -31,6 +31,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
   const certificationCenterRepository = {};
   const certificationBadgesService = {};
   const placementProfileService = {};
+  const languageService = {};
   const verifyCertificateCodeService = {};
   const userRepository = {};
 
@@ -46,6 +47,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
     certificationChallengesService,
     placementProfileService,
     verifyCertificateCodeService,
+    languageService,
     userRepository,
   };
 
@@ -70,6 +72,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
     placementProfileService.getPlacementProfile = sinon.stub();
     verifyCertificateCodeService.generateCertificateVerificationCode = sinon.stub().resolves(verificationCode);
     certificationCenterRepository.getBySessionId = sinon.stub();
+    languageService.isLanguageAvailableForV3Certification = sinon.stub();
   });
 
   afterEach(function () {
@@ -504,6 +507,8 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                     const user = domainBuilder.buildUser({ id: userId, lang: 'nl' });
                     userRepository.get.withArgs(userId).resolves(user);
 
+                    languageService.isLanguageAvailableForV3Certification.withArgs(user.lang).returns(false);
+
                     // when
                     const error = await catchErr(await retrieveLastOrCreateCertificationCourse)({
                       domainTransaction,
@@ -565,6 +570,8 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
 
                     const user = domainBuilder.buildUser({ id: userId });
                     userRepository.get.withArgs(userId).resolves(user);
+
+                    languageService.isLanguageAvailableForV3Certification.withArgs(user.lang).returns(true);
 
                     const certificationCourseToSave = CertificationCourse.from({
                       certificationCandidate: foundCertificationCandidate,

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -76,6 +76,11 @@
     },
     "french-education-ministry": "Ministry of national education and youth",
     "french-republic": "French Republic. Liberty, equality, fraternity.",
+    "languages": {
+      "en": "English",
+      "fr": "French",
+      "nl": "Dutch"
+    },
     "level": "level",
     "loading": {
       "default": "Loading",
@@ -441,6 +446,8 @@
           "check-session-number": "Check the session number.",
           "disclaimer": "The information entered does not match any candidate registered for the session."
         },
+        "language-not-supported": "The Pix certification is not yet available in %%language of account%%. The languages currently available for taking the certification exam are: Accepted languages%%. You may choose another language from ",
+        "language-not-supported-link": "My account page",
         "session-not-accessible": "The session you are trying to join is no longer available.",
         "wrong-account": "The information entered matches a candidate enrolled in the session and already logged in with another account. Please check that you are logged into the account that started the exam.",
         "wrong-account-sco": "You are currently using an account that is not linked to your school/organisation.\nLog in to the account you used to complete your customised tests or ask the invigilator for help.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -76,6 +76,11 @@
     },
     "french-education-ministry": "Ministère de l'éducation nationale et de la jeunesse. Liberté égalité fraternité",
     "french-republic": "République française. Liberté, égalité, fraternité.",
+    "languages": {
+      "en": "Anglais",
+      "fr": "Français",
+      "nl": "Néerlandais"
+    },
     "level": "niveau",
     "loading": {
       "default": "Chargement en cours",
@@ -441,6 +446,8 @@
           "check-session-number": "Vérifiez le numéro de session.",
           "disclaimer": "Les informations saisies ne correspondent à aucun candidat inscrit à la session."
         },
+        "language-not-supported": "La certification Pix n'est pas encore disponible en {userLanguage}. '<br>' Les langues disponibles actuellement pour passer la certification sont : {availableLanguages}. '<br>' Vous pouvez choisir une autre langue depuis la page ",
+        "language-not-supported-link": "Mon compte",
         "session-not-accessible": "La session que vous tentez de rejoindre n'est plus accessible.",
         "wrong-account": "Les informations saisies correspondent à un.e candidat.e inscrit.e à la session et déjà connecté.e avec un autre compte. Vérifiez que vous êtes connecté.e au compte qui a démarré la certification.",
         "wrong-account-sco": "Vous utilisez actuellement un compte qui n'est pas lié à votre établissement.\nConnectez vous au compte avec lequel vous avez effectué vos parcours ou demandez de l'aide au surveillant.",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -77,6 +77,11 @@
     "french-education-ministry": "Ministerie van Onderwijs en Jeugdzaken. Vrijheid gelijkheid broederschap",
     "french-republic": "Franse Republiek. Vrijheid, gelijkheid, broederschap.",
     "level": "niveau",
+    "languages": {
+      "en": "Engels",
+      "fr": "Frans",
+      "nl": "Nederlands"
+    },
     "loading": {
       "default": "Bezig met laden",
       "results": "Je resultaten voorbereiden",
@@ -440,6 +445,8 @@
           "check-session-number": "Controleer het sessienummer.",
           "disclaimer": "De ingevoerde informatie komt niet overeen met een kandidaat die is ingeschreven voor de sessie."
         },
+        "language-not-supported": "La certification Pix n'est pas encore disponible en {userLanguage}. '<br>' Les langues disponibles actuellement pour passer la certification sont : {availableLanguages}. '<br>' Vous pouvez choisir une autre langue depuis la page ",
+        "language-not-supported-link": "Mon compte",
         "session-not-accessible": "De sessie die u probeert te bezoeken is niet langer toegankelijk.",
         "wrong-account": "De ingevoerde informatie komt overeen met een kandidaat die is geregistreerd voor de sessie en al is ingelogd met een ander account. Controleer of u bent aangemeld bij het account waarmee de certificering is gestart.",
         "wrong-account-sco": "Je gebruikt momenteel een account dat niet aan je school is gekoppeld.\nLog in op het account waarmee je je cursussen hebt afgerond of vraag de supervisor om hulp.",


### PR DESCRIPTION
## :unicorn: Problème

Toutes les langues actuellement présentes dans le référentiel Pix ne sont pas forcément proposées en certification. En effet, la certification peut être passée en FR ou EN uniquement. C’est la langue du compte du candidat au lancement de son test qui définira la langue de passage du test.

Si le candidat clique sur l’onglet “Certification”, entre ses informations et tente d'entrer en certification alors que son compte est dans une langue non supportée par la certification, un message d'erreur sera affiché. Aucune question ne lui sera proposée et il sera bloqué.

## :robot: Proposition

Sur Pix App > menu “Certification” : 

• ajouter une vérification sur la langue du compte de l’utilisateur
• si langue de l’utilisateur != EN ou FR : 
• lorsque l'utilisateur a rempli son formulaire et qu'il tente d'entrer en session,
• un message d'erreur s'affiche en bas, au même endroit que les autres messages d'erreur (liés au numéro de session etc)
• le message d'erreur contient un lien vers la page de modification de la langue

Wording : 

La certification Pix n'est pas encore disponible en %%langue du compte%%. Les langues disponibles actuellement pour passer la certification sont : %%langues acceptées%%. Vous pouvez choisir une autre langue depuis la page [lien]"Mon compte"[/lien]. 

## :100: Pour tester
- Créer une session de certif v3 // identifiant : certifv3@example.net - mot de passe : pix123
- Se connecter à mon-pix // identifiant : certifiable-contenu-user@example.net - mot de passe : pix123
- Changer la langue de l'utilisateur en NL
- Cliquer sur le menu "Certificering" ("Certification" en NL)
- Remplir le formulaire avec les informations d'un candidat de la certif v3 créée en amont
- Le message d'erreur doit s'afficher en bas du formulaire
- Le candidat n'a pas accès à la certification
- Changer la langue en FR
- Retourner sur "Certification"
- Remplir le formulaire avec les informations d'un candidat de la certif v3 créée en amont
- La certification doit à nouveau être accessible

<img width="327" alt="Capture d’écran 2024-04-08 à 16 56 13" src="https://github.com/1024pix/pix/assets/11388201/db7ce7d4-c341-4a6f-a672-61abafab8610">

