### PR TITLE
[TECH] extrait la validation de fichier siecle xml un usecase dédié (Pix-11967)

### DIFF
--- a/api/src/prescription/learner-management/application/sco-organization-management-controller.js
+++ b/api/src/prescription/learner-management/application/sco-organization-management-controller.js
@@ -21,6 +21,7 @@ const importOrganizationLearnersFromSIECLE = async function (
         organizationId,
         payload: request.payload,
       });
+      await usecases.validateSiecleXmlFile({ organizationId });
       await usecases.addOrUpdateOrganizationLearners({ organizationId });
     } else if (format === 'csv') {
       await usecases.importOrganizationLearnersFromSIECLECSVFormat({

--- a/api/src/prescription/learner-management/application/sco-organization-management-controller.js
+++ b/api/src/prescription/learner-management/application/sco-organization-management-controller.js
@@ -16,7 +16,7 @@ const importOrganizationLearnersFromSIECLE = async function (
   const { format } = request.query;
   try {
     if (format === 'xml') {
-      await usecases.importOrganizationLearnersFromSIECLEXMLFormat({
+      await usecases.uploadSiecleFile({
         userId: authenticatedUserId,
         organizationId,
         payload: request.payload,

--- a/api/src/prescription/learner-management/domain/usecases/import-organization-learners-from-siecle-xml-format.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-organization-learners-from-siecle-xml-format.js
@@ -1,27 +1,13 @@
 import fs from 'fs/promises';
 
-import { AggregateImportError, SiecleXmlImportError } from '../errors.js';
-
-const { isEmpty } = lodash;
-
-import lodash from 'lodash';
-
-import { SiecleParser } from '../../infrastructure/serializers/xml/siecle-parser.js';
 import { detectEncoding } from '../../infrastructure/utils/xml/detect-encoding.js';
-import { SiecleFileStreamer } from '../../infrastructure/utils/xml/siecle-file-streamer.js';
 import * as zip from '../../infrastructure/utils/xml/zip.js';
 import { OrganizationImport } from '../models/OrganizationImport.js';
-
-const ERRORS = {
-  EMPTY: 'EMPTY',
-  INVALID_FILE_EXTENSION: 'INVALID_FILE_EXTENSION',
-};
 
 const importOrganizationLearnersFromSIECLEXMLFormat = async function ({
   userId,
   organizationId,
   payload,
-  organizationRepository,
   importStorage,
   organizationImportRepository,
   siecleService = {
@@ -29,11 +15,8 @@ const importOrganizationLearnersFromSIECLEXMLFormat = async function ({
     detectEncoding,
   },
 }) {
-  let organizationLearnerData = [];
+  const organizationImport = OrganizationImport.create({ organizationId, createdBy: userId });
 
-  let organizationImport = OrganizationImport.create({ organizationId, createdBy: userId });
-
-  const organization = await organizationRepository.get(organizationId);
   const path = payload.path;
 
   let filename, encoding;
@@ -50,32 +33,6 @@ const importOrganizationLearnersFromSIECLEXMLFormat = async function ({
     throw error;
   } finally {
     organizationImport.upload({ filename, encoding, errors });
-    await organizationImportRepository.save(organizationImport);
-  }
-
-  try {
-    const readableStreamForUAJ = await importStorage.readFile({ filename });
-    const siecleFileStreamerForUAJ = await SiecleFileStreamer.create(readableStreamForUAJ, encoding);
-    const parserForUAJ = SiecleParser.create(siecleFileStreamerForUAJ);
-    await parserForUAJ.parseUAJ(organization.externalId);
-
-    const readableStream = await importStorage.readFile({ filename });
-    const siecleFileStreamer = await SiecleFileStreamer.create(readableStream, encoding);
-    const parser = SiecleParser.create(siecleFileStreamer);
-    organizationLearnerData = await parser.parse();
-    if (isEmpty(organizationLearnerData)) {
-      throw new SiecleXmlImportError(ERRORS.EMPTY);
-    }
-  } catch (error) {
-    if (error instanceof AggregateImportError) {
-      errors.push(...error.meta);
-    } else {
-      errors.push(error);
-    }
-    throw error;
-  } finally {
-    organizationImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
-    organizationImport.validate({ errors });
     await organizationImportRepository.save(organizationImport);
   }
 };

--- a/api/src/prescription/learner-management/domain/usecases/validate-siecle-xml-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/validate-siecle-xml-file.js
@@ -1,0 +1,54 @@
+import { AggregateImportError, SiecleXmlImportError } from '../errors.js';
+
+const { isEmpty } = lodash;
+
+import lodash from 'lodash';
+
+import { SiecleParser } from '../../infrastructure/serializers/xml/siecle-parser.js';
+import { SiecleFileStreamer } from '../../infrastructure/utils/xml/siecle-file-streamer.js';
+
+const ERRORS = {
+  EMPTY: 'EMPTY',
+  INVALID_FILE_EXTENSION: 'INVALID_FILE_EXTENSION',
+};
+
+const validateSiecleXmlFile = async function ({
+  organizationId,
+  organizationRepository,
+  organizationImportRepository,
+  importStorage,
+}) {
+  const organizationImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
+
+  const organization = await organizationRepository.get(organizationId);
+
+  const errors = [];
+
+  try {
+    const readableStreamForUAJ = await importStorage.readFile({ filename: organizationImport.filename });
+    const siecleFileStreamerForUAJ = await SiecleFileStreamer.create(readableStreamForUAJ, organizationImport.encoding);
+    const parserForUAJ = SiecleParser.create(siecleFileStreamerForUAJ);
+    await parserForUAJ.parseUAJ(organization.externalId);
+
+    const readableStream = await importStorage.readFile({ filename: organizationImport.filename });
+    const siecleFileStreamer = await SiecleFileStreamer.create(readableStream, organizationImport.encoding);
+    const parser = SiecleParser.create(siecleFileStreamer);
+    const organizationLearnerData = await parser.parse();
+    if (isEmpty(organizationLearnerData)) {
+      throw new SiecleXmlImportError(ERRORS.EMPTY);
+    }
+  } catch (error) {
+    if (error instanceof AggregateImportError) {
+      errors.push(...error.meta);
+    } else {
+      errors.push(error);
+    }
+    await importStorage.deleteFile({ filename: organizationImport.filename });
+    throw error;
+  } finally {
+    organizationImport.validate({ errors });
+    await organizationImportRepository.save(organizationImport);
+  }
+};
+
+export { validateSiecleXmlFile };

--- a/api/tests/prescription/learner-management/unit/application/sco-organization-management-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/sco-organization-management-controller_test.js
@@ -22,11 +22,11 @@ describe('Unit | Application | Organizations | organization-controller', functio
 
     beforeEach(function () {
       sinon.stub(fs, 'unlink').resolves();
-      sinon.stub(usecases, 'importOrganizationLearnersFromSIECLEXMLFormat');
+      sinon.stub(usecases, 'uploadSiecleFile');
       sinon.stub(usecases, 'validateSiecleXmlFile');
       sinon.stub(usecases, 'addOrUpdateOrganizationLearners');
       sinon.stub(usecases, 'importOrganizationLearnersFromSIECLECSVFormat');
-      usecases.importOrganizationLearnersFromSIECLEXMLFormat.resolves();
+      usecases.uploadSiecleFile.resolves();
       dependencies = { logErrorWithCorrelationIds: sinon.stub() };
     });
 
@@ -71,7 +71,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       await scoOrganizationManagementController.importOrganizationLearnersFromSIECLE(request, hFake, dependencies);
 
       // then
-      expect(usecases.importOrganizationLearnersFromSIECLEXMLFormat).to.have.been.calledWithExactly({
+      expect(usecases.uploadSiecleFile).to.have.been.calledWithExactly({
         userId,
         organizationId,
         payload,

--- a/api/tests/prescription/learner-management/unit/application/sco-organization-management-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/sco-organization-management-controller_test.js
@@ -23,6 +23,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
     beforeEach(function () {
       sinon.stub(fs, 'unlink').resolves();
       sinon.stub(usecases, 'importOrganizationLearnersFromSIECLEXMLFormat');
+      sinon.stub(usecases, 'validateSiecleXmlFile');
       sinon.stub(usecases, 'addOrUpdateOrganizationLearners');
       sinon.stub(usecases, 'importOrganizationLearnersFromSIECLECSVFormat');
       usecases.importOrganizationLearnersFromSIECLEXMLFormat.resolves();
@@ -75,6 +76,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
         organizationId,
         payload,
       });
+      expect(usecases.validateSiecleXmlFile).to.have.been.calledWithExactly({ organizationId });
       expect(usecases.addOrUpdateOrganizationLearners).to.have.been.calledWithExactly({
         organizationId,
       });

--- a/api/tests/prescription/learner-management/unit/domain/usecases/validate-siecle-xml-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/validate-siecle-xml-file_test.js
@@ -1,0 +1,118 @@
+import {
+  AggregateImportError,
+  SiecleXmlImportError,
+} from '../../../../../../src/prescription/learner-management/domain/errors.js';
+import { validateSiecleXmlFile } from '../../../../../../src/prescription/learner-management/domain/usecases/validate-siecle-xml-file.js';
+import { SiecleParser } from '../../../../../../src/prescription/learner-management/infrastructure/serializers/xml/siecle-parser.js';
+import { SiecleFileStreamer } from '../../../../../../src/prescription/learner-management/infrastructure/utils/xml/siecle-file-streamer.js';
+import { catchErr, expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | UseCase | import-organization-learners-from-siecle-xml', function () {
+  const organizationId = 1234;
+  let parserStub;
+  let organizationImportRepositoryStub;
+  let organizationRepositoryStub;
+  let streamerSymbol;
+  let importStorageStub;
+  let organizationImportStub;
+  let readableSymbol;
+  let dataStub;
+  let externalIdSymbol;
+
+  beforeEach(function () {
+    organizationImportRepositoryStub = {
+      getLastByOrganizationId: sinon.stub(),
+      save: sinon.stub(),
+    };
+    organizationImportStub = { filename: Symbol('filename'), encoding: Symbol('encoding'), validate: sinon.stub() };
+    organizationImportRepositoryStub.getLastByOrganizationId.returns(organizationImportStub);
+    externalIdSymbol = Symbol('externalId');
+    organizationRepositoryStub = {
+      get: sinon.stub().withArgs(organizationId).returns({ externalId: externalIdSymbol }),
+    };
+
+    importStorageStub = {
+      deleteFile: sinon.stub(),
+      readFile: sinon.stub().withArgs({ filename: organizationImportStub.filename }).resolves(readableSymbol),
+    };
+    streamerSymbol = Symbol('streamer');
+    sinon
+      .stub(SiecleFileStreamer, 'create')
+      .withArgs(readableSymbol, organizationImportStub.encoding)
+      .resolves(streamerSymbol);
+
+    dataStub = [{ id: 1 }];
+    parserStub = {
+      parse: sinon.stub().resolves(dataStub),
+      parseUAJ: sinon.stub().resolves(),
+    };
+    sinon.stub(SiecleParser, 'create').withArgs(streamerSymbol).returns(parserStub);
+  });
+
+  it('should validate the xml file', async function () {
+    await validateSiecleXmlFile({
+      organizationId,
+      organizationImportRepository: organizationImportRepositoryStub,
+      organizationRepository: organizationRepositoryStub,
+      importStorage: importStorageStub,
+    });
+    expect(parserStub.parseUAJ).to.have.been.calledWithExactly(externalIdSymbol);
+    expect(parserStub.parse).to.have.been.calledWithExactly();
+    expect(organizationImportStub.validate).to.have.been.calledWith({ errors: [] });
+    expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(organizationImportStub);
+  });
+
+  context('error cases', function () {
+    it('should save error when there is error', async function () {
+      const s3Error = new Error('s3 error');
+      importStorageStub.readFile.rejects(s3Error);
+      const error = await catchErr(validateSiecleXmlFile)({
+        organizationId,
+        organizationImportRepository: organizationImportRepositoryStub,
+        organizationRepository: organizationRepositoryStub,
+        importStorage: importStorageStub,
+      });
+      expect(error).to.eq(s3Error);
+      expect(organizationImportStub.validate).to.have.been.calledWith({ errors: [s3Error] });
+      expect(importStorageStub.deleteFile).to.have.been.calledWithExactly({
+        filename: organizationImportStub.filename,
+      });
+      expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(organizationImportStub);
+    });
+
+    context('when there is validation errors', function () {
+      it('should save parsing errors', async function () {
+        const parsingErrors = [new Error('parsing'), new Error('parsing2')];
+        parserStub.parse.rejects(new AggregateImportError(parsingErrors));
+        const error = await catchErr(validateSiecleXmlFile)({
+          organizationId,
+          organizationImportRepository: organizationImportRepositoryStub,
+          organizationRepository: organizationRepositoryStub,
+          importStorage: importStorageStub,
+        });
+        expect(importStorageStub.deleteFile).to.have.been.calledWithExactly({
+          filename: organizationImportStub.filename,
+        });
+        expect(error).to.be.an.instanceOf(AggregateImportError);
+        expect(organizationImportStub.validate).to.have.been.calledWith({ errors: parsingErrors });
+        expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(organizationImportStub);
+      });
+
+      it('should save empty learner error', async function () {
+        parserStub.parse.resolves([]);
+        const error = await catchErr(validateSiecleXmlFile)({
+          organizationId,
+          organizationImportRepository: organizationImportRepositoryStub,
+          organizationRepository: organizationRepositoryStub,
+          importStorage: importStorageStub,
+        });
+        expect(importStorageStub.deleteFile).to.have.been.calledWithExactly({
+          filename: organizationImportStub.filename,
+        });
+        expect(error).to.be.an.instanceOf(SiecleXmlImportError);
+        expect(organizationImportStub.validate).to.have.been.calledWith({ errors: [error] });
+        expect(organizationImportRepositoryStub.save).to.have.been.calledWithExactly(organizationImportStub);
+      });
+    });
+  });
+});

--- a/orga/app/components/import-banner.gjs
+++ b/orga/app/components/import-banner.gjs
@@ -55,7 +55,9 @@ export default class ImportBanner extends Component {
     if (this.args.organizationImportDetail?.hasWarning) {
       return this.intl.t('pages.organization-participants-import.banner.warning-banner', { htmlSafe: true });
     }
-    const status = this.args.organizationImportDetail?.status || 'STARTED';
+
+    const status = this.args.isLoading ? 'STARTED' : this.args.organizationImportDetail?.status;
+
     const title = this.intl.t(`pages.organization-participants-import.banner.${statusI18nLabel[status]}`);
     return title;
   }

--- a/orga/tests/integration/components/import-banner_test.gjs
+++ b/orga/tests/integration/components/import-banner_test.gjs
@@ -19,6 +19,25 @@ module('Integration | Component | ImportBanner', function (hooks) {
       assert.ok(screen.getByText(this.intl.t('pages.organization-participants-import.banner.upload-in-progress')));
     });
 
+    test('it should display loading message when there is already an import', async function (assert) {
+      // when
+      const store = this.owner.lookup('service:store');
+      const organizationImportDetail = store.createRecord('organization-import-detail', {
+        status: 'UPLOADED',
+        createdAt: new Date(2023, 10, 2),
+        createdBy: { firstName: 'Obi', lastName: 'Wan' },
+      });
+      const isLoading = true;
+      const screen = await render(
+        <template>
+          <ImportBanner @isLoading={{isLoading}} @organizationImportDetail={{organizationImportDetail}} />
+        </template>,
+      );
+
+      // then
+      assert.ok(screen.getByText(this.intl.t('pages.organization-participants-import.banner.upload-in-progress')));
+    });
+
     test('display validation in progress banner', async function (assert) {
       //given
       const store = this.owner.lookup('service:store');


### PR DESCRIPTION
## :unicorn: Problème
En prévision de l'ajout de PGBoss pour la refonte de l'import, on veut commencer par découper le usecase initial, en 3 sous parties, qui partiront par la suite dans des handlers. Le traitement des données est fait, il manque la validation et l'envoi du fichier.

## :robot: Proposition
Dans cette PR, on extrait la validation de l'envoi du fichier.

## :rainbow: Remarques
Etant donné que nos 3 usecases sont maintenant séparés, on peut renommer le usecase initial

## :100: Pour tester
Se connecter sur l'import SCO et faire un import de fichier xml et de fichier zip. Valider qu'on a toujours les bon messages (succès / erreur)
