### PR TITLE
[TECH] :recycle: Petite optimisation dans le filtrage des skill déjà testé

### DIFF
--- a/api/lib/domain/services/algorithm-methods/skills-filter.js
+++ b/api/lib/domain/services/algorithm-methods/skills-filter.js
@@ -6,9 +6,9 @@ import {
 
 const getPlayableSkills = (skills) => skills.filter(({ isPlayable }) => isPlayable);
 
-const notAlreadyTestedSkill = (knowledgeElements) => (skill) => {
+const notAlreadyTestedSkill = (knowledgeElements) => {
   const alreadyTestedSkillIds = knowledgeElements.map(({ skillId }) => skillId);
-  return !alreadyTestedSkillIds.includes(skill.id);
+  return (skill) => !alreadyTestedSkillIds.includes(skill.id);
 };
 
 const getUntestedSkills = (knowledgeElements, skills) => skills.filter(notAlreadyTestedSkill(knowledgeElements));


### PR DESCRIPTION
## :unicorn: Problème
Pour savoir si une skill a déjà été testée par un utilisateur, on compile une liste des id de skill testée à partir de la liste des knowledge elements. Cette liste d'id reste la même pour la liste des skills d'une compétence. Or la fonction généré pour filtrer la liste des skill de la compétence comprend le recalcul systématique de cette liste.

## :robot: Proposition
Extraire le calcul de la liste des id de skill testée de la fonction généré pour le mettre dans la "closure" de la fonction lors de sa génération.

## :rainbow: Remarques
Il est possible que l'interpréteur/jit javascript optimise déjà ce code. Mais ce changement permet d'en être sur et rend plus clair l'intention de la fonction générée.

## :100: Pour tester
Le code ainsi corrigé est fonctionnellement identique à la version précédente.