### PR TITLE
[TECH] Modifier le design du message d'erreur de la page de connexion à la certif (PIX-11988)

### DIFF
--- a/mon-pix/app/components/certification-joiner.hbs
+++ b/mon-pix/app/components/certification-joiner.hbs
@@ -76,23 +76,26 @@
     </div>
 
     {{#if this.errorMessage}}
-      <div class="certification-course-page__errors">{{this.errorMessage}}
-        {{#if this.errorDetailList}}
-          <ul class="certification-course-page__errors__list">
-            {{#each this.errorDetailList as |errorDetailElement|}}
-              <li>{{errorDetailElement}}</li>
-            {{/each}}
-          </ul>
-        {{/if}}
-        {{#if this.errorMessageLink}}
-          <a
-            rel="noopener noreferrer"
-            target="_blank"
-            href={{this.errorMessageLink.url}}
-          >{{this.errorMessageLink.label}}
-          </a>
-          <FaIcon @icon="up-right-from-square" />
-        {{/if}}
+      <div class="certification-course-page__errors">
+        <PixMessage @type="error">
+          {{this.errorMessage}}
+          {{#if this.errorDetailList}}
+            <ul class="certification-course-page__errors__list">
+              {{#each this.errorDetailList as |errorDetailElement|}}
+                <li>{{errorDetailElement}}</li>
+              {{/each}}
+            </ul>
+          {{/if}}
+          {{#if this.errorMessageLink}}
+            <a
+              rel="noopener noreferrer"
+              target="_blank"
+              href={{this.errorMessageLink.url}}
+            >{{this.errorMessageLink.label}}
+            </a>
+            <FaIcon @icon="up-right-from-square" />
+          {{/if}}
+        </PixMessage>
       </div>
     {{/if}}
     <PixButton @id="certificationJoinerSubmitButton" @type="submit">{{t


### PR DESCRIPTION
## :unicorn: Problème
Lors de l’entrée en certification, le candidat doit remplir un formulaire avec ses informations avant de le valider. En cas de problème avec la validation du formulaire, un message d’erreur apparaît : 
<img width="385" alt="Capture d’écran 2024-04-08 à 16 45 29" src="https://github.com/1024pix/pix/assets/11388201/600d3bcc-7efd-47f6-a47f-37b5eeb226d5)">

## :robot: Proposition
Il faudrait remplacer le design du message d’erreur par le composant PixUI PixMessage, avec le paramètre Error : 

![image](https://github.com/1024pix/pix/assets/11388201/c44b3165-23ec-4fed-a48d-7d865aada988)

## :100: Pour tester

- Créer une session de certif v3 // identifiant : [certifv3@example.net](mailto:certifv3@example.net) - mot de passe : pix123
- Se connecter à mon-pix // identifiant : [certifiable-contenu-user@example.net](mailto:certifiable-contenu-user@example.net) - mot de passe : pix123
- Cliquer sur le menu "Certification"
- Remplir le formulaire avec l'id de la session créée, et de fausses informations sur le candidat (le candidat ne doit pas exister dans la session)
- Le message d'erreur doit s'afficher en bas du formulaire

<img width="385" alt="Capture d’écran 2024-04-08 à 16 45 29" src="https://github.com/1024pix/pix/assets/11388201/a52124f7-48cd-4d99-9f12-57b2a390988c">
