### PR TITLE
[BUGFIX] Rétablir la mise en place de acr_values suite à la mise en place de la lib openid-client (PIX-11980)

### DIFF
--- a/api/lib/domain/services/authentication/fwb-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/fwb-oidc-authentication-service.js
@@ -15,6 +15,7 @@ class FwbOidcAuthenticationService extends OidcAuthenticationService {
       clientId: config[configKey].clientId,
       clientSecret: config[configKey].clientSecret,
       configKey,
+      extraAuthorizationUrlParameters: config[configKey].acrValues && { acr_values: config[configKey].acrValues },
       shouldCloseSession: true,
       identityProvider: FWB.code,
       openidConfigurationUrl: config[configKey].openidConfigurationUrl,

--- a/api/sample.env
+++ b/api/sample.env
@@ -663,6 +663,14 @@ AUTH_SECRET=the-password-must-be-at-least-32-characters-long
 # type: URL
 # sample: FWB_OPENID_CONFIGURATION_URL=
 
+# Property to use in extraAuthorizationUrlParameters
+#
+# presence: optional
+# type: string
+# samples:
+# FWB_ACR_VALUES=secure/name/password/multidomaine/pix
+# FWB_ACR_VALUES=secure/name/password/accV2
+
 # ==============================
 # PAYS DE LA LOIRE CONFIGURATION
 # ==============================

--- a/api/scripts/team-acces/load-oidc-providers-from-env-variables.js
+++ b/api/scripts/team-acces/load-oidc-providers-from-env-variables.js
@@ -54,6 +54,8 @@ const OIDC_PROVIDERS_FWB = {
   customProperties: {
     logoutUrl: process.env.FWB_OIDC_LOGOUT_URL,
   },
+
+  extraAuthorizationUrlParameters: { acr_values: process.env.FWB_ACR_VALUES },
 };
 const OIDC_PROVIDERS_CNAV = {
   identityProvider: 'CNAV',

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -213,6 +213,7 @@ const configuration = (function () {
       logoutUrl: process.env.FWB_OIDC_LOGOUT_URL,
       openidConfigurationUrl: process.env.FWB_OPENID_CONFIGURATION_URL,
       redirectUri: process.env.FWB_REDIRECT_URI,
+      acrValues: process.env.FWB_ACR_VALUES,
     },
     google: {
       accessTokenLifespanMs: ms(process.env.GOOGLE_ACCESS_TOKEN_LIFESPAN || '7d'),


### PR DESCRIPTION
## :unicorn: Problème

Avec #8028 pour l’utilisation de la lib _openid-client_, la mise en place du query param `acr_values` dans l'_Authorization URL_ a disparu.

## :robot: Proposition

Rétablir la mise en place du query param `acr_values` dans l'_Authorization URL_ .

Comme il est nécessaire de spécifier une valeur pour `acr_values` différente selon les environnements (pour la production : `secure/name/password/multidomaine/pix` et pour l'acceptance : `secure/name/password/accV2`), l’utilisation de la variable d'environnement `FWB_ACR_VALUES` a été retenue.

Avoir plusieurs valeurs pour `acr_values` différentes selon les environnements est compatible avec la nouvelle architecture à venir utilisant la table `oidc-providers`. Il n’y a pas de migration à faire pour la table `oidc-providers` mais il a fallu modifier le script `api/scripts/team-acces/load-oidc-providers-from-env-variables.js`.

## :rainbow: Remarques

RAS

## :100: Pour tester

1. Lorsque la variable d’environnement `FWB_ACR_VALUES` n'est pas configurée, constater que la chaîne de caractères `acr_values` **n’apparaît pas** dans l’_Authorization URL_ auprès du SSO de la FWB et que la connexion et la déconnexion sont bien fonctionnelles.
2. Configurer la variable d’environnement `FWB_ACR_VALUES`  et constater que la chaîne de caractères `acr_values` **apparaît** dans l’_Authorization URL_ auprès du SSO de la FWB et que la connexion et la déconnexion sont bien fonctionnelles.
3. Lancer le script `scripts/team-acces/load-oidc-providers-from-env-variables.js` dans le dossier `api` et constater que la colonne `extraAuthorizationUrlParameters` contient la valeur `{"acr_values": "secure/name/password/multidomaine/pix"}`  ou `{"acr_values": "secure/name/password/accV2"}` (selon ce que vous mettez dans `FWB_ACR_VALUES`) pour l’`identityProvider` ayant pour valeur `FWB`.