### PR TITLE
[TECH] Ajouter les fichiers à risque que sont *.json et *.csv dans le fichier .gitignore à la racine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 
+# Possible personal data
+*.json
+*.csv
+
 # compiled output
 **/dist
 **/tmp
@@ -30,8 +34,6 @@
 .DS_Store
 
 **/.env
-
-OIDC_PROVIDERS.json
 
 # CircleCI
 *.circle-cache-key

--- a/api/src/devcomp/infrastructure/datasources/learning-content/.gitignore
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/.gitignore
@@ -1,0 +1,1 @@
+!modules/*.json


### PR DESCRIPTION
## :unicorn: Problème

Nous manipulons régulièrement des fichiers JSON ou CSV dont on ne veut pas qu'ils soient poussés dans le dépôt GitHub parce qu'ils contiennent des données personnelles, des clés privés ou toutes autre données secrètes/sensibles.

## :robot: Proposition

Pour éviter les catastrophes, ajouter dans le fichier `.gitignore` ajouter les fichiers à risque que sont `*.json` et `*.csv`.

Pour les rares fois où on veut vraiment ajouter un fichier json/csv au repository, il reste possible de faire :
```shell
git add -f file.json
```

## :rainbow: Remarques

Le fichier spécifique `OIDC_PROVIDERS.json` contentant des données à ne pas publier n’a plus besoin d'être spécifié explicitement dans le fichier `.gitignore`.

## :100: Pour tester

* Lire tout le fichier `.gitignore` et vérifier que ces modifications sont cohérentes.
* En local rendez-vous dans le clone du monorepo sur votre système de fichiers et vérifier que les fichiers ignorés sont cohérents avec vos fichiers