### PR TITLE
[TECH] Protège de commit sur la branche dev via Husky

### DIFF
--- a/.husky/detect-learning-content
+++ b/.husky/detect-learning-content
@@ -7,17 +7,18 @@ IFS=$'\n'
 
 CHANGED_FILES=($(git diff --name-only --cached --diff-filter=ACMR))
 
+# This SECRET value is in the referential
 SECRET=postgres://postgres:J9FUMSBhei8oU@db.dbhostprovider.com:5434/thedb
 
 RED='\033[0;31m'
-GREEN='\033[0;32m'
 NO_COLOR='\033[0m'
 
 for file in "${CHANGED_FILES[@]}"
 do
+# GREEN='\033[0;32m'
 #  echo -e "Inspecting file : ${GREEN} ${file} ${NO_COLOR}"
   MATCHES="$(grep --count "$SECRET" "${file}" || true)"
-  if [[ "$MATCHES" > 0 ]]
+  if [ "$MATCHES" -gt 0 ]
     then
       echo -e "Oops, we found the secret ${RED} ${SECRET} ${NO_COLOR} in file ${file} ! "
       exit 255

--- a/.husky/lint
+++ b/.husky/lint
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+npx lint-staged --cwd 1d
+npx lint-staged --cwd admin
+npx lint-staged --cwd certif
+npx lint-staged --cwd mon-pix
+npx lint-staged --cwd orga
+npx lint-staged

--- a/.husky/lint
+++ b/.husky/lint
@@ -1,6 +1,6 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-set -eo pipefail
+set -e
 
 npx lint-staged --cwd 1d
 npx lint-staged --cwd admin

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,4 +4,4 @@ set -eo pipefail
 
 .husky/protect-branch
 .husky/lint
-.husky/detect-secret
+.husky/detect-learning-content

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -eo pipefail
+set -e
 
 .husky/protect-branch
 .husky/lint

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,10 +1,4 @@
 set -eo pipefail
 
-npx lint-staged --cwd 1d
-npx lint-staged --cwd admin
-npx lint-staged --cwd certif
-npx lint-staged --cwd mon-pix
-npx lint-staged --cwd orga
-npx lint-staged
-
+.husky/lint
 .husky/detect-secret

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 set -eo pipefail
 
 .husky/protect-branch

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 set -eo pipefail
 
+.husky/protect-branch
 .husky/lint
 .husky/detect-secret

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,5 @@
+set -eo pipefail
+
 npx lint-staged --cwd 1d
 npx lint-staged --cwd admin
 npx lint-staged --cwd certif

--- a/.husky/protect-branch
+++ b/.husky/protect-branch
@@ -1,0 +1,12 @@
+current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+
+protected_branch=dev
+
+[[ $current_branch = "${protected_branch}" ]] && {
+ echo "You're trying to push to protected branch \"${protected_branch}\""
+ echo "If you need to enforce, use --no-verify option"
+ exit 1
+}
+
+exit 0
+

--- a/.husky/protect-branch
+++ b/.husky/protect-branch
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 
 protected_branch=dev

--- a/.husky/protect-branch
+++ b/.husky/protect-branch
@@ -1,4 +1,6 @@
-current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+#!/usr/bin/env bash
+
+current_branch=$(git rev-parse --abbrev-ref HEAD)
 
 protected_branch=dev
 

--- a/.husky/protect-branch
+++ b/.husky/protect-branch
@@ -1,14 +1,15 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 
 protected_branch=dev
 
-[[ $current_branch = "${protected_branch}" ]] && {
+if [ $current_branch = "${protected_branch}" ]
+then
  echo "You're trying to push to protected branch \"${protected_branch}\""
  echo "If you need to enforce, use --no-verify option"
  exit 1
-}
+fi
 
 exit 0
 


### PR DESCRIPTION
## :unicorn: Problème
"Tout le monde" peut commiter sur la branch dev alors que cela ne devrait être fait que via un merge.
Proteger directement la branche via github n'est pour le moment pas possible à cause de la CI

## :robot: Proposition
Utiliser husky pour prevenir tout commit sur dev

## :rainbow: Remarques
- La partie lint ne bloquait pas le commit, elle affichait l'erreur mais c'est tout
- Renome le detect-secret en detect-referentiel. On verifie uniquement le referentiel et pas les secret en general


## :100: Pour tester
En local:
`npm run local:add-optional-checks`
Remplacer dans `.husky/protect-branch` 
`protected_branch=dev` par le nom de la branche à tester, par exemple `protected_branch=protect-dev-commit-husky`

Tenter de faire un commit et s'assurer que ca ne fonctionne pas. 

Remettre `dev`
ajouter une erreur de lint
Tenter de commiter et s'assurer que cela ne fonctionne pas
