### PR TITLE
[TECH] Corrige la configuration du linter pour les fichiers GJS (PIX-12008)

### DIFF
--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -14990,6 +14990,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
@@ -15019,6 +15020,8 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
       "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "6.21.0",
         "@typescript-eslint/visitor-keys": "6.21.0"
@@ -15036,6 +15039,8 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
       "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
       },
@@ -15049,6 +15054,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
       "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "6.21.0",
@@ -15078,6 +15084,7 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -15088,6 +15095,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -15098,6 +15106,7 @@
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
       "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -15115,6 +15124,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -15128,6 +15138,7 @@
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
       "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "dependencies": {
         "array-union": "^2.1.0",
@@ -15149,6 +15160,7 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
@@ -15162,6 +15174,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
       "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -15178,6 +15191,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
       "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -15194,6 +15208,7 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "node_modules/@typescript-eslint/visitor-keys": {
@@ -15201,6 +15216,8 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
       "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "6.21.0",
         "eslint-visitor-keys": "^3.4.1"
@@ -15218,6 +15235,8 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -36858,56 +36877,6 @@
         }
       }
     },
-    "node_modules/eslint-plugin-ember/node_modules/@babel/eslint-parser": {
-      "version": "7.23.10",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.23.10.tgz",
-      "integrity": "sha512-3wSYDPZVnhseRnxRJH6ZVTNknBz76AEnyC+AYYhasjP3Yy23qz0ERR7Fcd2SHmYuSFJ2kY9gaaDd3vyqU09eSw==",
-      "dev": true,
-      "dependencies": {
-        "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
-        "eslint-visitor-keys": "^2.1.0",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.11.0",
-        "eslint": "^7.5.0 || ^8.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-ember/node_modules/@glimmer/interfaces": {
-      "version": "0.88.1",
-      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.88.1.tgz",
-      "integrity": "sha512-BOcN8xFNX/eppGxwS9Rm1+PlQaFX+tK91cuQLHj2sRwB+qVbL/WeutIa3AUQYr0VVEzMm2S6bYCLvG6p0a8v9A==",
-      "dev": true,
-      "dependencies": {
-        "@simple-dom/interface": "^1.4.0"
-      }
-    },
-    "node_modules/eslint-plugin-ember/node_modules/@glimmer/syntax": {
-      "version": "0.88.1",
-      "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.88.1.tgz",
-      "integrity": "sha512-tucexG0j5SSbk3d4ayCOnvjg5FldvWyrZbzxukZOBhDgAYhGWUnGFAqdoXjpr3w6FkD4xIVliVD9GFrH4lI8DA==",
-      "dev": true,
-      "dependencies": {
-        "@glimmer/interfaces": "^0.88.1",
-        "@glimmer/util": "^0.88.1",
-        "@glimmer/wire-format": "^0.88.1",
-        "@handlebars/parser": "~2.0.0",
-        "simple-html-tokenizer": "^0.5.11"
-      }
-    },
-    "node_modules/eslint-plugin-ember/node_modules/@glimmer/util": {
-      "version": "0.88.1",
-      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.88.1.tgz",
-      "integrity": "sha512-PV/24+vBmsReR78UQXJlEHDblU6QBAeIJa8MwKhQoxSD6WgvQHP4KmX23rvlCz11GxApTwyPm/2qyp/SwVvX2A==",
-      "dev": true,
-      "dependencies": {
-        "@glimmer/env": "0.1.7",
-        "@glimmer/interfaces": "^0.88.1"
-      }
-    },
     "node_modules/eslint-plugin-ember/node_modules/css-tree": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
@@ -36919,44 +36888,6 @@
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-ember/node_modules/ember-eslint-parser": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/ember-eslint-parser/-/ember-eslint-parser-0.3.8.tgz",
-      "integrity": "sha512-P1VEHlbL8RZ/2GcdwaiG/jySWJzY6eBPkzQoA3g4lSDSG6CH0Xwmlem38wIdYy/lN28EBu++vlJvRm2KROpDRw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/eslint-parser": "7.23.10",
-        "@glimmer/syntax": "^0.88.0",
-        "@typescript-eslint/scope-manager": "^6.21.0",
-        "content-tag": "^1.2.2",
-        "eslint-scope": "^7.2.2",
-        "html-tags": "^3.3.1"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.23.6",
-        "@typescript-eslint/parser": "^6.15.0",
-        "typescript": "^5.3.3"
-      }
-    },
-    "node_modules/eslint-plugin-ember/node_modules/eslint-scope": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
-      "dev": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-plugin-ember/node_modules/mdn-data": {
@@ -48554,6 +48485,7 @@
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
       "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=16"
@@ -48701,6 +48633,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
       "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/orga/package.json
+++ b/orga/package.json
@@ -41,6 +41,11 @@
     "test:lint": "npm test && npm run lint",
     "test:watch": "ember exam --serve --reporter dot"
   },
+  "overrides": {
+    "eslint-plugin-ember": {
+      "ember-eslint-parser": "^0.4.1"
+    }
+  },
   "devDependencies": {
     "@1024pix/ember-cli-notifications": "^8.0.2",
     "@1024pix/ember-testing-library": "^1.1.0",


### PR DESCRIPTION
## :unicorn: Problème

Suite au setup pour utiliser les composants GJS dans PixOrga, on s'est retrouvé avec des warnings de configuration à chaque fichier GJS : 

```
To lint Gjs/Gts files please follow the setup guide at https://github.com/ember-cli/eslint-plugin-ember#gtsgjs
``` 

Cependant les fichiers étaient bien linté par Eslint et Prettier.

En cherchant dans le code, on a pu se rendre compte que ces messages étaient produit par la dépendence `ember-eslint-parser` dans ce fichier : https://github.com/ember-tooling/ember-eslint-parser/blob/204a15ac7725d36f8c8da22676d302c8b32baa4d/src/preprocessor/noop.js#L25

On voit que le code de se préprocesseur vérifie que les fichiers gts/gjs sont bien lintés et si ça n'est pas le cas il affiche ce warning.

En aprem tech, avec @Osirisxxl on a pris le temps d'investiguer. En mettant des logs dans le fonction `registerParsedFile` et `postprocess` on a pu constaté que la première fonction est bien appelé mais pas la deuxième. 

On a donc lancé un npm why sur la dépendance `ember-eslint-parser` pour y voir plus clair avec le résultat suivant : 
```
ember-eslint-parser@0.4.1 dev
node_modules/ember-eslint-parser
  dev ember-eslint-parser@"^0.4.1" from the root project

ember-eslint-parser@0.3.8 dev
node_modules/eslint-plugin-ember/node_modules/ember-eslint-parser
  ember-eslint-parser@"^0.3.7" from eslint-plugin-ember@12.0.2
  node_modules/eslint-plugin-ember
    dev eslint-plugin-ember@"^12.0.2" from the root project
```
On a donc pu constaté que la dépendance est installé deux fois avec des versions différentes. C'est dû à la configuration recommandé qui demande d'utiliser la section `overrides` dans le fichier eslintrc qui spécifie le parser à utiliser : 
```
  overrides: [
    {
      files: ['**/*.gjs'],
      parser: 'ember-eslint-parser',
      plugins: ['ember', 'qunit'],
      extends: [
        '@1024pix',
        'plugin:ember/recommended',
        'plugin:ember/recommended-gjs',
        'plugin:qunit/recommended',
        'plugin:prettier/recommended',
      ],
    },
]

```
## :robot: Proposition

On propose de downgrade la version de `ember-eslint-parser` pour suivre celle utilisé dans `eslint-plugin-ember` c'est à dire la 0.3.8.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
La commande npm run lint dans le dossier orga ne produit plus le warning de configuration.
