### PR TITLE
[BUGFIX] Remettre la capacité dans le rendu des simulateurs de déroulé V3 (PIX-12007).

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/scenario-simulator-batch-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/scenario-simulator-batch-serializer.js
@@ -15,7 +15,7 @@ const SERIALIZER_CONFIGURATION = {
       'minimumCapability',
       'reward',
       'errorRate',
-      'estimatedLevel',
+      'capacity',
       'answerStatus',
       'difficulty',
       'discriminant',

--- a/api/src/certification/flash-certification/application/scenario-simulator-controller.js
+++ b/api/src/certification/flash-certification/application/scenario-simulator-controller.js
@@ -87,7 +87,7 @@ async function simulateFlashAssessmentScenario(
           reward: answer.reward,
           errorRate: answer.errorRate,
           answerStatus: answer.answerStatus,
-          estimatedLevel: answer.estimatedLevel,
+          capacity: answer.capacity,
         })),
       }) + '\n';
     }

--- a/api/tests/acceptance/application/scenario-simulator/scenario-simulator-controller_test.js
+++ b/api/tests/acceptance/application/scenario-simulator/scenario-simulator-controller_test.js
@@ -177,6 +177,13 @@ ko,aband,ok`;
         expect(response).to.have.property('statusCode', 200);
         const parsedResponse = parseJsonStream(response);
         expect(parsedResponse[0].simulationReport).to.have.lengthOf(2);
+        expect(parsedResponse[0].simulationReport[0].challengeId).to.exist;
+        expect(parsedResponse[0].simulationReport[0].capacity).to.exist;
+        expect(parsedResponse[0].simulationReport[0].difficulty).to.exist;
+        expect(parsedResponse[0].simulationReport[0].discriminant).to.exist;
+        expect(parsedResponse[0].simulationReport[0].reward).to.exist;
+        expect(parsedResponse[0].simulationReport[0].errorRate).to.exist;
+        expect(parsedResponse[0].simulationReport[0].answerStatus).to.exist;
       });
     });
 

--- a/api/tests/certification/flash-certification/integration/application/scenario-simulator-controller_test.js
+++ b/api/tests/certification/flash-certification/integration/application/scenario-simulator-controller_test.js
@@ -12,7 +12,7 @@ describe('Integration | Application | scenario-simulator-controller', function (
   let reward1;
   let errorRate1;
   let challenge1;
-  let estimatedLevel1;
+  let capacity1;
   const initialCapacity = 2;
 
   beforeEach(async function () {
@@ -26,13 +26,13 @@ describe('Integration | Application | scenario-simulator-controller', function (
     challenge1 = domainBuilder.buildChallenge({ id: 'chall1', successProbabilityThreshold: 0.65 });
     reward1 = 0.2;
     errorRate1 = 0.3;
-    estimatedLevel1 = 0.4;
+    capacity1 = 0.4;
     simulationResults = [
       {
         challenge: challenge1,
         reward: reward1,
         errorRate: errorRate1,
-        estimatedLevel: estimatedLevel1,
+        capacity: capacity1,
       },
     ];
 
@@ -46,13 +46,13 @@ describe('Integration | Application | scenario-simulator-controller', function (
         challenge1 = domainBuilder.buildChallenge({ id: 'chall1', successProbabilityThreshold: 0.65 });
         reward1 = 0.2;
         errorRate1 = 0.3;
-        estimatedLevel1 = 0.4;
+        capacity1 = 0.4;
         simulationResults = [
           {
             challenge: challenge1,
             reward: reward1,
             errorRate: errorRate1,
-            estimatedLevel: estimatedLevel1,
+            capacity: capacity1,
             answerStatus: 'ok',
           },
         ];
@@ -107,7 +107,7 @@ describe('Integration | Application | scenario-simulator-controller', function (
                   {
                     challengeId: challenge1.id,
                     errorRate: errorRate1,
-                    estimatedLevel: estimatedLevel1,
+                    capacity: capacity1,
                     minimumCapability: 0.6190392084062237,
                     answerStatus: 'ok',
                     reward: reward1,
@@ -169,7 +169,7 @@ describe('Integration | Application | scenario-simulator-controller', function (
                 {
                   challengeId: challenge1.id,
                   errorRate: errorRate1,
-                  estimatedLevel: estimatedLevel1,
+                  capacity: capacity1,
                   minimumCapability: 0.6190392084062237,
                   answerStatus: 'ok',
                   reward: reward1,
@@ -231,7 +231,7 @@ describe('Integration | Application | scenario-simulator-controller', function (
                 {
                   challengeId: challenge1.id,
                   errorRate: errorRate1,
-                  estimatedLevel: estimatedLevel1,
+                  capacity: capacity1,
                   minimumCapability: 0.6190392084062237,
                   answerStatus: 'ok',
                   reward: reward1,
@@ -292,7 +292,7 @@ describe('Integration | Application | scenario-simulator-controller', function (
                 {
                   challengeId: challenge1.id,
                   errorRate: errorRate1,
-                  estimatedLevel: estimatedLevel1,
+                  capacity: capacity1,
                   minimumCapability: 0.6190392084062237,
                   answerStatus: 'ok',
                   reward: reward1,
@@ -383,7 +383,7 @@ describe('Integration | Application | scenario-simulator-controller', function (
                   {
                     challengeId: challenge1.id,
                     errorRate: errorRate1,
-                    estimatedLevel: estimatedLevel1,
+                    capacity: capacity1,
                     minimumCapability: 0.6190392084062237,
                     answerStatus: 'ok',
                     reward: reward1,
@@ -564,7 +564,7 @@ describe('Integration | Application | scenario-simulator-controller', function (
                 {
                   challengeId: challenge1.id,
                   errorRate: errorRate1,
-                  estimatedLevel: estimatedLevel1,
+                  capacity: capacity1,
                   minimumCapability: 0.6190392084062237,
                   answerStatus: 'ok',
                   reward: reward1,
@@ -624,7 +624,7 @@ describe('Integration | Application | scenario-simulator-controller', function (
                     {
                       challengeId: challenge1.id,
                       errorRate: errorRate1,
-                      estimatedLevel: estimatedLevel1,
+                      capacity: capacity1,
                       minimumCapability: 0.6190392084062237,
                       answerStatus: 'ok',
                       reward: reward1,
@@ -680,7 +680,7 @@ describe('Integration | Application | scenario-simulator-controller', function (
                     {
                       challengeId: challenge1.id,
                       errorRate: errorRate1,
-                      estimatedLevel: estimatedLevel1,
+                      capacity: capacity1,
                       minimumCapability: 0.6190392084062237,
                       answerStatus: 'ok',
                       reward: reward1,
@@ -733,7 +733,7 @@ describe('Integration | Application | scenario-simulator-controller', function (
               const result = {
                 challengeId: challenge1.id,
                 errorRate: errorRate1,
-                estimatedLevel: estimatedLevel1,
+                capacity: capacity1,
                 minimumCapability: 0.6190392084062237,
                 answerStatus: 'ok',
                 reward: reward1,
@@ -808,7 +808,7 @@ describe('Integration | Application | scenario-simulator-controller', function (
                     {
                       challengeId: challenge1.id,
                       errorRate: errorRate1,
-                      estimatedLevel: estimatedLevel1,
+                      capacity: capacity1,
                       minimumCapability: 0.6190392084062237,
                       answerStatus: 'ok',
                       reward: reward1,
@@ -869,7 +869,7 @@ describe('Integration | Application | scenario-simulator-controller', function (
                     {
                       challengeId: challenge1.id,
                       errorRate: errorRate1,
-                      estimatedLevel: estimatedLevel1,
+                      capacity: capacity1,
                       minimumCapability: 0.6190392084062237,
                       answerStatus: 'ok',
                       reward: reward1,
@@ -929,7 +929,7 @@ describe('Integration | Application | scenario-simulator-controller', function (
                     {
                       challengeId: challenge1.id,
                       errorRate: errorRate1,
-                      estimatedLevel: estimatedLevel1,
+                      capacity: capacity1,
                       minimumCapability: 0.6190392084062237,
                       answerStatus: 'ok',
                       reward: reward1,
@@ -987,7 +987,7 @@ describe('Integration | Application | scenario-simulator-controller', function (
                     {
                       challengeId: challenge1.id,
                       errorRate: errorRate1,
-                      estimatedLevel: estimatedLevel1,
+                      capacity: capacity1,
                       minimumCapability: 0.6190392084062237,
                       answerStatus: 'ok',
                       reward: reward1,
@@ -1013,23 +1013,23 @@ describe('Integration | Application | scenario-simulator-controller', function (
           const challenge2 = domainBuilder.buildChallenge({ id: 'chall2', successProbabilityThreshold: 0.5 });
           const reward1 = 0.2;
           const errorRate1 = 0.3;
-          const estimatedLevel1 = 0.4;
+          const capacity1 = 0.4;
           const reward2 = 0.6;
           const errorRate2 = 0.7;
-          const estimatedLevel2 = 0.8;
+          const capacity2 = 0.8;
           const simulationResults1 = [
             {
               challenge: challenge1,
               reward: reward1,
               errorRate: errorRate1,
-              estimatedLevel: estimatedLevel1,
+              capacity: capacity1,
               answerStatus: 'ok',
             },
             {
               challenge: challenge2,
               reward: reward2,
               errorRate: errorRate2,
-              estimatedLevel: estimatedLevel2,
+              capacity: capacity2,
               answerStatus: 'ok',
             },
           ];
@@ -1054,14 +1054,14 @@ describe('Integration | Application | scenario-simulator-controller', function (
               challenge: challenge1,
               reward: reward1,
               errorRate: errorRate1,
-              estimatedLevel: estimatedLevel1,
+              capacity: capacity1,
               answerStatus: 'ko',
             },
             {
               challenge: challenge2,
               reward: reward2,
               errorRate: errorRate2,
-              estimatedLevel: estimatedLevel2,
+              capacity: capacity2,
               answerStatus: 'ok',
             },
           ];
@@ -1107,7 +1107,7 @@ describe('Integration | Application | scenario-simulator-controller', function (
                       'minimum-capability': 0.6190392084062237,
                       reward: reward1,
                       'error-rate': errorRate1,
-                      'estimated-level': estimatedLevel1,
+                      capacity: capacity1,
                       'answer-status': 'ok',
                       difficulty: challenge1.difficulty,
                       discriminant: challenge1.discriminant,
@@ -1117,7 +1117,7 @@ describe('Integration | Application | scenario-simulator-controller', function (
                       'minimum-capability': 0,
                       reward: reward2,
                       'error-rate': errorRate2,
-                      'estimated-level': estimatedLevel2,
+                      capacity: capacity2,
                       'answer-status': 'ok',
                       difficulty: challenge2.difficulty,
                       discriminant: challenge2.discriminant,
@@ -1135,7 +1135,7 @@ describe('Integration | Application | scenario-simulator-controller', function (
                       'minimum-capability': 0.6190392084062237,
                       reward: reward1,
                       'error-rate': errorRate1,
-                      'estimated-level': estimatedLevel1,
+                      capacity: capacity1,
                       'answer-status': 'ko',
                       difficulty: challenge1.difficulty,
                       discriminant: challenge1.discriminant,
@@ -1145,7 +1145,7 @@ describe('Integration | Application | scenario-simulator-controller', function (
                       'minimum-capability': 0,
                       reward: reward2,
                       'error-rate': errorRate2,
-                      'estimated-level': estimatedLevel2,
+                      capacity: capacity2,
                       'answer-status': 'ok',
                       difficulty: challenge2.difficulty,
                       discriminant: challenge2.discriminant,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/scenario-simulator-batch-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/scenario-simulator-batch-serializer_test.js
@@ -18,7 +18,7 @@ describe('Unit | Serializer | JSONAPI | scenario-simulator-batch-serializer', fu
             {
               challenge,
               reward: 2,
-              estimatedLevel: 1,
+              capacity: 1,
               errorRate: 1.5,
               answerStatus: 'ok',
               difficulty: 0.6,
@@ -41,7 +41,7 @@ describe('Unit | Serializer | JSONAPI | scenario-simulator-batch-serializer', fu
                   'challenge-id': challenge.id,
                   'answer-status': 'ok',
                   'error-rate': 1.5,
-                  'estimated-level': 1,
+                  capacity: 1,
                   'minimum-capability': 0.6,
                   reward: 2,
                   difficulty: 0.6,


### PR DESCRIPTION
## :unicorn: Problème

Suite au renommage de `estimatedLevel` en `capacity` effectué dans la PR #8485 , `estimatedLevel` n'est plus retourné dans les simulations car son nom n'a pas été changé.

## :robot: Proposition

Renommer `estimatedLevel` en `capacity` dans les simulateurs de déroulé V3

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

Lancer la simulation suivante et vérifier que les objets retournés dans `simulationReport` contiennent la propriété `capacity`.

```
TOKEN=$(curl 'https://api-pr8622.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr8622.review.pix.fr/api/scenario-simulator \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "type": "deterministic", "answerStatusArray": ["ok","ok","ok"]}' | jq '.'