### PR TITLE
[TECH] Activer la règle prefer-node-protocol du plugin eslint unicorn

### DIFF
--- a/api/.eslintrc.cjs
+++ b/api/.eslintrc.cjs
@@ -35,6 +35,7 @@ module.exports = {
     'no-empty-function': 'error',
     'n/no-process-exit': 'error',
     'unicorn/no-empty-file': 'error',
+    'unicorn/prefer-node-protocol': 'error',
     'n/no-unpublished-import': [
       'error',
       {

--- a/api/db/database-builder/factory/build-badge.js
+++ b/api/db/database-builder/factory/build-badge.js
@@ -1,4 +1,5 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
+
 import _ from 'lodash';
 
 import { databaseBuffer } from '../database-buffer.js';

--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -4,7 +4,7 @@ const types = pg.types;
 import _ from 'lodash';
 
 const { get } = _;
-import perf_hooks from 'perf_hooks';
+import perf_hooks from 'node:perf_hooks';
 
 import { config } from '../lib/config.js';
 import { monitoringTools } from '../lib/infrastructure/monitoring-tools.js';

--- a/api/db/knexfile.js
+++ b/api/db/knexfile.js
@@ -1,4 +1,4 @@
-import * as url from 'url';
+import * as url from 'node:url';
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 import * as dotenv from 'dotenv';
 dotenv.config({ path: `${__dirname}/../.env` });

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -1,5 +1,6 @@
+import perf_hooks from 'node:perf_hooks';
+
 import _ from 'lodash';
-import perf_hooks from 'perf_hooks';
 
 import * as complementaryCertificationBadgesRepository from '../../../src/certification/complementary-certification/infrastructure/repositories/complementary-certification-badge-repository.js';
 import * as flashAlgorithmService from '../../../src/certification/flash-certification/domain/services/algorithm-methods/flash.js';

--- a/api/lib/domain/services/authentication/fwb-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/fwb-oidc-authentication-service.js
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 
 import { OidcAuthenticationService } from '../../../../src/authentication/domain/services/oidc-authentication-service.js';
 import { config } from '../../../config.js';

--- a/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
@@ -1,4 +1,5 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
+
 import dayjs from 'dayjs';
 
 import { OidcAuthenticationService } from '../../../../src/authentication/domain/services/oidc-authentication-service.js';

--- a/api/lib/domain/services/reset-password-service.js
+++ b/api/lib/domain/services/reset-password-service.js
@@ -1,4 +1,5 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
+
 import jsonwebtoken from 'jsonwebtoken';
 
 import { config } from '../../config.js';

--- a/api/lib/domain/usecases/account-recovery/send-email-for-account-recovery.js
+++ b/api/lib/domain/usecases/account-recovery/send-email-for-account-recovery.js
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 import { AccountRecoveryDemand } from '../../models/AccountRecoveryDemand.js';
 

--- a/api/lib/domain/usecases/publish-sessions-in-batch.js
+++ b/api/lib/domain/usecases/publish-sessions-in-batch.js
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 
 import { SessionPublicationBatchResult } from '../models/SessionPublicationBatchResult.js';
 

--- a/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
+++ b/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
@@ -2,8 +2,9 @@ import lodash from 'lodash';
 
 const { get } = lodash;
 
+import querystring from 'node:querystring';
+
 import dayjs from 'dayjs';
-import querystring from 'querystring';
 
 import { config } from '../../../config.js';
 import * as OidcIdentityProviders from '../../../domain/constants/oidc-identity-providers.js';

--- a/api/lib/infrastructure/files/candidates-import/fill-candidates-import-sheet.js
+++ b/api/lib/infrastructure/files/candidates-import/fill-candidates-import-sheet.js
@@ -1,5 +1,6 @@
+import * as url from 'node:url';
+
 import _ from 'lodash';
-import * as url from 'url';
 
 import { CertificationCandidate } from '../../../domain/models/CertificationCandidate.js';
 import * as readOdsUtils from '../../utils/ods/read-ods-utils.js';

--- a/api/lib/infrastructure/helpers/csv.js
+++ b/api/lib/infrastructure/helpers/csv.js
@@ -1,4 +1,4 @@
-import fs, { promises } from 'fs';
+import fs, { promises } from 'node:fs';
 
 const { readFile, access } = promises;
 

--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -1,5 +1,6 @@
+import perf_hooks from 'node:perf_hooks';
+
 import axios from 'axios';
-import perf_hooks from 'perf_hooks';
 
 const { performance } = perf_hooks;
 

--- a/api/lib/infrastructure/jobs/cpf-export/handlers/create-and-upload.js
+++ b/api/lib/infrastructure/jobs/cpf-export/handlers/create-and-upload.js
@@ -1,6 +1,6 @@
+import * as uuid from 'node:crypto';
 import { createGzip } from 'node:zlib';
 
-import * as uuid from 'crypto';
 import dayjs from 'dayjs';
 import timezone from 'dayjs/plugin/timezone.js';
 import utc from 'dayjs/plugin/utc.js';

--- a/api/lib/infrastructure/monitoring-tools.js
+++ b/api/lib/infrastructure/monitoring-tools.js
@@ -4,7 +4,7 @@ import lodash from 'lodash';
 import { config } from '../config.js';
 
 const { get, set, update, omit } = lodash;
-import async_hooks from 'async_hooks';
+import async_hooks from 'node:async_hooks';
 
 import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 import * as requestResponseUtils from '../infrastructure/utils/request-response-utils.js';

--- a/api/lib/infrastructure/plugins/i18n.js
+++ b/api/lib/infrastructure/plugins/i18n.js
@@ -1,5 +1,6 @@
+import * as url from 'node:url';
+
 import hapiI18n from 'hapi-i18n';
-import * as url from 'url';
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 const plugin = hapiI18n;
 const options = {

--- a/api/lib/infrastructure/plugins/pino.js
+++ b/api/lib/infrastructure/plugins/pino.js
@@ -1,4 +1,5 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
+
 import { stdSerializers } from 'pino';
 
 import { logger } from '../../../src/shared/infrastructure/utils/logger.js';

--- a/api/lib/infrastructure/serializers/csv/campaigns-administration/csv-campaigns-ids-parser.js
+++ b/api/lib/infrastructure/serializers/csv/campaigns-administration/csv-campaigns-ids-parser.js
@@ -1,4 +1,4 @@
-import * as fs from 'fs/promises';
+import * as fs from 'node:fs/promises';
 
 import { CsvParser } from '../csv-parser.js';
 import { CampaignIdsCsvHeader } from './campaign-ids-csv-header.js';

--- a/api/lib/infrastructure/temporary-storage/TemporaryStorage.js
+++ b/api/lib/infrastructure/temporary-storage/TemporaryStorage.js
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 
 class TemporaryStorage {
   static generateKey() {

--- a/api/lib/infrastructure/utils/ods/common-ods-utils.js
+++ b/api/lib/infrastructure/utils/ods/common-ods-utils.js
@@ -1,4 +1,5 @@
-import * as fs from 'fs/promises';
+import * as fs from 'node:fs/promises';
+
 import JSZip from 'jszip';
 
 async function loadOdsZip(odsFilePath) {

--- a/api/scripts/_template.js
+++ b/api/scripts/_template.js
@@ -1,7 +1,7 @@
 import 'dotenv/config';
 
-import perf_hooks from 'perf_hooks';
-import * as url from 'url';
+import perf_hooks from 'node:perf_hooks';
+import * as url from 'node:url';
 
 const { performance } = perf_hooks;
 

--- a/api/scripts/add-or-update-certification-centers-dpo-infos.js
+++ b/api/scripts/add-or-update-certification-centers-dpo-infos.js
@@ -1,8 +1,9 @@
 import 'dotenv/config';
 
+import * as url from 'node:url';
+
 import bluebird from 'bluebird';
 import _ from 'lodash';
-import * as url from 'url';
 
 import { disconnect } from '../db/knex-database-connection.js';
 import { updateCertificationCenterDataProtectionOfficerInformation } from '../lib/domain/usecases/update-certification-center-data-protection-officer-information.js';

--- a/api/scripts/add-or-update-organizations-dpo-infos.js
+++ b/api/scripts/add-or-update-organizations-dpo-infos.js
@@ -1,8 +1,9 @@
 import 'dotenv/config';
 
+import * as url from 'node:url';
+
 import bluebird from 'bluebird';
 import _ from 'lodash';
-import * as url from 'url';
 
 import { disconnect } from '../db/knex-database-connection.js';
 import { updateOrganizationDataProtectionOfficerInformation } from '../lib/domain/usecases/update-organization-data-protection-officer-information.js';

--- a/api/scripts/add-tags-to-organizations.js
+++ b/api/scripts/add-tags-to-organizations.js
@@ -11,7 +11,7 @@ import * as tagRepository from '../lib/infrastructure/repositories/tag-repositor
 import { parseCsv } from './helpers/csvHelpers.js';
 
 const { uniq } = lodash;
-import * as url from 'url';
+import * as url from 'node:url';
 
 import { disconnect } from '../db/knex-database-connection.js';
 

--- a/api/scripts/arborescence-monitoring/add-metrics-to-gist.js
+++ b/api/scripts/arborescence-monitoring/add-metrics-to-gist.js
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from 'fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 
 import { countFilesInPath } from './stats.js';
 import { TimeSeries } from './time-series.js';

--- a/api/scripts/certification/cancel-certifications-and-publish-sessions.js
+++ b/api/scripts/certification/cancel-certifications-and-publish-sessions.js
@@ -1,5 +1,6 @@
+import * as url from 'node:url';
+
 import _ from 'lodash';
-import * as url from 'url';
 import yargs from 'yargs';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';

--- a/api/scripts/certification/fill-issue-report-category-id.js
+++ b/api/scripts/certification/fill-issue-report-category-id.js
@@ -1,5 +1,6 @@
+import * as url from 'node:url';
+
 import bluebird from 'bluebird';
-import * as url from 'url';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 import { logger } from '../../src/shared/infrastructure/utils/logger.js';

--- a/api/scripts/certification/fill-last-assessment-result-certification-course-table.js
+++ b/api/scripts/certification/fill-last-assessment-result-certification-course-table.js
@@ -1,7 +1,8 @@
 import 'dotenv/config';
 
+import * as url from 'node:url';
+
 import bluebird from 'bluebird';
-import * as url from 'url';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 import { learningContentCache as cache } from '../../lib/infrastructure/caches/learning-content-cache.js';

--- a/api/scripts/certification/fill-pix-certification-status-column-in-certification-courses-table.js
+++ b/api/scripts/certification/fill-pix-certification-status-column-in-certification-courses-table.js
@@ -1,12 +1,13 @@
 import 'dotenv/config';
 
-import perf_hooks from 'perf_hooks';
+import perf_hooks from 'node:perf_hooks';
 
 const { performance } = perf_hooks;
 
+import readline from 'node:readline';
+import * as url from 'node:url';
+
 import bluebird from 'bluebird';
-import readline from 'readline';
-import * as url from 'url';
 import yargs from 'yargs';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';

--- a/api/scripts/certification/generate-certificate-verification-code.js
+++ b/api/scripts/certification/generate-certificate-verification-code.js
@@ -1,8 +1,9 @@
 /* eslint no-console: ["off"] */
 import 'dotenv/config';
 
+import * as url from 'node:url';
+
 import bluebird from 'bluebird';
-import * as url from 'url';
 import yargs from 'yargs';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';

--- a/api/scripts/certification/generate-certification-csv-results-by-session-ids.js
+++ b/api/scripts/certification/generate-certification-csv-results-by-session-ids.js
@@ -1,11 +1,13 @@
+import * as url from 'node:url';
+
 import * as dotenv from 'dotenv';
-import * as url from 'url';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 dotenv.config({ path: `${__dirname}/../.env` });
 
+import fs from 'node:fs';
+
 import bluebird from 'bluebird';
-import fs from 'fs';
 import lodash from 'lodash';
 const { isEmpty } = lodash;
 import { disconnect } from '../../db/knex-database-connection.js';

--- a/api/scripts/certification/generate-certification-results.js
+++ b/api/scripts/certification/generate-certification-results.js
@@ -1,8 +1,9 @@
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 
 const ASSESSMENT_COUNT = parseInt(process.env.ASSESSMENT_COUNT) || 100;
+import * as url from 'node:url';
+
 import bluebird from 'bluebird';
-import * as url from 'url';
 
 import * as scoringCertificationService from '../../lib/domain/services/scoring/scoring-certification-service.js';
 import * as certificationAssessmentRepository from '../../src/certification/shared/infrastructure/repositories/certification-assessment-repository.js';

--- a/api/scripts/certification/generate-certification-test-statistics.js
+++ b/api/scripts/certification/generate-certification-test-statistics.js
@@ -4,8 +4,9 @@ import _ from 'lodash';
 import originalFp from 'lodash/fp.js';
 
 const fp = originalFp.convert({ cap: false });
+import * as url from 'node:url';
+
 import bluebird from 'bluebird';
-import * as url from 'url';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 import * as certificationChallengeService from '../../lib/domain/services/certification-challenges-service.js';

--- a/api/scripts/certification/generate-last-assessments-score.js
+++ b/api/scripts/certification/generate-last-assessments-score.js
@@ -4,8 +4,9 @@ import { disconnect, knex } from '../../db/knex-database-connection.js';
 
 const ASSESSMENT_COUNT = parseInt(process.env.ASSESSMENT_COUNT) || 100;
 const ASSESSMENT_ID = parseInt(process.env.ASSESSMENT_ID) || null;
+import * as url from 'node:url';
+
 import bluebird from 'bluebird';
-import * as url from 'url';
 
 import * as scoringCertificationService from '../../lib/domain/services/scoring/scoring-certification-service.js';
 import * as certificationAssessmentRepository from '../../src/certification/shared/infrastructure/repositories/certification-assessment-repository.js';

--- a/api/scripts/certification/get-cpf-import-status-from-xml.js
+++ b/api/scripts/certification/get-cpf-import-status-from-xml.js
@@ -1,4 +1,4 @@
-import * as url from 'url';
+import * as url from 'node:url';
 
 import { disconnect } from '../../db/knex-database-connection.js';
 import { usecases } from '../../src/certification/session/domain/usecases/index.js';

--- a/api/scripts/certification/get-user-certification-eligibility.js
+++ b/api/scripts/certification/get-user-certification-eligibility.js
@@ -1,4 +1,4 @@
-import * as url from 'url';
+import * as url from 'node:url';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 import * as dotenv from 'dotenv';

--- a/api/scripts/certification/import-certification-cpf-cities.js
+++ b/api/scripts/certification/import-certification-cpf-cities.js
@@ -14,7 +14,7 @@ import { logger } from '../../src/shared/infrastructure/utils/logger.js';
  **/
 import { checkCsvHeader, parseCsv } from '../helpers/csvHelpers.js';
 const { uniqBy, values } = lodash;
-import * as url from 'url';
+import * as url from 'node:url';
 
 const wordsToReplace = [
   {

--- a/api/scripts/certification/import-certification-cpf-countries.js
+++ b/api/scripts/certification/import-certification-cpf-countries.js
@@ -2,8 +2,9 @@
 // File Millésime 2021 : Liste des pays et territoires étrangers au 01/01/2021
 // downloaded from https://www.data.gouv.fr/fr/datasets/code-officiel-geographique-cog/
 
+import * as url from 'node:url';
+
 import _ from 'lodash';
-import * as url from 'url';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 import { normalizeAndSortChars } from '../../src/shared/infrastructure/utils/string-utils.js';

--- a/api/scripts/certification/import-certifications-from-csv.js
+++ b/api/scripts/certification/import-certifications-from-csv.js
@@ -1,8 +1,9 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import * as url from 'node:url';
+
 import axios from 'axios';
-import fs from 'fs';
 import papa from 'papaparse';
-import path from 'path';
-import * as url from 'url';
 
 import { disconnect } from '../../db/knex-database-connection.js';
 

--- a/api/scripts/certification/launch-auto-jury-for-session.js
+++ b/api/scripts/certification/launch-auto-jury-for-session.js
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 
-import * as url from 'url';
+import * as url from 'node:url';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 import { handleAutoJury } from '../../lib/domain/events/handle-auto-jury.js';

--- a/api/scripts/certification/next-gen/generate-flash-algorithm-configuration.js
+++ b/api/scripts/certification/next-gen/generate-flash-algorithm-configuration.js
@@ -1,4 +1,4 @@
-import * as url from 'url';
+import * as url from 'node:url';
 
 import { disconnect } from '../../../db/knex-database-connection.js';
 import { FlashAssessmentAlgorithmConfiguration } from '../../../src/certification/flash-certification/domain/models/FlashAssessmentAlgorithmConfiguration.js';

--- a/api/scripts/certification/send-certification-result-emails.js
+++ b/api/scripts/certification/send-certification-result-emails.js
@@ -1,9 +1,10 @@
 import 'dotenv/config';
 
+import path from 'node:path';
+import * as url from 'node:url';
+
 import bluebird from 'bluebird';
 import i18n from 'i18n';
-import path from 'path';
-import * as url from 'url';
 
 import { disconnect } from '../../db/knex-database-connection.js';
 import * as mailService from '../../lib/domain/services/mail-service.js';

--- a/api/scripts/certification/trigger-autojury-on-finalized-sessions.js
+++ b/api/scripts/certification/trigger-autojury-on-finalized-sessions.js
@@ -1,5 +1,6 @@
+import * as url from 'node:url';
+
 import bluebird from 'bluebird';
-import * as url from 'url';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 import { handleAutoJury } from '../../lib/domain/events/handle-auto-jury.js';

--- a/api/scripts/certification/update-certification-infos.js
+++ b/api/scripts/certification/update-certification-infos.js
@@ -1,12 +1,13 @@
-import * as url from 'url';
+import * as url from 'node:url';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 import * as dotenv from 'dotenv';
 
 dotenv.config({ path: `${__dirname}/../.env` });
 
+import { readFile } from 'node:fs/promises';
+
 import bluebird from 'bluebird';
-import { readFile } from 'fs/promises';
 import lodash from 'lodash';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';

--- a/api/scripts/certification/validate-cpf-xml.js
+++ b/api/scripts/certification/validate-cpf-xml.js
@@ -1,7 +1,8 @@
-import { readFile } from 'fs/promises';
+import { readFile } from 'node:fs/promises';
+import * as url from 'node:url';
+
 // eslint-disable-next-line n/no-unpublished-import
 import { parseXml } from 'libxmljs2';
-import * as url from 'url';
 
 import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 

--- a/api/scripts/compare-pix-with-latest-release.js
+++ b/api/scripts/compare-pix-with-latest-release.js
@@ -1,7 +1,8 @@
 import 'dotenv/config';
 
+import * as url from 'node:url';
+
 import _ from 'lodash';
-import * as url from 'url';
 
 import { buildKnowledgeElement } from '../db/database-builder/factory/build-knowledge-element.js';
 import { disconnect } from '../db/knex-database-connection.js';

--- a/api/scripts/create-badge-criteria-for-specified-badge.js
+++ b/api/scripts/create-badge-criteria-for-specified-badge.js
@@ -1,7 +1,8 @@
+import { readFile } from 'node:fs/promises';
+import * as url from 'node:url';
+
 import bluebird from 'bluebird';
-import { readFile } from 'fs/promises';
 import Joi from 'joi';
-import * as url from 'url';
 
 import { disconnect } from '../db/knex-database-connection.js';
 import { NotFoundError } from '../lib/domain/errors.js';

--- a/api/scripts/create-certification-center-memberships-from-organization-admins.js
+++ b/api/scripts/create-certification-center-memberships-from-organization-admins.js
@@ -1,6 +1,7 @@
+import * as url from 'node:url';
+
 import bluebird from 'bluebird';
 import _ from 'lodash';
-import * as url from 'url';
 
 import { disconnect, knex } from '../db/knex-database-connection.js';
 import { Membership } from '../lib/domain/models/Membership.js';

--- a/api/scripts/create-organizations-with-tags-and-target-profiles.js
+++ b/api/scripts/create-organizations-with-tags-and-target-profiles.js
@@ -113,7 +113,7 @@ async function createOrganizationWithTagsAndTargetProfiles(filePath) {
   });
 }
 
-import * as url from 'url';
+import * as url from 'node:url';
 
 const modulePath = url.fileURLToPath(import.meta.url);
 const isLaunchedFromCommandLine = process.argv[1] === modulePath;

--- a/api/scripts/create-users-accounts-for-contest.js
+++ b/api/scripts/create-users-accounts-for-contest.js
@@ -1,5 +1,6 @@
+import * as url from 'node:url';
+
 import bluebird from 'bluebird';
-import * as url from 'url';
 
 import { disconnect } from '../db/knex-database-connection.js';
 import * as userService from '../lib/domain/services/user-service.js';

--- a/api/scripts/data-generation/add-many-divisions-and-students-to-sco-organization.js
+++ b/api/scripts/data-generation/add-many-divisions-and-students-to-sco-organization.js
@@ -1,6 +1,7 @@
+import * as url from 'node:url';
+
 import _ from 'lodash';
 import randomString from 'randomstring';
-import * as url from 'url';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 import { OrganizationLearnersCouldNotBeSavedError } from '../../lib/domain/errors.js';

--- a/api/scripts/data-generation/add-many-fake-members-related-to-one-organization.js
+++ b/api/scripts/data-generation/add-many-fake-members-related-to-one-organization.js
@@ -3,7 +3,7 @@ import lodash from 'lodash';
 import { MembershipUpdateError, UserCantBeCreatedError } from '../../lib/domain/errors.js';
 import { DomainTransaction } from '../../lib/infrastructure/DomainTransaction.js';
 const { times } = lodash;
-import * as url from 'url';
+import * as url from 'node:url';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 import { ForbiddenAccess } from '../../src/shared/domain/errors.js';

--- a/api/scripts/data-generation/add-many-students-to-sco-certification-center.js
+++ b/api/scripts/data-generation/add-many-students-to-sco-certification-center.js
@@ -1,5 +1,6 @@
+import * as url from 'node:url';
+
 import _ from 'lodash';
-import * as url from 'url';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 import { OrganizationLearnersCouldNotBeSavedError } from '../../lib/domain/errors.js';

--- a/api/scripts/data-generation/generate-campaign-with-participants.js
+++ b/api/scripts/data-generation/generate-campaign-with-participants.js
@@ -1,4 +1,4 @@
-import * as url from 'url';
+import * as url from 'node:url';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 import * as dotenv from 'dotenv';

--- a/api/scripts/data-generation/generate-certif-cli.js
+++ b/api/scripts/data-generation/generate-certif-cli.js
@@ -1,4 +1,4 @@
-import * as url from 'url';
+import * as url from 'node:url';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 

--- a/api/scripts/data-generation/generate-certifications-for-organization.js
+++ b/api/scripts/data-generation/generate-certifications-for-organization.js
@@ -1,5 +1,6 @@
+import * as url from 'node:url';
+
 import _ from 'lodash';
-import * as url from 'url';
 import yargs from 'yargs';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';

--- a/api/scripts/data-generation/seeds/dump-target-profile-data-as-seeds.js
+++ b/api/scripts/data-generation/seeds/dump-target-profile-data-as-seeds.js
@@ -1,4 +1,4 @@
-import * as url from 'url';
+import * as url from 'node:url';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 import * as dotenv from 'dotenv';

--- a/api/scripts/database/restore-dump/download-backup.js
+++ b/api/scripts/database/restore-dump/download-backup.js
@@ -2,7 +2,8 @@ import * as dotenv from 'dotenv';
 
 dotenv.config({ path: '../../../.env' });
 
-import fs from 'fs';
+import fs from 'node:fs';
+
 import Joi from 'joi';
 
 import { disconnect } from '../../../db/knex-database-connection.js';

--- a/api/scripts/database/restore-dump/helpers/scalingo/db-client.js
+++ b/api/scripts/database/restore-dump/helpers/scalingo/db-client.js
@@ -1,7 +1,8 @@
+import fs from 'node:fs';
+import pipeline from 'node:stream';
+import util from 'node:util';
+
 import axios from 'axios';
-import fs from 'fs';
-import pipeline from 'stream';
-import util from 'util';
 
 const streamPipeline = util.promisify(pipeline);
 

--- a/api/scripts/delete-assessment.js
+++ b/api/scripts/delete-assessment.js
@@ -1,4 +1,4 @@
-import * as url from 'url';
+import * as url from 'node:url';
 
 import { PgClient } from './PgClient.js';
 

--- a/api/scripts/fill-campaign-participation-id-in-badge-acquisitions.js
+++ b/api/scripts/fill-campaign-participation-id-in-badge-acquisitions.js
@@ -1,5 +1,6 @@
+import * as url from 'node:url';
+
 import bluebird from 'bluebird';
-import * as url from 'url';
 
 import { disconnect, knex } from '../db/knex-database-connection.js';
 

--- a/api/scripts/fill-score-level.js
+++ b/api/scripts/fill-score-level.js
@@ -1,5 +1,6 @@
+import * as url from 'node:url';
+
 import axios from 'axios';
-import * as url from 'url';
 
 function parseArgs(argv) {
   return argv.slice(3);

--- a/api/scripts/fill-skill-id-in-user-saved-tutorials.js
+++ b/api/scripts/fill-skill-id-in-user-saved-tutorials.js
@@ -2,7 +2,7 @@ import 'dotenv/config';
 
 import lodash from 'lodash';
 const { groupBy } = lodash;
-import * as url from 'url';
+import * as url from 'node:url';
 
 import { disconnect, knex } from '../db/knex-database-connection.js';
 import { KnowledgeElement } from '../lib/domain/models/KnowledgeElement.js';

--- a/api/scripts/fill-target-profiles-with-default-image-url.js
+++ b/api/scripts/fill-target-profiles-with-default-image-url.js
@@ -1,7 +1,7 @@
 import 'dotenv/config';
 
-import perf_hooks from 'perf_hooks';
-import * as url from 'url';
+import perf_hooks from 'node:perf_hooks';
+import * as url from 'node:url';
 
 import { disconnect, knex } from '../db/knex-database-connection.js';
 import { logger } from '../src/shared/infrastructure/utils/logger.js';

--- a/api/scripts/generate-api-documentation.js
+++ b/api/scripts/generate-api-documentation.js
@@ -1,8 +1,9 @@
 import 'dotenv/config';
 
+import * as url from 'node:url';
+
 // eslint-disable-next-line n/no-unpublished-import
 import jsdocToMarkdown from 'jsdoc-to-markdown';
-import * as url from 'url';
 
 import { logger } from '../src/shared/infrastructure/utils/logger.js';
 

--- a/api/scripts/get-difficulties-from-challenge-ids.js
+++ b/api/scripts/get-difficulties-from-challenge-ids.js
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 
-import { readFile } from 'fs/promises';
+import { readFile } from 'node:fs/promises';
+
 import Redis from 'ioredis';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';

--- a/api/scripts/helpers/csvHelpers.js
+++ b/api/scripts/helpers/csvHelpers.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'node:fs';
 
 const { difference, isEmpty } = lodash;
 

--- a/api/scripts/make-saml-env.js
+++ b/api/scripts/make-saml-env.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'node:fs';
 
 const { promises } = fs;
 

--- a/api/scripts/mark-users-for-TermsOfService-revalidation.js
+++ b/api/scripts/mark-users-for-TermsOfService-revalidation.js
@@ -1,4 +1,4 @@
-import * as url from 'url';
+import * as url from 'node:url';
 
 import { disconnect, knex } from '../db/knex-database-connection.js';
 

--- a/api/scripts/prod/archive-campaigns.js
+++ b/api/scripts/prod/archive-campaigns.js
@@ -1,5 +1,6 @@
+import * as url from 'node:url';
+
 import bluebird from 'bluebird';
-import * as url from 'url';
 
 import { disconnect } from '../../db/knex-database-connection.js';
 import { archiveCampaignFromCampaignCode } from '../../lib/domain/usecases/archive-campaign-from-campaign-code.js';

--- a/api/scripts/prod/compute-badge-acquisitions.js
+++ b/api/scripts/prod/compute-badge-acquisitions.js
@@ -1,12 +1,14 @@
 import 'dotenv/config';
 
+import perf_hooks from 'node:perf_hooks';
+
 import bluebird from 'bluebird';
 import _ from 'lodash';
-import perf_hooks from 'perf_hooks';
 
 const { performance } = perf_hooks;
 
-import * as url from 'url';
+import * as url from 'node:url';
+
 import { hideBin } from 'yargs/helpers';
 import yargs from 'yargs/yargs';
 

--- a/api/scripts/prod/compute-participation-results.js
+++ b/api/scripts/prod/compute-participation-results.js
@@ -1,5 +1,5 @@
 // Usage: node compute-participation-results.js
-import * as url from 'url';
+import * as url from 'node:url';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 import * as dotenv from 'dotenv';

--- a/api/scripts/prod/create-assessment-campaigns-for-sco.js
+++ b/api/scripts/prod/create-assessment-campaigns-for-sco.js
@@ -1,6 +1,7 @@
+import * as url from 'node:url';
+
 import bluebird from 'bluebird';
 import _ from 'lodash';
-import * as url from 'url';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 import * as campaignUpdateValidator from '../../src/prescription/campaign/domain/validators/campaign-update-validator.js';

--- a/api/scripts/prod/create-organization-places-lot.js
+++ b/api/scripts/prod/create-organization-places-lot.js
@@ -1,4 +1,4 @@
-import * as url from 'url';
+import * as url from 'node:url';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 import * as categories from '../../src/prescription/organization-place/domain/constants/organization-places-categories.js';

--- a/api/scripts/prod/create-profiles-collection-campaigns.js
+++ b/api/scripts/prod/create-profiles-collection-campaigns.js
@@ -1,5 +1,6 @@
+import * as url from 'node:url';
+
 import bluebird from 'bluebird';
-import * as url from 'url';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 import * as campaignUpdateValidator from '../../src/prescription/campaign/domain/validators/campaign-update-validator.js';

--- a/api/scripts/prod/delete-organization-learners-from-organization.js
+++ b/api/scripts/prod/delete-organization-learners-from-organization.js
@@ -1,4 +1,4 @@
-import * as url from 'url';
+import * as url from 'node:url';
 
 import { disconnect } from '../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../lib/infrastructure/DomainTransaction.js';

--- a/api/scripts/prod/enable-compute-certificability-on-sco-aefe-organizations.js
+++ b/api/scripts/prod/enable-compute-certificability-on-sco-aefe-organizations.js
@@ -1,4 +1,4 @@
-import * as url from 'url';
+import * as url from 'node:url';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 import { ORGANIZATION_FEATURE } from '../../src/shared/domain/constants.js';

--- a/api/scripts/prod/enable-compute-certificability-on-sco-organizations-that-manage-students.js
+++ b/api/scripts/prod/enable-compute-certificability-on-sco-organizations-that-manage-students.js
@@ -1,4 +1,4 @@
-import * as url from 'url';
+import * as url from 'node:url';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 import { ORGANIZATION_FEATURE } from '../../src/shared/domain/constants.js';

--- a/api/scripts/prod/generate-knowledge-element-snapshots-for-campaigns.js
+++ b/api/scripts/prod/generate-knowledge-element-snapshots-for-campaigns.js
@@ -1,5 +1,6 @@
+import * as url from 'node:url';
+
 import bluebird from 'bluebird';
-import * as url from 'url';
 import yargs from 'yargs';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';

--- a/api/scripts/prod/hide-skills-in-csv-export.js
+++ b/api/scripts/prod/hide-skills-in-csv-export.js
@@ -1,4 +1,4 @@
-import * as url from 'url';
+import * as url from 'node:url';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 

--- a/api/scripts/prod/select-category-for-target-profiles.js
+++ b/api/scripts/prod/select-category-for-target-profiles.js
@@ -4,7 +4,7 @@ import bluebird from 'bluebird';
 import lodash from 'lodash';
 const { groupBy, sum, has, partition, negate } = lodash;
 
-import * as url from 'url';
+import * as url from 'node:url';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 import { categories } from '../../lib/domain/models/TargetProfile.js';

--- a/api/scripts/prod/target-profile-migrations/convert-target-profiles-into-new-format.js
+++ b/api/scripts/prod/target-profile-migrations/convert-target-profiles-into-new-format.js
@@ -1,7 +1,8 @@
 import 'dotenv/config';
 
+import * as url from 'node:url';
+
 import _ from 'lodash';
-import * as url from 'url';
 
 import { disconnect, knex } from '../../../db/knex-database-connection.js';
 import { learningContentCache } from '../../../lib/infrastructure/caches/learning-content-cache.js';

--- a/api/scripts/prod/target-profile-migrations/extract-need-stages-migration.js
+++ b/api/scripts/prod/target-profile-migrations/extract-need-stages-migration.js
@@ -1,8 +1,9 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { fileURLToPath } from 'node:url';
+
 import * as dotenv from 'dotenv';
-import { readFile, writeFile } from 'fs/promises';
-import { resolve } from 'path';
-import { performance } from 'perf_hooks';
-import { fileURLToPath } from 'url';
 import { read as readXlsx, utils as xlsxUtils } from 'xlsx';
 
 import { logger } from '../../../src/shared/infrastructure/utils/logger.js';

--- a/api/scripts/prod/target-profile-migrations/migrate-stages-to-level.js
+++ b/api/scripts/prod/target-profile-migrations/migrate-stages-to-level.js
@@ -1,10 +1,11 @@
 import 'dotenv/config';
 
-import { readFile, writeFile } from 'fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { fileURLToPath } from 'node:url';
+
 import fp from 'lodash/fp.js';
-import { dirname, resolve } from 'path';
-import { performance } from 'perf_hooks';
-import { fileURLToPath } from 'url';
 import { utils as xlsxUtils, writeXLSX } from 'xlsx';
 
 import { disconnect } from '../../../db/knex-database-connection.js';

--- a/api/scripts/prod/target-profile-migrations/parse-xls-files-for-target-profiles-migration.js
+++ b/api/scripts/prod/target-profile-migrations/parse-xls-files-for-target-profiles-migration.js
@@ -1,4 +1,4 @@
-import * as url from 'url';
+import * as url from 'node:url';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 import * as dotenv from 'dotenv';
@@ -6,8 +6,9 @@ import * as dotenv from 'dotenv';
 dotenv.config({
   path: `${__dirname}/../../../.env`,
 });
+import perf_hooks from 'node:perf_hooks';
+
 import _ from 'lodash';
-import perf_hooks from 'perf_hooks';
 
 const { performance } = perf_hooks;
 

--- a/api/scripts/prod/target-profile-migrations/revert-stages-to-threshold.js
+++ b/api/scripts/prod/target-profile-migrations/revert-stages-to-threshold.js
@@ -1,10 +1,11 @@
 import 'dotenv/config';
 
-import * as fs from 'fs';
+import * as fs from 'node:fs';
+import { resolve } from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { fileURLToPath } from 'node:url';
+
 import fp from 'lodash/fp.js';
-import { resolve } from 'path';
-import { performance } from 'perf_hooks';
-import { fileURLToPath } from 'url';
 import { readFile, set_fs, utils as xlsxUtils } from 'xlsx';
 
 import { disconnect } from '../../../db/knex-database-connection.js';

--- a/api/scripts/prod/update-documentation-url.js
+++ b/api/scripts/prod/update-documentation-url.js
@@ -1,4 +1,4 @@
-import * as url from 'url';
+import * as url from 'node:url';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 

--- a/api/scripts/switch-campaign-to-flash.js
+++ b/api/scripts/switch-campaign-to-flash.js
@@ -1,7 +1,8 @@
 import 'dotenv/config';
 
+import * as url from 'node:url';
+
 import _ from 'lodash';
-import * as url from 'url';
 
 import { knex } from '../db/knex-database-connection.js';
 import { Assessment } from '../src/shared/domain/models/Assessment.js';

--- a/api/scripts/team-acces/set-certification-center-memberships-role-to-admin.js
+++ b/api/scripts/team-acces/set-certification-center-memberships-role-to-admin.js
@@ -1,6 +1,7 @@
+import url from 'node:url';
+
 import bluebird from 'bluebird';
 import _ from 'lodash';
-import url from 'url';
 
 import { disconnect } from '../../db/knex-database-connection.js';
 import { usecases } from '../../lib/domain/usecases/index.js';

--- a/api/scripts/team-acces/update-fwb-authentication-complements.js
+++ b/api/scripts/team-acces/update-fwb-authentication-complements.js
@@ -1,6 +1,7 @@
+import url from 'node:url';
+
 import bluebird from 'bluebird';
 import _ from 'lodash';
-import url from 'url';
 
 import { disconnect } from '../../db/knex-database-connection.js';
 import { FWB } from '../../lib/domain/constants/oidc-identity-providers.js';

--- a/api/scripts/update-audit-api-csv-file.js
+++ b/api/scripts/update-audit-api-csv-file.js
@@ -1,4 +1,4 @@
-import url from 'url';
+import url from 'node:url';
 
 import { parseCsvWithHeader } from '../lib/infrastructure/helpers/csv.js';
 import { logger } from '../src/shared/infrastructure/utils/logger.js';

--- a/api/src/authentication/domain/services/oidc-authentication-service.js
+++ b/api/src/authentication/domain/services/oidc-authentication-service.js
@@ -1,4 +1,5 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
+
 import jsonwebtoken from 'jsonwebtoken';
 import lodash from 'lodash';
 import { Issuer } from 'openid-client';

--- a/api/src/authentication/domain/services/refresh-token-service.js
+++ b/api/src/authentication/domain/services/refresh-token-service.js
@@ -1,5 +1,6 @@
+import { randomUUID } from 'node:crypto';
+
 import bluebird from 'bluebird';
-import { randomUUID } from 'crypto';
 
 import { temporaryStorage } from '../../../../lib/infrastructure/temporary-storage/index.js';
 import { UnauthorizedError } from '../../../shared/application/http-errors.js';

--- a/api/src/certification/course/infrastructure/utils/pdf/certification-attestation-pdf.js
+++ b/api/src/certification/course/infrastructure/utils/pdf/certification-attestation-pdf.js
@@ -1,11 +1,12 @@
+import { readFile } from 'node:fs/promises';
+import * as url from 'node:url';
+
 import pdfLibFontkit from '@pdf-lib/fontkit';
 import axios from 'axios';
 import bluebird from 'bluebird';
 import dayjs from 'dayjs';
-import { readFile } from 'fs/promises';
 import _ from 'lodash';
 import { PDFDocument, rgb } from 'pdf-lib';
-import * as url from 'url';
 
 import { CertificationAttestationGenerationError } from '../../../../../shared/domain/errors.js';
 import { LANGUAGES_CODE } from '../../../../../shared/domain/services/language-service.js';

--- a/api/src/certification/course/scripts/generate-certification-attestations-by-session-ids.js
+++ b/api/src/certification/course/scripts/generate-certification-attestations-by-session-ids.js
@@ -1,13 +1,15 @@
 import 'dotenv/config';
 
+import fs from 'node:fs';
+
 import bluebird from 'bluebird';
-import fs from 'fs';
 import lodash from 'lodash';
 
 const { isEmpty, compact } = lodash;
+import path from 'node:path';
+import * as url from 'node:url';
+
 import i18n from 'i18n';
-import path from 'path';
-import * as url from 'url';
 
 import { disconnect } from '../../../../db/knex-database-connection.js';
 import { learningContentCache as cache } from '../../../../lib/infrastructure/caches/learning-content-cache.js';

--- a/api/src/certification/flash-certification/application/scenario-simulator-controller.js
+++ b/api/src/certification/flash-certification/application/scenario-simulator-controller.js
@@ -1,5 +1,6 @@
+import { Readable } from 'node:stream';
+
 import _ from 'lodash';
-import { Readable } from 'stream';
 
 import { HttpErrors } from '../../../../lib/application/http-errors.js';
 import { pickAnswerStatusService } from '../../../../lib/domain/services/pick-answer-status-service.js';

--- a/api/src/certification/session/domain/services/temporary-sessions-storage-for-mass-import-service.js
+++ b/api/src/certification/session/domain/services/temporary-sessions-storage-for-mass-import-service.js
@@ -2,7 +2,7 @@ import { config } from '../../../../../lib/config.js';
 import { temporaryStorage } from '../../../../../lib/infrastructure/temporary-storage/index.js';
 
 const sessionMassImportTemporaryStorage = temporaryStorage.withPrefix('sessions-mass-import:');
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 
 const EXPIRATION_DELAY_SECONDS = config.temporarySessionsStorageForMassImport.expirationDelaySeconds;
 

--- a/api/src/certification/session/infrastructure/utils/pdf/attendance-sheet-pdf.js
+++ b/api/src/certification/session/infrastructure/utils/pdf/attendance-sheet-pdf.js
@@ -1,9 +1,10 @@
+import { readFile } from 'node:fs/promises';
+import * as url from 'node:url';
+
 import pdfLibFontkit from '@pdf-lib/fontkit';
 import dayjs from 'dayjs';
 import localizedFormat from 'dayjs/plugin/localizedFormat.js';
-import { readFile } from 'fs/promises';
 import { PDFDocument, rgb } from 'pdf-lib';
-import * as url from 'url';
 dayjs.extend(localizedFormat);
 
 import _ from 'lodash';

--- a/api/src/certification/session/infrastructure/utils/pdf/invigilator-kit-pdf.js
+++ b/api/src/certification/session/infrastructure/utils/pdf/invigilator-kit-pdf.js
@@ -1,7 +1,8 @@
+import { readFile } from 'node:fs/promises';
+import * as url from 'node:url';
+
 import pdfLibFontkit from '@pdf-lib/fontkit';
-import { readFile } from 'fs/promises';
 import { PDFDocument, rgb } from 'pdf-lib';
-import * as url from 'url';
 
 import { PIX_CERTIF } from '../../../../../../lib/domain/constants.js';
 import { LOCALE } from '../../../../../shared/domain/constants.js';

--- a/api/src/certification/shared/application/helpers/csvHelpers.js
+++ b/api/src/certification/shared/application/helpers/csvHelpers.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'node:fs';
 
 const { promises } = fs;
 const { readFile, access } = promises;

--- a/api/src/prescription/campaign/application/campaign-detail-controller.js
+++ b/api/src/prescription/campaign/application/campaign-detail-controller.js
@@ -1,4 +1,4 @@
-import stream from 'stream';
+import stream from 'node:stream';
 
 import { escapeFileName } from '../../../../lib/infrastructure/utils/request-response-utils.js';
 import { tokenService } from '../../../shared/domain/services/token-service.js';

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js
@@ -1,4 +1,5 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
+
 import _ from 'lodash';
 
 import { knex } from '../../../../../db/knex-database-connection.js';

--- a/api/src/prescription/learner-management/application/sco-organization-management-controller.js
+++ b/api/src/prescription/learner-management/application/sco-organization-management-controller.js
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import fs from 'node:fs/promises';
 
 import { FileValidationError } from '../../../../lib/domain/errors.js';
 import { logErrorWithCorrelationIds } from '../../../../lib/infrastructure/monitoring-tools.js';

--- a/api/src/prescription/learner-management/application/sup-organization-management-controller.js
+++ b/api/src/prescription/learner-management/application/sup-organization-management-controller.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'node:fs';
 
 import { logErrorWithCorrelationIds } from '../../../../lib/infrastructure/monitoring-tools.js';
 import { tokenService } from '../../../shared/domain/services/token-service.js';

--- a/api/src/prescription/learner-management/domain/usecases/import-from-feature/send-organization-learners-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-from-feature/send-organization-learners-file.js
@@ -1,4 +1,4 @@
-import { createReadStream } from 'fs';
+import { createReadStream } from 'node:fs';
 
 import { CommonCsvLearnerParser } from '../../../infrastructure/serializers/csv/common-csv-learner-parser.js';
 import { getDataBuffer } from '../../../infrastructure/utils/bufferize/get-data-buffer.js';

--- a/api/src/prescription/learner-management/domain/usecases/import-organization-learners-from-siecle-csv-format.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-organization-learners-from-siecle-csv-format.js
@@ -1,8 +1,9 @@
 import { AggregateImportError, SiecleXmlImportError } from '../errors.js';
 
 const { isEmpty, chunk } = lodash;
+import { createReadStream } from 'node:fs';
+
 import bluebird from 'bluebird';
-import { createReadStream } from 'fs';
 import lodash from 'lodash';
 
 import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';

--- a/api/src/prescription/learner-management/domain/usecases/import-sup-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-sup-organization-learners.js
@@ -1,4 +1,4 @@
-import { createReadStream } from 'fs';
+import { createReadStream } from 'node:fs';
 
 import { SupOrganizationLearnerParser } from '../../infrastructure/serializers/csv/sup-organization-learner-parser.js';
 import { getDataBuffer } from '../../infrastructure/utils/bufferize/get-data-buffer.js';

--- a/api/src/prescription/learner-management/domain/usecases/replace-sup-organization-learner.js
+++ b/api/src/prescription/learner-management/domain/usecases/replace-sup-organization-learner.js
@@ -1,4 +1,4 @@
-import { createReadStream } from 'fs';
+import { createReadStream } from 'node:fs';
 
 import { SupOrganizationLearnerParser } from '../../infrastructure/serializers/csv/sup-organization-learner-parser.js';
 import { getDataBuffer } from '../../infrastructure/utils/bufferize/get-data-buffer.js';

--- a/api/src/prescription/learner-management/domain/usecases/upload-siecle-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/upload-siecle-file.js
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import fs from 'node:fs/promises';
 
 import { logErrorWithCorrelationIds } from '../../../../../lib/infrastructure/monitoring-tools.js';
 import { detectEncoding } from '../../infrastructure/utils/xml/detect-encoding.js';

--- a/api/src/prescription/learner-management/infrastructure/storage/import-storage.js
+++ b/api/src/prescription/learner-management/infrastructure/storage/import-storage.js
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import { FileValidationError } from '../../../../../lib/domain/errors.js';
 import { logErrorWithCorrelationIds } from '../../../../../lib/infrastructure/monitoring-tools.js';

--- a/api/src/prescription/learner-management/infrastructure/utils/xml/detect-encoding.js
+++ b/api/src/prescription/learner-management/infrastructure/utils/xml/detect-encoding.js
@@ -1,5 +1,6 @@
-import buffer from 'buffer';
-import * as fs from 'fs/promises';
+import buffer from 'node:buffer';
+import * as fs from 'node:fs/promises';
+
 import xmlBufferTostring from 'xml-buffer-tostring';
 
 import { FileValidationError } from '../../../../../../lib/domain/errors.js';

--- a/api/src/prescription/learner-management/infrastructure/utils/xml/zip.js
+++ b/api/src/prescription/learner-management/infrastructure/utils/xml/zip.js
@@ -1,12 +1,13 @@
 import _ from 'lodash';
 const { isObject, values } = _;
-import fs from 'fs';
+import fs from 'node:fs';
 const fsPromises = fs.promises;
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
+import os from 'node:os';
+import Path from 'node:path';
+
 import { fileTypeFromFile } from 'file-type';
 import StreamZip from 'node-stream-zip';
-import os from 'os';
-import Path from 'path';
 
 import { FileValidationError } from '../../../../../../lib/domain/errors.js';
 import { logErrorWithCorrelationIds } from '../../../../../../lib/infrastructure/monitoring-tools.js';

--- a/api/src/prescription/target-profile/application/presenter/pdf/manager/font-manager.js
+++ b/api/src/prescription/target-profile/application/presenter/pdf/manager/font-manager.js
@@ -1,5 +1,5 @@
-import { readFile } from 'fs/promises';
-import * as url from 'url';
+import { readFile } from 'node:fs/promises';
+import * as url from 'node:url';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 

--- a/api/src/prescription/target-profile/application/presenter/pdf/manager/template-page-manager.js
+++ b/api/src/prescription/target-profile/application/presenter/pdf/manager/template-page-manager.js
@@ -1,5 +1,5 @@
-import { readFile } from 'fs/promises';
-import * as url from 'url';
+import { readFile } from 'node:fs/promises';
+import * as url from 'node:url';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 

--- a/api/src/school/scripts/create-school-learners.js
+++ b/api/src/school/scripts/create-school-learners.js
@@ -1,5 +1,6 @@
+import * as url from 'node:url';
+
 import bluebird from 'bluebird';
-import * as url from 'url';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -1,9 +1,10 @@
 import 'dotenv/config';
 
+import path from 'node:path';
+import * as url from 'node:url';
+
 import dayjs from 'dayjs';
 import ms from 'ms';
-import path from 'path';
-import * as url from 'url';
 
 import { getArrayOfStrings, getArrayOfUpperStrings } from './infrastructure/utils/string-utils.js';
 

--- a/api/tests/acceptance/application/authentication/authentication-route_test.js
+++ b/api/tests/acceptance/application/authentication/authentication-route_test.js
@@ -1,4 +1,4 @@
-import querystring from 'querystring';
+import querystring from 'node:querystring';
 
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/identity-providers.js';
 import { tokenService } from '../../../../src/shared/domain/services/token-service.js';

--- a/api/tests/acceptance/application/authentication/oidc/authentication-url-route-get_test.js
+++ b/api/tests/acceptance/application/authentication/oidc/authentication-url-route-get_test.js
@@ -1,4 +1,4 @@
-import querystring from 'querystring';
+import querystring from 'node:querystring';
 
 import { createServer, expect } from '../../../../test-helper.js';
 

--- a/api/tests/acceptance/application/authentication/oidc/token-route-post_test.js
+++ b/api/tests/acceptance/application/authentication/oidc/token-route-post_test.js
@@ -1,5 +1,6 @@
+import querystring from 'node:querystring';
+
 import jsonwebtoken from 'jsonwebtoken';
-import querystring from 'querystring';
 
 import { AuthenticationSessionContent } from '../../../../../lib/domain/models/AuthenticationSessionContent.js';
 import { oidcAuthenticationServiceRegistry } from '../../../../../lib/domain/services/authentication/authentication-service-registry.js';

--- a/api/tests/acceptance/application/session/session-controller-import-certification-candidates-from-attendance-sheet_reports_categorization_test.js
+++ b/api/tests/acceptance/application/session/session-controller-import-certification-candidates-from-attendance-sheet_reports_categorization_test.js
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import * as url from 'url';
+import fs from 'node:fs';
+import * as url from 'node:url';
 
 import { clearResolveMx, setResolveMx } from '../../../../src/shared/mail/infrastructure/services/mail-check.js';
 import {

--- a/api/tests/acceptance/scripts/arborescence-monitoring_test.js
+++ b/api/tests/acceptance/scripts/arborescence-monitoring_test.js
@@ -1,5 +1,5 @@
-import * as Path from 'path';
-import * as url from 'url';
+import * as Path from 'node:path';
+import * as url from 'node:url';
 
 import { countFilesInPath } from '../../../scripts/arborescence-monitoring/stats.js';
 import { expect } from '../../test-helper.js';

--- a/api/tests/acceptance/scripts/certification/import-certifications-from-csv_test.js
+++ b/api/tests/acceptance/scripts/certification/import-certifications-from-csv_test.js
@@ -1,4 +1,4 @@
-import * as url from 'url';
+import * as url from 'node:url';
 
 import * as script from '../../../../scripts/certification/import-certifications-from-csv.js';
 import { expect, nock } from '../../../test-helper.js';

--- a/api/tests/acceptance/scripts/certification/update-certification-infos_test.js
+++ b/api/tests/acceptance/scripts/certification/update-certification-infos_test.js
@@ -1,9 +1,10 @@
-import { rm, writeFile } from 'fs/promises';
+import { rm, writeFile } from 'node:fs/promises';
+
 import lodash from 'lodash';
 
 import { databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';
 const { values } = lodash;
-import * as url from 'url';
+import * as url from 'node:url';
 
 import { headers, updateCertificationInfos } from '../../../../scripts/certification/update-certification-infos.js';
 import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';

--- a/api/tests/authentication/acceptance/application/token.route.test.js
+++ b/api/tests/authentication/acceptance/application/token.route.test.js
@@ -1,4 +1,4 @@
-import querystring from 'querystring';
+import querystring from 'node:querystring';
 
 import { PIX_ADMIN } from '../../../../src/authorization/domain/constants.js';
 import { createServer, databaseBuilder, expect, knex } from '../../../test-helper.js';

--- a/api/tests/authentication/integration/routes_test.js
+++ b/api/tests/authentication/integration/routes_test.js
@@ -1,4 +1,4 @@
-import querystring from 'querystring';
+import querystring from 'node:querystring';
 
 import { tokenController } from '../../../src/authentication/application/token-controller.js';
 import { createServer, expect, sinon } from '../../test-helper.js';

--- a/api/tests/certification/course/acceptance/application/certification-attestation-route_test.js
+++ b/api/tests/certification/course/acceptance/application/certification-attestation-route_test.js
@@ -1,6 +1,5 @@
 import { readFile } from 'node:fs/promises';
-
-import * as url from 'url';
+import * as url from 'node:url';
 
 import { AssessmentResult, Membership } from '../../../../../lib/domain/models/index.js';
 import { generateCertificateVerificationCode } from '../../../../../lib/domain/services/verify-certificate-code-service.js';

--- a/api/tests/certification/course/integration/infrastructure/utils/pdf/certification-attestation-pdf_test.js
+++ b/api/tests/certification/course/integration/infrastructure/utils/pdf/certification-attestation-pdf_test.js
@@ -1,8 +1,8 @@
 import { readFile, writeFile } from 'node:fs/promises';
+import * as url from 'node:url';
 
 import dayjs from 'dayjs';
 import pdfLibUtils from 'pdf-lib/cjs/utils/index.js';
-import * as url from 'url';
 
 import { getCertificationAttestationsPdfBuffer } from '../../../../../../../src/certification/course/infrastructure/utils/pdf/certification-attestation-pdf.js';
 import { CertificationAttestationGenerationError } from '../../../../../../../src/shared/domain/errors.js';

--- a/api/tests/certification/session/acceptance/application/update-cpf-import-status-controller_test.js
+++ b/api/tests/certification/session/acceptance/application/update-cpf-import-status-controller_test.js
@@ -1,6 +1,6 @@
-import fs from 'fs';
-import path from 'path';
-import * as url from 'url';
+import fs from 'node:fs';
+import path from 'node:path';
+import * as url from 'node:url';
 
 import {
   createServer,

--- a/api/tests/certification/session/integration/domain/usecases/integrate-cpf-processing-receipts_test.js
+++ b/api/tests/certification/session/integration/domain/usecases/integrate-cpf-processing-receipts_test.js
@@ -1,6 +1,6 @@
-import fs from 'fs';
-import path from 'path';
-import * as url from 'url';
+import fs from 'node:fs';
+import path from 'node:path';
+import * as url from 'node:url';
 
 import { CpfImportStatus } from '../../../../../../src/certification/session/domain/models/CpfImportStatus.js';
 import { integrateCpfProccessingReceipts } from '../../../../../../src/certification/session/domain/usecases/integrate-cpf-processing-receipts.js';

--- a/api/tests/certification/session/integration/domain/usecases/upload-cpf-files_test.js
+++ b/api/tests/certification/session/integration/domain/usecases/upload-cpf-files_test.js
@@ -1,4 +1,4 @@
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 
 import { uploadCpfFiles } from '../../../../../../src/certification/session/domain/usecases/upload-cpf-files.js';
 import { cpfExportsStorage } from '../../../../../../src/certification/session/infrastructure/storage/cpf-exports-storage.js';

--- a/api/tests/certification/session/integration/infrastructure/utils/pdf/attendance-sheet-pdf_test.js
+++ b/api/tests/certification/session/integration/infrastructure/utils/pdf/attendance-sheet-pdf_test.js
@@ -1,8 +1,9 @@
-import { writeFile } from 'fs/promises';
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import * as url from 'node:url';
+
 import i18n from 'i18n';
-import path from 'path';
 import pdfLibUtils from 'pdf-lib/cjs/utils/index.js';
-import * as url from 'url';
 
 import { getAttendanceSheetPdfBuffer } from '../../../../../../../src/certification/session/infrastructure/utils/pdf/attendance-sheet-pdf.js';
 import { domainBuilder, expect, sinon } from '../../../../../../test-helper.js';

--- a/api/tests/certification/session/integration/infrastructure/utils/pdf/invigilator-kit-pdf_test.js
+++ b/api/tests/certification/session/integration/infrastructure/utils/pdf/invigilator-kit-pdf_test.js
@@ -1,6 +1,7 @@
-import { writeFile } from 'fs/promises';
+import { writeFile } from 'node:fs/promises';
+import * as url from 'node:url';
+
 import pdfLibUtils from 'pdf-lib/cjs/utils/index.js';
-import * as url from 'url';
 
 import { getInvigilatorKitPdfBuffer } from '../../../../../../../src/certification/session/infrastructure/utils/pdf/invigilator-kit-pdf.js';
 import { LOCALE } from '../../../../../../../src/shared/domain/constants.js';

--- a/api/tests/certification/session/unit/application/session-mass-import-route_test.js
+++ b/api/tests/certification/session/unit/application/session-mass-import-route_test.js
@@ -1,8 +1,9 @@
+import fs from 'node:fs';
+import { stat, unlink, writeFile } from 'node:fs/promises';
+import * as url from 'node:url';
+
 import FormData from 'form-data';
-import fs from 'fs';
-import { stat, unlink, writeFile } from 'fs/promises';
 import streamToPromise from 'stream-to-promise';
-import * as url from 'url';
 
 import { sessionMassImportController } from '../../../../../src/certification/session/application/session-mass-import-controller.js';
 import * as moduleUnderTest from '../../../../../src/certification/session/application/session-mass-import-route.js';

--- a/api/tests/certification/session/unit/infrastructure/deserializers/xml/cpf-receipt-file-deserializer_test.js
+++ b/api/tests/certification/session/unit/infrastructure/deserializers/xml/cpf-receipt-file-deserializer_test.js
@@ -1,6 +1,6 @@
-import fs from 'fs';
-import path from 'path';
-import * as url from 'url';
+import fs from 'node:fs';
+import path from 'node:path';
+import * as url from 'node:url';
 
 import { deserialize } from '../../../../../../../src/certification/session/infrastructure/deserializers/xml/cpf-receipt-file-deserializer.js';
 import { catchErr, expect } from '../../../../../../test-helper.js';

--- a/api/tests/certification/session/unit/infrastructure/storage/cpf-receipts-storage_test.js
+++ b/api/tests/certification/session/unit/infrastructure/storage/cpf-receipts-storage_test.js
@@ -1,6 +1,6 @@
-import fs from 'fs';
-import path from 'path';
-import * as url from 'url';
+import fs from 'node:fs';
+import path from 'node:path';
+import * as url from 'node:url';
 
 import { CpfReceipt } from '../../../../../../src/certification/session/domain/models/CpfReceipt.js';
 import { CpfReceiptsStorage } from '../../../../../../src/certification/session/infrastructure/storage/cpf-receipts-storage.js';

--- a/api/tests/certification/shared/integration/application/helpers/csvHelpers_test.js
+++ b/api/tests/certification/shared/integration/application/helpers/csvHelpers_test.js
@@ -1,4 +1,4 @@
-import * as url from 'url';
+import * as url from 'node:url';
 
 import { CsvWithNoSessionDataError } from '../../../../../../src/certification/session/domain/errors.js';
 import {

--- a/api/tests/integration/application/authentication/index_test.js
+++ b/api/tests/integration/application/authentication/index_test.js
@@ -1,4 +1,4 @@
-import querystring from 'querystring';
+import querystring from 'node:querystring';
 
 import { authenticationController } from '../../../../lib/application/authentication/authentication-controller.js';
 import { createServer, expect, sinon } from '../../../test-helper.js';

--- a/api/tests/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
+++ b/api/tests/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
@@ -1,6 +1,7 @@
-import fs from 'fs';
+import fs from 'node:fs';
+import * as url from 'node:url';
+
 import _ from 'lodash';
-import * as url from 'url';
 
 import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../../../lib/domain/constants/certification-candidates-errors.js';
 import { CertificationCandidatesError } from '../../../../../lib/domain/errors.js';

--- a/api/tests/integration/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
+++ b/api/tests/integration/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
@@ -1,12 +1,12 @@
+import fs from 'node:fs';
+import stream from 'node:stream';
+import * as url from 'node:url';
 import { createUnzip } from 'node:zlib';
 
 import dayjs from 'dayjs';
 import timezone from 'dayjs/plugin/timezone.js';
 import utc from 'dayjs/plugin/utc.js';
-import fs from 'fs';
 import lodash from 'lodash';
-import stream from 'stream';
-import * as url from 'url';
 
 import * as cpfCertificationXmlExportService from '../../../../../../lib/domain/services/cpf-certification-xml-export-service.js';
 import { createAndUpload } from '../../../../../../lib/infrastructure/jobs/cpf-export/handlers/create-and-upload.js';

--- a/api/tests/integration/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
+++ b/api/tests/integration/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 
 import { config as settings } from '../../../../lib/config.js';
 import { RedisTemporaryStorage } from '../../../../lib/infrastructure/temporary-storage/RedisTemporaryStorage.js';

--- a/api/tests/integration/infrastructure/utils/RedisClient_test.js
+++ b/api/tests/integration/infrastructure/utils/RedisClient_test.js
@@ -1,5 +1,6 @@
+import { randomUUID } from 'node:crypto';
+
 import bluebird from 'bluebird';
-import { randomUUID } from 'crypto';
 import Redis from 'ioredis';
 
 import { config } from '../../../../lib/config.js';

--- a/api/tests/integration/infrastructure/utils/ods/files/fill-candidates-import-sheet_test.js
+++ b/api/tests/integration/infrastructure/utils/ods/files/fill-candidates-import-sheet_test.js
@@ -1,11 +1,12 @@
-import fs from 'fs';
+import fs from 'node:fs';
 
 const { promises } = fs;
 
 const { unlink, writeFile } = promises;
 
+import * as url from 'node:url';
+
 import _ from 'lodash';
-import * as url from 'url';
 
 import { usecases } from '../../../../../../lib/domain/usecases/index.js';
 import { fillCandidatesImportSheet } from '../../../../../../lib/infrastructure/files/candidates-import/fill-candidates-import-sheet.js';

--- a/api/tests/integration/infrastructure/utils/ods/read-ods-utils_test.js
+++ b/api/tests/integration/infrastructure/utils/ods/read-ods-utils_test.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'node:fs';
 
 const { promises } = fs;
 
@@ -9,7 +9,7 @@ import _ from 'lodash';
 import { getI18n } from '../../../../tooling/i18n/i18n.js';
 const i18n = getI18n();
 
-import * as url from 'url';
+import * as url from 'node:url';
 
 import { UnprocessableEntityError } from '../../../../../lib/application/http-errors.js';
 import { getTransformationStructsForPixCertifCandidatesImport } from '../../../../../lib/infrastructure/files/candidates-import/candidates-import-transformation-structures.js';

--- a/api/tests/integration/infrastructure/utils/ods/write-ods-utils_test.js
+++ b/api/tests/integration/infrastructure/utils/ods/write-ods-utils_test.js
@@ -1,10 +1,10 @@
-import fs from 'fs';
+import fs from 'node:fs';
 
 const { promises } = fs;
 
 const { writeFile, unlink } = promises;
 
-import * as url from 'url';
+import * as url from 'node:url';
 
 import { AddedCellOption } from '../../../../../lib/infrastructure/utils/ods/added-cell-option.js';
 import { getContentXml } from '../../../../../lib/infrastructure/utils/ods/read-ods-utils.js';

--- a/api/tests/integration/scripts/helpers/csvHelpers_test.js
+++ b/api/tests/integration/scripts/helpers/csvHelpers_test.js
@@ -1,4 +1,4 @@
-import * as url from 'url';
+import * as url from 'node:url';
 
 import { FileValidationError, NotFoundError } from '../../../../lib/domain/errors.js';
 import { checkCsvHeader } from '../../../../scripts/helpers/csvHelpers.js';

--- a/api/tests/integration/scripts/prod/archive-campaigns_test.js
+++ b/api/tests/integration/scripts/prod/archive-campaigns_test.js
@@ -1,5 +1,6 @@
+import * as url from 'node:url';
+
 import lodash from 'lodash';
-import * as url from 'url';
 
 import { archiveCampaigns } from '../../../../scripts/prod/archive-campaigns.js';
 import { databaseBuilder, expect, knex, sinon } from '../../../test-helper.js';

--- a/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -1,4 +1,4 @@
-import stream from 'stream';
+import stream from 'node:stream';
 
 const { PassThrough } = stream;
 

--- a/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -1,4 +1,4 @@
-import stream from 'stream';
+import stream from 'node:stream';
 
 const { PassThrough } = stream;
 

--- a/api/tests/prescription/campaign/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -1,4 +1,4 @@
-import stream from 'stream';
+import stream from 'node:stream';
 
 const { PassThrough } = stream;
 

--- a/api/tests/prescription/campaign/unit/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -1,4 +1,4 @@
-import stream from 'stream';
+import stream from 'node:stream';
 
 const { PassThrough } = stream;
 

--- a/api/tests/prescription/learner-management/acceptance/application/organization-controller-import-sco-organization-learners_test.js
+++ b/api/tests/prescription/learner-management/acceptance/application/organization-controller-import-sco-organization-learners_test.js
@@ -1,4 +1,5 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
+
 import iconv from 'iconv-lite';
 import _ from 'lodash';
 

--- a/api/tests/prescription/learner-management/integration/infrastructure/serializers/xml/siecle-parser_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/serializers/xml/siecle-parser_test.js
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import * as url from 'url';
+import fs from 'node:fs';
+import * as url from 'node:url';
 
 import { FileValidationError, SIECLE_ERRORS } from '../../../../../../../lib/domain/errors.js';
 import {

--- a/api/tests/prescription/learner-management/integration/infrastructure/utils/xml/detect-encoding_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/utils/xml/detect-encoding_test.js
@@ -1,4 +1,4 @@
-import * as url from 'url';
+import * as url from 'node:url';
 
 import { FileValidationError } from '../../../../../../../lib/domain/errors.js';
 import { detectEncoding } from '../../../../../../../src/prescription/learner-management/infrastructure/utils/xml/detect-encoding.js';

--- a/api/tests/prescription/learner-management/integration/infrastructure/utils/xml/siecle-file-streamer_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/utils/xml/siecle-file-streamer_test.js
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import * as url from 'url';
+import fs from 'node:fs';
+import * as url from 'node:url';
 
 import { FileValidationError } from '../../../../../../../lib/domain/errors.js';
 import { SiecleXmlImportError } from '../../../../../../../src/prescription/learner-management/domain/errors.js';

--- a/api/tests/prescription/learner-management/integration/infrastructure/utils/xml/zip_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/utils/xml/zip_test.js
@@ -1,6 +1,6 @@
-import fs from 'fs/promises';
-import Path from 'path';
-import * as url from 'url';
+import fs from 'node:fs/promises';
+import Path from 'node:path';
+import * as url from 'node:url';
 
 import { FileValidationError } from '../../../../../../../lib/domain/errors.js';
 import { unzip } from '../../../../../../../src/prescription/learner-management/infrastructure/utils/xml/zip.js';

--- a/api/tests/prescription/learner-management/unit/application/sco-organization-management-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/sco-organization-management-controller_test.js
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import fs from 'node:fs/promises';
 
 import { FileValidationError } from '../../../../../lib/domain/errors.js';
 import { scoOrganizationManagementController } from '../../../../../src/prescription/learner-management/application/sco-organization-management-controller.js';

--- a/api/tests/prescription/learner-management/unit/domain/usecases/import-organization-learners-from-siecle-csv-format_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/import-organization-learners-from-siecle-csv-format_test.js
@@ -1,5 +1,6 @@
+import { Readable } from 'node:stream';
+
 import iconv from 'iconv-lite';
-import { Readable } from 'stream';
 
 import { DomainTransaction } from '../../../../../../lib/infrastructure/DomainTransaction.js';
 import { OrganizationImport } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationImport.js';

--- a/api/tests/prescription/learner-management/unit/domain/usecases/import-sup-organization-learners_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/import-sup-organization-learners_test.js
@@ -1,5 +1,6 @@
+import { Readable } from 'node:stream';
+
 import iconv from 'iconv-lite';
-import { Readable } from 'stream';
 
 import { OrganizationImport } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationImport.js';
 import { importSupOrganizationLearners } from '../../../../../../src/prescription/learner-management/domain/usecases/import-sup-organization-learners.js';

--- a/api/tests/prescription/learner-management/unit/domain/usecases/replace-sup-organization-learners_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/replace-sup-organization-learners_test.js
@@ -1,5 +1,6 @@
+import { Readable } from 'node:stream';
+
 import iconv from 'iconv-lite';
-import { Readable } from 'stream';
 
 import { OrganizationImport } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationImport.js';
 import { replaceSupOrganizationLearners } from '../../../../../../src/prescription/learner-management/domain/usecases/replace-sup-organization-learner.js';

--- a/api/tests/prescription/learner-management/unit/domain/usecases/upload-siecle-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/upload-siecle-file_test.js
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import fs from 'node:fs/promises';
 
 import { OrganizationImport } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationImport.js';
 import { uploadSiecleFile } from '../../../../../../src/prescription/learner-management/domain/usecases/upload-siecle-file.js';

--- a/api/tests/prescription/target-profile/integration/application/presenter/pdf/learning-content-pdf-presenter_test.js
+++ b/api/tests/prescription/target-profile/integration/application/presenter/pdf/learning-content-pdf-presenter_test.js
@@ -1,6 +1,7 @@
-import { writeFile } from 'fs/promises';
+import { writeFile } from 'node:fs/promises';
+import * as url from 'node:url';
+
 import pdfLibUtils from 'pdf-lib/cjs/utils/index.js';
-import * as url from 'url';
 
 import * as learningContentPDFPresenter from '../../../../../../../src/prescription/target-profile/application/presenter/pdf/learning-content-pdf-presenter.js';
 import { domainBuilder, expect, MockDate, sinon } from '../../../../../../test-helper.js';

--- a/api/tests/shared/integration/infrastructure/utils/imports/import-named-exports-from-directory_test.js
+++ b/api/tests/shared/integration/infrastructure/utils/imports/import-named-exports-from-directory_test.js
@@ -1,5 +1,5 @@
-import { dirname, join } from 'path';
-import { fileURLToPath } from 'url';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { importNamedExportsFromDirectory } from '../../../../../../src/shared/infrastructure/utils/import-named-exports-from-directory.js';
 import { catchErr, expect } from '../../../../../test-helper.js';

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -2,6 +2,8 @@
 /* eslint-disable n/no-unpublished-import */
 import 'dayjs/locale/fr.js';
 
+import * as url from 'node:url';
+
 import { Assertion, AssertionError, expect, use as chaiUse, util as chaiUtil } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import chaiSorted from 'chai-sorted';
@@ -13,7 +15,6 @@ import MockDate from 'mockdate';
 import nock from 'nock';
 import sinon, { restore } from 'sinon';
 import sinonChai from 'sinon-chai';
-import * as url from 'url';
 
 import { DatabaseBuilder } from '../db/database-builder/database-builder.js';
 import { disconnect, knex } from '../db/knex-database-connection.js';

--- a/api/tests/tooling/binary-comparator.js
+++ b/api/tests/tooling/binary-comparator.js
@@ -1,5 +1,5 @@
-import crypto from 'crypto';
-import { readFile } from 'fs/promises';
+import crypto from 'node:crypto';
+import { readFile } from 'node:fs/promises';
 
 const { createHash } = crypto;
 

--- a/api/tests/tooling/i18n/i18n.js
+++ b/api/tests/tooling/i18n/i18n.js
@@ -1,6 +1,7 @@
+import path from 'node:path';
+import * as url from 'node:url';
+
 import { I18n } from 'i18n';
-import path from 'path';
-import * as url from 'url';
 
 import { options } from '../../../lib/infrastructure/plugins/i18n.js';
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));

--- a/api/tests/tooling/temporary-file.js
+++ b/api/tests/tooling/temporary-file.js
@@ -1,7 +1,6 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
-
-import fs from 'fs/promises';
-import os from 'os';
 
 async function removeTempFile(filePath) {
   return (

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -1,8 +1,9 @@
+import fs from 'node:fs';
+import { stat, unlink, writeFile } from 'node:fs/promises';
+import * as url from 'node:url';
+
 import FormData from 'form-data';
-import fs from 'fs';
-import { stat, unlink, writeFile } from 'fs/promises';
 import streamToPromise from 'stream-to-promise';
-import * as url from 'url';
 
 import { NotFoundError } from '../../../../lib/application/http-errors.js';
 import { authorization } from '../../../../lib/application/preHandlers/authorization.js';

--- a/api/tests/unit/domain/services/cpf/cpf-certification-xml-export-service_test.js
+++ b/api/tests/unit/domain/services/cpf/cpf-certification-xml-export-service_test.js
@@ -1,11 +1,12 @@
+import { readFile } from 'node:fs/promises';
+import stream from 'node:stream';
+import * as url from 'node:url';
+
 import dayjs from 'dayjs';
 import timezone from 'dayjs/plugin/timezone.js';
 import utc from 'dayjs/plugin/utc.js';
-import { readFile } from 'fs/promises';
 // eslint-disable-next-line n/no-unpublished-import
 import { parseXml } from 'libxmljs2';
-import stream from 'stream';
-import * as url from 'url';
 
 import * as cpfCertificationXmlExportService from '../../../../../lib/domain/services/cpf-certification-xml-export-service.js';
 import { domainBuilder, expect, sinon, streamToPromise } from '../../../../test-helper.js';

--- a/api/tests/unit/domain/services/reset-password-service_test.js
+++ b/api/tests/unit/domain/services/reset-password-service_test.js
@@ -1,4 +1,5 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
+
 import jsonwebtoken from 'jsonwebtoken';
 
 import { config as settings } from '../../../../lib/config.js';

--- a/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
+++ b/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
@@ -1,5 +1,6 @@
+import querystring from 'node:querystring';
+
 import dayjs from 'dayjs';
-import querystring from 'querystring';
 
 import { config as settings } from '../../../../../lib/config.js';
 import * as OidcIdentityProviders from '../../../../../lib/domain/constants/oidc-identity-providers.js';

--- a/api/tests/unit/infrastructure/helpers/csv.js
+++ b/api/tests/unit/infrastructure/helpers/csv.js
@@ -6,7 +6,7 @@ import { catchErr, expect } from '../../../test-helper.js';
 
 const { isEmpty } = lodash;
 
-import * as url from 'url';
+import * as url from 'node:url';
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 describe('Unit | Infrastructure | Helpers | csv.js', function () {

--- a/api/tests/unit/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
+++ b/api/tests/unit/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
@@ -1,9 +1,10 @@
-import * as uuidService from 'crypto';
+import * as uuidService from 'node:crypto';
+import stream from 'node:stream';
+
 import dayjs from 'dayjs';
 import timezone from 'dayjs/plugin/timezone.js';
 import utc from 'dayjs/plugin/utc.js';
 import lodash from 'lodash';
-import stream from 'stream';
 
 import { createAndUpload } from '../../../../../../lib/infrastructure/jobs/cpf-export/handlers/create-and-upload.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';

--- a/api/tests/unit/infrastructure/serializers/csv/campaign-profile-collection-export_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/campaign-profile-collection-export_test.js
@@ -1,4 +1,4 @@
-import stream from 'stream';
+import stream from 'node:stream';
 
 const { PassThrough } = stream;
 

--- a/api/tests/unit/scripts/helpers/csvHelpers_test.js
+++ b/api/tests/unit/scripts/helpers/csvHelpers_test.js
@@ -1,4 +1,4 @@
-import * as url from 'url';
+import * as url from 'node:url';
 
 import { FileValidationError, NotFoundError } from '../../../../lib/domain/errors.js';
 import { batchOrganizationOptionsWithHeader } from '../../../../scripts/create-organizations-with-tags-and-target-profiles.js';

--- a/api/worker.js
+++ b/api/worker.js
@@ -1,8 +1,9 @@
 import 'dotenv/config';
 
+import * as url from 'node:url';
+
 import _ from 'lodash';
 import PgBoss from 'pg-boss';
-import * as url from 'url';
 
 import { config } from './lib/config.js';
 import { UserAnonymizedEventLoggingJob } from './lib/infrastructure/jobs/audit-log/UserAnonymizedEventLoggingJob.js';


### PR DESCRIPTION
## :unicorn: Problème

Depuis 2021 Node.js s'est doté du protocole `node:` pour les modules _built-in_ :  https://2ality.com/2021/12/node-protocol-imports.html

Et actuellement dans le code de Pix : 
* les 2 notations, _« avec le protocole `node:` »_ et  _« sans le protocole `node:` »_ cohéxistent
* tous les exemples donnés dans la doc de Node.js, par exemple https://nodejs.org/api/path.html, utilisent le protocole `node:`
* les modules _builtin_ de Node.js ne sont pas facilement identifiables par rapport aux modules récupérés par NPM

## :robot: Proposition

Rendre les imports des modules _built-in_ de Node.js cohérents en utilisant systématiquement le protocole `node:` en activant la règle `prefer-node-protocol` du plugin [eslint-plugin-unicorn](https://www.npmjs.com/package/eslint-plugin-unicorn) déjà présent dans Pix API : https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-node-protocol.md

### Discussion sur les avantages

Tous les avantages du protocole `node:` sont discuté dans ce ticket https://github.com/import-js/eslint-plugin-import/issues/2717 (où seul _ljharb_ ne semble pas convaincu).

### Exemple concret sur le code de pix

Exemple sur le fichier https://github.com/1024pix/pix/blob/dev/api/src/certification/course/infrastructure/utils/pdf/certification-attestation-pdf.js

AVANT un `npm run lint:js:fix` : 

```js
import pdfLibFontkit from '@pdf-lib/fontkit';
import axios from 'axios';
import bluebird from 'bluebird';
import dayjs from 'dayjs';
import { readFile } from 'fs/promises';
import _ from 'lodash';
import { PDFDocument, rgb } from 'pdf-lib';
import * as url from 'url';
```

APRÈS un `npm run lint:js:fix` (l’association des différentes règles séparen les imports des modules _built-in_ de Node.js produit un ordonnancement clair) : 

```js
import { readFile } from 'node:fs/promises';
import * as url from 'node:url';

import pdfLibFontkit from '@pdf-lib/fontkit';
import axios from 'axios';
import bluebird from 'bluebird';
import dayjs from 'dayjs';
import _ from 'lodash';
import { PDFDocument, rgb } from 'pdf-lib';
```

## :rainbow: Remarques

RAS

## :100: Pour tester

1. Vérifier que la CI passe
2. Constater les modifications des imports sur les fichiers, à la fois au niveau des noms des paquets builtin de Node.js et de leur ordonnancement par rapport aux autres modules