### PR TITLE
[REFACTOR] Utilisation des design tokens de typographie sur certif (PIX-11308)

### DIFF
--- a/certif/app/components/import/file-import-block.hbs
+++ b/certif/app/components/import/file-import-block.hbs
@@ -2,7 +2,9 @@
   <FaIcon @icon="cloud-arrow-up" class="file-import-block__icon" />
   <div class="file-import-section">
     <div>
-      <span>{{t "pages.sessions.import.step-one.actions.session-import-upload.extra-information"}}</span>
+      <h3 class="import-download-section__title">{{t
+          "pages.sessions.import.step-one.actions.session-import-upload.extra-information"
+        }}</h3>
       <p>{{t "pages.sessions.import.step-one.actions.session-import-upload.information"}}</p>
 
       {{#if @file}}

--- a/certif/app/components/import/step-one-section.hbs
+++ b/certif/app/components/import/step-one-section.hbs
@@ -24,7 +24,9 @@
     <FaIcon @icon="file-arrow-down" class="import-download-block__icon" />
     <div class="import-download-section">
       <div>
-        <span>{{t "pages.sessions.import.step-one.actions.session-import-template.extra-information"}}</span>
+        <h3 class="import-download-section__title">{{t
+            "pages.sessions.import.step-one.actions.session-import-template.extra-information"
+          }}</h3>
         <p>{{t "pages.sessions.import.step-one.actions.session-import-template.information" htmlSafe=true}}</p>
       </div>
       <div class="import-download-section__button">

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -65,7 +65,6 @@ html {
   min-height: 100vh;
   margin: 0;
   color: var(--pix-neutral-900);
-  font-family: $font-roboto;
   background-color: var(--pix-neutral-20);
 }
 

--- a/certif/app/styles/components/add-student-list.scss
+++ b/certif/app/styles/components/add-student-list.scss
@@ -90,7 +90,6 @@
     width: 100vw;
     height: 68px;
     color: var(--pix-neutral-500);
-    font-family: $font-roboto;
     background-color: var(--pix-neutral-0);
     box-shadow: -2px 2px 9px 0 rgb(0 0 0 / 22%);
 

--- a/certif/app/styles/components/auth/toggable-login-form.scss
+++ b/certif/app/styles/components/auth/toggable-login-form.scss
@@ -1,17 +1,17 @@
 .login-form {
-  max-width: 450px;
   display: flex;
   flex-direction: column;
   gap: $pix-spacing-m;
+  max-width: 450px;
+  padding: 0 2px;
   font-size: 0.875rem;
-  padding: 0 2px 0 2px;
 
   &__information {
-    text-align: center;
     margin-bottom: $pix-spacing-s;
     color: var(--pix-neutral-900);
-    font-family: $font-roboto;
-    letter-spacing: 0.0094rem;
+    text-align: center;
+
+    @extend %pix-body-s;
   }
 
   &__forgotten-password {

--- a/certif/app/styles/components/dropdown.scss
+++ b/certif/app/styles/components/dropdown.scss
@@ -20,7 +20,6 @@
       padding: 0;
 
       > button {
-        font-family: $font-roboto;
         text-align: start;
         background-color: transparent;
         border: none;

--- a/certif/app/styles/components/issue-report-modal.scss
+++ b/certif/app/styles/components/issue-report-modal.scss
@@ -36,7 +36,6 @@
     justify-content: space-between;
     margin: 0;
     padding: 0;
-    font-family: $font-roboto;
     line-height: 32px;
 
     svg {
@@ -50,7 +49,6 @@
     margin: 8px 0 0;
     padding: 0 0 0 16px;
     color: var(--pix-neutral-20);
-    font-family: $font-roboto;
   }
 }
 

--- a/certif/app/styles/components/layout/footer.scss
+++ b/certif/app/styles/components/layout/footer.scss
@@ -35,8 +35,7 @@
   &__copyright {
     color: var(--pix-neutral-500);
     cursor: default;
-    font-size: 0.75rem;
-    font-family: $font-roboto;
+    @extend %pix-body-xs;
     padding: 16px 0;
   }
 }
@@ -46,9 +45,8 @@
   &__item {
     margin-right: 3px;
     color: var(--pix-neutral-500);
-    font-size: 0.8125rem;
+    @extend %pix-body-s;
     font-weight: 500;
-    font-family: $font-roboto;
     text-decoration: none;
 
     @include device-is('desktop') {

--- a/certif/app/styles/components/login-or-register.scss
+++ b/certif/app/styles/components/login-or-register.scss
@@ -34,10 +34,11 @@
   }
 
   &__invitation {
+    @extend %pix-body-l;
+
     margin-top: 24px;
     color: var(--pix-neutral-900);
     font-size: 1.125rem;
-    font-family: $font-roboto;
     text-align: center;
   }
 

--- a/certif/app/styles/components/login-session-supervisor-form.scss
+++ b/certif/app/styles/components/login-session-supervisor-form.scss
@@ -25,9 +25,10 @@
   &__subtitle {
     margin: 0;
     color: var(--pix-neutral-800);
+
+    @extend %pix-title-s;
+
     font-weight: normal;
-    font-size: 1.75rem;
-    font-family: $font-open-sans;
   }
 
   &__required-fields-notice {

--- a/certif/app/styles/components/register-form.scss
+++ b/certif/app/styles/components/register-form.scss
@@ -1,11 +1,9 @@
 .register-form {
   max-width: 360px;
   overflow-y: auto;
-  font-size: 0.875rem;
 
   &__cgu-label {
     margin: 0;
-    font-family: $font-roboto;
   }
 
   &__cgu-error {

--- a/certif/app/styles/components/select-referer-modal.scss
+++ b/certif/app/styles/components/select-referer-modal.scss
@@ -3,9 +3,10 @@
 
   &__title {
     color: var(--pix-neutral-900);
+
+    @extend %pix-title-xs;
+
     font-weight: 600;
-    font-size: 1.25rem;
-    font-family: $font-open-sans;
   }
 
   &__label {

--- a/certif/app/styles/components/session-finalization-step-container.scss
+++ b/certif/app/styles/components/session-finalization-step-container.scss
@@ -6,16 +6,17 @@
   &__page-title {
     margin: 0;
     color: var(--pix-neutral-900);
-    font-weight: 700;
+
+    @extend %pix-title-xs;
+
     font-size: 1rem;
-    font-family: $font-open-sans;
   }
 
   p {
     margin: 8px 0 0;
     color: var(--pix-neutral-500);
-    font-weight: normal;
-    font-size: 0.875rem;
+
+    @extend %pix-body-s;
   }
 
   &__header {

--- a/certif/app/styles/components/session-supervising/candidate-in-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-in-list.scss
@@ -69,8 +69,6 @@
     }
 
     > .pix-tag--compact {
-      font-family: $font-roboto;
-      font-weight: $font-normal;
       text-transform: none;
     }
   }

--- a/certif/app/styles/components/session-supervising/candidate-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-list.scss
@@ -27,11 +27,10 @@
     }
 
     &__title {
+      @extend %pix-title-xs;
       font-weight: 600;
       margin: 0 0 8px;
-      font-family: $font-open-sans;
       color: var(--pix-neutral-20);
-      font-size: 1.25rem;
     }
 
     &__candidates {
@@ -50,7 +49,7 @@
 
     &__empty-message {
       color: var(--pix-neutral-20);
-      font-family: $font-open-sans;
+      @extend %pix-title-xs;
       font-size: 1.125rem;
       font-weight: 600;
       margin: auto;
@@ -90,7 +89,6 @@
       border: none;
       box-shadow: none;
       color: var(--pix-neutral-900);
-      font-family: $font-roboto;
       font-size: 1rem;
       padding: 0 10px;
       width: 100%;

--- a/certif/app/styles/components/session-supervising/header.scss
+++ b/certif/app/styles/components/session-supervising/header.scss
@@ -20,8 +20,7 @@
   }
 
   &__title {
-    font-family: $font-open-sans;
-    font-size: 1.75rem;
+    @extend %pix-title-s;
     font-weight: normal;
     margin-bottom: 4px;
   }

--- a/certif/app/styles/globals/forms.scss
+++ b/certif/app/styles/globals/forms.scss
@@ -87,8 +87,8 @@ input[type='number'] {
 
 .error-message {
   color: var(--pix-error-700);
-  font-size: 0.875rem;
-  font-family: $font-roboto;
+
+  @extend %pix-body-s;
 
   & a {
     text-decoration: underline;
@@ -103,8 +103,9 @@ input[type='number'] {
 
   &--showed-as-link {
     color: var(--pix-neutral-500);
-    font-size: 0.875rem;
-    font-family: $font-roboto;
+
+    @extend %pix-body-s;
+
     text-decoration: underline;
     background: none;
     border: none;

--- a/certif/app/styles/globals/panels.scss
+++ b/certif/app/styles/globals/panels.scss
@@ -14,9 +14,10 @@
     align-items: center;
     margin: 0 12px;
     color: var(--pix-neutral-500);
+
+    @extend %pix-body-s;
+
     font-weight: 500;
-    font-size: 0.9rem;
-    font-family: $font-roboto;
     text-decoration: none;
     border: none;
     border-bottom: 2px solid transparent;

--- a/certif/app/styles/globals/texts.scss
+++ b/certif/app/styles/globals/texts.scss
@@ -1,14 +1,13 @@
 .label-text {
   color: var(--pix-neutral-100);
-  font-weight: 400;
-  font-size: 0.8125rem;
-  font-family: $font-roboto;
+
+  @extend %pix-body-s;
 }
 
 .content-text {
   color: var(--pix-neutral-500);
-  font-size: 1rem;
-  font-family: $font-roboto;
+
+  @extend %pix-body-m;
 
   &--bold {
     color: var(--pix-neutral-800);
@@ -20,6 +19,7 @@
     font-size: 2rem;
   }
 
+  // FIXME: Probably useless but need to check if BEM is respected
   &--small {
     font-size: 0.8125rem;
   }

--- a/certif/app/styles/globals/titles.scss
+++ b/certif/app/styles/globals/titles.scss
@@ -2,5 +2,4 @@
   @extend %pix-title-m;
 
   margin: 24px 0;
-  color: var(--pix-neutral-800);
 }

--- a/certif/app/styles/pages/authenticated/restricted-access.scss
+++ b/certif/app/styles/pages/authenticated/restricted-access.scss
@@ -1,7 +1,7 @@
 .restricted-access-page {
-  align-items: center;
   display: flex;
   flex-direction: column;
+  align-items: center;
 }
 
 .restricted-access-content {
@@ -12,36 +12,35 @@
   }
 
   &__opening-title {
-    @extend %pix-title-m;
-    font-size: 2rem;
-    font-weight: 300;
-    letter-spacing: 0.15px;
-    line-height: 43px;
+    @extend %pix-title-s;
+
     margin: 0;
     margin-bottom: 16px;
     text-align: center;
   }
 
   &__opening-dates {
-    background: var(--pix-neutral-500);
-    border-radius: 8px;
-    color: var(--pix-neutral-0);
-    @extend %pix-title-s;
-    font-size: 1.5rem;
-    font-weight: 600;
-    letter-spacing: 0.15px;
     margin: 0;
     margin-bottom: 16px;
     padding: 8px 16px;
+    color: var(--pix-neutral-0);
+    font-weight: 600;
+    font-size: 1.5rem;
+    letter-spacing: 0.15px;
     text-align: center;
+    background: var(--pix-neutral-500);
+    border-radius: 8px;
+
+    @extend %pix-title-s;
   }
 
   &__link-calendar {
     @extend %pix-body-s;
-    letter-spacing: 0.15px;
-    line-height: 22px;
+
     margin: 0;
     margin-bottom: 16px;
+    line-height: 22px;
+    letter-spacing: 0.15px;
     text-align: center;
   }
 }

--- a/certif/app/styles/pages/authenticated/restricted-access.scss
+++ b/certif/app/styles/pages/authenticated/restricted-access.scss
@@ -18,29 +18,4 @@
     margin-bottom: 16px;
     text-align: center;
   }
-
-  &__opening-dates {
-    margin: 0;
-    margin-bottom: 16px;
-    padding: 8px 16px;
-    color: var(--pix-neutral-0);
-    font-weight: 600;
-    font-size: 1.5rem;
-    letter-spacing: 0.15px;
-    text-align: center;
-    background: var(--pix-neutral-500);
-    border-radius: 8px;
-
-    @extend %pix-title-s;
-  }
-
-  &__link-calendar {
-    @extend %pix-body-s;
-
-    margin: 0;
-    margin-bottom: 16px;
-    line-height: 22px;
-    letter-spacing: 0.15px;
-    text-align: center;
-  }
 }

--- a/certif/app/styles/pages/authenticated/restricted-access.scss
+++ b/certif/app/styles/pages/authenticated/restricted-access.scss
@@ -12,7 +12,7 @@
   }
 
   &__opening-title {
-    font-family: $font-open-sans;
+    @extend %pix-title-m;
     font-size: 2rem;
     font-weight: 300;
     letter-spacing: 0.15px;
@@ -26,7 +26,7 @@
     background: var(--pix-neutral-500);
     border-radius: 8px;
     color: var(--pix-neutral-0);
-    font-family: $font-open-sans;
+    @extend %pix-title-s;
     font-size: 1.5rem;
     font-weight: 600;
     letter-spacing: 0.15px;
@@ -37,9 +37,7 @@
   }
 
   &__link-calendar {
-    font-family: $font-roboto;
-    font-size: 0.875rem;
-    font-weight: normal;
+    @extend %pix-body-s;
     letter-spacing: 0.15px;
     line-height: 22px;
     margin: 0;

--- a/certif/app/styles/pages/authenticated/sessions/details.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details.scss
@@ -154,9 +154,8 @@
   &__clea-results-download-title {
     margin: 0 0 8px;
     color: var(--pix-neutral-900);
+    @extend %pix-title-xs;
     font-weight: 500;
-    font-size: 20px;
-    font-family: $font-open-sans;
   }
 
   &__clea-results-download-description {

--- a/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
@@ -17,9 +17,9 @@
 }
 
 .panel-actions__header-title {
-  margin: 0 0 0 2rem;
-  font-size: 1.3rem;
-  font-weight: 400;
+  margin-left: 1rem;
+
+  @extend %pix-title-s;
 }
 
 .panel-actions__header-icon {
@@ -49,8 +49,8 @@
 }
 
 .panel-actions__action-icon {
-  color: var(--pix-neutral-100);
-  font-size: 1.87rem;
+  color: var(--pix-neutral-500);
+  font-size: 2rem;
   width: 3.125rem;
   text-align: center;
 }
@@ -69,8 +69,8 @@
 }
 
 .panel-actions__title {
-  margin: 0;
-  font-weight: bold;
+  @extend %pix-title-xs;
+
   color: var(--pix-neutral-800);
 }
 
@@ -108,13 +108,13 @@
   display: flex;
   align-items: center;
   color: var(--pix-neutral-500);
-  padding: 8px 16px;
+  padding: 20px;
 
   &__title {
     display: flex;
     flex-grow: 1;
-    font-size: 1rem;
-    font-weight: bold;
+
+    @extend %pix-title-s;
   }
 
   &__action {

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -15,7 +15,6 @@
 
     > h2 {
       @extend %pix-title-s;
-      color: var(--pix-neutral-900);
     }
   }
 
@@ -166,6 +165,10 @@
     button {
       max-width: 164px;
     }
+  }
+
+  &__title {
+    @extend %pix-title-xs;
   }
 }
 

--- a/certif/app/styles/pages/authenticated/team.scss
+++ b/certif/app/styles/pages/authenticated/team.scss
@@ -28,14 +28,14 @@
   }
 
   &__no-referer-title {
-    font-weight: 500;
-    font-size: 1.25rem;
-    font-family: $font-open-sans;
-    color: var(--pix-neutral-900);
+    @extend %pix-title-s;
+
     margin: 0 0 4px;
   }
 
   &__no-referer-description {
+    @extend %pix-body-m;
+
     color: var(--pix-neutral-500);
     margin: 16px 0;
   }

--- a/certif/app/styles/pages/login-session-supervisor.scss
+++ b/certif/app/styles/pages/login-session-supervisor.scss
@@ -21,9 +21,9 @@
       width: 100%;
       height: 80px;
       color: var(--pix-neutral-500);
-      font-weight: normal;
-      font-size: 14px;
-      font-family: $font-roboto;
+
+      @extend %pix-body-s;
+
       line-height: 22px;
       letter-spacing: 0.15px;
       background: var(--pix-neutral-20);

--- a/certif/app/styles/pages/session-supervising-error.scss
+++ b/certif/app/styles/pages/session-supervising-error.scss
@@ -27,9 +27,10 @@
 
   &__title {
     color: var(--pix-neutral-800);
+
+    @extend %pix-title-s;
+
     font-weight: normal;
-    font-size: 1.75rem;
-    font-family: $font-open-sans;
   }
 
   &__subtitle {

--- a/certif/app/styles/pages/terms-of-service.scss
+++ b/certif/app/styles/pages/terms-of-service.scss
@@ -44,7 +44,6 @@
     margin: 0 60px 20px;
     padding: 0 35px;
     overflow: hidden scroll;
-    font-family: $font-open-sans;
 
     p,
     li {


### PR DESCRIPTION
## :unicorn: Problème
Il y a quelques pages qui n’utilisent pas les tokens font (pour rappel Nunito pour les titres et Roboto pour les textes). 

## :robot: Proposition
Utiliser les [tokens de typographies](https://ui.pix.fr/?path=/docs/utiliser-pix-ui-design-tokens-typographie--docs) pour définir les changement de fonts.

## :rainbow: Remarques
Le premier commit est construit comme étant ISO. J'ai laissé les surcharges de propriétés de typographies.
(J'ai simplement transformer des petites valeurs de fontes: `0.8125rem => 0.850rem || ~ px` par exemple)
Dans un second temps, on pourrait réévaluer la pertinence de toutes ces surcharges.

Le règles changées dans le deuxième commit sont dépendantes d'une cascade CSS et les composants associés ont été vérifiés pendant le développement pour produire le même rendu qu'avec la règle précédente.
## :100: Pour tester

Idéalement se promener sur toutes les pages impactées:
En vrac:
Commit ISO:
- Footer 
- Page de login de l’app
- Page de login du surveillant
- Page d’erreur de l’espace surveillant
- Sélection d’un référant Cléa
- Finalisation de session
- Liste des candidats dans l’espace surveillant
- Titre de l’espace surveillant (nom de la session)
- Les messages d’erreur dans les formulaires
- Textes de label et de contenus
- La page d’accès limité à une certification sco
- La zone de téléchargement des résultats pour une certif Cléa
- La page équipe

Commit Cascade:
- Page d’ajout de candidats sco à partir d’une classe
- Formulaire pour rejoindre un centre de certification suite à une invitation
- Tag du statut d’un candidat dans l’espace surveillant
- Modale d’édition d’un signalement (lors de la finalisation) Modale des conditions d’utilisation
- Input de recherche des candidats dans l’espace surveillant