### PR TITLE
[BUGFIX] Erreur 502 lors du rattachement d'un nouveau PC à une certification complémentaire (PIX-12044)

### DIFF
--- a/api/src/certification/complementary-certification/domain/usecases/index.js
+++ b/api/src/certification/complementary-certification/domain/usecases/index.js
@@ -6,6 +6,7 @@ import { injectDependencies } from '../../../../shared/infrastructure/utils/depe
 import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as complementaryCertificationForTargetProfileAttachmentRepository from '../../../complementary-certification/infrastructure/repositories/complementary-certification-for-target-profile-attachment-repository.js';
 import * as organizationRepository from '../../../complementary-certification/infrastructure/repositories/organization-repository.js';
+import { mailService } from '../../../shared/domain/services/mail-service.js';
 import * as complementaryCertificationBadgesRepository from '../../infrastructure/repositories/complementary-certification-badge-repository.js';
 import * as complementaryCertificationRepository from '../../infrastructure/repositories/complementary-certification-repository.js';
 import * as targetProfileHistoryRepository from '../../infrastructure/repositories/target-profile-history-repository.js';
@@ -19,6 +20,7 @@ import * as targetProfileHistoryRepository from '../../infrastructure/repositori
  * @typedef {complementaryCertificationForTargetProfileAttachmentRepository} ComplementaryCertificationForTargetProfileAttachmentRepository
  * @typedef {targetProfileHistoryRepository} TargetProfileHistoryRepository
  * @typedef {organizationRepository} OrganizationRepository
+ * @typedef {mailService} MailService
  **/
 const dependencies = {
   complementaryCertificationBadgesRepository,
@@ -26,6 +28,7 @@ const dependencies = {
   complementaryCertificationForTargetProfileAttachmentRepository,
   targetProfileHistoryRepository,
   organizationRepository,
+  mailService,
 };
 
 const path = dirname(fileURLToPath(import.meta.url));

--- a/api/tests/certification/complementary-certification/acceptance/application/attach-target-profile-controller_test.js
+++ b/api/tests/certification/complementary-certification/acceptance/application/attach-target-profile-controller_test.js
@@ -23,12 +23,24 @@ describe('Acceptance | Controller | Complementary certification | attach-target-
       // given
       const superAdmin = await insertUserWithRoleSuperAdmin();
       const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
+        id: 52,
         key: 'Pix+ key',
         label: 'Pix+ label',
       });
 
+      const organization = databaseBuilder.factory.buildOrganization();
+      databaseBuilder.factory.buildMembership({
+        organizationId: organization.id,
+        userId: superAdmin.id,
+      });
       const alreadyAttachedTargetProfile = databaseBuilder.factory.buildTargetProfile({
+        ownerOrganizationId: organization.id,
         id: 11,
+      });
+
+      const targetProfile = databaseBuilder.factory.buildTargetProfile({
+        ownerOrganizationId: organization.id,
+        id: 12,
       });
       const alreadyAttachedBadge = databaseBuilder.factory.buildBadge({
         id: 999,
@@ -40,18 +52,9 @@ describe('Acceptance | Controller | Complementary certification | attach-target-
         badgeId: alreadyAttachedBadge.id,
         detachedAt: null,
       });
-
-      const targetProfile = databaseBuilder.factory.buildTargetProfile({
-        id: 12,
-      });
-      const organization = databaseBuilder.factory.buildOrganization();
-      databaseBuilder.factory.buildMembership({
-        organizationId: organization.id,
-        userId: superAdmin.id,
-      });
       databaseBuilder.factory.buildCampaign({
         organizationId: organization.id,
-        targetProfileId: targetProfile.id,
+        targetProfileId: alreadyAttachedTargetProfile.id,
       });
       databaseBuilder.factory.buildBadge({ id: 1, targetProfileId: targetProfile.id });
 


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Admin en recette, onglet Certifications complémentaires, lorsqu’on clique sur l’une des certifications complémentaires, on peut changer le profil cible (PC) rattaché à celle-ci en cliquant sur “Rattacher un nouveau profil cible”

On rempli le tableau avec les informations manquantes pour chaque résultat thématique (RT) du nouveau PC à rattacher

On coche la case “Notifier les organisations avec une campagne basée sur l’ancien PC”

On clique sur “Rattacher le profil cible”

Resultat: On a un message “Error dans Ember” qui s’affiche et en ouvrant la console une erreur 502 sur la route 

## :robot: Proposition
corriger l'injection du mail service 


## :100: Pour tester
Dans pix-admin:

- retenter les étapes ci dessus
- constater le message de succès