### PR TITLE
[FEATURE] affiche l'état de l'import sur la page participant (Pix-11671)

### DIFF
--- a/orga/app/components/import-information-banner.gjs
+++ b/orga/app/components/import-information-banner.gjs
@@ -1,0 +1,60 @@
+import PixMessage from '@1024pix/pix-ui/components/pix-message';
+import { LinkTo } from '@ember/routing';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+
+export default class ImportBanner extends Component {
+  @service intl;
+  @service dayjs;
+
+  get displayBanner() {
+    if (!this.args.importDetail) {
+      return false;
+    }
+    return this.dayjs.self().diff(this.args.importDetail.updatedAt, 'day') < 15;
+  }
+
+  get bannerType() {
+    if (this.args.importDetail?.hasError) {
+      return 'error';
+    } else if (this.args.importDetail?.isDone) {
+      return 'success';
+    }
+    return 'information';
+  }
+
+  get message() {
+    if (this.args.importDetail?.hasError) {
+      return this.intl.t('components.import-information-banner.error');
+    } else if (this.args.importDetail?.isDone) {
+      return this.intl.t('components.import-information-banner.success');
+    }
+    if (this.args.importDetail?.inProgress) {
+      return this.intl.t('components.import-information-banner.in-progress');
+    }
+    return null;
+  }
+
+  get linkMessage() {
+    if (this.args.importDetail?.inProgress) {
+      return this.intl.t('components.import-information-banner.in-progress-link');
+    }
+    if (this.args.importDetail?.hasError) {
+      return this.intl.t('components.import-information-banner.error-link');
+    }
+    return null;
+  }
+
+  <template>
+    {{#if this.displayBanner}}
+      <PixMessage class="import-information-banner" @type={{this.bannerType}} @withIcon="true">
+        <strong>{{this.message}}</strong>
+        {{#if this.linkMessage}}
+          <LinkTo @route="authenticated.import-organization-participants" class="import-information-banner__link link">
+            {{this.linkMessage}}
+          </LinkTo>
+        {{/if}}
+      </PixMessage>
+    {{/if}}
+  </template>
+}

--- a/orga/app/components/import.js
+++ b/orga/app/components/import.js
@@ -13,6 +13,10 @@ export default class Import extends Component {
     return this.args.organizationImportDetail?.hasError || this.args.organizationImportDetail?.hasWarning;
   }
 
+  get inProgress() {
+    return Boolean(this.args.organizationImportDetail?.inProgress);
+  }
+
   get panelClasses() {
     const classes = ['import-students-page__error-panel'];
 

--- a/orga/app/components/sco-organization-participant/list.hbs
+++ b/orga/app/components/sco-organization-participant/list.hbs
@@ -1,3 +1,5 @@
+<ImportInformationBanner @importDetail={{@importDetail}} />
+
 <ScoOrganizationParticipant::ScoLearnerFilters
   @studentsCount={{@students.meta.rowCount}}
   @onFilter={{@onFilter}}

--- a/orga/app/components/sup-organization-participant/list.hbs
+++ b/orga/app/components/sup-organization-participant/list.hbs
@@ -1,3 +1,5 @@
+<ImportInformationBanner @importDetail={{@importDetail}} />
+
 <div id={{this.filtersId}} />
 
 <div class="panel">

--- a/orga/app/controllers/authenticated/import-organization-participants.js
+++ b/orga/app/controllers/authenticated/import-organization-participants.js
@@ -82,4 +82,12 @@ export default class ImportController extends Controller {
     this.warnings = null;
     this.warningBanner = null;
   }
+
+  get participantListRoute() {
+    return this.currentUser.isSCOManagingStudents
+      ? 'authenticated.sco-organization-participants.list'
+      : this.currentUser.isSUPManagingStudents
+        ? 'authenticated.sup-organization-participants.list'
+        : 'authenticated';
+  }
 }

--- a/orga/app/routes/authenticated/sco-organization-participants/list.js
+++ b/orga/app/routes/authenticated/sco-organization-participants/list.js
@@ -1,6 +1,7 @@
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import RSVP from 'rsvp';
 
 export default class ListRoute extends Route {
   queryParams = {
@@ -18,24 +19,30 @@ export default class ListRoute extends Route {
   @service currentUser;
   @service store;
 
-  model(params) {
-    return this.store.query('sco-organization-participant', {
-      filter: {
+  async model(params) {
+    const organizationId = this.currentUser.organization.id;
+    return RSVP.hash({
+      importDetail: await this.store.queryRecord('organization-import-detail', {
         organizationId: this.currentUser.organization.id,
-        search: params.search,
-        divisions: params.divisions,
-        connectionTypes: params.connectionTypes,
-        certificability: params.certificability,
-      },
-      sort: {
-        participationCount: params.participationCountOrder,
-        lastnameSort: params.lastnameSort,
-        divisionSort: params.divisionSort,
-      },
-      page: {
-        number: params.pageNumber,
-        size: params.pageSize,
-      },
+      }),
+      participants: this.store.query('sco-organization-participant', {
+        filter: {
+          organizationId,
+          search: params.search,
+          divisions: params.divisions,
+          connectionTypes: params.connectionTypes,
+          certificability: params.certificability,
+        },
+        sort: {
+          participationCount: params.participationCountOrder,
+          lastnameSort: params.lastnameSort,
+          divisionSort: params.divisionSort,
+        },
+        page: {
+          number: params.pageNumber,
+          size: params.pageSize,
+        },
+      }),
     });
   }
 

--- a/orga/app/routes/authenticated/sup-organization-participants/list.js
+++ b/orga/app/routes/authenticated/sup-organization-participants/list.js
@@ -1,6 +1,7 @@
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import RSVP from 'rsvp';
 
 export default class ListRoute extends Route {
   queryParams = {
@@ -19,22 +20,27 @@ export default class ListRoute extends Route {
 
   async model(params) {
     const organizationId = this.currentUser.organization.id;
-    return this.store.query('sup-organization-participant', {
-      filter: {
-        organizationId,
-        search: params.search,
-        studentNumber: params.studentNumber,
-        groups: params.groups,
-        certificability: params.certificability,
-      },
-      sort: {
-        participationCount: params.participationCountOrder,
-        lastnameSort: params.lastnameSort,
-      },
-      page: {
-        number: params.pageNumber,
-        size: params.pageSize,
-      },
+    return RSVP.hash({
+      importDetail: await this.store.queryRecord('organization-import-detail', {
+        organizationId: this.currentUser.organization.id,
+      }),
+      participants: this.store.query('sup-organization-participant', {
+        filter: {
+          organizationId,
+          search: params.search,
+          studentNumber: params.studentNumber,
+          groups: params.groups,
+          certificability: params.certificability,
+        },
+        sort: {
+          participationCount: params.participationCountOrder,
+          lastnameSort: params.lastnameSort,
+        },
+        page: {
+          number: params.pageNumber,
+          size: params.pageSize,
+        },
+      }),
     });
   }
 

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -50,6 +50,7 @@
 @import 'components/learner/header';
 @import 'components/sup-organization-participant/replace-students-modal';
 @import 'components/import-banner';
+@import 'components/import-information-banner.scss';
 
 // pages
 @import 'pages/login';

--- a/orga/app/styles/components/import-information-banner.scss
+++ b/orga/app/styles/components/import-information-banner.scss
@@ -1,0 +1,7 @@
+.import-information-banner {
+  margin: var(--pix-spacing-4x) 0;
+
+  &__link {
+    color: currentcolor;
+  }
+}

--- a/orga/app/templates/authenticated/import-organization-participants.hbs
+++ b/orga/app/templates/authenticated/import-organization-participants.hbs
@@ -1,6 +1,6 @@
 {{page-title (t "pages.organization-participants-import.title")}}
 
-<PixReturnTo @route="authenticated.sup-organization-participants.list">
+<PixReturnTo @route={{this.participantListRoute}}>
   {{t "common.actions.back"}}
 </PixReturnTo>
 

--- a/orga/app/templates/authenticated/sco-organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/sco-organization-participants/list.hbs
@@ -1,9 +1,10 @@
 {{page-title (t "pages.sco-organization-participants.page-title")}}
 
 <div class="organization-participant-list-page sco-organization-participant-list-page">
-  <ScoOrganizationParticipant::HeaderActions @participantCount={{@model.meta.participantCount}} />
+  <ScoOrganizationParticipant::HeaderActions @participantCount={{@model.participants.meta.participantCount}} />
   <ScoOrganizationParticipant::List
-    @students={{@model}}
+    @students={{@model.participants}}
+    @importDetail={{@model.importDetail}}
     @searchFilter={{this.search}}
     @divisionsFilter={{this.divisions}}
     @connectionTypeFilter={{this.connectionTypes}}

--- a/orga/app/templates/authenticated/sup-organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/sup-organization-participants/list.hbs
@@ -1,9 +1,10 @@
 {{page-title (t "pages.sup-organization-participants.page-title")}}
 <div class="organization-participant-list-page sup-organization-participant-list-page">
-  <SupOrganizationParticipant::HeaderActions @participantCount={{@model.meta.participantCount}} />
+  <SupOrganizationParticipant::HeaderActions @participantCount={{@model.participants.meta.participantCount}} />
 
   <SupOrganizationParticipant::List
-    @students={{@model}}
+    @students={{@model.participants}}
+    @importDetail={{@model.importDetail}}
     @searchFilter={{this.search}}
     @studentNumberFilter={{this.studentNumber}}
     @groupsFilter={{this.groups}}

--- a/orga/tests/integration/components/import-information-banner_test.gjs
+++ b/orga/tests/integration/components/import-information-banner_test.gjs
@@ -1,0 +1,105 @@
+import { render } from '@1024pix/ember-testing-library';
+import dayjs from 'dayjs';
+import ImportInformationBanner from 'pix-orga/components/import-information-banner';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+
+module('Integration | Component | ImportInformationBanner', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it show nothing when there is no import', async function (assert) {
+    // when
+    const screen = await render(<template><ImportInformationBanner /></template>);
+
+    // then
+    assert.notOk(screen.queryByText(this.intl.t('components.import-information-banner.success')));
+    assert.notOk(screen.queryByText(this.intl.t('components.import-information-banner.error')));
+    assert.notOk(screen.queryByText(this.intl.t('components.import-information-banner.in-progress')));
+  });
+
+  test('it show nothing when there is no import since 14 days', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const updatedAt = dayjs().subtract(16, 'day').toDate();
+    const importDetail = store.createRecord('organization-import-detail', {
+      status: 'IMPORTED',
+      updatedAt,
+    });
+    // when
+    const screen = await render(<template><ImportInformationBanner @importDetail={{importDetail}} /></template>);
+
+    // then
+    assert.notOk(screen.queryByText(this.intl.t('components.import-information-banner.success')));
+    assert.notOk(screen.queryByText(this.intl.t('components.import-information-banner.error')));
+    assert.notOk(screen.queryByText(this.intl.t('components.import-information-banner.in-progress')));
+  });
+  ['UPLOADED', 'VALIDATED'].forEach(async function (status) {
+    test(`display import in progress banner when status is ${status}`, async function (assert) {
+      //given
+      const store = this.owner.lookup('service:store');
+      const importDetail = store.createRecord('organization-import-detail', {
+        status,
+        updatedAt: dayjs().toDate(),
+      });
+
+      // when
+      const screen = await render(<template><ImportInformationBanner @importDetail={{importDetail}} /></template>);
+      assert.ok(
+        screen.getByText(this.intl.t('components.import-information-banner.in-progress'), {
+          exact: false,
+        }),
+      );
+
+      assert.ok(
+        screen.getByRole(
+          'link',
+          { name: this.intl.t('components.import-information-banner.in-progress-link') },
+          { exact: false },
+        ),
+      );
+    });
+  });
+
+  test('display success banner', async function (assert) {
+    const store = this.owner.lookup('service:store');
+    const importDetail = store.createRecord('organization-import-detail', {
+      status: 'IMPORTED',
+      updatedAt: dayjs().toDate(),
+    });
+    // when
+    const screen = await render(<template><ImportInformationBanner @importDetail={{importDetail}} /></template>);
+
+    assert.ok(
+      screen.getByText(this.intl.t('components.import-information-banner.success'), {
+        exact: false,
+      }),
+    );
+  });
+
+  ['UPLOAD_ERROR', 'IMPORT_ERROR', 'VALIDATION_ERROR'].forEach(async function (status) {
+    test(`display import error banner when status is ${status}`, async function (assert) {
+      const store = this.owner.lookup('service:store');
+      const importDetail = store.createRecord('organization-import-detail', {
+        status,
+        updatedAt: dayjs().toDate(),
+        errors: [{ code: 'some_error' }],
+      });
+      // when
+      const screen = await render(<template><ImportInformationBanner @importDetail={{importDetail}} /></template>);
+
+      assert.ok(
+        screen.getByText(this.intl.t('components.import-information-banner.error'), {
+          exact: false,
+        }),
+      );
+      assert.ok(
+        screen.getByRole(
+          'link',
+          { name: this.intl.t('components.import-information-banner.error-link') },
+          { exact: false },
+        ),
+      );
+    });
+  });
+});

--- a/orga/tests/unit/components/import_test.js
+++ b/orga/tests/unit/components/import_test.js
@@ -12,6 +12,30 @@ module('Unit | Component | import', (hooks) => {
   hooks.beforeEach(function () {
     component = createGlimmerComponent('component:import');
   });
+  module('get#inProgress', function () {
+    test('should return false if no organizationImportDetail', function (assert) {
+      //when
+      component.args.organizationImportDetail = undefined;
+
+      // then
+      assert.false(component.inProgress);
+    });
+    test('should return false organizationImportDetail is not inProgress', function (assert) {
+      //when
+      component.args.organizationImportDetail = { inProgress: false };
+
+      // then
+      assert.false(component.inProgress);
+    });
+    test('should return true organizationImportDetail is inProgress', function (assert) {
+      //when
+      component.args.organizationImportDetail = { inProgress: true };
+
+      // then
+      assert.true(component.inProgress);
+    });
+  });
+
   module('get#displayImportMessagePanel', () => {
     test('should return false if there is no error nor warning', (assert) => {
       //when

--- a/orga/tests/unit/controllers/authenticated/import-organization-participants_test.js
+++ b/orga/tests/unit/controllers/authenticated/import-organization-participants_test.js
@@ -7,18 +7,18 @@ module('Unit | Controller | authenticated/import-organization-participant', func
   setupTest(hooks);
   setupIntl(hooks);
   const files = Symbol('files');
-  const currentUser = { organization: { id: 1 } };
   let controller;
   let addStudentsCsvStub;
   let replaceStudentsCsvStub;
   let importScoStudentStub;
+  let currentUser;
 
   hooks.beforeEach(function () {
     this.owner.lookup('service:intl').setLocale('fr');
     controller = this.owner.lookup('controller:authenticated/import-organization-participants');
     controller.send = sinon.stub();
+    currentUser = { organization: { id: 1 } };
     controller.currentUser = currentUser;
-
     const store = this.owner.lookup('service:store');
     const adapter = store.adapterFor('students-import');
     addStudentsCsvStub = sinon.stub(adapter, 'addStudentsCsv');
@@ -92,6 +92,21 @@ module('Unit | Controller | authenticated/import-organization-participant', func
         await controller.replaceStudents(files);
         assert.ok(controller.send.calledWithExactly('refreshGroups'));
       });
+    });
+  });
+  module('#participantListRoute', function () {
+    test('it returns sco participant route if currentUser is SCO managing', async function (assert) {
+      controller.currentUser.isSCOManagingStudents = true;
+
+      assert.strictEqual(controller.participantListRoute, 'authenticated.sco-organization-participants.list');
+    });
+    test('it returns sup participant route if currentUser is SUP managing', async function (assert) {
+      controller.currentUser.isSUPManagingStudents = true;
+
+      assert.strictEqual(controller.participantListRoute, 'authenticated.sup-organization-participants.list');
+    });
+    test('it returns autenticated route if currentUser is neither SCO or SUP managing', async function (assert) {
+      assert.strictEqual(controller.participantListRoute, 'authenticated');
     });
   });
 });

--- a/orga/tests/unit/routes/authenticated/sco-organization-participants/list_test.js
+++ b/orga/tests/unit/routes/authenticated/sco-organization-participants/list_test.js
@@ -1,0 +1,76 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/sco-organization-participants/list', function (hooks) {
+  setupTest(hooks);
+  let route;
+  let store;
+  const importDetailSymbol = Symbol('organization-import-detail');
+  const scoOrganizationParticipantSymbol = Symbol('sco-organization-participant');
+  const searchSymbol = Symbol('search');
+  const divisionsSymbol = Symbol('divisions');
+  const connectionTypesSymbol = Symbol('connectionTypes');
+  const certificabilitySymbol = Symbol('certificability');
+  const pageNumberSymbol = Symbol('pageNumber');
+  const pageSizeSymbol = Symbol('pageSize');
+  const participationCountOrderSymbol = Symbol('participationCountOrder');
+  const lastnameSortSymbol = Symbol('lastnameSort');
+  const divisionSortSymbol = Symbol('divisionSort');
+
+  hooks.beforeEach(function () {
+    route = this.owner.lookup('route:authenticated/sco-organization-participants/list');
+    store = this.owner.lookup('service:store');
+    route.currentUser = { shouldAccessImportPage: true, organization: { id: Symbol('organization-id') } };
+    sinon
+      .stub(store, 'queryRecord')
+      .withArgs('organization-import-detail', {
+        organizationId: route.currentUser.organization.id,
+      })
+      .resolves(importDetailSymbol);
+
+    sinon
+      .stub(store, 'query')
+      .withArgs('sco-organization-participant', {
+        filter: {
+          organizationId: route.currentUser.organization.id,
+          search: searchSymbol,
+          divisions: divisionsSymbol,
+          connectionTypes: connectionTypesSymbol,
+          certificability: certificabilitySymbol,
+        },
+        sort: {
+          participationCount: participationCountOrderSymbol,
+          lastnameSort: lastnameSortSymbol,
+          divisionSort: divisionSortSymbol,
+        },
+        page: {
+          number: pageNumberSymbol,
+          size: pageSizeSymbol,
+        },
+      })
+      .resolves(scoOrganizationParticipantSymbol);
+  });
+
+  test('should return models', async function (assert) {
+    // given
+    const params = {
+      search: searchSymbol,
+      divisions: divisionsSymbol,
+      connectionTypes: connectionTypesSymbol,
+      certificability: certificabilitySymbol,
+      pageNumber: pageNumberSymbol,
+      pageSize: pageSizeSymbol,
+      participationCountOrder: participationCountOrderSymbol,
+      lastnameSort: lastnameSortSymbol,
+      divisionSort: divisionSortSymbol,
+    };
+
+    // when
+    const { participants, importDetail } = await route.model(params);
+
+    // then
+    assert.strictEqual(importDetail, importDetailSymbol);
+    assert.strictEqual(participants, scoOrganizationParticipantSymbol);
+  });
+});

--- a/orga/tests/unit/routes/authenticated/sup-organization-participants/list_test.js
+++ b/orga/tests/unit/routes/authenticated/sup-organization-participants/list_test.js
@@ -1,0 +1,73 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/sup-organization-participants/list', function (hooks) {
+  setupTest(hooks);
+  let route;
+  let store;
+  const importDetailSymbol = Symbol('organization-import-detail');
+  const supOrganizationParticipantSymbol = Symbol('sup-organization-participant');
+  const searchSymbol = Symbol('search');
+  const studentNumberSymbol = Symbol('studentNumber');
+  const groupsSymbol = Symbol('groups');
+  const certificabilitySymbol = Symbol('certificability');
+  const pageNumberSymbol = Symbol('pageNumber');
+  const pageSizeSymbol = Symbol('pageSize');
+  const participationCountSymbol = Symbol('participationCountOrder');
+  const lastnameSortSymbol = Symbol('lastnameSort');
+
+  hooks.beforeEach(function () {
+    route = this.owner.lookup('route:authenticated/sup-organization-participants/list');
+    store = this.owner.lookup('service:store');
+    route.currentUser = { shouldAccessImportPage: true, organization: { id: Symbol('organization-id') } };
+    sinon
+      .stub(store, 'queryRecord')
+      .withArgs('organization-import-detail', {
+        organizationId: route.currentUser.organization.id,
+      })
+      .resolves(importDetailSymbol);
+
+    sinon
+      .stub(store, 'query')
+      .withArgs('sup-organization-participant', {
+        filter: {
+          organizationId: route.currentUser.organization.id,
+          search: searchSymbol,
+          studentNumber: studentNumberSymbol,
+          groups: groupsSymbol,
+          certificability: certificabilitySymbol,
+        },
+        sort: {
+          participationCount: participationCountSymbol,
+          lastnameSort: lastnameSortSymbol,
+        },
+        page: {
+          number: pageNumberSymbol,
+          size: pageSizeSymbol,
+        },
+      })
+      .resolves(supOrganizationParticipantSymbol);
+  });
+
+  test('should return models', async function (assert) {
+    // given
+    const params = {
+      search: searchSymbol,
+      studentNumber: studentNumberSymbol,
+      groups: groupsSymbol,
+      certificability: certificabilitySymbol,
+      pageNumber: pageNumberSymbol,
+      pageSize: pageSizeSymbol,
+      participationCountOrder: participationCountSymbol,
+      lastnameSort: lastnameSortSymbol,
+    };
+
+    // when
+    const { participants, importDetail } = await route.model(params);
+
+    // then
+    assert.strictEqual(importDetail, importDetailSymbol);
+    assert.strictEqual(participants, supOrganizationParticipantSymbol);
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -245,6 +245,13 @@
       "SCO": "Class",
       "SUP": "Group"
     },
+    "import-information-banner": {
+      "error": "The file contains errors.",
+      "error-link": "Consult the list of errors here.",
+      "in-progress": "An import is in progress.",
+      "in-progress-link": "Check import status here.",
+      "success": "Participants have been successfully imported."
+    },
     "participation-status": {
       "SHARED-ASSESSMENT": "Submitted results",
       "SHARED-PROFILES_COLLECTION": "Submitted profile",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -245,6 +245,13 @@
       "SCO": "Classe",
       "SUP": "Groupe"
     },
+    "import-information-banner": {
+      "error": "Échec de l’import",
+      "error-link": "(voir l'état de l'import).",
+      "in-progress": "Un import est en cours.",
+      "in-progress-link": "(consulter l'état de l'import).",
+      "success": "Vos participants ont bien été importés."
+    },
     "participation-status": {
       "SHARED-ASSESSMENT": "Résultats reçus",
       "SHARED-PROFILES_COLLECTION": "Profil reçu",
@@ -1094,6 +1101,7 @@
         },
         "students-count": "{count, plural, =0 {0 élève} =1 {1 élève} other {{count} élèves}}"
       },
+
       "manage-authentication-method-modal": {
         "title": "Gestion du compte Pix de l’élève",
         "authentication-methods": "Méthodes de connexion",


### PR DESCRIPTION
## :unicorn: Problème
Il est difficile de connaître l'état de l'import en cours (ou du dernier import)

## :robot: Proposition
On souhaite rendre plus visible l'information sur les dernier import en cours et l'afficher sous la forme d'une bannière simplifiée sur la page des participants.  

## :rainbow: Remarques
on profite de la PR pour rajouter une test pour vérifier que la route `import-participant` appelle bien l'api.
on profite aussi de la PR pour réparer la desactivation des boutons d'upload :cold_sweat: 
on fixe aussi le lien de retour de la page import :)

## :100: Pour tester
Sco 
- aller sur la page participant
- voir le bandeau d'import
- cliquer sur lien
- voir l'import en cours
- voir le bouton d'upload inactif
- cliquer sur retour
- valider qu'on est bien sur la page `/eleves`

Sco agri (cas d'un import non récent)
- faire un import
- lancer un pgsql-console sur scalingo et modifier la date de l'imprt pour qu'elle soit plus vielle de 15j
- rafraichir la page
- valider qu'on ne voit plus le bandeau

Sup   
- aller sur la page participant
- voir le bandeau d'import erreur
- cliquer sur lien  
- cliquer sur retour
- valider qu'on est bien sur la page `/eleves`