### PR TITLE
[TECH] Utiliser la classe screen-reader-only de Pix UI sur Pix Admin et Pix Certif (PIX-12036).

### DIFF
--- a/admin/app/components/autonomous-courses/list-items.hbs
+++ b/admin/app/components/autonomous-courses/list-items.hbs
@@ -1,7 +1,7 @@
 <div class="content-text content-text--small">
   <div class="table-admin">
     <table>
-      <caption class="sr-only">Liste des parcours autonomes</caption>
+      <caption class="screen-reader-only">Liste des parcours autonomes</caption>
       <thead>
         <tr>
           <th scope="col" class="table__column table__column--id">Id</th>

--- a/admin/app/components/common/tubes-details/competence.hbs
+++ b/admin/app/components/common/tubes-details/competence.hbs
@@ -2,7 +2,7 @@
   <PixCollapsible @title="{{@title}}">
     <div class="panel">
       <table class="table content-text content-text--small select-tube-table">
-        <caption class="sr-only">Sélection des sujets</caption>
+        <caption class="screen-reader-only">Sélection des sujets</caption>
         <thead>
           <tr>
             <Table::Header @size="medium" scope="col">

--- a/admin/app/components/common/tubes-selection/competence.hbs
+++ b/admin/app/components/common/tubes-selection/competence.hbs
@@ -2,7 +2,7 @@
   <PixCollapsible @title="{{@competence.index}} {{@competence.name}}">
     <div class="panel">
       <table class="table content-text content-text--small select-tube-table">
-        <caption class="sr-only">Sélection des sujets</caption>
+        <caption class="screen-reader-only">Sélection des sujets</caption>
         <thead>
           <tr>
             <Table::Header @size="medium" scope="col">

--- a/admin/app/components/trainings/list-summary-items.hbs
+++ b/admin/app/components/trainings/list-summary-items.hbs
@@ -1,7 +1,7 @@
 <div class="content-text content-text--small">
   <div class="table-admin">
     <table>
-      <caption class="sr-only">Liste des contenus formatifs</caption>
+      <caption class="screen-reader-only">Liste des contenus formatifs</caption>
       <thead>
         <tr>
           <th class="table__column table__column--id" id="training-id" scope="col">ID</th>

--- a/admin/app/components/users/user-profile.hbs
+++ b/admin/app/components/users/user-profile.hbs
@@ -7,7 +7,7 @@
 
 <div class="user-profile-table">
   <table class="table-admin">
-    <caption class="sr-only">Pix et niveau obtenus en fonction des compétences</caption>
+    <caption class="screen-reader-only">Pix et niveau obtenus en fonction des compétences</caption>
     <thead>
       <tr>
         <th scope="col">Compétences</th>

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -26,7 +26,7 @@
   <div class="table content-text content-text--small certification-candidates-table">
     {{#if (or @certificationCandidates this.candidatesInStaging)}}
       <table class="certification-candidates-table-cpf-toggle-enabled">
-        <caption class="sr-only">
+        <caption class="screen-reader-only">
           {{#if @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
             {{t "pages.sessions.detail.candidates.list.without-details-description"}}
           {{else}}

--- a/certif/app/components/issue-report-modal/fraud-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/fraud-certification-issue-report-fields.hbs
@@ -19,7 +19,7 @@
           fraudFormUrl=this.fraudFormUrl
         }}
         <FaIcon @icon="up-right-from-square" aria-hidden="true" />
-        <span class="sr-only">{{t "navigation.external-link-title"}}</span>
+        <span class="screen-reader-only">{{t "navigation.external-link-title"}}</span>
       </p>
     </div>
   {{/if}}

--- a/certif/app/components/session-finalization/completed-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/completed-reports-information-step.hbs
@@ -9,7 +9,7 @@
         >
           {{t "pages.session-finalization.reporting.completed-reports-information.description"}}
         </PixMessage>
-        <span class="sr-only">
+        <span class="screen-reader-only">
           {{t "pages.session-finalization.reporting.completed-reports-information.extra-information"}}
         </span>
       </caption>

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
@@ -9,7 +9,7 @@
       >
         {{t "pages.session-finalization.reporting.uncompleted-reports-information.description"}}
       </PixMessage>
-      <span class="sr-only">
+      <span class="screen-reader-only">
         {{t "pages.session-finalization.reporting.uncompleted-reports-information.extra-information"}}
       </span>
     </caption>

--- a/certif/app/components/session-summary-list.hbs
+++ b/certif/app/components/session-summary-list.hbs
@@ -32,7 +32,7 @@
               {{t "common.forms.session-labels.status"}}
             </th>
             <th class="table__column table__column--small" scope="col">
-              <span class="sr-only">
+              <span class="screen-reader-only">
                 {{t "pages.sessions.list.table.header.actions"}}
               </span>
             </th>

--- a/certif/app/templates/authenticated/sessions/add-student.hbs
+++ b/certif/app/templates/authenticated/sessions/add-student.hbs
@@ -14,7 +14,7 @@
     {{t "pages.sco.enrol-candidates-in-session.information" htmlSafe=true}}
     <a href={{this.supportUrl}} target="_blank" rel="noopener noreferrer">
       {{t "pages.sco.enrol-candidates-in-session.link-label"}}
-      <span class="sr-only">{{t "navigation.external-link-title"}}</span>
+      <span class="screen-reader-only">{{t "navigation.external-link-title"}}</span>
     </a>
   </PixMessage>
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement on utilise la classe sr-only, distribué par font-awesome alors qu’on a une classe coté Pix UI exprès pour ça maintenant 🙂


## :robot: Proposition
Utiliser cette merveilleuse classe sur Admin et Certif

## :rainbow: Remarques
Je ne le fait volontairement pas sur mon-pix dont le sr-only provient d'une classe custom. Une PR à part sera à faire.

## :100: Pour tester
Non régression des pages avec le contenu masqué : 

Pix Certif **(en vérifier un suffit)**

- Liste des sessions, dernières colonne "Actions" masqué http://localhost:4203/sessions/liste
- SCO : La caption masqué du tableau qui liste les élèves que l'on peut inscrire à une certification (certif-sco@example.net)
- La caption masqué du tableau qui liste les élèves inscrit à une certification http://localhost:4203/sessions/7403/candidats 
- La caption masqué du tableau qui liste les candidats qui n'ont pas terminé leur certification dans la page de finalisation
- La caption masqué du tableau des candidats qui ont terminé leur certif dans la page de finalisation


Pix Admin **(en vérifier un suffit)**