### PR TITLE
[TECH] Utiliser le Pix Message pour le bandeau des certifications terminées sur la page de finalisation de session sur Pix Certif (PIX-11829).

### DIFF
--- a/certif/app/components/session-finalization/completed-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/completed-reports-information-step.hbs
@@ -2,10 +2,13 @@
   <table>
     {{#if (gt @session.uncompletedCertificationReports.length 0)}}
       <caption>
-        <div class="session-finalization-reports-information-step__title-completed">
-          <FaIcon @icon="check-circle" class="session-finalization-reports-information-step__icon" />
+        <PixMessage
+          class="session-finalization-reports-information-step__title-completed"
+          @withIcon={{true}}
+          @type="success"
+        >
           {{t "pages.session-finalization.reporting.completed-reports-information.description"}}
-        </div>
+        </PixMessage>
         <span class="sr-only">
           {{t "pages.session-finalization.reporting.completed-reports-information.extra-information"}}
         </span>

--- a/certif/app/styles/components/session-finalization/reports-information-step.scss
+++ b/certif/app/styles/components/session-finalization/reports-information-step.scss
@@ -2,12 +2,6 @@
   font-size: 0.8125rem;
 
   &__title-completed {
-    display: flex;
-    background: var(--pix-success-100);
-    margin: 8px;
-    color: var(--pix-success-700);
-    font-size: 0.875rem;
-    font-weight: normal;
     padding: 20px 0 20px 24px;
 
     &--hidden {
@@ -16,11 +10,6 @@
   }
 
   &__title-uncompleted {
-    display: flex;
-    background: var(--pix-warning-100);
-    margin: 8px;
-    color: var(--pix-warning-700);
-    font-weight: bold;
     padding: 20px 0 20px 24px;
   }
 
@@ -89,10 +78,5 @@
         }
       }
     }
-  }
-
-  &__icon {
-    height: 14px;
-    margin-right: 8px;
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
On utilise un pixMessage pour le warning mais pas pour le bandeau de succès ce qui donne une incohérence quand les deux sont présents sur la page

<img width="1522" alt="Capture d’écran 2024-03-25 à 15 19 31" src="https://github.com/1024pix/pix/assets/58915422/b97ed531-1a9c-44a9-b42c-6efa7d3bc41b">

## :robot: Proposition
Utiliser le Pix Message pour le bandeau des certifications terminées

## :rainbow: Remarques
Suppression de css inutile

## :100: Pour tester
Se connecter sur Pix Certif avec certif-pro@example
Constater la présence du bandeau [sur cette session](https://certif-pr8639.review.pix.fr/sessions/7405/finalisation)

<img width="1514" alt="Capture d’écran 2024-04-11 à 11 32 41" src="https://github.com/1024pix/pix/assets/58915422/689ed309-e9e9-4907-b948-3a65e16d0832">
