### PR TITLE
[FEATURE] Créer le point d'entrée permettant de récupérer la liste des learners de l'import générique (PIX-11617)

### DIFF
--- a/api/db/database-builder/factory/index.js
+++ b/api/db/database-builder/factory/index.js
@@ -21,8 +21,16 @@ const databaseBuilders = await importNamedExportsFromDirectory({
   ignoredFileNames: unwantedFiles,
 });
 
+const organizationLearners = await importNamedExportsFromDirectory({
+  path: join(path, './prescription/organization-learners'),
+  ignoredFileNames: unwantedFiles,
+});
+
 export const factory = {
   ...databaseBuilders,
+  prescription: {
+    organizationLearners,
+  },
   campaignParticipationOverviewFactory,
   knowledgeElementSnapshotFactory,
   poleEmploiSendingFactory,

--- a/api/db/database-builder/factory/prescription/organization-learners/build-organization-learner.js
+++ b/api/db/database-builder/factory/prescription/organization-learners/build-organization-learner.js
@@ -1,0 +1,43 @@
+import _ from 'lodash';
+
+import { databaseBuffer } from '../../../database-buffer.js';
+import { buildOrganization } from '../../build-organization.js';
+import { buildUser } from '../../build-user.js';
+
+const buildOrganizationLearner = function ({
+  id = databaseBuffer.getNextId(),
+  firstName = 'first-name',
+  lastName = 'last-name',
+  isDisabled = false,
+  createdAt = new Date('2021-01-01'),
+  updatedAt = new Date('2021-02-01'), // for BEGINNING_OF_THE_2020_SCHOOL_YEAR, can outdate very fast! ;)
+  organizationId,
+  userId,
+  deletedBy = null,
+  deletedAt = null,
+  attributes = null,
+} = {}) {
+  organizationId = _.isUndefined(organizationId) ? buildOrganization().id : organizationId;
+  userId = _.isUndefined(userId) ? buildUser().id : userId;
+
+  const values = {
+    id,
+    lastName,
+    firstName,
+    isDisabled,
+    createdAt,
+    updatedAt,
+    organizationId,
+    userId,
+    deletedBy,
+    deletedAt,
+    attributes,
+  };
+
+  return databaseBuffer.pushInsertable({
+    tableName: 'organization-learners',
+    values,
+  });
+};
+
+export { buildOrganizationLearner };

--- a/api/db/migrations/20240411124340_refresh-view-organization-learner.js
+++ b/api/db/migrations/20240411124340_refresh-view-organization-learner.js
@@ -1,0 +1,23 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/DEV/pages/2153512965/Cr+er+une+migration
+
+// If your migrations target `answers` or `knowledge-elements`
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+const VIEW_NAME = 'view-active-organization-learners';
+const REFERENCE_TABLE_NAME = 'organization-learners';
+
+const up = async function (knex) {
+  await knex.schema.createViewOrReplace(VIEW_NAME, function (view) {
+    view.as(knex(REFERENCE_TABLE_NAME).whereNull('deletedAt'));
+  });
+};
+
+const down = async function () {
+  return true;
+};
+
+export { down, up };

--- a/api/src/prescription/API.md
+++ b/api/src/prescription/API.md
@@ -7,6 +7,26 @@
 <dd></dd>
 </dl>
 
+## Functions
+
+<dl>
+<dt><a href="#findPaginatedOrganizationLearners">findPaginatedOrganizationLearners(payload)</a> ⇒ <code><a href="#OrganizationLearnerListResponse">Promise.&lt;OrganizationLearnerListResponse&gt;</a></code></dt>
+<dd></dd>
+</dl>
+
+## Typedefs
+
+<dl>
+<dt><a href="#PageDefinition">PageDefinition</a> : <code>object</code></dt>
+<dd></dd>
+<dt><a href="#OrganizationLearnerListPayload">OrganizationLearnerListPayload</a> : <code>object</code></dt>
+<dd></dd>
+<dt><a href="#Pagination">Pagination</a> : <code>object</code></dt>
+<dd></dd>
+<dt><a href="#OrganizationLearnerListResponse">OrganizationLearnerListResponse</a> : <code>object</code></dt>
+<dd></dd>
+</dl>
+
 <a name="module_CampaignApi"></a>
 
 ## CampaignApi
@@ -99,6 +119,8 @@
 | --- | --- |
 | campaignId | <code>number</code> | 
 | name | <code>string</code> | 
+| title | <code>string</code> | 
+| customLandingPageText | <code>string</code> | 
 
 <a name="module_CampaignApi..PageDefinition"></a>
 
@@ -120,7 +142,7 @@
 | Name | Type |
 | --- | --- |
 | organizationId | <code>number</code> | 
-| page | <code>PageDefinition</code> | 
+| page | [<code>PageDefinition</code>](#PageDefinition) | 
 
 <a name="module_CampaignApi..Pagination"></a>
 
@@ -144,7 +166,7 @@
 | Name | Type |
 | --- | --- |
 | models | <code>Array.&lt;CampaignListItem&gt;</code> | 
-| meta | <code>Pagination</code> | 
+| meta | [<code>Pagination</code>](#Pagination) | 
 
 <a name="module_TargetProfileApi"></a>
 
@@ -171,5 +193,60 @@
 | Param | Type |
 | --- | --- |
 | id | <code>number</code> | 
+
+<a name="findPaginatedOrganizationLearners"></a>
+
+## findPaginatedOrganizationLearners(payload) ⇒ [<code>Promise.&lt;OrganizationLearnerListResponse&gt;</code>](#OrganizationLearnerListResponse)
+**Kind**: global function  
+
+| Param | Type |
+| --- | --- |
+| payload | [<code>OrganizationLearnerListPayload</code>](#OrganizationLearnerListPayload) | 
+
+<a name="PageDefinition"></a>
+
+## PageDefinition : <code>object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| size | <code>number</code> | 
+| number | <code>Page</code> | 
+
+<a name="OrganizationLearnerListPayload"></a>
+
+## OrganizationLearnerListPayload : <code>object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| organizationId | <code>number</code> | 
+| page | [<code>PageDefinition</code>](#PageDefinition) | 
+
+<a name="Pagination"></a>
+
+## Pagination : <code>object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| page | <code>number</code> | 
+| pageSize | <code>number</code> | 
+| rowCount | <code>number</code> | 
+| pageCount | <code>number</code> | 
+
+<a name="OrganizationLearnerListResponse"></a>
+
+## OrganizationLearnerListResponse : <code>object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| learners | <code>Array.&lt;OrganizationLeanerListItem&gt;</code> | 
+| pagination | [<code>Pagination</code>](#Pagination) | 
 
 

--- a/api/src/prescription/organization-learner/application/api/models/OrganizationLearnerListItem.js
+++ b/api/src/prescription/organization-learner/application/api/models/OrganizationLearnerListItem.js
@@ -1,0 +1,8 @@
+export class OrganizationLearnerListItem {
+  constructor({ id, firstName, lastName, classe }) {
+    this.id = id;
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.classe = classe;
+  }
+}

--- a/api/src/prescription/organization-learner/application/api/organization-learners-api.js
+++ b/api/src/prescription/organization-learner/application/api/organization-learners-api.js
@@ -1,0 +1,47 @@
+import { usecases } from '../../domain/usecases/index.js';
+import { OrganizationLearnerListItem } from './models/OrganizationLearnerListItem.js';
+
+/**
+ * @typedef PageDefinition
+ * @type {object}
+ * @property {number} size
+ * @property {Page} number
+ */
+
+/**
+ * @typedef OrganizationLearnerListPayload
+ * @type {object}
+ * @property {number} organizationId
+ * @property {PageDefinition} page
+ */
+
+/**
+ * @typedef Pagination
+ * @type {object}
+ * @property {number} page
+ * @property {number} pageSize
+ * @property {number} rowCount
+ * @property {number} pageCount
+ */
+
+/**
+ * @typedef OrganizationLearnerListResponse
+ * @type {object}
+ * @property {Array<OrganizationLeanerListItem>} learners
+ * @property {Pagination} pagination
+ */
+
+/**
+ * @function
+ * @name findPaginatedOrganizationLearners
+ *
+ * @param {OrganizationLearnerListPayload} payload
+ * @returns {Promise<OrganizationLearnerListResponse>}
+ */
+export const findPaginatedOrganizationLearners = async ({ organizationId, page = {} }) => {
+  const result = await usecases.findPaginatedOrganizationLearners({ organizationId, page });
+
+  const organizationLearnersList = result.learners.map((learner) => new OrganizationLearnerListItem(learner));
+
+  return { learners: organizationLearnersList, pagination: result.pagination };
+};

--- a/api/src/prescription/organization-learner/domain/models/OrganizationLearnerImported.js
+++ b/api/src/prescription/organization-learner/domain/models/OrganizationLearnerImported.js
@@ -1,0 +1,15 @@
+class OrganizationLearnerImported {
+  constructor({ id, firstName, lastName, attributes } = {}) {
+    this.id = id;
+    this.firstName = firstName;
+    this.lastName = lastName;
+
+    if (attributes) {
+      Object.entries(attributes).forEach(([key, value]) => {
+        this[key] = value;
+      });
+    }
+  }
+}
+
+export { OrganizationLearnerImported };

--- a/api/src/prescription/organization-learner/domain/usecases/find-paginated-organization-learners.js
+++ b/api/src/prescription/organization-learner/domain/usecases/find-paginated-organization-learners.js
@@ -1,0 +1,5 @@
+const findPaginatedOrganizationLearners = async function ({ organizationId, page, organizationLearnerRepository }) {
+  return organizationLearnerRepository.findPaginatedLearners({ organizationId, page });
+};
+
+export { findPaginatedOrganizationLearners };

--- a/api/src/prescription/organization-learner/domain/usecases/get-organization-learner.js
+++ b/api/src/prescription/organization-learner/domain/usecases/get-organization-learner.js
@@ -1,5 +1,5 @@
-const getOrganizationLearner = async function ({ organizationLearnerId, organizationLearnerFollowUpRepository }) {
-  return organizationLearnerFollowUpRepository.get(organizationLearnerId);
+const getOrganizationLearner = async function ({ organizationLearnerId, organizationLearnerRepository }) {
+  return organizationLearnerRepository.get(organizationLearnerId);
 };
 
 export { getOrganizationLearner };

--- a/api/src/prescription/organization-learner/domain/usecases/index.js
+++ b/api/src/prescription/organization-learner/domain/usecases/index.js
@@ -5,7 +5,7 @@ import * as groupRepository from '../../../../../lib/infrastructure/repositories
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as organizationLearnerActivityRepository from '../../infrastructure/repositories/organization-learner-activity-repository.js';
-import * as organizationLearnerFollowUpRepository from '../../infrastructure/repositories/organization-learner-repository.js';
+import * as organizationLearnerRepository from '../../infrastructure/repositories/organization-learner-repository.js';
 import * as organizationParticipantRepository from '../../infrastructure/repositories/organization-participant-repository.js';
 import * as scoOrganizationParticipantRepository from '../../infrastructure/repositories/sco-organization-participant-repository.js';
 import * as supOrganizationParticipantRepository from '../../infrastructure/repositories/sup-organization-participant-repository.js';
@@ -16,7 +16,7 @@ const dependencies = {
   scoOrganizationParticipantRepository,
   organizationParticipantRepository,
   organizationLearnerActivityRepository,
-  organizationLearnerFollowUpRepository,
+  organizationLearnerRepository,
 };
 
 const path = dirname(fileURLToPath(import.meta.url));

--- a/api/tests/prescription/organization-learner/integration/domain/usecases/get-organization-learner_test.js
+++ b/api/tests/prescription/organization-learner/integration/domain/usecases/get-organization-learner_test.js
@@ -19,7 +19,7 @@ describe('Integration | UseCases | get-organization-learner', function () {
     // when
     const organizationLearner = await getOrganizationLearner({
       organizationLearnerId: learner.id,
-      organizationLearnerFollowUpRepository: organizationLearnerRepository,
+      organizationLearnerRepository,
     });
 
     // then

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -1,7 +1,7 @@
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../../../lib/domain/constants/identity-providers.js';
 import { NotFoundError } from '../../../../../../lib/domain/errors.js';
 import { OrganizationLearner } from '../../../../../../src/prescription/organization-learner/domain/read-models/OrganizationLearner.js';
-import * as organizationLearnerFollowUpRepository from '../../../../../../src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js';
+import * as organizationLearnerRepository from '../../../../../../src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js';
 import { catchErr, databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Integration | Infrastructure | Repository | Organization Learner Follow Up | Organization Learner', function () {
@@ -11,7 +11,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner Follo
         //given
         const randomOrganizationLearnerId = 123;
         //when
-        const err = await catchErr(organizationLearnerFollowUpRepository.get)(randomOrganizationLearnerId);
+        const err = await catchErr(organizationLearnerRepository.get)(randomOrganizationLearnerId);
         //then
         expect(err.message).to.equal(`Student not found for ID ${randomOrganizationLearnerId}`);
         expect(err).to.be.an.instanceOf(NotFoundError);
@@ -34,7 +34,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner Follo
         });
         await databaseBuilder.commit();
 
-        const organizationLearner = await organizationLearnerFollowUpRepository.get(1233);
+        const organizationLearner = await organizationLearnerRepository.get(1233);
 
         expect(organizationLearner.id).to.equal(1233);
         expect(organizationLearner.firstName).to.equal('Dark');
@@ -51,7 +51,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner Follo
 
         await databaseBuilder.commit();
 
-        const organizationLearner = await organizationLearnerFollowUpRepository.get(id);
+        const organizationLearner = await organizationLearnerRepository.get(id);
 
         expect(organizationLearner.id).to.equal(id);
       });
@@ -67,7 +67,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner Follo
             });
             await databaseBuilder.commit();
 
-            const organizationLearner = await organizationLearnerFollowUpRepository.get(organizationLearnerId);
+            const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
 
             expect(organizationLearner.group).to.equal('L3');
             expect(organizationLearner.division).to.equal(null);
@@ -84,7 +84,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner Follo
             });
             await databaseBuilder.commit();
 
-            const organizationLearner = await organizationLearnerFollowUpRepository.get(organizationLearnerId);
+            const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
 
             expect(organizationLearner.division).to.equal('3B');
             expect(organizationLearner.group).to.equal(null);
@@ -101,7 +101,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner Follo
             });
             await databaseBuilder.commit();
 
-            const organizationLearner = await organizationLearnerFollowUpRepository.get(organizationLearnerId);
+            const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
 
             expect(organizationLearner.group).to.equal(null);
             expect(organizationLearner.division).to.equal(null);
@@ -116,7 +116,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner Follo
             const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({ userId });
             await databaseBuilder.commit();
 
-            const organizationLearner = await organizationLearnerFollowUpRepository.get(organizationLearnerId);
+            const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
 
             expect(organizationLearner.authenticationMethods).to.be.empty;
           });
@@ -130,7 +130,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner Follo
             const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({ userId });
             await databaseBuilder.commit();
 
-            const organizationLearner = await organizationLearnerFollowUpRepository.get(organizationLearnerId);
+            const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
 
             expect(organizationLearner.authenticationMethods).to.have.members([
               NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
@@ -164,7 +164,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner Follo
             await databaseBuilder.commit();
 
             // when
-            const organizationLearner = await organizationLearnerFollowUpRepository.get(organizationLearnerId);
+            const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
 
             //then
             expect(organizationLearner.isCertifiable).to.be.true;
@@ -197,7 +197,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner Follo
             });
             await databaseBuilder.commit();
 
-            const organizationLearner = await organizationLearnerFollowUpRepository.get(organizationLearnerId);
+            const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
 
             expect(organizationLearner.isCertifiable).to.be.true;
             expect(organizationLearner.certifiableAt).to.deep.equal(certifiableParticipation.sharedAt);
@@ -239,7 +239,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner Follo
             await databaseBuilder.commit();
 
             // when
-            const organizationLearner = await organizationLearnerFollowUpRepository.get(organizationLearnerId);
+            const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
 
             //then
             expect(organizationLearner.isCertifiable).to.be.false;
@@ -260,7 +260,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner Follo
             await databaseBuilder.commit();
 
             // when
-            const organizationLearner = await organizationLearnerFollowUpRepository.get(organizationLearnerId);
+            const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
 
             //then
             expect(organizationLearner.isCertifiable).to.be.true;
@@ -290,7 +290,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner Follo
             });
             await databaseBuilder.commit();
 
-            const organizationLearner = await organizationLearnerFollowUpRepository.get(organizationLearnerId);
+            const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
 
             expect(organizationLearner.isCertifiable).to.be.false;
             expect(organizationLearner).to.be.an.instanceOf(OrganizationLearner);
@@ -318,7 +318,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner Follo
 
             await databaseBuilder.commit();
 
-            const organizationLearner = await organizationLearnerFollowUpRepository.get(organizationLearnerId);
+            const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
 
             expect(organizationLearner.isCertifiable).to.be.null;
             expect(organizationLearner.certifiableAt).to.be.null;
@@ -343,7 +343,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner Follo
             });
             await databaseBuilder.commit();
 
-            const organizationLearner = await organizationLearnerFollowUpRepository.get(organizationLearnerId);
+            const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
 
             expect(organizationLearner.isCertifiable).to.be.null;
             expect(organizationLearner.certifiableAt).to.equal(null);
@@ -382,7 +382,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner Follo
 
             await databaseBuilder.commit();
 
-            const organizationLearner = await organizationLearnerFollowUpRepository.get(organizationLearnerId);
+            const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
 
             expect(organizationLearner.isCertifiable).to.equal(certifiableParticipation.isCertifiable);
             expect(organizationLearner.certifiableAt).to.deep.equal(certifiableParticipation.sharedAt);
@@ -414,7 +414,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner Follo
               });
               await databaseBuilder.commit();
 
-              const organizationLearner = await organizationLearnerFollowUpRepository.get(organizationLearnerId);
+              const organizationLearner = await organizationLearnerRepository.get(organizationLearnerId);
 
               expect(organizationLearner.isCertifiable).to.equal(notDeletedParticipation.isCertifiable);
               expect(organizationLearner.certifiableAt).to.deep.equal(notDeletedParticipation.sharedAt);

--- a/api/tests/prescription/organization-learner/unit/application/api/models/OrganizationLearnerListItem_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/api/models/OrganizationLearnerListItem_test.js
@@ -1,0 +1,20 @@
+import { OrganizationLearnerListItem } from '../../../../../../../src/prescription/organization-learner/application/api/models/OrganizationLearnerListItem.js';
+import { expect } from '../../../../../../test-helper.js';
+
+describe('Unit | Application| API | Models | OrganizationLearnerListItem', function () {
+  it('should return attributes from learner', function () {
+    // given
+
+    // when
+    const organizationLearnerListItem = new OrganizationLearnerListItem({
+      firstName: 'Jean-Hugues',
+      lastName: 'Delaforêt',
+      classe: '4ème',
+    });
+
+    // then
+    expect(organizationLearnerListItem.firstName).to.equal('Jean-Hugues');
+    expect(organizationLearnerListItem.lastName).to.equal('Delaforêt');
+    expect(organizationLearnerListItem.classe).to.equal('4ème');
+  });
+});

--- a/api/tests/prescription/organization-learner/unit/application/api/organization-learners-api_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/api/organization-learners-api_test.js
@@ -1,0 +1,40 @@
+import * as organizationLearnersApi from '../../../../../../src/prescription/organization-learner/application/api/organization-learners-api.js';
+import { OrganizationLearnerImported } from '../../../../../../src/prescription/organization-learner/domain/models/OrganizationLearnerImported.js';
+import { usecases } from '../../../../../../src/prescription/organization-learner/domain/usecases/index.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+
+describe('Unit | API | Organization Learner', function () {
+  describe('#findPaginatedOrganizationLearners', function () {
+    it('should paginated learners', async function () {
+      const organizationLearner = domainBuilder.prescription.organizationLearner.buildOrganizationLearnerImported({
+        id: 1242,
+        firstName: 'Paul',
+        lastName: 'Henri',
+        attributes: { classe: '3ème' },
+      });
+
+      const getPaginatedOrganizationLearnerStub = sinon.stub(usecases, 'findPaginatedOrganizationLearners');
+      getPaginatedOrganizationLearnerStub
+        .withArgs({
+          organizationId: 3,
+          page: { size: 18, number: 1 },
+        })
+        .resolves({
+          learners: [organizationLearner],
+          pagination: { pageSize: 18, pageNumber: 1, rowCount: 1, page: 1 },
+        });
+
+      // when
+      const result = await organizationLearnersApi.findPaginatedOrganizationLearners({
+        organizationId: 3,
+        page: { size: 18, number: 1 },
+      });
+
+      // then
+      expect(result.learners[0].id).to.equal(organizationLearner.id);
+      expect(result.learners[0].classe).to.equal('3ème');
+      expect(result.learners[0]).not.to.be.instanceOf(OrganizationLearnerImported);
+    });
+  });
+});

--- a/api/tests/prescription/organization-learner/unit/domain/models/OrganizationLearnerImported_test.js
+++ b/api/tests/prescription/organization-learner/unit/domain/models/OrganizationLearnerImported_test.js
@@ -1,0 +1,19 @@
+import { OrganizationLearnerImported } from '../../../../../../src/prescription/organization-learner/domain/models/OrganizationLearnerImported.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | Domain | Models | OrganizationLearnerImported', function () {
+  it('should flattened attributes from learner', function () {
+    // given
+
+    // when
+    const organizationLearnerImported = new OrganizationLearnerImported({
+      firstName: 'Jean-Michel',
+      lastName: 'Dubois',
+      attributes: { classe: '2nd', 'date de naissance': '2000-03-09' },
+    });
+
+    // then
+    expect(organizationLearnerImported.classe).to.equal('2nd');
+    expect(organizationLearnerImported['date de naissance']).to.equal('2000-03-09');
+  });
+});

--- a/api/tests/prescription/organization-learner/unit/domain/usecases/find-paginated-organization-learners_test.js
+++ b/api/tests/prescription/organization-learner/unit/domain/usecases/find-paginated-organization-learners_test.js
@@ -1,0 +1,26 @@
+import { findPaginatedOrganizationLearners } from '../../../../../../src/prescription/organization-learner/domain/usecases/find-paginated-organization-learners.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | UseCase | find-organisation-learner', function () {
+  it('should call organization learner repository', async function () {
+    // given
+    const organizationId = 1234;
+
+    const organizationLearnerRepository = {
+      findPaginatedLearners: sinon.stub(),
+    };
+
+    // when
+    await findPaginatedOrganizationLearners({
+      organizationId,
+      page: { size: 1, number: 1 },
+      organizationLearnerRepository,
+    });
+
+    // then
+    expect(organizationLearnerRepository.findPaginatedLearners).to.have.been.calledWithExactly({
+      organizationId,
+      page: { size: 1, number: 1 },
+    });
+  });
+});

--- a/api/tests/prescription/organization-learner/unit/domain/usecases/get-organization-learner_test.js
+++ b/api/tests/prescription/organization-learner/unit/domain/usecases/get-organization-learner_test.js
@@ -19,7 +19,7 @@ describe('Unit | UseCase | get-organisation-learner', function () {
     // when
     const organizationLearner = await getOrganizationLearner({
       organizationLearnerId,
-      organizationLearnerFollowUpRepository: organizationLearnerRepository,
+      organizationLearnerRepository,
     });
 
     // then

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -181,6 +181,7 @@ import { buildCertificationSessionEnrolledCandidate } from './certification/sess
 import { buildJuryComment } from './certification/shared/build-jury-comment.js';
 import { buildCampaign as boundedContextCampaignBuildCampaign } from './prescription/campaign/build-campaign.js';
 import { buildCampaignParticipation as boundedContextCampaignParticipationBuildCampaignParticipation } from './prescription/campaign-participation/build-campaign-participation.js';
+import { buildOrganizationLearnerImported } from './prescription/organization-learner/build-organization-learner-imported.js';
 import { buildStageCollection as buildStageCollectionForTargetProfileManagement } from './target-profile-management/build-stage-collection.js';
 import { buildStageCollection as buildStageCollectionForUserCampaignResults } from './user-campaign-results/build-stage-collection.js';
 
@@ -213,6 +214,9 @@ const prescription = {
   },
   campaignParticipation: {
     buildCampaignParticipation: boundedContextCampaignParticipationBuildCampaignParticipation,
+  },
+  organizationLearner: {
+    buildOrganizationLearnerImported,
   },
 };
 

--- a/api/tests/tooling/domain-builder/factory/prescription/organization-learner/build-organization-learner-imported.js
+++ b/api/tests/tooling/domain-builder/factory/prescription/organization-learner/build-organization-learner-imported.js
@@ -1,0 +1,17 @@
+import { OrganizationLearnerImported } from '../../../../../../src/prescription/organization-learner/domain/models/OrganizationLearnerImported.js';
+
+const buildOrganizationLearnerImported = function ({
+  id = 1,
+  firstName = 'Arthur',
+  lastName = 'The king',
+  attributes = null,
+} = {}) {
+  return new OrganizationLearnerImported({
+    id,
+    firstName,
+    lastName,
+    attributes,
+  });
+};
+
+export { buildOrganizationLearnerImported };


### PR DESCRIPTION
## :unicorn: Problème
Maintenant que l'import générique existe, nous avons besoin de récupérer ces données

## :robot: Proposition
Ajouter une API interne qui récupère les données de l'import générique. (Dans notre cas, pour déccoreler le métier Prescritpion de l'affichage côté Pix1D)

## :rainbow: Remarques
RAS

## :100: Pour tester
CI au vert