### PR TITLE
[FEATURE] Retirer l'utilisation du terme "Modulix" (PIX-11991)

### DIFF
--- a/admin/app/models/training.js
+++ b/admin/app/models/training.js
@@ -9,7 +9,7 @@ export const typeCategories = {
   'e-learning': 'Formation en ligne',
   'hybrid-training': 'Formation hybride',
   'in-person-training': 'Formation en présentiel',
-  modulix: 'Modulix',
+  modulix: 'Module Pix',
 };
 
 export const optionsTypeList = formatList(typeCategories);

--- a/api/db/seeds/data/team-devcomp/build-trainings.js
+++ b/api/db/seeds/data/team-devcomp/build-trainings.js
@@ -46,7 +46,7 @@ export function buildTrainings(databaseBuilder) {
   });
 
   const frFrTrainingId2 = databaseBuilder.factory.buildTraining({
-    title: 'Didacticiel Modulix',
+    title: 'Didacticiel Module Pix',
     link: '/modules/didacticiel-modulix/details',
     duration: '00:10:00',
     editorName: 'Pix',

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1575,7 +1575,7 @@
         "e-learning": "E-Learning",
         "hybrid-training": "Hybrid training",
         "in-person-training": "In person training",
-        "modulix": "Modulix",
+        "modulix": "Pix Module",
         "webinaire": "Webinar"
       }
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1575,7 +1575,7 @@
         "e-learning": "Formation à distance",
         "hybrid-training": "Formation hybride",
         "in-person-training": "Formation en présentiel",
-        "modulix": "Modulix",
+        "modulix": "Module Pix (Bêta)",
         "webinaire": "Webinaire"
       }
     },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1575,7 +1575,7 @@
         "e-learning": "Afstandsonderwijs",
         "hybrid-training": "Hybride training",
         "in-person-training": "Persoonlijke training",
-        "modulix": "Modulix",
+        "modulix": "Pix Module",
         "webinaire": "Webinar"
       }
     },


### PR DESCRIPTION
## :unicorn: Problème
Le Comité Sponsor ne souhaite pas voir le nom de projet “Modulix” sur Pix App, car ne n'est pas le nom officiel.

## :robot: Proposition
Supprimer les mentions du terme "Modulix" sur Pix App et Pix Admin.
Remplacer ce terme par "Module Pix".

## :rainbow: Remarques
RAS.

## :100: Pour tester
### 🌼 **Pix Admin**

1. Se connecter à Pix Admin
2. Se rendre sur la page `Contenus formatifs`
3. Vérifier dans la liste qu'il n'y a plus de contenu avec le terme "modulix" dedans
4. Vérifier que le `Didacticiel Module Pix` est bien présent

### 👾 **Pix App**

1. Se connecter à Pix App sur le domaine français (.fr) avec l'utilisateur suivant : `learneremail1003_31@example.net`
2. Cliquer sur le bouton `J'ai un code` et entrer le code suivant : `EDUMULTIP`
3. Cliquer sur le bouton `Remettre à zéro et tout retenter`
4. Répondre ou passer toutes les questions
5. Arriver sur la page de résultats, cliquer sur le bouton `J'envoie mes résultats`
6. Dans la section `Vous souhaitez en apprendre plus ?` vous devez voir un module `Didacticiel Module Pix`
7. Vérifiez qu'il n'y a plus aucune mention de `modulix` 