### PR TITLE
[TECH] Simplifier l'usage des solutions dans les QROCM, QCU et QCM (PIX-11086)

### DIFF
--- a/api/src/devcomp/domain/models/element/QCM-for-answer-verification.js
+++ b/api/src/devcomp/domain/models/element/QCM-for-answer-verification.js
@@ -15,7 +15,9 @@ class QCMForAnswerVerification extends QCM {
 
     assertNotNullOrUndefined(solutions, 'The solutions are required for a QCM for verification');
 
-    this.solutionsValue = solutions;
+    this.solution = {
+      value: solutions,
+    };
 
     if (feedbacks) {
       this.feedbacks = new Feedbacks(feedbacks);
@@ -24,7 +26,7 @@ class QCMForAnswerVerification extends QCM {
     if (validator) {
       this.validator = validator;
     } else {
-      this.validator = new ValidatorQCM({ solution: { value: this.solutionsValue } });
+      this.validator = new ValidatorQCM({ solution: this.solution });
     }
   }
 
@@ -39,7 +41,7 @@ class QCMForAnswerVerification extends QCM {
     return new QcmCorrectionResponse({
       status: validation.result,
       feedback: validation.result.isOK() ? this.feedbacks.valid : this.feedbacks.invalid,
-      solution: this.solutionsValue,
+      solution: this.solution.value,
     });
   }
 

--- a/api/src/devcomp/domain/models/element/QCU-for-answer-verification.js
+++ b/api/src/devcomp/domain/models/element/QCU-for-answer-verification.js
@@ -14,7 +14,7 @@ class QCUForAnswerVerification extends QCU {
 
     assertNotNullOrUndefined(solution, 'The solution is required for a verification QCU');
 
-    this.solutionValue = solution;
+    this.solution = { value: solution };
 
     if (feedbacks) {
       this.feedbacks = new Feedbacks(feedbacks);
@@ -23,7 +23,7 @@ class QCUForAnswerVerification extends QCU {
     if (validator) {
       this.validator = validator;
     } else {
-      this.validator = new ValidatorQCU({ solution: { value: this.solutionValue } });
+      this.validator = new ValidatorQCU({ solution: this.solution });
     }
   }
 
@@ -38,7 +38,7 @@ class QCUForAnswerVerification extends QCU {
     return new QcuCorrectionResponse({
       status: validation.result,
       feedback: validation.result.isOK() ? this.feedbacks.valid : this.feedbacks.invalid,
-      solution: this.solutionValue,
+      solution: this.solution.value,
     });
   }
 

--- a/api/src/devcomp/domain/models/element/QROCM-for-answer-verification.js
+++ b/api/src/devcomp/domain/models/element/QROCM-for-answer-verification.js
@@ -8,7 +8,6 @@ import { ValidatorQROCMInd } from '../validator/ValidatorQROCMInd.js';
 import { QROCM } from './QROCM.js';
 
 class QROCMForAnswerVerification extends QROCM {
-  #solution;
   userResponse;
 
   constructor({ id, instruction, feedbacks, proposals, locales, validator }) {
@@ -18,17 +17,15 @@ class QROCMForAnswerVerification extends QROCM {
 
     this.feedbacks = feedbacks;
 
-    this.#solution = new QrocmSolutions(proposals);
-    this.solutionValues = this.#solution.value;
-    this.solutionTolerances = this.#solution.tolerances;
+    this.solution = new QrocmSolutions(proposals);
 
     if (validator) {
       this.validator = validator;
     } else {
       this.validator = new ValidatorQROCMInd({
         solution: {
-          value: this.solutionValues,
-          enabledTolerances: this.solutionTolerances,
+          value: this.solution.value,
+          enabledTolerances: this.solution.tolerances,
         },
       });
     }
@@ -50,7 +47,7 @@ class QROCMForAnswerVerification extends QROCM {
     return new QrocmCorrectionResponse({
       status: validation.result,
       feedback: validation.result.isOK() ? this.feedbacks.valid : this.feedbacks.invalid,
-      solution: this.solutionValues,
+      solution: this.solution.value,
     });
   }
 

--- a/api/tests/devcomp/unit/domain/models/element/QCM-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCM-for-answer-verification_test.js
@@ -13,6 +13,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QcmForAnswerVerification'
       const proposal2 = Symbol('proposal2');
       const feedbacks = { valid: 'valid', invalid: 'invalid' };
       const solutions = Symbol('solutions');
+      const expectedSolution = { value: solutions };
 
       // When
       const qcm = new QCMForAnswerVerification({
@@ -29,7 +30,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QcmForAnswerVerification'
       expect(qcm.instruction).equal('instruction');
       expect(qcm.locales).deep.equal(['fr-FR']);
       expect(qcm.proposals).deep.equal([proposal1, proposal2]);
-      expect(qcm.solutionsValue).deep.equal(solutions);
+      expect(qcm.solution).deep.equal(expectedSolution);
       expect(qcm.feedbacks).to.be.instanceof(Feedbacks);
       expect(qcm.type).to.be.equal('qcm');
       expect(qcm.validator).to.be.instanceof(ValidatorQCM);

--- a/api/tests/devcomp/unit/domain/models/element/QCU-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QCU-for-answer-verification_test.js
@@ -12,6 +12,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QcuForAnswerVerification'
       const proposal2 = Symbol('proposal2');
       const feedbacks = { valid: 'valid', invalid: 'invalid' };
       const solution = Symbol('solution');
+      const expectedSolution = { value: solution };
 
       // When
       const qcu = new QCUForAnswerVerification({
@@ -28,7 +29,7 @@ describe('Unit | Devcomp | Domain | Models | Element | QcuForAnswerVerification'
       expect(qcu.instruction).equal('instruction');
       expect(qcu.locales).deep.equal(['fr-FR']);
       expect(qcu.proposals).deep.equal([proposal1, proposal2]);
-      expect(qcu.solutionValue).deep.equal(solution);
+      expect(qcu.solution).deep.equal(expectedSolution);
       expect(qcu.feedbacks).to.be.instanceof(Feedbacks);
     });
 

--- a/api/tests/devcomp/unit/domain/models/element/QROCM-for-answer-verification_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/QROCM-for-answer-verification_test.js
@@ -50,12 +50,13 @@ describe('Unit | Devcomp | Domain | Models | Element | QrocMForAnswerVerificatio
         },
       });
 
+      const { value, tolerances } = qrocm.solution;
       // then
-      expect(qrocm.solutionValues).deep.equal({
+      expect(value).deep.equal({
         inputBlock: ['@'],
         selectBlock: ['2'],
       });
-      expect(qrocm.solutionTolerances).deep.equal({
+      expect(tolerances).deep.equal({
         inputBlock: ['t1', 't2'],
         selectBlock: ['t2', 't3'],
       });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le modèle `QCUForAnswerVerification` n'a besoin que de sa solution unique pour permettre la vérification de la réponse du user.

`QCMForAnswerVerification` et `QROCMForAnswerVerification` quant à eux, nécessitent un tableau de solutions. En plus de quoi `QROCMForAnswerVerification` a besoin d'un tableau de tolérances.

Ces différences ont amené à des nommages ambigües dans ces trois modèles tels que les propriétés `solutionValue` dans un cas, `solution**s**Value` dans un autre ou encore `solutionValue**s**`.

Il est donc nécessaire de rapprocher la structure de ces trois modèles pour éviter ces ambiguïtés.

## :robot: Proposition
Dans les trois modèles nous proposons d'implémenter une variable d'instance `solution`.
Elle aura à minima ce format: `{ value: solution }`. Et dans le cas de `QROCMForAnswerVerification`, le tableau de tolérances en plus.

## :rainbow: Remarques

## :100: Pour tester
La CI passe.
