### PR TITLE
[TECH] Passage en entier de l'id de mission en base (PIX-12070)

### DIFF
--- a/api/db/migrations/20240411151140_alter_table_mission_assessments_mission_id.js
+++ b/api/db/migrations/20240411151140_alter_table_mission_assessments_mission_id.js
@@ -1,0 +1,25 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/DEV/pages/2153512965/Cr+er+une+migration
+
+// If your migrations target `answers` or `knowledge-elements`
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+const TABLE_NAME = 'mission-assessments';
+const COLUMN_NAME = 'missionId';
+
+const up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME).unsigned().notNullable().alter();
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).notNullable().alter();
+  });
+};
+
+export { down, up };

--- a/api/src/school/application/mission-controller.js
+++ b/api/src/school/application/mission-controller.js
@@ -3,7 +3,7 @@ import * as missionSerializer from '../infrastructure/serializers/mission-serial
 
 const getById = async function (request, h, dependencies = { missionSerializer }) {
   const { id: organizationId, missionId } = request.params;
-  const mission = await usecases.getMission({ missionId: parseInt(missionId), organizationId });
+  const mission = await usecases.getMission({ missionId, organizationId });
   return dependencies.missionSerializer.serialize(mission);
 };
 

--- a/api/src/shared/domain/types/identifiers-type.js
+++ b/api/src/shared/domain/types/identifiers-type.js
@@ -43,6 +43,7 @@ const typesPositiveInteger32bits = [
   'complementaryCertificationCourseId',
   'complementaryCertificationId',
   'membershipId',
+  'missionId',
   'organizationId',
   'organizationInvitationId',
   'organizationLearnerId',
@@ -63,7 +64,7 @@ const typesPositiveInteger32bits = [
 ];
 
 const typesAlphanumeric = ['courseId', 'tutorialId'];
-const typesAlphanumeric255 = ['challengeId', 'competenceId', 'frameworkId', 'tubeId', 'missionId', 'code', 'skillId'];
+const typesAlphanumeric255 = ['challengeId', 'competenceId', 'frameworkId', 'tubeId', 'code', 'skillId'];
 
 _assignValueToExport(typesPositiveInteger32bits, implementationType.positiveInteger32bits);
 _assignValueToExport(typesAlphanumeric, implementationType.alphanumeric);

--- a/api/tests/school/acceptance/application/assessments/assessment-controller_test.js
+++ b/api/tests/school/acceptance/application/assessments/assessment-controller_test.js
@@ -93,7 +93,7 @@ describe('Acceptance | Controller | assessment-controller', function () {
         expect(response.statusCode).to.equal(201);
         expect(response.result.data).to.deep.equal({
           attributes: {
-            'mission-id': `${mission.id}`,
+            'mission-id': mission.id,
             'organization-learner-id': learner.id,
             state: 'started',
           },
@@ -135,7 +135,7 @@ describe('Acceptance | Controller | assessment-controller', function () {
         // then
         expect(response.result.data).to.deep.equal({
           attributes: {
-            'mission-id': `${mission.id}`,
+            'mission-id': mission.id,
             'organization-learner-id': learner.id,
             state: 'started',
           },

--- a/api/tests/school/integration/application/assessment-controller_test.js
+++ b/api/tests/school/integration/application/assessment-controller_test.js
@@ -6,7 +6,7 @@ import { expect, hFake, sinon } from '../../../test-helper.js';
 describe('Integration | Controller | assessment-controller', function () {
   describe('#getById', function () {
     it('should call the expected usecase and return the serialized assessment', async function () {
-      const missionId = 'mission-id';
+      const missionId = 1;
       const assessmentId = 1234;
       const organizationLearnerId = 5678;
       const createdMissionAssessment = new Assessment({

--- a/api/tests/school/integration/application/mission-controller_test.js
+++ b/api/tests/school/integration/application/mission-controller_test.js
@@ -38,7 +38,7 @@ describe('Integration | Controller | mission-controller', function () {
           'competence-name': mission.competenceName,
           'started-by': '',
         },
-        id: mission.id.toString(),
+        id: `${mission.id}`,
         type: 'missions',
       });
       expect(usecases.getMission).to.have.been.calledWithExactly({
@@ -68,7 +68,7 @@ describe('Integration | Controller | mission-controller', function () {
             'competence-name': mission.competenceName,
             'started-by': mission.startedBy,
           },
-          id: mission.id.toString(),
+          id: `${mission.id}`,
           type: 'missions',
         },
       ]);

--- a/api/tests/school/integration/domain/services/update-assessment_test.js
+++ b/api/tests/school/integration/domain/services/update-assessment_test.js
@@ -34,7 +34,7 @@ describe('Integration | Usecase | update-assessment', function () {
 
     context('when there is at least one activity left in the mission', function () {
       it('should leave assessment STARTED', async function () {
-        const { assessmentId } = databaseBuilder.factory.buildMissionAssessment({ missionId: 'mission-id' });
+        const { assessmentId } = databaseBuilder.factory.buildMissionAssessment();
         const lastActivity = domainBuilder.buildActivity({
           assessmentId,
           level: Activity.levels.VALIDATION,

--- a/api/tests/school/integration/domain/usecases/get-assessment-by-id_test.js
+++ b/api/tests/school/integration/domain/usecases/get-assessment-by-id_test.js
@@ -21,7 +21,7 @@ describe('Integration | UseCase | getAssessmentById', function () {
     const expectedMissionAssessment = {
       id: assessmentId,
       organizationLearnerId: missionAssessment.organizationLearnerId,
-      missionId: `${missionAssessment.missionId}`,
+      missionId: missionAssessment.missionId,
       state: Assessment.states.STARTED,
     };
 

--- a/api/tests/school/integration/domain/usecases/get-organization-learner-with-completed-mission-ids_test.js
+++ b/api/tests/school/integration/domain/usecases/get-organization-learner-with-completed-mission-ids_test.js
@@ -15,13 +15,15 @@ describe('Integration | Usecase | get-organization-learner-with-completed-missio
       const startedAssessmentId = databaseBuilder.factory.buildPix1dAssessment({
         state: Assessment.states.STARTED,
       }).id;
+      const completedMissionId = 123;
+      const startedMissionId = 456;
       databaseBuilder.factory.buildMissionAssessment({
-        missionId: 'COMPLETED_ID',
+        missionId: completedMissionId,
         organizationLearnerId: organizationLearner.id,
         assessmentId: completedAssessmentId,
       });
       databaseBuilder.factory.buildMissionAssessment({
-        missionId: 'STARTED_ID',
+        missionId: startedMissionId,
         organizationLearnerId: organizationLearner.id,
         assessmentId: startedAssessmentId,
       });
@@ -34,7 +36,7 @@ describe('Integration | Usecase | get-organization-learner-with-completed-missio
       expect(result).to.deep.equal(
         new OrganizationLearner({
           ...organizationLearner,
-          completedMissionIds: ['COMPLETED_ID'],
+          completedMissionIds: [completedMissionId],
         }),
       );
     });
@@ -44,18 +46,20 @@ describe('Integration | Usecase | get-organization-learner-with-completed-missio
       const completedAssessmentId = databaseBuilder.factory.buildPix1dAssessment({
         state: Assessment.states.COMPLETED,
       }).id;
+      const completedMissionId = 456;
+      const otherCompletedMissionId = 123;
+
       databaseBuilder.factory.buildMissionAssessment({
-        missionId: 'COMPLETED_ID',
+        missionId: completedMissionId,
         organizationLearnerId: organizationLearner.id,
         assessmentId: completedAssessmentId,
       });
-
       const otherOrganizationLearner = databaseBuilder.factory.buildOrganizationLearner();
       const otherCompletedAssessmentId = databaseBuilder.factory.buildPix1dAssessment({
         state: Assessment.states.COMPLETED,
       }).id;
       databaseBuilder.factory.buildMissionAssessment({
-        missionId: 'OTHER_LEARNER_COMPLETED_ID',
+        missionId: otherCompletedMissionId,
         organizationLearnerId: otherOrganizationLearner.id,
         assessmentId: otherCompletedAssessmentId,
       });
@@ -69,7 +73,7 @@ describe('Integration | Usecase | get-organization-learner-with-completed-missio
       expect(result).to.deep.equal(
         new OrganizationLearner({
           ...organizationLearner,
-          completedMissionIds: ['COMPLETED_ID'],
+          completedMissionIds: [completedMissionId],
         }),
       );
     });

--- a/api/tests/school/integration/domain/usecases/play-mission_test.js
+++ b/api/tests/school/integration/domain/usecases/play-mission_test.js
@@ -75,7 +75,7 @@ describe('Integration | UseCases | play-mission', function () {
       });
 
       const expectedMissionAssesment = {
-        missionId: `${missionId}`,
+        missionId,
         organizationLearnerId,
         assessmentId: result.id,
       };
@@ -195,7 +195,7 @@ describe('Integration | UseCases | play-mission', function () {
 
       const expectedAssessment = domainBuilder.buildSchoolAssessment({
         organizationLearnerId,
-        missionId: `${missionId}`,
+        missionId,
         state: Assessment.states.STARTED,
         id: currentAssessment.id,
       });

--- a/api/tests/school/integration/infrastructure/repositories/mission-assessment-repository_test.js
+++ b/api/tests/school/integration/infrastructure/repositories/mission-assessment-repository_test.js
@@ -6,7 +6,7 @@ import { databaseBuilder, expect } from '../../../../test-helper.js';
 describe('Integration | Repository | mission-assessment-repository', function () {
   describe('#getByAssessmentId', function () {
     it('returns the missionAssessment corresponding to the assessmentId', async function () {
-      const missionId = 'flute78';
+      const missionId = 123;
       const assessmentId = databaseBuilder.factory.buildPix1dAssessment().id;
       const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
       databaseBuilder.factory.buildMissionAssessment({ missionId, assessmentId, organizationLearnerId });
@@ -20,8 +20,8 @@ describe('Integration | Repository | mission-assessment-repository', function ()
 
   describe('#getCurrent', function () {
     it('should return a started assessment for learner and missionId', async function () {
-      const missionId = 'flute79';
-      const otherMissionId = 'flute80';
+      const missionId = 123;
+      const otherMissionId = 456;
       const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
       const otherOrganizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
 
@@ -57,7 +57,7 @@ describe('Integration | Repository | mission-assessment-repository', function ()
     });
 
     it('should not return any assessment', async function () {
-      const missionId = 'flute79';
+      const missionId = 123;
       const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
       await databaseBuilder.commit();
 
@@ -79,25 +79,29 @@ describe('Integration | Repository | mission-assessment-repository', function ()
       const startedAssessmentId = databaseBuilder.factory.buildPix1dAssessment({
         state: Assessment.states.STARTED,
       }).id;
+      const completedMissionId = 123;
+      const otherCompletedMissionId = 456;
+      const startedMissionId = 789;
+
       databaseBuilder.factory.buildMissionAssessment({
-        missionId: 'COMPLETED_ID',
+        missionId: completedMissionId,
         organizationLearnerId: organizationLearner.id,
         assessmentId: completedAssessmentId,
       });
       databaseBuilder.factory.buildMissionAssessment({
-        missionId: 'OTHER_COMPLETED_ID',
+        missionId: otherCompletedMissionId,
         organizationLearnerId: organizationLearner.id,
         assessmentId: otherCompletedAssessmentId,
       });
       databaseBuilder.factory.buildMissionAssessment({
-        missionId: 'STARTED_ID',
+        missionId: startedMissionId,
         organizationLearnerId: organizationLearner.id,
         assessmentId: startedAssessmentId,
       });
       await databaseBuilder.commit();
 
       const result = await missionAssessmentRepository.getAllCompletedMissionIds(organizationLearner.id);
-      expect(result).to.deep.equal(['COMPLETED_ID', 'OTHER_COMPLETED_ID']);
+      expect(result).to.deep.equal([completedMissionId, otherCompletedMissionId]);
     });
 
     it('should return organization learner even without completed missions', async function () {

--- a/api/tests/school/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/school/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -64,7 +64,7 @@ describe('Integration | Repository | organizationLearner', function () {
 
   describe('#getDivisionsWhichStartedMission', function () {
     it('returns all divisions which started the mission', async function () {
-      const missionId = 'flute78';
+      const missionId = 123;
       const organizationId = databaseBuilder.factory.buildOrganization().id;
 
       const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
@@ -95,7 +95,7 @@ describe('Integration | Repository | organizationLearner', function () {
     });
 
     it('returns the divisions which started the mission for the given organizationId', async function () {
-      const missionId = 'flute78';
+      const missionId = 123;
       const organizationId = databaseBuilder.factory.buildOrganization().id;
 
       const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({
@@ -122,7 +122,7 @@ describe('Integration | Repository | organizationLearner', function () {
     });
 
     it('returns the divisions of organizationLearners who started the mission and who are not disabled', async function () {
-      const missionId = 'flute78';
+      const missionId = 123;
       const organizationId = databaseBuilder.factory.buildOrganization().id;
 
       const organizationLearner = databaseBuilder.factory.buildOrganizationLearner({

--- a/api/tests/school/unit/application/assessment-route_test.js
+++ b/api/tests/school/unit/application/assessment-route_test.js
@@ -43,7 +43,7 @@ describe('Unit | Application | Router | assessment-router', function () {
 
       // when
       await httpTestServer.request('POST', '/api/pix1d/assessments', {
-        missionId: 'unMissionID',
+        missionId: 1,
         learnerId: 34567,
       });
 


### PR DESCRIPTION
## :unicorn: Problème
L'id de mission est fourni dans la version de référentiel en tant qu'entier, mais stocké dans les `mission-assessments` comme un texte.

## :robot: Proposition
Mettre à jour le modèle de base de données et les contraintes JOI sur les routes pour n'accepter que des requêtes fournissant un entier;

## :100: Pour tester
Passer une mission.
