### PR TITLE
[BUGFIX] Corriger l'appel au usecase d'envoie de notification (PIX-12077)

### DIFF
--- a/api/src/certification/complementary-certification/application/attach-target-profile-controller.js
+++ b/api/src/certification/complementary-certification/application/attach-target-profile-controller.js
@@ -18,7 +18,7 @@ const attachTargetProfile = async function (request, h, dependencies = { complem
   });
 
   if (notifyOrganizations) {
-    usecases.sendTargetProfileNotifications({
+    await usecases.sendTargetProfileNotifications({
       targetProfileIdToDetach: targetProfileId,
       complementaryCertification,
     });


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Admin en recette, onglet Certifications complémentaires, lorsqu’on clique sur l’une des certifications complémentaires, on peut changer le profil cible (PC) rattaché à celle-ci en cliquant sur “Rattacher un nouveau profil cible”

On rempli le tableau avec les informations manquantes pour chaque résultat thématique (RT) du nouveau PC à rattacher

On coche la case “Notifier les organisations avec une campagne basée sur l’ancien PC”

On clique sur “Rattacher le profil cible”

Resultat: On a un message “Error dans Ember” qui s’affiche et en ouvrant la console une erreur 502 sur la route 

## :robot: Proposition
corriger l'injection du mail service 


## :100: Pour tester
Dans pix-admin:

- retenter les étapes ci dessus
- constater le message de succès

Dans le fichier `api/src/certification/complementary-certification/domain/usecases/index.js`: 
- commenter la ligne 31
- lancer le fichier `api/tests/certification/complementary-certification/acceptance/application/attach-target-profile-controller_test.js`
- constater que les tests d'acceptance échouent et que les pb d'injections sont bien détéctés
