### PR TITLE
[TECH][API] Factorisation du code de stockage des ID Tokens pour 2 services d'authentification de type OIDC (PIX-12069)

### DIFF
--- a/api/lib/domain/services/authentication/fwb-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/fwb-oidc-authentication-service.js
@@ -32,12 +32,18 @@ class FwbOidcAuthenticationService extends OidcAuthenticationService {
   async getRedirectLogoutUrl({ userId, logoutUrlUUID }) {
     const redirectTarget = new URL(this.logoutUrl);
     const key = `${userId}:${logoutUrlUUID}`;
-    const idToken = await logoutUrlTemporaryStorage.get(key);
+
+    let idToken = await logoutUrlTemporaryStorage.get(key);
+    if (!idToken) {
+      idToken = this.sessionTemporaryStorage.get(key);
+    }
+
     const params = [{ key: 'id_token_hint', value: idToken }];
 
     params.forEach(({ key, value }) => redirectTarget.searchParams.append(key, value));
 
     await logoutUrlTemporaryStorage.delete(key);
+    await this.sessionTemporaryStorage.delete(key);
 
     return redirectTarget.toString();
   }

--- a/api/lib/domain/services/authentication/fwb-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/fwb-oidc-authentication-service.js
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import { OidcAuthenticationService } from '../../../../src/authentication/domain/services/oidc-authentication-service.js';
 import { config } from '../../../config.js';
 import { temporaryStorage } from '../../../infrastructure/temporary-storage/index.js';
@@ -46,18 +44,6 @@ class FwbOidcAuthenticationService extends OidcAuthenticationService {
     await this.sessionTemporaryStorage.delete(key);
 
     return redirectTarget.toString();
-  }
-
-  async saveIdToken({ idToken, userId }) {
-    const uuid = randomUUID();
-
-    await logoutUrlTemporaryStorage.save({
-      key: `${userId}:${uuid}`,
-      value: idToken,
-      expirationDelaySeconds: this.sessionDurationSeconds,
-    });
-
-    return uuid;
   }
 }
 

--- a/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import dayjs from 'dayjs';
 
 import { OidcAuthenticationService } from '../../../../src/authentication/domain/services/oidc-authentication-service.js';
@@ -82,18 +80,6 @@ class PoleEmploiOidcAuthenticationService extends OidcAuthenticationService {
     await this.sessionTemporaryStorage.delete(key);
 
     return redirectTarget.toString();
-  }
-
-  async saveIdToken({ idToken, userId }) {
-    const uuid = randomUUID();
-
-    await logoutUrlTemporaryStorage.save({
-      key: `${userId}:${uuid}`,
-      value: idToken,
-      expirationDelaySeconds: this.sessionDurationSeconds,
-    });
-
-    return uuid;
   }
 
   createAuthenticationComplement({ sessionContent }) {

--- a/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
@@ -65,7 +65,12 @@ class PoleEmploiOidcAuthenticationService extends OidcAuthenticationService {
   async getRedirectLogoutUrl({ userId, logoutUrlUUID }) {
     const redirectTarget = new URL(this.logoutUrl);
     const key = `${userId}:${logoutUrlUUID}`;
-    const idToken = await logoutUrlTemporaryStorage.get(key);
+
+    let idToken = await logoutUrlTemporaryStorage.get(key);
+    if (!idToken) {
+      idToken = this.sessionTemporaryStorage.get(key);
+    }
+
     const params = [
       { key: 'id_token_hint', value: idToken },
       { key: 'redirect_uri', value: this.afterLogoutUrl },
@@ -74,6 +79,7 @@ class PoleEmploiOidcAuthenticationService extends OidcAuthenticationService {
     params.forEach(({ key, value }) => redirectTarget.searchParams.append(key, value));
 
     await logoutUrlTemporaryStorage.delete(key);
+    await this.sessionTemporaryStorage.delete(key);
 
     return redirectTarget.toString();
   }

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -439,7 +439,7 @@ const configuration = (function () {
     config.poleEmploi.clientId = 'PIX_POLE_EMPLOI_CLIENT_ID';
     config.poleEmploi.clientSecret = 'PIX_POLE_EMPLOI_CLIENT_SECRET';
     config.poleEmploi.sendingUrl = 'http://sendingUrl.fr';
-    config.poleEmploi.logoutUrl = 'http://logout-url.fr';
+    config.poleEmploi.logoutUrl = 'https://logout-url.fr';
     config.poleEmploi.afterLogoutUrl = 'http://after-logout.url';
     config.poleEmploi.pushEnabled = true;
 
@@ -450,7 +450,7 @@ const configuration = (function () {
     config.cnav.clientSecret = 'PIX_CNAV_CLIENT_SECRET';
 
     config.fwb.isEnabled = false;
-    config.fwb.logoutUrl = 'http://logout-url.org';
+    config.fwb.logoutUrl = 'https://logout-url.org';
 
     config.google.isEnabled = false;
     config.google.isEnabledForPixAdmin = true;

--- a/api/tests/integration/domain/services/authentication/fwb-oidc-authentication-service_test.js
+++ b/api/tests/integration/domain/services/authentication/fwb-oidc-authentication-service_test.js
@@ -1,31 +1,60 @@
+import { randomUUID } from 'node:crypto';
+
 import { FwbOidcAuthenticationService } from '../../../../../lib/domain/services/authentication/fwb-oidc-authentication-service.js';
 import { temporaryStorage } from '../../../../../lib/infrastructure/temporary-storage/index.js';
 import { expect } from '../../../../test-helper.js';
 
+const defaultSessionTemporaryStorage = temporaryStorage.withPrefix('oidc-session:');
 const logoutUrlTemporaryStorage = temporaryStorage.withPrefix('logout-url:');
 
 describe('Integration | Domain | Service | fwb-oidc-authentication-service', function () {
   describe('#getRedirectLogoutUrl', function () {
-    it('removes the idToken from temporary storage and returns a redirect logout url', async function () {
-      // given
-      const idToken =
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
-      const userId = 1;
-      const logoutUrlUUID = '1f3dbb71-f399-4c1c-85ae-0a863c78aeea';
-      const key = `${userId}:${logoutUrlUUID}`;
-      const fwbOidcAuthenticationService = new FwbOidcAuthenticationService();
-      await logoutUrlTemporaryStorage.save({ key, value: idToken, expirationDelaySeconds: 1140 });
+    describe('when the user ID Token is not stored in the parent default temporary storage', function () {
+      it('removes the idToken from temporary storage and returns a redirect logout url', async function () {
+        // given
+        const idToken =
+          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+        const userId = 1;
+        const logoutUrlUUID = randomUUID();
+        const key = `${userId}:${logoutUrlUUID}`;
+        const fwbOidcAuthenticationService = new FwbOidcAuthenticationService();
+        await logoutUrlTemporaryStorage.save({ key, value: idToken, expirationDelaySeconds: 1140 });
 
-      // when
-      const redirectTarget = await fwbOidcAuthenticationService.getRedirectLogoutUrl({ userId, logoutUrlUUID });
+        // when
+        const redirectTarget = await fwbOidcAuthenticationService.getRedirectLogoutUrl({ userId, logoutUrlUUID });
 
-      // then
-      const expectedResult = await logoutUrlTemporaryStorage.get(key);
-      expect(expectedResult).to.be.undefined;
+        // then
+        const expectedResult = await logoutUrlTemporaryStorage.get(key);
+        expect(expectedResult).to.be.undefined;
 
-      expect(redirectTarget).to.equal(
-        'http://logout-url.org/?id_token_hint=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
-      );
+        expect(redirectTarget).to.equal(
+          'https://logout-url.org/?id_token_hint=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+        );
+      });
+    });
+
+    describe('when the user ID Token is stored in the parent default temporary storage', function () {
+      it('removes the idToken from temporary storage and returns a redirect logout url', async function () {
+        // given
+        const idToken =
+          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+        const userId = 1;
+        const logoutUrlUUID = randomUUID();
+        const key = `${userId}:${logoutUrlUUID}`;
+        const fwbOidcAuthenticationService = new FwbOidcAuthenticationService();
+        await defaultSessionTemporaryStorage.save({ key, value: idToken, expirationDelaySeconds: 1140 });
+
+        // when
+        const redirectTarget = await fwbOidcAuthenticationService.getRedirectLogoutUrl({ userId, logoutUrlUUID });
+
+        // then
+        const expectedResult = await defaultSessionTemporaryStorage.get(key);
+        expect(expectedResult).to.be.undefined;
+
+        expect(redirectTarget).to.equal(
+          'https://logout-url.org/?id_token_hint=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+        );
+      });
     });
   });
 

--- a/api/tests/integration/domain/services/authentication/fwb-oidc-authentication-service_test.js
+++ b/api/tests/integration/domain/services/authentication/fwb-oidc-authentication-service_test.js
@@ -70,7 +70,7 @@ describe('Integration | Domain | Service | fwb-oidc-authentication-service', fun
 
       // then
       expect(uuid.match(uuidPattern)).to.be.ok;
-      const idToken = logoutUrlTemporaryStorage.get(`${userId}:${uuid}`);
+      const idToken = await defaultSessionTemporaryStorage.get(`${userId}:${uuid}`);
       expect(idToken).to.deep.equal('id_token');
     });
   });

--- a/api/tests/integration/domain/services/authentication/fwb-oidc-authentication-service_test.js
+++ b/api/tests/integration/domain/services/authentication/fwb-oidc-authentication-service_test.js
@@ -34,11 +34,12 @@ describe('Integration | Domain | Service | fwb-oidc-authentication-service', fun
       const redirectTarget = await fwbOidcAuthenticationService.getRedirectLogoutUrl({ userId, logoutUrlUUID });
 
       // then
+      const expectedResult = await logoutUrlTemporaryStorage.get(key);
+      expect(expectedResult).to.be.undefined;
+
       expect(redirectTarget).to.equal(
         'http://logout-url.org/?id_token_hint=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
       );
-      const expectedResult = await logoutUrlTemporaryStorage.get(key);
-      expect(expectedResult).to.be.undefined;
     });
   });
 

--- a/api/tests/integration/domain/services/authentication/fwb-oidc-authentication-service_test.js
+++ b/api/tests/integration/domain/services/authentication/fwb-oidc-authentication-service_test.js
@@ -5,20 +5,6 @@ import { expect } from '../../../../test-helper.js';
 const logoutUrlTemporaryStorage = temporaryStorage.withPrefix('logout-url:');
 
 describe('Integration | Domain | Service | fwb-oidc-authentication-service', function () {
-  describe('instanciate', function () {
-    it('has speficic properties related to this identity provider', async function () {
-      // when
-      const fwbOidcAuthenticationService = new FwbOidcAuthenticationService();
-
-      // then
-      expect(fwbOidcAuthenticationService.source).to.equal('fwb');
-      expect(fwbOidcAuthenticationService.identityProvider).to.equal('FWB');
-      expect(fwbOidcAuthenticationService.slug).to.equal('fwb');
-      expect(fwbOidcAuthenticationService.organizationName).to.equal('Fédération Wallonie-Bruxelles');
-      expect(fwbOidcAuthenticationService.shouldCloseSession).to.be.true;
-    });
-  });
-
   describe('#getRedirectLogoutUrl', function () {
     it('removes the idToken from temporary storage and returns a redirect logout url', async function () {
       // given

--- a/api/tests/integration/domain/services/authentication/pole-emploi-oidc-authentication-service_test.js
+++ b/api/tests/integration/domain/services/authentication/pole-emploi-oidc-authentication-service_test.js
@@ -58,6 +58,33 @@ describe('Integration | Domain | Services | pole-emploi-oidc-authentication-serv
     });
   });
 
+  describe('#getRedirectLogoutUrl', function () {
+    it('removes the idToken from temporary storage and returns a redirect logout url', async function () {
+      // given
+      const idToken =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+      const userId = '1';
+      const logoutUrlUUID = '1f3dbb71-f399-4c1c-85ae-0a863c78aeea';
+      const key = `${userId}:${logoutUrlUUID}`;
+      const poleEmploiOidcAuthenticationService = new PoleEmploiOidcAuthenticationService();
+      await logoutUrlTemporaryStorage.save({ key, value: idToken, expirationDelaySeconds: 1140 });
+
+      // when
+      const redirectTarget = await poleEmploiOidcAuthenticationService.getRedirectLogoutUrl({
+        userId,
+        logoutUrlUUID,
+      });
+
+      // then
+      const expectedIdToken = await logoutUrlTemporaryStorage.get(key);
+      expect(expectedIdToken).to.be.undefined;
+
+      expect(redirectTarget).to.equal(
+        'http://logout-url.fr/?id_token_hint=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c&redirect_uri=http%3A%2F%2Fafter-logout.url',
+      );
+    });
+  });
+
   describe('#saveIdToken', function () {
     it('saves an idToken and returns an uuid', async function () {
       // given

--- a/api/tests/integration/domain/services/authentication/pole-emploi-oidc-authentication-service_test.js
+++ b/api/tests/integration/domain/services/authentication/pole-emploi-oidc-authentication-service_test.js
@@ -9,20 +9,6 @@ import { expect, knex } from '../../../../test-helper.js';
 const logoutUrlTemporaryStorage = temporaryStorage.withPrefix('logout-url:');
 
 describe('Integration | Domain | Services | pole-emploi-oidc-authentication-service', function () {
-  describe('instanciate', function () {
-    it('has speficic properties related to this identity provider', async function () {
-      // when
-      const oidcAuthenticationService = new PoleEmploiOidcAuthenticationService();
-
-      // then
-      expect(oidcAuthenticationService.source).to.equal('pole_emploi_connect');
-      expect(oidcAuthenticationService.identityProvider).to.equal('POLE_EMPLOI');
-      expect(oidcAuthenticationService.slug).to.equal('pole-emploi');
-      expect(oidcAuthenticationService.organizationName).to.equal('France Travail');
-      expect(oidcAuthenticationService.shouldCloseSession).to.be.true;
-    });
-  });
-
   describe('#createUserAccount', function () {
     it('creates a user with an authentication method and returns a user id', async function () {
       // given

--- a/api/tests/integration/domain/services/authentication/pole-emploi-oidc-authentication-service_test.js
+++ b/api/tests/integration/domain/services/authentication/pole-emploi-oidc-authentication-service_test.js
@@ -115,7 +115,7 @@ describe('Integration | Domain | Services | pole-emploi-oidc-authentication-serv
 
       // then
       expect(uuid.match(uuidPattern)).to.be.ok;
-      const idToken = logoutUrlTemporaryStorage.get(`${userId}:${uuid}`);
+      const idToken = await defaultSessionTemporaryStorage.get(`${userId}:${uuid}`);
       expect(idToken).to.deep.equal('id_token');
     });
   });

--- a/api/tests/unit/domain/services/authentication/fwb-oidc-authentication-service.test.js
+++ b/api/tests/unit/domain/services/authentication/fwb-oidc-authentication-service.test.js
@@ -1,0 +1,18 @@
+import { FwbOidcAuthenticationService } from '../../../../../lib/domain/services/authentication/fwb-oidc-authentication-service.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Domain | Services | fwb-oidc-authentication-service', function () {
+  describe('#constructor', function () {
+    it('has specific properties related to this identity provider', async function () {
+      // when
+      const fwbOidcAuthenticationService = new FwbOidcAuthenticationService();
+
+      // then
+      expect(fwbOidcAuthenticationService.source).to.equal('fwb');
+      expect(fwbOidcAuthenticationService.identityProvider).to.equal('FWB');
+      expect(fwbOidcAuthenticationService.slug).to.equal('fwb');
+      expect(fwbOidcAuthenticationService.organizationName).to.equal('Fédération Wallonie-Bruxelles');
+      expect(fwbOidcAuthenticationService.shouldCloseSession).to.be.true;
+    });
+  });
+});

--- a/api/tests/unit/domain/services/authentication/pole-emploi-oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/pole-emploi-oidc-authentication-service_test.js
@@ -2,11 +2,8 @@ import { Issuer } from 'openid-client';
 
 import { AuthenticationMethod } from '../../../../../lib/domain/models/AuthenticationMethod.js';
 import { PoleEmploiOidcAuthenticationService } from '../../../../../lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js';
-import { temporaryStorage } from '../../../../../lib/infrastructure/temporary-storage/index.js';
 import { config as settings } from '../../../../../src/shared/config.js';
 import { expect, sinon } from '../../../../test-helper.js';
-
-const logoutUrlTemporaryStorage = temporaryStorage.withPrefix('logout-url:');
 
 describe('Unit | Domain | Services | pole-emploi-oidc-authentication-service', function () {
   describe('#createClient', function () {
@@ -33,33 +30,6 @@ describe('Unit | Domain | Services | pole-emploi-oidc-authentication-service', f
         redirect_uris: ['https://app.dev.pix.local/connexion/oidc-example-net'],
         token_endpoint_auth_method: 'client_secret_post',
       });
-    });
-  });
-
-  describe('#getRedirectLogoutUrl', function () {
-    it('removes the idToken from temporary storage and returns a redirect logout url', async function () {
-      // given
-      const idToken =
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
-      const userId = '1';
-      const logoutUrlUUID = '1f3dbb71-f399-4c1c-85ae-0a863c78aeea';
-      const key = `${userId}:${logoutUrlUUID}`;
-      const poleEmploiOidcAuthenticationService = new PoleEmploiOidcAuthenticationService();
-      await logoutUrlTemporaryStorage.save({ key, value: idToken, expirationDelaySeconds: 1140 });
-
-      // when
-      const redirectTarget = await poleEmploiOidcAuthenticationService.getRedirectLogoutUrl({
-        userId,
-        logoutUrlUUID,
-      });
-
-      // then
-      const expectedIdToken = await logoutUrlTemporaryStorage.get(key);
-      expect(expectedIdToken).to.be.undefined;
-
-      expect(redirectTarget).to.equal(
-        'http://logout-url.fr/?id_token_hint=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c&redirect_uri=http%3A%2F%2Fafter-logout.url',
-      );
     });
   });
 

--- a/api/tests/unit/domain/services/authentication/pole-emploi-oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/pole-emploi-oidc-authentication-service_test.js
@@ -6,6 +6,20 @@ import { config as settings } from '../../../../../src/shared/config.js';
 import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Domain | Services | pole-emploi-oidc-authentication-service', function () {
+  describe('#constructor', function () {
+    it('has specific properties related to this identity provider', async function () {
+      // when
+      const oidcAuthenticationService = new PoleEmploiOidcAuthenticationService();
+
+      // then
+      expect(oidcAuthenticationService.source).to.equal('pole_emploi_connect');
+      expect(oidcAuthenticationService.identityProvider).to.equal('POLE_EMPLOI');
+      expect(oidcAuthenticationService.slug).to.equal('pole-emploi');
+      expect(oidcAuthenticationService.organizationName).to.equal('France Travail');
+      expect(oidcAuthenticationService.shouldCloseSession).to.be.true;
+    });
+  });
+
   describe('#createClient', function () {
     it('creates an openid client with extra metadata', async function () {
       // given

--- a/api/tests/unit/domain/services/authentication/pole-emploi-oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/pole-emploi-oidc-authentication-service_test.js
@@ -37,15 +37,15 @@ describe('Unit | Domain | Services | pole-emploi-oidc-authentication-service', f
   });
 
   describe('#getRedirectLogoutUrl', function () {
-    it('should return a redirect logout url', async function () {
+    it('removes the idToken from temporary storage and returns a redirect logout url', async function () {
       // given
       const idToken =
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
       const userId = '1';
       const logoutUrlUUID = '1f3dbb71-f399-4c1c-85ae-0a863c78aeea';
       const key = `${userId}:${logoutUrlUUID}`;
-      await logoutUrlTemporaryStorage.save({ key, value: idToken, expirationDelaySeconds: 1140 });
       const poleEmploiOidcAuthenticationService = new PoleEmploiOidcAuthenticationService();
+      await logoutUrlTemporaryStorage.save({ key, value: idToken, expirationDelaySeconds: 1140 });
 
       // when
       const redirectTarget = await poleEmploiOidcAuthenticationService.getRedirectLogoutUrl({
@@ -54,30 +54,12 @@ describe('Unit | Domain | Services | pole-emploi-oidc-authentication-service', f
       });
 
       // then
+      const expectedIdToken = await logoutUrlTemporaryStorage.get(key);
+      expect(expectedIdToken).to.be.undefined;
+
       expect(redirectTarget).to.equal(
         'http://logout-url.fr/?id_token_hint=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c&redirect_uri=http%3A%2F%2Fafter-logout.url',
       );
-    });
-
-    it('removes idToken from temporary storage', async function () {
-      // given
-      const idToken =
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
-      const userId = '2';
-      const logoutUrlUUID = 'f9f1b471-a74e-4722-8dde-f5731279146a';
-      const key = `${userId}:${logoutUrlUUID}`;
-      await logoutUrlTemporaryStorage.save({ key, value: idToken, expirationDelaySeconds: 1140 });
-      const poleEmploiOidcAuthenticationService = new PoleEmploiOidcAuthenticationService();
-
-      // when
-      await poleEmploiOidcAuthenticationService.getRedirectLogoutUrl({
-        userId,
-        logoutUrlUUID,
-      });
-      const expectedIdToken = await logoutUrlTemporaryStorage.get(key);
-
-      // then
-      expect(expectedIdToken).to.be.undefined;
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème

Actuellement certains services de connexion de type OIDC utilise leur propre code pour enregistrer l'ID token.

## :robot: Proposition

Utiliser le code d'enregistrement de l'ID token de la classe parente `oidc-authentication-service`.

## :rainbow: Remarques

Lors de la déconnexion, nous allons supprimer le contenu se trouvant à l'ancien emplacement de stockage temporaire ainsi que dans le nouvel emplacement pour des raisons de rétro-compatibilité.

## :100: Pour tester

Faire des tests de non-régressions avec tous les fournisseurs d'identité de type OIDC.

1. Se créer un compte ou se connecter à un compte avec un SSO de type OIDC
2. Se déconnecter
3. Constater que le fonctionnement de déconnexion est toujours valide. Ne pas oublier de prendre en compte les cas particulier.
