### PR TITLE
[FEATURE] Remplacer Choisissez par Sélectionnez dans les instructions des QCU et QCM (PIX-11919).

### DIFF
--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -715,8 +715,8 @@
       "parts": {
         "answer-input": "Votre réponse",
         "answer-instructions": {
-          "qcm": "Choisissez plusieurs réponses.",
-          "qcu": "Choisissez une seule réponse."
+          "qcm": "Sélectionnez plusieurs réponses.",
+          "qcu": "Sélectionnez une seule réponse."
         },
         "feedback": "Signaler un problème",
         "feedback-v3": "Signaler un problème avec la question",


### PR DESCRIPTION
## :unicorn: Problème
ETQ utilisateur de pix app, sur les questions QCU et QCM, je vois “Sélectionnez plusieurs réponses” dans le bloc réponses.

## :robot: Proposition
Remplacer Choisissez par Sélectionnez dans le fichier de traductions. 

## :100: Pour tester
 - Démarrer Mon Pix
 - Lancer un parcours
 - Trouver une Question à Choix Multiples 
 - Vérifier que la phrase affichée est bien "Sélectionnez plusieurs réponses".
 - Trouver une Question à Choix Unique 
 - Vérifier que la phrase affichée est bien "Sélectionnez une seule réponse".