### PR TITLE
[FEATURE] Corriger le wording pour l'affichage du statut de l'import sur la page participant (PIX-12080)

### DIFF
--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -246,11 +246,11 @@
       "SUP": "Group"
     },
     "import-information-banner": {
-      "error": "The file contains errors.",
-      "error-link": "Consult the list of errors here.",
-      "in-progress": "An import is in progress.",
-      "in-progress-link": "Check import status here.",
-      "success": "Participants have been successfully imported."
+      "error": "Import failed",
+      "error-link": "(see import page).",
+      "in-progress": "An import is in progress",
+      "in-progress-link": "(check import status).",
+      "success": "Participants have been imported."
     },
     "participation-status": {
       "SHARED-ASSESSMENT": "Submitted results",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -247,10 +247,10 @@
     },
     "import-information-banner": {
       "error": "Échec de l’import",
-      "error-link": "(voir l'état de l'import).",
-      "in-progress": "Un import est en cours.",
+      "error-link": "(voir la page d'import).",
+      "in-progress": "Un import est en cours",
       "in-progress-link": "(consulter l'état de l'import).",
-      "success": "Vos participants ont bien été importés."
+      "success": "Les participants ont bien été importés."
     },
     "participation-status": {
       "SHARED-ASSESSMENT": "Résultats reçus",


### PR DESCRIPTION
## :unicorn: Problème
Le wording en FR et EN n'est pas bon pour l’affichage de l’état de l’import dans la page participants. 

## :robot: Proposition
Corriger le wording dans les fichiers de trad FR & EN pour les clés utilisés dans le composant de statut de l'import dans la page participant

## :rainbow: Remarques
⚠️ Attendre revue PO avant de merge

## :100: Pour tester
Se connecter à Pix Orga avec `sco-orga@exemple.net`
`Orga SCO MANAGING`
Vérifier le wording du bandeau d'information sur la page participant pour un import "en cours". (en FR & en EN)

Aller sur  `Orga FREGATA`
Vérifier le wording du bandeau d'information sur la page participant pour un import "validé". (en FR & en EN)

Se connecter à Pix Orga avec `sup-orga@example.net`
Vérifier le wording du bandeau d'information sur la page participant pour un import "en echec". (en FR & en EN)

🐈‍⬛ 

