### PR TITLE
[TECH] Envoyer un postMessage au demarrage d'une certification (PIX-12115)

### DIFF
--- a/mon-pix/app/components/certification-starter.js
+++ b/mon-pix/app/components/certification-starter.js
@@ -19,6 +19,10 @@ export default class CertificationJoiner extends Component {
     return this.inputAccessCode.toUpperCase();
   }
 
+  get postMessage() {
+    return this.args.postMessage ?? ((...args) => window.postMessage(...args));
+  }
+
   @action
   async submit(e) {
     e.preventDefault();
@@ -36,6 +40,7 @@ export default class CertificationJoiner extends Component {
       await newCertificationCourse.save();
       this.focusedCertificationChallengeWarningManager.reset();
       this.router.replaceWith('authenticated.certifications.resume', newCertificationCourse.id);
+      this.postMessage({ event: 'pix:activated', detail: { activated: true } }, window.location.origin);
     } catch (err) {
       newCertificationCourse.deleteRecord();
       const statusCode = err.errors?.[0]?.status;

--- a/mon-pix/app/components/certification-starter.js
+++ b/mon-pix/app/components/certification-starter.js
@@ -9,6 +9,7 @@ export default class CertificationJoiner extends Component {
   @service currentUser;
   @service intl;
   @service focusedCertificationChallengeWarningManager;
+  @service windowPostMessage;
 
   @tracked inputAccessCode = '';
   @tracked errorMessage = null;
@@ -17,10 +18,6 @@ export default class CertificationJoiner extends Component {
 
   get accessCode() {
     return this.inputAccessCode.toUpperCase();
-  }
-
-  get postMessage() {
-    return this.args.postMessage ?? ((...args) => window.postMessage(...args));
   }
 
   @action
@@ -40,7 +37,7 @@ export default class CertificationJoiner extends Component {
       await newCertificationCourse.save();
       this.focusedCertificationChallengeWarningManager.reset();
       this.router.replaceWith('authenticated.certifications.resume', newCertificationCourse.id);
-      this.postMessage({ event: 'pix:activated', detail: { activated: true } }, window.location.origin);
+      this.windowPostMessage.startCertification();
     } catch (err) {
       newCertificationCourse.deleteRecord();
       const statusCode = err.errors?.[0]?.status;

--- a/mon-pix/app/routes/authenticated/certifications/results.js
+++ b/mon-pix/app/routes/authenticated/certifications/results.js
@@ -3,10 +3,15 @@ import { service } from '@ember/service';
 
 export default class ResultsRoute extends Route {
   @service store;
+  @service windowPostMessage;
 
   async model(params) {
     const certificationCourse = await this.store.findRecord('certification-course', params.certification_id);
     await certificationCourse.assessment.reload();
     return certificationCourse;
+  }
+
+  afterModel() {
+    return this.windowPostMessage.stopCertification();
   }
 }

--- a/mon-pix/app/services/window-post-message.js
+++ b/mon-pix/app/services/window-post-message.js
@@ -8,4 +8,8 @@ export default class WindowPostMessage extends Service {
   startCertification(postMessage = this.#postMessage) {
     postMessage({ event: 'pix:certification:start' }, window.location.origin);
   }
+
+  stopCertification(postMessage = this.#postMessage) {
+    postMessage({ event: 'pix:certification:stop' }, window.location.origin);
+  }
 }

--- a/mon-pix/app/services/window-post-message.js
+++ b/mon-pix/app/services/window-post-message.js
@@ -1,0 +1,11 @@
+import Service from '@ember/service';
+
+export default class WindowPostMessage extends Service {
+  #postMessage(...args) {
+    return window.postMessage(...args);
+  }
+
+  startCertification(postMessage = this.#postMessage) {
+    postMessage({ event: 'pix:certification:start' }, window.location.origin);
+  }
+}

--- a/mon-pix/tests/acceptance/user-account/connection-methods_test.js
+++ b/mon-pix/tests/acceptance/user-account/connection-methods_test.js
@@ -19,6 +19,10 @@ module('Acceptance | user-account | connection-methods', function (hooks) {
   setupMirage(hooks);
   setupIntl(hooks);
 
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
   module('connection method details', function () {
     test("should display user's email and username", async function (assert) {
       // given

--- a/mon-pix/tests/integration/components/certification-starter_test.js
+++ b/mon-pix/tests/integration/components/certification-starter_test.js
@@ -153,16 +153,13 @@ module('Integration | Component | certification-starter', function (hooks) {
           class StoreServiceStub extends Service {
             createRecord = createRecordStub;
           }
-
           this.owner.register('service:store', StoreServiceStub);
           createRecordStub.returns(certificationCourse);
 
           const resetStub = sinon.stub();
-
           class FocusedCertificationChallengeWarningManagerStub extends Service {
             reset = resetStub;
           }
-
           this.owner.register(
             'service:focused-certification-challenge-warning-manager',
             FocusedCertificationChallengeWarningManagerStub,
@@ -177,9 +174,8 @@ module('Integration | Component | certification-starter', function (hooks) {
           routerObserver.replaceWith = sinon.stub();
 
           this.set('certificationCandidateSubscription', { sessionId: 123 });
-          this.set('postMessageStub', postMessageStub);
           await render(
-            hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}} @postMessage={{this.postMessageStub}}/>`,
+            hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}}/>`,
           );
           await fillIn('#certificationStarterSessionCode', 'ABC123');
           routerObserver.replaceWith.returns('ok');
@@ -197,6 +193,7 @@ module('Integration | Component | certification-starter', function (hooks) {
           sinon.assert.calledOnce(resetStub);
           sinon.assert.calledOnce(postMessageStub);
           sinon.assert.calledWithExactly(routerObserver.replaceWith, 'authenticated.certifications.resume', 456);
+
           assert.ok(true);
         });
       });

--- a/mon-pix/tests/integration/components/certification-starter_test.js
+++ b/mon-pix/tests/integration/components/certification-starter_test.js
@@ -143,7 +143,6 @@ module('Integration | Component | certification-starter', function (hooks) {
       module('when the creation of certification course is successful', function () {
         test('should redirect to certifications.resume', async function (assert) {
           // given
-
           const certificationCourse = {
             id: 456,
             save: sinon.stub(),
@@ -151,7 +150,6 @@ module('Integration | Component | certification-starter', function (hooks) {
           };
 
           const createRecordStub = sinon.stub();
-
           class StoreServiceStub extends Service {
             createRecord = createRecordStub;
           }
@@ -169,13 +167,19 @@ module('Integration | Component | certification-starter', function (hooks) {
             'service:focused-certification-challenge-warning-manager',
             FocusedCertificationChallengeWarningManagerStub,
           );
+          const postMessageStub = sinon.stub();
+          class WindowPostMessageServiceStub extends Service {
+            startCertification = postMessageStub;
+          }
+          this.owner.register('service:window-post-message', WindowPostMessageServiceStub);
 
           const routerObserver = this.owner.lookup('service:router');
           routerObserver.replaceWith = sinon.stub();
 
           this.set('certificationCandidateSubscription', { sessionId: 123 });
+          this.set('postMessageStub', postMessageStub);
           await render(
-            hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}}/>`,
+            hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}} @postMessage={{this.postMessageStub}}/>`,
           );
           await fillIn('#certificationStarterSessionCode', 'ABC123');
           routerObserver.replaceWith.returns('ok');
@@ -188,14 +192,60 @@ module('Integration | Component | certification-starter', function (hooks) {
             accessCode: 'ABC123',
             sessionId: 123,
           });
+
           sinon.assert.calledOnce(certificationCourse.save);
           sinon.assert.calledOnce(resetStub);
+          sinon.assert.calledOnce(postMessageStub);
           sinon.assert.calledWithExactly(routerObserver.replaceWith, 'authenticated.certifications.resume', 456);
           assert.ok(true);
         });
       });
 
       module('when the creation of certification course is in error', function () {
+        test('should not send a postMessage', async function (assert) {
+          // given
+          const replaceWithStub = sinon.stub();
+          const postMessageStub = sinon.stub();
+          class WindowPostMessageServiceStub extends Service {
+            startCertification = postMessageStub;
+          }
+          this.owner.register('service:window-post-message', WindowPostMessageServiceStub);
+
+          class RouterServiceStub extends Service {
+            replaceWith = replaceWithStub;
+          }
+
+          this.owner.register('service:router', RouterServiceStub);
+          const createRecordStub = sinon.stub();
+
+          class StoreStubService extends Service {
+            createRecord = createRecordStub;
+          }
+
+          this.owner.register('service:store', StoreStubService);
+
+          const certificationCourse = {
+            id: 123,
+            save: sinon.stub(),
+            deleteRecord: sinon.stub(),
+          };
+          createRecordStub.returns(certificationCourse);
+          this.set('certificationCandidateSubscription', { sessionId: 123 });
+          this.set('postMessageStub', postMessageStub);
+          const screen = await render(
+            hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}} @postMessage={{this.postMessageStub}}/>`,
+          );
+          await fillIn('#certificationStarterSessionCode', 'ABC123');
+          certificationCourse.save.rejects({ errors: [{ status: '404' }] });
+
+          // when
+          await clickByLabel(this.intl.t('pages.certification-start.actions.submit'));
+
+          // then
+          assert.ok(screen.getByText('Ce code n’existe pas ou n’est plus valide.'));
+          sinon.assert.notCalled(postMessageStub);
+        });
+
         test('should display the appropriate error message when error status is 404', async function (assert) {
           // given
           const replaceWithStub = sinon.stub();

--- a/mon-pix/tests/unit/routes/assessments/resume_test.js
+++ b/mon-pix/tests/unit/routes/assessments/resume_test.js
@@ -209,15 +209,13 @@ module('Unit | Route | Assessments | Resume', function (hooks) {
           assessment.certificationNumber = 666;
         });
 
-        test('should redirect to certifications.results page', function (assert) {
+        test('should redirect to certifications.results page', async function (assert) {
           // when
-          const promise = route.redirect(assessment);
+          await route.redirect(assessment);
 
           // then
-          return promise.then(() => {
-            sinon.assert.calledWith(route.router.replaceWith, 'authenticated.certifications.results', 666);
-            assert.ok(true);
-          });
+          sinon.assert.calledWith(route.router.replaceWith, 'authenticated.certifications.results', 666);
+          assert.ok(true);
         });
       });
 

--- a/mon-pix/tests/unit/routes/authenticated/certifications/results_test.js
+++ b/mon-pix/tests/unit/routes/authenticated/certifications/results_test.js
@@ -28,4 +28,24 @@ module('Unit | Route | Certifications | Results', function (hooks) {
       assert.deepEqual(model, certificationCourse);
     });
   });
+
+  module('afterModel', function () {
+    test('should send a stop certification postMessage', async function (assert) {
+      // given
+      const postMessageStub = sinon.stub();
+      class WindowPostMessageServiceStub extends Service {
+        stopCertification = postMessageStub;
+      }
+      this.owner.register('service:window-post-message', WindowPostMessageServiceStub);
+
+      const route = this.owner.lookup('route:authenticated/certifications.results');
+
+      // when
+      route.afterModel();
+
+      // then
+      sinon.assert.calledOnce(postMessageStub);
+      assert.ok(true);
+    });
+  });
 });

--- a/mon-pix/tests/unit/routes/authentication/login-gar_test.js
+++ b/mon-pix/tests/unit/routes/authentication/login-gar_test.js
@@ -7,6 +7,10 @@ import sinon from 'sinon';
 module('Unit | Routes | authentication | login-gar', function (hooks) {
   setupTest(hooks);
 
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
   module('#beforeModel', function () {
     module('when a token is set as an hash of an url', function () {
       test('should authenticate the user', async function (assert) {

--- a/mon-pix/tests/unit/services/window-post-message_test.js
+++ b/mon-pix/tests/unit/services/window-post-message_test.js
@@ -1,0 +1,22 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Service | window-post-message', function (hooks) {
+  setupTest(hooks);
+
+  module('#startCertification', function () {
+    test('call the window.postMessage', function (assert) {
+      // Given
+      const postMessage = sinon.stub();
+      const windowPostMessage = this.owner.lookup('service:windowPostMessage');
+
+      // When
+      windowPostMessage.startCertification(postMessage);
+
+      // Then
+      sinon.assert.calledWith(postMessage, { event: 'pix:certification:start' }, window.location.origin);
+      assert.ok(true);
+    });
+  });
+});

--- a/mon-pix/tests/unit/services/window-post-message_test.js
+++ b/mon-pix/tests/unit/services/window-post-message_test.js
@@ -6,7 +6,7 @@ module('Unit | Service | window-post-message', function (hooks) {
   setupTest(hooks);
 
   module('#startCertification', function () {
-    test('call the window.postMessage', function (assert) {
+    test('call the window.postMessage with start event', function (assert) {
       // Given
       const postMessage = sinon.stub();
       const windowPostMessage = this.owner.lookup('service:windowPostMessage');
@@ -16,6 +16,21 @@ module('Unit | Service | window-post-message', function (hooks) {
 
       // Then
       sinon.assert.calledWith(postMessage, { event: 'pix:certification:start' }, window.location.origin);
+      assert.ok(true);
+    });
+  });
+
+  module('#stopCertification', function () {
+    test('call the window.postMessage with stop event', function (assert) {
+      // Given
+      const postMessage = sinon.stub();
+      const windowPostMessage = this.owner.lookup('service:windowPostMessage');
+
+      // When
+      windowPostMessage.stopCertification(postMessage);
+
+      // Then
+      sinon.assert.calledWith(postMessage, { event: 'pix:certification:stop' }, window.location.origin);
       assert.ok(true);
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
On souhaite pouvoir envoyer l'information à l'extérieur qu'une certification est demarrée/terminée

## :robot: Proposition
On envoi un message à la creation et cloture d'une certification via "window.postMessage"

## :rainbow: Remarques
Utilisé en interne pour le moment

une session créé

```
  {
    "sessionId": 1100013,
    "accessCode": "BBFB68",
    "firstName": "pro1000003",
    "lastName": "pro1000003",
    "email": "pro1000003@example.net",
    "birthdate": "2000-01-01",
  }

```

pour autoriser les candidats:
`update "certification-candidates" set "authorizedToStart"= true;`


## :100: Pour tester
N/A
