### PR TITLE
[FEATURE] Simulateur de score et de capacité de certification V3 (PIX-11993).

### DIFF
--- a/api/src/certification/scoring/application/scoring-and-capacity-simulator-controller.js
+++ b/api/src/certification/scoring/application/scoring-and-capacity-simulator-controller.js
@@ -1,0 +1,29 @@
+import { usecases } from '../domain/usecases/index.js';
+import * as serializer from '../infrastructure/serializers/jsonapi/scoring-and-capacity-simulator-report-serializer.js';
+
+const simulateScoringOrCapacity = async (req, h) => {
+  const { capacity, score } = req.payload.data;
+
+  let scoringAndCapacitySimulatorReport;
+  if (score) {
+    scoringAndCapacitySimulatorReport = await usecases.simulateCapacityFromScore({
+      score,
+      date: new Date(),
+    });
+  }
+
+  if (capacity) {
+    scoringAndCapacitySimulatorReport = await usecases.simulateScoreFromCapacity({
+      capacity,
+      date: new Date(),
+    });
+  }
+
+  return h.response(serializer.serialize(scoringAndCapacitySimulatorReport)).code(200);
+};
+
+const scoringAndCapacitySimulatorController = {
+  simulateScoringOrCapacity,
+};
+
+export { scoringAndCapacitySimulatorController };

--- a/api/src/certification/scoring/application/scoring-and-capacity-simulator-route.js
+++ b/api/src/certification/scoring/application/scoring-and-capacity-simulator-route.js
@@ -1,0 +1,39 @@
+import Joi from 'joi';
+
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
+import { scoringAndCapacitySimulatorController } from './scoring-and-capacity-simulator-controller.js';
+
+const register = async (server) => {
+  server.route([
+    {
+      method: 'POST',
+      path: '/api/admin/simulate-score-or-capacity',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          payload: Joi.object({
+            data: Joi.object({
+              score: Joi.number(),
+              capacity: Joi.number(),
+            }).xor('score', 'capacity'),
+          }),
+        },
+        handler: scoringAndCapacitySimulatorController.simulateScoringOrCapacity,
+        tags: ['api', 'admin', 'scoring-and-capacity-simulator'],
+        notes: [
+          '**Cette route est restreinte aux super-administrateurs** \n' +
+            'Simulation de score ou de capacité pour la certification v3',
+        ],
+      },
+    },
+  ]);
+};
+
+const name = 'scoring-and-capacity-simulator';
+
+export { name, register };

--- a/api/src/certification/scoring/domain/models/CapacitySimulator.js
+++ b/api/src/certification/scoring/domain/models/CapacitySimulator.js
@@ -1,0 +1,33 @@
+import { ScoringAndCapacitySimulatorReport } from './ScoringAndCapacitySimulatorReport.js';
+
+export class CapacitySimulator {
+  static compute({ certificationScoringIntervals, competencesForScoring, score }) {
+    const MAX_PIX_SCORE = 1024;
+    const numberOfIntervals = certificationScoringIntervals.length;
+    const SCORE_THRESHOLD = MAX_PIX_SCORE / numberOfIntervals;
+
+    const intervalIndex = Math.floor(score / SCORE_THRESHOLD);
+
+    const intervalMaxValue = certificationScoringIntervals[intervalIndex].bounds.max;
+    const intervalMinValue = certificationScoringIntervals[intervalIndex].bounds.min;
+
+    const capacity =
+      (intervalMaxValue - intervalMinValue) * (score / SCORE_THRESHOLD - (intervalIndex + 1)) + intervalMaxValue;
+
+    const competences = competencesForScoring.map(({ intervals, competenceCode }) => {
+      return {
+        competenceCode,
+        level: intervals[_findIntervalIndex(capacity, intervals)].competenceLevel,
+      };
+    });
+
+    return new ScoringAndCapacitySimulatorReport({
+      capacity,
+      competences,
+    });
+  }
+}
+
+function _findIntervalIndex(capacity, competenceForScoring) {
+  return competenceForScoring.findIndex(({ bounds }) => capacity < bounds.max && capacity >= bounds.min);
+}

--- a/api/src/certification/scoring/domain/models/CapacitySimulator.js
+++ b/api/src/certification/scoring/domain/models/CapacitySimulator.js
@@ -22,6 +22,7 @@ export class CapacitySimulator {
     });
 
     return new ScoringAndCapacitySimulatorReport({
+      score,
       capacity,
       competences,
     });

--- a/api/src/certification/scoring/domain/models/ScoringAndCapacitySimulatorReport.js
+++ b/api/src/certification/scoring/domain/models/ScoringAndCapacitySimulatorReport.js
@@ -1,0 +1,7 @@
+export class ScoringAndCapacitySimulatorReport {
+  constructor({ capacity, score, competences }) {
+    this.capacity = capacity;
+    this.score = score;
+    this.competences = competences;
+  }
+}

--- a/api/src/certification/scoring/domain/models/ScoringSimulator.js
+++ b/api/src/certification/scoring/domain/models/ScoringSimulator.js
@@ -41,6 +41,7 @@ export class ScoringSimulator {
     });
 
     return new ScoringAndCapacitySimulatorReport({
+      capacity,
       score: Math.round(limitedScore),
       competences,
     });

--- a/api/src/certification/scoring/domain/models/ScoringSimulator.js
+++ b/api/src/certification/scoring/domain/models/ScoringSimulator.js
@@ -1,0 +1,52 @@
+import { ScoringAndCapacitySimulatorReport } from './ScoringAndCapacitySimulatorReport.js';
+
+export class ScoringSimulator {
+  static compute({ capacity, certificationScoringIntervals, competencesForScoring }) {
+    const MAX_REACHABLE_LEVEL = 7;
+    const MAX_PIX_SCORE = 1024;
+    const NUMBER_OF_COMPETENCES = 16;
+    const PIX_PER_LEVEL = 8;
+
+    const numberOfIntervals = certificationScoringIntervals.length;
+    const intervalHeight = MAX_PIX_SCORE / numberOfIntervals;
+
+    let normalizedCapacity = capacity;
+    const minimumCapacity = certificationScoringIntervals[0].bounds.min;
+    const maximumCapacity = certificationScoringIntervals.at(-1).bounds.max;
+
+    if (normalizedCapacity < minimumCapacity) {
+      normalizedCapacity = minimumCapacity;
+    }
+    if (normalizedCapacity > maximumCapacity) {
+      normalizedCapacity = maximumCapacity;
+    }
+
+    const intervalIndex = _findIntervalIndex(normalizedCapacity, certificationScoringIntervals);
+
+    const intervalMaxValue = certificationScoringIntervals[intervalIndex].bounds.max;
+    const intervalWidth =
+      certificationScoringIntervals[intervalIndex].bounds.max - certificationScoringIntervals[intervalIndex].bounds.min;
+
+    const score = intervalHeight * (intervalIndex + 1 + (normalizedCapacity - intervalMaxValue) / intervalWidth);
+
+    const maximumReachableScore = MAX_REACHABLE_LEVEL * NUMBER_OF_COMPETENCES * PIX_PER_LEVEL;
+
+    const limitedScore = Math.min(maximumReachableScore, score);
+
+    const competences = competencesForScoring.map(({ intervals, competenceCode }) => {
+      return {
+        competenceCode,
+        level: intervals[_findIntervalIndex(normalizedCapacity, intervals)].competenceLevel,
+      };
+    });
+
+    return new ScoringAndCapacitySimulatorReport({
+      score: Math.round(limitedScore),
+      competences,
+    });
+  }
+}
+
+function _findIntervalIndex(capacity, certificationScoringIntervals) {
+  return certificationScoringIntervals.findIndex(({ bounds }) => capacity < bounds.max && capacity >= bounds.min);
+}

--- a/api/src/certification/scoring/domain/models/V3CertificationScoring.js
+++ b/api/src/certification/scoring/domain/models/V3CertificationScoring.js
@@ -18,6 +18,10 @@ export class V3CertificationScoring {
     return this._certificationScoringConfiguration;
   }
 
+  get competencesForScoring() {
+    return this._competencesForScoring;
+  }
+
   static fromConfigurations({
     competenceForScoringConfiguration,
     certificationScoringConfiguration,

--- a/api/src/certification/scoring/domain/usecases/simulate-capacity-from-score.js
+++ b/api/src/certification/scoring/domain/usecases/simulate-capacity-from-score.js
@@ -1,0 +1,16 @@
+import { CapacitySimulator } from '../models/CapacitySimulator.js';
+
+export async function simulateCapacityFromScore({ score, date, scoringConfigurationRepository }) {
+  const v3CertificationScoring = await scoringConfigurationRepository.getLatestByDateAndLocale({
+    locale: 'fr-fr',
+    date,
+  });
+
+  const certificationScoringIntervals = v3CertificationScoring.getIntervals();
+
+  return CapacitySimulator.compute({
+    score,
+    certificationScoringIntervals,
+    competencesForScoring: v3CertificationScoring.competencesForScoring,
+  });
+}

--- a/api/src/certification/scoring/domain/usecases/simulate-score-from-capacity.js
+++ b/api/src/certification/scoring/domain/usecases/simulate-score-from-capacity.js
@@ -1,0 +1,16 @@
+import { ScoringSimulator } from '../models/ScoringSimulator.js';
+
+export async function simulateScoreFromCapacity({ capacity, date, scoringConfigurationRepository }) {
+  const v3CertificationScoring = await scoringConfigurationRepository.getLatestByDateAndLocale({
+    locale: 'fr-fr',
+    date,
+  });
+
+  const certificationScoringIntervals = v3CertificationScoring.getIntervals();
+
+  return ScoringSimulator.compute({
+    capacity,
+    certificationScoringIntervals,
+    competencesForScoring: v3CertificationScoring.competencesForScoring,
+  });
+}

--- a/api/src/certification/scoring/infrastructure/serializers/jsonapi/scoring-and-capacity-simulator-report-serializer.js
+++ b/api/src/certification/scoring/infrastructure/serializers/jsonapi/scoring-and-capacity-simulator-report-serializer.js
@@ -1,0 +1,14 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+/**
+ * @param {ScoringAndCapacitySimulatorReport} scoringAndCapacitySimulatorReport
+ */
+const serialize = function (scoringAndCapacitySimulatorReport = {}) {
+  return new Serializer('scoring-and-capacity-simulator-report', {
+    attributes: ['capacity', 'score', 'competences'],
+  }).serialize(scoringAndCapacitySimulatorReport);
+};
+
+export { serialize };

--- a/api/src/certification/scoring/routes.js
+++ b/api/src/certification/scoring/routes.js
@@ -1,5 +1,6 @@
+import * as scoringAndCapacitySimulator from './application/scoring-and-capacity-simulator-route.js';
 import * as scoringConfiguration from './application/scoring-configuration-route.js';
 
-const scoringRoutes = [scoringConfiguration];
+const scoringRoutes = [scoringConfiguration, scoringAndCapacitySimulator];
 
 export { scoringRoutes };

--- a/api/tests/certification/scoring/acceptance/application/scoring-and-capacity-simulator-route_test.js
+++ b/api/tests/certification/scoring/acceptance/application/scoring-and-capacity-simulator-route_test.js
@@ -517,7 +517,7 @@ describe('Acceptance | Application | scoring-and-capacity-simulator-route', func
             type: 'scoring-and-capacity-simulator-reports',
             attributes: {
               capacity: -6,
-              score: undefined,
+              score: 128,
               competences: [
                 {
                   competenceCode: '1.1',

--- a/api/tests/certification/scoring/acceptance/application/scoring-and-capacity-simulator-route_test.js
+++ b/api/tests/certification/scoring/acceptance/application/scoring-and-capacity-simulator-route_test.js
@@ -1,0 +1,533 @@
+import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
+import {
+  createServer,
+  databaseBuilder,
+  expect,
+  generateValidRequestAuthorizationHeader,
+  learningContentBuilder,
+  mockLearningContent,
+} from '../../../../test-helper.js';
+
+describe('Acceptance | Application | scoring-and-capacity-simulator-route', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('POST /api/admin/simulate-score-or-capacity', function () {
+    describe('when called without being authenticated', function () {
+      it('should return a 401', async function () {
+        // given
+        const options = {
+          method: 'POST',
+          url: '/api/admin/simulate-score-or-capacity',
+        };
+        // when
+        const response = await server.inject(options);
+        // then
+        expect(response.statusCode).to.equal(401);
+      });
+    });
+
+    describe('when called without a super admin role', function () {
+      it('should return a 403', async function () {
+        // given
+        const authorization = generateValidRequestAuthorizationHeader();
+
+        const options = {
+          method: 'POST',
+          url: '/api/admin/simulate-score-or-capacity',
+          headers: {
+            authorization,
+          },
+          payload: {
+            data: {
+              capacity: 1,
+              score: undefined,
+            },
+          },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+
+    describe('when called with a super admin role', function () {
+      describe('when called with an invalid payload', function () {
+        it('should return a 400', async function () {
+          // given
+          const superAdmin = databaseBuilder.factory.buildUser.withRole({
+            role: PIX_ADMIN.ROLES.SUPER_ADMIN,
+          });
+
+          await databaseBuilder.commit();
+
+          const authorization = generateValidRequestAuthorizationHeader(superAdmin.id);
+
+          const options = {
+            method: 'POST',
+            url: '/api/admin/simulate-score-or-capacity',
+            headers: {
+              authorization,
+            },
+            payload: {
+              data: {
+                toto: 1,
+              },
+            },
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+      });
+
+      describe('when called with a valid payload', function () {
+        it('should return a 200 and the simulation result', async function () {
+          // given
+          const easyChallengeParams = {
+            alpha: 1,
+            delta: -3,
+            langues: ['Franco Français'],
+          };
+          const hardChallengeParams = {
+            alpha: 1,
+            delta: 3,
+            langues: ['Franco Français'],
+          };
+          const learningContent = [
+            {
+              id: 'recArea0',
+              code: 'area0',
+              competences: [
+                {
+                  id: 'recCompetence0',
+                  index: '1.1',
+                  tubes: [
+                    {
+                      id: 'recTube0_0',
+                      skills: [
+                        {
+                          id: 'recSkill0_0',
+                          nom: '@recSkill0_0',
+                          level: 2,
+                          challenges: [{ id: 'recChallenge0_0_0', ...easyChallengeParams }],
+                        },
+                        {
+                          id: 'recSkill0_1',
+                          nom: '@recSkill0_1',
+                          challenges: [{ id: 'recChallenge0_1_0', ...easyChallengeParams }],
+                        },
+                        {
+                          id: 'recSkill0_2',
+                          nom: '@recSkill0_2',
+                          challenges: [{ id: 'recChallenge0_2_0', ...hardChallengeParams }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  id: 'recCompetence1',
+                  index: '1.2',
+                  tubes: [
+                    {
+                      id: 'recTube1_0',
+                      skills: [
+                        {
+                          id: 'recSkill1_0',
+                          nom: '@recSkill1_0',
+                          challenges: [{ id: 'recChallenge1_0_0', ...easyChallengeParams }],
+                        },
+                        {
+                          id: 'recSkill1_1',
+                          nom: '@recSkill1_1',
+                          challenges: [{ id: 'recChallenge1_1_0', ...easyChallengeParams }],
+                        },
+                        {
+                          id: 'recSkill1_2',
+                          nom: '@recSkill1_2',
+                          challenges: [{ id: 'recChallenge1_2_0', ...hardChallengeParams }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  id: 'recCompetence2',
+                  index: '1.3',
+                  tubes: [
+                    {
+                      id: 'recTube2_0',
+                      skills: [
+                        {
+                          id: 'recSkill2_0',
+                          nom: '@recSkill2_0',
+                          challenges: [{ id: 'recChallenge2_0_0', ...easyChallengeParams }],
+                        },
+                        {
+                          id: 'recSkill2_1',
+                          nom: '@recSkill2_1',
+                          challenges: [{ id: 'recChallenge2_1_0', ...easyChallengeParams }],
+                        },
+                        {
+                          id: 'recSkill2_2',
+                          nom: '@recSkill2_2',
+                          challenges: [{ id: 'recChallenge2_2_0', ...hardChallengeParams }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  id: 'recCompetence3',
+                  index: '1.4',
+                  tubes: [
+                    {
+                      id: 'recTube3_0',
+                      skills: [
+                        {
+                          id: 'recSkill3_0',
+                          nom: '@recSkill3_0',
+                          challenges: [{ id: 'recChallenge3_0_0', ...easyChallengeParams }],
+                        },
+                        {
+                          id: 'recSkill3_1',
+                          nom: '@recSkill3_1',
+                          challenges: [{ id: 'recChallenge3_1_0', ...easyChallengeParams }],
+                        },
+                        {
+                          id: 'recSkill3_2',
+                          nom: '@recSkill3_2',
+                          challenges: [{ id: 'recChallenge3_2_0', ...hardChallengeParams }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              id: 'recArea1',
+              code: 'area1',
+              competences: [
+                {
+                  id: 'recCompetence4',
+                  index: '2.1',
+                  tubes: [
+                    {
+                      id: 'recTube4_0',
+                      skills: [
+                        {
+                          id: 'recSkill4_0',
+                          nom: '@recSkill4_0',
+                          challenges: [{ id: 'recChallenge4_0_0', ...easyChallengeParams }],
+                        },
+                        {
+                          id: 'recSkill4_1',
+                          nom: '@recSkill4_1',
+                          challenges: [{ id: 'recChallenge4_1_0', ...easyChallengeParams }],
+                        },
+                        {
+                          id: 'recSkill4_2',
+                          nom: '@recSkill4_2',
+                          challenges: [{ id: 'recChallenge4_2_0', ...hardChallengeParams }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  id: 'recCompetence5',
+                  index: '2.2',
+                  tubes: [
+                    {
+                      id: 'recTube4_0',
+                      skills: [
+                        {
+                          id: 'recSkill5_0',
+                          nom: '@recSkill5_0',
+                          challenges: [{ id: 'recChallenge5_0_0', ...easyChallengeParams }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  id: 'recCompetence6',
+                  index: '2.3',
+                  tubes: [
+                    {
+                      id: 'recTube4_0',
+                      skills: [
+                        {
+                          id: 'recSkill6_0',
+                          nom: '@recSkill6_0',
+                          challenges: [{ id: 'recChallenge6_0_0', ...easyChallengeParams }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  id: 'recCompetence7',
+                  index: '2.4',
+                  tubes: [
+                    {
+                      id: 'recTube7_0',
+                      skills: [
+                        {
+                          id: 'recSkill7_0',
+                          nom: '@recSkill7_0',
+                          challenges: [{ id: 'recChallenge7_0_0', ...easyChallengeParams }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              id: 'recArea2',
+              code: 'area2',
+              competences: [
+                {
+                  id: 'recCompetence8',
+                  index: '3.1',
+                  tubes: [
+                    {
+                      id: 'recTube8_0',
+                      skills: [
+                        {
+                          id: 'recSkill8_0',
+                          nom: '@recSkill8_0',
+                          challenges: [{ id: 'recChallenge8_0_0', ...easyChallengeParams }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  id: 'recCompetence9',
+                  index: '3.2',
+                  tubes: [
+                    {
+                      id: 'recTube9_0',
+                      skills: [
+                        {
+                          id: 'recSkill9_0',
+                          nom: '@recSkill9_0',
+                          challenges: [{ id: 'recChallenge9_0_0', ...easyChallengeParams }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  id: 'recCompetence10',
+                  index: '3.3',
+                  tubes: [
+                    {
+                      id: 'recTube10_0',
+                      skills: [
+                        {
+                          id: 'recSkill10_0',
+                          nom: '@recSkill10_0',
+                          challenges: [{ id: 'recChallenge10_0_0', ...easyChallengeParams }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  id: 'recCompetence11',
+                  index: '3.4',
+                  tubes: [
+                    {
+                      id: 'recTube11_0',
+                      skills: [
+                        {
+                          id: 'recSkill11_0',
+                          nom: '@recSkill11_0',
+                          challenges: [{ id: 'recChallenge11_0_0', ...easyChallengeParams }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              id: 'recArea3',
+              code: 'area3',
+              competences: [
+                {
+                  id: 'recCompetence12',
+                  index: '4.1',
+                  tubes: [
+                    {
+                      id: 'recTube4_0',
+                      skills: [
+                        {
+                          id: 'recSkill12_0',
+                          nom: '@recSkill12_0',
+                          challenges: [{ id: 'recChallenge12_0_0', ...easyChallengeParams }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  id: 'recCompetence13',
+                  index: '4.2',
+                  tubes: [
+                    {
+                      id: 'recTube13_0',
+                      skills: [
+                        {
+                          id: 'recSkill13_0',
+                          nom: '@recSkill13_0',
+                          challenges: [{ id: 'recChallenge13_0_0', ...easyChallengeParams }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  id: 'recCompetence14',
+                  index: '4.3',
+                  tubes: [
+                    {
+                      id: 'recTube14_0',
+                      skills: [
+                        {
+                          id: 'recSkill14_0',
+                          nom: '@recSkill14_0',
+                          challenges: [{ id: 'recChallenge14_0_0', ...easyChallengeParams }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              id: 'recArea4',
+              code: 'area4',
+              competences: [
+                {
+                  id: 'recCompetence15',
+                  index: '5.1',
+                  tubes: [
+                    {
+                      id: 'recTube15_0',
+                      skills: [
+                        {
+                          id: 'recSkill15_0',
+                          nom: '@recSkill15_0',
+                          challenges: [{ id: 'recChallenge15_0_0', ...easyChallengeParams }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  id: 'recCompetence16',
+                  index: '5.2',
+                  tubes: [
+                    {
+                      id: 'recTube16_0',
+                      skills: [
+                        {
+                          id: 'recSkill16_0',
+                          nom: '@recSkill16_0',
+                          challenges: [{ id: 'recChallenge16_0_0', ...easyChallengeParams }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ];
+          const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
+          mockLearningContent(learningContentObjects);
+
+          const superAdmin = databaseBuilder.factory.buildUser.withRole({
+            role: PIX_ADMIN.ROLES.SUPER_ADMIN,
+          });
+
+          databaseBuilder.factory.buildScoringConfiguration({
+            createdByUserId: superAdmin.id,
+          });
+
+          const competenceScoringConfiguration = [
+            {
+              competence: '1.1',
+              values: [
+                { bounds: { max: -2, min: -8 }, competenceLevel: 0 },
+                { bounds: { max: -0.5, min: -2 }, competenceLevel: 1 },
+                { bounds: { max: 0.6, min: -0.5 }, competenceLevel: 2 },
+                { bounds: { max: 1.5, min: 0.6 }, competenceLevel: 3 },
+                { bounds: { max: 2.25, min: 1.5 }, competenceLevel: 4 },
+                { bounds: { max: 3.1, min: 2.25 }, competenceLevel: 5 },
+                { bounds: { max: 4, min: 3.1 }, competenceLevel: 6 },
+                { bounds: { max: 8, min: 4 }, competenceLevel: 7 },
+              ],
+            },
+          ];
+
+          databaseBuilder.factory.buildCompetenceScoringConfiguration({
+            createdByUserId: superAdmin.id,
+            configuration: competenceScoringConfiguration,
+          });
+
+          await databaseBuilder.commit();
+
+          const authorization = generateValidRequestAuthorizationHeader(superAdmin.id);
+
+          const options = {
+            method: 'POST',
+            url: '/api/admin/simulate-score-or-capacity',
+            headers: {
+              authorization,
+            },
+            payload: {
+              data: {
+                score: 128,
+                capacity: undefined,
+              },
+            },
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          expect(response.result.data).to.deep.equal({
+            type: 'scoring-and-capacity-simulator-reports',
+            attributes: {
+              capacity: -6,
+              score: undefined,
+              competences: [
+                {
+                  competenceCode: '1.1',
+                  level: 0,
+                },
+              ],
+            },
+          });
+        });
+      });
+    });
+  });
+});

--- a/api/tests/certification/scoring/unit/application/scoring-and-capacity-simulator-controller_test.js
+++ b/api/tests/certification/scoring/unit/application/scoring-and-capacity-simulator-controller_test.js
@@ -1,0 +1,76 @@
+import { scoringAndCapacitySimulatorController } from '../../../../../src/certification/scoring/application/scoring-and-capacity-simulator-controller.js';
+import { usecases } from '../../../../../src/certification/scoring/domain/usecases/index.js';
+import { expect, hFake, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Application | scoringAndCapacitySimulatorController', function () {
+  describe('#simulateScoringOrCapacity', function () {
+    let clock;
+    let now;
+
+    beforeEach(function () {
+      now = new Date();
+      clock = sinon.useFakeTimers({
+        now,
+        toFake: ['Date'],
+      });
+    });
+
+    afterEach(async function () {
+      clock.restore();
+    });
+
+    describe('when given a capacity', function () {
+      it('should simulate a score', async function () {
+        // given
+        const capacity = 2;
+        sinon.stub(usecases, 'simulateScoreFromCapacity');
+
+        const request = {
+          payload: {
+            data: {
+              capacity,
+              score: undefined,
+            },
+          },
+        };
+
+        // when
+        const response = await scoringAndCapacitySimulatorController.simulateScoringOrCapacity(request, hFake);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(usecases.simulateScoreFromCapacity).to.have.been.calledWith({
+          capacity,
+          date: now,
+        });
+      });
+    });
+
+    describe('when given a score', function () {
+      it('should simulate a capacity', async function () {
+        // given
+        const score = 128;
+        sinon.stub(usecases, 'simulateCapacityFromScore');
+
+        const request = {
+          payload: {
+            data: {
+              capacity: undefined,
+              score,
+            },
+          },
+        };
+
+        // when
+        const response = await scoringAndCapacitySimulatorController.simulateScoringOrCapacity(request, hFake);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(usecases.simulateCapacityFromScore).to.have.been.calledWith({
+          score,
+          date: now,
+        });
+      });
+    });
+  });
+});

--- a/api/tests/certification/scoring/unit/application/scoring-and-capacity-simulator-route_test.js
+++ b/api/tests/certification/scoring/unit/application/scoring-and-capacity-simulator-route_test.js
@@ -1,0 +1,51 @@
+import { scoringAndCapacitySimulatorController } from '../../../../../src/certification/scoring/application/scoring-and-capacity-simulator-controller.js';
+import * as moduleUnderTest from '../../../../../src/certification/scoring/application/scoring-and-capacity-simulator-route.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
+import { expect, HttpTestServer, sinon } from '../../../../../tests/test-helper.js';
+
+describe('Unit | Route | scoring-and-capacity-simulator-route', function () {
+  describe('GET /api/admin/simulate-score-or-capacity', function () {
+    it('should return 200 if everything goes well', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').callsFake((request, h) => h.response(true));
+      sinon
+        .stub(scoringAndCapacitySimulatorController, 'simulateScoringOrCapacity')
+        .callsFake((request, h) => h.response('ok'));
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('POST', '/api/admin/simulate-score-or-capacity', {
+        data: {
+          score: 128,
+        },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should return 400 when payload contains both a score and a capacity', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').callsFake((request, h) => h.response(true));
+      sinon
+        .stub(scoringAndCapacitySimulatorController, 'simulateScoringOrCapacity')
+        .callsFake((request, h) => h.response('ok'));
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('POST', '/api/admin/simulate-score-or-capacity', {
+        data: {
+          score: 128,
+          capacity: 2.5,
+        },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+  });
+});

--- a/api/tests/certification/scoring/unit/domain/models/CapacitySimulator_test.js
+++ b/api/tests/certification/scoring/unit/domain/models/CapacitySimulator_test.js
@@ -235,7 +235,7 @@ describe('Unit | Domain | Models | CapacitySimulator', function () {
         // then
         expect(result).to.deepEqualInstance(
           domainBuilder.buildScoringAndCapacitySimulatorReport({
-            score: undefined,
+            score,
             capacity: expectedCapacity,
             competences: expectedCompetences,
           }),

--- a/api/tests/certification/scoring/unit/domain/models/CapacitySimulator_test.js
+++ b/api/tests/certification/scoring/unit/domain/models/CapacitySimulator_test.js
@@ -1,0 +1,246 @@
+import { CapacitySimulator } from '../../../../../../src/certification/scoring/domain/models/CapacitySimulator.js';
+import { domainBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Unit | Domain | Models | CapacitySimulator', function () {
+  const certificationScoringIntervals = [
+    { bounds: { max: -2, min: -8 }, meshLevel: 0 }, // Score de 0 à 127
+    { bounds: { max: -0.5, min: -2 }, meshLevel: 1 }, // Score de 128 à 255
+    { bounds: { max: 0.6, min: -0.5 }, meshLevel: 2 }, // score de 256 à 383
+    { bounds: { max: 1.5, min: 0.6 }, meshLevel: 3 }, // score de 384 à 511
+    { bounds: { max: 2.25, min: 1.5 }, meshLevel: 4 }, // score de 512 à 639
+    { bounds: { max: 3.1, min: 2.25 }, meshLevel: 5 }, // score de 640 à 767
+    { bounds: { max: 4, min: 3.1 }, meshLevel: 6 }, // score de 768 à 895
+    { bounds: { max: 8, min: 4 }, meshLevel: 7 }, // score de 896 à 1024
+  ];
+
+  const competencesForScoring = [
+    {
+      intervals: [
+        { bounds: { max: -2, min: -8 }, competenceLevel: 0 },
+        { bounds: { max: -0.5, min: -2 }, competenceLevel: 1 },
+        { bounds: { max: 0.6, min: -0.5 }, competenceLevel: 2 },
+        { bounds: { max: 1.5, min: 0.6 }, competenceLevel: 3 },
+        { bounds: { max: 2.25, min: 1.5 }, competenceLevel: 4 },
+        { bounds: { max: 3.1, min: 2.25 }, competenceLevel: 5 },
+        { bounds: { max: 4, min: 3.1 }, competenceLevel: 6 },
+        { bounds: { max: 8, min: 4 }, competenceLevel: 7 },
+      ],
+      competenceCode: '1.1',
+    },
+    {
+      intervals: [
+        { bounds: { max: -4, min: -8 }, competenceLevel: 0 },
+        { bounds: { max: -3, min: -4 }, competenceLevel: 1 },
+        { bounds: { max: 1, min: -3 }, competenceLevel: 2 },
+        { bounds: { max: 3, min: 1 }, competenceLevel: 3 },
+        { bounds: { max: 4, min: 3 }, competenceLevel: 4 },
+        { bounds: { max: 5, min: 4 }, competenceLevel: 5 },
+        { bounds: { max: 7, min: 5 }, competenceLevel: 6 },
+        { bounds: { max: 8, min: 7 }, competenceLevel: 7 },
+      ],
+      competenceCode: '1.2',
+    },
+    {
+      intervals: [
+        { bounds: { max: -5, min: -8 }, competenceLevel: 0 },
+        { bounds: { max: -2, min: -5 }, competenceLevel: 1 },
+        { bounds: { max: 0, min: -2 }, competenceLevel: 2 },
+        { bounds: { max: 1.5, min: 0 }, competenceLevel: 3 },
+        { bounds: { max: 2.25, min: 1.5 }, competenceLevel: 4 },
+        { bounds: { max: 3, min: 2.25 }, competenceLevel: 5 },
+        { bounds: { max: 6, min: 3 }, competenceLevel: 6 },
+        { bounds: { max: 8, min: 6 }, competenceLevel: 7 },
+      ],
+      competenceCode: '2.1',
+    },
+    {
+      intervals: [
+        { bounds: { max: -7, min: -8 }, competenceLevel: 0 },
+        { bounds: { max: -5, min: -7 }, competenceLevel: 1 },
+        { bounds: { max: -1, min: -5 }, competenceLevel: 2 },
+        { bounds: { max: 1.5, min: -1 }, competenceLevel: 3 },
+        { bounds: { max: 2, min: 1.5 }, competenceLevel: 4 },
+        { bounds: { max: 3.6, min: 2 }, competenceLevel: 5 },
+        { bounds: { max: 6, min: 3.6 }, competenceLevel: 6 },
+        { bounds: { max: 8, min: 8 }, competenceLevel: 7 },
+      ],
+      competenceCode: '2.2',
+    },
+    {
+      intervals: [
+        { bounds: { max: -5.8, min: -8 }, competenceLevel: 0 },
+        { bounds: { max: -2.7, min: -5.8 }, competenceLevel: 1 },
+        { bounds: { max: 0.6, min: -2.7 }, competenceLevel: 2 },
+        { bounds: { max: 1.7, min: 0.6 }, competenceLevel: 3 },
+        { bounds: { max: 3.28, min: 1.7 }, competenceLevel: 4 },
+        { bounds: { max: 5.12, min: 3.28 }, competenceLevel: 5 },
+        { bounds: { max: 6.34, min: 5.12 }, competenceLevel: 6 },
+        { bounds: { max: 8, min: 6.34 }, competenceLevel: 7 },
+      ],
+      competenceCode: '2.3',
+    },
+  ];
+
+  describe('#compute', function () {
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    [
+      {
+        score: 0,
+        expectedCapacity: -8,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 0 },
+          { competenceCode: '1.2', level: 0 },
+          { competenceCode: '2.1', level: 0 },
+          { competenceCode: '2.2', level: 0 },
+          { competenceCode: '2.3', level: 0 },
+        ],
+      },
+      {
+        score: 101,
+        expectedCapacity: -3.265625,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 0 },
+          { competenceCode: '1.2', level: 1 },
+          { competenceCode: '2.1', level: 1 },
+          { competenceCode: '2.2', level: 2 },
+          { competenceCode: '2.3', level: 1 },
+        ],
+      },
+      {
+        score: 107,
+        expectedCapacity: -2.984375,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 0 },
+          { competenceCode: '1.2', level: 2 },
+          { competenceCode: '2.1', level: 1 },
+          { competenceCode: '2.2', level: 2 },
+          { competenceCode: '2.3', level: 1 },
+        ],
+      },
+      {
+        score: 112,
+        expectedCapacity: -2.75,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 0 },
+          { competenceCode: '1.2', level: 2 },
+          { competenceCode: '2.1', level: 1 },
+          { competenceCode: '2.2', level: 2 },
+          { competenceCode: '2.3', level: 1 },
+        ],
+      },
+      {
+        score: 117,
+        expectedCapacity: -2.515625,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 0 },
+          { competenceCode: '1.2', level: 2 },
+          { competenceCode: '2.1', level: 1 },
+          { competenceCode: '2.2', level: 2 },
+          { competenceCode: '2.3', level: 2 },
+        ],
+      },
+      {
+        score: 123,
+        expectedCapacity: -2.234375,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 0 },
+          { competenceCode: '1.2', level: 2 },
+          { competenceCode: '2.1', level: 1 },
+          { competenceCode: '2.2', level: 2 },
+          { competenceCode: '2.3', level: 2 },
+        ],
+      },
+      {
+        score: 128,
+        expectedCapacity: -2,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 1 },
+          { competenceCode: '1.2', level: 2 },
+          { competenceCode: '2.1', level: 2 },
+          { competenceCode: '2.2', level: 2 },
+          { competenceCode: '2.3', level: 2 },
+        ],
+      },
+      {
+        score: 224,
+        expectedCapacity: -0.875,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 1 },
+          { competenceCode: '1.2', level: 2 },
+          { competenceCode: '2.1', level: 2 },
+          { competenceCode: '2.2', level: 3 },
+          { competenceCode: '2.3', level: 2 },
+        ],
+      },
+      {
+        score: 327,
+        expectedCapacity: 0.11015624999999996,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 2 },
+          { competenceCode: '1.2', level: 2 },
+          { competenceCode: '2.1', level: 3 },
+          { competenceCode: '2.2', level: 3 },
+          { competenceCode: '2.3', level: 2 },
+        ],
+      },
+      {
+        score: 453,
+        expectedCapacity: 1.08515625,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 3 },
+          { competenceCode: '1.2', level: 3 },
+          { competenceCode: '2.1', level: 3 },
+          { competenceCode: '2.2', level: 3 },
+          { competenceCode: '2.3', level: 3 },
+        ],
+      },
+      {
+        score: 591,
+        expectedCapacity: 1.962890625,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 4 },
+          { competenceCode: '1.2', level: 3 },
+          { competenceCode: '2.1', level: 4 },
+          { competenceCode: '2.2', level: 4 },
+          { competenceCode: '2.3', level: 4 },
+        ],
+      },
+      {
+        score: 752,
+        expectedCapacity: 2.99375,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 5 },
+          { competenceCode: '1.2', level: 3 },
+          { competenceCode: '2.1', level: 5 },
+          { competenceCode: '2.2', level: 5 },
+          { competenceCode: '2.3', level: 4 },
+        ],
+      },
+      {
+        score: 897,
+        expectedCapacity: 4.03125,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 7 },
+          { competenceCode: '1.2', level: 5 },
+          { competenceCode: '2.1', level: 6 },
+          { competenceCode: '2.2', level: 6 },
+          { competenceCode: '2.3', level: 5 },
+        ],
+      },
+    ].forEach(({ score, expectedCapacity, expectedCompetences }) => {
+      it(`returns the capacity ${expectedCapacity} and ${expectedCompetences} when score is ${score}`, function () {
+        // when
+        const result = CapacitySimulator.compute({ certificationScoringIntervals, competencesForScoring, score });
+
+        // then
+        expect(result).to.deepEqualInstance(
+          domainBuilder.buildScoringAndCapacitySimulatorReport({
+            score: undefined,
+            capacity: expectedCapacity,
+            competences: expectedCompetences,
+          }),
+        );
+      });
+    });
+  });
+});

--- a/api/tests/certification/scoring/unit/domain/models/ScoringSimulator_test.js
+++ b/api/tests/certification/scoring/unit/domain/models/ScoringSimulator_test.js
@@ -236,7 +236,7 @@ describe('Unit | Domain | Models | ScoringSimulator', function () {
         // then
         expect(result).to.deepEqualInstance(
           domainBuilder.buildScoringAndCapacitySimulatorReport({
-            capacity: undefined,
+            capacity,
             score: expectedScore,
             competences: expectedCompetences,
           }),

--- a/api/tests/certification/scoring/unit/domain/models/ScoringSimulator_test.js
+++ b/api/tests/certification/scoring/unit/domain/models/ScoringSimulator_test.js
@@ -1,0 +1,247 @@
+import { ScoringSimulator } from '../../../../../../src/certification/scoring/domain/models/ScoringSimulator.js';
+import { domainBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Unit | Domain | Models | ScoringSimulator', function () {
+  describe('#compute', function () {
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    [
+      {
+        capacity: -8,
+        expectedScore: 0,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 0 },
+          { competenceCode: '1.2', level: 0 },
+          { competenceCode: '2.1', level: 0 },
+          { competenceCode: '2.2', level: 0 },
+          { competenceCode: '2.3', level: 0 },
+        ],
+      },
+      {
+        capacity: -3.25390625,
+        expectedScore: 101,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 0 },
+          { competenceCode: '1.2', level: 1 },
+          { competenceCode: '2.1', level: 1 },
+          { competenceCode: '2.2', level: 2 },
+          { competenceCode: '2.3', level: 1 },
+        ],
+      },
+      {
+        capacity: -2.99609375,
+        expectedScore: 107,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 0 },
+          { competenceCode: '1.2', level: 2 },
+          { competenceCode: '2.1', level: 1 },
+          { competenceCode: '2.2', level: 2 },
+          { competenceCode: '2.3', level: 1 },
+        ],
+      },
+      {
+        capacity: -2.75,
+        expectedScore: 112,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 0 },
+          { competenceCode: '1.2', level: 2 },
+          { competenceCode: '2.1', level: 1 },
+          { competenceCode: '2.2', level: 2 },
+          { competenceCode: '2.3', level: 1 },
+        ],
+      },
+      {
+        capacity: -2.50390625,
+        expectedScore: 117,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 0 },
+          { competenceCode: '1.2', level: 2 },
+          { competenceCode: '2.1', level: 1 },
+          { competenceCode: '2.2', level: 2 },
+          { competenceCode: '2.3', level: 2 },
+        ],
+      },
+      {
+        capacity: -2.24609375,
+        expectedScore: 123,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 0 },
+          { competenceCode: '1.2', level: 2 },
+          { competenceCode: '2.1', level: 1 },
+          { competenceCode: '2.2', level: 2 },
+          { competenceCode: '2.3', level: 2 },
+        ],
+      },
+      {
+        capacity: -2,
+        expectedScore: 128,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 1 },
+          { competenceCode: '1.2', level: 2 },
+          { competenceCode: '2.1', level: 2 },
+          { competenceCode: '2.2', level: 2 },
+          { competenceCode: '2.3', level: 2 },
+        ],
+      },
+      {
+        capacity: -0.8695312500000002,
+        expectedScore: 224,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 1 },
+          { competenceCode: '1.2', level: 2 },
+          { competenceCode: '2.1', level: 2 },
+          { competenceCode: '2.2', level: 3 },
+          { competenceCode: '2.3', level: 2 },
+        ],
+      },
+      {
+        capacity: 0.10781249999999987,
+        expectedScore: 327,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 2 },
+          { competenceCode: '1.2', level: 2 },
+          { competenceCode: '2.1', level: 3 },
+          { competenceCode: '2.2', level: 3 },
+          { competenceCode: '2.3', level: 2 },
+        ],
+      },
+      {
+        capacity: 1.083984375,
+        expectedScore: 453,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 3 },
+          { competenceCode: '1.2', level: 3 },
+          { competenceCode: '2.1', level: 3 },
+          { competenceCode: '2.2', level: 3 },
+          { competenceCode: '2.3', level: 3 },
+        ],
+      },
+      {
+        capacity: 1.964453125,
+        expectedScore: 591,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 4 },
+          { competenceCode: '1.2', level: 3 },
+          { competenceCode: '2.1', level: 4 },
+          { competenceCode: '2.2', level: 4 },
+          { competenceCode: '2.3', level: 4 },
+        ],
+      },
+      {
+        capacity: 2.99453125,
+        expectedScore: 752,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 5 },
+          { competenceCode: '1.2', level: 3 },
+          { competenceCode: '2.1', level: 5 },
+          { competenceCode: '2.2', level: 5 },
+          { competenceCode: '2.3', level: 4 },
+        ],
+      },
+      {
+        capacity: 4.03125,
+        expectedScore: 896,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 7 },
+          { competenceCode: '1.2', level: 5 },
+          { competenceCode: '2.1', level: 6 },
+          { competenceCode: '2.2', level: 6 },
+          { competenceCode: '2.3', level: 5 },
+        ],
+      },
+    ].forEach(({ capacity, expectedScore, expectedCompetences }) => {
+      it(`returns the score ${expectedScore} and competences ${expectedCompetences}  when capacity is ${capacity}`, function () {
+        // given
+        const certificationScoringIntervals = [
+          { bounds: { max: -2, min: -8 }, meshLevel: 0 },
+          { bounds: { max: -0.5, min: -2 }, meshLevel: 1 },
+          { bounds: { max: 0.6, min: -0.5 }, meshLevel: 2 },
+          { bounds: { max: 1.5, min: 0.6 }, meshLevel: 3 },
+          { bounds: { max: 2.25, min: 1.5 }, meshLevel: 4 },
+          { bounds: { max: 3.1, min: 2.25 }, meshLevel: 5 },
+          { bounds: { max: 4, min: 3.1 }, meshLevel: 6 },
+          { bounds: { max: 8, min: 4 }, meshLevel: 7 },
+        ];
+
+        const competencesForScoring = [
+          {
+            intervals: [
+              { bounds: { max: -2, min: -8 }, competenceLevel: 0 },
+              { bounds: { max: -0.5, min: -2 }, competenceLevel: 1 },
+              { bounds: { max: 0.6, min: -0.5 }, competenceLevel: 2 },
+              { bounds: { max: 1.5, min: 0.6 }, competenceLevel: 3 },
+              { bounds: { max: 2.25, min: 1.5 }, competenceLevel: 4 },
+              { bounds: { max: 3.1, min: 2.25 }, competenceLevel: 5 },
+              { bounds: { max: 4, min: 3.1 }, competenceLevel: 6 },
+              { bounds: { max: 8, min: 4 }, competenceLevel: 7 },
+            ],
+            competenceCode: '1.1',
+          },
+          {
+            intervals: [
+              { bounds: { max: -4, min: -8 }, competenceLevel: 0 },
+              { bounds: { max: -3, min: -4 }, competenceLevel: 1 },
+              { bounds: { max: 1, min: -3 }, competenceLevel: 2 },
+              { bounds: { max: 3, min: 1 }, competenceLevel: 3 },
+              { bounds: { max: 4, min: 3 }, competenceLevel: 4 },
+              { bounds: { max: 5, min: 4 }, competenceLevel: 5 },
+              { bounds: { max: 7, min: 5 }, competenceLevel: 6 },
+              { bounds: { max: 8, min: 7 }, competenceLevel: 7 },
+            ],
+            competenceCode: '1.2',
+          },
+          {
+            intervals: [
+              { bounds: { max: -5, min: -8 }, competenceLevel: 0 },
+              { bounds: { max: -2, min: -5 }, competenceLevel: 1 },
+              { bounds: { max: 0, min: -2 }, competenceLevel: 2 },
+              { bounds: { max: 1.5, min: 0 }, competenceLevel: 3 },
+              { bounds: { max: 2.25, min: 1.5 }, competenceLevel: 4 },
+              { bounds: { max: 3, min: 2.25 }, competenceLevel: 5 },
+              { bounds: { max: 6, min: 3 }, competenceLevel: 6 },
+              { bounds: { max: 8, min: 6 }, competenceLevel: 7 },
+            ],
+            competenceCode: '2.1',
+          },
+          {
+            intervals: [
+              { bounds: { max: -7, min: -8 }, competenceLevel: 0 },
+              { bounds: { max: -5, min: -7 }, competenceLevel: 1 },
+              { bounds: { max: -1, min: -5 }, competenceLevel: 2 },
+              { bounds: { max: 1.5, min: -1 }, competenceLevel: 3 },
+              { bounds: { max: 2, min: 1.5 }, competenceLevel: 4 },
+              { bounds: { max: 3.6, min: 2 }, competenceLevel: 5 },
+              { bounds: { max: 6, min: 3.6 }, competenceLevel: 6 },
+              { bounds: { max: 8, min: 6 }, competenceLevel: 7 },
+            ],
+            competenceCode: '2.2',
+          },
+          {
+            intervals: [
+              { bounds: { max: -5.8, min: -8 }, competenceLevel: 0 },
+              { bounds: { max: -2.7, min: -5.8 }, competenceLevel: 1 },
+              { bounds: { max: 0.6, min: -2.7 }, competenceLevel: 2 },
+              { bounds: { max: 1.7, min: 0.6 }, competenceLevel: 3 },
+              { bounds: { max: 3.28, min: 1.7 }, competenceLevel: 4 },
+              { bounds: { max: 5.12, min: 3.28 }, competenceLevel: 5 },
+              { bounds: { max: 6.34, min: 5.12 }, competenceLevel: 6 },
+              { bounds: { max: 8, min: 6.34 }, competenceLevel: 7 },
+            ],
+            competenceCode: '2.3',
+          },
+        ];
+
+        // when
+        const result = ScoringSimulator.compute({ capacity, certificationScoringIntervals, competencesForScoring });
+
+        // then
+        expect(result).to.deepEqualInstance(
+          domainBuilder.buildScoringAndCapacitySimulatorReport({
+            capacity: undefined,
+            score: expectedScore,
+            competences: expectedCompetences,
+          }),
+        );
+      });
+    });
+  });
+});

--- a/api/tests/certification/scoring/unit/domain/usecases/simulate-capacity-from-score_test.js
+++ b/api/tests/certification/scoring/unit/domain/usecases/simulate-capacity-from-score_test.js
@@ -1,0 +1,67 @@
+import { simulateCapacityFromScore } from '../../../../../../src/certification/scoring/domain/usecases/simulate-capacity-from-score.js';
+import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | UseCase | simulate-capacity-from-score', function () {
+  let scoringConfigurationRepository;
+
+  beforeEach(function () {
+    scoringConfigurationRepository = {
+      getLatestByDateAndLocale: sinon.stub(),
+    };
+  });
+
+  it('should return a capacity', async function () {
+    // given
+    const date = new Date();
+
+    const v3CertificationScoring = domainBuilder.buildV3CertificationScoring({
+      competencesForScoring: [
+        domainBuilder.buildCompetenceForScoring({
+          competenceId: 'recCompetenceId',
+          areaCode: '1',
+          competenceCode: '1.1',
+          intervals: [
+            {
+              bounds: {
+                max: 4,
+                min: -4,
+              },
+              competenceLevel: 0,
+            },
+          ],
+        }),
+      ],
+      certificationScoringConfiguration: [
+        {
+          bounds: { max: 4, min: -4 },
+          meshLevel: 0,
+        },
+      ],
+    });
+
+    scoringConfigurationRepository.getLatestByDateAndLocale
+      .withArgs({ date, locale: 'fr-fr' })
+      .resolves(v3CertificationScoring);
+
+    // when
+    const result = await simulateCapacityFromScore({
+      score: 768,
+      date,
+      scoringConfigurationRepository,
+    });
+
+    // then
+    expect(result).to.deepEqualInstance(
+      domainBuilder.buildScoringAndCapacitySimulatorReport({
+        capacity: 2,
+        score: undefined,
+        competences: [
+          {
+            level: 0,
+            competenceCode: '1.1',
+          },
+        ],
+      }),
+    );
+  });
+});

--- a/api/tests/certification/scoring/unit/domain/usecases/simulate-capacity-from-score_test.js
+++ b/api/tests/certification/scoring/unit/domain/usecases/simulate-capacity-from-score_test.js
@@ -13,6 +13,7 @@ describe('Unit | UseCase | simulate-capacity-from-score', function () {
   it('should return a capacity', async function () {
     // given
     const date = new Date();
+    const score = 768;
 
     const v3CertificationScoring = domainBuilder.buildV3CertificationScoring({
       competencesForScoring: [
@@ -45,7 +46,7 @@ describe('Unit | UseCase | simulate-capacity-from-score', function () {
 
     // when
     const result = await simulateCapacityFromScore({
-      score: 768,
+      score,
       date,
       scoringConfigurationRepository,
     });
@@ -54,7 +55,7 @@ describe('Unit | UseCase | simulate-capacity-from-score', function () {
     expect(result).to.deepEqualInstance(
       domainBuilder.buildScoringAndCapacitySimulatorReport({
         capacity: 2,
-        score: undefined,
+        score,
         competences: [
           {
             level: 0,

--- a/api/tests/certification/scoring/unit/domain/usecases/simulate-score-from-capacity_test.js
+++ b/api/tests/certification/scoring/unit/domain/usecases/simulate-score-from-capacity_test.js
@@ -1,0 +1,67 @@
+import { simulateScoreFromCapacity } from '../../../../../../src/certification/scoring/domain/usecases/simulate-score-from-capacity.js';
+import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | UseCase | simulate-score-from-capacity', function () {
+  let scoringConfigurationRepository;
+
+  beforeEach(function () {
+    scoringConfigurationRepository = {
+      getLatestByDateAndLocale: sinon.stub(),
+    };
+  });
+
+  it('should return a score', async function () {
+    // given
+    const date = new Date();
+
+    const v3CertificationScoring = domainBuilder.buildV3CertificationScoring({
+      competencesForScoring: [
+        domainBuilder.buildCompetenceForScoring({
+          competenceId: 'recCompetenceId',
+          areaCode: '1',
+          competenceCode: '1.1',
+          intervals: [
+            {
+              bounds: {
+                max: 4,
+                min: -4,
+              },
+              competenceLevel: 0,
+            },
+          ],
+        }),
+      ],
+      certificationScoringConfiguration: [
+        {
+          bounds: { max: 4, min: -4 },
+          meshLevel: 0,
+        },
+      ],
+    });
+
+    scoringConfigurationRepository.getLatestByDateAndLocale
+      .withArgs({ date, locale: 'fr-fr' })
+      .resolves(v3CertificationScoring);
+
+    // when
+    const result = await simulateScoreFromCapacity({
+      capacity: 2,
+      date,
+      scoringConfigurationRepository,
+    });
+
+    // then
+    expect(result).to.deepEqualInstance(
+      domainBuilder.buildScoringAndCapacitySimulatorReport({
+        capacity: undefined,
+        score: 768,
+        competences: [
+          {
+            level: 0,
+            competenceCode: '1.1',
+          },
+        ],
+      }),
+    );
+  });
+});

--- a/api/tests/certification/scoring/unit/domain/usecases/simulate-score-from-capacity_test.js
+++ b/api/tests/certification/scoring/unit/domain/usecases/simulate-score-from-capacity_test.js
@@ -13,6 +13,7 @@ describe('Unit | UseCase | simulate-score-from-capacity', function () {
   it('should return a score', async function () {
     // given
     const date = new Date();
+    const capacity = 2;
 
     const v3CertificationScoring = domainBuilder.buildV3CertificationScoring({
       competencesForScoring: [
@@ -45,7 +46,7 @@ describe('Unit | UseCase | simulate-score-from-capacity', function () {
 
     // when
     const result = await simulateScoreFromCapacity({
-      capacity: 2,
+      capacity,
       date,
       scoringConfigurationRepository,
     });
@@ -53,7 +54,7 @@ describe('Unit | UseCase | simulate-score-from-capacity', function () {
     // then
     expect(result).to.deepEqualInstance(
       domainBuilder.buildScoringAndCapacitySimulatorReport({
-        capacity: undefined,
+        capacity,
         score: 768,
         competences: [
           {

--- a/api/tests/certification/scoring/unit/infrastructure/serializers/jsonapi/scoring-and-capacity-simulator-report-serializer_test.js
+++ b/api/tests/certification/scoring/unit/infrastructure/serializers/jsonapi/scoring-and-capacity-simulator-report-serializer_test.js
@@ -1,0 +1,32 @@
+import * as serializer from '../../../../../../../src/certification/scoring/infrastructure/serializers/jsonapi/scoring-and-capacity-simulator-report-serializer.js';
+import { domainBuilder, expect } from '../../../../../../test-helper.js';
+
+describe('Unit | Serializer | JSONAPI | scoring-and-capacity-simulator-report', function () {
+  describe('#serialize', function () {
+    it('should convert a ScoringAndCapacitySimulatorReport model object into JSON API data', function () {
+      // given
+      const scoringAndCapacitySimulatorReport = domainBuilder.buildScoringAndCapacitySimulatorReport({
+        score: 128,
+        capacity: undefined,
+        competences: [{ competenceCode: '1.1', level: 7 }],
+      });
+
+      const expectedSerializedScoringAndCapacitySimulatorReport = {
+        data: {
+          attributes: {
+            score: 128,
+            capacity: undefined,
+            competences: [{ competenceCode: '1.1', level: 7 }],
+          },
+          type: 'scoring-and-capacity-simulator-reports',
+        },
+      };
+
+      // when
+      const json = serializer.serialize(scoringAndCapacitySimulatorReport);
+
+      // then
+      expect(json).to.deep.equal(expectedSerializedScoringAndCapacitySimulatorReport);
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-scoring-and-capacity-simulator-report.js
+++ b/api/tests/tooling/domain-builder/factory/build-scoring-and-capacity-simulator-report.js
@@ -1,0 +1,18 @@
+import { ScoringAndCapacitySimulatorReport } from '../../../../src/certification/scoring/domain/models/ScoringAndCapacitySimulatorReport.js';
+
+function buildScoringAndCapacitySimulatorReport({
+  capacity,
+  score,
+  competences = [
+    { competenceCode: '1.1', level: 1 },
+    { competenceCode: '1.2', level: 2 },
+  ],
+} = {}) {
+  return new ScoringAndCapacitySimulatorReport({
+    capacity,
+    score,
+    competences,
+  });
+}
+
+export { buildScoringAndCapacitySimulatorReport };

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -1,3 +1,4 @@
+import { buildScoringAndCapacitySimulatorReport } from './/build-scoring-and-capacity-simulator-report.js';
 import { buildAccountRecoveryDemand } from './build-account-recovery-demand.js';
 import { buildActivity } from './build-activity.js';
 import { buildActivityAnswer } from './build-activity-answer.js';
@@ -342,6 +343,7 @@ export {
   buildResultCompetenceTree,
   buildSchoolAssessment,
   buildSCOCertificationCandidate,
+  buildScoringAndCapacitySimulatorReport,
   buildSession,
   buildSessionForAttendanceSheet,
   buildSessionForInvigilatorKit,


### PR DESCRIPTION
## :unicorn: Problème
Le scoring certif v3 permet actuellement, à partir d’une capacité, de définir le score global en Pix et les niveaux par compétence d’un candidat en certification. Pour des besoins d’analyse, d’aide à la décision sur différents sujets produit, nous aurions besoin de voir concrètement les différents profils possible pour un candidat à une certif v3, et donc de savoir quel score global en Pix donne quelle capacité et quel niveau pour chacune des 16 compétences.

## :robot: Proposition
- Permettre le calcul, à partir d’un score global en Pix donné, d’avoir la capacité et les niveaux par compétence correspondants

- Permettre le calcul, à partir d’une capacité donnée, d’avoir le score global en Pix et les niveaux par compétence correspondants


## :100: Pour tester
Pour tester à partir d'un score:

```
TOKEN=$(curl 'https://api-pr8651.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr8651.review.pix.fr/api/admin/simulate-score-or-capacity \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "data": { "score": 128 }}' | jq '.'
```

constater le resultat suivant:

![image](https://github.com/1024pix/pix/assets/37305474/bef362e9-c27b-4ac7-ad40-2008c9f2c493)


---------------------------------------------------------------------------------------------------------------------------------------------------------------------------


Pour tester à partir d'une capacité:

```
TOKEN=$(curl 'https://api-pr8651.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin@example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr8651.review.pix.fr/api/admin/simulate-score-or-capacity \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d '{ "data": { "capacity": 4 }}' | jq '.'
```

constater le resulta suivant: 

![image](https://github.com/1024pix/pix/assets/37305474/3e9cc38f-f7e8-4b6f-abd5-66ec3efe0a08)
