### PR TITLE
[BUGFIX][API] (PIX-12118)

### DIFF
--- a/api/lib/application/authentication/oidc/oidc-controller.js
+++ b/api/lib/application/authentication/oidc/oidc-controller.js
@@ -25,6 +25,7 @@ const getRedirectLogoutUrl = async function (
   const userId = request.auth.credentials.userId;
   const { identity_provider: identityProvider, logout_url_uuid: logoutUrlUUID } = request.query;
 
+  dependencies.oidcAuthenticationServiceRegistry.loadOidcProviderServices();
   await dependencies.oidcAuthenticationServiceRegistry.configureReadyOidcProviderServiceByCode(identityProvider);
 
   const oidcAuthenticationService = dependencies.oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({
@@ -65,7 +66,10 @@ const reconcileUser = async function (
   },
 ) {
   const { identityProvider, authenticationKey } = request.deserializedPayload;
+
+  dependencies.oidcAuthenticationServiceRegistry.loadOidcProviderServices();
   await dependencies.oidcAuthenticationServiceRegistry.configureReadyOidcProviderServiceByCode(identityProvider);
+
   const oidcAuthenticationService = dependencies.oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({
     identityProviderCode: identityProvider,
   });
@@ -86,7 +90,10 @@ const getAuthorizationUrl = async function (
   },
 ) {
   const { identity_provider: identityProvider, audience } = request.query;
+
+  dependencies.oidcAuthenticationServiceRegistry.loadOidcProviderServices();
   await dependencies.oidcAuthenticationServiceRegistry.configureReadyOidcProviderServiceByCode(identityProvider);
+
   const oidcAuthenticationService = dependencies.oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({
     identityProviderCode: identityProvider,
     audience,
@@ -117,7 +124,9 @@ const authenticateUser = async function (
     throw new BadRequestError('Required cookie "state" is missing');
   }
 
+  dependencies.oidcAuthenticationServiceRegistry.loadOidcProviderServices();
   await dependencies.oidcAuthenticationServiceRegistry.configureReadyOidcProviderServiceByCode(identityProvider);
+
   const oidcAuthenticationService = dependencies.oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({
     identityProviderCode: identityProvider,
     audience,
@@ -155,7 +164,9 @@ const createUser = async function (
   const { identityProvider, authenticationKey } = request.deserializedPayload;
   const localeFromCookie = request.state?.locale;
 
+  dependencies.oidcAuthenticationServiceRegistry.loadOidcProviderServices();
   await dependencies.oidcAuthenticationServiceRegistry.configureReadyOidcProviderServiceByCode(identityProvider);
+
   const oidcAuthenticationService = dependencies.oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({
     identityProviderCode: identityProvider,
   });
@@ -179,7 +190,9 @@ const reconcileUserForAdmin = async function (
 ) {
   const { email, identityProvider, authenticationKey } = request.deserializedPayload;
 
+  dependencies.oidcAuthenticationServiceRegistry.loadOidcProviderServices();
   await dependencies.oidcAuthenticationServiceRegistry.configureReadyOidcProviderServiceByCode(identityProvider);
+
   const oidcAuthenticationService = dependencies.oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({
     identityProviderCode: identityProvider,
     audience: PIX_ADMIN.AUDIENCE,

--- a/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
+++ b/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
@@ -10,6 +10,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
 
   beforeEach(function () {
     oidcAuthenticationServiceRegistryStub = {
+      loadOidcProviderServices: sinon.stub(),
       configureReadyOidcProviderServiceByCode: sinon.stub().resolves(),
       getOidcProviderServiceByCode: sinon.stub(),
     };
@@ -127,6 +128,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       await oidcController.getRedirectLogoutUrl(request, hFake, dependencies);
 
       // then
+      expect(oidcAuthenticationServiceRegistryStub.loadOidcProviderServices).to.have.been.calledOnce;
       expect(
         oidcAuthenticationServiceRegistryStub.configureReadyOidcProviderServiceByCode,
       ).to.have.been.calledWithExactly(identityProvider);
@@ -161,6 +163,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       await oidcController.getAuthorizationUrl(request, hFake, dependencies);
 
       //then
+      expect(oidcAuthenticationServiceRegistryStub.loadOidcProviderServices).to.have.been.calledOnce;
       expect(
         oidcAuthenticationServiceRegistryStub.configureReadyOidcProviderServiceByCode,
       ).to.have.been.calledWithExactly(identityProvider);
@@ -192,6 +195,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
         await oidcController.getAuthorizationUrl(request, hFake, dependencies);
 
         // then
+        expect(oidcAuthenticationServiceRegistryStub.loadOidcProviderServices).to.have.been.calledOnce;
         expect(
           oidcAuthenticationServiceRegistryStub.configureReadyOidcProviderServiceByCode,
         ).to.have.been.calledWithExactly(identityProvider);
@@ -254,6 +258,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       await oidcController.authenticateUser(request, hFake, dependencies);
 
       // then
+      expect(oidcAuthenticationServiceRegistryStub.loadOidcProviderServices).to.have.been.calledOnce;
       expect(
         oidcAuthenticationServiceRegistryStub.configureReadyOidcProviderServiceByCode,
       ).to.have.been.calledWithExactly(identityProvider);
@@ -302,6 +307,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
         await oidcController.authenticateUser(request, hFake, dependencies);
 
         // then
+        expect(oidcAuthenticationServiceRegistryStub.loadOidcProviderServices).to.have.been.calledOnce;
         expect(
           oidcAuthenticationServiceRegistryStub.configureReadyOidcProviderServiceByCode,
         ).to.have.been.calledWithExactly(identityProvider);
@@ -349,6 +355,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
         const response = await oidcController.authenticateUser(request, hFake, dependencies);
 
         // then
+        expect(oidcAuthenticationServiceRegistryStub.loadOidcProviderServices).to.have.been.calledOnce;
         expect(
           oidcAuthenticationServiceRegistryStub.configureReadyOidcProviderServiceByCode,
         ).to.have.been.calledWithExactly(identityProvider);
@@ -382,6 +389,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
         const error = await catchErr(oidcController.authenticateUser)(request, hFake, dependencies);
 
         // then
+        expect(oidcAuthenticationServiceRegistryStub.loadOidcProviderServices).to.have.been.calledOnce;
         expect(
           oidcAuthenticationServiceRegistryStub.configureReadyOidcProviderServiceByCode,
         ).to.have.been.calledWithExactly(identityProvider);
@@ -426,6 +434,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       const result = await oidcController.createUser(request, hFake, dependencies);
 
       //then
+      expect(oidcAuthenticationServiceRegistryStub.loadOidcProviderServices).to.have.been.calledOnce;
       expect(
         oidcAuthenticationServiceRegistryStub.configureReadyOidcProviderServiceByCode,
       ).to.have.been.calledWithExactly(identityProvider);
@@ -505,6 +514,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       const result = await oidcController.reconcileUser(request, hFake, dependencies);
 
       // then
+      expect(oidcAuthenticationServiceRegistryStub.loadOidcProviderServices).to.have.been.calledOnce;
       expect(
         oidcAuthenticationServiceRegistryStub.configureReadyOidcProviderServiceByCode,
       ).to.have.been.calledWithExactly(identityProvider);
@@ -532,6 +542,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       const result = await oidcController.reconcileUserForAdmin(request, hFake, dependencies);
 
       // then
+      expect(oidcAuthenticationServiceRegistryStub.loadOidcProviderServices).to.have.been.calledOnce;
       expect(
         oidcAuthenticationServiceRegistryStub.configureReadyOidcProviderServiceByCode,
       ).to.have.been.calledWithExactly(identityProvider);

--- a/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
+++ b/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
@@ -6,6 +6,14 @@ import { catchErr, domainBuilder, expect, hFake, sinon } from '../../../../test-
 
 describe('Unit | Application | Controller | Authentication | OIDC', function () {
   const identityProvider = 'OIDC';
+  let oidcAuthenticationServiceRegistryStub;
+
+  beforeEach(function () {
+    oidcAuthenticationServiceRegistryStub = {
+      configureReadyOidcProviderServiceByCode: sinon.stub().resolves(),
+      getOidcProviderServiceByCode: sinon.stub(),
+    };
+  });
 
   describe('#getAllIdentityProvidersForAdmin', function () {
     it('returns the list of oidc identity providers', async function () {
@@ -107,11 +115,6 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
         getRedirectLogoutUrl: sinon.stub(),
       };
 
-      const oidcAuthenticationServiceRegistryStub = {
-        configureReadyOidcProviderServiceByCode: sinon.stub().resolves(),
-        getOidcProviderServiceByCode: sinon.stub(),
-      };
-
       oidcAuthenticationServiceRegistryStub.getOidcProviderServiceByCode
         .withArgs({ identityProviderCode: identityProvider })
         .returns(oidcAuthenticationService);
@@ -143,10 +146,6 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       };
       const oidcAuthenticationService = {
         getAuthorizationUrl: sinon.stub(),
-      };
-      const oidcAuthenticationServiceRegistryStub = {
-        configureReadyOidcProviderServiceByCode: sinon.stub().resolves(),
-        getOidcProviderServiceByCode: sinon.stub(),
       };
 
       oidcAuthenticationServiceRegistryStub.getOidcProviderServiceByCode
@@ -184,10 +183,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
         const oidcAuthenticationService = {
           getAuthorizationUrl: sinon.stub().returns('an authentication url'),
         };
-        const oidcAuthenticationServiceRegistryStub = {
-          configureReadyOidcProviderServiceByCode: sinon.stub().resolves(),
-          getOidcProviderServiceByCode: sinon.stub().returns(oidcAuthenticationService),
-        };
+        oidcAuthenticationServiceRegistryStub.getOidcProviderServiceByCode.returns(oidcAuthenticationService);
         const dependencies = {
           oidcAuthenticationServiceRegistry: oidcAuthenticationServiceRegistryStub,
         };
@@ -236,10 +232,6 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
     it('authenticates the user with payload parameters', async function () {
       // given
       const oidcAuthenticationService = {};
-      const oidcAuthenticationServiceRegistryStub = {
-        configureReadyOidcProviderServiceByCode: sinon.stub().resolves(),
-        getOidcProviderServiceByCode: sinon.stub(),
-      };
 
       oidcAuthenticationServiceRegistryStub.getOidcProviderServiceByCode
         .withArgs({ identityProviderCode: identityProvider, audience: undefined })
@@ -288,10 +280,6 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
           },
         };
         const oidcAuthenticationService = {};
-        const oidcAuthenticationServiceRegistryStub = {
-          configureReadyOidcProviderServiceByCode: sinon.stub().resolves(),
-          getOidcProviderServiceByCode: sinon.stub(),
-        };
 
         oidcAuthenticationServiceRegistryStub.getOidcProviderServiceByCode
           .withArgs({ identityProviderCode: identityProvider })
@@ -343,10 +331,6 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       it('returns PIX access token and logout url uuid', async function () {
         // given
         const oidcAuthenticationService = {};
-        const oidcAuthenticationServiceRegistryStub = {
-          configureReadyOidcProviderServiceByCode: sinon.stub().resolves(),
-          getOidcProviderServiceByCode: sinon.stub(),
-        };
 
         oidcAuthenticationServiceRegistryStub.getOidcProviderServiceByCode
           .withArgs({ identityProviderCode: identityProvider })
@@ -380,10 +364,6 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       it('returns UnauthorizedError', async function () {
         // given
         const oidcAuthenticationService = {};
-        const oidcAuthenticationServiceRegistryStub = {
-          configureReadyOidcProviderServiceByCode: sinon.stub().resolves(),
-          getOidcProviderServiceByCode: sinon.stub(),
-        };
 
         oidcAuthenticationServiceRegistryStub.getOidcProviderServiceByCode
           .withArgs({ identityProviderCode: identityProvider })
@@ -424,10 +404,6 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       };
       const accessToken = 'access.token';
       const oidcAuthenticationService = {};
-      const oidcAuthenticationServiceRegistryStub = {
-        configureReadyOidcProviderServiceByCode: sinon.stub().resolves(),
-        getOidcProviderServiceByCode: sinon.stub(),
-      };
 
       oidcAuthenticationServiceRegistryStub.getOidcProviderServiceByCode
         .withArgs({ identityProviderCode: identityProvider })
@@ -516,10 +492,6 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
           authenticationKey: '123abc',
         },
       };
-      const oidcAuthenticationServiceRegistryStub = {
-        configureReadyOidcProviderServiceByCode: sinon.stub().resolves(),
-        getOidcProviderServiceByCode: sinon.stub(),
-      };
 
       const dependencies = {
         oidcAuthenticationServiceRegistry: oidcAuthenticationServiceRegistryStub,
@@ -549,10 +521,6 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
           authenticationKey: '123abc',
           email: 'user@example.net',
         },
-      };
-      const oidcAuthenticationServiceRegistryStub = {
-        configureReadyOidcProviderServiceByCode: sinon.stub().resolves(),
-        getOidcProviderServiceByCode: sinon.stub(),
       };
 
       const dependencies = {


### PR DESCRIPTION
## :unicorn: Problème

Les oidc authentication services ne sont pas chargés à la demande pour certaines routes.

## :robot: Proposition

Pour toutes les routes concernées, charger tous les services OIDC avant configuration de l'instance OpenID Client.
Toutes les routes concernées sont les routes de `oidc-controller` sauf la route qui fait appel à `findUserForReconciliation` parce qu'elle ne fait pas appel à un oidc authentication service, ni les routes `getAllIdentityProvidersForAdmin` et `getIdentityProviders` car elles utilise le registry dans leurs usecases.

## :rainbow: Remarques

RAS

## :100: Pour tester

Test à faire en local

1. Se connecter via un SSO
2. Stopper et relancer son API
3. Rafraichir la page
4. Se déconnecter
5. Constater que la déconnexion se passe comme prévu de ce SSO
