### PR TITLE
[FEATURE] Proposer l'enquête Sco dans le bandeau du dashboard (PIX-12068).

### DIFF
--- a/mon-pix/app/components/dashboard/banner.hbs
+++ b/mon-pix/app/components/dashboard/banner.hbs
@@ -1,4 +1,15 @@
-{{#if @show}}
+{{#if @isScoUser}}
+  <section class="dashboard-banner">
+    <NewInformation
+      @information="<h2>Donne ton avis sur Pix&nbsp;!</h2><p>Aide-nous en répondant à ce court questionnaire. Promis, c’est moins de 1 minute&nbsp;!</p>"
+      @image="/images/illustrations/discovery_TDB_pix.svg"
+      @backgroundColorClass="new-information--blue-gradient-background"
+      @textColorClass="new-information--white-text"
+      @linkText="Accéder au questionnaire"
+      @linkTo="{{this.scoSurveyLink}}"
+    />
+  </section>
+{{else if @show}}
   <section class="dashboard-banner">
     {{#unless @hasSeenNewDashboardInfo}}
       <NewInformation

--- a/mon-pix/app/components/dashboard/banner.hbs
+++ b/mon-pix/app/components/dashboard/banner.hbs
@@ -1,4 +1,5 @@
 {{#if @isScoUser}}
+  {{! this banner is temperary and will be deleted before september 2024 }}
   <section class="dashboard-banner">
     <NewInformation
       @information="<h2>Donne ton avis sur Pix&nbsp;!</h2><p>Aide-nous en répondant à ce court questionnaire. Promis, c’est moins de 1 minute&nbsp;!</p>"
@@ -8,6 +9,18 @@
       @linkText="Accéder au questionnaire"
       @linkTo="{{this.scoSurveyLink}}"
     />
+    {{#if @code}}
+      <NewInformation
+        @information="{{t 'pages.dashboard.campaigns.resume.text'}}"
+        @image="/images/profile_collect_TDB_pix.svg"
+        @backgroundColorClass="new-information--yellow-gradient-background"
+        @textColorClass="new-information--black-text"
+        @linkDisplayType="button"
+        @linkText="{{t 'pages.dashboard.campaigns.resume.action'}}"
+        @linkTo="campaigns.profiles-collection.start-or-resume"
+        @code={{@code}}
+      />
+    {{/if}}
   </section>
 {{else if @show}}
   <section class="dashboard-banner">

--- a/mon-pix/app/components/dashboard/banner.js
+++ b/mon-pix/app/components/dashboard/banner.js
@@ -1,0 +1,8 @@
+import Component from '@glimmer/component';
+import ENV from 'mon-pix/config/environment';
+
+export default class Banner extends Component {
+  get scoSurveyLink() {
+    return ENV.APP.SCO_SURVEY_LINK;
+  }
+}

--- a/mon-pix/app/components/dashboard/content.hbs
+++ b/mon-pix/app/components/dashboard/content.hbs
@@ -9,6 +9,7 @@
     @closeInformationAboutNewDashboard={{this.closeInformationAboutNewDashboard}}
     @userFirstname={{this.userFirstname}}
     @code={{this.codeForLastProfileToShare}}
+    @isScoUser={{this.isScoUser}}
   />
 
   <section class="dashboard-content__score">
@@ -33,6 +34,7 @@
       @closeInformationAboutNewDashboard={{this.closeInformationAboutNewDashboard}}
       @userFirstname={{this.userFirstname}}
       @code={{this.codeForLastProfileToShare}}
+      @isScoUser={{this.isScoUser}}
     />
 
     {{#if this.hasNothingToShow}}

--- a/mon-pix/app/components/dashboard/content.js
+++ b/mon-pix/app/components/dashboard/content.js
@@ -92,4 +92,8 @@ export default class Content extends Component {
       url: this.currentDomain.isFranceDomain ? this.intl.t('pages.dashboard.presentation.link.url') : null,
     };
   }
+
+  get isScoUser() {
+    return this.currentUser.user.isSco && this.currentDomain.isFranceDomain;
+  }
 }

--- a/mon-pix/app/models/user.js
+++ b/mon-pix/app/models/user.js
@@ -34,4 +34,8 @@ export default class User extends Model {
   get fullName() {
     return `${this.firstName} ${this.lastName}`;
   }
+
+  get isSco() {
+    return !this.cgu && !this.isAnonymous;
+  }
 }

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -59,6 +59,7 @@ module.exports = function (environment) {
       }),
       BANNER_CONTENT: process.env.BANNER_CONTENT || '',
       BANNER_TYPE: process.env.BANNER_TYPE || '',
+      SCO_SURVEY_LINK: process.env.SCO_SURVEY_LINK || '',
       IS_PROD_ENVIRONMENT: (process.env.REVIEW_APP === 'false' && environment === 'production') || false,
       EMBED_ALLOWED_ORIGINS: (
         process.env.EMBED_ALLOWED_ORIGINS || 'https://epreuves.pix.fr,https://1024pix.github.io'

--- a/mon-pix/tests/integration/components/dashboard/content_test.js
+++ b/mon-pix/tests/integration/components/dashboard/content_test.js
@@ -378,10 +378,12 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
             pixScore,
           }),
           hasSeenNewDashboardInfo: false,
+          cgu: true,
         });
       }
 
       this.owner.register('service:currentUser', CurrentUserStub);
+
       this.set('model', {
         campaignParticipationOverviews: [],
         campaignParticipations: [],
@@ -442,6 +444,7 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
             pixScore,
           }),
           hasSeenNewDashboardInfo: false,
+          cgu: true,
         });
       }
 
@@ -497,6 +500,51 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
       assert
         .dom(screen.queryByRole('link', { name: this.intl.t('pages.dashboard.presentation.link.text') }))
         .doesNotExist();
+    });
+
+    test('should display survey link banner if user is SCO and domain is pix.fr', async function (assert) {
+      // given
+      class CurrentDomainServiceStub extends Service {
+        get isFranceDomain() {
+          return true;
+        }
+      }
+      class CurrentUserStub extends Service {
+        user = store.createRecord('user', {
+          firstName: 'Banana',
+          lastName: 'Split',
+          email: 'banana.split@example.net',
+          profile: store.createRecord('profile', {
+            pixScore,
+          }),
+          hasSeenNewDashboardInfo: false,
+          cgu: false,
+          isAnonymous: false,
+        });
+      }
+
+      this.owner.register('service:currentUser', CurrentUserStub);
+      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+
+      this.set('model', {
+        campaignParticipationOverviews: [],
+        campaignParticipations: [],
+        scorecards: [],
+      });
+
+      // when
+      const screen = await render(hbs`<Dashboard::Content @model={{this.model}}/>`);
+
+      // then
+      assert
+        .dom(
+          screen.getByRole('heading', {
+            name: /Donne ton avis sur Pix/,
+            exact: false,
+          }),
+        )
+        .exists();
+      assert.dom(screen.queryByRole('link', { name: 'Accéder au questionnaire' })).exists();
     });
   });
 
@@ -612,6 +660,7 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
           }),
           hasSeenNewDashboardInfo: false,
           codeForLastProfileToShare: 'SNAP1234',
+          cgu: true,
         });
       }
 

--- a/mon-pix/tests/unit/models/user_test.js
+++ b/mon-pix/tests/unit/models/user_test.js
@@ -29,4 +29,30 @@ module('Unit | Model | user model', function (hooks) {
       assert.strictEqual(fullName, 'Manu Phillip');
     });
   });
+
+  module('#isSco', function () {
+    module('when user has not seen CGU and is not anonymous', function () {
+      test('should return true', function (assert) {
+        // given
+        const user = store.createRecord('user');
+        user.cgu = false;
+        user.isAnonymous = false;
+
+        // then
+        assert.true(user.isSco);
+      });
+    });
+
+    module('when user has seen CGU or is anonymous', function () {
+      test('should return false', function (assert) {
+        // given
+        const user = store.createRecord('user');
+        user.cgu = true;
+        user.isAnonymous = true;
+
+        // then
+        assert.false(user.isSco);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème

Une enquête va être lancée pour le public SCO

## :robot: Proposition

Proposer l'enquête Sco dans le bandeau du dashboard

## :rainbow: Remarques

L'URL de la bannière est remplie via une nouvelle var d'env

## :100: Pour tester

- ✅ Voir le bandeau en RA avec l'utilisateur `eval-sco@example.net`
- 🙈 Avec un autre utilisateur, ce nouveau bandeau ne devrait pas être présent