### PR TITLE
[BUGFIX] Réparer les largeurs des champs du formulaire de création de compte sur Pix Certif (PIX-12144).

### DIFF
--- a/certif/app/components/auth/register-form.hbs
+++ b/certif/app/components/auth/register-form.hbs
@@ -54,13 +54,7 @@
     <:label>{{t "common.forms.login.password"}}</:label>
   </PixInputPassword>
 
-  <PixCheckbox
-    @size="small"
-    required={{true}}
-    aria-required={{true}}
-    aria-label="{{t 'pages.login-or-register.register-form.fields.cgu.aria-label'}}"
-    {{on "click" this.validateCgu}}
-  >
+  <PixCheckbox @size="small" required={{true}} aria-required={{true}} {{on "click" this.validateCgu}}>
     <:label>
       <p>
         {{t "pages.login-or-register.register-form.fields.cgu.accept"}}

--- a/certif/app/components/auth/register-form.hbs
+++ b/certif/app/components/auth/register-form.hbs
@@ -1,106 +1,90 @@
-<div class="register-form">
-  <form {{on "submit" this.register}}>
-    <p class="login-form__information">{{t "common.form-errors.mandatory-all-fields"}}</p>
-    <div class="input-container">
-      <PixInput
-        @id="register-firstName"
-        name="firstName"
-        type="firstName"
-        {{on "change" this.validateFirstName}}
-        required={{true}}
-        aria-required={{true}}
-        autocomplete="given-name"
-        @validationStatus={{this.validation.firstName.status}}
-        @errorMessage={{this.validation.firstName.message}}
-      >
-        <:label>{{t "common.labels.candidate.firstname"}}</:label>
-      </PixInput>
-    </div>
+<form class="register-form" {{on "submit" this.register}}>
+  <p class="register-form__information">{{t "common.form-errors.mandatory-all-fields"}}</p>
 
-    <div class="input-container">
-      <PixInput
-        @id="register-lastName"
-        name="lastName"
-        type="lastName"
-        {{on "change" this.validateLastName}}
-        required={{true}}
-        aria-required={{true}}
-        autocomplete="family-name"
-        @validationStatus={{this.validation.lastName.status}}
-        @errorMessage={{this.validation.lastName.message}}
-      >
-        <:label>{{t "common.labels.candidate.lastname"}}</:label>
-      </PixInput>
-    </div>
+  <PixInput
+    @id="register-firstName"
+    name="firstName"
+    {{on "change" this.validateFirstName}}
+    required={{true}}
+    aria-required={{true}}
+    autocomplete="given-name"
+    @validationStatus={{this.validation.firstName.status}}
+    @errorMessage={{this.validation.firstName.message}}
+  >
+    <:label>{{t "common.labels.candidate.firstname"}}</:label>
+  </PixInput>
 
-    <div class="input-container">
-      <PixInput
-        @id="register-email"
-        name="email"
-        type="email"
-        {{on "change" this.validateEmail}}
-        required={{true}}
-        aria-required={{true}}
-        autocomplete="email"
-        @validationStatus={{this.validation.email.status}}
-        @errorMessage={{this.validation.email.message}}
-      >
-        <:label>{{t "common.forms.login.email"}}</:label>
-      </PixInput>
-    </div>
+  <PixInput
+    @id="register-lastName"
+    name="lastName"
+    {{on "change" this.validateLastName}}
+    required={{true}}
+    aria-required={{true}}
+    autocomplete="family-name"
+    @validationStatus={{this.validation.lastName.status}}
+    @errorMessage={{this.validation.lastName.message}}
+  >
+    <:label>{{t "common.labels.candidate.lastname"}}</:label>
+  </PixInput>
 
-    <div class="input-container">
-      <PixInputPassword
-        @id="register-password"
-        name="password"
-        autocomplete="current-password"
-        required={{true}}
-        aria-required={{true}}
-        {{on "change" this.validatePassword}}
-        @validationStatus={{this.validation.password.status}}
-        @errorMessage={{this.validation.password.message}}
-      >
-        <:label>{{t "common.forms.login.password"}}</:label>
-      </PixInputPassword>
-    </div>
+  <PixInput
+    @id="register-email"
+    name="email"
+    type="email"
+    {{on "change" this.validateEmail}}
+    required={{true}}
+    aria-required={{true}}
+    autocomplete="email"
+    @validationStatus={{this.validation.email.status}}
+    @errorMessage={{this.validation.email.message}}
+  >
+    <:label>{{t "common.forms.login.email"}}</:label>
+  </PixInput>
 
-    <div class="checkbox-container input-container">
-      <PixCheckbox
-        @size="small"
-        required={{true}}
-        aria-required={{true}}
-        aria-label="{{t 'pages.login-or-register.register-form.fields.cgu.aria-label'}}"
-        {{on "click" this.validateCgu}}
-      >
-        <:label>
-          <p class="register-form__cgu-label">
-            {{t "pages.login-or-register.register-form.fields.cgu.accept"}}
-            <a href={{this.cguUrl}} class="link" target="_blank" rel="noopener noreferrer">
-              {{t "pages.login-or-register.register-form.fields.cgu.terms-of-use"}}
-            </a>
-            {{t "pages.login-or-register.register-form.fields.cgu.and"}}
-            <a href={{this.dataProtectionPolicyUrl}} class="link" target="_blank" rel="noopener noreferrer">
-              {{t "pages.login-or-register.register-form.fields.cgu.data-protection-policy"}}
-            </a>
-          </p>
-        </:label>
-      </PixCheckbox>
-    </div>
-    {{#if this.cguValidationMessage}}
-      <p class="register-form__cgu-error" role="alert">{{this.cguValidationMessage}}</p>
-    {{/if}}
+  <PixInputPassword
+    @id="register-password"
+    name="password"
+    autocomplete="current-password"
+    required={{true}}
+    aria-required={{true}}
+    {{on "change" this.validatePassword}}
+    @validationStatus={{this.validation.password.status}}
+    @errorMessage={{this.validation.password.message}}
+  >
+    <:label>{{t "common.forms.login.password"}}</:label>
+  </PixInputPassword>
 
-    {{#if this.errorMessage}}
-      <PixMessage @type="error">
-        {{this.errorMessage}}
-      </PixMessage>
-    {{/if}}
+  <PixCheckbox
+    @size="small"
+    required={{true}}
+    aria-required={{true}}
+    aria-label="{{t 'pages.login-or-register.register-form.fields.cgu.aria-label'}}"
+    {{on "click" this.validateCgu}}
+  >
+    <:label>
+      <p>
+        {{t "pages.login-or-register.register-form.fields.cgu.accept"}}
+        <a href={{this.cguUrl}} class="link" target="_blank" rel="noopener noreferrer">
+          {{t "pages.login-or-register.register-form.fields.cgu.terms-of-use"}}
+        </a>
+        {{t "pages.login-or-register.register-form.fields.cgu.and"}}
+        <a href={{this.dataProtectionPolicyUrl}} class="link" target="_blank" rel="noopener noreferrer">
+          {{t "pages.login-or-register.register-form.fields.cgu.data-protection-policy"}}
+        </a>
+      </p>
+    </:label>
+  </PixCheckbox>
+  {{#if this.cguValidationMessage}}
+    <p class="register-form__cgu-error" role="alert">{{this.cguValidationMessage}}</p>
+  {{/if}}
 
-    <div class="input-container">
-      <PixButton @type="submit" @isLoading={{this.isLoading}} class="register-form__submit-button">
-        {{t "pages.login-or-register.register-form.actions.login-button"}}
-      </PixButton>
-    </div>
+  {{#if this.errorMessage}}
+    <PixMessage @type="error">
+      {{this.errorMessage}}
+    </PixMessage>
+  {{/if}}
 
-  </form>
-</div>
+  <PixButton @type="submit" @isLoading={{this.isLoading}}>
+    {{t "pages.login-or-register.register-form.actions.login-button"}}
+  </PixButton>
+</form>

--- a/certif/app/styles/components/auth/toggable-login-form.scss
+++ b/certif/app/styles/components/auth/toggable-login-form.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: $pix-spacing-m;
-  max-width: 450px;
+  max-width: 400px;
   padding: 0 2px;
   font-size: 0.875rem;
 

--- a/certif/app/styles/components/login-or-register.scss
+++ b/certif/app/styles/components/login-or-register.scss
@@ -1,7 +1,4 @@
 .login-or-register {
-  display: flex;
-  flex-direction: column;
-  gap: $pix-spacing-s;
   margin: 20px 0;
 
   &__panel {
@@ -9,11 +6,10 @@
     flex-direction: column;
     align-items: center;
     justify-content: space-between;
-    padding: 20px 2px;
-    border-radius: 10px;
+    padding: var(--pix-spacing-6x) 0 var(--pix-spacing-8x);
 
     @include device-is('tablet') {
-      padding: 20px;
+      padding: var(--pix-spacing-8x);
     }
 
     @include device-is('large-screen') {
@@ -36,9 +32,7 @@
   &__invitation {
     @extend %pix-body-l;
 
-    margin-top: 24px;
-    color: var(--pix-neutral-900);
-    font-size: 1.125rem;
+    padding: var(--pix-spacing-6x) var(--pix-spacing-8x) var(--pix-spacing-3x);
     text-align: center;
   }
 
@@ -46,8 +40,6 @@
     display: flex;
     flex-flow: row;
     justify-content: space-around;
-    min-height: 500px;
-    margin-top: 10px;
 
     @include device-is('large-screen') {
       flex-flow: row;
@@ -65,7 +57,7 @@
     flex-direction: column;
 
     @include device-is('tablet') {
-      min-width: 360px;
+      min-width: 400px;
     }
   }
 
@@ -74,8 +66,7 @@
     border-left: 1px solid var(--pix-neutral-100);
 
     @include device-is('tablet') {
-      margin: 30px;
-      margin-bottom: 0;
+      margin: var(--pix-spacing-8x) var(--pix-spacing-6x) 0;
     }
 
     @include device-is('large-screen') {
@@ -86,9 +77,6 @@
 
 .login-or-register-panel-form {
   &__expandable {
-    display: flex;
-    flex-direction: column;
-    max-height: 0;
     overflow-y: hidden;
     transition: max-height 0.4s ease-in-out;
 

--- a/certif/app/styles/components/register-form.scss
+++ b/certif/app/styles/components/register-form.scss
@@ -1,30 +1,19 @@
 .register-form {
+  display: flex;
+  flex-direction: column;
+  gap: $pix-spacing-m;
   max-width: 360px;
-  overflow-y: auto;
 
-  &__cgu-label {
-    margin: 0;
+  &__information {
+    margin-bottom: $pix-spacing-s;
+    color: var(--pix-neutral-900);
+    text-align: center;
+
+    @extend %pix-body-s;
   }
 
   &__cgu-error {
-    margin-top: 4px;
     color: var(--pix-error-700);
     font-size: 0.75rem;
-  }
-
-  &__submit-button {
-    width: 100%;
-  }
-
-  .input-container {
-    margin-top: $pix-spacing-m;
-  }
-
-  .checkbox-container {
-    display: flex;
-
-    input[type='checkbox'] {
-      margin: 1px 6px 0 0;
-    }
   }
 }

--- a/certif/app/styles/components/register-form.scss
+++ b/certif/app/styles/components/register-form.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: $pix-spacing-m;
-  max-width: 360px;
+  max-width: 400px;
 
   &__information {
     margin-bottom: $pix-spacing-s;

--- a/certif/tests/acceptance/routes/join_test.js
+++ b/certif/tests/acceptance/routes/join_test.js
@@ -25,7 +25,11 @@ module('Acceptance | Routes | join', function (hooks) {
       await fillIn(screen.getByRole('textbox', { name: 'Nom' }), 'Nom');
       await fillIn(screen.getByRole('textbox', { name: 'Adresse e-mail' }), 'p.n@email.com');
       await fillIn(screen.getByLabelText('Mot de passe'), 'Pa$$w0rd');
-      await click(screen.getByRole('checkbox', { name: "Accepter les conditions d'utilisation de Pix" }));
+      await click(
+        screen.getByRole('checkbox', {
+          name: "J'accepte les conditions d'utilisation de Pix et la politique de confidentialité",
+        }),
+      );
       await clickByName(`Je m'inscris`);
       await clickByName(`J’accepte les conditions d’utilisation`);
 

--- a/certif/tests/integration/components/auth/register-form_test.js
+++ b/certif/tests/integration/components/auth/register-form_test.js
@@ -26,7 +26,7 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
     lastNameInputLabel = this.intl.t('common.labels.candidate.lastname');
     emailInputLabel = this.intl.t('common.forms.login.email');
     passwordInputLabel = this.intl.t('common.forms.login.password');
-    cguAriaLabel = this.intl.t('pages.login-or-register.register-form.fields.cgu.aria-label');
+    cguAriaLabel = "J'accepte les conditions d'utilisation de Pix et la politique de confidentialité";
   });
 
   test('[a11y] it should display a message that all inputs are required', async function (assert) {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -245,7 +245,6 @@
           "cgu": {
             "accept": "I agree to the",
             "and": "and",
-            "aria-label": "Accept the terms of use of the Pix platform",
             "data-protection-policy": "personal data protection policy",
             "error": "You must agree to the Pix terms of use and personal data protection policy to create an account.",
             "terms-of-use": "Pix terms of use"

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -245,7 +245,6 @@
           "cgu": {
             "accept": "J'accepte les",
             "and": "et la",
-            "aria-label": "Accepter les conditions d'utilisation de Pix",
             "data-protection-policy": "politique de confidentialité",
             "error": "Vous devez accepter les conditions d’utilisation de Pix et la politique de confidentialité pour créer un compte.",
             "terms-of-use": "conditions d'utilisation de Pix"


### PR DESCRIPTION
## :unicorn: Problème
Actuellement le formulaire de création ressemble à ça : 
<img width="752" alt="Capture d’écran 2024-04-16 à 10 54 12" src="https://github.com/1024pix/pix/assets/58915422/c8f8af8c-a213-464c-a5e2-62477f298580">

Cela doit être une régression de la montée de version de Pix UI

## :robot: Proposition
Corriger le tir en améliorant au passage de formulaire (suppression de` <div>` inutiles et de css)

## :100: Pour tester

- Se connecter avec certif-pro@example.net
- Dans Equipe, inviter un membre et s'inviter soi même
- Vous recevrez un mail pour rejoindre le centre de certification
- Cliquer sur le bouton du mail et constater que les formulaires de la double mire se portent bien
- 
<img width="810" alt="Capture d’écran 2024-04-16 à 11 14 56" src="https://github.com/1024pix/pix/assets/58915422/43638cf2-9785-41e5-aa74-2ed9e2d28521">

