### PR TITLE
[FEATURE] Ajouter Pro Santé Connect comme fournisseur d'identité (PIX-12081)

### DIFF
--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -24,6 +24,7 @@ const reassignAuthenticationMethodJoiSchema = Joi.object({
           OidcIdentityProviders.CNAV.code,
           OidcIdentityProviders.FWB.code,
           OidcIdentityProviders.PAYSDELALOIRE.code,
+          OidcIdentityProviders.PROSANTECONNECT.code,
         )
         .required(),
     },

--- a/api/lib/domain/constants/oidc-identity-providers.js
+++ b/api/lib/domain/constants/oidc-identity-providers.js
@@ -18,9 +18,13 @@ const PAYSDELALOIRE = {
   code: 'PAYSDELALOIRE',
   configKey: 'paysdelaloire',
 };
+const PROSANTECONNECT = {
+  code: 'PROSANTECONNECT',
+  configKey: 'proSanteConnect',
+};
 
 function getValidOidcProviderCodes() {
-  return [POLE_EMPLOI.code, CNAV.code, FWB.code, GOOGLE.code, PAYSDELALOIRE.code];
+  return [POLE_EMPLOI.code, CNAV.code, FWB.code, GOOGLE.code, PAYSDELALOIRE.code, PROSANTECONNECT.code];
 }
 
-export { CNAV, FWB, getValidOidcProviderCodes, GOOGLE, PAYSDELALOIRE, POLE_EMPLOI };
+export { CNAV, FWB, getValidOidcProviderCodes, GOOGLE, PAYSDELALOIRE, POLE_EMPLOI, PROSANTECONNECT };

--- a/api/lib/domain/models/AuthenticationMethod.js
+++ b/api/lib/domain/models/AuthenticationMethod.js
@@ -3,7 +3,7 @@ import BaseJoi from 'joi';
 const Joi = BaseJoi.extend(JoiDate);
 import { validateEntity } from '../../../src/shared/domain/validators/entity-validator.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
-import { CNAV, FWB, PAYSDELALOIRE, POLE_EMPLOI } from '../constants/oidc-identity-providers.js';
+import { CNAV, FWB, PAYSDELALOIRE, POLE_EMPLOI, PROSANTECONNECT } from '../constants/oidc-identity-providers.js';
 
 class PixAuthenticationComplement {
   constructor({ password, shouldChangePassword } = {}) {
@@ -70,6 +70,7 @@ const validationSchema = Joi.object({
     { is: CNAV.code, then: Joi.object().instance(OidcAuthenticationComplement).allow(null) },
     { is: FWB.code, then: Joi.object().instance(OidcAuthenticationComplement).allow(null) },
     { is: PAYSDELALOIRE.code, then: Joi.object().instance(OidcAuthenticationComplement).allow(null) },
+    { is: PROSANTECONNECT.code, then: Joi.object().instance(OidcAuthenticationComplement).allow(null) },
   ]),
   externalIdentifier: Joi.when('identityProvider', [
     { is: NON_OIDC_IDENTITY_PROVIDERS.PIX.code, then: Joi.any().forbidden() },
@@ -78,6 +79,7 @@ const validationSchema = Joi.object({
     { is: CNAV.code, then: Joi.string().required() },
     { is: FWB.code, then: Joi.string().required() },
     { is: PAYSDELALOIRE.code, then: Joi.string().required() },
+    { is: PROSANTECONNECT.code, then: Joi.string().required() },
   ]),
   userId: Joi.number().integer().required(),
   createdAt: Joi.date().optional(),

--- a/api/lib/domain/services/authentication/oidc-authentication-service-registry.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service-registry.js
@@ -1,3 +1,4 @@
+import { ProSanteConnectOidcAuthenticationService } from '../../../../src/authentication/domain/services/pro-sante-connect-oidc-authentication.service.js';
 import { InvalidIdentityProviderError } from '../../errors.js';
 import { CnavOidcAuthenticationService } from './cnav-oidc-authentication-service.js';
 import { FwbOidcAuthenticationService } from './fwb-oidc-authentication-service.js';
@@ -61,6 +62,7 @@ export class OidcAuthenticationServiceRegistry {
       new GoogleOidcAuthenticationService(),
       new PaysdelaloireOidcAuthenticationService(),
       new PoleEmploiOidcAuthenticationService(),
+      new ProSanteConnectOidcAuthenticationService(),
     ];
 
     this.#allOidcProviderServices = oidcProviderServices ?? defaultOidcProviderServices;

--- a/api/sample.env
+++ b/api/sample.env
@@ -771,6 +771,58 @@ AUTH_SECRET=the-password-must-be-at-least-32-characters-long
 # type: URL
 GOOGLE_OPENID_CONFIGURATION_URL=https://accounts.google.com/.well-known/openid-configuration
 
+# ==============================
+# PRO SANTE CONNECT CONFIGURATION
+# ==============================
+
+# Enable connection to the OIDC provider
+#
+# presence: optional
+# type: boolean
+# default: `false`
+# PROSANTECONNECT_ENABLED=false
+
+# Client ID
+#
+# presence: required for PAYS DE LA LOIRE authentication, optional otherwise
+# type: string
+# sample: PROSANTECONNECT_CLIENT_ID=
+
+# Client Secret
+#
+# presence: required for PAYS DE LA LOIRE authentication, optional otherwise
+# type: string
+# sample: PROSANTECONNECT_CLIENT_SECRET=
+
+# End session URL
+#
+# presence: required for PAYS DE LA LOIRE logout, optional otherwise
+# type: URL
+# sample: PROSANTECONNECT_END_SESSION_URL=
+
+# Post logout redirect URI
+#
+# sample: PROSANTECONNECT_POST_LOGOUT_REDIRECT_URI=https://app.pix.fr/connexion
+
+# Access token lifespan
+#
+# presence: optional
+# type: string
+# default: 7d
+# sample: PROSANTECONNECT_ACCESS_TOKEN_LIFESPAN=7d
+
+# presence: required
+# type: URL
+# sample: PROSANTECONNECT_REDIRECT_URI=
+
+# presence: required
+# type: URL
+# sample: PROSANTECONNECT_OPENID_CONFIGURATION_URL=
+
+# presence: required
+# type: URL
+# sample: PROSANTECONNECT_SCOPE='openid scope_all'
+
 # ===================
 # AUTHENTICATION SESSION CONFIGURATION
 # ===================

--- a/api/src/authentication/domain/services/oidc-authentication-service.js
+++ b/api/src/authentication/domain/services/oidc-authentication-service.js
@@ -275,10 +275,11 @@ class OidcAuthenticationService {
     const key = `${userId}:${logoutUrlUUID}`;
     const idToken = await this.sessionTemporaryStorage.get(key);
 
-    const parameters = {
-      post_logout_redirect_uri: this.postLogoutRedirectUri,
-      id_token_hint: idToken,
-    };
+    const parameters = { id_token_hint: idToken };
+
+    if (this.postLogoutRedirectUri) {
+      parameters.post_logout_redirect_uri = this.postLogoutRedirectUri;
+    }
 
     try {
       const endSessionUrl = this.client.endSessionUrl(parameters);

--- a/api/src/authentication/domain/services/pro-sante-connect-oidc-authentication.service.js
+++ b/api/src/authentication/domain/services/pro-sante-connect-oidc-authentication.service.js
@@ -1,0 +1,25 @@
+import { PROSANTECONNECT } from '../../../../lib/domain/constants/oidc-identity-providers.js';
+import { config } from '../../../shared/config.js';
+import { OidcAuthenticationService } from './oidc-authentication-service.js';
+
+const configKey = PROSANTECONNECT.configKey;
+
+export class ProSanteConnectOidcAuthenticationService extends OidcAuthenticationService {
+  constructor() {
+    super({
+      accessTokenLifespanMs: config[configKey].accessTokenLifespanMs,
+      clientId: config[configKey].clientId,
+      clientSecret: config[configKey].clientSecret,
+      configKey,
+      identityProvider: PROSANTECONNECT.code,
+      openidConfigurationUrl: config[configKey].openidConfigurationUrl,
+      organizationName: 'Pro Santé Connect',
+      postLogoutRedirectUri: config[configKey].postLogoutRedirectUri,
+      redirectUri: config[configKey].redirectUri,
+      scope: config[configKey].scope,
+      shouldCloseSession: true,
+      slug: 'pro-sante-connect',
+      source: 'prosanteconnect',
+    });
+  }
+}

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -325,6 +325,17 @@ const configuration = (function () {
       tokenUrl: process.env.POLE_EMPLOI_TOKEN_URL,
     },
     port: parseInt(process.env.PORT, 10) || 3000,
+    proSanteConnect: {
+      accessTokenLifespanMs: ms(process.env.PROSANTECONNECT_ACCESS_TOKEN_LIFESPAN || '7d'),
+      clientId: process.env.PROSANTECONNECT_CLIENT_ID,
+      clientSecret: process.env.PROSANTECONNECT_CLIENT_SECRET,
+      isEnabled: isFeatureEnabled(process.env.PROSANTECONNECT_ENABLED),
+      isEnabledForPixAdmin: false,
+      openidConfigurationUrl: process.env.PROSANTECONNECT_OPENID_CONFIGURATION_URL,
+      postLogoutRedirectUri: process.env.PROSANTECONNECT_POST_LOGOUT_REDIRECT_URI,
+      redirectUri: process.env.PROSANTECONNECT_REDIRECT_URI,
+      scope: process.env.PROSANTECONNECT_SCOPE,
+    },
     rootPath: path.normalize(__dirname + '/..'),
     saml: {
       spConfig: parseJSONEnv('SAML_SP_CONFIG'),

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -1191,7 +1191,7 @@ describe('Unit | Router | user-router', function () {
         // then
         expect(statusCode).to.equal(400);
         expect(result.errors[0].detail).to.equal(
-          '"data.attributes.identity-provider" must be one of [GAR, POLE_EMPLOI, CNAV, FWB, PAYSDELALOIRE]',
+          '"data.attributes.identity-provider" must be one of [GAR, POLE_EMPLOI, CNAV, FWB, PAYSDELALOIRE, PROSANTECONNECT]',
         );
       });
 


### PR DESCRIPTION
## :unicorn: Problème

Pas de possiblité de se connecter à Pix via le SSO de Pro Santé Connect.

## :robot: Proposition

Permettre de se connecter à Pix via le SSO de Pro Santé Connect.

## :rainbow: Remarques

RAS

## :100: Pour tester

⚠️ Il vous faut un compte de test activé via l'application mobile e-CPS (bac à sable) **uniquement disponible sur Android**

- Ajouter la variable d'environnement `PROSANTECONNECT_SCOPE='openid scope_all'`
- Se connecter via le SSO de Pro Santé Connect (en RA https://app-sso.review.pix.fr/connexion/pro-sante-connect)
- Si vous n'avez jamais utilisé le compte sur lequel vous tentez de vous connecter
  - vous devez arriver sur la page d'inscription/rattachement (double mire OIDC)
  - dans le cas contraire, vous arriverez directement sur la page d'accueil
- Se déconnecter
- Si vous avez ajouter la variable d'environnement `PROSANTECONNECT_POST_LOGOUT_REDIRECT_URI`
  - Constater l'affichage de la page de connexion de Pix App
  - Sinon, constater l'affichage d'un message sur le domaine de Pro Santé Connect que la session a bien été fermé
- Se connecter à nouveau via le SSO de Pro Santé Connect
- Constater que la session a été bien fermé (une nouvelle demande d'identifiant de connexion)
