### PR TITLE
[BUGFIX] Empêcher la souscription à une certification complémentaire lors de l'import de masse des sessions lorsque le centre ne possède pas les habilitations nécessaires (PIX-11928)

### DIFF
--- a/api/src/certification/session/application/session-mass-import-controller.js
+++ b/api/src/certification/session/application/session-mass-import-controller.js
@@ -29,7 +29,9 @@ const validateSessions = async function (request, h, dependencies = { csvHelpers
   const sessions = dependencies.csvSerializer.deserializeForSessionsImport({
     parsedCsvData,
     hasBillingMode: certificationCenter.hasBillingMode,
+    certificationCenterHabilitations: certificationCenter.habilitations,
   });
+
   const sessionMassImportReport = await usecases.validateSessions({
     sessions,
     certificationCenterId,

--- a/api/tests/certification/session/acceptance/application/session-mass-import-route_test.js
+++ b/api/tests/certification/session/acceptance/application/session-mass-import-route_test.js
@@ -41,6 +41,12 @@ describe('Acceptance | Controller | Session | session-mass-import-route', functi
           type: 'SUP',
           externalId: '1234AB',
         }).id;
+        const { id: complementaryCertificationId } =
+          databaseBuilder.factory.buildComplementaryCertification.pixEdu2ndDegre({});
+        databaseBuilder.factory.buildComplementaryCertificationHabilitation({
+          certificationCenterId: certificationCenterId,
+          complementaryCertificationId,
+        });
         databaseBuilder.factory.buildOrganization({ externalId: '1234AB', isManagingStudents: false, type: 'SUP' });
         databaseBuilder.factory.buildCertificationCpfCountry({
           commonName: 'FRANCE',

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -205,6 +205,68 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
       });
     });
 
+    describe('when a header corresponding to a complementary certification subscription is present', function () {
+      describe('when the certification center does not have necessary habilitations', function () {
+        it('should throw a FileValidationError', async function () {
+          // given
+          const parsedCsvDataWithCleASubscription = [
+            {
+              'Numéro de session préexistante': '',
+              '* Nom du site': 'Site CléA',
+              '* Nom de la salle': 'Salle CléA',
+              '* Date de début (format: JJ/MM/AAAA)': '01/01/4000',
+              '* Heure de début (heure locale format: HH:MM)': '12:00',
+              '* Surveillant(s)': 'Surveillant A',
+              'Observations (optionnel)': '',
+              '* Nom de naissance': 'Testeur',
+              '* Prénom': 'Toto',
+              '* Date de naissance (format: JJ/MM/AAAA)': '01/01/2000',
+              '* Sexe (M ou F)': 'M',
+              'Code INSEE de la commune de naissance': '',
+              'Code postal de la commune de naissance': '75001',
+              'Nom de la commune de naissance': 'PARIS',
+              '* Pays de naissance': 'FRANCE',
+              'E-mail du destinataire des résultats (formateur, enseignant…)': '',
+              'E-mail de convocation': '',
+              'Identifiant externe': '',
+              'Temps majoré ? (exemple format: 33%)': '',
+              '* Tarification part Pix (Gratuite, Prépayée ou Payante)': 'Gratuite',
+              'Code de prépaiement (si Tarification part Pix Prépayée)': '',
+              "CléA Numérique ('oui' ou laisser vide)": 'Oui',
+            },
+          ];
+          const habilitationsWithoutCleA = [
+            {
+              id: 53,
+              label: 'Pix+ Droit',
+              key: 'DROIT',
+            },
+            {
+              id: 54,
+              label: 'Pix+ Édu 1er degré',
+              key: 'EDU_1ER_DEGRE',
+            },
+            {
+              id: 55,
+              label: 'Pix+ Édu 2nd degré',
+              key: 'EDU_2ND_DEGRE',
+            },
+          ];
+
+          // when
+          const error = await catchErr(csvSerializer.deserializeForSessionsImport)({
+            parsedCsvData: parsedCsvDataWithCleASubscription,
+            hasBillingMode: true,
+            certificationCenterHabilitations: habilitationsWithoutCleA,
+          });
+
+          // then
+          expect(error).to.be.instanceOf(FileValidationError);
+          expect(error.code).to.equal('CSV_HEADERS_NOT_VALID');
+        });
+      });
+    });
+
     describe('when certification center does not have billing mode', function () {
       context('when billing mode header is present', function () {
         it('should throw an error', async function () {


### PR DESCRIPTION
## :unicorn: Problème
La création de session, l’ajout de candidat et l’inscription à une certification complémentaire pour laquelle le CDC n’est pas habilité réussissent lors d 'un import de masse de sessions.

## :robot: Proposition
Retourner un message bloquant de modèle altéré si l’un des candidats du fichier est inscrit à une certification complémentaire pour laquelle le CDC n’est pas habilité.

## :rainbow: Remarques
Les headers des fichiers CSV d'import de masse de sessions sont uniques à chaque centre. Les headers concernant la souscription aux certifications complémentaires sont rajoutés en vérifiant les habilitations du centre.

Un centre de certification sans habilitations ne comprend pas dans son modèle de fichier CSV de colonnes permettant la souscription aux certifications complémentaires.

## :100: Pour tester
1. Se connecter à l'app certif (certif-pro@example.net)
2. Se rendre sur la page d'import de masse de sessions en cliquant sur [Créer/éditer plusieurs sessions]
3. Importer un fichier CSV comportant l'inscription d'un candidat à une certification complémentaire dont le centre de n'a pas l'habilitation. (Le centre actuel n'a pas l'habilitation **Cléa A** et le fichier CSV en pièce jointe inscrit un candidat à une certificartion complémentaire Cléa A 😉)
4. Constater l'affichage d'un message d'erreur bloquant l'envoi du fichier CSV intitulé **"Le modèle a été altéré, merci de le télécharger à nouveau"**

[Import masse CléA.csv](https://github.com/1024pix/pix/files/15042313/Import.masse.CleA.csv)
