### PR TITLE
[FEATURE] Interdire l'HTML sur les champs qui ne le permettent pas (PIX-10243) (PIX-10241)

### DIFF
--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/image.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/image.js
@@ -1,12 +1,12 @@
 import Joi from 'joi';
 
-import { htmlSchema, uuidSchema } from '../utils.js';
+import { htmlNotAllowedSchema, htmlSchema, uuidSchema } from '../utils.js';
 
 const imageElementSchema = Joi.object({
   id: uuidSchema,
   type: Joi.string().valid('image').required(),
   url: Joi.string().uri().required(),
-  alt: Joi.string().allow('').required(),
+  alt: htmlNotAllowedSchema.allow('').required(),
   alternativeText: htmlSchema.allow(''),
 }).required();
 

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/index.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/index.js
@@ -1,11 +1,13 @@
 import { imageElementSchema } from './image.js';
 import { qcmElementSchema } from './qcm.js';
 import { qcuElementSchema } from './qcu.js';
-import { qrocmElementSchema } from './qrocm.js';
+import { blockInputSchema, blockSelectSchema, qrocmElementSchema } from './qrocm.js';
 import { textElementSchema } from './text.js';
 import { videoElementSchema } from './video.js';
 
 export {
+  blockInputSchema,
+  blockSelectSchema,
   imageElementSchema,
   qcmElementSchema,
   qcuElementSchema,

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qrocm.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qrocm.js
@@ -1,16 +1,16 @@
 import Joi from 'joi';
 
-import { htmlSchema, proposalIdSchema, uuidSchema } from '../utils.js';
+import { htmlNotAllowedSchema, htmlSchema, proposalIdSchema, uuidSchema } from '../utils.js';
 
 const blockInputSchema = Joi.object({
-  input: Joi.string().required(),
+  input: htmlNotAllowedSchema.required(),
   type: Joi.string().valid('input').required(),
   inputType: Joi.string().valid('text', 'number').required(),
   size: Joi.number().positive().required(),
   display: Joi.string().valid('inline', 'block').required(),
-  placeholder: Joi.string().allow('').required(),
-  ariaLabel: Joi.string().required(),
-  defaultValue: Joi.string().allow('').required(),
+  placeholder: htmlNotAllowedSchema.allow('').required(),
+  ariaLabel: htmlNotAllowedSchema.required(),
+  defaultValue: htmlNotAllowedSchema.allow('').required(),
   tolerances: Joi.array()
     .unique()
     .items(Joi.string().valid('t1', 't2', 't3'))
@@ -19,18 +19,18 @@ const blockInputSchema = Joi.object({
 }).required();
 
 const blockSelectSchema = Joi.object({
-  input: Joi.string().required(),
+  input: htmlNotAllowedSchema.required(),
   type: Joi.string().valid('select').required(),
   display: Joi.string().valid('inline', 'block').required(),
-  placeholder: Joi.string().allow('').required(),
-  ariaLabel: Joi.string().required(),
-  defaultValue: Joi.string().allow('').required(),
+  placeholder: htmlNotAllowedSchema.allow('').required(),
+  ariaLabel: htmlNotAllowedSchema.required(),
+  defaultValue: htmlNotAllowedSchema.allow('').required(),
   tolerances: Joi.array().empty().required(),
   options: Joi.array()
     .items(
       Joi.object({
         id: proposalIdSchema,
-        content: Joi.string().required(),
+        content: htmlNotAllowedSchema.required(),
       }),
     )
     .required(),
@@ -55,4 +55,4 @@ const qrocmElementSchema = Joi.object({
   }).required(),
 });
 
-export { qrocmElementSchema };
+export { blockInputSchema, blockSelectSchema, qrocmElementSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/video.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/video.js
@@ -1,11 +1,11 @@
 import Joi from 'joi';
 
-import { htmlSchema, uuidSchema } from '../utils.js';
+import { htmlNotAllowedSchema, htmlSchema, uuidSchema } from '../utils.js';
 
 const videoElementSchema = Joi.object({
   id: uuidSchema,
   type: Joi.string().valid('video').required(),
-  title: Joi.string().required(),
+  title: htmlNotAllowedSchema.required(),
   url: Joi.string().uri().required(),
   subtitles: Joi.string().uri().allow('').required(),
   transcription: htmlSchema.allow(''),

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -6,6 +6,8 @@ import { getTextSample } from '../../../../../../../src/devcomp/infrastructure/d
 import { getVideoSample } from '../../../../../../../src/devcomp/infrastructure/datasources/learning-content/samples/elements/video.sample.js';
 import { expect } from '../../../../../../test-helper.js';
 import {
+  blockInputSchema,
+  blockSelectSchema,
   imageElementSchema,
   qcmElementSchema,
   qcuElementSchema,
@@ -14,59 +16,270 @@ import {
   videoElementSchema,
 } from './element/index.js';
 import { joiErrorParser } from './joi-error-parser.js';
+import { grainSchema, moduleDetailsSchema, moduleSchema } from './module.js';
 
 describe('Unit | Infrastructure | Datasources | Learning Content | Module Datasource | format validation', function () {
-  it('should validate sample image structure', async function () {
-    try {
-      await imageElementSchema.validateAsync(getImageSample(), { abortEarly: false });
-    } catch (joiError) {
-      const formattedError = joiErrorParser.format(joiError);
-      expect(joiError).to.equal(undefined, formattedError);
-    }
+  describe('when element has a valid structure', function () {
+    it('should validate sample image structure', async function () {
+      try {
+        await imageElementSchema.validateAsync(getImageSample(), { abortEarly: false });
+      } catch (joiError) {
+        const formattedError = joiErrorParser.format(joiError);
+        expect(joiError).to.equal(undefined, formattedError);
+      }
+    });
+
+    it('should validate sample qcm structure', async function () {
+      try {
+        await qcmElementSchema.validateAsync(getQcmSample(), { abortEarly: false });
+      } catch (joiError) {
+        const formattedError = joiErrorParser.format(joiError);
+        expect(joiError).to.equal(undefined, formattedError);
+      }
+    });
+
+    it('should validate sample qcu structure', async function () {
+      try {
+        await qcuElementSchema.validateAsync(getQcuSample(), { abortEarly: false });
+      } catch (joiError) {
+        const formattedError = joiErrorParser.format(joiError);
+        expect(joiError).to.equal(undefined, formattedError);
+      }
+    });
+
+    it('should validate sample qrocm structure', async function () {
+      try {
+        await qrocmElementSchema.validateAsync(getQrocmSample(), { abortEarly: false });
+      } catch (joiError) {
+        const formattedError = joiErrorParser.format(joiError);
+        expect(joiError).to.equal(undefined, formattedError);
+      }
+    });
+
+    it('should validate sample text structure', async function () {
+      try {
+        await textElementSchema.validateAsync(getTextSample(), { abortEarly: false });
+      } catch (joiError) {
+        const formattedError = joiErrorParser.format(joiError);
+        expect(joiError).to.equal(undefined, formattedError);
+      }
+    });
+
+    it('should validate sample video structure', async function () {
+      try {
+        await videoElementSchema.validateAsync(getVideoSample(), { abortEarly: false });
+      } catch (joiError) {
+        const formattedError = joiErrorParser.format(joiError);
+        expect(joiError).to.equal(undefined, formattedError);
+      }
+    });
   });
 
-  it('should validate sample qcm structure', async function () {
-    try {
-      await qcmElementSchema.validateAsync(getQcmSample(), { abortEarly: false });
-    } catch (joiError) {
-      const formattedError = joiErrorParser.format(joiError);
-      expect(joiError).to.equal(undefined, formattedError);
-    }
+  describe('when element contains not allowed HTML', function () {
+    it('should throw htmlNotAllowedSchema custom error for image.alt field', async function () {
+      // given
+      const invalidImage = {
+        id: '167907eb-ee0d-4de0-9fc8-609b2b62ed9f',
+        type: 'image',
+        url: 'https://images.pix.fr/modulix/placeholder-image.svg',
+        alt: '<p>cooucou</p>',
+        alternativeText: '',
+      };
+
+      try {
+        await imageElementSchema.validateAsync(invalidImage, { abortEarly: false });
+        throw new Error('Joi validation should have thrown');
+      } catch (joiError) {
+        expect(joiError.message).to.deep.equal(
+          '"alt" failed custom validation because HTML is not allowed in this field',
+        );
+      }
+    });
+
+    it('should throw htmlNotAllowedSchema custom error for video.title field', async function () {
+      // given
+      const invalidVideo = {
+        id: '73ac3644-7637-4cee-86d4-1a75f53f0b9c',
+        type: 'video',
+        title: '<h1>Une vidéo</h1>',
+        url: 'https://videos.pix.fr/modulix/placeholder-video.mp4',
+        subtitles: 'https://videos.pix.fr/modulix/placeholder-video.vtt',
+        transcription: '<p>Vidéo manquante</p>',
+      };
+
+      try {
+        await videoElementSchema.validateAsync(invalidVideo, { abortEarly: false });
+        throw new Error('Joi validation should have thrown');
+      } catch (joiError) {
+        expect(joiError.message).to.deep.equal(
+          '"title" failed custom validation because HTML is not allowed in this field',
+        );
+      }
+    });
+
+    it('should throw htmlNotAllowedSchema custom error for qrocm.blockInput fields', async function () {
+      // given
+      const invalidQrocmBlockInput = {
+        input: '<h2>symbole-separateur-email</h2>',
+        type: 'input',
+        inputType: 'text',
+        size: 1,
+        display: 'inline',
+        placeholder: '<br> hello',
+        ariaLabel: "Remplir avec le <span>caractère</span> qui permet de séparer les deux parties d'une adresse mail",
+        defaultValue: '<div>cassé</div>',
+        tolerances: ['t1'],
+        solutions: ['@'],
+      };
+
+      const expectedErrorMessages = [
+        '"input" failed custom validation because HTML is not allowed in this field',
+        '"placeholder" failed custom validation because HTML is not allowed in this field',
+        '"ariaLabel" failed custom validation because HTML is not allowed in this field',
+        '"defaultValue" failed custom validation because HTML is not allowed in this field',
+      ];
+
+      try {
+        await blockInputSchema.validateAsync(invalidQrocmBlockInput, { abortEarly: false });
+        throw new Error('Joi validation should have thrown');
+      } catch (joiError) {
+        expect(joiError.message).to.deep.equal(expectedErrorMessages.join('. '));
+      }
+    });
+
+    it('should throw htmlNotAllowedSchema custom error for qrocm.blockSelect fields', async function () {
+      // given
+      const invalidQrocmBlockSelect = {
+        input: '<h2>symbole-separateur-email</h2>',
+        type: 'select',
+        display: 'block',
+        placeholder: '<br> hello',
+        ariaLabel: "Remplir avec le <span>caractère</span> qui permet de séparer les deux parties d'une adresse mail",
+        defaultValue: '<div>cassé</div>',
+        tolerances: [],
+        options: [
+          {
+            id: '1',
+            content: '<strong>Génial</strong>',
+          },
+        ],
+        solutions: ['1'],
+      };
+
+      const expectedErrorMessages = [
+        '"input" failed custom validation because HTML is not allowed in this field',
+        '"placeholder" failed custom validation because HTML is not allowed in this field',
+        '"ariaLabel" failed custom validation because HTML is not allowed in this field',
+        '"defaultValue" failed custom validation because HTML is not allowed in this field',
+        '"options[0].content" failed custom validation because HTML is not allowed in this field',
+      ];
+
+      try {
+        await blockSelectSchema.validateAsync(invalidQrocmBlockSelect, { abortEarly: false });
+        throw new Error('Joi validation should have thrown');
+      } catch (joiError) {
+        expect(joiError.message).to.deep.equal(expectedErrorMessages.join('. '));
+      }
+    });
   });
 
-  it('should validate sample qcu structure', async function () {
-    try {
-      await qcuElementSchema.validateAsync(getQcuSample(), { abortEarly: false });
-    } catch (joiError) {
-      const formattedError = joiErrorParser.format(joiError);
-      expect(joiError).to.equal(undefined, formattedError);
-    }
-  });
+  describe('When module contains not allowed HTML', function () {
+    it('should throw htmlNotAllowedSchema custom error for title field', async function () {
+      // given
+      const invalidModule = {
+        id: '6282925d-4775-4bca-b513-4c3009ec5886',
+        slug: 'didacticiel-modulix',
+        title: '<h1>Didacticiel Modulix</h1>',
+        details: {
+          image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+          description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',
+          duration: 5,
+          level: 'Débutant',
+          objectives: ['Naviguer dans Modulix', 'Découvrir les leçons et les activités'],
+        },
+        grains: [
+          {
+            id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+            type: 'lesson',
+            title: 'Voici une leçon',
+            elements: [
+              {
+                id: '84726001-1665-457d-8f13-4a74dc4768ea',
+                type: 'text',
+                content: '<h3>Content.</h3>',
+              },
+            ],
+          },
+        ],
+      };
 
-  it('should validate sample qrocm structure', async function () {
-    try {
-      await qrocmElementSchema.validateAsync(getQrocmSample(), { abortEarly: false });
-    } catch (joiError) {
-      const formattedError = joiErrorParser.format(joiError);
-      expect(joiError).to.equal(undefined, formattedError);
-    }
-  });
+      try {
+        await moduleSchema.validateAsync(invalidModule, { abortEarly: false });
+        throw new Error('Joi validation should have thrown');
+      } catch (joiError) {
+        expect(joiError.message).to.deep.equal(
+          '"title" failed custom validation because HTML is not allowed in this field',
+        );
+      }
+    });
 
-  it('should validate sample text structure', async function () {
-    try {
-      await textElementSchema.validateAsync(getTextSample(), { abortEarly: false });
-    } catch (joiError) {
-      const formattedError = joiErrorParser.format(joiError);
-      expect(joiError).to.equal(undefined, formattedError);
-    }
-  });
+    it('should throw htmlNotAllowedSchema custom error for details.description field', async function () {
+      // given
+      const invalidModuleDetails = {
+        image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+        description: '<strong>Découvrez avec ce didacticiel</strong> comment fonctionne Modulix !',
+        duration: 5,
+        level: 'Débutant',
+        objectives: ['Naviguer dans Modulix', 'Découvrir les leçons et les activités'],
+      };
 
-  it('should validate sample video structure', async function () {
-    try {
-      await videoElementSchema.validateAsync(getVideoSample(), { abortEarly: false });
-    } catch (joiError) {
-      const formattedError = joiErrorParser.format(joiError);
-      expect(joiError).to.equal(undefined, formattedError);
-    }
+      try {
+        await moduleDetailsSchema.validateAsync(invalidModuleDetails, { abortEarly: false });
+        throw new Error('Joi validation should have thrown');
+      } catch (joiError) {
+        expect(joiError.message).to.deep.equal(
+          '"description" failed custom validation because HTML is not allowed in this field',
+        );
+      }
+    });
+
+    it('should throw htmlNotAllowedSchema custom error for details.objectives fields', async function () {
+      // given
+      const invalidModuleDetails = {
+        image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+        description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',
+        duration: 5,
+        level: 'Débutant',
+        objectives: ['<span>Naviguer dans Modulix<span>', 'Découvrir les leçons et les activités'],
+      };
+
+      try {
+        await moduleDetailsSchema.validateAsync(invalidModuleDetails, { abortEarly: false });
+        throw new Error('Joi validation should have thrown');
+      } catch (joiError) {
+        expect(joiError.message).to.deep.equal(
+          '"objectives[0]" failed custom validation because HTML is not allowed in this field',
+        );
+      }
+    });
+
+    it('should throw htmlNotAllowedSchema custom error for grains.title field', async function () {
+      // given
+      const invalidGrain = {
+        id: '34d225e8-5d52-4ebd-9acd-8bde8438cfc9',
+        type: 'lesson',
+        title: '<strong>Sûr de ton adresse mail ?</strong>',
+        elements: [],
+      };
+
+      try {
+        await grainSchema.validateAsync(invalidGrain, { abortEarly: false });
+        throw new Error('Joi validation should have thrown');
+      } catch (joiError) {
+        expect(joiError.message).to.deep.equal(
+          '"title" failed custom validation because HTML is not allowed in this field',
+        );
+      }
+    });
   });
 });

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module.js
@@ -8,11 +8,39 @@ import {
   textElementSchema,
   videoElementSchema,
 } from './element/index.js';
-import { htmlSchema, uuidSchema } from './utils.js';
+import { htmlNotAllowedSchema, htmlSchema, uuidSchema } from './utils.js';
 
 const transitionTextSchema = Joi.object({
   grainId: uuidSchema,
   content: htmlSchema,
+}).required();
+
+const moduleDetailsSchema = Joi.object({
+  image: Joi.string().uri().required(),
+  description: htmlNotAllowedSchema.required(),
+  duration: Joi.number().integer().min(0).max(120).required(),
+  level: Joi.string().valid('Débutant', 'Intermédiaire', 'Avancé', 'Expert').required(),
+  objectives: Joi.array().items(htmlNotAllowedSchema).min(1).required(),
+});
+
+const grainSchema = Joi.object({
+  id: uuidSchema,
+  type: Joi.string().valid('lesson', 'activity').required(),
+  title: htmlNotAllowedSchema.required(),
+  elements: Joi.array()
+    .items(
+      Joi.alternatives().conditional('.type', {
+        switch: [
+          { is: 'text', then: textElementSchema },
+          { is: 'image', then: imageElementSchema },
+          { is: 'qcu', then: qcuElementSchema },
+          { is: 'qcm', then: qcmElementSchema },
+          { is: 'qrocm', then: qrocmElementSchema },
+          { is: 'video', then: videoElementSchema },
+        ],
+      }),
+    )
+    .required(),
 }).required();
 
 const moduleSchema = Joi.object({
@@ -20,38 +48,10 @@ const moduleSchema = Joi.object({
   slug: Joi.string()
     .regex(/^[a-z0-9-]+$/)
     .required(),
-  title: Joi.string().required(),
-  details: Joi.object({
-    image: Joi.string().uri().required(),
-    description: Joi.string().required(),
-    duration: Joi.number().integer().min(0).max(120).required(),
-    level: Joi.string().valid('Débutant', 'Intermédiaire', 'Avancé', 'Expert').required(),
-    objectives: Joi.array().items(Joi.string()).min(1).required(),
-  }).required(),
+  title: htmlNotAllowedSchema.required(),
+  details: moduleDetailsSchema.required(),
   transitionTexts: Joi.array().items(transitionTextSchema),
-  grains: Joi.array()
-    .items(
-      Joi.object({
-        id: uuidSchema,
-        type: Joi.string().valid('lesson', 'activity').required(),
-        title: Joi.string().required(),
-        elements: Joi.array()
-          .items(
-            Joi.alternatives().conditional('.type', {
-              switch: [
-                { is: 'text', then: textElementSchema },
-                { is: 'image', then: imageElementSchema },
-                { is: 'qcu', then: qcuElementSchema },
-                { is: 'qcm', then: qcmElementSchema },
-                { is: 'qrocm', then: qrocmElementSchema },
-                { is: 'video', then: videoElementSchema },
-              ],
-            }),
-          )
-          .required(),
-      }).required(),
-    )
-    .required(),
+  grains: Joi.array().items(grainSchema).required(),
 }).required();
 
-export { moduleSchema };
+export { grainSchema, moduleDetailsSchema, moduleSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/utils.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/utils.js
@@ -16,4 +16,8 @@ const htmlSchema = Joi.string()
   })
   .required();
 
-export { htmlSchema, proposalIdSchema, uuidSchema };
+const htmlNotAllowedSchema = Joi.string()
+  .regex(/<.*?>/, { invert: true })
+  .message('{{:#label}} failed custom validation because HTML is not allowed in this field');
+
+export { htmlNotAllowedSchema, htmlSchema, proposalIdSchema, uuidSchema };


### PR DESCRIPTION
## :unicorn: Problème
En tant que l'equipe contenu qui redige les modules, ils sont pas notifier si un champ peut contenir HTML ou pas.

## :robot: Proposition
Ajouter validation pour les champs qui doivent pas contenir HTML.

## :rainbow: Remarques
Pour le schema QROCM Block Select options, on a vu qu'il n'y a pas un minimum des options dans le joi schema. Il faut ajouter un minimum de 2 option.

## :100: Pour tester
CI passe

En local:
1. Aller sur un module.json eg. `bien-ecrire-son-adresse-mail.json`
2. Modifier l'objet Image en ajoutant une balise HTML dans le champ `alt`

Par exemple :

```
{
        id: '167907eb-ee0d-4de0-9fc8-609b2b62ed9f',
        type: 'image',
        url: 'https://images.pix.fr/modulix/placeholder-image.svg',
        alt: '<p>une alt text invalid</p>',
        alternativeText: '',
      };
```

3. Relancer les tests
4. Verifier que les tests expliquent lisiblement où et pourquoi le test casse