### PR TITLE
[FEATURE] Ne pas retourner d'erreur à l'import de colonnes inconnues (PIX-12139)

### DIFF
--- a/api/src/prescription/learner-management/infrastructure/serializers/csv/common-csv-learner-parser.js
+++ b/api/src/prescription/learner-management/infrastructure/serializers/csv/common-csv-learner-parser.js
@@ -7,7 +7,6 @@ const ERRORS = {
   ENCODING_NOT_SUPPORTED: 'ENCODING_NOT_SUPPORTED',
   BAD_CSV_FORMAT: 'BAD_CSV_FORMAT',
   HEADER_REQUIRED: 'HEADER_REQUIRED',
-  HEADER_UNKNOWN: 'HEADER_UNKNOWN',
 };
 
 const PARSING_OPTIONS = {
@@ -109,15 +108,6 @@ class CommonCsvLearnerParser {
       if (!parsedColumns.includes(colum.name)) {
         this.#errors.push(new CsvImportError(ERRORS.HEADER_REQUIRED, { field: colum.name }));
       }
-    });
-
-    // Expected columns
-    const acceptedColumns = this.#columns.map((column) => column.name);
-
-    const unknowColumns = parsedColumns.filter((columnName) => !acceptedColumns.includes(columnName));
-
-    unknowColumns.forEach((columnName) => {
-      if (columnName !== '') this.#errors.push(new CsvImportError(ERRORS.HEADER_UNKNOWN, { field: columnName }));
     });
   }
 }

--- a/api/tests/prescription/learner-management/unit/infrastructure/serializers/csv/common-csv-learner-parser_test.js
+++ b/api/tests/prescription/learner-management/unit/infrastructure/serializers/csv/common-csv-learner-parser_test.js
@@ -162,45 +162,24 @@ describe('Unit | Infrastructure | CommonCsvLearnerParser', function () {
       expect(errors[1].meta.field).to.equal('GodZilla');
     });
 
-    it('should throw all errors on unknown header', async function () {
+    it('should accept unknown header', async function () {
       // given
       const input = `nom;Gidorah;King Kong;GodZilla
-      The;;;`;
+      The;Best;Of;All`;
       const encodedInput = iconv.encode(input, 'utf8');
       const parser = CommonCsvLearnerParser.buildParser({ buffer: encodedInput, importFormat });
 
       // when
-      const errors = await catchErr(parser.parse, parser)('utf8');
+      const result = parser.parse('utf8');
 
       // then
-      expect(errors).to.lengthOf(2);
-
-      expect(errors[0].code).to.equal('HEADER_UNKNOWN');
-      expect(errors[0].meta.field).to.equal('Gidorah');
-      expect(errors[1].code).to.equal('HEADER_UNKNOWN');
-      expect(errors[1].meta.field).to.equal('King Kong');
-    });
-
-    it('should throw all errors on unknown and missing header', async function () {
-      // given
-      const input = `prénom;Gidorah
-      The;`;
-      const encodedInput = iconv.encode(input, 'utf8');
-      const parser = CommonCsvLearnerParser.buildParser({ buffer: encodedInput, importFormat });
-      parser.getEncoding();
-
-      // when
-      const errors = await catchErr(parser.parse, parser)('utf8');
-
-      // then
-      expect(errors).to.lengthOf(3);
-
-      expect(errors[0].code).to.equal('HEADER_REQUIRED');
-      expect(errors[0].meta.field).to.equal('nom');
-      expect(errors[1].code).to.equal('HEADER_REQUIRED');
-      expect(errors[1].meta.field).to.equal('GodZilla');
-      expect(errors[2].code).to.equal('HEADER_UNKNOWN');
-      expect(errors[2].meta.field).to.equal('Gidorah');
+      expect(result).lengthOf(1);
+      expect(result[0]).to.be.deep.equal({
+        nom: 'The',
+        Gidorah: 'Best',
+        'King Kong': 'Of',
+        GodZilla: 'All',
+      });
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Dans la config, on a dit que pour toutes les colonnes inconnues, on générait une erreur. Or il se peut qu’on reçoive un csv avec des colonne inconnu parce que les personnes n’ont pas la main pour modifier les fichiers/colonnes. 

## :robot: Proposition

Ne pas générer throw d’erreur en cas de colonnes inconnues

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
CI au vert ✅ 