### PR TITLE
[BUGFIX] Corriger l'enregistrements des adresses email lors d'un ajout de candidat à une certification sur Pix Certif (PIX-12160).

### DIFF
--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -203,6 +203,7 @@
         <PixInput
           @id="result-recipient-email"
           {{on "input" (fn @updateCandidateData @candidateData "resultRecipientEmail")}}
+          type="email"
           autocomplete="off"
         >
           <:label>{{t "common.forms.certification-labels.email-results"}}</:label>
@@ -216,8 +217,8 @@
       <div class="new-certification-candidate-modal-form__field">
         <PixInput
           @id="email"
-          @type="email"
           {{on "input" (fn @updateCandidateData @candidateData "email")}}
+          type="email"
           autocomplete="off"
         >
           <:label>{{t "common.forms.certification-labels.email-convocation"}}</:label>

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -217,7 +217,7 @@
         <PixInput
           @id="email"
           @type="email"
-          {{on "input" (fn @updateCandidateData @candidateData "resultRecipientEmail")}}
+          {{on "input" (fn @updateCandidateData @candidateData "email")}}
           autocomplete="off"
         >
           <:label>{{t "common.forms.certification-labels.email-convocation"}}</:label>

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -511,7 +511,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
             assert.dom(within(rows[1]).getByRole('cell', { name: '28/04/2019' })).exists();
             assert.dom(within(rows[1]).getByRole('cell', { name: '20 %' })).exists();
             assert.dom(within(rows[1]).getByRole('cell', { name: 'Gratuite' })).exists();
-            assert.dom(within(rows[1]).getByRole('cell', { name: 'roooooar@example.net' })).exists();
+            assert.dom(within(rows[1]).getByRole('cell', { name: 'email.destinataire@example.net' })).exists();
           });
 
           module('when shouldDisplayPaymentOptions is true', function () {
@@ -570,9 +570,9 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
     );
     await fillIn(
       screen.getByRole('textbox', { name: 'E-mail du destinataire des résultats (formateur, enseignant...)' }),
-      'guybrush.threepwood@example.net',
+      'email.destinataire@example.net',
     );
-    await fillIn(screen.getByRole('textbox', { name: 'E-mail de convocation' }), 'roooooar@example.net');
+    await fillIn(screen.getByRole('textbox', { name: 'E-mail de convocation' }), 'email.convocation@example.net');
   }
 });
 /* eslint-enable ember/no-settled-after-test-helper */


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'utilisateur Pix Certif veut inscrire un candidat à une session de certification, il rempli le champ email de convocation avec le mail du candidat et le champ destinataire des résultats avec celui du prof/formateur.

Sauf qu'on se retrouve actuellement avec l'adresse email de convocation dans le champ email destinataire des résultats et pas d'adresse de convocation enregistré.

## :robot: Proposition
Enregistrer correctement les deux adresses en question

## :rainbow: Remarques
Les deux adresses email étaient mal transmis à l'API, suite à une régression lors de la [montée de version de Pix UI](https://github.com/1024pix/pix/pull/8452/files#diffc41044b410a0b717923cc9db632f3083232e23b820f17e912fdc636007401270)

## :100: Pour tester
- Se connecter avec certif-pro@example.net
- Aller sur une session existante
- Onglet candidats
- Inscrire un candidat
- Enregistrer un candidat en renseignant email de convocation et email de destinataire de résultat
- S'assurer en BDD que les colonnes sont correctement rempli
