### PR TITLE
[FEATURE] Rend stoppable les jobs de validation et d'import pour SIECLE (PIX-12017)

### DIFF
--- a/api/lib/infrastructure/jobs/JobQueue.js
+++ b/api/lib/infrastructure/jobs/JobQueue.js
@@ -18,7 +18,7 @@ class JobQueue {
   }
 
   async stop() {
-    await this.pgBoss.stop({ graceful: false, timeout: 1000 });
+    await this.pgBoss.stop({ graceful: false, timeout: 1000, destroy: true });
   }
 }
 

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -17,12 +17,8 @@ function parseJSONEnv(varName) {
   return undefined;
 }
 
-function isFeatureEnabled(environmentVariable) {
+function toBoolean(environmentVariable) {
   return environmentVariable === 'true';
-}
-
-function isFeatureNotDisabled(environmentVariable) {
-  return environmentVariable !== 'false';
 }
 
 function _getNumber(numberAsString, defaultValue) {
@@ -90,7 +86,7 @@ const configuration = (function () {
       },
     ],
     auditLogger: {
-      isEnabled: isFeatureEnabled(process.env.PIX_AUDIT_LOGGER_ENABLED),
+      isEnabled: toBoolean(process.env.PIX_AUDIT_LOGGER_ENABLED),
       baseUrl: process.env.PIX_AUDIT_LOGGER_BASE_URL,
       clientSecret: process.env.PIX_AUDIT_LOGGER_CLIENT_SECRET,
     },
@@ -122,7 +118,7 @@ const configuration = (function () {
       accessTokenLifespanMs: ms(process.env.CNAV_ACCESS_TOKEN_LIFESPAN || '7d'),
       clientId: process.env.CNAV_CLIENT_ID,
       clientSecret: process.env.CNAV_CLIENT_SECRET,
-      isEnabled: isFeatureEnabled(process.env.CNAV_ENABLED),
+      isEnabled: toBoolean(process.env.CNAV_ENABLED),
       isEnabledForPixAdmin: false,
       openidConfigurationUrl: process.env.CNAV_OPENID_CONFIGURATION_URL,
       redirectUri: process.env.CNAV_REDIRECT_URI,
@@ -181,7 +177,7 @@ const configuration = (function () {
       dayBeforeImproving: _getNumber(process.env.DAY_BEFORE_IMPROVING, 4),
       dayBeforeRetrying: _getNumber(process.env.DAY_BEFORE_RETRYING, 4),
       dayBeforeCompetenceResetV2: _getNumber(process.env.DAY_BEFORE_COMPETENCE_RESET_V2, 7),
-      garAccessV2: isFeatureEnabled(process.env.GAR_ACCESS_V2),
+      garAccessV2: toBoolean(process.env.GAR_ACCESS_V2),
       maxReachableLevel: _getNumber(process.env.MAX_REACHABLE_LEVEL, 5),
       newYearOrganizationLearnersImportDate: _getDate(process.env.NEW_YEAR_ORGANIZATION_LEARNERS_IMPORT_DATE),
       numberOfChallengesForFlashMethod: _getNumber(process.env.NUMBER_OF_CHALLENGES_FOR_FLASH_METHOD),
@@ -196,19 +192,19 @@ const configuration = (function () {
       scoAccountRecoveryKeyLifetimeMinutes: process.env.SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES,
     },
     featureToggles: {
-      isAlwaysOkValidateNextChallengeEndpointEnabled: isFeatureEnabled(
+      isAlwaysOkValidateNextChallengeEndpointEnabled: toBoolean(
         process.env.FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT,
       ),
-      isPix1dEnabled: isFeatureEnabled(process.env.FT_PIX_1D_ENABLED),
-      isPixPlusLowerLeverEnabled: isFeatureEnabled(process.env.FT_ENABLE_PIX_PLUS_LOWER_LEVEL),
-      isCertificationTokenScopeEnabled: isFeatureEnabled(process.env.FT_ENABLE_CERTIF_TOKEN_SCOPE),
+      isPix1dEnabled: toBoolean(process.env.FT_PIX_1D_ENABLED),
+      isPixPlusLowerLeverEnabled: toBoolean(process.env.FT_ENABLE_PIX_PLUS_LOWER_LEVEL),
+      isCertificationTokenScopeEnabled: toBoolean(process.env.FT_ENABLE_CERTIF_TOKEN_SCOPE),
     },
     fwb: {
       accessTokenLifespanMs: ms(process.env.FWB_ACCESS_TOKEN_LIFESPAN || '7d'),
       claimsToStore: getArrayOfStrings(process.env.FWB_CLAIMS_TO_STORE),
       clientId: process.env.FWB_CLIENT_ID,
       clientSecret: process.env.FWB_CLIENT_SECRET,
-      isEnabled: isFeatureEnabled(process.env.FWB_ENABLED),
+      isEnabled: toBoolean(process.env.FWB_ENABLED),
       isEnabledForPixAdmin: false,
       logoutUrl: process.env.FWB_OIDC_LOGOUT_URL,
       openidConfigurationUrl: process.env.FWB_OPENID_CONFIGURATION_URL,
@@ -220,13 +216,13 @@ const configuration = (function () {
       clientId: process.env.GOOGLE_CLIENT_ID,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET,
       isEnabled: false,
-      isEnabledForPixAdmin: isFeatureEnabled(process.env.GOOGLE_ENABLED_FOR_PIX_ADMIN),
+      isEnabledForPixAdmin: toBoolean(process.env.GOOGLE_ENABLED_FOR_PIX_ADMIN),
       openidConfigurationUrl: process.env.GOOGLE_OPENID_CONFIGURATION_URL,
       redirectUri: process.env.GOOGLE_REDIRECT_URI,
     },
     hapi: {
       options: {},
-      enableRequestMonitoring: isFeatureEnabled(process.env.ENABLE_REQUEST_MONITORING),
+      enableRequestMonitoring: toBoolean(process.env.ENABLE_REQUEST_MONITORING),
     },
     infra: {
       concurrencyForHeavyOperations: _getNumber(process.env.INFRA_CONCURRENCY_HEAVY_OPERATIONS, 2),
@@ -251,13 +247,13 @@ const configuration = (function () {
       apiKey: process.env.CYPRESS_LCMS_API_KEY || process.env.LCMS_API_KEY,
     },
     logging: {
-      enabled: isFeatureNotDisabled(process.env.LOG_ENABLED),
+      enabled: toBoolean(process.env.LOG_ENABLED),
       logLevel: process.env.LOG_LEVEL || 'info',
       logForHumans: _getLogForHumans(),
-      enableKnexPerformanceMonitoring: isFeatureEnabled(process.env.ENABLE_KNEX_PERFORMANCE_MONITORING),
-      enableLogStartingEventDispatch: isFeatureEnabled(process.env.LOG_STARTING_EVENT_DISPATCH),
-      enableLogEndingEventDispatch: isFeatureEnabled(process.env.LOG_ENDING_EVENT_DISPATCH),
-      emitOpsEventEachSeconds: isFeatureEnabled(process.env.OPS_EVENT_EACH_SECONDS) || 15,
+      enableKnexPerformanceMonitoring: toBoolean(process.env.ENABLE_KNEX_PERFORMANCE_MONITORING),
+      enableLogStartingEventDispatch: toBoolean(process.env.LOG_STARTING_EVENT_DISPATCH),
+      enableLogEndingEventDispatch: toBoolean(process.env.LOG_ENDING_EVENT_DISPATCH),
+      emitOpsEventEachSeconds: toBoolean(process.env.OPS_EVENT_EACH_SECONDS) || 15,
     },
     login: {
       temporaryBlockingThresholdFailureCount: _getNumber(
@@ -266,9 +262,9 @@ const configuration = (function () {
       temporaryBlockingBaseTimeMs: ms(process.env.LOGIN_TEMPORARY_BLOCKING_BASE_TIME || '2m'),
       blockingLimitFailureCount: _getNumber(process.env.LOGIN_BLOCKING_LIMIT_FAILURE_COUNT || 50),
     },
-    logOpsMetrics: isFeatureEnabled(process.env.LOG_OPS_METRICS),
+    logOpsMetrics: toBoolean(process.env.LOG_OPS_METRICS),
     mailing: {
-      enabled: isFeatureEnabled(process.env.MAILING_ENABLED),
+      enabled: toBoolean(process.env.MAILING_ENABLED),
       provider: process.env.MAILING_PROVIDER || 'brevo',
       smtpUrl: process.env.MAILING_SMTP_URL || 'smtp://username:password@localhost:1025/',
       brevo: {
@@ -295,7 +291,7 @@ const configuration = (function () {
       accessTokenLifespanMs: ms(process.env.PAYSDELALOIRE_ACCESS_TOKEN_LIFESPAN || '7d'),
       clientId: process.env.PAYSDELALOIRE_CLIENT_ID,
       clientSecret: process.env.PAYSDELALOIRE_CLIENT_SECRET,
-      isEnabled: isFeatureEnabled(process.env.PAYSDELALOIRE_ENABLED),
+      isEnabled: toBoolean(process.env.PAYSDELALOIRE_ENABLED),
       isEnabledForPixAdmin: false,
       openidConfigurationUrl: process.env.PAYSDELALOIRE_OPENID_CONFIGURATION_URL,
       postLogoutRedirectUri: process.env.PAYSDELALOIRE_POST_LOGOUT_REDIRECT_URI,
@@ -314,12 +310,12 @@ const configuration = (function () {
       afterLogoutUrl: process.env.POLE_EMPLOI_OIDC_AFTER_LOGOUT_URL,
       clientId: process.env.POLE_EMPLOI_CLIENT_ID,
       clientSecret: process.env.POLE_EMPLOI_CLIENT_SECRET,
-      isEnabled: isFeatureEnabled(process.env.POLE_EMPLOI_ENABLED),
+      isEnabled: toBoolean(process.env.POLE_EMPLOI_ENABLED),
       isEnabledForPixAdmin: false,
       logoutUrl: process.env.POLE_EMPLOI_OIDC_LOGOUT_URL,
       openidConfigurationUrl: process.env.POLE_EMPLOI_OPENID_CONFIGURATION_URL,
       poleEmploiSendingsLimit: _getNumber(process.env.POLE_EMPLOI_SENDING_LIMIT, 100),
-      pushEnabled: isFeatureEnabled(process.env.PUSH_DATA_TO_POLE_EMPLOI_ENABLED),
+      pushEnabled: toBoolean(process.env.PUSH_DATA_TO_POLE_EMPLOI_ENABLED),
       redirectUri: process.env.POLE_EMPLOI_REDIRECT_URI,
       sendingUrl: process.env.POLE_EMPLOI_SENDING_URL,
       tokenUrl: process.env.POLE_EMPLOI_TOKEN_URL,
@@ -329,7 +325,7 @@ const configuration = (function () {
       accessTokenLifespanMs: ms(process.env.PROSANTECONNECT_ACCESS_TOKEN_LIFESPAN || '7d'),
       clientId: process.env.PROSANTECONNECT_CLIENT_ID,
       clientSecret: process.env.PROSANTECONNECT_CLIENT_SECRET,
-      isEnabled: isFeatureEnabled(process.env.PROSANTECONNECT_ENABLED),
+      isEnabled: toBoolean(process.env.PROSANTECONNECT_ENABLED),
       isEnabledForPixAdmin: false,
       openidConfigurationUrl: process.env.PROSANTECONNECT_OPENID_CONFIGURATION_URL,
       postLogoutRedirectUri: process.env.PROSANTECONNECT_POST_LOGOUT_REDIRECT_URI,
@@ -348,11 +344,11 @@ const configuration = (function () {
       accessTokenLifespanMs: ms(process.env.SAML_ACCESS_TOKEN_LIFESPAN || '7d'),
     },
     sentry: {
-      enabled: isFeatureEnabled(process.env.SENTRY_ENABLED),
+      enabled: toBoolean(process.env.SENTRY_ENABLED),
       dsn: process.env.SENTRY_DSN,
       environment: process.env.SENTRY_ENVIRONMENT || 'development',
       maxBreadcrumbs: _getNumber(process.env.SENTRY_MAX_BREADCRUMBS, 100),
-      debug: isFeatureEnabled(process.env.SENTRY_DEBUG),
+      debug: toBoolean(process.env.SENTRY_DEBUG),
       maxValueLength: 1000,
     },
     temporaryKey: {
@@ -519,7 +515,7 @@ const configuration = (function () {
     config.jwtConfig.livretScolaire = { secret: 'secretosmose', tokenLifespan: '1h' };
     config.jwtConfig.poleEmploi = { secret: 'secretPoleEmploi', tokenLifespan: '1h' };
 
-    config.logging.enabled = isFeatureEnabled(process.env.TEST_LOG_ENABLED);
+    config.logging.enabled = toBoolean(process.env.TEST_LOG_ENABLED);
     config.logging.enableLogKnexQueries = false;
     config.logging.enableLogStartingEventDispatch = false;
     config.logging.enableLogEndingEventDispatch = false;

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -304,6 +304,12 @@ const configuration = (function () {
       monitorStateIntervalSeconds: _getNumber(process.env.PGBOSS_MONITOR_STATE_INTERVAL_SECONDS, undefined),
       // 43200 is equal to 12 hours - its the default pgboss configuration
       archiveFailedAfterSeconds: _getNumber(process.env.PGBOSS_ARCHIVE_FAILED_AFTER_SECONDS, 43200),
+      validationFileJobEnabled: process.env.PGBOSS_VALIDATION_FILE_JOB_ENABLED
+        ? toBoolean(process.env.PGBOSS_VALIDATION_FILE_JOB_ENABLED)
+        : true,
+      importFileJobEnabled: process.env.PGBOSS_IMPORT_FILE_JOB_ENABLED
+        ? toBoolean(process.env.PGBOSS_IMPORT_FILE_JOB_ENABLED)
+        : true,
     },
     poleEmploi: {
       accessTokenLifespanMs: ms(process.env.POLE_EMPLOI_ACCESS_TOKEN_LIFESPAN || '7d'),

--- a/api/tests/unit/worker_test.js
+++ b/api/tests/unit/worker_test.js
@@ -2,19 +2,26 @@ import { ImportOrganizationLearnersJob } from '../../src/prescription/learner-ma
 import { ImportOrganizationLearnersJobHandler } from '../../src/prescription/learner-management/infrastructure/jobs/ImportOrganizationLearnersJobHandler.js';
 import { ValidateOrganizationImportFileJob } from '../../src/prescription/learner-management/infrastructure/jobs/ValidateOrganizationImportFileJob.js';
 import { ValidateOrganizationImportFileJobHandler } from '../../src/prescription/learner-management/infrastructure/jobs/ValidateOrganizationImportFileJobHandler.js';
+import { config } from '../../src/shared/config.js';
 import { runJobs } from '../../worker.js';
 import { expect, sinon } from '../test-helper.js';
 
 describe('#runjobs', function () {
+  let startPgBossStub, createMonitoredJobQueueStub, scheduleCpfJobsStub, monitoredJobQueueStub;
+
+  beforeEach(function () {
+    const pgBossStub = { schedule: sinon.stub() };
+    monitoredJobQueueStub = { performJob: sinon.stub() };
+    startPgBossStub = sinon.stub();
+    startPgBossStub.resolves(pgBossStub);
+    createMonitoredJobQueueStub = sinon.stub();
+    createMonitoredJobQueueStub.withArgs(pgBossStub).returns(monitoredJobQueueStub);
+    scheduleCpfJobsStub = sinon.stub();
+  });
+
   it('should register ImportOrganizationLearnersJob', async function () {
     //given
-    const pgBossStub = { schedule: sinon.stub() };
-    const monitoredJobQueueStub = { performJob: sinon.stub() };
-    const startPgBossStub = sinon.stub();
-    startPgBossStub.resolves(pgBossStub);
-    const createMonitoredJobQueueStub = sinon.stub();
-    createMonitoredJobQueueStub.withArgs(pgBossStub).returns(monitoredJobQueueStub);
-    const scheduleCpfJobsStub = sinon.stub();
+    sinon.stub(config.pgBoss, 'importFileJobEnabled').value(true);
 
     // when
     await runJobs({
@@ -33,13 +40,7 @@ describe('#runjobs', function () {
 
   it('should register ValidateOrganizationImportFileJob', async function () {
     //given
-    const pgBossStub = { schedule: sinon.stub() };
-    const monitoredJobQueueStub = { performJob: sinon.stub() };
-    const startPgBossStub = sinon.stub();
-    startPgBossStub.resolves(pgBossStub);
-    const createMonitoredJobQueueStub = sinon.stub();
-    createMonitoredJobQueueStub.withArgs(pgBossStub).returns(monitoredJobQueueStub);
-    const scheduleCpfJobsStub = sinon.stub();
+    sinon.stub(config.pgBoss, 'validationFileJobEnabled').value(true);
 
     // when
     await runJobs({
@@ -54,5 +55,45 @@ describe('#runjobs', function () {
       .find(({ args }) => args[0] === ValidateOrganizationImportFileJob.name);
 
     expect(calls.args[1]).to.equal(ValidateOrganizationImportFileJobHandler);
+  });
+
+  it('should not register validation job if PGBOSS_VALIDATION_FILE_JOB_ENABLED is false', async function () {
+    //given
+    sinon.stub(config.pgBoss, 'validationFileJobEnabled').value(false);
+    // when
+    await runJobs({
+      startPgBoss: startPgBossStub,
+      createMonitoredJobQueue: createMonitoredJobQueueStub,
+      scheduleCpfJobs: scheduleCpfJobsStub,
+    });
+
+    // then
+    const calls = monitoredJobQueueStub.performJob.getCalls();
+
+    const validatationJob = calls.find(({ args }) => args[0] === ValidateOrganizationImportFileJob.name);
+    const importJob = calls.find(({ args }) => args[0] === ImportOrganizationLearnersJob.name);
+
+    expect(validatationJob).to.be.undefined;
+    expect(importJob).to.exist;
+  });
+
+  it('should not register import job if PGBOSS_IMPORT_FILE_JOB_ENABLED is false', async function () {
+    //given
+    sinon.stub(config.pgBoss, 'importFileJobEnabled').value(false);
+    // when
+    await runJobs({
+      startPgBoss: startPgBossStub,
+      createMonitoredJobQueue: createMonitoredJobQueueStub,
+      scheduleCpfJobs: scheduleCpfJobsStub,
+    });
+
+    // then
+    const calls = monitoredJobQueueStub.performJob.getCalls();
+
+    const validatationJob = calls.find(({ args }) => args[0] === ValidateOrganizationImportFileJob.name);
+    const importJob = calls.find(({ args }) => args[0] === ImportOrganizationLearnersJob.name);
+
+    expect(validatationJob).to.exist;
+    expect(importJob).to.be.undefined;
   });
 });

--- a/api/worker.js
+++ b/api/worker.js
@@ -85,9 +85,13 @@ export async function runJobs(dependencies = { startPgBoss, createMonitoredJobQu
 
   monitoredJobQueue.performJob(UserAnonymizedEventLoggingJob.name, UserAnonymizedEventLoggingJobHandler);
 
-  monitoredJobQueue.performJob(ImportOrganizationLearnersJob.name, ImportOrganizationLearnersJobHandler);
+  if (config.pgBoss.validationFileJobEnabled) {
+    monitoredJobQueue.performJob(ValidateOrganizationImportFileJob.name, ValidateOrganizationImportFileJobHandler);
+  }
 
-  monitoredJobQueue.performJob(ValidateOrganizationImportFileJob.name, ValidateOrganizationImportFileJobHandler);
+  if (config.pgBoss.importFileJobEnabled) {
+    monitoredJobQueue.performJob(ImportOrganizationLearnersJob.name, ImportOrganizationLearnersJobHandler);
+  }
 
   await pgBoss.schedule(
     ScheduleComputeOrganizationLearnersCertificabilityJob.name,

--- a/api/worker.js
+++ b/api/worker.js
@@ -57,8 +57,12 @@ function createMonitoredJobQueue(pgBoss) {
   const monitoredJobQueue = new MonitoredJobQueue(jobQueue);
   process.on('SIGINT', async () => {
     await monitoredJobQueue.stop();
-    // eslint-disable-next-line n/no-process-exit
-    process.exit(0);
+
+    // Make sure pgBoss stopped before quitting
+    pgBoss.on('stopped', () => {
+      // eslint-disable-next-line n/no-process-exit
+      process.exit(0);
+    });
   });
   return monitoredJobQueue;
 }


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la refonte de l'import, nous avons rendus asynchrone les taches de validation de fichier ainsi que l'import des learners en BDD dans les PR suivantes : 
- https://github.com/1024pix/pix/pull/8632  
- https://github.com/1024pix/pix/pull/8660

On veut maintenant pouvoir rendre ces deux jobs stoppable indépendamment.

## :robot: Proposition
Utiliser une variable d'environnement par job pour pouvoir activer/désactiver la validation et/ou l'import

## :rainbow: Remarques
Si les variables ne sont pas présentent dans les variables d'env, elles sont true par défaut.

## :100: Pour tester

- Scale un worker à 1 sur scalingo, et supprimer la variable d'env `START_JOB_IN_WEB_PROCESS`

**Cas nominal :**

- Se connecter à Pix Orga avec sco-orga@example.net
- Faire un import SIECLE valide
- Vérifier que tout s'est bien passé pour le cas nominal

**Stop à la validation :**

- Ajouter la variable d'env `PGBOSS_VALIDATION_FILE_JOB_ENABLED` et la mettre à false
- Scale le worker à 0. Puis une fois coupé, le rescale à 1.
- Faire un import SIECLE valide
- Vérifier que l'import reste à l'état de validation du fichier et ne passe pas à l'étape d'import

**Stop à l'import :**

- Ajouter la variable d'env `PGBOSS_IMPORT_FILE_JOB_ENABLED` et la mettre à false
- Scale le worker à 0. Puis une fois coupé, le rescale à 1.
- Faire un import SIECLE valide
- Vérifier que l'import reste à l'état d'import du fichier et ne passe pas à l'étape importé en succès

🐈‍⬛
