### PR TITLE
[BUGFIX] Corriger l'affichage de la page étudiant pour les membres (PIX-12169)

### DIFF
--- a/orga/app/routes/authenticated/sup-organization-participants/list.js
+++ b/orga/app/routes/authenticated/sup-organization-participants/list.js
@@ -21,9 +21,11 @@ export default class ListRoute extends Route {
   async model(params) {
     const organizationId = this.currentUser.organization.id;
     return RSVP.hash({
-      importDetail: await this.store.queryRecord('organization-import-detail', {
-        organizationId: this.currentUser.organization.id,
-      }),
+      importDetail: this.currentUser.shouldAccessImportPage
+        ? await this.store.queryRecord('organization-import-detail', {
+            organizationId: this.currentUser.organization.id,
+          })
+        : null,
       participants: this.store.query('sup-organization-participant', {
         filter: {
           organizationId,

--- a/orga/tests/unit/routes/authenticated/sup-organization-participants/list_test.js
+++ b/orga/tests/unit/routes/authenticated/sup-organization-participants/list_test.js
@@ -16,11 +16,21 @@ module('Unit | Route | authenticated/sup-organization-participants/list', functi
   const pageSizeSymbol = Symbol('pageSize');
   const participationCountSymbol = Symbol('participationCountOrder');
   const lastnameSortSymbol = Symbol('lastnameSort');
+  const params = {
+    search: searchSymbol,
+    studentNumber: studentNumberSymbol,
+    groups: groupsSymbol,
+    certificability: certificabilitySymbol,
+    pageNumber: pageNumberSymbol,
+    pageSize: pageSizeSymbol,
+    participationCountOrder: participationCountSymbol,
+    lastnameSort: lastnameSortSymbol,
+  };
 
   hooks.beforeEach(function () {
     route = this.owner.lookup('route:authenticated/sup-organization-participants/list');
     store = this.owner.lookup('service:store');
-    route.currentUser = { shouldAccessImportPage: true, organization: { id: Symbol('organization-id') } };
+    route.currentUser = { organization: { id: Symbol('organization-id') } };
     sinon
       .stub(store, 'queryRecord')
       .withArgs('organization-import-detail', {
@@ -50,24 +60,37 @@ module('Unit | Route | authenticated/sup-organization-participants/list', functi
       .resolves(supOrganizationParticipantSymbol);
   });
 
-  test('should return models', async function (assert) {
-    // given
-    const params = {
-      search: searchSymbol,
-      studentNumber: studentNumberSymbol,
-      groups: groupsSymbol,
-      certificability: certificabilitySymbol,
-      pageNumber: pageNumberSymbol,
-      pageSize: pageSizeSymbol,
-      participationCountOrder: participationCountSymbol,
-      lastnameSort: lastnameSortSymbol,
-    };
-
+  test('should return participant model', async function (assert) {
     // when
-    const { participants, importDetail } = await route.model(params);
+    const { participants } = await route.model(params);
 
     // then
-    assert.strictEqual(importDetail, importDetailSymbol);
     assert.strictEqual(participants, supOrganizationParticipantSymbol);
+  });
+
+  module('when user is admin of organization', function () {
+    test('should return import information model', async function (assert) {
+      //given
+
+      route.currentUser.shouldAccessImportPage = true;
+      //when
+      const { importDetail } = await route.model(params);
+
+      //then
+      assert.strictEqual(importDetail, importDetailSymbol);
+    });
+  });
+
+  module('when user is member of organization', function () {
+    test('should not return import information model', async function (assert) {
+      //given
+      route.currentUser.shouldAccessImportPage = false;
+
+      //when
+      const { importDetail } = await route.model(params);
+
+      //then
+      assert.notEqual(importDetail, importDetailSymbol);
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Dans la PR : https://github.com/1024pix/pix/pull/8635 nous avons introduit un bug. On récupère les informations sur l'import depuis la page étudiants sans vérifier si l'utilisateur est admin ou non. Donc dans le cas d'un membre, cette route est appelée mais retourne une 403 (car seuls les admins ont accès à l'import). La page étudiants ne s'affiche donc plus pour les membres et affiche un loader en boucle.

## :robot: Proposition
Vérifier dans la route si l'utilisateur est admin, si il l'est on va chercher les données du dernier import. Si l'utilisateur est simple membre on retourne null afin de ne plus les bloquer.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
**ROLE MEMBRE :**
- Se connecter à PixOrga avec `all-orga@example.net`
- Aller sur l'organisation `SUP Orga - Managing Students` (Membre de l'organisation)
- Aller sur la page `Etudiants`
- **Vérifier qu'elle s'affiche de nouveau**
- **Vérifier qu'aucune information sur l'import ne s'affiche**

**ROLE ADMIN :**
- Se connecter à PixOrga avec `sup-orga@example.net`
- Aller sur l'organisation `SUP Orga - Managing Students` (Admin de l'organisation)
- Aller sur la page `Etudiants`
- **Vérifier que les informations sur l'import s'affiche**
