### PR TITLE
[FEATURE] Permettre la modification d'un critère d'obtention de RT sur l'ensemble du PF (PIX-12157).

### DIFF
--- a/admin/app/adapters/badge-criterion.js
+++ b/admin/app/adapters/badge-criterion.js
@@ -6,4 +6,12 @@ export default class BadgeCriterionAdapter extends ApplicationAdapter {
   urlForCreateRecord(_modelName, badgeCriterion) {
     return `${this.host}/${this.namespace}/badges/${badgeCriterion.belongsTo('badge').id}/badge-criteria`;
   }
+
+  updateRecord(store, type, snapshot) {
+    const payload = this.serialize(snapshot);
+    delete payload.data.attributes['scope'];
+
+    const url = this.buildURL(type.modelName, snapshot.id, snapshot, 'updateRecord');
+    return this.ajax(url, 'PATCH', { data: payload });
+  }
 }

--- a/admin/app/components/badges/badge.hbs
+++ b/admin/app/components/badges/badge.hbs
@@ -125,7 +125,10 @@
   <section class="badge__criteria main-admin-form">
     <div class="admin-form__content">
       {{#if this.campaignScopeCriterion}}
-        <Badges::CampaignCriterion @criterion={{this.campaignScopeCriterion}} />
+        <Badges::CampaignCriterion
+          @criterion={{this.campaignScopeCriterion}}
+          @isEditable={{(not @targetProfile.hasLinkedCampaign)}}
+        />
       {{/if}}
       {{#if this.cappedTubesCriteria.length}}
         <h2 class="badge-criterion__title">

--- a/admin/app/components/badges/badge.hbs
+++ b/admin/app/components/badges/badge.hbs
@@ -88,7 +88,9 @@
                 @isBorderVisible={{true}}
                 @triggerAction={{this.cancel}}
               >Annuler</PixButton>
-              <PixButton @type="submit" @size="small" @backgroundColor="success">Enregistrer</PixButton>
+              <PixButton @type="submit" @size="small" @backgroundColor="success" data-testid="save-badge-edit">
+                Enregistrer
+              </PixButton>
             </div>
           </form>
         </div>

--- a/admin/app/components/badges/badge.hbs
+++ b/admin/app/components/badges/badge.hbs
@@ -125,15 +125,10 @@
   <section class="badge__criteria main-admin-form">
     <div class="admin-form__content">
       {{#if this.campaignScopeCriterion}}
-        <h2 class="badge__criteria-title">Critère d'obtention basé sur l'ensemble du profil cible&nbsp;:</h2>
-        <div class="card">
-          <div class="card__content">
-            <Badges::CampaignCriterion @criterion={{this.campaignScopeCriterion}} />
-          </div>
-        </div>
+        <Badges::CampaignCriterion @criterion={{this.campaignScopeCriterion}} />
       {{/if}}
       {{#if this.cappedTubesCriteria.length}}
-        <h2 class="badge__criteria-title">
+        <h2 class="badge-criterion__title">
           Liste des critères d'obtention basés sur une sélection de sujets du profil cible&nbsp;:
         </h2>
         {{#each this.cappedTubesCriteria as |criterion|}}

--- a/admin/app/components/badges/campaign-criterion.hbs
+++ b/admin/app/components/badges/campaign-criterion.hbs
@@ -1,10 +1,64 @@
-<h2 class="badge__criteria-title">Critère d'obtention basé sur l'ensemble du profil cible&nbsp;:</h2>
-<div class="card">
-  <div class="card__content">
-    <p data-testid="campaign-criterion-text">
-      L'évalué doit obtenir
-      <strong>{{@criterion.threshold}}%</strong>
-      sur l'ensemble des sujets du profil cible.
-    </p>
+<article class="badge-criterion">
+  <div class="badge-criterion__header">
+    <h2 class="badge-criterion__title">Critère d'obtention basé sur l'ensemble du profil cible&nbsp;:</h2>
+    <PixTooltip @hide={{@isEditable}} @isWide={{true}}>
+      <:triggerElement>
+        <PixButton
+          @backgroundColor="transparent-light"
+          @isBorderVisible={{true}}
+          @size="small"
+          @triggerAction={{this.toggleEditModal}}
+          @isDisabled={{(not @isEditable)}}
+        >
+          Modifier le critère
+        </PixButton>
+      </:triggerElement>
+
+      <:tooltip>
+        Non modifiable car le profil cible est relié à une&nbsp;campagne
+      </:tooltip>
+    </PixTooltip>
   </div>
-</div>
+  <div class="card">
+    <div class="card__content">
+      <p data-testid="campaign-criterion-text">
+        L'évalué doit obtenir
+        <strong>{{@criterion.threshold}}%</strong>
+        sur l'ensemble des sujets du profil cible.
+      </p>
+    </div>
+  </div>
+</article>
+
+{{#if @isEditable}}
+  <PixModal
+    @title="Modification du critère d'obtention basé sur l'ensemble du profil cible"
+    @showModal={{this.isEditModalVisible}}
+    @onCloseButtonClick={{this.toggleEditModal}}
+  >
+    <:content>
+      <PixInput
+        @id="campaign-criterion-threshold"
+        value={{this.thresholdInputValue}}
+        onchange={{this.handleThresholdChange}}
+        @subLabel="En pourcent (%)"
+        @requiredLabel="Champ requis"
+      >
+        <:label>Nouveau seuil d'obtention du critère&nbsp;:</:label>
+      </PixInput>
+    </:content>
+    <:footer>
+      <PixButton
+        @triggerAction={{this.toggleEditModal}}
+        @size="small"
+        @backgroundColor="transparent-light"
+        @isBorderVisible={{true}}
+      >
+        Annuler
+      </PixButton>
+      <PixButton @triggerAction={{this.updateThreshold}} @size="small">
+        Enregistrer
+      </PixButton>
+    </:footer>
+  </PixModal>
+{{/if}}

--- a/admin/app/components/badges/campaign-criterion.hbs
+++ b/admin/app/components/badges/campaign-criterion.hbs
@@ -1,3 +1,10 @@
-<p data-testid="triste">L‘évalué doit obtenir
-  <strong>{{@criterion.threshold}}%</strong>
-  sur l‘ensemble des sujets du profil cible.</p>
+<h2 class="badge__criteria-title">Critère d'obtention basé sur l'ensemble du profil cible&nbsp;:</h2>
+<div class="card">
+  <div class="card__content">
+    <p data-testid="campaign-criterion-text">
+      L'évalué doit obtenir
+      <strong>{{@criterion.threshold}}%</strong>
+      sur l'ensemble des sujets du profil cible.
+    </p>
+  </div>
+</div>

--- a/admin/app/components/badges/campaign-criterion.js
+++ b/admin/app/components/badges/campaign-criterion.js
@@ -1,0 +1,40 @@
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class CampaignCriterion extends Component {
+  @service notifications;
+
+  @tracked isEditModalVisible = false;
+  @tracked thresholdInputValue = this.previousTreshold;
+
+  get previousTreshold() {
+    return this.args.criterion.threshold;
+  }
+
+  @action
+  toggleEditModal() {
+    this.isEditModalVisible = !this.isEditModalVisible;
+  }
+
+  @action
+  handleThresholdChange(event) {
+    this.thresholdInputValue = Number(event.target.value);
+  }
+
+  @action
+  async updateThreshold() {
+    const criterion = this.args.criterion;
+    criterion.threshold = this.thresholdInputValue;
+
+    try {
+      await criterion.save();
+      this.notifications.success("Seuil d'obtention du critère modifié avec succès.");
+      this.toggleEditModal();
+    } catch (error) {
+      this.notifications.error("Problème lors de la modification du seuil d'obtention du critère.");
+      console.log(error);
+    }
+  }
+}

--- a/admin/app/models/badge-criterion.js
+++ b/admin/app/models/badge-criterion.js
@@ -1,10 +1,12 @@
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class BadgeCriterion extends Model {
   @attr('string') scope;
   @attr('number') threshold;
   @attr() cappedTubes;
   @attr() name;
+
+  @belongsTo('badge') badge;
 
   get isCampaignScope() {
     return this.scope === 'CampaignParticipation';

--- a/admin/app/styles/components/badges/badge.scss
+++ b/admin/app/styles/components/badges/badge.scss
@@ -48,7 +48,16 @@
   margin: 20px 0;
 }
 
-.badge__criteria-title {
+.badge-criterion__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pix-spacing-2x) var(--pix-spacing-4x);
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--pix-spacing-3x);
+}
+
+.badge-criterion__title {
   @extend %pix-title-xs;
 
   &:not(:first-child) {

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -9,6 +9,7 @@ import {
   getPaginatedAutonomousCourses,
   updateAutonomousCourse,
 } from './handlers/autonomous-courses';
+import { updateBadgeCriterion } from './handlers/badge-criteria';
 import { findPaginatedAndFilteredSessions } from './handlers/find-paginated-and-filtered-sessions';
 import { findFrameworkAreas } from './handlers/frameworks';
 import { getPaginatedJuryCertificationSummariesBySessionId } from './handlers/get-jury-certification-summaries-by-session-id';
@@ -73,6 +74,8 @@ function routes() {
   this.get('/admin/autonomous-courses', getPaginatedAutonomousCourses);
   this.get('/admin/autonomous-courses/:id', getAutonomousCourseDetails);
   this.patch('/admin/autonomous-courses/:id', updateAutonomousCourse);
+
+  this.patch('/admin/badge-criteria/:id', updateBadgeCriterion);
 
   this.get('/admin/campaigns/:id');
   this.get('/admin/campaigns/:id/participations', (schema) => {

--- a/admin/mirage/handlers/badge-criteria.js
+++ b/admin/mirage/handlers/badge-criteria.js
@@ -1,0 +1,11 @@
+function updateBadgeCriterion(schema, request) {
+  const badgeCriterionId = request.params.id;
+  const params = JSON.parse(request.requestBody);
+
+  const badgeCriterion = schema.badgeCriteria.find(badgeCriterionId);
+  badgeCriterion.update(params.data.attributes);
+
+  return badgeCriterion;
+}
+
+export { updateBadgeCriterion };

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
@@ -459,8 +459,8 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         assert.dom(screen.getByText('Certifiable')).exists();
         assert.dom(screen.getByText('Lacunes')).exists();
         assert.deepEqual(
-          screen.getByTestId('triste').innerText,
-          'L‘évalué doit obtenir 50% sur l‘ensemble des sujets du profil cible.',
+          screen.getByTestId('campaign-criterion-text').innerText,
+          "L'évalué doit obtenir 50% sur l'ensemble des sujets du profil cible.",
         );
       });
 
@@ -652,8 +652,8 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         assert.dom(screen.getByText('Lacunes')).exists();
         assert.dom(screen.getByText("Critère d'obtention basé sur l'ensemble du profil cible :")).exists();
         assert.deepEqual(
-          screen.getByTestId('triste').innerText,
-          'L‘évalué doit obtenir 50% sur l‘ensemble des sujets du profil cible.',
+          screen.getByTestId('campaign-criterion-text').innerText,
+          "L'évalué doit obtenir 50% sur l'ensemble des sujets du profil cible.",
         );
         assert
           .dom(screen.getByText("Liste des critères d'obtention basés sur une sélection de sujets du profil cible :"))

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
@@ -515,7 +515,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         assert.dom(screen.getByText('Message alternatif : nouveau alt')).exists();
         assert.dom(screen.getByText('Certifiable')).exists();
         assert.dom(screen.queryByText('Lacunes')).doesNotExist();
-        assert.dom(screen.queryByText('Enregistrer')).doesNotExist();
+        assert.dom(screen.queryByTestId('save-badge-edit')).doesNotExist();
       });
 
       test('it should cancel badge edition', async function (assert) {
@@ -534,7 +534,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         // then
         assert.strictEqual(currentURL(), '/target-profiles/1/badges/100');
         assert.dom(screen.getByText('Nom du résultat thématique : tagada')).exists();
-        assert.dom(screen.queryByText('Enregistrer')).doesNotExist();
+        assert.dom(screen.queryByTestId('save-badge-edit')).doesNotExist();
       });
 
       test('it should create a badge', async function (assert) {
@@ -680,6 +680,28 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         assert.strictEqual(currentURL(), '/target-profiles/1/insights');
         assert.dom(screen.queryByText('Enregistrer')).doesNotExist();
         assert.dom(screen.queryByText('Voir détail')).doesNotExist();
+      });
+
+      test('it should edit a campaign criterion', async function (assert) {
+        // given
+        const badge = server.create('badge');
+        targetProfile.update({ badges: [badge] });
+
+        const campaignCriterion = badge.criteria.models[0];
+        console.log(campaignCriterion);
+
+        // when
+        const screen = await visit(`/target-profiles/1/badges/${badge.id}`);
+        await clickByName('Modifier le critère');
+        await fillByLabel(/Nouveau seuil d'obtention du critère :/, 99);
+        await clickByName('Enregistrer');
+
+        // then
+        assert.dom(screen.getByText("Seuil d'obtention du critère modifié avec succès.")).exists();
+        assert.deepEqual(
+          screen.getByTestId('campaign-criterion-text').innerText,
+          "L'évalué doit obtenir 99% sur l'ensemble des sujets du profil cible.",
+        );
       });
     });
   });

--- a/admin/tests/integration/components/badges/badge_test.js
+++ b/admin/tests/integration/components/badges/badge_test.js
@@ -73,8 +73,8 @@ module('Integration | Component | Badges::Badge', function (hooks) {
 
     // then
     assert.deepEqual(
-      screen.getByTestId('triste').innerText,
-      'L‘évalué doit obtenir 25% sur l‘ensemble des sujets du profil cible.',
+      screen.getByTestId('campaign-criterion-text').innerText,
+      "L'évalué doit obtenir 25% sur l'ensemble des sujets du profil cible.",
     );
     assert.deepEqual(
       screen.getByTestId('toujourstriste').innerText,

--- a/admin/tests/integration/components/badges/campaign-criterion_test.js
+++ b/admin/tests/integration/components/badges/campaign-criterion_test.js
@@ -1,7 +1,10 @@
-import { render } from '@1024pix/ember-testing-library';
+import { clickByName, fillByLabel, fireEvent, render, within } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 module('Integration | Component | Badges::CampaignCriterion', function (hooks) {
   setupRenderingTest(hooks);
@@ -10,6 +13,7 @@ module('Integration | Component | Badges::CampaignCriterion', function (hooks) {
     // given
     const store = this.owner.lookup('service:store');
     const criterion = store.createRecord('badge-criterion', {
+      id: 123,
       threshold: 60,
     });
     this.set('criterion', criterion);
@@ -22,5 +26,94 @@ module('Integration | Component | Badges::CampaignCriterion', function (hooks) {
       screen.getByTestId('campaign-criterion-text').innerText,
       "L'évalué doit obtenir 60% sur l'ensemble des sujets du profil cible.",
     );
+  });
+
+  module('#update', function () {
+    module('when the target profile is linked with a campaign', function () {
+      test('should display a disabled edit button', async function (assert) {
+        // when
+        const screen = await render(
+          hbs`<Badges::CampaignCriterion @criterion={{this.criterion}} @isEditable={{false}} />`,
+        );
+
+        fireEvent.mouseOver(screen.getByRole('button', { name: 'Modifier le critère' }));
+
+        // then
+        assert.true(screen.getByRole('button', { name: 'Modifier le critère' }).disabled);
+        assert.dom(screen.getByText(/Non modifiable car le profil cible est relié à une campagne/)).exists();
+        assert.notOk(screen.queryByText(/Modification du critère d'obtention basé sur l'ensemble du profil cible/));
+      });
+    });
+
+    module('when the target profile is not linked with a campaign', function (hooks) {
+      let modal, notificationErrorStub, notificationSuccessStub, screen, store;
+
+      hooks.beforeEach(async function () {
+        // given
+        store = this.owner.lookup('service:store');
+
+        const criterion = store.createRecord('badge-criterion', {
+          scope: 'CampaignParticipation',
+          threshold: 60,
+          save: sinon.stub(),
+        });
+        this.set('criterion', criterion);
+
+        notificationSuccessStub = sinon.stub();
+        notificationErrorStub = sinon.stub();
+        class NotificationsStub extends Service {
+          success = notificationSuccessStub;
+          error = notificationErrorStub;
+        }
+        this.owner.register('service:notifications', NotificationsStub);
+
+        // when
+        screen = await render(hbs`<Badges::CampaignCriterion @criterion={{this.criterion}} @isEditable={{true}} />`);
+        await clickByName('Modifier le critère');
+        modal = within(await screen.findByRole('dialog'));
+      });
+
+      test('should display an edit modal with a filled input', async function (assert) {
+        // then
+        assert.notOk(this.element.querySelector('.pix-modal__overlay--hidden'));
+        assert.dom(modal.getByDisplayValue(60)).exists();
+      });
+
+      test('should close the edit modal on cancel action', async function (assert) {
+        await click(modal.getByRole('button', { name: 'Annuler' }));
+        assert.dom(this.element.querySelector('.pix-modal__overlay--hidden')).exists();
+      });
+
+      test('should call the save method and success notification service', async function (assert) {
+        // given
+        this.criterion.save.resolves();
+
+        // when
+        await fillByLabel(/Nouveau seuil d'obtention du critère :/, 33);
+        assert.dom(modal.getByDisplayValue(33)).exists();
+
+        await click(modal.getByRole('button', { name: 'Enregistrer' }));
+
+        //then
+        assert.ok(this.criterion.save.called);
+        sinon.assert.calledWith(notificationSuccessStub, "Seuil d'obtention du critère modifié avec succès.");
+        assert.dom(this.element.querySelector('.pix-modal__overlay--hidden')).exists();
+      });
+
+      test('should display an error notification', async function (assert) {
+        // given
+        this.criterion.save.throws();
+
+        // when
+        await click(modal.getByRole('button', { name: 'Enregistrer' }));
+
+        // then
+        sinon.assert.calledWith(
+          notificationErrorStub,
+          "Problème lors de la modification du seuil d'obtention du critère.",
+        );
+        assert.ok(true);
+      });
+    });
   });
 });

--- a/admin/tests/integration/components/badges/campaign-criterion_test.js
+++ b/admin/tests/integration/components/badges/campaign-criterion_test.js
@@ -19,8 +19,8 @@ module('Integration | Component | Badges::CampaignCriterion', function (hooks) {
 
     // then
     assert.deepEqual(
-      screen.getByTestId('triste').innerText,
-      'L‘évalué doit obtenir 60% sur l‘ensemble des sujets du profil cible.',
+      screen.getByTestId('campaign-criterion-text').innerText,
+      "L'évalué doit obtenir 60% sur l'ensemble des sujets du profil cible.",
     );
   });
 });

--- a/admin/tests/unit/adapters/badge-criterion_test.js
+++ b/admin/tests/unit/adapters/badge-criterion_test.js
@@ -1,5 +1,6 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 module('Unit | Adapters | badge-criterion', function (hooks) {
   setupTest(hooks);
@@ -23,6 +24,53 @@ module('Unit | Adapters | badge-criterion', function (hooks) {
 
       // then
       assert.true(url.endsWith('/api/admin/badges/90/badge-criteria'));
+    });
+  });
+
+  module('#updateRecord', function () {
+    test('should trigger an ajax call with the right method and payload', function (assert) {
+      // given
+      const attributes = {
+        scope: Symbol('should-be-removed'),
+        name: 'Dummy name',
+        threshold: 12,
+        'capped-tubes': [],
+      };
+
+      const snapshot = {
+        id: 123,
+        serialize: sinon.stub().returns({
+          data: {
+            attributes,
+          },
+        }),
+      };
+
+      // when
+      adapter.ajax = sinon.stub();
+
+      adapter.updateRecord(null, { modelName: 'badge-criterion' }, snapshot);
+
+      // then
+      const expectedPayload = {
+        data: {
+          data: {
+            attributes: {
+              name: 'Dummy name',
+              threshold: 12,
+              'capped-tubes': [],
+            },
+          },
+        },
+      };
+
+      sinon.assert.calledWithExactly(
+        adapter.ajax,
+        'http://localhost:3000/api/admin/badge-criteria/123',
+        'PATCH',
+        expectedPayload,
+      );
+      assert.ok(adapter);
     });
   });
 });

--- a/api/src/evaluation/application/badge-criteria/index.js
+++ b/api/src/evaluation/application/badge-criteria/index.js
@@ -35,9 +35,9 @@ const register = async function (server) {
                     id: Joi.string(),
                     level: Joi.number().min(0),
                   })
-                  .optional(),
-                name: Joi.string().optional(),
-                threshold: Joi.number().integer().min(0).max(100).optional(),
+                  .allow(null),
+                name: Joi.string().allow('').allow(null),
+                threshold: Joi.number().integer().min(0).max(100),
               })
                 .or('capped-tubes', 'name', 'threshold')
                 .required(),


### PR DESCRIPTION
## :unicorn: Problème

Jusqu'à présent, on ne permettait pas la modification d'un critère d'obtention de résultat thématique basé sur l'ensemble du profil cible.

## :robot: Proposition

On peut maintenant modifier ce critère au travers d'une modale.

Si le profil cible est déjà relié à une campagne, alors le bouton pour modifier est désactivé et au survol un tooltip vient expliquer la raison.

## :rainbow: Remarques

La modification des critères basés sur des sujets spécifiques viendra dans un second temps.

## :100: Pour tester

En RA :
1. Modifier le seuil d'un critère de badge de profil cible non relié à une campagne : https://admin-pr8690.review.pix.fr/target-profiles/56/badges/57
2. Constater que, dans le cas d'un profil cible déjà relié à une campagne, le bouton est désactivé et affiche un tooltip d'explication : https://admin-pr8690.review.pix.fr/target-profiles/6001/badges/6000
