### PR TITLE
[FEATURE] Rediriger vers app.pix.org lors d'un test statique (PIX-11941).

### DIFF
--- a/mon-pix/app/templates/assessments/results.hbs
+++ b/mon-pix/app/templates/assessments/results.hbs
@@ -20,7 +20,7 @@
     <div class="assessment-results__index-link-container">
       {{#if @model.isDemo}}
         <PixButtonLink
-          @href="https://app.pix.fr/inscription"
+          @href="https://app.pix.org/inscription"
           class="assessment-results__index-link__element assessment-results__index-a-link"
         >
           <span class="assessment-results__link-back">{{t

--- a/mon-pix/tests/acceptance/course-ending-screen_test.js
+++ b/mon-pix/tests/acceptance/course-ending-screen_test.js
@@ -64,7 +64,7 @@ module('Acceptance | Course ending screen', function (hooks) {
     assert.dom('.assessment-results__index-link__element').exists();
     assert.strictEqual(
       find('.assessment-results__index-a-link').attributes.href.value,
-      'https://app.pix.fr/inscription',
+      'https://app.pix.org/inscription',
     );
     assert.ok(find('.assessment-results__link-back').textContent.includes('Continuer mon expérience Pix'));
   });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, lorsqu'un utilisateur réalise un test statique, il est systématiquement redirigé vers app.pix.fr

## :robot: Proposition
Mettre à jour le lien de redirection

## :100: Pour tester
- démarrer le [test statique](https://app-pr8695.review.pix.fr//courses/recif2CZqh4EQvGX8)
- tout passer
- constater la redirection vers app.pix.org lorsqu'on clique sur le bouton de fin de parcours : 
<img width="360" alt="image" src="https://github.com/1024pix/pix/assets/26234185/820a8ad3-cbc5-4677-ac32-52ae8941fd0e">
