### PR TITLE
[TECH] Corriger le test flaky sur la vérification du schéma des modules (PIX-12183)

### DIFF
--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js
@@ -36,6 +36,8 @@ describe('Unit | Infrastructure | Datasources | Learning Content | ModuleDatasou
       // eslint-disable-next-line mocha/no-setup-in-describe
       modules.forEach((module) => {
         it(`module "${module.slug}" should contain a valid structure`, async function () {
+          // We need to increase the timeout because the validation can be slow for large modules
+          this.timeout(3000);
           try {
             await moduleSchema.validateAsync(module, { abortEarly: false });
           } catch (joiError) {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le test du schéma des modules peut être flaky car beaucoup d'élements peuvent être à vérifier.

## :robot: Proposition
Après analyse cela nous parait pertinent d'augmenter le timeout

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- CI OK