### PR TITLE
[TECH] Remise à jour de la config `docker compose`

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   postgres:
     image: postgres:14.11-alpine

--- a/docs/Anatomy.md
+++ b/docs/Anatomy.md
@@ -28,7 +28,7 @@ pix                      → Sources de la plateforme
  └ .gitignore            → Listing des fichiers / répertoires à ignorer de Git 
  └ .slugignore           → Listing des fichiers / répertoires que Scalingo doit ignorer au moment du build
  └ CHANGELOG.md          → Listing des modifications opérées sur la plateforme (mise à jour automatique)
- └ docker-compose.yml    → Fichier utilisé pour les développements afin de démarrer un environnement iso-prod
+ └ compose.yaml          → Fichier utilisé pour les développements afin de démarrer un environnement iso-prod
  └ INSTALLATION.md       → Instructions d'installation de la plateforme en local
  └ LICENSE.md            → Texte de la licence logicielle utilisée sur Pix (AGPL-3.0)
  └ nginx.conf.erb        → Fichier de configuration du reverse proxy / API gateway (Nginx) 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "lint:scripts": "eslint scripts",
     "lint:yaml": "run-p lint:yaml:*",
     "lint:yaml:dotfiles": "eslint --ext .yml .circleci && eslint --ext .yaml .github",
-    "lint:yaml:files": "eslint --ext .yaml --ignore-pattern docker-compose.yaml ./*.yaml",
+    "lint:yaml:files": "eslint --ext .yaml --ignore-pattern compose.yaml ./*.yaml",
     "lint:docs": "find ./docs -type f -name '*.md' | xargs -L1 markdown-link-check --quiet --config ./docs/link--check-config.json ",
     "local:add-optional-checks": "husky",
     "local:remove-optional-checks": "git config --unset core.hooksPath",


### PR DESCRIPTION
## :unicorn: Problème
Lors du `docker compose up -d` nécessaire pour lancer l'environnement de développement, un warning est lancé :
```
WARN[0000] /pix/docker-compose.yaml: `version` is obsolete
```

## :robot: Proposition
- Retirer le champ `version` déprécié,
- Utiliser le nom de fichier `compose.yaml` qui semble être [le nom de fichier de config recommandé par Docker](https://docs.docker.com/compose/multiple-compose-files/merge/).

## :rainbow: Remarques
J'ai laissé en `yaml` plutôt qu'en `yml` (je ne sais pas ce que ça change).

## :100: Pour tester
Vérifier que le log de warning disparait à l'usage de `docker compose`.
