### PR TITLE
[FEATURE] Retourner une erreur lors de la création d'un passage pour un utilisateur non-existant (PIX-12184)

### DIFF
--- a/api/src/devcomp/domain/usecases/create-passage.js
+++ b/api/src/devcomp/domain/usecases/create-passage.js
@@ -1,9 +1,11 @@
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { ModuleDoesNotExistError } from '../errors.js';
 
-const createPassage = async function ({ moduleId, userId, moduleRepository, passageRepository }) {
+const createPassage = async function ({ moduleId, userId, moduleRepository, passageRepository, userRepository }) {
   await _verifyIfModuleExists({ moduleId, moduleRepository });
-
+  if (userId !== null) {
+    await userRepository.get(userId);
+  }
   return passageRepository.save({ moduleId, userId });
 };
 

--- a/api/src/devcomp/domain/usecases/index.js
+++ b/api/src/devcomp/domain/usecases/index.js
@@ -7,6 +7,7 @@ import * as knowledgeElementRepository from '../../../../lib/infrastructure/repo
 import * as targetProfileRepository from '../../../../lib/infrastructure/repositories/target-profile-repository.js';
 import * as targetProfileTrainingRepository from '../../../../lib/infrastructure/repositories/target-profile-training-repository.js';
 import * as skillRepository from '../../../shared/infrastructure/repositories/skill-repository.js';
+import * as userRepository from '../../../shared/infrastructure/repositories/user-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import { repositories } from '../../infrastructure/repositories/index.js';
@@ -21,6 +22,7 @@ const dependencies = {
   targetProfileRepository,
   targetProfileTrainingRepository,
   skillRepository,
+  userRepository,
 };
 
 const usecasesWithoutInjectedDependencies = {

--- a/api/tests/devcomp/integration/application/passages/index_test.js
+++ b/api/tests/devcomp/integration/application/passages/index_test.js
@@ -1,3 +1,4 @@
+import { UserNotFoundError } from '../../../../../lib/domain/errors.js';
 import { passageController } from '../../../../../src/devcomp/application/passages/controller.js';
 import * as moduleUnderTest from '../../../../../src/devcomp/application/passages/index.js';
 import {
@@ -28,6 +29,28 @@ describe('Integration | Devcomp | Application | Passage | Router | passage-route
 
         // then
         expect(response.statusCode).to.equal(422);
+      });
+    });
+
+    describe('when controller throw a UserNotFoundError', function () {
+      it('should return a 404', async function () {
+        // given
+        sinon.stub(passageController, 'create').throws(new UserNotFoundError());
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+        const validPayload = {
+          data: {
+            attributes: {
+              'module-id': 'existing id',
+            },
+          },
+        };
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/passages', validPayload);
+
+        // then
+        expect(response.statusCode).to.equal(404);
       });
     });
   });

--- a/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/create-passage_test.js
@@ -1,3 +1,4 @@
+import { UserNotFoundError } from '../../../../../lib/domain/errors.js';
 import { ModuleDoesNotExistError } from '../../../../../src/devcomp/domain/errors.js';
 import { createPassage } from '../../../../../src/devcomp/domain/usecases/create-passage.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
@@ -22,12 +23,41 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
     });
   });
 
+  describe('when user does not exist', function () {
+    it('should throw an UserNotExists', async function () {
+      // given
+      const userId = Symbol('userId');
+
+      const moduleRepositoryStub = {
+        getBySlug: sinon.stub(),
+      };
+      const userRepositoryStub = {
+        get: sinon.stub(),
+      };
+      userRepositoryStub.get.withArgs(userId).throws(new UserNotFoundError());
+
+      // when
+      const error = await catchErr(createPassage)({
+        userId,
+        moduleRepository: moduleRepositoryStub,
+        userRepository: userRepositoryStub,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(UserNotFoundError);
+    });
+  });
+
   it('should call passage repository to save the passage', async function () {
     // given
     const moduleId = Symbol('moduleId');
     const userId = Symbol('userId');
     const repositoryResult = Symbol('repository-result');
 
+    const userRepositoryStub = {
+      get: sinon.stub(),
+    };
+    userRepositoryStub.get.withArgs(userId).resolves();
     const moduleRepositoryStub = {
       getBySlug: sinon.stub(),
     };
@@ -43,6 +73,7 @@ describe('Unit | Devcomp | Domain | UseCases | create-passage', function () {
       userId,
       passageRepository: passageRepositoryStub,
       moduleRepository: moduleRepositoryStub,
+      userRepository: userRepositoryStub,
     });
 
     // then


### PR DESCRIPTION
## :unicorn: Problème
En intégration sur Modulix, si un utilisateur est connecté à pix-app et qu'entre temps la BDD a été réinitialisée, au moment où l'utilisateur commence un module, cela va faire remonter une erreur 500.
Cela est dû au fait que le user connecté n'est plus en base de données et donc la requête d'`insert` en BDD échoue.

## :robot: Proposition
Dans le _usecase_ `createPassage`, vérifier que le userId existe en BDD sinon retourner une `UserNotFoundError`.

## :rainbow: Remarques
Actuellement, le `userRepository` se trouve dans _src/shared_ mais il serait peut-être mieux de faire appel à une API de _bounded-context_ plutôt que d'injecter un repo d'un autre BC dans le nôtre.

## :100: Pour tester

En local:
- Créer un compte sur Pix app
- Aller sur `http://localhost:4200/modules/bien-ecrire-son-adresse-mail/details` par exemple
- Aller sur la table `Users` et chercher pour ton user
- `Delete` ou `Modifier` le `ID` de ton user pour qu'il n'existe plus
```SQL
delete from "user-logins" where "userId"='1000003';
delete from "authentication-methods" where "userId"='1000003';
delete from "users" where "id"='1000003';
```
- Cliquer sur le bouton "Commencer le module"
- Verifier qu'on reçu un error `404`
