### PR TITLE
[TECH] Ajouter une API interne pour le domaine "User Account" (PIX-12220)

### DIFF
--- a/api/lib/domain/usecases/authenticate-external-user.js
+++ b/api/lib/domain/usecases/authenticate-external-user.js
@@ -21,7 +21,7 @@ async function authenticateExternalUser({
   obfuscationService,
   authenticationMethodRepository,
   userRepository,
-  userLoginRepository,
+  userAccountApi,
 }) {
   try {
     const userFromCredentials = await pixAuthenticationService.getUserByUsernameAndPassword({
@@ -55,7 +55,7 @@ async function authenticateExternalUser({
 
     const token = tokenService.createAccessTokenForSaml(userFromCredentials.id);
 
-    await userLoginRepository.updateLastLoggedAt({ userId: userFromCredentials.id });
+    await userAccountApi.updateUserAccountLastLoggedAtDate(userFromCredentials.id);
 
     return token;
   } catch (error) {

--- a/api/lib/domain/usecases/authentication/authenticate-oidc-user.js
+++ b/api/lib/domain/usecases/authentication/authenticate-oidc-user.js
@@ -12,8 +12,8 @@ const authenticateOidcUser = async function ({
   authenticationSessionService,
   authenticationMethodRepository,
   userRepository,
-  userLoginRepository,
   adminMemberRepository,
+  userAccountApi,
 }) {
   const sessionContent = await oidcAuthenticationService.exchangeCodeForTokens({
     code,
@@ -57,7 +57,7 @@ const authenticateOidcUser = async function ({
     });
   }
 
-  await userLoginRepository.updateLastLoggedAt({ userId: user.id });
+  await userAccountApi.updateUserAccountLastLoggedAtDate(user.id);
 
   return { pixAccessToken, logoutUrlUUID, isAuthenticationComplete: true };
 };

--- a/api/lib/domain/usecases/create-oidc-user.js
+++ b/api/lib/domain/usecases/create-oidc-user.js
@@ -9,7 +9,7 @@ const createOidcUser = async function ({
   oidcAuthenticationService,
   authenticationMethodRepository,
   userToCreateRepository,
-  userLoginRepository,
+  userAccountApi,
 }) {
   const sessionContentAndUserInfo = await authenticationSessionService.getByKey(authenticationKey);
   if (!sessionContentAndUserInfo) {
@@ -51,7 +51,7 @@ const createOidcUser = async function ({
     logoutUrlUUID = await oidcAuthenticationService.saveIdToken({ idToken: sessionContent.idToken, userId });
   }
 
-  await userLoginRepository.updateLastLoggedAt({ userId });
+  await userAccountApi.updateUserAccountLastLoggedAtDate(userId);
 
   return { accessToken, logoutUrlUUID };
 };

--- a/api/lib/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
+++ b/api/lib/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user.js
@@ -21,10 +21,10 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
   authenticationMethodRepository,
   campaignRepository,
   userRepository,
-  userLoginRepository,
   userToCreateRepository,
   organizationLearnerRepository,
   studentRepository,
+  userAccountApi,
 }) {
   const campaign = await campaignRepository.getByCode(campaignCode);
   if (!campaign) {
@@ -117,7 +117,7 @@ const createUserAndReconcileToOrganizationLearnerFromExternalUser = async functi
   }
   const tokenUserId = userWithSamlId ? userWithSamlId.id : userId;
   const accessToken = tokenService.createAccessTokenForSaml(tokenUserId);
-  await userLoginRepository.updateLastLoggedAt({ userId: tokenUserId });
+  await userAccountApi.updateUserAccountLastLoggedAtDate(tokenUserId);
   return accessToken;
 };
 

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -70,7 +70,6 @@ import * as competenceRepository from '../../../src/shared/infrastructure/reposi
 import * as organizationRepository from '../../../src/shared/infrastructure/repositories/organization-repository.js';
 import * as skillRepository from '../../../src/shared/infrastructure/repositories/skill-repository.js';
 import * as targetProfileForAdminRepository from '../../../src/shared/infrastructure/repositories/target-profile-for-admin-repository.js';
-import * as userLoginRepository from '../../../src/shared/infrastructure/repositories/user-login-repository.js';
 import * as userRepository from '../../../src/shared/infrastructure/repositories/user-repository.js';
 import * as userToCreateRepository from '../../../src/shared/infrastructure/repositories/user-to-create-repository.js';
 import * as codeUtils from '../../../src/shared/infrastructure/utils/code-utils.js';
@@ -361,8 +360,8 @@ const dependencies = {
   tubeRepository,
   tutorialEvaluationRepository: repositories.tutorialEvaluationRepository,
   tutorialRepository: repositories.tutorialRepository,
+  userAccountApi,
   userEmailRepository,
-  userLoginRepository,
   userOrganizationsForAdminRepository,
   userOrgaSettingsRepository,
   userRecommendedTrainingRepository: repositories.userRecommendedTrainingRepository,

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -80,6 +80,7 @@ import { importNamedExportsFromDirectory } from '../../../src/shared/infrastruct
 import * as userOrgaSettingsRepository from '../../../src/shared/prescriber-management/infrastructure/repositories/user-orga-settings-repository.js';
 import * as certificationCenterInvitationService from '../../../src/team/domain/services/certification-center-invitation-service.js';
 import * as certificationCenterInvitationRepository from '../../../src/team/infrastructure/repositories/certification-center-invitation-repository.js';
+import { userAccountApi } from '../../../src/user-account/application/api/index.js';
 import { config } from '../../config.js';
 import * as algorithmDataFetcherService from '../../domain/services/algorithm-methods/data-fetcher.js';
 import * as smartRandom from '../../domain/services/algorithm-methods/smart-random.js';

--- a/api/lib/domain/usecases/reconcile-oidc-user-for-admin.js
+++ b/api/lib/domain/usecases/reconcile-oidc-user-for-admin.js
@@ -3,7 +3,6 @@
  * @typedef {import ('./index.js').AuthenticationSessionService} AuthenticationSessionService
  * @typedef {import ('./index.js').AuthenticationMethodRepository} AuthenticationMethodRepository
  * @typedef {import ('./index.js').UserRepository} UserRepository
- * @typedef {import ('./index.js').UserLoginRepository} UserLoginRepository
  */
 
 import { AuthenticationKeyExpired, DifferentExternalIdentifierError } from '../errors.js';
@@ -18,7 +17,7 @@ import { AuthenticationMethod } from '../models/index.js';
  * @param {AuthenticationSessionService} params.authenticationSessionService
  * @param {AuthenticationMethodRepository} params.authenticationMethodRepository
  * @param {UserRepository} params.userRepository
- * @param {UserLoginRepository} params.userLoginRepository
+ * @param {UserAccountApi} params.userAccountApi
  */
 const reconcileOidcUserForAdmin = async function ({
   authenticationKey,
@@ -28,7 +27,7 @@ const reconcileOidcUserForAdmin = async function ({
   authenticationSessionService,
   authenticationMethodRepository,
   userRepository,
-  userLoginRepository,
+  userAccountApi,
 }) {
   const sessionContentAndUserInfo = await authenticationSessionService.getByKey(authenticationKey);
   if (!sessionContentAndUserInfo) {
@@ -59,7 +58,7 @@ const reconcileOidcUserForAdmin = async function ({
   });
 
   const accessToken = await oidcAuthenticationService.createAccessToken(userId);
-  await userLoginRepository.updateLastLoggedAt({ userId });
+  await userAccountApi.updateUserAccountLastLoggedAtDate(userId);
 
   return accessToken;
 };

--- a/api/lib/domain/usecases/reconcile-oidc-user.js
+++ b/api/lib/domain/usecases/reconcile-oidc-user.js
@@ -6,7 +6,7 @@ const reconcileOidcUser = async function ({
   oidcAuthenticationService,
   authenticationSessionService,
   authenticationMethodRepository,
-  userLoginRepository,
+  userAccountApi,
 }) {
   const sessionContentAndUserInfo = await authenticationSessionService.getByKey(authenticationKey);
   if (!sessionContentAndUserInfo) {
@@ -43,7 +43,7 @@ const reconcileOidcUser = async function ({
     });
   }
 
-  await userLoginRepository.updateLastLoggedAt({ userId });
+  await userAccountApi.updateUserAccountLastLoggedAtDate(userId);
 
   return { accessToken, logoutUrlUUID };
 };

--- a/api/src/authentication/domain/models/UserLogin.js
+++ b/api/src/authentication/domain/models/UserLogin.js
@@ -1,6 +1,6 @@
 import { config } from '../../../shared/config.js';
 
-class UserLogin {
+export class UserLogin {
   /**
    * @param {object} params
    * @param {string|number} params.id
@@ -81,5 +81,3 @@ class UserLogin {
     return !!this.blockedAt;
   }
 }
-
-export { UserLogin };

--- a/api/src/authentication/domain/models/UserLogin.js
+++ b/api/src/authentication/domain/models/UserLogin.js
@@ -1,6 +1,16 @@
 import { config } from '../../../shared/config.js';
 
 class UserLogin {
+  /**
+   * @param {object} params
+   * @param {string|number} params.id
+   * @param {string|number} params.userId
+   * @param {number} params.failureCount
+   * @param {date} params.temporaryBlockedUntil
+   * @param {date} params.blockedAt
+   * @param {date} params.createdAt
+   * @param {date} params.updatedAt
+   */
   constructor({ id, userId, failureCount = 0, temporaryBlockedUntil, blockedAt, createdAt, updatedAt } = {}) {
     this.id = id;
     this.userId = userId;
@@ -15,6 +25,9 @@ class UserLogin {
     this.failureCount++;
   }
 
+  /**
+   * @return {boolean}
+   */
   isUserMarkedAsTemporaryBlocked() {
     const now = new Date();
     return !!this.temporaryBlockedUntil && this.temporaryBlockedUntil > now;
@@ -25,6 +38,9 @@ class UserLogin {
     this.temporaryBlockedUntil = null;
   }
 
+  /**
+   * @return {boolean}
+   */
   shouldMarkUserAsTemporarilyBlocked() {
     return this.failureCount % config.login.temporaryBlockingThresholdFailureCount === 0;
   }
@@ -34,10 +50,16 @@ class UserLogin {
     this.temporaryBlockedUntil = new Date(Date.now() + config.login.temporaryBlockingBaseTimeMs * commonRatio);
   }
 
+  /**
+   * @return {boolean}
+   */
   hasFailedAtLeastOnce() {
     return this.failureCount > 0 || !!this.temporaryBlockedUntil;
   }
 
+  /**
+   * @return {boolean}
+   */
   shouldMarkUserAsBlocked() {
     return this.failureCount >= config.login.blockingLimitFailureCount;
   }
@@ -52,6 +74,9 @@ class UserLogin {
     this.blockedAt = null;
   }
 
+  /**
+   * @return {boolean}
+   */
   isUserMarkedAsBlocked() {
     return !!this.blockedAt;
   }

--- a/api/src/shared/infrastructure/repositories/user-login-repository.js
+++ b/api/src/shared/infrastructure/repositories/user-login-repository.js
@@ -5,23 +5,6 @@ import { NotFoundError } from '../../../shared/domain/errors.js';
 const USER_LOGINS_TABLE_NAME = 'user-logins';
 
 /**
- * @param {object} userLoginDTO
- * @return {UserLogin}
- * @private
- */
-function _toDomain(userLoginDTO) {
-  return new UserLogin({
-    id: userLoginDTO.id,
-    userId: userLoginDTO.userId,
-    failureCount: userLoginDTO.failureCount,
-    temporaryBlockedUntil: userLoginDTO.temporaryBlockedUntil,
-    blockedAt: userLoginDTO.blockedAt,
-    createdAt: userLoginDTO.createdAt,
-    updatedAt: userLoginDTO.updatedAt,
-  });
-}
-
-/**
  * @typedef findByUserId
  * @type {function}
  * @param {string|number} userId
@@ -113,3 +96,20 @@ const updateLastLoggedAt = async function ({ userId }) {
  * @property {updateLastLoggedAt} updateLastLoggedAt
  */
 export { create, findByUserId, findByUsername, getByUserId, update, updateLastLoggedAt };
+
+/**
+ * @param {object} userLoginDTO
+ * @return {UserLogin}
+ * @private
+ */
+function _toDomain(userLoginDTO) {
+  return new UserLogin({
+    id: userLoginDTO.id,
+    userId: userLoginDTO.userId,
+    failureCount: userLoginDTO.failureCount,
+    temporaryBlockedUntil: userLoginDTO.temporaryBlockedUntil,
+    blockedAt: userLoginDTO.blockedAt,
+    createdAt: userLoginDTO.createdAt,
+    updatedAt: userLoginDTO.updatedAt,
+  });
+}

--- a/api/src/shared/infrastructure/repositories/user-login-repository.js
+++ b/api/src/shared/infrastructure/repositories/user-login-repository.js
@@ -4,6 +4,11 @@ import { NotFoundError } from '../../../shared/domain/errors.js';
 
 const USER_LOGINS_TABLE_NAME = 'user-logins';
 
+/**
+ * @param {object} userLoginDTO
+ * @return {UserLogin}
+ * @private
+ */
 function _toDomain(userLoginDTO) {
   return new UserLogin({
     id: userLoginDTO.id,
@@ -16,6 +21,12 @@ function _toDomain(userLoginDTO) {
   });
 }
 
+/**
+ * @typedef findByUserId
+ * @type {function}
+ * @param {string|number} userId
+ * @return {Promise<UserLogin|null>}
+ */
 const findByUserId = async function (userId) {
   const userLoginDTO = await knex.from(USER_LOGINS_TABLE_NAME).where({ userId }).first();
   return userLoginDTO ? _toDomain(userLoginDTO) : null;
@@ -30,11 +41,23 @@ const getByUserId = async function (userId) {
   return foundUserLogin;
 };
 
+/**
+ * @typedef create
+ * @type {function}
+ * @param {UserLogin} userLogin
+ * @return {Promise<UserLogin>}
+ */
 const create = async function (userLogin) {
   const [userLoginDTO] = await knex(USER_LOGINS_TABLE_NAME).insert(userLogin).returning('*');
   return _toDomain(userLoginDTO);
 };
 
+/**
+ * @typedef update
+ * @type {function}
+ * @param {UserLogin} userLogin
+ * @return {Promise<UserLogin>}
+ */
 const update = async function (userLogin) {
   userLogin.updatedAt = new Date();
   const [userLoginDTO] = await knex(USER_LOGINS_TABLE_NAME)
@@ -44,6 +67,12 @@ const update = async function (userLogin) {
   return _toDomain(userLoginDTO);
 };
 
+/**
+ * @typedef findByUsername
+ * @type {function}
+ * @param {string} username
+ * @return {Promise<UserLogin|null>}
+ */
 const findByUsername = async function (username) {
   const userLoginDTO = await knex
     .select('user-logins.*')
@@ -56,6 +85,12 @@ const findByUsername = async function (username) {
   return userLoginDTO ? _toDomain(userLoginDTO) : null;
 };
 
+/**
+ * @typedef updateLastLoggedAt
+ * @type {function}
+ * @param {string|number} userId
+ * @return {Promise<void>}
+ */
 const updateLastLoggedAt = async function ({ userId }) {
   const now = new Date();
 
@@ -68,4 +103,13 @@ const updateLastLoggedAt = async function ({ userId }) {
     .merge();
 };
 
+/**
+ * @typedef UserLoginRepository
+ * @type {object}
+ * @property {create} create
+ * @property {findByUserId} findByUserId
+ * @property {findByUsername} findByUsername
+ * @property {update} update
+ * @property {updateLastLoggedAt} updateLastLoggedAt
+ */
 export { create, findByUserId, findByUsername, getByUserId, update, updateLastLoggedAt };

--- a/api/src/user-account/application/api/index.js
+++ b/api/src/user-account/application/api/index.js
@@ -1,0 +1,14 @@
+import * as userLoginRepository from '../../../shared/infrastructure/repositories/user-login-repository.js';
+import { UpdateUserAccountLastLoggedAtDateApi } from './update-user-account-last-logged-at-date.api.js';
+
+const updateUserAccountLastLoggedAtDate = new UpdateUserAccountLastLoggedAtDateApi(userLoginRepository);
+
+/**
+ * @typedef {object} UserAccountApi
+ * @property {UpdateUserAccountLastLoggedAtDateApi} updateUserAccountLastLoggedAtDate
+ */
+const userAccountApi = {
+  updateUserAccountLastLoggedAtDate: updateUserAccountLastLoggedAtDate.execute.bind(updateUserAccountLastLoggedAtDate),
+};
+
+export { userAccountApi };

--- a/api/src/user-account/application/api/update-user-account-last-logged-at-date.api.js
+++ b/api/src/user-account/application/api/update-user-account-last-logged-at-date.api.js
@@ -1,0 +1,20 @@
+export class UpdateUserAccountLastLoggedAtDateApi {
+  #userLoginRepository;
+
+  /**
+   * @param {UserLoginRepository} userLoginRepository
+   */
+  constructor(userLoginRepository) {
+    this.#userLoginRepository = userLoginRepository;
+  }
+
+  /**
+   * Update lastLoggedAt date for the provider userId
+   *
+   * @param {string|number} userId
+   * @return {Promise<void>}
+   */
+  execute(userId) {
+    return this.#userLoginRepository.updateLastLoggedAt({ userId });
+  }
+}

--- a/api/tests/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/integration/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -14,9 +14,9 @@ import * as studentRepository from '../../../../lib/infrastructure/repositories/
 import { tokenService } from '../../../../src/shared/domain/services/token-service.js';
 import * as userService from '../../../../src/shared/domain/services/user-service.js';
 import * as authenticationMethodRepository from '../../../../src/shared/infrastructure/repositories/authentication-method-repository.js';
-import * as userLoginRepository from '../../../../src/shared/infrastructure/repositories/user-login-repository.js';
 import * as userRepository from '../../../../src/shared/infrastructure/repositories/user-repository.js';
 import * as userToCreateRepository from '../../../../src/shared/infrastructure/repositories/user-to-create-repository.js';
+import { userAccountApi } from '../../../../src/user-account/application/api/index.js';
 import { catchErr, databaseBuilder, expect, knex } from '../../../test-helper.js';
 
 describe('Integration | UseCases | create-user-and-reconcile-to-organization-learner-from-external-user', function () {
@@ -191,7 +191,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
         organizationLearnerRepository,
         studentRepository,
         userRepository,
-        userLoginRepository,
+        userAccountApi,
         userToCreateRepository,
       });
 
@@ -230,7 +230,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
             campaignRepository,
             organizationLearnerRepository,
             userRepository,
-            userLoginRepository,
+            userAccountApi,
           });
 
           // then
@@ -285,7 +285,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
               organizationLearnerRepository,
               studentRepository,
               userRepository,
-              userLoginRepository,
+              userAccountApi,
             });
 
             // then
@@ -346,7 +346,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
               organizationLearnerRepository,
               studentRepository,
               userRepository,
-              userLoginRepository,
+              userAccountApi,
             });
 
             // then
@@ -399,7 +399,7 @@ describe('Integration | UseCases | create-user-and-reconcile-to-organization-lea
           organizationLearnerRepository,
           studentRepository,
           userRepository,
-          userLoginRepository,
+          userAccountApi,
         });
 
         // then

--- a/api/tests/unit/domain/usecases/authenticate-external-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-external-user_test.js
@@ -19,7 +19,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
   let obfuscationService;
   let authenticationMethodRepository;
   let userRepository;
-  let userLoginRepository;
+  let userAccountApi;
 
   beforeEach(function () {
     tokenService = {
@@ -40,8 +40,8 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
       getBySamlId: sinon.stub(),
       getForObfuscation: sinon.stub(),
     };
-    userLoginRepository = {
-      updateLastLoggedAt: sinon.stub(),
+    userAccountApi = {
+      updateUserAccountLastLoggedAtDate: sinon.stub(),
     };
   });
 
@@ -78,7 +78,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
         obfuscationService,
         authenticationMethodRepository,
         userRepository,
-        userLoginRepository,
+        userAccountApi,
       });
 
       // then
@@ -117,11 +117,11 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
         obfuscationService,
         authenticationMethodRepository,
         userRepository,
-        userLoginRepository,
+        userAccountApi,
       });
 
       // then
-      expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWithExactly({ userId: user.id });
+      expect(userAccountApi.updateUserAccountLastLoggedAtDate).to.have.been.calledWithExactly(user.id);
     });
 
     it("should throw an UnexpectedUserAccountError (with expected user's username or email) when the authenticated user does not match the expected one", async function () {
@@ -155,7 +155,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
         obfuscationService,
         authenticationMethodRepository,
         userRepository,
-        userLoginRepository,
+        userAccountApi,
       });
 
       // then
@@ -192,7 +192,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
           pixAuthenticationService,
           authenticationMethodRepository,
           userRepository,
-          userLoginRepository,
+          userAccountApi,
         });
 
         // then
@@ -231,7 +231,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
           pixAuthenticationService,
           authenticationMethodRepository,
           userRepository,
-          userLoginRepository,
+          userAccountApi,
         });
 
         // then
@@ -283,7 +283,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
           pixAuthenticationService,
           authenticationMethodRepository,
           userRepository,
-          userLoginRepository,
+          userAccountApi,
         });
 
         // then
@@ -332,7 +332,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
           pixAuthenticationService,
           authenticationMethodRepository,
           userRepository,
-          userLoginRepository,
+          userAccountApi,
         });
 
         // then
@@ -363,7 +363,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
         tokenService,
         pixAuthenticationService,
         userRepository,
-        userLoginRepository,
+        userAccountApi,
       });
 
       // then
@@ -390,7 +390,7 @@ describe('Unit | Application | UseCase | authenticate-external-user', function (
         tokenService,
         pixAuthenticationService,
         userRepository,
-        userLoginRepository,
+        userAccountApi,
       });
 
       // then

--- a/api/tests/unit/domain/usecases/authentication/authenticate-oidc-user_test.js
+++ b/api/tests/unit/domain/usecases/authentication/authenticate-oidc-user_test.js
@@ -14,7 +14,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
     let authenticationMethodRepository;
     let userRepository;
     let adminMemberRepository;
-    let userLoginRepository;
+    let userAccountApi;
     const externalIdentityId = '094b83ac-2e20-4aa8-b438-0bc91748e4a6';
 
     beforeEach(function () {
@@ -40,8 +40,8 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
       adminMemberRepository = {
         get: sinon.stub(),
       };
-      userLoginRepository = {
-        updateLastLoggedAt: sinon.stub().resolves(),
+      userAccountApi = {
+        updateUserAccountLastLoggedAtDate: sinon.stub().resolves(),
       };
     });
 
@@ -115,7 +115,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
         authenticationSessionService,
         authenticationMethodRepository,
         userRepository,
-        userLoginRepository,
+        userAccountApi,
       });
 
       // then
@@ -140,7 +140,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
         authenticationSessionService,
         authenticationMethodRepository,
         userRepository,
-        userLoginRepository,
+        userAccountApi,
       });
 
       // then
@@ -162,7 +162,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
         authenticationSessionService,
         authenticationMethodRepository,
         userRepository,
-        userLoginRepository,
+        userAccountApi,
       });
 
       // then
@@ -205,7 +205,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
           authenticationSessionService,
           authenticationMethodRepository,
           userRepository,
-          userLoginRepository,
+          userAccountApi,
         });
 
         // then
@@ -232,13 +232,13 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
           authenticationSessionService,
           authenticationMethodRepository,
           userRepository,
-          userLoginRepository,
+          userAccountApi,
         });
 
         // then
         expect(oidcAuthenticationService.saveIdToken).to.not.have.been.called;
         expect(oidcAuthenticationService.createAccessToken).to.not.have.been.called;
-        expect(userLoginRepository.updateLastLoggedAt).to.not.have.been.called;
+        expect(userAccountApi.updateUserAccountLastLoggedAtDate).to.not.have.been.called;
       });
     });
 
@@ -259,7 +259,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
             authenticationSessionService,
             authenticationMethodRepository,
             userRepository,
-            userLoginRepository,
+            userAccountApi,
           });
 
           // then
@@ -292,7 +292,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
             authenticationSessionService,
             authenticationMethodRepository,
             userRepository,
-            userLoginRepository,
+            userAccountApi,
           });
 
           // then
@@ -313,7 +313,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
     let authenticationSessionService;
     let authenticationMethodRepository;
     let userRepository;
-    let userLoginRepository;
+    let userAccountApi;
     const externalIdentityId = '094b83ac-2e20-4aa8-b438-0bc91748e4a6';
 
     beforeEach(function () {
@@ -336,8 +336,8 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
       };
 
       userRepository = { findByExternalIdentifier: sinon.stub() };
-      userLoginRepository = {
-        updateLastLoggedAt: sinon.stub().resolves(),
+      userAccountApi = {
+        updateUserAccountLastLoggedAtDate: sinon.stub().resolves(),
       };
     });
 
@@ -361,7 +361,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
           authenticationSessionService,
           authenticationMethodRepository,
           userRepository,
-          userLoginRepository,
+          userAccountApi,
         });
 
         // then
@@ -394,12 +394,12 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
           authenticationSessionService,
           authenticationMethodRepository,
           userRepository,
-          userLoginRepository,
+          userAccountApi,
         });
 
         // then
-        sinon.assert.calledOnce(oidcAuthenticationService.createAccessToken);
-        sinon.assert.calledOnceWithExactly(userLoginRepository.updateLastLoggedAt, { userId: 10 });
+        expect(oidcAuthenticationService.createAccessToken).to.have.been.calledOnce;
+        expect(userAccountApi.updateUserAccountLastLoggedAtDate).to.have.been.calledWithExactly(10);
         expect(accessToken).to.deep.equal({
           pixAccessToken: 'accessTokenForExistingExternalUser',
           logoutUrlUUID: 'logoutUrlUUID',
@@ -430,7 +430,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
           authenticationSessionService,
           authenticationMethodRepository,
           userRepository,
-          userLoginRepository,
+          userAccountApi,
         });
 
         // then

--- a/api/tests/unit/domain/usecases/create-oidc-user_test.js
+++ b/api/tests/unit/domain/usecases/create-oidc-user_test.js
@@ -6,7 +6,7 @@ import { createOidcUser } from '../../../../lib/domain/usecases/create-oidc-user
 import { catchErr, expect, sinon } from '../../../test-helper.js';
 
 describe('Unit | UseCase | create-oidc-user', function () {
-  let authenticationMethodRepository, userToCreateRepository, userLoginRepository;
+  let authenticationMethodRepository, userToCreateRepository, userAccountApi;
   let authenticationSessionService, oidcAuthenticationService;
   let clock;
   const now = new Date('2021-01-02');
@@ -30,8 +30,8 @@ describe('Unit | UseCase | create-oidc-user', function () {
       saveIdToken: sinon.stub(),
     };
 
-    userLoginRepository = {
-      updateLastLoggedAt: sinon.stub(),
+    userAccountApi = {
+      updateUserAccountLastLoggedAtDate: sinon.stub(),
     };
   });
 
@@ -109,7 +109,7 @@ describe('Unit | UseCase | create-oidc-user', function () {
       authenticationSessionService,
       authenticationMethodRepository,
       userToCreateRepository,
-      userLoginRepository,
+      userAccountApi,
     });
 
     // then
@@ -126,9 +126,9 @@ describe('Unit | UseCase | create-oidc-user', function () {
       userToCreateRepository,
       authenticationMethodRepository,
     });
-    sinon.assert.calledOnce(oidcAuthenticationService.createAccessToken);
-    sinon.assert.calledOnce(oidcAuthenticationService.saveIdToken);
-    sinon.assert.calledOnceWithExactly(userLoginRepository.updateLastLoggedAt, { userId: 10 });
+    expect(oidcAuthenticationService.createAccessToken).to.have.been.calledOnce;
+    expect(oidcAuthenticationService.saveIdToken).to.have.been.calledOnce;
+    expect(userAccountApi.updateUserAccountLastLoggedAtDate).to.have.been.calledOnceWithExactly(10);
     expect(result).to.deep.equal({
       accessToken: 'accessTokenForExistingExternalUser',
       logoutUrlUUID: 'logoutUrlUUID',

--- a/api/tests/unit/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
+++ b/api/tests/unit/domain/usecases/create-user-and-reconcile-to-organization-learner-from-external-user_test.js
@@ -9,7 +9,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
   let authenticationMethodRepository;
   let campaignRepository;
   let userRepository;
-  let userLoginRepository;
+  let userAccountApi;
   let organizationLearnerRepository;
   let studentRepository;
 
@@ -28,8 +28,8 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
     userRepository = {
       getBySamlId: sinon.stub(),
     };
-    userLoginRepository = {
-      updateLastLoggedAt: sinon.stub(),
+    userAccountApi = {
+      updateUserAccountLastLoggedAtDate: sinon.stub(),
     };
     userService = {
       createAndReconcileUserToOrganizationLearner: sinon.stub(),
@@ -62,13 +62,13 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
         authenticationMethodRepository,
         campaignRepository,
         userRepository,
-        userLoginRepository,
+        userAccountApi,
         organizationLearnerRepository,
         studentRepository,
       });
 
       // then
-      expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWithExactly({ userId: user.id });
+      expect(userAccountApi.updateUserAccountLastLoggedAtDate).to.have.been.calledWithExactly(user.id);
     });
 
     it('should return an access token', async function () {
@@ -98,7 +98,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
         authenticationMethodRepository,
         campaignRepository,
         userRepository,
-        userLoginRepository,
+        userAccountApi,
         organizationLearnerRepository,
         studentRepository,
       });
@@ -135,13 +135,13 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
         authenticationMethodRepository,
         campaignRepository,
         userRepository,
-        userLoginRepository,
+        userAccountApi,
         organizationLearnerRepository,
         studentRepository,
       });
 
       // then
-      expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWithExactly({ userId: user.id });
+      expect(userAccountApi.updateUserAccountLastLoggedAtDate).to.have.been.calledWithExactly(user.id);
     });
 
     it('should return an access token', async function () {
@@ -172,7 +172,7 @@ describe('Unit | UseCase | create-user-and-reconcile-to-organization-learner-fro
         authenticationMethodRepository,
         campaignRepository,
         userRepository,
-        userLoginRepository,
+        userAccountApi,
         organizationLearnerRepository,
         studentRepository,
       });

--- a/api/tests/unit/domain/usecases/reconcile-oidc-user-for-admin_test.js
+++ b/api/tests/unit/domain/usecases/reconcile-oidc-user-for-admin_test.js
@@ -7,7 +7,7 @@ import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js'
 describe('Unit | UseCase | reconcile-oidc-user-for-admin', function () {
   let authenticationMethodRepository,
     userRepository,
-    userLoginRepository,
+    userAccountApi,
     authenticationSessionService,
     oidcAuthenticationService;
   const identityProvider = 'GOOGLE';
@@ -15,7 +15,7 @@ describe('Unit | UseCase | reconcile-oidc-user-for-admin', function () {
   beforeEach(function () {
     authenticationMethodRepository = { create: sinon.stub(), findOneByUserIdAndIdentityProvider: sinon.stub() };
     userRepository = { getByEmail: sinon.stub() };
-    userLoginRepository = { updateLastLoggedAt: sinon.stub() };
+    userAccountApi = { updateUserAccountLastLoggedAtDate: sinon.stub() };
     authenticationSessionService = { getByKey: sinon.stub() };
     oidcAuthenticationService = {
       identityProvider,
@@ -46,7 +46,7 @@ describe('Unit | UseCase | reconcile-oidc-user-for-admin', function () {
       authenticationSessionService,
       authenticationMethodRepository,
       userRepository,
-      userLoginRepository,
+      userAccountApi,
     });
 
     // then
@@ -76,7 +76,7 @@ describe('Unit | UseCase | reconcile-oidc-user-for-admin', function () {
       authenticationSessionService,
       authenticationMethodRepository,
       userRepository,
-      userLoginRepository,
+      userAccountApi,
     });
 
     // then
@@ -111,12 +111,12 @@ describe('Unit | UseCase | reconcile-oidc-user-for-admin', function () {
       authenticationSessionService,
       authenticationMethodRepository,
       userRepository,
-      userLoginRepository,
+      userAccountApi,
     });
 
     // then
     expect(oidcAuthenticationService.createAccessToken).to.be.calledOnceWith(userId);
-    expect(userLoginRepository.updateLastLoggedAt).to.be.calledOnceWith({ userId });
+    expect(userAccountApi.updateUserAccountLastLoggedAtDate).to.be.calledOnceWith(userId);
     expect(result).to.equal('accessToken');
   });
 

--- a/api/tests/unit/domain/usecases/reconcile-oidc-user_test.js
+++ b/api/tests/unit/domain/usecases/reconcile-oidc-user_test.js
@@ -8,15 +8,15 @@ describe('Unit | UseCase | reconcile-oidc-user', function () {
   context('when identityProvider is generic', function () {
     let identityProvider;
     let authenticationMethodRepository;
-    let userLoginRepository;
+    let userAccountApi;
     let authenticationSessionService;
     let oidcAuthenticationService;
 
     beforeEach(function () {
       identityProvider = PAYSDELALOIRE.code;
       authenticationMethodRepository = { create: sinon.stub() };
-      userLoginRepository = {
-        updateLastLoggedAt: sinon.stub(),
+      userAccountApi = {
+        updateUserAccountLastLoggedAtDate: sinon.stub(),
       };
       authenticationSessionService = { getByKey: sinon.stub() };
       oidcAuthenticationService = {
@@ -38,7 +38,7 @@ describe('Unit | UseCase | reconcile-oidc-user', function () {
           oidcAuthenticationService,
           authenticationSessionService,
           authenticationMethodRepository,
-          userLoginRepository,
+          userAccountApi,
         });
 
         // then
@@ -61,7 +61,7 @@ describe('Unit | UseCase | reconcile-oidc-user', function () {
         oidcAuthenticationService,
         authenticationSessionService,
         authenticationMethodRepository,
-        userLoginRepository,
+        userAccountApi,
       });
 
       // then
@@ -81,7 +81,7 @@ describe('Unit | UseCase | reconcile-oidc-user', function () {
           oidcAuthenticationService,
           authenticationSessionService,
           authenticationMethodRepository,
-          userLoginRepository,
+          userAccountApi,
         });
 
         // then
@@ -113,7 +113,7 @@ describe('Unit | UseCase | reconcile-oidc-user', function () {
         oidcAuthenticationService,
         authenticationSessionService,
         authenticationMethodRepository,
-        userLoginRepository,
+        userAccountApi,
       });
 
       // then
@@ -129,15 +129,15 @@ describe('Unit | UseCase | reconcile-oidc-user', function () {
   context('when identityProvider is POLE_EMPLOI', function () {
     let identityProvider;
     let authenticationMethodRepository;
-    let userLoginRepository;
+    let userAccountApi;
     let authenticationSessionService;
     let oidcAuthenticationService;
 
     beforeEach(function () {
       identityProvider = POLE_EMPLOI.code;
       authenticationMethodRepository = { create: sinon.stub() };
-      userLoginRepository = {
-        updateLastLoggedAt: sinon.stub(),
+      userAccountApi = {
+        updateUserAccountLastLoggedAtDate: sinon.stub(),
       };
       authenticationSessionService = { getByKey: sinon.stub() };
       oidcAuthenticationService = {
@@ -172,7 +172,7 @@ describe('Unit | UseCase | reconcile-oidc-user', function () {
         oidcAuthenticationService,
         authenticationSessionService,
         authenticationMethodRepository,
-        userLoginRepository,
+        userAccountApi,
       });
 
       // then
@@ -211,13 +211,13 @@ describe('Unit | UseCase | reconcile-oidc-user', function () {
         oidcAuthenticationService,
         authenticationSessionService,
         authenticationMethodRepository,
-        userLoginRepository,
+        userAccountApi,
       });
 
       // then
-      sinon.assert.calledOnce(oidcAuthenticationService.createAccessToken);
-      sinon.assert.calledOnce(oidcAuthenticationService.saveIdToken);
-      sinon.assert.calledOnceWithExactly(userLoginRepository.updateLastLoggedAt, { userId });
+      expect(oidcAuthenticationService.createAccessToken).to.have.been.calledOnce;
+      expect(oidcAuthenticationService.saveIdToken).to.have.been.calledOnce;
+      expect(userAccountApi.updateUserAccountLastLoggedAtDate).to.have.been.calledOnceWithExactly(userId);
       expect(result).to.deep.equal({
         accessToken: 'accessToken',
         logoutUrlUUID: 'logoutUrlUUID',

--- a/api/tests/user-account/unit/application/api/update-user-account-last-logged-at-date.api.test.js
+++ b/api/tests/user-account/unit/application/api/update-user-account-last-logged-at-date.api.test.js
@@ -1,0 +1,17 @@
+import { UpdateUserAccountLastLoggedAtDateApi } from '../../../../../src/user-account/application/api/update-user-account-last-logged-at-date.api.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | User-Account | Application | Api | UpdateUserAccountLastLoggedAtDate', function () {
+  it('updates the user account lastLoggedAt date', async function () {
+    // given
+    const userId = 1489;
+    const userLoginRepository = { updateLastLoggedAt: sinon.stub().resolves() };
+    const updateUserAccountLastLoggedAtDate = new UpdateUserAccountLastLoggedAtDateApi(userLoginRepository);
+
+    // when
+    await updateUserAccountLastLoggedAtDate.execute(userId);
+
+    // then
+    expect(userLoginRepository.updateLastLoggedAt).to.have.been.calledWithExactly({ userId: 1489 });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

La mise à jour de la date de dernière connexion d'un compte PIX est faite par l'utilisation du repository `UserLoginRepository` qui se trouve dans le domaine `Shared`. Or cette mise à concerne le domaine `User Account`. Il faudrait rapatrier cette gestion au niveau du domaine `User Account` et fournir une API interne pour son utilisation dans d'autres domaines.

## :robot: Proposition

Créer une API interne pour le domaine **User Account** en y intégrant la première méthode permettant de mettre à jour la date de dernière connexion d'un compte utilisateur.

## :rainbow: Remarques

RAS

## :100: Pour tester

Faire les tests en local pour plus de facilité.

#### Création d’un nouveau compte via SSO

1. Se connecter via un SSO utilisable sur le domaine `pix.fr`
2. Sur la double mire (Inscription/Connexion), créer un compte
3. Constater en base de données l’insertion d’une nouvelle ligne dans la table `user-logins` lié à la création du compte ci-dessus
4. Copier la date se trouvant dans la colonne `lastLoggedAt` pour ce compte pour une comparaison
5. Se déconnecter
6. Se connecter de nouveau au même compte via SSO
7. Constater en base de données la mise à jour de la colonne `lastLoggedAt` pour ce compte
8. Se déconnecter

#### Rattachement d’une méthode de connexion à un compte existant sur Pix App

1. Récupérer en base de données la valeur de la colonne **lastLoggedAt** du compte PIX sur lequel vous allez rattacher la nouvelle méthode de connexion
2. Se connecter via un SSO utilisable sur le domaine **pix.fr**
3. Sur la double mire (Inscription/Connexion), se connecter à un compte PIX existant
4. Rattacher cette nouvelle méthode de connexion à ce compte PIX existant
5. Constater en base de données la mise à jour de la colonne **lastLoggedAt** pour ce compte PIX
6. Se déconnecter
7. Se connecter de nouveau au même compte via SSO
8. Constater en base de données la mise à jour de la colonne **lastLoggedAt** pour ce compte
9. Se déconnecter

#### Rattachement d’une méthode de connexion à un compte existant sur Pix Admin

1. Se créer un compte sur Pix App avec votre adresse e-mail PIX
2. Récupérer en base de données la valeur de la colonne **lastLoggedAt** du compte PIX sur lequel vous allez rattacher la nouvelle méthode de connexion
3. Activer l’utilisation du SSO Google sur Pix Admin (modification de la valeur de la variable d'environnement GOOGLE_ENABLED_FOR_PIX_ADMIN) et relancer l’API
4. Se connecter via le SSO Google sur Pix Admin
5. Constater en base de données la mise à jour de la colonne **lastLoggedAt** pour ce compte PIX
6. Se déconnecter
7. Se connecter de nouveau au même compte via le SSO Google
8. Constater en base de données la mise à jour de la colonne **lastLoggedAt** pour ce compte
