### PR TITLE
[FEATURE] Empêcher le passage d'un centre de certification en V3 s'il est pilote de la feature de Séparation Pix/Pix+ (PIX-12140).

### DIFF
--- a/admin/app/controllers/authenticated/certification-centers/get.js
+++ b/admin/app/controllers/authenticated/certification-centers/get.js
@@ -2,6 +2,7 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import get from 'lodash/get';
 
 import { types } from '../../../models/certification-center';
 
@@ -10,6 +11,7 @@ export default class AuthenticatedCertificationCentersGetController extends Cont
 
   @service notifications;
   @service store;
+  @service intl;
 
   @tracked isEditMode = false;
   @tracked selectedCertificationCenterType;
@@ -24,7 +26,12 @@ export default class AuthenticatedCertificationCentersGetController extends Cont
     try {
       await this.model.certificationCenter.save();
       this.notifications.success('Centre de certification mis à jour avec succès.');
-    } catch (e) {
+    } catch (error) {
+      if (get(error, 'errors[0].code') === 'V3_PILOT_NOT_AUTHORIZED') {
+        return this.notifications.error(
+          this.intl.t('pages.certification-centers.notifications.update.errors.update-to-v3-pilot'),
+        );
+      }
       this.notifications.error("Une erreur est survenue, le centre de certification n'a pas été mis à jour.");
     }
   }

--- a/admin/tests/acceptance/authenticated/certification-centers/get_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get_test.js
@@ -192,6 +192,42 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
         .dom(screen.getByText("Une erreur est survenue, le centre de certification n'a pas été mis à jour."))
         .exists();
     });
+
+    module('when the certification is updated with v3Pilot with a feature pilot', function () {
+      test('should display an error notification', async function (assert) {
+        // given
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+        const certificationCenter = server.create('certification-center', {
+          name: 'Center 1',
+          externalId: 'ABCDEF',
+          type: 'SCO',
+        });
+        this.server.patch(
+          `/admin/certification-centers/${certificationCenter.id}`,
+          { errors: [{ code: 'V3_PILOT_NOT_AUTHORIZED' }] },
+          403,
+        );
+        const screen = await visit(`/certification-centers/${certificationCenter.id}`);
+        await clickByName('Modifier');
+        await click(
+          screen.getByRole('checkbox', {
+            name: 'Pilote Certification V3 (ce centre de certification ne pourra organiser que des sessions V3)',
+          }),
+        );
+
+        // when
+        await clickByName('Enregistrer');
+
+        // then
+        assert
+          .dom(
+            screen.getByText(
+              'Ce centre de certification est incompatible avec le pilote certification v3 car il est déjà pilote pour la séparation Pix/Pix+',
+            ),
+          )
+          .exists();
+      });
+    });
   });
 
   module('tab navigation', function () {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -183,6 +183,11 @@
         },
         "success": {
           "update-certification-center-membership-role": "The member's role has been modified."
+        },
+        "update": {
+          "errors": {
+            "update-to-v3-pilot": "Ce centre de certification est incompatible avec le pilote certification v3 car il est déjà pilote pour la séparation Pix/Pix+"
+          }
         }
       }
     },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -193,6 +193,11 @@
         },
         "success": {
           "update-certification-center-membership-role": "Le rôle du membre a été modifié."
+        },
+        "update": {
+          "errors": {
+            "update-to-v3-pilot": "Ce centre de certification est incompatible avec le pilote certification v3 car il est déjà pilote pour la séparation Pix/Pix+"
+          }
         }
       }
     },

--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -23,10 +23,12 @@ const create = async function (request) {
 };
 
 const update = async function (request) {
-  const certificationCenter = certificationCenterForAdminSerializer.deserialize(request.payload);
+  const certificationCenterId = request.params.id;
+  const certificationCenterInformation = certificationCenterForAdminSerializer.deserialize(request.payload);
   const complementaryCertificationIds = map(request.payload.data.relationships?.habilitations?.data, 'id');
   const updatedCertificationCenter = await usecases.updateCertificationCenter({
-    certificationCenter,
+    certificationCenterId,
+    certificationCenterInformation,
     complementaryCertificationIds,
   });
   return certificationCenterForAdminSerializer.serialize(updatedCertificationCenter);

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -164,9 +164,9 @@ const register = async function (server) {
         ],
         notes: [
           "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès**\n" +
-            '- Création d‘un nouveau centre de certification\n',
+            '- Elle met à jour les informations d‘un centre de certification\n',
         ],
-        tags: ['api', 'certification-center'],
+        tags: ['api', 'admin', 'certification-center'],
       },
     },
     {

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -1,5 +1,6 @@
 // eslint-disable-next-line eslint-comments/disable-enable-pair
-/* eslint-disable import/no-restricted-paths */ import { dirname, join } from 'node:path';
+/* eslint-disable import/no-restricted-paths */
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import * as pixAuthenticationService from '../../../src/authentication/domain/services/pix-authentication-service.js';
@@ -16,6 +17,7 @@ import { pickChallengeService } from '../../../src/certification/flash-certifica
 import * as flashAlgorithmConfigurationRepository from '../../../src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js';
 import * as certificationCpfService from '../../../src/certification/session/domain/services/certification-cpf-service.js';
 import * as sessionCodeService from '../../../src/certification/session/domain/services/session-code-service.js';
+import * as centerRepository from '../../../src/certification/session/infrastructure/repositories/center-repository.js';
 import * as certificationCandidateRepository from '../../../src/certification/session/infrastructure/repositories/certification-candidate-repository.js';
 import * as certificationCpfCityRepository from '../../../src/certification/session/infrastructure/repositories/certification-cpf-city-repository.js';
 import * as certificationCpfCountryRepository from '../../../src/certification/session/infrastructure/repositories/certification-cpf-country-repository.js';
@@ -200,6 +202,7 @@ function requirePoleEmploiNotifier() {
  * @typedef {placementProfileService} PlacementProfileService
  * @typedef {sessionPublicationService} SessionPublicationService
  * @typedef {sessionRepository} SessionRepository
+ * @typedef {centerRepository} CenterRepository
  */
 
 const dependencies = {
@@ -232,6 +235,7 @@ const dependencies = {
   campaignProfileRepository,
   campaignRepository,
   campaignToJoinRepository,
+  centerRepository,
   certifiableProfileForLearningContentRepository,
   certificateRepository,
   certificationAssessmentRepository,

--- a/api/src/certification/session/domain/models/Center.js
+++ b/api/src/certification/session/domain/models/Center.js
@@ -1,4 +1,5 @@
 import { assertEnumValue } from '../../../../shared/domain/models/asserts.js';
+import { CERTIFICATION_FEATURES } from '../../../shared/domain/constants.js';
 import { CenterTypes } from './CenterTypes.js';
 
 export class Center {
@@ -20,5 +21,11 @@ export class Center {
 
   get hasBillingMode() {
     return this.type !== CenterTypes.SCO;
+  }
+
+  get isComplementaryAlonePilot() {
+    return this.features.find(
+      (feature) => feature === CERTIFICATION_FEATURES.CAN_REGISTER_FOR_A_COMPLEMENTARY_CERTIFICATION_ALONE.key,
+    );
   }
 }

--- a/api/src/certification/session/domain/models/Center.js
+++ b/api/src/certification/session/domain/models/Center.js
@@ -7,13 +7,15 @@ export class Center {
    * @param {number} props.id
    * @param {CenterTypes} props.type
    * @param {Array<number>} props.habilitations List of complementary certification id
+   * @param {Array<string>} props.features List of center features
    */
-  constructor({ id, type, habilitations = [] } = {}) {
+  constructor({ id, type, habilitations = [], features = [] } = {}) {
     assertEnumValue(CenterTypes, type);
 
     this.id = id;
     this.type = type;
     this.habilitations = habilitations;
+    this.features = features;
   }
 
   get hasBillingMode() {

--- a/api/src/certification/session/infrastructure/repositories/center-repository.js
+++ b/api/src/certification/session/infrastructure/repositories/center-repository.js
@@ -4,7 +4,6 @@ import { Center } from '../../domain/models/Center.js';
 
 const getById = async ({ id }) => {
   const center = await knex
-    .select(knex.raw('"certification-center-features"."certificationCenterId" IS NOT NULL as "isFeaturePilot"'))
     .select({
       id: 'certification-centers.id',
       type: 'certification-centers.type',

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -16,6 +16,7 @@ import {
   EntityValidationError,
   OidcError,
   TargetProfileRequiresToBeLinkedToAutonomousCourseOrganization,
+  V3PilotNotAuthorizedForCertificationCenterError,
 } from '../domain/errors.js';
 import * as errorSerializer from '../infrastructure/serializers/jsonapi/error-serializer.js';
 import { domainErrorMapper } from './domain-error-mapper.js';
@@ -158,6 +159,10 @@ function _mapToHttpError(error) {
 
   if (error instanceof EmptyAnswerError) {
     return new HttpErrors.BadRequestError(error.message, error.code);
+  }
+
+  if (error instanceof V3PilotNotAuthorizedForCertificationCenterError) {
+    return new HttpErrors.ForbiddenError(error.message, error.code);
   }
 
   return new HttpErrors.BaseHttpError(error.message);

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -277,6 +277,16 @@ class UserNotAuthorizedToAccessEntityError extends DomainError {
   }
 }
 
+class V3PilotNotAuthorizedForCertificationCenterError extends DomainError {
+  constructor(
+    message = 'Certification center is not authorized to switch to a V3 pilot.',
+    code = 'V3_PILOT_NOT_AUTHORIZED',
+  ) {
+    super(message);
+    this.code = code;
+  }
+}
+
 export {
   AlreadyExistingEntityError,
   AssessmentEndedError,
@@ -304,4 +314,5 @@ export {
   OidcError,
   TargetProfileRequiresToBeLinkedToAutonomousCourseOrganization,
   UserNotAuthorizedToAccessEntityError,
+  V3PilotNotAuthorizedForCertificationCenterError,
 };

--- a/api/tests/certification/session/integration/infrastructure/repositories/center-repository_test.js
+++ b/api/tests/certification/session/integration/infrastructure/repositories/center-repository_test.js
@@ -1,5 +1,6 @@
 import { CertificationCenter } from '../../../../../../lib/domain/models/CertificationCenter.js';
 import * as centerRepository from '../../../../../../src/certification/session/infrastructure/repositories/center-repository.js';
+import { CERTIFICATION_FEATURES } from '../../../../../../src/certification/shared/domain/constants.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
 
@@ -37,6 +38,40 @@ describe('Integration | Certification |  Center | Repository | center-repository
           id: centerId,
           type: 'PRO',
           habilitations: [],
+          features: [],
+        });
+        expect(result).to.deepEqualInstance(expectedCenter);
+      });
+    });
+
+    context('when the certification center is a feature pilot', function () {
+      it('should return the information', async function () {
+        // given
+        const centerId = 1;
+        databaseBuilder.factory.buildCertificationCenter({
+          id: centerId,
+          type: CertificationCenter.types.PRO,
+        });
+        const feature = databaseBuilder.factory.buildFeature({
+          key: CERTIFICATION_FEATURES.CAN_REGISTER_FOR_A_COMPLEMENTARY_CERTIFICATION_ALONE.key,
+        });
+        databaseBuilder.factory.buildCertificationCenterFeature({
+          certificationCenterId: centerId,
+          featureId: feature.id,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const result = await centerRepository.getById({
+          id: centerId,
+        });
+
+        // then
+        const expectedCenter = domainBuilder.certification.session.buildCenter({
+          id: centerId,
+          type: 'PRO',
+          habilitations: [],
+          features: [CERTIFICATION_FEATURES.CAN_REGISTER_FOR_A_COMPLEMENTARY_CERTIFICATION_ALONE.key],
         });
         expect(result).to.deepEqualInstance(expectedCenter);
       });
@@ -71,6 +106,7 @@ describe('Integration | Certification |  Center | Repository | center-repository
         id: centerId,
         type: 'SCO',
         habilitations: [cleaId, droitId],
+        features: [],
       });
       expect(result).to.deepEqualInstance(expectedCenter);
     });

--- a/api/tests/integration/domain/usecases/update-certification-center_test.js
+++ b/api/tests/integration/domain/usecases/update-certification-center_test.js
@@ -1,16 +1,28 @@
-import { CertificationCenterForAdmin } from '../../../../lib/domain/models/CertificationCenterForAdmin.js';
+import { CertificationCenterForAdmin } from '../../../../lib/domain/models/index.js';
 import { updateCertificationCenter } from '../../../../lib/domain/usecases/update-certification-center.js';
 import * as certificationCenterForAdminRepository from '../../../../lib/infrastructure/repositories/certification-center-for-admin-repository.js';
 import * as complementaryCertificationHabilitationRepository from '../../../../lib/infrastructure/repositories/complementary-certification-habilitation-repository.js';
 import * as dataProtectionOfficerRepository from '../../../../lib/infrastructure/repositories/data-protection-officer-repository.js';
-import { databaseBuilder, domainBuilder, expect } from '../../../test-helper.js';
+import * as centerRepository from '../../../../src/certification/session/infrastructure/repositories/center-repository.js';
+import { CERTIFICATION_FEATURES } from '../../../../src/certification/shared/domain/constants.js';
+import { catchErr, databaseBuilder, domainBuilder, expect } from '../../../test-helper.js';
 
 describe('Integration | UseCases | update-certification-center', function () {
   it('should update certification center and his data protection officer information', async function () {
     // given
     const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+    const anotherCertificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+
+    const feature = databaseBuilder.factory.buildFeature({
+      key: CERTIFICATION_FEATURES.CAN_REGISTER_FOR_A_COMPLEMENTARY_CERTIFICATION_ALONE.key,
+    });
+    databaseBuilder.factory.buildCertificationCenterFeature({
+      certificationCenterId: anotherCertificationCenterId,
+      featureId: feature.id,
+    });
+
     const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification();
-    const certificationCenter = domainBuilder.buildCertificationCenterForAdmin({
+    const certificationCenterInformation = domainBuilder.buildCertificationCenterForAdmin({
       id: certificationCenterId,
       name: 'Pix Super Center',
       type: 'PRO',
@@ -25,11 +37,13 @@ describe('Integration | UseCases | update-certification-center', function () {
 
     // when
     const updatedCertificationCenter = await updateCertificationCenter({
-      certificationCenter,
+      certificationCenterId,
+      certificationCenterInformation,
       complementaryCertificationIds,
       certificationCenterForAdminRepository,
       complementaryCertificationHabilitationRepository,
       dataProtectionOfficerRepository,
+      centerRepository,
     });
 
     // then
@@ -45,5 +59,49 @@ describe('Integration | UseCases | update-certification-center', function () {
     expect(updatedCertificationCenter.habilitations[0].id).to.equal(complementaryCertification.id);
     expect(updatedCertificationCenter.habilitations[0].key).to.equal(complementaryCertification.key);
     expect(updatedCertificationCenter.habilitations[0].label).to.equal(complementaryCertification.label);
+  });
+
+  describe('when certification center is update to be V3 pilot', function () {
+    describe('when certification center is already a feature pilot', function () {
+      it('should throw an error', async function () {
+        // given
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+        const feature = databaseBuilder.factory.buildFeature({
+          key: CERTIFICATION_FEATURES.CAN_REGISTER_FOR_A_COMPLEMENTARY_CERTIFICATION_ALONE.key,
+        });
+        databaseBuilder.factory.buildCertificationCenterFeature({
+          certificationCenterId,
+          featureId: feature.id,
+        });
+        const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification();
+        const certificationCenterInformation = domainBuilder.buildCertificationCenterForAdmin({
+          id: certificationCenterId,
+          name: 'Pix Super Center',
+          type: 'PRO',
+          habilitations: [],
+          dataProtectionOfficerFirstName: 'Justin',
+          dataProtectionOfficerLastName: 'Ptipeu',
+          dataProtectionOfficerEmail: 'justin.ptipeu@example.net',
+          isV3Pilot: true,
+        });
+        const complementaryCertificationIds = [complementaryCertification.id];
+
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(updateCertificationCenter)({
+          certificationCenterId,
+          certificationCenterInformation,
+          complementaryCertificationIds,
+          certificationCenterForAdminRepository,
+          complementaryCertificationHabilitationRepository,
+          dataProtectionOfficerRepository,
+          centerRepository,
+        });
+
+        // then
+        expect(error).to.be.an.instanceOf(Error);
+      });
+    });
   });
 });

--- a/api/tests/shared/unit/application/error-manager_test.js
+++ b/api/tests/shared/unit/application/error-manager_test.js
@@ -17,6 +17,7 @@ import {
   NotFoundError,
   OidcError,
   UserNotAuthorizedToAccessEntityError,
+  V3PilotNotAuthorizedForCertificationCenterError,
 } from '../../../../src/shared/domain/errors.js';
 import { expect, hFake, sinon } from '../../../test-helper.js';
 
@@ -321,6 +322,24 @@ describe('Shared | Unit | Application | ErrorManager', function () {
           error.message,
           error.code,
           error.meta,
+        );
+      });
+    });
+
+    context('when handling an V3PilotNotAuthorizedForCertificationCenterError', function () {
+      it('maps to ForbiddenError', async function () {
+        // given
+        const error = new V3PilotNotAuthorizedForCertificationCenterError();
+        sinon.stub(HttpErrors, 'ForbiddenError');
+        const params = { request: {}, h: hFake, error };
+
+        // when
+        await handle(params.request, params.h, params.error);
+
+        // then
+        expect(HttpErrors.ForbiddenError).to.have.been.calledWithExactly(
+          'Certification center is not authorized to switch to a V3 pilot.',
+          'V3_PILOT_NOT_AUTHORIZED',
         );
       });
     });

--- a/api/tests/shared/unit/domain/errors_test.js
+++ b/api/tests/shared/unit/domain/errors_test.js
@@ -121,4 +121,25 @@ describe('Unit | Shared | Domain | Errors', function () {
       });
     });
   });
+
+  context('V3PilotNotAuthorizedForCertificationCenterError', function () {
+    it('exports "V3PilotNotAuthorizedForCertificationCenterError" class', function () {
+      // then
+      expect(errors.V3PilotNotAuthorizedForCertificationCenterError).to.exist;
+      expect(errors.V3PilotNotAuthorizedForCertificationCenterError.prototype).to.be.instanceOf(errors.DomainError);
+    });
+
+    context('when an instance of "V3PilotNotAuthorizedForCertificationCenterError" is created', function () {
+      it('contains "message" and "code" attributes', function () {
+        // given & when
+        const error = new errors.V3PilotNotAuthorizedForCertificationCenterError();
+
+        // then
+        expect(error).to.have.property('code');
+        expect(error.code).to.equal('V3_PILOT_NOT_AUTHORIZED');
+        expect(error).to.have.property('message');
+        expect(error.message).to.equal('Certification center is not authorized to switch to a V3 pilot.');
+      });
+    });
+  });
 });

--- a/api/tests/tooling/domain-builder/factory/certification/session/build-center.js
+++ b/api/tests/tooling/domain-builder/factory/certification/session/build-center.js
@@ -1,11 +1,12 @@
 import { Center } from '../../../../../../src/certification/session/domain/models/Center.js';
 import { CenterTypes } from '../../../../../../src/certification/session/domain/models/CenterTypes.js';
 
-const buildCenter = function ({ id = 1, type = CenterTypes.SUP, habilitations } = {}) {
+const buildCenter = function ({ id = 1, type = CenterTypes.SUP, habilitations, features } = {}) {
   return new Center({
     id,
     type,
     habilitations,
+    features,
   });
 };
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur Pix Admin, il est possible de mettre à jour un centre de certification en V3.
La V3 est incompatible avec les certifications complémentaire en ce moment, aussi si le centre de certification est déjà pilote de la feature de séparation, il ne peut pas passer en V3.

## :robot: Proposition
Empêcher le passage d'un centre de certification en V3 s'il est pilote de la feature de Séparation Pix/Pix+

## :100: Pour tester

- Se connecter sur Pix Admin
- Aller ici : https://admin-pr8703.review.pix.fr/certification-centers/7304 
- Cocher la case V3
- Constater le message d'erreur suivant : 
<img width="402" alt="Capture d’écran 2024-04-19 à 11 19 38" src="https://github.com/1024pix/pix/assets/58915422/b4c1a176-0a1b-4db8-a56b-5ecc1b168a06">
