### PR TITLE
[FEATURE] Ajouter la mention "PIX" à "J'ai déjà un compte" sur les doubles mires de connexion (PIX-12048)

### DIFF
--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -223,7 +223,7 @@
     "login-or-register": {
       "title": "You have been invited to join the certification center {certificationCenterName}",
       "login-form": {
-        "title": "Already have an account?",
+        "title": "Already have a PIX account?",
         "button": "Log in",
         "errors": {
           "status": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -223,7 +223,7 @@
     "login-or-register": {
       "title": "Vous êtes invité(e) à rejoindre le centre de certification {certificationCenterName}",
       "login-form": {
-        "title": "J'ai déjà un compte",
+        "title": "J'ai déjà un compte PIX",
         "button": "Se connecter",
         "errors": {
           "status": {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -730,7 +730,7 @@
     "login-or-register": {
       "title": "You have been invited to join the organisation {organizationName}",
       "login-form": {
-        "title": "Already have an account?",
+        "title": "Already have a PIX account?",
         "button": "Log in"
       },
       "register-form": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -730,7 +730,7 @@
     "login-or-register": {
       "title": "Vous êtes invité(e) à rejoindre l'organisation {organizationName}",
       "login-form": {
-        "title": "J'ai déjà un compte",
+        "title": "J'ai déjà un compte PIX",
         "button": "Se connecter"
       },
       "register-form": {


### PR DESCRIPTION
## :unicorn: Problème

Sans la mention "PIX" sur le texte "J'ai déjà un compte", sur les doubles mires pour rejoindre un centre de certification (Pix Certif) ou une organisation (Pix Orga), fait penser que c'est un compte par application alors que ce n'est pas le cas. Le compte PIX est partagé par toute les applications.

## :robot: Proposition

Modifier les traductions pour ajouter la mention "PIX" pour être explicite.

## :rainbow: Remarques

RAS

## :100: Pour tester

1. Se connecter sur Scalingo https://dashboard.scalingo.com/apps/osc-fr1/pix-api-review-pr8704/environment et modifier la valeur de la variable d'environnement `MAILING_ENABLED` pour activer l'envoie d'e-mail
2. Relancer le container associé à l'API
3. Se connecter sur Pix Admin https://admin-pr8704.review.pix.fr/ avec le compte `superadmin@example.net`
4. Aller sur la page de détails de l'organisation `Collège House of The Dragon` dont l'ID est `2023`
5. Cliquer sur l'onglet `Invitations`
6. Créer une invitation
7. Constater la réception de l'e-mail d'invitation à rejoindre l'organisation `Collège House of The Dragon`
8. Cliquer sur le lien d'invitation à rejoindre l'organisation `Collège House of The Dragon`
9. Constater l'affichage du texte `J'ai déjà un compte PIX` sur la mire (droite) de connexion
10. Depuis Pix Admin, aller sur la page de détails du centre de certification `Accèssorium` dont l'ID est `8000`
11. Cliquer sur l'onglet `Invitations`
12. Créer une invitation
13. Constater la réception de l'e-mail d'invitation à rejoindre le centre de certification `Accèssorium`
14. Cliquer sur le lien d'invitation à rejoindre le centre de certification `Accèssorium`
15. Constater l'affichage du texte `J'ai déjà un compte PIX` sur la mire (droite) de connexion