### PR TITLE
[FEATURE] Ajout du lien vers la page Status dans pixOrga (pix-12226)

### DIFF
--- a/orga/app/components/layout/footer.hbs
+++ b/orga/app/components/layout/footer.hbs
@@ -12,6 +12,12 @@
           {{t "navigation.footer.a11y"}}
         </a>
       </li>
+
+      <li>
+        <a href="{{this.serverStatusUrl}}" target="_blank" class="footer-navigation__item" rel="noopener noreferrer">
+          {{t "navigation.footer.server-status"}}
+        </a>
+      </li>
     </ul>
   </nav>
 

--- a/orga/app/components/layout/footer.js
+++ b/orga/app/components/layout/footer.js
@@ -16,4 +16,8 @@ export default class Footer extends Component {
   get accessibilityUrl() {
     return this.url.accessibilityUrl;
   }
+
+  get serverStatusUrl() {
+    return this.url.serverStatusUrl;
+  }
 }

--- a/orga/app/services/url.js
+++ b/orga/app/services/url.js
@@ -5,6 +5,7 @@ const FRENCH_LOCALE = 'fr';
 const PIX_FR_DOMAIN = 'https://pix.fr';
 const PIX_ORG_DOMAIN_FR_LOCALE = 'https://pix.org/fr';
 const PIX_ORG_DOMAIN_EN_LOCALE = 'https://pix.org/en-gb';
+const PIX_STATUS_DOMAIN = 'https://status.pix.org';
 
 export default class Url extends Service {
   @service currentDomain;
@@ -63,6 +64,12 @@ export default class Url extends Service {
   get accessibilityUrl() {
     const { en, fr } = this.SHOWCASE_WEBSITE_LOCALE_PATH.ACCESSIBILITY;
     return this._computeShowcaseWebsiteUrl({ en, fr });
+  }
+
+  get serverStatusUrl() {
+    const currentLanguage = this.intl.primaryLocale;
+
+    return `${PIX_STATUS_DOMAIN}?locale=${currentLanguage}`;
   }
 
   get forgottenPasswordUrl() {

--- a/orga/app/styles/components/layout/footer.scss
+++ b/orga/app/styles/components/layout/footer.scss
@@ -43,7 +43,7 @@
 
 .footer-navigation {
   &__item {
-    margin-right: var(--pix-spacing-1x);
+    margin-right: var(--pix-spacing-2x);
     color: var(--pix-neutral-500);
     font-weight: 500;
     font-size: 0.8125rem;

--- a/orga/tests/integration/components/layout/footer_test.js
+++ b/orga/tests/integration/components/layout/footer_test.js
@@ -28,8 +28,8 @@ module('Integration | Component | Layout::Footer', function (hooks) {
     const screen = await renderScreen(hbs`<Layout::Footer />}`);
 
     // then
-    assert.dom(screen.getByText('Mentions légales')).exists();
-    assert.dom('a[href="https://pix.org/fr/mentions-legales"]').exists();
+    const link = screen.getByRole('link', { name: this.intl.t('navigation.footer.legal-notice') });
+    assert.dom(link).hasProperty('href', 'https://pix.org/fr/mentions-legales');
   });
 
   test('should display accessibility link', async function (assert) {
@@ -41,8 +41,8 @@ module('Integration | Component | Layout::Footer', function (hooks) {
     const screen = await renderScreen(hbs`<Layout::Footer />}`);
 
     // then
-    assert.dom(screen.getByText('Accessibilité : partiellement conforme')).exists();
-    assert.dom('a[href="https://pix.fr/accessibilite-pix-orga"]').exists();
+    const link = screen.getByRole('link', { name: this.intl.t('navigation.footer.a11y') });
+    assert.dom(link).hasProperty('href', 'https://pix.fr/accessibilite-pix-orga');
   });
 
   test('should display pix status link', async function (assert) {

--- a/orga/tests/integration/components/layout/footer_test.js
+++ b/orga/tests/integration/components/layout/footer_test.js
@@ -44,4 +44,13 @@ module('Integration | Component | Layout::Footer', function (hooks) {
     assert.dom(screen.getByText('Accessibilité : partiellement conforme')).exists();
     assert.dom('a[href="https://pix.fr/accessibilite-pix-orga"]').exists();
   });
+
+  test('should display pix status link', async function (assert) {
+    // when
+    const screen = await renderScreen(hbs`<Layout::Footer />}`);
+
+    // then
+    const link = screen.getByRole('link', { name: this.intl.t('navigation.footer.server-status') });
+    assert.dom(link).hasProperty('href', 'https://status.pix.org/?locale=fr');
+  });
 });

--- a/orga/tests/unit/services/url_test.js
+++ b/orga/tests/unit/services/url_test.js
@@ -228,4 +228,32 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(url, expectedUrl);
     });
   });
+
+  module('#serverStatusUrl', function () {
+    test('returns "status.pix.org" in english when current language is en', function (assert) {
+      // given
+      const expectedUrl = 'https://status.pix.org?locale=en';
+      const service = this.owner.lookup('service:url');
+      service.intl = { primaryLocale: 'en' };
+
+      // when
+      const serverStatusUrl = service.serverStatusUrl;
+
+      // then
+      assert.strictEqual(serverStatusUrl, expectedUrl);
+    });
+
+    test('returns "status.pix.org" in french when current language is en', function (assert) {
+      // given
+      const expectedUrl = 'https://status.pix.org?locale=fr';
+      const service = this.owner.lookup('service:url');
+      service.intl = { primaryLocale: 'fr' };
+
+      // when
+      const serverStatusUrl = service.serverStatusUrl;
+
+      // then
+      assert.strictEqual(serverStatusUrl, expectedUrl);
+    });
+  });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -276,7 +276,8 @@
       "aria-label": "Footer navigation",
       "copyrights": "©",
       "legal-notice": "Legal notice",
-      "pix": "Pix"
+      "pix": "Pix",
+      "server-status": "Services Status"
     },
     "main": {
       "aria-label": "Main navigation",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -276,7 +276,8 @@
       "aria-label": "Navigation de pied de page",
       "copyrights": "©",
       "legal-notice": "Mentions légales",
-      "pix": "Pix"
+      "pix": "Pix",
+      "server-status": "Statuts des services"
     },
     "main": {
       "aria-label": "Navigation principale",


### PR DESCRIPTION
## :unicorn: Problème
Nous avons maintenant une page de status officielle. Il es t intéréssant de la rendre accessible depuis pix Orga pour les utilisateurs.
## :robot: Proposition
Ajouter le lien dans le footer

## :rainbow: Remarques
Des bisous
## :100: Pour tester
- se connecter à PixOrga en tant que qui vous voulez
- Allez-voir le footer depuis la page que vous voulez
- Cliquez et vérifier 
  - Que le lien s'ouvre ans un nouvel onglet
  - Que la page de status est bien en Français quand vous venez d'un PixOrga en français
  - Que la page de status est bien en Anglais quand vous venez d'un PixOrga en anglais
  - 🎉 🦑 