### PR TITLE
[TECH] Modifier l'export du cryptoService (PIX-12228)

### DIFF
--- a/api/db/database-builder/factory/build-authentication-method.js
+++ b/api/db/database-builder/factory/build-authentication-method.js
@@ -3,7 +3,7 @@ const { isUndefined } = lodash;
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../lib/domain/constants/identity-providers.js';
 import * as OidcIdentityProviders from '../../../lib/domain/constants/oidc-identity-providers.js';
 import { AuthenticationMethod } from '../../../lib/domain/models/AuthenticationMethod.js';
-import * as encrypt from '../../../src/shared/domain/services/crypto-service.js';
+import { cryptoService } from '../../../src/shared/domain/services/crypto-service.js';
 import { databaseBuffer } from '../database-buffer.js';
 import { buildUser } from './build-user.js';
 
@@ -76,7 +76,7 @@ buildAuthenticationMethod.withPixAsIdentityProviderAndPassword = function ({
   updatedAt = new Date('2020-01-02'),
 } = {}) {
   // eslint-disable-next-line no-sync
-  const hashedPassword = encrypt.hashPasswordSync(password);
+  const hashedPassword = cryptoService.hashPasswordSync(password);
   userId = isUndefined(userId) ? buildUser().id : userId;
 
   const values = {

--- a/api/db/database-builder/factory/build-oidc-provider.js
+++ b/api/db/database-builder/factory/build-oidc-provider.js
@@ -1,4 +1,4 @@
-import * as cryptoService from '../../../src/shared/domain/services/crypto-service.js';
+import { cryptoService } from '../../../src/shared/domain/services/crypto-service.js';
 import { databaseBuffer } from '../database-buffer.js';
 
 const OIDC_PROVIDERS_TABLE_NAME = 'oidc-providers';

--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -5,7 +5,7 @@ const { isUndefined, isNil } = lodash;
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../lib/domain/constants/identity-providers.js';
 import { AuthenticationMethod, Membership } from '../../../lib/domain/models/index.js';
 import { PIX_ADMIN } from '../../../src/authorization/domain/constants.js';
-import * as encrypt from '../../../src/shared/domain/services/crypto-service.js';
+import { cryptoService } from '../../../src/shared/domain/services/crypto-service.js';
 import { databaseBuffer } from '../database-buffer.js';
 import { buildCertificationCenter } from './build-certification-center.js';
 import { buildCertificationCenterMembership } from './build-certification-center-membership.js';
@@ -25,7 +25,7 @@ function _buildPixAuthenticationMethod({
   updatedAt,
 } = {}) {
   // eslint-disable-next-line no-sync
-  const hashedPassword = encrypt.hashPasswordSync(rawPassword);
+  const hashedPassword = cryptoService.hashPasswordSync(rawPassword);
 
   const values = {
     id,

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -52,7 +52,7 @@ import * as activityAnswerRepository from '../../../src/school/infrastructure/re
 import * as missionRepository from '../../../src/school/infrastructure/repositories/mission-repository.js';
 import * as schoolRepository from '../../../src/school/infrastructure/repositories/school-repository.js';
 import * as codeGenerator from '../../../src/shared/domain/services/code-generator.js';
-import * as cryptoService from '../../../src/shared/domain/services/crypto-service.js';
+import { cryptoService } from '../../../src/shared/domain/services/crypto-service.js';
 import * as languageService from '../../../src/shared/domain/services/language-service.js';
 import * as localeService from '../../../src/shared/domain/services/locale-service.js';
 import { tokenService } from '../../../src/shared/domain/services/token-service.js';

--- a/api/scripts/create-users-accounts-for-contest.js
+++ b/api/scripts/create-users-accounts-for-contest.js
@@ -3,7 +3,7 @@ import * as url from 'node:url';
 import bluebird from 'bluebird';
 
 import { disconnect } from '../db/knex-database-connection.js';
-import * as cryptoService from '../src/shared/domain/services/crypto-service.js';
+import { cryptoService } from '../src/shared/domain/services/crypto-service.js';
 import * as userService from '../src/shared/domain/services/user-service.js';
 import * as authenticationMethodRepository from '../src/shared/infrastructure/repositories/authentication-method-repository.js';
 import * as userToCreateRepository from '../src/shared/infrastructure/repositories/user-to-create-repository.js';

--- a/api/scripts/team-acces/load-oidc-providers-from-env-variables.js
+++ b/api/scripts/team-acces/load-oidc-providers-from-env-variables.js
@@ -5,7 +5,7 @@ import { learningContentCache as cache } from '../../lib/infrastructure/caches/l
 import { temporaryStorage } from '../../lib/infrastructure/temporary-storage/index.js';
 import { usecases } from '../../src/authentication/domain/usecases/index.js';
 import { DomainTransaction } from '../../src/shared/domain/DomainTransaction.js';
-import * as cryptoService from '../../src/shared/domain/services/crypto-service.js';
+import { cryptoService } from '../../src/shared/domain/services/crypto-service.js';
 
 const debugOidcProvidersProperties = Debug('pix:oidc-providers:properties');
 

--- a/api/src/authentication/domain/services/pix-authentication-service.js
+++ b/api/src/authentication/domain/services/pix-authentication-service.js
@@ -1,4 +1,4 @@
-import * as cryptoService from '../../../shared/domain/services/crypto-service.js';
+import { cryptoService } from '../../../shared/domain/services/crypto-service.js';
 import * as userLoginRepository from '../../../shared/infrastructure/repositories/user-login-repository.js';
 import { PasswordNotMatching } from '../errors.js';
 

--- a/api/src/shared/domain/services/crypto-service.js
+++ b/api/src/shared/domain/services/crypto-service.js
@@ -95,5 +95,6 @@ const decrypt = async function (phcText) {
  * @property {function} hashPasswordSync
  * @property {RegExp} phcRegexp
  */
+const cryptoService = { checkPassword, decrypt, encrypt, hashPassword, hashPasswordSync, phcRegexp };
 
-export { checkPassword, decrypt, encrypt, hashPassword, hashPasswordSync, phcRegexp };
+export { cryptoService };

--- a/api/src/user-account/domain/usecases/index.js
+++ b/api/src/user-account/domain/usecases/index.js
@@ -2,7 +2,7 @@ import { join } from 'node:path';
 
 import * as mailService from '../../../../lib/domain/services/mail-service.js';
 import * as campaignRepository from '../../../../lib/infrastructure/repositories/campaign-repository.js';
-import * as cryptoService from '../../../shared/domain/services/crypto-service.js';
+import { cryptoService } from '../../../shared/domain/services/crypto-service.js';
 import * as userService from '../../../shared/domain/services/user-service.js';
 import * as passwordValidator from '../../../shared/domain/validators/password-validator.js';
 import * as userValidator from '../../../shared/domain/validators/user-validator.js';

--- a/api/tests/integration/domain/usecases/account-recovery/update-user-for-account-recovery_test.js
+++ b/api/tests/integration/domain/usecases/account-recovery/update-user-for-account-recovery_test.js
@@ -1,7 +1,7 @@
 import { updateUserForAccountRecovery } from '../../../../../lib/domain/usecases/account-recovery/update-user-for-account-recovery.js';
 import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';
 import * as accountRecoveryDemandRepository from '../../../../../lib/infrastructure/repositories/account-recovery-demand-repository.js';
-import * as cryptoService from '../../../../../src/shared/domain/services/crypto-service.js';
+import { cryptoService } from '../../../../../src/shared/domain/services/crypto-service.js';
 import * as authenticationMethodRepository from '../../../../../src/shared/infrastructure/repositories/authentication-method-repository.js';
 import * as userRepository from '../../../../../src/shared/infrastructure/repositories/user-repository.js';
 import { catchErr, databaseBuilder, expect, knex } from '../../../../test-helper.js';

--- a/api/tests/integration/domain/usecases/create-and-reconcile-user-to-organization-learner_test.js
+++ b/api/tests/integration/domain/usecases/create-and-reconcile-user-to-organization-learner_test.js
@@ -13,7 +13,7 @@ import { createAndReconcileUserToOrganizationLearner } from '../../../../lib/dom
 import * as campaignRepository from '../../../../lib/infrastructure/repositories/campaign-repository.js';
 import * as organizationLearnerRepository from '../../../../lib/infrastructure/repositories/organization-learner-repository.js';
 import { EntityValidationError } from '../../../../src/shared/domain/errors.js';
-import * as cryptoService from '../../../../src/shared/domain/services/crypto-service.js';
+import { cryptoService } from '../../../../src/shared/domain/services/crypto-service.js';
 import * as userService from '../../../../src/shared/domain/services/user-service.js';
 import * as passwordValidator from '../../../../src/shared/domain/validators/password-validator.js';
 import * as userValidator from '../../../../src/shared/domain/validators/user-validator.js';

--- a/api/tests/shared/unit/domain/services/crypto-service_test.js
+++ b/api/tests/shared/unit/domain/services/crypto-service_test.js
@@ -1,7 +1,7 @@
 import bcrypt from 'bcrypt';
 
 import { PasswordNotMatching } from '../../../../../src/authentication/domain/errors.js';
-import * as cryptoService from '../../../../../src/shared/domain/services/crypto-service.js';
+import { cryptoService } from '../../../../../src/shared/domain/services/crypto-service.js';
 import { catchErr, expect } from '../../../../test-helper.js';
 
 describe('Unit | Shared | Domain | Services | Crypto', function () {

--- a/api/tests/tooling/domain-builder/factory/build-authentication-method.js
+++ b/api/tests/tooling/domain-builder/factory/build-authentication-method.js
@@ -5,7 +5,7 @@ import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../lib/domain/constants/id
 import * as OidcIdentityProviders from '../../../../lib/domain/constants/oidc-identity-providers.js';
 import { AuthenticationMethod } from '../../../../lib/domain/models/AuthenticationMethod.js';
 import { User } from '../../../../src/shared/domain/models/User.js';
-import * as encrypt from '../../../../src/shared/domain/services/crypto-service.js';
+import { cryptoService } from '../../../../src/shared/domain/services/crypto-service.js';
 
 function _buildUser() {
   return new User({
@@ -53,7 +53,7 @@ buildAuthenticationMethod.withPixAsIdentityProviderAndRawPassword = function ({
   updatedAt,
 } = {}) {
   // eslint-disable-next-line no-sync
-  const password = encrypt.hashPasswordSync(rawPassword);
+  const password = cryptoService.hashPasswordSync(rawPassword);
   userId = isUndefined(userId) ? _buildUser().id : userId;
 
   return new AuthenticationMethod({


### PR DESCRIPTION
## :unicorn: Problème
Actuellement les méthodes du `cryptoService` sont exportées individuellement. 

## :robot: Proposition
Pour des questions de lisibilité et permettre que les méthodes du `cryptoService` puissent être _stubées_, il serait préférable d’exporter globalement le module `cryptoService`.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que la CI passe.
