### PR TITLE
[BUGFIX] Affichage d'un titre sur le bloc d'erreur d'import (Pix-12079)

### DIFF
--- a/orga/app/components/import.hbs
+++ b/orga/app/components/import.hbs
@@ -43,7 +43,7 @@
 
   {{#if this.displayImportMessagePanel}}
     <section id="import-error-messages" class={{this.panelClasses}} aria-live="assertive">
-      <h2 class="screen-reader-only">{{t "pages.organization-participants-import.error-panel.title"}}</h2>
+      <h2>{{t "pages.organization-participants-import.error-panel.title"}}</h2>
 
       <ul class="import-students-page__error-panel-list">
         {{#each this.errorDetailList as |errorElement|}}

--- a/orga/app/styles/components/import.scss
+++ b/orga/app/styles/components/import.scss
@@ -15,6 +15,12 @@
       color:var(--pix-warning-700);
     }
 
+    h2 {
+     @extend %pix-title-xs;
+
+      color: var(--pix-neutral-900);
+    }
+
     padding: var(--pix-spacing-6x);
     color:var(--pix-error-700);
     font-weight: var(--pix-font-medium);


### PR DESCRIPTION
## :unicorn: Problème
Le titre situé dans le block qui liste les erreur d'import ne s'affiche pas du tout.


## :robot: Proposition
Le rendre visible

## :100: Pour tester
Essayer d'importer un fichier au mauvais format pour vérifié la présence d'un h2 au dessus de la liste des erreurs