### PR TITLE
[FEATURE] Migrer vers nouveau nom de la table de souscriptions (PIX-12230).

### DIFF
--- a/api/db/database-builder/database-builder.js
+++ b/api/db/database-builder/database-builder.js
@@ -230,6 +230,14 @@ class DatabaseBuilder {
 
         if (!_.isEmpty(tableName)) {
           if (tableName === 'pgboss.version') return;
+          if (tableName === 'certification-subscriptions') {
+            // View are not part of pg_class, or due to a table migration
+            // we temporarily need to mark as dirty any operation on the view
+            // for retrocompatibility purpose
+            this._setTableAsDirty('complementary-certification-subscriptions');
+            return;
+          }
+
           this._setTableAsDirty(tableName);
         }
       }

--- a/api/db/database-builder/factory/build-complementary-certification-subscription.js
+++ b/api/db/database-builder/factory/build-complementary-certification-subscription.js
@@ -22,7 +22,7 @@ const buildComplementaryCertificationSubscription = function ({
     createdAt,
   };
   return databaseBuffer.pushInsertable({
-    tableName: 'complementary-certification-subscriptions',
+    tableName: 'certification-subscriptions',
     values,
   });
 };

--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -109,6 +109,7 @@ async function emptyAllTables() {
     'knex_migrations',
     'knex_migrations_lock',
     'view-active-organization-learners',
+    'certification-subscriptions',
   );
 
   const tables = _.map(tablesToDelete, (tableToDelete) => `"${tableToDelete}"`).join();

--- a/api/db/migrations/20240419144820_add-view-for-certification-subscriptions-table.js
+++ b/api/db/migrations/20240419144820_add-view-for-certification-subscriptions-table.js
@@ -1,0 +1,14 @@
+const VIEW_NAME = 'certification-subscriptions';
+const REFERENCE_TABLE_NAME = 'complementary-certification-subscriptions';
+
+const up = async function (knex) {
+  await knex.schema.createView(VIEW_NAME, function (view) {
+    view.as(knex(REFERENCE_TABLE_NAME));
+  });
+};
+
+const down = function (knex) {
+  return knex.schema.dropView(VIEW_NAME);
+};
+
+export { down, up };

--- a/api/lib/infrastructure/repositories/sessions/session-for-supervising-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-for-supervising-repository.js
@@ -58,14 +58,14 @@ const get = async function (idSession) {
     })
     .leftJoin('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
     .leftJoin(
-      'complementary-certification-subscriptions',
-      'complementary-certification-subscriptions.certificationCandidateId',
+      'certification-subscriptions',
+      'certification-subscriptions.certificationCandidateId',
       'certification-candidates.id',
     )
     .leftJoin(
       'complementary-certifications',
       'complementary-certifications.id',
-      'complementary-certification-subscriptions.complementaryCertificationId',
+      'certification-subscriptions.complementaryCertificationId',
     )
     .leftJoin('ongoing-live-alerts', 'ongoing-live-alerts.assessmentId', 'assessments.id')
     .groupBy('sessions.id')

--- a/api/src/certification/session/infrastructure/repositories/candidate-repository.js
+++ b/api/src/certification/session/infrastructure/repositories/candidate-repository.js
@@ -5,16 +5,16 @@ const findBySessionId = async function ({ sessionId }) {
   const results = await knex
     .select({
       certificationCandidate: 'certification-candidates.*',
-      complementaryCertificationId: 'complementary-certification-subscriptions.complementaryCertificationId',
+      complementaryCertificationId: 'certification-subscriptions.complementaryCertificationId',
     })
     .from('certification-candidates')
     .where({ 'certification-candidates.sessionId': sessionId })
     .leftJoin(
-      'complementary-certification-subscriptions',
+      'certification-subscriptions',
       'certification-candidates.id',
-      'complementary-certification-subscriptions.certificationCandidateId',
+      'certification-subscriptions.certificationCandidateId',
     )
-    .groupBy('certification-candidates.id', 'complementary-certification-subscriptions.complementaryCertificationId')
+    .groupBy('certification-candidates.id', 'certification-subscriptions.complementaryCertificationId')
     .orderByRaw('LOWER("certification-candidates"."lastName") asc')
     .orderByRaw('LOWER("certification-candidates"."firstName") asc');
   return results.map(_toDomain);

--- a/api/src/certification/session/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/src/certification/session/infrastructure/repositories/certification-candidate-repository.js
@@ -77,7 +77,7 @@ const saveInSession = async function ({
 
 const remove = async function ({ id }) {
   await knex.transaction(async (trx) => {
-    await trx('complementary-certification-subscriptions').where({ certificationCandidateId: id }).del();
+    await trx('certification-subscriptions').where({ certificationCandidateId: id }).del();
     return trx('certification-candidates').where({ id }).del();
   });
 
@@ -103,13 +103,13 @@ const getBySessionIdAndUserId = async function ({ sessionId, userId }) {
     })
     .from('certification-candidates')
     .leftJoin(
-      'complementary-certification-subscriptions',
+      'certification-subscriptions',
       'certification-candidates.id',
-      'complementary-certification-subscriptions.certificationCandidateId',
+      'certification-subscriptions.certificationCandidateId',
     )
     .leftJoin(
       'complementary-certifications',
-      'complementary-certification-subscriptions.complementaryCertificationId',
+      'certification-subscriptions.complementaryCertificationId',
       'complementary-certifications.id',
     )
     .where({ sessionId, userId })
@@ -129,13 +129,13 @@ const findBySessionId = async function (sessionId) {
     .from('certification-candidates')
     .where({ 'certification-candidates.sessionId': sessionId })
     .leftJoin(
-      'complementary-certification-subscriptions',
+      'certification-subscriptions',
       'certification-candidates.id',
-      'complementary-certification-subscriptions.certificationCandidateId',
+      'certification-subscriptions.certificationCandidateId',
     )
     .leftJoin(
       'complementary-certifications',
-      'complementary-certification-subscriptions.complementaryCertificationId',
+      'certification-subscriptions.complementaryCertificationId',
       'complementary-certifications.id',
     )
     .groupBy('certification-candidates.id', 'complementary-certifications.id')
@@ -189,7 +189,7 @@ const update = async function (certificationCandidate) {
 
 const deleteBySessionId = async function ({ sessionId, domainTransaction = DomainTransaction.emptyTransaction() }) {
   const knexConn = domainTransaction.knexTransaction ?? knex;
-  await knexConn('complementary-certification-subscriptions')
+  await knexConn('certification-subscriptions')
     .whereIn('certificationCandidateId', knexConn.select('id').from('certification-candidates').where({ sessionId }))
     .del();
 
@@ -205,14 +205,14 @@ const getWithComplementaryCertification = async function (id) {
       complementaryCertificationLabel: 'complementary-certifications.label',
     })
     .leftJoin(
-      'complementary-certification-subscriptions',
-      'complementary-certification-subscriptions.certificationCandidateId',
+      'certification-subscriptions',
+      'certification-subscriptions.certificationCandidateId',
       'certification-candidates.id',
     )
     .leftJoin(
       'complementary-certifications',
       'complementary-certifications.id',
-      'complementary-certification-subscriptions.complementaryCertificationId',
+      'certification-subscriptions.complementaryCertificationId',
     )
     .where('certification-candidates.id', id)
     .first();

--- a/api/src/certification/session/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/src/certification/session/infrastructure/repositories/certification-candidate-repository.js
@@ -55,9 +55,9 @@ const saveInSession = async function ({
         certificationCandidateId: addedCertificationCandidate.id,
       };
 
-      const insertComplementaryCertificationSubscriptionQuery = knex(
-        'complementary-certification-subscriptions',
-      ).insert(complementaryCertificationSubscriptionToSave);
+      const insertComplementaryCertificationSubscriptionQuery = knex('certification-subscriptions').insert(
+        complementaryCertificationSubscriptionToSave,
+      );
 
       if (domainTransaction.knexTransaction) {
         insertComplementaryCertificationSubscriptionQuery.transacting(domainTransaction.knexTransaction);

--- a/api/src/certification/session/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/session/infrastructure/repositories/session-repository.js
@@ -69,14 +69,14 @@ const getWithCertificationCandidates = async function ({ id }) {
     })
     .from('certification-candidates')
     .leftJoin(
-      'complementary-certification-subscriptions',
-      'complementary-certification-subscriptions.certificationCandidateId',
+      'certification-subscriptions',
+      'certification-subscriptions.certificationCandidateId',
       'certification-candidates.id',
     )
     .leftJoin(
       'complementary-certifications',
       'complementary-certifications.id',
-      'complementary-certification-subscriptions.complementaryCertificationId',
+      'certification-subscriptions.complementaryCertificationId',
     )
     .groupBy('certification-candidates.id', 'complementary-certifications.id')
     .where({ sessionId: id })
@@ -169,7 +169,7 @@ const remove = async function ({ id }) {
     }
 
     if (certificationCandidateIdsInSession.length) {
-      await trx('complementary-certification-subscriptions')
+      await trx('certification-subscriptions')
         .whereIn('certificationCandidateId', certificationCandidateIdsInSession)
         .del();
       await trx('certification-candidates').whereIn('id', certificationCandidateIdsInSession).del();

--- a/api/tests/certification/session/acceptance/application/certification-candidate-controller-post-certification-candidate_test.js
+++ b/api/tests/certification/session/acceptance/application/certification-candidate-controller-post-certification-candidate_test.js
@@ -158,7 +158,7 @@ describe('Acceptance | Controller | session-controller-post-certification-candid
       await server.inject(options);
 
       // then
-      const complementaryCertificationRegistrationsInDB = await knex('complementary-certification-subscriptions');
+      const complementaryCertificationRegistrationsInDB = await knex('certification-subscriptions');
       expect(complementaryCertificationRegistrationsInDB.length).to.equal(1);
     });
   });

--- a/api/tests/certification/session/integration/infrastructure/repositories/certification-candidate-repository_test.js
+++ b/api/tests/certification/session/integration/infrastructure/repositories/certification-candidate-repository_test.js
@@ -80,7 +80,7 @@ describe('Integration | Repository | CertificationCandidate', function () {
 
       context('when there is complementary certifications to save', function () {
         afterEach(function () {
-          return knex('complementary-certification-subscriptions').del();
+          return knex('certification-subscriptions').del();
         });
 
         it('should save the complementary certification subscription', async function () {
@@ -105,7 +105,7 @@ describe('Integration | Repository | CertificationCandidate', function () {
 
           // then
           const [{ complementaryCertificationId: complementaryCertificationSubscriptionIdInDB }] = await knex(
-            'complementary-certification-subscriptions',
+            'certification-subscriptions',
           )
             .select('complementaryCertificationId')
             .where({

--- a/api/tests/certification/session/integration/infrastructure/repositories/certification-candidate-repository_test.js
+++ b/api/tests/certification/session/integration/infrastructure/repositories/certification-candidate-repository_test.js
@@ -206,10 +206,7 @@ describe('Integration | Repository | CertificationCandidate', function () {
         const isDeleted = await certificationCandidateRepository.remove({ id: certificationCandidateId });
 
         // then
-        const complementaryCertificationSubscriptions = await knex
-          .select()
-          .from('complementary-certification-subscriptions')
-          .first();
+        const complementaryCertificationSubscriptions = await knex.select().from('certification-subscriptions').first();
         expect(complementaryCertificationSubscriptions).to.be.undefined;
         expect(isDeleted).to.be.true;
       });
@@ -783,7 +780,7 @@ describe('Integration | Repository | CertificationCandidate', function () {
       await certificationCandidateRepository.deleteBySessionId({ sessionId });
 
       // then
-      const subscriptionsInDB = await knex('complementary-certification-subscriptions').select();
+      const subscriptionsInDB = await knex('certification-subscriptions').select();
       const certificationCandidateInDB = await knex('certification-candidates').select();
       expect(subscriptionsInDB).to.deep.equal([]);
       expect(certificationCandidateInDB).to.deep.equal([]);

--- a/api/tests/certification/session/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/certification/session/integration/infrastructure/repositories/session-repository_test.js
@@ -679,7 +679,7 @@ describe('Integration | Repository | Session', function () {
 
             // then
             const foundSession = await knex('sessions').select('id').where({ id: sessionId }).first();
-            const foundSubscriptions = await knex('complementary-certification-subscriptions').where({
+            const foundSubscriptions = await knex('certification-subscriptions').where({
               certificationCandidateId,
             });
             expect(foundSession).to.be.undefined;


### PR DESCRIPTION
## :unicorn: Problème
Nous voulons faire porter la notion d’inscription d’un candidat à une certif Pix coeur de manière détachée d’une certif complémentaire. Mais aujourd’jui nous assumons que un candidat passe toujours un pix coeur.

## :robot: Proposition
- Préparer la base de donnée à enregistrer si un candidat est inscrit indépendamment à pix coeur seul, pix coeur + complémentaire ou bien à une complémentaire seule (comprendre : pas forcément inscrit à pix coeur)
- Créer une vue PostgreSQL qui s’appelle certification-subscriptions
   - cela permet de préparer le futur renommage, en faisant migrer les applications en amont sur le futur nouveau nom avant le renommage côté PG
- Modifier toutes les dépendances dans le code pour utiliser la vue
- S’assurer auprès de DATA des impacts de la modification, et gérer cela avec eux le cas échéant
- S’assurer que la migration ne va pas planter la PROD, prévenir les captains

## :rainbow: Remarques
Pourquoi créer une vue ? Renommer une table va vite, mais il faut prendre en compte la notion de rolling-update des containers (risque donc de downtime pas négligeable avec toutes les jointures et autres qui dépendent de notre table)
Une solution tech (à challenger si vous avez mieux en tête), créer une “view” pour faire la transition, c’est à dire 
Une migration qui créé une view qui porte le nouveau nom de table
Les “vieux” containers seront toujours donc OK, ils appelleront la view
Les nouveaux containers eux utiliseront le nouveau code (et donc le nom de la view)
Ça laisse à la DATA, metabase, tout ça, le temps quand ils veulent de passer sur le nouveau nom de table
Faire un nouveau ticket qui va, une fois que tout le monde utilisera le “nouveau nom” qui est celui de la view, drop la view, et renommer la table
source : https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-rename-table/

## :100: Pour tester

C'est de la non reg uniquement, le but est de vérifier que tout est OK niveau complémentaires.

### Pix V2
* Sur Pix certif, centre non sco de préférence, certification V2
*  Inscrire via l'import deux candidats : avec et sans complémentaire
* Inscrire deux candidats via la modale d'inscription : avec et sans complémentaire
  * * Bien vérifier l'affichage des **détails session** notamment sur la partie complémentaire 
  * Bien vérifier l'affichage des **détails candidats** notamment sur la partie complémentaire 
* Passer au moins deux certifications : avec et sans complémentaire
  * Vérifier que le candidat avec complémentaire voit les infos d'affichage complémentaire
  * Bien vérifier l'affichage de la **supervision** notamment sur la partie complémentaire 
* Après le passage de la certification, faire le process vers la publication en vérifiant au passage
  * Pix Admin : détails autour de la certif, sur la partie complémentaire
  * Pix App : candidat voit son macaron & co après publication

# Pix V3
* Passer une certification V3 jusqu'à publication, rien à vérifier de particulier

### Scripts
* Générer des données de test avec generate-certif-cli, en mettant des complémentaires

### Metabase
* Est-ce possible de faire pointer un dashboard métier sur les complémentaires vers la RA ?