### PR TITLE
[FEATURE] Création de la page de simulation de scoring V3 (PIX-11995).

### DIFF
--- a/admin/app/adapters/scoring-and-capacity-simulator-report.js
+++ b/admin/app/adapters/scoring-and-capacity-simulator-report.js
@@ -1,0 +1,18 @@
+import ApplicationAdapter from './application';
+
+export default class ScoringAndCapacitySimulatorReportAdapter extends ApplicationAdapter {
+  namespace = 'api/admin';
+
+  getSimulationResult({ score, capacity }) {
+    let data;
+    if (score) {
+      data = { score };
+    } else if (capacity) {
+      data = { capacity };
+    }
+    const url = `${this.host}/${this.namespace}/simulate-score-or-capacity`;
+    return this.ajax(url, 'POST', {
+      data: { data },
+    });
+  }
+}

--- a/admin/app/controllers/authenticated/certifications/scoring-simulation.js
+++ b/admin/app/controllers/authenticated/certifications/scoring-simulation.js
@@ -1,0 +1,68 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class ConfigurationController extends Controller {
+  @tracked validationStatus = 'default';
+  @tracked score = null;
+  @tracked capacity = null;
+  @tracked simulatorReport = null;
+  @tracked errors = [];
+  @service store;
+
+  ERRORS = {
+    SCORE: 'Merci d’indiquer un score en Pix compris entre O et 896',
+    BOTH_INPUT_FILLED: 'Merci de ne renseigner que l’un des champs “Score global en Pix” ou “Capacité”',
+    BOTH_INPUT_EMPTY: "Merci de renseigner au moins l'un des deux champs",
+  };
+
+  @action
+  async onGenerateSimulationProfile(event) {
+    event.preventDefault();
+    this._cleanErrors();
+    this.checkFormValidity();
+    const adapter = this.store.adapterFor('scoring-and-capacity-simulator-report');
+    const isFormInvalid = (!this.score && !this.capacity) || this.errors.length > 0;
+
+    if (isFormInvalid) {
+      return;
+    }
+
+    this.simulatorReport = await adapter.getSimulationResult({
+      score: this.score,
+      capacity: this.capacity,
+    });
+
+    this.score = null;
+    this.capacity = null;
+  }
+
+  @action
+  updateScore(event) {
+    this._cleanErrors();
+    this.score = event.target.value;
+  }
+
+  @action
+  updateCapacity(event) {
+    this._cleanErrors();
+    this.capacity = event.target.value;
+  }
+
+  checkFormValidity() {
+    if (!this.score && !this.capacity) {
+      this.errors = [...this.errors, this.ERRORS.BOTH_INPUT_EMPTY];
+    }
+    if (this.score && this.capacity) {
+      this.errors = [...this.errors, this.ERRORS.BOTH_INPUT_FILLED];
+    }
+    if (this.score > 896 || this.score < 0) {
+      this.errors = [...this.errors, this.ERRORS.SCORE];
+    }
+  }
+
+  _cleanErrors() {
+    this.errors = [];
+  }
+}

--- a/admin/app/controllers/authenticated/certifications/scoring-simulation.js
+++ b/admin/app/controllers/authenticated/certifications/scoring-simulation.js
@@ -10,11 +10,12 @@ export default class ConfigurationController extends Controller {
   @tracked simulatorReport = null;
   @tracked errors = [];
   @service store;
+  @service intl;
 
   ERRORS = {
-    SCORE: 'Merci d’indiquer un score en Pix compris entre O et 896',
-    BOTH_INPUT_FILLED: 'Merci de ne renseigner que l’un des champs “Score global en Pix” ou “Capacité”',
-    BOTH_INPUT_EMPTY: "Merci de renseigner au moins l'un des deux champs",
+    SCORE: this.intl.t('pages.certifications.scoring-simulation.errors.score'),
+    BOTH_INPUT_FILLED: this.intl.t('pages.certifications.scoring-simulation.errors.both-input-filled'),
+    BOTH_INPUT_EMPTY: this.intl.t('pages.certifications.scoring-simulation.errors.both-input-empty'),
   };
 
   @action

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -84,6 +84,7 @@ Router.map(function () {
 
     this.route('certifications', function () {
       this.route('configuration');
+      this.route('scoring-simulation');
       this.route('certification', { path: '/:certification_id' }, function () {
         this.route('informations', { path: '/' });
         this.route('neutralization');

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -50,6 +50,7 @@
 @import 'components/certification/candidate-edit-modal';
 @import 'components/certification/certification-status-select';
 @import 'components/certification/competence-list';
+@import 'components/certification/scoring-simulation';
 @import 'components/certified-profile';
 @import 'components/common/tick-or-cross';
 @import 'components/common/tubes-selection';

--- a/admin/app/styles/components/certification/scoring-simulation.scss
+++ b/admin/app/styles/components/certification/scoring-simulation.scss
@@ -1,0 +1,45 @@
+.scoring-simulation__data {
+  margin: 20px 0;
+}
+
+.scoring-simulation-data__container {
+  display: flex;
+  gap: var(--pix-spacing-1x)
+}
+
+.scoring-simulation__form {
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: flex-end;
+
+  & > *:not(:first-child) {
+    margin-left: 30px;
+  }
+}
+
+.scoring-simulation__error-message {
+  width: fit-content;
+  margin-top: 10px;
+}
+
+.scoring-simulation__competences {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.scoring-simulation-competences__item {
+  display: flex;
+  flex-flow: row wrap;
+  margin-bottom: 0.5em;
+  padding-bottom: 0.5em;
+  border-bottom: 1px solid var(--pix-neutral-20);
+
+  > *:not(:last-of-type) {
+    min-width: 6em;
+  }
+
+  &:last-of-type {
+    border-bottom: none;
+  }
+}

--- a/admin/app/templates/authenticated/certifications/scoring-simulation.hbs
+++ b/admin/app/templates/authenticated/certifications/scoring-simulation.hbs
@@ -1,16 +1,18 @@
 <section>
   <form class="scoring-simulation__form">
     <PixInput {{on "input" this.updateScore}} @id="score" @value={{this.score}} type="number">
-      <:label>Score global en Pix</:label>
+      <:label>{{t "pages.certifications.scoring-simulation.labels.score-input"}}</:label>
     </PixInput>
 
     <PixInput @id="capacity" {{on "input" this.updateCapacity}} @value={{this.capacity}} type="number">
-      <:label>Capacité</:label>
+      <:label>{{t "pages.certifications.scoring-simulation.labels.capacity-input"}}</:label>
     </PixInput>
 
-    <PixButton @type="submit" @triggerAction={{this.onGenerateSimulationProfile}}>{{t
-        "pages.certifications.scoring-simulation.actions.submit"
-      }}</PixButton>
+    <PixButton
+      class="scoring-simulation__form-button"
+      @type="submit"
+      @triggerAction={{this.onGenerateSimulationProfile}}
+    >{{t "pages.certifications.scoring-simulation.actions.submit"}}</PixButton>
   </form>
 
   {{#each this.errors as |error|}}

--- a/admin/app/templates/authenticated/certifications/scoring-simulation.hbs
+++ b/admin/app/templates/authenticated/certifications/scoring-simulation.hbs
@@ -1,0 +1,42 @@
+<section>
+  <form class="scoring-simulation__form">
+    <PixInput {{on "input" this.updateScore}} @id="score" @value={{this.score}} type="number">
+      <:label>Score global en Pix</:label>
+    </PixInput>
+
+    <PixInput @id="capacity" {{on "input" this.updateCapacity}} @value={{this.capacity}} type="number">
+      <:label>Capacité</:label>
+    </PixInput>
+
+    <PixButton @type="submit" @triggerAction={{this.onGenerateSimulationProfile}}>{{t
+        "pages.certifications.scoring-simulation.actions.submit"
+      }}</PixButton>
+  </form>
+
+  {{#each this.errors as |error|}}
+    <PixMessage class="scoring-simulation__error-message" @type="error">{{error}}</PixMessage>
+  {{/each}}
+
+  <dl class="scoring-simulation__data">
+    <div class="scoring-simulation-data__container">
+      <dt>{{t "pages.certifications.scoring-simulation.labels.score"}}</dt>
+      <dd>{{this.simulatorReport.data.attributes.score}}</dd>
+    </div>
+    <div class="scoring-simulation-data__container">
+      <dt>{{t "pages.certifications.scoring-simulation.labels.capacity"}}</dt>
+      <dd>{{this.simulatorReport.data.attributes.capacity}}</dd>
+    </div>
+  </dl>
+
+  <ul class="scoring-simulation__competences">
+    {{#each this.simulatorReport.data.attributes.competences as |competence|}}
+      <li
+        class="scoring-simulation-competences__item"
+        aria-label="Niveau de la compétence {{competence.competenceCode}}"
+      >
+        <span aria-hidden="true">{{competence.competenceCode}}</span>
+        <span>{{t "pages.certifications.scoring-simulation.labels.level"}} {{competence.level}}</span>
+      </li>
+    {{/each}}
+  </ul>
+</section>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -132,6 +132,18 @@ function routes() {
     return session.update({ assignedCertificationOfficerId: userId });
   });
 
+  this.post('/admin/simulate-score-or-capacity', (_schema, _request) => {
+    return {
+      data: {
+        attributes: {
+          capacity: 1,
+          score: 768,
+          competences: [{ competenceCode: '1.1', level: '3' }],
+        },
+      },
+    };
+  });
+
   this.get('/admin/users');
   this.get('/admin/users/:id');
   this.get('/admin/users/:id/participations', (schema) => {

--- a/admin/tests/acceptance/authenticated/certifications/scoring-simulation_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/scoring-simulation_test.js
@@ -1,0 +1,119 @@
+import { clickByName, visit } from '@1024pix/ember-testing-library';
+import { fillIn } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import { authenticateAdminMemberWithRole } from '../../../helpers/test-init';
+
+module('Acceptance | Route | routes/authenticated/certifications/scoring-simulation', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function () {
+    this.server.create('user', { id: 888 });
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+  });
+
+  test('it should display form', async function (assert) {
+    // when
+    const screen = await visit(`/certifications/scoring-simulation`);
+
+    // then
+    assert.dom(screen.getByLabelText('Score global en Pix')).exists();
+    assert.dom(screen.getByLabelText('Capacité')).exists();
+    assert.dom(screen.getByRole('button', { name: 'Générer un profil' })).exists();
+  });
+
+  test('should display an error message when score is superior to 896', async function (assert) {
+    // given
+    const screen = await visit(`/certifications/scoring-simulation`);
+
+    // when
+    await fillIn(screen.getByLabelText('Score global en Pix'), 897);
+    await clickByName('Générer un profil');
+
+    // then
+    assert.dom(screen.getByText('Merci d’indiquer un score en Pix compris entre O et 896')).exists();
+  });
+
+  test('should display an error message when score is inferior to 0', async function (assert) {
+    // given
+    const screen = await visit(`/certifications/scoring-simulation`);
+
+    // when
+    await fillIn(screen.getByLabelText('Score global en Pix'), -1);
+    await clickByName('Générer un profil');
+
+    // then
+    assert.dom(screen.getByText('Merci d’indiquer un score en Pix compris entre O et 896')).exists();
+  });
+
+  test('should display an error message when both inputs are filled', async function (assert) {
+    // given
+    const screen = await visit(`/certifications/scoring-simulation`);
+
+    // when
+    await fillIn(screen.getByLabelText('Score global en Pix'), -1);
+    await fillIn(screen.getByLabelText('Capacité'), 1);
+    await clickByName('Générer un profil');
+
+    // then
+    assert
+      .dom(screen.getByText('Merci de ne renseigner que l’un des champs “Score global en Pix” ou “Capacité”'))
+      .exists();
+  });
+
+  test('should display an error message when both inputs are empty', async function (assert) {
+    // given
+    const screen = await visit(`/certifications/scoring-simulation`);
+
+    // when
+    await clickByName('Générer un profil');
+
+    // then
+    assert.dom(screen.getByText("Merci de renseigner au moins l'un des deux champs")).exists();
+  });
+
+  test('should display a score and competence levels list when a capacity is given', async function (assert) {
+    // given
+    const screen = await visit(`/certifications/scoring-simulation`);
+
+    // when
+    await fillIn(screen.getByLabelText('Capacité'), 1);
+    await clickByName('Générer un profil');
+
+    // then
+    const termsList = screen.getAllByRole('term');
+    const definitionsList = screen.getAllByRole('definition');
+
+    assert.strictEqual(termsList[0].textContent.trim(), 'Score :');
+    assert.strictEqual(definitionsList[0].textContent.trim(), '768');
+
+    assert.strictEqual(termsList[1].textContent.trim(), 'Capacité :');
+    assert.strictEqual(definitionsList[1].textContent.trim(), '1');
+
+    assert.dom(screen.getByLabelText('Niveau de la compétence 1.1')).exists();
+  });
+
+  test('should display a competence and competence levels list when a score is given', async function (assert) {
+    // given
+    const screen = await visit(`/certifications/scoring-simulation`);
+
+    // when
+    await fillIn(screen.getByLabelText('Score global en Pix'), 768);
+    await clickByName('Générer un profil');
+
+    // then
+    const termsList = screen.getAllByRole('term');
+    const definitionsList = screen.getAllByRole('definition');
+
+    assert.strictEqual(termsList[0].textContent.trim(), 'Score :');
+    assert.strictEqual(definitionsList[0].textContent.trim(), '768');
+
+    assert.strictEqual(termsList[1].textContent.trim(), 'Capacité :');
+    assert.strictEqual(definitionsList[1].textContent.trim(), '1');
+
+    assert.dom(screen.getByLabelText('Niveau de la compétence 1.1')).exists();
+  });
+});

--- a/admin/tests/unit/adapters/scoring-and-capacity-simulator-report_test.js
+++ b/admin/tests/unit/adapters/scoring-and-capacity-simulator-report_test.js
@@ -1,0 +1,65 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Adapter | scoring-and-capacity-simulator-report', function (hooks) {
+  setupTest(hooks);
+
+  module('#getSimulationResult', function () {
+    module('when a score is given', function () {
+      test('should trigger POST request with the correct payload and URL', async function (assert) {
+        // given
+        const adapter = this.owner.lookup('adapter:scoring-and-capacity-simulator-report');
+        sinon.stub(adapter, 'ajax');
+
+        const adapterOptions = {
+          score: 1,
+          capacity: null,
+        };
+
+        // when
+        await adapter.getSimulationResult(adapterOptions);
+
+        // then
+        const expectedUrl = 'http://localhost:3000/api/admin/simulate-score-or-capacity';
+        const expectedPayload = {
+          data: {
+            data: {
+              score: 1,
+            },
+          },
+        };
+        sinon.assert.calledWith(adapter.ajax, expectedUrl, 'POST', expectedPayload);
+        assert.ok(adapter); /* required because QUnit wants at least one expect (and does not accept Sinon's one) */
+      });
+    });
+
+    module('when a capacity is given', function () {
+      test('should trigger POST request with the correct payload and URL', async function (assert) {
+        // given
+        const adapter = this.owner.lookup('adapter:scoring-and-capacity-simulator-report');
+        sinon.stub(adapter, 'ajax');
+
+        const adapterOptions = {
+          capacity: 1,
+          score: null,
+        };
+
+        // when
+        await adapter.getSimulationResult(adapterOptions);
+
+        // then
+        const expectedUrl = 'http://localhost:3000/api/admin/simulate-score-or-capacity';
+        const expectedPayload = {
+          data: {
+            data: {
+              capacity: 1,
+            },
+          },
+        };
+        sinon.assert.calledWith(adapter.ajax, expectedUrl, 'POST', expectedPayload);
+        assert.ok(adapter); /* required because QUnit wants at least one expect (and does not accept Sinon's one) */
+      });
+    });
+  });
+});

--- a/admin/tests/unit/controllers/authenticated/certifications/certification/scoring-simulation_test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/certification/scoring-simulation_test.js
@@ -1,0 +1,99 @@
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
+
+module('Unit | Controller | authenticated/certifications/scoring-simulation', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('#checkFormValidity', function () {
+    module('when score and capacity are filled', function () {
+      test('it should set bothInputsFilledError to true', function (assert) {
+        // given
+        const controller = this.owner.lookup('controller:authenticated/certifications/scoring-simulation');
+        controller.score = 496;
+        controller.capacity = 3;
+
+        // when
+        controller.checkFormValidity();
+
+        // then
+        assert.deepEqual(
+          controller.errors[0],
+          this.intl.t('pages.certifications.scoring-simulation.errors.both-input-filled'),
+        );
+      });
+    });
+
+    module('when score is above 896', function () {
+      test('it should add a range error to errors', function (assert) {
+        // given
+        const controller = this.owner.lookup('controller:authenticated/certifications/scoring-simulation');
+        controller.score = 900;
+
+        // when
+        controller.checkFormValidity();
+
+        // then
+        assert.deepEqual(controller.errors[0], this.intl.t('pages.certifications.scoring-simulation.errors.score'));
+      });
+    });
+
+    module('when score is below 0', function () {
+      test('it should add a range error to errors', function (assert) {
+        // given
+        const controller = this.owner.lookup('controller:authenticated/certifications/scoring-simulation');
+        controller.score = -1;
+
+        // when
+        controller.checkFormValidity();
+
+        // then
+        assert.deepEqual(controller.errors[0], this.intl.t('pages.certifications.scoring-simulation.errors.score'));
+      });
+    });
+  });
+
+  module('#onGenerateSimulationProfile', function () {
+    test('should call getSimulationResult method with correct parameters', function (assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated/certifications/scoring-simulation');
+      const store = this.owner.lookup('service:store');
+      const adapter = store.adapterFor('scoring-and-capacity-simulator-report');
+      const getSimulationResultStub = sinon.stub(adapter, 'getSimulationResult');
+      const event = {
+        preventDefault: () => {},
+      };
+      controller.score = 1;
+
+      // when
+      controller.onGenerateSimulationProfile(event);
+
+      // then
+      sinon.assert.calledWithExactly(getSimulationResultStub, { score: 1, capacity: null });
+      assert.ok(true);
+    });
+
+    module('when an error occured', function () {
+      test('should not call getSimulationResult method', function (assert) {
+        // given
+        const controller = this.owner.lookup('controller:authenticated/certifications/scoring-simulation');
+        const store = this.owner.lookup('service:store');
+        const adapter = store.adapterFor('scoring-and-capacity-simulator-report');
+        const getSimulationResultStub = sinon.stub(adapter, 'getSimulationResult');
+        const event = {
+          preventDefault: () => {},
+        };
+        controller.score = 1;
+        controller.capacity = 1;
+
+        // when
+        controller.onGenerateSimulationProfile(event);
+
+        // then
+        sinon.assert.notCalled(getSimulationResultStub);
+        assert.ok(true);
+      });
+    });
+  });
+});

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -298,6 +298,23 @@
             }
           }
         }
+      },
+      "scoring-simulation": {
+        "actions": {
+          "submit": "Generate profile"
+        },
+        "errors": {
+          "both-input-empty": "Please fill at least only one field",
+          "both-input-filled": "Please fill only one of following fields “Global score in Pix“ or “Capacity”",
+          "score": "Please enter a Pix score between O and 896"
+        },
+        "labels": {
+          "capacity": "Capacity :",
+          "capacity-input": "Capacity",
+          "level": "Level :",
+          "score": "Score :",
+          "score-input": "Global score in Pix"
+        }
       }
     },
     "login": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -308,6 +308,23 @@
             }
           }
         }
+      },
+      "scoring-simulation": {
+        "actions": {
+          "submit": "Générer un profil"
+        },
+        "errors": {
+          "both-input-empty": "Merci de renseigner au moins l'un des deux champs",
+          "both-input-filled": "Merci de ne renseigner que l’un des champs “Score global en Pix” ou “Capacité”",
+          "score": "Merci d’indiquer un score en Pix compris entre O et 896"
+        },
+        "labels": {
+          "capacity": "Capacité :",
+          "capacity-input": "Capacité",
+          "level": "Niveau :",
+          "score": "Score :",
+          "score-input": "Score global en Pix"
+        }
       }
     },
     "login": {


### PR DESCRIPTION
## :unicorn: Problème

Le scoring certif v3 permet actuellement, à partir d’une capacité, de définir le score global en Pix et les niveaux par compétence d’un candidat en certification. Pour des besoins d’analyse, d’aide à la décision sur différents sujets produit, nous aurions besoin de voir concrètement les différents profils possible pour un candidat à une certif v3, et donc de savoir quel score global en Pix donne quelle capacité et quel niveau pour chacune des 16 compétences.

Problème :

La "calculatrice" a été implémentée dans la PR #8651 , mais n’est pas encore accessible autrement que par cURL.

## :robot: Proposition

Dans Pix Admin, créer une page accessible uniquement via URL dans un premier temps, avec les champs suivants : 
    Score global en Pix
    Capacité
    bouton  “Générer un profil”

• Si au clic sur le bouton, les 2 champs précédents sont remplis, afficher le message d’erreur : “Merci de ne renseigner que l’un des champs “Score global en Pix” ou “Capacité”

• Si au clic sur le bouton, le score global en Pix est inférieur au score en Pix min, ou supérieur au score en Pix max, afficher le message d’erreur : “Merci d’indiquer un score en Pix compris entre 0 et 896."

<img width="615" alt="Capture d’écran 2024-04-19 à 16 39 35" src="https://github.com/1024pix/pix/assets/36371437/0d3daaf6-9b1f-483e-bd65-6391993ac455">

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

Sur pix-admin, se connecter en tant que `superadmin@example.net`
Aller sur l'url `/certifications/scoring-simulation`

Test de l'obtention d'un score : 
- Remplir le champ capacité
- générer un profil de résultat
- Vérifier que l'on obtient un score et des niveaux par compétence

Test de l'obtention d'une capacité : 
- Remplir le champ score
- générer un profil de résultat
- Vérifier que l'on obtient un score et des niveaux par compétence

- Vérifier que l'on ne peut remplir les deux champs lors de l'envoi
- Vérifier que l'on ne peut remplir le champ score avec une valeur inférieure à 0 et supérieure à 896.