### PR TITLE
[FEATURE] Afficher dans le portail surveillant les appels sur /api/companion/ping (PIX-12028)

### DIFF
--- a/api/lib/infrastructure/temporary-storage/InMemoryTemporaryStorage.js
+++ b/api/lib/infrastructure/temporary-storage/InMemoryTemporaryStorage.js
@@ -1,4 +1,5 @@
 import lodash from 'lodash';
+import micromatch from 'micromatch';
 import NodeCache from 'node-cache';
 
 const { trim, noop } = lodash;
@@ -61,6 +62,10 @@ class InMemoryTemporaryStorage extends TemporaryStorage {
 
   async lrange(key) {
     return this._client.get(key) || [];
+  }
+
+  keys(pattern) {
+    return micromatch(this._client.keys(), pattern);
   }
 }
 

--- a/api/lib/infrastructure/temporary-storage/RedisTemporaryStorage.js
+++ b/api/lib/infrastructure/temporary-storage/RedisTemporaryStorage.js
@@ -7,6 +7,7 @@ import { TemporaryStorage } from './TemporaryStorage.js';
 
 const EXPIRATION_PARAMETER = 'ex';
 const KEEPTTL_PARAMETER = 'keepttl';
+const PREFIX = 'temporary-storage:';
 
 class RedisTemporaryStorage extends TemporaryStorage {
   constructor(redisUrl) {
@@ -15,7 +16,7 @@ class RedisTemporaryStorage extends TemporaryStorage {
   }
 
   static createClient(redisUrl) {
-    return new RedisClient(redisUrl, { name: 'temporary-storage', prefix: 'temporary-storage:' });
+    return new RedisClient(redisUrl, { name: 'temporary-storage', prefix: PREFIX });
   }
 
   async save({ key, value, expirationDelaySeconds }) {
@@ -64,6 +65,11 @@ class RedisTemporaryStorage extends TemporaryStorage {
 
   async lrange(key, start = 0, stop = -1) {
     return this._client.lrange(key, start, stop);
+  }
+
+  async keys(pattern) {
+    const keys = await this._client.keys(pattern);
+    return keys.map((key) => key.slice(PREFIX.length));
   }
 }
 

--- a/api/lib/infrastructure/temporary-storage/TemporaryStorage.js
+++ b/api/lib/infrastructure/temporary-storage/TemporaryStorage.js
@@ -41,6 +41,10 @@ class TemporaryStorage {
     throw new Error('Method #lrange(key) must be overridden');
   }
 
+  async keys(/* pattern */) {
+    throw new Error('Method #keys(pattern) must be overridden');
+  }
+
   quit() {
     throw new Error('Method #quit() must be overridden');
   }
@@ -84,6 +88,11 @@ class TemporaryStorage {
 
       lrange(key) {
         return storage.lrange(prefix + key);
+      },
+
+      async keys(pattern) {
+        const keys = await storage.keys(prefix + pattern);
+        return keys.map((key) => key.slice(prefix.length));
       },
     };
   }

--- a/api/lib/infrastructure/utils/RedisClient.js
+++ b/api/lib/infrastructure/utils/RedisClient.js
@@ -31,6 +31,7 @@ class RedisClient {
     this.rpush = this._wrapWithPrefix(this._client.rpush).bind(this._client);
     this.lrem = this._wrapWithPrefix(this._client.lrem).bind(this._client);
     this.lrange = this._wrapWithPrefix(this._client.lrange).bind(this._client);
+    this.keys = this._wrapWithPrefix(this._client.keys).bind(this._client);
     this.ping = this._client.ping.bind(this._client);
     this.flushall = this._client.flushall.bind(this._client);
     this.lockDisposer = this._clientWithLock.disposer.bind(this._clientWithLock);

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -50,6 +50,7 @@
         "jszip": "^3.10.0",
         "knex": "^3.0.0",
         "lodash": "^4.17.21",
+        "micromatch": "^4.0.5",
         "ms": "^2.1.3",
         "node-cache": "^5.1.2",
         "node-stream-zip": "^1.15.0",
@@ -4170,7 +4171,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -7037,7 +7037,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -8408,7 +8407,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -9556,7 +9554,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
       "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -10960,7 +10957,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -13287,7 +13283,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"

--- a/api/package.json
+++ b/api/package.json
@@ -56,6 +56,7 @@
     "jszip": "^3.10.0",
     "knex": "^3.0.0",
     "lodash": "^4.17.21",
+    "micromatch": "^4.0.5",
     "ms": "^2.1.3",
     "node-cache": "^5.1.2",
     "node-stream-zip": "^1.15.0",

--- a/api/sample.env
+++ b/api/sample.env
@@ -548,7 +548,6 @@ AUTH_SECRET=the-password-must-be-at-least-32-characters-long
 # default: 7200
 # sample: SESSIONS_MASS_IMPORT_TEMPORARY_STORAGE_EXP_DELAY_SECONDS=
 
-
 # ========
 # TEMPORARY STORAGE
 # ========
@@ -559,6 +558,14 @@ AUTH_SECRET=the-password-must-be-at-least-32-characters-long
 # type: Integer
 # default: 600
 TEMPORARY_STORAGE_EXPIRATION_DELAY_SECONDS=
+
+# Companion temporary storage expiration delay in seconds
+#
+# presence: optional
+# type: Integer
+# default: 45
+# sample: TEMPORARY_COMPANION_STORAGE_EXP_DELAY_SECONDS=
+
 
 # ========
 # V3 CERTIFICATION

--- a/api/src/certification/enrolment/application/companion-controller.js
+++ b/api/src/certification/enrolment/application/companion-controller.js
@@ -1,0 +1,11 @@
+import { usecases } from '../domain/usecases/index.js';
+
+const savePing = async function (request, h) {
+  const { userId } = request.auth.credentials;
+  await usecases.saveCompanionPing({ userId });
+  return h.response().code(204);
+};
+
+export const companionController = {
+  savePing,
+};

--- a/api/src/certification/enrolment/application/companion-route.js
+++ b/api/src/certification/enrolment/application/companion-route.js
@@ -1,0 +1,21 @@
+import { companionController } from './companion-controller.js';
+
+const register = async function (server) {
+  server.route([
+    {
+      method: 'POST',
+      path: '/api/companion/ping',
+      config: {
+        handler: companionController.savePing,
+        tags: ['api', 'sessions', 'companion'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs connectés**\n' +
+            '- Cette route permet d\'enregistrer un ping du "companion"',
+        ],
+      },
+    },
+  ]);
+};
+
+const name = 'companion-api';
+export { name, register };

--- a/api/src/certification/enrolment/domain/models/CertificationCandidateCompanion.js
+++ b/api/src/certification/enrolment/domain/models/CertificationCandidateCompanion.js
@@ -1,0 +1,8 @@
+class CertificationCandidateCompanion {
+  constructor({ sessionId, id } = {}) {
+    this.sessionId = sessionId;
+    this.id = id;
+  }
+}
+
+export { CertificationCandidateCompanion };

--- a/api/src/certification/enrolment/domain/usecases/index.js
+++ b/api/src/certification/enrolment/domain/usecases/index.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as attendanceSheetPdfUtils from '../../../enrolment/infrastructure/utils/pdf/attendance-sheet-pdf.js';
+import * as temporaryCompanionStorageService from '../../../shared/domain/services/temporary-companion-storage-service.js';
 import { enrolmentRepositories } from '../../infrastructure/repositories/index.js';
 import * as certificationCpfService from '../services/certification-cpf-service.js';
 import * as sessionCodeService from '../services/session-code-service.js';
@@ -26,6 +27,7 @@ import * as sessionValidator from '../validators/session-validator.js';
  * @typedef {import('../services/certification-cpf-service.js')} CertificationCpfService
  * @typedef {import('../../../enrolment/infrastructure/utils/pdf/attendance-sheet-pdf.js')} AttendanceSheetPdfUtils
  * @typedef {import('../services/temporary-sessions-storage-for-mass-import-service.js').TemporarySessionsStorageForMassImportService} TemporarySessionsStorageForMassImportService
+ * @typedef {import('../../../shared/domain/services/temporary-companion-storage-service.js')} TemporaryCompanionStorageService
  **/
 
 /**
@@ -46,6 +48,7 @@ import * as sessionValidator from '../validators/session-validator.js';
  * @typedef {TemporarySessionsStorageForMassImportService} TemporarySessionsStorageForMassImportService
  * @typedef {SessionValidator} SessionValidator
  * @typedef {AttendanceSheetPdfUtils} AttendanceSheetPdfUtils
+ * @typedef {TemporaryCompanionStorageService} TemporaryCompanionStorageService
  **/
 const dependencies = {
   ...enrolmentRepositories,
@@ -55,6 +58,7 @@ const dependencies = {
   sessionValidator,
   attendanceSheetPdfUtils,
   certificationCpfService,
+  temporaryCompanionStorageService,
 };
 
 const path = dirname(fileURLToPath(import.meta.url));

--- a/api/src/certification/enrolment/domain/usecases/save-companion-ping.js
+++ b/api/src/certification/enrolment/domain/usecases/save-companion-ping.js
@@ -1,5 +1,22 @@
-const saveCompanionPing = async function ({ userId }) {
-  return userId;
+/**
+ * @typedef {import('./index.js').CertificationCandidateRepository} CertificationCandidateRepository
+ * @typedef {import('./index.js').TemporaryCompanionStorageService} TemporaryCompanionStorageService
+ */
+
+/**
+ * @param {Object} params
+ * @param {number} params.userId
+ * @param {CertificationCandidateRepository} params.certificationCandidateRepository
+ * @param {TemporaryCompanionStorageService} params.temporaryCompanionStorageService
+ */
+const saveCompanionPing = async function ({
+  userId,
+  certificationCandidateRepository,
+  temporaryCompanionStorageService,
+}) {
+  const certificationCandidateCompanion =
+    await certificationCandidateRepository.findCertificationCandidateCompanionInfoByUserId({ userId });
+  await temporaryCompanionStorageService.save(certificationCandidateCompanion);
 };
 
 export { saveCompanionPing };

--- a/api/src/certification/enrolment/domain/usecases/save-companion-ping.js
+++ b/api/src/certification/enrolment/domain/usecases/save-companion-ping.js
@@ -3,6 +3,8 @@
  * @typedef {import('./index.js').TemporaryCompanionStorageService} TemporaryCompanionStorageService
  */
 
+import { NotFoundError } from '../../../../shared/domain/errors.js';
+
 /**
  * @param {Object} params
  * @param {number} params.userId
@@ -16,6 +18,9 @@ const saveCompanionPing = async function ({
 }) {
   const certificationCandidateCompanion =
     await certificationCandidateRepository.findCertificationCandidateCompanionInfoByUserId({ userId });
+  if (!certificationCandidateCompanion) {
+    throw new NotFoundError(`User ${userId} is not found in a certification's session`);
+  }
   await temporaryCompanionStorageService.save(certificationCandidateCompanion);
 };
 

--- a/api/src/certification/enrolment/domain/usecases/save-companion-ping.js
+++ b/api/src/certification/enrolment/domain/usecases/save-companion-ping.js
@@ -3,8 +3,6 @@
  * @typedef {import('./index.js').TemporaryCompanionStorageService} TemporaryCompanionStorageService
  */
 
-import { NotFoundError } from '../../../../shared/domain/errors.js';
-
 /**
  * @param {Object} params
  * @param {number} params.userId
@@ -18,9 +16,7 @@ const saveCompanionPing = async function ({
 }) {
   const certificationCandidateCompanion =
     await certificationCandidateRepository.findCertificationCandidateCompanionInfoByUserId({ userId });
-  if (!certificationCandidateCompanion) {
-    throw new NotFoundError(`User ${userId} is not found in a certification's session`);
-  }
+
   await temporaryCompanionStorageService.save(certificationCandidateCompanion);
 };
 

--- a/api/src/certification/enrolment/domain/usecases/save-companion-ping.js
+++ b/api/src/certification/enrolment/domain/usecases/save-companion-ping.js
@@ -1,0 +1,5 @@
+const saveCompanionPing = async function ({ userId }) {
+  return userId;
+};
+
+export { saveCompanionPing };

--- a/api/src/certification/enrolment/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/certification-candidate-repository.js
@@ -156,7 +156,7 @@ const getWithComplementaryCertification = async function (id) {
 const findCertificationCandidateCompanionInfoByUserId = async function ({ userId }) {
   const result = await knex.select('sessionId', 'id').from('certification-candidates').where({ userId }).first();
   if (!result) {
-    return undefined;
+    throw new NotFoundError(`User ${userId} is not found in a certification's session`);
   }
 
   return new CertificationCandidateCompanion(result);

--- a/api/src/certification/enrolment/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/certification-candidate-repository.js
@@ -12,6 +12,7 @@ import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTrans
 import { BookshelfCertificationCandidate } from '../../../../../lib/infrastructure/orm-models/CertificationCandidate.js';
 import * as bookshelfToDomainConverter from '../../../../../lib/infrastructure/utils/bookshelf-to-domain-converter.js';
 import { normalize } from '../../../../shared/infrastructure/utils/string-utils.js';
+import { CertificationCandidateCompanion } from '../../domain/models/CertificationCandidateCompanion.js';
 import { ComplementaryCertification } from '../../domain/models/ComplementaryCertification.js';
 import { Subscription } from '../../domain/models/Subscription.js';
 
@@ -152,11 +153,21 @@ const getWithComplementaryCertification = async function (id) {
   return _toDomain(candidateData);
 };
 
+const findCertificationCandidateCompanionInfoByUserId = async function ({ userId }) {
+  const result = await knex.select('sessionId', 'id').from('certification-candidates').where({ userId }).first();
+  if (!result) {
+    return undefined;
+  }
+
+  return new CertificationCandidateCompanion(result);
+};
+
 export {
   deleteBySessionId,
   doesLinkedCertificationCandidateInSessionExist,
   findBySessionId,
   findBySessionIdAndPersonalInfo,
+  findCertificationCandidateCompanionInfoByUserId,
   findOneBySessionIdAndUserId,
   getBySessionIdAndUserId,
   getWithComplementaryCertification,

--- a/api/src/certification/enrolment/routes.js
+++ b/api/src/certification/enrolment/routes.js
@@ -1,8 +1,9 @@
-import * as attendanceSheet from '../enrolment/application/attendance-sheet-route.js';
-import * as certificationCandidate from '../enrolment/application/certification-candidate-route.js';
+import * as attendanceSheet from './application/attendance-sheet-route.js';
+import * as certificationCandidate from './application/certification-candidate-route.js';
+import * as companion from './application/companion-route.js';
 import * as sessionMassImport from './application/session-mass-import-route.js';
 import * as session from './application/session-route.js';
 
-const certificationEnrolmentRoutes = [session, sessionMassImport, attendanceSheet, certificationCandidate];
+const certificationEnrolmentRoutes = [session, sessionMassImport, attendanceSheet, certificationCandidate, companion];
 
 export { certificationEnrolmentRoutes };

--- a/api/src/certification/session-management/domain/models/CertificationCandidateForSupervising.js
+++ b/api/src/certification/session-management/domain/models/CertificationCandidateForSupervising.js
@@ -15,6 +15,7 @@ class CertificationCandidateForSupervising {
     theoricalEndDateTime,
     enrolledComplementaryCertification,
     stillValidBadgeAcquisitions = [],
+    isCompanionActive = false,
   } = {}) {
     this.id = id;
     this.userId = userId;
@@ -28,6 +29,7 @@ class CertificationCandidateForSupervising {
     this.theoricalEndDateTime = theoricalEndDateTime;
     this.enrolledComplementaryCertification = enrolledComplementaryCertification;
     this.stillValidBadgeAcquisitions = stillValidBadgeAcquisitions;
+    this.isCompanionActive = isCompanionActive;
   }
 
   authorizeToStart() {

--- a/api/src/certification/session-management/domain/usecases/get-session-for-supervising.js
+++ b/api/src/certification/session-management/domain/usecases/get-session-for-supervising.js
@@ -23,7 +23,7 @@ const getSessionForSupervising = async function ({
   temporaryCompanionStorageService,
 }) {
   const sessionForSupervising = await sessionForSupervisingRepository.get({ id: sessionId });
-  const activatedCompanionCertificationCandidateId = await temporaryCompanionStorageService.getBySessionId(sessionId);
+  const activatedCompanionCertificationCandidateIds = await temporaryCompanionStorageService.getBySessionId(sessionId);
 
   await bluebird.map(
     sessionForSupervising.certificationCandidates,
@@ -32,9 +32,7 @@ const getSessionForSupervising = async function ({
   );
 
   sessionForSupervising.certificationCandidates.forEach((certificationCandidate) => {
-    if (activatedCompanionCertificationCandidateId.includes(certificationCandidate.id)) {
-      certificationCandidate.isCompanionActive = true;
-    }
+    _setCompanionStatus(certificationCandidate, activatedCompanionCertificationCandidateIds);
     _computeTheoricalEndDateTime(certificationCandidate);
   });
 
@@ -42,6 +40,12 @@ const getSessionForSupervising = async function ({
 };
 
 export { getSessionForSupervising };
+
+function _setCompanionStatus(certificationCandidate, activatedCompanionCertificationCandidateIds) {
+  if (activatedCompanionCertificationCandidateIds.includes(certificationCandidate.id)) {
+    certificationCandidate.isCompanionActive = true;
+  }
+}
 
 /**
  * @param {CertificationBadgesService} certificationBadgesService

--- a/api/src/certification/session-management/domain/usecases/index.js
+++ b/api/src/certification/session-management/domain/usecases/index.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import * as certificationBadgesService from '../../../../../lib/domain/services/certification-badges-service.js';
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
+import * as temporaryCompanionStorageService from '../../../shared/domain/services/temporary-companion-storage-service.js';
 import { assessmentRepository, sessionRepositories } from '../../infrastructure/repositories/index.js';
 import { cpfExportsStorage } from '../../infrastructure/storage/cpf-exports-storage.js';
 import { cpfReceiptsStorage } from '../../infrastructure/storage/cpf-receipts-storage.js';
@@ -25,6 +26,7 @@ import { cpfReceiptsStorage } from '../../infrastructure/storage/cpf-receipts-st
  * @typedef {import('../../infrastructure/storage/cpf-receipts-storage.js')} CpfReceiptsStorage
  * @typedef {import('../../infrastructure/storage/cpf-exports-storage.js')} CpfExportsStorage
  * @typedef {import('../../../../../lib/domain/services/certification-badges-service.js')} CertificationBadgesService
+ * @typedef {import('../../../shared/domain/services/temporary-companion-storage-service.js')} TemporaryCompanionStorageService
  **/
 
 /**
@@ -46,6 +48,7 @@ import { cpfReceiptsStorage } from '../../infrastructure/storage/cpf-receipts-st
  * @typedef {certificationReportRepository} CertificationReportRepository
  * @typedef {cpfReceiptsStorage} CpfReceiptsStorage
  * @typedef {cpfExportsStorage} CpfExportsStorage
+ * @typedef {TemporaryCompanionStorageService} TemporaryCompanionStorageService
  **/
 const dependencies = {
   ...sessionRepositories,
@@ -53,6 +56,7 @@ const dependencies = {
   cpfReceiptsStorage,
   cpfExportsStorage,
   certificationBadgesService,
+  temporaryCompanionStorageService,
 };
 
 const path = dirname(fileURLToPath(import.meta.url));

--- a/api/src/certification/session-management/infrastructure/serializers/session-for-supervising-serializer.js
+++ b/api/src/certification/session-management/infrastructure/serializers/session-for-supervising-serializer.js
@@ -35,6 +35,7 @@ const serialize = function (sessions) {
         'enrolledComplementaryCertificationLabel',
         'isStillEligibleToComplementaryCertification',
         'liveAlert',
+        'isCompanionActive',
       ],
     },
   }).serialize(sessions);

--- a/api/src/certification/shared/domain/services/temporary-companion-storage-service.js
+++ b/api/src/certification/shared/domain/services/temporary-companion-storage-service.js
@@ -1,0 +1,16 @@
+import { temporaryStorage } from '../../../../../lib/infrastructure/temporary-storage/index.js';
+import { config } from '../../../../shared/config.js';
+
+const _getTemporaryStorage = () => temporaryStorage.withPrefix('companion:ping:');
+
+const save = async function ({ sessionId, id: certificationCandidateId }) {
+  const expirationDelaySeconds = config.temporaryCompanionStorage.expirationDelaySeconds;
+  const companionPingStorage = _getTemporaryStorage();
+  await companionPingStorage.save({
+    key: `${sessionId}:${certificationCandidateId}`,
+    value: true,
+    expirationDelaySeconds,
+  });
+};
+
+export { save };

--- a/api/src/certification/shared/domain/services/temporary-companion-storage-service.js
+++ b/api/src/certification/shared/domain/services/temporary-companion-storage-service.js
@@ -13,4 +13,10 @@ const save = async function ({ sessionId, id: certificationCandidateId }) {
   });
 };
 
-export { save };
+const getBySessionId = async function (sessionId) {
+  const companionPingStorage = _getTemporaryStorage();
+  const values = await companionPingStorage.keys(`${sessionId}:*`);
+  return values.map((value) => parseInt(value.slice(`${sessionId}:`.length)));
+};
+
+export { getBySessionId, save };

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -310,6 +310,9 @@ const configuration = (function () {
       tokenLifespan: '1d',
       payload: 'PixResetPassword',
     },
+    temporaryCompanionStorage: {
+      expirationDelaySeconds: parseInt(process.env.TEMPORARY_COMPANION_STORAGE_EXP_DELAY_SECONDS, 10) || 45,
+    },
     temporarySessionsStorageForMassImport: {
       expirationDelaySeconds:
         parseInt(process.env.SESSIONS_MASS_IMPORT_TEMPORARY_STORAGE_EXP_DELAY_SECONDS, 10) || 7200,

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/certification-candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/certification-candidate-repository_test.js
@@ -4,6 +4,7 @@ import {
   CertificationCandidateMultipleUserLinksWithinSessionError,
   NotFoundError,
 } from '../../../../../../lib/domain/errors.js';
+import { CertificationCandidateCompanion } from '../../../../../../src/certification/enrolment/domain/models/CertificationCandidateCompanion.js';
 import * as certificationCandidateRepository from '../../../../../../src/certification/enrolment/infrastructure/repositories/certification-candidate-repository.js';
 import { ComplementaryCertification } from '../../../../../../src/certification/session-management/domain/models/ComplementaryCertification.js';
 import { ComplementaryCertificationKeys } from '../../../../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
@@ -885,6 +886,40 @@ describe('Integration | Repository | CertificationCandidate', function () {
               ),
           }),
         );
+      });
+    });
+  });
+
+  describe('#findCertificationCandidateCompanionInfoByUserId', function () {
+    context('where the user has joined a session', function () {
+      it('should return candidate info', async function () {
+        // given
+        databaseBuilder.factory.buildUser({ id: 99 });
+        databaseBuilder.factory.buildSession({ id: 49 });
+        databaseBuilder.factory.buildCertificationCandidate({ id: 89, userId: 99, sessionId: 49 });
+        await databaseBuilder.commit();
+
+        // when
+        const companionPingInfo =
+          await certificationCandidateRepository.findCertificationCandidateCompanionInfoByUserId({
+            userId: 99,
+          });
+
+        // then
+        expect(companionPingInfo).deepEqualInstance(new CertificationCandidateCompanion({ sessionId: 49, id: 89 }));
+      });
+    });
+
+    context('where the user has not joined a session', function () {
+      it('should return undefined', async function () {
+        // given  when
+        const companionPingInfo =
+          await certificationCandidateRepository.findCertificationCandidateCompanionInfoByUserId({
+            userId: 99,
+          });
+
+        // then
+        expect(companionPingInfo).to.be.undefined;
       });
     });
   });

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/certification-candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/certification-candidate-repository_test.js
@@ -894,32 +894,40 @@ describe('Integration | Repository | CertificationCandidate', function () {
     context('where the user has joined a session', function () {
       it('should return candidate info', async function () {
         // given
-        databaseBuilder.factory.buildUser({ id: 99 });
-        databaseBuilder.factory.buildSession({ id: 49 });
-        databaseBuilder.factory.buildCertificationCandidate({ id: 89, userId: 99, sessionId: 49 });
+        const userId = 99;
+        const sessionId = 49;
+        const candidateId = 80;
+        databaseBuilder.factory.buildUser({ id: userId });
+        databaseBuilder.factory.buildSession({ id: sessionId });
+        databaseBuilder.factory.buildCertificationCandidate({ id: candidateId, userId, sessionId });
         await databaseBuilder.commit();
 
         // when
         const companionPingInfo =
           await certificationCandidateRepository.findCertificationCandidateCompanionInfoByUserId({
-            userId: 99,
+            userId,
           });
 
         // then
-        expect(companionPingInfo).deepEqualInstance(new CertificationCandidateCompanion({ sessionId: 49, id: 89 }));
+        expect(companionPingInfo).deepEqualInstance(
+          new CertificationCandidateCompanion({ sessionId, id: candidateId }),
+        );
       });
     });
 
     context('where the user has not joined a session', function () {
-      it('should return undefined', async function () {
-        // given  when
-        const companionPingInfo =
-          await certificationCandidateRepository.findCertificationCandidateCompanionInfoByUserId({
-            userId: 99,
-          });
+      it('should throw a NotFoundError', async function () {
+        // given
+        const userId = 99;
+
+        // when
+        const error = await catchErr(certificationCandidateRepository.findCertificationCandidateCompanionInfoByUserId)({
+          userId,
+        });
 
         // then
-        expect(companionPingInfo).to.be.undefined;
+        expect(error).to.be.instanceOf(NotFoundError);
+        expect(error.message).to.equal(`User 99 is not found in a certification's session`);
       });
     });
   });

--- a/api/tests/certification/enrolment/unit/application/companion-controller_test.js
+++ b/api/tests/certification/enrolment/unit/application/companion-controller_test.js
@@ -1,0 +1,27 @@
+import { companionController } from '../../../../../src/certification/enrolment/application/companion-controller.js';
+import { usecases } from '../../../../../src/certification/enrolment/domain/usecases/index.js';
+import { expect, hFake, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Controller | companion-controller', function () {
+  describe('#savePing', function () {
+    it('should call the use case with the user id and return 204', async function () {
+      // given
+      const userId = 456;
+      sinon.stub(usecases, 'saveCompanionPing').withArgs({ userId }).resolves();
+
+      // when
+      const response = await companionController.savePing(
+        {
+          auth: {
+            credentials: { userId },
+          },
+        },
+        hFake,
+      );
+
+      // then
+      expect(response.statusCode).to.equal(204);
+      expect(usecases.saveCompanionPing).to.have.been.calledWith({ userId });
+    });
+  });
+});

--- a/api/tests/certification/enrolment/unit/application/companion-route_test.js
+++ b/api/tests/certification/enrolment/unit/application/companion-route_test.js
@@ -1,0 +1,20 @@
+import { companionController } from '../../../../../src/certification/enrolment/application/companion-controller.js';
+import * as moduleUnderTest from '../../../../../src/certification/enrolment/application/companion-route.js';
+import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Router | companion-route', function () {
+  describe('GET /api/companion/ping', function () {
+    it('should return 204', async function () {
+      // when
+      sinon.stub(companionController, 'savePing').callsFake((_, h) => h.response().code(204));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+      const auth = { credentials: { userId: 99 }, strategy: {} };
+
+      const response = await httpTestServer.request('POST', '/api/companion/ping', {}, auth);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+    });
+  });
+});

--- a/api/tests/certification/enrolment/unit/domain/usecases/save-companion-ping_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/save-companion-ping_test.js
@@ -1,6 +1,6 @@
 import { NotFoundError } from '../../../../../../lib/domain/errors.js';
-import { saveCompanionPing } from '../../../../../../src/certification/session/domain/usecases/save-companion-ping.js';
-import { catchErr, expect } from '../../../../../test-helper.js';
+import { saveCompanionPing } from '../../../../../../src/certification/enrolment/domain/usecases/save-companion-ping.js';
+import { catchErr, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | save-companion-ping', function () {
   describe('#saveCompanionPing', function () {
@@ -8,6 +8,10 @@ describe('Unit | UseCase | save-companion-ping', function () {
       it('should persist the companion ping in redis', async function () {
         // given
         const userId = 123;
+        const companionRepository = { getSessionInfo: sinon.stub() };
+        const temporaryStorageService = { saveCompanionPing: sinon.stub() };
+        companionRepository.getSessionInfo.withArgs(userId).resolves({ sessionId: 99, certificationCandidate: 101 });
+        temporaryStorageService.saveCompanionPing.withArgs({ sessionId: 99, certificationCandidate: 101 }).resolves();
 
         await saveCompanionPing({
           userId,
@@ -17,7 +21,8 @@ describe('Unit | UseCase | save-companion-ping', function () {
         const response = await saveCompanionPing({ userId });
 
         // then
-        expect(response).to.deep.equal(123);
+        expect(response).to.deep.equal();
+        expect(temporaryStorageService).to.have.been.calledWithExactly({ sessionId: 99, certificationCandidate: 101 });
       });
     });
 

--- a/api/tests/certification/enrolment/unit/domain/usecases/save-companion-ping_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/save-companion-ping_test.js
@@ -1,6 +1,6 @@
-import { NotFoundError } from '../../../../../../lib/domain/errors.js';
 import { CertificationCandidateCompanion } from '../../../../../../src/certification/enrolment/domain/models/CertificationCandidateCompanion.js';
 import { saveCompanionPing } from '../../../../../../src/certification/enrolment/domain/usecases/save-companion-ping.js';
+import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErr, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | save-companion-ping', function () {
@@ -35,15 +35,20 @@ describe('Unit | UseCase | save-companion-ping', function () {
       it('should throw a Not Found error', async function () {
         // given
         const userId = 123;
+        const certificationCandidateRepository = { findCertificationCandidateCompanionInfoByUserId: sinon.stub() };
+        certificationCandidateRepository.findCertificationCandidateCompanionInfoByUserId
+          .withArgs({ userId })
+          .resolves(undefined);
 
         // when
         const error = await catchErr(saveCompanionPing)({
           userId,
+          certificationCandidateRepository,
         });
 
         // then
         expect(error).to.be.instanceOf(NotFoundError);
-        expect(error.message).to.equal(`No candidate found for user id ${userId}`);
+        expect(error.message).to.equal(`User 123 is not found in a certification's session`);
       });
     });
   });

--- a/api/tests/certification/enrolment/unit/domain/usecases/save-companion-ping_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/save-companion-ping_test.js
@@ -1,4 +1,5 @@
 import { NotFoundError } from '../../../../../../lib/domain/errors.js';
+import { CertificationCandidateCompanion } from '../../../../../../src/certification/enrolment/domain/models/CertificationCandidateCompanion.js';
 import { saveCompanionPing } from '../../../../../../src/certification/enrolment/domain/usecases/save-companion-ping.js';
 import { catchErr, expect, sinon } from '../../../../../test-helper.js';
 
@@ -8,21 +9,25 @@ describe('Unit | UseCase | save-companion-ping', function () {
       it('should persist the companion ping in redis', async function () {
         // given
         const userId = 123;
-        const companionRepository = { getSessionInfo: sinon.stub() };
-        const temporaryStorageService = { saveCompanionPing: sinon.stub() };
-        companionRepository.getSessionInfo.withArgs(userId).resolves({ sessionId: 99, certificationCandidate: 101 });
-        temporaryStorageService.saveCompanionPing.withArgs({ sessionId: 99, certificationCandidate: 101 }).resolves();
+        const certificationCandidateCompanion = new CertificationCandidateCompanion({
+          sessionId: 99,
+          id: 101,
+        });
+        const certificationCandidateRepository = { findCertificationCandidateCompanionInfoByUserId: sinon.stub() };
+        const temporaryCompanionStorageService = { save: sinon.stub() };
+        certificationCandidateRepository.findCertificationCandidateCompanionInfoByUserId
+          .withArgs({ userId })
+          .resolves(certificationCandidateCompanion);
 
+        // when
         await saveCompanionPing({
           userId,
           certificationCandidateRepository,
           temporaryCompanionStorageService,
         });
-        const response = await saveCompanionPing({ userId });
 
         // then
-        expect(response).to.deep.equal();
-        expect(temporaryStorageService).to.have.been.calledWithExactly({ sessionId: 99, certificationCandidate: 101 });
+        expect(temporaryCompanionStorageService.save).to.have.been.calledWithExactly(certificationCandidateCompanion);
       });
     });
 

--- a/api/tests/certification/enrolment/unit/domain/usecases/save-companion-ping_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/save-companion-ping_test.js
@@ -1,0 +1,40 @@
+import { NotFoundError } from '../../../../../../lib/domain/errors.js';
+import { saveCompanionPing } from '../../../../../../src/certification/session/domain/usecases/save-companion-ping.js';
+import { catchErr, expect } from '../../../../../test-helper.js';
+
+describe('Unit | UseCase | save-companion-ping', function () {
+  describe('#saveCompanionPing', function () {
+    describe('when the user is in a running session', function () {
+      it('should persist the companion ping in redis', async function () {
+        // given
+        const userId = 123;
+
+        await saveCompanionPing({
+          userId,
+          certificationCandidateRepository,
+          temporaryCompanionStorageService,
+        });
+        const response = await saveCompanionPing({ userId });
+
+        // then
+        expect(response).to.deep.equal(123);
+      });
+    });
+
+    describe('when the user is not in a running session', function () {
+      it('should throw a Not Found error', async function () {
+        // given
+        const userId = 123;
+
+        // when
+        const error = await catchErr(saveCompanionPing)({
+          userId,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(NotFoundError);
+        expect(error.message).to.equal(`No candidate found for user id ${userId}`);
+      });
+    });
+  });
+});

--- a/api/tests/certification/enrolment/unit/domain/usecases/save-companion-ping_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/save-companion-ping_test.js
@@ -1,10 +1,17 @@
 import { CertificationCandidateCompanion } from '../../../../../../src/certification/enrolment/domain/models/CertificationCandidateCompanion.js';
 import { saveCompanionPing } from '../../../../../../src/certification/enrolment/domain/usecases/save-companion-ping.js';
-import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
-import { catchErr, expect, sinon } from '../../../../../test-helper.js';
+import { expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | save-companion-ping', function () {
   describe('#saveCompanionPing', function () {
+    let certificationCandidateRepository;
+    let temporaryCompanionStorageService;
+
+    beforeEach(function () {
+      certificationCandidateRepository = { findCertificationCandidateCompanionInfoByUserId: sinon.stub() };
+      temporaryCompanionStorageService = { save: sinon.stub() };
+    });
+
     describe('when the user is in a running session', function () {
       it('should persist the companion ping in redis', async function () {
         // given
@@ -13,8 +20,6 @@ describe('Unit | UseCase | save-companion-ping', function () {
           sessionId: 99,
           id: 101,
         });
-        const certificationCandidateRepository = { findCertificationCandidateCompanionInfoByUserId: sinon.stub() };
-        const temporaryCompanionStorageService = { save: sinon.stub() };
         certificationCandidateRepository.findCertificationCandidateCompanionInfoByUserId
           .withArgs({ userId })
           .resolves(certificationCandidateCompanion);
@@ -28,27 +33,6 @@ describe('Unit | UseCase | save-companion-ping', function () {
 
         // then
         expect(temporaryCompanionStorageService.save).to.have.been.calledWithExactly(certificationCandidateCompanion);
-      });
-    });
-
-    describe('when the user is not in a running session', function () {
-      it('should throw a Not Found error', async function () {
-        // given
-        const userId = 123;
-        const certificationCandidateRepository = { findCertificationCandidateCompanionInfoByUserId: sinon.stub() };
-        certificationCandidateRepository.findCertificationCandidateCompanionInfoByUserId
-          .withArgs({ userId })
-          .resolves(undefined);
-
-        // when
-        const error = await catchErr(saveCompanionPing)({
-          userId,
-          certificationCandidateRepository,
-        });
-
-        // then
-        expect(error).to.be.instanceOf(NotFoundError);
-        expect(error.message).to.equal(`User 123 is not found in a certification's session`);
       });
     });
   });

--- a/api/tests/certification/session-management/unit/domain/usecases/get-session-for-supervising_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/get-session-for-supervising_test.js
@@ -42,9 +42,9 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
         });
       });
 
-      context('when the candidate has no complementary certifications', function () {
+      context('when the candidates have no complementary certifications', function () {
         context('when the session has started', function () {
-          it('should compute a theorical end datetime', async function () {
+          it('should get certification candidates with theorical end datetime', async function () {
             // given
             const certificationCandidateWithNoComplementaryCertification =
               domainBuilder.buildCertificationCandidateForSupervising({
@@ -63,25 +63,22 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
               .toDate();
 
             // when
-            const sessionForSupervising = await getSessionForSupervising({
+            const { certificationCandidates } = await getSessionForSupervising({
               sessionId: 1,
               sessionForSupervisingRepository,
             });
             // then
-            expect(sessionForSupervising.certificationCandidates).to.have.lengthOf(1);
-            expect(sessionForSupervising.certificationCandidates[0]).to.have.deep.property(
+            const [certificationCandidate] = certificationCandidates;
+            expect(certificationCandidate).to.have.deep.property(
               'startDateTime',
               certificationCandidateWithNoComplementaryCertification.startDateTime,
             );
-            expect(sessionForSupervising.certificationCandidates[0]).to.have.deep.property(
-              'theoricalEndDateTime',
-              expectedTheoricalEndDateTime,
-            );
+            expect(certificationCandidate).to.have.deep.property('theoricalEndDateTime', expectedTheoricalEndDateTime);
           });
         });
       });
 
-      context('when the candidate has complementary certifications', function () {
+      context('when the candidates have complementary certifications', function () {
         context('when some candidates are still eligible to complementary certifications', function () {
           it("should return the session with the candidates' eligibility", async function () {
             // given
@@ -142,7 +139,7 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
             );
           });
 
-          it('should compute a theorical end datetime with extra time', async function () {
+          it('should get a theorical end datetime with extra time', async function () {
             const stillValidBadgeAcquisition = domainBuilder.buildCertifiableBadgeAcquisition({
               complementaryCertificationKey: 'aKey',
             });
@@ -236,7 +233,7 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
             );
           });
 
-          it('should not compute a theorical end datetime with extra time', async function () {
+          it('should not get a theorical end datetime with extra time', async function () {
             // given
             const complementaryCertification = domainBuilder.buildComplementaryCertificationForSupervising({
               key: 'aKey',

--- a/api/tests/certification/session-management/unit/domain/usecases/get-session-for-supervising_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/get-session-for-supervising_test.js
@@ -7,6 +7,7 @@ import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 const START_DATETIME_STUB = new Date('2022-10-01T13:00:00Z');
 const COMPLEMENTARY_EXTRATIME_STUB = 45;
 const sessionForSupervisingRepository = { get: sinon.stub() };
+const temporaryCompanionStorageService = { getBySessionId: sinon.stub() };
 
 const expectedSessionEndDateTimeFromStartDateTime = (startDateTime, extraMinutes = []) => {
   let computedEndDateTime = dayjs(startDateTime);
@@ -29,11 +30,13 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
             certificationCandidates: [certificationCandidateNotStarted],
           });
           sessionForSupervisingRepository.get.resolves(session);
+          temporaryCompanionStorageService.getBySessionId.withArgs(1).resolves([]);
 
           // when
           const sessionForSupervising = await getSessionForSupervising({
             sessionId: 1,
             sessionForSupervisingRepository,
+            temporaryCompanionStorageService,
           });
           // then
           expect(sessionForSupervising.certificationCandidates).to.have.lengthOf(1);
@@ -114,6 +117,7 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
             });
 
             sessionForSupervisingRepository.get.resolves(retrievedSessionForSupervising);
+            temporaryCompanionStorageService.getBySessionId.withArgs(1).resolves([]);
 
             const certificationBadgesService = {
               findStillValidBadgeAcquisitions: sinon.stub(),
@@ -127,6 +131,7 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
               sessionId: 1,
               sessionForSupervisingRepository,
               certificationBadgesService,
+              temporaryCompanionStorageService,
             });
 
             // then
@@ -170,6 +175,7 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
                 ],
               }),
             );
+            temporaryCompanionStorageService.getBySessionId.withArgs(1).resolves([]);
 
             const certificationBadgesService = { findStillValidBadgeAcquisitions: sinon.stub() };
             certificationBadgesService.findStillValidBadgeAcquisitions
@@ -181,6 +187,7 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
               sessionId: 1,
               sessionForSupervisingRepository,
               certificationBadgesService,
+              temporaryCompanionStorageService,
             });
 
             // then
@@ -211,6 +218,7 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
             });
 
             sessionForSupervisingRepository.get.resolves(retrievedSessionForSupervising);
+            temporaryCompanionStorageService.getBySessionId.withArgs(1).resolves([]);
 
             const certificationBadgesService = {
               findStillValidBadgeAcquisitions: sinon.stub(),
@@ -222,6 +230,7 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
               sessionId: 1,
               sessionForSupervisingRepository,
               certificationBadgesService,
+              temporaryCompanionStorageService,
             });
 
             // then
@@ -262,6 +271,7 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
                 ],
               }),
             );
+            temporaryCompanionStorageService.getBySessionId.withArgs(1).resolves([]);
 
             const certificationBadgesService = { findStillValidBadgeAcquisitions: sinon.stub() };
             certificationBadgesService.findStillValidBadgeAcquisitions.withArgs({ userId: 1234 }).resolves([]);
@@ -271,6 +281,7 @@ describe('Unit | UseCase | get-session-for-supervising', function () {
               sessionId: 1,
               sessionForSupervisingRepository,
               certificationBadgesService,
+              temporaryCompanionStorageService,
             });
 
             // then

--- a/api/tests/certification/session-management/unit/infrastructure/serializers/session-for-supervising-serializer_test.js
+++ b/api/tests/certification/session-management/unit/infrastructure/serializers/session-for-supervising-serializer_test.js
@@ -49,6 +49,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
                 'is-still-eligible-to-complementary-certification': true,
                 'user-id': 6789,
                 'live-alert': null,
+                'is-companion-active': true,
               },
               id: '1234',
               type: 'certification-candidate-for-supervising',
@@ -76,6 +77,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
               assessmentStatus: Assessment.states.STARTED,
               startDateTime: new Date('2022-10-01T13:37:00Z'),
               theoricalEndDateTime: new Date('2022-10-01T16:01:00Z'),
+              isCompanionActive: true,
               enrolledComplementaryCertification: domainBuilder.buildComplementaryCertificationForSupervising({
                 key: 'aKey',
                 label: 'Super Certification Complémentaire',
@@ -138,6 +140,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
                 'theorical-end-date-time': new Date('2022-10-01T16:01:00Z'),
                 'enrolled-complementary-certification-label': 'Super Certification Complémentaire',
                 'is-still-eligible-to-complementary-certification': true,
+                'is-companion-active': true,
                 'user-id': 6789,
                 'live-alert': {
                   status: 'ongoing',
@@ -190,6 +193,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
                 hasEmbed: false,
                 isFocus: false,
               },
+              isCompanionActive: true,
             }),
           ],
         });

--- a/api/tests/certification/shared/integration/domain/services/temporary-companion-storage-service_test.js
+++ b/api/tests/certification/shared/integration/domain/services/temporary-companion-storage-service_test.js
@@ -14,4 +14,19 @@ describe('Integration | Domain | Services | temporary companion storage service'
       expect(result).to.equal(true);
     });
   });
+
+  describe('#getBySessionId', function () {
+    it('should get all candidates ids stored for the given session id', async function () {
+      // given
+      await temporaryCompanionStorageService.save({ sessionId: 11, id: 123 });
+      await temporaryCompanionStorageService.save({ sessionId: 11, id: 456 });
+      await temporaryCompanionStorageService.save({ sessionId: 12, id: 789 });
+
+      // when
+      const values = await temporaryCompanionStorageService.getBySessionId(11);
+
+      // then
+      expect(values).to.exactlyContain([123, 456]);
+    });
+  });
 });

--- a/api/tests/certification/shared/integration/domain/services/temporary-companion-storage-service_test.js
+++ b/api/tests/certification/shared/integration/domain/services/temporary-companion-storage-service_test.js
@@ -1,0 +1,17 @@
+import { temporaryStorage } from '../../../../../../lib/infrastructure/temporary-storage/index.js';
+import * as temporaryCompanionStorageService from '../../../../../../src/certification/shared/domain/services/temporary-companion-storage-service.js';
+import { expect } from '../../../../../test-helper.js';
+const temporaryCompanionStorage = temporaryStorage.withPrefix('companion:ping:');
+
+describe('Integration | Domain | Services | temporary companion storage service', function () {
+  describe('#save', function () {
+    it('should save', async function () {
+      // given  when
+      await temporaryCompanionStorageService.save({ sessionId: 11, id: 123 });
+      const result = await temporaryCompanionStorage.get(`11:123`);
+
+      // then
+      expect(result).to.equal(true);
+    });
+  });
+});

--- a/api/tests/certification/shared/unit/domain/services/temporary-companion-storage-service_test.js
+++ b/api/tests/certification/shared/unit/domain/services/temporary-companion-storage-service_test.js
@@ -1,0 +1,26 @@
+import { temporaryStorage } from '../../../../../../lib/infrastructure/temporary-storage/index.js';
+import * as temporaryCompanionStorageService from '../../../../../../src/certification/shared/domain/services/temporary-companion-storage-service.js';
+import { config } from '../../../../../../src/shared/config.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | Domain | Services | temporary companion storage service', function () {
+  describe('#save', function () {
+    it('should save with a TTL', async function () {
+      // given
+      sinon.stub(config.temporaryCompanionStorage, 'expirationDelaySeconds').value(99);
+      const save = sinon.stub();
+      sinon.stub(temporaryStorage, 'withPrefix');
+      temporaryStorage.withPrefix.returns({ save });
+
+      // when
+      await temporaryCompanionStorageService.save({ sessionId: 11, id: 123 });
+
+      // then
+      expect(save).to.have.been.calledWith({
+        key: `11:123`,
+        value: true,
+        expirationDelaySeconds: 99,
+      });
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
+++ b/api/tests/integration/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
@@ -115,5 +115,29 @@ describe('Integration | Infrastructure | TemporaryStorage | RedisTemporaryStorag
         await storage.delete(key);
       });
     });
+
+    describe('#keys', function () {
+      it('should return matching keys', async function () {
+        // given
+        const oneMinute = 60;
+        const pattern = 'prefix:*';
+        const storage = new RedisTemporaryStorage(REDIS_URL);
+        await storage.save({ key: 'prefix:key1', value: true, expirationDelaySeconds: oneMinute });
+        await storage.save({ key: 'prefix:key2', value: true, expirationDelaySeconds: oneMinute });
+        await storage.save({ key: 'prefix:key3', value: true, expirationDelaySeconds: oneMinute });
+        await storage.save({ key: 'otherprefix:key4', value: true, expirationDelaySeconds: oneMinute });
+
+        // when
+        const keys = await storage.keys(pattern);
+
+        // then
+        expect(keys).to.exactlyContain(['prefix:key1', 'prefix:key2', 'prefix:key3']);
+
+        await storage.delete('prefix:key1');
+        await storage.delete('prefix:key2');
+        await storage.delete('prefix:key3');
+        await storage.delete('otherprefix:key4');
+      });
+    });
   }
 });

--- a/api/tests/unit/infrastructure/temporary-storage/InMemoryTemporaryStorage_test.js
+++ b/api/tests/unit/infrastructure/temporary-storage/InMemoryTemporaryStorage_test.js
@@ -224,4 +224,21 @@ describe('Unit | Infrastructure | temporary-storage | InMemoryTemporaryStorage',
       expect(values).to.deep.equal(['value3', 'value2', 'value1']);
     });
   });
+
+  describe('#keys', function () {
+    it('should return matching keys', async function () {
+      // given
+      const inMemoryTemporaryStorage = new InMemoryTemporaryStorage();
+      inMemoryTemporaryStorage.save({ key: 'prefix:key1', value: true });
+      inMemoryTemporaryStorage.save({ key: 'prefix:key2', value: true });
+      inMemoryTemporaryStorage.save({ key: 'prefix:key3', value: true });
+      inMemoryTemporaryStorage.save({ key: 'otherprefix:key4', value: true });
+
+      // when
+      const values = inMemoryTemporaryStorage.keys('prefix:*');
+
+      // then
+      expect(values).to.deep.equal(['prefix:key1', 'prefix:key2', 'prefix:key3']);
+    });
+  });
 });

--- a/api/tests/unit/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
+++ b/api/tests/unit/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
@@ -16,6 +16,7 @@ describe('Unit | Infrastructure | temporary-storage | RedisTemporaryStorage', fu
       lpush: sinon.stub(),
       lrem: sinon.stub(),
       lrange: sinon.stub(),
+      keys: sinon.stub(),
     };
 
     sinon.stub(RedisTemporaryStorage, 'createClient').withArgs(REDIS_URL).returns(clientStub);
@@ -220,6 +221,21 @@ describe('Unit | Infrastructure | temporary-storage | RedisTemporaryStorage', fu
 
       // then
       expect(clientStub.lrange).to.have.been.calledWithExactly('key', 0, -1);
+    });
+  });
+
+  describe('#keys', function () {
+    it('should call client keys and return matching keys', async function () {
+      // given
+      const pattern = 'prefix:*';
+      clientStub.keys.withArgs(pattern).resolves(['temporary-storage:key1', 'temporary-storage:key2']);
+      const redisTemporaryStorage = new RedisTemporaryStorage(REDIS_URL);
+
+      // when
+      const actualKeys = await redisTemporaryStorage.keys(pattern);
+
+      // then
+      expect(actualKeys).to.deep.equal(['key1', 'key2']);
     });
   });
 });

--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -28,6 +28,18 @@
     <div class="session-supervising-candidate-in-list__full-name">
       {{@candidate.lastName}}
       {{@candidate.firstName}}
+      {{#if @candidate.isCompanionActive}}
+        <span
+          role="status"
+          aria-label={{t
+            "pages.session-supervising.candidate-in-list.companion.active"
+            firstName=@candidate.firstName
+            lastName=@candidate.lastName
+          }}
+        >
+          🛡️
+        </span>
+      {{/if}}
     </div>
     <div class="session-supervising-candidate-in-list__details">
       {{dayjs-format @candidate.birthdate "DD/MM/YYYY"}}

--- a/certif/app/models/certification-candidate-for-supervising.js
+++ b/certif/app/models/certification-candidate-for-supervising.js
@@ -20,6 +20,7 @@ export default class CertificationCandidateForSupervising extends Model {
   @attr('string') enrolledComplementaryCertificationLabel;
   @attr('string') userId;
   @attr('boolean') isStillEligibleToComplementaryCertification;
+  @attr('boolean') isCompanionActive;
   @attr() liveAlert;
 
   get hasStarted() {

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -372,6 +372,50 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
     });
   });
 
+  module('when the candidate has companion extension activated', function () {
+    test('it renders a "shield"', async function (assert) {
+      // given
+      this.candidate = store.createRecord('certification-candidate-for-supervising', {
+        id: 456,
+        firstName: 'SpongeBob',
+        lastName: 'Squarepants',
+        isCompanionActive: true,
+      });
+
+      // when
+      const screen = await renderScreen(hbs`
+        <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
+      `);
+
+      // then
+      assert
+        .dom(screen.getByRole('status', { name: 'SpongeBob Squarepants a l’extension Companion activée' }))
+        .exists();
+    });
+  });
+
+  module('when the candidate has not its companion activated', function () {
+    test('it does not render a "shield"', async function (assert) {
+      // given
+      this.candidate = store.createRecord('certification-candidate-for-supervising', {
+        id: 456,
+        firstName: 'SpongeBob',
+        lastName: 'Squarepants',
+        isCompanionActive: false,
+      });
+
+      // when
+      const screen = await renderScreen(hbs`
+        <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
+      `);
+
+      // then
+      assert
+        .dom(screen.queryByRole('status', { name: 'SpongeBob Squarepants a l’extension Companion activée' }))
+        .doesNotExist();
+    });
+  });
+
   module('when the candidate has left the session and has been authorized to resume', function () {
     test('it renders the time and extra time', async function (assert) {
       // given

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -445,6 +445,9 @@
           }
         },
         "candidate-options": "Candidate's options",
+        "companion": {
+          "active": "{firstName} {lastName} has Companion extension enabled"
+        },
         "complementary-certification-enrolment": "{complementaryCertification} enrolment",
         "complementary-certification-non-eligibility-warning": "Candidate isn't or is no longer eligible for the additional certification. They are taking the Pix certification exam only.",
         "default-modal-title": "Information",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -445,6 +445,9 @@
           }
         },
         "candidate-options": "Options du candidat",
+        "companion": {
+          "active": "{firstName} {lastName} a l’extension Companion activée"
+        },
         "complementary-certification-enrolment": "Inscription à {complementaryCertification}",
         "complementary-certification-non-eligibility-warning": "Candidat pas ou plus éligible à la certification complémentaire. Il passe la certification Pix.",
         "default-modal-title": "Information",


### PR DESCRIPTION
## :unicorn: Problème
On souhaite enregistrer temporairement les appels sur `/api/companion/ping` et les afficher su le portail surveillant

## :robot: Proposition
Utiliser redis pour sauvegarder les appels pendant 30 secondes

## :rainbow: Remarques


## :100: Pour tester
Appeler la route /api/companion/ping avec l'id du user pendant une certification
Aller sur le portail surveillant et s'assurer que le candidat lié à une icone specifique affiché pendant 30 secondes
