### PR TITLE
[TECH] Les scripts de certification n'attendent pas certaines Promises (PIX-12244).

### DIFF
--- a/api/scripts/certification/import-certification-cpf-cities.js
+++ b/api/scripts/certification/import-certification-cpf-cities.js
@@ -415,12 +415,12 @@ async function main(filePath) {
     const batchInfo = await trx.batchInsert('certification-cpf-cities', cities);
     const insertedLines = _getInsertedLineNumber(batchInfo);
     logger.info('✅ ');
-    trx.commit();
+    await trx.commit();
     logger.info(`Added lines: ${insertedLines} (${districtCities.length} exception cases)`);
     logger.info('Done.');
   } catch (error) {
     if (trx) {
-      trx.rollback();
+      await trx.rollback();
     }
     throw error;
   }

--- a/api/scripts/certification/import-certification-cpf-countries.js
+++ b/api/scripts/certification/import-certification-cpf-countries.js
@@ -98,13 +98,13 @@ async function main(filePath) {
     await trx('certification-cpf-countries').del();
     console.log('Inserting countries in database... ');
     await trx.batchInsert('certification-cpf-countries', countries);
-    trx.commit();
+    await trx.commit();
     console.log('ok');
 
     console.log('\nDone.');
   } catch (error) {
     if (trx) {
-      trx.rollback();
+      await trx.rollback();
     }
     throw error;
   }

--- a/api/scripts/certification/import-pilot-certification-centers-from-csv.js
+++ b/api/scripts/certification/import-pilot-certification-centers-from-csv.js
@@ -91,12 +91,12 @@ async function main(filePath) {
     const batchInfo = await trx.batchInsert('certification-center-features', certificationCentersPilotsList);
     const insertedLines = _getInsertedLineNumber(batchInfo);
     logger.info('✅ ');
-    trx.commit();
+    await trx.commit();
     logger.info(`Added lines: ${insertedLines}`);
     logger.info('Done.');
   } catch (error) {
     if (trx) {
-      trx.rollback();
+      await trx.rollback();
     }
     throw error;
   }

--- a/api/tests/integration/scripts/certification/import-pilot-certification-centers-from-csv_test.js
+++ b/api/tests/integration/scripts/certification/import-pilot-certification-centers-from-csv_test.js
@@ -5,8 +5,8 @@ import { catchErr, createTempFile, databaseBuilder, expect, knex, removeTempFile
 describe('Integration | Scripts | Certification | import-pilot-certification-centers-from-csv', function () {
   let file;
 
-  afterEach(function () {
-    removeTempFile(file);
+  afterEach(async function () {
+    await removeTempFile(file);
   });
 
   context('when pilot certification center list from a csv file is imported', function () {


### PR DESCRIPTION
## :unicorn: Problème
Le test d'ajout d'un centre de certif en certif complémentaire seule plantait.

## :robot: Proposition
Ajouter un `await` sur le commit de la transaction knex et sur le rollback pour tous les scripts de certification à qui il en manque

## :100: Pour tester
commande :
`node scripts/certification/import-pilot-certification-centers-from-csv.js path/file.csv`

- Créer un fichier csv comprenant un id de centre V2 et un id de centre V3
exemple :
```
certification_center_id;
7303; // V3
7304; // V2
```

- Constater qu'une erreur apparaît indiquant qu'on ne peut ajouter un centre V3 en tant que pilote (7403)
- Enlever le 7403 et faire un doublon d'un centre de certification V2
- Constater qu'une erreur apparaît indiquant un soucis d'unicité (pas d'erreur propre, mais on s'en fiche pour le besoin de ce script)
- Enlever les potentiels doublons et les V3 et valider
- Constater que la table certification-center-features contient bien les IDS des centres renseignés (avec la date du jour)