### PR TITLE
[BUGFIX] Pour le déblocage d'un compte utilisateur, gérer le cas d'erreur où le compte n'est pas/plus bloqué (PIX-12247)

### DIFF
--- a/api/src/shared/infrastructure/repositories/user-login-repository.js
+++ b/api/src/shared/infrastructure/repositories/user-login-repository.js
@@ -17,8 +17,8 @@ function _toDomain(userLoginDTO) {
 }
 
 const findByUserId = async function (userId) {
-  const foundUserLogin = await knex.from(USER_LOGINS_TABLE_NAME).where({ userId }).first();
-  return foundUserLogin ? _toDomain(foundUserLogin) : null;
+  const userLoginDTO = await knex.from(USER_LOGINS_TABLE_NAME).where({ userId }).first();
+  return userLoginDTO ? _toDomain(userLoginDTO) : null;
 };
 
 const getByUserId = async function (userId) {
@@ -45,7 +45,7 @@ const update = async function (userLogin) {
 };
 
 const findByUsername = async function (username) {
-  const foundUserLogin = await knex
+  const userLoginDTO = await knex
     .select('user-logins.*')
     .from(USER_LOGINS_TABLE_NAME)
     .where('users.email', username.toLowerCase())
@@ -53,7 +53,7 @@ const findByUsername = async function (username) {
     .join('users', 'users.id', 'user-logins.userId')
     .first();
 
-  return foundUserLogin ? _toDomain(foundUserLogin) : null;
+  return userLoginDTO ? _toDomain(userLoginDTO) : null;
 };
 
 const updateLastLoggedAt = async function ({ userId }) {

--- a/api/src/shared/infrastructure/repositories/user-login-repository.js
+++ b/api/src/shared/infrastructure/repositories/user-login-repository.js
@@ -1,5 +1,6 @@
 import { knex } from '../../../../db/knex-database-connection.js';
 import { UserLogin } from '../../../authentication/domain/models/UserLogin.js';
+import { NotFoundError } from '../../../shared/domain/errors.js';
 
 const USER_LOGINS_TABLE_NAME = 'user-logins';
 
@@ -18,6 +19,15 @@ function _toDomain(userLoginDTO) {
 const findByUserId = async function (userId) {
   const foundUserLogin = await knex.from(USER_LOGINS_TABLE_NAME).where({ userId }).first();
   return foundUserLogin ? _toDomain(foundUserLogin) : null;
+};
+
+const getByUserId = async function (userId) {
+  const foundUserLogin = await findByUserId(userId);
+  if (!foundUserLogin) {
+    throw new NotFoundError();
+  }
+
+  return foundUserLogin;
 };
 
 const create = async function (userLogin) {
@@ -58,4 +68,4 @@ const updateLastLoggedAt = async function ({ userId }) {
     .merge();
 };
 
-export { create, findByUserId, findByUsername, update, updateLastLoggedAt };
+export { create, findByUserId, findByUsername, getByUserId, update, updateLastLoggedAt };

--- a/api/src/user-account/domain/usecases/unblock-user-account.js
+++ b/api/src/user-account/domain/usecases/unblock-user-account.js
@@ -1,5 +1,5 @@
 const unblockUserAccount = async function ({ userId, userLoginRepository }) {
-  const userLogin = await userLoginRepository.findByUserId(userId);
+  const userLogin = await userLoginRepository.getByUserId(userId);
   userLogin.resetUserBlocking();
 
   return await userLoginRepository.update(userLogin);

--- a/api/tests/shared/integration/infrastructure/repositories/user-login-repository_test.js
+++ b/api/tests/shared/integration/infrastructure/repositories/user-login-repository_test.js
@@ -1,6 +1,7 @@
 import { UserLogin } from '../../../../../src/authentication/domain/models/UserLogin.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import * as userLoginRepository from '../../../../../src/shared/infrastructure/repositories/user-login-repository.js';
-import { databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, knex, sinon } from '../../../../test-helper.js';
 
 const USER_LOGINS_TABLE_NAME = 'user-logins';
 
@@ -30,6 +31,34 @@ describe('Integration | Shared | Infrastructure | Repositories | UserLoginReposi
 
       // then
       expect(result).to.be.null;
+    });
+  });
+
+  describe('#getByUserId', function () {
+    it('returns the found user-login', async function () {
+      // given
+      const userLogin = databaseBuilder.factory.buildUserLogin({
+        id: 1,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await userLoginRepository.getByUserId(userLogin.userId);
+
+      // then
+      expect(result).to.be.an.instanceOf(UserLogin);
+      expect(result.id).to.equal(1);
+    });
+
+    it('throws NotFoundError if no user is found', async function () {
+      // given
+      const nonExistentUserId = 678;
+
+      // when
+      const result = await catchErr(userLoginRepository.getByUserId)(nonExistentUserId);
+
+      // then
+      expect(result).to.be.instanceOf(NotFoundError);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème

Pour le déblocage d'un compte utilisateur, le compte peut ne pas/plus être bloqué et cela génère des erreurs `500`.

## :robot: Proposition

Ajouter la prise en compte du cas où aucun `userLogin` ne correspond au paramètre passé.

## :rainbow: Remarques

RAS

## :100: Pour tester

1. Obtenir un compte bloqué, par exemple en effectuant des tentatives infructueuses de connexion avec le compte blocked@example.net
2. Aller dans Pix Admin et ouvrir le panneau Réseau de la console de développeur
3. Débloquer ce compte en notant l'appel réseau effectué
4. À partir du panneau Réseau de la console de développeur modifier et renvoyer la requête de déblocage de compte en passant un identifiant de compte n'existant pas.
5. Constater que l'API renvoie une erreur `404` et non plus une erreur `500`.
