### PR TITLE
[FEATURE] Ajouter des fichiers de traductions pour la langue espagnol sur Pix Api et Pix App (PIX-12189)

### DIFF
--- a/api/translations/es.json
+++ b/api/translations/es.json
@@ -1,0 +1,403 @@
+{
+  "account-recovery-email": {
+    "params": {
+      "choosePassword": "Elija una contraseña",
+      "context": "Ha solicitado la recuperación de su cuenta Pix.",
+      "doNotAnswer": "Este es un correo electrónico automático, por favor no responda.",
+      "instruction": "Elija una contraseña para completar el procedimiento.",
+      "linkValidFor": "Este enlace es válido durante 24 horas. Si usted no es el autor de esta solicitud, ignore este correo electrónico.",
+      "moreOn": "Más información",
+      "pixPresentation": "Pix es el servicio público en línea para evaluar, desarrollar y certificar tus competencias digitales.",
+      "signing": "- El equipo Pix"
+    }
+  },
+  "attendance-sheet": {
+    "certification-information": {
+      "date": "Fecha :",
+      "local-time": "Hora local (inicio) :",
+      "location-name": "Nombre del sitio :",
+      "number": "N°",
+      "room-name": "Nombre del lugar :",
+      "session": ""
+    },
+    "examiner-information": {
+      "invigilated-by": "",
+      "signature": "",
+      "title": ""
+    },
+    "file-name": "",
+    "header": {
+      "page": "",
+      "title": ""
+    },
+    "table": {
+      "birth-name": "",
+      "date-of-birth": {
+        "example": "",
+        "label": ""
+      },
+      "division": "",
+      "external-id": "",
+      "first-name": "",
+      "signature": "",
+      "title": ""
+    }
+  },
+  "campaign-export": {
+    "assessment": {
+      "competence-area": {
+        "items-successfully-completed": "",
+        "mastery-percentage": "",
+        "total-items": ""
+      },
+      "is-shared": "",
+      "mastery-percentage-target-profile": "",
+      "progress": "",
+      "shared-on": "",
+      "skill": {
+        "items-successfully-completed": "",
+        "mastery-percentage": "",
+        "total-items": ""
+      },
+      "started-on": "",
+      "status": {
+        "ko": "",
+        "not-tested": "",
+        "ok": ""
+      },
+      "success-rate": "",
+      "target-profile-name": "",
+      "thematic-result-name": ""
+    },
+    "common": {
+      "campaign-code": "",
+      "campaign-id": "",
+      "campaign-name": "",
+      "file-name": "",
+      "no": "",
+      "not-available": "",
+      "organization-name": "",
+      "participant-division": "",
+      "participant-firstname": "",
+      "participant-group": "",
+      "participant-lastname": "",
+      "participant-student-number": "",
+      "yes": ""
+    },
+    "profiles-collection": {
+      "certifiable-skills": "",
+      "is-certifiable": "",
+      "is-sent": "",
+      "pix-score": "",
+      "sent-on": "",
+      "skill-level": "",
+      "skill-ranking": ""
+    }
+  },
+  "candidate-list-template": {
+    "billing-mode": {
+      "free": "",
+      "paid": "",
+      "prepaid": ""
+    },
+    "certification": "",
+    "complementary": "",
+    "filename": "",
+    "headers": {
+      "birth-date": "",
+      "birthcity": "",
+      "birthcity-inseecode": "",
+      "birthcity-postcode": "",
+      "birthcountry": "",
+      "birthname": "",
+      "birthplace": "",
+      "birthplace-instructions": "",
+      "birthplace-instructions-abroad": "",
+      "birthplace-instructions-abroad-insee": "",
+      "birthplace-instructions-france": "",
+      "birthplace-instructions-france-insee": "",
+      "birthplace-instructions-france-postal": "",
+      "born-abroad": "",
+      "born-in-france": "",
+      "candidates": "",
+      "candidates-list": "",
+      "date": "",
+      "email-convocation": "",
+      "email-results": "",
+      "externalid": "",
+      "extra-time": "",
+      "firstname": "",
+      "gender": "",
+      "locale-time": "",
+      "room-name": "",
+      "session-certification": "",
+      "session-invigilates-by": "",
+      "session-invigilators": "",
+      "session-number": "",
+      "site-name": ""
+    },
+    "one-per-candidate": "",
+    "options": "",
+    "prepayment": "",
+    "pricing": "",
+    "pricing-pix": "",
+    "title": "",
+    "tooltip-line-1": "",
+    "tooltip-line-2": "",
+    "tooltip-line-3": "",
+    "tooltips": {
+      "date-format": "",
+      "email-format": "",
+      "email-results": "",
+      "extra-time": "",
+      "gender-format": ""
+    },
+    "yes": "",
+    "yes-or-empty": ""
+  },
+  "certification-center-invitation-email": {
+    "params": {
+      "acceptInvitation": "",
+      "doNotAnswer": "",
+      "here": "",
+      "moreAbout": "",
+      "needHelp": "",
+      "oneTimeLink": "",
+      "pixCertifPresentation": "",
+      "title": "",
+      "yourCertificationCenter": ""
+    },
+    "subject": ""
+  },
+  "certification-confirmation": {
+    "absolute-max-level-indication": "",
+    "file-name": "",
+    "from-birthplace": "",
+    "max-level": "",
+    "max-reachable-level-indication": ""
+  },
+  "certification-result-email": {
+    "params": {
+      "doNotReply": "",
+      "download": "",
+      "emailValidFor": "",
+      "findOutMore": "",
+      "findOutMoreFranceSuffix": "",
+      "findOutMoreInternationalSuffix": "",
+      "guidelines": "",
+      "guidelinesLinkName": "",
+      "overviewText": "",
+      "resultsAvailable": "",
+      "subject": "",
+      "viewResultsInProfile": ""
+    },
+    "title": ""
+  },
+  "certification-results-csv": {
+    "filenames": {
+      "DIVISION_CERTIFICATION_RESULTS_FILENAME": "",
+      "SESSION_CERTIFICATION_RESULTS_FILENAME": ""
+    },
+    "headers": {
+      "BIRTHDATE": "",
+      "BIRTHPLACE": "",
+      "CERTIFICATION_CENTER": "",
+      "CERTIFICATION_DATE": "",
+      "CERTIFICATION_LABEL": "",
+      "CERTIFICATION_NUMBER": "",
+      "EXTERNAL_ID": "",
+      "FIRSTNAME": "",
+      "JURY_COMMENT_FOR_ORGANIZATION": "",
+      "LASTNAME": "",
+      "PIX_SCORE": "",
+      "REGISTRATION_STATUS": "",
+      "SESSION_ID": "",
+      "SKILL_LABEL": "",
+      "STATUS": ""
+    },
+    "values": {
+      "CERTIFICATION_CANCELLED": "",
+      "CERTIFICATION_IN_ERROR": "",
+      "CERTIFICATION_REJECTED": "",
+      "CERTIFICATION_STARTED": "",
+      "CERTIFICATION_VALIDATED": "",
+      "COMPLEMENTARY_CERTIFICATION_CANCELLED": "",
+      "COMPLEMENTARY_CERTIFICATION_NOT_DONE": "",
+      "COMPLEMENTARY_CERTIFICATION_REJECTED": "",
+      "COMPLEMENTARY_CERTIFICATION_VALIDATED": "",
+      "REJECTED_AUTOMATICALLY_COMMENT": ""
+    }
+  },
+  "csv-import-values": {
+    "sup-organization-learner": {
+      "diplomas": {
+        "bts": "",
+        "classe-preparatoire": "",
+        "dcg ": "",
+        "deust": "",
+        "dma ": "",
+        "dnmade": "",
+        "doctorat": "",
+        "dts": "",
+        "dut": "",
+        "etat-controle": "",
+        "ingenieur": "",
+        "license": "",
+        "license-grade": "",
+        "master": "",
+        "master-grade": "",
+        "other": "",
+        "vise": ""
+      },
+      "study-schemes": {
+        "continuous-training": "",
+        "initial-training": "",
+        "other": "",
+        "training": ""
+      },
+      "unknown": ""
+    }
+  },
+  "csv-template": {
+    "organization-learners": {
+      "birth-city": "",
+      "birth-city-code": "",
+      "birth-country-code": "",
+      "birth-province-code": "",
+      "birthdate": "",
+      "division": "",
+      "first-name": "",
+      "last-name": "",
+      "mef-code": "",
+      "middle-name": "",
+      "national-identifier": "",
+      "preferred-last-name": "",
+      "sex": "",
+      "status": "",
+      "third-name": ""
+    },
+    "sup-organization-learners": {
+      "birthdate": "",
+      "department": "",
+      "diploma": "",
+      "educational-team": "",
+      "email": "",
+      "first-name": "",
+      "group": "",
+      "last-name": "",
+      "middle-name": "",
+      "preferred-lastname": "",
+      "student-number": "",
+      "study-scheme": "",
+      "third-name": ""
+    },
+    "template-name": ""
+  },
+  "email-sender-name": {
+    "pix-app": "PIX - No contestar"
+  },
+  "entity-validation-errors": {
+    "ACCEPT_CGU": "Debes aceptar las condiciones de uso de Pix para crear una cuenta.",
+    "ALREADY_REGISTERED_EMAIL": "Esta dirección de correo electrónico ya está registrada, inicie sesión.",
+    "CUSTOM_RESULT_PAGE_BUTTON_TEXT_IS_REQUIRED_WHEN_CUSTOM_RESULT_PAGE_BUTTON_URL_IS_FILLED": "Se introduce una URL para el botón: también se requiere un texto.",
+    "CUSTOM_RESULT_PAGE_BUTTON_URL_IS_REQUIRED_WHEN_CUSTOM_RESULT_PAGE_BUTTON_TEXT_IS_FILLED": "Se introduce un texto para el botón: también se requiere una URL.",
+    "CUSTOM_RESULT_PAGE_BUTTON_URL_MUST_BE_A_URL": "La URL del botón debe ser una URL completa y válida.",
+    "EMPTY_EMAIL": "No se ha introducido su dirección de correo electrónico.",
+    "EMPTY_FIRST_NAME": "Su nombre de pila no está rellenado.",
+    "EMPTY_INPUT": "No se rellena ningún campo.",
+    "EMPTY_LAST_NAME": "No se ha introducido su nombre.",
+    "EMPTY_USERNAME": "Su nombre de usuario no se ha rellenado.",
+    "FILL_USERNAME_OR_EMAIL": "Debe introducir una dirección de correo electrónico y/o un nombre de usuario.",
+    "MAX_SIZE_EMAIL": "Su dirección de correo electrónico no debe superar los 255 caracteres.",
+    "MAX_SIZE_FIRST_NAME": "Su nombre no debe superar los 255 caracteres.",
+    "MAX_SIZE_LAST_NAME": "Su nombre no debe superar los 255 caracteres.",
+    "STAGE_TARGET_PROFILE_IS_REQUIRED": "El perfil objetivo es obligatorio",
+    "STAGE_THRESHOLD_IS_REQUIRED": "El umbral de aterrizaje es obligatorio",
+    "STAGE_TITLE_IS_REQUIRED": "El título del nivel es obligatorio",
+    "WRONG_EMAIL_FORMAT": "El formato de la dirección de correo electrónico es incorrecto."
+  },
+  "jury": {
+    "comment": {
+      "CANCELLED_DUE_TO_LACK_OF_ANSWERS_FOR_TECHNICAL_REASON": {
+        "candidate": "",
+        "organization": ""
+      },
+      "CANCELLED_DUE_TO_NEUTRALIZATION": {
+        "candidate": "",
+        "organization": ""
+      },
+      "FRAUD": {
+        "candidate": "",
+        "organization": ""
+      },
+      "LOWER_LEVEL_COMPLEMENTARY_CERTIFICATION_ACQUIRED": {
+        "candidate": "",
+        "organization": ""
+      },
+      "REJECTED_DUE_TO_INSUFFICIENT_CORRECT_ANSWERS": {
+        "candidate": "",
+        "organization": ""
+      },
+      "REJECTED_DUE_TO_LACK_OF_ANSWERS": {
+        "candidate": "",
+        "organization": ""
+      }
+    }
+  },
+  "organization-invitation-email": {
+    "params": {
+      "acceptInvitation": "",
+      "doNotAnswer": "",
+      "here": "",
+      "moreAbout": "",
+      "needHelp": "",
+      "oneTimeLink": "",
+      "pixPresentation": "",
+      "subtitle": "",
+      "title": "",
+      "yourOrganization": ""
+    },
+    "subject": ""
+  },
+  "pix-account-creation-email": {
+    "params": {
+      "askForHelp": "¿Necesita ayuda? Póngase en contacto con nosotros",
+      "disclaimer": "Si no creó la cuenta en primer lugar, puede pedir que se elimine.",
+      "doNotAnswer": "Este es un correo electrónico automático, por favor no responda.",
+      "goToPix": "Empezar a probar",
+      "helpdeskLinkLabel": "aquí",
+      "moreOn": "Más información",
+      "pixPresentation": "Pix es el servicio público en línea para evaluar, desarrollar y certificar tus competencias digitales.",
+      "subtitle": "Ya puede empezar a hacer pruebas.",
+      "title": "¡Tu cuenta Pix ha sido creada!"
+    },
+    "subject": "Su cuenta Pix ha sido creada"
+  },
+  "reset-password-demand-email": {
+    "params": {
+      "clickOnTheButton": "Haga clic en el botón de abajo para elegir una nueva contraseña.",
+      "contactUs": "póngase en contacto con nosotros",
+      "doNotAnswer": "Este es un correo electrónico automático, por favor no responda. Necesitamos su ayuda,",
+      "linkValidFor": "Este enlace es válido durante 24 horas. Si usted no es el autor de esta solicitud, ignore este correo electrónico.",
+      "moreOn": "Más información",
+      "pixPresentation": "Pix es el servicio público en línea para evaluar, desarrollar y certificar tus competencias digitales.",
+      "resetMyPassword": "Establecer una nueva contraseña",
+      "title": "Restablecer la contraseña",
+      "weCannotSendYourPassword": "Hola, por razones de seguridad, no le enviamos su contraseña por correo electrónico."
+    },
+    "subject": "Solicitud de restablecimiento de contraseña de Pix"
+  },
+  "verification-code-email": {
+    "body": {
+      "context": "Desea cambiar la dirección de correo electrónico de su cuenta. Para continuar, introduzca el siguiente código en Pix :",
+      "doNotAnswer": "Este es un correo electrónico automático, por favor no responda.",
+      "greeting": "Hola,",
+      "moreOn": "Más información",
+      "pixPresentation": "Pix es el servicio público en línea para evaluar, desarrollar y certificar tus competencias digitales.",
+      "seeYouSoon": "Nos vemos pronto en Pix.",
+      "signing": "- El equipo Pix",
+      "warningMessage": "Si no has sido tú, restablece tu contraseña lo antes posible para garantizar la seguridad de tu cuenta."
+    },
+    "subject": "Tu código Pix es {code}"
+  }
+}

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1,0 +1,1776 @@
+{
+	"api-error-messages": {
+		"join-error": {
+			"r11": "Ya tiene una cuenta Pix con la dirección de correo electrónico'<br>'{ value }'<br><br>'Para continuar, inicie sesión con esta cuenta o pida ayuda a un profesor'<br><br>'(Para el profesor: vea el 'Kit de solución de problemas' en Pix Orga &gt; ) Documentación - Código R11)",
+			"r12": "Ya dispone de una cuenta Pix utilizada con el identificador de la forma nombre.apellido seguido de 4 dígitos:'<br>'{ value }'<br><br>'Para continuar, inicie sesión con esta cuenta o pida ayuda a un profesor.'<br><br>'(Para el profesor: consulte el 'Kit de solución de problemas' en Pix Orga &gt; Documentación - Código R12)",
+			"r13": "Usted ya tiene una cuenta Pix a través de la ENT en otra escuela.'<br><br>'Para continuar, contacte con un profesor que pueda darle acceso a esta cuenta usando Pix Orga.'<br><br>'(Para el profesor: vea el 'Kit de solución de problemas' en Pix Orga &gt; ) Documentación - Código R13)",
+			"r31": "Ya tiene una cuenta Pix con la dirección de correo electrónico'<br>'{ value }'<br><br>'Para continuar, inicie sesión con esta cuenta o pida ayuda a un profesor'<br><br>'(Para el profesor: vea el 'Kit de solución de problemas' en Pix Orga &gt; ) Documentación - Código R31)",
+			"r32": "Ya dispone de una cuenta Pix utilizada con el identificador de la forma nombre.apellido seguido de 4 dígitos:'<br>'{ value }'<br><br>'Para continuar, inicie sesión con esta cuenta o pida ayuda a un profesor.'<br><br>'(Para el profesor: consulte el 'Kit de resolución de problemas' en Pix Orga &gt; Documentación - Código R32)",
+			"r33": "Ya tienes una cuenta Pix a través de ENT. Úsala para unirte al curso.",
+			"r70": "Se ha producido un error. Cierre la sesión e inténtelo de nuevo.",
+			"r90": {
+				"account-belonging-to-another-user": "Parece que un estudiante ya está utilizando esta cuenta.",
+				"details": {
+					"code": "(especificando el código R90)",
+					"contact-support": {
+						"link-text": " contactar con el servicio de asistencia",
+						"link-url": "https://support.pix.org/fr/support/tickets/new"
+					},
+					"disconnect-user": "De lo contrario, cierre la sesión y únase a la campaña desde su cuenta",
+					"if-account-belonging-to-user": "Si la cuenta le pertenece,"
+				}
+			}
+		},
+		"register-error": {
+			"s50": "Este identificador ya existe",
+			"s51": "Ya tiene una cuenta Pix con la dirección de correo electrónico'<br>'{ value }'<br><br>'Para continuar, inicie sesión con esta cuenta o pida ayuda a un profesor'<br><br>'(Para el profesor: vea el 'Kit de solución de problemas' en Pix Orga &gt; ) Documentación - Código R51)",
+			"s52": "Ya dispone de una cuenta Pix utilizada con el identificador de la forma nombre.apellido seguido de 4 dígitos:'<br>'{ value }'<br><br>'Para continuar, conéctese a esta cuenta o pida ayuda a un profesor.'<br><br>'(Para el profesor: consulte el 'Kit de resolución de problemas' en Pix Orga &gt; Documentación - Código R52)",
+			"s53": "Ya tiene una cuenta Pix a través de ENT.'<br>'Utilícela para unirse al curso.",
+			"s61": "Ya tiene una cuenta Pix con la dirección de correo electrónico'<br>'{ value }'<br><br>'Para continuar, inicie sesión con esta cuenta o pida ayuda a un profesor'<br><br>'(Para el profesor: consulte el 'Kit de solución de problemas' en Pix Orga &gt; Documentación - Código R61)",
+			"s62": "Ya dispone de una cuenta Pix utilizada con el identificador de la forma nombre.apellido seguido de 4 dígitos:'<br>'{ value }'<br><br>'Para continuar, inicie sesión con esta cuenta o pida ayuda a un profesor.'<br><br>'(Para el profesor: consulte el 'Kit de solución de problemas' en Pix Orga &gt; Documentación - Código R62)",
+			"s63": "Usted ya tiene una cuenta Pix a través de la ENT en otra escuela.'<br><br>'Para continuar, contacte con un profesor que pueda darle acceso a esta cuenta usando Pix Orga.'<br><br>'(Para el profesor: ver el 'Kit de Resolución de Problemas' en Pix Orga &gt; Documentación - Código R63)"
+		}
+	},
+	"application": {
+		"description": "Pix es una plataforma en línea para evaluar y certificar las competencias digitales de los ciudadanos francófonos (alumnos, estudiantes, jóvenes que abandonan la escuela, solicitantes de empleo, personas mayores)."
+	},
+	"common": {
+		"actions": {
+			"back": "Volver",
+			"cancel": "Cancelar",
+			"close": "Cerrar",
+			"confirm": "Confirme",
+			"quit": "Deja",
+			"sign-out": "Desconectando",
+			"stay": "Permanezca en",
+			"validate": "Confirme"
+		},
+		"api-error-messages": {
+			"bad-request-error": "Los datos que ha enviado no están en el formato correcto.",
+			"gateway-timeout-error": "El servicio está experimentando ralentizaciones. Vuelva a intentarlo más tarde.",
+			"internal-server-error": "Se ha producido un error interno. Nuestros equipos están resolviendo el problema. Vuelva a intentarlo más tarde.",
+			"login-unauthorized-error": "La dirección de correo electrónico o el nombre de usuario y/o la contraseña introducidos son incorrectos.",
+			"login-user-blocked-error": "Su cuenta está bloqueada porque ha realizado demasiados intentos de conexión. Para desbloquearla, '<'a href=\"{url}\"'>'contacta con nosotros'</a>'.",
+			"login-user-temporary-blocked-error": "Ha realizado demasiados intentos de conexión. Inténtalo de nuevo más tarde o haz clic en '<'a href=\"{url}\"'>'contraseña olvidada'</a>' para restablecerla."
+		},
+		"cgu": {
+			"cgu": "Condiciones de uso",
+			"data-protection-policy": "Política de privacidad",
+			"error": "Debe aceptar las condiciones de uso y la política de privacidad de Pix para crear una cuenta.",
+			"label": "Acepto las condiciones de uso y la política de privacidad de Pix",
+			"message": "Acepto las '<'a href=\"{cguUrl}\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\"'>'condiciones de uso'</a>' y la '<'a href=\"{dataProtectionPolicyUrl}\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\"'>'política de privacidad'</a>' de Pix."
+		},
+		"data-protection-policy-information-banner": {
+			"title": "Nuestra política de privacidad ha cambiado. Le invitamos a leerla:",
+			"url-label": "Política de protección de datos."
+		},
+		"error": "Se ha producido un error. Vuelva a intentarlo o póngase en contacto con el servicio de asistencia.",
+		"form": {
+			"error": "Error",
+			"invisible-password": "ocultar contraseña",
+			"mandatory": "obligatorio",
+			"mandatory-all-fields": "Todos los campos son obligatorios.",
+			"mandatory-fields": "Los campos marcados con '<abbr title=\"obligatoire\" class=\"mandatory-mark\">'*'</abbr>' son obligatorios.",
+			"success": "correcto",
+			"visible-password": "Mostrar contraseña"
+		},
+		"french-education-ministry": "Ministerio de Educación y Juventud. Libertad igualdad fraternidad",
+		"french-republic": "República Francesa. Libertad, igualdad, fraternidad.",
+		"languages": {
+			"en": "Inglés",
+			"fr": "Francés",
+			"nl": "Holandés"
+		},
+		"level": "nivel",
+		"loading": {
+			"default": "Carga en curso",
+			"results": "Preparación de los resultados",
+			"test": "Su prueba se está cargando"
+		},
+		"new-information-banner": {
+			"close-label": "Cerrar el banner",
+			"lvl-seven": "¡Por fin está disponible el nivel 7! Más información en '<'a href=\"{lvlSevenUrl}\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\"'>'this news'</a>'."
+		},
+		"or": "o",
+		"pagination": {
+			"action": {
+				"next": "Ir a la página siguiente",
+				"previous": "Ir a la página anterior",
+				"select-page-size": "Número de elementos a mostrar por página"
+			},
+			"page-info": "{start, number}-{end, number} en {total, plural, =0 {0 élément} =1 {1 élément} other {{total, number} éléments}}",
+			"page-number": "Página {current, number} / {total, number}",
+			"page-results": "{total, plural, =0 {0 élément} =1 {1 élément} other {{total, number} éléments}}",
+			"result-by-page": "Véase"
+		},
+		"pix": "pix",
+		"skip-links": {
+			"skip-to-content": "Ir al contenido",
+			"skip-to-footer": "Ir al final de la página"
+		}
+	},
+	"navigation": {
+		"back-to-homepage": "Volver a la página de inicio",
+		"back-to-profile": "Volver al perfil",
+		"copyrights": "©",
+		"error": "Error",
+		"external-link-title": "Abrir en una ventana nueva",
+		"footer": {
+			"a11y": "Accesibilidad: parcialmente conforme",
+			"data-protection-policy": "Política de protección de datos",
+			"eula": "CGU",
+			"help-center": "Centro de ayuda",
+			"label": "Menú secundario",
+			"sitemap": "Mapa del sitio",
+			"student-data-protection-policy": "Política de protección de datos de los estudiantes",
+			"student-data-protection-policy-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39"
+		},
+		"homepage": "Página de inicio de Pix",
+		"main": {
+			"code": "Tengo un código",
+			"dashboard": "INICIO",
+			"help": "Ayuda",
+			"label": "Menú principal",
+			"link-help": "https://support.pix.org/fr/support/home",
+			"skills": "Habilidades",
+			"start-certification": "Certificación",
+			"trainings": "Mis cursos de formación",
+			"tutorials": "Mis tutoriales"
+		},
+		"mobile-button-title": "Abrir el menú",
+		"not-logged": {
+			"sign-in": "Iniciar sesión",
+			"sign-up": "Inscríbete"
+		},
+		"pix": "Pix",
+		"showcase-homepage": "Página de inicio de Pix.{ tld }",
+		"user": {
+			"account": "Mi cuenta",
+			"certifications": "Mis certificaciones",
+			"sign-out": "Desconectando",
+			"tests": "Mis trayectorias profesionales"
+		},
+		"user-logged-menu": {
+			"details": "Ver mis datos"
+		}
+	},
+	"pages": {
+		"account-recovery": {
+			"errors": {
+				"account-exists": "Ya existe una cuenta con esta dirección de correo electrónico.",
+				"key-expired": "El enlace de recuperación ha caducado,",
+				"key-expired-renew-demand-link": "renueve aquí su solicitud.",
+				"key-invalid": "El enlace de recuperación no existe.",
+				"key-used": "Esta cuenta ya ha sido recuperada.",
+				"title": "¡Uy, ha habido un error!"
+			},
+			"find-sco-record": {
+				"backup-email-confirmation": {
+					"ask-for-new-email-message": "o proporcionar uno nuevo",
+					"email-already-exist-for-account-message": "La dirección de correo electrónico que aparece a continuación ya está asociada a su cuenta:",
+					"email-is-needed-message": "{ firstName }, necesitamos su dirección de correo electrónico",
+					"email-is-valid-message": "Si es válido,",
+					"email-reset-message": "Restablecer contraseña",
+					"email-sent-to-choose-password-message": "Le enviaremos un correo electrónico para que elija una contraseña.",
+					"form": {
+						"actions": {
+							"cancel": "Cancelar",
+							"submit": "Allá vamos."
+						},
+						"email": "Su dirección de correo electrónico",
+						"error": {
+							"email-already-exist": {
+								"existing-email": "Ya tiene esta dirección de correo electrónico. Si es válida,",
+								"init-password": " restablecer contraseña",
+								"new-email": "Si no, introduce uno nuevo."
+							},
+							"empty-email": "El campo de dirección de correo electrónico es obligatorio.",
+							"new-backup-email": "Introduzca una dirección de correo electrónico válida para recuperar su cuenta",
+							"new-email-already-exist": "Esta dirección de correo electrónico ya está en uso",
+							"wrong-email-format": "Su dirección de correo electrónico no es válida."
+						}
+					}
+				},
+				"confirmation-step": {
+					"buttons": {
+						"cancel": "Cancelar",
+						"confirm": "Puedo confirmar"
+					},
+					"certify-account": "Certifico por mi honor que la cuenta asociada a estos datos me pertenece.",
+					"contact-support": "Si observa un error o si estos datos no son suyos,",
+					"fields": {
+						"first-name": "Su nombre",
+						"last-name": "Su nombre",
+						"latest-organization-name": "Su último establecimiento",
+						"username": "Su nombre de usuario"
+					},
+					"found-account": "Hemos encontrado su cuenta:",
+					"good-news": "Buenas noticias { firstName } !"
+				},
+				"conflict": {
+					"found-you-but": "{ firstName }, te encontramos pero ...",
+					"title": "Conflicto",
+					"warning": "Por precaución, tenemos que comprobar juntos sus datos."
+				},
+				"contact-support": {
+					"link-text": "contacte con soporte.",
+					"link-url": "https://support.pix.org/fr/support/tickets/new"
+				},
+				"send-email-confirmation": {
+					"check-spam": "Si no ve este correo electrónico, compruebe su carpeta de correo no deseado.",
+					"return": "Volver",
+					"send-email": "Acabamos de enviarle un correo electrónico para que pueda elegir una contraseña. Ya puede consultar su buzón.",
+					"title": "Recuperar tu cuenta Pix"
+				},
+				"student-information": {
+					"errors": {
+						"empty-first-name": "El campo del nombre es obligatorio.",
+						"empty-ine-ina": "El campo INE es obligatorio.",
+						"empty-last-name": "El campo nombre es obligatorio.",
+						"invalid-ine-ina-format": "El campo INE tiene un formato incorrecto.",
+						"not-found": "Pix no reconoce sus datos. Por favor, compruebe que son correctos, de lo contrario"
+					},
+					"form": {
+						"birthdate": "Fecha de nacimiento",
+						"first-name": "Nombre",
+						"ine-ina": "INE (Identifiant National Élève)",
+						"label": {
+							"birth-day": "día de nacimiento",
+							"birth-month": "mes de nacimiento",
+							"birth-year": "año de nacimiento"
+						},
+						"last-name": "Nombre",
+						"placeholder": {
+							"birth-day": "JJ",
+							"birth-month": "MM",
+							"birth-year": "AAAA"
+						},
+						"submit": "¡Ven a verme!",
+						"tooltip": "<strong>¿Dónde puedo encontrar mi INE?</strong> <p>Este identificador puede encontrarse normalmente en su informe escolar, o su antiguo colegio puede proporcionárselo.</p>"
+					},
+					"mandatory-all-fields": "Todos los campos son obligatorios.",
+					"subtitle": {
+						"link": "restablezca su contraseña aquí.",
+						"text": "Si tiene una cuenta con una dirección de correo electrónico válida,"
+					},
+					"title": "Ha abandonado el sistema escolar y desea recuperar el acceso a Pix"
+				},
+				"title": "Recuperar mi cuenta"
+			},
+			"support": {
+				"recover": " de asistencia.",
+				"url": "https://support.pix.org/fr/support/tickets/new",
+				"url-text": "Contactar con el servicio de asistencia"
+			},
+			"update-sco-record": {
+				"fill-password": "Introduce tu contraseña y Pix será tuyo.",
+				"form": {
+					"email-label": "Correo electrónico",
+					"errors": {
+						"empty-password": "El campo de contraseña es obligatorio.",
+						"invalid-password": "Su contraseña debe tener al menos 8 caracteres y contener como mínimo una letra mayúscula, una letra minúscula y un número."
+					},
+					"login-button": "Quiero conectar",
+					"password-label": "Contraseña"
+				},
+				"welcome-message": "¡Bienvenido de nuevo { firstName } !"
+			}
+		},
+		"assessment-banner": {
+			"modal": {
+				"actions": {
+					"quit": {
+						"extra-information": "Salir de la prueba y volver a la página de inicio"
+					}
+				},
+				"content": "Todos tus progresos quedan registrados. Puedes continuar donde lo dejaste.",
+				"title": "¿Necesitas un descanso?"
+			},
+			"title": "Prueba de evaluación :"
+		},
+		"assessment-results": {
+			"actions": {
+				"continue-pix-experience": "Continuar mi experiencia Pix",
+				"return-to-homepage": "Volver a la página de inicio"
+			},
+			"answers": {
+				"header": "Sus respuestas"
+			},
+			"title": "Fin de la prueba"
+		},
+		"autonomous-course": {
+			"landing-page": {
+				"actions": {
+					"sign-in": "Ya tengo una cuenta, me conecto",
+					"start-anonymously": "Empiezo sin cuenta Pix",
+					"start-connected": "Comienzo"
+				},
+				"texts": {
+					"first-course": "¿Es su primera gira Pix?",
+					"legal-informations": "Con o sin una cuenta Pix, la información sobre su progreso será transmitida a nosotros.<br>'Esta información es utilizada por Pix para mejorar el servicio.",
+					"title": "Comienza el curso:"
+				}
+			}
+		},
+		"campaign": {
+			"errors": {
+				"existing-participation": "El curso no es accesible para usted.",
+				"existing-participation-info": "Ponte en contacto con tu profesor para que te retire la participación en Pix Orga.",
+				"existing-participation-user-info": "Ya existe una participación asociada a nombre de",
+				"no-longer-accessible": "Oops, la página solicitada ya no es accesible.",
+				"not-accessible": "Oops, la página solicitada no es accesible."
+			}
+		},
+		"campaign-landing": {
+			"assessment": {
+				"action": "Comienzo",
+				"announcement": "Regístrese o inicie sesión en la plataforma Pix y comience su prueba.",
+				"certify": {
+					"description": "En función de su situación y bajo ciertas condiciones, puede acceder a la certificación Pix, reconocida por el mundo profesional y que le permite mejorar sus competencias digitales. Para más información, ponte en contacto con el organizador del curso.",
+					"title": "Las respuestas validadas en este curso contribuirán a tu perfil personal de competencias digitales en Pix."
+				},
+				"details": "Durante este curso, tendrá la oportunidad de :",
+				"develop": {
+					"description": "Cada 5 preguntas, ves las respuestas correctas y obtienes consejos y una recomendación personalizada de tutoriales para desarrollar tus habilidades.",
+					"title": "Conoce tus resultados a medida que avanza la prueba y consulta pistas para mejorar."
+				},
+				"evaluate": {
+					"description": "Deberá realizar búsquedas en Internet, utilizar su entorno de trabajo digital, poner a prueba sus conocimientos, etc.",
+					"title": "Mide tus habilidades digitales con divertidos retos de aprendizaje que se adaptan a tu nivel de competencia (mediante un algoritmo adaptativo)."
+				},
+				"legal": "Al hacer clic en \"Estoy empezando\", se enviará información sobre tu progreso en el curso al organizador del mismo para que pueda apoyarte. Al final del curso, haz clic en el botón \"Enviar mis resultados\" y tus resultados se enviarán al organizador.",
+				"title": "Comienza tu viaje Pix",
+				"title-with-username": "'<span>'{userFirstName}'</span>','<br>' comienza tu viaje"
+			},
+			"profiles-collection": {
+				"action": "¡Nos vamos!",
+				"announcement": "Regístrese o inicie sesión en la plataforma Pix y envíe su perfil a la organización destinataria.",
+				"legal": "La información relativa a su perfil PIX se enviará al organizador para que pueda acompañarle. Sólo se transmitirá con su consentimiento.",
+				"title": "Envíe su perfil",
+				"title-with-username": "'<span>'{userFirstName}'</span>','<br>' envíe su perfil"
+			},
+			"title": "Presentación",
+			"warning-message": "¿No eres { firstName } { lastName } ?",
+			"warning-message-logout": "Desconectando"
+		},
+		"campaign-participation": {
+			"title": "Curso"
+		},
+		"campaign-participation-overview": {
+			"card": {
+				"finished-at": "Completado el {date}",
+				"results": "{result, number, ::percent} de éxito",
+				"resume": {
+					"extra-information": "Reanudar ruta {campaignTitle}",
+					"information": "Currículum"
+				},
+				"see-more": "Ver detalles",
+				"send": "Enviar mis resultados",
+				"stages": "{count} { count, plural, =0 {étoile} =1 {étoile} other {étoiles} } en {total}",
+				"started-at": "Comenzó el {date}",
+				"tag": {
+					"completed": "Para enviar",
+					"disabled": "Inactivo",
+					"finished": "Completado",
+					"started": "En curso"
+				},
+				"text-disabled": "Curso desactivado por su organización\"<br>\"Ya no puede enviar sus resultados."
+			},
+			"title": "Curso"
+		},
+		"certificate": {
+			"attestation": "Descargar mi certificado",
+			"back-link": "Volver a mis certificaciones",
+			"candidate-birth": "Nacido en {birthdate}",
+			"candidate-birth-complete": "Fecha de nacimiento {birthdate} en {birthplace}.",
+			"certification-center": "Centro de certificación :",
+			"competences": {
+				"information": "Su puntuación certificada se ha calculado a partir de sus respuestas durante el proceso de certificación. Por lo tanto, puede diferir del número de Pix que aparece en tu perfil. El día de tu certificación, era posible alcanzar el nivel {maxReachableLevelOnCertificationDate} de habilidades y {maxReachablePixCountOnCertificationDate} píxeles al máximo.",
+				"subtitle": "(niveles en {maxReachableLevel})",
+				"title": "Habilidades certificadas"
+			},
+			"complementary": {
+				"alternative": "Certificación complementaria",
+				"title": "Otras certificaciones obtenidas"
+			},
+			"exam-date": "Fecha de la visita :",
+			"hexagon-score": {
+				"certified": "Certificado"
+			},
+			"issued-on": "Emitido el",
+			"jury-info": "Las observaciones del jurado no se comparten en la página de verificación de su certificado.",
+			"jury-title": "Comentarios del jurado",
+			"professionalizing-warning": "El certificado Pix está reconocido como cualificación profesional por France Compétences una vez alcanzada una puntuación mínima de 120 píxeles.",
+			"title": "Certificado Pix",
+			"verification-code": {
+				"alt": "Copia",
+				"copied": "¡Código copiado!",
+				"copy": "Copie el código",
+				"info": "(?)",
+				"title": "Código de verificación",
+				"tooltip": "Facilite este código para que un tercero pueda comprobar la autenticidad de su certificado"
+			}
+		},
+		"certification-ender": {
+			"candidate": {
+				"disconnect": "Salir de mi cuenta",
+				"disconnect-tip": "Si no es tu ordenador, recuerda desconectarte.",
+				"ended-by-supervisor": "Su supervisor ha dado por terminada su prueba de certificación. No puede continuar respondiendo a las preguntas.",
+				"ended-due-to-finalization": "Su centro de certificación ha finalizado la sesión. Ya no puede responder a las preguntas.",
+				"remote-certification": "Si está realizando la certificación Pix de forma remota, asegúrese de desconectarse de la herramienta de supervisión una vez que haya completado la prueba.",
+				"title": "¡Prueba completada!"
+			},
+			"results": {
+				"disclaimer": "Sus resultados, pendientes de validación por los equipos de Pix, estarán pronto disponibles en su cuenta Pix.",
+				"step-1": "Sólo tienes que conectarte a tu cuenta Pix y podrás encontrar tus resultados en tu perfil, en \"Mis certificaciones\" (accesible haciendo clic en tu nombre en la esquina superior derecha de la pantalla).",
+				"step-2": "Puede descargar su certificado de certificación y compartirlo con otras personas, o enviarnos el código de verificación para utilizarlo en el sitio web de Pix.",
+				"title": "¿Consultar y compartir los resultados de mi certificación?"
+			}
+		},
+		"certification-joiner": {
+			"congratulation-banner": {
+				"complementary-certification": {
+					"eligible": "También puede optar a { count, plural, =1 {à la certification complémentaire} other {aux certifications complémentaires} } :",
+					"outdated": "<strong>Ya no puedes optar a la certificación {complementaryCertificationName} tras su desarrollo.</strong><br />Ponte de nuevo en contacto con tu escuela o con la organización que te ofreció el curso para realizar otra campaña y volver a ser elegible. Tu progreso se ha conservado y lo único que tienes que hacer es presentarte a las nuevas pruebas, que deberían ser rápidas."
+				},
+				"link": {
+					"text": "¿Cómo puedo obtener el certificado?",
+					"url": "https://pix.fr/se-certifier#slice-2"
+				},
+				"message": "Bien hecho {fullName}, tu perfil Pix es certificable."
+			},
+			"error-messages": {
+				"generic": {
+					"check-personal-info": "Compruebe con el supervisor que sus datos personales coinciden con los de la hoja de inscripción.",
+					"check-session-number": "Compruebe el número de sesión.",
+					"disclaimer": "La información introducida no corresponde a ningún candidato inscrito en la sesión."
+				},
+				"language-not-supported": "La certificación Pix aún no está disponible en {userLanguage}. '<br>' Los idiomas disponibles actualmente para la certificación son: {availableLanguages}. '<br>' Puede elegir otro idioma en la página",
+				"language-not-supported-link": "Mi cuenta",
+				"session-not-accessible": "La sesión a la que intentas entrar ya no es accesible.",
+				"wrong-account": "La información introducida corresponde a un candidato inscrito en la sesión y que ya ha iniciado sesión con otra cuenta. Compruebe que ha iniciado sesión con la cuenta que inició la certificación.",
+				"wrong-account-sco": "Actualmente está utilizando una cuenta que no está vinculada a su escuela.\nInicie sesión en la cuenta con la que completó sus cursos o pida ayuda a su supervisor.",
+				"wrong-account-sco-link": "¿Cómo encuentro la cuenta vinculada al establecimiento?"
+			},
+			"first-title": "Participar en una sesión",
+			"form": {
+				"actions": {
+					"submit": "Continúe en"
+				},
+				"fields": {
+					"birth-date": "Fecha de nacimiento",
+					"birth-day": "día de nacimiento (DD)",
+					"birth-month": "mes de nacimiento (MM)",
+					"birth-name": "Nombre de nacimiento",
+					"birth-year": "año de nacimiento (AAAA)",
+					"first-name": "Nombre",
+					"session-number": "Número de sesión",
+					"session-number-information": "Comunicado únicamente por el vigilante al inicio de la sesión"
+				},
+				"fields-validation": {
+					"session-number-error": "El número de sesión se compone únicamente de números."
+				}
+			},
+			"title": "Participe en una sesión de certificación"
+		},
+		"certification-not-certifiable": {
+			"action": {
+				"back": "Volver a la página de inicio"
+			},
+			"text": "Para que su perfil sea certificado, debe haber alcanzado un nivel superior a 0 en al menos 5 competencias.",
+			"title": "Su perfil aún no es certificable."
+		},
+		"certification-results": {
+			"action": {
+				"confirm": "Puedo confirmar",
+				"logout": "Desconectando"
+			},
+			"finished": {
+				"description": "Sus resultados estarán disponibles en breve en su cuenta.",
+				"title": "¡Bravo, se acabó!",
+				"warning-text": "Si no es tu ordenador, recuerda desconectarte."
+			},
+			"flag-alt": "Bandera",
+			"title": "Prueba finalizada"
+		},
+		"certification-start": {
+			"access-code": "Código de acceso facilitado por el supervisor",
+			"actions": {
+				"submit": "Empezar mi prueba"
+			},
+			"cgu": {
+				"contact": {
+					"email": "dpo@pix.fr",
+					"info": "De conformidad con la Ley francesa de Protección de Datos, puede ejercer su derecho de acceso y rectificación de sus datos personales enviando un correo electrónico a"
+				},
+				"info": "Al hacer clic en \"Iniciar mi prueba\", acepto que mis datos de identidad, el número de certificación y las circunstancias de la prueba introducidos por el vigilante se transmitan a Pix. Pix utilizará esta información durante las deliberaciones del jurado para elaborar y archivar mis resultados y expedir mi certificado. Si esta certificación ha sido prescrita por una organización, acepto que Pix pueda comunicarles mis resultados."
+			},
+			"error-messages": {
+				"access-code-error": "Este código no existe o ya no es válido.",
+				"candidate-not-authorized-to-resume": "Póngase en contacto con su vigilante para que autorice la reanudación de su examen.",
+				"candidate-not-authorized-to-start": "Su supervisor no ha confirmado su presencia en la sala de examen. Por lo tanto, aún no puede comenzar la prueba de certificación. Por favor, informe a su supervisor.",
+				"generic": "Acaba de producirse un error inesperado en el servidor.",
+				"session-not-accessible": "La sesión de certificación ya no es accesible."
+			},
+			"first-title": "Está a punto de comenzar su prueba de certificación",
+			"link-to-user-certification": "Ver mis certificaciones",
+			"non-eligible-subscription": "No puedes optar al {nonEligibleSubscriptionLabel}. Sin embargo, puede obtener su certificación Pix.",
+			"subscription": "Además de la certificación Pix, está inscrito en la siguiente certificación complementaria:",
+			"title": "Participe en una sesión de certificación"
+		},
+		"certifications-list": {
+			"header": {
+				"certification-center": "Centro de certificación",
+				"date": "Fecha",
+				"score": "puntuación pix",
+				"status": "Estado"
+			},
+			"no-certification": {
+				"text": "Aún no tienes la certificación."
+			},
+			"statuses": {
+				"cancelled": {
+					"title": "Certificación anulada"
+				},
+				"fail": {
+					"action": "Mostrar detalles",
+					"title": "Certificación no obtenida"
+				},
+				"not-published": {
+					"title": "A la espera de los resultados"
+				},
+				"success": {
+					"action": "ver los resultados",
+					"title": "Certificación obtenida"
+				}
+			},
+			"title": "Mis certificaciones"
+		},
+		"challenge": {
+			"actions": {
+				"continue": "Continúe en",
+				"continue-go-to-next": "Paso a la siguiente pregunta",
+				"skip": "Paso",
+				"skip-go-to-next": "Paso a la siguiente pregunta",
+				"validate": "Válido",
+				"validate-go-to-next": "Valido y paso a la siguiente pregunta",
+				"wait-for-invigilator": "Las acciones se detienen hasta que llega el supervisor"
+			},
+			"already-answered": "Ya ha respondido a esta pregunta",
+			"answer-input": {
+				"numbered-label": "Respuesta {number}"
+			},
+			"certification": {
+				"banner": {
+					"certification-number": "Número de certificación"
+				},
+				"feedback-panel": {
+					"certification-number": "su número de certificación (parte superior derecha de la pantalla)",
+					"description": "Para informar de un problema, llame a su supervisor y facilítele la siguiente información:",
+					"problem": "el problema encontrado",
+					"question-number": "el número de la pregunta (parte superior derecha de la pantalla)"
+				},
+				"title": "Certificación {certificationNumber}"
+			},
+			"embed-simulator": {
+				"actions": {
+					"launch": "INICIO",
+					"launch-label": "Iniciar simulación",
+					"reset": "Restablecer"
+				},
+				"placeholder": "Cargar la aplicación actual"
+			},
+			"feedback-panel": {
+				"actions": {
+					"open-close": "Informar de un problema con la pregunta"
+				},
+				"description": "Pix siempre está dispuesto a escuchar sus comentarios sobre cómo podemos mejorar las pruebas que ofrecemos*.",
+				"form": {
+					"actions": {
+						"submit": "Enviar",
+						"submit-aria-label": "Enviar mi mensaje"
+					},
+					"fields": {
+						"category-selection": {
+							"label": "Tengo un problema con",
+							"options": {
+								"accessibility": "Accesibilidad de la prueba",
+								"answer": "La respuesta",
+								"download": "El archivo a descargar",
+								"embed": "El simulador/aplicación",
+								"link": "El enlace indicado en la pregunta",
+								"other": "Otros",
+								"picture": "La imagen",
+								"question": "La cuestión",
+								"tutorial": "El tutorial"
+							}
+						},
+						"detail-selection": {
+							"add-comment": "Añade un comentario",
+							"aria-first": "Tengo un problema con",
+							"aria-secondary": "Seleccione una opción para especificar su problema",
+							"label": "Seleccione una opción para especificar su problema",
+							"options": {
+								"answer-not-accepted": "Mi respuesta es correcta pero no ha sido validada",
+								"answer-not-agreed": "No estoy de acuerdo con la respuesta",
+								"download": {
+									"edit-failure": {
+										"label": "No puedo editar el",
+										"solution": "Es probable que el archivo esté abierto en \"Sólo lectura\" o \"Modo protegido\".<br>'Haga clic en \"Permitir modificación\" o \"Editar documento\" en el banner de la parte superior del archivo si aparece.<br>'Si no es así, guarde el archivo con otro nombre y abra este nuevo archivo."
+									},
+									"lost": {
+										"label": "No encuentro el archivo descargado",
+										"solution": "Por defecto, un archivo descargado se guarda en una carpeta \"Descargas\". También puede descargarse en la misma ubicación que su última descarga...."
+									},
+									"open-failure": {
+										"label": "No puedo abrir el archivo en un ordenador",
+										"solution": "Para superar esta prueba, puede utilizar la suite LibreOffice, que es gratuita y está disponible para PC y Mac. Contiene Libre Office Writer (equivalente a Word) y Libre Office Calc (equivalente a Excel).'<a href=\"https://fr.libreoffice.org/download/telecharger-libreoffice\">'Descargar Libre Office'</a>'"
+									},
+									"other": "Tengo otro problema con el"
+								},
+								"embed-displayed-on-desktop-with-problems": {
+									"label": "En un ordenador, el simulador se muestra pero tiene un problema",
+									"solution": "Hacemos todo lo posible para que los simuladores funcionen en todos los dispositivos, todos los sistemas operativos y todos los navegadores, pero es posible que estés utilizando un sistema concreto. Puedes parar aquí y empezar de nuevo en otro ordenador'<br>'Especifica tu problema indicando tu navegador y sistema operativo."
+								},
+								"embed-displayed-on-mobile-devices-with-problems": {
+									"label": "En un teléfono o tableta, el simulador se muestra pero tiene un problema",
+									"solution": "Hacemos todo lo posible para que los simuladores funcionen en todos los dispositivos, todos los sistemas operativos y todos los navegadores, pero es posible que estés utilizando un sistema concreto.'<br>'Especifica tu problema indicando tu tipo de dispositivo (smartphone, tableta, etc.), tu sistema operativo y tu navegador."
+								},
+								"embed-not-displayed": {
+									"label": "No se muestra el simulador/aplicación",
+									"solution": "Su conexión a Internet puede ser demasiado débil'<br>'Recargue la página pulsando el botón de actualización '<img class=\"tuto-icon\" src=\"/images/icons/icon-reload.svg\" alt=\"\" />' situado junto a la barra de direcciones. Espere un poco, puede que aparezca el simulador.<br><br>'Si no es así, ¿puede volver a intentarlo en otro momento o desde otro lugar con mejor conexión?"
+								},
+								"embed-other": "El simulador/aplicación tiene otro problema",
+								"link-other": "El enlace no funciona o tiene otro problema",
+								"link-unauthorized": {
+									"label": "El enlace está bloqueado por mi organización/institución...",
+									"solution": "Es posible que pertenezcas a una organización (escuelas, universidades, empresas, administraciones, asociaciones, etc.) que protege a sus usuarios y equipos limitando las páginas de Internet a las que tienes acceso.'<br>'"
+								},
+								"other-challenge-proposal": "Tengo una (brillante) idea para proponer una prueba",
+								"other-difficulty": "Tengo otro problema",
+								"other-site-improvement": "Tengo una sugerencia para mejorar la plataforma",
+								"picture-not-displayed": {
+									"label": "La imagen no se muestra",
+									"solution": "Su conexión a Internet puede ser demasiado débil'<br>'Recargue la página pulsando el botón de actualización '<img class=\"tuto-icon\" src=\"/images/icons/icon-reload.svg\" alt=\"\" />' situado junto a la barra de direcciones. Espere un poco, puede que aparezca la imagen.<br><br>'Si no es así, ¿puede volver a intentarlo en otro momento o desde otro lugar con mejor conexión?"
+								},
+								"picture-other": "La imagen tiene otro problema",
+								"question-improvement": "Me gustaría proponer una mejora a la pregunta",
+								"question-not-understood": "No entiendo la pregunta",
+								"tutorial-link-error": "El enlace al tutorial lleva a otra página o a una página de error",
+								"tutorial-not-accepted": "El tutorial no es adecuado",
+								"tutorial-proposal": "Tengo un tutorial para ti"
+							},
+							"problem-suggestion-description": "Describa su problema o sugerencia"
+						}
+					},
+					"status": {
+						"error": {
+							"empty-message": "Debe introducir un mensaje.",
+							"max-characters": "Su mensaje está limitado a 10.000 caracteres."
+						},
+						"success": "'<p>'Su comentario ha sido transmitido al equipo del proyecto Pix'</p><p>'Mercix !'</p>'"
+					}
+				},
+				"information": {
+					"data-usage": "'<p>'Pix trata los datos en este ámbito para gestionar y analizar la dificultad encontrada y beneficiarse de sus comentarios. Puede ejercer sus derechos en relación con sus datos personales dirigiéndose a : <strong>dpo@pix.fr</strong>.'</p><p><a href=\"https://pix.fr/dp-formulaire-signalement-epreuve\" target=\"_blank\" class=\"link\">'Más información sobre la protección de datos y sus derechos.'</a></p>'",
+					"guidance": "<p>\"* Tenga cuidado con lo que escribe en esta área: sea objetivo y basado en hechos, en su propio beneficio y en el de los demás.\"</p><p>\"En particular, no introduzca ninguna información, que le concierna a usted o a terceros, sobre salud, religión, opiniones políticas, sindicales o filosóficas, orígenes étnicos, o sobre sanciones o convicciones.\"</p>\"...\"."
+				},
+				"modal": {
+					"content": "<p><strong>'¿Está seguro de que desea informar de este problema?'</strong></p><p>'Gracias por su informe, que será revisado cuidadosamente por el equipo de Pix. Tenemos en cuenta todos sus comentarios para mejorar continuamente nuestros servicios y la experiencia del usuario. No podremos darle una respuesta personalizada. Gracias por su colaboración\"</p>'",
+					"title": "Confirmación de la alerta"
+				}
+			},
+			"feedback-panel-v3": {
+				"actions": {
+					"no-send-feedback": "No, vuelvo a la prueba",
+					"open-close": "Informar de un problema con la pregunta",
+					"refresh-page": "Actualizar página",
+					"send-feedback": "Sí, estoy seguro"
+				},
+				"description": "¿Está seguro de que quiere informar de un problema?",
+				"information": "Cuando usted informa de un problema, su certificación se detiene hasta que el supervisor interviene para validar o invalidar su informe.",
+				"problem-banner": "Comunícaselo a tu superior para que averigüe cuál es el problema.",
+				"waiting-information": "Esperando al supervisor..."
+			},
+			"has-focused-out-of-window": {
+				"certification": "Hemos detectado un cambio de página. Su respuesta se contabilizará como incorrecta. Si se ha visto obligado a cambiar de página, informe a su supervisor y responda a la pregunta en su presencia.",
+				"default": "Hemos detectado un cambio de página. En certificación, su respuesta no sería validada.",
+				"v3-certification": "Hemos detectado un cambio de página. Su respuesta se contabilizará como incorrecta. Si se ha visto obligado a cambiar de página, comuníqueselo a su supervisor para que pueda verlo y denunciarlo, si es necesario."
+			},
+			"illustration": {
+				"placeholder": "Cargar la imagen actual"
+			},
+			"is-focused-challenge": {
+				"info-alert": {
+					"subtitle": "En certificación, si cambia de página, su respuesta no será validada.",
+					"title": "Responde a esta pregunta sin buscar en Internet ni utilizar ningún programa informático."
+				}
+			},
+			"parts": {
+				"answer-input": "Su respuesta",
+				"answer-instructions": {
+					"qcm": "Seleccione varias respuestas.",
+					"qcu": "Seleccione una sola respuesta."
+				},
+				"feedback": "Informar de un problema",
+				"feedback-v3": "Informar de un problema con la pregunta",
+				"instruction": "Instrucciones de ensayo",
+				"progress": "Tus progresos",
+				"validation": "Validar o superar la prueba"
+			},
+			"progress-bar": {
+				"label": "Pregunta"
+			},
+			"skip-error-message": {
+				"qcm": "Para validar, seleccione al menos dos respuestas. Si no es así, sáltese.",
+				"qcu": "Para confirmar, seleccione una respuesta. En caso contrario, salte.",
+				"qroc": "Para validar, rellene el campo de texto. De lo contrario, omitir.",
+				"qroc-auto-reply": "\"Puede validar\" se muestra cuando se pasa la prueba. Inténtelo de nuevo o pase.",
+				"qroc-positive-number": "Para validar, introduzca un número mayor o igual que 0; de lo contrario, omita.",
+				"qrocm": "Para validar, rellene todos los campos de respuesta. Si no es así, sáltese."
+			},
+			"statement": {
+				"alternative-instruction": {
+					"actions": {
+						"display": "Mostrar la alternativa de texto",
+						"hide": "Ocultar texto alternativo"
+					}
+				},
+				"file-download": {
+					"actions": {
+						"choose-type": "Elija el tipo de archivo que desea utilizar",
+						"download": "Descargar"
+					},
+					"description": "Pix le permite elegir el formato de archivo que desea descargar. Si no sabes qué opción elegir, quédate con la opción por defecto. Este es el formato de archivo admitido por el mayor número de aplicaciones de software.",
+					"file-type": "archivo .{fileExtension}",
+					"help": "¿Necesita ayuda con '<a href=\"https://support.pix.org/fr/support/solutions/articles/15000036390\" class=\"challenge-statement__action-help--link\" target=\"_blank\" aria-label=\"ouvrir, modifier ou retrouver ce fichier (ouverture dans une nouvelle fenêtre)\">'abrir, modificar o encontrar este archivo'</a>'?"
+				},
+				"sr-only": {
+					"alternative-instruction": "Esta prueba contiene una ilustración con un texto alternativo.",
+					"embed": "Esta prueba incluye un simulador."
+				},
+				"tooltip": {
+					"aria-label": "Muestra la indicación en la prueba.",
+					"close": "Comprendo",
+					"focused": {
+						"content": "<p class=\"tooltip-tag-information__title--focused\">'Permanezca en esta página para responder'</p>'No utilice Internet o una aplicación para responder. Se detectará cualquier actividad fuera de la zona.",
+						"title": "Modo de enfoque"
+					},
+					"other": {
+						"content": "Puedes utilizar Internet o aplicaciones para responder a esta pregunta.",
+						"title": "Modo libre"
+					}
+				}
+			},
+			"timed": {
+				"cannot-answer": "El tiempo límite ha pasado. Su respuesta no será validada."
+			},
+			"title": {
+				"default": "Modo libre - Pregunta {stepNumber} sobre {totalChallengeNumber}.",
+				"focused": "Modo de enfoque - Pregunta {stepNumber} en {totalChallengeNumber}.",
+				"focused-out": "Fallo - Modo de enfoque - Pregunta {stepNumber} sobre {totalChallengeNumber}.",
+				"timed-out": "Tiempo transcurrido - Pregunta {stepNumber} de {totalChallengeNumber}."
+			}
+		},
+		"checkpoint": {
+			"actions": {
+				"next-page": {
+					"continue": "Continúe en",
+					"results": "Ver mis resultados"
+				}
+			},
+			"answers": {
+				"already-finished": {
+					"explanation": "Ya has respondido a estas preguntas en tus pruebas anteriores: puedes acceder directamente a tus resultados.\n\n¿Quieres mejorar tu puntuación? Haz clic en \"Ver mis resultados\" para volver a hacer el test.",
+					"info": "¡Ya has contestado!"
+				},
+				"header": "Sus respuestas"
+			},
+			"completion-percentage": {
+				"caption": "progreso de la ruta",
+				"label": "'<p class=\"sr-only\">'Has completado '</p>'{completionPercentage}%'<p class=\"sr-only\">' de tu viaje.'</p>'"
+			},
+			"title": {
+				"assessment-progress": "Avance",
+				"end-of-assessment": "Fin de su evaluación"
+			}
+		},
+		"comparison-window": {
+			"results": {
+				"a11y": {
+					"good-answer": "La respuesta dada es válida",
+					"skipped-answer": "Pregunta anterior",
+					"the-answer-was": "La respuesta correcta es",
+					"wrong-answer": "La respuesta dada es incorrecta"
+				},
+				"aband": {
+					"title": "Usted no dio una respuesta",
+					"tooltip": "Sin respuesta"
+				},
+				"abandAutoReply": {
+					"title": "Ha superado la prueba",
+					"tooltip": "Prueba anterior"
+				},
+				"default": {
+					"title": "Respuesta",
+					"tooltip": "Corrección automática en desarrollo ;)"
+				},
+				"feedback": {
+					"correct": "Respuesta correcta",
+					"wrong": "Respuesta incorrecta.<br>'La respuesta correcta es :"
+				},
+				"focusedOut": {
+					"title": "Has superado la prueba",
+					"tooltip": "Prueba fallida"
+				},
+				"ko": {
+					"title": "No tienes la respuesta correcta",
+					"tooltip": "Respuesta incorrecta"
+				},
+				"koAutoReply": {
+					"title": "No ha superado la prueba",
+					"tooltip": "Prueba fallida"
+				},
+				"ok": {
+					"title": "Tienes la respuesta correcta.",
+					"tooltip": "Respuesta correcta"
+				},
+				"okAutoReply": {
+					"title": "Ha superado la prueba",
+					"tooltip": "Prueba superada"
+				},
+				"partially": {
+					"title": "Ha dado una respuesta parcial",
+					"tooltip": "Respuesta parcial"
+				},
+				"solutions": {
+					"end": "o...",
+					"or": "o"
+				},
+				"timedout": {
+					"title": "Ha superado el límite de tiempo",
+					"tooltip": "Tiempo muerto"
+				},
+				"tips": {
+					"other-proposition": "Otra propuesta",
+					"your-answer": "Su respuesta"
+				}
+			},
+			"upcoming-tutorials": "Pronto encontrarás aquí tutoriales que te ayudarán a superar con éxito este tipo de pruebas."
+		},
+		"competence-details": {
+			"actions": {
+				"continue": {
+					"extra-information": "Reanudar habilidad {competenceName}",
+					"label": "Currículum"
+				},
+				"improve": {
+					"description": {
+						"countdown": "{ daysBeforeImproving, plural, =0 {0 jour.} =1 {1 jour.} other {# jours.} }",
+						"waiting-text": "Prueba el siguiente nivel en"
+					},
+					"improvingText": "¡Intenta alcanzar el siguiente nivel!",
+					"label": "Retentor"
+				},
+				"reset": {
+					"description": "Reinicio disponible en { daysBeforeReset, plural, =0 {0 jour.} =1 {1 jour.} other {# jours.} }",
+					"label": "Puesta a cero",
+					"modal": {
+						"important-message": "Tu { earnedPix } Pix será eliminado de la habilidad: { scoreCardName }.",
+						"important-message-above-level-one": "Tu { level } nivel y { earnedPix } Pix serán eliminados de la habilidad: { scoreCardName }.",
+						"title": "Restablecimiento de las competencias",
+						"warning": {
+							"certification": "si desea que se certifique su perfil y sus distintos resultados, esto podría afectar a su certificación.",
+							"header": "Tenga en cuenta lo siguiente:",
+							"ongoing-assessment": "si tiene un curso de evaluación en curso, es posible que le vuelvan a hacer ciertas preguntas."
+						}
+					}
+				},
+				"start": {
+					"extra-information": "Habilidad inicial {competenceName}",
+					"label": "INICIO"
+				}
+			},
+			"for-competence": "competencia {competence}",
+			"next-level-info": "{ remainingPixToNextLevel } pix antes del nivel { level }",
+			"title": "Experiencia",
+			"tutorials": {
+				"description": "Aquí tienes una selección de tutoriales que te ayudarán a ganar Pix.",
+				"title": "Cultiva tus habilidades"
+			}
+		},
+		"competence-result": {
+			"header": {
+				"congratulations": "¡Felicidades!",
+				"not-bad": "No está mal, pero no es genial.",
+				"not-bad-subtitle": "Un poco más de esfuerzo y habrás alcanzado el primer nivel.",
+				"too-bad": "¡Cuántas fotos!",
+				"too-bad-subtitle": "Obviamente no es tu día, pero lo harás mejor la próxima vez.",
+				"you-have-earned": "Usted tiene",
+				"you-have-reached-level": "Ha alcanzado"
+			},
+			"title": "Resultados de su destreza"
+		},
+		"course": {
+			"errors": {
+				"not-accessible": "Oops, la página solicitada no es accesible."
+			}
+		},
+		"dashboard": {
+			"campaigns": {
+				"resume": {
+					"action": "Continúe en",
+					"text": "<h2>¡No olvides finalizar la carga de tu perfil!</h2>"
+				},
+				"subtitle": "Continúe con sus pruebas actuales o envíe sus resultados",
+				"tests-link": "Todas mis trayectorias profesionales",
+				"title": "Curso"
+			},
+			"empty-dashboard": {
+				"link-to-competences": "Ver mis competencias",
+				"message": "<h2>¡Bien hecho, has completado las habilidades recomendadas!</h2> <p> Para ir más lejos, sigue practicando reintentando las habilidades. </p>"
+			},
+			"improvable-competences": {
+				"extra-information": "Accede a todas las habilidades para volver a intentarlo",
+				"profile-link": "Todas las competencias",
+				"subtitle": "¿Listo para pasar al siguiente nivel?",
+				"title": "Reintentar una habilidad"
+			},
+			"presentation": {
+				"link": {
+					"text": "Más información",
+					"url": "https://pix.fr/actualites/decouvrez-votre-nouveau-tableau-de-bord"
+				},
+				"message": "<h2>Hola { firstname }, descubre tu panel de control</h2><p>Acceso rápido y fácil a tus cursos y pruebas de habilidades que ya has empezado.<br/>Haz un seguimiento de tu puntuación Pix y comprueba si tu perfil está listo para la certificación Pix.</p>"
+			},
+			"recommended-competences": {
+				"extra-information": "Acceder a todas las competencias recomendadas",
+				"profile-link": "Todas las competencias",
+				"subtitle": "Explora las competencias recomendadas para ti.",
+				"title": "Competencias recomendadas"
+			},
+			"score": {
+				"profile-link": "Ver mis competencias"
+			},
+			"started-competences": {
+				"subtitle": "Continúe con sus pruebas de aptitud, aquí encontrará las más recientes.",
+				"title": "Recuperar una habilidad"
+			},
+			"title": "INICIO"
+		},
+		"error": {
+			"content-text": "'<p>'Por favor, vuelva a cargar esta página o regrese a la página de inicio.'</p><p>'También puede ponerse en contacto con nosotros a través de '<a href=\"https://support.pix.fr/support/tickets/new\">'el formulario del centro de ayuda.'</a>'especificando el código de error que aparece a continuación en la descripción.'</p><p>'Le pedimos disculpas por las molestias ocasionadas.'</p><p>'El equipo de Pix.'</p>'",
+			"first-title": "¡Uy, ha habido un error!"
+		},
+		"fill-in-campaign-code": {
+			"description": "Este código se compone de 9 números y/o letras. Lo envía tu centro educativo/organización y sirve para iniciar un curso o enviar tu perfil.",
+			"errors": {
+				"forbidden": "No le encontramos. Compruebe sus datos para continuar o informe al organizador.",
+				"missing-code": "Por favor, introduzca un código.",
+				"not-found": "Su código es incorrecto, compruebe su formato (por ejemplo, ABCDEF234) o póngase en contacto con el organizador."
+			},
+			"explanation-link": "https://support.pix.org/fr/support/solutions/articles/15000029147-qu-est-ce-qu-un-code-parcours-et-comment-l-utiliser-",
+			"explanation-message": "¿Qué es un código de ruta y cómo se utiliza?",
+			"first-title-connected": "{ firstName }, introduzca su código",
+			"first-title-not-connected": "Introduzca su código",
+			"label": "Introduce tu código para empezar.",
+			"mediacentre-start-campaign-modal": {
+				"actions": {
+					"continue": "Continúe en",
+					"quit": "Deja"
+				},
+				"message": "Para acceder al curso :",
+				"message-footer": "Conéctate a Pix a través de tu Mediacentre",
+				"organised-by": "propuesto por",
+				"title": "Acceso al curso a través de Mediacentre"
+			},
+			"start": "Acceder al curso",
+			"title": "Tengo un código",
+			"warning-message": "¿No eres { firstName } { lastName } ?",
+			"warning-message-logout": "Desconectando"
+		},
+		"fill-in-certificate-verification-code": {
+			"description": "La certificación Pix acredita un nivel de competencia en competencias digitales: introduzca a continuación el \"código de verificación\" del certificado Pix que desea comprobar.",
+			"errors": {
+				"missing-code": "Por favor, introduzca el código de verificación.",
+				"not-found": "No existe el certificado Pix correspondiente.",
+				"unallowed-access": "Introduzca el código de verificación con el formato P-XXXXXXXX en el campo de arriba.",
+				"wrong-format": "Compruebe el formato de su código (P-XXXXXXXX)."
+			},
+			"first-title": "Comprobación de un certificado Pix",
+			"label": "Código de verificación (P-XXXXXXXX)",
+			"title": "Comprobación de un certificado Pix",
+			"verify": "Comprobar el certificado"
+		},
+		"fill-in-participant-external-id": {
+			"announcement": "El organizador necesita la siguiente información para poder acompañarle:",
+			"buttons": {
+				"cancel": "Cancelar",
+				"continue": "Continúe en"
+			},
+			"errors": {
+				"max-length-id-pix-label": "Su { idPixLabel } no debe superar los 255 caracteres.",
+				"missing-id-pix-label": "Por favor, introduzca su { idPixLabel }."
+			},
+			"first-title": "Antes de empezar",
+			"title": "Introduzca mi nombre de usuario"
+		},
+		"focused-certification-challenge-instructions": {
+			"action": "Estoy listo",
+			"description": "Para la siguiente pregunta o preguntas, no podrá salir de la página.",
+			"title": "Modo de enfoque"
+		},
+		"inscription": {
+			"choose-language-aria-label": "Seleccione un idioma"
+		},
+		"join": {
+			"button": "¡Nos vamos!",
+			"fields": {
+				"birthdate": {
+					"day-error": "Tu día de nacimiento no es válido.",
+					"day-format": "JJ",
+					"day-label": "día de nacimiento",
+					"label": "Fecha de nacimiento",
+					"month-error": "Tu mes de nacimiento no es válido.",
+					"month-format": "MM",
+					"month-label": "mes de nacimiento",
+					"year-error": "Tu año de nacimiento no es válido.",
+					"year-format": "AAAA",
+					"year-label": "año de nacimiento"
+				},
+				"firstname": {
+					"error": "Su nombre de pila no está rellenado.",
+					"label": "Nombre"
+				},
+				"lastname": {
+					"error": "No se ha introducido su nombre.",
+					"label": "Nombre"
+				}
+			},
+			"rgpd-legal-notice": "Para saber cómo se tratan sus datos y cuáles son sus derechos, puede leer el",
+			"rgpd-legal-notice-link": "Información.",
+			"rgpd-legal-notice-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39",
+			"sco": {
+				"associate": "Asociado",
+				"continue-with-pix": "Continuar con mi cuenta Pix",
+				"error-not-found": "¿Es usted estudiante? '<br>' Comprueba tus datos (nombre, apellidos y fecha de nacimiento) o ponte en contacto con un profesor.'<br><br>' ¿Eres profesor? '<br>' El acceso a un curso no está disponible en este momento.",
+				"first-title": "Afiliarse a la organización { organizationName }",
+				"invalid-reconciliation-error": "Se ha producido un error.<br>' Póngase en contacto con el servicio de asistencia.",
+				"login-information-message": "La cuenta Pix '<b>'{ connectionMethod }'</b>' se asociará con el estudiante: '<b>'{ firstName } { lastName }'</b>'.'<br><br>'Si es usted, haga clic en \"Asociar\", de lo contrario cierre la sesión.",
+				"login-information-title": "Información sobre la conexión",
+				"subtitle": "Rellene la información que falta"
+			},
+			"sup": {
+				"error": "Compruebe la información que ha introducido o, si ya tiene una cuenta Pix, inicie sesión con ella.",
+				"fields": {
+					"student-number": {
+						"error": "No se ha introducido su número de estudiante.",
+						"label": "Número de estudiante",
+						"modify": "Cambiar el número de estudiante",
+						"not-existing": "No tengo número de estudiante"
+					}
+				},
+				"message": "Introduce la información tal y como aparece en tu tarjeta de estudiante para acceder a la prueba y enviar los resultados. Pix se acordará la próxima vez.",
+				"title": "Registre su cuenta Pix con {organizationName}."
+			},
+			"title": "Póngase en contacto con"
+		},
+		"learning-more": {
+			"info": "Estos enlaces a tutoriales han sido sugeridos por usuarios de Pix.",
+			"title": "Más información"
+		},
+		"levelup-notif": {
+			"obtained-level": "¡Nivel { level } ganado!"
+		},
+		"login-or-register": {
+			"invitation": "{ organizationName } le invita a unirse a Pix",
+			"login-form": {
+				"button": "Iniciar sesión",
+				"error": "La dirección de correo electrónico o el nombre de usuario y/o la contraseña introducidos son incorrectos.",
+				"fields": {
+					"login": {
+						"label": "Dirección de correo electrónico o nombre de usuario"
+					},
+					"password": {
+						"label": "Contraseña"
+					}
+				},
+				"forgotten-password": {
+					"email": "Una dirección de correo electrónico :",
+					"instruction": "¿Has olvidado tu contraseña? Tienes una cuenta Pix con :",
+					"other-identity": "Un inicio de sesión : Póngase en contacto con su profesor para restablecerla",
+					"reset-link": "Haga clic aquí para restablecerlo"
+				},
+				"title": "Ya tengo una cuenta Pix",
+				"unexpected-user-account-error": "La dirección de correo electrónico o el nombre de usuario son incorrectos. Para continuar, debe iniciar sesión en su cuenta, que se encuentra en el formulario :"
+			},
+			"register-form": {
+				"button": "Inscríbete",
+				"button-form": "Deseo inscribirme",
+				"fields": {
+					"birthdate": {
+						"day": {
+							"error": "Tu día de nacimiento no es válido.",
+							"label": "Día de nacimiento",
+							"placeholder": "JJ"
+						},
+						"label": "Fecha de nacimiento (dd/mm/aaaa)",
+						"month": {
+							"error": "Tu mes de nacimiento no es válido.",
+							"label": "Mes de nacimiento",
+							"placeholder": "MM"
+						},
+						"year": {
+							"error": "Tu año de nacimiento no es válido.",
+							"label": "Año de nacimiento",
+							"placeholder": "AAAA"
+						}
+					},
+					"cgu": "Acepto las '<a href=\"https://pix.fr/conditions-generales-d-utilisation\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\">'condiciones de uso de Pix'</a>'.",
+					"email": {
+						"error": "Su correo electrónico no es válido.",
+						"help": "(por ejemplo, nom@exemple.fr)",
+						"label": "Correo electrónico"
+					},
+					"firstname": {
+						"error": "Su nombre de pila no está rellenado.",
+						"label": "Nombre"
+					},
+					"lastname": {
+						"error": "No se ha introducido su nombre.",
+						"label": "Nombre"
+					},
+					"password": {
+						"error": "Su contraseña debe tener al menos 8 caracteres y contener como mínimo una letra mayúscula, una letra minúscula y un número.",
+						"help": "(mínimo 8 caracteres, incluyendo una mayúscula, una minúscula y un número)",
+						"label": "Contraseña",
+						"show-button": "hacer legible la contraseña"
+					},
+					"username": {
+						"label": "Mi nombre de usuario"
+					}
+				},
+				"not-me": "No soy yo.",
+				"options": {
+					"email": "Mi dirección de correo electrónico",
+					"text": "Me gustaría registrarme en :",
+					"username": "Mi nombre de usuario"
+				},
+				"rgpd-legal-notice": "Para saber cómo se tratan sus datos y cuáles son sus derechos, puede leer el",
+				"rgpd-legal-notice-link": "Información.",
+				"rgpd-legal-notice-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39",
+				"title": "Deseo inscribirme en Pix"
+			},
+			"title": "Conectar con Pix"
+		},
+		"login-or-register-oidc": {
+			"error": {
+				"account-conflict": "Esta cuenta ya está asociada a esta organización. Inicie sesión con otra cuenta o póngase en contacto con el servicio de asistencia.",
+				"data-sharing-refused": "Le informamos de que la transmisión de sus datos, especificados en la página anterior, es imprescindible para poder acceder y utilizar el servicio.",
+				"error-message": "Debes aceptar las condiciones de uso de Pix.",
+				"expired-authentication-key": "Su solicitud de autenticación ha caducado.",
+				"invalid-email": "Su dirección de correo electrónico no es válida.",
+				"login-unauthorized-error": "La dirección de correo electrónico y/o la contraseña introducidas son incorrectas."
+			},
+			"login-form": {
+				"button": "Quiero conectar",
+				"description": "Inicie sesión para vincular su cuenta existente y recuperar sus competencias evaluadas anteriormente.",
+				"email": "Correo electrónico",
+				"password": "Contraseña",
+				"title": "Ya tengo una cuenta Pix"
+			},
+			"register-form": {
+				"button": "Creo mi cuenta",
+				"description": "Se creará una cuenta utilizando la información facilitada por la organización",
+				"information": {
+					"family-name": "Nombre: {familyName}",
+					"given-name": "Nombre: {givenName}"
+				},
+				"title": "No tengo una cuenta Pix"
+			},
+			"title": "Crea tu cuenta Pix"
+		},
+		"modulix": {
+			"beta-banner": "Este módulo está en versión beta. Puede enviarnos sus comentarios al final de este módulo para ayudarnos a mejorarlo.",
+			"buttons": {
+				"activity": {
+					"retry": "Inténtalo de nuevo",
+					"verify": "Consulte"
+				},
+				"element": {
+					"alternativeText": "Mostrar la alternativa de texto",
+					"transcription": "Ver transcripción"
+				},
+				"grain": {
+					"continue": "Continúe en",
+					"skip": "Ir a",
+					"terminate": "Acabado"
+				}
+			},
+			"details": {
+				"duration": "Duración",
+				"durationValue": "'<span aria-hidden=\"true\">'≈'</span><span class=\"screen-reader-only\">'Sobre '</span>'{duration} min",
+				"explanationText1": "Los módulos de formación Pix se componen de lecciones y actividades que le ayudarán a practicar y desarrollar sus competencias digitales. Las lecciones se presentan en forma de vídeos, audio, imágenes y texto. Las actividades permiten practicar y comprobar directamente las respuestas. Cada módulo tiene una duración aproximada de 10 minutos, sobre un tema específico, con un nivel de dificultad que va de principiante a experto.",
+				"explanationText2": "Estos módulos de formación se encuentran actualmente en fase de prueba beta. Puede enviarnos sus sugerencias de mejora a través del cuestionario que figura al final de cada módulo.",
+				"explanationTitle": "¿Qué es un módulo?",
+				"level": "Nivel",
+				"objectives": "Objetivos",
+				"startModule": "Iniciar el módulo"
+			},
+			"grain": {
+				"tag": {
+					"activity": "Actividad",
+					"lesson": "lección"
+				}
+			},
+			"modals": {
+				"alternativeText": {
+					"title": "Texto alternativo"
+				},
+				"transcription": {
+					"title": "Transcripción"
+				}
+			},
+			"preview": {
+				"textarea-label": "Contenido del módulo"
+			},
+			"qcm": {
+				"direction": "Seleccione varias respuestas."
+			},
+			"qcu": {
+				"direction": "Seleccione una sola respuesta."
+			},
+			"qrocm": {
+				"direction": "Rellena {count, plural, =1 {le champ vide} other {les champs vides}}."
+			},
+			"recap": {
+				"backToModuleDetails": "Volver a los detalles del módulo",
+				"goToForm": "Responder al cuestionario",
+				"subtitle": "Has alcanzado los siguientes objetivos:",
+				"title": "¡Enhorabuena! Módulo completado"
+			},
+			"verification-precondition-failed-alert": {
+				"qcm": "Para confirmar, seleccione al menos dos respuestas.",
+				"qcu": "Para confirmar, seleccione una respuesta.",
+				"qrocm": "Para validar, rellene todos los campos de respuesta."
+			}
+		},
+		"not-connected": {
+			"message": "Estás bien fuera de contacto.'<br>'Gracias y hasta pronto.",
+			"title": "Desconectado"
+		},
+		"oidc-reconciliation": {
+			"authentication-method-to-add": "Conexión añadida :",
+			"confirm": "Continúe en",
+			"current-authentication-methods": "Mis métodos de conexión actuales:",
+			"email": "Correo electrónico",
+			"external-connection": "Conexión externa",
+			"external-connection-via": "Conexión a través de",
+			"information": "Dado que la evaluación de competencias es personalizada, su cuenta debe seguir siendo estrictamente personal.",
+			"return": "Volver",
+			"sub-title": "Un nuevo método de conexión está a punto de ser añadido a tu cuenta Pix",
+			"switch-account": "Cambiar cuenta",
+			"title": "¡Atención!",
+			"username": "Identificador"
+		},
+		"password-reset-demand": {
+			"actions": {
+				"back-home": "Volver a la página de inicio",
+				"back-sign-in": "Volver a la página de inicio de sesión",
+				"reset": "Restablecer mi contraseña"
+			},
+			"error": {
+				"message": "Esta dirección de correo electrónico no corresponde a ninguna cuenta"
+			},
+			"fields": {
+				"email": {
+					"label": "Correo electrónico"
+				}
+			},
+			"page-title": "Contraseña olvidada",
+			"subtitle": "Introduzca a continuación su dirección de correo electrónico y ¡listo!",
+			"succeed": {
+				"help": "Si no recibe este correo electrónico, compruebe su carpeta de correo no deseado.",
+				"instructions": "Se le ha enviado un correo electrónico con instrucciones para restablecer su contraseña\n a la dirección de correo electrónico {email}.",
+				"subtitle": "Solicitud de restablecimiento de contraseña"
+			},
+			"title": "¿Ha olvidado su contraseña?"
+		},
+		"profile": {
+			"accessibility": {
+				"title": "Tu perfil Pix",
+				"user-score": "Su número de Pix",
+				"user-skills": "Tus habilidades Pix"
+			},
+			"competence-card": {
+				"congrats": "¡Bien hecho!",
+				"details": "Detalles",
+				"image-info": {
+					"first-level": "El primer nivel está en marcha, {percentageAheadOfNextLevel}% completado.",
+					"level": "Nivel actual: {currentLevel}. El siguiente nivel se completa en {percentageAheadOfNextLevel}%.",
+					"no-level": "Habilidad no iniciada"
+				}
+			},
+			"first-title": "Tienes 16 habilidades para probar.<br>'¡Concéntrate y vamos&nbsp;!",
+			"resume-campaign-banner": {
+				"accessibility": {
+					"resume": "Continúa tu viaje",
+					"share": "Comparta los resultados de su viaje"
+				},
+				"actions": {
+					"continue": "Continúe en",
+					"resume": "Currículum"
+				},
+				"reminder-continue-campaign": "No ha terminado el curso",
+				"reminder-continue-campaign-with-title": "No has completado la ruta \"{title}\".",
+				"reminder-send-campaign": "No olvide finalizar su envío.",
+				"reminder-send-campaign-with-title": "{title}\" ruta completada. No olvide finalizar su envío."
+			},
+			"title": "Habilidades",
+			"total-score-helper": {
+				"explanation": "'<p>'Este es el número máximo de píxeles que se puede alcanzar cuando están disponibles los 8 niveles del repositorio de píxeles.'</p><p>'Actualmente, '<span class=\"hexagon-score-information__text--strong\">'el máximo es de {maxReachablePixScore} píxeles'</span>', correspondientes al nivel {maxReachableLevel}.'</p>'",
+				"icon": "Información sobre píxeles",
+				"label": "Abrir información sobre herramientas",
+				"title": "¿Por qué 1024 píxeles?"
+			}
+		},
+		"profile-already-shared": {
+			"actions": {
+				"continue": "Continúa tu experiencia Pix"
+			},
+			"explanation": "Ya ha enviado el siguiente perfil a la organización {organization}'<br>'el {date} a {hour,time,hhmm}",
+			"first-title": "No todo sale según lo previsto",
+			"retry": {
+				"button": "Reenviar mi perfil",
+				"message": "{organization} le invita a enviar su perfil para medir su progreso."
+			},
+			"title": "Perfil ya enviado"
+		},
+		"reset-password": {
+			"actions": {
+				"sign-in": "Conéctese a",
+				"submit": "Enviar"
+			},
+			"error": {
+				"expired-demand": "Lo sentimos, pero tu solicitud de restablecimiento de contraseña ya ha sido utilizada o ha caducado. Por favor, inténtalo de nuevo.",
+				"forbidden": "Se ha producido un error, póngase en contacto con el servicio de asistencia.",
+				"wrong-format": "Su contraseña debe tener al menos 8 caracteres y contener como mínimo una letra mayúscula, una letra minúscula y un número."
+			},
+			"fields": {
+				"password": {
+					"label": "Contraseña"
+				}
+			},
+			"instruction": "Introduzca su nueva contraseña",
+			"succeed": "Su contraseña ha sido cambiada con éxito.",
+			"title": "Cambiar mi contraseña"
+		},
+		"result-item": {
+			"aband": "Sin respuesta",
+			"actions": {
+				"see-answers-and-tutorials": {
+					"label": "Respuestas y tutoriales"
+				}
+			},
+			"ko": "Respuesta incorrecta",
+			"ok": "Respuesta correcta",
+			"partially": "Respuesta parcial",
+			"timedout": "Tiempo muerto"
+		},
+		"send-profile": {
+			"disabled-share": "Este curso ha sido desactivado por el organizador. Ya no es posible enviar resultados.",
+			"errors": {
+				"archived": "Ya no puede enviar su perfil porque el organizador ha archivado la colección de perfiles."
+			},
+			"first-title": "Envío de su perfil Pix",
+			"form": {
+				"continue": "Continúa tu experiencia Pix",
+				"recipient": "Para: {recipient}",
+				"send": "Envío mi perfil",
+				"shared": "Gracias, su perfil ha sido enviado."
+			},
+			"instructions": "Transmitirás la puntuación y los niveles de habilidad de tu perfil Pix.<br>' Cualquier cambio en tu perfil después de haber enviado esta información no se transmitirá. '<br>' ¡Recuerda comprobarlo antes de enviar!",
+			"title": "Enviar mi perfil"
+		},
+		"shared-certification": {
+			"back-link": "Volver a la introducción del código de verificación",
+			"title": "Compartir certificados"
+		},
+		"sign-in": {
+			"actions": {
+				"submit": "Quiero conectar"
+			},
+			"error": {
+				"message": "La dirección de correo electrónico o el nombre de usuario y/o la contraseña introducidos son incorrectos."
+			},
+			"fields": {
+				"legend": "Información necesaria para iniciar sesión.",
+				"login": {
+					"label": "Dirección de correo electrónico o nombre de usuario"
+				},
+				"password": {
+					"label": "Contraseña"
+				}
+			},
+			"first-title": "Conéctese a",
+			"forgotten-password": "¿Ha olvidado su contraseña?",
+			"fwb": {
+				"link": {
+					"img": "Conexión FWB"
+				},
+				"title": "Conectar a través de la FWB"
+			},
+			"or": "O",
+			"pole-emploi": {
+				"link": {
+					"img": "Polo Empleo connect"
+				},
+				"title": "Conectar con Pôle Emploi"
+			},
+			"subtitle": {
+				"link": "Crear una cuenta",
+				"text": "¿Aún no tienes una cuenta Pix?"
+			},
+			"title": "Conexión"
+		},
+		"sign-up": {
+			"actions": {
+				"submit": "Deseo inscribirme"
+			},
+			"errors": {
+				"invalid-locale-format": "Tu configuración regional \"{invalidLocale}\" tiene un formato incorrecto.",
+				"locale-not-supported": "Su configuración regional \"{localeNotSupported}\" no es compatible actualmente."
+			},
+			"fields": {
+				"email": {
+					"error": "Su dirección de correo electrónico no es válida.",
+					"help": "(por ejemplo, nom@exemple.fr)",
+					"label": "Correo electrónico"
+				},
+				"firstname": {
+					"error": "Su nombre de pila no está rellenado.",
+					"label": "Nombre"
+				},
+				"lastname": {
+					"error": "No se ha introducido su nombre.",
+					"label": "Nombre"
+				},
+				"legend": "Información necesaria para la inscripción.",
+				"password": {
+					"error": "Su contraseña debe tener al menos 8 caracteres y contener como mínimo una letra mayúscula, una letra minúscula y un número.",
+					"help": "(mínimo 8 caracteres, incluyendo una mayúscula, una minúscula y un número)",
+					"label": "Contraseña"
+				}
+			},
+			"first-title": "Inscríbete en",
+			"instructions": "Los campos marcados con '<abbr title=\"obligatoire\" class=\"mandatory-mark\">'*'</abbr>' son obligatorios.",
+			"subtitle": {
+				"link": "conéctese a su cuenta"
+			},
+			"title": "Inscripción"
+		},
+		"sitemap": {
+			"accessibility": {
+				"help": "Ayuda con tus preguntas sobre accesibilidad en Pix",
+				"title": "Accesibilidad"
+			},
+			"cgu": {
+				"policy": "Política de protección de datos",
+				"subcontractors": "Lista de subcontratistas"
+			},
+			"resources": "Recursos",
+			"title": "Mapa del sitio"
+		},
+		"skill-review": {
+			"abstract": "Has dominado '<strong>'{rate, number, ::percent}'</strong><br>'las habilidades evaluadas.",
+			"abstract-title": "Su resultado para esta ruta",
+			"actions": {
+				"continue": "Continúa tu experiencia Pix",
+				"improve": "Lo intentaré de nuevo.",
+				"send": "Envío mis resultados"
+			},
+			"already-shared": "Gracias, sus resultados han sido enviados.",
+			"badge-card": {
+				"acquired": "Obtenido",
+				"not-acquired": "No se ha obtenido",
+				"progress-bar-label": "Porcentaje de resultados positivos"
+			},
+			"badges-title": "Sus resultados temáticos",
+			"details": {
+				"caption": "Detalle de sus resultados en términos porcentuales según las competencias",
+				"flash-pix-score": "{score, number, ::.} Pix",
+				"header-result": "RESULTADOS",
+				"header-skill": "Habilidades comprobadas",
+				"percentage": "{rate, number, ::percent}",
+				"progress-bar-label": "Porcentaje de éxito de la habilidad",
+				"result": "Resultado global",
+				"title": "Sus resultados por habilidad"
+			},
+			"disabled-share": "Este curso ha sido desactivado por el organizador.\"<br>\"Ya no es posible enviar resultados.",
+			"error": "¡Uy, ha habido un error!",
+			"flash": {
+				"abstract": "¡Bien hecho, has llegado hasta el final!",
+				"nonDefinitive": "(cálculo no definitivo)",
+				"pixScore": "Has obtenido {score, number, ::.} Pix"
+			},
+			"improve": {
+				"description": "Puedes volver a intentar algunas de las preguntas",
+				"title": "¿Quiere mejorar sus resultados?"
+			},
+			"information": "Si ya ha completado una ruta Pix, no se le volverán a hacer las mismas preguntas. Sin embargo, los resultados que se muestran aquí tienen en cuenta todas tus respuestas.",
+			"net-promoter-score": {
+				"link": {
+					"href": "https://pix.fr",
+					"label": "Doy mi opinión"
+				},
+				"text": "Dedique unos minutos a decirnos qué le ha parecido esta prueba y ayúdenos a mejorarla.",
+				"title": "¡Tu opinión cuenta!"
+			},
+			"not-finished": "Todavía no puedes enviar tus resultados, así que aún tenemos algunas preguntas para ti.",
+			"organization-message": "Mensaje de su organización",
+			"reset": {
+				"button": "Reiniciar y volver a intentarlo",
+				"modal": {
+					"text": "Estás a punto de reiniciar tu curso <strong>{targetProfileName}</strong>para intentar mejorar tu nivel. Al final del curso, podrás volver a enviar tus resultados.",
+					"warning-text": "Tus Pix, niveles y certificabilidad obtenidos durante este curso serán eliminados."
+				},
+				"notifications": "Si vuelve a intentar las preguntas fallidas o restablece a cero para volver a intentarlo todo, su organización ya no podrá ver su último resultado. Para que el organizador de la prueba contabilice tu resultado, tendrás que volver a enviarlo."
+			},
+			"retry": {
+				"button": "Repasando mi viaje",
+				"message": "{organizationName} le invita a realizar de nuevo este test para mejorar su resultado y seguir progresando."
+			},
+			"send-results": "No olvides enviar tus resultados al organizador del curso.",
+			"send-status": {
+				"in-progress": "Envío de"
+			},
+			"send-title": "Envíenos sus resultados",
+			"stage": {
+				"caption": "Detalles de sus resultados en forma de porcentajes y estrellas según las competencias",
+				"masteryPercentage": "{rate, number, ::percent} de éxito",
+				"starsAcquired": "{acquired, plural, =0 {aucune étoile acquise} =1 {# étoile acquise} other {# étoiles acquises}} en {total}",
+				"title": "Competencias"
+			},
+			"title": "RESULTADOS",
+			"trainings": {
+				"description": "Descubra los cursos de formación recomendados para usted, basados en sus resultados, ¡para ayudarle a progresar!",
+				"title": "¿Quiere saber más?"
+			}
+		},
+		"terms-of-service": {
+			"cgu": "Acepto las '<a href=\"https://pix.fr/conditions-generales-d-utilisation\" class=\"link\" target=\"_blank\">'condiciones de uso de Pix'</a>'.",
+			"form": {
+				"button": "Continúo",
+				"error-message": "Debes aceptar las condiciones de uso de Pix."
+			},
+			"message": "Hemos actualizado nuestras condiciones de uso. Por favor, acéptelas para continuar con su experiencia Pix.",
+			"title": "Condiciones de uso"
+		},
+		"timed-challenge-instructions": {
+			"action": "Iniciar la prueba",
+			"primary": "Tendrás '<span class=\"timed-challenge-instructions__time\">'{time}'</span>' para pasar a la siguiente pregunta.",
+			"secondary": "Puede seguir respondiendo después, pero la pregunta no se considerará acertada."
+		},
+		"training": {
+			"editor": "Contenidos de formación propuestos por",
+			"type": {
+				"autoformation": "Cursos de autoformación",
+				"e-learning": "Formación a distancia",
+				"hybrid-training": "Formación híbrida",
+				"in-person-training": "Formación presencial",
+				"modulix": "Módulo Pix (Beta)",
+				"webinaire": "Webinar"
+			}
+		},
+		"tutorial": {
+			"next": "Siguiente",
+			"pages": {
+				"page0": {
+					"explanation": "Si no conoce la respuesta\nprobablemente esté en Internet.",
+					"icon": "icn-investigación.svg",
+					"title": "Puede buscar en Internet..."
+				},
+				"page1": {
+					"explanation": "Si aparece esta imagen, ¡utiliza sólo tus conocimientos!\n No debe utilizar Internet ni su software.",
+					"icon": "icn-enfoque.svg",
+					"title": "... excepto para ciertas preguntas"
+				},
+				"page2": {
+					"explanation": "Tómese el tiempo que necesite para completar el curso.\nSi una pregunta es cronometrada, se indicará.",
+					"icon": "icn-tiempo.svg",
+					"title": "Sin límite de tiempo."
+				},
+				"page3": {
+					"explanation": "Accede a tutoriales para aprender más\nsobre cada pregunta y progresar.",
+					"icon": "icn-tutos.svg",
+					"title": "Tutoriales para aprender"
+				},
+				"page4": {
+					"explanation": "En función de tus respuestas,\nPix adapta la dificultad de las preguntas.",
+					"icon": "icn-algo.svg",
+					"title": "El nivel adecuado de dificultad"
+				}
+			},
+			"pass": "Ignore",
+			"start": "Comenzar mi viaje",
+			"title": "Tutorial de campaña"
+		},
+		"tutorial-panel": {
+			"info": "Estos enlaces a tutoriales han sido sugeridos por usuarios de Pix.",
+			"title": "Para tener éxito la próxima vez"
+		},
+		"update-expired-password": {
+			"button": "Restablecer",
+			"fields": {
+				"error": "Su contraseña debe tener al menos 8 caracteres y contener como mínimo una letra mayúscula, una letra minúscula y un número.",
+				"help": "(mínimo 8 caracteres, incluyendo una mayúscula, una minúscula y un número)",
+				"label": "Contraseña"
+			},
+			"first-title": "Restablecer contraseña",
+			"go-to-login": "Quiero conectar",
+			"subtitle": "Elija una nueva contraseña para continuar",
+			"title": "Cambiar mi contraseña",
+			"validation": "Su contraseña ha sido actualizada."
+		},
+		"user-account": {
+			"account-update-email": {
+				"email-information": "Esta dirección de correo electrónico debe ser válida en caso de que olvide su contraseña.<br>' Esta será su nueva dirección de inicio de sesión.",
+				"fields": {
+					"errors": {
+						"empty-password": "Tu contraseña no puede estar vacía.",
+						"invalid-password": "La contraseña que ha introducido no es válida.",
+						"mismatching-email": "Las dos direcciones de correo electrónico no son idénticas. Por favor, compruebe su entrada.",
+						"new-email-already-exist": "Esta dirección de correo electrónico ya está en uso.",
+						"unknown-error": "Se ha producido un error. Vuelva a intentarlo o póngase en contacto con el servicio de asistencia.",
+						"wrong-email-format": "Su dirección de correo electrónico no es válida."
+					},
+					"new-email": {
+						"label": "Nueva dirección de correo electrónico"
+					},
+					"new-email-confirmation": {
+						"label": "Confirmación de la dirección de correo electrónico"
+					},
+					"password": {
+						"label": "Contraseña"
+					}
+				},
+				"password-information": "Introduzca su contraseña para confirmar",
+				"save-button": "Confirme",
+				"title": "Cambiar la dirección de correo electrónico"
+			},
+			"account-update-email-with-validation": {
+				"fields": {
+					"errors": {
+						"empty-password": "Tu contraseña no puede estar vacía.",
+						"invalid-email": "Su dirección de correo electrónico no es válida.",
+						"invalid-password": "La contraseña que ha introducido no es válida.",
+						"new-email-already-exist": "Esta dirección de correo electrónico ya está en uso."
+					},
+					"new-email": {
+						"label": "Nueva dirección de correo electrónico"
+					},
+					"password": {
+						"label": "Contraseña",
+						"security-information": "La seguridad de su información personal es esencial. Por ello, comprobamos que usted es el autor de esta solicitud. Introduzca su contraseña para recibir un código de verificación."
+					}
+				},
+				"save-button": "Recibir un código de verificación",
+				"title": "Cambiar la dirección de correo electrónico"
+			},
+			"connexion-methods": {
+				"authentication-methods": {
+					"gar": "vía ENT/Mediacentre",
+					"label": "Conexión externa",
+					"via": "vía {identityProviderOrganizationName}"
+				},
+				"edit-button": "Modifique",
+				"email": "Correo electrónico",
+				"menu-link-title": "Mis métodos de conexión",
+				"username": "Identificador"
+			},
+			"email-verification": {
+				"code-explanation-of-use": "Para pasar de un campo a otro, utilice el tabulador o las flechas izquierda y derecha del teclado. Para rellenar un campo, introduzca números del 1 al 9 o utilice las flechas arriba y abajo del teclado.",
+				"code-label": "Campo",
+				"code-legend": "Introduzca el código de verificación enviado por correo electrónico",
+				"confirmation-message": "¡E-mail enviado!",
+				"description": "Introduzca el código de verificación recibido en la dirección de correo electrónico :",
+				"did-not-receive": "No he recibido nada,",
+				"errors": {
+					"email-modification-demand-expired": "Este código ha caducado. Por favor, renueve la solicitud.",
+					"incorrect-code": "El código introducido es incorrecto.",
+					"new-email-already-exist": "Esta dirección de correo electrónico ya está en uso.",
+					"unknown-error": "Se ha producido un error. Vuelva a intentarlo o póngase en contacto con el servicio de asistencia."
+				},
+				"send-back-the-code": "envíeme el código",
+				"title": "Comprobar su dirección de correo electrónico",
+				"update-successful": "Su dirección de correo electrónico ha sido modificada."
+			},
+			"language": {
+				"lang": "Idioma",
+				"menu-link-title": "Elija su idioma",
+				"update-successful": "Tu idioma ha cambiado."
+			},
+			"personal-information": {
+				"first-name": "Nombre",
+				"last-name": "Nombre",
+				"menu-link-title": "Mis datos personales"
+			},
+			"title": "Mi cuenta"
+		},
+		"user-tests": {
+			"title": "Mis trayectorias profesionales"
+		},
+		"user-trainings": {
+			"description": "Siga progresando gracias a los cursos de formación recomendados al final de su evaluación.",
+			"title": "Mis cursos de formación"
+		},
+		"user-tutorials": {
+			"description": "Aprovecha al máximo los tutoriales sugeridos por la comunidad de usuarios de Pix.",
+			"empty-list-info": {
+				"description": {
+					"part1": "A medida que realice sus pruebas, se le recomendarán tutoriales: haga clic en el icono del marcador",
+					"part2": "¡para registrar los que desee encontrar aquí!"
+				},
+				"image-link": "images/ilustraciones/tutoriales-de-usuario/ilustracion-es.svg",
+				"title": "Aún no has registrado nada"
+			},
+			"filter": "Filtro",
+			"label": "tutoriales",
+			"list": {
+				"title": "Mi lista",
+				"tutorial": {
+					"actions": {
+						"evaluate": {
+							"extra-information": "Marcar este tutorial como útil",
+							"label": "Ya no considero útil este tutorial"
+						},
+						"remove": {
+							"label": "Eliminar de mi lista de tutoriales"
+						},
+						"save": {
+							"label": "Añadir a mi lista de tutoriales"
+						}
+					},
+					"source": "Por"
+				}
+			},
+			"recommended": "Recomendado",
+			"recommended-empty": {
+				"description": "Para poder recomendarte tutoriales adaptados a tu nivel, es necesario que inicies una prueba de aptitudes.",
+				"link": "Comienzo",
+				"title": "{firstName}, encuentra aquí tus tutoriales favoritos"
+			},
+			"saved": "Registrado",
+			"saved-empty": {
+				"description": "Debe registrar un tutorial recomendado para que aparezca aquí.",
+				"title": "Aún no tienes ningún tutorial registrado"
+			},
+			"sidebar": {
+				"reset": "Restablecer",
+				"reset-aria-label": "Restablecer y anular la selección de todos los filtros",
+				"see-results": "Ver los resultados"
+			},
+			"title": "Mis tutoriales"
+		}
+	}
+}


### PR DESCRIPTION
## :unicorn: Problème

Il n'existe pas de fichier de traductions pour la langue espagnol sur Pix App et Pix Api.

## :robot: Proposition

Ajouter le fichier de traductions `es.json` sur Pix App et Pix Api avec du contenu traduit par DeepL.

## :rainbow: Remarques

J'ai utilisé l'outil BabelEdit pour faire la traduction automatique vers l'espagnol.

## :100: Pour tester

CI ✅ 
