### PR TITLE
[FEATURE] Change l'ordre de la methode find et ajoute l'organizationId sur la méthode get du organizationLearnersRepository (PIX-12255)

### DIFF
--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
@@ -38,6 +38,7 @@ async function get(organizationLearnerId) {
       'view-active-organization-learners.lastName',
       'view-active-organization-learners.division',
       'view-active-organization-learners.group',
+      'view-active-organization-learners.organizationId',
       'view-active-organization-learners.attributes',
       'view-active-organization-learners.isCertifiable as isCertifiableFromLearner',
       'view-active-organization-learners.certifiableAt as certifiableAtFromLearner',
@@ -58,6 +59,7 @@ async function get(organizationLearnerId) {
       'view-active-organization-learners.lastName',
       'view-active-organization-learners.division',
       'view-active-organization-learners.group',
+      'view-active-organization-learners.organizationId',
       'view-active-organization-learners.attributes',
       'users.id',
       'subquery.isCertifiableFromCampaign',
@@ -77,8 +79,8 @@ async function findPaginatedLearners({ organizationId, page }) {
     .select('id', 'firstName', 'lastName', 'organizationId', 'attributes')
     .from('view-active-organization-learners')
     .where({ isDisabled: false, organizationId })
-    .orderBy('lastName', 'ASC')
-    .orderBy('firstName', 'ASC');
+    .orderBy('firstName', 'ASC')
+    .orderBy('lastName', 'ASC');
 
   const { results, pagination } = await fetchPage(query, page);
 

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -25,12 +25,15 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
           username: 'sassouk',
         });
 
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+
         databaseBuilder.factory.buildOrganizationLearner({
           id: 1233,
           firstName: 'Dark',
           lastName: 'Sasuke',
           division: 'Alone',
           userId,
+          organizationId,
         });
         await databaseBuilder.commit();
 
@@ -41,6 +44,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
         expect(organizationLearner.division).to.equal('Alone');
         expect(organizationLearner.email).to.equal('k.s@example.net');
         expect(organizationLearner.username).to.equal('sassouk');
+        expect(organizationLearner.organizationId).to.equal(organizationId);
       });
 
       it('Should return the organization learner with a given ID', async function () {
@@ -512,18 +516,18 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
       beforeEach(async function () {
         firstLearner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
           organizationId,
-          firstName: 'Gilgamesh',
-          lastName: 'Toto',
+          lastName: 'Gilgamesh',
+          firstName: 'Toto',
           attributes: { classe: 'Warlock' },
         });
         await databaseBuilder.commit();
       });
 
-      it('orders by lastName', async function () {
+      it('orders by firstName', async function () {
         const secondLearner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
           organizationId,
-          lastName: 'Tata',
-          firstName: 'Gilgamesh',
+          firstName: 'Tata',
+          lastName: 'Gilgamesh',
         });
 
         await databaseBuilder.commit();
@@ -534,11 +538,11 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
         expect(result.learners[0].id).to.equal(secondLearner.id);
         expect(result.learners[1].id).to.equal(firstLearner.id);
       });
-      it('orders by firstName when lastName are identical', async function () {
+      it('orders by lastName when firstName are identical', async function () {
         const secondLearner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
           organizationId,
-          lastName: 'Toto',
-          firstName: 'Zoro',
+          firstName: 'Toto',
+          lastName: 'Aubert',
         });
 
         await databaseBuilder.commit();
@@ -546,8 +550,8 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
         const result = await organizationLearnerRepository.findPaginatedLearners({ organizationId });
 
         expect(result.learners).lengthOf(2);
-        expect(result.learners[0].id).to.equal(firstLearner.id);
-        expect(result.learners[1].id).to.equal(secondLearner.id);
+        expect(result.learners[0].id).to.equal(secondLearner.id);
+        expect(result.learners[1].id).to.equal(firstLearner.id);
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème

Pix1D a besoin de l'organizationId sur le détail d'un prescrit et ils trient par le prénom dans leur affichage en liste.

## :robot: Proposition

Changer le tri par défaut sur la méthode find.
Ajouter l'organizationId dans le détail d'un prescrit.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
Les tests sont verts ✅ 
