### PR TITLE
[FEATURE] Permettre l'import de fichier ONDE (Pix-12248)

### DIFF
--- a/api/src/prescription/learner-management/application/organization-import-controller.js
+++ b/api/src/prescription/learner-management/application/organization-import-controller.js
@@ -2,7 +2,7 @@ import { usecases } from '../domain/usecases/index.js';
 import * as organizationImportDetailSerializer from '../infrastructure/serializers/jsonapi/organization-import-detail-serializer.js';
 
 const getOrganizationImportStatus = async function (request, h, dependencies = { organizationImportDetailSerializer }) {
-  const organizationId = request.params.id;
+  const { organizationId } = request.params;
   const organizationImportDetail = await usecases.getOrganizationImportStatus({
     organizationId,
   });

--- a/api/src/prescription/learner-management/application/organization-import-route.js
+++ b/api/src/prescription/learner-management/application/organization-import-route.js
@@ -1,6 +1,7 @@
 import Joi from 'joi';
 
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
+import { ORGANIZATION_FEATURE } from '../../../shared/domain/constants.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { organizationImportController } from './organization-import-controller.js';
 
@@ -16,6 +17,10 @@ const register = async (server) => {
               securityPreHandlers.hasAtLeastOneAccessOf([
                 securityPreHandlers.checkUserIsAdminInSCOOrganizationManagingStudents,
                 securityPreHandlers.checkUserIsAdminInSUPOrganizationManagingStudents,
+                securityPreHandlers.validateAllAccess([
+                  securityPreHandlers.makeCheckOrganizationHasFeature(ORGANIZATION_FEATURE.LEARNER_IMPORT.key),
+                  securityPreHandlers.checkUserIsAdminInOrganization,
+                ]),
               ])(request, h),
             assign: 'isAdminInOrganizationManagingStudents',
           },

--- a/api/src/prescription/learner-management/application/organization-import-route.js
+++ b/api/src/prescription/learner-management/application/organization-import-route.js
@@ -8,7 +8,7 @@ const register = async (server) => {
   server.route([
     {
       method: 'GET',
-      path: '/api/organizations/{id}/import-information',
+      path: '/api/organizations/{organizationId}/import-information',
       config: {
         pre: [
           {
@@ -22,7 +22,7 @@ const register = async (server) => {
         ],
         validate: {
           params: Joi.object({
-            id: identifiersType.organizationId,
+            organizationId: identifiersType.organizationId,
           }),
         },
         handler: organizationImportController.getOrganizationImportStatus,

--- a/api/src/shared/application/security-pre-handlers.js
+++ b/api/src/shared/application/security-pre-handlers.js
@@ -623,6 +623,14 @@ function hasAtLeastOneAccessOf(securityChecks) {
   };
 }
 
+function validateAllAccess(securityChecks) {
+  return async (request, h) => {
+    const responses = await bluebird.map(securityChecks, (securityCheck) => securityCheck(request, h));
+    const hasAccess = responses.every((response) => !response.source?.errors);
+    return hasAccess ? hasAccess : _replyForbiddenError(h);
+  };
+}
+
 async function checkPix1dActivated(request, h, dependencies = { checkPix1dEnabled }) {
   const isPix1dEnabled = await dependencies.checkPix1dEnabled.execute();
 
@@ -703,6 +711,7 @@ function _noOrganizationFound(error) {
 
 const securityPreHandlers = {
   hasAtLeastOneAccessOf,
+  validateAllAccess,
   checkAdminMemberHasRoleCertif,
   checkAdminMemberHasRoleMetier,
   checkAdminMemberHasRoleSuperAdmin,

--- a/api/src/shared/application/security-pre-handlers.js
+++ b/api/src/shared/application/security-pre-handlers.js
@@ -478,7 +478,7 @@ async function checkUserIsAdminInSCOOrganizationManagingStudents(
   dependencies = { checkUserIsAdminAndManagingStudentsForOrganization },
 ) {
   const userId = request.auth.credentials.userId;
-  const organizationId = request.params.id;
+  const organizationId = request.params.organizationId || request.params.id;
 
   if (
     await dependencies.checkUserIsAdminAndManagingStudentsForOrganization.execute(
@@ -498,7 +498,7 @@ async function checkUserIsAdminInSUPOrganizationManagingStudents(
   dependencies = { checkUserIsAdminAndManagingStudentsForOrganization },
 ) {
   const userId = request.auth.credentials.userId;
-  const organizationId = request.params.id;
+  const organizationId = request.params.organizationId || request.params.id;
 
   if (
     await dependencies.checkUserIsAdminAndManagingStudentsForOrganization.execute(

--- a/api/tests/acceptance/application/security-pre-handlers_test.js
+++ b/api/tests/acceptance/application/security-pre-handlers_test.js
@@ -182,7 +182,7 @@ describe('Acceptance | Application | SecurityPreHandlers', function () {
     beforeEach(async function () {
       server.route({
         method: 'GET',
-        path: '/test_route/{id}',
+        path: '/test_route/{organizationId}',
         handler: (r, h) => h.response({}).code(200),
         config: {
           pre: [
@@ -239,7 +239,7 @@ describe('Acceptance | Application | SecurityPreHandlers', function () {
     beforeEach(async function () {
       server.route({
         method: 'GET',
-        path: '/test_route/{id}',
+        path: '/test_route/{organizationId}',
         handler: (r, h) => h.response({}).code(200),
         config: {
           pre: [

--- a/api/tests/prescription/learner-management/acceptance/application/organization-import-route_test.js
+++ b/api/tests/prescription/learner-management/acceptance/application/organization-import-route_test.js
@@ -1,4 +1,5 @@
 import { Membership } from '../../../../../lib/domain/models/Membership.js';
+import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
 import { CsvImportError } from '../../../../../src/shared/domain/errors.js';
 import {
   createServer,
@@ -59,6 +60,44 @@ describe('Acceptance | Application | organization-import', function () {
       // given
       const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
 
+      databaseBuilder.factory.buildMembership({
+        organizationId: organization.id,
+        userId: connectedUser.id,
+        organizationRole: Membership.roles.ADMIN,
+      });
+
+      databaseBuilder.factory.buildOrganizationImport({
+        organizationId: organization.id,
+        createdBy: connectedUser.id,
+        errors: JSON.stringify([]),
+      });
+
+      await databaseBuilder.commit();
+
+      options = {
+        method: 'GET',
+        url: `/api/organizations/${organization.id}/import-information`,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(connectedUser.id),
+        },
+      };
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should return the last organization import status for an organization with learnerImport feature with no error', async function () {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization({ type: 'PRO' });
+      const featureId = databaseBuilder.factory.buildFeature({
+        key: ORGANIZATION_FEATURE.LEARNER_IMPORT.key,
+      }).id;
+      databaseBuilder.factory.buildOrganizationFeature({
+        organizationId: organization.id,
+        featureId,
+      });
       databaseBuilder.factory.buildMembership({
         organizationId: organization.id,
         userId: connectedUser.id,

--- a/api/tests/prescription/learner-management/unit/application/organization-import-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/organization-import-controller_test.js
@@ -6,7 +6,7 @@ describe('Unit | Application | Learner Management | organization-import-controll
   let dependencies, serializeStub, usecaseResultSymbol;
   const organizationId = 123;
   const request = {
-    params: { id: organizationId },
+    params: { organizationId },
   };
 
   beforeEach(function () {

--- a/api/tests/prescription/learner-management/unit/application/organization-import-route_test.js
+++ b/api/tests/prescription/learner-management/unit/application/organization-import-route_test.js
@@ -1,12 +1,35 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
 import { organizationImportController } from '../../../../../src/prescription/learner-management/application/organization-import-controller.js';
 import * as moduleUnderTest from '../../../../../src/prescription/learner-management/application/organization-import-route.js';
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
+import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Router | organization-import-router', function () {
+  let checkOrganizationHasLearnerImportFeature, respondWithError;
+
   beforeEach(function () {
     sinon.stub(securityPreHandlers, 'checkUserIsAdminInSUPOrganizationManagingStudents');
     sinon.stub(securityPreHandlers, 'checkUserIsAdminInSCOOrganizationManagingStudents');
+    sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization');
+    checkOrganizationHasLearnerImportFeature = sinon.stub();
+    sinon
+      .stub(securityPreHandlers, 'makeCheckOrganizationHasFeature')
+      .withArgs(ORGANIZATION_FEATURE.LEARNER_IMPORT.key)
+      .returns(checkOrganizationHasLearnerImportFeature);
+
+    respondWithError = (_, h) =>
+      h
+        .response(
+          new jsonapiSerializer.Error({
+            code: 403,
+            title: 'Forbidden access',
+            detail: 'Missing or insufficient permissions.',
+          }),
+        )
+        .code(403)
+        .takeover();
   });
 
   describe('GET /api/organizations/{organizationId}/import-information', function () {
@@ -34,14 +57,15 @@ describe('Unit | Router | organization-import-router', function () {
           const url = '/api/organizations/1/import-information';
           const payload = {};
 
-          securityPreHandlers.checkUserIsAdminInSCOOrganizationManagingStudents.callsFake((request, h) =>
-            h.response().code(403).takeover(),
-          );
           securityPreHandlers.checkUserIsAdminInSUPOrganizationManagingStudents.resolves(true);
+          securityPreHandlers.checkUserIsAdminInSCOOrganizationManagingStudents.callsFake(respondWithError);
+          securityPreHandlers.checkUserIsAdminInOrganization.resolves(true);
+          checkOrganizationHasLearnerImportFeature.callsFake(respondWithError);
 
           sinon
             .stub(organizationImportController, 'getOrganizationImportStatus')
-            .callsFake((request, h) => h.response('ok').code(200));
+            .callsFake((_, h) => h.response('ok').code(200));
+
           const httpTestServer = new HttpTestServer();
           await httpTestServer.register(moduleUnderTest);
 
@@ -63,14 +87,15 @@ describe('Unit | Router | organization-import-router', function () {
           const url = '/api/organizations/1/import-information';
           const payload = {};
 
-          securityPreHandlers.checkUserIsAdminInSUPOrganizationManagingStudents.callsFake((request, h) =>
-            h.response().code(403).takeover(),
-          );
           securityPreHandlers.checkUserIsAdminInSCOOrganizationManagingStudents.resolves(true);
+          securityPreHandlers.checkUserIsAdminInSUPOrganizationManagingStudents.callsFake(respondWithError);
+          securityPreHandlers.checkUserIsAdminInOrganization.resolves(true);
+          checkOrganizationHasLearnerImportFeature.callsFake(respondWithError);
 
           sinon
             .stub(organizationImportController, 'getOrganizationImportStatus')
-            .callsFake((request, h) => h.response('ok').code(200));
+            .callsFake((_, h) => h.response('ok').code(200));
+
           const httpTestServer = new HttpTestServer();
           await httpTestServer.register(moduleUnderTest);
 
@@ -83,20 +108,76 @@ describe('Unit | Router | organization-import-router', function () {
         });
       },
     );
-  });
-  context('when the user is not admin for the SUP organization nor SCO organizations', function () {
-    it('responds 403', async function () {
-      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf');
-      securityPreHandlers.hasAtLeastOneAccessOf.returns((request, h) => h.response().code(403).takeover());
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
+    context('when the organization has learner import feature', function () {
+      context('when user is admin of the organization', function () {
+        it('responds 200', async function () {
+          // given
+          const method = 'GET';
+          const url = '/api/organizations/1/import-information';
+          const payload = {};
 
-      const method = 'GET';
-      const url = '/api/organizations/1/import-information';
+          checkOrganizationHasLearnerImportFeature.resolves(true);
+          securityPreHandlers.checkUserIsAdminInOrganization.resolves(true);
+          securityPreHandlers.checkUserIsAdminInSUPOrganizationManagingStudents.callsFake(respondWithError);
+          securityPreHandlers.checkUserIsAdminInSCOOrganizationManagingStudents.callsFake(respondWithError);
 
-      const response = await httpTestServer.request(method, url);
+          sinon
+            .stub(organizationImportController, 'getOrganizationImportStatus')
+            .callsFake((_, h) => h.response('ok').code(200));
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
 
-      expect(response.statusCode).to.equal(403);
+          // when
+          const response = await httpTestServer.request(method, url, payload);
+
+          // then
+          expect(organizationImportController.getOrganizationImportStatus).to.have.been.calledOnce;
+          expect(response.statusCode).to.equal(200);
+        });
+      });
+      context('when user is not admin of the organization', function () {
+        it('responds 403', async function () {
+          // given
+          const method = 'GET';
+          const url = '/api/organizations/1/import-information';
+          const payload = {};
+
+          checkOrganizationHasLearnerImportFeature.resolves(true);
+          securityPreHandlers.checkUserIsAdminInOrganization.callsFake(respondWithError);
+          securityPreHandlers.checkUserIsAdminInSUPOrganizationManagingStudents.callsFake(respondWithError);
+          securityPreHandlers.checkUserIsAdminInSCOOrganizationManagingStudents.callsFake(respondWithError);
+
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          // when
+          const response = await httpTestServer.request(method, url, payload);
+
+          // then
+          expect(response.statusCode).to.equal(403);
+        });
+      });
     });
   });
+  context(
+    'when the user is not admin for the SUP organization nor SCO organizations nor has learner import feature',
+    function () {
+      it('responds 403', async function () {
+        checkOrganizationHasLearnerImportFeature.callsFake(respondWithError);
+        securityPreHandlers.checkUserIsAdminInOrganization.callsFake(respondWithError);
+        securityPreHandlers.checkUserIsAdminInSUPOrganizationManagingStudents.callsFake(respondWithError);
+        securityPreHandlers.checkUserIsAdminInSCOOrganizationManagingStudents.callsFake(respondWithError);
+
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const method = 'GET';
+        const url = '/api/organizations/1/import-information';
+
+        const response = await httpTestServer.request(method, url);
+
+        expect(response.statusCode).to.equal(403);
+      });
+    },
+  );
 });

--- a/orga/app/adapters/students-import.js
+++ b/orga/app/adapters/students-import.js
@@ -21,4 +21,11 @@ export default class StudentImportsAdapter extends ApplicationAdapter {
     const url = `${this.host}/${this.namespace}/organizations/${organizationId}/sco-organization-learners/import-siecle?format=${format}`;
     return this.ajax(url, 'POST', { data: files[0] });
   }
+
+  importOrganizationLearners(organizationId, files) {
+    if (!files || files.length === 0) return;
+
+    const url = `${this.host}/${this.namespace}/organizations/${organizationId}/import-organization-learners`;
+    return this.ajax(url, 'POST', { data: files[0] });
+  }
 }

--- a/orga/app/components/import.hbs
+++ b/orga/app/components/import.hbs
@@ -34,6 +34,12 @@
           @supportedFormats={{this.supportedFormats}}
           @disabled={{this.inProgress}}
         />
+      {{else if this.currentUser.hasLearnerImportFeature}}
+        <ScoOrganizationParticipant::Add
+          @importHandler={{@onImportLearners}}
+          @supportedFormats={{this.supportedFormats}}
+          @disabled={{this.inProgress}}
+        />
       {{/if}}
     </div>
   {{/unless}}

--- a/orga/app/components/import.js
+++ b/orga/app/components/import.js
@@ -52,6 +52,14 @@ export default class Import extends Component {
       return ['.csv'];
     } else if (this.currentUser.isSCOManagingStudents) {
       return ['.xml', '.zip'];
+    } else if (this.currentUser.hasLearnerImportFeature) {
+      /**
+       * On choisi de renvoyer une valeur en dur ('.csv') dans le cas de la feature d'import
+       * afin de pouvoir avancer sur l'import ONDE. Cela est temporaire. par la suite
+       * il faudra récupérer la valeur depuis le champ `fileType` de la table `organization-learner-import-formats`
+       * en passant par un endpoint API
+       */
+      return ['.csv'];
     } else return [];
   }
 
@@ -67,6 +75,15 @@ export default class Import extends Component {
         title: 'pages.organization-participants-import.sup.title',
         'error-wrapper': 'pages.organization-participants-import.sup.error-wrapper',
         'global-error': 'pages.organization-participants-import.sup.title.global-error',
+      };
+    } else if (this.currentUser.hasLearnerImportFeature) {
+      // ici aussi on gére les traductions en dur pour les imports à format
+      // en se basant sur les besoins de l'import onde.
+      // à modifier pour avoir des traduction spécifiques
+      return {
+        title: 'pages.organization-participants-import.sco.title',
+        'error-wrapper': 'pages.organization-participants-import.sco.error-wrapper',
+        'global-error': 'pages.organization-participants-import.sco.title.global-error',
       };
     } else {
       return {};

--- a/orga/app/controllers/authenticated/import-organization-participants.js
+++ b/orga/app/controllers/authenticated/import-organization-participants.js
@@ -72,6 +72,21 @@ export default class ImportController extends Controller {
     }
   }
 
+  @action
+  async importOrganizationLearners(files) {
+    this._initializeUpload;
+
+    const adapter = this.store.adapterFor('students-import');
+    const organizationId = this.currentUser.organization.id;
+
+    try {
+      await adapter.importOrganizationLearners(organizationId, files);
+    } finally {
+      this.send('refreshModel');
+      this.isLoading = false;
+    }
+  }
+
   _initializeUpload() {
     if (this.isLoading) return;
 

--- a/orga/app/models/prescriber.js
+++ b/orga/app/models/prescriber.js
@@ -17,6 +17,7 @@ export default class Prescriber extends Model {
       COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY: 'COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY',
       PLACES_MANAGEMENT: 'PLACES_MANAGEMENT',
       MISSIONS_MANAGEMENT: 'MISSIONS_MANAGEMENT',
+      LEARNER_IMPORT: 'LEARNER_IMPORT',
     };
   }
   get fullName() {
@@ -50,6 +51,10 @@ export default class Prescriber extends Model {
         membership.get('organizationRole') === 'ADMIN' &&
         membership.get('organization').get('id') === this.userOrgaSettings.get('organization').get('id'),
     );
+  }
+
+  get hasOrganizationLearnerImport() {
+    return this.features[Prescriber.featureList.LEARNER_IMPORT];
   }
 
   get hasParticipants() {

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -58,7 +58,10 @@ export default class CurrentUserService extends Service {
   }
 
   get shouldAccessImportPage() {
-    return Boolean((this.isSCOManagingStudents || this.isSUPManagingStudents) && this.isAdminInOrganization);
+    return Boolean(
+      (this.isSCOManagingStudents || this.isSUPManagingStudents || this.hasLearnerImportFeature) &&
+        this.isAdminInOrganization,
+    );
   }
 
   get shouldAccessPlacesPage() {
@@ -72,5 +75,8 @@ export default class CurrentUserService extends Service {
   }
   get shouldAccessParticipantsPage() {
     return !this.prescriber.missionsManagement;
+  }
+  get hasLearnerImportFeature() {
+    return this.prescriber.hasOrganizationLearnerImport;
   }
 }

--- a/orga/app/templates/authenticated/import-organization-participants.hbs
+++ b/orga/app/templates/authenticated/import-organization-participants.hbs
@@ -8,6 +8,7 @@
   @onImportScoStudents={{this.importScoStudents}}
   @onImportSupStudents={{this.importSupStudents}}
   @onReplaceStudents={{this.replaceStudents}}
+  @onImportLearners={{this.importOrganizationLearners}}
   @isLoading={{this.isLoading}}
   @organizationImportDetail={{@model}}
 />

--- a/orga/tests/integration/components/import_test.js
+++ b/orga/tests/integration/components/import_test.js
@@ -15,6 +15,7 @@ module('Integration | Component | Import', function (hooks) {
     this.set('onImportSupStudents', sinon.stub());
     this.set('onImportScoStudents', sinon.stub());
     this.set('onReplaceStudents', sinon.stub());
+    this.set('onImportLearners', sinon.stub());
   });
 
   module('when import is in progress', function (hooks) {
@@ -392,6 +393,29 @@ module('Integration | Component | Import', function (hooks) {
           this.intl.t('pages.organization-participants-import.supported-formats', { types: '.csv' }),
         ),
       );
+    });
+  });
+
+  module('when user has import feature', function (hooks) {
+    class CurrentUserStub extends Service {
+      isAdminInOrganization = true;
+      hasLearnerImportFeature = true;
+    }
+
+    hooks.beforeEach(function () {
+      this.owner.register('service:current-user', CurrentUserStub);
+    });
+
+    test('it trigger the importOrganizationLearners spy when clicking import button', async function (assert) {
+      const screen = await render(
+        hbs`<Import @onImportLearners={{this.onImportLearners}} @isLoading={{false}} @organizatioImport={{null}} />`,
+      );
+
+      const file = new Blob(['foo'], { type: 'valid-file' });
+      const input = screen.getByLabelText(this.intl.t('pages.organization-participants-import.actions.add-sco.label'));
+
+      await triggerEvent(input, 'change', { files: [file] });
+      assert.ok(this.onImportLearners.calledWithExactly([file]));
     });
   });
 });

--- a/orga/tests/unit/adapters/students-import_test.js
+++ b/orga/tests/unit/adapters/students-import_test.js
@@ -55,4 +55,32 @@ module('Unit | Adapters | Students import', function (hooks) {
       );
     });
   });
+
+  module('#importOrganizationLearners', function () {
+    test('it should not call api endpoint if no files are provided', async function (assert) {
+      // when
+      const organizationId = 1;
+      await adapter.importOrganizationLearners(organizationId, []);
+
+      //then
+      assert.ok(adapter.ajax.notCalled);
+    });
+
+    test('it should call api endpoint url corresponding to learner import', async function (assert) {
+      // given
+      const files = [Symbol('file')];
+      // when
+      const organizationId = 1;
+      await adapter.importOrganizationLearners(organizationId, files);
+
+      //then
+      assert.ok(
+        adapter.ajax.calledWithExactly(
+          `http://localhost:3000/api/organizations/${organizationId}/import-organization-learners`,
+          'POST',
+          { data: files[0] },
+        ),
+      );
+    });
+  });
 });

--- a/orga/tests/unit/components/import_test.js
+++ b/orga/tests/unit/components/import_test.js
@@ -158,11 +158,55 @@ module('Unit | Component | import', (hooks) => {
       assert.deepEqual(component.supportedFormats, ['.csv']);
     });
 
+    test('should return .csv when organization hasLearnerImportFeature', function (assert) {
+      // when
+      component.currentUser = { hasLearnerImportFeature: true };
+      // then
+      assert.deepEqual(component.supportedFormats, ['.csv']);
+    });
+
     test('should return .xml .zip when organization isManagingStudent SCO', function (assert) {
       // when
       component.currentUser = { isSCOManagingStudents: true, isAgriculture: false };
       // then
       assert.deepEqual(component.supportedFormats, ['.xml', '.zip']);
+    });
+  });
+
+  module('get#textsByOrganizationType', () => {
+    test('should return correct traduction key when organization isManagingStudent SCO', function (assert) {
+      // when
+      component.currentUser = { isSCOManagingStudents: true };
+      // then
+      assert.deepEqual(component.textsByOrganizationType, {
+        'error-wrapper': 'pages.organization-participants-import.sco.error-wrapper',
+        'global-error': 'pages.organization-participants-import.sco.title.global-error',
+        title: 'pages.organization-participants-import.sco.title',
+      });
+    });
+    test('should return correct traduction key when organization isManagingStudent SUP', function (assert) {
+      // when
+      component.currentUser = { isSUPManagingStudents: true };
+      // then
+      assert.deepEqual(component.textsByOrganizationType, {
+        'error-wrapper': 'pages.organization-participants-import.sup.error-wrapper',
+        'global-error': 'pages.organization-participants-import.sup.title.global-error',
+        title: 'pages.organization-participants-import.sup.title',
+      });
+    });
+    test('should return correct traduction key when organization hasLearnerImportFeature', function (assert) {
+      // when
+      component.currentUser = { hasLearnerImportFeature: true };
+      // then
+      assert.deepEqual(component.textsByOrganizationType, {
+        'error-wrapper': 'pages.organization-participants-import.sco.error-wrapper',
+        'global-error': 'pages.organization-participants-import.sco.title.global-error',
+        title: 'pages.organization-participants-import.sco.title',
+      });
+    });
+    test('should return an empty object by default', (assert) => {
+      component.currentUser = {};
+      assert.deepEqual(component.textsByOrganizationType, {});
     });
   });
 });

--- a/orga/tests/unit/controllers/authenticated/import-organization-participants_test.js
+++ b/orga/tests/unit/controllers/authenticated/import-organization-participants_test.js
@@ -11,6 +11,7 @@ module('Unit | Controller | authenticated/import-organization-participant', func
   let addStudentsCsvStub;
   let replaceStudentsCsvStub;
   let importScoStudentStub;
+  let importLearnersStub;
   let currentUser;
 
   hooks.beforeEach(function () {
@@ -24,6 +25,7 @@ module('Unit | Controller | authenticated/import-organization-participant', func
     addStudentsCsvStub = sinon.stub(adapter, 'addStudentsCsv');
     replaceStudentsCsvStub = sinon.stub(adapter, 'replaceStudentsCsv');
     importScoStudentStub = sinon.stub(adapter, 'importStudentsSiecle');
+    importLearnersStub = sinon.stub(adapter, 'importOrganizationLearners');
   });
 
   module('#importSupStudents', function () {
@@ -94,6 +96,19 @@ module('Unit | Controller | authenticated/import-organization-participant', func
       });
     });
   });
+
+  module('#importOrganizationLearners', function () {
+    test('it sends the chosen file to the API', async function (assert) {
+      await controller.importOrganizationLearners(files);
+      assert.ok(importLearnersStub.calledWith(currentUser.organization.id, files));
+    });
+
+    test('should refresh the model', async (assert) => {
+      await controller.importOrganizationLearners(files);
+      assert.ok(controller.send.calledWithExactly('refreshModel'));
+    });
+  });
+
   module('#participantListRoute', function () {
     test('it returns sco participant route if currentUser is SCO managing', async function (assert) {
       controller.currentUser.isSCOManagingStudents = true;

--- a/orga/tests/unit/models/prescriber_test.js
+++ b/orga/tests/unit/models/prescriber_test.js
@@ -189,4 +189,34 @@ module('Unit | Model | prescriber', function (hooks) {
       assert.false(missionsManagement);
     });
   });
+
+  module('#hasOrganizationLearnerImport', function () {
+    test('it return true when feature is enabled', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const model = store.createRecord('prescriber', {
+        features: { ['LEARNER_IMPORT']: true },
+      });
+
+      // when
+      const { hasOrganizationLearnerImport } = model;
+
+      // then
+      assert.true(hasOrganizationLearnerImport);
+    });
+
+    test('it return false when feature is disabled', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const model = store.createRecord('prescriber', {
+        features: { ['LEARNER_IMPORT']: false },
+      });
+
+      // when
+      const { hasOrganizationLearnerImport } = model;
+
+      // then
+      assert.false(hasOrganizationLearnerImport);
+    });
+  });
 });

--- a/orga/tests/unit/services/current-user_test.js
+++ b/orga/tests/unit/services/current-user_test.js
@@ -334,7 +334,11 @@ module('Unit | Service | current-user', function (hooks) {
       });
     });
 
-    module('#shouldAccessImportPage', function () {
+    module('#shouldAccessImportPage', function (hooks) {
+      hooks.beforeEach(function () {
+        currentUserService.prescriber = { hasOrganizationLearnerImport: false };
+      });
+
       module('when is admin of the organization', function () {
         test('should return false if organization is not sco managing student', function (assert) {
           currentUserService.isAdminInOrganization = true;
@@ -360,6 +364,13 @@ module('Unit | Service | current-user', function (hooks) {
         test('should return true if organization is sup managing student', function (assert) {
           currentUserService.isAdminInOrganization = true;
           currentUserService.isSUPManagingStudents = true;
+
+          assert.true(currentUserService.shouldAccessImportPage);
+        });
+
+        test('should return true if user can use import learner feature', function (assert) {
+          currentUserService.isAdminInOrganization = true;
+          currentUserService.prescriber = { hasOrganizationLearnerImport: true };
 
           assert.true(currentUserService.shouldAccessImportPage);
         });
@@ -393,6 +404,30 @@ module('Unit | Service | current-user', function (hooks) {
 
           assert.false(currentUserService.shouldAccessImportPage);
         });
+
+        test('should return false if user can use import learner feature', function (assert) {
+          currentUserService.isAdminInOrganization = false;
+          currentUserService.prescriber = { hasOrganizationLearnerImport: true };
+
+          assert.false(currentUserService.shouldAccessImportPage);
+        });
+      });
+    });
+    module('#hasLearnerImportFeature', function () {
+      test('should return true if user has learnerImport feature activated', function (assert) {
+        currentUserService.prescriber = {
+          hasOrganizationLearnerImport: true,
+        };
+
+        assert.true(currentUserService.hasLearnerImportFeature);
+      });
+
+      test('should return false if user does not have learnerImport feature activated', function (assert) {
+        currentUserService.prescriber = {
+          hasOrganizationLearnerImport: false,
+        };
+
+        assert.false(currentUserService.hasLearnerImportFeature);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on est une orga pix-junior, on peut pas réaliser d'import onde depuis pix-orga

## :robot: Proposition
Permettre l'import de fichier onde depuis pix-orga

## :rainbow: Remarques
Le security préhandler qui teste l'activation de la feature sur une organization n'étant pas suffisant, on rajoute un nouveau security check pour faire un ET logique sur le `role=admin` de l'utilisateur et l'activation de la feature

## :100: Pour tester
- Se connecter avec 1d-orga@example.net
- Se rendre sur la page `import-participant`
- Importer un fichier
- Se connecter sur pix-junior
- Valider que la liste des personnes de la classe correspond aux personnes importées
