### PR TITLE
[BUGFIX] Sur Pix Junior, afficher la mission comme terminée quand l'utilisateur l'a déjà terminée (PIX-12276).

### DIFF
--- a/1d/app/pods/assessment/resume/unit_test.js
+++ b/1d/app/pods/assessment/resume/unit_test.js
@@ -10,7 +10,7 @@ module('Unit | Route | AssessmentResumeRoute', function (hooks) {
     module('When there is an other challenge', function () {
       test('should call the assessment challenge route', function (assert) {
         const route = this.owner.lookup('route:assessment.resume');
-        const assessment = { id: 2, missionId: 'pix1dMission' };
+        const assessment = { id: '2', missionId: '1' };
         const transition = { to: { queryParams: { assessmentHasNoMoreQuestions: 'false' } } };
         sinon.stub(route.router, 'replaceWith');
 
@@ -23,7 +23,7 @@ module('Unit | Route | AssessmentResumeRoute', function (hooks) {
     module('When there is no more challenges', function () {
       test('should redirect to assessment result route', async function (assert) {
         const route = this.owner.lookup('route:assessment.resume');
-        const assessment = { id: 2, missionId: 'pix1dMission', save: sinon.stub() };
+        const assessment = { id: '2', missionId: '1', save: sinon.stub() };
         const transition = { to: { queryParams: { assessmentHasNoMoreQuestions: 'true' } } };
         sinon.stub(route.router, 'replaceWith');
 

--- a/1d/mirage/config.js
+++ b/1d/mirage/config.js
@@ -83,6 +83,6 @@ function routes() {
   this.get('/organization-learners/:id', (schema, request) => {
     const learner = schema.organizationLearners.find(request.params.id);
     if (learner) return learner;
-    return schema.create('organization-learner', { completedMissionIds: ['recExjO7RHeDI48HK'] });
+    return schema.create('organization-learner', { completedMissionIds: [] });
   });
 }

--- a/api/src/school/infrastructure/serializers/organization-learner.js
+++ b/api/src/school/infrastructure/serializers/organization-learner.js
@@ -3,6 +3,12 @@ import { Serializer } from 'jsonapi-serializer';
 const serialize = function (organizationLearner) {
   return new Serializer('organizationLearner', {
     attributes: ['firstName', 'displayName', 'division', 'organizationId', 'completedMissionIds'],
+    transform: function (organizationLearner) {
+      return {
+        ...organizationLearner,
+        completedMissionIds: organizationLearner.completedMissionIds.map((id) => id.toString()),
+      };
+    },
   }).serialize(organizationLearner);
 };
 

--- a/api/tests/school/unit/infrastructure/serializers/organization-learner_test.js
+++ b/api/tests/school/unit/infrastructure/serializers/organization-learner_test.js
@@ -1,0 +1,37 @@
+import { OrganizationLearner } from '../../../../../src/school/domain/models/OrganizationLearner.js';
+import * as serializer from '../../../../../src/school/infrastructure/serializers/organization-learner.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Serializer | JSONAPI | organization-learner', function () {
+  describe('#serialize', function () {
+    it('should convert an OrganizationLearner model object into JSON API data', function () {
+      const organizationLearner = new OrganizationLearner({
+        id: 123,
+        organizationId: 'orga-1',
+        firstName: 'Jean',
+        lastName: 'Miche',
+        division: 'CM3',
+        completedMissionIds: [1],
+      });
+
+      const expectedJSON = {
+        data: {
+          type: 'organizationLearners',
+          id: '123',
+          attributes: {
+            'first-name': 'Jean',
+            division: 'CM3',
+            'organization-id': 'orga-1',
+            'completed-mission-ids': ['1'],
+          },
+        },
+      };
+
+      // when
+      const json = serializer.serialize(organizationLearner);
+
+      // then
+      expect(json).to.deep.equal(expectedJSON);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Lors du retour sur l'écran de choix de mission, les missions terminées ne sont plus identifiées en tant que tel.
Après analyse, c'est à cause du passage du `missionId` en number qui ne permet plus de comparaison avec la propriété `completedMissionIds`.

## :robot: Proposition

Le missionId côté front, bien que stocker en number, est un string.
La sérialisation côté API le transforme en string.
En déroulant la pelote de laine, il s'agit en fait de la specification JSONAPI :
https://jsonapi.org/format/#document-resource-object-identification

Tous les identifiants de resource doivent donc être des strings.
Pour corriger le soucis, on sérialise `completedMissionIds` comme un tableau de string.

## :rainbow: Remarques

On en profite pour changer des missions id dans certains tests pour utiliser des number plutôt que des strings.

## :100: Pour tester

Se connecter à Pix Junior.
Faire une mission jusqu'à l'écran de résumé.
Retourner sur l'écran de sélection de mission.
Vérifier que l'écran affiche la carte de la mission en statut `terminée`.
