### PR TITLE
[FEATURE] Gérer la langue espagnol lors de l'envoi de certains e-mails (PIX-12194)

### DIFF
--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -5,10 +5,11 @@ import { tokenService } from '../../../src/shared/domain/services/token-service.
 import { mailer } from '../../../src/shared/mail/infrastructure/services/mailer.js';
 import enTranslations from '../../../translations/en.json' assert { type: 'json' };
 import frTranslations from '../../../translations/fr.json' assert { type: 'json' };
+import { es as esTranslations } from '../../../translations/index.js';
 import nlTranslations from '../../../translations/nl.json' assert { type: 'json' };
 import { config } from '../../config.js';
 
-const { ENGLISH_SPOKEN, FRENCH_FRANCE, FRENCH_SPOKEN, DUTCH_SPOKEN } = LOCALE;
+const { ENGLISH_SPOKEN, FRENCH_FRANCE, FRENCH_SPOKEN, DUTCH_SPOKEN, SPANISH_SPOKEN } = LOCALE;
 
 const EMAIL_ADDRESS_NO_RESPONSE = 'ne-pas-repondre@pix.fr';
 const PIX_ORGA_NAME_FR = 'Pix Orga - Ne pas répondre';
@@ -70,6 +71,17 @@ function sendAccountCreationEmail(email, locale, redirectionUrl) {
 
     pixName = nlTranslations['email-sender-name']['pix-app'];
     accountCreationEmailSubject = nlTranslations['pix-account-creation-email'].subject;
+  } else if (locale === SPANISH_SPOKEN) {
+    variables = {
+      homeName: PIX_HOME_NAME_INTERNATIONAL,
+      homeUrl: PIX_HOME_URL_INTERNATIONAL_ENGLISH_SPOKEN,
+      redirectionUrl: redirectionUrl || `${config.domain.pixApp + config.domain.tldOrg}/connexion/?lang=es`,
+      helpdeskUrl: HELPDESK_ENGLISH_SPOKEN,
+      displayNationalLogo: false,
+      ...esTranslations['pix-account-creation-email'].params,
+    };
+    pixName = esTranslations['email-sender-name']['pix-app'];
+    accountCreationEmailSubject = esTranslations['pix-account-creation-email'].subject;
   } else {
     variables = {
       homeName: PIX_HOME_NAME_FRENCH_FRANCE,
@@ -194,6 +206,20 @@ function sendResetPasswordDemandEmail({ email, locale, temporaryKey }) {
 
     pixName = nlTranslations['email-sender-name']['pix-app'];
     resetPasswordEmailSubject = nlTranslations['reset-password-demand-email'].subject;
+  }
+
+  if (localeParam === SPANISH_SPOKEN) {
+    templateParams = {
+      locale: localeParam,
+      ...esTranslations['reset-password-demand-email'].params,
+      homeName: PIX_HOME_NAME_INTERNATIONAL,
+      homeUrl: PIX_HOME_URL_INTERNATIONAL_ENGLISH_SPOKEN,
+      resetUrl: `${config.domain.pixApp + config.domain.tldOrg}/changer-mot-de-passe/${temporaryKey}/?lang=es`,
+      helpdeskURL: HELPDESK_ENGLISH_SPOKEN,
+    };
+
+    pixName = esTranslations['email-sender-name']['pix-app'];
+    resetPasswordEmailSubject = esTranslations['reset-password-demand-email'].subject;
   }
 
   return mailer.sendEmail({
@@ -458,6 +484,17 @@ function sendVerificationCodeEmail({ code, email, locale, translate }) {
       homeUrl: PIX_HOME_URL_INTERNATIONAL_DUTCH_SPOKEN,
       displayNationalLogo: false,
       ...nlTranslations['verification-code-email'].body,
+    };
+  } else if (locale === SPANISH_SPOKEN) {
+    options.subject = translate({ phrase: 'verification-code-email.subject', locale: 'es' }, { code });
+    options.fromName = esTranslations['email-sender-name']['pix-app'];
+
+    options.variables = {
+      code,
+      homeName: PIX_HOME_NAME_INTERNATIONAL,
+      homeUrl: PIX_HOME_URL_INTERNATIONAL_ENGLISH_SPOKEN,
+      displayNationalLogo: false,
+      ...esTranslations['verification-code-email'].body,
     };
   }
 

--- a/api/lib/infrastructure/utils/request-response-utils.js
+++ b/api/lib/infrastructure/utils/request-response-utils.js
@@ -5,7 +5,7 @@ import { LANGUAGES_CODE } from '../../../src/shared/domain/services/language-ser
 import { tokenService } from '../../../src/shared/domain/services/token-service.js';
 
 const { ENGLISH_SPOKEN, FRENCH_FRANCE, FRENCH_SPOKEN } = LOCALE;
-const { DUTCH } = LANGUAGES_CODE;
+const { DUTCH, SPANISH } = LANGUAGES_CODE;
 const requestResponseUtils = { escapeFileName, extractUserIdFromRequest, extractLocaleFromRequest };
 
 export { escapeFileName, extractLocaleFromRequest, extractUserIdFromRequest, requestResponseUtils };
@@ -34,6 +34,6 @@ function extractLocaleFromRequest(request) {
   if (!languageHeader) {
     return defaultLocale;
   }
-  const acceptedLanguages = [ENGLISH_SPOKEN, FRENCH_SPOKEN, FRENCH_FRANCE, DUTCH];
+  const acceptedLanguages = [ENGLISH_SPOKEN, FRENCH_SPOKEN, FRENCH_FRANCE, DUTCH, SPANISH];
   return accept.language(languageHeader, acceptedLanguages) || defaultLocale;
 }

--- a/api/src/shared/domain/constants.js
+++ b/api/src/shared/domain/constants.js
@@ -5,9 +5,10 @@ const LOCALE = {
   FRENCH_FRANCE: 'fr-fr',
   FRENCH_SPOKEN: 'fr',
   DUTCH_SPOKEN: 'nl',
+  SPANISH_SPOKEN: 'es',
 };
 
-const SUPPORTED_LOCALES = ['en', 'fr', 'fr-BE', 'fr-FR', 'nl-BE'];
+const SUPPORTED_LOCALES = ['en', 'es', 'fr', 'fr-BE', 'fr-FR', 'nl-BE'];
 
 const ORGANIZATION_FEATURE = {
   MISSIONS_MANAGEMENT: {

--- a/api/src/shared/domain/services/language-service.js
+++ b/api/src/shared/domain/services/language-service.js
@@ -4,6 +4,7 @@ const LANGUAGES_CODE = {
   ENGLISH: 'en',
   FRENCH: 'fr',
   DUTCH: 'nl',
+  SPANISH: 'es',
 };
 
 const AVAILABLE_LANGUAGES = Object.values(LANGUAGES_CODE);

--- a/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
+++ b/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
@@ -114,7 +114,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           },
           {
             attribute: 'locale',
-            message: "La locale doit avoir l'une des valeurs suivantes : en, fr, fr-be, fr-fr, nl-be",
+            message: "La locale doit avoir l'une des valeurs suivantes : en, es, fr, fr-be, fr-fr, nl-be",
           },
           {
             attribute: 'locale',

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -5,8 +5,8 @@ import { tokenService } from '../../../../src/shared/domain/services/token-servi
 import { mailer } from '../../../../src/shared/mail/infrastructure/services/mailer.js';
 import en from '../../../../translations/en.json' assert { type: 'json' };
 import fr from '../../../../translations/fr.json' assert { type: 'json' };
-import nl from '../../../../translations/nl.json' assert { type: 'json' };
 import { es } from '../../../../translations/index.js';
+import nl from '../../../../translations/nl.json' assert { type: 'json' };
 import { expect, sinon } from '../../../test-helper.js';
 import { getI18n } from '../../../tooling/i18n/i18n.js';
 
@@ -28,7 +28,7 @@ describe('Unit | Service | MailService', function () {
   });
 
   describe('#sendAccountCreationEmail', function () {
-    it('should call sendEmail with from, to, subject, template', async function () {
+    it('calls sendEmail with from, to, subject, template', async function () {
       // given
       const locale = undefined;
 
@@ -50,7 +50,7 @@ describe('Unit | Service | MailService', function () {
 
     context('according to redirectionUrl', function () {
       context('if redirectionUrl is provided', function () {
-        it('should call sendEmail with provided value', async function () {
+        it('calls sendEmail with provided value', async function () {
           // given
           const redirectionUrl = 'https://pix.fr';
           const locale = FRENCH_FRANCE;
@@ -66,8 +66,8 @@ describe('Unit | Service | MailService', function () {
     });
 
     context('according to locale', function () {
-      context('should call sendEmail with localized variable options', function () {
-        it(`should call sendEmail with from, to, template and locale ${FRENCH_SPOKEN} or undefined`, async function () {
+      context('call sendEmail with localized variable options', function () {
+        it(`calls sendEmail with from, to, template and locale ${FRENCH_SPOKEN} or undefined`, async function () {
           // given
           const locale = FRENCH_SPOKEN;
 
@@ -86,7 +86,8 @@ describe('Unit | Service | MailService', function () {
             ...mainTranslationsMapping.fr['pix-account-creation-email'].params,
           });
         });
-        it(`should call sendEmail with from, to, template and locale ${FRENCH_FRANCE}`, async function () {
+
+        it(`calls sendEmail with from, to, template and locale ${FRENCH_FRANCE}`, async function () {
           // given
           const locale = FRENCH_FRANCE;
 
@@ -105,7 +106,8 @@ describe('Unit | Service | MailService', function () {
             ...mainTranslationsMapping.fr['pix-account-creation-email'].params,
           });
         });
-        it(`should call sendEmail with from, to, template and locale ${ENGLISH_SPOKEN}`, async function () {
+
+        it(`calls sendEmail with from, to, template and locale ${ENGLISH_SPOKEN}`, async function () {
           // given
           const locale = ENGLISH_SPOKEN;
 
@@ -124,7 +126,8 @@ describe('Unit | Service | MailService', function () {
             ...mainTranslationsMapping.en['pix-account-creation-email'].params,
           });
         });
-        it(`should call sendEmail with from, to, template and locale ${DUTCH_SPOKEN}`, async function () {
+
+        it(`calls sendEmail with from, to, template and locale ${DUTCH_SPOKEN}`, async function () {
           // given
           const locale = DUTCH_SPOKEN;
 
@@ -143,6 +146,7 @@ describe('Unit | Service | MailService', function () {
             ...mainTranslationsMapping.nl['pix-account-creation-email'].params,
           });
         });
+
         it(`calls sendEmail with from, to, template and locale ${SPANISH_SPOKEN}`, async function () {
           // given
           const locale = SPANISH_SPOKEN;
@@ -231,7 +235,7 @@ describe('Unit | Service | MailService', function () {
     const temporaryKey = 'token';
 
     context('according to locale', function () {
-      it(`should call mailer with translated texts if locale is ${ENGLISH_SPOKEN}`, async function () {
+      it(`calls mailer with translated texts if locale is ${ENGLISH_SPOKEN}`, async function () {
         // given
         const expectedOptions = {
           from,
@@ -260,7 +264,7 @@ describe('Unit | Service | MailService', function () {
         expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);
       });
 
-      it(`should call mailer with translated texts if locale is ${DUTCH_SPOKEN}`, async function () {
+      it(`calls mailer with translated texts if locale is ${DUTCH_SPOKEN}`, async function () {
         // given
         const expectedOptions = {
           from,
@@ -318,7 +322,7 @@ describe('Unit | Service | MailService', function () {
         expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);
       });
 
-      it(`should call mailer with translated texts if locale is ${FRENCH_SPOKEN}`, async function () {
+      it(`calls mailer with translated texts if locale is ${FRENCH_SPOKEN}`, async function () {
         // given
         const expectedOptions = {
           from,
@@ -347,7 +351,7 @@ describe('Unit | Service | MailService', function () {
         expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);
       });
 
-      it(`should call mailer with translated texts if locale is ${FRENCH_FRANCE}`, async function () {
+      it(`calls mailer with translated texts if locale is ${FRENCH_FRANCE}`, async function () {
         // given
         const expectedOptions = {
           from,
@@ -376,7 +380,7 @@ describe('Unit | Service | MailService', function () {
         expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);
       });
 
-      it(`should call mailer with fr-fr translated texts if locale is undefined`, async function () {
+      it(`calls mailer with fr-fr translated texts if locale is undefined`, async function () {
         // given
         const expectedOptions = {
           from,
@@ -728,7 +732,7 @@ describe('Unit | Service | MailService', function () {
   });
 
   describe('#sendAccountRecoveryEmail', function () {
-    it('should call sendEmail with from, to, template, tags', async function () {
+    it('calls sendEmail with from, to, template, tags', async function () {
       // given
       const translationsMapping = mainTranslationsMapping.fr['account-recovery-email'];
 
@@ -764,7 +768,7 @@ describe('Unit | Service | MailService', function () {
   });
 
   describe('#sendVerificationCodeEmail', function () {
-    it(`should call sendEmail with from, to, template, tags and locale ${FRENCH_SPOKEN}`, async function () {
+    it(`calls sendEmail with from, to, template, tags and locale ${FRENCH_SPOKEN}`, async function () {
       // given
       const translate = getI18n().__;
       const userEmail = 'user@example.net';
@@ -791,7 +795,7 @@ describe('Unit | Service | MailService', function () {
       });
     });
 
-    it(`should call sendEmail with from, to, template, tags and locale ${FRENCH_FRANCE}`, async function () {
+    it(`calls sendEmail with from, to, template, tags and locale ${FRENCH_FRANCE}`, async function () {
       // given
       const translate = getI18n().__;
       const userEmail = 'user@example.net';
@@ -818,7 +822,7 @@ describe('Unit | Service | MailService', function () {
       });
     });
 
-    it(`should call sendEmail with from, to, template, tags and locale ${ENGLISH_SPOKEN}`, async function () {
+    it(`calls sendEmail with from, to, template, tags and locale ${ENGLISH_SPOKEN}`, async function () {
       // given
       const translate = getI18n().__;
       const userEmail = 'user@example.net';
@@ -847,7 +851,7 @@ describe('Unit | Service | MailService', function () {
       });
     });
 
-    it(`should call sendEmail with from, to, template, tags and locale ${DUTCH_SPOKEN}`, async function () {
+    it(`calls sendEmail with from, to, template, tags and locale ${DUTCH_SPOKEN}`, async function () {
       // given
       const translate = getI18n().__;
       const userEmail = 'user@example.net';

--- a/api/tests/unit/domain/validators/organization-with-tags-and-target-profiles-script_test.js
+++ b/api/tests/unit/domain/validators/organization-with-tags-and-target-profiles-script_test.js
@@ -100,7 +100,7 @@ describe('Unit | Domain | Validators | organization-with-tags-and-target-profile
         expect(error.message).to.equal(`Échec de validation de l'entité.`);
         expect(error.invalidAttributes).to.deep.include({
           attribute: 'locale',
-          message: `La locale doit avoir l'une des valeurs suivantes : en, fr, fr-be, fr-fr, nl-be`,
+          message: `La locale doit avoir l'une des valeurs suivantes : en, es, fr, fr-be, fr-fr, nl-be`,
         });
       });
     });

--- a/api/translations/index.js
+++ b/api/translations/index.js
@@ -1,5 +1,6 @@
 import en from "./en.json" assert {type:'json'};
+import es from "./es.json" assert {type:'json'};
 import fr from "./fr.json" assert {type:'json'};
 import nl from "./nl.json" assert {type:'json'};
 
-export { en, fr, nl };
+export { en, es, fr, nl };


### PR DESCRIPTION
## :unicorn: Problème

Lors de l'inscription, la réinitialisation du mot passe et de la modification de l'adresse e-mail d'un compte, un e-mail est envoyé dans la langue de l'utilisateur.

Si un utilisateur avec la langue espagnol tente l'une de ces actions, il recevra un e-mail avec la langue par défaut étant le français.

## :robot: Proposition

Permettre l'envoi d'e-mail en espagnol lors de l'inscription, la réinitialisation du mot de passe et la modification de l'adresse e-mail du compte.

## :rainbow: Remarques

- La traduction a été faite grâce au service DeepL, et nécessite donc une revue par des professionnels.
- Certains liens se trouvant dans les différents e-mails pointent vers la version anglaise des documents et pages, car ces ceux-ci n'ont pas encore été traduit.
- L'amélioration du code du fichier `mail-service.js` sera fait dans un autre ticket.

## :100: Pour tester

Modifier le variable d'environnement `MAILING_ENABLED` pour faire vos tests.

### Inscription

1. Ouvrir un onglet sur votre navigateur avec ce lien https://app-pr8726.review.pix.org/inscription?lang=es
2. Constater l'affichage de l'interface en espagnol
3. S'inscrire
4. Constater, après connexion, l'affichage de l'interface en espagnol
5. Parcourir l'application pour valider que le contenu est en espagnol (pas encore le référentiel)
6. Vérifier la bonne réception d'un e-mail en espagnol qui vous annonce la création de votre compte Pix
7. Se déconnecter
8. Ouvrir un onglet sur votre navigateur avec ce lien https://app-pr8726.review.pix.org/connexion
9. Se connecter avec le compte précédemment créé
10. Constater, après connexion, l'affichage de l'interface en espagnol

### Réinitialisation du mot de passe

1. Ouvrir un onglet sur votre navigateur avec ce lien https://app-pr8726.review.pix.org/mot-de-passe-oublie?lang=es
2. Fournir un e-mail existant en base de données, par exemple l'e-mail du compte utilisé pour le scénario précédent étant l'inscription
3. Cliquer sur le bouton `Restablecer mi contraseña`
4. Vérifier la bonne réception d'un e-mail en espagnol pour réinitialiser votre mot de passe

### Modification de l'adresse e-mail d'un compte

1. Ouvrir un onglet sur votre navigateur avec ce lien https://app-pr8726.review.pix.org/connexion?lang=es
2. Se connecter avec le compte précédemment créé
3. Aller dans les paramètres du compte utilisateur
4. Dans le menu `Mis Métodos de conexión`, modifier l'adresse e-mail du compte
5. Vérifier la bonne réception d'un e-mail en espagnol contenant le code pour valider le changement d'adresse e-mail