### PR TITLE
[FEATURE] Ajouter des tests e2e sur les pages élèves/étudiants pour vérifier l'affichage en tant que membre (PIX-12270)

### DIFF
--- a/high-level-tests/e2e/cypress/fixtures/authentication-methods.json
+++ b/high-level-tests/e2e/cypress/fixtures/authentication-methods.json
@@ -86,5 +86,23 @@
     "identityProvider": "GAR",
     "authenticationComplement": null,
     "externalIdentifier": "SAMLID-1234"
+  },
+  {
+    "id": 13,
+    "userId": 13,
+    "identityProvider": "PIX",
+    "authenticationComplement": {
+      "password": "$2a$05$IP2HpgRg180EVjTnnq5yTOAW.42Bt3dIxoRMu6lV1NYHTSJeXO.U.",
+      "shouldChangePassword": false
+    }
+  },
+  {
+    "id": 14,
+    "userId": 14,
+    "identityProvider": "PIX",
+    "authenticationComplement": {
+      "password": "$2a$05$IP2HpgRg180EVjTnnq5yTOAW.42Bt3dIxoRMu6lV1NYHTSJeXO.U.",
+      "shouldChangePassword": false
+    }
   }
 ]

--- a/high-level-tests/e2e/cypress/fixtures/memberships.json
+++ b/high-level-tests/e2e/cypress/fixtures/memberships.json
@@ -19,5 +19,17 @@
     "userId": 8,
     "organizationId": 3,
     "organizationRole": "ADMIN"
+  },
+  {
+    "id": 5,
+    "userId": 13,
+    "organizationId": 2,
+    "organizationRole": "MEMBER"
+  },
+  {
+    "id": 6,
+    "userId": 14,
+    "organizationId": 3,
+    "organizationRole": "MEMBER"
   }
 ]

--- a/high-level-tests/e2e/cypress/fixtures/users.json
+++ b/high-level-tests/e2e/cypress/fixtures/users.json
@@ -70,5 +70,21 @@
     "id": 12,
     "firstName": "user",
     "lastName": "gar"
+  },
+  {
+    "id": 13,
+    "firstName": "Alex",
+    "lastName": "Terieur",
+    "email": "alex.terieur@pix.fr",
+    "cgu": true,
+    "pixOrgaTermsOfServiceAccepted": true
+  },
+  {
+    "id": 14,
+    "firstName": "Alain",
+    "lastName": "Terieur",
+    "email": "alain.terieur@pix.fr",
+    "cgu": true,
+    "pixOrgaTermsOfServiceAccepted": true
   }
 ]

--- a/high-level-tests/e2e/cypress/integration/pix-orga/member-role.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-orga/member-role.feature
@@ -1,0 +1,18 @@
+#language: fr
+Fonctionnalité: Affichage des pages en tant que membre
+
+  Contexte:
+    Étant donné que je vais sur Pix Orga
+    Et que les données de test sont chargées
+
+  Scénario: J'affiche la liste des élèves
+    Lorsque je me connecte avec le compte "alex.terieur@pix.fr"
+    Et que je clique sur "Élèves"
+    Alors je suis redirigé vers la page "/eleves"
+    Et je vois 3 élèves
+
+  Scénario: J'affiche la liste des étudiants
+    Lorsque je me connecte avec le compte "alain.terieur@pix.fr"
+    Et que je clique sur "Étudiants"
+    Alors je suis redirigé vers la page "/etudiants"
+    Et je vois 1 étudiant


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'ajout de la fonctionnalité d'affichage des statuts d'import sur les pages élèves & étudiants (#8635) on a introduit un bug. 
Etant donné que ce nouvel affichage appelle une route réservée aux admins de l'orga, quand un membre allait sur les pages élèves/étudiants, il se retrouvait à faire un appel à une route réservée aux admins et donc recevait une 403.
On a corrigé ce bug dans deux PR (#8667 & #8684). 
Cela a mis en évidence le manque de tests e2e avec des rôles de membre pour ces différentes pages

## :robot: Proposition
On ajoute un contexte de test e2e avec un rôle membre dans une orga sco et une orga sup. Et on y vérifie le bon affichage de ces deux pages

## :rainbow: Remarques
Dans un premier temps, j'ai décidé de regrouper le test des deux scénarios dans un contexte "member-role" mais il serait peut être intéressant si on vient à enrichir par la suite ces tests de les séparer en deux fichiers différents.

## :100: Pour tester
La CI passe 
🐈‍⬛ 
