### PR TITLE
[TECH] Ajouter une fonction pour rafraîchir la vue "view-active-organization-learners" (PIX-12273)

### DIFF
--- a/api/db/utils/refresh-view-active-organization-learners.js
+++ b/api/db/utils/refresh-view-active-organization-learners.js
@@ -1,0 +1,10 @@
+const VIEW_NAME = 'view-active-organization-learners';
+const REFERENCE_TABLE_NAME = 'organization-learners';
+
+const refreshViewActiveOrganizationLearners = async (knex) => {
+  await knex.schema.createViewOrReplace(VIEW_NAME, function (view) {
+    view.as(knex(REFERENCE_TABLE_NAME).whereNull('deletedAt'));
+  });
+};
+
+export { refreshViewActiveOrganizationLearners };


### PR DESCRIPTION
## :unicorn: Problème
Nous avons une vue "view-active-organization-learners" qui se refere à la table "organization-learners".
Des que nous modifions la structure de la table parente, la vue n'est pas automatiquement rafrachit. Nous devons donc faire une migration pour le faire. 
Cela fait plusieurs fois que nous réecrivons le même code dans des migrations pour rafraichir la vue

## :robot: Proposition
Sortir la fonction dans un fichier, afin que l'on ai juste besoin d'appeler celle ci dans une migration, sans avoir à copier/coller à chaque fois le même bout de code

## :rainbow: Remarques
Cette fonction n'est pas testée car faire un test reviendrait possiblement à tester le fonctionnement de knex.
Mais vos idées sont bonnes à prendre si vous en avez ?

## :100: Pour tester
En local : 
- Faire une migration qui ajoute une colonne random sur la table organization-learners.
- Vérifier en BDD que la vue n'a pas cette colonne
- Refaire une nouvelle migration qui appelle la fonction créee dans cette PR
- Vérifier de nouveau en BDD : Cette fois la vue doit avoir la colonne
- 🐈‍⬛ 
