### PR TITLE
[FEATURE][APP] Permettre l'affichage de l'application en espagnol (PIX-12195)

### DIFF
--- a/mon-pix/app/languages.js
+++ b/mon-pix/app/languages.js
@@ -3,6 +3,10 @@ export default {
     value: 'English',
     languageSwitcherDisplayed: true,
   },
+  es: {
+    value: 'Español',
+    languageSwitcherDisplayed: false,
+  },
   fr: {
     value: 'Français',
     languageSwitcherDisplayed: true,

--- a/mon-pix/tests/unit/services/locale_test.js
+++ b/mon-pix/tests/unit/services/locale_test.js
@@ -31,7 +31,7 @@ module('Unit | Services | locale', function (hooks) {
     module('when language is not supported', function () {
       test('returns default language', function (assert) {
         // given
-        const language = 'es';
+        const language = 'de';
 
         // when
         const result = localeService.handleUnsupportedLanguage(language);


### PR DESCRIPTION
## :unicorn: Problème

La langue espagnol n'est pas encore supportée sur Pix App.

## :robot: Proposition

Permettre l'affichage de l'interface de Pix App en espagnol sans utiliser le sélecteur de langue.

## :rainbow: Remarques

- Pour le moment, nous n'afficherons pas cette nouvelle langue dans le sélecteur de langue. Ceci entrainera l'affichage d'un sélecteur vide si on fourni le paramètre `?lang=es` dans l'URL.
- L'inscription n'est pas encore possible car l'api ne gère pas encore la nouvelle langue.

## :100: Pour tester

1. Ouvrir un nouvel onglet sur votre navigateur avec ce lien https://app-pr8729.review.pix.org/?lang=es
2. Constater l'affichage de l'interface en espagnol
3. Se connecter avec un compte
4. Constater l'affichage de l'interface dans la langue du compte utilisateur
5. Modifier l'URL en y ajoutant `?lang=es`
6. Constater l'affichage de l'interface en espagnol
7. Se déconnecter du compte
