### PR TITLE
[FEATURE] [ADMIN] Ajouter une nouvelle action pour importer une liste de configuration SSO OIDC (PIX-11984)

### DIFF
--- a/admin/app/components/administration/oidc-providers-import.hbs
+++ b/admin/app/components/administration/oidc-providers-import.hbs
@@ -1,0 +1,16 @@
+<section class="page-section">
+  <header class="page-section__header">
+    <h2 class="page-section__title">{{t "components.administration.oidc-providers-import.title"}}</h2>
+  </header>
+  <p>{{t "components.administration.oidc-providers-import.description"}}</p>
+  <br />
+  <PixButtonUpload
+    @id="oidc-providers-file-upload"
+    @onChange={{this.importOidcProviders}}
+    @backgroundColor="transparent-light"
+    @isBorderVisible={{true}}
+    accept=".json"
+  >
+    {{t "components.administration.oidc-providers-import.upload-button"}}
+  </PixButtonUpload>
+</section>

--- a/admin/app/components/administration/oidc-providers-import.js
+++ b/admin/app/components/administration/oidc-providers-import.js
@@ -1,0 +1,59 @@
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import fetch from 'fetch';
+import ENV from 'pix-admin/config/environment';
+
+export default class OidcProvidersImport extends Component {
+  @service intl;
+  @service notifications;
+  @service session;
+
+  @action
+  async importOidcProviders(files) {
+    this.notifications.clearAll();
+
+    let response;
+    try {
+      const fileContent = await readFileAsText(files[0]);
+
+      const token = this.session.data.authenticated.access_token;
+      response = await fetch(`${ENV.APP.API_HOST}/api/admin/oidc-providers/import`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        method: 'POST',
+        body: fileContent,
+      });
+      if (response.ok) {
+        this.notifications.success(
+          this.intl.t('components.administration.oidc-providers-import.notifications.success'),
+        );
+        return;
+      }
+
+      const jsonResponse = await response.json();
+      if (!jsonResponse.errors) {
+        throw new Error('Generic error');
+      }
+
+      jsonResponse.errors.forEach((error) => {
+        this.notifications.error(error.detail, { autoClear: false });
+      });
+    } catch (error) {
+      this.notifications.error(this.intl.t('common.notifications.generic-error'));
+    } finally {
+      this.isLoading = false;
+    }
+  }
+}
+
+const readFileAsText = (file) =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (event) => resolve(event.target.result);
+    reader.onerror = reject;
+    reader.readAsText(file);
+  });

--- a/admin/app/templates/authenticated/administration.hbs
+++ b/admin/app/templates/authenticated/administration.hbs
@@ -18,6 +18,8 @@
     <Administration::SwapCampaignCodes />
 
     <Administration::UpdateCampaignCode />
+
+    <Administration::OidcProvidersImport />
   </main>
 
 </div>

--- a/admin/tests/integration/components/administration/oidc-providers-import_test.js
+++ b/admin/tests/integration/components/administration/oidc-providers-import_test.js
@@ -1,0 +1,75 @@
+import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import { triggerEvent } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component |  administration/oidc-providers-import', function (hooks) {
+  setupIntlRenderingTest(hooks);
+  setupMirage(hooks);
+
+  module('when import succeeds', function () {
+    test('it displays a success notification', async function (assert) {
+      // given
+      this.server.post('/admin/oidc-providers/import', () => new Response(204));
+      const file = new Blob(['foo'], { type: `valid-file` });
+      const notificationSuccessStub = sinon.stub();
+      class NotificationsStub extends Service {
+        clearAll = sinon.stub();
+        success = notificationSuccessStub;
+      }
+      this.owner.register('service:notifications', NotificationsStub);
+
+      // when
+      const screen = await render(hbs`<Administration::OidcProvidersImport />`);
+      const input = await screen.findByLabelText(
+        this.intl.t('components.administration.oidc-providers-import.upload-button'),
+      );
+      await triggerEvent(input, 'change', { files: [file] });
+
+      // then
+      sinon.assert.calledWith(
+        notificationSuccessStub,
+        this.intl.t('components.administration.oidc-providers-import.notifications.success'),
+      );
+      assert.ok(true);
+    });
+  });
+
+  module('when import fails', function () {
+    test('it displays an error notification', async function (assert) {
+      // given
+      this.server.post(
+        '/admin/oidc-providers/import',
+        () =>
+          new Response(
+            400,
+            {},
+            { errors: [{ status: '400', title: "Un soucis avec l'import", code: '400', detail: 'Erreur d’import' }] },
+          ),
+        400,
+      );
+      const file = new Blob(['foo'], { type: `invalid-file` });
+      const notificationErrorStub = sinon.stub().returns();
+      class NotificationsStub extends Service {
+        error = notificationErrorStub;
+        clearAll = sinon.stub();
+      }
+      this.owner.register('service:notifications', NotificationsStub);
+
+      // when
+      const screen = await render(hbs`<Administration::OidcProvidersImport />`);
+      const input = await screen.findByLabelText(
+        this.intl.t('components.administration.oidc-providers-import.upload-button'),
+      );
+      await triggerEvent(input, 'change', { files: [file] });
+
+      // then
+      assert.ok(notificationErrorStub.called);
+    });
+  });
+});

--- a/admin/tests/integration/components/administration/organizations-import_test.js
+++ b/admin/tests/integration/components/administration/organizations-import_test.js
@@ -12,30 +12,31 @@ module('Integration | Component |  administration/organizations-import', functio
   setupIntlRenderingTest(hooks);
   setupMirage(hooks);
 
-  module('when import succeeds', function () {});
-  test('it displays a success notification', async function (assert) {
-    // given
-    const file = new Blob(['foo'], { type: `valid-file` });
-    const notificationSuccessStub = sinon.stub();
-    class NotificationsStub extends Service {
-      success = notificationSuccessStub;
-      clearAll = sinon.stub();
-    }
-    this.owner.register('service:notifications', NotificationsStub);
+  module('when import succeeds', function () {
+    test('it displays a success notification', async function (assert) {
+      // given
+      const file = new Blob(['foo'], { type: `valid-file` });
+      const notificationSuccessStub = sinon.stub();
+      class NotificationsStub extends Service {
+        success = notificationSuccessStub;
+        clearAll = sinon.stub();
+      }
+      this.owner.register('service:notifications', NotificationsStub);
 
-    // when
-    const screen = await render(hbs`<Administration::OrganizationsImport />`);
-    const input = await screen.findByLabelText(
-      this.intl.t('components.administration.organizations-import.upload-button'),
-    );
-    await triggerEvent(input, 'change', { files: [file] });
+      // when
+      const screen = await render(hbs`<Administration::OrganizationsImport />`);
+      const input = await screen.findByLabelText(
+        this.intl.t('components.administration.organizations-import.upload-button'),
+      );
+      await triggerEvent(input, 'change', { files: [file] });
 
-    // then
-    assert.ok(true);
-    sinon.assert.calledWith(
-      notificationSuccessStub,
-      this.intl.t('components.administration.organizations-import.notifications.success'),
-    );
+      // then
+      assert.ok(true);
+      sinon.assert.calledWith(
+        notificationSuccessStub,
+        this.intl.t('components.administration.organizations-import.notifications.success'),
+      );
+    });
   });
 
   module('when import fails', function () {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -33,6 +33,14 @@
   },
   "components": {
     "administration": {
+      "oidc-providers-import": {
+        "title": "OIDC Providers import",
+        "description": "Note: Trying to import already existing OIDC Providers would produce an error.",
+        "notifications": {
+          "success": "The OIDC Providers have been created."
+        },
+        "upload-button": "Import JSON file"
+      },
       "organizations-import": {
         "title": "Mass creation of organizations",
         "description": "Existing organizations will not be changed.",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -41,6 +41,14 @@
         },
         "upload-button": "Importer un fichier CSV"
       },
+      "oidc-providers-import": {
+        "title": "Import d’OIDC Providers",
+        "description": "Note: Chercher à importer à nouveau des OIDC Providers déjà existants renverrait une erreur.",
+        "notifications": {
+          "success": "Les OIDC Providers ont bien été créés."
+        },
+        "upload-button": "Importer un fichier JSON"
+      },
       "organizations-import": {
         "title": "Création en masse d'organisations",
         "description": "Les organisations déjà existantes ne seront pas modifiées.",


### PR DESCRIPTION
## :unicorn: Problème

Depuis #8718 on dispose d'un endpoint dans l'API pour effectuer l'import d’OIDC Providers, mais il n'y a pas encore d'interface utilisateur pour permettre facilement cet import.

## :robot: Proposition

Créer une nouvelle section dédiée dans la page _Administration_ de Pix Admin.

## :rainbow: Remarques

RAS

## :100: Pour tester

1. Se connecter à Pix Admin avec le compte `superadmin@example.net`
2. Aller sur la page _Administration_
3. Aller dans la section _Import d’OIDC Providers_ et y soumettre un fichier JSON avec le contenu suivant : 

```json
[
  {
    "identityProvider": "INVALID",
    "organizationName": "Invalid",
    "scope": "openid profile",
    "clientId": "XXX",
    "clientSecret": "YYY"
  }
]
```

4. Constater que la soumission et le traitement renvoie un message d’erreur.
5. Aller dans la section _Import d’OIDC Providers_ et y soumettre un fichier JSON avec le contenu suivant : 

```json
[
    {
        "identityProvider": "GAGACONNECT",
        "organizationName": "Gaga Connect",
        "scope": "openid profile email",
        "slug": "gaga-connect",
        "source": "gagaconnect",
        "clientId": "__CLIENT_ID__",
        "clientSecret": "__CLIENT_SECRET__",
        "accessTokenLifespan": "4h",
        "claimsToStore": "email",
        "enabled": true,
        "enabledForPixAdmin": false,
        "openidConfigurationUrl": "https://gaga.example.net/.well-known/openid-configuration",
        "redirectUri": "https://app.dev.pix.org/connexion/gaga-connect"
    }
]
```

6. Constater que la soumission et le traitement renvoie le message de réussite `Les OIDC Providers ont bien été créés.`
7. Si vous pouvez le faire, vérifier en base de données l'insertion des fournisseurs d'identité