### PR TITLE
[TECH] Migrer le serializer de correction vers le dossier Evaluation (PIX-12292).

### DIFF
--- a/api/src/evaluation/application/answers/answer-controller.js
+++ b/api/src/evaluation/application/answers/answer-controller.js
@@ -1,8 +1,8 @@
 import { usecases } from '../../../../lib/domain/usecases/index.js';
-import * as correctionSerializer from '../../../../lib/infrastructure/serializers/jsonapi/correction-serializer.js';
 import * as requestResponseUtils from '../../../../lib/infrastructure/utils/request-response-utils.js';
 import { evaluationUsecases } from '../../domain/usecases/index.js';
 import * as answerSerializer from '../../infrastructure/serializers/jsonapi/answer-serializer.js';
+import * as correctionSerializer from '../../infrastructure/serializers/jsonapi/correction-serializer.js';
 
 const save = async function (request, h, dependencies = { answerSerializer, requestResponseUtils }) {
   const answer = dependencies.answerSerializer.deserialize(request.payload);

--- a/api/src/evaluation/infrastructure/serializers/jsonapi/correction-serializer.js
+++ b/api/src/evaluation/infrastructure/serializers/jsonapi/correction-serializer.js
@@ -1,6 +1,6 @@
 import jsonapiSerializer from 'jsonapi-serializer';
 
-import { tutorialAttributes } from '../../../../src/devcomp/infrastructure/serializers/jsonapi/tutorial-attributes.js';
+import { tutorialAttributes } from '../../../../devcomp/infrastructure/serializers/jsonapi/tutorial-attributes.js';
 
 const { Serializer } = jsonapiSerializer;
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/correction-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/correction-serializer_test.js
@@ -1,9 +1,9 @@
 import { Correction } from '../../../../../lib/domain/models/Correction.js';
 import { Hint } from '../../../../../lib/domain/models/Hint.js';
-import * as serializer from '../../../../../lib/infrastructure/serializers/jsonapi/correction-serializer.js';
 import { TutorialEvaluation } from '../../../../../src/devcomp/domain/models/TutorialEvaluation.js';
 import { UserSavedTutorial } from '../../../../../src/devcomp/domain/models/UserSavedTutorial.js';
 import { TutorialForUser } from '../../../../../src/devcomp/domain/read-models/TutorialForUser.js';
+import * as serializer from '../../../../../src/evaluation/infrastructure/serializers/jsonapi/correction-serializer.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | correction-serializer', function () {


### PR DESCRIPTION
## :unicorn: Problème
Suite de la migration de l'arborescence API. On s'occupe du serializer de correction. 

## :robot: Proposition
Déplacer le serializer dans le scope evaluation.

## :100: Pour tester
- Les tests passent