### PR TITLE
[FEATURE] Bloquer le rattachement de résultat thématique non certifiants à une certification complémentaire lors d'un versionning sur Pix Admin (PIX-12272).

### DIFF
--- a/admin/app/adapters/target-profile.js
+++ b/admin/app/adapters/target-profile.js
@@ -35,4 +35,14 @@ export default class TargetProfileAdapter extends ApplicationAdapter {
     });
     return result.data.attributes['detached-organization-ids'];
   }
+
+  urlForQueryRecord(query) {
+    if (query.targetProfileId) {
+      const { targetProfileId } = query;
+      delete query.targetProfileId;
+      return `${this.host}/${this.namespace}/target-profiles/${targetProfileId}`;
+    }
+
+    return super.urlForQueryRecord(...arguments);
+  }
 }

--- a/admin/app/components/complementary-certifications/attach-badges/badges/index.js
+++ b/admin/app/components/complementary-certifications/attach-badges/badges/index.js
@@ -39,17 +39,21 @@ export default class Badges extends Component {
     }
 
     this.store
-      .findRecord('target-profile', targetProfile.id)
+      .queryRecord('target-profile', {
+        targetProfileId: targetProfile.id,
+        filter: {
+          badges: 'certifiable',
+        },
+      })
       .then((targetProfile) => {
         if (this.isDestroyed) {
           return;
         }
-        const targetProfileBadges = targetProfile.badges?.map((badge) => ({
+        this.badges = targetProfile.badges?.map((badge) => ({
           id: badge.id,
           label: badge.title,
+          isCertifiable: badge.isCertifiable,
         }));
-
-        this.badges = targetProfileBadges;
       })
       .catch(this.#onfetchBadgesError)
       .finally(() => (this.isLoading = false));

--- a/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
+++ b/admin/tests/acceptance/authenticated/complementary-certifications/complementary-certification/attach-target-profile_test.js
@@ -110,6 +110,7 @@ module(
             const badge = server.create('badge', {
               id: 200,
               title: 'Badge Arène Feu',
+              isCertifiable: true,
             });
             server.create('target-profile', {
               id: 5,
@@ -154,6 +155,7 @@ module(
             const badge = server.create('badge', {
               id: 200,
               title: 'Badge Arène Feu',
+              isCertifiable: true,
             });
             server.create('target-profile', {
               id: 5,
@@ -221,6 +223,7 @@ module(
             const badge = server.create('badge', {
               id: 200,
               title: 'Badge Arène Feu',
+              isCertifiable: true,
             });
             server.create('target-profile', {
               id: 5,

--- a/admin/tests/integration/components/complementary-certifications/attach-form/badges/index_test.js
+++ b/admin/tests/integration/components/complementary-certifications/attach-form/badges/index_test.js
@@ -12,7 +12,7 @@ module('Integration | Component | complementary-certifications/attach-badges/bad
     test('it should display the loader', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      store.findRecord = sinon.stub().returns(new Promise(() => {}));
+      store.queryRecord = sinon.stub().returns(new Promise(() => {}));
       const attachableTargetProfile = store.createRecord('attachable-target-profile', {
         name: 'ALEX TARGET',
         id: 1,
@@ -37,7 +37,7 @@ module('Integration | Component | complementary-certifications/attach-badges/bad
       test('it should display an error message when there are no badges provided', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
-        store.findRecord = sinon.stub().resolves({
+        store.queryRecord = sinon.stub().resolves({
           badges: [],
         });
         const attachableTargetProfile = store.createRecord('attachable-target-profile', {
@@ -67,14 +67,15 @@ module('Integration | Component | complementary-certifications/attach-badges/bad
     });
 
     module('when there are badges', function () {
-      test('it should display the target profile badges', async function (assert) {
+      test('it should display target profile badges', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
-        store.findRecord = sinon.stub().resolves({
+        store.queryRecord = sinon.stub().resolves({
           badges: [
             {
               id: 1000,
               title: 'canards',
+              isCertifiable: true,
             },
           ],
         });

--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -64,6 +64,9 @@ const register = async function (server) {
           params: Joi.object({
             id: identifiersType.targetProfileId,
           }),
+          query: Joi.object({
+            'filter[badges]': Joi.string().valid('certifiable').allow(null).empty(''),
+          }),
         },
         handler: targetProfileController.getTargetProfileForAdmin,
         tags: ['api', 'admin', 'target-profiles'],

--- a/api/lib/application/target-profiles/target-profile-controller.js
+++ b/api/lib/application/target-profiles/target-profile-controller.js
@@ -22,10 +22,16 @@ const findPaginatedFilteredTargetProfileSummariesForAdmin = async function (requ
   return targetProfileSummaryForAdminSerializer.serialize(targetProfileSummaries, meta);
 };
 
-const getTargetProfileForAdmin = async function (request, h, dependencies = { targetProfileForAdminSerializer }) {
+const getTargetProfileForAdmin = async function (
+  request,
+  h,
+  dependencies = { targetProfileForAdminSerializer, queryParamsUtils },
+) {
   const targetProfileId = request.params.id;
-  const targetProfileForAdmin = await usecases.getTargetProfileForAdmin({ targetProfileId });
-  return dependencies.targetProfileForAdminSerializer.serialize(targetProfileForAdmin);
+  const { filter } = dependencies.queryParamsUtils.extractParameters(request.query);
+
+  const targetProfile = await usecases.getTargetProfileForAdmin({ targetProfileId });
+  return dependencies.targetProfileForAdminSerializer.serialize({ targetProfile, filter });
 };
 
 const findPaginatedFilteredTargetProfileOrganizations = async function (request) {

--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer.js
@@ -2,7 +2,22 @@ import jsonapiSerializer from 'jsonapi-serializer';
 
 const { Serializer } = jsonapiSerializer;
 
-const serialize = function (targetProfiles) {
+const serialize = function ({ targetProfile, filter }) {
+  if (filter?.badges === 'certifiable') {
+    return new Serializer('target-profile', {
+      transform(record) {
+        record.badges = record.badges.filter((badge) => badge.isCertifiable);
+        return record;
+      },
+      attributes: ['name', 'badges'],
+      badges: {
+        ref: 'id',
+        included: true,
+        attributes: ['title', 'isCertifiable'],
+      },
+    }).serialize(targetProfile);
+  }
+
   return new Serializer('target-profile', {
     transform(record) {
       record.stageCollection = record.stageCollection.toDTO();
@@ -88,7 +103,7 @@ const serialize = function (targetProfiles) {
       if (attribute === 'criteria') return 'badge-criteria';
       return undefined;
     },
-  }).serialize(targetProfiles);
+  }).serialize(targetProfile);
 };
 
 export { serialize };

--- a/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-badge-repository.js
+++ b/api/src/certification/complementary-certification/infrastructure/repositories/complementary-certification-badge-repository.js
@@ -41,6 +41,7 @@ const findAttachableBadgesByIds = async function ({ ids }) {
   const badges = await knex
     .from('badges')
     .whereIn('badges.id', ids)
+    .andWhere('badges.isCertifiable', true)
     .whereNotExists(
       knex
         .select(1)

--- a/api/tests/certification/complementary-certification/acceptance/application/attach-target-profile-controller_test.js
+++ b/api/tests/certification/complementary-certification/acceptance/application/attach-target-profile-controller_test.js
@@ -45,6 +45,7 @@ describe('Acceptance | Controller | Complementary certification | attach-target-
       const alreadyAttachedBadge = databaseBuilder.factory.buildBadge({
         id: 999,
         targetProfileId: alreadyAttachedTargetProfile.id,
+        isCertifiable: true,
       });
       databaseBuilder.factory.buildComplementaryCertificationBadge({
         id: 888,
@@ -56,7 +57,8 @@ describe('Acceptance | Controller | Complementary certification | attach-target-
         organizationId: organization.id,
         targetProfileId: alreadyAttachedTargetProfile.id,
       });
-      databaseBuilder.factory.buildBadge({ id: 1, targetProfileId: targetProfile.id });
+      databaseBuilder.factory.buildBadge({ id: 1, targetProfileId: targetProfile.id, isCertifiable: true });
+      databaseBuilder.factory.buildBadge({ id: 2, targetProfileId: targetProfile.id, isCertifiable: false });
 
       const options = {
         method: 'PUT',

--- a/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-badge-repository_test.js
+++ b/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-badge-repository_test.js
@@ -196,10 +196,11 @@ describe('Integration | Infrastructure | Repository | Certification | Complement
   });
 
   context('#findAttachableBadgesByIds', function () {
-    it('should return badges eligible to a complementary', async function () {
+    it('should return certifiable badges and eligible to a complementary', async function () {
       // given
       const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
-      databaseBuilder.factory.buildBadge({ id: 123, targetProfileId, key: 'key_xx' }).id;
+      databaseBuilder.factory.buildBadge({ id: 123, targetProfileId, key: 'key_xx', isCertifiable: true }).id;
+      databaseBuilder.factory.buildBadge({ id: 12345, targetProfileId, key: 'key_xxxxxx', isCertifiable: false }).id;
 
       await databaseBuilder.commit();
 
@@ -216,7 +217,7 @@ describe('Integration | Infrastructure | Repository | Certification | Complement
           id: 123,
           imageUrl: '/img_funny.svg',
           isAlwaysVisible: false,
-          isCertifiable: false,
+          isCertifiable: true,
           key: 'key_xx',
           message: 'message',
           targetProfileId,
@@ -243,7 +244,7 @@ describe('Integration | Infrastructure | Repository | Certification | Complement
     it('should not return badges tied to a complementary', async function () {
       // given
       const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
-      databaseBuilder.factory.buildBadge({ id: 123, targetProfileId }).id;
+      databaseBuilder.factory.buildBadge({ id: 123, targetProfileId, isCertifiable: true }).id;
       const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification().id;
       databaseBuilder.factory.buildComplementaryCertificationBadge({
         id: 456,

--- a/api/tests/certification/complementary-certification/unit/domain/usecases/attach-badges_test.js
+++ b/api/tests/certification/complementary-certification/unit/domain/usecases/attach-badges_test.js
@@ -149,7 +149,7 @@ describe('Unit | UseCase | attach-badges', function () {
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       { label: 'no badges found', resolve: [] },
-      { label: 'not all badges found', resolve: [{ badgeId: 1 }] },
+      { label: 'not all badges are certifiable', resolve: [{ badgeId: 1, level: 1, isCertifiable: true }] },
     ].forEach((assessment) => {
       // eslint-disable-next-line mocha/no-setup-in-describe
       context(`when  ${assessment.label}`, function () {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer_test.js
@@ -91,7 +91,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-admin-serializer', fu
         code: 'red',
         frameworkId: 'recFrameworkCool1',
       });
-      const targetProfileForAdmin = new TargetProfileForAdmin({
+      const targetProfile = new TargetProfileForAdmin({
         id: 132,
         name: 'Mon Super profil cible',
         outdated: true,
@@ -557,10 +557,67 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-admin-serializer', fu
       };
 
       // when
-      const serializedTargetProfile = serializer.serialize(targetProfileForAdmin);
+      const serializedTargetProfile = serializer.serialize({ targetProfile, filter: null });
 
       // then
       expect(serializedTargetProfile).to.deep.equal(expectedSerializedTargetProfile);
+    });
+
+    describe('when there is a badges filter', function () {
+      it('should serialize target profile to JSONAPI', function () {
+        // given
+        const badge1 = domainBuilder.buildBadgeDetails({
+          id: 100,
+          title: 'some title badge1',
+          isCertifiable: true,
+        });
+        const badge2 = domainBuilder.buildBadgeDetails({
+          id: 200,
+          title: 'some title badge2',
+          isCertifiable: false,
+        });
+        const targetProfile = new TargetProfileForAdmin({
+          id: 132,
+          name: 'Mon Super profil cible',
+          badges: [badge1, badge2],
+        });
+
+        const expectedSerializedTargetProfile = {
+          data: {
+            type: 'target-profiles',
+            id: '132',
+            attributes: {
+              name: 'Mon Super profil cible',
+            },
+            relationships: {
+              badges: {
+                data: [
+                  {
+                    id: '100',
+                    type: 'badges',
+                  },
+                ],
+              },
+            },
+          },
+          included: [
+            {
+              type: 'badges',
+              id: '100',
+              attributes: {
+                'is-certifiable': true,
+                title: 'some title badge1',
+              },
+            },
+          ],
+        };
+
+        // when
+        const serializedTargetProfile = serializer.serialize({ targetProfile, filter: { badges: 'certifiable' } });
+
+        // then
+        expect(serializedTargetProfile).to.deep.equal(expectedSerializedTargetProfile);
+      });
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Lors du rattachement d’un nouveau profil cible à une certification complémentaire existante, on saisit le numéro d’un profil cible ayant au moins un résultat thématique certifiant.

Ce profil cible peut néanmoins comporter d’autres résultats thématiques, non certifiants quant à eux, qui sont obtenus au fur et à mesure du passage du parcours de positionnement (exemple CléA Numérique).

On peut actuellement rattacher des RT `non certifiants` à une certification complémentaire.

## :robot: Proposition

- Ne faire apparaître que les résultat thématique **certifiants** lors du versionning
- Bloquer le rattachement de résultat thématique non certifiants coté API

## :100: Pour tester

⚠️ Pour tester le stop coté API lors du rattachement, mettre le 2eme commit (api) et 3eme commit (front) de coté 

- Se connecter sur Pix Admin avec superadmin@example.net
- Sur Certification Complémentaires > CléA > Rattacher un nouveau PC
- Aller voir la page de détails du PC ["TEAM FUSEE"](https://admin-pr8738.review.pix.fr/target-profiles/1100006/insights), il possède deux RT (un certifiable et un non certifiable)
- Chercher "TEAM FUSEE" dans le select pour le rattacher
- (si commit front mis de coté) vous verrez les deux RT > remplissez les champs > erreur lors de la validation
<img width="516" alt="Capture d’écran 2024-04-24 à 16 46 10" src="https://github.com/1024pix/pix/assets/58915422/8d58c27b-65f1-44ba-8d00-f4cdf7853bd4">

- (si commit front compris) vous ne verrez qu'un RT visible (le certifiable !)
- Remplissez et tout doit fonctionner comme avant