### PR TITLE
[BUGFIX] Petits correctifs graphiques Modulix (PIX-12304)

### DIFF
--- a/mon-pix/app/pods/components/module/grain/tag/component.js
+++ b/mon-pix/app/pods/components/module/grain/tag/component.js
@@ -7,4 +7,8 @@ export default class ModuleGrainTag extends Component {
   get typeText() {
     return this.intl.t(`pages.modulix.grain.tag.${this.args.type}`);
   }
+
+  get iconPath() {
+    return this.args.type === 'lesson' ? '/images/icons/icon-book.svg' : '/images/icons/icon-cog.svg';
+  }
 }

--- a/mon-pix/app/pods/components/module/grain/tag/styles.scss
+++ b/mon-pix/app/pods/components/module/grain/tag/styles.scss
@@ -1,36 +1,24 @@
-.align-icon {
-  line-height: 1;
-  vertical-align: middle;
-}
-
 .tag {
-  @extend .modulix-capitalize;
   @extend %pix-body-s;
 
-  width: fit-content;
+  display: flex;
+  gap: var(--pix-spacing-1x);
+  align-items: center;
+  justify-content: center;
   padding: var(--pix-spacing-2x) var(--pix-spacing-4x) var(--pix-spacing-2x) var(--pix-spacing-4x);
+  text-transform: uppercase;
   border-radius: var(--modulix-radius) var(--modulix-radius) 0 0;
 
   &--activity {
     background: var(--pix-neutral-20);
-
-    &::before {
-      @extend .align-icon;
-
-      content: url('/images/icons/icon-cog.svg');
-    }
   }
 
   &--lesson {
     background: var(--pix-info-50);
+  }
 
-    &::before {
-      @extend .align-icon;
-
-      line-height: 1;
-      vertical-align: middle;
-      content: url('/images/icons/icon-book.svg');
-    }
+  &_icon {
+    width: 1rem;
+    height: 1rem;
   }
 }
-

--- a/mon-pix/app/pods/components/module/grain/tag/template.hbs
+++ b/mon-pix/app/pods/components/module/grain/tag/template.hbs
@@ -1,3 +1,4 @@
 <div class="tag tag--{{@type}}">
+  <img src={{this.iconPath}} class="tag_icon" alt="" aria-hidden="true" />
   <span>{{this.typeText}}</span>
 </div>

--- a/mon-pix/app/pods/module/get/styles.scss
+++ b/mon-pix/app/pods/module/get/styles.scss
@@ -8,8 +8,3 @@
   color: var(--pix-neutral-900);
   background: var(--pix-neutral-0);
 }
-
-.modulix-capitalize {
-  letter-spacing: 0.04rem;
-  text-transform: uppercase;
-}

--- a/mon-pix/app/styles/pages/_module-preview.scss
+++ b/mon-pix/app/styles/pages/_module-preview.scss
@@ -6,6 +6,8 @@
 
     &__passage {
         @extend .module-passage;
+
+        width: 100%;
     }
 
     &__form {


### PR DESCRIPTION
## :unicorn: Problèmes
- L'icône de tag "leçon" ou "activité" n'est pas centrée verticalement.
- Les grains ne prennent pas toute la largeur disponibles dans la page de prévisualisation de module.

<img width="832" alt="image" src="https://github.com/1024pix/pix/assets/5855339/59b8c5dd-dc2c-463a-8692-212f70b7ae52">

## :robot: Proposition
- Utiliser du flex pour centrer. Redimensionner l'icône en relation avec la préférence de font.
- Forcer l'utilisation de toute la largeur dispo dans le passage.

## :rainbow: Remarques
RAS

## :100: Pour tester
- Vérifier que tout est bien centré, y compris au zoom textuel.
- En supprimant du contenu de la preview initiale, la largeur du passage (et donc du grain) ne doit pas changer. Ça ne doit pas avoir d'impact sur le reste de la page, peu importe la résolution.