### PR TITLE
[TECH] Migrer les erreurs du domaine Evaluation (PIX-12295).

### DIFF
--- a/admin/app/components/badges/campaign-criterion.js
+++ b/admin/app/components/badges/campaign-criterion.js
@@ -32,9 +32,14 @@ export default class CampaignCriterion extends Component {
       await criterion.save();
       this.notifications.success("Seuil d'obtention du critère modifié avec succès.");
       this.toggleEditModal();
-    } catch (error) {
-      this.notifications.error("Problème lors de la modification du seuil d'obtention du critère.");
-      console.log(error);
+    } catch (responseError) {
+      responseError?.errors?.forEach((error) => {
+        if (error?.detail) {
+          this.notifications.error(error.detail);
+        } else {
+          this.notifications.error("Problème lors de la modification du seuil d'obtention du critère.");
+        }
+      });
     }
   }
 }

--- a/admin/tests/integration/components/badges/campaign-criterion_test.js
+++ b/admin/tests/integration/components/badges/campaign-criterion_test.js
@@ -102,7 +102,13 @@ module('Integration | Component | Badges::CampaignCriterion', function (hooks) {
 
       test('should display an error notification', async function (assert) {
         // given
-        this.criterion.save.throws();
+        this.criterion.save.throws({
+          errors: [
+            {
+              detail: "Il est interdit de modifier un critère d'un résultat thématique déjà acquis par un utilisateur.",
+            },
+          ],
+        });
 
         // when
         await click(modal.getByRole('button', { name: 'Enregistrer' }));
@@ -110,7 +116,7 @@ module('Integration | Component | Badges::CampaignCriterion', function (hooks) {
         // then
         sinon.assert.calledWith(
           notificationErrorStub,
-          "Problème lors de la modification du seuil d'obtention du critère.",
+          "Il est interdit de modifier un critère d'un résultat thématique déjà acquis par un utilisateur.",
         );
         assert.ok(true);
       });

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -261,9 +261,6 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.TargetProfileInvalidError) {
     return new HttpErrors.PreconditionFailedError(error.message);
   }
-  if (error instanceof DomainErrors.StageModificationForbiddenForLinkedTargetProfileError) {
-    return new HttpErrors.PreconditionFailedError(error.message);
-  }
   if (error instanceof DomainErrors.NoStagesForCampaign) {
     return new HttpErrors.PreconditionFailedError(error.message);
   }

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -37,9 +37,6 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.AccountRecoveryUserAlreadyConfirmEmail) {
     return new HttpErrors.ConflictError(error.message);
   }
-  if (error instanceof DomainErrors.ImproveCompetenceEvaluationForbiddenError) {
-    return new HttpErrors.ImproveCompetenceEvaluationForbiddenError(error.message);
-  }
   if (error instanceof DomainErrors.AlreadyRatedAssessmentError) {
     return new HttpErrors.PreconditionFailedError('Assessment is already rated.');
   }

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -40,9 +40,6 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.AlreadyRatedAssessmentError) {
     return new HttpErrors.PreconditionFailedError('Assessment is already rated.');
   }
-  if (error instanceof DomainErrors.CompetenceResetError) {
-    return new HttpErrors.PreconditionFailedError(error.message);
-  }
   if (error instanceof DomainErrors.NotEnoughDaysPassedBeforeResetCampaignParticipationError) {
     return new HttpErrors.PreconditionFailedError(error.message);
   }

--- a/api/lib/application/http-errors.js
+++ b/api/lib/application/http-errors.js
@@ -95,14 +95,6 @@ class ServiceUnavailableError extends BaseHttpError {
   }
 }
 
-class ImproveCompetenceEvaluationForbiddenError extends BaseHttpError {
-  constructor(message) {
-    super(message);
-    this.title = 'ImproveCompetenceEvaluationForbidden';
-    this.status = 403;
-  }
-}
-
 class BadRequestError extends BaseHttpError {
   constructor(message, code, meta) {
     super(message);
@@ -155,7 +147,6 @@ const HttpErrors = {
   BaseHttpError,
   ConflictError,
   ForbiddenError,
-  ImproveCompetenceEvaluationForbiddenError,
   MissingQueryParamError,
   NotFoundError,
   PasswordShouldChangeError,
@@ -175,7 +166,6 @@ export {
   ConflictError,
   ForbiddenError,
   HttpErrors,
-  ImproveCompetenceEvaluationForbiddenError,
   MissingQueryParamError,
   NotFoundError,
   PasswordShouldChangeError,

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -588,12 +588,6 @@ class CsvParsingError extends DomainError {
   }
 }
 
-class ImproveCompetenceEvaluationForbiddenError extends DomainError {
-  constructor(message = 'Le niveau maximum est déjà atteint pour cette compétence.') {
-    super(message);
-  }
-}
-
 class InvalidPasswordForUpdateEmailError extends DomainError {
   constructor(message = 'Le mot de passe que vous avez saisi est invalide.') {
     super(message);
@@ -1138,7 +1132,6 @@ export {
   DomainError,
   EmailModificationDemandNotFoundOrExpiredError,
   FileValidationError,
-  ImproveCompetenceEvaluationForbiddenError,
   InvalidCertificationCandidate,
   InvalidCertificationIssueReportForSaving,
   InvalidExternalAPIResponseError,

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -747,14 +747,6 @@ class TargetProfileInvalidError extends DomainError {
   }
 }
 
-class StageModificationForbiddenForLinkedTargetProfileError extends DomainError {
-  constructor(targetProfileId) {
-    super(
-      `Le profil cible ${targetProfileId} est déjà rattaché à une campagne. La modification du seuil ou niveau est alors impossible.`,
-    );
-  }
-}
-
 class OrganizationTagNotFound extends DomainError {
   constructor(message = 'Le tag de l’organization n’existe pas.') {
     super(message);
@@ -1167,7 +1159,6 @@ export {
   SessionNotAccessible,
   SessionWithIdAndInformationOnMassImportError,
   SIECLE_ERRORS,
-  StageModificationForbiddenForLinkedTargetProfileError,
   SupervisorAccessNotAuthorizedError,
   TargetProfileCannotBeCreated,
   TargetProfileInvalidError,

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -419,12 +419,6 @@ class SendingEmailToResultRecipientError extends DomainError {
   }
 }
 
-class CompetenceResetError extends DomainError {
-  constructor(remainingDaysBeforeReset) {
-    super(`Il reste ${remainingDaysBeforeReset} jours avant de pouvoir réinitiliser la compétence.`);
-  }
-}
-
 class NotEnoughDaysPassedBeforeResetCampaignParticipationError extends DomainError {
   constructor() {
     super(`Il n'est pas possible de remettre à zéro votre parcours pour le moment.`);
@@ -1123,7 +1117,6 @@ export {
   ChallengeNotAskedError,
   ChallengeToBeDeneutralizedNotFoundError,
   ChallengeToBeNeutralizedNotFoundError,
-  CompetenceResetError,
   CsvParsingError,
   DeletedError,
   DeprecatedCertificationIssueReportCategoryError,

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -1001,14 +1001,6 @@ class AcquiredBadgeForbiddenDeletionError extends DomainError {
   }
 }
 
-class AcquiredBadgeForbiddenUpdateError extends DomainError {
-  constructor(
-    message = "Il est interdit de modifier un critère d'un résultat thématique déjà acquis par un utilisateur.",
-  ) {
-    super(message);
-  }
-}
-
 class CertificationBadgeForbiddenDeletionError extends DomainError {
   constructor(message = 'Il est interdit de supprimer un résultat thématique lié à une certification.') {
     super(message);
@@ -1064,7 +1056,6 @@ export {
   AccountRecoveryDemandNotCreatedError,
   AccountRecoveryUserAlreadyConfirmEmail,
   AcquiredBadgeForbiddenDeletionError,
-  AcquiredBadgeForbiddenUpdateError,
   AlreadyAcceptedOrCancelledInvitationError,
   AlreadyExistingAdminMemberError,
   AlreadyExistingCampaignParticipationError,

--- a/api/src/evaluation/application/answers/index.js
+++ b/api/src/evaluation/application/answers/index.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 
-import { NotFoundError } from '../../../../lib/domain/errors.js';
+import { NotFoundError } from '../../../shared/domain/errors.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { answerController } from './answer-controller.js';
 

--- a/api/src/evaluation/application/http-error-mapper-configuration.js
+++ b/api/src/evaluation/application/http-error-mapper-configuration.js
@@ -1,12 +1,18 @@
 import { HttpErrors } from '../../shared/application/http-errors.js';
 import { DomainErrorMappingConfiguration } from '../../shared/application/models/domain-error-mapping-configuration.js';
-import { EmptyAnswerError } from '../domain/errors.js';
+import { EmptyAnswerError, ImproveCompetenceEvaluationForbiddenError } from '../domain/errors.js';
 
 const evaluationDomainErrorMappingConfiguration = [
   {
     name: EmptyAnswerError.name,
     httpErrorFn: (error) => {
       return new HttpErrors.BadRequestError(error.message, error.code);
+    },
+  },
+  {
+    name: ImproveCompetenceEvaluationForbiddenError.name,
+    httpErrorFn: (error) => {
+      return new HttpErrors.ForbiddenError(error.message, error.code);
     },
   },
 ].map((domainErrorMappingConfiguration) => new DomainErrorMappingConfiguration(domainErrorMappingConfiguration));

--- a/api/src/evaluation/application/http-error-mapper-configuration.js
+++ b/api/src/evaluation/application/http-error-mapper-configuration.js
@@ -1,6 +1,6 @@
 import { HttpErrors } from '../../shared/application/http-errors.js';
 import { DomainErrorMappingConfiguration } from '../../shared/application/models/domain-error-mapping-configuration.js';
-import { EmptyAnswerError, ImproveCompetenceEvaluationForbiddenError } from '../domain/errors.js';
+import { CompetenceResetError, EmptyAnswerError, ImproveCompetenceEvaluationForbiddenError } from '../domain/errors.js';
 
 const evaluationDomainErrorMappingConfiguration = [
   {
@@ -13,6 +13,12 @@ const evaluationDomainErrorMappingConfiguration = [
     name: ImproveCompetenceEvaluationForbiddenError.name,
     httpErrorFn: (error) => {
       return new HttpErrors.ForbiddenError(error.message, error.code);
+    },
+  },
+  {
+    name: CompetenceResetError.name,
+    httpErrorFn: (error) => {
+      return new HttpErrors.PreconditionFailedError(error.message);
     },
   },
 ].map((domainErrorMappingConfiguration) => new DomainErrorMappingConfiguration(domainErrorMappingConfiguration));

--- a/api/src/evaluation/application/http-error-mapper-configuration.js
+++ b/api/src/evaluation/application/http-error-mapper-configuration.js
@@ -1,6 +1,6 @@
 import { HttpErrors } from '../../shared/application/http-errors.js';
 import { DomainErrorMappingConfiguration } from '../../shared/application/models/domain-error-mapping-configuration.js';
-import { CompetenceResetError, EmptyAnswerError, ImproveCompetenceEvaluationForbiddenError } from '../domain/errors.js';
+import { CompetenceResetError, EmptyAnswerError, ImproveCompetenceEvaluationForbiddenError, AcquiredBadgeForbiddenUpdateError } from '../domain/errors.js';
 
 const evaluationDomainErrorMappingConfiguration = [
   {
@@ -19,6 +19,12 @@ const evaluationDomainErrorMappingConfiguration = [
     name: CompetenceResetError.name,
     httpErrorFn: (error) => {
       return new HttpErrors.PreconditionFailedError(error.message);
+    },
+  },
+  {
+    name: AcquiredBadgeForbiddenUpdateError.name,
+    httpErrorFn: (error) => {
+      return new HttpErrors.ForbiddenError(error.message);
     },
   },
 ].map((domainErrorMappingConfiguration) => new DomainErrorMappingConfiguration(domainErrorMappingConfiguration));

--- a/api/src/evaluation/application/http-error-mapper-configuration.js
+++ b/api/src/evaluation/application/http-error-mapper-configuration.js
@@ -1,6 +1,12 @@
 import { HttpErrors } from '../../shared/application/http-errors.js';
 import { DomainErrorMappingConfiguration } from '../../shared/application/models/domain-error-mapping-configuration.js';
-import { CompetenceResetError, EmptyAnswerError, ImproveCompetenceEvaluationForbiddenError, AcquiredBadgeForbiddenUpdateError } from '../domain/errors.js';
+import {
+  AcquiredBadgeForbiddenUpdateError,
+  CompetenceResetError,
+  EmptyAnswerError,
+  ImproveCompetenceEvaluationForbiddenError,
+  StageModificationForbiddenForLinkedTargetProfileError,
+} from '../domain/errors.js';
 
 const evaluationDomainErrorMappingConfiguration = [
   {
@@ -17,6 +23,12 @@ const evaluationDomainErrorMappingConfiguration = [
   },
   {
     name: CompetenceResetError.name,
+    httpErrorFn: (error) => {
+      return new HttpErrors.PreconditionFailedError(error.message);
+    },
+  },
+  {
+    name: StageModificationForbiddenForLinkedTargetProfileError.name,
     httpErrorFn: (error) => {
       return new HttpErrors.PreconditionFailedError(error.message);
     },

--- a/api/src/evaluation/domain/errors.js
+++ b/api/src/evaluation/domain/errors.js
@@ -19,4 +19,15 @@ class ImproveCompetenceEvaluationForbiddenError extends DomainError {
   }
 }
 
-export { EmptyAnswerError, ImproveCompetenceEvaluationForbiddenError, StageWithLinkedCampaignError };
+class CompetenceResetError extends DomainError {
+  constructor(remainingDaysBeforeReset) {
+    super(`Il reste ${remainingDaysBeforeReset} jours avant de pouvoir réinitiliser la compétence.`);
+  }
+}
+
+export {
+  CompetenceResetError,
+  EmptyAnswerError,
+  ImproveCompetenceEvaluationForbiddenError,
+  StageWithLinkedCampaignError,
+};

--- a/api/src/evaluation/domain/errors.js
+++ b/api/src/evaluation/domain/errors.js
@@ -25,7 +25,16 @@ class CompetenceResetError extends DomainError {
   }
 }
 
+class AcquiredBadgeForbiddenUpdateError extends DomainError {
+  constructor(
+    message = "Il est interdit de modifier un critère d'un résultat thématique déjà acquis par un utilisateur.",
+  ) {
+    super(message);
+  }
+}
+
 export {
+  AcquiredBadgeForbiddenUpdateError,
   CompetenceResetError,
   EmptyAnswerError,
   ImproveCompetenceEvaluationForbiddenError,

--- a/api/src/evaluation/domain/errors.js
+++ b/api/src/evaluation/domain/errors.js
@@ -33,10 +33,19 @@ class AcquiredBadgeForbiddenUpdateError extends DomainError {
   }
 }
 
+class StageModificationForbiddenForLinkedTargetProfileError extends DomainError {
+  constructor(targetProfileId) {
+    super(
+      `Le profil cible ${targetProfileId} est déjà rattaché à une campagne. La modification du seuil ou niveau est alors impossible.`,
+    );
+  }
+}
+
 export {
   AcquiredBadgeForbiddenUpdateError,
   CompetenceResetError,
   EmptyAnswerError,
   ImproveCompetenceEvaluationForbiddenError,
+  StageModificationForbiddenForLinkedTargetProfileError,
   StageWithLinkedCampaignError,
 };

--- a/api/src/evaluation/domain/errors.js
+++ b/api/src/evaluation/domain/errors.js
@@ -12,4 +12,11 @@ class EmptyAnswerError extends DomainError {
   }
 }
 
-export { EmptyAnswerError, StageWithLinkedCampaignError };
+class ImproveCompetenceEvaluationForbiddenError extends DomainError {
+  constructor(message = 'Le niveau maximum est déjà atteint pour cette compétence.') {
+    super(message);
+    this.code = 'IMPROVE_COMPETENCE_EVALUATION_FORBIDDEN';
+  }
+}
+
+export { EmptyAnswerError, ImproveCompetenceEvaluationForbiddenError, StageWithLinkedCampaignError };

--- a/api/src/evaluation/domain/usecases/create-or-update-stage-collection.js
+++ b/api/src/evaluation/domain/usecases/create-or-update-stage-collection.js
@@ -1,5 +1,5 @@
-import { StageModificationForbiddenForLinkedTargetProfileError } from '../../../../lib/domain/errors.js';
 import { StageCollectionUpdate } from '../../../shared/domain/models/target-profile-management/StageCollectionUpdate.js';
+import { StageModificationForbiddenForLinkedTargetProfileError } from '../errors.js';
 
 const createOrUpdateStageCollection = async function ({
   targetProfileId,

--- a/api/src/evaluation/domain/usecases/find-answer-by-assessment.js
+++ b/api/src/evaluation/domain/usecases/find-answer-by-assessment.js
@@ -1,5 +1,4 @@
-import { UserNotAuthorizedToAccessEntityError } from '../../../../lib/domain/errors.js';
-import { EntityValidationError } from '../../../shared/domain/errors.js';
+import { EntityValidationError, UserNotAuthorizedToAccessEntityError } from '../../../shared/domain/errors.js';
 
 const findAnswerByAssessment = async function ({ assessmentId, userId, answerRepository, assessmentRepository } = {}) {
   const integerAssessmentId = parseInt(assessmentId);

--- a/api/src/evaluation/domain/usecases/get-answer.js
+++ b/api/src/evaluation/domain/usecases/get-answer.js
@@ -1,4 +1,4 @@
-import { NotFoundError } from '../../../../lib/domain/errors.js';
+import { NotFoundError } from '../../../shared/domain/errors.js';
 
 const getAnswer = async function ({ answerId, userId, answerRepository, assessmentRepository } = {}) {
   const integerAnswerId = parseInt(answerId);

--- a/api/src/evaluation/domain/usecases/get-scorecard.js
+++ b/api/src/evaluation/domain/usecases/get-scorecard.js
@@ -1,4 +1,4 @@
-import { UserNotAuthorizedToAccessEntityError } from '../../../../lib/domain/errors.js';
+import { UserNotAuthorizedToAccessEntityError } from '../../../shared/domain/errors.js';
 import { Scorecard } from '../models/Scorecard.js';
 
 const getScorecard = async function ({

--- a/api/src/evaluation/domain/usecases/improve-competence-evaluation.js
+++ b/api/src/evaluation/domain/usecases/improve-competence-evaluation.js
@@ -1,6 +1,6 @@
 import { MAX_REACHABLE_LEVEL } from '../../../../lib/domain/constants.js';
-import { ImproveCompetenceEvaluationForbiddenError } from '../../../../lib/domain/errors.js';
 import { Assessment } from '../../../shared/domain/models/Assessment.js';
+import { ImproveCompetenceEvaluationForbiddenError } from '../errors.js';
 
 const improveCompetenceEvaluation = async function ({
   competenceEvaluationRepository,

--- a/api/src/evaluation/domain/usecases/reset-scorecard.js
+++ b/api/src/evaluation/domain/usecases/reset-scorecard.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import { CompetenceResetError } from '../../../../lib/domain/errors.js';
+import { CompetenceResetError } from '../errors.js';
 import { Scorecard } from '../models/Scorecard.js';
 
 const resetScorecard = async function ({

--- a/api/src/evaluation/domain/usecases/update-badge-criterion.js
+++ b/api/src/evaluation/domain/usecases/update-badge-criterion.js
@@ -1,4 +1,4 @@
-import { AcquiredBadgeForbiddenUpdateError } from '../../../../lib/domain/errors.js';
+import { AcquiredBadgeForbiddenUpdateError } from '../errors.js';
 
 const updateBadgeCriterion = async ({ id, badgeId, attributesToUpdate, badgeCriteriaRepository, badgeRepository }) => {
   const isBadgeAlreadyAcquired = await badgeRepository.isAssociated(badgeId);

--- a/api/src/evaluation/infrastructure/repositories/autonomous-course-target-profile-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/autonomous-course-target-profile-repository.js
@@ -1,5 +1,5 @@
 import { constants } from '../../../../lib/domain/constants.js';
-import { NotFoundError } from '../../../../lib/domain/errors.js';
+import { NotFoundError } from '../../../shared/domain/errors.js';
 import { AutonomousCourseTargetProfile } from '../../domain/models/AutonomousCourseTargetProfile.js';
 
 function _toDomain(AutonomousCourseTargetProfileDTO) {

--- a/api/tests/evaluation/integration/infrastructure/repositories/autonomous-course-target-profile-repository_test.js
+++ b/api/tests/evaluation/integration/infrastructure/repositories/autonomous-course-target-profile-repository_test.js
@@ -1,7 +1,7 @@
 import { constants } from '../../../../../lib/domain/constants.js';
-import { NotFoundError } from '../../../../../lib/domain/errors.js';
 import { AutonomousCourseTargetProfile } from '../../../../../src/evaluation/domain/models/AutonomousCourseTargetProfile.js';
 import { repositories } from '../../../../../src/evaluation/infrastructure/repositories/index.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { catchErr, databaseBuilder, expect, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Repository | Autonomous Course Target Profile', function () {

--- a/api/tests/evaluation/unit/domain/usecases/find-answer-by-assessment_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/find-answer-by-assessment_test.js
@@ -1,6 +1,8 @@
-import { UserNotAuthorizedToAccessEntityError } from '../../../../../lib/domain/errors.js';
 import { findAnswerByAssessment } from '../../../../../src/evaluation/domain/usecases/find-answer-by-assessment.js';
-import { EntityValidationError } from '../../../../../src/shared/domain/errors.js';
+import {
+  EntityValidationError,
+  UserNotAuthorizedToAccessEntityError,
+} from '../../../../../src/shared/domain/errors.js';
 import { catchErr, expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | UseCase | find-answer-by-challenge-and-assessment', function () {

--- a/api/tests/evaluation/unit/domain/usecases/get-answer_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/get-answer_test.js
@@ -1,5 +1,5 @@
-import { NotFoundError } from '../../../../../lib/domain/errors.js';
 import { getAnswer } from '../../../../../src/evaluation/domain/usecases/get-answer.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | UseCase | get-answer', function () {

--- a/api/tests/evaluation/unit/domain/usecases/get-progression_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/get-progression_test.js
@@ -1,5 +1,5 @@
-import { NotFoundError } from '../../../../../lib/domain/errors.js';
 import { getProgression } from '../../../../../src/evaluation/domain/usecases/get-progression.js';
+import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.js';
 

--- a/api/tests/evaluation/unit/domain/usecases/get-scorecard_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/get-scorecard_test.js
@@ -1,6 +1,6 @@
-import { UserNotAuthorizedToAccessEntityError } from '../../../../../lib/domain/errors.js';
 import { Scorecard } from '../../../../../src/evaluation/domain/models/Scorecard.js';
 import { getScorecard } from '../../../../../src/evaluation/domain/usecases/get-scorecard.js';
+import { UserNotAuthorizedToAccessEntityError } from '../../../../../src/shared/domain/errors.js';
 import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | UseCase | get-scorecard', function () {

--- a/api/tests/evaluation/unit/domain/usecases/reset-scorecard_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/reset-scorecard_test.js
@@ -1,4 +1,4 @@
-import { CompetenceResetError } from '../../../../../lib/domain/errors.js';
+import { CompetenceResetError } from '../../../../../src/evaluation/domain/errors.js';
 import { Scorecard } from '../../../../../src/evaluation/domain/models/Scorecard.js';
 import { resetScorecard } from '../../../../../src/evaluation/domain/usecases/reset-scorecard.js';
 import { catchErr, expect, sinon } from '../../../../test-helper.js';

--- a/api/tests/evaluation/unit/domain/usecases/update-badge-criterion_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/update-badge-criterion_test.js
@@ -1,4 +1,4 @@
-import { AcquiredBadgeForbiddenUpdateError } from '../../../../../lib/domain/errors.js';
+import { AcquiredBadgeForbiddenUpdateError } from '../../../../../src/evaluation/domain/errors.js';
 import { updateBadgeCriterion } from '../../../../../src/evaluation/domain/usecases/update-badge-criterion.js';
 import { catchErr, expect, sinon } from '../../../../test-helper.js';
 

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -4,6 +4,8 @@ import {
   MissingOrInvalidCredentialsError,
   UserShouldChangePasswordError,
 } from '../../../src/identity-access-management/domain/errors.js';
+import { InvalidCertificationReportForFinalization } from '../../../src/certification/shared/domain/errors.js';
+import * as EvaluationDomainErrors from '../../../src/evaluation/domain/errors.js';
 import { CampaignParticipationDeletedError } from '../../../src/prescription/campaign-participation/domain/errors.js';
 import {
   CsvImportError,
@@ -419,12 +421,13 @@ describe('Integration | API | Controller Error', function () {
     });
 
     it('responds Forbidden when a ImproveCompetenceEvaluationForbiddenError error occurs', async function () {
-      routeHandler.throws(new DomainErrors.ImproveCompetenceEvaluationForbiddenError());
+      routeHandler.throws(new EvaluationDomainErrors.ImproveCompetenceEvaluationForbiddenError());
       const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
       expect(responseDetail(response)).to.equal('Le niveau maximum est déjà atteint pour cette compétence.');
-      expect(responseTitle(response)).to.equal('ImproveCompetenceEvaluationForbidden');
+      expect(responseTitle(response)).to.equal('Forbidden');
+      expect(responseCode(response)).to.equal('IMPROVE_COMPETENCE_EVALUATION_FORBIDDEN');
     });
 
     it('responds Forbidden when a ApplicationScopeNotAllowedError error occurs', async function () {

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -1,11 +1,11 @@
 import * as DomainErrors from '../../../lib/domain/errors.js';
 import { InvalidCertificationReportForFinalization } from '../../../src/certification/shared/domain/errors.js';
+import * as EvaluationDomainErrors from '../../../src/evaluation/domain/errors.js';
+import { CompetenceResetError } from '../../../src/evaluation/domain/errors.js';
 import {
   MissingOrInvalidCredentialsError,
   UserShouldChangePasswordError,
 } from '../../../src/identity-access-management/domain/errors.js';
-import { InvalidCertificationReportForFinalization } from '../../../src/certification/shared/domain/errors.js';
-import * as EvaluationDomainErrors from '../../../src/evaluation/domain/errors.js';
 import { CampaignParticipationDeletedError } from '../../../src/prescription/campaign-participation/domain/errors.js';
 import {
   CsvImportError,
@@ -80,7 +80,7 @@ describe('Integration | API | Controller Error', function () {
     });
 
     it('responds Precondition Failed when a CompetenceResetError error occurs', async function () {
-      routeHandler.throws(new DomainErrors.CompetenceResetError(2));
+      routeHandler.throws(new CompetenceResetError(2));
       const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(PRECONDITION_FAILED);

--- a/api/tests/unit/domain/usecases/create-or-update-stage-collection_test.js
+++ b/api/tests/unit/domain/usecases/create-or-update-stage-collection_test.js
@@ -1,4 +1,4 @@
-import { StageModificationForbiddenForLinkedTargetProfileError } from '../../../../lib/domain/errors.js';
+import { StageModificationForbiddenForLinkedTargetProfileError } from '../../../../src/evaluation/domain/errors.js';
 import { createOrUpdateStageCollection } from '../../../../src/evaluation/domain/usecases/create-or-update-stage-collection.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';
 

--- a/api/tests/unit/domain/usecases/improve-competence-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/improve-competence-evaluation_test.js
@@ -1,5 +1,5 @@
 import { MAX_REACHABLE_LEVEL } from '../../../../lib/domain/constants.js';
-import { ImproveCompetenceEvaluationForbiddenError } from '../../../../lib/domain/errors.js';
+import { ImproveCompetenceEvaluationForbiddenError } from '../../../../src/evaluation/domain/errors.js';
 import { improveCompetenceEvaluation } from '../../../../src/evaluation/domain/usecases/improve-competence-evaluation.js';
 import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';

--- a/mon-pix/app/services/competence-evaluation.js
+++ b/mon-pix/app/services/competence-evaluation.js
@@ -9,12 +9,13 @@ export default class CompetenceEvaluationService extends Service {
       await this.store.queryRecord('competence-evaluation', { improve: true, userId, competenceId });
       this.router.transitionTo('authenticated.competences.resume', competenceId);
     } catch (error) {
-      const title = 'errors' in error ? error.errors.get('firstObject').title : null;
-      if (title === 'ImproveCompetenceEvaluationForbidden') {
-        return this._reloadScorecard(scorecardId);
-      } else {
-        throw error;
-      }
+      error.errors.forEach((error) => {
+        if (error.code === 'IMPROVE_COMPETENCE_EVALUATION_FORBIDDEN') {
+          return this._reloadScorecard(scorecardId);
+        } else {
+          throw error;
+        }
+      });
     }
   }
 

--- a/mon-pix/tests/unit/services/competence-evaluation_test.js
+++ b/mon-pix/tests/unit/services/competence-evaluation_test.js
@@ -55,7 +55,7 @@ module('Unit | Service | competence-evaluation', function (hooks) {
         // given
         competenceEvaluationService = this.owner.lookup('service:competence-evaluation');
         store = Service.create({
-          queryRecord: () => reject({ errors: [{ title: 'ImproveCompetenceEvaluationForbidden' }] }),
+          queryRecord: () => reject({ errors: [{ code: 'IMPROVE_COMPETENCE_EVALUATION_FORBIDDEN' }] }),
           findRecord: sinon.stub().resolves(),
         });
         router = EmberObject.create({ transitionTo: sinon.stub() });
@@ -97,7 +97,7 @@ module('Unit | Service | competence-evaluation', function (hooks) {
           // eslint-disable-next-line qunit/no-early-return
           return;
         }
-        sinon.assert.fail('Improve Competence Evaluation should have throw an error.');
+        sinon.assert.fail('Improve Competence Evaluation should have thrown an error.');
         assert.ok(true);
       });
 


### PR DESCRIPTION
## :unicorn: Problème
On continue la migration vers les bounded contexts. Dans cette PR on s'attaque aux erreurs du scope Evaluation qui seraient encore dans lib.

## :robot: Proposition
Migrer les erreurs vers le dossier Evaluation ou utiliser les erreurs déjà migrées dans le dossier partagé.

## :100: Pour tester
- Les tests passent