### PR TITLE
[TECH] Ajout de la colonne de typage des souscriptions à une certification (PIX-1221).

### DIFF
--- a/api/db/database-builder/factory/build-complementary-certification-subscription.js
+++ b/api/db/database-builder/factory/build-complementary-certification-subscription.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 
+import { SubscriptionTypes } from '../../../src/certification/shared/domain/models/SubscriptionTypes.js';
 import { databaseBuffer } from '../database-buffer.js';
 import { buildCertificationCandidate } from './build-certification-candidate.js';
 import { buildComplementaryCertification } from './build-complementary-certification.js';
@@ -16,14 +17,14 @@ const buildComplementaryCertificationSubscription = function ({
     ? buildComplementaryCertification().id
     : complementaryCertificationId;
 
-  const values = {
-    certificationCandidateId,
-    complementaryCertificationId,
-    createdAt,
-  };
   return databaseBuffer.pushInsertable({
     tableName: 'certification-subscriptions',
-    values,
+    values: {
+      certificationCandidateId,
+      complementaryCertificationId,
+      createdAt,
+      type: SubscriptionTypes.COMPLEMENTARY,
+    },
   });
 };
 

--- a/api/db/migrations/20240425162400_add-type-column-to-certification-subscriptions-table.js
+++ b/api/db/migrations/20240425162400_add-type-column-to-certification-subscriptions-table.js
@@ -1,0 +1,19 @@
+const up = async function (knex) {
+  await knex.schema.table('complementary-certification-subscriptions', function (table) {
+    table.text('type').notNull().defaultTo('COMPLEMENTARY');
+  });
+
+  await knex.schema.dropView('certification-subscriptions');
+  return knex.schema.createView('certification-subscriptions', function (view) {
+    view.as(knex('complementary-certification-subscriptions'));
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.dropView('certification-subscriptions');
+  return knex.schema.createView('certification-subscriptions', function (view) {
+    view.as(knex('complementary-certification-subscriptions'));
+  });
+};
+
+export { down, up };

--- a/api/src/certification/session/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/src/certification/session/infrastructure/repositories/certification-candidate-repository.js
@@ -14,6 +14,7 @@ import * as bookshelfToDomainConverter from '../../../../../lib/infrastructure/u
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 import { normalize } from '../../../../shared/infrastructure/utils/string-utils.js';
 import { ComplementaryCertification } from '../../../complementary-certification/domain/models/ComplementaryCertification.js';
+import { SubscriptionTypes } from '../../../shared/domain/models/SubscriptionTypes.js';
 
 const linkToUser = async function ({ id, userId }) {
   try {
@@ -53,6 +54,7 @@ const saveInSession = async function ({
       const complementaryCertificationSubscriptionToSave = {
         complementaryCertificationId: certificationCandidate.complementaryCertification.id,
         certificationCandidateId: addedCertificationCandidate.id,
+        type: SubscriptionTypes.COMPLEMENTARY,
       };
 
       const insertComplementaryCertificationSubscriptionQuery = knex('certification-subscriptions').insert(

--- a/api/src/certification/shared/domain/models/SubscriptionTypes.js
+++ b/api/src/certification/shared/domain/models/SubscriptionTypes.js
@@ -1,0 +1,8 @@
+/**
+ * Types of certification subscriptions
+ * @readonly
+ * @enum {string}
+ */
+export const SubscriptionTypes = Object.freeze({
+  COMPLEMENTARY: 'COMPLEMENTARY',
+});


### PR DESCRIPTION
## :unicorn: Problème

Nous voulons faire porter la notion d’inscription d’un candidat à une certif Pix coeur de manière détachée d’une certif complémentaire. Mais aujourd’jui nous assumons que un candidat passe toujours un pix coeur.

## :robot: Proposition

Préparer l'arrivée d'une souscription de type "coeur" en typant l'existant (choisi à COMPLEMENTARY)

## :rainbow: Remarques

## :100: Pour tester

* Sur Pix certif avec `certif-pro@example.net`
* Ajouter un candidat via l'import de candidats avec une complémentaire
* Ajouter un candidat via l'import de sessions avec une complémentaire
* Ajouter candidat via la modale avec une complémentaire

