### PR TITLE
[BUGFIX] Vérifier la présence d'un doublon de session uniquement dans le centre de certification courant lors de l'import en masse sur Pix Certif (PIX-11930).

### DIFF
--- a/api/src/certification/session/domain/services/sessions-import-validation-service.js
+++ b/api/src/certification/session/domain/services/sessions-import-validation-service.js
@@ -51,7 +51,10 @@ const validateSession = async function ({
     }
   } else {
     if (_isDateAndTimeValid(session)) {
-      const isSessionExisting = await sessionRepository.isSessionExisting({ ...session });
+      const isSessionExisting = await sessionRepository.isSessionExistingByCertificationCenterId({
+        ...session,
+        certificationCenterId,
+      });
       if (isSessionExisting) {
         _addToErrorList({
           errorList: sessionErrors,

--- a/api/src/certification/session/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/session/infrastructure/repositories/session-repository.js
@@ -43,8 +43,8 @@ const get = async function ({ id }) {
   return new Session({ ...foundSession });
 };
 
-const isSessionExisting = async function ({ address, room, date, time }) {
-  const sessions = await knex('sessions').where({ address, room, date, time });
+const isSessionExistingByCertificationCenterId = async function ({ address, room, date, time, certificationCenterId }) {
+  const sessions = await knex('sessions').where({ address, room, date, time }).andWhere({ certificationCenterId });
   return sessions.length > 0;
 };
 
@@ -237,7 +237,7 @@ export {
   isFinalized,
   isPublished,
   isSco,
-  isSessionExisting,
+  isSessionExistingByCertificationCenterId,
   isSessionExistingBySessionAndCertificationCenterIds,
   remove,
   save,

--- a/api/tests/certification/session/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/certification/session/integration/infrastructure/repositories/session-repository_test.js
@@ -1019,7 +1019,7 @@ describe('Integration | Repository | Session', function () {
     });
   });
 
-  describe('#isSessionExisting', function () {
+  describe('#isSessionExistingByCertificationCenterId', function () {
     it('should return true if the session already exists', async function () {
       // given
       const session = {
@@ -1029,12 +1029,19 @@ describe('Integration | Repository | Session', function () {
         date: '2018-02-23',
         time: '12:00:00',
       };
-      databaseBuilder.factory.buildSession({ ...session, examiner: 'Monsieur Examinateur, Madame Examinatrice' });
-
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      databaseBuilder.factory.buildSession({
+        ...session,
+        examiner: 'Monsieur Examinateur, Madame Examinatrice',
+        certificationCenterId,
+      });
       await databaseBuilder.commit();
 
       // when
-      const result = await sessionRepository.isSessionExisting({ ...session });
+      const result = await sessionRepository.isSessionExistingByCertificationCenterId({
+        ...session,
+        certificationCenterId,
+      });
 
       // then
       expect(result).to.equal(true);
@@ -1049,9 +1056,14 @@ describe('Integration | Repository | Session', function () {
         date: '2018-02-23',
         time: '12:00:00',
       };
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      await databaseBuilder.commit();
 
       // when
-      const result = await sessionRepository.isSessionExisting({ ...session });
+      const result = await sessionRepository.isSessionExistingByCertificationCenterId({
+        ...session,
+        certificationCenterId,
+      });
 
       // then
       expect(result).to.equal(false);

--- a/api/tests/certification/session/unit/domain/services/sessions-import-validation-service_test.js
+++ b/api/tests/certification/session/unit/domain/services/sessions-import-validation-service_test.js
@@ -19,7 +19,7 @@ describe('Unit | Service | sessions import validation Service', function () {
         toFake: ['Date'],
       });
       sessionRepository = {
-        isSessionExisting: sinon.stub(),
+        isSessionExistingByCertificationCenterId: sinon.stub(),
         isSessionExistingBySessionAndCertificationCenterIds: sinon.stub(),
       };
       certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
@@ -34,8 +34,11 @@ describe('Unit | Service | sessions import validation Service', function () {
         context('when there is no sessionId', function () {
           it('should return an empty sessionErrors array', async function () {
             // given
+            const certificationCenterId = domainBuilder.buildCertificationCenter({}).id;
             const session = _buildValidSessionWithoutId();
-            sessionRepository.isSessionExisting.withArgs({ ...session }).resolves(false);
+            sessionRepository.isSessionExistingByCertificationCenterId
+              .withArgs({ ...session, certificationCenterId })
+              .resolves(false);
 
             // when
             const sessionErrors = await sessionsImportValidationService.validateSession({
@@ -251,13 +254,17 @@ describe('Unit | Service | sessions import validation Service', function () {
     context('when there already is an existing session with the same data as a newly imported one', function () {
       it('should return a sessionErrors array that contains a session already existing error', async function () {
         // given
+        const certificationCenterId = domainBuilder.buildCertificationCenter({}).id;
         const session = _buildValidSessionWithoutId();
-        sessionRepository.isSessionExisting.withArgs({ ...session }).resolves(true);
+        sessionRepository.isSessionExistingByCertificationCenterId
+          .withArgs({ ...session, certificationCenterId })
+          .resolves(true);
 
         // when
         const sessionErrors = await sessionsImportValidationService.validateSession({
           session,
           line: 1,
+          certificationCenterId,
           sessionRepository,
           certificationCourseRepository,
         });
@@ -288,7 +295,7 @@ describe('Unit | Service | sessions import validation Service', function () {
         });
 
         // then
-        expect(sessionRepository.isSessionExisting).to.not.have.been.called;
+        expect(sessionRepository.isSessionExistingByCertificationCenterId).to.not.have.been.called;
         expect(sessionErrors).to.deep.equal([
           {
             line: 1,
@@ -314,7 +321,7 @@ describe('Unit | Service | sessions import validation Service', function () {
         });
 
         // then
-        expect(sessionRepository.isSessionExisting).to.not.have.been.called;
+        expect(sessionRepository.isSessionExistingByCertificationCenterId).to.not.have.been.called;
         expect(sessionErrors).to.deep.equal([
           {
             line: 1,


### PR DESCRIPTION
## :unicorn: Problème
Actuellement dans l'import en masse, il est possible d'avoir cette erreur bloquante lorsque la session existe déjà en BDD (même infos address, time, date etc...).
<img width="1256" alt="Capture d’écran 2024-04-25 à 16 48 26" src="https://github.com/1024pix/pix/assets/58915422/0f5c26e9-20fa-49a7-ae83-9fb503eafafd">

On souhaite ne pas avoir de doublon de session oui, mais au sein du même centre de certification uniquement. 
Or ici, on jette cette erreur en recherchant dans l'ensemble des sessions en BDD, tout centre confondu 

## :robot: Proposition
Rechercher la présence de doublon uniquement pour le centre de certification courant.

## :rainbow: Remarques
Cette vérification de doublon ne se fait que dans l'import en masse actuellement. 
Question posée à Agnès pour savoir si on souhaite l'appliquer à la création de session classique.

## :100: Pour tester

- Se connecter sur Pix Certif avec certif-pro@example.net
- Créer une session classique (retenez les infos mises !)
- Cliquer sur Créer/éditer des sessions
- Télécharger un CSV et le remplir avec les mêmes infos que dans la première session créé (faut qu'ils soient iso)
- Importer le fichier
- Constater l'erreur suivante

<img width="1256" alt="Capture d’écran 2024-04-25 à 16 48 26" src="https://github.com/1024pix/pix/assets/58915422/961a169b-e88c-4beb-91e1-a837d4fd41bd">

- Changer de centre via le menu en haut à droite
- Cliquer sur Créer/éditer des sessions
- Télécharger un CSV et le remplir avec les mêmes infos que dans la première session créé (faut qu'ils soient iso)
- Importer le fichier
- Constater que l'import autorise ce doublon de session dans des CDC différents.
