### PR TITLE
[BUGFIX] Faire la redirection vers application avant de faire le reload d'un user (pix-12322)

### DIFF
--- a/orga/app/components/layout/user-logged-menu.js
+++ b/orga/app/components/layout/user-logged-menu.js
@@ -51,12 +51,12 @@ export default class UserLoggedMenu extends Component {
     userOrgaSettings.organization = selectedOrganization;
     await userOrgaSettings.save({ adapterOptions: { userId: prescriber.id } });
 
-    await this.currentUser.load();
-
-    this.closeMenu();
-
     const queryParams = {};
     Object.keys(this.router.currentRoute.queryParams).forEach((key) => (queryParams[key] = undefined));
     this.router.replaceWith('authenticated', { queryParams });
+
+    await this.currentUser.load();
+
+    this.closeMenu();
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Bug: 
1. Un user s’est connecté sur pix orga avec une orga qui a une feature 
2. Ce user va sur une page seulement accessible que si l'orga a la dite feature 
3. Ce user change d’orga (dans le men en haut à droite) pour une qui n'a pas la feature  ==> cela peut faire planter l'appli.

Après investigation, on s'est rendu compte lorsque le user change d'orga pour une sans la feature (donc techniquement ne devrait plus avoir accès à cette page), la page sur laquelle était le user (celle qui ne devrait pas voir) est d'abord rechargée  et ensuite la redirection avec la page d'accueil est faite.

## :robot: Proposition
Faire en sorte de faire d'abord la redirect et ensuite on recharge le user

## :rainbow: Remarques

## :100: Pour tester
- Se connecter avec `1d-orga@example.net`
- Aller sur l'orga `École des Pyrénées`
- Aller sur l'url `import-participants`
- Changer d'orga et sélectionner `École des Alpes` => Voir qu'on est redirigé vers la page des missions