### PR TITLE
[TECH] Ajoute la certification complementaire PRO_SANTE (PIX-12284)

### DIFF
--- a/api/db/migrations/20240425154143_add-pix-pro-sante.js
+++ b/api/db/migrations/20240425154143_add-pix-pro-sante.js
@@ -1,0 +1,34 @@
+const TABLE_NAME = 'complementary-certifications';
+const key = 'PRO_SANTE';
+
+const up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.string('key').unique().notNullable().alter();
+  });
+
+  await knex(TABLE_NAME)
+    .insert({
+      label: 'Pix+ Professionnels de santé',
+      key: 'PRO_SANTE',
+      hasComplementaryReferential: true,
+      hasExternalJury: false,
+      certificationExtraTime: 45,
+      minimumReproducibilityRate: 75,
+      minimumReproducibilityRateLowerLevel: 60,
+    })
+    .onConflict('key')
+    .merge([
+      'label',
+      'hasComplementaryReferential',
+      'hasExternalJury',
+      'certificationExtraTime',
+      'minimumReproducibilityRate',
+      'minimumReproducibilityRateLowerLevel',
+    ]);
+};
+
+const down = async function (knex) {
+  await knex(TABLE_NAME).where({ key }).del();
+};
+
+export { down, up };

--- a/api/db/seeds/data/common/common-builder.js
+++ b/api/db/seeds/data/common/common-builder.js
@@ -10,7 +10,6 @@ const { ROLES } = PIX_ADMIN;
 const CLEA_COMPLEMENTARY_CERTIFICATION_ID = 52;
 const PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID = 53;
 const PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID = 54;
-const PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID = 55;
 
 // USERS
 const REAL_PIX_SUPER_ADMIN_ID = 90000;
@@ -68,7 +67,6 @@ export {
   PIX_EDU_1ER_DEGRE_FI_INITIE_CERTIFIABLE_BADGE_ID,
   PIX_EDU_1ER_DEGRE_FI_INITIE_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
   PIX_EDU_1ER_DEGRE_FI_TARGET_PROFILE_ID,
-  PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
   PIX_EDU_2ND_DEGRE_CONFIRME_CERTIFIABLE_BADGE_ID,
   PIX_EDU_2ND_DEGRE_CONFIRME_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
   PIX_EDU_2ND_DEGRE_INITIE_CERTIFIABLE_BADGE_ID,
@@ -140,13 +138,12 @@ function _createCertifAdmin(databaseBuilder) {
 }
 
 function _createComplementaryCertifications(databaseBuilder) {
-  _createClea(databaseBuilder);
-  _createDroit(databaseBuilder);
-  _createPixEdu1erDegre(databaseBuilder);
-  _createPixEdu2ndDegre(databaseBuilder);
+  _createComplementaryWithoutReferential(databaseBuilder);
+  _createComplementaryWithHasComplementaryReferential(databaseBuilder);
+  _createWithHasExternalJury(databaseBuilder);
 }
 
-function _createClea(databaseBuilder) {
+function _createComplementaryWithoutReferential(databaseBuilder) {
   databaseBuilder.factory.buildComplementaryCertification.clea({
     id: CLEA_COMPLEMENTARY_CERTIFICATION_ID,
   });
@@ -339,7 +336,7 @@ function _createClea(databaseBuilder) {
   });
 }
 
-function _createDroit(databaseBuilder) {
+function _createComplementaryWithHasComplementaryReferential(databaseBuilder) {
   databaseBuilder.factory.buildComplementaryCertification.droit({
     id: PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
   });
@@ -693,7 +690,7 @@ function _createDroit(databaseBuilder) {
   });
 }
 
-function _createPixEdu1erDegre(databaseBuilder) {
+function _createWithHasExternalJury(databaseBuilder) {
   databaseBuilder.factory.buildComplementaryCertification.pixEdu1erDegre({
     id: PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
   });
@@ -989,254 +986,6 @@ function _createPixEdu1erDegre(databaseBuilder) {
     temporaryCertificateMessage:
       'Vous avez obtenu le niveau “Confirmé” dans le cadre du volet 1 de la certification Pix+Édu. Votre niveau final sera déterminé à l’issue du volet 2',
     stickerUrl: 'https://images.pix.fr/stickers/macaron_edu_1er_confirme.pdf',
-    createdBy: REAL_PIX_SUPER_ADMIN_ID,
-  });
-}
-
-function _createPixEdu2ndDegre(databaseBuilder) {
-  databaseBuilder.factory.buildComplementaryCertification.pixEdu2ndDegre({
-    id: PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
-  });
-  databaseBuilder.factory.buildTargetProfile({
-    id: PIX_EDU_2ND_DEGRE_TARGET_PROFILE_ID,
-    imageUrl: null,
-    description: null,
-    name: '[Pix+Édu 2D FI] Prêt pour la certification du volet 1 (CRCN et CRCNÉ) 20 04 2023',
-    isSimplifiedAccess: false,
-    category: 'PREDEFINED',
-    isPublic: true,
-    ownerOrganizationId: PRO_ORGANIZATION_ID,
-  });
-  [
-    { tubeId: 'rec5D8oOcnSVc1wb5', level: 6 },
-    { tubeId: 'recS1VZiU2ZNQEJey', level: 6 },
-    { tubeId: 'recFj3ODyi6whwFzk', level: 3 },
-    { tubeId: 'recy4WSQsbpvLjL1g', level: 5 },
-    { tubeId: 'recfRTGX0vJNzhApQ', level: 6 },
-    { tubeId: 'rec1oD4DBP8UIXzSR', level: 3 },
-    { tubeId: 'recWYmbh7BF8BNj4', level: 4 },
-    { tubeId: 'rec2LvRgMZNGPbSKs', level: 4 },
-    { tubeId: 'rec1S5JJUERpVhoYn', level: 2 },
-    { tubeId: 'rec2gMOBRcypr0ckl', level: 2 },
-    { tubeId: 'rec2fyFEOv1ef9iOY', level: 2 },
-    { tubeId: 'rec28mkBzkQlNxsU4', level: 5 },
-    { tubeId: 'recsoZIZxVEr3h2og', level: 5 },
-    { tubeId: 'rec2fpugR3auJLwcH', level: 4 },
-    { tubeId: 'rec2CFQNcZNEpr6jk', level: 3 },
-    { tubeId: 'recCTEeJefuFO1Pjy', level: 5 },
-    { tubeId: 'rec2Vi2Bg4LdMmEjd', level: 4 },
-    { tubeId: 'recLtN5zlea2WhR6', level: 3 },
-    { tubeId: 'recPtX9sny8yBBvn', level: 4 },
-    { tubeId: 'rece5w6NqPCDo87zS', level: 4 },
-    { tubeId: 'rec18Fli7IwDRdxUM', level: 2 },
-    { tubeId: 'rec1BYw6lxKdlGoPA', level: 2 },
-    { tubeId: 'rec1Y7stSsdwX4tkM', level: 3 },
-    { tubeId: 'recVpgUtxW3xx5Pu', level: 6 },
-    { tubeId: 'rec2cFYduLeErwNQE', level: 5 },
-    { tubeId: 'rec23QiLTJkPc7Sk1', level: 2 },
-    { tubeId: 'recYmSqXBdRWCbTL6', level: 6 },
-    { tubeId: 'recPUBbe8eBDIpJH', level: 2 },
-    { tubeId: 'rec1gP2RFbGcAaKC3', level: 5 },
-    { tubeId: 'recDXjekxwm1Nh77T', level: 4 },
-    { tubeId: 'rec4RO6t7qai3ODuJ', level: 5 },
-    { tubeId: 'rec2lCszrDoN3t4XI', level: 2 },
-    { tubeId: 'recoPAkxe29Ru3r3h', level: 6 },
-    { tubeId: 'rec2mSskzOmeuvu5x', level: 3 },
-    { tubeId: 'recLlI3H6pPzlZ3c', level: 2 },
-    { tubeId: 'reczBuVhH7fuC4u3k', level: 5 },
-    { tubeId: 'recZOEoQzjBUQR9hw', level: 5 },
-    { tubeId: 'recnK0Dzr3R9NGG12', level: 5 },
-    { tubeId: 'recZfuVlR27qVXcAt', level: 4 },
-    { tubeId: 'rectTJBNUL6lz0sEJ', level: 5 },
-    { tubeId: 'recb576QI4qODr9EQ', level: 6 },
-    { tubeId: 'recW9R9lBG3faLOzL', level: 4 },
-    { tubeId: 'recIEuCfChJpc8UyH', level: 6 },
-    { tubeId: 'recVpHG0NDURRRycg', level: 5 },
-    { tubeId: 'recO7LXR9gQ2TOiDd', level: 3 },
-    { tubeId: 'reccqGUKgzIOK8f9U', level: 4 },
-    { tubeId: 'rec1Z5gkirQNvtjrK', level: 5 },
-    { tubeId: 'recqjSAxTnNej5zSQ', level: 6 },
-    { tubeId: 'recYFCpGlmwQwAONl', level: 5 },
-    { tubeId: 'recY3xrzPegD40fkO', level: 5 },
-    { tubeId: 'rec5hclRSqG7gpadZ', level: 5 },
-    { tubeId: 'rec38YpXqa8RtM1Yy', level: 6 },
-    { tubeId: 'recpz9gZET6VJFeen', level: 5 },
-    { tubeId: 'recghgiH1DlfS0vv4', level: 5 },
-    { tubeId: 'recEC0V9qBbLSqHhx', level: 5 },
-    { tubeId: 'recf0RoWlVKSMke8l', level: 6 },
-    { tubeId: 'reczVXRbD2PcCcfgf', level: 5 },
-    { tubeId: 'recpe7Y8Wq2D56q6I', level: 6 },
-    { tubeId: 'recd3rYCdpWLtHXLk', level: 6 },
-    { tubeId: 'recwoTBW9eVqCl7Vd', level: 5 },
-    { tubeId: 'recyNCBKtjN1MN1mZ', level: 5 },
-    { tubeId: 'rec8lYF4iaCcI6Stl', level: 5 },
-    { tubeId: 'reczOjAWmveW8RSkv', level: 6 },
-    { tubeId: 'recMvKBYMz7qjPn5o', level: 4 },
-    { tubeId: 'recdd0tt0BaQxeSj5', level: 6 },
-    { tubeId: 'recJmEjTV9NacUqZ8', level: 5 },
-    { tubeId: 'recprH1OzWoAgWvw9', level: 5 },
-    { tubeId: 'recTVcQOH3zhL8h29', level: 6 },
-    { tubeId: 'recbjdy2SrgCRVBNu', level: 4 },
-    { tubeId: 'recwanhWqP3VMPic1', level: 5 },
-    { tubeId: 'recgkzKSGhyw1Gwtz', level: 6 },
-    { tubeId: 'recvalrsm02e63lw4', level: 5 },
-    { tubeId: 'recgrxoIilcw9uj0U', level: 5 },
-    { tubeId: 'recgPVFxgVPDUkQWX', level: 5 },
-    { tubeId: 'recEC92AOM3EAcse6', level: 4 },
-    { tubeId: 'recf4znvmRGaGBUNQ', level: 5 },
-    { tubeId: 'rectOrHRTau047Kyc', level: 3 },
-    { tubeId: 'reco9L9TNFYvZ4Bt6', level: 6 },
-    { tubeId: 'rec53o75CXpVN1soh', level: 4 },
-    { tubeId: 'recZuHNGEtpCbBPUD', level: 5 },
-    { tubeId: 'recPOjwrHFhM21yGE', level: 5 },
-    { tubeId: 'recIMsNGpsxv2GSCI', level: 6 },
-    { tubeId: 'rec1upvYVZyTbJJ4J', level: 3 },
-    { tubeId: 'recYwQBNHPtwEIchq', level: 4 },
-    { tubeId: 'recbH7WZIRE41pyVE', level: 6 },
-    { tubeId: 'recx9VucrG4p7FAOO', level: 4 },
-    { tubeId: 'recwTYcY432rb0SGA', level: 5 },
-    { tubeId: 'recLjGqbXq7Utibkb', level: 4 },
-    { tubeId: 'recPXUEpkQWNTNtIy', level: 6 },
-    { tubeId: 'recVyULQAf8zFXjCg', level: 5 },
-    { tubeId: 'recN4ik49NYTUUbVm', level: 5 },
-    { tubeId: 'recGTIO2R0edgARcA', level: 3 },
-    { tubeId: 'recl6FCNC8DBsclHV', level: 4 },
-    { tubeId: 'recps4jQoK8zCW5wI', level: 5 },
-    { tubeId: 'recRRCalqd5y2CyVD', level: 6 },
-    { tubeId: 'recTNeDmFIhhWQZi9', level: 4 },
-    { tubeId: 'recBbCIEKgrQi7eb6', level: 6 },
-    { tubeId: 'recXz8qMNXvEwIPlO', level: 5 },
-    { tubeId: 'recpnZGFdYz0siz9O', level: 5 },
-    { tubeId: 'tube28291WoQhI8rLB', level: 2 },
-    { tubeId: 'tube1weUWgKFzDS1f6', level: 2 },
-    { tubeId: 'tube1UYqjflF0Pm6Ny', level: 4 },
-    { tubeId: 'tube1xnoVru2aOYLRF', level: 2 },
-    { tubeId: 'tube29I1zg5tzEQU0H', level: 2 },
-    { tubeId: 'tube1Jgpwmj8j4OMYb', level: 4 },
-    { tubeId: 'tube2fkLl5aBvQdMyv', level: 2 },
-    { tubeId: 'tubeWKfoLk9Mlg0O0', level: 2 },
-    { tubeId: 'tube28coNkBrSHdW34', level: 2 },
-    { tubeId: 'recpP9Uaz1x6qq95e', level: 4 },
-    { tubeId: 'tube1vZZM0oflmZWvU', level: 2 },
-    { tubeId: 'recT17TO1XinYCD95', level: 6 },
-    { tubeId: 'tube2l7fFnDh1vPn4s', level: 5 },
-    { tubeId: 'tube1fUwkP4nkSMt3H', level: 2 },
-    { tubeId: 'tube1TzWCkSfVTOTIA', level: 2 },
-    { tubeId: 'tube1hzZBLOmWp9KoP', level: 3 },
-    { tubeId: 'tubeL9gPGU3vgfGuC', level: 2 },
-    { tubeId: 'tube2x5v8i5gRE3inE', level: 1 },
-    { tubeId: 'tube15ybmhs2qK2vYd', level: 3 },
-    { tubeId: 'tube1ggNIZJYHY4sxA', level: 2 },
-    { tubeId: 'tube26F5w4J602048x', level: 1 },
-  ].map(({ tubeId, level }) => {
-    databaseBuilder.factory.buildTargetProfileTube({
-      targetProfileId: PIX_EDU_2ND_DEGRE_TARGET_PROFILE_ID,
-      tubeId,
-      level,
-    });
-  });
-
-  databaseBuilder.factory.buildBadge({
-    id: PIX_EDU_2ND_DEGRE_INITIE_CERTIFIABLE_BADGE_ID,
-    targetProfileId: PIX_EDU_2ND_DEGRE_TARGET_PROFILE_ID,
-    message:
-      'Félicitations ! Votre profil est prêt pour vous présenter à une certification Pix+Édu de niveau Initié (entrée dans le métier).',
-    altMessage: 'Pix+Édu niveau Initié (entrée dans le métier)',
-    imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-1-Initie.svg',
-    key: badges.keys.PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
-    title: 'Pix+Édu niveau Initié (entrée dans le métier)',
-    isCertifiable: true,
-    isAlwaysVisible: false,
-  });
-
-  [
-    {
-      scope: 'CappedTubes',
-      threshold: 50,
-      cappedTubes:
-        '[{"id":"recPOjwrHFhM21yGE","level":5},{"id":"recpe7Y8Wq2D56q6I","level":6},{"id":"recBbCIEKgrQi7eb6","level":6},{"id":"reccqGUKgzIOK8f9U","level":4},{"id":"rec4RO6t7qai3ODuJ","level":5},{"id":"recsoZIZxVEr3h2og","level":5},{"id":"recYmSqXBdRWCbTL6","level":6},{"id":"rec5D8oOcnSVc1wb5","level":6},{"id":"recqjSAxTnNej5zSQ","level":6},{"id":"recYwQBNHPtwEIchq","level":4},{"id":"recfRTGX0vJNzhApQ","level":6},{"id":"recwanhWqP3VMPic1","level":5},{"id":"rec1gP2RFbGcAaKC3","level":5},{"id":"recN4ik49NYTUUbVm","level":5},{"id":"reczOjAWmveW8RSkv","level":6},{"id":"recXz8qMNXvEwIPlO","level":5},{"id":"recl6FCNC8DBsclHV","level":4},{"id":"recps4jQoK8zCW5wI","level":5},{"id":"reco9L9TNFYvZ4Bt6","level":6},{"id":"recS1VZiU2ZNQEJey","level":6},{"id":"recghgiH1DlfS0vv4","level":5},{"id":"recIEuCfChJpc8UyH","level":6},{"id":"recbjdy2SrgCRVBNu","level":4},{"id":"tube1UYqjflF0Pm6Ny","level":4},{"id":"recf4znvmRGaGBUNQ","level":5},{"id":"recy4WSQsbpvLjL1g","level":5},{"id":"recyNCBKtjN1MN1mZ","level":5},{"id":"recRRCalqd5y2CyVD","level":6},{"id":"recVpHG0NDURRRycg","level":5},{"id":"recZfuVlR27qVXcAt","level":4},{"id":"recb576QI4qODr9EQ","level":6},{"id":"recEC0V9qBbLSqHhx","level":5},{"id":"recwTYcY432rb0SGA","level":5},{"id":"recZuHNGEtpCbBPUD","level":5},{"id":"rec28mkBzkQlNxsU4","level":5},{"id":"recVpgUtxW3xx5Pu","level":6},{"id":"rec2cFYduLeErwNQE","level":5},{"id":"recbH7WZIRE41pyVE","level":6},{"id":"rec1Z5gkirQNvtjrK","level":5},{"id":"recd3rYCdpWLtHXLk","level":6},{"id":"recTNeDmFIhhWQZi9","level":4},{"id":"recJmEjTV9NacUqZ8","level":5},{"id":"recFj3ODyi6whwFzk","level":3},{"id":"recwoTBW9eVqCl7Vd","level":5},{"id":"recGTIO2R0edgARcA","level":3},{"id":"reczBuVhH7fuC4u3k","level":5},{"id":"recY3xrzPegD40fkO","level":5},{"id":"rec2fpugR3auJLwcH","level":4},{"id":"recEC92AOM3EAcse6","level":4},{"id":"recgPVFxgVPDUkQWX","level":5},{"id":"rec5hclRSqG7gpadZ","level":5},{"id":"recf0RoWlVKSMke8l","level":6},{"id":"recLjGqbXq7Utibkb","level":4},{"id":"recpnZGFdYz0siz9O","level":5},{"id":"recnK0Dzr3R9NGG12","level":5},{"id":"reczVXRbD2PcCcfgf","level":5},{"id":"recCTEeJefuFO1Pjy","level":5},{"id":"recgkzKSGhyw1Gwtz","level":6},{"id":"rec38YpXqa8RtM1Yy","level":6},{"id":"recTVcQOH3zhL8h29","level":6},{"id":"recx9VucrG4p7FAOO","level":4},{"id":"recprH1OzWoAgWvw9","level":5},{"id":"recIMsNGpsxv2GSCI","level":6},{"id":"recdd0tt0BaQxeSj5","level":6},{"id":"recVyULQAf8zFXjCg","level":5},{"id":"recgrxoIilcw9uj0U","level":5},{"id":"recpz9gZET6VJFeen","level":5},{"id":"rece5w6NqPCDo87zS","level":4},{"id":"rec2LvRgMZNGPbSKs","level":4},{"id":"recPtX9sny8yBBvn","level":4},{"id":"recpP9Uaz1x6qq95e","level":4},{"id":"tube2l7fFnDh1vPn4s","level":5},{"id":"rec8lYF4iaCcI6Stl","level":5},{"id":"recYFCpGlmwQwAONl","level":5},{"id":"recW9R9lBG3faLOzL","level":4},{"id":"recZOEoQzjBUQR9hw","level":5},{"id":"rec2Vi2Bg4LdMmEjd","level":4},{"id":"rectTJBNUL6lz0sEJ","level":5},{"id":"recMvKBYMz7qjPn5o","level":4},{"id":"recDXjekxwm1Nh77T","level":4},{"id":"recT17TO1XinYCD95","level":6},{"id":"recO7LXR9gQ2TOiDd","level":3},{"id":"recvalrsm02e63lw4","level":5},{"id":"rectOrHRTau047Kyc","level":3},{"id":"rec53o75CXpVN1soh","level":4},{"id":"recPXUEpkQWNTNtIy","level":6},{"id":"recoPAkxe29Ru3r3h","level":6},{"id":"rec18Fli7IwDRdxUM","level":2},{"id":"recLtN5zlea2WhR6","level":3},{"id":"rec2gMOBRcypr0ckl","level":2},{"id":"rec1Y7stSsdwX4tkM","level":3},{"id":"rec2fyFEOv1ef9iOY","level":2},{"id":"rec1S5JJUERpVhoYn","level":2},{"id":"recLlI3H6pPzlZ3c","level":2},{"id":"rec1upvYVZyTbJJ4J","level":3},{"id":"tubeWKfoLk9Mlg0O0","level":2},{"id":"recWYmbh7BF8BNj4","level":4},{"id":"recPUBbe8eBDIpJH","level":2},{"id":"rec23QiLTJkPc7Sk1","level":2},{"id":"rec2CFQNcZNEpr6jk","level":3},{"id":"rec2mSskzOmeuvu5x","level":3},{"id":"rec1oD4DBP8UIXzSR","level":3},{"id":"rec2lCszrDoN3t4XI","level":2},{"id":"rec1BYw6lxKdlGoPA","level":2},{"id":"tube26F5w4J602048x","level":1},{"id":"tube1vZZM0oflmZWvU","level":2},{"id":"tube1hzZBLOmWp9KoP","level":3},{"id":"tube1weUWgKFzDS1f6","level":2},{"id":"tube1Jgpwmj8j4OMYb","level":4},{"id":"tube1fUwkP4nkSMt3H","level":2},{"id":"tube28coNkBrSHdW34","level":2},{"id":"tubeL9gPGU3vgfGuC","level":2},{"id":"tube2fkLl5aBvQdMyv","level":2},{"id":"tube1ggNIZJYHY4sxA","level":2},{"id":"tube29I1zg5tzEQU0H","level":2},{"id":"tube28291WoQhI8rLB","level":2},{"id":"tube1xnoVru2aOYLRF","level":2},{"id":"tube15ybmhs2qK2vYd","level":3},{"id":"tube2x5v8i5gRE3inE","level":1},{"id":"tube1TzWCkSfVTOTIA","level":2}]',
-      name: '[Pix+Édu] Parcours CRCN + CRCNÉ',
-    },
-    {
-      scope: 'CappedTubes',
-      threshold: 50,
-      cappedTubes:
-        '[{"id":"rec18Fli7IwDRdxUM","level":2},{"id":"recLtN5zlea2WhR6","level":3},{"id":"rec2gMOBRcypr0ckl","level":2},{"id":"rec1Y7stSsdwX4tkM","level":3},{"id":"rec2fyFEOv1ef9iOY","level":2},{"id":"rec1S5JJUERpVhoYn","level":2},{"id":"recLlI3H6pPzlZ3c","level":2},{"id":"rec1upvYVZyTbJJ4J","level":3},{"id":"tubeWKfoLk9Mlg0O0","level":2},{"id":"recWYmbh7BF8BNj4","level":4},{"id":"recPUBbe8eBDIpJH","level":2},{"id":"rec23QiLTJkPc7Sk1","level":2},{"id":"rec2CFQNcZNEpr6jk","level":3},{"id":"rec2mSskzOmeuvu5x","level":3},{"id":"rec1oD4DBP8UIXzSR","level":3},{"id":"rec2lCszrDoN3t4XI","level":2},{"id":"rec1BYw6lxKdlGoPA","level":2},{"id":"tube26F5w4J602048x","level":1},{"id":"tube1vZZM0oflmZWvU","level":2},{"id":"tube1hzZBLOmWp9KoP","level":3},{"id":"tube1weUWgKFzDS1f6","level":2},{"id":"tube1Jgpwmj8j4OMYb","level":4},{"id":"tube1fUwkP4nkSMt3H","level":2},{"id":"tube28coNkBrSHdW34","level":2},{"id":"tubeL9gPGU3vgfGuC","level":2},{"id":"tube2fkLl5aBvQdMyv","level":2},{"id":"tube1ggNIZJYHY4sxA","level":2},{"id":"tube29I1zg5tzEQU0H","level":2},{"id":"tube28291WoQhI8rLB","level":2},{"id":"tube1xnoVru2aOYLRF","level":2},{"id":"tube15ybmhs2qK2vYd","level":3},{"id":"tube2x5v8i5gRE3inE","level":1},{"id":"tube1TzWCkSfVTOTIA","level":2}]',
-      name: '[Pix+Édu 2nd degré] Parcours CRCNÉ',
-    },
-  ].map(({ scope, threshold, cappedTubes, name }) => {
-    databaseBuilder.factory.buildBadgeCriterion({
-      badgeId: PIX_EDU_2ND_DEGRE_INITIE_CERTIFIABLE_BADGE_ID,
-      scope,
-      threshold,
-      cappedTubes,
-      name,
-    });
-  });
-
-  databaseBuilder.factory.buildComplementaryCertificationBadge({
-    id: PIX_EDU_2ND_DEGRE_INITIE_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
-    badgeId: PIX_EDU_2ND_DEGRE_INITIE_CERTIFIABLE_BADGE_ID,
-    complementaryCertificationId: PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
-    level: 1,
-    imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-1-Initie-certif.svg',
-    label: 'Pix+ Édu 2nd degré Initié (entrée dans le métier)',
-    certificateMessage: 'Vous avez obtenu la certification Pix+Édu niveau “Initié (entrée dans le métier)”',
-    temporaryCertificateMessage:
-      'Vous avez obtenu le niveau “Initié (entrée dans le métier)” dans le cadre du volet 1 de la certification Pix+Édu. Votre niveau final sera déterminé à l’issue du volet 2',
-    stickerUrl: 'https://images.pix.fr/stickers/macaron_edu_2nd_initie.pdf',
-    createdBy: REAL_PIX_SUPER_ADMIN_ID,
-  });
-
-  databaseBuilder.factory.buildBadge({
-    id: PIX_EDU_2ND_DEGRE_CONFIRME_CERTIFIABLE_BADGE_ID,
-    targetProfileId: PIX_EDU_2ND_DEGRE_TARGET_PROFILE_ID,
-    message:
-      'Félicitations ! Votre profil est prêt pour vous présenter à une certification Pix+Édu de niveau Confirmé.',
-    altMessage: 'Pix+Édu niveau Confirmé',
-    key: badges.keys.PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
-    imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-2-Confirme.svg',
-    title: 'Pix+Édu niveau Confirmé',
-    isCertifiable: true,
-    isAlwaysVisible: false,
-  });
-
-  [
-    {
-      scope: 'CappedTubes',
-      threshold: 60,
-      cappedTubes:
-        '[{"id":"recPOjwrHFhM21yGE","level":5},{"id":"recpe7Y8Wq2D56q6I","level":6},{"id":"recBbCIEKgrQi7eb6","level":6},{"id":"reccqGUKgzIOK8f9U","level":4},{"id":"rec4RO6t7qai3ODuJ","level":5},{"id":"recsoZIZxVEr3h2og","level":5},{"id":"recYmSqXBdRWCbTL6","level":6},{"id":"rec5D8oOcnSVc1wb5","level":6},{"id":"recqjSAxTnNej5zSQ","level":6},{"id":"recYwQBNHPtwEIchq","level":4},{"id":"recfRTGX0vJNzhApQ","level":6},{"id":"recwanhWqP3VMPic1","level":5},{"id":"rec1gP2RFbGcAaKC3","level":5},{"id":"recN4ik49NYTUUbVm","level":5},{"id":"reczOjAWmveW8RSkv","level":6},{"id":"recXz8qMNXvEwIPlO","level":5},{"id":"recl6FCNC8DBsclHV","level":4},{"id":"recps4jQoK8zCW5wI","level":5},{"id":"reco9L9TNFYvZ4Bt6","level":6},{"id":"recS1VZiU2ZNQEJey","level":6},{"id":"recghgiH1DlfS0vv4","level":5},{"id":"recIEuCfChJpc8UyH","level":6},{"id":"recbjdy2SrgCRVBNu","level":4},{"id":"tube1UYqjflF0Pm6Ny","level":4},{"id":"recf4znvmRGaGBUNQ","level":5},{"id":"recy4WSQsbpvLjL1g","level":5},{"id":"recyNCBKtjN1MN1mZ","level":5},{"id":"recRRCalqd5y2CyVD","level":6},{"id":"recVpHG0NDURRRycg","level":5},{"id":"recZfuVlR27qVXcAt","level":4},{"id":"recb576QI4qODr9EQ","level":6},{"id":"recEC0V9qBbLSqHhx","level":5},{"id":"recwTYcY432rb0SGA","level":5},{"id":"recZuHNGEtpCbBPUD","level":5},{"id":"rec28mkBzkQlNxsU4","level":5},{"id":"recVpgUtxW3xx5Pu","level":6},{"id":"rec2cFYduLeErwNQE","level":5},{"id":"recbH7WZIRE41pyVE","level":6},{"id":"rec1Z5gkirQNvtjrK","level":5},{"id":"recd3rYCdpWLtHXLk","level":6},{"id":"recTNeDmFIhhWQZi9","level":4},{"id":"recJmEjTV9NacUqZ8","level":5},{"id":"recFj3ODyi6whwFzk","level":3},{"id":"recwoTBW9eVqCl7Vd","level":5},{"id":"recGTIO2R0edgARcA","level":3},{"id":"reczBuVhH7fuC4u3k","level":5},{"id":"recY3xrzPegD40fkO","level":5},{"id":"rec2fpugR3auJLwcH","level":4},{"id":"recEC92AOM3EAcse6","level":4},{"id":"recgPVFxgVPDUkQWX","level":5},{"id":"rec5hclRSqG7gpadZ","level":5},{"id":"recf0RoWlVKSMke8l","level":6},{"id":"recLjGqbXq7Utibkb","level":4},{"id":"recpnZGFdYz0siz9O","level":5},{"id":"recnK0Dzr3R9NGG12","level":5},{"id":"reczVXRbD2PcCcfgf","level":5},{"id":"recCTEeJefuFO1Pjy","level":5},{"id":"recgkzKSGhyw1Gwtz","level":6},{"id":"rec38YpXqa8RtM1Yy","level":6},{"id":"recTVcQOH3zhL8h29","level":6},{"id":"recx9VucrG4p7FAOO","level":4},{"id":"recprH1OzWoAgWvw9","level":5},{"id":"recIMsNGpsxv2GSCI","level":6},{"id":"recdd0tt0BaQxeSj5","level":6},{"id":"recVyULQAf8zFXjCg","level":5},{"id":"recgrxoIilcw9uj0U","level":5},{"id":"recpz9gZET6VJFeen","level":5},{"id":"rece5w6NqPCDo87zS","level":4},{"id":"rec2LvRgMZNGPbSKs","level":4},{"id":"recPtX9sny8yBBvn","level":4},{"id":"recpP9Uaz1x6qq95e","level":4},{"id":"tube2l7fFnDh1vPn4s","level":5},{"id":"rec8lYF4iaCcI6Stl","level":5},{"id":"recYFCpGlmwQwAONl","level":5},{"id":"recW9R9lBG3faLOzL","level":4},{"id":"recZOEoQzjBUQR9hw","level":5},{"id":"rec2Vi2Bg4LdMmEjd","level":4},{"id":"rectTJBNUL6lz0sEJ","level":5},{"id":"recMvKBYMz7qjPn5o","level":4},{"id":"recDXjekxwm1Nh77T","level":4},{"id":"recT17TO1XinYCD95","level":6},{"id":"recO7LXR9gQ2TOiDd","level":3},{"id":"recvalrsm02e63lw4","level":5},{"id":"rectOrHRTau047Kyc","level":3},{"id":"rec53o75CXpVN1soh","level":4},{"id":"recPXUEpkQWNTNtIy","level":6},{"id":"recoPAkxe29Ru3r3h","level":6},{"id":"rec18Fli7IwDRdxUM","level":2},{"id":"recLtN5zlea2WhR6","level":3},{"id":"rec2gMOBRcypr0ckl","level":2},{"id":"rec1Y7stSsdwX4tkM","level":3},{"id":"rec2fyFEOv1ef9iOY","level":2},{"id":"rec1S5JJUERpVhoYn","level":2},{"id":"recLlI3H6pPzlZ3c","level":2},{"id":"rec1upvYVZyTbJJ4J","level":3},{"id":"tubeWKfoLk9Mlg0O0","level":2},{"id":"recWYmbh7BF8BNj4","level":4},{"id":"recPUBbe8eBDIpJH","level":2},{"id":"rec23QiLTJkPc7Sk1","level":2},{"id":"rec2CFQNcZNEpr6jk","level":3},{"id":"rec2mSskzOmeuvu5x","level":3},{"id":"rec1oD4DBP8UIXzSR","level":3},{"id":"rec2lCszrDoN3t4XI","level":2},{"id":"rec1BYw6lxKdlGoPA","level":2},{"id":"tube26F5w4J602048x","level":1},{"id":"tube1vZZM0oflmZWvU","level":2},{"id":"tube1hzZBLOmWp9KoP","level":3},{"id":"tube1weUWgKFzDS1f6","level":2},{"id":"tube1Jgpwmj8j4OMYb","level":4},{"id":"tube1fUwkP4nkSMt3H","level":2},{"id":"tube28coNkBrSHdW34","level":2},{"id":"tubeL9gPGU3vgfGuC","level":2},{"id":"tube2fkLl5aBvQdMyv","level":2},{"id":"tube1ggNIZJYHY4sxA","level":2},{"id":"tube29I1zg5tzEQU0H","level":2},{"id":"tube28291WoQhI8rLB","level":2},{"id":"tube1xnoVru2aOYLRF","level":2},{"id":"tube15ybmhs2qK2vYd","level":3},{"id":"tube2x5v8i5gRE3inE","level":1},{"id":"tube1TzWCkSfVTOTIA","level":2}]',
-      name: '[Pix+Édu] Parcours CRCN + CRCNÉ',
-    },
-    {
-      scope: 'CappedTubes',
-      threshold: 60,
-      cappedTubes:
-        '[{"id":"rec18Fli7IwDRdxUM","level":2},{"id":"recLtN5zlea2WhR6","level":3},{"id":"rec2gMOBRcypr0ckl","level":2},{"id":"rec1Y7stSsdwX4tkM","level":3},{"id":"rec2fyFEOv1ef9iOY","level":2},{"id":"rec1S5JJUERpVhoYn","level":2},{"id":"recLlI3H6pPzlZ3c","level":2},{"id":"rec1upvYVZyTbJJ4J","level":3},{"id":"tubeWKfoLk9Mlg0O0","level":2},{"id":"recWYmbh7BF8BNj4","level":4},{"id":"recPUBbe8eBDIpJH","level":2},{"id":"rec23QiLTJkPc7Sk1","level":2},{"id":"rec2CFQNcZNEpr6jk","level":3},{"id":"rec2mSskzOmeuvu5x","level":3},{"id":"rec1oD4DBP8UIXzSR","level":3},{"id":"rec2lCszrDoN3t4XI","level":2},{"id":"rec1BYw6lxKdlGoPA","level":2},{"id":"tube26F5w4J602048x","level":1},{"id":"tube1vZZM0oflmZWvU","level":2},{"id":"tube1hzZBLOmWp9KoP","level":3},{"id":"tube1weUWgKFzDS1f6","level":2},{"id":"tube1Jgpwmj8j4OMYb","level":4},{"id":"tube1fUwkP4nkSMt3H","level":2},{"id":"tube28coNkBrSHdW34","level":2},{"id":"tubeL9gPGU3vgfGuC","level":2},{"id":"tube2fkLl5aBvQdMyv","level":2},{"id":"tube1ggNIZJYHY4sxA","level":2},{"id":"tube29I1zg5tzEQU0H","level":2},{"id":"tube28291WoQhI8rLB","level":2},{"id":"tube1xnoVru2aOYLRF","level":2},{"id":"tube15ybmhs2qK2vYd","level":3},{"id":"tube2x5v8i5gRE3inE","level":1},{"id":"tube1TzWCkSfVTOTIA","level":2}]',
-      name: '[Pix+Édu 2nd degré] Parcours CRCNÉ',
-    },
-  ].map(({ scope, threshold, cappedTubes, name }) => {
-    databaseBuilder.factory.buildBadgeCriterion({
-      badgeId: PIX_EDU_2ND_DEGRE_CONFIRME_CERTIFIABLE_BADGE_ID,
-      scope,
-      threshold,
-      cappedTubes,
-      name,
-    });
-  });
-
-  databaseBuilder.factory.buildComplementaryCertificationBadge({
-    id: PIX_EDU_2ND_DEGRE_CONFIRME_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
-    badgeId: PIX_EDU_2ND_DEGRE_CONFIRME_CERTIFIABLE_BADGE_ID,
-    complementaryCertificationId: PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
-    level: 2,
-    imageUrl: 'https://images.pix.fr/badges/Pix_plus_Edu-2-Confirme-certif.svg',
-    label: 'Pix+ Édu 2nd degré Confirmé',
-    certificateMessage: 'Vous avez obtenu la certification Pix+Édu niveau “Confirmé”',
-    temporaryCertificateMessage:
-      'Vous avez obtenu le niveau “Confirmé” dans le cadre du volet 1 de la certification Pix+Édu. Votre niveau final sera déterminé à l’issue du volet 2',
-    stickerUrl: 'https://images.pix.fr/stickers/macaron_edu_2nd_confirme.pdf',
     createdBy: REAL_PIX_SUPER_ADMIN_ID,
   });
 }

--- a/api/db/seeds/data/common/tooling/session-tooling.js
+++ b/api/db/seeds/data/common/tooling/session-tooling.js
@@ -5,7 +5,6 @@ import {
   CLEA_COMPLEMENTARY_CERTIFICATION_ID,
   PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
   PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
-  PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
 } from '../common-builder.js';
 import * as generic from './generic.js';
 import * as learningContent from './learning-content.js';
@@ -927,7 +926,6 @@ async function _makeCandidatesComplementaryCertifiable(databaseBuilder, certific
   for (const { complementaryCertificationId, frameworkName } of [
     { complementaryCertificationId: PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID, frameworkName: 'Droit' },
     { complementaryCertificationId: PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID, frameworkName: 'Edu' },
-    { complementaryCertificationId: PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID, frameworkName: 'Edu' },
     { complementaryCertificationId: CLEA_COMPLEMENTARY_CERTIFICATION_ID, frameworkName: '' },
   ]) {
     const certificationCandidatesWithSubscription = certificationCandidates.filter(

--- a/api/db/seeds/data/team-certification/data-builder.js
+++ b/api/db/seeds/data/team-certification/data-builder.js
@@ -5,7 +5,6 @@ import {
   CLEA_COMPLEMENTARY_CERTIFICATION_ID,
   PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
   PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
-  PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
 } from '../common/common-builder.js';
 import { COLLEGE_TAG, FEATURE_CAN_REGISTER_FOR_A_COMPLEMENTARY_CERTIFICATION_ALONE_ID } from '../common/constants.js';
 import * as campaignTooling from '../common/tooling/campaign-tooling.js';
@@ -54,7 +53,6 @@ const complementaryCertificationIds = [
   CLEA_COMPLEMENTARY_CERTIFICATION_ID,
   PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
   PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
-  PIX_EDU_2ND_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
 ];
 
 async function teamCertificationDataBuilder({ databaseBuilder }) {

--- a/api/tests/acceptance/application/certifications/index_test.js
+++ b/api/tests/acceptance/application/certifications/index_test.js
@@ -658,7 +658,7 @@ async function _buildDatabaseForV2Certification() {
   const userId = databaseBuilder.factory.buildUser().id;
   const session = databaseBuilder.factory.buildSession({ publishedAt: new Date('2018-12-01T01:02:03Z') });
   const badge = databaseBuilder.factory.buildBadge({ key: 'charlotte_aux_fraises' });
-  const cc = databaseBuilder.factory.buildComplementaryCertification();
+  const cc = databaseBuilder.factory.buildComplementaryCertification({ key: 'A' });
   const ccBadge = databaseBuilder.factory.buildComplementaryCertificationBadge({
     complementaryCertificationId: cc.id,
     badgeId: badge.id,
@@ -692,6 +692,7 @@ async function _buildDatabaseForV2Certification() {
   });
   const { id } = databaseBuilder.factory.buildComplementaryCertificationCourse({
     certificationCourseId: certificationCourse.id,
+    complementaryCertificationCourseId: cc.id,
     name: 'patisseries au fruits',
   });
   databaseBuilder.factory.buildComplementaryCertificationCourseResult({

--- a/api/tests/acceptance/application/session/session-with-clea-certified-candidate-controller-get-clea-certified-candidate-data-csv_test.js
+++ b/api/tests/acceptance/application/session/session-with-clea-certified-candidate-controller-get-clea-certified-candidate-data-csv_test.js
@@ -25,17 +25,18 @@ describe('Acceptance | Controller | session-with-clea-certified-candidate', func
         key: ComplementaryCertificationKeys.CLEA,
       });
       const badgeClea = databaseBuilder.factory.buildBadge({ id: 1, isCertifiable: true });
-      const complementaryBadgeId = databaseBuilder.factory.buildComplementaryCertificationBadge({
+      const complementaryCertificationBadgeId = databaseBuilder.factory.buildComplementaryCertificationBadge({
         complementaryCertificationId: 1,
         badgeId: badgeClea.id,
       }).id;
       const complementaryCertificationCourse = dbf.buildComplementaryCertificationCourse({
         certificationCourseId: certificationCourse.id,
         complementaryCertificationId: 1,
-        complementaryCertificationBadgeId: complementaryBadgeId,
+        complementaryCertificationBadgeId,
       });
       dbf.buildComplementaryCertificationCourseResult({
         complementaryCertificationCourseId: complementaryCertificationCourse.id,
+        complementaryCertificationBadgeId,
         acquired: true,
       });
 

--- a/api/tests/certification/complementary-certification/acceptance/application/complementary-certification-controller_test.js
+++ b/api/tests/certification/complementary-certification/acceptance/application/complementary-certification-controller_test.js
@@ -26,12 +26,14 @@ describe('Acceptance | API | complementary-certification-controller', function (
         id: 3,
         label: 'Pix+ Édu 1er degré',
         hasExternalJury: true,
+        key: 'EDU_1',
       });
 
       const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification({
         id: complementaryCertificationId,
         label: 'Pix+ Édu 2nd degré',
         hasExternalJury: true,
+        key: 'EDU_2',
       });
 
       const targetProfile = databaseBuilder.factory.buildTargetProfile({ id: 999, name: 'Target' });

--- a/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-badge-repository_test.js
+++ b/api/tests/certification/complementary-certification/integration/infrastucture/repositories/complementary-certification-badge-repository_test.js
@@ -277,6 +277,9 @@ describe('Integration | Infrastructure | Repository | Certification | Complement
 
           const { id: badgeId1, imageUrl: imageUrl1 } = databaseBuilder.factory.buildBadge({ targetProfileId });
           const { id: badgeId2, imageUrl: imageUrl2 } = databaseBuilder.factory.buildBadge({ targetProfileId });
+          const { id: complementaryCertificationId } = databaseBuilder.factory.buildComplementaryCertification({
+            key: 'kiki',
+          });
 
           const ccBadge1 = databaseBuilder.factory.buildComplementaryCertificationBadge({
             badgeId: badgeId1,
@@ -290,8 +293,8 @@ describe('Integration | Infrastructure | Repository | Certification | Complement
             stickerUrl: 'http://stiker-url.fr',
             detachedAt: null,
             createdBy: userId,
+            complementaryCertificationId,
           });
-
           const ccBadge2 = databaseBuilder.factory.buildComplementaryCertificationBadge({
             badgeId: badgeId2,
             level: 2,
@@ -304,10 +307,8 @@ describe('Integration | Infrastructure | Repository | Certification | Complement
             stickerUrl: 'http://stiker-url.fr',
             detachedAt: null,
             createdBy: userId,
+            complementaryCertificationId,
           });
-
-          databaseBuilder.factory.buildComplementaryCertificationBadge();
-
           await databaseBuilder.commit();
 
           // when

--- a/api/tests/certification/course/acceptance/application/certification-attestation-route_test.js
+++ b/api/tests/certification/course/acceptance/application/certification-attestation-route_test.js
@@ -239,7 +239,7 @@ async function _buildDatabaseForV2Certification({ userId, certificationCourseId 
     publishedAt: new Date('2018-12-01T01:02:03Z'),
   });
   const badge = databaseBuilder.factory.buildBadge({ key: 'charlotte_aux_fraises' });
-  const cc = databaseBuilder.factory.buildComplementaryCertification();
+  const cc = databaseBuilder.factory.buildComplementaryCertification({ key: 'A' });
   const ccBadge = databaseBuilder.factory.buildComplementaryCertificationBadge({
     complementaryCertificationId: cc.id,
     badgeId: badge.id,
@@ -274,6 +274,7 @@ async function _buildDatabaseForV2Certification({ userId, certificationCourseId 
   const { id } = databaseBuilder.factory.buildComplementaryCertificationCourse({
     certificationCourseId: certificationCourse.id,
     complementaryCertificationBadgeId: ccBadge.id,
+    complementaryCertificationId: cc.id,
     name: 'patisseries au fruits',
   });
   databaseBuilder.factory.buildComplementaryCertificationCourseResult({

--- a/api/tests/certification/course/integration/infrastructure/repositories/certificate-repository_test.js
+++ b/api/tests/certification/course/integration/infrastructure/repositories/certificate-repository_test.js
@@ -414,10 +414,12 @@ describe('Integration | Infrastructure | Repository | Certification', function (
         const complementaryCertification1Id = databaseBuilder.factory.buildComplementaryCertification({
           label: 'Pix+ Test 1',
           hasExternalJury: false,
+          key: 'A',
         }).id;
         const complementaryCertification2Id = databaseBuilder.factory.buildComplementaryCertification({
           label: 'Pix+ Test 2',
           hasExternalJury: true,
+          key: 'B',
         }).id;
         databaseBuilder.factory.buildComplementaryCertificationBadge({
           id: 21,

--- a/api/tests/certification/session/acceptance/application/session-mass-import-route_test.js
+++ b/api/tests/certification/session/acceptance/application/session-mass-import-route_test.js
@@ -58,8 +58,11 @@ describe('Acceptance | Controller | Session | session-mass-import-route', functi
           name: 'Paris',
           isActualName: true,
         });
-        databaseBuilder.factory.buildComplementaryCertification({ id: 1, label: 'Pix+ Édu 2nd degré' });
-        databaseBuilder.factory.buildComplementaryCertificationBadge({ label: 'Pix+ Édu 2nd degré' });
+        databaseBuilder.factory.buildComplementaryCertification({ id: 1, label: 'Pix+ Édu 2nd degré', key: 'A' });
+        databaseBuilder.factory.buildComplementaryCertificationBadge({
+          label: 'Pix+ Édu 2nd degré',
+          complementaryCertificationId: 1,
+        });
         databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
         await databaseBuilder.commit();
 

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-center-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-center-repository_test.js
@@ -340,7 +340,7 @@ describe('Integration | Repository | Certification Center', function () {
         databaseBuilder.factory.buildComplementaryCertification({
           id: 33,
           label: 'Complementary certification name',
-          key: 'COMP',
+          key: 'COMP1',
         });
         databaseBuilder.factory.buildComplementaryCertificationHabilitation({
           certificationCenterId: 3,
@@ -349,7 +349,7 @@ describe('Integration | Repository | Certification Center', function () {
         const expectedComplementaryCertification3 = domainBuilder.buildComplementaryCertification({
           id: 33,
           label: 'Complementary certification name',
-          key: 'COMP',
+          key: 'COMP1',
         });
         const expectedCertificationCenter3 = domainBuilder.buildCertificationCenter({
           id: 3,
@@ -372,7 +372,7 @@ describe('Integration | Repository | Certification Center', function () {
         databaseBuilder.factory.buildComplementaryCertification({
           id: 11,
           label: 'Complementary certification name',
-          key: 'COMP',
+          key: 'COMP2',
         });
         databaseBuilder.factory.buildComplementaryCertificationHabilitation({
           certificationCenterId: 1,
@@ -381,7 +381,7 @@ describe('Integration | Repository | Certification Center', function () {
         const expectedComplementaryCertification1 = domainBuilder.buildComplementaryCertification({
           id: 11,
           label: 'Complementary certification name',
-          key: 'COMP',
+          key: 'COMP2',
         });
         const expectedCertificationCenter1 = domainBuilder.buildCertificationCenter({
           id: 1,
@@ -403,7 +403,7 @@ describe('Integration | Repository | Certification Center', function () {
         databaseBuilder.factory.buildComplementaryCertification({
           id: 22,
           label: 'Complementary certification name',
-          key: 'COMP',
+          key: 'COMP3',
         });
         databaseBuilder.factory.buildComplementaryCertificationHabilitation({
           certificationCenterId: 2,
@@ -412,7 +412,7 @@ describe('Integration | Repository | Certification Center', function () {
         const expectedComplementaryCertification2 = domainBuilder.buildComplementaryCertification({
           id: 22,
           label: 'Complementary certification name',
-          key: 'COMP',
+          key: 'COMP3',
         });
         const expectedCertificationCenter2 = domainBuilder.buildCertificationCenter({
           id: 2,

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -568,17 +568,17 @@ function _buildCertificationCourse({ createdAt, description, version = 2 }) {
       {
         certificationCourseId: expectedCertificationCourse.id,
         badge: databaseBuilder.factory.buildBadge({ key: 'forêt_noire' }),
-        complementaryCertificationId: databaseBuilder.factory.buildComplementaryCertification().id,
+        complementaryCertificationId: databaseBuilder.factory.buildComplementaryCertification({ key: 'CHOCO' }).id,
       },
       {
         certificationCourseId: expectedCertificationCourse.id,
         badge: databaseBuilder.factory.buildBadge({ key: 'baba_au_rhum' }),
-        complementaryCertificationId: databaseBuilder.factory.buildComplementaryCertification().id,
+        complementaryCertificationId: databaseBuilder.factory.buildComplementaryCertification({ key: 'EPONGE' }).id,
       },
       {
         certificationCourseId: anotherCourseId,
         badge: databaseBuilder.factory.buildBadge({ key: 'tropézienne' }),
-        complementaryCertificationId: databaseBuilder.factory.buildComplementaryCertification().id,
+        complementaryCertificationId: databaseBuilder.factory.buildComplementaryCertification({ key: 'CREME' }).id,
       },
     ],
     ({ certificationCourseId, complementaryCertificationId, badge }) => {
@@ -593,7 +593,7 @@ function _buildCertificationCourse({ createdAt, description, version = 2 }) {
       }).id;
       databaseBuilder.factory.buildComplementaryCertificationCourseResult({
         complementaryCertificationCourseId,
-        certificationCourseId,
+        complementaryCertificationBadgeId,
       });
     },
   );

--- a/api/tests/integration/infrastructure/repositories/certifiable-badge-acquisition-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certifiable-badge-acquisition-repository_test.js
@@ -162,7 +162,12 @@ describe('Integration | Repository | Certifiable Badge Acquisition', function ()
         it('should return the highest level and latest certifiable badge acquired for each complementary certification', async function () {
           //given
           const userId = databaseBuilder.factory.buildUser().id;
+          databaseBuilder.factory.buildComplementaryCertification({
+            key: 'A',
+            id: 10,
+          });
           const firstComplementaryBadges = buildComplementaryCertificationWithMultipleCertifiableBadges({
+            complementaryCertificationId: 10,
             keyLevelList: [
               { key: 1, level: 1 },
               { key: 2, level: 2 },
@@ -183,7 +188,12 @@ describe('Integration | Repository | Certifiable Badge Acquisition', function ()
             createdAt: new Date('2022-09-29'),
           });
 
+          databaseBuilder.factory.buildComplementaryCertification({
+            key: 'B',
+            id: 20,
+          });
           const secondComplementaryBadges = buildComplementaryCertificationWithMultipleCertifiableBadges({
+            complementaryCertificationId: 20,
             keyLevelList: [
               { key: 3, level: 3 },
               { key: 4, level: 4 },

--- a/api/tests/integration/infrastructure/repositories/certificate-repository_private_test.js
+++ b/api/tests/integration/infrastructure/repositories/certificate-repository_private_test.js
@@ -559,10 +559,12 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({
           name: 'Pix+ test',
           hasExternalJury: false,
+          key: 'A',
         }).id;
         const complementaryCertificationWithJuryId = databaseBuilder.factory.buildComplementaryCertification({
           name: 'Pix+ test with Jury',
           hasExternalJury: true,
+          key: 'WITH_JURY',
         }).id;
 
         const learningContentObjects = learningContentBuilder.fromAreas(minimalLearningContent);

--- a/api/tests/integration/infrastructure/repositories/certificate-repository_shareable_test.js
+++ b/api/tests/integration/infrastructure/repositories/certificate-repository_shareable_test.js
@@ -478,10 +478,12 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
         const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({
           label: 'Pix+ Test',
           hasExternalJury: false,
+          key: 'TEST_1',
         }).id;
         const complementaryCertificationWithJuryId = databaseBuilder.factory.buildComplementaryCertification({
           label: 'Pix+ Test 2',
           hasExternalJury: true,
+          key: 'TEST_2',
         }).id;
 
         const learningContentObjects = learningContentBuilder.fromAreas(minimalLearningContent);

--- a/api/tests/integration/infrastructure/repositories/certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-result-repository_test.js
@@ -326,7 +326,7 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
         assessmentResultId: oneAssessmentResultId,
         competenceMarkId: oneCompetenceMarkId,
       } = await _buildCertificationResultInSession(sessionId);
-      const oneComplementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification().id;
+      const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({ key: 'A' }).id;
       databaseBuilder.factory.buildBadge({ id: 12345, key: 'PARTNER_KEY_PIX' });
       databaseBuilder.factory.buildBadge({ id: 12346, key: 'PARTNER_KEY_EXTERNAL' });
       databaseBuilder.factory.buildComplementaryCertificationCourse({
@@ -336,13 +336,13 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
       databaseBuilder.factory.buildComplementaryCertificationBadge({
         id: 100,
         badgeId: 12345,
-        complementaryCertificationId: oneComplementaryCertificationId,
+        complementaryCertificationId: complementaryCertificationId,
         label: 'PARTNER_LABEL_PIX',
       });
       databaseBuilder.factory.buildComplementaryCertificationBadge({
         id: 101,
         badgeId: 12346,
-        complementaryCertificationId: oneComplementaryCertificationId,
+        complementaryCertificationId: complementaryCertificationId,
         label: 'PARTNER_LABEL_EXTERNAL',
       });
       databaseBuilder.factory.buildComplementaryCertificationCourseResult({
@@ -708,18 +708,20 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
       const sessionId = databaseBuilder.factory.buildSession().id;
       const { certificationCourseId } = await _buildCertificationResultInSession(sessionId, userId);
 
-      const oneComplementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({
+      const complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({
         label: 'PARTNER_LABEL',
+        key: 'A',
       }).id;
       databaseBuilder.factory.buildBadge({ id: 12345, key: 'PARTNER_KEY' });
       databaseBuilder.factory.buildComplementaryCertificationCourse({
         id: 997,
         certificationCourseId,
+        complementaryCertificationId: complementaryCertificationId,
       });
       databaseBuilder.factory.buildComplementaryCertificationBadge({
         id: 789,
         badgeId: 12345,
-        complementaryCertificationId: oneComplementaryCertificationId,
+        complementaryCertificationId: complementaryCertificationId,
         label: 'PARTNER_LABEL',
       });
       databaseBuilder.factory.buildComplementaryCertificationCourseResult({

--- a/api/tests/integration/infrastructure/repositories/clea-certified-candidate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/clea-certified-candidate-repository_test.js
@@ -50,7 +50,7 @@ describe('Integration | Repository | clea-certified-candidate-repository', funct
           id: 1,
         });
         const badgeClea = databaseBuilder.factory.buildBadge({ id: 1, isCertifiable: true });
-        const complementaryBadgeId = databaseBuilder.factory.buildComplementaryCertificationBadge({
+        const complementaryCertificationBadgeId = databaseBuilder.factory.buildComplementaryCertificationBadge({
           complementaryCertificationId: 1,
           badgeId: badgeClea.id,
         }).id;
@@ -62,22 +62,23 @@ describe('Integration | Repository | clea-certified-candidate-repository', funct
           id: 991,
           certificationCourseId: 91,
           complementaryCertificationId: 1,
-          complementaryCertificationBadgeId: complementaryBadgeId,
+          complementaryCertificationBadgeId,
         });
         databaseBuilder.factory.buildComplementaryCertificationCourse({
           id: 992,
           certificationCourseId: 92,
           complementaryCertificationId: 1,
-          complementaryCertificationBadgeId: complementaryBadgeId,
+          complementaryCertificationBadgeId,
         });
-
         databaseBuilder.factory.buildComplementaryCertificationCourseResult({
           complementaryCertificationCourseId: 991,
           acquired: true,
+          complementaryCertificationBadgeId,
         });
         databaseBuilder.factory.buildComplementaryCertificationCourseResult({
           complementaryCertificationCourseId: 992,
           acquired: true,
+          complementaryCertificationBadgeId,
         });
 
         await databaseBuilder.commit();
@@ -114,7 +115,7 @@ describe('Integration | Repository | clea-certified-candidate-repository', funct
         ]);
       });
 
-      describe('when there is not certified candidates for Clea certification in the session', function () {
+      describe('when there is no certified candidates for Clea certification in the session', function () {
         it('returns the list of clea certified candidates only', async function () {
           // given
           const sessionId = databaseBuilder.factory.buildSession().id;
@@ -168,10 +169,12 @@ describe('Integration | Repository | clea-certified-candidate-repository', funct
 
           databaseBuilder.factory.buildComplementaryCertificationCourseResult({
             complementaryCertificationCourseId: 991,
+            complementaryCertificationBadgeId: complementaryBadgeId,
             acquired: true,
           });
           databaseBuilder.factory.buildComplementaryCertificationCourseResult({
             complementaryCertificationCourseId: 992,
+            complementaryCertificationBadgeId: complementaryBadgeId,
             acquired: false,
           });
 

--- a/api/tests/integration/infrastructure/repositories/complementary-certification-course-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/complementary-certification-course-result-repository_test.js
@@ -65,16 +65,24 @@ describe('Integration | Repository | complementary-certification-courses-result-
           databaseBuilder.factory.buildComplementaryCertification({
             id: 1,
             name: 'Pix+ Test',
+            key: 'A',
           });
           databaseBuilder.factory.buildCertificationCourse({ id: 99 });
+          databaseBuilder.factory.buildBadge({ id: 1, key: 'PIX_TEST_1' });
+          databaseBuilder.factory.buildComplementaryCertificationBadge({
+            id: 99,
+            badgeId: 1,
+            complementaryCertificationId: 1,
+          });
           databaseBuilder.factory.buildComplementaryCertificationCourse({
             id: 999,
             certificationCourseId: 99,
             complementaryCertificationId: 1,
+            complementaryCertificationBadgeId: 99,
           });
-          databaseBuilder.factory.buildBadge({ key: 'PIX_TEST_1' });
           databaseBuilder.factory.buildComplementaryCertificationCourseResult({
             complementaryCertificationCourseId: 999,
+            complementaryCertificationBadgeId: 99,
             source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
             acquired: true,
           });
@@ -99,7 +107,7 @@ describe('Integration | Repository | complementary-certification-courses-result-
       it('should return the allowed jury level for that complementary certification', async function () {
         // given
         databaseBuilder.factory.buildTargetProfile({ id: 123 });
-        databaseBuilder.factory.buildComplementaryCertification({ id: 1 });
+        databaseBuilder.factory.buildComplementaryCertification({ id: 1, key: 'A' });
         databaseBuilder.factory.buildBadge({
           id: 1212,
           targetProfileId: 123,
@@ -111,7 +119,7 @@ describe('Integration | Repository | complementary-certification-courses-result-
         });
 
         databaseBuilder.factory.buildTargetProfile({ id: 456 });
-        databaseBuilder.factory.buildComplementaryCertification({ id: 2 });
+        databaseBuilder.factory.buildComplementaryCertification({ id: 2, key: 'B' });
         databaseBuilder.factory.buildBadge({ id: 1213, targetProfileId: 456 });
         databaseBuilder.factory.buildComplementaryCertificationBadge({
           id: 98,

--- a/api/tests/integration/infrastructure/repositories/complementary-certification-habilitation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/complementary-certification-habilitation-repository_test.js
@@ -31,9 +31,11 @@ describe('Integration | Infrastructure | Repository | complementary-certificatio
       // given
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
       const otherCertificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-      const complementaryCertification1Id = databaseBuilder.factory.buildComplementaryCertification().id;
-      const complementaryCertification2Id = databaseBuilder.factory.buildComplementaryCertification().id;
-      const otherComplementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification().id;
+      const complementaryCertification1Id = databaseBuilder.factory.buildComplementaryCertification({ key: 'A' }).id;
+      const complementaryCertification2Id = databaseBuilder.factory.buildComplementaryCertification({ key: 'B' }).id;
+      const otherComplementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({
+        key: 'C',
+      }).id;
       databaseBuilder.factory.buildComplementaryCertificationHabilitation({
         certificationCenterId,
         complementaryCertificationId: complementaryCertification1Id,

--- a/api/tests/integration/infrastructure/repositories/complementary-certification-scoring-criteria-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/complementary-certification-scoring-criteria-repository_test.js
@@ -15,11 +15,13 @@ describe('Integration | Repository | complementary certification scoring criteri
         minimumReproducibilityRate: 70,
         minimumReproducibilityRateLowerLevel: 60,
         hasComplementaryReferential: true,
+        key: 'REF',
       });
       const complementaryCertification2 = databaseBuilder.factory.buildComplementaryCertification({
         minimumReproducibilityRate: 75,
         minimumReproducibilityRateLowerLevel: 60,
         hasComplementaryReferential: false,
+        key: 'NO_REF',
       });
 
       databaseBuilder.factory.buildComplementaryCertificationBadge({
@@ -46,7 +48,10 @@ describe('Integration | Repository | complementary certification scoring criteri
         complementaryCertificationBadgeId: 768,
       });
 
-      databaseBuilder.factory.buildComplementaryCertificationCourse({ certificationCourseId: 12 });
+      databaseBuilder.factory.buildComplementaryCertificationCourse({
+        certificationCourseId: 12,
+        complementaryCertificationBadgeId: 768,
+      });
 
       await databaseBuilder.commit();
 

--- a/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
@@ -336,9 +336,13 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
           hasBeenAutomaticallyResolved: false,
         });
         const badgeId = dbf.buildBadge({ key: 'PARTNER_KEY' }).id;
-        dbf.buildComplementaryCertification({ id: 1 });
+        dbf.buildComplementaryCertification({ id: 1, key: 'A' });
         dbf.buildComplementaryCertificationBadge({ id: 11, label, badgeId, complementaryCertificationId: 1 });
-        dbf.buildComplementaryCertificationCourse({ id: 998, certificationCourseId: manyAsrCertification.id });
+        dbf.buildComplementaryCertificationCourse({
+          id: 998,
+          certificationCourseId: manyAsrCertification.id,
+          complementaryCertificationId: 1,
+        });
         dbf.buildComplementaryCertificationCourseResult({
           complementaryCertificationCourseId: 998,
           complementaryCertificationBadgeId: 11,


### PR DESCRIPTION
## :unicorn: Problème
On doit ajoute une nouvelle certification (PIX pro santé) mais l'interface ne le permet pas encore

## :robot: Proposition
Ajouter un script de migration

## :rainbow: Remarques
Il faut aussi raccorder les badges a cette certification complementaire. Ce sera gere dans une PR specifique

## :100: Pour tester
`select * from "complementary-certifications" where key = 'PRO_SANTE'`
