### PR TITLE
[FEATURE] Masquer les indices dans l'activité finale qroc. Module bien-ecrire-son-adresse-mail (MODC-83)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -387,13 +387,13 @@
         {
           "id": "6c69a919-4fc6-4039-9abc-ad70c49be7d8",
           "type": "text",
-          "content": "<hr>Si vous êtes bloqué, vous pouvez lire les indices ci-dessous."
+          "content": "<span aria-hidden=\"true\">🗝️</span> Si vous êtes bloqué, vous pouvez lire les indices ci-dessous."
         },
         {
           "id": "0856af53-1060-478f-8416-ddbc5ed3940c",
           "type": "text",
-          "content": "<h3>Indice n°1&nbsp;:</h3><p>L'ordre à suivre est&nbsp;: l'identifiant, l'arobase puis le fournisseur d'adresse mail.</p><h3>Indice n°2&nbsp;:</h3><p>Les adresses mails fournies par Yahoo se terminent par yahoo.com.</p>"
-        }
+          "content": "<details><summary>Indice n°1&nbsp;:</summary><p>L'ordre à suivre est&nbsp;: l'identifiant, l'arobase puis le fournisseur d'adresse mail.</p></details><details><summary>Indice n°2&nbsp;:</summary><p>Les adresses mails fournies par Yahoo se terminent par <code>yahoo.com</code>.</p></details>"
+          }
       ]
     }
   ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -387,13 +387,8 @@
         {
           "id": "6c69a919-4fc6-4039-9abc-ad70c49be7d8",
           "type": "text",
-          "content": "<span aria-hidden=\"true\">🗝️</span> Si vous êtes bloqué, vous pouvez lire les indices ci-dessous."
-        },
-        {
-          "id": "0856af53-1060-478f-8416-ddbc5ed3940c",
-          "type": "text",
-          "content": "<details><summary>Indice n°1&nbsp;:</summary><p>L'ordre à suivre est&nbsp;: l'identifiant, l'arobase puis le fournisseur d'adresse mail.</p></details><details><summary>Indice n°2&nbsp;:</summary><p>Les adresses mails fournies par Yahoo se terminent par <code>yahoo.com</code>.</p></details>"
-          }
+          "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous êtes bloqué, vous pouvez lire les indices ci-dessous&nbsp;:</p><details><summary>Indice n°1</summary><p>L'ordre à suivre est&nbsp;: l'identifiant, l'arobase puis le fournisseur d'adresse mail.</p></details><details><summary>Indice n°2</summary><p>L'adresse mail se termine par <code>yahoo.com</code> quand le fournisseur est Yahoo.</p></details>"
+        }
       ]
     }
   ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -381,13 +381,13 @@
           ],
           "feedbacks": {
             "valid": "<p>Correct.&nbsp;<span aria-hidden=\"true\">🎉</span> Tout est dans l'ordre&nbsp;: l'identifiant, l'arobase puis le fournisseur d'adresse mail</p>",
-            "invalid": "<p> Incorrect. Pour réussir la prochaine fois, lisez les indices ci-dessous&nbsp;<span aria-hidden=\"true\">👇</span> </p>"
+            "invalid": "<p> Incorrect. Pour réussir la prochaine fois, utilisez les indices ci-dessous&nbsp;<span aria-hidden=\"true\">👇</span> </p>"
           }
         },
         {
           "id": "6c69a919-4fc6-4039-9abc-ad70c49be7d8",
           "type": "text",
-          "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous êtes bloqué, vous pouvez lire les indices ci-dessous&nbsp;:</p><details><summary>Indice 1</summary><p>L'ordre à suivre est&nbsp;: l'identifiant, l'arobase puis le fournisseur d'adresse mail.</p></details><details><summary>Indice 2</summary><p>L'adresse mail se termine par <code>yahoo.com</code> quand le fournisseur est Yahoo.</p></details>"
+          "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous avez besoin d'aide, vous pouvez cliquer sur les indices ci-dessous&nbsp;:</p><details><summary>Indice 1</summary><p>L'ordre à suivre est&nbsp;: l'identifiant, l'arobase puis le fournisseur d'adresse mail.</p></details><details><summary>Indice 2</summary><p>L'adresse mail se termine par <code>yahoo.com</code> quand le fournisseur est Yahoo.</p></details>"
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -113,7 +113,7 @@
         {
           "id": "1fd829f8-1799-4779-a28d-5d26fba31b8b",
           "type": "text",
-          "content": "<h3 class=\"screen-reader-only\">Le fournisseur d’adresse mail</h3><h4>Partie n°2&nbsp;: le fournisseur d’adresse mail. Cette partie de l’adresse est donnée par le fournisseur.</h4><p><span aria-hidden=\"true\">✅</span> Voici des exemples de fournisseurs d’adresses mail&nbsp;: </p><ul><li>La Poste (laposte.net)</li><li>Google (gmail.com)</li><li>Yahoo (yahoo.com, yahoo.fr)</li><li>Microsoft (hotmail.com, live.fr)</li></ul>"
+          "content": "<h3 class=\"screen-reader-only\">Le fournisseur d’adresse mail</h3><h4>Partie 2&nbsp;: le fournisseur d’adresse mail. Cette partie de l’adresse est donnée par le fournisseur.</h4><p><span aria-hidden=\"true\">✅</span> Voici des exemples de fournisseurs d’adresses mail&nbsp;: </p><ul><li>La Poste (laposte.net)</li><li>Google (gmail.com)</li><li>Yahoo (yahoo.com, yahoo.fr)</li><li>Microsoft (hotmail.com, live.fr)</li></ul>"
         }
       ]
     },
@@ -387,7 +387,7 @@
         {
           "id": "6c69a919-4fc6-4039-9abc-ad70c49be7d8",
           "type": "text",
-          "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous êtes bloqué, vous pouvez lire les indices ci-dessous&nbsp;:</p><details><summary>Indice n°1</summary><p>L'ordre à suivre est&nbsp;: l'identifiant, l'arobase puis le fournisseur d'adresse mail.</p></details><details><summary>Indice n°2</summary><p>L'adresse mail se termine par <code>yahoo.com</code> quand le fournisseur est Yahoo.</p></details>"
+          "content": "<p><span aria-hidden=\"true\">🗝️</span> Si vous êtes bloqué, vous pouvez lire les indices ci-dessous&nbsp;:</p><details><summary>Indice 1</summary><p>L'ordre à suivre est&nbsp;: l'identifiant, l'arobase puis le fournisseur d'adresse mail.</p></details><details><summary>Indice 2</summary><p>L'adresse mail se termine par <code>yahoo.com</code> quand le fournisseur est Yahoo.</p></details>"
         }
       ]
     }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -79,7 +79,7 @@
         {
           "id": "c1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d",
           "type": "text",
-          "content": "<h3 class=\"screen-reader-only\">L'identifiant</h3><h4>Partie n°1&nbsp;: l’identifiant choisi par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque, même avec des majuscules&#8239;!</p><p><span aria-hidden=\"true\">✅</span> Par exemple&nbsp;: mika671 ou G3oDu671</p><p class=\"pix-list-inline\"><span aria-hidden=\"true\">❌</span> Mais certains caractères sont interdits&nbsp;:</p><ul><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>"
+          "content": "<h3 class=\"screen-reader-only\">L'identifiant</h3><h4>Partie 1&nbsp;: l’identifiant choisi par Mickaël.</h4><p>Tous les identifiants sont possibles, ou presque, même avec des majuscules&#8239;!</p><p><span aria-hidden=\"true\">✅</span> Par exemple&nbsp;: mika671 ou G3oDu671</p><p class=\"pix-list-inline\"><span aria-hidden=\"true\">❌</span> Mais certains caractères sont interdits&nbsp;:</p><ul><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>"
         },
         {
           "id": "8137ddf4-f689-4297-8beb-a8de0c64b14d",
@@ -165,7 +165,7 @@
           "proposals": [
             {
               "type": "text",
-              "content": "<span>Partie n°1&nbsp;:</span>"
+              "content": "<span>Partie 1&nbsp;:</span>"
             },
             {
               "input": "premiere-partie",
@@ -191,7 +191,7 @@
             },
             {
               "type": "text",
-              "content": "<span>Partie n°2&nbsp;:</span>"
+              "content": "<span>Partie 2&nbsp;:</span>"
             },
             {
               "input": "seconde-partie",

--- a/mon-pix/app/pods/components/module/passage/styles.scss
+++ b/mon-pix/app/pods/components/module/passage/styles.scss
@@ -58,6 +58,23 @@
     font-family: var(--pix-font-family-monospace);
   }
 
+  details {
+    color: var(--pix-neutral-800);
+
+    & + details {
+      margin-top: var(--pix-spacing-2x);
+    }
+
+    summary {
+      color: var(--pix-neutral-900);
+      font-weight: var(--pix-font-medium);
+    }
+  }
+
+  p + details {
+    margin-top: var(--pix-spacing-4x);
+  }
+
   &__title {
     @extend %pix-title-m;
 


### PR DESCRIPTION
## :unicorn: Problème
Les indices étaient écrits en clair. De nombreux retours testeurs ont demandé de les masquer. Pdv conception, nous avions également prévu de le faire.

**et** les "n°" dans le texte du module posent pb niveau a11Y
## :robot: Proposition
Cacher les indices, avec un système "low tech". Un système plus poussé à déjà été maquetté par Quentin et testé, cf. [ce GIF](https://docs.google.com/presentation/d/10D-AsfBw3Ju-XNv19MYBX_RFJmSU6wSzDtAe6JTpFy0/edit#slide=id.g2caf6449452_0_190)

Le principal point d'attention lors de tests : les indices étant "gratuits", certains utilisateurs les ouvrent tous à la suite, sans attendre / réfléchir. Piste de donner un coût aux indices, à creuser. Pour le détail du constat sur ce test, cf [ici](https://docs.google.com/presentation/d/1Xwh-5ZuZSkowCv6ncNbBo7yKXsK0o-cG6r0c42VSvck/edit#slide=id.g257bd19178b_0_569)

**et** supprimer les "n°" du module
## :rainbow: Remarques
Modifs de contenu au passage pour éviter que "yahoo.com" soit en fin de phrase (conflit avec le point final de la phrase)

## :100: Pour tester
Suivre le lien : https://app-pr8756.review.pix.fr/modules/bien-ecrire-son-adresse-mail/passage
Tester les indices (ou cf. screen)
Arrivée sur l'activité : 
![Capture d’écran 2024-04-29 à 12 37 43](https://github.com/1024pix/pix/assets/82821474/dbece9ed-d430-415b-a155-351768b2069d)
Indice 1 ouvert
![Capture d’écran 2024-04-29 à 12 37 55](https://github.com/1024pix/pix/assets/82821474/ea5c65a7-3ebf-4e80-b38b-1107822c1697)
Indices 1 et 2 ouverts
![Capture d’écran 2024-04-29 à 12 38 04](https://github.com/1024pix/pix/assets/82821474/848638d9-d340-4167-8828-52459706f992)

