### PR TITLE
[FEATURE] Modifier les trads du titre du bloc d'erreur d'import et ajouter une marge en dessous (PIX-12291)

### DIFF
--- a/orga/app/styles/components/import.scss
+++ b/orga/app/styles/components/import.scss
@@ -18,6 +18,7 @@
     h2 {
      @extend %pix-title-xs;
 
+      margin-bottom: var(--pix-spacing-6x);
       color: var(--pix-neutral-900);
     }
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -956,7 +956,7 @@
         "warning-banner": "However some values were not recognised. They have been replaced by \"Not recognised\". If you need other values, please contact us at '<a href=\"mailto:sup@pix.fr\">'sup@pix.fr'</a></div>'"
       },
       "error-panel": {
-        "title": "Errors list encountered",
+        "title": "Errors in the last file imported :",
         "error-wrapper": "Import has failed. Please check or edit your file and try to import it again.",
         "global-error": "Import has failed. Please try again or contact us through '<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://pix.org/en-gb/contact-form\">'the help form'</a>'."
       },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -956,7 +956,7 @@
         "warning-banner": "Certaines valeurs n’ont pas été reconnues. Elles ont été remplacées par “Non reconnu”. Si vous considérez qu’il manque des valeurs dans la liste limitative, veuillez nous contacter à '<a href=\"mailto:sup@pix.fr\">'sup@pix.fr'</a></div>'"
       },
       "error-panel": {
-        "title": "Liste des erreurs rencontrées",
+        "title": "Erreurs dans le dernier fichier importé :",
         "error-wrapper": "Aucun participant n’a été importé. Veuillez modifier votre fichier et l’importer à nouveau.",
         "global-error": "Aucun participant n’a été importé. Veuillez réessayer ou nous contacter via '<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://support.pix.fr/support/tickets/new\">'le formulaire du centre d’aide'</a>'."
       },


### PR DESCRIPTION
## :unicorn: Problème
Le titre du bloc d'erreur lors d'un import n'est pas iso à la maquette et les trads ne sont pas bonnes.

## :robot: Proposition
Ajouter une marge en dessous du titre, et modifier les fichiers de trads avec les bons wording

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

- Se connecter à Pix Orga (avec Sco par exemple)
- Faire un import comportant des erreurs
- Vérifier le texte du titre du bloc d'erreur ainsi que son style
- 🐈‍⬛ 
