### PR TITLE
[BUGFIX] Corriger l'erreur 500 lors du rejet d'une certification pour une certification antérieure aux configuration de scoring.

### DIFF
--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
@@ -687,14 +687,12 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         const badge = server.create('badge');
         targetProfile.update({ badges: [badge] });
 
-        const campaignCriterion = badge.criteria.models[0];
-        console.log(campaignCriterion);
-
         // when
         const screen = await visit(`/target-profiles/1/badges/${badge.id}`);
         await clickByName('Modifier le critère');
+        await screen.findByRole('dialog');
         await fillByLabel(/Nouveau seuil d'obtention du critère :/, 99);
-        await clickByName('Enregistrer');
+        await click(screen.getByRole('button', { name: 'Enregistrer' }));
 
         // then
         assert.dom(screen.getByText("Seuil d'obtention du critère modifié avec succès.")).exists();

--- a/api/src/certification/scoring/infrastructure/repositories/scoring-configuration-repository.js
+++ b/api/src/certification/scoring/infrastructure/repositories/scoring-configuration-repository.js
@@ -1,4 +1,5 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
+import { NotFoundError } from '../../../../shared/domain/errors.js';
 import * as areaRepository from '../../../../shared/infrastructure/repositories/area-repository.js';
 import * as competenceRepository from '../../../../shared/infrastructure/repositories/competence-repository.js';
 import { V3CertificationScoring } from '../../domain/models/V3CertificationScoring.js';
@@ -7,21 +8,29 @@ export const getLatestByDateAndLocale = async ({ locale, date }) => {
   const allAreas = await areaRepository.list();
   const competenceList = await competenceRepository.list({ locale });
 
-  const { configuration: competenceForScoringConfiguration } = await knex('competence-scoring-configurations')
+  const competenceScoringConfiguration = await knex('competence-scoring-configurations')
     .select('configuration')
     .where('createdAt', '<=', date)
     .orderBy('createdAt', 'desc')
     .first();
 
-  const { configuration: certificationScoringConfiguration } = await knex('certification-scoring-configurations')
+  if (!competenceScoringConfiguration) {
+    throw new NotFoundError(`No competence scoring configuration found for date ${date.toISOString()}`);
+  }
+
+  const certificationScoringConfiguration = await knex('certification-scoring-configurations')
     .select('configuration')
     .where('createdAt', '<=', date)
     .orderBy('createdAt', 'desc')
     .first();
+
+  if (!certificationScoringConfiguration) {
+    throw new NotFoundError(`No certification scoring configuration found for date ${date.toISOString()}`);
+  }
 
   return V3CertificationScoring.fromConfigurations({
-    competenceForScoringConfiguration,
-    certificationScoringConfiguration,
+    competenceForScoringConfiguration: competenceScoringConfiguration.configuration,
+    certificationScoringConfiguration: certificationScoringConfiguration.configuration,
     allAreas,
     competenceList,
   });


### PR DESCRIPTION
## :unicorn: Problème
Lors du rejet d'une certification, une erreur 500 peut être renvoyée lorsque la certification a été réalisée avant que les configurations de scoring soient créées. (exemple en [recette](https://app.datadoghq.eu/logs?query=service%3Apix-api-recette%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1714119820069&to_ts=1714119820550&live=false))

## :robot: Proposition
Renvoyer une `NotFoundError` dans ce cas plutôt qu'une erreur 500 non gérée.

## :rainbow: Remarques
Bien que cette erreur ne devrait pas arriver en production, il est préférable de renvoyer une erreur 404 plutôt qu'une 500.  

## :100: Pour tester
- Se connecter à Pix Admin avec le compte `superadmin@example.net`
- Aller sur la page de détail de la certification 152903
- Cliquer sur rejeter la certification
- Il y a eu une erreur mais pas une erreur 500 :clap: 