### PR TITLE
[TECH] Supprimer l'utilisation du custom logoutUrlTemporaryStorage (PIX-12119)

### DIFF
--- a/api/lib/domain/services/authentication/fwb-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/fwb-oidc-authentication-service.js
@@ -1,8 +1,5 @@
 import { OidcAuthenticationService } from '../../../../src/authentication/domain/services/oidc-authentication-service.js';
 import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
-import { temporaryStorage } from '../../../infrastructure/temporary-storage/index.js';
-
-const logoutUrlTemporaryStorage = temporaryStorage.withPrefix('logout-url:');
 
 export class FwbOidcAuthenticationService extends OidcAuthenticationService {
   constructor(oidcProvider, dependencies) {
@@ -22,17 +19,12 @@ export class FwbOidcAuthenticationService extends OidcAuthenticationService {
   async getRedirectLogoutUrl({ userId, logoutUrlUUID }) {
     const redirectTarget = new URL(this.logoutUrl);
     const key = `${userId}:${logoutUrlUUID}`;
-
-    let idToken = await logoutUrlTemporaryStorage.get(key);
-    if (!idToken) {
-      idToken = this.sessionTemporaryStorage.get(key);
-    }
+    const idToken = this.sessionTemporaryStorage.get(key);
 
     const params = [{ key: 'id_token_hint', value: idToken }];
 
     params.forEach(({ key, value }) => redirectTarget.searchParams.append(key, value));
 
-    await logoutUrlTemporaryStorage.delete(key);
     await this.sessionTemporaryStorage.delete(key);
 
     return redirectTarget.toString();

--- a/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
@@ -3,10 +3,7 @@ import dayjs from 'dayjs';
 import { OidcAuthenticationService } from '../../../../src/authentication/domain/services/oidc-authentication-service.js';
 import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
 import { DomainTransaction } from '../../../infrastructure/DomainTransaction.js';
-import { temporaryStorage } from '../../../infrastructure/temporary-storage/index.js';
 import { AuthenticationMethod } from '../../models/index.js';
-
-const logoutUrlTemporaryStorage = temporaryStorage.withPrefix('logout-url:');
 
 export class PoleEmploiOidcAuthenticationService extends OidcAuthenticationService {
   constructor(oidcProvider, dependencies) {
@@ -54,11 +51,7 @@ export class PoleEmploiOidcAuthenticationService extends OidcAuthenticationServi
   async getRedirectLogoutUrl({ userId, logoutUrlUUID }) {
     const redirectTarget = new URL(this.logoutUrl);
     const key = `${userId}:${logoutUrlUUID}`;
-
-    let idToken = await logoutUrlTemporaryStorage.get(key);
-    if (!idToken) {
-      idToken = this.sessionTemporaryStorage.get(key);
-    }
+    const idToken = this.sessionTemporaryStorage.get(key);
 
     const params = [
       { key: 'id_token_hint', value: idToken },
@@ -67,7 +60,6 @@ export class PoleEmploiOidcAuthenticationService extends OidcAuthenticationServi
 
     params.forEach(({ key, value }) => redirectTarget.searchParams.append(key, value));
 
-    await logoutUrlTemporaryStorage.delete(key);
     await this.sessionTemporaryStorage.delete(key);
 
     return redirectTarget.toString();

--- a/api/src/authentication/domain/services/oidc-authentication-service.js
+++ b/api/src/authentication/domain/services/oidc-authentication-service.js
@@ -123,7 +123,7 @@ export class OidcAuthenticationService {
     return jsonwebtoken.sign({ user_id: userId }, config.authentication.secret, this.accessTokenJwtOptions);
   }
 
-  async saveIdToken({ idToken, userId } = {}) {
+  async saveIdToken({ idToken, userId }) {
     const uuid = randomUUID();
 
     await this.sessionTemporaryStorage.save({
@@ -252,7 +252,7 @@ export class OidcAuthenticationService {
     return new AuthenticationMethod.OidcAuthenticationComplement(claimsToStoreWithValues);
   }
 
-  async getRedirectLogoutUrl({ userId, logoutUrlUUID } = {}) {
+  async getRedirectLogoutUrl({ userId, logoutUrlUUID }) {
     const key = `${userId}:${logoutUrlUUID}`;
     const idToken = await this.sessionTemporaryStorage.get(key);
 

--- a/api/tests/integration/domain/services/authentication/fwb-oidc-authentication-service_test.js
+++ b/api/tests/integration/domain/services/authentication/fwb-oidc-authentication-service_test.js
@@ -6,72 +6,37 @@ import { config } from '../../../../../src/shared/config.js';
 import { expect } from '../../../../test-helper.js';
 
 const defaultSessionTemporaryStorage = temporaryStorage.withPrefix('oidc-session:');
-const logoutUrlTemporaryStorage = temporaryStorage.withPrefix('logout-url:');
 
 describe('Integration | Domain | Service | fwb-oidc-authentication-service', function () {
   describe('#getRedirectLogoutUrl', function () {
-    describe('when the user ID Token is not stored in the parent default temporary storage', function () {
-      it('removes the idToken from temporary storage and returns a redirect logout url', async function () {
-        // given
-        const idToken =
-          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
-        const userId = 1;
-        const logoutUrlUUID = randomUUID();
-        const key = `${userId}:${logoutUrlUUID}`;
-        const fwbOidcAuthenticationService = new FwbOidcAuthenticationService({
-          ...config.oidcExampleNet,
-          additionalRequiredProperties: { logoutUrl: 'https://logout-url.org' },
-          identityProvider: 'FWB',
-          organizationName: 'Fédération Wallonie-Bruxelles',
-          shouldCloseSession: true,
-          slug: 'fwb',
-          source: 'fwb',
-        });
-        await logoutUrlTemporaryStorage.save({ key, value: idToken, expirationDelaySeconds: 1140 });
-
-        // when
-        const redirectTarget = await fwbOidcAuthenticationService.getRedirectLogoutUrl({ userId, logoutUrlUUID });
-
-        // then
-        const expectedResult = await logoutUrlTemporaryStorage.get(key);
-        expect(expectedResult).to.be.undefined;
-
-        expect(redirectTarget).to.equal(
-          'https://logout-url.org/?id_token_hint=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
-        );
+    it('removes the idToken from temporary storage and returns a redirect logout url', async function () {
+      // given
+      const idToken =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+      const userId = 1;
+      const logoutUrlUUID = randomUUID();
+      const key = `${userId}:${logoutUrlUUID}`;
+      const fwbOidcAuthenticationService = new FwbOidcAuthenticationService({
+        ...config.oidcExampleNet,
+        additionalRequiredProperties: { logoutUrl: 'https://logout-url.org' },
+        identityProvider: 'FWB',
+        organizationName: 'Fédération Wallonie-Bruxelles',
+        shouldCloseSession: true,
+        slug: 'fwb',
+        source: 'fwb',
       });
-    });
+      await defaultSessionTemporaryStorage.save({ key, value: idToken, expirationDelaySeconds: 1140 });
 
-    describe('when the user ID Token is stored in the parent default temporary storage', function () {
-      it('removes the idToken from temporary storage and returns a redirect logout url', async function () {
-        // given
-        const idToken =
-          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
-        const userId = 1;
-        const logoutUrlUUID = randomUUID();
-        const key = `${userId}:${logoutUrlUUID}`;
-        const fwbOidcAuthenticationService = new FwbOidcAuthenticationService({
-          ...config.oidcExampleNet,
-          additionalRequiredProperties: { logoutUrl: 'https://logout-url.org' },
-          identityProvider: 'FWB',
-          organizationName: 'Fédération Wallonie-Bruxelles',
-          shouldCloseSession: true,
-          slug: 'fwb',
-          source: 'fwb',
-        });
-        await defaultSessionTemporaryStorage.save({ key, value: idToken, expirationDelaySeconds: 1140 });
+      // when
+      const redirectTarget = await fwbOidcAuthenticationService.getRedirectLogoutUrl({ userId, logoutUrlUUID });
 
-        // when
-        const redirectTarget = await fwbOidcAuthenticationService.getRedirectLogoutUrl({ userId, logoutUrlUUID });
+      // then
+      const expectedResult = await defaultSessionTemporaryStorage.get(key);
+      expect(expectedResult).to.be.undefined;
 
-        // then
-        const expectedResult = await defaultSessionTemporaryStorage.get(key);
-        expect(expectedResult).to.be.undefined;
-
-        expect(redirectTarget).to.equal(
-          'https://logout-url.org/?id_token_hint=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
-        );
-      });
+      expect(redirectTarget).to.equal(
+        'https://logout-url.org/?id_token_hint=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+      );
     });
   });
 });

--- a/api/tests/integration/domain/services/authentication/pole-emploi-oidc-authentication-service_test.js
+++ b/api/tests/integration/domain/services/authentication/pole-emploi-oidc-authentication-service_test.js
@@ -10,7 +10,6 @@ import * as userToCreateRepository from '../../../../../src/shared/infrastructur
 import { expect, knex } from '../../../../test-helper.js';
 
 const defaultSessionTemporaryStorage = temporaryStorage.withPrefix('oidc-session:');
-const logoutUrlTemporaryStorage = temporaryStorage.withPrefix('logout-url:');
 
 describe('Integration | Domain | Services | pole-emploi-oidc-authentication-service', function () {
   describe('#createUserAccount', function () {
@@ -58,82 +57,41 @@ describe('Integration | Domain | Services | pole-emploi-oidc-authentication-serv
   });
 
   describe('#getRedirectLogoutUrl', function () {
-    describe('when the user ID Token is not stored in the parent default temporary storage', function () {
-      it('removes the idToken from temporary storage and returns a redirect logout url', async function () {
-        // given
-        const idToken =
-          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
-        const userId = 1;
-        const logoutUrlUUID = randomUUID();
-        const key = `${userId}:${logoutUrlUUID}`;
-        const poleEmploiOidcAuthenticationService = new PoleEmploiOidcAuthenticationService({
-          ...config.oidcExampleNet,
-          additionalRequiredProperties: {
-            logoutUrl: 'https://logout-url.fr',
-            afterLogoutUrl: 'https://after-logout.fr',
-          },
-          identityProvider: 'POLE_EMPLOI',
-          openidClientExtraMetadata: { token_endpoint_auth_method: 'client_secret_post' },
-          organizationName: 'France Travail',
-          shouldCloseSession: true,
-          slug: 'pole-emploi',
-          source: 'pole_emploi_connect',
-        });
-        await logoutUrlTemporaryStorage.save({ key, value: idToken, expirationDelaySeconds: 1140 });
-
-        // when
-        const redirectTarget = await poleEmploiOidcAuthenticationService.getRedirectLogoutUrl({
-          userId,
-          logoutUrlUUID,
-        });
-
-        // then
-        const expectedResult = await logoutUrlTemporaryStorage.get(key);
-        expect(expectedResult).to.be.undefined;
-
-        expect(redirectTarget).to.equal(
-          'https://logout-url.fr/?id_token_hint=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c&redirect_uri=https%3A%2F%2Fafter-logout.fr',
-        );
+    it('removes the idToken from temporary storage and returns a redirect logout url', async function () {
+      // given
+      const idToken =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+      const userId = 1;
+      const logoutUrlUUID = randomUUID();
+      const key = `${userId}:${logoutUrlUUID}`;
+      const poleEmploiOidcAuthenticationService = new PoleEmploiOidcAuthenticationService({
+        ...config.oidcExampleNet,
+        additionalRequiredProperties: {
+          logoutUrl: 'https://logout-url.fr',
+          afterLogoutUrl: 'https://after-logout.fr',
+        },
+        identityProvider: 'POLE_EMPLOI',
+        openidClientExtraMetadata: { token_endpoint_auth_method: 'client_secret_post' },
+        organizationName: 'France Travail',
+        shouldCloseSession: true,
+        slug: 'pole-emploi',
+        source: 'pole_emploi_connect',
       });
-    });
+      await defaultSessionTemporaryStorage.save({ key, value: idToken, expirationDelaySeconds: 1140 });
 
-    describe('when the user ID Token is stored in the parent default temporary storage', function () {
-      it('removes the idToken from temporary storage and returns a redirect logout url', async function () {
-        // given
-        const idToken =
-          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
-        const userId = 1;
-        const logoutUrlUUID = randomUUID();
-        const key = `${userId}:${logoutUrlUUID}`;
-        const poleEmploiOidcAuthenticationService = new PoleEmploiOidcAuthenticationService({
-          ...config.oidcExampleNet,
-          additionalRequiredProperties: {
-            logoutUrl: 'https://logout-url.fr',
-            afterLogoutUrl: 'https://after-logout.fr',
-          },
-          identityProvider: 'POLE_EMPLOI',
-          openidClientExtraMetadata: { token_endpoint_auth_method: 'client_secret_post' },
-          organizationName: 'France Travail',
-          shouldCloseSession: true,
-          slug: 'pole-emploi',
-          source: 'pole_emploi_connect',
-        });
-        await defaultSessionTemporaryStorage.save({ key, value: idToken, expirationDelaySeconds: 1140 });
-
-        // when
-        const redirectTarget = await poleEmploiOidcAuthenticationService.getRedirectLogoutUrl({
-          userId,
-          logoutUrlUUID,
-        });
-
-        // then
-        const expectedResult = await defaultSessionTemporaryStorage.get(key);
-        expect(expectedResult).to.be.undefined;
-
-        expect(redirectTarget).to.equal(
-          'https://logout-url.fr/?id_token_hint=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c&redirect_uri=https%3A%2F%2Fafter-logout.fr',
-        );
+      // when
+      const redirectTarget = await poleEmploiOidcAuthenticationService.getRedirectLogoutUrl({
+        userId,
+        logoutUrlUUID,
       });
+
+      // then
+      const expectedResult = await defaultSessionTemporaryStorage.get(key);
+      expect(expectedResult).to.be.undefined;
+
+      expect(redirectTarget).to.equal(
+        'https://logout-url.fr/?id_token_hint=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c&redirect_uri=https%3A%2F%2Fafter-logout.fr',
+      );
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

`PoleEmploiOidcAuthenticationService` et `FwbOidcAuthenticationService` utilisent un `logoutUrlTemporaryStorage` custom.


## :robot: Proposition

On peut supprimer le `logoutUrlTemporaryStorage` custom de `PoleEmploiOidcAuthenticationService` et `FwbOidcAuthenticationService` maintenant que #8646 a été déployée en production depuis plus de 1 semaine (16 avril 2024).

## :rainbow: Remarques

Pour pouvoir lire plus facilement le diff des commits sur les tests : ignorer les espaces. Cela permet de voir que ce qui a été fait sur les tests pour les 2 _OidcAuthenticationServices_ est uniquement de supprimer un contexte et le test associé.

## :100: Pour tester

Tester que la déconnexion fonctionne bien comme attendu avec FranceTravail et FWB.