### PR TITLE
[TECH] Avoir des recommandations de CFs par défaut dans les seeds DevComp (PIX-12180)

### DIFF
--- a/api/db/seeds/data/common/tooling/campaign-tooling.js
+++ b/api/db/seeds/data/common/tooling/campaign-tooling.js
@@ -46,7 +46,8 @@ export { createAssessmentCampaign, createProfilesCollectionCampaign };
  *    shared: number,
  *    shared_one_validated_skill: number,
  *    shared_perfect: number,
- *  }
+ *  },
+ *  recommendedTrainingsIds: number[]
  * }
  * @returns {Promise<{campaignId: number}>}
  */
@@ -203,6 +204,18 @@ async function createAssessmentCampaign({
         snappedAt: sharedAt,
         snapshot: JSON.stringify(keDataForSnapshot),
       });
+
+      if (configCampaign.recommendedTrainingsIds?.length > 0) {
+        for (const recommendedTrainingId of configCampaign.recommendedTrainingsIds) {
+          databaseBuilder.factory.buildUserRecommendedTraining({
+            userId,
+            trainingId: recommendedTrainingId,
+            campaignParticipationId,
+            createdAt: sharedAt,
+            updatedAt: sharedAt,
+          });
+        }
+      }
     }
   }
 

--- a/api/db/seeds/data/common/tooling/campaign-tooling.js
+++ b/api/db/seeds/data/common/tooling/campaign-tooling.js
@@ -206,10 +206,10 @@ async function createAssessmentCampaign({
       });
 
       if (configCampaign.recommendedTrainingsIds?.length > 0) {
-        for (const recommendedTrainingId of configCampaign.recommendedTrainingsIds) {
+        for (const trainingId of configCampaign.recommendedTrainingsIds) {
           databaseBuilder.factory.buildUserRecommendedTraining({
             userId,
-            trainingId: recommendedTrainingId,
+            trainingId,
             campaignParticipationId,
             createdAt: sharedAt,
             updatedAt: sharedAt,

--- a/api/db/seeds/data/team-devcomp/build-campaigns.js
+++ b/api/db/seeds/data/team-devcomp/build-campaigns.js
@@ -2,7 +2,7 @@ import { SCO_ORGANIZATION_ID, SCO_ORGANIZATION_USER_ID } from '../common/constan
 import { createAssessmentCampaign } from '../common/tooling/campaign-tooling.js';
 import { PIX_EDU_SMALL_TARGET_PROFILE_ID } from './constants.js';
 
-async function _createScoCampaigns(databaseBuilder) {
+async function _createScoCampaigns(databaseBuilder, trainingIds) {
   await createAssessmentCampaign({
     databaseBuilder,
     organizationId: SCO_ORGANIZATION_ID,
@@ -10,7 +10,11 @@ async function _createScoCampaigns(databaseBuilder) {
     name: 'PIX+ EDU - SCO - envoi simple',
     code: 'EDUSIMPLE',
     targetProfileId: PIX_EDU_SMALL_TARGET_PROFILE_ID,
-    configCampaign: { participantCount: 3, profileDistribution: { beginner: 1, perfect: 1, blank: 1 } },
+    configCampaign: {
+      participantCount: 3,
+      profileDistribution: { beginner: 1, perfect: 1, blank: 1 },
+      recommendedTrainingsIds: trainingIds,
+    },
   });
   await createAssessmentCampaign({
     databaseBuilder,
@@ -20,10 +24,14 @@ async function _createScoCampaigns(databaseBuilder) {
     code: 'EDUMULTIP',
     multipleSendings: true,
     targetProfileId: PIX_EDU_SMALL_TARGET_PROFILE_ID,
-    configCampaign: { participantCount: 3, profileDistribution: { beginner: 1, perfect: 1, blank: 1 } },
+    configCampaign: {
+      participantCount: 3,
+      profileDistribution: { beginner: 1, perfect: 1, blank: 1 },
+      recommendedTrainingsIds: trainingIds,
+    },
   });
 }
 
-export function buildCampaigns(databaseBuilder) {
-  return _createScoCampaigns(databaseBuilder);
+export function buildCampaigns(databaseBuilder, trainingIds) {
+  return _createScoCampaigns(databaseBuilder, trainingIds);
 }

--- a/api/db/seeds/data/team-devcomp/build-trainings.js
+++ b/api/db/seeds/data/team-devcomp/build-trainings.js
@@ -74,7 +74,7 @@ export function buildTrainings(databaseBuilder) {
 
   const enTrainingId = databaseBuilder.factory.buildTraining({
     title: 'Eat a croissant like the french',
-    locale: 'en-gb',
+    locale: 'en',
   }).id;
 
   databaseBuilder.factory.buildTargetProfileTraining({
@@ -93,4 +93,6 @@ export function buildTrainings(databaseBuilder) {
     tubeId: 'tube1NLpOetQhutFlA',
     level: 2,
   });
+
+  return [frTrainingId, frFrTrainingId1, frFrTrainingId2, enTrainingId];
 }

--- a/api/db/seeds/data/team-devcomp/data-builder.js
+++ b/api/db/seeds/data/team-devcomp/data-builder.js
@@ -4,8 +4,8 @@ import { buildTrainings } from './build-trainings.js';
 
 async function teamDevcompDataBuilder({ databaseBuilder }) {
   await buildTargetProfiles(databaseBuilder);
-  await buildTrainings(databaseBuilder);
-  await buildCampaigns(databaseBuilder);
+  const trainingsIds = await buildTrainings(databaseBuilder);
+  await buildCampaigns(databaseBuilder, trainingsIds);
 }
 
 export { teamDevcompDataBuilder };


### PR DESCRIPTION
## :unicorn: Problème
Dans les seeds DevComp, il n'y a pas d'accès simple à des CFs en tant qu'utilisateur prescrit. Cela nécessite de retenter/remettre à zéro ses résultats à une campagne (ou carrément tout faire de zéro) pour pouvoir y accéder.

## :robot: Proposition
Faire en sorte d'avoir des CFs directement dans les seeds DevComp.

Techniquement, j'ai ajouté un paramètre dans la configuration de la campagne `configCampaign` pour passer une liste de CFs existants qui seront recommandés. C'est très basique mais ça simplifie déjà la vie.

## :rainbow: Remarques
RAS

## :100: Pour tester
- Vérifier que les seeds passent avec succès.

Parcours utilisateur sur [Pix App](https://app-pr8763.review.pix.fr/)
- Se connecter en tant que `learneremail1003_30@example.net`, `learneremail1003_31@example.net` et `learneremail1003_32@example.net`.
- Vérifier qu'ils ont accès à un menu "Mes formations" dans la barre de navigation.
- Vérifier qu'il y trouvent des Contenus Formatifs.
