### PR TITLE
[FEATURE][ADMIN] Ajouter l'espagnol dans la liste des langues disponibles (PIX-12196)

### DIFF
--- a/admin/app/services/references.js
+++ b/admin/app/services/references.js
@@ -6,6 +6,7 @@ export default class ReferencesService extends Service {
       { value: 'fr', label: 'Français' },
       { value: 'en', label: 'Anglais' },
       { value: 'nl', label: 'Néerlandais' },
+      { value: 'es', label: 'Espagnol' },
     ];
   }
 

--- a/admin/tests/unit/services/references_test.js
+++ b/admin/tests/unit/services/references_test.js
@@ -10,11 +10,12 @@ module('Unit | Service | references', function (hooks) {
       const references = this.owner.lookup('service:references');
 
       // then
-      assert.strictEqual(references.availableLanguages.length, 3);
+      assert.strictEqual(references.availableLanguages.length, 4);
       assert.deepEqual(references.availableLanguages, [
         { value: 'fr', label: 'Français' },
         { value: 'en', label: 'Anglais' },
         { value: 'nl', label: 'Néerlandais' },
+        { value: 'es', label: 'Espagnol' },
       ]);
     });
   });

--- a/admin/tests/unit/services/references_test.js
+++ b/admin/tests/unit/services/references_test.js
@@ -1,0 +1,38 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Service | references', function (hooks) {
+  setupTest(hooks);
+
+  module('#availableLanguages', function () {
+    test('returns the list of available languages', function (assert) {
+      // given
+      const references = this.owner.lookup('service:references');
+
+      // then
+      assert.strictEqual(references.availableLanguages.length, 3);
+      assert.deepEqual(references.availableLanguages, [
+        { value: 'fr', label: 'Français' },
+        { value: 'en', label: 'Anglais' },
+        { value: 'nl', label: 'Néerlandais' },
+      ]);
+    });
+  });
+
+  module('#availableLocales', function () {
+    test('returns the list of available locales', function (assert) {
+      // given
+      const references = this.owner.lookup('service:references');
+
+      // then
+      assert.strictEqual(references.availableLocales.length, 5);
+      assert.deepEqual(references.availableLocales, [
+        { value: 'en', label: 'en' },
+        { value: 'fr', label: 'fr' },
+        { value: 'fr-BE', label: 'fr-BE' },
+        { value: 'fr-FR', label: 'fr-FR' },
+        { value: 'nl-BE', label: 'nl-BE' },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Il n'est pas possible de modifier la langue d'un compte utilisateur en espagnol.

## :robot: Proposition

Ajouter l'espagnol dans la liste de langues gérer dans Pix Admin.

## :rainbow: Remarques

RAS

## :100: Pour tester

1. Se connecter sur Pix Admin (https://admin-pr8789.review.pix.fr/) avec le compte `superadmin@example.net`
2. Ouvrir la page de détails d'un compte utilisateur
3. Modifier la langue de ce compte utilisateur en **espagnol**
4. Constater que la modification se passe bien et que la nouvelle langue du compte est bien l'espagnol
5. Se connecter sur Pix App du domaine .org (https://app-pr8789.review.pix.org/) avec le compte utilisateur que vous venez de modifier
6. Constater l'affichage de l'interface en espagnol