### PR TITLE
[FEATURE] Ajouter la notion de component dans nos modèles métiers (PIX-12299)

### DIFF
--- a/api/src/devcomp/domain/models/ComponentElement.js
+++ b/api/src/devcomp/domain/models/ComponentElement.js
@@ -1,0 +1,12 @@
+import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.js';
+
+class ComponentElement {
+  constructor({ element }) {
+    assertNotNullOrUndefined(element, 'An element is required for a componentElement');
+
+    this.element = element;
+    this.type = 'element';
+  }
+}
+
+export { ComponentElement };

--- a/api/src/devcomp/domain/models/Grain.js
+++ b/api/src/devcomp/domain/models/Grain.js
@@ -2,16 +2,18 @@ import { NotFoundError } from '../../../shared/domain/errors.js';
 import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.js';
 
 class Grain {
-  constructor({ id, title, type, elements }) {
+  constructor({ id, title, type, elements, components }) {
     assertNotNullOrUndefined(id, 'The id is required for a grain');
     assertNotNullOrUndefined(title, 'The title is required for a grain');
     assertNotNullOrUndefined(elements, `A list of elements is required for a grain`);
     this.#assertElementsIsAnArray(elements);
+    this.#assertComponentsIsDefinedAndAnArray(components);
 
     this.id = id;
     this.title = title;
     this.type = type;
     this.elements = elements;
+    this.components = components;
   }
 
   getElementById(elementId) {
@@ -27,6 +29,12 @@ class Grain {
   #assertElementsIsAnArray(elements) {
     if (!Array.isArray(elements)) {
       throw new Error(`A grain should have a list of elements`);
+    }
+  }
+
+  #assertComponentsIsDefinedAndAnArray(components) {
+    if (components !== undefined && !Array.isArray(components)) {
+      throw new Error(`Grain components should be a list of components`);
     }
   }
 }

--- a/api/src/devcomp/domain/models/module/Module.js
+++ b/api/src/devcomp/domain/models/module/Module.js
@@ -6,6 +6,7 @@ import { BlockInput } from '../block/BlockInput.js';
 import { BlockSelect } from '../block/BlockSelect.js';
 import { BlockSelectOption } from '../block/BlockSelectOption.js';
 import { BlockText } from '../block/BlockText.js';
+import { ComponentElement } from '../ComponentElement.js';
 import { Image } from '../element/Image.js';
 import { QCM } from '../element/QCM.js';
 import { QCMForAnswerVerification } from '../element/QCM-for-answer-verification.js';
@@ -48,19 +49,49 @@ class Module {
         transitionTexts: moduleData.transitionTexts?.map((transitionText) => new TransitionText(transitionText)) ?? [],
         details: new Details(moduleData.details),
         grains: moduleData.grains.map((grain) => {
-          return new Grain({
-            id: grain.id,
-            title: grain.title,
-            type: grain.type,
-            elements: grain.elements.map(Module.#mapElement).filter((element) => element !== undefined),
-          });
+          if (grain.components) {
+            if (!grain.elements) {
+              throw new Error('Elements should always be provided');
+            }
+
+            return new Grain({
+              id: grain.id,
+              title: grain.title,
+              type: grain.type,
+              elements: grain.elements.map(Module.#mapElement).filter((element) => element !== undefined),
+              components: grain.components
+                .map((component) => {
+                  if (component.type === 'element') {
+                    const element = Module.#mapElement(component.element);
+                    if (element) {
+                      return new ComponentElement({ element });
+                    } else {
+                      return undefined;
+                    }
+                  } else {
+                    logger.warn({
+                      event: 'module_component_type_unknown',
+                      message: `Component inconnu: ${component.type}`,
+                    });
+                    return undefined;
+                  }
+                })
+                .filter((component) => component !== undefined),
+            });
+          } else {
+            return new Grain({
+              id: grain.id,
+              title: grain.title,
+              type: grain.type,
+              elements: grain.elements.map(Module.#mapElement).filter((element) => element !== undefined),
+            });
+          }
         }),
       });
     } catch (e) {
       throw new ModuleInstantiationError(e.message);
     }
   }
-
   static #mapElement(element) {
     switch (element.type) {
       case 'image':

--- a/api/src/devcomp/domain/models/module/Module.js
+++ b/api/src/devcomp/domain/models/module/Module.js
@@ -52,35 +52,35 @@ class Module {
             id: grain.id,
             title: grain.title,
             type: grain.type,
-            elements: grain.elements
-              .map((element) => {
-                switch (element.type) {
-                  case 'image':
-                    return Module.#toImageDomain(element);
-                  case 'text':
-                    return Module.#toTextDomain(element);
-                  case 'qcm':
-                    return Module.#toQCMDomain(element);
-                  case 'qcu':
-                    return Module.#toQCUDomain(element);
-                  case 'qrocm':
-                    return Module.#toQROCMDomain(element);
-                  case 'video':
-                    return Module.#toVideoDomain(element);
-                  default:
-                    logger.warn({
-                      event: 'module_element_type_unknown',
-                      message: `Element inconnu: ${element.type}`,
-                    });
-                    return undefined;
-                }
-              })
-              .filter((element) => element !== undefined),
+            elements: grain.elements.map(Module.#mapElement).filter((element) => element !== undefined),
           });
         }),
       });
     } catch (e) {
       throw new ModuleInstantiationError(e.message);
+    }
+  }
+
+  static #mapElement(element) {
+    switch (element.type) {
+      case 'image':
+        return Module.#toImageDomain(element);
+      case 'text':
+        return Module.#toTextDomain(element);
+      case 'qcm':
+        return Module.#toQCMDomain(element);
+      case 'qcu':
+        return Module.#toQCUDomain(element);
+      case 'qrocm':
+        return Module.#toQROCMDomain(element);
+      case 'video':
+        return Module.#toVideoDomain(element);
+      default:
+        logger.warn({
+          event: 'module_element_type_unknown',
+          message: `Element inconnu: ${element.type}`,
+        });
+        return undefined;
     }
   }
 

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -56,7 +56,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
 
     it('should return a module with grains if it exists', async function () {
       // given
-      const existingModuleSlug = 'bien-ecrire-son-adresse-mail';
+      const existingModuleSlug = 'didacticiel-modulix';
 
       // when
       const module = await moduleRepository.getBySlug({

--- a/api/tests/devcomp/unit/domain/models/ComponentElement_test.js
+++ b/api/tests/devcomp/unit/domain/models/ComponentElement_test.js
@@ -1,0 +1,25 @@
+import { ComponentElement } from '../../../../../src/devcomp/domain/models/ComponentElement.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | ComponentElement', function () {
+  describe('#constructor', function () {
+    it('should create a componentElement', function () {
+      // given
+      const element = Symbol('element');
+      const type = 'element';
+
+      // when
+      const componentElement = new ComponentElement({ element });
+
+      // then
+      expect(componentElement.element).to.equal(element);
+      expect(componentElement.type).to.equal(type);
+    });
+  });
+
+  describe('if a componentElement does not have an element', function () {
+    it('should throw an error', function () {
+      expect(() => new ComponentElement({})).to.throw('An element is required for a componentElement');
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/models/Grain_test.js
+++ b/api/tests/devcomp/unit/domain/models/Grain_test.js
@@ -9,14 +9,16 @@ describe('Unit | Devcomp | Domain | Models | Grain', function () {
       const id = 1;
       const title = 'Les adresses email';
       const elements = [Symbol('text')];
+      const components = [Symbol('component')];
 
       // when
-      const grain = new Grain({ id, title, elements });
+      const grain = new Grain({ id, title, elements, components });
 
       // then
       expect(grain.id).to.equal(id);
       expect(grain.title).to.equal(title);
       expect(grain.elements).to.have.length(elements.length);
+      expect(grain.components).to.have.length(components.length);
     });
 
     describe('if a grain does not have an id', function () {
@@ -28,6 +30,12 @@ describe('Unit | Devcomp | Domain | Models | Grain', function () {
     describe('if a grain does not have a title', function () {
       it('should throw an error', function () {
         expect(() => new Grain({ id: 1 })).to.throw('The title is required for a grain');
+      });
+    });
+
+    describe('if a grain does not have components', function () {
+      it('should not throw an error', function () {
+        expect(() => new Grain({ id: 1, title: 'Les adresses mail', elements: [] })).not.to.throw();
       });
     });
 
@@ -50,6 +58,22 @@ describe('Unit | Devcomp | Domain | Models | Grain', function () {
                 elements: 'elements',
               }),
           ).to.throw(`A grain should have a list of elements`);
+        });
+      });
+    });
+
+    describe('if a grain does have components', function () {
+      describe('given a wrong typed grain.components in param', function () {
+        it('should throw an error', function () {
+          expect(
+            () =>
+              new Grain({
+                id: 'id_grain_1',
+                title: 'Bien écrire son adresse mail',
+                elements: [],
+                components: 'components',
+              }),
+          ).to.throw(`Grain components should be a list of components`);
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Afin de fluidifier la navigation d'un passage de module, nous avons besoin d'ajouter des transitions entre nos différents éléments. Pour se faire, nous avons besoin de changer la structure de nos modules pour y intégrer des `components` (au même niveau que les éléments actuels) dans les `grains`. 
Ces components vont contenir des composants type `element` dans un premier temps et d'autres pourront être ajoutés par la suite.

## :robot: Proposition
Ajouter la gestion des components dans la lecture de `Module`.
Nos modules peuvent contenir des `components` avec un premier `component` de type `element`. Le code métier n'en fait rien pour le moment.

## :rainbow: Remarques
RAS

## :100: Pour tester

1. Se rendre sur Pix App
2. Aller sur le module [Didactitiel Modulix ](https://app-pr8790.review.pix.fr/modules/didacticiel-modulix/details)
3. Parcourez le module et vérifiez qu'il n'y a pas de régressions 
