### PR TITLE
[FEATURE] Amélioration de la formule de score pour simulateurs (PIX-12316).

### DIFF
--- a/api/src/certification/scoring/domain/models/CapacitySimulator.js
+++ b/api/src/certification/scoring/domain/models/CapacitySimulator.js
@@ -12,7 +12,7 @@ export class CapacitySimulator {
     const intervalMinValue = certificationScoringIntervals[intervalIndex].bounds.min;
 
     const capacity =
-      (intervalMaxValue - intervalMinValue) * (score / SCORE_THRESHOLD - (intervalIndex + 1)) + intervalMaxValue;
+      (intervalMaxValue - intervalMinValue) * ((score + 1) / SCORE_THRESHOLD - (intervalIndex + 1)) + intervalMaxValue;
 
     const competences = competencesForScoring.map(({ intervals, competenceCode }) => {
       return {
@@ -30,5 +30,15 @@ export class CapacitySimulator {
 }
 
 function _findIntervalIndex(capacity, competenceForScoring) {
-  return competenceForScoring.findIndex(({ bounds }) => capacity < bounds.max && capacity >= bounds.min);
+  if (capacity < competenceForScoring[0].bounds.min) {
+    return 0;
+  }
+
+  for (const [index, { bounds }] of competenceForScoring.entries()) {
+    if (bounds.max >= capacity) {
+      return index;
+    }
+  }
+
+  return competenceForScoring.length - 1;
 }

--- a/api/src/certification/scoring/domain/models/CapacitySimulator.js
+++ b/api/src/certification/scoring/domain/models/CapacitySimulator.js
@@ -1,23 +1,26 @@
+import { Intervals } from './Intervals.js';
 import { ScoringAndCapacitySimulatorReport } from './ScoringAndCapacitySimulatorReport.js';
 
 export class CapacitySimulator {
   static compute({ certificationScoringIntervals, competencesForScoring, score }) {
+    const scoringIntervals = new Intervals({ intervals: certificationScoringIntervals });
     const MAX_PIX_SCORE = 1024;
-    const numberOfIntervals = certificationScoringIntervals.length;
+    const numberOfIntervals = scoringIntervals.length();
     const SCORE_THRESHOLD = MAX_PIX_SCORE / numberOfIntervals;
 
     const intervalIndex = Math.floor(score / SCORE_THRESHOLD);
 
-    const intervalMaxValue = certificationScoringIntervals[intervalIndex].bounds.max;
-    const intervalMinValue = certificationScoringIntervals[intervalIndex].bounds.min;
+    const intervalMaxValue = scoringIntervals.max(intervalIndex);
+    const intervalMinValue = scoringIntervals.min(intervalIndex);
 
     const capacity =
       (intervalMaxValue - intervalMinValue) * ((score + 1) / SCORE_THRESHOLD - (intervalIndex + 1)) + intervalMaxValue;
 
     const competences = competencesForScoring.map(({ intervals, competenceCode }) => {
+      const competenceIntervals = new Intervals({ intervals });
       return {
         competenceCode,
-        level: intervals[_findIntervalIndex(capacity, intervals)].competenceLevel,
+        level: intervals[competenceIntervals.findIntervalIndex(capacity)].competenceLevel,
       };
     });
 
@@ -27,18 +30,4 @@ export class CapacitySimulator {
       competences,
     });
   }
-}
-
-function _findIntervalIndex(capacity, competenceForScoring) {
-  if (capacity < competenceForScoring[0].bounds.min) {
-    return 0;
-  }
-
-  for (const [index, { bounds }] of competenceForScoring.entries()) {
-    if (bounds.max >= capacity) {
-      return index;
-    }
-  }
-
-  return competenceForScoring.length - 1;
 }

--- a/api/src/certification/scoring/domain/models/CertificationAssessmentScoreV3.js
+++ b/api/src/certification/scoring/domain/models/CertificationAssessmentScoreV3.js
@@ -1,3 +1,4 @@
+import { COMPETENCES_COUNT, PIX_COUNT_BY_LEVEL } from '../../../../../lib/domain/constants.js';
 import { config } from '../../../../shared/config.js';
 import { status as CertificationStatus } from '../../../../shared/domain/models/AssessmentResult.js';
 import { Intervals } from './Intervals.js';
@@ -64,10 +65,8 @@ const _calculateScore = ({ capacity, certificationScoringIntervals }) => {
   const numberOfIntervals = certificationScoringIntervals.length;
   const SCORE_THRESHOLD = MAX_PIX_SCORE / numberOfIntervals;
   const MAX_REACHABLE_LEVEL = 7;
-  const NUMBER_OF_COMPETENCES = 16;
   const MIN_PIX_SCORE = 0;
-  const PIX_PER_LEVEL = 8;
-  const maximumReachableScore = MAX_REACHABLE_LEVEL * NUMBER_OF_COMPETENCES * PIX_PER_LEVEL - 1;
+  const maximumReachableScore = MAX_REACHABLE_LEVEL * COMPETENCES_COUNT * PIX_COUNT_BY_LEVEL - 1;
 
   const scoringIntervals = new Intervals({ intervals: certificationScoringIntervals });
 

--- a/api/src/certification/scoring/domain/models/Intervals.js
+++ b/api/src/certification/scoring/domain/models/Intervals.js
@@ -1,0 +1,47 @@
+export class Intervals {
+  constructor({ intervals }) {
+    this.intervals = intervals;
+  }
+
+  length() {
+    return this.intervals.length;
+  }
+
+  min(intervalIndex) {
+    return this.intervals[intervalIndex].bounds.min;
+  }
+
+  max(intervalIndex) {
+    return this.intervals[intervalIndex].bounds.max;
+  }
+
+  intervalWidth(intervalIndex) {
+    return this.intervals[intervalIndex].bounds.max - this.intervals[intervalIndex].bounds.min;
+  }
+
+  toIntervalMax(intervalIndex, capacity) {
+    return capacity - this.intervals[intervalIndex].bounds.max;
+  }
+
+  findIntervalIndex(capacity) {
+    if (capacity < this.intervals[0].bounds.min) {
+      return 0;
+    }
+
+    for (const [index, { bounds }] of this.intervals.entries()) {
+      if (bounds.max >= capacity) {
+        return index;
+      }
+    }
+
+    return this.intervals.length - 1;
+  }
+
+  isCapacityBelowMinimum(capacity) {
+    return capacity <= this.intervals[0].bounds.min;
+  }
+
+  isCapacityAboveMaximum(capacity) {
+    return capacity >= this.intervals.at(-1).bounds.max;
+  }
+}

--- a/api/src/certification/scoring/domain/models/ScoringSimulator.js
+++ b/api/src/certification/scoring/domain/models/ScoringSimulator.js
@@ -1,3 +1,4 @@
+import { COMPETENCES_COUNT, PIX_COUNT_BY_LEVEL } from '../../../../../lib/domain/constants.js';
 import { Intervals } from './Intervals.js';
 import { ScoringAndCapacitySimulatorReport } from './ScoringAndCapacitySimulatorReport.js';
 
@@ -38,10 +39,8 @@ function _calculateScore({
   const numberOfIntervals = certificationScoringIntervals.length();
   const SCORE_THRESHOLD = MAX_PIX_SCORE / numberOfIntervals;
   const MAX_REACHABLE_LEVEL = 7;
-  const NUMBER_OF_COMPETENCES = 16;
   const MIN_PIX_SCORE = 0;
-  const PIX_PER_LEVEL = 8;
-  const maximumReachableScore = MAX_REACHABLE_LEVEL * NUMBER_OF_COMPETENCES * PIX_PER_LEVEL - 1;
+  const maximumReachableScore = MAX_REACHABLE_LEVEL * COMPETENCES_COUNT * PIX_COUNT_BY_LEVEL - 1;
 
   if (certificationScoringIntervals.isCapacityBelowMinimum(capacity)) {
     return MIN_PIX_SCORE;

--- a/api/src/certification/scoring/domain/models/ScoringSimulator.js
+++ b/api/src/certification/scoring/domain/models/ScoringSimulator.js
@@ -2,52 +2,90 @@ import { ScoringAndCapacitySimulatorReport } from './ScoringAndCapacitySimulator
 
 export class ScoringSimulator {
   static compute({ capacity, certificationScoringIntervals, competencesForScoring }) {
-    const MAX_REACHABLE_LEVEL = 7;
-    const MAX_PIX_SCORE = 1024;
-    const NUMBER_OF_COMPETENCES = 16;
-    const PIX_PER_LEVEL = 8;
+    const intervalIndex = _findIntervalIndex(capacity, certificationScoringIntervals);
 
-    const numberOfIntervals = certificationScoringIntervals.length;
-    const intervalHeight = MAX_PIX_SCORE / numberOfIntervals;
-
-    let normalizedCapacity = capacity;
-    const minimumCapacity = certificationScoringIntervals[0].bounds.min;
-    const maximumCapacity = certificationScoringIntervals.at(-1).bounds.max;
-
-    if (normalizedCapacity < minimumCapacity) {
-      normalizedCapacity = minimumCapacity;
-    }
-    if (normalizedCapacity > maximumCapacity) {
-      normalizedCapacity = maximumCapacity;
-    }
-
-    const intervalIndex = _findIntervalIndex(normalizedCapacity, certificationScoringIntervals);
-
-    const intervalMaxValue = certificationScoringIntervals[intervalIndex].bounds.max;
     const intervalWidth =
       certificationScoringIntervals[intervalIndex].bounds.max - certificationScoringIntervals[intervalIndex].bounds.min;
 
-    const score = intervalHeight * (intervalIndex + 1 + (normalizedCapacity - intervalMaxValue) / intervalWidth);
+    const differenceBetweenCapacityAndMaximumIntervalCapacity =
+      capacity - certificationScoringIntervals[intervalIndex].bounds.max;
 
-    const maximumReachableScore = MAX_REACHABLE_LEVEL * NUMBER_OF_COMPETENCES * PIX_PER_LEVEL;
-
-    const limitedScore = Math.min(maximumReachableScore, score);
-
-    const competences = competencesForScoring.map(({ intervals, competenceCode }) => {
-      return {
-        competenceCode,
-        level: intervals[_findIntervalIndex(normalizedCapacity, intervals)].competenceLevel,
-      };
+    const score = _calculateScore({
+      certificationScoringIntervals,
+      capacity,
+      intervalIndex,
+      differenceBetweenCapacityAndMaximumIntervalCapacity,
+      intervalWidth,
     });
+    const competences = _computeCompetences({ competencesForScoring, capacity });
 
     return new ScoringAndCapacitySimulatorReport({
       capacity,
-      score: Math.round(limitedScore),
+      score: Math.round(score),
       competences,
     });
   }
 }
 
 function _findIntervalIndex(capacity, certificationScoringIntervals) {
-  return certificationScoringIntervals.findIndex(({ bounds }) => capacity < bounds.max && capacity >= bounds.min);
+  if (capacity < certificationScoringIntervals[0].bounds.min) {
+    return 0;
+  }
+
+  for (const [index, { bounds }] of certificationScoringIntervals.entries()) {
+    if (bounds.max >= capacity) {
+      return index;
+    }
+  }
+
+  return certificationScoringIntervals.length - 1;
+}
+
+function _calculateScore({
+  certificationScoringIntervals,
+  capacity,
+  intervalIndex,
+  differenceBetweenCapacityAndMaximumIntervalCapacity,
+  intervalWidth,
+}) {
+  const MAX_PIX_SCORE = 1024;
+  const numberOfIntervals = certificationScoringIntervals.length;
+  const SCORE_THRESHOLD = MAX_PIX_SCORE / numberOfIntervals;
+  const MAX_REACHABLE_LEVEL = 7;
+  const NUMBER_OF_COMPETENCES = 16;
+  const MIN_PIX_SCORE = 0;
+  const PIX_PER_LEVEL = 8;
+  const maximumReachableScore = MAX_REACHABLE_LEVEL * NUMBER_OF_COMPETENCES * PIX_PER_LEVEL - 1;
+
+  if (_isCapacityBelowMinimum(capacity, certificationScoringIntervals)) {
+    return MIN_PIX_SCORE;
+  }
+
+  if (_isCapacityAboveMaximum(capacity, certificationScoringIntervals)) {
+    return maximumReachableScore;
+  }
+
+  const score =
+    Math.ceil(
+      SCORE_THRESHOLD * (intervalIndex + 1 + differenceBetweenCapacityAndMaximumIntervalCapacity / intervalWidth),
+    ) - 1;
+
+  return Math.min(maximumReachableScore, score);
+}
+
+function _isCapacityBelowMinimum(capacity, certificationScoringIntervals) {
+  return capacity <= certificationScoringIntervals[0].bounds.min;
+}
+
+function _isCapacityAboveMaximum(capacity, certificationScoringIntervals) {
+  return capacity >= certificationScoringIntervals.at(-1).bounds.max;
+}
+
+function _computeCompetences({ competencesForScoring, capacity }) {
+  return competencesForScoring.map(({ intervals, competenceCode }) => {
+    return {
+      competenceCode,
+      level: intervals[_findIntervalIndex(capacity, intervals)].competenceLevel,
+    };
+  });
 }

--- a/api/tests/certification/scoring/acceptance/application/scoring-and-capacity-simulator-route_test.js
+++ b/api/tests/certification/scoring/acceptance/application/scoring-and-capacity-simulator-route_test.js
@@ -502,7 +502,7 @@ describe('Acceptance | Application | scoring-and-capacity-simulator-route', func
             },
             payload: {
               data: {
-                score: 128,
+                score: 127,
                 capacity: undefined,
               },
             },
@@ -517,7 +517,7 @@ describe('Acceptance | Application | scoring-and-capacity-simulator-route', func
             type: 'scoring-and-capacity-simulator-reports',
             attributes: {
               capacity: -6,
-              score: 128,
+              score: 127,
               competences: [
                 {
                   competenceCode: '1.1',

--- a/api/tests/certification/scoring/unit/domain/models/CapacitySimulator_test.js
+++ b/api/tests/certification/scoring/unit/domain/models/CapacitySimulator_test.js
@@ -86,7 +86,7 @@ describe('Unit | Domain | Models | CapacitySimulator', function () {
     [
       {
         score: 0,
-        expectedCapacity: -8,
+        expectedCapacity: -7.953125,
         expectedCompetences: [
           { competenceCode: '1.1', level: 0 },
           { competenceCode: '1.2', level: 0 },
@@ -96,7 +96,7 @@ describe('Unit | Domain | Models | CapacitySimulator', function () {
         ],
       },
       {
-        score: 101,
+        score: 100,
         expectedCapacity: -3.265625,
         expectedCompetences: [
           { competenceCode: '1.1', level: 0 },
@@ -107,7 +107,7 @@ describe('Unit | Domain | Models | CapacitySimulator', function () {
         ],
       },
       {
-        score: 107,
+        score: 106,
         expectedCapacity: -2.984375,
         expectedCompetences: [
           { competenceCode: '1.1', level: 0 },
@@ -118,7 +118,7 @@ describe('Unit | Domain | Models | CapacitySimulator', function () {
         ],
       },
       {
-        score: 112,
+        score: 111,
         expectedCapacity: -2.75,
         expectedCompetences: [
           { competenceCode: '1.1', level: 0 },
@@ -129,7 +129,7 @@ describe('Unit | Domain | Models | CapacitySimulator', function () {
         ],
       },
       {
-        score: 117,
+        score: 116,
         expectedCapacity: -2.515625,
         expectedCompetences: [
           { competenceCode: '1.1', level: 0 },
@@ -140,7 +140,7 @@ describe('Unit | Domain | Models | CapacitySimulator', function () {
         ],
       },
       {
-        score: 123,
+        score: 122,
         expectedCapacity: -2.234375,
         expectedCompetences: [
           { competenceCode: '1.1', level: 0 },
@@ -151,18 +151,18 @@ describe('Unit | Domain | Models | CapacitySimulator', function () {
         ],
       },
       {
-        score: 128,
+        score: 127,
         expectedCapacity: -2,
         expectedCompetences: [
-          { competenceCode: '1.1', level: 1 },
+          { competenceCode: '1.1', level: 0 },
           { competenceCode: '1.2', level: 2 },
-          { competenceCode: '2.1', level: 2 },
+          { competenceCode: '2.1', level: 1 },
           { competenceCode: '2.2', level: 2 },
           { competenceCode: '2.3', level: 2 },
         ],
       },
       {
-        score: 224,
+        score: 223,
         expectedCapacity: -0.875,
         expectedCompetences: [
           { competenceCode: '1.1', level: 1 },
@@ -173,7 +173,7 @@ describe('Unit | Domain | Models | CapacitySimulator', function () {
         ],
       },
       {
-        score: 327,
+        score: 326,
         expectedCapacity: 0.11015624999999996,
         expectedCompetences: [
           { competenceCode: '1.1', level: 2 },
@@ -184,7 +184,7 @@ describe('Unit | Domain | Models | CapacitySimulator', function () {
         ],
       },
       {
-        score: 453,
+        score: 452,
         expectedCapacity: 1.08515625,
         expectedCompetences: [
           { competenceCode: '1.1', level: 3 },
@@ -195,7 +195,7 @@ describe('Unit | Domain | Models | CapacitySimulator', function () {
         ],
       },
       {
-        score: 591,
+        score: 590,
         expectedCapacity: 1.962890625,
         expectedCompetences: [
           { competenceCode: '1.1', level: 4 },
@@ -206,7 +206,7 @@ describe('Unit | Domain | Models | CapacitySimulator', function () {
         ],
       },
       {
-        score: 752,
+        score: 751,
         expectedCapacity: 2.99375,
         expectedCompetences: [
           { competenceCode: '1.1', level: 5 },
@@ -217,7 +217,18 @@ describe('Unit | Domain | Models | CapacitySimulator', function () {
         ],
       },
       {
-        score: 897,
+        score: 895,
+        expectedCapacity: 4,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 6 },
+          { competenceCode: '1.2', level: 4 },
+          { competenceCode: '2.1', level: 6 },
+          { competenceCode: '2.2', level: 6 },
+          { competenceCode: '2.3', level: 5 },
+        ],
+      },
+      {
+        score: 896,
         expectedCapacity: 4.03125,
         expectedCompetences: [
           { competenceCode: '1.1', level: 7 },

--- a/api/tests/certification/scoring/unit/domain/models/CertificationAssessmentScoreV3_test.js
+++ b/api/tests/certification/scoring/unit/domain/models/CertificationAssessmentScoreV3_test.js
@@ -85,7 +85,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
   describe('when the candidate finished the test', function () {
     it('should return the full score', async function () {
       const expectedCapacity = 2;
-      const expectedScoreForCapacity = 640;
+      const expectedScoreForCapacity = 639;
 
       const numberOfQuestions = 32;
 
@@ -169,7 +169,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
     describe('when the abort reason is technical difficulties', function () {
       it('should return the raw score', async function () {
         const expectedCapacity = 2;
-        const expectedScoreForCapacity = 640;
+        const expectedScoreForCapacity = 639;
 
         const numberOfAnsweredQuestions = 20;
         const numberCertificationQuestions = 32;
@@ -378,7 +378,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
   });
 
   describe('when we reach an estimated level above the MAXIMUM', function () {
-    it('the score should be 896', function () {
+    it('the score should be the maximum score reachable at the moment', function () {
       // given
       const veryHighCapacity = 1200;
       const veryHardDifficulty = 8;
@@ -406,7 +406,7 @@ describe('Unit | Domain | Models | CertificationAssessmentScoreV3 ', function ()
       });
 
       // then
-      expect(score.nbPix).to.equal(896);
+      expect(score.nbPix).to.equal(895);
     });
 
     it('should return the competence marks', function () {

--- a/api/tests/certification/scoring/unit/domain/models/Intervals_test.js
+++ b/api/tests/certification/scoring/unit/domain/models/Intervals_test.js
@@ -1,0 +1,104 @@
+import { Intervals } from '../../../../../../src/certification/scoring/domain/models/Intervals.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | Domain | Models | Intervals ', function () {
+  describe('length', function () {
+    it('returns the length of the given intervals', async function () {
+      const intervals = new Intervals({ intervals: [{ hello: 'world' }, { goodbye: 'world' }] });
+
+      expect(intervals.length()).to.equal(2);
+    });
+  });
+
+  describe('min', function () {
+    it('returns the minimum value of the given interval index', async function () {
+      const intervals = new Intervals({ intervals: [{ bounds: { min: 1, max: 3 } }, { bounds: { min: 4, max: 6 } }] });
+
+      expect(intervals.min(1)).to.equal(4);
+    });
+  });
+
+  describe('max', function () {
+    it('returns the maximum value of the given interval index', async function () {
+      const intervals = new Intervals({ intervals: [{ bounds: { min: 1, max: 3 } }, { bounds: { min: 4, max: 6 } }] });
+
+      expect(intervals.max(0)).to.equal(3);
+    });
+  });
+
+  describe('intervalWidth', function () {
+    it('returns the maximum value of the given interval index', async function () {
+      const intervals = new Intervals({ intervals: [{ bounds: { min: 1, max: 3 } }, { bounds: { min: 4, max: 7 } }] });
+
+      expect(intervals.intervalWidth(0)).to.equal(2);
+    });
+  });
+
+  describe('toIntervalMax', function () {
+    it('returns the value from the maximum to the given capacity at a given interval index', async function () {
+      const intervals = new Intervals({ intervals: [{ bounds: { min: 1, max: 3 } }, { bounds: { min: 4, max: 7 } }] });
+
+      expect(intervals.toIntervalMax(0, 1)).to.equal(-2);
+    });
+  });
+
+  describe('findIntervalIndex', function () {
+    describe('when the given capacity is inferior to the first interval minimum value', function () {
+      it('returns the index of the first interval', async function () {
+        const intervals = new Intervals({
+          intervals: [{ bounds: { min: 1, max: 3 } }, { bounds: { min: 4, max: 7 } }],
+        });
+
+        expect(intervals.findIntervalIndex(0)).to.equal(0);
+      });
+    });
+
+    describe('when the given capacity is superior to the last interval maximum value', function () {
+      it('returns the index of the last interval', async function () {
+        const intervals = new Intervals({
+          intervals: [{ bounds: { min: 1, max: 3 } }, { bounds: { min: 4, max: 7 } }],
+        });
+
+        expect(intervals.findIntervalIndex(10)).to.equal(1);
+      });
+    });
+
+    describe('when the given capacity is included in one of the intervals', function () {
+      it('returns the index of the interval containing this value', async function () {
+        const intervals = new Intervals({
+          intervals: [{ bounds: { min: 1, max: 3 } }, { bounds: { min: 4, max: 7 } }],
+        });
+
+        expect(intervals.findIntervalIndex(2)).to.equal(0);
+      });
+    });
+  });
+
+  describe('isCapacityBelowMinimum', function () {
+    it('returns true if the given capacity is inferior to the minimum value of the first interval', async function () {
+      const intervals = new Intervals({ intervals: [{ bounds: { min: 1, max: 3 } }, { bounds: { min: 4, max: 7 } }] });
+
+      expect(intervals.isCapacityBelowMinimum(0)).to.equal(true);
+    });
+
+    it('returns false if the given capacity is not inferior to the minimum value of the first interval', async function () {
+      const intervals = new Intervals({ intervals: [{ bounds: { min: 1, max: 3 } }, { bounds: { min: 4, max: 7 } }] });
+
+      expect(intervals.isCapacityBelowMinimum(7)).to.equal(false);
+    });
+  });
+
+  describe('isCapacityAboveMaximum', function () {
+    it('returns true if the given capacity is superior to the maximum value of the last interval', async function () {
+      const intervals = new Intervals({ intervals: [{ bounds: { min: 1, max: 3 } }, { bounds: { min: 4, max: 7 } }] });
+
+      expect(intervals.isCapacityAboveMaximum(10)).to.equal(true);
+    });
+
+    it('returns false if the given capacity is not superior to the minimum value of the last interval', async function () {
+      const intervals = new Intervals({ intervals: [{ bounds: { min: 1, max: 3 } }, { bounds: { min: 4, max: 7 } }] });
+
+      expect(intervals.isCapacityAboveMaximum(2)).to.equal(false);
+    });
+  });
+});

--- a/api/tests/certification/scoring/unit/domain/models/ScoringSimulator_test.js
+++ b/api/tests/certification/scoring/unit/domain/models/ScoringSimulator_test.js
@@ -6,6 +6,17 @@ describe('Unit | Domain | Models | ScoringSimulator', function () {
     // eslint-disable-next-line mocha/no-setup-in-describe
     [
       {
+        capacity: -10,
+        expectedScore: 0,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 0 },
+          { competenceCode: '1.2', level: 0 },
+          { competenceCode: '2.1', level: 0 },
+          { competenceCode: '2.2', level: 0 },
+          { competenceCode: '2.3', level: 0 },
+        ],
+      },
+      {
         capacity: -8,
         expectedScore: 0,
         expectedCompetences: [
@@ -29,7 +40,7 @@ describe('Unit | Domain | Models | ScoringSimulator', function () {
       },
       {
         capacity: -2.99609375,
-        expectedScore: 107,
+        expectedScore: 106,
         expectedCompetences: [
           { competenceCode: '1.1', level: 0 },
           { competenceCode: '1.2', level: 2 },
@@ -40,7 +51,7 @@ describe('Unit | Domain | Models | ScoringSimulator', function () {
       },
       {
         capacity: -2.75,
-        expectedScore: 112,
+        expectedScore: 111,
         expectedCompetences: [
           { competenceCode: '1.1', level: 0 },
           { competenceCode: '1.2', level: 2 },
@@ -62,7 +73,7 @@ describe('Unit | Domain | Models | ScoringSimulator', function () {
       },
       {
         capacity: -2.24609375,
-        expectedScore: 123,
+        expectedScore: 122,
         expectedCompetences: [
           { competenceCode: '1.1', level: 0 },
           { competenceCode: '1.2', level: 2 },
@@ -73,11 +84,11 @@ describe('Unit | Domain | Models | ScoringSimulator', function () {
       },
       {
         capacity: -2,
-        expectedScore: 128,
+        expectedScore: 127,
         expectedCompetences: [
-          { competenceCode: '1.1', level: 1 },
+          { competenceCode: '1.1', level: 0 },
           { competenceCode: '1.2', level: 2 },
-          { competenceCode: '2.1', level: 2 },
+          { competenceCode: '2.1', level: 1 },
           { competenceCode: '2.2', level: 2 },
           { competenceCode: '2.3', level: 2 },
         ],
@@ -95,7 +106,7 @@ describe('Unit | Domain | Models | ScoringSimulator', function () {
       },
       {
         capacity: 0.10781249999999987,
-        expectedScore: 327,
+        expectedScore: 326,
         expectedCompetences: [
           { competenceCode: '1.1', level: 2 },
           { competenceCode: '1.2', level: 2 },
@@ -106,7 +117,7 @@ describe('Unit | Domain | Models | ScoringSimulator', function () {
       },
       {
         capacity: 1.083984375,
-        expectedScore: 453,
+        expectedScore: 452,
         expectedCompetences: [
           { competenceCode: '1.1', level: 3 },
           { competenceCode: '1.2', level: 3 },
@@ -138,14 +149,36 @@ describe('Unit | Domain | Models | ScoringSimulator', function () {
         ],
       },
       {
+        capacity: 4,
+        expectedScore: 895,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 6 },
+          { competenceCode: '1.2', level: 4 },
+          { competenceCode: '2.1', level: 6 },
+          { competenceCode: '2.2', level: 6 },
+          { competenceCode: '2.3', level: 5 },
+        ],
+      },
+      {
         capacity: 4.03125,
-        expectedScore: 896,
+        expectedScore: 895,
         expectedCompetences: [
           { competenceCode: '1.1', level: 7 },
           { competenceCode: '1.2', level: 5 },
           { competenceCode: '2.1', level: 6 },
           { competenceCode: '2.2', level: 6 },
           { competenceCode: '2.3', level: 5 },
+        ],
+      },
+      {
+        capacity: 10,
+        expectedScore: 895,
+        expectedCompetences: [
+          { competenceCode: '1.1', level: 7 },
+          { competenceCode: '1.2', level: 7 },
+          { competenceCode: '2.1', level: 7 },
+          { competenceCode: '2.2', level: 7 },
+          { competenceCode: '2.3', level: 7 },
         ],
       },
     ].forEach(({ capacity, expectedScore, expectedCompetences }) => {

--- a/api/tests/certification/scoring/unit/domain/usecases/simulate-capacity-from-score_test.js
+++ b/api/tests/certification/scoring/unit/domain/usecases/simulate-capacity-from-score_test.js
@@ -13,7 +13,7 @@ describe('Unit | UseCase | simulate-capacity-from-score', function () {
   it('should return a capacity', async function () {
     // given
     const date = new Date();
-    const score = 768;
+    const score = 767;
 
     const v3CertificationScoring = domainBuilder.buildV3CertificationScoring({
       competencesForScoring: [

--- a/api/tests/certification/scoring/unit/domain/usecases/simulate-score-from-capacity_test.js
+++ b/api/tests/certification/scoring/unit/domain/usecases/simulate-score-from-capacity_test.js
@@ -55,7 +55,7 @@ describe('Unit | UseCase | simulate-score-from-capacity', function () {
     expect(result).to.deepEqualInstance(
       domainBuilder.buildScoringAndCapacitySimulatorReport({
         capacity,
-        score: 768,
+        score: 767,
         competences: [
           {
             level: 0,

--- a/api/tests/unit/domain/services/scoring/scoring-certification-service_test.js
+++ b/api/tests/unit/domain/services/scoring/scoring-certification-service_test.js
@@ -2145,7 +2145,7 @@ describe('Unit | Service | Certification Result Service', function () {
           it('builds and save a lack of answers assessment result', async function () {
             // given
             const expectedCapacity = 2;
-            const scoreForCapacity = 640;
+            const scoreForCapacity = 639;
             const abortedCertificationCourse = domainBuilder.buildCertificationCourse({
               id: certificationCourseId,
               createdAt: certificationCourseStartDate,
@@ -2259,7 +2259,7 @@ describe('Unit | Service | Certification Result Service', function () {
             // given
             const abortReason = ABORT_REASONS.TECHNICAL;
             const expectedCapacity = 2;
-            const scoreForCapacity = 640;
+            const scoreForCapacity = 639;
             const abortedCertificationCourse = domainBuilder.buildCertificationCourse({
               id: certificationCourseId,
               createdAt: certificationCourseStartDate,
@@ -2385,7 +2385,7 @@ describe('Unit | Service | Certification Result Service', function () {
           it('builds and save an assessment result with a validated status', async function () {
             // given
             const expectedCapacity = 2;
-            const scoreForCapacity = 640;
+            const scoreForCapacity = 639;
             const challenges = _generateCertificationChallengeForScoringList({ length: maximumAssessmentLength });
             const answers = generateAnswersForChallenges({ challenges });
             const assessmentResultId = 123;
@@ -2490,7 +2490,7 @@ describe('Unit | Service | Certification Result Service', function () {
             it('should return the score capped based on the maximum available level when the certification was done', async function () {
               // given
               const expectedCapacity = 8;
-              const cappedScoreForCapacity = 896;
+              const cappedScoreForCapacity = 895;
               const challenges = _generateCertificationChallengeForScoringList({ length: maximumAssessmentLength });
 
               const answers = generateAnswersForChallenges({ challenges });
@@ -2586,7 +2586,7 @@ describe('Unit | Service | Certification Result Service', function () {
             it('should build and save an assessment result with a validated status with the raw score', async function () {
               // given
               const expectedCapacity = 2;
-              const rawScore = 640;
+              const rawScore = 639;
               const challenges = _generateCertificationChallengeForScoringList({
                 length: minimumAnswersRequiredToValidateACertification,
               });
@@ -2691,7 +2691,7 @@ describe('Unit | Service | Certification Result Service', function () {
             it('should build and save an assessment result with a validated status', async function () {
               // given
               const expectedCapacity = 2;
-              const pixScore = 640;
+              const pixScore = 639;
               const challenges = _generateCertificationChallengeForScoringList({
                 length: minimumAnswersRequiredToValidateACertification,
               });
@@ -2829,7 +2829,7 @@ describe('Unit | Service | Certification Result Service', function () {
             const answers = generateAnswersForChallenges({ challenges });
 
             const expectedCapacity = 2;
-            const scoreForCapacity = 640;
+            const scoreForCapacity = 639;
             const { certificationCourseId } = certificationAssessment;
 
             const capacityHistory = [
@@ -2949,7 +2949,7 @@ describe('Unit | Service | Certification Result Service', function () {
             const answers = generateAnswersForChallenges({ challenges });
 
             const expectedCapacity = 2;
-            const scoreForCapacity = 640;
+            const scoreForCapacity = 639;
             const { certificationCourseId } = certificationAssessment;
 
             const capacityHistory = [
@@ -3072,7 +3072,7 @@ describe('Unit | Service | Certification Result Service', function () {
             const answers = generateAnswersForChallenges({ challenges });
 
             const expectedCapacity = 2;
-            const rawScore = 640;
+            const rawScore = 639;
             const { certificationCourseId } = certificationAssessment;
 
             const capacityHistory = [
@@ -3193,7 +3193,7 @@ describe('Unit | Service | Certification Result Service', function () {
           const answers = generateAnswersForChallenges({ challenges });
 
           const expectedCapacity = 2;
-          const scoreForCapacity = 640;
+          const scoreForCapacity = 639;
           const { certificationCourseId } = certificationAssessment;
 
           const capacityHistory = [
@@ -3323,7 +3323,7 @@ describe('Unit | Service | Certification Result Service', function () {
             const answers = generateAnswersForChallenges({ challenges });
 
             const expectedCapacity = 2;
-            const scoreForCapacity = 640;
+            const scoreForCapacity = 639;
             const { certificationCourseId } = certificationAssessment;
 
             const capacityHistory = [
@@ -3442,7 +3442,7 @@ describe('Unit | Service | Certification Result Service', function () {
             const answers = generateAnswersForChallenges({ challenges });
 
             const expectedCapacity = 8;
-            const cappedscoreForCapacity = 896;
+            const cappedscoreForCapacity = 895;
             const { certificationCourseId } = certificationAssessment;
 
             const capacityHistory = [


### PR DESCRIPTION
## :unicorn: Problème

Le [schéma de score/niveau global](https://docs.google.com/document/d/12VDA9ROiV78XuPH9tkJ_nID21abhO0K8/edit#heading=h.h4kg5219i5bv) a été mis à jour pour rendre la certif plus bienveillante pour les bas niveaux notamment. Cela implique 2 changements :

- D’un point de vue métier, la séparation de la maille 1 du scoring global en 2 sous-mailles
- Un nouveau score max pour le niveau 7 (en attendant le niveau 8)

## :robot: Proposition

Dans un premier temps, on va caper le score global en Pix à 895 au lieu de 896 tant que le niveau max atteignable = 7

UPDATE : on va aussi modifier la formule de scoring pour éviter que 2 candidats avec le même score Pix se retrouve dans des mailles différentes.

Pour donner un peu plus de contexte, et avec l'ancienne implémentation :

Prenons l'exemple du tableau de mailles suivant : 
`[{ bounds: { max: -2, min: -8 }, meshLevel: 0 }, { bounds: { max: -0.5, min: -2 }, meshLevel: 1 }]`

Dans l'éventualité où un candidat aurait une capacité finale estimée à `-2.01`, son score aurait été de `128 Pix`, tout en faisant partie de la première maille.
Un autre candidat qui aurait eu une capacité finale estimée à `-1.99`, aurait également eu un score de `128 Pix`, tout en faisant partie cette fois de la seconde maille.

La nouvelle implémentation corrige ce problème en faisant passer le score maximal atteignable de la première maille à `127 Pix` et en démarrant à `128 Pix` pour la seconde.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

Sur pix-admin, se connecter en tant que superadmin@example.net
Aller sur l'url /certifications/scoring-simulation

Test de l'obtention d'un score :

- Remplir le champ capacité
- générer un profil de résultat
- Vérifier que l'on obtient un score et des niveaux par compétence


Test de l'obtention d'une capacité :
- Remplir le champ score
- générer un profil de résultat
- Vérifier que l'on obtient un score et des niveaux par compétence

Vérifier que l'on ne peut remplir les deux champs lors de l'envoi

Vérifier que l'on ne peut remplir le champ score avec une valeur inférieure à 0 et supérieure à 896.

Vérifier que l'on peut remplir le champ capacité avec une valeur inférieur à -8 (score attendu 0) ou supérieur  à  8 (score attendu 895) et qu'on ne prend pas d'erreur 500.

