### PR TITLE
[FEATURE] Ajouter components à notre Module Serializer (PIX-12300)

### DIFF
--- a/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
@@ -11,12 +11,22 @@ function serialize(module) {
         transitionTexts: module.transitionTexts,
         details: module.details,
         grains: module.grains.map((grain) => {
-          return {
-            id: grain.id,
-            title: grain.title,
-            type: grain.type,
-            elements: grain.elements,
-          };
+          if (grain.components) {
+            return {
+              id: grain.id,
+              title: grain.title,
+              type: grain.type,
+              elements: grain.elements,
+              components: grain.components,
+            };
+          } else {
+            return {
+              id: grain.id,
+              title: grain.title,
+              type: grain.type,
+              elements: grain.elements,
+            };
+          }
         }),
       };
     },
@@ -24,7 +34,7 @@ function serialize(module) {
     grains: {
       ref: 'id',
       includes: true,
-      attributes: ['title', 'type', 'elements'],
+      attributes: ['title', 'type', 'elements', 'components'],
     },
     typeForAttribute(attribute) {
       if (attribute === 'grains') {

--- a/api/tests/devcomp/unit/domain/models/module/Module_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/Module_test.js
@@ -1,4 +1,10 @@
 import { ModuleInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
+import { Image } from '../../../../../../src/devcomp/domain/models/element/Image.js';
+import { QCM } from '../../../../../../src/devcomp/domain/models/element/QCM.js';
+import { QCU } from '../../../../../../src/devcomp/domain/models/element/QCU.js';
+import { QROCM } from '../../../../../../src/devcomp/domain/models/element/QROCM.js';
+import { Text } from '../../../../../../src/devcomp/domain/models/element/Text.js';
+import { Video } from '../../../../../../src/devcomp/domain/models/element/Video.js';
 import { Module } from '../../../../../../src/devcomp/domain/models/module/Module.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { catchErrSync, expect } from '../../../../../test-helper.js';
@@ -216,7 +222,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
         );
       });
 
-      it('should instanciate a Module with only elements', function () {
+      it('should instantiate a Module with only elements', function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -255,6 +261,314 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
           expect(grain.elements).not.to.be.empty;
           expect(grain.components).to.be.undefined;
         }
+      });
+
+      it('should instantiate a Module with an Image Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              elements: [
+                {
+                  id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
+                  type: 'image',
+                  url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg',
+                  alt: 'Alternative',
+                  alternativeText: 'Alternative textuelle',
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = Module.toDomain(moduleData);
+
+        // then
+        expect(module.grains[0].elements[0]).to.be.an.instanceOf(Image);
+      });
+
+      it('should instantiate a Module with a Text Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              elements: [
+                {
+                  id: '84726001-1665-457d-8f13-4a74dc4768ea',
+                  type: 'text',
+                  content: '<h3>Content</h3>',
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = Module.toDomain(moduleData);
+
+        // then
+        expect(module.grains[0].elements[0]).to.be.an.instanceOf(Text);
+      });
+
+      it('should instantiate a Module with a Video Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              elements: [
+                {
+                  id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
+                  type: 'video',
+                  title: 'Le format des adress mail',
+                  url: 'https://videos.pix.fr/modulix/chat_animation_2.webm',
+                  subtitles: 'Insert subtitles here',
+                  transcription: 'Insert transcription here',
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = Module.toDomain(moduleData);
+
+        // then
+        expect(module.grains[0].elements[0]).to.be.an.instanceOf(Video);
+      });
+
+      it('should instantiate a Module with a QCU Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              elements: [
+                {
+                  id: 'ba78dead-a806-4954-b408-e8ef28d28fab',
+                  type: 'qcu',
+                  instruction: '<p>L’adresse mail M3g4Cool1415@gmail.com est correctement écrite ?</p>',
+                  proposals: [
+                    {
+                      id: '1',
+                      content: 'Vrai',
+                    },
+                    {
+                      id: '2',
+                      content: 'Faux',
+                    },
+                  ],
+                  feedbacks: {
+                    valid:
+                      '<p>On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>',
+                    invalid:
+                      '<p>On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>',
+                  },
+                  solution: '1',
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = Module.toDomain(moduleData);
+
+        // then
+        expect(module.grains[0].elements[0]).to.be.an.instanceOf(QCU);
+      });
+
+      it('should instantiate a Module with a QCM Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              elements: [
+                {
+                  id: '30701e93-1b4d-4da4-b018-fa756c07d53f',
+                  type: 'qcm',
+                  instruction: '<p>Quels sont les 3 piliers de Pix ?</p>',
+                  proposals: [
+                    {
+                      id: '1',
+                      content: 'Evaluer ses connaissances et savoir-faire sur 16 compétences du numérique',
+                    },
+                    {
+                      id: '2',
+                      content: 'Développer son savoir-faire sur les jeux de type TPS',
+                    },
+                    {
+                      id: '3',
+                      content: 'Développer ses compétences numériques',
+                    },
+                    {
+                      id: '4',
+                      content: 'Certifier ses compétences Pix',
+                    },
+                    {
+                      id: '5',
+                      content: 'Evaluer ses compétences de logique et compréhension mathématique',
+                    },
+                  ],
+                  feedbacks: {
+                    valid: '<p>Correct ! Vous nous avez bien cernés :)</p>',
+                    invalid: '<p>Et non ! Pix sert à évaluer, certifier et développer ses compétences numériques.',
+                  },
+                  solutions: ['1', '3', '4'],
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = Module.toDomain(moduleData);
+
+        // then
+        expect(module.grains[0].elements[0]).to.be.an.instanceOf(QCM);
+      });
+
+      it('should instantiate a Module with a QROCM Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              elements: [
+                {
+                  id: '98c51fa7-03b7-49b1-8c5e-49341d35909c',
+                  type: 'qrocm',
+                  instruction:
+                    "<p>Pour être sûr que tout est clair, complétez le texte ci-dessous <span aria-hidden='true'>🧩</span></p><p>Si vous avez besoin d’aide, revenez en arrière <span aria-hidden='true'>⬆️</span></p>",
+                  proposals: [
+                    {
+                      type: 'text',
+                      content: '<p>Le symbole</>',
+                    },
+                    {
+                      input: 'symbole',
+                      type: 'input',
+                      inputType: 'text',
+                      size: 1,
+                      display: 'inline',
+                      placeholder: '',
+                      ariaLabel: 'Réponse 1',
+                      defaultValue: '',
+                      tolerances: ['t1'],
+                      solutions: ['@'],
+                    },
+                    {
+                      input: 'premiere-partie',
+                      type: 'select',
+                      display: 'inline',
+                      placeholder: '',
+                      ariaLabel: 'Réponse 2',
+                      defaultValue: '',
+                      tolerances: [],
+                      options: [
+                        {
+                          id: '1',
+                          content: "l'identifiant",
+                        },
+                        {
+                          id: '2',
+                          content: "le fournisseur d'adresse mail",
+                        },
+                      ],
+                      solutions: ['1'],
+                    },
+                  ],
+                  feedbacks: {
+                    valid: '<p>Bravo ! 🎉 </p>',
+                    invalid: "<p class='pix-list-inline'>Et non !</p>",
+                  },
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = Module.toDomain(moduleData);
+
+        // then
+        expect(module.grains[0].elements[0]).to.be.an.instanceOf(QROCM);
       });
 
       it('should filter out unknown element types', function () {
@@ -400,7 +714,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
         expect(error.message).to.deep.equal('Elements should always be provided');
       });
 
-      it('should instanciate a Module, keep elements and components if present', function () {
+      it('should instantiate a Module, keep elements and components if present', function () {
         // given
         const moduleData = {
           id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -451,6 +765,374 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
           expect(grain.elements).not.to.be.empty;
           expect(grain.components).not.to.be.empty;
         }
+      });
+
+      it('should instantiate a Module with a ComponentElement which contains an Image Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              elements: [
+                {
+                  id: '84726001-1665-457d-8f13-4a74dc4768ea',
+                  type: 'text',
+                  content: '<h3>Content</h3>',
+                },
+              ],
+              components: [
+                {
+                  type: 'element',
+                  element: {
+                    id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
+                    type: 'image',
+                    url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg',
+                    alt: 'Alternative',
+                    alternativeText: 'Alternative textuelle',
+                  },
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = Module.toDomain(moduleData);
+
+        // then
+        expect(module.grains[0].components[0].element).to.be.an.instanceOf(Image);
+      });
+
+      it('should instantiate a Module with a ComponentElement which contains a Text Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              elements: [
+                {
+                  id: '84726001-1665-457d-8f13-4a74dc4768ea',
+                  type: 'text',
+                  content: '<h3>Content</h3>',
+                },
+              ],
+              components: [
+                {
+                  type: 'element',
+                  element: {
+                    id: '84726001-1665-457d-8f13-4a74dc4768ea',
+                    type: 'text',
+                    content: '<h3>Content</h3>',
+                  },
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = Module.toDomain(moduleData);
+
+        // then
+        expect(module.grains[0].components[0].element).to.be.an.instanceOf(Text);
+      });
+
+      it('should instantiate a Module with a ComponentElement which contains a Video Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              elements: [
+                {
+                  id: '84726001-1665-457d-8f13-4a74dc4768ea',
+                  type: 'text',
+                  content: '<h3>Content</h3>',
+                },
+              ],
+              components: [
+                {
+                  type: 'element',
+                  element: {
+                    id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
+                    type: 'video',
+                    title: 'Le format des adress mail',
+                    url: 'https://videos.pix.fr/modulix/chat_animation_2.webm',
+                    subtitles: 'Insert subtitles here',
+                    transcription: 'Insert transcription here',
+                  },
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = Module.toDomain(moduleData);
+
+        // then
+        expect(module.grains[0].components[0].element).to.be.an.instanceOf(Video);
+      });
+
+      it('should instantiate a Module with a ComponentElement which contains a QCU Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              elements: [
+                {
+                  id: '84726001-1665-457d-8f13-4a74dc4768ea',
+                  type: 'text',
+                  content: '<h3>Content</h3>',
+                },
+              ],
+              components: [
+                {
+                  type: 'element',
+                  element: {
+                    id: 'ba78dead-a806-4954-b408-e8ef28d28fab',
+                    type: 'qcu',
+                    instruction: '<p>L’adresse mail M3g4Cool1415@gmail.com est correctement écrite ?</p>',
+                    proposals: [
+                      {
+                        id: '1',
+                        content: 'Vrai',
+                      },
+                      {
+                        id: '2',
+                        content: 'Faux',
+                      },
+                    ],
+                    feedbacks: {
+                      valid:
+                        '<p>On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>',
+                      invalid:
+                        '<p>On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>',
+                    },
+                    solution: '1',
+                  },
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = Module.toDomain(moduleData);
+
+        // then
+        expect(module.grains[0].components[0].element).to.be.an.instanceOf(QCU);
+      });
+
+      it('should instantiate a Module with a ComponentElement which contains a QCM Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              elements: [
+                {
+                  id: '84726001-1665-457d-8f13-4a74dc4768ea',
+                  type: 'text',
+                  content: '<h3>Content</h3>',
+                },
+              ],
+              components: [
+                {
+                  type: 'element',
+                  element: {
+                    id: '30701e93-1b4d-4da4-b018-fa756c07d53f',
+                    type: 'qcm',
+                    instruction: '<p>Quels sont les 3 piliers de Pix ?</p>',
+                    proposals: [
+                      {
+                        id: '1',
+                        content: 'Evaluer ses connaissances et savoir-faire sur 16 compétences du numérique',
+                      },
+                      {
+                        id: '2',
+                        content: 'Développer son savoir-faire sur les jeux de type TPS',
+                      },
+                      {
+                        id: '3',
+                        content: 'Développer ses compétences numériques',
+                      },
+                      {
+                        id: '4',
+                        content: 'Certifier ses compétences Pix',
+                      },
+                      {
+                        id: '5',
+                        content: 'Evaluer ses compétences de logique et compréhension mathématique',
+                      },
+                    ],
+                    feedbacks: {
+                      valid: '<p>Correct ! Vous nous avez bien cernés :)</p>',
+                      invalid: '<p>Et non ! Pix sert à évaluer, certifier et développer ses compétences numériques.',
+                    },
+                    solutions: ['1', '3', '4'],
+                  },
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = Module.toDomain(moduleData);
+
+        // then
+        expect(module.grains[0].components[0].element).to.be.an.instanceOf(QCM);
+      });
+
+      it('should instantiate a Module with a ComponentElement which contains a QROCM Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              elements: [
+                {
+                  id: '84726001-1665-457d-8f13-4a74dc4768ea',
+                  type: 'text',
+                  content: '<h3>Content</h3>',
+                },
+              ],
+              components: [
+                {
+                  type: 'element',
+                  element: {
+                    id: '98c51fa7-03b7-49b1-8c5e-49341d35909c',
+                    type: 'qrocm',
+                    instruction:
+                      "<p>Pour être sûr que tout est clair, complétez le texte ci-dessous <span aria-hidden='true'>🧩</span></p><p>Si vous avez besoin d’aide, revenez en arrière <span aria-hidden='true'>⬆️</span></p>",
+                    proposals: [
+                      {
+                        type: 'text',
+                        content: '<p>Le symbole</>',
+                      },
+                      {
+                        input: 'symbole',
+                        type: 'input',
+                        inputType: 'text',
+                        size: 1,
+                        display: 'inline',
+                        placeholder: '',
+                        ariaLabel: 'Réponse 1',
+                        defaultValue: '',
+                        tolerances: ['t1'],
+                        solutions: ['@'],
+                      },
+                      {
+                        input: 'premiere-partie',
+                        type: 'select',
+                        display: 'inline',
+                        placeholder: '',
+                        ariaLabel: 'Réponse 2',
+                        defaultValue: '',
+                        tolerances: [],
+                        options: [
+                          {
+                            id: '1',
+                            content: "l'identifiant",
+                          },
+                          {
+                            id: '2',
+                            content: "le fournisseur d'adresse mail",
+                          },
+                        ],
+                        solutions: ['1'],
+                      },
+                    ],
+                    feedbacks: {
+                      valid: '<p>Bravo ! 🎉 </p>',
+                      invalid: "<p class='pix-list-inline'>Et non !</p>",
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = Module.toDomain(moduleData);
+
+        // then
+        expect(module.grains[0].components[0].element).to.be.an.instanceOf(QROCM);
       });
 
       it('should filter out unknown component types', function () {

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -14,7 +14,7 @@ import { expect } from '../../../../../test-helper.js';
 
 describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerializer', function () {
   describe('#serialize', function () {
-    it('should serialize with empty list', function () {
+    it('should serialize with empty grains list', function () {
       // given
       const id = 'id';
       const slug = 'bien-ecrire-son-adresse-mail';
@@ -56,7 +56,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
       expect(json).to.deep.equal(expectedJson);
     });
 
-    it('should serialize with list', function () {
+    it('should serialize with grains list of elements only', function () {
       // given
       const id = 'id';
       const slug = 'bien-ecrire-son-adresse-mail';
@@ -90,76 +90,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
             id: '1',
             title: 'Grain 1',
             type: 'activity',
-            elements: [
-              new Text({ id: '1', content: 'toto' }),
-              new QCU({
-                id: '2',
-                proposals: [{ id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'toto' }],
-                instruction: 'hello',
-                solution: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
-              }),
-              new QCM({
-                id: '2000',
-                proposals: [
-                  { id: '1', content: 'toto' },
-                  { id: '2', content: 'tata' },
-                  { id: '3', content: 'titi' },
-                ],
-                instruction: 'hello',
-                solutions: ['1', '3'],
-              }),
-              new QROCM({
-                id: '100',
-                instruction: '',
-                locales: ['fr-FR'],
-                proposals: [
-                  new BlockText({
-                    type: 'text',
-                    content: '<p>Adresse mail de Naomi : ${email}</p>',
-                  }),
-                  new BlockInput({
-                    type: 'input',
-                    input: 'email',
-                    inputType: 'text',
-                    size: 10,
-                    display: 'inline',
-                    placeholder: '',
-                    ariaLabel: 'Adresse mail de Naomi',
-                    defaultValue: '',
-                    tolerances: [],
-                    solutions: ['naomizao@yahoo.com', 'naomizao@yahoo.fr'],
-                  }),
-                  new BlockSelect({
-                    type: 'select',
-                    input: 'seconde-partie',
-                    display: 'inline',
-                    placeholder: '',
-                    ariaLabel: 'Réponse 3',
-                    defaultValue: '',
-                    tolerances: [],
-                    options: [
-                      new BlockSelectOption({
-                        id: '1',
-                        content: "l'identifiant",
-                      }),
-                      new BlockSelectOption({
-                        id: '2',
-                        content: "le fournisseur d'adresse mail",
-                      }),
-                    ],
-                    solutions: ['2'],
-                  }),
-                ],
-              }),
-              new Image({ id: '3', type: 'image', url: 'url', alt: 'alt', alternativeText: 'alternativeText' }),
-              new Video({
-                id: '4',
-                title: 'title',
-                url: 'url',
-                subtitles: 'subtitles',
-                transcription: 'transcription',
-              }),
-            ],
+            elements: getElements(),
           },
         ],
       });
@@ -187,110 +118,87 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
           {
             attributes: {
               title: 'Grain 1',
-              elements: [
+              elements: getAttributesElements(),
+              type: 'activity',
+            },
+            id: '1',
+            type: 'grains',
+          },
+        ],
+      };
+
+      // when
+      const json = moduleSerializer.serialize(moduleFromDomain);
+
+      // then
+      expect(json).to.deep.equal(expectedJson);
+    });
+
+    it('should serialize with grains list of elements and components', function () {
+      // given
+      const id = 'id';
+      const slug = 'bien-ecrire-son-adresse-mail';
+      const title = 'Bien écrire son adresse mail';
+      const details = {
+        image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+        description:
+          'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
+        duration: 12,
+        level: 'Débutant',
+        objectives: [
+          'Écrire une adresse mail correctement, en évitant les erreurs courantes',
+          'Connaître les parties d’une adresse mail et les identifier sur des exemples',
+          'Comprendre les fonctions des parties d’une adresse mail',
+        ],
+      };
+      const transitionTexts = [
+        {
+          content: '<p>content</p>',
+          grainId: '1',
+        },
+      ];
+      const moduleFromDomain = new Module({
+        id,
+        slug,
+        title,
+        details,
+        transitionTexts,
+        grains: [
+          {
+            id: '1',
+            title: 'Grain 1',
+            type: 'activity',
+            elements: getElements(),
+            components: getElements().map((element) => ({ element: element, type: 'element' })),
+          },
+        ],
+      });
+      const expectedJson = {
+        data: {
+          attributes: {
+            title: 'Bien écrire son adresse mail',
+            'transition-texts': transitionTexts,
+            details,
+          },
+          id: 'bien-ecrire-son-adresse-mail',
+          relationships: {
+            grains: {
+              data: [
                 {
-                  content: 'toto',
                   id: '1',
-                  isAnswerable: false,
-                  type: 'text',
-                },
-                {
-                  id: '2',
-                  instruction: 'hello',
-                  isAnswerable: true,
-                  locales: undefined,
-                  proposals: [
-                    {
-                      content: 'toto',
-                      id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
-                    },
-                  ],
-                  type: 'qcu',
-                },
-                {
-                  id: '2000',
-                  instruction: 'hello',
-                  isAnswerable: true,
-                  locales: undefined,
-                  proposals: [
-                    {
-                      content: 'toto',
-                      id: '1',
-                    },
-                    {
-                      content: 'tata',
-                      id: '2',
-                    },
-                    {
-                      content: 'titi',
-                      id: '3',
-                    },
-                  ],
-                  type: 'qcm',
-                },
-                {
-                  id: '100',
-                  instruction: '',
-                  isAnswerable: true,
-                  locales: ['fr-FR'],
-                  proposals: [
-                    {
-                      content: '<p>Adresse mail de Naomi : ${email}</p>',
-                      type: 'text',
-                    },
-                    {
-                      ariaLabel: 'Adresse mail de Naomi',
-                      defaultValue: '',
-                      display: 'inline',
-                      input: 'email',
-                      inputType: 'text',
-                      placeholder: '',
-                      size: 10,
-                      solutions: ['naomizao@yahoo.com', 'naomizao@yahoo.fr'],
-                      tolerances: [],
-                      type: 'input',
-                    },
-                    {
-                      ariaLabel: 'Réponse 3',
-                      defaultValue: '',
-                      display: 'inline',
-                      input: 'seconde-partie',
-                      options: [
-                        {
-                          content: "l'identifiant",
-                          id: '1',
-                        },
-                        {
-                          content: "le fournisseur d'adresse mail",
-                          id: '2',
-                        },
-                      ],
-                      placeholder: '',
-                      solutions: ['2'],
-                      tolerances: [],
-                      type: 'select',
-                    },
-                  ],
-                  type: 'qrocm',
-                },
-                {
-                  alt: 'alt',
-                  alternativeText: 'alternativeText',
-                  id: '3',
-                  isAnswerable: false,
-                  type: 'image',
-                  url: 'url',
-                },
-                {
-                  id: '4',
-                  isAnswerable: false,
-                  subtitles: 'subtitles',
-                  title: 'title',
-                  transcription: 'transcription',
-                  type: 'video',
-                  url: 'url',
+                  type: 'grains',
                 },
               ],
+            },
+          },
+          type: 'modules',
+        },
+        included: [
+          {
+            attributes: {
+              title: 'Grain 1',
+              elements: getAttributesElements(),
+              components: getAttributesElements().map((element) => ({ element: element, type: 'element' })),
               type: 'activity',
             },
             id: '1',
@@ -307,3 +215,178 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
     });
   });
 });
+
+function getElements() {
+  return [
+    new Text({ id: '1', content: 'toto' }),
+    new QCU({
+      id: '2',
+      proposals: [{ id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'toto' }],
+      instruction: 'hello',
+    }),
+    new QCM({
+      id: '2000',
+      proposals: [
+        { id: '1', content: 'toto' },
+        { id: '2', content: 'tata' },
+        { id: '3', content: 'titi' },
+      ],
+      instruction: 'hello',
+    }),
+    new QROCM({
+      id: '100',
+      instruction: '',
+      locales: ['fr-FR'],
+      proposals: [
+        new BlockText({
+          content: '<p>Adresse mail de Naomi : ${email}</p>',
+        }),
+        new BlockInput({
+          input: 'email',
+          inputType: 'text',
+          size: 10,
+          display: 'inline',
+          placeholder: '',
+          ariaLabel: 'Adresse mail de Naomi',
+          defaultValue: '',
+          tolerances: [],
+          solutions: ['naomizao@yahoo.com', 'naomizao@yahoo.fr'],
+        }),
+        new BlockSelect({
+          input: 'seconde-partie',
+          display: 'inline',
+          placeholder: '',
+          ariaLabel: 'Réponse 3',
+          defaultValue: '',
+          tolerances: [],
+          options: [
+            new BlockSelectOption({
+              id: '1',
+              content: "l'identifiant",
+            }),
+            new BlockSelectOption({
+              id: '2',
+              content: "le fournisseur d'adresse mail",
+            }),
+          ],
+          solutions: ['2'],
+        }),
+      ],
+    }),
+    new Image({ id: '3', url: 'url', alt: 'alt', alternativeText: 'alternativeText' }),
+    new Video({
+      id: '4',
+      title: 'title',
+      url: 'url',
+      subtitles: 'subtitles',
+      transcription: 'transcription',
+    }),
+  ];
+}
+
+function getAttributesElements() {
+  return [
+    {
+      content: 'toto',
+      id: '1',
+      isAnswerable: false,
+      type: 'text',
+    },
+    {
+      id: '2',
+      instruction: 'hello',
+      isAnswerable: true,
+      locales: undefined,
+      proposals: [
+        {
+          content: 'toto',
+          id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6',
+        },
+      ],
+      type: 'qcu',
+    },
+    {
+      id: '2000',
+      instruction: 'hello',
+      isAnswerable: true,
+      locales: undefined,
+      proposals: [
+        {
+          content: 'toto',
+          id: '1',
+        },
+        {
+          content: 'tata',
+          id: '2',
+        },
+        {
+          content: 'titi',
+          id: '3',
+        },
+      ],
+      type: 'qcm',
+    },
+    {
+      id: '100',
+      instruction: '',
+      isAnswerable: true,
+      locales: ['fr-FR'],
+      proposals: [
+        {
+          content: '<p>Adresse mail de Naomi : ${email}</p>',
+          type: 'text',
+        },
+        {
+          ariaLabel: 'Adresse mail de Naomi',
+          defaultValue: '',
+          display: 'inline',
+          input: 'email',
+          inputType: 'text',
+          placeholder: '',
+          size: 10,
+          solutions: ['naomizao@yahoo.com', 'naomizao@yahoo.fr'],
+          tolerances: [],
+          type: 'input',
+        },
+        {
+          ariaLabel: 'Réponse 3',
+          defaultValue: '',
+          display: 'inline',
+          input: 'seconde-partie',
+          options: [
+            {
+              content: "l'identifiant",
+              id: '1',
+            },
+            {
+              content: "le fournisseur d'adresse mail",
+              id: '2',
+            },
+          ],
+          placeholder: '',
+          solutions: ['2'],
+          tolerances: [],
+          type: 'select',
+        },
+      ],
+      type: 'qrocm',
+    },
+    {
+      alt: 'alt',
+      alternativeText: 'alternativeText',
+      id: '3',
+      isAnswerable: false,
+      type: 'image',
+      url: 'url',
+    },
+    {
+      id: '4',
+      isAnswerable: false,
+      subtitles: 'subtitles',
+      title: 'title',
+      transcription: 'transcription',
+      type: 'video',
+      url: 'url',
+    },
+  ];
+}


### PR DESCRIPTION
## :unicorn: Problème
Afin de fluidifier la navigation d'un passage de module, nous avons besoin d'ajouter des transitions entre nos différents éléments. Nous avons déjà ajouté la notion de `component` dans les models metier (cf. https://github.com/1024pix/pix/pull/8790). 

Il nous faut à présent un moyen pour que l'API envoi ce nouveau `component` côté Client.

## :robot: Proposition
Modifier le serializer cote API pour qu'il inclue les `components`.

## :rainbow: Remarques
RAS.

## :100: Pour tester
Aller sur [l'api bien ecrire son adresse mail](https://api-pr8796.review.pix.fr/api/modules/bien-ecrire-son-adresse-mail) et verifier qu'il contiens que les elements
Aller sur [l'api didacticiel](https://api-pr8796.review.pix.fr/api/modules/didacticiel-modulix) et verifier qu'il contiens les elements et les composants

Verifier qu'il y n a pas des regressions coté front
