### PR TITLE
[FEATURE]: ajoute une bannière d'alerte en cas de dépassement du nombre de place (PIX-12441)

### DIFF
--- a/orga/app/components/places/capacity-alert.gjs
+++ b/orga/app/components/places/capacity-alert.gjs
@@ -1,0 +1,11 @@
+import PixBanner from '@1024pix/pix-ui/components/pix-banner';
+import { t } from 'ember-intl';
+import { gt } from 'ember-truth-helpers';
+
+<template>
+  {{#if (gt @occupied @total)}}
+    <PixBanner class="capacity-alert" @type="error" @withIcon="true">
+      {{t "banners.over-capacity.message"}}
+    </PixBanner>
+  {{/if}}
+</template>

--- a/orga/app/styles/components/places/capacity-alert.scss
+++ b/orga/app/styles/components/places/capacity-alert.scss
@@ -1,0 +1,3 @@
+.capacity-alert {
+  margin-top: var(--pix-spacing-8x);
+}

--- a/orga/app/styles/components/places/index.scss
+++ b/orga/app/styles/components/places/index.scss
@@ -1,3 +1,4 @@
 @import 'title';
 @import 'statistics';
 @import 'place-info';
+@import 'capacity-alert';

--- a/orga/app/templates/authenticated/places.hbs
+++ b/orga/app/templates/authenticated/places.hbs
@@ -2,5 +2,6 @@
 
 <Places::Title />
 
+<Places::CapacityAlert @occupied={{@model.occupied}} @total={{@model.total}} />
 <Places::Statistics @available={{@model.available}} @occupied={{@model.occupied}} @total={{@model.total}} />
 <Places::PlaceInfo @currentUser={{this.currentUser}} />

--- a/orga/tests/integration/components/places/capacity-alert_test.gjs
+++ b/orga/tests/integration/components/places/capacity-alert_test.gjs
@@ -1,0 +1,31 @@
+import { render } from '@1024pix/ember-testing-library';
+import CapacityAlert from 'pix-orga/components/places/capacity-alert';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Places | CapacityAlert', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should render an alert if occupied seats is greater than total seats', async function (assert) {
+    // when
+    const screen = await render(<template><CapacityAlert @occupied="2" @total="1" /></template>);
+
+    // then
+    assert.ok(screen.getByRole('alert', { value: { text: this.intl.t('banners.over-capacity.message') } }));
+  });
+  test('it should not show alert if occupied seats is equal to total seats', async function (assert) {
+    // when
+    const screen = await render(<template><CapacityAlert @occupied="1" @total="1" /></template>);
+
+    // then
+    assert.notOk(screen.queryByRole('alert', { value: { text: this.intl.t('banners.over-capacity.message') } }));
+  });
+  test('it should not show alert if occupied seats is less to total seats', async function (assert) {
+    // when
+    const screen = await render(<template><CapacityAlert @occupied="0" @total="1" /></template>);
+
+    // then
+    assert.notOk(screen.queryByRole('alert', { value: { text: this.intl.t('banners.over-capacity.message') } }));
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -62,6 +62,9 @@
     },
     "language-availability": {
       "message": "Your language is not yet available on Pix Orga. For your convenience, the application will be presented in English. The entire Pix team is working to add your language."
+    },
+    "over-capacity": {
+      "message": "Please note that you are using more seats than your total capacity."
     }
   },
   "cards": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -62,6 +62,9 @@
     },
     "language-availability": {
       "message": "Votre langue n'est pas encore disponible sur Pix Orga. Pour votre confort, l'application sera présentée en anglais. Toute l'équipe de Pix travaille à l'ajout de votre langue."
+    },
+    "over-capacity": {
+      "message": "Attention, vous consommez plus de places que votre capacité totale."
     }
   },
   "cards": {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement on ne bloque pas l’utilisation de PixOrga lorsqu’il n’y a plus de place disponible.
Nous souhaitons toutefois alerter l’admin de l’espace qu’il est en dépassement.

## :robot: Proposition
On affichage une alert banner sur la page Places de PixOrga lorsque la fonctionnalité est activée pour indiquer à l’admin que l’orga est en dépassement (ils consomment plus de places qu’ils n’ont de places actives). 
On affiche pas le bandeau lorsque l’orga est à 0 places disponibles et ne dépasse pas.

## :rainbow: Remarques
Dans un premier temps, on ne va pas faire le lien vers l’adresse mail générique de contact.

## :100: Pour tester

- Se connecter sur orga avec pro-orga@example.net
- aller sur la page places 
- ne pas voir la bannière d'alerte
- Modifier le nombre de place disponible à 10 pour l'orga 1005 dans admin
- Rafraîchir la page
- Voir la bannière d'alerte
