### PR TITLE
[TECH] Corriger l'unicité des requiredClaims (PIX-12368)

### DIFF
--- a/api/src/authentication/domain/services/oidc-authentication-service.js
+++ b/api/src/authentication/domain/services/oidc-authentication-service.js
@@ -69,7 +69,7 @@ export class OidcAuthenticationService {
 
     if (!lodash.isEmpty(claimsToStore)) {
       this.claimsToStore = claimsToStore.split(',').map((claim) => claim.trim());
-      this.#requiredClaims.push(...this.claimsToStore);
+      this.#requiredClaims = Array.from(new Set([...this.#requiredClaims, ...this.claimsToStore]));
     }
 
     if (!enabled && !enabledForPixAdmin) {

--- a/api/tests/authentication/unit/domain/services/oidc-authentication-service_test.js
+++ b/api/tests/authentication/unit/domain/services/oidc-authentication-service_test.js
@@ -501,8 +501,8 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       });
     });
 
-    describe('when required properties are not returned in id token', function () {
-      it('should call userInfo endpoint', async function () {
+    describe('when default required properties are not returned in id token', function () {
+      it('calls userInfo endpoint', async function () {
         // given
         function generateIdToken(payload) {
           return jsonwebtoken.sign(
@@ -519,6 +519,41 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         });
 
         const oidcAuthenticationService = new OidcAuthenticationService({});
+        sinon.stub(oidcAuthenticationService, '_getUserInfoFromEndpoint').resolves({});
+
+        // when
+        await oidcAuthenticationService.getUserInfo({
+          idToken,
+          accessToken: 'accessToken',
+        });
+
+        // then
+        expect(oidcAuthenticationService._getUserInfoFromEndpoint).to.have.been.calledOnceWithExactly({
+          accessToken: 'accessToken',
+        });
+      });
+    });
+
+    describe('when claimsToStore are not returned in id token', function () {
+      it('calls userInfo endpoint', async function () {
+        // given
+        function generateIdToken(payload) {
+          return jsonwebtoken.sign(
+            {
+              ...payload,
+            },
+            'secret',
+          );
+        }
+
+        const idToken = generateIdToken({
+          nonce: 'bb041272-d6e6-457c-99fb-ff1aa02217fd',
+          sub: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
+          family_name: 'Le Gaulois',
+          given_name: 'Astérix',
+        });
+
+        const oidcAuthenticationService = new OidcAuthenticationService({ claimsToStore: 'employeeNumber' });
         sinon.stub(oidcAuthenticationService, '_getUserInfoFromEndpoint').resolves({});
 
         // when


### PR DESCRIPTION
## :unicorn: Problème

La variable `requiredClaims` peut contenir plusieurs fois la même propriété si on définit dans les `claimsToStore` des propriétés déjà définies dans `DEFAULT_REQUIRED_CLAIMS`.

## :robot: Proposition

Utiliser un `Set` pour s'assurer de l'unicité des propriétés à l'instanciation de #requiredClaims.

## :rainbow: Remarques

RAS

## :100: Pour tester

Tester qu'il n'y a pas de régression avec les SSO OIDC en testant 3 cas : 
* un cas de SSO sans `claimsToStore`
* un cas de SSO avec des `claimsToStore` différents des `DEFAULT_REQUIRED_CLAIMS`

   Par exemple : 
   ```sql
   update "oidc-providers" set "claimsToStore"='employeeNumber' where "identityProvider"='FWB';
   ```

* un cas de SSO avec des `claimsToStore` avec une intersection non-vide avec les `DEFAULT_REQUIRED_CLAIMS`

   Par exemple : 
   ```sql
   update "oidc-providers" set "claimsToStore"='family_name,given_name,employeeNumber' where "identityProvider"='FWB';
   ```
