### PR TITLE
[BUGFIX][MON-PIX] Modifier l'URL du bandeau de politique de protection des données en néerlandais qui s'affiche lorsqu'elle a été modifié (PIX-11707)

### DIFF
--- a/mon-pix/app/components/data-protection-policy-information-banner.js
+++ b/mon-pix/app/components/data-protection-policy-information-banner.js
@@ -8,6 +8,7 @@ export default class DataProtectionPolicyInformationBanner extends Component {
   @service currentUser;
   @service currentDomain;
   @service intl;
+  @service url;
 
   bannerType = ENV.APP.BANNER_TYPE;
   _rawBannerContent = ENV.APP.BANNER_CONTENT;
@@ -27,11 +28,7 @@ export default class DataProtectionPolicyInformationBanner extends Component {
   }
 
   get dataProtectionPolicyUrl() {
-    const currentLanguage = this.intl.prumaryLocale;
-    if (currentLanguage === 'en') {
-      return 'https://pix.org/en-gb/personal-data-protection-policy';
-    }
-    return `https://pix.${this.currentDomain.getExtension()}/politique-protection-donnees-personnelles-app`;
+    return this.url.dataProtectionPolicyUrl;
   }
 
   @action

--- a/mon-pix/app/services/current-domain.js
+++ b/mon-pix/app/services/current-domain.js
@@ -1,12 +1,14 @@
 import Service from '@ember/service';
 import last from 'lodash/last';
+import PixWindow from 'mon-pix/utils/pix-window';
 
 const FRANCE_TLD = 'fr';
 
 export default class CurrentDomainService extends Service {
   getExtension() {
-    return last(location.hostname.split('.'));
+    return last(PixWindow.getLocationHostname().split('.'));
   }
+
   get isFranceDomain() {
     return this.getExtension() === FRANCE_TLD;
   }

--- a/mon-pix/app/utils/pix-window.js
+++ b/mon-pix/app/utils/pix-window.js
@@ -2,12 +2,17 @@ function getLocationHash() {
   return window.location.hash;
 }
 
+function getLocationHostname() {
+  return window.location.hostname;
+}
+
 function getLocationHref() {
   return window.location.href;
 }
 
 const PixWindow = {
   getLocationHash,
+  getLocationHostname,
   getLocationHref,
 };
 

--- a/mon-pix/app/utils/pix-window.js
+++ b/mon-pix/app/utils/pix-window.js
@@ -1,14 +1,14 @@
-function getLocationHref() {
-  return window.location.href;
-}
-
 function getLocationHash() {
   return window.location.hash;
 }
 
+function getLocationHref() {
+  return window.location.href;
+}
+
 const PixWindow = {
-  getLocationHref,
   getLocationHash,
+  getLocationHref,
 };
 
 export default PixWindow;

--- a/mon-pix/tests/integration/components/data-protection-policy-information-banner_test.js
+++ b/mon-pix/tests/integration/components/data-protection-policy-information-banner_test.js
@@ -10,7 +10,7 @@ module('Integration | Component | data-protection-policy-information-banner', fu
   setupIntlRenderingTest(hooks);
 
   module('when user is not logged in', function () {
-    test('should never display the data protection policy banner', async function (assert) {
+    test('does not display the data protection policy banner', async function (assert) {
       // given
       _userIsNotLoggedIn(this);
 
@@ -31,7 +31,7 @@ module('Integration | Component | data-protection-policy-information-banner', fu
 
   module('when user is logged in', function () {
     module('when communication banner is displayed', function () {
-      test('should never display the data protection policy banner', async function (assert) {
+      test('does not display the data protection policy banner', async function (assert) {
         // given
         _communicationBannerIsDisplayed();
         _userShouldSeeTheDataProtectionPolicyUpdateInformation(this);
@@ -52,8 +52,8 @@ module('Integration | Component | data-protection-policy-information-banner', fu
     });
 
     module('when communication banner is not displayed', function () {
-      module('when user should not see the data protection policy update information', function () {
-        test('should not display the banner', async function (assert) {
+      module('when user has already seen and accepted the data protection policy update information', function () {
+        test('does not display the data protection policy banner', async function (assert) {
           // given
           _communicationBannerIsNotDisplayed();
           _userShouldNotSeeTheDataProtectionPolicyUpdateInformation(this);
@@ -73,8 +73,8 @@ module('Integration | Component | data-protection-policy-information-banner', fu
         });
       });
 
-      module('when user should see the data protection policy update information', function () {
-        test('should display the banner', async function (assert) {
+      module('when user has not seen and accepted the data protection policy update information', function () {
+        test('displays the data protection policy banner', async function (assert) {
           // given
           _communicationBannerIsNotDisplayed();
           _userShouldSeeTheDataProtectionPolicyUpdateInformation(this);

--- a/mon-pix/tests/integration/components/data-protection-policy-information-banner_test.js
+++ b/mon-pix/tests/integration/components/data-protection-policy-information-banner_test.js
@@ -102,6 +102,33 @@ module('Integration | Component | data-protection-policy-information-banner', fu
           );
           assert.dom(content).exists();
         });
+
+        module('when on international domain (.org)', function () {
+          module('when user language is "en"', function () {
+            test('displays the data protection policy banner in english', async function (assert) {
+              // given
+              _stubWindowLocationHostname('pix.org');
+              this.intl.setLocale('en');
+              _communicationBannerIsNotDisplayed();
+              _userShouldSeeTheDataProtectionPolicyUpdateInformation(this);
+
+              // when
+              const screen = await render(hbs`<DataProtectionPolicyInformationBanner />`);
+
+              // then
+              assert
+                .dom(screen.getByRole('link', { name: 'Personal data protection policy.' }))
+                .hasAttribute('href', 'https://pix.org/en-gb/personal-data-protection-policy');
+
+              const content = screen.getByText((content) =>
+                content.startsWith(
+                  `Please note that our personal data protection policy has been updated. To take a look at what's changing, click here:`,
+                ),
+              );
+              assert.dom(content).exists();
+            });
+          });
+        });
       });
     });
   });

--- a/mon-pix/tests/integration/components/data-protection-policy-information-banner_test.js
+++ b/mon-pix/tests/integration/components/data-protection-policy-information-banner_test.js
@@ -2,12 +2,18 @@ import { render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
 import ENV from 'mon-pix/config/environment';
+import PixWindow from 'mon-pix/utils/pix-window';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | data-protection-policy-information-banner', function (hooks) {
   setupIntlRenderingTest(hooks);
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
 
   module('when user is not logged in', function () {
     test('does not display the data protection policy banner', async function (assert) {
@@ -76,6 +82,7 @@ module('Integration | Component | data-protection-policy-information-banner', fu
       module('when user has not seen and accepted the data protection policy update information', function () {
         test('displays the data protection policy banner', async function (assert) {
           // given
+          _stubWindowLocationHostname('pix.fr');
           _communicationBannerIsNotDisplayed();
           _userShouldSeeTheDataProtectionPolicyUpdateInformation(this);
 
@@ -84,7 +91,9 @@ module('Integration | Component | data-protection-policy-information-banner', fu
 
           // then
           assert.dom(screen.getByRole('alert')).exists();
-          assert.dom(screen.getByRole('link', { name: 'Politique de protection des données.' })).exists();
+          assert
+            .dom(screen.getByRole('link', { name: 'Politique de protection des données.' }))
+            .hasAttribute('href', 'https://pix.fr/politique-protection-donnees-personnelles-app');
 
           const content = screen.getByText((content) =>
             content.startsWith(
@@ -131,4 +140,8 @@ function _stubUserWithShouldSeeTheDataProtectionPolicyUpdateInformationAs(should
     });
   }
   component.owner.register('service:currentUser', CurrentUserStub);
+}
+
+function _stubWindowLocationHostname(hostname) {
+  sinon.stub(PixWindow, 'getLocationHostname').returns(hostname);
 }

--- a/mon-pix/tests/integration/components/data-protection-policy-information-banner_test.js
+++ b/mon-pix/tests/integration/components/data-protection-policy-information-banner_test.js
@@ -128,6 +128,29 @@ module('Integration | Component | data-protection-policy-information-banner', fu
               assert.dom(content).exists();
             });
           });
+
+          module('when user language is "nl"', function () {
+            test('displays the data protection policy banner in dutch', async function (assert) {
+              // given
+              _stubWindowLocationHostname('pix.org');
+              this.intl.setLocale('nl');
+              _communicationBannerIsNotDisplayed();
+              _userShouldSeeTheDataProtectionPolicyUpdateInformation(this);
+
+              // when
+              const screen = await render(hbs`<DataProtectionPolicyInformationBanner />`);
+
+              // then
+              assert
+                .dom(screen.getByRole('link', { name: 'Beleid gegevensbescherming.' }))
+                .hasAttribute('href', 'https://pix.org/nl-be/beleid-inzake-de-bescherming-van-persoonsgegevens');
+
+              const content = screen.getByText((content) =>
+                content.startsWith('Ons privacybeleid is gewijzigd. We nodigen je uit om het te lezen:'),
+              );
+              assert.dom(content).exists();
+            });
+          });
         });
       });
     });

--- a/mon-pix/tests/integration/components/data-protection-policy-information-banner_test.js
+++ b/mon-pix/tests/integration/components/data-protection-policy-information-banner_test.js
@@ -84,13 +84,7 @@ module('Integration | Component | data-protection-policy-information-banner', fu
 
           // then
           assert.dom(screen.getByRole('alert')).exists();
-          assert
-            .dom(
-              screen.getByRole('link', {
-                name: this.intl.t('common.data-protection-policy-information-banner.url-label'),
-              }),
-            )
-            .exists();
+          assert.dom(screen.getByRole('link', { name: 'Politique de protection des données.' })).exists();
 
           const content = screen.getByText((content) =>
             content.startsWith(

--- a/mon-pix/tests/unit/services/current-domain_test.js
+++ b/mon-pix/tests/unit/services/current-domain_test.js
@@ -10,6 +10,33 @@ module('Unit | Service | currentDomain', function (hooks) {
     sinon.restore();
   });
 
+  module('#getExtension', function () {
+    [
+      {
+        hostname: 'pix.fr',
+        extension: 'fr',
+      },
+      {
+        hostname: 'pix.org',
+        extension: 'org',
+      },
+    ].forEach(function ({ hostname, extension: expectedExtension }) {
+      module(`when hostname is ${hostname}`, function () {
+        test(`returns ${expectedExtension}`, function (assert) {
+          // given
+          _stubWindowLocationHostname(hostname);
+          const service = this.owner.lookup('service:currentDomain');
+
+          // when
+          const extension = service.getExtension();
+
+          // then
+          assert.strictEqual(extension, expectedExtension);
+        });
+      });
+    });
+  });
+
   module('#isFranceDomain', function () {
     module('when TLD is the France domain (.fr)', function () {
       test('returns true', function (assert) {

--- a/mon-pix/tests/unit/services/current-domain_test.js
+++ b/mon-pix/tests/unit/services/current-domain_test.js
@@ -9,28 +9,32 @@ module('Unit | Service | currentDomain', function (hooks) {
   setupTest(hooks);
 
   module('#isFranceDomain', function () {
-    test('returns true when TLD is the France domain (.fr)', function (assert) {
-      // given
-      const service = this.owner.lookup('service:currentDomain');
-      service.getExtension = sinon.stub().returns(FRANCE_TLD);
+    module('when TLD is the France domain (.fr)', function () {
+      test('returns true', function (assert) {
+        // given
+        const service = this.owner.lookup('service:currentDomain');
+        service.getExtension = sinon.stub().returns(FRANCE_TLD);
 
-      // when
-      const isFranceDomain = service.isFranceDomain;
+        // when
+        const isFranceDomain = service.isFranceDomain;
 
-      // then
-      assert.true(isFranceDomain);
+        // then
+        assert.true(isFranceDomain);
+      });
     });
 
-    test('returns false when TLD is the international domain (.org)', function (assert) {
-      // given
-      const service = this.owner.lookup('service:currentDomain');
-      service.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
+    module('when TLD is the international domain (.org)', function () {
+      test('returns false', function (assert) {
+        // given
+        const service = this.owner.lookup('service:currentDomain');
+        service.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
 
-      // when
-      const isFranceDomain = service.isFranceDomain;
+        // when
+        const isFranceDomain = service.isFranceDomain;
 
-      // then
-      assert.false(isFranceDomain);
+        // then
+        assert.false(isFranceDomain);
+      });
     });
   });
 });

--- a/mon-pix/tests/unit/services/current-domain_test.js
+++ b/mon-pix/tests/unit/services/current-domain_test.js
@@ -1,19 +1,21 @@
 import { setupTest } from 'ember-qunit';
+import PixWindow from 'mon-pix/utils/pix-window';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-const FRANCE_TLD = 'fr';
-const INTERNATIONAL_TLD = 'org';
-
 module('Unit | Service | currentDomain', function (hooks) {
   setupTest(hooks);
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
 
   module('#isFranceDomain', function () {
     module('when TLD is the France domain (.fr)', function () {
       test('returns true', function (assert) {
         // given
+        _stubWindowLocationHostname('pix.fr');
         const service = this.owner.lookup('service:currentDomain');
-        service.getExtension = sinon.stub().returns(FRANCE_TLD);
 
         // when
         const isFranceDomain = service.isFranceDomain;
@@ -26,8 +28,8 @@ module('Unit | Service | currentDomain', function (hooks) {
     module('when TLD is the international domain (.org)', function () {
       test('returns false', function (assert) {
         // given
+        _stubWindowLocationHostname('pix.org');
         const service = this.owner.lookup('service:currentDomain');
-        service.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
 
         // when
         const isFranceDomain = service.isFranceDomain;
@@ -38,3 +40,7 @@ module('Unit | Service | currentDomain', function (hooks) {
     });
   });
 });
+
+function _stubWindowLocationHostname(hostname) {
+  sinon.stub(PixWindow, 'getLocationHostname').returns(hostname);
+}

--- a/mon-pix/tests/unit/utils/pix-window_test.js
+++ b/mon-pix/tests/unit/utils/pix-window_test.js
@@ -23,6 +23,19 @@ module('Unit | Utilities | pix-window', function (hooks) {
     });
   });
 
+  module('GET window.location.hostname', function () {
+    test('returns the hostname', function (assert) {
+      // given
+      sinon.stub(PixWindow, 'getLocationHostname').returns('pix.fr');
+
+      // when
+      const hash = PixWindow.getLocationHostname();
+
+      // then
+      assert.strictEqual(hash, 'pix.fr');
+    });
+  });
+
   module('GET window.location.href', function () {
     test('returns an URL', function (assert) {
       // given

--- a/mon-pix/tests/unit/utils/pix-window_test.js
+++ b/mon-pix/tests/unit/utils/pix-window_test.js
@@ -10,21 +10,8 @@ module('Unit | Utilities | pix-window', function (hooks) {
     sinon.restore();
   });
 
-  module('GET window.location.href', function () {
-    test('should return an URL', function (assert) {
-      // given
-      sinon.stub(PixWindow, 'getLocationHref').returns('http://domain.com/timely#hash');
-
-      // when
-      const url = PixWindow.getLocationHref();
-
-      // then
-      assert.strictEqual(url, 'http://domain.com/timely#hash');
-    });
-  });
-
   module('GET window.location.hash', function () {
-    test('should return the hash found in the URL', function (assert) {
+    test('returns the hash found in the URL', function (assert) {
       // given
       sinon.stub(PixWindow, 'getLocationHash').returns('#hash');
 
@@ -33,6 +20,19 @@ module('Unit | Utilities | pix-window', function (hooks) {
 
       // then
       assert.strictEqual(hash, '#hash');
+    });
+  });
+
+  module('GET window.location.href', function () {
+    test('returns an URL', function (assert) {
+      // given
+      sinon.stub(PixWindow, 'getLocationHref').returns('http://domain.com/timely#hash');
+
+      // when
+      const url = PixWindow.getLocationHref();
+
+      // then
+      assert.strictEqual(url, 'http://domain.com/timely#hash');
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Lorsque la politique de protection des données est modifiée, un bandeau s'affichera pour prévenir les utilisateurs qu'ils doivent lire et accepter cette modification. Si un utilisateur, ayant comme langue le néerlandais, se connecter après une modification de la politique de protection des données, ce dernier n'aura pas le bon lien. Il sera redirigé vers la version française.

## :robot: Proposition

Faire en sorte de fournir le lien de la version néerlandaise.

## :rainbow: Remarques

Un fichier de constantes a été créé pour centraliser les URLs sur la protection des données personnelles pour chaque langue.

## :100: Pour tester

#### Via Scalingo

1. Supprimer les variables d'environnement `BANNER_CONTENT` et `BANNER_TYPE` sur [scalingo front](https://dashboard.scalingo.com/apps/osc-fr1/pix-front-review-pr8807/environment)
2. Redéployer le container pour prendre en compte ce changement
3. Modifier la variable d'environnement `DATA_PROTECTION_POLICY_UPDATE_DATE` avec une date antérieur à aujourd'hui sur [scalingo api](https://dashboard.scalingo.com/apps/osc-fr1/pix-api-review-pr8807/environment)
4. Redémarrer le container `web` pour prendre en compte ce changement
5. Se connecter avec un compte sur domaine .org
6. Modifier la langue du compte utilisateur si ce dernier n'est pas en néerlandais
7. Se déconnecter après modification de la langue
8. Se connecter à nouveau au même compte
9. Constater l'affichage de la bannière en néerlandais avec le lien vers la version néerlandaise des CGUs (https://pix.org/nl-be/beleid-inzake-de-bescherming-van-persoonsgegevens)

#### En local

1. Modifier la variable d'environnement `DATA_PROTECTION_POLICY_UPDATE_DATE` avec une date antérieur à aujourd'hui
2. Redémarrer votre api
3. Se connecter avec un compte sur domaine .org
4. Modifier la langue du compte utilisateur si ce dernier n'est pas en néerlandais
5. Se déconnecter après modification de la langue
6. Se connecter à nouveau au même compte
7. Constater l'affichage de la bannière en néerlandais avec le lien vers la version néerlandaise des CGUs (https://pix.org/nl-be/beleid-inzake-de-bescherming-van-persoonsgegevens)