### PR TITLE
[FEATURE] Supporter l'affichage des `components` (PIX-12364) (PIX-12023).

### DIFF
--- a/api/src/devcomp/domain/models/Grain.js
+++ b/api/src/devcomp/domain/models/Grain.js
@@ -17,6 +17,7 @@ class Grain {
   }
 
   getElementById(elementId) {
+    // ToDo PIX-12363 migrate to components
     const foundElement = this.elements.find(({ id }) => id === elementId);
 
     if (foundElement === undefined) {

--- a/api/src/devcomp/domain/models/module/Module.js
+++ b/api/src/devcomp/domain/models/module/Module.js
@@ -50,6 +50,7 @@ class Module {
         details: new Details(moduleData.details),
         grains: moduleData.grains.map((grain) => {
           if (grain.components) {
+            // ToDo PIX-12363 migrate to components
             if (!grain.elements) {
               throw new Error('Elements should always be provided');
             }
@@ -128,6 +129,7 @@ class Module {
             id: grain.id,
             title: grain.title,
             type: grain.type,
+            // ToDo PIX-12363 migrate to components
             elements: grain.elements
               .map((element) => {
                 switch (element.type) {
@@ -177,6 +179,7 @@ class Module {
 
   getGrainByElementId(elementId) {
     const foundGrain = this.grains.find((grain) => {
+      // ToDo PIX-12363 migrate to components
       const isElementFound = grain.elements.some((element) => element.id === elementId);
 
       return isElementFound;

--- a/api/tests/devcomp/integration/domain/models/Module_test.js
+++ b/api/tests/devcomp/integration/domain/models/Module_test.js
@@ -10,6 +10,7 @@ describe('Integration | Devcomp | Domain | Models | Module', function () {
       const grain = new Grain({
         id: '1',
         title: 'Le format des adresses email',
+        // ToDo PIX-12363 migrate to components
         elements: [new Text({ id: 'id', content: 'content' })],
       });
       const id = '1';

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -107,6 +107,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
             id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
             type: 'lesson',
             title: 'Explications : les parties d’une adresse mail',
+            // ToDo PIX-12363 migrate to components
             elements: [
               {
                 id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
@@ -130,6 +131,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       });
 
       // then
+      // ToDo PIX-12363 migrate to components
       expect(module.grains[0].elements).to.have.lengthOf(1);
       expect(module.grains[0].elements[0]).to.be.instanceOf(Text);
     });
@@ -158,6 +160,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
             id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
             type: 'lesson',
             title: 'Explications : les parties d’une adresse mail',
+            // ToDo PIX-12363 migrate to components
             elements: [
               {
                 id: 'ba78dead-a806-4954-b408-e8ef28d28fab',
@@ -197,6 +200,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       });
 
       // then
+      // ToDo PIX-12363 migrate to components
       expect(module.grains[0].elements).to.have.lengthOf(1);
       expect(module.grains[0].elements[0]).to.be.instanceOf(QCU);
     });
@@ -225,6 +229,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
             id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
             type: 'lesson',
             title: 'Explications : les parties d’une adresse mail',
+            // ToDo PIX-12363 migrate to components
             elements: [
               {
                 id: '30701e93-1b4d-4da4-b018-fa756c07d53f',
@@ -274,6 +279,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       });
 
       // then
+      // ToDo PIX-12363 migrate to components
       expect(module.grains[0].elements).to.have.lengthOf(1);
       expect(module.grains[0].elements[0]).to.be.instanceOf(QCM);
     });
@@ -302,6 +308,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
             id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
             type: 'lesson',
             title: 'Explications : les parties d’une adresse mail',
+            // ToDo PIX-12363 migrate to components
             elements: [
               {
                 id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
@@ -326,6 +333,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       });
 
       // then
+      // ToDo PIX-12363 migrate to components
       expect(module.grains[0].elements).to.have.lengthOf(1);
       expect(module.grains[0].elements[0]).to.be.instanceOf(Image);
     });
@@ -354,6 +362,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
             id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
             type: 'lesson',
             title: 'Explications : les parties d’une adresse mail',
+            // ToDo PIX-12363 migrate to components
             elements: [
               {
                 id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
@@ -379,6 +388,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       });
 
       // then
+      // ToDo PIX-12363 migrate to components
       expect(module.grains[0].elements).to.have.lengthOf(1);
       expect(module.grains[0].elements[0]).to.be.instanceOf(Video);
     });
@@ -407,6 +417,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
             id: 'b7ea7630-824a-4a49-83d1-abb9b8d0d120',
             type: 'activity',
             title: 'Écrire une adresse mail correctement',
+            // ToDo PIX-12363 migrate to components
             elements: [
               {
                 id: '98c51fa7-03b7-49b1-8c5e-49341d35909c',
@@ -476,6 +487,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       });
 
       // then
+      // ToDo PIX-12363 migrate to components
       expect(module.grains[0].elements).to.have.lengthOf(1);
       expect(module.grains[0].elements[0]).to.be.instanceOf(QROCM);
       expect(module.grains[0].elements[0].proposals[BLOCK_TEXT_INDEX]).to.be.instanceOf(BlockText);
@@ -507,6 +519,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
             id: 'b7ea7630-824a-4a49-83d1-abb9b8d0d120',
             type: 'activity',
             title: 'Écrire une adresse mail correctement',
+            // ToDo PIX-12363 migrate to components
             elements: [
               {
                 id: '98c51fa7-03b7-49b1-8c5e-49341d35909c',
@@ -539,6 +552,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
 
       // then
       expect(logger.warn).to.have.been.calledWithExactly(loggerMessage);
+      // ToDo PIX-12363 migrate to components
       expect(module.grains[0].elements).to.be.deep.equal([]);
     });
   });
@@ -604,6 +618,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
             id: 'b7ea7630-824a-4a49-83d1-abb9b8d0d120',
             type: 'activity',
             title: 'Écrire une adresse mail correctement',
+            // ToDo PIX-12363 migrate to components
             elements: [
               {
                 id: '98c51fa7-03b7-49b1-8c5e-49341d35909c',
@@ -727,14 +742,17 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       // then
       expect(module).to.be.instanceOf(Module);
 
+      // ToDo PIX-12363 migrate to components
       const qcus = module.grains.flatMap((grain) => grain.elements.filter((element) => element.type === 'qcu'));
       expect(qcus).to.have.length(1);
       qcus.forEach((qcu) => expect(qcu).to.be.instanceOf(QCUForAnswerVerification));
 
+      // ToDo PIX-12363 migrate to components
       const qrocms = module.grains.flatMap((grain) => grain.elements.filter((element) => element.type === 'qrocm'));
       expect(qrocms).to.have.length(1);
       qrocms.forEach((qrocm) => expect(qrocm).to.be.instanceOf(QROCMForAnswerVerification));
 
+      // ToDo PIX-12363 migrate to components
       const qcms = module.grains.flatMap((grain) => grain.elements.filter((element) => element.type === 'qcm'));
       expect(qcms).to.have.length(1);
       qcms.forEach((qcm) => expect(qcm).to.be.instanceOf(QCMForAnswerVerification));
@@ -764,6 +782,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
             id: 'b7ea7630-824a-4a49-83d1-abb9b8d0d120',
             type: 'activity',
             title: 'Écrire une adresse mail correctement',
+            // ToDo PIX-12363 migrate to components
             elements: [
               {
                 id: '98c51fa7-03b7-49b1-8c5e-49341d35909c',
@@ -799,6 +818,7 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
 
       // then
       expect(logger.warn).to.have.been.calledWithExactly(loggerMessage);
+      // ToDo PIX-12363 migrate to components
       expect(module.grains[0].elements).to.be.deep.equal([]);
     });
   });

--- a/api/tests/devcomp/unit/domain/models/Grain_test.js
+++ b/api/tests/devcomp/unit/domain/models/Grain_test.js
@@ -17,6 +17,7 @@ describe('Unit | Devcomp | Domain | Models | Grain', function () {
       // then
       expect(grain.id).to.equal(id);
       expect(grain.title).to.equal(title);
+      // ToDo PIX-12363 migrate to components
       expect(grain.elements).to.have.length(elements.length);
       expect(grain.components).to.have.length(components.length);
     });
@@ -35,6 +36,7 @@ describe('Unit | Devcomp | Domain | Models | Grain', function () {
 
     describe('if a grain does not have components', function () {
       it('should not throw an error', function () {
+        // ToDo PIX-12363 migrate to components
         expect(() => new Grain({ id: 1, title: 'Les adresses mail', elements: [] })).not.to.throw();
       });
     });
@@ -55,6 +57,7 @@ describe('Unit | Devcomp | Domain | Models | Grain', function () {
               new Grain({
                 id: 'id_grain_1',
                 title: 'Bien écrire son adresse mail',
+                // ToDo PIX-12363 migrate to components
                 elements: 'elements',
               }),
           ).to.throw(`A grain should have a list of elements`);
@@ -70,6 +73,7 @@ describe('Unit | Devcomp | Domain | Models | Grain', function () {
               new Grain({
                 id: 'id_grain_1',
                 title: 'Bien écrire son adresse mail',
+                // ToDo PIX-12363 migrate to components
                 elements: [],
                 components: 'components',
               }),
@@ -86,6 +90,7 @@ describe('Unit | Devcomp | Domain | Models | Grain', function () {
       const expectedElement = { id: elementId };
 
       // when
+      // ToDo PIX-12363 migrate to components
       const grain = new Grain({ id: 1, title: '', elements: [expectedElement] });
 
       // then
@@ -97,6 +102,7 @@ describe('Unit | Devcomp | Domain | Models | Grain', function () {
       const elementId = 'elementId';
       const expectedElement = { id: elementId };
 
+      // ToDo PIX-12363 migrate to components
       const grain = new Grain({ id: 1, title: '', elements: [expectedElement] });
 
       // when

--- a/api/tests/devcomp/unit/domain/models/module/Module_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/Module_test.js
@@ -99,6 +99,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
         const slug = 'les-adresses-email';
         const title = 'Les adresses email';
         const element = { id: elementId };
+        // ToDo PIX-12363 migrate to components
         const expectedGrain = { elements: [element] };
         const details = Symbol('details');
 
@@ -118,6 +119,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
         const slug = 'les-adresses-email';
         const title = 'Les adresses email';
         const element = { id: elementId };
+        // ToDo PIX-12363 migrate to components
         const grain = { elements: [element] };
         const details = Symbol('details');
         const module = new Module({ id, slug, title, grains: [grain], details });
@@ -201,6 +203,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
               type: 'lesson',
               title: 'title',
+              // ToDo PIX-12363 migrate to components
               elements: [
                 {
                   id: '84726001-1665-457d-8f13-4a74dc4768ea',
@@ -240,6 +243,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
               type: 'lesson',
               title: 'title',
+              // ToDo PIX-12363 migrate to components
               elements: [
                 {
                   id: '84726001-1665-457d-8f13-4a74dc4768ea',
@@ -281,6 +285,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
               type: 'lesson',
               title: 'title',
+              // ToDo PIX-12363 migrate to components
               elements: [
                 {
                   id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
@@ -319,6 +324,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
               type: 'lesson',
               title: 'title',
+              // ToDo PIX-12363 migrate to components
               elements: [
                 {
                   id: '84726001-1665-457d-8f13-4a74dc4768ea',
@@ -355,6 +361,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
               type: 'lesson',
               title: 'title',
+              // ToDo PIX-12363 migrate to components
               elements: [
                 {
                   id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
@@ -394,6 +401,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
               type: 'lesson',
               title: 'title',
+              // ToDo PIX-12363 migrate to components
               elements: [
                 {
                   id: 'ba78dead-a806-4954-b408-e8ef28d28fab',
@@ -447,6 +455,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
               type: 'lesson',
               title: 'title',
+              // ToDo PIX-12363 migrate to components
               elements: [
                 {
                   id: '30701e93-1b4d-4da4-b018-fa756c07d53f',
@@ -510,6 +519,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
               type: 'lesson',
               title: 'title',
+              // ToDo PIX-12363 migrate to components
               elements: [
                 {
                   id: '98c51fa7-03b7-49b1-8c5e-49341d35909c',
@@ -589,6 +599,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
               type: 'lesson',
               title: 'title',
+              // ToDo PIX-12363 migrate to components
               elements: [
                 {
                   id: '84726001-1665-457d-8f13-4a74dc4768ea',
@@ -641,6 +652,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
               type: 'lesson',
               title: 'title',
+              // ToDo PIX-12363 migrate to components
               elements: [
                 {
                   id: '84726001-1665-457d-8f13-4a74dc4768ea',
@@ -732,6 +744,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
               type: 'lesson',
               title: 'title',
+              // ToDo PIX-12363 migrate to components
               elements: [
                 {
                   id: '84726001-1665-457d-8f13-4a74dc4768ea',
@@ -762,6 +775,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
         expect(module).to.be.an.instanceOf(Module);
         expect(module.grains).not.to.be.empty;
         for (const grain of module.grains) {
+          // ToDo PIX-12363 migrate to components
           expect(grain.elements).not.to.be.empty;
           expect(grain.components).not.to.be.empty;
         }
@@ -785,6 +799,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
               type: 'lesson',
               title: 'title',
+              // ToDo PIX-12363 migrate to components
               elements: [
                 {
                   id: '84726001-1665-457d-8f13-4a74dc4768ea',
@@ -833,6 +848,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
               type: 'lesson',
               title: 'title',
+              // ToDo PIX-12363 migrate to components
               elements: [
                 {
                   id: '84726001-1665-457d-8f13-4a74dc4768ea',
@@ -879,6 +895,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
               type: 'lesson',
               title: 'title',
+              // ToDo PIX-12363 migrate to components
               elements: [
                 {
                   id: '84726001-1665-457d-8f13-4a74dc4768ea',
@@ -928,6 +945,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
               type: 'lesson',
               title: 'title',
+              // ToDo PIX-12363 migrate to components
               elements: [
                 {
                   id: '84726001-1665-457d-8f13-4a74dc4768ea',
@@ -991,6 +1009,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
               type: 'lesson',
               title: 'title',
+              // ToDo PIX-12363 migrate to components
               elements: [
                 {
                   id: '84726001-1665-457d-8f13-4a74dc4768ea',
@@ -1064,6 +1083,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
               type: 'lesson',
               title: 'title',
+              // ToDo PIX-12363 migrate to components
               elements: [
                 {
                   id: '84726001-1665-457d-8f13-4a74dc4768ea',
@@ -1153,6 +1173,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
               type: 'lesson',
               title: 'title',
+              // ToDo PIX-12363 migrate to components
               elements: [
                 {
                   id: '84726001-1665-457d-8f13-4a74dc4768ea',
@@ -1210,6 +1231,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
               id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
               type: 'lesson',
               title: 'title',
+              // ToDo PIX-12363 migrate to components
               elements: [
                 {
                   id: '84726001-1665-457d-8f13-4a74dc4768ea',
@@ -1281,6 +1303,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
             id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
             type: 'lesson',
             title: 'title',
+            // ToDo PIX-12363 migrate to components
             elements: [
               {
                 id: '123',

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/joi-error-parser_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/joi-error-parser_test.js
@@ -22,6 +22,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
           },
         },
         {
+          // ToDo PIX-12363 migrate to components
           message: '"grains[0].elements[0]" does not match any of the allowed types',
           path: ['grains', 0, 'elements', 0],
           type: 'alternatives.any',

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js
@@ -202,6 +202,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
             id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
             type: 'lesson',
             title: 'Voici une leçon',
+            // ToDo PIX-12363 migrate to components
             elements: [
               {
                 id: '84726001-1665-457d-8f13-4a74dc4768ea',
@@ -269,6 +270,7 @@ describe('Unit | Infrastructure | Datasources | Learning Content | Module Dataso
         id: '34d225e8-5d52-4ebd-9acd-8bde8438cfc9',
         type: 'lesson',
         title: '<strong>Sûr de ton adresse mail ?</strong>',
+        // ToDo PIX-12363 migrate to components
         elements: [],
       };
 

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module.js
@@ -38,6 +38,7 @@ const grainSchema = Joi.object({
   id: uuidSchema,
   type: Joi.string().valid('lesson', 'activity').required(),
   title: htmlNotAllowedSchema.required(),
+  // ToDo PIX-12363 migrate to components
   elements: Joi.array().items(elementSchema).required(),
   components: Joi.array().items(
     Joi.object({

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -90,6 +90,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
             id: '1',
             title: 'Grain 1',
             type: 'activity',
+            // ToDo PIX-12363 migrate to components
             elements: getElements(),
           },
         ],
@@ -118,6 +119,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
           {
             attributes: {
               title: 'Grain 1',
+              // ToDo PIX-12363 migrate to components
               elements: getAttributesElements(),
               type: 'activity',
             },
@@ -168,6 +170,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
             id: '1',
             title: 'Grain 1',
             type: 'activity',
+            // ToDo PIX-12363 migrate to components
             elements: getElements(),
             components: getElements().map((element) => ({ element: element, type: 'element' })),
           },
@@ -197,6 +200,7 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
           {
             attributes: {
               title: 'Grain 1',
+              // ToDo PIX-12363 migrate to components
               elements: getAttributesElements(),
               components: getAttributesElements().map((element) => ({ element: element, type: 'element' })),
               type: 'activity',

--- a/mon-pix/app/pods/components/module/grain/component.js
+++ b/mon-pix/app/pods/components/module/grain/component.js
@@ -22,6 +22,18 @@ export default class ModuleGrain extends Component {
   }
 
   static getSupportedElements(grain) {
+    if (grain.components && grain.components.length > 0) {
+      return grain.components
+        .map((component) => {
+          if (component.type === 'element') {
+            return component.element;
+          } else {
+            return undefined;
+          }
+        })
+        .filter((element) => ModuleGrain.AVAILABLE_ELEMENT_TYPES.includes(element.type));
+    }
+
     return grain.elements.filter((element) => ModuleGrain.AVAILABLE_ELEMENT_TYPES.includes(element.type));
   }
 

--- a/mon-pix/app/pods/grain/model.js
+++ b/mon-pix/app/pods/grain/model.js
@@ -3,6 +3,7 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 export default class Grain extends Model {
   @attr('string') title;
   @attr({ defaultValue: () => [] }) elements;
+  @attr({ defaultValue: () => [] }) components;
   @attr('string') type;
 
   @belongsTo('module', { async: false, inverse: 'grains' }) module;

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
@@ -9,135 +9,261 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
   setupMirage(hooks);
 
   module('when user arrive on the module passage page', function () {
-    test('should display only the first lesson grain', async function (assert) {
-      // given
-      const grains = _createGrains(server);
+    module('with elements', function () {
+      test('should display only the first lesson grain', async function (assert) {
+        // given
+        const grains = _createDeprecatedGrains(server);
 
-      server.create('module', {
-        id: 'bien-ecrire-son-adresse-mail',
-        title: 'Bien écrire son adresse mail',
-        grains,
+        server.create('module', {
+          id: 'bien-ecrire-son-adresse-mail',
+          title: 'Bien écrire son adresse mail',
+          grains,
+        });
+
+        server.create('passage', {
+          moduleId: 'bien-ecrire-son-adresse-mail',
+        });
+
+        // when
+        const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+        // then
+        assert.dom(screen.getByRole('heading', { name: grains[0].title, level: 2 })).exists();
+        assert.dom(screen.queryByRole('heading', { name: grains[1].title, level: 2 })).doesNotExist();
+        assert.dom(screen.queryByRole('heading', { name: grains[2].title, level: 2 })).doesNotExist();
+        assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists({ count: 1 });
       });
+    });
 
-      server.create('passage', {
-        moduleId: 'bien-ecrire-son-adresse-mail',
+    module('with components', function () {
+      test('should display only the first lesson grain', async function (assert) {
+        // given
+        const grains = _createGrains(server);
+
+        server.create('module', {
+          id: 'bien-ecrire-son-adresse-mail',
+          title: 'Bien écrire son adresse mail',
+          grains,
+        });
+
+        server.create('passage', {
+          moduleId: 'bien-ecrire-son-adresse-mail',
+        });
+
+        // when
+        const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+        // then
+        assert.dom(screen.getByRole('heading', { name: grains[0].title, level: 2 })).exists();
+        assert.dom(screen.queryByRole('heading', { name: grains[1].title, level: 2 })).doesNotExist();
+        assert.dom(screen.queryByRole('heading', { name: grains[2].title, level: 2 })).doesNotExist();
+        assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists({ count: 1 });
       });
-
-      // when
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-      // then
-      assert.dom(screen.getByRole('heading', { name: grains[0].title, level: 2 })).exists();
-      assert.dom(screen.queryByRole('heading', { name: grains[1].title, level: 2 })).doesNotExist();
-      assert.dom(screen.queryByRole('heading', { name: grains[2].title, level: 2 })).doesNotExist();
-      assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists({ count: 1 });
     });
   });
 
   module('when user click on continue button', function () {
     module('when the grain displayed is not the last', function () {
-      test('should display the continue button', async function (assert) {
-        // given
-        const grains = _createGrains(server);
+      module('with elements', function () {
+        test('should display the continue button', async function (assert) {
+          // given
+          const grains = _createDeprecatedGrains(server);
 
-        server.create('module', {
-          id: 'bien-ecrire-son-adresse-mail',
-          title: 'Bien écrire son adresse mail',
-          grains,
+          server.create('module', {
+            id: 'bien-ecrire-son-adresse-mail',
+            title: 'Bien écrire son adresse mail',
+            grains,
+          });
+
+          // when
+          const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+          // then
+          assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists({ count: 1 });
+
+          // when
+          await clickByName('Continuer');
+
+          // then
+          const secondGrain = grains[1];
+          assert.dom(screen.getByRole('heading', { name: secondGrain.title, level: 2 })).exists();
+          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists();
         });
+      });
 
-        // when
-        const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+      module('with components', function () {
+        test('should display the continue button', async function (assert) {
+          // given
+          const grains = _createGrains(server);
 
-        // then
-        assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists({ count: 1 });
+          server.create('module', {
+            id: 'bien-ecrire-son-adresse-mail',
+            title: 'Bien écrire son adresse mail',
+            grains,
+          });
 
-        // when
-        await clickByName('Continuer');
+          // when
+          const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
 
-        // then
-        const secondGrain = grains[1];
-        assert.dom(screen.getByRole('heading', { name: secondGrain.title, level: 2 })).exists();
-        assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists();
+          // then
+          assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists({ count: 1 });
+
+          // when
+          await clickByName('Continuer');
+
+          // then
+          const secondGrain = grains[1];
+          assert.dom(screen.getByRole('heading', { name: secondGrain.title, level: 2 })).exists();
+          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists();
+        });
       });
     });
 
     module('when the grain displayed is the last', function () {
-      test('should not display continue button', async function (assert) {
-        // given
-        const grains = _createGrains(server);
+      module('with elements', function () {
+        test('should not display continue button', async function (assert) {
+          // given
+          const grains = _createDeprecatedGrains(server);
 
+          server.create('module', {
+            id: 'bien-ecrire-son-adresse-mail',
+            title: 'Bien écrire son adresse mail',
+            grains,
+          });
+
+          // when
+          const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+          // then
+          assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists({ count: 1 });
+
+          // when
+          await clickByName('Continuer');
+          await clickByName('Continuer');
+
+          // then
+          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+        });
+      });
+
+      module('with components', function () {
+        test('should not display continue button', async function (assert) {
+          // given
+          const grains = _createGrains(server);
+
+          server.create('module', {
+            id: 'bien-ecrire-son-adresse-mail',
+            title: 'Bien écrire son adresse mail',
+            grains,
+          });
+
+          // when
+          const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+          // then
+          assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists({ count: 1 });
+
+          // when
+          await clickByName('Continuer');
+          await clickByName('Continuer');
+
+          // then
+          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+        });
+      });
+    });
+
+    module('with elements', function () {
+      test('should navigate to recap page when terminate is clicked', async function (assert) {
+        // given
+        const text1 = {
+          id: 'elementId-1',
+          type: 'text',
+          content: 'content-1',
+        };
+        const grain1 = server.create('grain', {
+          id: 'grainId-1',
+          title: 'title grain 1',
+          elements: [text1],
+        });
         server.create('module', {
           id: 'bien-ecrire-son-adresse-mail',
           title: 'Bien écrire son adresse mail',
-          grains,
+          grains: [grain1],
         });
 
         // when
         const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
 
         // then
-        assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists({ count: 1 });
+        assert.dom(screen.getByRole('button', { name: 'Terminer' })).exists({ count: 1 });
 
         // when
-        await clickByName('Continuer');
-        await clickByName('Continuer');
+        await clickByName('Terminer');
 
         // then
-        assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+        assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/recap');
       });
     });
 
-    test('should navigate to recap page when terminate is clicked', async function (assert) {
-      // given
-      const text1 = {
-        id: 'elementId-1',
-        type: 'text',
-        content: 'content-1',
-      };
-      const grain1 = server.create('grain', {
-        id: 'grainId-1',
-        title: 'title grain 1',
-        elements: [text1],
+    module('with components', function () {
+      test('should navigate to recap page when terminate is clicked', async function (assert) {
+        // given
+        const text1 = {
+          id: 'elementId-1',
+          type: 'text',
+          content: 'content-1',
+        };
+        const grain1 = server.create('grain', {
+          id: 'grainId-1',
+          title: 'title grain 1',
+          components: [
+            {
+              type: 'element',
+              element: text1,
+            },
+          ],
+        });
+        server.create('module', {
+          id: 'bien-ecrire-son-adresse-mail',
+          title: 'Bien écrire son adresse mail',
+          grains: [grain1],
+        });
+
+        // when
+        const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+        // then
+        assert.dom(screen.getByRole('button', { name: 'Terminer' })).exists({ count: 1 });
+
+        // when
+        await clickByName('Terminer');
+
+        // then
+        assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/recap');
       });
-      server.create('module', {
-        id: 'bien-ecrire-son-adresse-mail',
-        title: 'Bien écrire son adresse mail',
-        grains: [grain1],
-      });
-
-      // when
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-      // then
-      assert.dom(screen.getByRole('button', { name: 'Terminer' })).exists({ count: 1 });
-
-      // when
-      await clickByName('Terminer');
-
-      // then
-      assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/recap');
     });
   });
 });
 
-function _createGrains(server) {
-  const text1 = {
-    id: 'elementId-1',
-    type: 'text',
-    content: 'content-1',
-  };
-  const text2 = {
-    id: 'elementId-2',
-    type: 'text',
-    content: 'content-2',
-  };
-  const text3 = {
-    id: 'elementId-3',
-    type: 'text',
-    content: 'content-3',
-  };
+const text1 = {
+  id: 'elementId-1',
+  type: 'text',
+  content: 'content-1',
+};
 
+const text2 = {
+  id: 'elementId-2',
+  type: 'text',
+  content: 'content-2',
+};
+
+const text3 = {
+  id: 'elementId-3',
+  type: 'text',
+  content: 'content-3',
+};
+function _createDeprecatedGrains(server) {
   const grain1 = server.create('grain', {
     id: 'grainId-1',
     title: 'title grain 1',
@@ -152,6 +278,41 @@ function _createGrains(server) {
     id: 'grainId-3',
     title: 'title grain 3',
     elements: [text3],
+  });
+
+  return [grain1, grain2, grain3];
+}
+
+function _createGrains(server) {
+  const grain1 = server.create('grain', {
+    id: 'grainId-1',
+    title: 'title grain 1',
+    components: [
+      {
+        type: 'element',
+        element: text1,
+      },
+    ],
+  });
+  const grain2 = server.create('grain', {
+    id: 'grainId-2',
+    title: 'title grain 2',
+    components: [
+      {
+        type: 'element',
+        element: text2,
+      },
+    ],
+  });
+  const grain3 = server.create('grain', {
+    id: 'grainId-3',
+    title: 'title grain 3',
+    components: [
+      {
+        type: 'element',
+        element: text3,
+      },
+    ],
   });
 
   return [grain1, grain2, grain3];

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
@@ -11,56 +11,119 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleRecap', function (ho
   setupMirage(hooks);
   setupIntl(hooks);
 
-  module('when user arrive on the module recap page', function (hooks) {
-    let screen;
-    hooks.beforeEach(async function () {
-      const grain = server.create('grain', {
-        id: 'grain1',
-        elements: [{ type: 'text' }],
+  module('with elements', function () {
+    module('when user arrive on the module recap page', function (hooks) {
+      let screen;
+      hooks.beforeEach(async function () {
+        const grain = server.create('grain', {
+          id: 'grain1',
+          elements: [{ type: 'text' }],
+        });
+        server.create('module', {
+          id: 'bien-ecrire-son-adresse-mail',
+          title: 'Bien écrire son adresse mail',
+          grains: [grain],
+          details: {
+            image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+            description: 'Description',
+            duration: 'duration',
+            level: 'level',
+            objectives: ['Objectif #1'],
+          },
+        });
+
+        screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+        await clickByName('Terminer');
       });
-      server.create('module', {
-        id: 'bien-ecrire-son-adresse-mail',
-        title: 'Bien écrire son adresse mail',
-        grains: [grain],
-        details: {
-          image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
-          description: 'Description',
-          duration: 'duration',
-          level: 'level',
-          objectives: ['Objectif #1'],
-        },
+
+      test('should include the right page title', async function (assert) {
+        // then
+        assert.ok(document.title.includes(this.intl.t('pages.modulix.recap.title')));
+        assert.ok(screen.getByRole('heading', { level: 1, name: this.intl.t('pages.modulix.recap.title') }));
       });
 
-      screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-      await clickByName('Terminer');
+      test('should display the links to details button and to form builder', async function (assert) {
+        // when
+        const formLink = screen.getByRole('link', { name: this.intl.t('pages.modulix.recap.goToForm') });
+
+        // then
+        const passage = server.schema.passages.all().models[0];
+        assert.ok(formLink);
+        assert.ok(screen.getByRole('link', { name: this.intl.t('pages.modulix.recap.backToModuleDetails') }));
+        assert.strictEqual(
+          formLink.getAttribute('href'),
+          `https://form-eu.123formbuilder.com/71180/modulix-experimentation?2850087=${passage.id}`,
+        );
+      });
+
+      test('should navigate to details page by clicking on back to module details button', async function (assert) {
+        // when
+        await click(screen.getByRole('link', { name: this.intl.t('pages.modulix.recap.backToModuleDetails') }));
+
+        // then
+        assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/details');
+      });
     });
+  });
 
-    test('should include the right page title', async function (assert) {
-      // then
-      assert.ok(document.title.includes(this.intl.t('pages.modulix.recap.title')));
-      assert.ok(screen.getByRole('heading', { level: 1, name: this.intl.t('pages.modulix.recap.title') }));
-    });
+  module('with components', function () {
+    module('when user arrive on the module recap page', function (hooks) {
+      let screen;
+      hooks.beforeEach(async function () {
+        const text = {
+          id: '84726001-1665-457d-8f13-4a74dc4768ea',
+          type: 'text',
+          content: '<h3>content</h3>',
+        };
 
-    test('should display the links to details button and to form builder', async function (assert) {
-      // when
-      const formLink = screen.getByRole('link', { name: this.intl.t('pages.modulix.recap.goToForm') });
+        const grain = server.create('grain', {
+          id: 'grain1',
+          components: [{ type: 'element', element: text }],
+        });
+        server.create('module', {
+          id: 'bien-ecrire-son-adresse-mail',
+          title: 'Bien écrire son adresse mail',
+          grains: [grain],
+          details: {
+            image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+            description: 'Description',
+            duration: 'duration',
+            level: 'level',
+            objectives: ['Objectif #1'],
+          },
+        });
 
-      // then
-      const passage = server.schema.passages.all().models[0];
-      assert.ok(formLink);
-      assert.ok(screen.getByRole('link', { name: this.intl.t('pages.modulix.recap.backToModuleDetails') }));
-      assert.strictEqual(
-        formLink.getAttribute('href'),
-        `https://form-eu.123formbuilder.com/71180/modulix-experimentation?2850087=${passage.id}`,
-      );
-    });
+        screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+        await clickByName('Terminer');
+      });
 
-    test('should navigate to details page by clicking on back to module details button', async function (assert) {
-      // when
-      await click(screen.getByRole('link', { name: this.intl.t('pages.modulix.recap.backToModuleDetails') }));
+      test('should include the right page title', async function (assert) {
+        // then
+        assert.ok(document.title.includes(this.intl.t('pages.modulix.recap.title')));
+        assert.ok(screen.getByRole('heading', { level: 1, name: this.intl.t('pages.modulix.recap.title') }));
+      });
 
-      // then
-      assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/details');
+      test('should display the links to details button and to form builder', async function (assert) {
+        // when
+        const formLink = screen.getByRole('link', { name: this.intl.t('pages.modulix.recap.goToForm') });
+
+        // then
+        const passage = server.schema.passages.all().models[0];
+        assert.ok(formLink);
+        assert.ok(screen.getByRole('link', { name: this.intl.t('pages.modulix.recap.backToModuleDetails') }));
+        assert.strictEqual(
+          formLink.getAttribute('href'),
+          `https://form-eu.123formbuilder.com/71180/modulix-experimentation?2850087=${passage.id}`,
+        );
+      });
+
+      test('should navigate to details page by clicking on back to module details button', async function (assert) {
+        // when
+        await click(screen.getByRole('link', { name: this.intl.t('pages.modulix.recap.backToModuleDetails') }));
+
+        // then
+        assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/details');
+      });
     });
   });
 });

--- a/mon-pix/tests/acceptance/module/retake_completed_module_test.js
+++ b/mon-pix/tests/acceptance/module/retake_completed_module_test.js
@@ -8,76 +8,163 @@ module('Acceptance | Module | Routes | retakeCompletedModule', function (hooks) 
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  test('should reset activities when I retake a completed module', async function (assert) {
-    // given
-    const qcu = {
-      id: 'elementId-1',
-      type: 'qcu',
-      instruction: 'instruction',
-      isAnswerable: true,
-      proposals: [
-        { id: 'qcu-1-proposal-1', content: 'I am the wrong answer!' },
-        { id: 'qcu-1-proposal-2', content: 'I am the right answer!' },
-      ],
-    };
+  module('with elements', function () {
+    test('should reset activities when I retake a completed module', async function (assert) {
+      // given
+      const qcu = {
+        id: 'elementId-1',
+        type: 'qcu',
+        instruction: 'instruction',
+        isAnswerable: true,
+        proposals: [
+          { id: 'qcu-1-proposal-1', content: 'I am the wrong answer!' },
+          { id: 'qcu-1-proposal-2', content: 'I am the right answer!' },
+        ],
+      };
 
-    const grain1 = server.create('grain', {
-      id: 'grainId1',
-      title: 'title',
-      elements: [qcu],
+      const grain1 = server.create('grain', {
+        id: 'grainId1',
+        title: 'title',
+        elements: [qcu],
+      });
+
+      const text = {
+        id: 'elementId-1',
+        type: 'text',
+        content: 'content-1',
+        isAnswerable: false,
+      };
+
+      const grain2 = server.create('grain', {
+        id: 'grainId2',
+        title: 'title',
+        elements: [text],
+      });
+
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [grain1, grain2],
+      });
+
+      server.create('correction-response', {
+        id: 'elementId-1',
+        feedback: "Bravo ! C'est la bonne réponse.",
+        status: 'ok',
+        solution: 'qcu-1-proposal-2',
+      });
+
+      // when
+      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+      await click(screen.getByLabelText('I am the right answer!'));
+
+      const verifyButton = screen.getByRole('button', { name: 'Vérifier' });
+      await click(verifyButton);
+
+      assert.dom(screen.queryByText("Bravo ! C'est la bonne réponse.")).exists();
+
+      const continueButton = screen.getByRole('button', { name: 'Continuer' });
+      await click(continueButton);
+
+      const terminateButton = screen.getByRole('button', { name: 'Terminer' });
+      await click(terminateButton);
+
+      const backToDetailsButton = screen.getByRole('link', { name: 'Revenir aux détails du module' });
+      await click(backToDetailsButton);
+
+      const startModuleButton = screen.getByRole('link', { name: 'Commencer le module' });
+      await click(startModuleButton);
+
+      // then
+      assert.dom(screen.queryByText("Bravo ! C'est la bonne réponse.")).doesNotExist();
+
+      assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+      assert.dom(screen.queryByRole('button', { name: 'Passer' })).exists();
     });
+  });
 
-    const text = {
-      id: 'elementId-1',
-      type: 'text',
-      content: 'content-1',
-      isAnswerable: false,
-    };
+  module('with components', function () {
+    test('should reset activities when I retake a completed module', async function (assert) {
+      // given
+      const qcu = {
+        id: 'elementId-1',
+        type: 'qcu',
+        instruction: 'instruction',
+        isAnswerable: true,
+        proposals: [
+          { id: 'qcu-1-proposal-1', content: 'I am the wrong answer!' },
+          { id: 'qcu-1-proposal-2', content: 'I am the right answer!' },
+        ],
+      };
 
-    const grain2 = server.create('grain', {
-      id: 'grainId2',
-      title: 'title',
-      elements: [text],
+      const grain1 = server.create('grain', {
+        id: 'grainId1',
+        title: 'title',
+        components: [
+          {
+            type: 'element',
+            element: qcu,
+          },
+        ],
+      });
+
+      const text = {
+        id: 'elementId-1',
+        type: 'text',
+        content: 'content-1',
+        isAnswerable: false,
+      };
+
+      const grain2 = server.create('grain', {
+        id: 'grainId2',
+        title: 'title',
+        components: [
+          {
+            type: 'element',
+            element: text,
+          },
+        ],
+      });
+
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [grain1, grain2],
+      });
+
+      server.create('correction-response', {
+        id: 'elementId-1',
+        feedback: "Bravo ! C'est la bonne réponse.",
+        status: 'ok',
+        solution: 'qcu-1-proposal-2',
+      });
+
+      // when
+      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+      await click(screen.getByLabelText('I am the right answer!'));
+
+      const verifyButton = screen.getByRole('button', { name: 'Vérifier' });
+      await click(verifyButton);
+
+      assert.dom(screen.queryByText("Bravo ! C'est la bonne réponse.")).exists();
+
+      const continueButton = screen.getByRole('button', { name: 'Continuer' });
+      await click(continueButton);
+
+      const terminateButton = screen.getByRole('button', { name: 'Terminer' });
+      await click(terminateButton);
+
+      const backToDetailsButton = screen.getByRole('link', { name: 'Revenir aux détails du module' });
+      await click(backToDetailsButton);
+
+      const startModuleButton = screen.getByRole('link', { name: 'Commencer le module' });
+      await click(startModuleButton);
+
+      // then
+      assert.dom(screen.queryByText("Bravo ! C'est la bonne réponse.")).doesNotExist();
+
+      assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+      assert.dom(screen.queryByRole('button', { name: 'Passer' })).exists();
     });
-
-    server.create('module', {
-      id: 'bien-ecrire-son-adresse-mail',
-      title: 'Bien écrire son adresse mail',
-      grains: [grain1, grain2],
-    });
-
-    server.create('correction-response', {
-      id: 'elementId-1',
-      feedback: "Bravo ! C'est la bonne réponse.",
-      status: 'ok',
-      solution: 'qcu-1-proposal-2',
-    });
-
-    // when
-    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-    await click(screen.getByLabelText('I am the right answer!'));
-
-    const verifyButton = screen.getByRole('button', { name: 'Vérifier' });
-    await click(verifyButton);
-
-    assert.dom(screen.queryByText("Bravo ! C'est la bonne réponse.")).exists();
-
-    const continueButton = screen.getByRole('button', { name: 'Continuer' });
-    await click(continueButton);
-
-    const terminateButton = screen.getByRole('button', { name: 'Terminer' });
-    await click(terminateButton);
-
-    const backToDetailsButton = screen.getByRole('link', { name: 'Revenir aux détails du module' });
-    await click(backToDetailsButton);
-
-    const startModuleButton = screen.getByRole('link', { name: 'Commencer le module' });
-    await click(startModuleButton);
-
-    // then
-    assert.dom(screen.queryByText("Bravo ! C'est la bonne réponse.")).doesNotExist();
-
-    assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
-    assert.dom(screen.queryByRole('button', { name: 'Passer' })).exists();
   });
 });

--- a/mon-pix/tests/acceptance/module/retry-qcm_test.js
+++ b/mon-pix/tests/acceptance/module/retry-qcm_test.js
@@ -8,129 +8,269 @@ module('Acceptance | Module | Routes | retryQcm', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  test('can retry a QCM', async function (assert) {
-    // given
-    const qcm = {
-      id: 'elementId-1',
-      type: 'qcm',
-      instruction: 'instruction',
-      proposals: [
-        { id: '1', content: 'I am the first wrong answer!' },
-        { id: '2', content: 'I am the first right answer!' },
-        { id: '3', content: 'I am the second right answer!' },
-        { id: '4', content: 'I am the second wrong answer!' },
-      ],
-    };
+  module('with elements', function () {
+    test('can retry a QCM', async function (assert) {
+      // given
+      const qcm = {
+        id: 'elementId-1',
+        type: 'qcm',
+        instruction: 'instruction',
+        proposals: [
+          { id: '1', content: 'I am the first wrong answer!' },
+          { id: '2', content: 'I am the first right answer!' },
+          { id: '3', content: 'I am the second right answer!' },
+          { id: '4', content: 'I am the second wrong answer!' },
+        ],
+      };
 
-    const grain = server.create('grain', {
-      id: 'grainId',
-      title: 'title',
-      elements: [qcm],
+      const grain = server.create('grain', {
+        id: 'grainId',
+        title: 'title',
+        elements: [qcm],
+      });
+
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [grain],
+      });
+
+      server.create('correction-response', {
+        id: 'elementId-1',
+        feedback: 'Faux',
+        status: 'ko',
+        solution: [qcm.proposals[1].id, qcm.proposals[2].id],
+      });
+
+      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+      const qcmVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
+      const rightAnswerCheckbox = screen.getByLabelText('I am the second right answer!');
+      const wrongAnswerCheckbox = screen.getByLabelText('I am the first wrong answer!');
+      const qcmForm = screen.getByRole('group');
+
+      await click(rightAnswerCheckbox);
+      await click(wrongAnswerCheckbox);
+      await click(qcmVerifyButton);
+
+      assert.dom(screen.getByRole('status')).exists();
+
+      // when
+      const retryButton = screen.getByRole('button', { name: 'Réessayer' });
+      await click(retryButton);
+
+      // then
+      assert.strictEqual(screen.queryByRole('status').innerText, '');
+      assert.false(qcmForm.disabled);
+      assert.false(wrongAnswerCheckbox.checked);
+      assert.false(rightAnswerCheckbox.checked);
+
+      const qcmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
+      await click(wrongAnswerCheckbox);
+      await click(rightAnswerCheckbox);
+      await click(qcmVerifyButtonCameBack);
+      assert.strictEqual(screen.queryByRole('status').innerText, 'Faux');
     });
 
-    server.create('module', {
-      id: 'bien-ecrire-son-adresse-mail',
-      title: 'Bien écrire son adresse mail',
-      grains: [grain],
+    test('after retrying a QCM, it display an error message if QCM is validated without response', async function (assert) {
+      // given
+      const qcm = {
+        id: 'elementId-1',
+        type: 'qcm',
+        instruction: 'instruction',
+        proposals: [
+          { id: '1', content: 'I am the first wrong answer!' },
+          { id: '2', content: 'I am the first right answer!' },
+          { id: '3', content: 'I am the second right answer!' },
+          { id: '4', content: 'I am the second wrong answer!' },
+        ],
+      };
+
+      const grain = server.create('grain', {
+        id: 'grainId',
+        title: 'title',
+        elements: [qcm],
+      });
+
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [grain],
+      });
+
+      server.create('correction-response', {
+        id: 'elementId-1',
+        feedback: 'Faux',
+        status: 'ko',
+        solution: [qcm.proposals[1].id, qcm.proposals[2].id],
+      });
+
+      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+      const qcmVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
+      const rightAnswerCheckbox = screen.getByLabelText('I am the second right answer!');
+      const wrongAnswerCheckbox = screen.getByLabelText('I am the first wrong answer!');
+      const qcmForm = screen.getByRole('group');
+
+      await click(rightAnswerCheckbox);
+      await click(wrongAnswerCheckbox);
+      await click(qcmVerifyButton);
+
+      assert.dom(screen.getByRole('status')).exists();
+
+      // when
+      const retryButton = screen.getByRole('button', { name: 'Réessayer' });
+      await click(retryButton);
+
+      // then
+      assert.strictEqual(screen.queryByRole('status').innerText, '');
+      assert.false(qcmForm.disabled);
+      assert.false(wrongAnswerCheckbox.checked);
+      assert.false(rightAnswerCheckbox.checked);
+
+      const qcmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
+      await click(qcmVerifyButtonCameBack);
+      const validationAlert = screen.queryAllByRole('alert')[1];
+
+      assert.strictEqual(validationAlert.innerText, 'Pour valider, sélectionnez au moins deux réponses.');
     });
-
-    server.create('correction-response', {
-      id: 'elementId-1',
-      feedback: 'Faux',
-      status: 'ko',
-      solution: [qcm.proposals[1].id, qcm.proposals[2].id],
-    });
-
-    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-    const qcmVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
-    const rightAnswerCheckbox = screen.getByLabelText('I am the second right answer!');
-    const wrongAnswerCheckbox = screen.getByLabelText('I am the first wrong answer!');
-    const qcmForm = screen.getByRole('group');
-
-    await click(rightAnswerCheckbox);
-    await click(wrongAnswerCheckbox);
-    await click(qcmVerifyButton);
-
-    assert.dom(screen.getByRole('status')).exists();
-
-    // when
-    const retryButton = screen.getByRole('button', { name: 'Réessayer' });
-    await click(retryButton);
-
-    // then
-    assert.strictEqual(screen.queryByRole('status').innerText, '');
-    assert.false(qcmForm.disabled);
-    assert.false(wrongAnswerCheckbox.checked);
-    assert.false(rightAnswerCheckbox.checked);
-
-    const qcmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
-    await click(wrongAnswerCheckbox);
-    await click(rightAnswerCheckbox);
-    await click(qcmVerifyButtonCameBack);
-    assert.strictEqual(screen.queryByRole('status').innerText, 'Faux');
   });
 
-  test('after retrying a QCM, it display an error message if QCM is validated without response', async function (assert) {
-    // given
-    const qcm = {
-      id: 'elementId-1',
-      type: 'qcm',
-      instruction: 'instruction',
-      proposals: [
-        { id: '1', content: 'I am the first wrong answer!' },
-        { id: '2', content: 'I am the first right answer!' },
-        { id: '3', content: 'I am the second right answer!' },
-        { id: '4', content: 'I am the second wrong answer!' },
-      ],
-    };
+  module('with components', function () {
+    test('can retry a QCM', async function (assert) {
+      // given
+      const qcm = {
+        id: 'elementId-1',
+        type: 'qcm',
+        instruction: 'instruction',
+        proposals: [
+          { id: '1', content: 'I am the first wrong answer!' },
+          { id: '2', content: 'I am the first right answer!' },
+          { id: '3', content: 'I am the second right answer!' },
+          { id: '4', content: 'I am the second wrong answer!' },
+        ],
+      };
 
-    const grain = server.create('grain', {
-      id: 'grainId',
-      title: 'title',
-      elements: [qcm],
+      const grain = server.create('grain', {
+        id: 'grainId',
+        title: 'title',
+        components: [
+          {
+            type: 'element',
+            element: qcm,
+          },
+        ],
+      });
+
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [grain],
+      });
+
+      server.create('correction-response', {
+        id: 'elementId-1',
+        feedback: 'Faux',
+        status: 'ko',
+        solution: [qcm.proposals[1].id, qcm.proposals[2].id],
+      });
+
+      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+      const qcmVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
+      const rightAnswerCheckbox = screen.getByLabelText('I am the second right answer!');
+      const wrongAnswerCheckbox = screen.getByLabelText('I am the first wrong answer!');
+      const qcmForm = screen.getByRole('group');
+
+      await click(rightAnswerCheckbox);
+      await click(wrongAnswerCheckbox);
+      await click(qcmVerifyButton);
+
+      assert.dom(screen.getByRole('status')).exists();
+
+      // when
+      const retryButton = screen.getByRole('button', { name: 'Réessayer' });
+      await click(retryButton);
+
+      // then
+      assert.strictEqual(screen.queryByRole('status').innerText, '');
+      assert.false(qcmForm.disabled);
+      assert.false(wrongAnswerCheckbox.checked);
+      assert.false(rightAnswerCheckbox.checked);
+
+      const qcmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
+      await click(wrongAnswerCheckbox);
+      await click(rightAnswerCheckbox);
+      await click(qcmVerifyButtonCameBack);
+      assert.strictEqual(screen.queryByRole('status').innerText, 'Faux');
     });
 
-    server.create('module', {
-      id: 'bien-ecrire-son-adresse-mail',
-      title: 'Bien écrire son adresse mail',
-      grains: [grain],
+    test('after retrying a QCM, it display an error message if QCM is validated without response', async function (assert) {
+      // given
+      const qcm = {
+        id: 'elementId-1',
+        type: 'qcm',
+        instruction: 'instruction',
+        proposals: [
+          { id: '1', content: 'I am the first wrong answer!' },
+          { id: '2', content: 'I am the first right answer!' },
+          { id: '3', content: 'I am the second right answer!' },
+          { id: '4', content: 'I am the second wrong answer!' },
+        ],
+      };
+
+      const grain = server.create('grain', {
+        id: 'grainId',
+        title: 'title',
+        components: [
+          {
+            type: 'element',
+            element: qcm,
+          },
+        ],
+      });
+
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [grain],
+      });
+
+      server.create('correction-response', {
+        id: 'elementId-1',
+        feedback: 'Faux',
+        status: 'ko',
+        solution: [qcm.proposals[1].id, qcm.proposals[2].id],
+      });
+
+      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+      const qcmVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
+      const rightAnswerCheckbox = screen.getByLabelText('I am the second right answer!');
+      const wrongAnswerCheckbox = screen.getByLabelText('I am the first wrong answer!');
+      const qcmForm = screen.getByRole('group');
+
+      await click(rightAnswerCheckbox);
+      await click(wrongAnswerCheckbox);
+      await click(qcmVerifyButton);
+
+      assert.dom(screen.getByRole('status')).exists();
+
+      // when
+      const retryButton = screen.getByRole('button', { name: 'Réessayer' });
+      await click(retryButton);
+
+      // then
+      assert.strictEqual(screen.queryByRole('status').innerText, '');
+      assert.false(qcmForm.disabled);
+      assert.false(wrongAnswerCheckbox.checked);
+      assert.false(rightAnswerCheckbox.checked);
+
+      const qcmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
+      await click(qcmVerifyButtonCameBack);
+      const validationAlert = screen.queryAllByRole('alert')[1];
+
+      assert.strictEqual(validationAlert.innerText, 'Pour valider, sélectionnez au moins deux réponses.');
     });
-
-    server.create('correction-response', {
-      id: 'elementId-1',
-      feedback: 'Faux',
-      status: 'ko',
-      solution: [qcm.proposals[1].id, qcm.proposals[2].id],
-    });
-
-    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-    const qcmVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
-    const rightAnswerCheckbox = screen.getByLabelText('I am the second right answer!');
-    const wrongAnswerCheckbox = screen.getByLabelText('I am the first wrong answer!');
-    const qcmForm = screen.getByRole('group');
-
-    await click(rightAnswerCheckbox);
-    await click(wrongAnswerCheckbox);
-    await click(qcmVerifyButton);
-
-    assert.dom(screen.getByRole('status')).exists();
-
-    // when
-    const retryButton = screen.getByRole('button', { name: 'Réessayer' });
-    await click(retryButton);
-
-    // then
-    assert.strictEqual(screen.queryByRole('status').innerText, '');
-    assert.false(qcmForm.disabled);
-    assert.false(wrongAnswerCheckbox.checked);
-    assert.false(rightAnswerCheckbox.checked);
-
-    const qcmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
-    await click(qcmVerifyButtonCameBack);
-    const validationAlert = screen.queryAllByRole('alert')[1];
-
-    assert.strictEqual(validationAlert.innerText, 'Pour valider, sélectionnez au moins deux réponses.');
   });
 });

--- a/mon-pix/tests/acceptance/module/retry-qcu_test.js
+++ b/mon-pix/tests/acceptance/module/retry-qcu_test.js
@@ -8,155 +8,331 @@ module('Acceptance | Module | Routes | retryQcu', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  test('can retry a QCU', async function (assert) {
-    // given
-    const qcu1 = {
-      id: 'elementId-1',
-      type: 'qcu',
-      instruction: 'instruction',
-      proposals: [
-        { id: '1', content: 'I am the wrong answer!' },
-        { id: '2', content: 'I am the right answer!' },
-      ],
-    };
-    const qcu2 = {
-      id: 'elementId-2',
-      type: 'qcu',
-      instruction: 'instruction',
-      proposals: [
-        { id: '1', content: 'Vrai' },
-        { id: '2', content: 'Faux' },
-      ],
-    };
+  module('with elements', function () {
+    test('can retry a QCU', async function (assert) {
+      // given
+      const qcu1 = {
+        id: 'elementId-1',
+        type: 'qcu',
+        instruction: 'instruction',
+        proposals: [
+          { id: '1', content: 'I am the wrong answer!' },
+          { id: '2', content: 'I am the right answer!' },
+        ],
+      };
+      const qcu2 = {
+        id: 'elementId-2',
+        type: 'qcu',
+        instruction: 'instruction',
+        proposals: [
+          { id: '1', content: 'Vrai' },
+          { id: '2', content: 'Faux' },
+        ],
+      };
 
-    const grain1 = server.create('grain', {
-      id: 'grainId1',
-      title: 'title',
-      elements: [qcu1],
+      const grain1 = server.create('grain', {
+        id: 'grainId1',
+        title: 'title',
+        elements: [qcu1],
+      });
+
+      const grain2 = server.create('grain', {
+        id: 'grainId2',
+        title: 'title',
+        elements: [qcu2],
+      });
+
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [grain1, grain2],
+      });
+
+      server.create('correction-response', {
+        id: 'elementId-1',
+        feedback: 'Faux',
+        status: 'ko',
+        solution: qcu1.proposals[1].id,
+      });
+
+      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+      const firstQcuVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
+      const rightAnswerRadio = screen.getByLabelText('I am the right answer!');
+      const wrongAnswerRadio = screen.getByLabelText('I am the wrong answer!');
+      const firstQcuForm = screen.getByRole('group');
+
+      await click(wrongAnswerRadio);
+      await click(firstQcuVerifyButton);
+
+      assert.dom(screen.getByRole('status')).exists();
+
+      // when
+      const retryButton = screen.getByRole('button', { name: 'Réessayer' });
+      await click(retryButton);
+
+      // then
+      assert.strictEqual(screen.queryByRole('status').innerText, '');
+      assert.false(firstQcuForm.disabled);
+      assert.false(wrongAnswerRadio.checked);
+      assert.false(rightAnswerRadio.checked);
+
+      const firstQcuVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
+      await click(wrongAnswerRadio);
+      await click(firstQcuVerifyButtonCameBack);
+      assert.strictEqual(screen.queryByRole('status').innerText, 'Faux');
     });
 
-    const grain2 = server.create('grain', {
-      id: 'grainId2',
-      title: 'title',
-      elements: [qcu2],
+    test('after retrying a QCU, it display an error message if QCU is validated without response', async function (assert) {
+      // given
+      const qcu1 = {
+        id: 'elementId-1',
+        type: 'qcu',
+        instruction: 'instruction',
+        proposals: [
+          { id: '1', content: 'I am the wrong answer!' },
+          { id: '2', content: 'I am the right answer!' },
+        ],
+      };
+      const qcu2 = {
+        id: 'elementId-2',
+        type: 'qcu',
+        instruction: 'instruction',
+        proposals: [
+          { id: '1', content: 'Vrai' },
+          { id: '2', content: 'Faux' },
+        ],
+      };
+
+      const grain1 = server.create('grain', {
+        id: 'grainId1',
+        title: 'title',
+        type: 'activity',
+        elements: [qcu1],
+      });
+
+      const grain2 = server.create('grain', {
+        id: 'grainId2',
+        title: 'title',
+        type: 'activity',
+        elements: [qcu2],
+      });
+
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [grain1, grain2],
+      });
+
+      // look at mirage
+      server.create('correction-response', {
+        id: 'elementId-1',
+        feedback: 'Faux',
+        status: 'ko',
+        solution: qcu1.proposals[1].id,
+      });
+
+      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+      const firstQcuVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
+      const rightAnswerRadio = screen.getByLabelText('I am the right answer!');
+      const wrongAnswerRadio = screen.getByLabelText('I am the wrong answer!');
+      const firstQcuForm = screen.getByRole('group');
+
+      await click(wrongAnswerRadio);
+      await click(firstQcuVerifyButton);
+
+      assert.dom(screen.getByRole('status')).exists();
+
+      // when
+      const retryButton = screen.getByRole('button', { name: 'Réessayer' });
+      await click(retryButton);
+
+      // then
+      assert.strictEqual(screen.queryByRole('status').innerText, '');
+      assert.false(firstQcuForm.disabled);
+      assert.false(wrongAnswerRadio.checked);
+      assert.false(rightAnswerRadio.checked);
+
+      const firstQcuVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
+      await click(firstQcuVerifyButtonCameBack);
+      const validationAlert = screen.queryAllByRole('alert')[1];
+
+      assert.strictEqual(validationAlert.innerText, 'Pour valider, sélectionnez une réponse.');
     });
-
-    server.create('module', {
-      id: 'bien-ecrire-son-adresse-mail',
-      title: 'Bien écrire son adresse mail',
-      grains: [grain1, grain2],
-    });
-
-    server.create('correction-response', {
-      id: 'elementId-1',
-      feedback: 'Faux',
-      status: 'ko',
-      solution: qcu1.proposals[1].id,
-    });
-
-    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-    const firstQcuVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
-    const rightAnswerRadio = screen.getByLabelText('I am the right answer!');
-    const wrongAnswerRadio = screen.getByLabelText('I am the wrong answer!');
-    const firstQcuForm = screen.getByRole('group');
-
-    await click(wrongAnswerRadio);
-    await click(firstQcuVerifyButton);
-
-    assert.dom(screen.getByRole('status')).exists();
-
-    // when
-    const retryButton = screen.getByRole('button', { name: 'Réessayer' });
-    await click(retryButton);
-
-    // then
-    assert.strictEqual(screen.queryByRole('status').innerText, '');
-    assert.false(firstQcuForm.disabled);
-    assert.false(wrongAnswerRadio.checked);
-    assert.false(rightAnswerRadio.checked);
-
-    const firstQcuVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
-    await click(wrongAnswerRadio);
-    await click(firstQcuVerifyButtonCameBack);
-    assert.strictEqual(screen.queryByRole('status').innerText, 'Faux');
   });
 
-  test('after retrying a QCU, it display an error message if QCU is validated without response', async function (assert) {
-    // given
-    const qcu1 = {
-      id: 'elementId-1',
-      type: 'qcu',
-      instruction: 'instruction',
-      proposals: [
-        { id: '1', content: 'I am the wrong answer!' },
-        { id: '2', content: 'I am the right answer!' },
-      ],
-    };
-    const qcu2 = {
-      id: 'elementId-2',
-      type: 'qcu',
-      instruction: 'instruction',
-      proposals: [
-        { id: '1', content: 'Vrai' },
-        { id: '2', content: 'Faux' },
-      ],
-    };
+  module('with components', function () {
+    test('can retry a QCU', async function (assert) {
+      // given
+      const qcu1 = {
+        id: 'elementId-1',
+        type: 'qcu',
+        instruction: 'instruction',
+        proposals: [
+          { id: '1', content: 'I am the wrong answer!' },
+          { id: '2', content: 'I am the right answer!' },
+        ],
+      };
+      const qcu2 = {
+        id: 'elementId-2',
+        type: 'qcu',
+        instruction: 'instruction',
+        proposals: [
+          { id: '1', content: 'Vrai' },
+          { id: '2', content: 'Faux' },
+        ],
+      };
 
-    const grain1 = server.create('grain', {
-      id: 'grainId1',
-      title: 'title',
-      type: 'activity',
-      elements: [qcu1],
+      const grain1 = server.create('grain', {
+        id: 'grainId1',
+        title: 'title',
+        components: [
+          {
+            type: 'element',
+            element: qcu1,
+          },
+        ],
+      });
+
+      const grain2 = server.create('grain', {
+        id: 'grainId2',
+        title: 'title',
+        components: [
+          {
+            type: 'element',
+            element: qcu2,
+          },
+        ],
+      });
+
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [grain1, grain2],
+      });
+
+      server.create('correction-response', {
+        id: 'elementId-1',
+        feedback: 'Faux',
+        status: 'ko',
+        solution: qcu1.proposals[1].id,
+      });
+
+      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+      const firstQcuVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
+      const rightAnswerRadio = screen.getByLabelText('I am the right answer!');
+      const wrongAnswerRadio = screen.getByLabelText('I am the wrong answer!');
+      const firstQcuForm = screen.getByRole('group');
+
+      await click(wrongAnswerRadio);
+      await click(firstQcuVerifyButton);
+
+      assert.dom(screen.getByRole('status')).exists();
+
+      // when
+      const retryButton = screen.getByRole('button', { name: 'Réessayer' });
+      await click(retryButton);
+
+      // then
+      assert.strictEqual(screen.queryByRole('status').innerText, '');
+      assert.false(firstQcuForm.disabled);
+      assert.false(wrongAnswerRadio.checked);
+      assert.false(rightAnswerRadio.checked);
+
+      const firstQcuVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
+      await click(wrongAnswerRadio);
+      await click(firstQcuVerifyButtonCameBack);
+      assert.strictEqual(screen.queryByRole('status').innerText, 'Faux');
     });
 
-    const grain2 = server.create('grain', {
-      id: 'grainId2',
-      title: 'title',
-      type: 'activity',
-      elements: [qcu2],
+    test('after retrying a QCU, it display an error message if QCU is validated without response', async function (assert) {
+      // given
+      const qcu1 = {
+        id: 'elementId-1',
+        type: 'qcu',
+        instruction: 'instruction',
+        proposals: [
+          { id: '1', content: 'I am the wrong answer!' },
+          { id: '2', content: 'I am the right answer!' },
+        ],
+      };
+      const qcu2 = {
+        id: 'elementId-2',
+        type: 'qcu',
+        instruction: 'instruction',
+        proposals: [
+          { id: '1', content: 'Vrai' },
+          { id: '2', content: 'Faux' },
+        ],
+      };
+
+      const grain1 = server.create('grain', {
+        id: 'grainId1',
+        title: 'title',
+        type: 'activity',
+        components: [
+          {
+            type: 'element',
+            element: qcu1,
+          },
+        ],
+      });
+
+      const grain2 = server.create('grain', {
+        id: 'grainId2',
+        title: 'title',
+        type: 'activity',
+        components: [
+          {
+            type: 'element',
+            element: qcu2,
+          },
+        ],
+      });
+
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [grain1, grain2],
+      });
+
+      // look at mirage
+      server.create('correction-response', {
+        id: 'elementId-1',
+        feedback: 'Faux',
+        status: 'ko',
+        solution: qcu1.proposals[1].id,
+      });
+
+      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+      const firstQcuVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
+      const rightAnswerRadio = screen.getByLabelText('I am the right answer!');
+      const wrongAnswerRadio = screen.getByLabelText('I am the wrong answer!');
+      const firstQcuForm = screen.getByRole('group');
+
+      await click(wrongAnswerRadio);
+      await click(firstQcuVerifyButton);
+
+      assert.dom(screen.getByRole('status')).exists();
+
+      // when
+      const retryButton = screen.getByRole('button', { name: 'Réessayer' });
+      await click(retryButton);
+
+      // then
+      assert.strictEqual(screen.queryByRole('status').innerText, '');
+      assert.false(firstQcuForm.disabled);
+      assert.false(wrongAnswerRadio.checked);
+      assert.false(rightAnswerRadio.checked);
+
+      const firstQcuVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
+      await click(firstQcuVerifyButtonCameBack);
+      const validationAlert = screen.queryAllByRole('alert')[1];
+
+      assert.strictEqual(validationAlert.innerText, 'Pour valider, sélectionnez une réponse.');
     });
-
-    server.create('module', {
-      id: 'bien-ecrire-son-adresse-mail',
-      title: 'Bien écrire son adresse mail',
-      grains: [grain1, grain2],
-    });
-
-    // look at mirage
-    server.create('correction-response', {
-      id: 'elementId-1',
-      feedback: 'Faux',
-      status: 'ko',
-      solution: qcu1.proposals[1].id,
-    });
-
-    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-    const firstQcuVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
-    const rightAnswerRadio = screen.getByLabelText('I am the right answer!');
-    const wrongAnswerRadio = screen.getByLabelText('I am the wrong answer!');
-    const firstQcuForm = screen.getByRole('group');
-
-    await click(wrongAnswerRadio);
-    await click(firstQcuVerifyButton);
-
-    assert.dom(screen.getByRole('status')).exists();
-
-    // when
-    const retryButton = screen.getByRole('button', { name: 'Réessayer' });
-    await click(retryButton);
-
-    // then
-    assert.strictEqual(screen.queryByRole('status').innerText, '');
-    assert.false(firstQcuForm.disabled);
-    assert.false(wrongAnswerRadio.checked);
-    assert.false(rightAnswerRadio.checked);
-
-    const firstQcuVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
-    await click(firstQcuVerifyButtonCameBack);
-    const validationAlert = screen.queryAllByRole('alert')[1];
-
-    assert.strictEqual(validationAlert.innerText, 'Pour valider, sélectionnez une réponse.');
   });
 });

--- a/mon-pix/tests/acceptance/module/retry-qrocm_test.js
+++ b/mon-pix/tests/acceptance/module/retry-qrocm_test.js
@@ -8,218 +8,447 @@ module('Acceptance | Module | Routes | retryQrocm', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  test('can retry a Qrocm', async function (assert) {
-    // given
-    const qrocm1 = {
-      id: 'elementId-1',
-      type: 'qrocm',
-      instruction: 'instruction',
-      proposals: [
-        {
-          type: 'text',
-          content: '<p>Le symbole</>',
-        },
-        {
-          input: 'symbole',
-          type: 'input',
-          inputType: 'text',
-          size: 1,
-          display: 'block',
-          placeholder: '',
-          ariaLabel: 'Réponse 1',
-          defaultValue: '',
-        },
-        {
-          input: 'premiere-partie',
-          type: 'select',
-          display: 'block',
-          placeholder: '',
-          ariaLabel: 'Réponse 2',
-          defaultValue: '',
-          options: [
-            {
-              id: '1',
-              content: "l'identifiant",
-            },
-            {
-              id: '2',
-              content: "le fournisseur d'adresse mail",
-            },
-          ],
-        },
-      ],
-    };
+  module('with elements', function () {
+    test('can retry a Qrocm', async function (assert) {
+      // given
+      const qrocm1 = {
+        id: 'elementId-1',
+        type: 'qrocm',
+        instruction: 'instruction',
+        proposals: [
+          {
+            type: 'text',
+            content: '<p>Le symbole</>',
+          },
+          {
+            input: 'symbole',
+            type: 'input',
+            inputType: 'text',
+            size: 1,
+            display: 'block',
+            placeholder: '',
+            ariaLabel: 'Réponse 1',
+            defaultValue: '',
+          },
+          {
+            input: 'premiere-partie',
+            type: 'select',
+            display: 'block',
+            placeholder: '',
+            ariaLabel: 'Réponse 2',
+            defaultValue: '',
+            options: [
+              {
+                id: '1',
+                content: "l'identifiant",
+              },
+              {
+                id: '2',
+                content: "le fournisseur d'adresse mail",
+              },
+            ],
+          },
+        ],
+      };
 
-    const grain = server.create('grain', {
-      id: 'grainId',
-      title: 'title',
-      elements: [qrocm1],
-    });
+      const grain = server.create('grain', {
+        id: 'grainId',
+        title: 'title',
+        elements: [qrocm1],
+      });
 
-    server.create('module', {
-      id: 'bien-ecrire-son-adresse-mail',
-      title: 'Bien écrire son adresse mail',
-      grains: [grain],
-    });
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [grain],
+      });
 
-    server.create('correction-response', {
-      id: 'elementId-1',
-      feedback: 'Faux',
-      status: 'ko',
-      solution: { symbole: '@', 'premiere-partie': '2' },
-    });
+      server.create('correction-response', {
+        id: 'elementId-1',
+        feedback: 'Faux',
+        status: 'ko',
+        solution: { symbole: '@', 'premiere-partie': '2' },
+      });
 
-    // when
-    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+      // when
+      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
 
-    const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
-    const qrocmForm = screen.getByRole('group');
-    const input = screen.getByLabelText('Réponse 1');
+      const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
+      const qrocmForm = screen.getByRole('group');
+      const input = screen.getByLabelText('Réponse 1');
 
-    // answer input proposal
-    await fillIn(input, '#');
-    // answer select proposal
-    await clickByName('Réponse 2');
-    await screen.findByRole('listbox');
-    await click(
-      screen.queryByRole('option', {
-        name: "le fournisseur d'adresse mail",
-      }),
-    );
-
-    // submit
-    await click(verifyButton);
-
-    assert.dom(screen.getByRole('status')).exists();
-
-    // when
-    const retryButton = screen.getByRole('button', { name: 'Réessayer' });
-    await click(retryButton);
-
-    await screen.findByRole('listbox');
-
-    // then
-    assert.strictEqual(screen.queryByRole('status').innerText, '');
-    assert.false(qrocmForm.disabled);
-    assert.strictEqual(
-      screen
-        .queryByRole('option', {
+      // answer input proposal
+      await fillIn(input, '#');
+      // answer select proposal
+      await clickByName('Réponse 2');
+      await screen.findByRole('listbox');
+      await click(
+        screen.queryByRole('option', {
           name: "le fournisseur d'adresse mail",
-        })
-        .getAttribute('aria-selected'),
-      'false',
-    );
-    assert.strictEqual(input.value, '');
+        }),
+      );
 
-    const qrocmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
+      // submit
+      await click(verifyButton);
 
-    // answer input proposal
-    await fillIn(input, '#');
-    // answer select proposal
-    await clickByName('Réponse 2');
-    await screen.findByRole('listbox');
-    await click(
-      screen.queryByRole('option', {
-        name: "le fournisseur d'adresse mail",
-      }),
-    );
-    await click(qrocmVerifyButtonCameBack);
+      assert.dom(screen.getByRole('status')).exists();
 
-    assert.strictEqual(screen.queryByRole('status').innerText, 'Faux');
+      // when
+      const retryButton = screen.getByRole('button', { name: 'Réessayer' });
+      await click(retryButton);
+
+      await screen.findByRole('listbox');
+
+      // then
+      assert.strictEqual(screen.queryByRole('status').innerText, '');
+      assert.false(qrocmForm.disabled);
+      assert.strictEqual(
+        screen
+          .queryByRole('option', {
+            name: "le fournisseur d'adresse mail",
+          })
+          .getAttribute('aria-selected'),
+        'false',
+      );
+      assert.strictEqual(input.value, '');
+
+      const qrocmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
+
+      // answer input proposal
+      await fillIn(input, '#');
+      // answer select proposal
+      await clickByName('Réponse 2');
+      await screen.findByRole('listbox');
+      await click(
+        screen.queryByRole('option', {
+          name: "le fournisseur d'adresse mail",
+        }),
+      );
+      await click(qrocmVerifyButtonCameBack);
+
+      assert.strictEqual(screen.queryByRole('status').innerText, 'Faux');
+    });
+
+    test('after retrying a Qrocm, it display an error message if Qrocm is validated without response', async function (assert) {
+      // given
+      const qrocm1 = {
+        id: 'elementId-1',
+        type: 'qrocm',
+        instruction: 'instruction',
+        proposals: [
+          {
+            type: 'text',
+            content: '<p>Le symbole</>',
+          },
+          {
+            input: 'symbole',
+            type: 'input',
+            inputType: 'text',
+            size: 1,
+            display: 'block',
+            placeholder: '',
+            ariaLabel: 'Réponse 1',
+            defaultValue: '',
+          },
+          {
+            input: 'premiere-partie',
+            type: 'select',
+            display: 'block',
+            placeholder: '',
+            ariaLabel: 'Réponse 2',
+            defaultValue: '',
+            options: [
+              {
+                id: '1',
+                content: "l'identifiant",
+              },
+              {
+                id: '2',
+                content: "le fournisseur d'adresse mail",
+              },
+            ],
+          },
+        ],
+      };
+
+      const grain = server.create('grain', {
+        id: 'grainId',
+        title: 'title',
+        elements: [qrocm1],
+      });
+
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [grain],
+      });
+
+      server.create('correction-response', {
+        id: 'elementId-1',
+        feedback: 'Faux',
+        status: 'ko',
+        solution: { symbole: '@', 'premiere-partie': '2' },
+      });
+
+      // when
+      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+      const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
+      const input = screen.getByLabelText('Réponse 1');
+
+      // answer input proposal
+      await fillIn(input, '#');
+      // answer select proposal
+      await clickByName('Réponse 2');
+      await screen.findByRole('listbox');
+      await click(
+        screen.queryByRole('option', {
+          name: "le fournisseur d'adresse mail",
+        }),
+      );
+
+      // submit
+      await click(verifyButton);
+
+      assert.dom(screen.getByRole('status')).exists();
+
+      // when
+      const retryButton = screen.getByRole('button', { name: 'Réessayer' });
+      await click(retryButton);
+
+      // then
+      const qrocmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
+      await click(qrocmVerifyButtonCameBack);
+      const validationAlert = screen.queryAllByRole('alert')[1];
+
+      assert.strictEqual(validationAlert.innerText, 'Pour valider, veuillez remplir tous les champs réponse.');
+    });
   });
 
-  test('after retrying a Qrocm, it display an error message if Qrocm is validated without response', async function (assert) {
-    // given
-    const qrocm1 = {
-      id: 'elementId-1',
-      type: 'qrocm',
-      instruction: 'instruction',
-      proposals: [
-        {
-          type: 'text',
-          content: '<p>Le symbole</>',
-        },
-        {
-          input: 'symbole',
-          type: 'input',
-          inputType: 'text',
-          size: 1,
-          display: 'block',
-          placeholder: '',
-          ariaLabel: 'Réponse 1',
-          defaultValue: '',
-        },
-        {
-          input: 'premiere-partie',
-          type: 'select',
-          display: 'block',
-          placeholder: '',
-          ariaLabel: 'Réponse 2',
-          defaultValue: '',
-          options: [
-            {
-              id: '1',
-              content: "l'identifiant",
-            },
-            {
-              id: '2',
-              content: "le fournisseur d'adresse mail",
-            },
-          ],
-        },
-      ],
-    };
+  module('with components', function () {
+    test('can retry a Qrocm', async function (assert) {
+      // given
+      const qrocm1 = {
+        id: 'elementId-1',
+        type: 'qrocm',
+        instruction: 'instruction',
+        proposals: [
+          {
+            type: 'text',
+            content: '<p>Le symbole</>',
+          },
+          {
+            input: 'symbole',
+            type: 'input',
+            inputType: 'text',
+            size: 1,
+            display: 'block',
+            placeholder: '',
+            ariaLabel: 'Réponse 1',
+            defaultValue: '',
+          },
+          {
+            input: 'premiere-partie',
+            type: 'select',
+            display: 'block',
+            placeholder: '',
+            ariaLabel: 'Réponse 2',
+            defaultValue: '',
+            options: [
+              {
+                id: '1',
+                content: "l'identifiant",
+              },
+              {
+                id: '2',
+                content: "le fournisseur d'adresse mail",
+              },
+            ],
+          },
+        ],
+      };
 
-    const grain = server.create('grain', {
-      id: 'grainId',
-      title: 'title',
-      elements: [qrocm1],
+      const grain = server.create('grain', {
+        id: 'grainId',
+        title: 'title',
+        components: [
+          {
+            type: 'element',
+            element: qrocm1,
+          },
+        ],
+      });
+
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [grain],
+      });
+
+      server.create('correction-response', {
+        id: 'elementId-1',
+        feedback: 'Faux',
+        status: 'ko',
+        solution: { symbole: '@', 'premiere-partie': '2' },
+      });
+
+      // when
+      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+      const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
+      const qrocmForm = screen.getByRole('group');
+      const input = screen.getByLabelText('Réponse 1');
+
+      // answer input proposal
+      await fillIn(input, '#');
+      // answer select proposal
+      await clickByName('Réponse 2');
+      await screen.findByRole('listbox');
+      await click(
+        screen.queryByRole('option', {
+          name: "le fournisseur d'adresse mail",
+        }),
+      );
+
+      // submit
+      await click(verifyButton);
+
+      assert.dom(screen.getByRole('status')).exists();
+
+      // when
+      const retryButton = screen.getByRole('button', { name: 'Réessayer' });
+      await click(retryButton);
+
+      await screen.findByRole('listbox');
+
+      // then
+      assert.strictEqual(screen.queryByRole('status').innerText, '');
+      assert.false(qrocmForm.disabled);
+      assert.strictEqual(
+        screen
+          .queryByRole('option', {
+            name: "le fournisseur d'adresse mail",
+          })
+          .getAttribute('aria-selected'),
+        'false',
+      );
+      assert.strictEqual(input.value, '');
+
+      const qrocmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
+
+      // answer input proposal
+      await fillIn(input, '#');
+      // answer select proposal
+      await clickByName('Réponse 2');
+      await screen.findByRole('listbox');
+      await click(
+        screen.queryByRole('option', {
+          name: "le fournisseur d'adresse mail",
+        }),
+      );
+      await click(qrocmVerifyButtonCameBack);
+
+      assert.strictEqual(screen.queryByRole('status').innerText, 'Faux');
     });
 
-    server.create('module', {
-      id: 'bien-ecrire-son-adresse-mail',
-      title: 'Bien écrire son adresse mail',
-      grains: [grain],
+    test('after retrying a Qrocm, it display an error message if Qrocm is validated without response', async function (assert) {
+      // given
+      const qrocm1 = {
+        id: 'elementId-1',
+        type: 'qrocm',
+        instruction: 'instruction',
+        proposals: [
+          {
+            type: 'text',
+            content: '<p>Le symbole</>',
+          },
+          {
+            input: 'symbole',
+            type: 'input',
+            inputType: 'text',
+            size: 1,
+            display: 'block',
+            placeholder: '',
+            ariaLabel: 'Réponse 1',
+            defaultValue: '',
+          },
+          {
+            input: 'premiere-partie',
+            type: 'select',
+            display: 'block',
+            placeholder: '',
+            ariaLabel: 'Réponse 2',
+            defaultValue: '',
+            options: [
+              {
+                id: '1',
+                content: "l'identifiant",
+              },
+              {
+                id: '2',
+                content: "le fournisseur d'adresse mail",
+              },
+            ],
+          },
+        ],
+      };
+
+      const grain = server.create('grain', {
+        id: 'grainId',
+        title: 'title',
+        components: [
+          {
+            type: 'element',
+            element: qrocm1,
+          },
+        ],
+      });
+
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [grain],
+      });
+
+      server.create('correction-response', {
+        id: 'elementId-1',
+        feedback: 'Faux',
+        status: 'ko',
+        solution: { symbole: '@', 'premiere-partie': '2' },
+      });
+
+      // when
+      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+      const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
+      const input = screen.getByLabelText('Réponse 1');
+
+      // answer input proposal
+      await fillIn(input, '#');
+      // answer select proposal
+      await clickByName('Réponse 2');
+      await screen.findByRole('listbox');
+      await click(
+        screen.queryByRole('option', {
+          name: "le fournisseur d'adresse mail",
+        }),
+      );
+
+      // submit
+      await click(verifyButton);
+
+      assert.dom(screen.getByRole('status')).exists();
+
+      // when
+      const retryButton = screen.getByRole('button', { name: 'Réessayer' });
+      await click(retryButton);
+
+      // then
+      const qrocmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
+      await click(qrocmVerifyButtonCameBack);
+      const validationAlert = screen.queryAllByRole('alert')[1];
+
+      assert.strictEqual(validationAlert.innerText, 'Pour valider, veuillez remplir tous les champs réponse.');
     });
-
-    server.create('correction-response', {
-      id: 'elementId-1',
-      feedback: 'Faux',
-      status: 'ko',
-      solution: { symbole: '@', 'premiere-partie': '2' },
-    });
-
-    // when
-    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-    const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
-    const input = screen.getByLabelText('Réponse 1');
-
-    // answer input proposal
-    await fillIn(input, '#');
-    // answer select proposal
-    await clickByName('Réponse 2');
-    await screen.findByRole('listbox');
-    await click(
-      screen.queryByRole('option', {
-        name: "le fournisseur d'adresse mail",
-      }),
-    );
-
-    // submit
-    await click(verifyButton);
-
-    assert.dom(screen.getByRole('status')).exists();
-
-    // when
-    const retryButton = screen.getByRole('button', { name: 'Réessayer' });
-    await click(retryButton);
-
-    // then
-    const qrocmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
-    await click(qrocmVerifyButtonCameBack);
-    const validationAlert = screen.queryAllByRole('alert')[1];
-
-    assert.strictEqual(validationAlert.innerText, 'Pour valider, veuillez remplir tous les champs réponse.');
   });
 });

--- a/mon-pix/tests/acceptance/module/verify-qcm_test.js
+++ b/mon-pix/tests/acceptance/module/verify-qcm_test.js
@@ -8,76 +8,162 @@ module('Acceptance | Module | Routes | verifyQcm', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  test('can validate my QCM answer', async function (assert) {
-    // given
-    const qcm1 = {
-      id: 'elementId-1',
-      type: 'qcm',
-      instruction: 'instruction',
-      proposals: [
-        { id: '1', content: 'I am one of the wrong answers!' },
-        { id: '2', content: 'I am the first right answer!' },
-        { id: '3', content: 'I am the second right answer!' },
-        { id: '4', content: 'I am one of the wrong answers!' },
-      ],
-    };
-    const qcm2 = {
-      id: 'elementId-2',
-      type: 'qcm',
-      instruction: 'instruction',
-      proposals: [
-        { id: '1', content: 'I am one of the right answers!' },
-        { id: '2', content: 'I am the first wrong answer!' },
-        { id: '3', content: 'Click Me!' },
-        { id: '4', content: 'I am the second wrong answer!' },
-      ],
-    };
+  module('with elements', function () {
+    test('can validate my QCM answer', async function (assert) {
+      // given
+      const qcm1 = {
+        id: 'elementId-1',
+        type: 'qcm',
+        instruction: 'instruction',
+        proposals: [
+          { id: '1', content: 'I am one of the wrong answers!' },
+          { id: '2', content: 'I am the first right answer!' },
+          { id: '3', content: 'I am the second right answer!' },
+          { id: '4', content: 'I am one of the wrong answers!' },
+        ],
+      };
+      const qcm2 = {
+        id: 'elementId-2',
+        type: 'qcm',
+        instruction: 'instruction',
+        proposals: [
+          { id: '1', content: 'I am one of the right answers!' },
+          { id: '2', content: 'I am the first wrong answer!' },
+          { id: '3', content: 'Click Me!' },
+          { id: '4', content: 'I am the second wrong answer!' },
+        ],
+      };
 
-    const grain = server.create('grain', {
-      id: 'grainId',
-      title: 'title',
-      elements: [qcm1, qcm2],
+      const grain = server.create('grain', {
+        id: 'grainId',
+        title: 'title',
+        elements: [qcm1, qcm2],
+      });
+
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [grain],
+      });
+
+      server.create('correction-response', {
+        id: 'elementId-1',
+        feedback: "Bravo ! C'est la bonne réponse.",
+        status: 'ok',
+        solution: [qcm1.proposals[1].id, qcm1.proposals[2].id],
+      });
+
+      server.create('correction-response', {
+        id: 'elementId-2',
+        feedback: 'Pas ouf',
+        status: 'ko',
+        solution: [qcm2.proposals[0].id, qcm2.proposals[2].id],
+      });
+
+      // when
+      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+      const allVerifyButtons = screen.getAllByRole('button', { name: 'Vérifier' });
+      const [firstQcmVerifyButton, nextQcmVerifyButton] = allVerifyButtons;
+
+      // when
+      await click(screen.getByLabelText('I am the first right answer!'));
+      await click(screen.getByLabelText('I am the second right answer!'));
+      await click(firstQcmVerifyButton);
+
+      // then
+      assert.dom(screen.getByText("Bravo ! C'est la bonne réponse.")).exists();
+
+      // when
+      await click(screen.getByLabelText('I am the first wrong answer!'));
+      await click(screen.getByLabelText('Click Me!'));
+      await click(nextQcmVerifyButton);
+
+      // then
+      assert.dom(screen.getByText('Pas ouf')).exists();
     });
+  });
 
-    server.create('module', {
-      id: 'bien-ecrire-son-adresse-mail',
-      title: 'Bien écrire son adresse mail',
-      grains: [grain],
+  module('with components', function () {
+    test('can validate my QCM answer', async function (assert) {
+      // given
+      const qcm1 = {
+        id: 'elementId-1',
+        type: 'qcm',
+        instruction: 'instruction',
+        proposals: [
+          { id: '1', content: 'I am one of the wrong answers!' },
+          { id: '2', content: 'I am the first right answer!' },
+          { id: '3', content: 'I am the second right answer!' },
+          { id: '4', content: 'I am one of the wrong answers!' },
+        ],
+      };
+      const qcm2 = {
+        id: 'elementId-2',
+        type: 'qcm',
+        instruction: 'instruction',
+        proposals: [
+          { id: '1', content: 'I am one of the right answers!' },
+          { id: '2', content: 'I am the first wrong answer!' },
+          { id: '3', content: 'Click Me!' },
+          { id: '4', content: 'I am the second wrong answer!' },
+        ],
+      };
+
+      const grain = server.create('grain', {
+        id: 'grainId',
+        title: 'title',
+        components: [
+          {
+            type: 'element',
+            element: qcm1,
+          },
+          {
+            type: 'element',
+            element: qcm2,
+          },
+        ],
+      });
+
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [grain],
+      });
+
+      server.create('correction-response', {
+        id: 'elementId-1',
+        feedback: "Bravo ! C'est la bonne réponse.",
+        status: 'ok',
+        solution: [qcm1.proposals[1].id, qcm1.proposals[2].id],
+      });
+
+      server.create('correction-response', {
+        id: 'elementId-2',
+        feedback: 'Pas ouf',
+        status: 'ko',
+        solution: [qcm2.proposals[0].id, qcm2.proposals[2].id],
+      });
+
+      // when
+      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+      const allVerifyButtons = screen.getAllByRole('button', { name: 'Vérifier' });
+      const [firstQcmVerifyButton, nextQcmVerifyButton] = allVerifyButtons;
+
+      // when
+      await click(screen.getByLabelText('I am the first right answer!'));
+      await click(screen.getByLabelText('I am the second right answer!'));
+      await click(firstQcmVerifyButton);
+
+      // then
+      assert.dom(screen.getByText("Bravo ! C'est la bonne réponse.")).exists();
+
+      // when
+      await click(screen.getByLabelText('I am the first wrong answer!'));
+      await click(screen.getByLabelText('Click Me!'));
+      await click(nextQcmVerifyButton);
+
+      // then
+      assert.dom(screen.getByText('Pas ouf')).exists();
     });
-
-    server.create('correction-response', {
-      id: 'elementId-1',
-      feedback: "Bravo ! C'est la bonne réponse.",
-      status: 'ok',
-      solution: [qcm1.proposals[1].id, qcm1.proposals[2].id],
-    });
-
-    server.create('correction-response', {
-      id: 'elementId-2',
-      feedback: 'Pas ouf',
-      status: 'ko',
-      solution: [qcm2.proposals[0].id, qcm2.proposals[2].id],
-    });
-
-    // when
-    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-    const allVerifyButtons = screen.getAllByRole('button', { name: 'Vérifier' });
-    const [firstQcmVerifyButton, nextQcmVerifyButton] = allVerifyButtons;
-
-    // when
-    await click(screen.getByLabelText('I am the first right answer!'));
-    await click(screen.getByLabelText('I am the second right answer!'));
-    await click(firstQcmVerifyButton);
-
-    // then
-    assert.dom(screen.getByText("Bravo ! C'est la bonne réponse.")).exists();
-
-    // when
-    await click(screen.getByLabelText('I am the first wrong answer!'));
-    await click(screen.getByLabelText('Click Me!'));
-    await click(nextQcmVerifyButton);
-
-    // then
-    assert.dom(screen.getByText('Pas ouf')).exists();
   });
 });

--- a/mon-pix/tests/acceptance/module/verify-qcu_test.js
+++ b/mon-pix/tests/acceptance/module/verify-qcu_test.js
@@ -8,70 +8,149 @@ module('Acceptance | Module | Routes | verifyQcu', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  test('can validate my QCU answer', async function (assert) {
-    // given
-    const qcu1 = {
-      id: 'elementId-1',
-      type: 'qcu',
-      instruction: 'instruction',
-      proposals: [
-        { id: '1', content: 'I am the wrong answer!' },
-        { id: '2', content: 'I am the right answer!' },
-      ],
-    };
-    const qcu2 = {
-      id: 'elementId-2',
-      type: 'qcu',
-      instruction: 'instruction',
-      proposals: [
-        { id: '1', content: 'Vrai' },
-        { id: '2', content: 'Faux' },
-      ],
-    };
+  module('with elements', function () {
+    test('can validate my QCU answer', async function (assert) {
+      // given
+      const qcu1 = {
+        id: 'elementId-1',
+        type: 'qcu',
+        instruction: 'instruction',
+        proposals: [
+          { id: '1', content: 'I am the wrong answer!' },
+          { id: '2', content: 'I am the right answer!' },
+        ],
+      };
+      const qcu2 = {
+        id: 'elementId-2',
+        type: 'qcu',
+        instruction: 'instruction',
+        proposals: [
+          { id: '1', content: 'Vrai' },
+          { id: '2', content: 'Faux' },
+        ],
+      };
 
-    const grain = server.create('grain', {
-      id: 'grainId',
-      title: 'title',
-      elements: [qcu1, qcu2],
+      const grain = server.create('grain', {
+        id: 'grainId',
+        title: 'title',
+        elements: [qcu1, qcu2],
+      });
+
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [grain],
+      });
+
+      server.create('correction-response', {
+        id: 'elementId-1',
+        feedback: "Bravo ! C'est la bonne réponse.",
+        status: 'ok',
+        solution: qcu1.proposals[1].id,
+      });
+
+      server.create('correction-response', {
+        id: 'elementId-2',
+        feedback: 'Pas ouf',
+        status: 'ko',
+        solution: qcu2.proposals[0].id,
+      });
+
+      // when
+      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+      const allVerifyButtons = screen.getAllByRole('button', { name: 'Vérifier' });
+      const [firstQcuVerifyButton, nextQcuVerifyButton] = allVerifyButtons;
+
+      // when
+      await click(screen.getByLabelText('I am the right answer!'));
+      await click(firstQcuVerifyButton);
+
+      // then
+      assert.dom(screen.getByText("Bravo ! C'est la bonne réponse.")).exists();
+
+      // when
+      await click(screen.getByLabelText('Faux'));
+      await click(nextQcuVerifyButton);
+
+      // then
+      assert.dom(screen.getByText('Pas ouf')).exists();
     });
+  });
+  module('with components', function () {
+    test('can validate my QCU answer', async function (assert) {
+      // given
+      const qcu1 = {
+        id: 'elementId-1',
+        type: 'qcu',
+        instruction: 'instruction',
+        proposals: [
+          { id: '1', content: 'I am the wrong answer!' },
+          { id: '2', content: 'I am the right answer!' },
+        ],
+      };
+      const qcu2 = {
+        id: 'elementId-2',
+        type: 'qcu',
+        instruction: 'instruction',
+        proposals: [
+          { id: '1', content: 'Vrai' },
+          { id: '2', content: 'Faux' },
+        ],
+      };
 
-    server.create('module', {
-      id: 'bien-ecrire-son-adresse-mail',
-      title: 'Bien écrire son adresse mail',
-      grains: [grain],
+      const grain = server.create('grain', {
+        id: 'grainId',
+        title: 'title',
+        components: [
+          {
+            type: 'element',
+            element: qcu1,
+          },
+          {
+            type: 'element',
+            element: qcu2,
+          },
+        ],
+      });
+
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [grain],
+      });
+
+      server.create('correction-response', {
+        id: 'elementId-1',
+        feedback: "Bravo ! C'est la bonne réponse.",
+        status: 'ok',
+        solution: qcu1.proposals[1].id,
+      });
+
+      server.create('correction-response', {
+        id: 'elementId-2',
+        feedback: 'Pas ouf',
+        status: 'ko',
+        solution: qcu2.proposals[0].id,
+      });
+
+      // when
+      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+      const allVerifyButtons = screen.getAllByRole('button', { name: 'Vérifier' });
+      const [firstQcuVerifyButton, nextQcuVerifyButton] = allVerifyButtons;
+
+      // when
+      await click(screen.getByLabelText('I am the right answer!'));
+      await click(firstQcuVerifyButton);
+
+      // then
+      assert.dom(screen.getByText("Bravo ! C'est la bonne réponse.")).exists();
+
+      // when
+      await click(screen.getByLabelText('Faux'));
+      await click(nextQcuVerifyButton);
+
+      // then
+      assert.dom(screen.getByText('Pas ouf')).exists();
     });
-
-    server.create('correction-response', {
-      id: 'elementId-1',
-      feedback: "Bravo ! C'est la bonne réponse.",
-      status: 'ok',
-      solution: qcu1.proposals[1].id,
-    });
-
-    server.create('correction-response', {
-      id: 'elementId-2',
-      feedback: 'Pas ouf',
-      status: 'ko',
-      solution: qcu2.proposals[0].id,
-    });
-
-    // when
-    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-    const allVerifyButtons = screen.getAllByRole('button', { name: 'Vérifier' });
-    const [firstQcuVerifyButton, nextQcuVerifyButton] = allVerifyButtons;
-
-    // when
-    await click(screen.getByLabelText('I am the right answer!'));
-    await click(firstQcuVerifyButton);
-
-    // then
-    assert.dom(screen.getByText("Bravo ! C'est la bonne réponse.")).exists();
-
-    // when
-    await click(screen.getByLabelText('Faux'));
-    await click(nextQcuVerifyButton);
-
-    // then
-    assert.dom(screen.getByText('Pas ouf')).exists();
   });
 });

--- a/mon-pix/tests/acceptance/module/verify-qrocm_test.js
+++ b/mon-pix/tests/acceptance/module/verify-qrocm_test.js
@@ -8,87 +8,180 @@ module('Acceptance | Module | Routes | verifyQrocm', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  test('can validate my QROCM answer', async function (assert) {
-    // given
-    const qrocm1 = {
-      id: 'elementId-1',
-      type: 'qrocm',
-      instruction: 'instruction',
-      proposals: [
-        {
-          type: 'text',
-          content: '<p>Le symbole</>',
-        },
-        {
-          input: 'symbole',
-          type: 'input',
-          inputType: 'text',
-          size: 1,
-          display: 'block',
-          placeholder: '',
-          ariaLabel: 'Réponse 1',
-          defaultValue: '',
-        },
-        {
-          input: 'premiere-partie',
-          type: 'select',
-          display: 'block',
-          placeholder: '',
-          ariaLabel: 'Réponse 2',
-          defaultValue: '',
-          options: [
-            {
-              id: '1',
-              content: "l'identifiant",
-            },
-            {
-              id: '2',
-              content: "le fournisseur d'adresse mail",
-            },
-          ],
-        },
-      ],
-    };
+  module('with elements', function () {
+    test('can validate my QROCM answer', async function (assert) {
+      // given
+      const qrocm1 = {
+        id: 'elementId-1',
+        type: 'qrocm',
+        instruction: 'instruction',
+        proposals: [
+          {
+            type: 'text',
+            content: '<p>Le symbole</>',
+          },
+          {
+            input: 'symbole',
+            type: 'input',
+            inputType: 'text',
+            size: 1,
+            display: 'block',
+            placeholder: '',
+            ariaLabel: 'Réponse 1',
+            defaultValue: '',
+          },
+          {
+            input: 'premiere-partie',
+            type: 'select',
+            display: 'block',
+            placeholder: '',
+            ariaLabel: 'Réponse 2',
+            defaultValue: '',
+            options: [
+              {
+                id: '1',
+                content: "l'identifiant",
+              },
+              {
+                id: '2',
+                content: "le fournisseur d'adresse mail",
+              },
+            ],
+          },
+        ],
+      };
 
-    const grain = server.create('grain', {
-      id: 'grainId',
-      title: 'title',
-      elements: [qrocm1],
+      const grain = server.create('grain', {
+        id: 'grainId',
+        title: 'title',
+        elements: [qrocm1],
+      });
+
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [grain],
+      });
+
+      server.create('correction-response', {
+        id: 'elementId-1',
+        feedback: "Bravo ! C'est la bonne réponse.",
+        status: 'ok',
+        solution: { symbole: '@', 'premiere-partie': '2' },
+      });
+
+      // when
+      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+      const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
+
+      // answer input proposal
+      await fillIn(screen.getByLabelText('Réponse 1'), '@');
+      // answer select proposal
+      await clickByName('Réponse 2');
+      await screen.findByRole('listbox');
+      await click(
+        screen.queryByRole('option', {
+          name: "le fournisseur d'adresse mail",
+        }),
+      );
+      // submit
+      await click(verifyButton);
+
+      // then
+      assert.dom(screen.getByText("Bravo ! C'est la bonne réponse.")).exists();
+      assert.notOk(screen.queryByRole('button', { name: 'Vérifier' }));
     });
+  });
 
-    server.create('module', {
-      id: 'bien-ecrire-son-adresse-mail',
-      title: 'Bien écrire son adresse mail',
-      grains: [grain],
+  module('with components', function () {
+    test('can validate my QROCM answer', async function (assert) {
+      // given
+      const qrocm1 = {
+        id: 'elementId-1',
+        type: 'qrocm',
+        instruction: 'instruction',
+        proposals: [
+          {
+            type: 'text',
+            content: '<p>Le symbole</>',
+          },
+          {
+            input: 'symbole',
+            type: 'input',
+            inputType: 'text',
+            size: 1,
+            display: 'block',
+            placeholder: '',
+            ariaLabel: 'Réponse 1',
+            defaultValue: '',
+          },
+          {
+            input: 'premiere-partie',
+            type: 'select',
+            display: 'block',
+            placeholder: '',
+            ariaLabel: 'Réponse 2',
+            defaultValue: '',
+            options: [
+              {
+                id: '1',
+                content: "l'identifiant",
+              },
+              {
+                id: '2',
+                content: "le fournisseur d'adresse mail",
+              },
+            ],
+          },
+        ],
+      };
+
+      const grain = server.create('grain', {
+        id: 'grainId',
+        title: 'title',
+        components: [
+          {
+            type: 'element',
+            element: qrocm1,
+          },
+        ],
+      });
+
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [grain],
+      });
+
+      server.create('correction-response', {
+        id: 'elementId-1',
+        feedback: "Bravo ! C'est la bonne réponse.",
+        status: 'ok',
+        solution: { symbole: '@', 'premiere-partie': '2' },
+      });
+
+      // when
+      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+      const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
+
+      // answer input proposal
+      await fillIn(screen.getByLabelText('Réponse 1'), '@');
+      // answer select proposal
+      await clickByName('Réponse 2');
+      await screen.findByRole('listbox');
+      await click(
+        screen.queryByRole('option', {
+          name: "le fournisseur d'adresse mail",
+        }),
+      );
+      // submit
+      await click(verifyButton);
+
+      // then
+      assert.dom(screen.getByText("Bravo ! C'est la bonne réponse.")).exists();
+      assert.notOk(screen.queryByRole('button', { name: 'Vérifier' }));
     });
-
-    server.create('correction-response', {
-      id: 'elementId-1',
-      feedback: "Bravo ! C'est la bonne réponse.",
-      status: 'ok',
-      solution: { symbole: '@', 'premiere-partie': '2' },
-    });
-
-    // when
-    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-    const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
-
-    // answer input proposal
-    await fillIn(screen.getByLabelText('Réponse 1'), '@');
-    // answer select proposal
-    await clickByName('Réponse 2');
-    await screen.findByRole('listbox');
-    await click(
-      screen.queryByRole('option', {
-        name: "le fournisseur d'adresse mail",
-      }),
-    );
-    // submit
-    await click(verifyButton);
-
-    // then
-    assert.dom(screen.getByText("Bravo ! C'est la bonne réponse.")).exists();
-    assert.notOk(screen.queryByRole('button', { name: 'Vérifier' }));
   });
 });

--- a/mon-pix/tests/integration/components/module/grain_test.js
+++ b/mon-pix/tests/integration/components/module/grain_test.js
@@ -42,7 +42,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
     });
   });
 
-  module('when grain has not transition', function () {
+  module('when grain has no transition', function () {
     test('should not create header', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
@@ -88,163 +88,140 @@ module('Integration | Component | Module | Grain', function (hooks) {
     assert.dom(screen.getByText('leçon'));
   });
 
-  module('when element is a text', function () {
-    test('should display text element', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const textElement = {
-        content: 'element content',
-        type: 'text',
-        isAnswerable: false,
-      };
-      const grain = store.createRecord('grain', { title: 'Grain title', elements: [textElement] });
-      this.set('grain', grain);
+  module('with elements', function () {
+    module('when element is a text', function () {
+      test('should display text element', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const textElement = {
+          content: 'element content',
+          type: 'text',
+          isAnswerable: false,
+        };
+        const grain = store.createRecord('grain', { title: 'Grain title', elements: [textElement] });
+        this.set('grain', grain);
 
-      // when
-      const screen = await render(hbs`
-          <Module::Grain @grain={{this.grain}} />`);
+        // when
+        const screen = await render(hbs`
+            <Module::Grain @grain={{this.grain}} />`);
 
-      // then
-      assert.ok(screen.getByText('element content'));
-    });
-  });
-
-  module('when element is a qcu', function () {
-    test('should display qcu element', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const qcuElement = {
-        instruction: 'instruction',
-        proposals: ['radio1', 'radio2'],
-        type: 'qcu',
-        isAnswerable: true,
-      };
-      const grain = store.createRecord('grain', { title: 'Grain title', elements: [qcuElement] });
-      this.set('grain', grain);
-      const passage = store.createRecord('passage');
-      this.set('passage', passage);
-
-      // when
-      const screen = await render(hbs`
-          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} />`);
-
-      // then
-      assert.strictEqual(screen.getAllByRole('radio').length, qcuElement.proposals.length);
-    });
-  });
-
-  module('when element is a qrocm', function () {
-    test('should display qrocm element', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const qrocmElement = {
-        instruction: 'Mon instruction',
-        proposals: [
-          {
-            type: 'text',
-            content: '<p>Le symbole</>',
-          },
-          {
-            input: 'symbole',
-            type: 'input',
-            inputType: 'text',
-            size: 1,
-            display: 'inline',
-            placeholder: '',
-            ariaLabel: 'Réponse 1',
-            defaultValue: '',
-          },
-          {
-            input: 'premiere-partie',
-            type: 'select',
-            display: 'inline',
-            placeholder: '',
-            ariaLabel: 'Réponse 2',
-            defaultValue: '',
-            options: [
-              {
-                id: '1',
-                content: "l'identifiant",
-              },
-              {
-                id: '2',
-                content: "le fournisseur d'adresse mail",
-              },
-            ],
-          },
-        ],
-        type: 'qrocm',
-        isAnswerable: true,
-      };
-      const grain = store.createRecord('grain', { title: 'Grain title', elements: [qrocmElement] });
-      this.set('grain', grain);
-      const passage = store.createRecord('passage');
-      this.set('passage', passage);
-
-      // when
-      const screen = await render(hbs`
-          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} />`);
-
-      // then
-      assert.ok(screen);
-      assert.dom(screen.getByText('Mon instruction')).exists({ count: 1 });
-    });
-  });
-
-  module('when element is an image', function () {
-    test('should display image element', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const url =
-        'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg';
-      const imageElement = {
-        url,
-        alt: 'alt text',
-        alternativeText: 'alternative instruction',
-        type: 'image',
-      };
-      const grain = store.createRecord('grain', { title: 'Grain title', elements: [imageElement] });
-      this.set('grain', grain);
-
-      // when
-      const screen = await render(hbs`
-          <Module::Grain @grain={{this.grain}} />`);
-
-      // then
-      assert.ok(screen.getByRole('img', { name: 'alt text' }).hasAttribute('src', url));
-    });
-  });
-
-  module('when all elements are answered', function () {
-    test('should not display skip button', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const element = { type: 'qcu', isAnswerable: true };
-      const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
-      this.set('grain', grain);
-      const passage = store.createRecord('passage');
-      this.set('passage', passage);
-
-      const correction = store.createRecord('correction-response');
-      store.createRecord('element-answer', { element, correction, passage });
-
-      // when
-      const screen = await render(hbs`
-          <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
-
-      // then
-      assert
-        .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') }))
-        .doesNotExist();
+        // then
+        assert.ok(screen.getByText('element content'));
+      });
     });
 
-    module('when canMoveToNextGrain is true', function () {
-      test('should display continue button', async function (assert) {
+    module('when element is a qcu', function () {
+      test('should display qcu element', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const qcuElement = {
+          instruction: 'instruction',
+          proposals: ['radio1', 'radio2'],
+          type: 'qcu',
+          isAnswerable: true,
+        };
+        const grain = store.createRecord('grain', { title: 'Grain title', elements: [qcuElement] });
+        this.set('grain', grain);
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
+
+        // when
+        const screen = await render(hbs`
+            <Module::Grain @grain={{this.grain}} @passage={{this.passage}} />`);
+
+        // then
+        assert.strictEqual(screen.getAllByRole('radio').length, qcuElement.proposals.length);
+      });
+    });
+
+    module('when element is a qrocm', function () {
+      test('should display qrocm element', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const qrocmElement = {
+          instruction: 'Mon instruction',
+          proposals: [
+            {
+              type: 'text',
+              content: '<p>Le symbole</>',
+            },
+            {
+              input: 'symbole',
+              type: 'input',
+              inputType: 'text',
+              size: 1,
+              display: 'inline',
+              placeholder: '',
+              ariaLabel: 'Réponse 1',
+              defaultValue: '',
+            },
+            {
+              input: 'premiere-partie',
+              type: 'select',
+              display: 'inline',
+              placeholder: '',
+              ariaLabel: 'Réponse 2',
+              defaultValue: '',
+              options: [
+                {
+                  id: '1',
+                  content: "l'identifiant",
+                },
+                {
+                  id: '2',
+                  content: "le fournisseur d'adresse mail",
+                },
+              ],
+            },
+          ],
+          type: 'qrocm',
+          isAnswerable: true,
+        };
+        const grain = store.createRecord('grain', { title: 'Grain title', elements: [qrocmElement] });
+        this.set('grain', grain);
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
+
+        // when
+        const screen = await render(hbs`
+            <Module::Grain @grain={{this.grain}} @passage={{this.passage}} />`);
+
+        // then
+        assert.ok(screen);
+        assert.dom(screen.getByText('Mon instruction')).exists({ count: 1 });
+      });
+    });
+
+    module('when element is an image', function () {
+      test('should display image element', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const url =
+          'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg';
+        const imageElement = {
+          url,
+          alt: 'alt text',
+          alternativeText: 'alternative instruction',
+          type: 'image',
+        };
+        const grain = store.createRecord('grain', { title: 'Grain title', elements: [imageElement] });
+        this.set('grain', grain);
+
+        // when
+        const screen = await render(hbs`
+            <Module::Grain @grain={{this.grain}} />`);
+
+        // then
+        assert.ok(screen.getByRole('img', { name: 'alt text' }).hasAttribute('src', url));
+      });
+    });
+
+    module('when all elements are answered', function () {
+      test('should not display skip button', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
         const element = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', { title: '1st Grain title', elements: [element] });
-        store.createRecord('module', { grains: [grain] });
+        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
         this.set('grain', grain);
         const passage = store.createRecord('passage');
         this.set('passage', passage);
@@ -257,252 +234,739 @@ module('Integration | Component | Module | Grain', function (hooks) {
             <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
 
         // then
-        assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists();
+        assert
+          .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') }))
+          .doesNotExist();
+      });
+
+      module('when canMoveToNextGrain is true', function () {
+        test('should display continue button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const element = { type: 'qcu', isAnswerable: true };
+          const grain = store.createRecord('grain', { title: '1st Grain title', elements: [element] });
+          store.createRecord('module', { grains: [grain] });
+          this.set('grain', grain);
+          const passage = store.createRecord('passage');
+          this.set('passage', passage);
+
+          const correction = store.createRecord('correction-response');
+          store.createRecord('element-answer', { element, correction, passage });
+
+          // when
+          const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
+
+          // then
+          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists();
+        });
+      });
+      module('when canMoveToNextGrain is false', function () {
+        test('should not display continue button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const element = { type: 'qcu', isAnswerable: true };
+          const grain = store.createRecord('grain', { title: '1st Grain title', elements: [element] });
+          store.createRecord('module', { grains: [grain] });
+          this.set('grain', grain);
+          const passage = store.createRecord('passage');
+          this.set('passage', passage);
+
+          // when
+          const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
+
+          // then
+          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+        });
       });
     });
-    module('when canMoveToNextGrain is false', function () {
-      test('should not display continue button', async function (assert) {
+
+    module('when at least one element has not been answered', function () {
+      module('when canMoveToNextGrain is true', function () {
+        test('should not display continue button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const element = { type: 'qcu', isAnswerable: true };
+          const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+          this.set('grain', grain);
+          const passage = store.createRecord('passage');
+          this.set('passage', passage);
+
+          // when
+          const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
+
+          // then
+          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+        });
+
+        test('should display skip button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const element = { type: 'qcu', isAnswerable: true };
+          const grain = store.createRecord('grain', { title: '1st Grain title', elements: [element] });
+          store.createRecord('module', { grains: [grain] });
+          this.set('grain', grain);
+          const passage = store.createRecord('passage');
+          this.set('passage', passage);
+
+          // when
+          const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
+
+          // then
+          assert.dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') })).exists();
+        });
+      });
+
+      module('when canMoveToNextGrain is false', function () {
+        test('should not display continue button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const element = { type: 'qcu', isAnswerable: true };
+          const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+          this.set('grain', grain);
+          const passage = store.createRecord('passage');
+          this.set('passage', passage);
+
+          // when
+          const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
+
+          // then
+          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+        });
+
+        test('should not display skip button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const element = { type: 'qcu', isAnswerable: true };
+          const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+          store.createRecord('module', { grains: [grain] });
+          this.set('grain', grain);
+          const passage = store.createRecord('passage');
+          this.set('passage', passage);
+
+          // when
+          const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
+
+          // then
+          assert
+            .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') }))
+            .doesNotExist();
+        });
+      });
+    });
+
+    module('when continueAction is called', function () {
+      test('should call continueAction pass in argument', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = { type: 'text', isAnswerable: false };
+        const grain = store.createRecord('grain', { title: '1st Grain title', elements: [element] });
+        store.createRecord('module', { id: 'module-id', grains: [grain] });
+        this.set('grain', grain);
+
+        const stubContinueAction = sinon.stub();
+        this.set('continueAction', stubContinueAction);
+
+        // when
+        await render(
+          hbs`
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}}
+                             @continueAction={{this.continueAction}} />`,
+        );
+        await clickByName('Continuer');
+
+        // then
+        sinon.assert.calledOnce(stubContinueAction);
+        assert.ok(true);
+      });
+    });
+
+    module('when skipAction is called', function () {
+      test('should call skipAction pass in argument', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
         const element = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', { title: '1st Grain title', elements: [element] });
-        store.createRecord('module', { grains: [grain] });
+        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+        store.createRecord('module', { id: 'module-id', grains: [grain] });
         this.set('grain', grain);
         const passage = store.createRecord('passage');
         this.set('passage', passage);
 
+        const skipActionStub = sinon.stub();
+        this.set('skipAction', skipActionStub);
+
+        this.set('continueAction', () => {});
+
         // when
-        const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
+        await render(
+          hbs`
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}}
+                             @continueAction={{this.continueAction}} @skipAction={{this.skipAction}} @passage={{this.passage}} />`,
+        );
+        await clickByName(this.intl.t('pages.modulix.buttons.grain.skip'));
 
         // then
-        assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+        sinon.assert.calledOnce(skipActionStub);
+        assert.ok(true);
+      });
+    });
+
+    module('when shouldDisplayTerminateButton is true', function () {
+      test('should display the terminate button', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = { type: 'text', isAnswerable: false };
+        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+        this.set('grain', grain);
+
+        // when
+        const screen = await render(hbs`
+            <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{true}} />`);
+
+        // then
+        assert
+          .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.terminate') }))
+          .exists();
+      });
+
+      module('when terminateAction is called', function () {
+        test('should call terminateAction passed in argument', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const element = { type: 'qcu', isAnswerable: true };
+          const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+          this.set('grain', grain);
+          const passage = store.createRecord('passage');
+          this.set('passage', passage);
+
+          const terminateActionStub = sinon.stub();
+          this.set('terminateAction', terminateActionStub);
+
+          // when
+          await render(
+            hbs`
+              <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{true}}
+                             @terminateAction={{this.terminateAction}} @passage={{this.passage}} />`,
+          );
+          await clickByName(this.intl.t('pages.modulix.buttons.grain.terminate'));
+
+          // then
+          sinon.assert.calledOnce(terminateActionStub);
+          assert.ok(true);
+        });
+      });
+    });
+
+    module('when shouldDisplayTerminateButton is false', function () {
+      test('should not display the terminate button', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = { type: 'text', isAnswerable: false };
+        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+        this.set('grain', grain);
+
+        // when
+        const screen = await render(hbs`
+            <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{false}} />`);
+
+        // then
+        assert
+          .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.terminate') }))
+          .doesNotExist();
+      });
+    });
+
+    module('when retryElement is called', function () {
+      test('should call retryElement pass in argument', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = { type: 'qcu', isAnswerable: true };
+        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+        this.set('grain', grain);
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
+
+        const retryElementStub = sinon.stub().withArgs({ element });
+        this.set('retryElement', retryElementStub);
+
+        const correction = store.createRecord('correction-response', { status: 'ko' });
+        store.createRecord('element-answer', { element, correction, passage });
+
+        // when
+        await render(hbs`
+            <Module::Grain @grain={{this.grain}} @retryElement={{this.retryElement}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
+
+        await clickByName(this.intl.t('pages.modulix.buttons.activity.retry'));
+
+        // then
+        sinon.assert.calledOnce(retryElementStub);
+        assert.ok(true);
       });
     });
   });
 
-  module('when at least one element has not been answered', function () {
-    module('when canMoveToNextGrain is true', function () {
-      test('should not display continue button', async function (assert) {
+  module('with components', function () {
+    module('when element is a text', function () {
+      test('should display text element', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
-        const element = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+        const textElement = {
+          content: 'element content',
+          type: 'text',
+          isAnswerable: false,
+        };
+        const grain = store.createRecord('grain', {
+          title: 'Grain title',
+          components: [{ type: 'element', element: textElement }],
+        });
         this.set('grain', grain);
-        const passage = store.createRecord('passage');
-        this.set('passage', passage);
 
         // when
         const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
+            <Module::Grain @grain={{this.grain}} />`);
 
         // then
-        assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
-      });
-
-      test('should display skip button', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const element = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', { title: '1st Grain title', elements: [element] });
-        store.createRecord('module', { grains: [grain] });
-        this.set('grain', grain);
-        const passage = store.createRecord('passage');
-        this.set('passage', passage);
-
-        // when
-        const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
-
-        // then
-        assert.dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') })).exists();
+        assert.ok(screen.getByText('element content'));
       });
     });
 
-    module('when canMoveToNextGrain is false', function () {
-      test('should not display continue button', async function (assert) {
+    module('when element is a qcu', function () {
+      test('should display qcu element', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
-        const element = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+        const qcuElement = {
+          instruction: 'instruction',
+          proposals: ['radio1', 'radio2'],
+          type: 'qcu',
+          isAnswerable: true,
+        };
+        const grain = store.createRecord('grain', {
+          title: 'Grain title',
+          components: [{ type: 'element', element: qcuElement }],
+        });
         this.set('grain', grain);
         const passage = store.createRecord('passage');
         this.set('passage', passage);
 
         // when
         const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
+            <Module::Grain @grain={{this.grain}} @passage={{this.passage}} />`);
 
         // then
-        assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+        assert.strictEqual(screen.getAllByRole('radio').length, qcuElement.proposals.length);
       });
+    });
 
+    module('when element is a qrocm', function () {
+      test('should display qrocm element', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const qrocmElement = {
+          instruction: 'Mon instruction',
+          proposals: [
+            {
+              type: 'text',
+              content: '<p>Le symbole</>',
+            },
+            {
+              input: 'symbole',
+              type: 'input',
+              inputType: 'text',
+              size: 1,
+              display: 'inline',
+              placeholder: '',
+              ariaLabel: 'Réponse 1',
+              defaultValue: '',
+            },
+            {
+              input: 'premiere-partie',
+              type: 'select',
+              display: 'inline',
+              placeholder: '',
+              ariaLabel: 'Réponse 2',
+              defaultValue: '',
+              options: [
+                {
+                  id: '1',
+                  content: "l'identifiant",
+                },
+                {
+                  id: '2',
+                  content: "le fournisseur d'adresse mail",
+                },
+              ],
+            },
+          ],
+          type: 'qrocm',
+          isAnswerable: true,
+        };
+        const grain = store.createRecord('grain', {
+          title: 'Grain title',
+          components: [{ type: 'element', element: qrocmElement }],
+        });
+        this.set('grain', grain);
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
+
+        // when
+        const screen = await render(hbs`
+            <Module::Grain @grain={{this.grain}} @passage={{this.passage}} />`);
+
+        // then
+        assert.ok(screen);
+        assert.dom(screen.getByText('Mon instruction')).exists({ count: 1 });
+      });
+    });
+
+    module('when element is an image', function () {
+      test('should display image element', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const url =
+          'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg';
+        const imageElement = {
+          url,
+          alt: 'alt text',
+          alternativeText: 'alternative instruction',
+          type: 'image',
+        };
+        const grain = store.createRecord('grain', {
+          title: 'Grain title',
+          components: [{ type: 'element', element: imageElement }],
+        });
+        this.set('grain', grain);
+
+        // when
+        const screen = await render(hbs`
+            <Module::Grain @grain={{this.grain}} />`);
+
+        // then
+        assert.ok(screen.getByRole('img', { name: 'alt text' }).hasAttribute('src', url));
+      });
+    });
+
+    module('when all elements are answered', function () {
       test('should not display skip button', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
         const element = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
-        store.createRecord('module', { grains: [grain] });
+        const grain = store.createRecord('grain', {
+          title: 'Grain title',
+          components: [{ type: 'element', element }],
+        });
         this.set('grain', grain);
         const passage = store.createRecord('passage');
         this.set('passage', passage);
 
+        const correction = store.createRecord('correction-response');
+        store.createRecord('element-answer', { element, correction, passage });
+
         // when
         const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
+            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
 
         // then
         assert
           .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') }))
           .doesNotExist();
       });
-    });
-  });
 
-  module('when continueAction is called', function () {
-    test('should call continueAction pass in argument', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const element = { type: 'text', isAnswerable: false };
-      const grain = store.createRecord('grain', { title: '1st Grain title', elements: [element] });
-      store.createRecord('module', { id: 'module-id', grains: [grain] });
-      this.set('grain', grain);
+      module('when canMoveToNextGrain is true', function () {
+        test('should display continue button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const element = { type: 'qcu', isAnswerable: true };
+          const grain = store.createRecord('grain', {
+            title: '1st Grain title',
+            components: [{ type: 'element', element }],
+          });
+          store.createRecord('module', { grains: [grain] });
+          this.set('grain', grain);
+          const passage = store.createRecord('passage');
+          this.set('passage', passage);
 
-      const stubContinueAction = sinon.stub();
-      this.set('continueAction', stubContinueAction);
+          const correction = store.createRecord('correction-response');
+          store.createRecord('element-answer', { element, correction, passage });
 
-      // when
-      await render(
-        hbs`
-            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}}
-                           @continueAction={{this.continueAction}} />`,
-      );
-      await clickByName('Continuer');
+          // when
+          const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
 
-      // then
-      sinon.assert.calledOnce(stubContinueAction);
-      assert.ok(true);
-    });
-  });
+          // then
+          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists();
+        });
+      });
+      module('when canMoveToNextGrain is false', function () {
+        test('should not display continue button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const element = { type: 'qcu', isAnswerable: true };
+          const grain = store.createRecord('grain', {
+            title: '1st Grain title',
+            components: [{ type: 'element', element }],
+          });
+          store.createRecord('module', { grains: [grain] });
+          this.set('grain', grain);
+          const passage = store.createRecord('passage');
+          this.set('passage', passage);
 
-  module('when skipAction is called', function () {
-    test('should call skipAction pass in argument', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const element = { type: 'qcu', isAnswerable: true };
-      const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
-      store.createRecord('module', { id: 'module-id', grains: [grain] });
-      this.set('grain', grain);
-      const passage = store.createRecord('passage');
-      this.set('passage', passage);
+          // when
+          const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
 
-      const skipActionStub = sinon.stub();
-      this.set('skipAction', skipActionStub);
-
-      this.set('continueAction', () => {});
-
-      // when
-      await render(
-        hbs`
-            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}}
-                           @continueAction={{this.continueAction}} @skipAction={{this.skipAction}} @passage={{this.passage}} />`,
-      );
-      await clickByName(this.intl.t('pages.modulix.buttons.grain.skip'));
-
-      // then
-      sinon.assert.calledOnce(skipActionStub);
-      assert.ok(true);
-    });
-  });
-
-  module('when shouldDisplayTerminateButton is true', function () {
-    test('should display the terminate button', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const element = { type: 'text', isAnswerable: false };
-      const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
-      this.set('grain', grain);
-
-      // when
-      const screen = await render(hbs`
-          <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{true}} />`);
-
-      // then
-      assert.dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.terminate') })).exists();
+          // then
+          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+        });
+      });
     });
 
-    module('when terminateAction is called', function () {
-      test('should call terminateAction passed in argument', async function (assert) {
+    module('when at least one element has not been answered', function () {
+      module('when canMoveToNextGrain is true', function () {
+        test('should not display continue button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const element = { type: 'qcu', isAnswerable: true };
+          const grain = store.createRecord('grain', {
+            title: 'Grain title',
+            components: [{ type: 'element', element }],
+          });
+          this.set('grain', grain);
+          const passage = store.createRecord('passage');
+          this.set('passage', passage);
+
+          // when
+          const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
+
+          // then
+          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+        });
+
+        test('should display skip button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const element = { type: 'qcu', isAnswerable: true };
+          const grain = store.createRecord('grain', {
+            title: '1st Grain title',
+            components: [{ type: 'element', element }],
+          });
+          store.createRecord('module', { grains: [grain] });
+          this.set('grain', grain);
+          const passage = store.createRecord('passage');
+          this.set('passage', passage);
+
+          // when
+          const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
+
+          // then
+          assert.dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') })).exists();
+        });
+      });
+
+      module('when canMoveToNextGrain is false', function () {
+        test('should not display continue button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const element = { type: 'qcu', isAnswerable: true };
+          const grain = store.createRecord('grain', {
+            title: 'Grain title',
+            components: [{ type: 'element', element }],
+          });
+          this.set('grain', grain);
+          const passage = store.createRecord('passage');
+          this.set('passage', passage);
+
+          // when
+          const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
+
+          // then
+          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+        });
+
+        test('should not display skip button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const element = { type: 'qcu', isAnswerable: true };
+          const grain = store.createRecord('grain', {
+            title: 'Grain title',
+            components: [{ type: 'element', element }],
+          });
+          store.createRecord('module', { grains: [grain] });
+          this.set('grain', grain);
+          const passage = store.createRecord('passage');
+          this.set('passage', passage);
+
+          // when
+          const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
+
+          // then
+          assert
+            .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') }))
+            .doesNotExist();
+        });
+      });
+    });
+
+    module('when continueAction is called', function () {
+      test('should call continueAction pass in argument', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
-        const element = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+        const element = { type: 'text', isAnswerable: false };
+        const grain = store.createRecord('grain', {
+          title: '1st Grain title',
+          components: [{ type: 'element', element }],
+        });
+        store.createRecord('module', { id: 'module-id', grains: [grain] });
         this.set('grain', grain);
-        const passage = store.createRecord('passage');
-        this.set('passage', passage);
 
-        const terminateActionStub = sinon.stub();
-        this.set('terminateAction', terminateActionStub);
+        const stubContinueAction = sinon.stub();
+        this.set('continueAction', stubContinueAction);
 
         // when
         await render(
           hbs`
-            <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{true}}
-                           @terminateAction={{this.terminateAction}} @passage={{this.passage}} />`,
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}}
+                             @continueAction={{this.continueAction}} />`,
         );
-        await clickByName(this.intl.t('pages.modulix.buttons.grain.terminate'));
+        await clickByName('Continuer');
 
         // then
-        sinon.assert.calledOnce(terminateActionStub);
+        sinon.assert.calledOnce(stubContinueAction);
         assert.ok(true);
       });
     });
-  });
 
-  module('when shouldDisplayTerminateButton is false', function () {
-    test('should not display the terminate button', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const element = { type: 'text', isAnswerable: false };
-      const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
-      this.set('grain', grain);
+    module('when skipAction is called', function () {
+      test('should call skipAction pass in argument', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = { type: 'qcu', isAnswerable: true };
+        const grain = store.createRecord('grain', { title: 'Grain title', components: [{ type: 'element', element }] });
+        store.createRecord('module', { id: 'module-id', grains: [grain] });
+        this.set('grain', grain);
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
 
-      // when
-      const screen = await render(hbs`
-          <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{false}} />`);
+        const skipActionStub = sinon.stub();
+        this.set('skipAction', skipActionStub);
 
-      // then
-      assert
-        .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.terminate') }))
-        .doesNotExist();
+        this.set('continueAction', () => {});
+
+        // when
+        await render(
+          hbs`
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}}
+                             @continueAction={{this.continueAction}} @skipAction={{this.skipAction}} @passage={{this.passage}} />`,
+        );
+        await clickByName(this.intl.t('pages.modulix.buttons.grain.skip'));
+
+        // then
+        sinon.assert.calledOnce(skipActionStub);
+        assert.ok(true);
+      });
     });
-  });
 
-  module('when retryElement is called', function () {
-    test('should call retryElement pass in argument', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const element = { type: 'qcu', isAnswerable: true };
-      const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
-      this.set('grain', grain);
-      const passage = store.createRecord('passage');
-      this.set('passage', passage);
+    module('when shouldDisplayTerminateButton is true', function () {
+      test('should display the terminate button', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = { type: 'text', isAnswerable: false };
+        const grain = store.createRecord('grain', { title: 'Grain title', components: [{ type: 'element', element }] });
+        this.set('grain', grain);
 
-      const retryElementStub = sinon.stub().withArgs({ element });
-      this.set('retryElement', retryElementStub);
+        // when
+        const screen = await render(hbs`
+            <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{true}} />`);
 
-      const correction = store.createRecord('correction-response', { status: 'ko' });
-      store.createRecord('element-answer', { element, correction, passage });
+        // then
+        assert
+          .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.terminate') }))
+          .exists();
+      });
 
-      // when
-      await render(hbs`
-          <Module::Grain @grain={{this.grain}} @retryElement={{this.retryElement}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
+      module('when terminateAction is called', function () {
+        test('should call terminateAction passed in argument', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const element = { type: 'qcu', isAnswerable: true };
+          const grain = store.createRecord('grain', {
+            title: 'Grain title',
+            components: [{ type: 'element', element }],
+          });
+          this.set('grain', grain);
+          const passage = store.createRecord('passage');
+          this.set('passage', passage);
 
-      await clickByName(this.intl.t('pages.modulix.buttons.activity.retry'));
+          const terminateActionStub = sinon.stub();
+          this.set('terminateAction', terminateActionStub);
 
-      // then
-      sinon.assert.calledOnce(retryElementStub);
-      assert.ok(true);
+          // when
+          await render(
+            hbs`
+              <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{true}}
+                             @terminateAction={{this.terminateAction}} @passage={{this.passage}} />`,
+          );
+          await clickByName(this.intl.t('pages.modulix.buttons.grain.terminate'));
+
+          // then
+          sinon.assert.calledOnce(terminateActionStub);
+          assert.ok(true);
+        });
+      });
+    });
+
+    module('when shouldDisplayTerminateButton is false', function () {
+      test('should not display the terminate button', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = { type: 'text', isAnswerable: false };
+        const grain = store.createRecord('grain', { title: 'Grain title', components: [{ type: 'element', element }] });
+        this.set('grain', grain);
+
+        // when
+        const screen = await render(hbs`
+            <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{false}} />`);
+
+        // then
+        assert
+          .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.terminate') }))
+          .doesNotExist();
+      });
+    });
+
+    module('when retryElement is called', function () {
+      test('should call retryElement pass in argument', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = { type: 'qcu', isAnswerable: true };
+        const grain = store.createRecord('grain', { title: 'Grain title', components: [{ type: 'element', element }] });
+        this.set('grain', grain);
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
+
+        const retryElementStub = sinon.stub().withArgs({ element });
+        this.set('retryElement', retryElementStub);
+
+        const correction = store.createRecord('correction-response', { status: 'ko' });
+        store.createRecord('element-answer', { element, correction, passage });
+
+        // when
+        await render(hbs`
+            <Module::Grain @grain={{this.grain}} @retryElement={{this.retryElement}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
+        await clickByName(this.intl.t('pages.modulix.buttons.activity.retry'));
+
+        // then
+        sinon.assert.calledOnce(retryElementStub);
+        assert.ok(true);
+      });
     });
   });
 });

--- a/mon-pix/tests/integration/components/module/passage_test.js
+++ b/mon-pix/tests/integration/components/module/passage_test.js
@@ -9,24 +9,6 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | Module | Passage', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('should display a banner at the top of the screen for a passage', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const textElement = { content: 'content', type: 'text' };
-    const grain = store.createRecord('grain', { id: 'grainId1', elements: [textElement] });
-    const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
-    this.set('module', module);
-
-    const passage = store.createRecord('passage');
-    this.set('passage', passage);
-
-    // when
-    const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
-
-    // then
-    assert.dom(screen.getByRole('alert')).exists();
-  });
-
   test('should display given module with one grain', async function (assert) {
     // given
     const store = this.owner.lookup('service:store');
@@ -56,211 +38,6 @@ module('Integration | Component | Module | Passage', function (hooks) {
     assert.strictEqual(findAll('.element-qcu').length, 1);
 
     assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
-  });
-
-  test('should display given module with more than one grain', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const textElement = { content: 'content', type: 'text' };
-    const qcuElement = {
-      instruction: 'instruction',
-      proposals: ['radio1', 'radio2'],
-      type: 'qcu',
-    };
-    const grain1 = store.createRecord('grain', { elements: [textElement] });
-    const grain2 = store.createRecord('grain', { elements: [qcuElement] });
-
-    const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
-    this.set('module', module);
-
-    const passage = store.createRecord('passage');
-    this.set('passage', passage);
-
-    // when
-    const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
-
-    // then
-    assert.ok(screen.getByRole('heading', { name: module.title, level: 1 }));
-    assert.strictEqual(findAll('.element-text').length, 1);
-    assert.strictEqual(findAll('.element-qcu').length, 0);
-
-    assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists({ count: 1 });
-  });
-
-  module('when user click on skip button', function () {
-    test('should display next grain', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const textElement = { content: 'content', type: 'text' };
-      const qcuElement = {
-        instruction: 'instruction',
-        proposals: ['radio1', 'radio2'],
-        type: 'qcu',
-        isAnswerable: true,
-      };
-      const grain1 = store.createRecord('grain', { elements: [qcuElement] });
-      const grain2 = store.createRecord('grain', { elements: [textElement] });
-
-      const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
-      this.set('module', module);
-
-      const passage = store.createRecord('passage');
-      this.set('passage', passage);
-
-      await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
-
-      assert.strictEqual(findAll('.element-text').length, 0);
-
-      // when
-      await clickByName(this.intl.t('pages.modulix.buttons.grain.skip'));
-
-      // then
-      assert.strictEqual(findAll('.element-text').length, 1);
-    });
-
-    test('should push event', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const textElement = { content: 'content', type: 'text' };
-      const qcuElement = {
-        instruction: 'instruction',
-        proposals: ['radio1', 'radio2'],
-        type: 'qcu',
-        isAnswerable: true,
-      };
-      const grain1 = store.createRecord('grain', { elements: [qcuElement] });
-      const grain2 = store.createRecord('grain', { elements: [textElement] });
-
-      const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
-      this.set('module', module);
-
-      const passage = store.createRecord('passage');
-      this.set('passage', passage);
-
-      await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
-
-      const metrics = this.owner.lookup('service:metrics');
-      metrics.add = sinon.stub();
-
-      // when
-      await clickByName(this.intl.t('pages.modulix.buttons.grain.skip'));
-
-      // then
-      sinon.assert.calledWithExactly(metrics.add, {
-        event: 'custom-event',
-        'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.id}`,
-        'pix-event-name': `Click sur le bouton passer du grain : ${grain1.id}`,
-      });
-      assert.ok(true);
-    });
-  });
-
-  module('when user click on continue button', function (hooks) {
-    let continueButtonName;
-    hooks.beforeEach(function () {
-      continueButtonName = this.intl.t('pages.modulix.buttons.grain.continue');
-    });
-
-    test('should display next grain', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const text1Element = { content: 'content', type: 'text' };
-      const text2Element = { content: 'content 2', type: 'text' };
-      const grain1 = store.createRecord('grain', { elements: [text1Element] });
-      const grain2 = store.createRecord('grain', { elements: [text2Element] });
-
-      const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
-      this.set('module', module);
-
-      const passage = store.createRecord('passage');
-      this.set('passage', passage);
-
-      const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
-
-      const grainsBeforeAnyAction = screen.getAllByRole('article');
-      assert.strictEqual(grainsBeforeAnyAction.length, 1);
-
-      // when
-      await clickByName(continueButtonName);
-
-      // then
-      const grainsAfterContinueAction = screen.getAllByRole('article');
-      assert.strictEqual(grainsAfterContinueAction.length, 2);
-    });
-
-    test('should give focus on the last grain when appearing', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const text1Element = { content: 'content', type: 'text' };
-      const text2Element = { content: 'content 2', type: 'text' };
-      const text3Element = { content: 'content 3', type: 'text' };
-      const grain1 = store.createRecord('grain', { elements: [text1Element] });
-      const grain2 = store.createRecord('grain', { elements: [text2Element] });
-      const grain3 = store.createRecord('grain', { elements: [text3Element] });
-
-      const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2, grain3] });
-      this.set('module', module);
-
-      const passage = store.createRecord('passage');
-      this.set('passage', passage);
-
-      const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
-
-      const grainsBeforeAnyAction = screen.getAllByRole('article');
-      assert.strictEqual(grainsBeforeAnyAction.length, 1);
-      assert.strictEqual(document.activeElement, document.body);
-
-      // when
-      await clickByName(continueButtonName);
-
-      // then
-      const grainsAfterOneContinueActions = screen.getAllByRole('article');
-      assert.strictEqual(grainsAfterOneContinueActions.length, 2);
-      const secondGrain = grainsAfterOneContinueActions.at(-1);
-      assert.strictEqual(document.activeElement, secondGrain);
-
-      // when
-      await clickByName(continueButtonName);
-
-      // then
-      const grainsAfterTwoContinueActions = screen.getAllByRole('article');
-      assert.strictEqual(grainsAfterTwoContinueActions.length, 3);
-      const thirdGrain = grainsAfterTwoContinueActions.at(-1);
-      assert.strictEqual(document.activeElement, thirdGrain);
-    });
-
-    test('should push event', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const text1Element = { content: 'content', type: 'text' };
-      const text2Element = { content: 'content 2', type: 'text' };
-      const grain1 = store.createRecord('grain', { elements: [text1Element] });
-      const grain2 = store.createRecord('grain', { elements: [text2Element] });
-
-      const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
-      this.set('module', module);
-
-      const passage = store.createRecord('passage');
-      this.set('passage', passage);
-
-      await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
-
-      const metrics = this.owner.lookup('service:metrics');
-      metrics.add = sinon.stub();
-
-      // when
-      await clickByName(continueButtonName);
-
-      // then
-      sinon.assert.calledWithExactly(metrics.add, {
-        event: 'custom-event',
-        'pix-event-category': 'Modulix',
-        'pix-event-action': `Passage du module : ${module.id}`,
-        'pix-event-name': `Click sur le bouton continuer du grain : ${grain1.id}`,
-      });
-      assert.ok(true);
-    });
   });
 
   module('When a grain contains non existing elements', function () {
@@ -308,6 +85,459 @@ module('Integration | Component | Module | Passage', function (hooks) {
       // then
       assert.ok(screen.queryByRole('heading', { name: 'existing element content', level: 3 }));
       assert.dom('.grain-card-content__element').exists({ count: 1 });
+    });
+  });
+
+  module('with elements', function () {
+    test('should display a banner at the top of the screen for a passage', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const textElement = { content: 'content', type: 'text' };
+      const grain = store.createRecord('grain', { id: 'grainId1', elements: [textElement] });
+      const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
+      this.set('module', module);
+
+      const passage = store.createRecord('passage');
+      this.set('passage', passage);
+
+      // when
+      const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
+
+      // then
+      assert.dom(screen.getByRole('alert')).exists();
+    });
+
+    test('should display given module with more than one grain', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const textElement = { content: 'content', type: 'text' };
+      const qcuElement = {
+        instruction: 'instruction',
+        proposals: ['radio1', 'radio2'],
+        type: 'qcu',
+      };
+      const grain1 = store.createRecord('grain', { elements: [textElement] });
+      const grain2 = store.createRecord('grain', { elements: [qcuElement] });
+
+      const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+      this.set('module', module);
+
+      const passage = store.createRecord('passage');
+      this.set('passage', passage);
+
+      // when
+      const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
+
+      // then
+      assert.ok(screen.getByRole('heading', { name: module.title, level: 1 }));
+      assert.strictEqual(findAll('.element-text').length, 1);
+      assert.strictEqual(findAll('.element-qcu').length, 0);
+
+      assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists({ count: 1 });
+    });
+
+    module('when user click on skip button', function () {
+      test('should display next grain', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const textElement = { content: 'content', type: 'text' };
+        const qcuElement = {
+          instruction: 'instruction',
+          proposals: ['radio1', 'radio2'],
+          type: 'qcu',
+          isAnswerable: true,
+        };
+        const grain1 = store.createRecord('grain', { elements: [qcuElement] });
+        const grain2 = store.createRecord('grain', { elements: [textElement] });
+
+        const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+        this.set('module', module);
+
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
+
+        await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
+
+        assert.strictEqual(findAll('.element-text').length, 0);
+
+        // when
+        await clickByName(this.intl.t('pages.modulix.buttons.grain.skip'));
+
+        // then
+        assert.strictEqual(findAll('.element-text').length, 1);
+      });
+
+      test('should push event', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const textElement = { content: 'content', type: 'text' };
+        const qcuElement = {
+          instruction: 'instruction',
+          proposals: ['radio1', 'radio2'],
+          type: 'qcu',
+          isAnswerable: true,
+        };
+        const grain1 = store.createRecord('grain', { elements: [qcuElement] });
+        const grain2 = store.createRecord('grain', { elements: [textElement] });
+
+        const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+        this.set('module', module);
+
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
+
+        await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
+
+        const metrics = this.owner.lookup('service:metrics');
+        metrics.add = sinon.stub();
+
+        // when
+        await clickByName(this.intl.t('pages.modulix.buttons.grain.skip'));
+
+        // then
+        sinon.assert.calledWithExactly(metrics.add, {
+          event: 'custom-event',
+          'pix-event-category': 'Modulix',
+          'pix-event-action': `Passage du module : ${module.id}`,
+          'pix-event-name': `Click sur le bouton passer du grain : ${grain1.id}`,
+        });
+        assert.ok(true);
+      });
+    });
+
+    module('when user click on continue button', function (hooks) {
+      let continueButtonName;
+      hooks.beforeEach(function () {
+        continueButtonName = this.intl.t('pages.modulix.buttons.grain.continue');
+      });
+
+      test('should display next grain', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const text1Element = { content: 'content', type: 'text' };
+        const text2Element = { content: 'content 2', type: 'text' };
+        const grain1 = store.createRecord('grain', { elements: [text1Element] });
+        const grain2 = store.createRecord('grain', { elements: [text2Element] });
+
+        const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+        this.set('module', module);
+
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
+
+        const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
+
+        const grainsBeforeAnyAction = screen.getAllByRole('article');
+        assert.strictEqual(grainsBeforeAnyAction.length, 1);
+
+        // when
+        await clickByName(continueButtonName);
+
+        // then
+        const grainsAfterContinueAction = screen.getAllByRole('article');
+        assert.strictEqual(grainsAfterContinueAction.length, 2);
+      });
+
+      test('should give focus on the last grain when appearing', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const text1Element = { content: 'content', type: 'text' };
+        const text2Element = { content: 'content 2', type: 'text' };
+        const text3Element = { content: 'content 3', type: 'text' };
+        const grain1 = store.createRecord('grain', { elements: [text1Element] });
+        const grain2 = store.createRecord('grain', { elements: [text2Element] });
+        const grain3 = store.createRecord('grain', { elements: [text3Element] });
+
+        const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2, grain3] });
+        this.set('module', module);
+
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
+
+        const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
+
+        const grainsBeforeAnyAction = screen.getAllByRole('article');
+        assert.strictEqual(grainsBeforeAnyAction.length, 1);
+        assert.strictEqual(document.activeElement, document.body);
+
+        // when
+        await clickByName(continueButtonName);
+
+        // then
+        const grainsAfterOneContinueActions = screen.getAllByRole('article');
+        assert.strictEqual(grainsAfterOneContinueActions.length, 2);
+        const secondGrain = grainsAfterOneContinueActions.at(-1);
+        assert.strictEqual(document.activeElement, secondGrain);
+
+        // when
+        await clickByName(continueButtonName);
+
+        // then
+        const grainsAfterTwoContinueActions = screen.getAllByRole('article');
+        assert.strictEqual(grainsAfterTwoContinueActions.length, 3);
+        const thirdGrain = grainsAfterTwoContinueActions.at(-1);
+        assert.strictEqual(document.activeElement, thirdGrain);
+      });
+
+      test('should push event', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const text1Element = { content: 'content', type: 'text' };
+        const text2Element = { content: 'content 2', type: 'text' };
+        const grain1 = store.createRecord('grain', { elements: [text1Element] });
+        const grain2 = store.createRecord('grain', { elements: [text2Element] });
+
+        const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+        this.set('module', module);
+
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
+
+        await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
+
+        const metrics = this.owner.lookup('service:metrics');
+        metrics.add = sinon.stub();
+
+        // when
+        await clickByName(continueButtonName);
+
+        // then
+        sinon.assert.calledWithExactly(metrics.add, {
+          event: 'custom-event',
+          'pix-event-category': 'Modulix',
+          'pix-event-action': `Passage du module : ${module.id}`,
+          'pix-event-name': `Click sur le bouton continuer du grain : ${grain1.id}`,
+        });
+        assert.ok(true);
+      });
+    });
+  });
+
+  module('with components', function () {
+    test('should display a banner at the top of the screen for a passage', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const textElement = { content: 'content', type: 'text' };
+      const grain = store.createRecord('grain', {
+        id: 'grainId1',
+        components: [{ type: 'element', element: textElement }],
+      });
+      const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
+      this.set('module', module);
+
+      const passage = store.createRecord('passage');
+      this.set('passage', passage);
+
+      // when
+      const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
+
+      // then
+      assert.dom(screen.getByRole('alert')).exists();
+    });
+
+    test('should display given module with more than one grain', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const textElement = { content: 'content', type: 'text' };
+      const qcuElement = {
+        instruction: 'instruction',
+        proposals: ['radio1', 'radio2'],
+        type: 'qcu',
+      };
+      const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: textElement }] });
+      const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: qcuElement }] });
+
+      const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+      this.set('module', module);
+
+      const passage = store.createRecord('passage');
+      this.set('passage', passage);
+
+      // when
+      const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
+
+      // then
+      assert.ok(screen.getByRole('heading', { name: module.title, level: 1 }));
+      assert.strictEqual(findAll('.element-text').length, 1);
+      assert.strictEqual(findAll('.element-qcu').length, 0);
+
+      assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists({ count: 1 });
+    });
+
+    module('when user click on skip button', function () {
+      test('should display next grain', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const textElement = { content: 'content', type: 'text' };
+        const qcuElement = {
+          instruction: 'instruction',
+          proposals: ['radio1', 'radio2'],
+          type: 'qcu',
+          isAnswerable: true,
+        };
+        const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: qcuElement }] });
+        const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: textElement }] });
+
+        const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+        this.set('module', module);
+
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
+
+        await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
+
+        assert.strictEqual(findAll('.element-text').length, 0);
+
+        // when
+        await clickByName(this.intl.t('pages.modulix.buttons.grain.skip'));
+
+        // then
+        assert.strictEqual(findAll('.element-text').length, 1);
+      });
+
+      test('should push event', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const textElement = { content: 'content', type: 'text' };
+        const qcuElement = {
+          instruction: 'instruction',
+          proposals: ['radio1', 'radio2'],
+          type: 'qcu',
+          isAnswerable: true,
+        };
+        const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: qcuElement }] });
+        const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: textElement }] });
+
+        const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+        this.set('module', module);
+
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
+
+        await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
+
+        const metrics = this.owner.lookup('service:metrics');
+        metrics.add = sinon.stub();
+
+        // when
+        await clickByName(this.intl.t('pages.modulix.buttons.grain.skip'));
+
+        // then
+        sinon.assert.calledWithExactly(metrics.add, {
+          event: 'custom-event',
+          'pix-event-category': 'Modulix',
+          'pix-event-action': `Passage du module : ${module.id}`,
+          'pix-event-name': `Click sur le bouton passer du grain : ${grain1.id}`,
+        });
+        assert.ok(true);
+      });
+    });
+
+    module('when user click on continue button', function (hooks) {
+      let continueButtonName;
+      hooks.beforeEach(function () {
+        continueButtonName = this.intl.t('pages.modulix.buttons.grain.continue');
+      });
+
+      test('should display next grain', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const text1Element = { content: 'content', type: 'text' };
+        const text2Element = { content: 'content 2', type: 'text' };
+        const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: text1Element }] });
+        const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: text2Element }] });
+
+        const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+        this.set('module', module);
+
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
+
+        const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
+
+        const grainsBeforeAnyAction = screen.getAllByRole('article');
+        assert.strictEqual(grainsBeforeAnyAction.length, 1);
+
+        // when
+        await clickByName(continueButtonName);
+
+        // then
+        const grainsAfterContinueAction = screen.getAllByRole('article');
+        assert.strictEqual(grainsAfterContinueAction.length, 2);
+      });
+
+      test('should give focus on the last grain when appearing', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const text1Element = { content: 'content', type: 'text' };
+        const text2Element = { content: 'content 2', type: 'text' };
+        const text3Element = { content: 'content 3', type: 'text' };
+        const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: text1Element }] });
+        const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: text2Element }] });
+        const grain3 = store.createRecord('grain', { components: [{ type: 'element', element: text3Element }] });
+
+        const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2, grain3] });
+        this.set('module', module);
+
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
+
+        const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
+
+        const grainsBeforeAnyAction = screen.getAllByRole('article');
+        assert.strictEqual(grainsBeforeAnyAction.length, 1);
+        assert.strictEqual(document.activeElement, document.body);
+
+        // when
+        await clickByName(continueButtonName);
+
+        // then
+        const grainsAfterOneContinueActions = screen.getAllByRole('article');
+        assert.strictEqual(grainsAfterOneContinueActions.length, 2);
+        const secondGrain = grainsAfterOneContinueActions.at(-1);
+        assert.strictEqual(document.activeElement, secondGrain);
+
+        // when
+        await clickByName(continueButtonName);
+
+        // then
+        const grainsAfterTwoContinueActions = screen.getAllByRole('article');
+        assert.strictEqual(grainsAfterTwoContinueActions.length, 3);
+        const thirdGrain = grainsAfterTwoContinueActions.at(-1);
+        assert.strictEqual(document.activeElement, thirdGrain);
+      });
+
+      test('should push event', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const text1Element = { content: 'content', type: 'text' };
+        const text2Element = { content: 'content 2', type: 'text' };
+        const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: text1Element }] });
+        const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: text2Element }] });
+
+        const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+        this.set('module', module);
+
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
+
+        await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
+
+        const metrics = this.owner.lookup('service:metrics');
+        metrics.add = sinon.stub();
+
+        // when
+        await clickByName(continueButtonName);
+
+        // then
+        sinon.assert.calledWithExactly(metrics.add, {
+          event: 'custom-event',
+          'pix-event-category': 'Modulix',
+          'pix-event-action': `Passage du module : ${module.id}`,
+          'pix-event-name': `Click sur le bouton continuer du grain : ${grain1.id}`,
+        });
+        assert.ok(true);
+      });
     });
   });
 });

--- a/mon-pix/tests/integration/components/module/qcm_test.js
+++ b/mon-pix/tests/integration/components/module/qcm_test.js
@@ -72,97 +72,6 @@ module('Integration | Component | Module | QCM', function (hooks) {
     assert.ok(true);
   });
 
-  test('should display an ok feedback when exists', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-
-    const correctionResponse = store.createRecord('correction-response', {
-      feedback: 'Good job!',
-      status: 'ok',
-      solution: ['1', '4'],
-    });
-
-    prepareContextRecords.call(this, store, correctionResponse);
-    this.set('submitAnswer', () => {});
-
-    // when
-    const screen = await render(
-      hbs`<Module::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
-    );
-
-    // then
-    const status = screen.getByRole('status');
-    assert.strictEqual(status.innerText, 'Good job!');
-    assert.ok(screen.getByRole('group').disabled);
-    assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
-  });
-
-  test('should display a ko feedback when exists', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const correctionResponse = store.createRecord('correction-response', {
-      feedback: 'Too Bad!',
-      status: 'ko',
-      solution: ['1', '4'],
-    });
-
-    prepareContextRecords.call(this, store, correctionResponse);
-    this.set('submitAnswer', () => {});
-
-    // when
-    const screen = await render(
-      hbs`<Module::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
-    );
-
-    // then
-    const status = screen.getByRole('status');
-    assert.strictEqual(status.innerText, 'Too Bad!');
-    assert.ok(screen.getByRole('group').disabled);
-    assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
-  });
-
-  test('should display retry button when a ko feedback appears', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const correctionResponse = store.createRecord('correction-response', {
-      feedback: 'Too Bad!',
-      status: 'ko',
-      solution: 'solution',
-    });
-
-    prepareContextRecords.call(this, store, correctionResponse);
-    this.set('submitAnswer', () => {});
-
-    // when
-    const screen = await render(
-      hbs`<Module::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
-    );
-
-    // then
-    assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).exists();
-  });
-
-  test('should not display retry button when an ok feedback appears', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const correctionResponse = store.createRecord('correction-response', {
-      feedback: 'Nice!',
-      status: 'ok',
-      solution: 'solution',
-    });
-
-    prepareContextRecords.call(this, store, correctionResponse);
-    this.set('submitAnswer', () => {});
-
-    // when
-    const screen = await render(
-      hbs`<Module::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
-    );
-
-    // then
-    assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).doesNotExist();
-  });
-
   test('should display an error message if QCM is validated with less than two responses', async function (assert) {
     // given
     const qcmElement = {
@@ -214,7 +123,217 @@ module('Integration | Component | Module | QCM', function (hooks) {
     // then
     assert.dom(screen.queryByRole('alert', { name: 'Pour valider, sélectionnez une réponse.' })).doesNotExist();
   });
+
+  module('with elements', function () {
+    test('should display an ok feedback when exists', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const correctionResponse = store.createRecord('correction-response', {
+        feedback: 'Good job!',
+        status: 'ok',
+        solution: ['1', '4'],
+      });
+
+      prepareDeprecatedContextRecords.call(this, store, correctionResponse);
+      this.set('submitAnswer', () => {});
+
+      // when
+      const screen = await render(
+        hbs`<Module::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
+      );
+
+      // then
+      const status = screen.getByRole('status');
+      assert.strictEqual(status.innerText, 'Good job!');
+      assert.ok(screen.getByRole('group').disabled);
+      assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+    });
+
+    test('should display a ko feedback when exists', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const correctionResponse = store.createRecord('correction-response', {
+        feedback: 'Too Bad!',
+        status: 'ko',
+        solution: ['1', '4'],
+      });
+
+      prepareDeprecatedContextRecords.call(this, store, correctionResponse);
+      this.set('submitAnswer', () => {});
+
+      // when
+      const screen = await render(
+        hbs`<Module::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
+      );
+
+      // then
+      const status = screen.getByRole('status');
+      assert.strictEqual(status.innerText, 'Too Bad!');
+      assert.ok(screen.getByRole('group').disabled);
+      assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+    });
+
+    test('should display retry button when a ko feedback appears', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const correctionResponse = store.createRecord('correction-response', {
+        feedback: 'Too Bad!',
+        status: 'ko',
+        solution: 'solution',
+      });
+
+      prepareDeprecatedContextRecords.call(this, store, correctionResponse);
+      this.set('submitAnswer', () => {});
+
+      // when
+      const screen = await render(
+        hbs`<Module::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+      );
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).exists();
+    });
+
+    test('should not display retry button when an ok feedback appears', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const correctionResponse = store.createRecord('correction-response', {
+        feedback: 'Nice!',
+        status: 'ok',
+        solution: 'solution',
+      });
+
+      prepareDeprecatedContextRecords.call(this, store, correctionResponse);
+      this.set('submitAnswer', () => {});
+
+      // when
+      const screen = await render(
+        hbs`<Module::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+      );
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).doesNotExist();
+    });
+  });
+
+  module('with components', function () {
+    test('should display an ok feedback when exists', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const correctionResponse = store.createRecord('correction-response', {
+        feedback: 'Good job!',
+        status: 'ok',
+        solution: ['1', '4'],
+      });
+
+      prepareContextRecords.call(this, store, correctionResponse);
+      this.set('submitAnswer', () => {});
+
+      // when
+      const screen = await render(
+        hbs`<Module::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
+      );
+
+      // then
+      const status = screen.getByRole('status');
+      assert.strictEqual(status.innerText, 'Good job!');
+      assert.ok(screen.getByRole('group').disabled);
+      assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+    });
+
+    test('should display a ko feedback when exists', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const correctionResponse = store.createRecord('correction-response', {
+        feedback: 'Too Bad!',
+        status: 'ko',
+        solution: ['1', '4'],
+      });
+
+      prepareContextRecords.call(this, store, correctionResponse);
+      this.set('submitAnswer', () => {});
+
+      // when
+      const screen = await render(
+        hbs`<Module::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
+      );
+
+      // then
+      const status = screen.getByRole('status');
+      assert.strictEqual(status.innerText, 'Too Bad!');
+      assert.ok(screen.getByRole('group').disabled);
+      assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+    });
+
+    test('should display retry button when a ko feedback appears', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const correctionResponse = store.createRecord('correction-response', {
+        feedback: 'Too Bad!',
+        status: 'ko',
+        solution: 'solution',
+      });
+
+      prepareContextRecords.call(this, store, correctionResponse);
+      this.set('submitAnswer', () => {});
+
+      // when
+      const screen = await render(
+        hbs`<Module::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+      );
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).exists();
+    });
+
+    test('should not display retry button when an ok feedback appears', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const correctionResponse = store.createRecord('correction-response', {
+        feedback: 'Nice!',
+        status: 'ok',
+        solution: 'solution',
+      });
+
+      prepareContextRecords.call(this, store, correctionResponse);
+      this.set('submitAnswer', () => {});
+
+      // when
+      const screen = await render(
+        hbs`<Module::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+      );
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).doesNotExist();
+    });
+  });
 });
+
+function prepareDeprecatedContextRecords(store, correctionResponse) {
+  const qcmElement = {
+    id: 'a6838f8e-05ee-42e0-9820-13a9977cf5dc',
+    instruction: 'Instruction',
+    proposals: [
+      { id: '1', content: 'checkbox1' },
+      { id: '2', content: 'checkbox2' },
+      { id: '3', content: 'checkbox3' },
+    ],
+    type: 'qcm',
+  };
+  store.createRecord('element-answer', {
+    correction: correctionResponse,
+    element: qcmElement,
+  });
+  store.createRecord('grain', { id: 'id', elements: [qcmElement] });
+  store.createRecord('element-answer', {
+    correction: correctionResponse,
+    elementId: qcmElement.id,
+  });
+  this.set('el', qcmElement);
+  this.set('correctionResponse', correctionResponse);
+}
 
 function prepareContextRecords(store, correctionResponse) {
   const qcmElement = {
@@ -231,7 +350,7 @@ function prepareContextRecords(store, correctionResponse) {
     correction: correctionResponse,
     element: qcmElement,
   });
-  store.createRecord('grain', { id: 'id', elements: [qcmElement] });
+  store.createRecord('grain', { id: 'id', components: [{ type: 'element', element: qcmElement }] });
   store.createRecord('element-answer', {
     correction: correctionResponse,
     elementId: qcmElement.id,

--- a/mon-pix/tests/integration/components/module/qcu_test.js
+++ b/mon-pix/tests/integration/components/module/qcu_test.js
@@ -65,97 +65,6 @@ module('Integration | Component | Module | QCU', function (hooks) {
     assert.ok(true);
   });
 
-  test('should display an ok feedback when exists', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-
-    const correctionResponse = store.createRecord('correction-response', {
-      feedback: 'Good job!',
-      status: 'ok',
-      solution: 'solution',
-    });
-
-    prepareContextRecords.call(this, store, correctionResponse);
-    this.set('submitAnswer', () => {});
-
-    // when
-    const screen = await render(
-      hbs`<Module::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
-    );
-
-    // then
-    const status = screen.getByRole('status');
-    assert.strictEqual(status.innerText, 'Good job!');
-    assert.ok(screen.getByRole('group').disabled);
-    assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
-  });
-
-  test('should display a ko feedback when exists', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const correctionResponse = store.createRecord('correction-response', {
-      feedback: 'Too Bad!',
-      status: 'ko',
-      solution: 'solution',
-    });
-
-    prepareContextRecords.call(this, store, correctionResponse);
-    this.set('submitAnswer', () => {});
-
-    // when
-    const screen = await render(
-      hbs`<Module::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
-    );
-
-    // then
-    const status = screen.getByRole('status');
-    assert.strictEqual(status.innerText, 'Too Bad!');
-    assert.ok(screen.getByRole('group').disabled);
-    assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
-  });
-
-  test('should display retry button when a ko feedback appears', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const correctionResponse = store.createRecord('correction-response', {
-      feedback: 'Too Bad!',
-      status: 'ko',
-      solution: 'solution',
-    });
-
-    prepareContextRecords.call(this, store, correctionResponse);
-    this.set('submitAnswer', () => {});
-
-    // when
-    const screen = await render(
-      hbs`<Module::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
-    );
-
-    // then
-    assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).exists();
-  });
-
-  test('should not display retry button when an ok feedback appears', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const correctionResponse = store.createRecord('correction-response', {
-      feedback: 'Nice!',
-      status: 'ok',
-      solution: 'solution',
-    });
-
-    prepareContextRecords.call(this, store, correctionResponse);
-    this.set('submitAnswer', () => {});
-
-    // when
-    const screen = await render(
-      hbs`<Module::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
-    );
-
-    // then
-    assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).doesNotExist();
-  });
-
   test('should display an error message if QCU is validated without response', async function (assert) {
     // given
     const qcuElement = {
@@ -204,7 +113,216 @@ module('Integration | Component | Module | QCU', function (hooks) {
     // then
     assert.dom(screen.queryByRole('alert', { name: 'Pour valider, sélectionnez une réponse.' })).doesNotExist();
   });
+
+  module('with elements', function () {
+    test('should display an ok feedback when exists', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const correctionResponse = store.createRecord('correction-response', {
+        feedback: 'Good job!',
+        status: 'ok',
+        solution: 'solution',
+      });
+
+      prepareDeprecatedContextRecords.call(this, store, correctionResponse);
+      this.set('submitAnswer', () => {});
+
+      // when
+      const screen = await render(
+        hbs`<Module::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
+      );
+
+      // then
+      const status = screen.getByRole('status');
+      assert.strictEqual(status.innerText, 'Good job!');
+      assert.ok(screen.getByRole('group').disabled);
+      assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+    });
+
+    test('should display a ko feedback when exists', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const correctionResponse = store.createRecord('correction-response', {
+        feedback: 'Too Bad!',
+        status: 'ko',
+        solution: 'solution',
+      });
+
+      prepareDeprecatedContextRecords.call(this, store, correctionResponse);
+      this.set('submitAnswer', () => {});
+
+      // when
+      const screen = await render(
+        hbs`<Module::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+      );
+
+      // then
+      const status = screen.getByRole('status');
+      assert.strictEqual(status.innerText, 'Too Bad!');
+      assert.ok(screen.getByRole('group').disabled);
+      assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+    });
+
+    test('should display retry button when a ko feedback appears', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const correctionResponse = store.createRecord('correction-response', {
+        feedback: 'Too Bad!',
+        status: 'ko',
+        solution: 'solution',
+      });
+
+      prepareDeprecatedContextRecords.call(this, store, correctionResponse);
+      this.set('submitAnswer', () => {});
+
+      // when
+      const screen = await render(
+        hbs`<Module::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+      );
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).exists();
+    });
+
+    test('should not display retry button when an ok feedback appears', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const correctionResponse = store.createRecord('correction-response', {
+        feedback: 'Nice!',
+        status: 'ok',
+        solution: 'solution',
+      });
+
+      prepareDeprecatedContextRecords.call(this, store, correctionResponse);
+      this.set('submitAnswer', () => {});
+
+      // when
+      const screen = await render(
+        hbs`<Module::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+      );
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).doesNotExist();
+    });
+  });
+
+  module('with components', function () {
+    test('should display an ok feedback when exists', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const correctionResponse = store.createRecord('correction-response', {
+        feedback: 'Good job!',
+        status: 'ok',
+        solution: 'solution',
+      });
+
+      prepareContextRecords.call(this, store, correctionResponse);
+      this.set('submitAnswer', () => {});
+
+      // when
+      const screen = await render(
+        hbs`<Module::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
+      );
+
+      // then
+      const status = screen.getByRole('status');
+      assert.strictEqual(status.innerText, 'Good job!');
+      assert.ok(screen.getByRole('group').disabled);
+      assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+    });
+
+    test('should display a ko feedback when exists', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const correctionResponse = store.createRecord('correction-response', {
+        feedback: 'Too Bad!',
+        status: 'ko',
+        solution: 'solution',
+      });
+
+      prepareContextRecords.call(this, store, correctionResponse);
+      this.set('submitAnswer', () => {});
+
+      // when
+      const screen = await render(
+        hbs`<Module::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+      );
+
+      // then
+      const status = screen.getByRole('status');
+      assert.strictEqual(status.innerText, 'Too Bad!');
+      assert.ok(screen.getByRole('group').disabled);
+      assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+    });
+
+    test('should display retry button when a ko feedback appears', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const correctionResponse = store.createRecord('correction-response', {
+        feedback: 'Too Bad!',
+        status: 'ko',
+        solution: 'solution',
+      });
+
+      prepareContextRecords.call(this, store, correctionResponse);
+      this.set('submitAnswer', () => {});
+
+      // when
+      const screen = await render(
+        hbs`<Module::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+      );
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).exists();
+    });
+
+    test('should not display retry button when an ok feedback appears', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const correctionResponse = store.createRecord('correction-response', {
+        feedback: 'Nice!',
+        status: 'ok',
+        solution: 'solution',
+      });
+
+      prepareContextRecords.call(this, store, correctionResponse);
+      this.set('submitAnswer', () => {});
+
+      // when
+      const screen = await render(
+        hbs`<Module::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+      );
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).doesNotExist();
+    });
+  });
 });
+
+function prepareDeprecatedContextRecords(store, correctionResponse) {
+  const qcuElement = {
+    id: 'd0690f26-978c-41c3-9a21-da931857739c',
+    instruction: 'Instruction',
+    proposals: [
+      { id: '1', content: 'radio1' },
+      { id: '2', content: 'radio2' },
+    ],
+    type: 'qcu',
+  };
+  store.createRecord('element-answer', {
+    correction: correctionResponse,
+    element: qcuElement,
+  });
+  store.createRecord('grain', { id: 'id', elements: [qcuElement] });
+  store.createRecord('element-answer', {
+    correction: correctionResponse,
+    elementId: qcuElement.id,
+  });
+  this.set('el', qcuElement);
+  this.set('correctionResponse', correctionResponse);
+}
 
 function prepareContextRecords(store, correctionResponse) {
   const qcuElement = {
@@ -220,7 +338,7 @@ function prepareContextRecords(store, correctionResponse) {
     correction: correctionResponse,
     element: qcuElement,
   });
-  store.createRecord('grain', { id: 'id', elements: [qcuElement] });
+  store.createRecord('grain', { id: 'id', components: [{ type: 'element', element: qcuElement }] });
   store.createRecord('element-answer', {
     correction: correctionResponse,
     elementId: qcuElement.id,

--- a/mon-pix/tests/integration/components/module/qrocm_test.js
+++ b/mon-pix/tests/integration/components/module/qrocm_test.js
@@ -351,95 +351,227 @@ module('Integration | Component | Module | QROCM', function (hooks) {
     });
   });
 
-  test('should display an ok feedback when exists', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
+  module('with elements', function () {
+    test('should display an ok feedback when exists', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
 
-    const correctionResponse = store.createRecord('correction-response', {
-      feedback: 'Good job!',
-      status: 'ok',
-      solution: 'solution',
+      const correctionResponse = store.createRecord('correction-response', {
+        feedback: 'Good job!',
+        status: 'ok',
+        solution: 'solution',
+      });
+      prepareContextRecords.call(this, store, correctionResponse);
+      this.set('submitAnswer', () => {});
+
+      // when
+      const screen = await render(
+        hbs`<Module::Qrocm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+      );
+
+      // then
+      const status = screen.getByRole('status');
+      assert.strictEqual(status.innerText, 'Good job!');
+      assert.ok(screen.getByRole('group').disabled);
+      assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
     });
-    prepareContextRecords.call(this, store, correctionResponse);
-    this.set('submitAnswer', () => {});
 
-    // when
-    const screen = await render(
-      hbs`<Module::Qrocm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
-    );
+    test('should display a ko feedback when exists', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const correctionResponse = store.createRecord('correction-response', {
+        feedback: 'Too Bad!',
+        status: 'ko',
+        solution: 'solution',
+      });
+      prepareContextRecords.call(this, store, correctionResponse);
+      this.set('submitAnswer', () => {});
 
-    // then
-    const status = screen.getByRole('status');
-    assert.strictEqual(status.innerText, 'Good job!');
-    assert.ok(screen.getByRole('group').disabled);
-    assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+      // when
+      const screen = await render(
+        hbs`<Module::Qrocm @element={{this.el}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
+      );
+
+      // then
+      const status = screen.getByRole('status');
+      assert.strictEqual(status.innerText, 'Too Bad!');
+      assert.ok(screen.getByRole('group').disabled);
+      assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+    });
+
+    test('should display retry button when a ko feedback appears', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const correctionResponse = store.createRecord('correction-response', {
+        feedback: 'Too Bad!',
+        status: 'ko',
+        solution: 'solution',
+      });
+
+      prepareDeprecatedContextRecords.call(this, store, correctionResponse);
+      this.set('submitAnswer', () => {});
+
+      // when
+      const screen = await render(
+        hbs`<Module::Qrocm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+      );
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).exists();
+    });
+
+    test('should not display retry button when an ok feedback appears', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const correctionResponse = store.createRecord('correction-response', {
+        feedback: 'Nice!',
+        status: 'ok',
+        solution: 'solution',
+      });
+
+      prepareDeprecatedContextRecords.call(this, store, correctionResponse);
+      this.set('submitAnswer', () => {});
+
+      // when
+      const screen = await render(
+        hbs`<Module::Qrocm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+      );
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).doesNotExist();
+    });
   });
 
-  test('should display a ko feedback when exists', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const correctionResponse = store.createRecord('correction-response', {
-      feedback: 'Too Bad!',
-      status: 'ko',
-      solution: 'solution',
-    });
-    prepareContextRecords.call(this, store, correctionResponse);
-    this.set('submitAnswer', () => {});
+  module('with components', function () {
+    test('should display an ok feedback when exists', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
 
-    // when
-    const screen = await render(
-      hbs`<Module::Qrocm @element={{this.el}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
-    );
+      const correctionResponse = store.createRecord('correction-response', {
+        feedback: 'Good job!',
+        status: 'ok',
+        solution: 'solution',
+      });
+      prepareContextRecords.call(this, store, correctionResponse);
+      this.set('submitAnswer', () => {});
 
-    // then
-    const status = screen.getByRole('status');
-    assert.strictEqual(status.innerText, 'Too Bad!');
-    assert.ok(screen.getByRole('group').disabled);
-    assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
-  });
+      // when
+      const screen = await render(
+        hbs`<Module::Qrocm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+      );
 
-  test('should display retry button when a ko feedback appears', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const correctionResponse = store.createRecord('correction-response', {
-      feedback: 'Too Bad!',
-      status: 'ko',
-      solution: 'solution',
+      // then
+      const status = screen.getByRole('status');
+      assert.strictEqual(status.innerText, 'Good job!');
+      assert.ok(screen.getByRole('group').disabled);
+      assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
     });
 
-    prepareContextRecords.call(this, store, correctionResponse);
-    this.set('submitAnswer', () => {});
+    test('should display a ko feedback when exists', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const correctionResponse = store.createRecord('correction-response', {
+        feedback: 'Too Bad!',
+        status: 'ko',
+        solution: 'solution',
+      });
+      prepareContextRecords.call(this, store, correctionResponse);
+      this.set('submitAnswer', () => {});
 
-    // when
-    const screen = await render(
-      hbs`<Module::Qrocm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
-    );
+      // when
+      const screen = await render(
+        hbs`<Module::Qrocm @element={{this.el}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
+      );
 
-    // then
-    assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).exists();
-  });
-
-  test('should not display retry button when an ok feedback appears', async function (assert) {
-    // given
-    const store = this.owner.lookup('service:store');
-    const correctionResponse = store.createRecord('correction-response', {
-      feedback: 'Nice!',
-      status: 'ok',
-      solution: 'solution',
+      // then
+      const status = screen.getByRole('status');
+      assert.strictEqual(status.innerText, 'Too Bad!');
+      assert.ok(screen.getByRole('group').disabled);
+      assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
     });
 
-    prepareContextRecords.call(this, store, correctionResponse);
-    this.set('submitAnswer', () => {});
+    test('should display retry button when a ko feedback appears', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const correctionResponse = store.createRecord('correction-response', {
+        feedback: 'Too Bad!',
+        status: 'ko',
+        solution: 'solution',
+      });
 
-    // when
-    const screen = await render(
-      hbs`<Module::Qrocm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
-    );
+      prepareContextRecords.call(this, store, correctionResponse);
+      this.set('submitAnswer', () => {});
 
-    // then
-    assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).doesNotExist();
+      // when
+      const screen = await render(
+        hbs`<Module::Qrocm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+      );
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).exists();
+    });
+
+    test('should not display retry button when an ok feedback appears', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const correctionResponse = store.createRecord('correction-response', {
+        feedback: 'Nice!',
+        status: 'ok',
+        solution: 'solution',
+      });
+
+      prepareContextRecords.call(this, store, correctionResponse);
+      this.set('submitAnswer', () => {});
+
+      // when
+      const screen = await render(
+        hbs`<Module::Qrocm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+      );
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).doesNotExist();
+    });
   });
 });
+
+function prepareDeprecatedContextRecords(store, correctionResponse) {
+  const qrocm = {
+    id: '994b6a96-a3c2-47ae-a461-87548ac6e02b',
+    instruction: 'Instruction',
+    proposals: [
+      {
+        input: 'premiere-partie',
+        type: 'select',
+        display: 'block',
+        placeholder: '',
+        ariaLabel: 'select-aria',
+        defaultValue: '',
+        options: [
+          {
+            id: '1',
+            content: "l'identifiant",
+          },
+          {
+            id: '2',
+            content: "le fournisseur d'adresse mail",
+          },
+        ],
+      },
+    ],
+    type: 'qrocm',
+  };
+  store.createRecord('element-answer', {
+    correction: correctionResponse,
+    element: qrocm,
+  });
+  store.createRecord('grain', { id: 'id', elements: [qrocm] });
+  store.createRecord('element-answer', {
+    correction: correctionResponse,
+    elementId: qrocm.id,
+  });
+  this.set('el', qrocm);
+  this.set('correctionResponse', correctionResponse);
+}
 
 function prepareContextRecords(store, correctionResponse) {
   const qrocm = {
@@ -471,7 +603,7 @@ function prepareContextRecords(store, correctionResponse) {
     correction: correctionResponse,
     element: qrocm,
   });
-  store.createRecord('grain', { id: 'id', elements: [qrocm] });
+  store.createRecord('grain', { id: 'id', components: [{ type: 'element', element: qrocm }] });
   store.createRecord('element-answer', {
     correction: correctionResponse,
     elementId: qrocm.id,

--- a/mon-pix/tests/unit/components/module/grain_test.js
+++ b/mon-pix/tests/unit/components/module/grain_test.js
@@ -6,131 +6,274 @@ import createPodsComponent from '../../../helpers/create-pods-component';
 module('Unit | Component | Module | Grain', function (hooks) {
   setupTest(hooks);
 
-  module('#hasAnswerableElements', function () {
-    module('when there are answerable elements in grain', function () {
-      test('should return true', function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const qcu = { type: 'qcu', isAnswerable: true };
-        const qcm = { type: 'qcm', isAnswerable: true };
-        const qrocm = { type: 'qrocm', isAnswerable: true };
-        const text = { type: 'text', isAnswerable: false };
-        const grain = store.createRecord('grain', {
-          elements: [qcu, qcm, qrocm, text],
+  module('with elements', function () {
+    module('#hasAnswerableElements', function () {
+      module('when there are answerable elements in grain', function () {
+        test('should return true', function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const qcu = { type: 'qcu', isAnswerable: true };
+          const qcm = { type: 'qcm', isAnswerable: true };
+          const qrocm = { type: 'qrocm', isAnswerable: true };
+          const text = { type: 'text', isAnswerable: false };
+          const grain = store.createRecord('grain', {
+            elements: [qcu, qcm, qrocm, text],
+          });
+          const component = createPodsComponent('module/grain', { grain });
+
+          // when
+          const hasAnswerableElements = component.hasAnswerableElements;
+
+          // then
+          assert.true(hasAnswerableElements);
         });
-        const component = createPodsComponent('module/grain', { grain });
+      });
 
-        // when
-        const hasAnswerableElements = component.hasAnswerableElements;
+      module('when there are no answerable element in grain', function () {
+        test('should return false', function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const text = { type: 'text', isAnswerable: false };
+          const grain = store.createRecord('grain', {
+            elements: [text],
+          });
+          const component = createPodsComponent('module/grain', { grain });
 
-        // then
-        assert.true(hasAnswerableElements);
+          // when
+          const hasAnswerableElements = component.hasAnswerableElements;
+
+          // then
+          assert.false(hasAnswerableElements);
+        });
       });
     });
 
-    module('when there are no answerable element in grain', function () {
-      test('should return false', function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const text = { type: 'text', isAnswerable: false };
-        const grain = store.createRecord('grain', {
-          elements: [text],
+    module('#answerableElements', function () {
+      module('when there are answerable elements in elements', function () {
+        test('should return only answerable elements', function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const qcu = { type: 'qcu', isAnswerable: true };
+          const qcm = { type: 'qcm', isAnswerable: true };
+          const qrocm = { type: 'qrocm', isAnswerable: true };
+          const text = { type: 'text', isAnswerable: false };
+          const grain = store.createRecord('grain', {
+            elements: [qcu, qcm, qrocm, text],
+          });
+          const component = createPodsComponent('module/grain', { grain });
+
+          // when
+          const answerableElements = component.answerableElements;
+
+          // then
+          assert.strictEqual(answerableElements.length, 3);
+          assert.deepEqual(answerableElements, [qcu, qcm, qrocm]);
         });
-        const component = createPodsComponent('module/grain', { grain });
+      });
 
-        // when
-        const hasAnswerableElements = component.hasAnswerableElements;
+      module('when there are no answerable elements in elements', function () {
+        test('should return an empty array', function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const text = { type: 'text' };
+          const grain = store.createRecord('grain', {
+            elements: [text],
+          });
+          const component = createPodsComponent('module/grain', { grain });
 
-        // then
-        assert.false(hasAnswerableElements);
+          // when
+          const answerableElements = component.answerableElements;
+
+          // then
+          assert.strictEqual(answerableElements.length, 0);
+        });
+      });
+    });
+
+    module('#allElementsAreAnswered', function () {
+      module('when all answerable elements are answered', function () {
+        test('should return true', function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const qcu = { id: 'qcu-id-1', type: 'qcu' };
+          const elementAnswer = store.createRecord('element-answer', {
+            elementId: qcu.id,
+          });
+          const passage = store.createRecord('passage', {
+            elementAnswers: [elementAnswer],
+          });
+          const grain = store.createRecord('grain', {
+            elements: [qcu],
+          });
+
+          const component = createPodsComponent('module/grain', { grain, passage });
+
+          // when
+          const allElementsAreAnswered = component.allElementsAreAnswered;
+
+          // then
+          assert.true(allElementsAreAnswered);
+        });
+      });
+
+      module('when all answerable elements are not answered', function () {
+        test('should return false', function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const qcu = { type: 'qcu', isAnswerable: true };
+          const grain = store.createRecord('grain', {
+            elements: [qcu],
+          });
+          const passage = store.createRecord('passage');
+          const component = createPodsComponent('module/grain', { grain, passage });
+
+          // when
+          const allElementsAreAnswered = component.allElementsAreAnswered;
+
+          // then
+          assert.false(allElementsAreAnswered);
+        });
       });
     });
   });
 
-  module('#answerableElements', function () {
-    module('when there are answerable elements in elements', function () {
-      test('should return only answerable elements', function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const qcu = { type: 'qcu', isAnswerable: true };
-        const qcm = { type: 'qcm', isAnswerable: true };
-        const qrocm = { type: 'qrocm', isAnswerable: true };
-        const text = { type: 'text', isAnswerable: false };
-        const grain = store.createRecord('grain', {
-          elements: [qcu, qcm, qrocm, text],
+  module('with components', function () {
+    module('#hasAnswerableElements', function () {
+      module('when there are answerable elements in grain', function () {
+        test('should return true', function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const qcu = { type: 'qcu', isAnswerable: true };
+          const qcm = { type: 'qcm', isAnswerable: true };
+          const qrocm = { type: 'qrocm', isAnswerable: true };
+          const text = { type: 'text', isAnswerable: false };
+          const grain = store.createRecord('grain', {
+            components: [
+              { type: 'element', element: qcu },
+              { type: 'element', element: qcm },
+              { type: 'element', element: qrocm },
+              { type: 'element', element: text },
+            ],
+          });
+          const component = createPodsComponent('module/grain', { grain });
+
+          // when
+          const hasAnswerableElements = component.hasAnswerableElements;
+
+          // then
+          assert.true(hasAnswerableElements);
         });
-        const component = createPodsComponent('module/grain', { grain });
+      });
 
-        // when
-        const answerableElements = component.answerableElements;
+      module('when there are no answerable element in grain', function () {
+        test('should return false', function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const text = { type: 'text', isAnswerable: false };
+          const grain = store.createRecord('grain', {
+            components: [{ type: 'element', element: text }],
+          });
+          const component = createPodsComponent('module/grain', { grain });
 
-        // then
-        assert.strictEqual(answerableElements.length, 3);
-        assert.deepEqual(answerableElements, [qcu, qcm, qrocm]);
+          // when
+          const hasAnswerableElements = component.hasAnswerableElements;
+
+          // then
+          assert.false(hasAnswerableElements);
+        });
       });
     });
 
-    module('when there are no answerable elements in elements', function () {
-      test('should return an empty array', function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const text = { type: 'text' };
-        const grain = store.createRecord('grain', {
-          elements: [text],
+    module('#answerableElements', function () {
+      module('when there are answerable elements in elements', function () {
+        test('should return only answerable elements', function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const qcu = { type: 'qcu', isAnswerable: true };
+          const qcm = { type: 'qcm', isAnswerable: true };
+          const qrocm = { type: 'qrocm', isAnswerable: true };
+          const text = { type: 'text', isAnswerable: false };
+          const grain = store.createRecord('grain', {
+            components: [
+              { type: 'element', element: qcu },
+              { type: 'element', element: qcm },
+              { type: 'element', element: qrocm },
+              { type: 'element', element: text },
+            ],
+          });
+          const component = createPodsComponent('module/grain', { grain });
+
+          // when
+          const answerableElements = component.answerableElements;
+
+          // then
+          assert.strictEqual(answerableElements.length, 3);
+          assert.deepEqual(answerableElements, [qcu, qcm, qrocm]);
         });
-        const component = createPodsComponent('module/grain', { grain });
+      });
 
-        // when
-        const answerableElements = component.answerableElements;
+      module('when there are no answerable elements in elements', function () {
+        test('should return an empty array', function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const text = { type: 'text' };
+          const grain = store.createRecord('grain', {
+            components: [{ type: 'element', element: text }],
+          });
+          const component = createPodsComponent('module/grain', { grain });
 
-        // then
-        assert.strictEqual(answerableElements.length, 0);
+          // when
+          const answerableElements = component.answerableElements;
+
+          // then
+          assert.strictEqual(answerableElements.length, 0);
+        });
       });
     });
-  });
 
-  module('#allElementsAreAnswered', function () {
-    module('when all answerable elements are answered', function () {
-      test('should return true', function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const qcu = { id: 'qcu-id-1', type: 'qcu' };
-        const elementAnswer = store.createRecord('element-answer', {
-          elementId: qcu.id,
+    module('#allElementsAreAnswered', function () {
+      module('when all answerable elements are answered', function () {
+        test('should return true', function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const qcu = { id: 'qcu-id-1', type: 'qcu' };
+          const elementAnswer = store.createRecord('element-answer', {
+            elementId: qcu.id,
+          });
+          const passage = store.createRecord('passage', {
+            elementAnswers: [elementAnswer],
+          });
+          const grain = store.createRecord('grain', {
+            components: [{ type: 'element', element: qcu }],
+          });
+
+          const component = createPodsComponent('module/grain', { grain, passage });
+
+          // when
+          const allElementsAreAnswered = component.allElementsAreAnswered;
+
+          // then
+          assert.true(allElementsAreAnswered);
         });
-        const passage = store.createRecord('passage', {
-          elementAnswers: [elementAnswer],
-        });
-        const grain = store.createRecord('grain', {
-          elements: [qcu],
-        });
-
-        const component = createPodsComponent('module/grain', { grain, passage });
-
-        // when
-        const allElementsAreAnswered = component.allElementsAreAnswered;
-
-        // then
-        assert.true(allElementsAreAnswered);
       });
-    });
 
-    module('when all answerable elements are not answered', function () {
-      test('should return false', function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const qcu = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', {
-          elements: [qcu],
+      module('when all answerable elements are not answered', function () {
+        test('should return false', function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const qcu = { type: 'qcu', isAnswerable: true };
+          const grain = store.createRecord('grain', {
+            components: [{ type: 'element', element: qcu }],
+          });
+          const passage = store.createRecord('passage');
+          const component = createPodsComponent('module/grain', { grain, passage });
+
+          // when
+          const allElementsAreAnswered = component.allElementsAreAnswered;
+
+          // then
+          assert.false(allElementsAreAnswered);
         });
-        const passage = store.createRecord('passage');
-        const component = createPodsComponent('module/grain', { grain, passage });
-
-        // when
-        const allElementsAreAnswered = component.allElementsAreAnswered;
-
-        // then
-        assert.false(allElementsAreAnswered);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Nos modules peuvent maintenant contenir des `components` à l'intérieur des `grains`. Ils sont amenés à utiliser cette nouvelle structure.

## :robot: Proposition
Faire en sorte de pouvoir consommer des `components` plutôt que les `elements` historiques.

C'est fait de manière rétrocompatible, c'est à dire qu'on va utiliser les `components` en priorité et les `elements` si on n'a pas de `components`.

On a dupliqué nos tests avec des `describe` `with elements` pour le support de l'ancienne structure, et `with components` pour la nouvelle. Les premiers devraient pouvoir être supprimés dans la prochaine version.

## :rainbow: Remarques
Depuis #8129, on a fait le choix de ne pas faire de model Ember pour nos `elements` car ce n'est pas conseillé pour du read-only. On fait le même choix pour `components` pour le moment.

On a glissé pas mal de `ToDo` sur l'usage de `grain.elements` qu'il faudra migrer plus tard !

## :100: Pour tester
- Non régression du module `didacticiel` qui possède des `components`.
- Non régression d'un autre module, les autres ont tous une liste d'`elements`. 
