### PR TITLE
[BUGFIX] Permettre de contribuer des CFs anglophone (PIX-12348)

### DIFF
--- a/admin/app/models/training.js
+++ b/admin/app/models/training.js
@@ -17,7 +17,7 @@ export const optionsTypeList = formatList(typeCategories);
 export const localeCategories = {
   fr: 'Francophone (fr)',
   'fr-fr': 'Franco-français (fr-fr)',
-  'en-gb': 'Anglais (en-gb)',
+  en: 'Anglophone (en)',
 };
 
 export const optionsLocaleList = formatList(localeCategories);

--- a/api/src/devcomp/application/trainings/index.js
+++ b/api/src/devcomp/application/trainings/index.js
@@ -128,7 +128,7 @@ const register = async function (server) {
                 type: Joi.string()
                   .valid('autoformation', 'e-learning', 'hybrid-training', 'in-person-training', 'modulix', 'webinaire')
                   .required(),
-                locale: Joi.string().valid('fr-fr', 'fr', 'en-gb').required(),
+                locale: Joi.string().valid('fr-fr', 'fr', 'en').required(),
                 'editor-name': Joi.string().required(),
                 'editor-logo-url': Joi.string().uri().required(),
               }),
@@ -174,7 +174,7 @@ const register = async function (server) {
                 type: Joi.string()
                   .valid('autoformation', 'e-learning', 'hybrid-training', 'in-person-training', 'modulix', 'webinaire')
                   .allow(null),
-                locale: Joi.string().valid('fr-fr', 'fr', 'en-gb').allow(null),
+                locale: Joi.string().valid('fr-fr', 'fr', 'en').allow(null),
                 'editor-name': Joi.string().allow(null),
                 'editor-logo-url': Joi.string().allow(null),
               }),

--- a/api/src/devcomp/application/trainings/index.js
+++ b/api/src/devcomp/application/trainings/index.js
@@ -2,8 +2,11 @@ import Joi from 'joi';
 
 import { BadRequestError, NotFoundError, sendJsonApiError } from '../../../../lib/application/http-errors.js';
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
+import { SUPPORTED_LOCALES } from '../../../shared/domain/constants.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { trainingController as trainingsController } from './training-controller.js';
+
+const lowerCaseSupportedLocales = SUPPORTED_LOCALES.map((supportedLocale) => supportedLocale.toLowerCase());
 
 const register = async function (server) {
   server.route([
@@ -128,7 +131,9 @@ const register = async function (server) {
                 type: Joi.string()
                   .valid('autoformation', 'e-learning', 'hybrid-training', 'in-person-training', 'modulix', 'webinaire')
                   .required(),
-                locale: Joi.string().valid('fr-fr', 'fr', 'en').required(),
+                locale: Joi.string()
+                  .valid(...lowerCaseSupportedLocales)
+                  .required(),
                 'editor-name': Joi.string().required(),
                 'editor-logo-url': Joi.string().uri().required(),
               }),
@@ -174,7 +179,9 @@ const register = async function (server) {
                 type: Joi.string()
                   .valid('autoformation', 'e-learning', 'hybrid-training', 'in-person-training', 'modulix', 'webinaire')
                   .allow(null),
-                locale: Joi.string().valid('fr-fr', 'fr', 'en').allow(null),
+                locale: Joi.string()
+                  .valid(...lowerCaseSupportedLocales)
+                  .allow(null),
                 'editor-name': Joi.string().allow(null),
                 'editor-logo-url': Joi.string().allow(null),
               }),

--- a/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/training-repository_test.js
@@ -427,7 +427,7 @@ describe('Integration | Repository | training-repository', function () {
         id: 3,
         title: 'training 3',
         targetProfileIds: [targetProfile1.id],
-        locale: 'en-gb',
+        locale: 'en',
         trainingTriggers: [],
       });
       const trainingWithDifferentTargetProfile = domainBuilder.buildTraining({
@@ -705,7 +705,7 @@ describe('Integration | Repository | training-repository', function () {
       const training2 = databaseBuilder.factory.buildTraining();
       const training3 = databaseBuilder.factory.buildTraining();
       const training4 = databaseBuilder.factory.buildTraining();
-      const trainingWithAnotherLocale = databaseBuilder.factory.buildTraining({ locale: 'en-gb' });
+      const trainingWithAnotherLocale = databaseBuilder.factory.buildTraining({ locale: 'en' });
       databaseBuilder.factory.buildUserRecommendedTraining({
         userId,
         trainingId: training1.id,

--- a/api/tests/devcomp/integration/infrastructure/repositories/user-recommended-training-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/user-recommended-training-repository_test.js
@@ -74,7 +74,7 @@ describe('Integration | Repository | user-recommended-training-repository', func
       };
       const userRecommendedTrainingWithAnotherLocale = {
         userId,
-        trainingId: databaseBuilder.factory.buildTraining({ locale: 'en-gb' }).id,
+        trainingId: databaseBuilder.factory.buildTraining({ locale: 'en' }).id,
         campaignParticipationId,
       };
       const anotherCampaignParticipation = databaseBuilder.factory.buildCampaignParticipation();

--- a/api/tests/devcomp/unit/application/trainings/index_test.js
+++ b/api/tests/devcomp/unit/application/trainings/index_test.js
@@ -587,6 +587,78 @@ describe('Unit | Devcomp | Application | Trainings | Router | training-router', 
         // then
         expect(response.statusCode).to.equal(400);
       });
+
+      describe('locale', function () {
+        it('should return 400 if the locale is not in lowercase', async function () {
+          // given
+          const invalidPayload = {
+            data: {
+              attributes: {
+                link: 'http://www.example.net',
+                title: 'ma formation',
+                duration: { days: 2, hours: 2, minutes: 2 },
+                type: 'webinaire',
+                locale: 'fr-BE',
+                'editor-name': 'ministère',
+                'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+              },
+            },
+          };
+          sinon.stub(trainingController, 'create').returns('ok');
+
+          sinon
+            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+            .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+          sinon
+            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+            .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+          sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
+
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          // when
+          const response = await httpTestServer.request('POST', '/api/admin/trainings', invalidPayload);
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+
+        it('should return 400 if the locale is not supported', async function () {
+          // given
+          const invalidPayload = {
+            data: {
+              attributes: {
+                link: 'http://www.example.net',
+                title: 'ma formation',
+                duration: { days: 2, hours: 2, minutes: 2 },
+                type: 'webinaire',
+                locale: 'ja-Jpan-JP-u-ca-japanese-hc-h12',
+                'editor-name': 'ministère',
+                'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+              },
+            },
+          };
+          sinon.stub(trainingController, 'create').returns('ok');
+
+          sinon
+            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+            .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+          sinon
+            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+            .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+          sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
+
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          // when
+          const response = await httpTestServer.request('POST', '/api/admin/trainings', invalidPayload);
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+      });
     });
   });
 
@@ -800,6 +872,48 @@ describe('Unit | Devcomp | Application | Trainings | Router | training-router', 
               expect(result.statusCode).to.equal(200);
             });
           });
+        });
+      });
+
+      describe('locale', function () {
+        it('should return bad request when locale is not in lowercase', async function () {
+          // given
+          sinon.stub(trainingController, 'update').returns('ok');
+          sinon
+            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+            .callsFake((request, h) => h.response(true));
+          sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
+
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          const payload = { data: { attributes: { locale: 'fr-BE' } } };
+
+          // when
+          const result = await httpTestServer.request('PATCH', '/api/admin/trainings/12344', payload);
+
+          // then
+          expect(result.statusCode).to.equal(400);
+        });
+
+        it('should return bad request when locale is not supported', async function () {
+          // given
+          sinon.stub(trainingController, 'update').returns('ok');
+          sinon
+            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+            .callsFake((request, h) => h.response(true));
+          sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
+
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          const payload = { data: { attributes: { locale: 'ja-Jpan-JP-u-ca-japanese-hc-h12' } } };
+
+          // when
+          const result = await httpTestServer.request('PATCH', '/api/admin/trainings/12344', payload);
+
+          // then
+          expect(result.statusCode).to.equal(400);
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Les Contenus Formatifs anglophones ne sont jamais affichés dans Pix App. Les CFs utilisent pour le moment la clé de traduction `en-gb` alors que cette valeur est dépréciée et remplacée par `en`.

## :robot: Proposition
Migrer vers `en`.

Pour le moment, il n'y a pas de CF en prod en anglais `en-gb` donc pas de migration à prévoir. Et vu qu'il n'y en a pas de prévu pour le moment, je propose de le faire d'un coup sans phase de rétrocompatibilité.

## :rainbow: Remarques
RAS

## :100: Pour tester
Pix Admin : Vérifier on peut créer un CF en "Anglophone (en)".

Pix App : Vérifier qu'en étant connecté sur .org avec `learneremail1003_32@example.net` configuré comme préférant l'anglophone on a un bien un CF affiché dans "Mes formations".
