### PR TITLE
[FEATURE] Affiche les épreuves contenant des illustrations/embed et un formulaire sur 2 colonnes (PIX-11513).

### DIFF
--- a/1d/app/models/challenge.js
+++ b/1d/app/models/challenge.js
@@ -49,4 +49,8 @@ export default class Challenge extends Model {
   get isQCM() {
     return this.autoReply === false && (this.type === 'QCM' || this.type === 'QCMIMG');
   }
+
+  get hasForm() {
+    return this.autoReply === false;
+  }
 }

--- a/1d/app/pods/assessment/results/controller.js
+++ b/1d/app/pods/assessment/results/controller.js
@@ -2,6 +2,6 @@ import Controller from '@ember/controller';
 
 export default class Missions extends Controller {
   get validatedObjectives() {
-    return this.model.validatedObjectives.split('\n');
+    return this.model.validatedObjectives?.split('\n') ?? [];
   }
 }

--- a/1d/app/pods/components/challenge/challenge-actions/challenge-actions.scss
+++ b/1d/app/pods/components/challenge/challenge-actions/challenge-actions.scss
@@ -1,10 +1,7 @@
 .challenge-actions {
   display: flex;
-  flex-direction: row;
   justify-content: space-between;
-  max-width: 850px;
   margin: 16px auto;
-  padding: 0 30px;
 
   button:only-child {
     margin-left: auto;

--- a/1d/app/pods/components/challenge/challenge.scss
+++ b/1d/app/pods/components/challenge/challenge.scss
@@ -1,8 +1,0 @@
-.container__actions {
-  position: fixed;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  background-color: var(--pix-neutral-0);
-  box-shadow: 0 0 2px 0 rgb(70 77 98 / 32%), 2px 4px 6px 0 rgb(70 77 98 / 20%);
-}

--- a/1d/app/pods/components/challenge/item/challenge-item-proposals.scss
+++ b/1d/app/pods/components/challenge/item/challenge-item-proposals.scss
@@ -30,7 +30,7 @@
   &__qcm-checkboxes, &__qcu-radios{
     display: flex;
     flex-direction: column;
-    width: 50%;
+    width: 100%;
   }
 }
 

--- a/1d/app/pods/components/challenge/item/challenge-item.scss
+++ b/1d/app/pods/components/challenge/item/challenge-item.scss
@@ -1,28 +1,32 @@
-.modal-footer {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 16px;
-  justify-content: flex-end;
-  margin-bottom: 16px
-}
-
 .challenge-item {
   display: flex;
-  flex-direction: column;
-  max-width: 860px;
-  margin: 0 auto 80px;
+  align-content: center;
+  margin: 0 152px;
 
-  &__playground {
-    display: flex;
-    flex-flow: row wrap;
-    flex-grow: 1;
-    align-content: center;
-    justify-content: space-evenly;
+  @include device-is('tablet') {
+    margin: 0 122px;
   }
 
-  &__image, &__qrocm {
-    display: flex;
-    width: 49%;
+  &--single-display {
+    flex-direction: column;
+  }
+
+  &__media {
+    width: 60%;
+    margin-right: var(--pix-spacing-6x);
+
+    &--single-display {
+      width: unset;
+      margin-right: unset;
+    }
+  }
+
+  &__proposals {
+    width: 40%;
+
+    &--single-display {
+      width: unset;
+    }
   }
 
   &__qrocm {
@@ -34,8 +38,6 @@
     display: flex;
     justify-content: center;
     width: 100%;
-    padding-right: 50px;
-    padding-left: 50px;
   }
 
   &__autoreply {

--- a/1d/app/pods/components/challenge/item/component.js
+++ b/1d/app/pods/components/challenge/item/component.js
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export default class Item extends Component {
+  get isMediaWithForm() {
+    return this.args.challenge.hasForm && this.#hasMedia;
+  }
+
+  get #hasMedia() {
+    return this.args.challenge.illustrationUrl || this.args.challenge.hasValidEmbedDocument;
+  }
+}

--- a/1d/app/pods/components/challenge/item/template.hbs
+++ b/1d/app/pods/components/challenge/item/template.hbs
@@ -1,5 +1,5 @@
-<div class="challenge-item">
-  <div class="challenge-item__playground">
+<div class="challenge-item {{unless this.isMediaWithForm 'challenge-item--single-display'}}">
+  <div class="challenge-item__media {{unless this.isMediaWithForm 'challenge-item__media--single-display'}}">
     {{#if @challenge.illustrationUrl}}
       <div class="challenge-item__image">
         <Challenge::ChallengeIllustration @src={{@challenge.illustrationUrl}} @alt={{@challenge.illustrationAlt}} />
@@ -14,6 +14,8 @@
         />
       </div>
     {{/if}}
+  </div>
+  <div class="challenge-item__proposals {{unless this.isMediaWithForm 'challenge-item__proposals--single-display'}}">
     {{#if @challenge.autoReply}}
       <div class="challenge-item__autoreply">
         <Challenge::ChallengeItemAutoReply @setAnswerValue={{@setAnswerValue}} />
@@ -42,5 +44,15 @@
         />
       </div>
     {{/if}}
+    <div class="container__actions">
+      <Challenge::ChallengeActions
+        @validateAnswer={{@validateAnswer}}
+        @skipChallenge={{@skipChallenge}}
+        @level={{@activity.level}}
+        @nextAction={{@resume}}
+        @disableCheckButton={{@disableCheckButton}}
+        @answerHasBeenValidated={{@answerHasBeenValidated}}
+      />
+    </div>
   </div>
 </div>

--- a/1d/app/pods/components/challenge/template.hbs
+++ b/1d/app/pods/components/challenge/template.hbs
@@ -10,16 +10,15 @@
     {{/if}}
 
   </RobotDialog>
-  <Challenge::Item @challenge={{@challenge}} @setAnswerValue={{this.setAnswerValue}} @assessment={{@assessment}} />
-
-  <div class="container__actions">
-    <Challenge::ChallengeActions
-      @validateAnswer={{this.validateAnswer}}
-      @skipChallenge={{this.skipChallenge}}
-      @level={{@activity.level}}
-      @nextAction={{this.resume}}
-      @disableCheckButton={{this.disableCheckButton}}
-      @answerHasBeenValidated={{this.answerHasBeenValidated}}
-    />
-  </div>
+  <Challenge::Item
+    @setAnswerValue={{this.setAnswerValue}}
+    @validateAnswer={{this.validateAnswer}}
+    @skipChallenge={{this.skipChallenge}}
+    @challenge={{@challenge}}
+    @assessment={{@assessment}}
+    @disableCheckButton={{this.disableCheckButton}}
+    @answerHasBeenValidated={{this.answerHasBeenValidated}}
+    @activity={{@activity}}
+    @resume={{this.resume}}
+  />
 </div>

--- a/1d/app/pods/components/issue/issue.scss
+++ b/1d/app/pods/components/issue/issue.scss
@@ -16,6 +16,7 @@
     padding-left: 20px;
     margin-inline-start: 25%;
 
+
     &__logo {
       width: 196px;
       max-height: unset;

--- a/1d/app/pods/components/issue/issue.scss
+++ b/1d/app/pods/components/issue/issue.scss
@@ -16,6 +16,9 @@
     padding-left: 20px;
     margin-inline-start: 25%;
 
+    @include device-is('tablet') {
+      margin-inline-start: unset;
+    }
 
     &__logo {
       width: 196px;
@@ -24,6 +27,10 @@
 
     .bubbles {
       margin-top: 112px;
+
+      @include device-is('tablet') {
+        margin-top: 75px;
+      }
     }
   }
 

--- a/1d/app/pods/components/robot-dialog/robot-dialog.scss
+++ b/1d/app/pods/components/robot-dialog/robot-dialog.scss
@@ -1,21 +1,26 @@
 .robot-speaking {
   display: flex;
-  flex-direction: row;
   width: 100%;
-  padding: 40px 40px 0;
 
   .bubbles {
     display: flex;
     flex-direction: column;
     max-width: 80%;
     margin-top: auto;
-    margin-bottom: 95px;
+    margin-bottom: var(--pix-spacing-12x);
+
   }
 
   &__logo {
     align-self: end;
     width: 128px;
-    padding-bottom: 10px;
+    margin-right: var(--pix-spacing-3x);
+    margin-bottom: -30px;
+
+    @include device-is('tablet') {
+      width: 106px;
+      margin-right: var(--pix-spacing-4x);
+    }
   }
 }
 

--- a/1d/app/styles/app.scss
+++ b/1d/app/styles/app.scss
@@ -23,32 +23,11 @@ b {
 }
 
 .app {
-  display: flex;
-  flex-direction: column;
-
-  // Simuler l'affichage d'une tablette
-  max-width: 1194px;
-  min-height: 100vh;
-  margin: auto 10%;
-
-  @include device-is('large-screen') {
-    margin: auto;
-  }
+  margin: 32px 95px;
+  max-width: 1730px;
 }
 
-footer {
-  margin-top: auto;
-  margin-bottom: 32px;
-  margin-left: 32px;
-  text-align: start;
-
-  img {
-    width: 128px;
-  }
-}
-
-
-@media screen and (width <= 800px) {
+@media screen and (width <= 1194px) {
   .issue {
     .robot-speaking {
       margin-inline-start: unset;
@@ -60,8 +39,22 @@ footer {
   }
 
   .robot-speaking {
-      &__logo {
-        width: 106px;
-      }
+    &__logo {
+      width: 106px;
+      margin-right: 16px;
+    }
+  }
+  .challenge-item {
+    margin: 0 146px;
+  }
+  .app {
+    margin: 32px 80px;
   }
 }
+
+@media screen and (width > 1920px) {
+  .app {
+    margin: 32px auto;
+  }
+}
+

--- a/1d/app/styles/app.scss
+++ b/1d/app/styles/app.scss
@@ -8,6 +8,7 @@
 @import 'globals/fonts';
 @import 'globals/colors';
 @import 'globals/buttons';
+@import 'globals/breakpoints';
 
 
 body {
@@ -23,37 +24,17 @@ b {
 }
 
 .app {
-  margin: 32px 95px;
   max-width: 1730px;
-}
 
-@media screen and (width <= 1194px) {
-  .issue {
-    .robot-speaking {
-      margin-inline-start: unset;
-
-      .bubbles {
-        margin-top: 75px;
-      }
-    }
-  }
-
-  .robot-speaking {
-    &__logo {
-      width: 106px;
-      margin-right: 16px;
-    }
-  }
-  .challenge-item {
-    margin: 0 146px;
-  }
-  .app {
+  @include device-is('tablet') {
     margin: 32px 80px;
   }
-}
 
-@media screen and (width > 1920px) {
-  .app {
+  @include device-is('desktop') {
+    margin: 32px 95px;
+  }
+
+  @include device-is('large-screen') {
     margin: 32px auto;
   }
 }

--- a/1d/app/styles/globals/_breakpoints.scss
+++ b/1d/app/styles/globals/_breakpoints.scss
@@ -1,0 +1,7 @@
+$breakpoints: (
+  'mobile': (max-width: 768px),
+  'tablet': (max-width: 1194px),
+  'desktop': (min-width: 1195px),
+  'large-screen': (min-width: 1920px),
+);
+


### PR DESCRIPTION
## :unicorn: Problème
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Lors de l’affichage du carrousel ou encore d’un embed avec un QCM ou QCU à compléter, l’utilisateur ne comprend pas qu’il faille scroller pour voir d’autres éléments en dessous.​

## :robot: Proposition
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
Une amélioration de design serait de mettre à droite des illustrations ou des embed, le QCM ou le QCU.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

Des ajustements sont à apporter sur l'adaptation d'affichage des embed, directement par l'équipe Contenus.

## :100: Pour tester
Faire une mission (du didacticiel au défi) et constater que l'affichage des épreuves sont bien sur 2 colonnes lorsque celles-ci contiennent un media (illustration ou embed) et un formulaire (QCM/QCU).