### PR TITLE
[FEATURE] ajoute une route pour récupérer les participations d'un prescrit à une campagne (PIX-11638)

### DIFF
--- a/api/db/database-builder/factory/build-campaign-participation.js
+++ b/api/db/database-builder/factory/build-campaign-participation.js
@@ -31,6 +31,8 @@ const buildCampaignParticipation = function ({
   const isShared = status === SHARED;
   sharedAt = isShared ? sharedAt : null;
 
+  if (deletedAt && !deletedBy) deletedBy = buildUser().id;
+
   const values = {
     id,
     campaignId,

--- a/api/src/prescription/campaign-participation/application/campaign-participation-controller.js
+++ b/api/src/prescription/campaign-participation/application/campaign-participation-controller.js
@@ -2,12 +2,12 @@ import { extractLocaleFromRequest } from '../../../../lib/infrastructure/utils/r
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { extractParameters } from '../../../shared/infrastructure/utils/query-params-utils.js';
 import { usecases } from '../domain/usecases/index.js';
+import * as availableCampaignParticipationsSerializer from '../infrastructure/serializers/jsonapi/available-campaign-participation-serializer.js';
 import * as campaignAnalysisSerializer from '../infrastructure/serializers/jsonapi/campaign-analysis-serializer.js';
 import * as campaignAssessmentParticipationResultSerializer from '../infrastructure/serializers/jsonapi/campaign-assessment-participation-result-serializer.js';
 import * as campaignAssessmentParticipationSerializer from '../infrastructure/serializers/jsonapi/campaign-assessment-participation-serializer.js';
 import * as campaignProfileSerializer from '../infrastructure/serializers/jsonapi/campaign-profile-serializer.js';
 import * as participationForCampaignManagementSerializer from '../infrastructure/serializers/jsonapi/participation-for-campaign-management-serializer.js';
-
 const findPaginatedParticipationsForCampaignManagement = async function (request) {
   const { campaignId } = request.params;
   const { page } = extractParameters(request.query);
@@ -107,11 +107,25 @@ const deleteCampaignParticipationForAdmin = async function (request, h) {
   return h.response({}).code(204);
 };
 
+const getCampaignParticipationsForOrganizationLearner = async function (
+  request,
+  h,
+  dependencies = { availableCampaignParticipationsSerializer },
+) {
+  const { campaignId, organizationLearnerId } = request.params;
+  const availableCampaignParticipations = await usecases.getCampaignParticipationsForOrganizationLearner({
+    campaignId,
+    organizationLearnerId,
+  });
+  return dependencies.availableCampaignParticipationsSerializer.serialize(availableCampaignParticipations);
+};
+
 const campaignParticipationController = {
   findPaginatedParticipationsForCampaignManagement,
   getAnalysis,
   getCampaignProfile,
   getCampaignAssessmentParticipation,
+  getCampaignParticipationsForOrganizationLearner,
   deleteParticipation,
   getCampaignAssessmentParticipationResult,
   updateParticipantExternalId,

--- a/api/src/prescription/campaign-participation/application/campaign-participation-route.js
+++ b/api/src/prescription/campaign-participation/application/campaign-participation-route.js
@@ -134,6 +134,26 @@ const register = async function (server) {
       },
     },
     {
+      method: 'GET',
+      path: '/api/campaigns/{campaignId}/organization-learners/{organizationLearnerId}/participations',
+      config: {
+        pre: [{ method: securityPreHandlers.checkAuthorizationToAccessCampaign }],
+        validate: {
+          params: Joi.object({
+            campaignId: identifiersType.campaignId,
+            organizationLearnerId: identifiersType.organizationLearnerId,
+          }),
+        },
+        handler: campaignParticipationController.getCampaignParticipationsForOrganizationLearner,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            '- L’utilisateur doit avoir les droits d‘accès à l‘organisation liée à la campagne\n' +
+            '- Récupération de la liste des participations d’un learner à une campagne',
+        ],
+        tags: ['api', 'campaign-participation'],
+      },
+    },
+    {
       method: 'PATCH',
       path: '/api/admin/campaign-participations/{id}',
       config: {

--- a/api/src/prescription/campaign-participation/domain/read-models/AvailableCampaignParticipation.js
+++ b/api/src/prescription/campaign-participation/domain/read-models/AvailableCampaignParticipation.js
@@ -1,0 +1,9 @@
+class AvailableCampaignParticipation {
+  constructor({ id, sharedAt, status }) {
+    this.id = id;
+    this.sharedAt = sharedAt;
+    this.status = status;
+  }
+}
+
+export { AvailableCampaignParticipation };

--- a/api/src/prescription/campaign-participation/domain/usecases/get-campaign-participations-for-organization-learner.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/get-campaign-participations-for-organization-learner.js
@@ -1,0 +1,13 @@
+const getCampaignParticipationsForOrganizationLearner = async function ({
+  campaignId,
+  organizationLearnerId,
+  campaignParticipationRepository,
+}) {
+  const campaignParticipations = await campaignParticipationRepository.getCampaignParticipationsForOrganizationLearner({
+    campaignId,
+    organizationLearnerId,
+  });
+  return campaignParticipations;
+};
+
+export { getCampaignParticipationsForOrganizationLearner };

--- a/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/available-campaign-participation-serializer.js
+++ b/api/src/prescription/campaign-participation/infrastructure/serializers/jsonapi/available-campaign-participation-serializer.js
@@ -1,0 +1,12 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (availableCampaignParticipation, meta) {
+  return new Serializer('available-campaign-participation', {
+    attributes: ['sharedAt', 'status'],
+    meta,
+  }).serialize(availableCampaignParticipation);
+};
+
+export { serialize };

--- a/api/src/shared/application/security-pre-handlers.js
+++ b/api/src/shared/application/security-pre-handlers.js
@@ -605,7 +605,7 @@ async function checkAuthorizationToAccessCampaign(
   dependencies = { checkAuthorizationToAccessCampaignUsecase },
 ) {
   const userId = request.auth.credentials.userId;
-  const campaignId = request.params.id;
+  const campaignId = request.params.campaignId || request.params.id;
   const belongsToOrganization = await dependencies.checkAuthorizationToAccessCampaignUsecase.execute({
     userId,
     campaignId,

--- a/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-controller_test.js
+++ b/api/tests/prescription/campaign-participation/acceptance/application/campaign-participation-controller_test.js
@@ -325,6 +325,36 @@ describe('Acceptance | API | Campaign Participations', function () {
     });
   });
 
+  describe('GET /api/campaigns/{campaignId}/organization-learners/{organizationLearnerId}/participations', function () {
+    beforeEach(function () {
+      const learningObjects = learningContentBuilder.fromAreas([]);
+      mockLearningContent(learningObjects);
+    });
+
+    it('should return the campaign profile as JSONAPI', async function () {
+      databaseBuilder.factory.buildMembership({ userId, organizationId });
+      const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner().id;
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId,
+        organizationLearnerId,
+      }).id;
+
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'GET',
+        url: `/api/campaigns/${campaignId}/organization-learners/${organizationLearnerId}/participations`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      };
+
+      const response = await server.inject(options);
+
+      expect(response.result.data[0].type).to.equal('available-campaign-participations');
+      expect(response.result.data[0].id).to.equal(`${campaignParticipationId}`);
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+
   describe('PATCH /api/admin/campaign-participations/{id}', function () {
     it('should update the participant external id', async function () {
       const superAdmin = await insertUserWithRoleSuperAdmin();

--- a/api/tests/prescription/campaign-participation/integration/application/campaign-participation-route_test.js
+++ b/api/tests/prescription/campaign-participation/integration/application/campaign-participation-route_test.js
@@ -115,4 +115,34 @@ describe('Integration | Application | Route | campaignParticipationRouter', func
       });
     });
   });
+
+  describe('GET /api/campaigns/{campaignId}/organization-learners/{organizationLearnerId}/participations', function () {
+    const method = 'GET';
+
+    context('when campaignId is not an integer', function () {
+      it('should return 400 - Bad request', async function () {
+        // when
+        const response = await httpTestServer.request(
+          method,
+          '/api/campaigns/BAD_ID/organization-learners/1/participations',
+        );
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+
+    context('when organizationLearnerId is not an integer', function () {
+      it('should return 400 - Bad request', async function () {
+        // when
+        const response = await httpTestServer.request(
+          method,
+          '/api/campaigns/1/organization-learners/BAD_ID/participations',
+        );
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+  });
 });

--- a/api/tests/prescription/campaign-participation/unit/application/campaign-participation-controller_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/campaign-participation-controller_test.js
@@ -134,6 +134,49 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
     });
   });
 
+  describe('#getCampaignParticipationsForOrganizationLearner', function () {
+    const campaignId = 123;
+    const organizationLearnerId = 456;
+    let dependencies;
+
+    beforeEach(function () {
+      sinon.stub(usecases, 'getCampaignParticipationsForOrganizationLearner');
+      const availableCampaignParticipationsSerializer = {
+        serialize: sinon.stub(),
+      };
+      dependencies = {
+        availableCampaignParticipationsSerializer,
+      };
+    });
+
+    it('should call the usecase with correct parameter', async function () {
+      // given
+      const availableCampaignParticipations = Symbol('availableCampaignParticipations');
+      const expectedResults = Symbol('results');
+      usecases.getCampaignParticipationsForOrganizationLearner
+        .withArgs({ campaignId, organizationLearnerId })
+        .resolves(availableCampaignParticipations);
+
+      dependencies.availableCampaignParticipationsSerializer.serialize
+        .withArgs(availableCampaignParticipations)
+        .returns(expectedResults);
+
+      const request = {
+        params: { campaignId, organizationLearnerId },
+      };
+      const h = Symbol('h');
+      // when
+      const response = await campaignParticipationController.getCampaignParticipationsForOrganizationLearner(
+        request,
+        h,
+        dependencies,
+      );
+
+      // then
+      expect(response).to.equal(expectedResults);
+    });
+  });
+
   describe('#updateParticipantExternalId', function () {
     beforeEach(function () {
       sinon.stub(usecases, 'updateParticipantExternalId');

--- a/api/tests/prescription/campaign-participation/unit/application/campaign-participation-route_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/campaign-participation-route_test.js
@@ -224,4 +224,21 @@ describe('Unit | Application | Router | campaign-participation-router ', functio
       expect(response.statusCode).to.equal(403);
     });
   });
+
+  describe('GET /api/campaigns/{campaignId}/organization-learners/{organizationLearnerId}/participations', function () {
+    it('should call expected prehandler', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkAuthorizationToAccessCampaign').callsFake((request, h) => h.response('ok'));
+      sinon.stub(campaignParticipationController, 'getCampaignParticipationsForOrganizationLearner').returns('ok');
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      await httpTestServer.request('GET', '/api/campaigns/2/organization-learners/1/participations');
+
+      // then
+      expect(securityPreHandlers.checkAuthorizationToAccessCampaign.called).to.be.true;
+    });
+  });
 });

--- a/api/tests/prescription/campaign-participation/unit/domain/usecases/get-campaign-participations-for-organization-learner_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/usecases/get-campaign-participations-for-organization-learner_test.js
@@ -1,0 +1,37 @@
+import { getCampaignParticipationsForOrganizationLearner } from '../../../../../../src/prescription/campaign-participation/domain/usecases/get-campaign-participations-for-organization-learner.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | UseCase | get-organization-learner-campaign-participations', function () {
+  let campaignParticipationRepository,
+    getCampaignParticipationsForOrganizationLearnerStub,
+    organizationLearnerId,
+    campaignId,
+    participations;
+
+  beforeEach(function () {
+    organizationLearnerId = Symbol('organisationLearnerId');
+    campaignId = Symbol('campaignId');
+    participations = Symbol('participations');
+    getCampaignParticipationsForOrganizationLearnerStub = sinon.stub();
+    campaignParticipationRepository = {
+      getCampaignParticipationsForOrganizationLearner: getCampaignParticipationsForOrganizationLearnerStub,
+    };
+  });
+
+  it('should return given participations', async function () {
+    //given
+    getCampaignParticipationsForOrganizationLearnerStub
+      .withArgs({ organizationLearnerId, campaignId })
+      .resolves(participations);
+
+    //when
+    const result = await getCampaignParticipationsForOrganizationLearner({
+      campaignId,
+      organizationLearnerId,
+      campaignParticipationRepository,
+    });
+
+    //then
+    expect(result).to.deep.equal(participations);
+  });
+});

--- a/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/available-campaign-participation-serializer_test.js
+++ b/api/tests/prescription/campaign-participation/unit/infrastructure/serializers/jsonapi/available-campaign-participation-serializer_test.js
@@ -1,0 +1,39 @@
+import { AvailableCampaignParticipation } from '../../../../../../../src/prescription/campaign-participation/domain/read-models/AvailableCampaignParticipation.js';
+import * as serializer from '../../../../../../../src/prescription/campaign-participation/infrastructure/serializers/jsonapi/available-campaign-participation-serializer.js';
+import { CampaignParticipationStatuses } from '../../../../../../../src/prescription/shared/domain/constants.js';
+import { expect } from '../../../../../../test-helper.js';
+
+const SHARED = CampaignParticipationStatuses.SHARED;
+
+describe('Unit | Serializer | JSONAPI | campaign-participation-serializer', function () {
+  describe('#serialize', function () {
+    const campaignParticipation = new AvailableCampaignParticipation({
+      id: 5,
+      status: SHARED,
+      sharedAt: new Date('2018-02-06T14:12:44Z'),
+    });
+
+    let expectedSerializedCampaignParticipation;
+
+    beforeEach(function () {
+      expectedSerializedCampaignParticipation = {
+        data: {
+          type: 'available-campaign-participations',
+          id: '5',
+          attributes: {
+            status: SHARED,
+            'shared-at': new Date('2018-02-06T14:12:44Z'),
+          },
+        },
+      };
+    });
+
+    it('should convert an AvailableCampaignParticipation model object into JSON API data', function () {
+      // when
+      const json = serializer.serialize(campaignParticipation);
+
+      // then
+      expect(json).to.deep.equal(expectedSerializedCampaignParticipation);
+    });
+  });
+});

--- a/api/tests/unit/application/security-pre-handlers_test.js
+++ b/api/tests/unit/application/security-pre-handlers_test.js
@@ -1532,6 +1532,28 @@ describe('Unit | Application | SecurityPreHandlers', function () {
         // then
         expect(response.source).to.be.true;
       });
+
+      it('should use campaignId param if id is not provided', async function () {
+        // given
+        const request = {
+          auth: { credentials: { accessToken: 'valid.access.token', userId: Symbol('UserId') } },
+          params: { campaignId: Symbol('campaignId') },
+        };
+
+        const checkAuthorizationToAccessCampaignUsecaseStub = {
+          execute: sinon.stub(),
+        };
+        checkAuthorizationToAccessCampaignUsecaseStub.execute
+          .withArgs({ campaignId: request.params.campaignId, userId: request.auth.credentials.userId })
+          .resolves(true);
+        // when
+        const response = await securityPreHandlers.checkAuthorizationToAccessCampaign(request, hFake, {
+          checkAuthorizationToAccessCampaignUsecase: checkAuthorizationToAccessCampaignUsecaseStub,
+        });
+
+        // then
+        expect(response.source).to.be.true;
+      });
     });
 
     context('Error cases', function () {


### PR DESCRIPTION
## :unicorn: Problème
Nous avons permis de voir le nombre de participations d’un participant à une campagne à envoi multiple et de conserver le dernier résultat partagé. 
Nous souhaitons également permettre au prescripteur de visualiser les résultats de toutes les participations d’un participant à une campagne d'évaluation. 

## :robot: Proposition
Créer un endpoint pour lister les participations d'un participant à une campagne. 

## :rainbow: Remarques


## :100: Pour tester

- La CI est toute belle et toute verte
- Possible de faire du cUrl si l'envie vous prends de faire du fonctionnel <3 
- 🐈‍⬛ 
- 🪂 
