### PR TITLE
[FEATURE] Mettre à jour le lien de redirection vers le centre d'aide sur Pix Certif (PIX-12405)

### DIFF
--- a/mon-pix/app/components/certification-joiner.js
+++ b/mon-pix/app/components/certification-joiner.js
@@ -136,7 +136,7 @@ export default class CertificationJoiner extends Component {
         this.errorMessage = this.intl.t('pages.certification-joiner.error-messages.wrong-account-sco');
         this.errorMessageLink = {
           label: this.intl.t('pages.certification-joiner.error-messages.wrong-account-sco-link'),
-          url: 'https://support.pix.org/fr/support/solutions/articles/15000047880',
+          url: 'https://pix.fr/support/enseignement-scolaire/enseignant-ou-personnel-de-direction/que-faire-si-une-eleve-ne-parvient-pas-rejoindre-sa-session-de-certification',
         };
       } else if (_isWrongAccount(err)) {
         this.errorMessage = this.intl.t('pages.certification-joiner.error-messages.wrong-account');

--- a/mon-pix/app/components/certification-joiner.js
+++ b/mon-pix/app/components/certification-joiner.js
@@ -135,8 +135,8 @@ export default class CertificationJoiner extends Component {
       } else if (_isMatchingReconciledStudentNotFoundError(err)) {
         this.errorMessage = this.intl.t('pages.certification-joiner.error-messages.wrong-account-sco');
         this.errorMessageLink = {
-          label: this.intl.t('pages.certification-joiner.error-messages.wrong-account-sco-link'),
-          url: 'https://pix.fr/support/enseignement-scolaire/enseignant-ou-personnel-de-direction/que-faire-si-une-eleve-ne-parvient-pas-rejoindre-sa-session-de-certification',
+          label: this.intl.t('pages.certification-joiner.error-messages.wrong-account-sco-link.label'),
+          url: this.intl.t('pages.certification-joiner.error-messages.wrong-account-sco-link.url'),
         };
       } else if (_isWrongAccount(err)) {
         this.errorMessage = this.intl.t('pages.certification-joiner.error-messages.wrong-account');

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -451,7 +451,10 @@
         "session-not-accessible": "The session you are trying to join is no longer available.",
         "wrong-account": "The information entered matches a candidate enrolled in the session and already logged in with another account. Please check that you are logged into the account that started the exam.",
         "wrong-account-sco": "You are currently using an account that is not linked to your school/organisation.\nLog in to the account you used to complete your customised tests or ask the invigilator for help.",
-        "wrong-account-sco-link": "How to find the account linked to the school/organisation ?"
+        "wrong-account-sco-link": {
+          "label": "How to find the account linked to the school/organisation ?",
+          "url": "https://pix.fr/support/enseignement-scolaire/enseignant-ou-personnel-de-direction/que-faire-si-une-eleve-ne-parvient-pas-rejoindre-sa-session-de-certification"
+        }
       },
       "first-title": "Join a session",
       "form": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -450,7 +450,10 @@
         "session-not-accessible": "La sesión a la que intentas entrar ya no es accesible.",
         "wrong-account": "La información introducida corresponde a un candidato inscrito en la sesión y que ya ha iniciado sesión con otra cuenta. Compruebe que ha iniciado sesión con la cuenta que inició la certificación.",
         "wrong-account-sco": "Actualmente está utilizando una cuenta que no está vinculada a su escuela.\nInicie sesión en la cuenta con la que completó sus cursos o pida ayuda a su supervisor.",
-        "wrong-account-sco-link": "¿Cómo encuentro la cuenta vinculada al establecimiento?"
+        "wrong-account-sco-link": {
+          "label": "¿Cómo encuentro la cuenta vinculada al establecimiento?",
+          "url": "https://pix.fr/support/enseignement-scolaire/enseignant-ou-personnel-de-direction/que-faire-si-une-eleve-ne-parvient-pas-rejoindre-sa-session-de-certification"
+        }
       },
       "first-title": "Participar en una sesión",
       "form": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -451,7 +451,10 @@
         "session-not-accessible": "La session que vous tentez de rejoindre n'est plus accessible.",
         "wrong-account": "Les informations saisies correspondent à un.e candidat.e inscrit.e à la session et déjà connecté.e avec un autre compte. Vérifiez que vous êtes connecté.e au compte qui a démarré la certification.",
         "wrong-account-sco": "Vous utilisez actuellement un compte qui n'est pas lié à votre établissement.\nConnectez vous au compte avec lequel vous avez effectué vos parcours ou demandez de l'aide au surveillant.",
-        "wrong-account-sco-link": "Comment trouver le compte lié à l'établissement ?"
+        "wrong-account-sco-link": {
+          "label": "Comment trouver le compte lié à l'établissement ?",
+          "url": "https://pix.fr/support/enseignement-scolaire/enseignant-ou-personnel-de-direction/que-faire-si-une-eleve-ne-parvient-pas-rejoindre-sa-session-de-certification"
+        }
       },
       "first-title": "Rejoindre une session",
       "form": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -450,7 +450,10 @@
         "session-not-accessible": "De sessie die u probeert te bezoeken is niet langer toegankelijk.",
         "wrong-account": "De ingevoerde informatie komt overeen met een kandidaat die is geregistreerd voor de sessie en al is ingelogd met een ander account. Controleer of u bent aangemeld bij het account waarmee de certificering is gestart.",
         "wrong-account-sco": "Je gebruikt momenteel een account dat niet aan je school is gekoppeld.\nLog in op het account waarmee je je cursussen hebt afgerond of vraag de supervisor om hulp.",
-        "wrong-account-sco-link": "Hoe vind ik de rekening die aan de vestiging is gekoppeld?"
+        "wrong-account-sco-link": {
+          "label": "Hoe vind ik de rekening die aan de vestiging is gekoppeld?",
+          "url": "https://pix.fr/support/enseignement-scolaire/enseignant-ou-personnel-de-direction/que-faire-si-une-eleve-ne-parvient-pas-rejoindre-sa-session-de-certification"
+        }
       },
       "first-title": "Deelnemen aan een sessie",
       "form": {


### PR DESCRIPTION
## :unicorn: Problème
Le pôle support a mis en service le nouveau centre d'aide pour les enseignants du SCO.
Afin de pouvoir dépublier tous les articles des enseignants sur freshdesk (ancien centre d’aide) il aurait besoin de modifier un lien présent dans les messages d'erreur lors de l'accès à une session de certification pour les candidats sco.

## :robot: Proposition
Mettre à jour le lien dans le fichier : https://github.com/1024pix/pix/blob/dev/mon-pix/app/components/certification-joiner.js 

Nouveau lien : [https://pix.fr/support/enseignement-scolaire/enseignant-ou-personnel-de-directio[…]i-une-eleve-ne-parvient-pas-rejoindre-sa-session-de-certification](https://pix.fr/support/enseignement-scolaire/enseignant-ou-personnel-de-direction/que-faire-si-une-eleve-ne-parvient-pas-rejoindre-sa-session-de-certification)

## :100: Pour tester
- Se connecter sur certif avec l'utilisateur `certif-sco@example.net` / `pix123`
- Créer une nouvelle session
- Créer un candidat
- Se connecter à l'app avec le compte `certif-success@example.net` / `pix123`
- Aller dans Certification > Rejoindre une session
- Rejoindre la certification créée avec le compte du candidat
- Un message d'erreur avec un lien doit apparaître
- Vérifier que le lien est bien : https://pix.fr/support/enseignement-scolaire/enseignant-ou-personnel-de-direction/que-faire-si-une-eleve-ne-parvient-pas-rejoindre-sa-session-de-certification

[EDIT] Changer la langue et vérifier que le lien est toujours présent, et dans la bonne langue

