### PR TITLE
[FEATURE] Retirer l'enquête Sco dans le bandeau du dashboard (PIX-12345).

### DIFF
--- a/mon-pix/app/components/dashboard/banner.hbs
+++ b/mon-pix/app/components/dashboard/banner.hbs
@@ -1,28 +1,4 @@
-{{#if @isScoUser}}
-  {{! this banner is temperary and will be deleted before september 2024 }}
-  <section class="dashboard-banner">
-    <NewInformation
-      @information="<h2>Donne ton avis sur Pix&nbsp;!</h2><p>Aide-nous en répondant à ce court questionnaire. Promis, c’est moins de 1 minute&nbsp;!</p>"
-      @image="/images/illustrations/discovery_TDB_pix.svg"
-      @backgroundColorClass="new-information--blue-gradient-background"
-      @textColorClass="new-information--white-text"
-      @linkText="Accéder au questionnaire"
-      @linkTo="{{this.scoSurveyLink}}"
-    />
-    {{#if @code}}
-      <NewInformation
-        @information="{{t 'pages.dashboard.campaigns.resume.text'}}"
-        @image="/images/profile_collect_TDB_pix.svg"
-        @backgroundColorClass="new-information--yellow-gradient-background"
-        @textColorClass="new-information--black-text"
-        @linkDisplayType="button"
-        @linkText="{{t 'pages.dashboard.campaigns.resume.action'}}"
-        @linkTo="campaigns.profiles-collection.start-or-resume"
-        @code={{@code}}
-      />
-    {{/if}}
-  </section>
-{{else if @show}}
+{{#if @show}}
   <section class="dashboard-banner">
     {{#unless @hasSeenNewDashboardInfo}}
       <NewInformation

--- a/mon-pix/app/components/dashboard/banner.js
+++ b/mon-pix/app/components/dashboard/banner.js
@@ -1,8 +1,0 @@
-import Component from '@glimmer/component';
-import ENV from 'mon-pix/config/environment';
-
-export default class Banner extends Component {
-  get scoSurveyLink() {
-    return ENV.APP.SCO_SURVEY_LINK;
-  }
-}

--- a/mon-pix/app/components/dashboard/content.hbs
+++ b/mon-pix/app/components/dashboard/content.hbs
@@ -9,7 +9,6 @@
     @closeInformationAboutNewDashboard={{this.closeInformationAboutNewDashboard}}
     @userFirstname={{this.userFirstname}}
     @code={{this.codeForLastProfileToShare}}
-    @isScoUser={{this.isScoUser}}
   />
 
   <section class="dashboard-content__score">
@@ -34,7 +33,6 @@
       @closeInformationAboutNewDashboard={{this.closeInformationAboutNewDashboard}}
       @userFirstname={{this.userFirstname}}
       @code={{this.codeForLastProfileToShare}}
-      @isScoUser={{this.isScoUser}}
     />
 
     {{#if this.hasNothingToShow}}

--- a/mon-pix/app/components/dashboard/content.js
+++ b/mon-pix/app/components/dashboard/content.js
@@ -92,8 +92,4 @@ export default class Content extends Component {
       url: this.currentDomain.isFranceDomain ? this.intl.t('pages.dashboard.presentation.link.url') : null,
     };
   }
-
-  get isScoUser() {
-    return this.currentUser.user.isSco && this.currentDomain.isFranceDomain;
-  }
 }

--- a/mon-pix/app/models/user.js
+++ b/mon-pix/app/models/user.js
@@ -34,8 +34,4 @@ export default class User extends Model {
   get fullName() {
     return `${this.firstName} ${this.lastName}`;
   }
-
-  get isSco() {
-    return !this.cgu && !this.isAnonymous;
-  }
 }

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -59,7 +59,6 @@ module.exports = function (environment) {
       }),
       BANNER_CONTENT: process.env.BANNER_CONTENT || '',
       BANNER_TYPE: process.env.BANNER_TYPE || '',
-      SCO_SURVEY_LINK: process.env.SCO_SURVEY_LINK || '',
       IS_PROD_ENVIRONMENT: (process.env.REVIEW_APP === 'false' && environment === 'production') || false,
       EMBED_ALLOWED_ORIGINS: (
         process.env.EMBED_ALLOWED_ORIGINS || 'https://epreuves.pix.fr,https://1024pix.github.io'

--- a/mon-pix/tests/integration/components/dashboard/content_test.js
+++ b/mon-pix/tests/integration/components/dashboard/content_test.js
@@ -378,12 +378,10 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
             pixScore,
           }),
           hasSeenNewDashboardInfo: false,
-          cgu: true,
         });
       }
 
       this.owner.register('service:currentUser', CurrentUserStub);
-
       this.set('model', {
         campaignParticipationOverviews: [],
         campaignParticipations: [],
@@ -444,7 +442,6 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
             pixScore,
           }),
           hasSeenNewDashboardInfo: false,
-          cgu: true,
         });
       }
 
@@ -500,100 +497,6 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
       assert
         .dom(screen.queryByRole('link', { name: this.intl.t('pages.dashboard.presentation.link.text') }))
         .doesNotExist();
-    });
-  });
-
-  module('sco user banners', function () {
-    test('should display survey link banner if user is SCO and domain is pix.fr and not profile collection banner', async function (assert) {
-      // given
-      class CurrentDomainServiceStub extends Service {
-        get isFranceDomain() {
-          return true;
-        }
-      }
-      class CurrentUserStub extends Service {
-        user = store.createRecord('user', {
-          firstName: 'Banana',
-          lastName: 'Split',
-          email: 'banana.split@example.net',
-          profile: store.createRecord('profile', {
-            pixScore,
-          }),
-          hasSeenNewDashboardInfo: false,
-          cgu: false,
-          isAnonymous: false,
-        });
-      }
-
-      this.owner.register('service:currentUser', CurrentUserStub);
-      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
-
-      this.set('model', {
-        campaignParticipationOverviews: [],
-        campaignParticipations: [],
-        scorecards: [],
-      });
-
-      // when
-      const screen = await render(hbs`<Dashboard::Content @model={{this.model}}/>`);
-
-      // then
-      assert
-        .dom(
-          screen.getByRole('heading', {
-            name: /Donne ton avis sur Pix/,
-            exact: false,
-          }),
-        )
-        .exists();
-      assert.dom(screen.queryByRole('link', { name: 'Accéder au questionnaire' })).exists();
-      assert.notOk(screen.queryByRole('link', { name: this.intl.t('pages.dashboard.campaigns.resume.action') }));
-    });
-    test('should display survey link banner if user is SCO and domain is pix.fr and profile collection banner', async function (assert) {
-      // given
-      class CurrentDomainServiceStub extends Service {
-        get isFranceDomain() {
-          return true;
-        }
-      }
-      class CurrentUserStub extends Service {
-        user = store.createRecord('user', {
-          firstName: 'Banana',
-          lastName: 'Split',
-          email: 'banana.split@example.net',
-          profile: store.createRecord('profile', {
-            pixScore,
-          }),
-          hasSeenNewDashboardInfo: false,
-          cgu: false,
-          isAnonymous: false,
-          codeForLastProfileToShare: 'SUPERCODE',
-        });
-      }
-
-      this.owner.register('service:currentUser', CurrentUserStub);
-      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
-
-      this.set('model', {
-        campaignParticipationOverviews: [],
-        campaignParticipations: [],
-        scorecards: [],
-      });
-
-      // when
-      const screen = await render(hbs`<Dashboard::Content @model={{this.model}}/>`);
-
-      // then
-      assert
-        .dom(
-          screen.getByRole('heading', {
-            name: /Donne ton avis sur Pix/,
-            exact: false,
-          }),
-        )
-        .exists();
-      assert.dom(screen.queryByRole('link', { name: 'Accéder au questionnaire' })).exists();
-      assert.dom(screen.queryByRole('link', { name: this.intl.t('pages.dashboard.campaigns.resume.action') })).exists();
     });
   });
 
@@ -709,7 +612,6 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
           }),
           hasSeenNewDashboardInfo: false,
           codeForLastProfileToShare: 'SNAP1234',
-          cgu: true,
         });
       }
 

--- a/mon-pix/tests/unit/models/user_test.js
+++ b/mon-pix/tests/unit/models/user_test.js
@@ -29,30 +29,4 @@ module('Unit | Model | user model', function (hooks) {
       assert.strictEqual(fullName, 'Manu Phillip');
     });
   });
-
-  module('#isSco', function () {
-    module('when user has not seen CGU and is not anonymous', function () {
-      test('should return true', function (assert) {
-        // given
-        const user = store.createRecord('user');
-        user.cgu = false;
-        user.isAnonymous = false;
-
-        // then
-        assert.true(user.isSco);
-      });
-    });
-
-    module('when user has seen CGU or is anonymous', function () {
-      test('should return false', function (assert) {
-        // given
-        const user = store.createRecord('user');
-        user.cgu = true;
-        user.isAnonymous = true;
-
-        // then
-        assert.false(user.isSco);
-      });
-    });
-  });
 });


### PR DESCRIPTION
Suite à la fin du sondage destiné aux utilisateurs SCO, on revert la PR de mise en place du bandeau.