### PR TITLE
[TECH] Utiliser le service générique pour les services OIDC non-spécifiques (PIX-10193)

### DIFF
--- a/api/src/identity-access-management/domain/services/cnav-oidc-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/cnav-oidc-authentication-service.js
@@ -1,7 +1,0 @@
-import { OidcAuthenticationService } from './oidc-authentication-service.js';
-
-export class CnavOidcAuthenticationService extends OidcAuthenticationService {
-  constructor(oidcProvider) {
-    super(oidcProvider);
-  }
-}

--- a/api/src/identity-access-management/domain/services/oidc-authentication-service-registry.js
+++ b/api/src/identity-access-management/domain/services/oidc-authentication-service-registry.js
@@ -1,12 +1,10 @@
 import { InvalidIdentityProviderError } from '../../../../lib/domain/errors.js';
 import { cryptoService } from '../../../shared/domain/services/crypto-service.js';
 import { oidcProviderRepository } from '../../infrastructure/repositories/oidc-provider-repository.js';
-import { CnavOidcAuthenticationService } from './cnav-oidc-authentication-service.js';
 import { FwbOidcAuthenticationService } from './fwb-oidc-authentication-service.js';
 import { GoogleOidcAuthenticationService } from './google-oidc-authentication-service.js';
-import { PaysdelaloireOidcAuthenticationService } from './paysdelaloire-oidc-authentication-service.js';
+import { OidcAuthenticationService } from './oidc-authentication-service.js';
 import { PoleEmploiOidcAuthenticationService } from './pole-emploi-oidc-authentication-service.js';
-import { ProSanteConnectOidcAuthenticationService } from './pro-sante-connect-oidc-authentication.service.js';
 
 export class OidcAuthenticationServiceRegistry {
   #allOidcProviderServices = null;
@@ -66,16 +64,12 @@ export class OidcAuthenticationServiceRegistry {
           switch (oidcProvider.identityProvider) {
             case 'FWB':
               return new FwbOidcAuthenticationService(oidcProvider);
-            case 'CNAV':
-              return new CnavOidcAuthenticationService(oidcProvider);
-            case 'PAYSDELALOIRE':
-              return new PaysdelaloireOidcAuthenticationService(oidcProvider);
             case 'GOOGLE':
               return new GoogleOidcAuthenticationService(oidcProvider);
             case 'POLE_EMPLOI':
               return new PoleEmploiOidcAuthenticationService(oidcProvider);
-            case 'PROSANTECONNECT':
-              return new ProSanteConnectOidcAuthenticationService(oidcProvider);
+            default:
+              return new OidcAuthenticationService(oidcProvider);
           }
         }),
       );

--- a/api/src/identity-access-management/domain/services/paysdelaloire-oidc-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/paysdelaloire-oidc-authentication-service.js
@@ -1,7 +1,0 @@
-import { OidcAuthenticationService } from './oidc-authentication-service.js';
-
-export class PaysdelaloireOidcAuthenticationService extends OidcAuthenticationService {
-  constructor(oidcProvider) {
-    super(oidcProvider);
-  }
-}

--- a/api/src/identity-access-management/domain/services/pro-sante-connect-oidc-authentication.service.js
+++ b/api/src/identity-access-management/domain/services/pro-sante-connect-oidc-authentication.service.js
@@ -1,7 +1,0 @@
-import { OidcAuthenticationService } from './oidc-authentication-service.js';
-
-export class ProSanteConnectOidcAuthenticationService extends OidcAuthenticationService {
-  constructor(oidcProvider) {
-    super(oidcProvider);
-  }
-}


### PR DESCRIPTION
## :unicorn: Problème
Actuellement certains services OIDC non spécifiques ont encore leur propre classe.

## :robot: Proposition
Supprimer les services des OIDC non spécifiques et utiliser à leur place la classe générique.

## :rainbow: Remarques
Les constantes faisant référence aux services OIDC non spécifiques seront supprimées dans un ticket ultérieur.

## :100: Pour tester
Vérifier la non régression sur les trois services OIDC non spécifiques.
