### PR TITLE
[FEATURE] Permettre la modification des sujets d'un profil cible non relié à une campagne (PIX-12436).

### DIFF
--- a/admin/app/adapters/target-profile.js
+++ b/admin/app/adapters/target-profile.js
@@ -4,12 +4,20 @@ export default class TargetProfileAdapter extends ApplicationAdapter {
   namespace = 'api/admin';
 
   updateRecord(store, type, snapshot) {
-    if (snapshot?.adapterOptions?.markTargetProfileAsSimplifiedAccess) {
+    const { adapterOptions } = snapshot;
+
+    if (adapterOptions?.markTargetProfileAsSimplifiedAccess) {
       const url = `${this.host}/${this.namespace}/target-profiles/${snapshot.id}/simplified-access`;
       return this.ajax(url, 'PUT');
     }
 
-    return super.updateRecord(...arguments);
+    const payload = this.serialize(snapshot, {
+      update: true,
+      tubes: adapterOptions?.tubes,
+    });
+
+    const url = `${this.host}/${this.namespace}/target-profiles/${snapshot.id}`;
+    return this.ajax(url, 'PATCH', { data: payload });
   }
 
   createRecord(store, type, snapshot) {

--- a/admin/app/serializers/target-profile.js
+++ b/admin/app/serializers/target-profile.js
@@ -1,0 +1,36 @@
+import JSONAPISerializer from '@ember-data/serializer/json-api';
+
+export default class TargetProfileSerializer extends JSONAPISerializer {
+  serialize(snapshot, options) {
+    const {
+      data: { attributes },
+    } = super.serialize(...arguments);
+
+    const json = {
+      data: {
+        attributes: {
+          'are-knowledge-elements-resettable': attributes['are-knowledge-elements-resettable'],
+          category: attributes.category,
+          comment: attributes.comment,
+          description: attributes.description,
+          'image-url': attributes['image-url'],
+          'is-public': attributes['is-public'],
+          name: attributes.name,
+          'owner-organization-id': attributes['owner-organization-id'],
+        },
+      },
+    };
+
+    if (options?.tubes) {
+      json.data.attributes.tubes = options.tubes;
+    }
+
+    const isUpdateMode = options?.update;
+    if (isUpdateMode) {
+      delete json.data.attributes['is-public'];
+      delete json.data.attributes['owner-organization-id'];
+    }
+
+    return json;
+  }
+}

--- a/admin/tests/unit/serializers/target-profile_test.js
+++ b/admin/tests/unit/serializers/target-profile_test.js
@@ -1,0 +1,134 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Serializer | Target Profile', function (hooks) {
+  setupTest(hooks);
+
+  module('initial behaviour', function () {
+    module('with tubes', function () {
+      test('it serializes records', function (assert) {
+        const store = this.owner.lookup('service:store');
+
+        const targetProfileData = {
+          areKnowledgeElementsResettable: true,
+          category: 'cat',
+          comment: 'comment',
+          description: 'desc',
+          imageUrl: 'some-url',
+          isPublic: true,
+          name: 'name',
+          ownerOrganizationId: 1,
+        };
+        const tubes = Symbol('tubes');
+
+        const record = store.createRecord('target-profile', targetProfileData);
+        const serializedRecord = record.serialize({ tubes });
+
+        assert.deepEqual(serializedRecord.data.attributes, {
+          'are-knowledge-elements-resettable': targetProfileData.areKnowledgeElementsResettable,
+          category: targetProfileData.category,
+          comment: targetProfileData.comment,
+          description: targetProfileData.description,
+          'image-url': targetProfileData.imageUrl,
+          'is-public': targetProfileData.isPublic,
+          name: targetProfileData.name,
+          'owner-organization-id': String(targetProfileData.ownerOrganizationId),
+          tubes,
+        });
+      });
+    });
+
+    module('without tubes', function () {
+      test('it serializes records', function (assert) {
+        const store = this.owner.lookup('service:store');
+
+        const targetProfileData = {
+          areKnowledgeElementsResettable: true,
+          category: 'cat',
+          comment: 'comment',
+          description: 'desc',
+          imageUrl: 'some-url',
+          isPublic: true,
+          name: 'name',
+          ownerOrganizationId: 1,
+        };
+
+        const record = store.createRecord('target-profile', targetProfileData);
+        const serializedRecord = record.serialize();
+
+        assert.deepEqual(serializedRecord.data.attributes, {
+          'are-knowledge-elements-resettable': targetProfileData.areKnowledgeElementsResettable,
+          category: targetProfileData.category,
+          comment: targetProfileData.comment,
+          description: targetProfileData.description,
+          'image-url': targetProfileData.imageUrl,
+          'is-public': targetProfileData.isPublic,
+          name: targetProfileData.name,
+          'owner-organization-id': String(targetProfileData.ownerOrganizationId),
+        });
+      });
+    });
+  });
+
+  module('update mode behaviour', function () {
+    module('with tubes', function () {
+      test('it serializes records', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+
+        const targetProfileData = {
+          areKnowledgeElementsResettable: true,
+          category: 'cat',
+          comment: 'comment',
+          description: 'desc',
+          imageUrl: 'some-url',
+          name: 'name',
+        };
+        const tubes = Symbol('tubes');
+
+        const record = store.createRecord('target-profile', targetProfileData);
+
+        // when
+        const serializedRecord = record.serialize({ update: true, tubes });
+
+        // then
+        assert.deepEqual(serializedRecord.data.attributes, {
+          'are-knowledge-elements-resettable': targetProfileData.areKnowledgeElementsResettable,
+          category: targetProfileData.category,
+          comment: targetProfileData.comment,
+          description: targetProfileData.description,
+          'image-url': targetProfileData.imageUrl,
+          name: targetProfileData.name,
+          tubes,
+        });
+      });
+    });
+
+    module('without tubes', function () {
+      test('it serializes records', function (assert) {
+        const store = this.owner.lookup('service:store');
+
+        const targetProfileData = {
+          areKnowledgeElementsResettable: true,
+          category: 'cat',
+          comment: 'comment',
+          description: 'desc',
+          imageUrl: 'some-url',
+          name: 'name',
+        };
+
+        const record = store.createRecord('target-profile', targetProfileData);
+        const serializedRecord = record.serialize({ update: true });
+
+        assert.deepEqual(serializedRecord.data.attributes, {
+          'are-knowledge-elements-resettable': targetProfileData.areKnowledgeElementsResettable,
+          category: targetProfileData.category,
+          comment: targetProfileData.comment,
+          description: targetProfileData.description,
+          'image-url': targetProfileData.imageUrl,
+          name: targetProfileData.name,
+        });
+      });
+    });
+  });
+});

--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -268,15 +268,23 @@ const register = async function (server) {
           payload: Joi.object({
             data: {
               attributes: {
-                name: Joi.string().required().min(1),
-                'image-url': Joi.string().required(),
-                description: Joi.string().required().allow(null).max(500),
-                comment: Joi.string().required().allow(null).max(500),
-                category: Joi.string().required(),
-                'are-knowledge-elements-resettable': Joi.boolean().required(),
+                'are-knowledge-elements-resettable': Joi.boolean(),
+                category: Joi.string(),
+                comment: Joi.string().allow(null).max(500),
+                description: Joi.string().allow(null).max(500),
+                'image-url': Joi.string().uri().allow(null),
+                name: Joi.string(),
+                tubes: Joi.array()
+                  .optional()
+                  .items(
+                    Joi.object({
+                      id: Joi.string(),
+                      level: Joi.number(),
+                    }),
+                  ),
               },
             },
-          }).options({ allowUnknown: true }),
+          }),
         },
         handler: targetProfileController.updateTargetProfile,
         tags: ['api', 'admin', 'target-profiles'],

--- a/api/lib/domain/models/TargetProfileForAdmin.js
+++ b/api/lib/domain/models/TargetProfileForAdmin.js
@@ -1,4 +1,6 @@
+import { DomainError } from '../errors.js';
 import { AreaForAdmin } from './index.js';
+import { categories } from './TargetProfile.js';
 
 class TargetProfileForAdmin {
   constructor({
@@ -67,6 +69,27 @@ class TargetProfileForAdmin {
   get maxLevel() {
     const levels = this.areas.map((area) => area.maxLevel);
     return Math.max(...levels);
+  }
+
+  update(attributes) {
+    const hasTubeToUpdate = attributes.tubes?.length > 0;
+
+    if (hasTubeToUpdate && this.hasLinkedCampaign) {
+      throw new DomainError('Le profil cible est relié à une campagne, interdiction de modifier le référentiel');
+    }
+
+    const validCategories = Object.values(categories);
+    if (!validCategories.includes(attributes.category)) {
+      throw new DomainError("La catégorie de profil cible renseignée n'est pas valide");
+    }
+
+    this.name = attributes.name;
+    this.imageUrl = attributes.imageUrl;
+    this.description = attributes.description;
+    this.comment = attributes.comment;
+    this.category = attributes.category;
+    this.areKnowledgeElementsResettable = attributes.areKnowledgeElementsResettable;
+    this.tubes = attributes.tubes;
   }
 }
 

--- a/api/lib/domain/usecases/update-target-profile.js
+++ b/api/lib/domain/usecases/update-target-profile.js
@@ -1,25 +1,15 @@
-import { validate } from '../validators/target-profile/base-validation.js';
-
 const updateTargetProfile = async function ({
   id,
-  name,
-  imageUrl,
-  description,
-  comment,
-  category,
-  areKnowledgeElementsResettable,
+  attributesToUpdate,
+  targetProfileForAdminRepository,
   targetProfileForUpdateRepository,
+  domainTransaction,
 }) {
-  validate({ name, imageUrl, description, comment, category });
-  return targetProfileForUpdateRepository.update({
-    targetProfileId: id,
-    name,
-    imageUrl,
-    description,
-    comment,
-    category,
-    areKnowledgeElementsResettable,
-  });
+  const targetProfileForAdmin = await targetProfileForAdminRepository.get({ id, domainTransaction });
+
+  targetProfileForAdmin.update(attributesToUpdate);
+
+  return targetProfileForUpdateRepository.update(targetProfileForAdmin, domainTransaction);
 };
 
 export { updateTargetProfile };

--- a/api/lib/infrastructure/repositories/target-profile-for-update-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-for-update-repository.js
@@ -1,23 +1,45 @@
 import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../DomainTransaction.js';
 
-const update = async function ({
-  targetProfileId,
-  name,
-  imageUrl,
-  description,
-  comment,
-  category,
-  areKnowledgeElementsResettable,
-}) {
-  const targetProfileToUpdate = {
+const TARGET_PROFILE_TABLE_NAME = 'target-profiles';
+const TARGET_PROFILE_TUBES_TABLE_NAME = 'target-profile_tubes';
+
+const update = async function (targetProfile, domainTransaction = DomainTransaction.emptyTransaction()) {
+  const knexConn = domainTransaction?.knexTransaction || (await knex.transaction());
+
+  const {
+    id: targetProfileId,
     name,
     imageUrl,
     description,
     comment,
     category,
     areKnowledgeElementsResettable,
-  };
-  return knex('target-profiles').where({ id: targetProfileId }).update(targetProfileToUpdate);
+  } = targetProfile;
+
+  await knexConn(TARGET_PROFILE_TABLE_NAME).where({ id: targetProfileId }).update({
+    name,
+    imageUrl,
+    description,
+    comment,
+    category,
+    areKnowledgeElementsResettable,
+  });
+
+  if (targetProfile.tubes?.length > 0) {
+    const tubesData = targetProfile.tubes.map((tube) => ({
+      targetProfileId,
+      tubeId: tube.id,
+      level: tube.level,
+    }));
+
+    await knexConn(TARGET_PROFILE_TUBES_TABLE_NAME).delete().where({ targetProfileId });
+    await knexConn(TARGET_PROFILE_TUBES_TABLE_NAME).insert(tubesData);
+  }
+
+  if (!domainTransaction?.knexTransaction) {
+    await knexConn.commit();
+  }
 };
 
 export { update };

--- a/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-serializer.js
+++ b/api/src/prescription/target-profile/infrastructure/serializers/jsonapi/target-profile-serializer.js
@@ -13,18 +13,24 @@ const serializeId = function (targetProfileId) {
   return new Serializer('target-profile', {}).serialize({ id: targetProfileId });
 };
 
-const deserializeCreationCommand = function (json) {
-  return {
-    name: json.data.attributes['name'],
-    category: json.data.attributes['category'],
-    description: json.data.attributes['description'],
-    comment: json.data.attributes['comment'],
-    isPublic: json.data.attributes['is-public'],
-    imageUrl: json.data.attributes['image-url'],
-    ownerOrganizationId: json.data.attributes['owner-organization-id'],
-    tubes: json.data.attributes['tubes'],
-    areKnowledgeElementsResettable: json.data.attributes['are-knowledge-elements-resettable'],
-  };
+const deserialize = function (json) {
+  const attributes = json.data.attributes;
+
+  const deserializedData = {};
+
+  if (attributes.name !== undefined) deserializedData.name = attributes.name;
+  if (attributes.category !== undefined) deserializedData.category = attributes.category;
+  if (attributes.description !== undefined) deserializedData.description = attributes.description;
+  if (attributes.comment !== undefined) deserializedData.comment = attributes.comment;
+  if (attributes['is-public'] !== undefined) deserializedData.isPublic = attributes['is-public'];
+  if (attributes['image-url'] !== undefined) deserializedData.imageUrl = attributes['image-url'];
+  if (attributes['owner-organization-id'] !== undefined)
+    deserializedData.ownerOrganizationId = attributes['owner-organization-id'];
+  if (attributes.tubes !== undefined) deserializedData.tubes = attributes.tubes;
+  if (attributes['are-knowledge-elements-resettable'] !== undefined)
+    deserializedData.areKnowledgeElementsResettable = attributes['are-knowledge-elements-resettable'];
+
+  return deserializedData;
 };
 
-export { deserializeCreationCommand, serialize, serializeId };
+export { deserialize, serialize, serializeId };

--- a/api/src/shared/infrastructure/repositories/target-profile-for-admin-repository.js
+++ b/api/src/shared/infrastructure/repositories/target-profile-for-admin-repository.js
@@ -12,12 +12,15 @@ import { TargetProfileForAdmin } from '../../../../lib/domain/models/index.js';
 import * as thematicRepository from '../../../../lib/infrastructure/repositories/thematic-repository.js';
 import * as tubeRepository from '../../../../lib/infrastructure/repositories/tube-repository.js';
 import * as areaRepository from '../../../shared/infrastructure/repositories/area-repository.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { StageCollection } from '../../domain/models/target-profile-management/StageCollection.js';
 import * as competenceRepository from './competence-repository.js';
 import * as skillRepository from './skill-repository.js';
 
-const get = async function ({ id, locale = FRENCH_FRANCE }) {
-  const targetProfileDTO = await knex('target-profiles')
+const get = async function ({ id, locale = FRENCH_FRANCE }, domainTransaction = DomainTransaction.emptyTransaction()) {
+  const knexConn = domainTransaction?.knexTransaction || knex;
+
+  const targetProfileDTO = await knexConn('target-profiles')
     .select(
       'target-profiles.id',
       'target-profiles.name',
@@ -39,7 +42,7 @@ const get = async function ({ id, locale = FRENCH_FRANCE }) {
     throw new NotFoundError("Le profil cible n'existe pas");
   }
 
-  const tubesData = await knex('target-profile_tubes')
+  const tubesData = await knexConn('target-profile_tubes')
     .select('tubeId', 'level')
     .where('targetProfileId', targetProfileDTO.id);
   return _toDomain(targetProfileDTO, tubesData, locale);

--- a/api/tests/acceptance/application/target-profiles/index_test.js
+++ b/api/tests/acceptance/application/target-profiles/index_test.js
@@ -261,34 +261,77 @@ describe('Acceptance | Route | target-profiles', function () {
   });
 
   describe('PATCH /api/admin/target-profiles/{id}', function () {
-    it('should return 204', async function () {
-      const targetProfile = databaseBuilder.factory.buildTargetProfile();
-      const user = databaseBuilder.factory.buildUser.withRole();
-      await databaseBuilder.commit();
+    beforeEach(async function () {
+      mockLearningContent(learningContent);
+    });
 
-      const options = {
-        method: 'PATCH',
-        url: `/api/admin/target-profiles/${targetProfile.id}`,
-        headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
-        payload: {
-          data: {
-            attributes: {
-              name: 'CoolPixer',
-              description: 'Amazing description',
-              comment: 'Amazing comment',
-              category: 'OTHER',
-              'image-url': 'http://valid-uri.com/image.png',
-              'are-knowledge-elements-resettable': false,
+    describe('when there is no tube to update', function () {
+      it('should return 204', async function () {
+        const targetProfile = databaseBuilder.factory.buildTargetProfile();
+        const user = databaseBuilder.factory.buildUser.withRole();
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'PATCH',
+          url: `/api/admin/target-profiles/${targetProfile.id}`,
+          headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+          payload: {
+            data: {
+              attributes: {
+                name: 'CoolPixer',
+                description: 'Amazing description',
+                comment: 'Amazing comment',
+                category: 'OTHER',
+                'image-url': 'http://valid-uri.com/image.png',
+                'are-knowledge-elements-resettable': false,
+              },
             },
           },
-        },
-      };
+        };
 
-      // when
-      const response = await server.inject(options);
+        // when
+        const response = await server.inject(options);
 
-      // then
-      expect(response.statusCode).to.equal(204);
+        // then
+        expect(response.statusCode).to.equal(204);
+      });
+    });
+
+    describe('when there is some tube update and the target profile is not linked with campaign', function () {
+      it('should return 204', async function () {
+        const targetProfile = databaseBuilder.factory.buildTargetProfile();
+        const targetProfileTube = databaseBuilder.factory.buildTargetProfileTube({
+          targetProfileId: targetProfile.id,
+          tubeId,
+          level: 1,
+        });
+        const user = databaseBuilder.factory.buildUser.withRole();
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'PATCH',
+          url: `/api/admin/target-profiles/${targetProfile.id}`,
+          headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+          payload: {
+            data: {
+              attributes: {
+                name: 'nom changé',
+                category: 'COMPETENCES',
+                description: 'description changée.',
+                comment: 'commentaire changé.',
+                'image-url': null,
+                tubes: [{ id: targetProfileTube.tubeId, level: 99 }],
+              },
+            },
+          },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(204);
+      });
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/target-profile-for-update-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-for-update-repository_test.js
@@ -3,39 +3,118 @@ import { databaseBuilder, expect, knex } from '../../../test-helper.js';
 
 describe('Integration | Repository | Target-profile-for-update', function () {
   describe('#update', function () {
-    it('should update the target profile', async function () {
-      // given
-      databaseBuilder.factory.buildTargetProfile({
-        id: 123,
+    let existingTargetProfile, tube1, tube2;
+
+    beforeEach(async function () {
+      existingTargetProfile = databaseBuilder.factory.buildTargetProfile({
         name: 'old name',
-        imageUrl: 'old image url',
+        category: 'old category',
         description: 'old description',
         comment: 'old comment',
-        category: 'old category',
-        areKnowledgeElementsResettable: false,
+        isPublic: false,
+        imageUrl: 'old image url',
       });
-      await databaseBuilder.commit();
-      const updatedData = {
-        targetProfileId: 123,
-        name: 'new-name',
-        imageUrl: 'new-image-url',
-        description: 'new description',
-        comment: 'new comment',
-        category: 'new category',
-        areKnowledgeElementsResettable: true,
+
+      tube1 = {
+        targetProfileId: existingTargetProfile.id,
+        tubeId: '1',
+        level: 1,
       };
+      tube2 = {
+        targetProfileId: existingTargetProfile.id,
+        tubeId: '2',
+        level: 2,
+      };
+      databaseBuilder.factory.buildTargetProfileTube(tube1);
+      databaseBuilder.factory.buildTargetProfileTube(tube2);
 
-      // when
-      await targetProfileForUpdateRepository.update(updatedData);
+      await databaseBuilder.commit();
+    });
 
-      // then
-      const targetProfileFromDB = await knex('target-profiles').where({ id: 123 }).first();
-      expect(targetProfileFromDB.name).to.equal('new-name');
-      expect(targetProfileFromDB.imageUrl).to.equal('new-image-url');
-      expect(targetProfileFromDB.description).to.equal('new description');
-      expect(targetProfileFromDB.comment).to.equal('new comment');
-      expect(targetProfileFromDB.category).to.equal('new category');
-      expect(targetProfileFromDB.areKnowledgeElementsResettable).to.be.true;
+    context('with tubes', function () {
+      it('should update the target profile and the tubes', async function () {
+        // given
+        const updatedData = {
+          name: 'new-name',
+          category: 'new category',
+          description: 'new description',
+          comment: 'new comment',
+          isPublic: true,
+          imageUrl: 'new-image-url',
+          tubes: [
+            {
+              id: '1',
+              level: 2,
+            },
+            {
+              id: '3',
+              level: 8,
+            },
+          ],
+        };
+
+        // when
+        await targetProfileForUpdateRepository.update({ ...existingTargetProfile, ...updatedData });
+
+        // then
+        const targetProfileFromDB = await knex('target-profiles').where({ id: existingTargetProfile.id }).first();
+
+        expect(targetProfileFromDB.name).to.equal('new-name');
+        expect(targetProfileFromDB.imageUrl).to.equal('new-image-url');
+        expect(targetProfileFromDB.description).to.equal('new description');
+        expect(targetProfileFromDB.comment).to.equal('new comment');
+        expect(targetProfileFromDB.category).to.equal('new category');
+
+        const targetProfileTubesFromDB = await knex('target-profile_tubes').where({
+          targetProfileId: existingTargetProfile.id,
+        });
+        expect(targetProfileTubesFromDB).to.have.length(2);
+        // eslint-disable-next-line no-unused-vars
+        expect(targetProfileTubesFromDB.map(({ id, ...tube }) => tube)).to.deep.equal([
+          {
+            ...tube1,
+            level: 2,
+          },
+          {
+            tubeId: '3',
+            level: 8,
+            targetProfileId: existingTargetProfile.id,
+          },
+        ]);
+      });
+    });
+
+    context('without tubes', function () {
+      it('should update the target profile informations', async function () {
+        // given
+        const updatedData = {
+          name: 'new-name',
+          category: 'new category',
+          description: 'new description',
+          comment: 'new comment',
+          isPublic: true,
+          imageUrl: 'new-image-url',
+        };
+
+        // when
+        await targetProfileForUpdateRepository.update({ ...existingTargetProfile, ...updatedData });
+
+        // then
+        const targetProfileFromDB = await knex('target-profiles').where({ id: existingTargetProfile.id }).first();
+
+        expect(targetProfileFromDB.name).to.equal('new-name');
+        expect(targetProfileFromDB.imageUrl).to.equal('new-image-url');
+        expect(targetProfileFromDB.description).to.equal('new description');
+        expect(targetProfileFromDB.comment).to.equal('new comment');
+        expect(targetProfileFromDB.category).to.equal('new category');
+
+        const targetProfileTubesFromDB = await knex('target-profile_tubes').where({
+          targetProfileId: existingTargetProfile.id,
+        });
+        expect(targetProfileTubesFromDB).to.have.length(2);
+        // eslint-disable-next-line no-unused-vars
+        expect(targetProfileTubesFromDB.map(({ id, ...tube }) => tube)).to.deep.equal([tube1, tube2]);
+      });
     });
   });
 });

--- a/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-serializer_test.js
+++ b/api/tests/prescription/target-profile/unit/infrastructure/serializers/jsonapi/target-profile-serializer_test.js
@@ -56,7 +56,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
     });
   });
 
-  describe('#deserializeCreationCommand', function () {
+  describe('#deserialize', function () {
     it('should deserialize JSONAPI to target profile creation command', function () {
       // given
       const json = {
@@ -79,7 +79,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function () 
       };
 
       // when
-      const deserializedTargetProfileCreationCommand = serializer.deserializeCreationCommand(json);
+      const deserializedTargetProfileCreationCommand = serializer.deserialize(json);
 
       // then
       const expectedTargetProfileCreationCommand = {

--- a/api/tests/unit/application/target-profiles/index_test.js
+++ b/api/tests/unit/application/target-profiles/index_test.js
@@ -532,18 +532,21 @@ describe('Unit | Application | Target Profiles | Routes', function () {
     const payload = {
       data: {
         attributes: {
-          name: 'test',
-          description: 'description changée.',
-          comment: 'commentaire changé.',
-          category: 'OTHER',
-          'image-url': 'some image',
           'are-knowledge-elements-resettable': false,
+          category: 'OTHER',
+          comment: 'commentaire changé.',
+          description: 'description changée.',
+          'image-url': 'http://some-image.url',
+          name: 'test',
+          tubes: [{ id: 'some-id', level: 1 }],
         },
       },
     };
 
     context('when user has role "SUPER_ADMIN", "SUPPORT" or "METIER"', function () {
-      it('should return a response with an HTTP status code 204', async function () {
+      let httpTestServer;
+
+      beforeEach(async function () {
         // given
         sinon
           .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
@@ -556,74 +559,116 @@ describe('Unit | Application | Target Profiles | Routes', function () {
         sinon
           .stub(targetProfileController, 'updateTargetProfile')
           .callsFake((request, h) => h.response('ok').code(204));
-        const httpTestServer = new HttpTestServer();
+        httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
-
-        // when
-        const { statusCode } = await httpTestServer.request(method, url, payload);
-
-        // then
-        expect(statusCode).to.equal(204);
       });
 
-      it('should return a 400 error when description is over than 500 characters', async function () {
-        // given
-        const httpTestServer = new HttpTestServer();
-        const description = 'description changée.';
-        await httpTestServer.register(moduleUnderTest);
-
+      it('should return a response with an HTTP status code 204', async function () {
         // when
-        const { statusCode } = await httpTestServer.request(method, url, {
-          data: {
-            attributes: {
-              name: 'test',
-              description: description.repeat(26),
-              comment: null,
-            },
-          },
-        });
+        const response = await httpTestServer.request(method, url, payload);
 
         // then
-        expect(statusCode).to.equal(400);
+        expect(response.statusCode).to.equal(204);
       });
 
-      it('should return a 400 error when comment is over than 500 characters', async function () {
-        // given
-        const httpTestServer = new HttpTestServer();
-        const comment = 'commentaire changé.';
-        await httpTestServer.register(moduleUnderTest);
-
-        // when
-        const { statusCode } = await httpTestServer.request(method, url, {
-          data: {
-            attributes: {
-              name: 'test',
-              description: 'good',
-              comment: comment.repeat(27),
+      context('payload validation', function () {
+        it('[are-knowledge-elements-resettable] should return a 400 error when it is not a boolean value', async function () {
+          // when
+          const response = await httpTestServer.request(method, url, {
+            data: {
+              attributes: {
+                'are-knowledge-elements-resettable': String('not a boolean value'),
+              },
             },
-          },
+          });
+
+          // then
+          expect(response.statusCode).to.equal(400);
         });
 
-        // then
-        expect(statusCode).to.equal(400);
-      });
-
-      it('should return a 400 error when the name is not defined', async function () {
-        // given
-        const httpTestServer = new HttpTestServer();
-        await httpTestServer.register(moduleUnderTest);
-
-        // when
-        const { statusCode } = await httpTestServer.request(method, url, {
-          data: {
-            attributes: {
-              name: undefined,
+        it('[category] should return a 400 error when it is not a string', async function () {
+          // when
+          const response = await httpTestServer.request(method, url, {
+            data: {
+              attributes: {
+                category: 404,
+              },
             },
-          },
+          });
+
+          // then
+          expect(response.statusCode).to.equal(400);
         });
 
-        // then
-        expect(statusCode).to.equal(400);
+        it('[comment] should return a 400 error when it has more than 500 characters', async function () {
+          // when
+          const response = await httpTestServer.request(method, url, {
+            data: {
+              attributes: {
+                comment: String('abcdef').repeat(100),
+              },
+            },
+          });
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+
+        it('[description] should return a 400 error when it has more than 500 characters', async function () {
+          // when
+          const { statusCode } = await httpTestServer.request(method, url, {
+            data: {
+              attributes: {
+                description: String('abcdef').repeat(100),
+              },
+            },
+          });
+
+          // then
+          expect(statusCode).to.equal(400);
+        });
+
+        it('[image-url] should return a 400 error when it is not a valid URI', async function () {
+          // when
+          const response = await httpTestServer.request(method, url, {
+            data: {
+              attributes: {
+                'image-url': String('not-a-valid-URI.org'),
+              },
+            },
+          });
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+
+        it('[name] should return a 400 error when it is not a string', async function () {
+          // when
+          const response = await httpTestServer.request(method, url, {
+            data: {
+              attributes: {
+                name: 404,
+              },
+            },
+          });
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+
+        it('[tubes] should return a 400 error when it is not an array of accepted object', async function () {
+          // when
+          const response = await httpTestServer.request(method, url, {
+            data: {
+              attributes: {
+                tubes: [{ id: 'some-id', level: NaN }],
+              },
+            },
+          });
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
       });
     });
 

--- a/api/tests/unit/domain/models/TargetProfileForAdmin_test.js
+++ b/api/tests/unit/domain/models/TargetProfileForAdmin_test.js
@@ -1,0 +1,77 @@
+import { DomainError } from '../../../../lib/domain/errors.js';
+import { catchErr, domainBuilder, expect } from '../../../test-helper.js';
+
+describe('Unit | Domain | Models | TargetProfileForAdmin', function () {
+  describe('#update', function () {
+    context('when has a linked campaign and has tubes to update', function () {
+      it('should throw an error', async function () {
+        // given
+        const targetProfileForAdmin = domainBuilder.buildTargetProfileForAdmin({ hasLinkedCampaign: true });
+
+        // when
+        const error = await catchErr(
+          targetProfileForAdmin.update,
+          targetProfileForAdmin,
+        )({
+          tubes: [Symbol('tube')],
+        });
+
+        // then
+        expect(error).to.be.an.instanceof(DomainError);
+      });
+    });
+
+    context('when the new category is not valid', function () {
+      it('should throw an error', async function () {
+        // given
+        const targetProfileForAdmin = domainBuilder.buildTargetProfileForAdmin({ category: 'NOT VALID' });
+
+        // when
+        const error = await catchErr(
+          targetProfileForAdmin.update,
+          targetProfileForAdmin,
+        )({
+          tubes: [Symbol('tube')],
+        });
+
+        // then
+        expect(error).to.be.an.instanceof(DomainError);
+      });
+    });
+
+    context('happy path', function () {
+      it('it should update the model', async function () {
+        // given
+        const targetProfileForAdmin = domainBuilder.buildTargetProfileForAdmin({
+          areKnowledgeElementsResettable: false,
+          category: 'CUSTOM',
+          comment: '',
+          description: '',
+          imageUrl: 'old url',
+          name: 'old name',
+          tubes: [],
+        });
+
+        // when
+        targetProfileForAdmin.update({
+          areKnowledgeElementsResettable: true,
+          category: 'OTHER',
+          comment: 'new comment',
+          description: 'new description',
+          imageUrl: 'new url',
+          name: 'new name',
+          tubes: ['tube'],
+        });
+
+        // then
+        expect(targetProfileForAdmin.areKnowledgeElementsResettable).to.be.true;
+        expect(targetProfileForAdmin.category).to.equal('OTHER');
+        expect(targetProfileForAdmin.comment).to.equal('new comment');
+        expect(targetProfileForAdmin.description).to.equal('new description');
+        expect(targetProfileForAdmin.imageUrl).to.equal('new url');
+        expect(targetProfileForAdmin.name).to.equal('new name');
+        expect(targetProfileForAdmin.tubes).to.deep.equal(['tube']);
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/update-target-profile_test.js
+++ b/api/tests/unit/domain/usecases/update-target-profile_test.js
@@ -1,236 +1,50 @@
 import { usecases } from '../../../../lib/domain/usecases/index.js';
-import { EntityValidationError } from '../../../../src/shared/domain/errors.js';
-import { catchErr, expect, sinon } from '../../../test-helper.js';
-
-const { updateTargetProfile } = usecases;
+import { expect, sinon } from '../../../test-helper.js';
 
 describe('Unit | UseCase | update-target-profile', function () {
-  let targetProfileForUpdateRepository = null;
+  let targetProfileForAdminRepository, targetProfileForUpdateRepository;
 
   beforeEach(function () {
+    targetProfileForAdminRepository = {
+      get: sinon.stub(),
+    };
+
     targetProfileForUpdateRepository = {
       update: sinon.stub(),
     };
   });
 
-  it('should throw error when name is null', async function () {
-    // when
-    const error = await catchErr(updateTargetProfile)({
-      id: 123,
-      name: null,
-      imageUrl: 'mon image',
-      description: 'description changée',
-      comment: 'commentaire changé',
-      category: 'OTHER',
-      targetProfileForUpdateRepository,
+  context('when the target profile exists', function () {
+    it('should call targetProfileForUpdateRepository #update method', async function () {
+      // given
+      const existingTargetProfileForAdmin = {
+        id: 1,
+        update: sinon.stub(),
+      };
+
+      const attributesToUpdate = {
+        name: 'new name',
+        category: 'OTHER',
+        description: 'new description',
+        comment: 'new comment',
+        imageUrl: 'http://img.org',
+        areKnowledgeElementsResettable: false,
+      };
+
+      targetProfileForAdminRepository.get.resolves(existingTargetProfileForAdmin);
+
+      // when
+      await usecases.updateTargetProfile({
+        id: 1,
+        attributesToUpdate,
+        targetProfileForAdminRepository,
+        targetProfileForUpdateRepository,
+      });
+
+      // then
+      expect(existingTargetProfileForAdmin.update).to.have.been.calledOnceWithExactly(attributesToUpdate);
+
+      expect(targetProfileForUpdateRepository.update).to.have.been.calledOnce;
     });
-
-    expect(error).to.be.an.instanceOf(EntityValidationError);
-    expect(error.invalidAttributes[0].attribute).to.eq('name');
-    expect(error.invalidAttributes[0].message).to.eq('NAME_IS_REQUIRED');
-    expect(targetProfileForUpdateRepository.update).to.not.have.been.called;
-  });
-
-  it('should throw error when name is undefined', async function () {
-    // when
-    const error = await catchErr(updateTargetProfile)({
-      id: 123,
-      imageUrl: 'mon image',
-      description: 'description changée',
-      comment: 'commentaire changé',
-      category: 'OTHER',
-      targetProfileForUpdateRepository,
-    });
-
-    expect(error).to.be.an.instanceOf(EntityValidationError);
-    expect(error.invalidAttributes[0].attribute).to.eq('name');
-    expect(error.invalidAttributes[0].message).to.eq('NAME_IS_REQUIRED');
-    expect(targetProfileForUpdateRepository.update).to.not.have.been.called;
-  });
-
-  it('should throw error when name is empty', async function () {
-    // when
-    const error = await catchErr(updateTargetProfile)({
-      id: 123,
-      name: '',
-      imageUrl: 'mon image',
-      description: 'description changée',
-      comment: 'commentaire changé',
-      category: 'OTHER',
-      targetProfileForUpdateRepository,
-    });
-
-    expect(error).to.be.an.instanceOf(EntityValidationError);
-    expect(error.invalidAttributes[0].attribute).to.eq('name');
-    expect(error.invalidAttributes[0].message).to.eq('NAME_IS_REQUIRED');
-    expect(targetProfileForUpdateRepository.update).to.not.have.been.called;
-  });
-
-  it('should throw error when category is null', async function () {
-    // when
-    const error = await catchErr(updateTargetProfile)({
-      id: 123,
-      name: 'name',
-      imageUrl: 'mon image',
-      description: 'description changée',
-      comment: 'commentaire changé',
-      category: null,
-      targetProfileForUpdateRepository,
-    });
-
-    expect(error).to.be.an.instanceOf(EntityValidationError);
-    expect(error.invalidAttributes[0].attribute).to.eq('category');
-    expect(error.invalidAttributes[0].message).to.eq('CATEGORY_IS_REQUIRED');
-    expect(targetProfileForUpdateRepository.update).to.not.have.been.called;
-  });
-
-  it('should throw error when category is undefined', async function () {
-    // when
-    const error = await catchErr(updateTargetProfile)({
-      id: 123,
-      name: 'name',
-      imageUrl: 'mon image',
-      description: 'description changée',
-      comment: 'commentaire changé',
-      targetProfileForUpdateRepository,
-    });
-
-    expect(error).to.be.an.instanceOf(EntityValidationError);
-    expect(error.invalidAttributes[0].attribute).to.eq('category');
-    expect(error.invalidAttributes[0].message).to.eq('CATEGORY_IS_REQUIRED');
-    expect(targetProfileForUpdateRepository.update).to.not.have.been.called;
-  });
-
-  it('should throw error when category is empty', async function () {
-    // when
-    const error = await catchErr(updateTargetProfile)({
-      id: 123,
-      name: 'name',
-      imageUrl: 'mon image',
-      description: 'description changée',
-      comment: 'commentaire changé',
-      category: '',
-      targetProfileForUpdateRepository,
-    });
-
-    expect(error).to.be.an.instanceOf(EntityValidationError);
-    expect(error.invalidAttributes[0].attribute).to.eq('category');
-    expect(error.invalidAttributes[0].message).to.eq('CATEGORY_IS_REQUIRED');
-    expect(targetProfileForUpdateRepository.update).to.not.have.been.called;
-  });
-
-  it('should throw error when imageUrl is null', async function () {
-    // when
-    const error = await catchErr(updateTargetProfile)({
-      id: 123,
-      name: 'name',
-      imageUrl: null,
-      description: 'description changée',
-      comment: 'commentaire changé',
-      category: 'OTHER',
-      targetProfileForUpdateRepository,
-    });
-
-    expect(error).to.be.an.instanceOf(EntityValidationError);
-    expect(error.invalidAttributes[0].attribute).to.eq('imageUrl');
-    expect(error.invalidAttributes[0].message).to.eq('IMAGE_URL_IS_REQUIRED');
-    expect(targetProfileForUpdateRepository.update).to.not.have.been.called;
-  });
-
-  it('should throw error when imageUrl is undefined', async function () {
-    // when
-    const error = await catchErr(updateTargetProfile)({
-      id: 123,
-      name: 'name',
-      description: 'description changée',
-      comment: 'commentaire changé',
-      category: 'OTHER',
-      targetProfileForUpdateRepository,
-    });
-
-    expect(error).to.be.an.instanceOf(EntityValidationError);
-    expect(error.invalidAttributes[0].attribute).to.eq('imageUrl');
-    expect(error.invalidAttributes[0].message).to.eq('IMAGE_URL_IS_REQUIRED');
-    expect(targetProfileForUpdateRepository.update).to.not.have.been.called;
-  });
-
-  it('should throw error when imageUrl is empty', async function () {
-    // when
-    const error = await catchErr(updateTargetProfile)({
-      id: 123,
-      name: 'name',
-      imageUrl: '',
-      description: 'description changée',
-      comment: 'commentaire changé',
-      category: 'OTHER',
-      targetProfileForUpdateRepository,
-    });
-
-    expect(error).to.be.an.instanceOf(EntityValidationError);
-    expect(error.invalidAttributes[0].attribute).to.eq('imageUrl');
-    expect(error.invalidAttributes[0].message).to.eq('IMAGE_URL_IS_REQUIRED');
-    expect(targetProfileForUpdateRepository.update).to.not.have.been.called;
-  });
-
-  it('should throw error when imageUrl is not an URI', async function () {
-    // when
-    const error = await catchErr(updateTargetProfile)({
-      id: 123,
-      name: 'name',
-      imageUrl: 'hello les copains !',
-      description: 'description changée',
-      comment: 'commentaire changé',
-      category: 'OTHER',
-      targetProfileForUpdateRepository,
-    });
-
-    expect(error).to.be.an.instanceOf(EntityValidationError);
-    expect(error.invalidAttributes[0].attribute).to.eq('imageUrl');
-    expect(error.invalidAttributes[0].message).to.eq('IMAGE_URL_IS_REQUIRED');
-    expect(targetProfileForUpdateRepository.update).to.not.have.been.called;
-  });
-
-  it('should throw error when category value is not amongst valid values', async function () {
-    // when
-    const error = await catchErr(updateTargetProfile)({
-      id: 123,
-      name: 'name',
-      imageUrl: 'mon image',
-      description: 'description changée',
-      comment: 'commentaire changé',
-      category: 'LE_PAIN_AU_CHOCOLAT_C_TRES_BON',
-      targetProfileForUpdateRepository,
-    });
-
-    expect(error).to.be.an.instanceOf(EntityValidationError);
-    expect(error.invalidAttributes[0].attribute).to.eq('category');
-    expect(error.invalidAttributes[0].message).to.eq('CATEGORY_IS_REQUIRED');
-    expect(targetProfileForUpdateRepository.update).to.not.have.been.called;
-  });
-
-  it('should call repository method to update a target profile', async function () {
-    // given
-    const baseTargetProfileData = {
-      name: 'Tom',
-      imageUrl: 'http://ma-super-image/image.png',
-      description: 'description changée',
-      comment: 'commentaire changé',
-      category: 'OTHER',
-      areKnowledgeElementsResettable: false,
-    };
-    const targetProfileToUpdate = {
-      targetProfileId: 123,
-      ...baseTargetProfileData,
-    };
-
-    //when
-    await updateTargetProfile({
-      id: 123,
-      ...baseTargetProfileData,
-      targetProfileForUpdateRepository,
-    });
-
-    //then
-    expect(targetProfileForUpdateRepository.update).to.have.been.calledOnceWithExactly(targetProfileToUpdate);
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Nous avons l'objectif de rendre possible la duplication d'un profil cible existant en autorisant la modification de son référentiel.

Or, à l'heure actuelle, il n'est pas permis de modifier ce référentiel.

## :robot: Proposition

La route `PATCH /api/admin/target-profiles/{id}` accepte maintenant les `tubes` en payload.

Pour respecter le DDD, dans le modèle `TargetProfileForAdmin`, on a ajouté une méthode dédiée à l'`update` qui gère les besoins métier :
- on permet la modification des tubes uniquement si le profil cible n'est pas relié à une campagne,
- on vérifie la validité de la nouvelle valeur de la propriété `category`,
- on vient mettre à jour les données du model directement dans cette méthode.

## :rainbow: Remarques

1. La méthode du TargetProfileSerializer `deserializeCreationCommand` a été renommée `deserialize` car elle est maintenant aussi utilisée pour la modification.

2. Dans tous les cas, on ne permet pas la modification de la propriété `isPublic`.

3. Le `allowUnknown` (https://github.com/1024pix/pix/blob/dev/api/lib/application/target-profiles/index.js#L337) sur la payload a été supprimé, il convient donc de modifier l'adapter d'Ember.

## :100: Pour tester

- Tests verts
- Vérifier que la modification de profil cible fonctionne toujours sur PixAdmin.
