### PR TITLE
[BUGFIX] Réparer l'alignement des labels des épreuves (PIX-12438).

### DIFF
--- a/mon-pix/app/styles/components/_rounded-panel.scss
+++ b/mon-pix/app/styles/components/_rounded-panel.scss
@@ -29,10 +29,6 @@
     padding: 16px;
     border-radius: 8px;
   }
-
-  &__row label {
-    display: inline;
-  }
 }
 
 .rounded-panel hr {

--- a/mon-pix/tests/acceptance/challenge-item-qcm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qcm_test.js
@@ -30,7 +30,7 @@ module('Acceptance | Displaying a QCM challenge', function (hooks) {
 
       assert.dom(screen.getByRole('checkbox', { name: 'possibilite 1, et/ou' })).exists();
       assert.dom(screen.getByRole('checkbox', { name: 'possibilite 2 , et/ou' })).exists();
-      assert.dom(screen.getByRole('checkbox', { name: 'possibilite 3, et/ou' })).exists();
+      assert.dom(screen.getByRole('checkbox', { name: 'possibilite 3 , et/ou' })).exists();
       assert.dom(screen.getByRole('checkbox', { name: 'possibilite 4' })).exists();
 
       assert
@@ -71,7 +71,7 @@ module('Acceptance | Displaying a QCM challenge', function (hooks) {
     test('should go to checkpoint when user validated', async function (assert) {
       // given
       await click(screen.getByRole('checkbox', { name: 'possibilite 2 , et/ou' }));
-      await click(screen.getByRole('checkbox', { name: 'possibilite 3, et/ou' }));
+      await click(screen.getByRole('checkbox', { name: 'possibilite 3 , et/ou' }));
 
       // when
       await click(screen.getByRole('button', { name: 'Je valide et je vais à la prochaine question' }));
@@ -102,8 +102,8 @@ module('Acceptance | Displaying a QCM challenge', function (hooks) {
       assert.true(screen.getByRole('checkbox', { name: 'possibilite 1, et/ou' }).disabled);
       assert.true(screen.getByRole('checkbox', { name: 'possibilite 2 , et/ou' }).checked);
       assert.true(screen.getByRole('checkbox', { name: 'possibilite 2 , et/ou' }).disabled);
-      assert.false(screen.getByRole('checkbox', { name: 'possibilite 3, et/ou' }).checked);
-      assert.true(screen.getByRole('checkbox', { name: 'possibilite 3, et/ou' }).disabled);
+      assert.false(screen.getByRole('checkbox', { name: 'possibilite 3 , et/ou' }).checked);
+      assert.true(screen.getByRole('checkbox', { name: 'possibilite 3 , et/ou' }).disabled);
       assert.true(screen.getByRole('checkbox', { name: 'possibilite 4' }).checked);
       assert.true(screen.getByRole('checkbox', { name: 'possibilite 4' }).disabled);
 


### PR DESCRIPTION
## :unicorn: Problème

L'alignement des labels des QCU et QCM est cassé depuis la montée de version de Pix UI v45.

## :robot: Proposition

Supprimer la ligne CSS impactant l'alignement des labels dans les épreuves.

## :100: Pour tester

Vérifier l'alignement des labels dans les différentes épreuves disponibles sur SOS-recid ([ex QCM](https://app-pr8843.review.pix.fr/challenges/recLt9uwa2dR3IYpi/preview), [ex QCU](https://app-pr8843.review.pix.fr/challenges/recT0Ks2EDgoDgEKc/preview)).
