### PR TITLE
[TECH] Ajouter une valeur par défaut pour LOG_ENABLED

### DIFF
--- a/api/lib/infrastructure/validate-environment-variables.js
+++ b/api/lib/infrastructure/validate-environment-variables.js
@@ -21,7 +21,7 @@ const schema = Joi.object({
   DOMAIN_PIX_ORGA: Joi.string().optional(),
   LCMS_API_KEY: Joi.string().required(),
   LCMS_API_URL: Joi.string().uri().required(),
-  LOG_ENABLED: Joi.string().optional().valid('true', 'false'),
+  LOG_ENABLED: Joi.string().required().valid('true', 'false'),
   LOG_LEVEL: Joi.string().optional().valid('silent', 'fatal', 'error', 'warn', 'info', 'debug', 'trace'),
   LOG_FOR_HUMANS: Joi.string().optional().valid('true', 'false'),
   LOG_OPS_METRICS: Joi.string().optional().valid('true', 'false'),

--- a/api/sample.env
+++ b/api/sample.env
@@ -337,10 +337,10 @@ LCMS_API_URL=https://lcms.minimal.pix.fr/api
 
 # Enable or disable the logging of the API.
 #
-# presence: optional
+# presence: required
 # type: Boolean
 # default: `true`
-# LOG_ENABLED=true
+LOG_ENABLED=true
 LOG_STARTING_EVENT_DISPATCH=true
 LOG_ENDING_EVENT_DISPATCH=true
 


### PR DESCRIPTION
## :unicorn: Problème
Lors de [cette PR](https://github.com/1024pix/pix/pull/8675), une régression a été introduite côté API dans la configuration des variables d'environnements. Ainsi, en local, nous n'avions plus de logs pour l'API, car la variable par défaut LOG_ENABLED était commentée dans le sample.env (et donc dans les .env locaux).

## :robot: Proposition
Par mesure de sécurité, nous avons passé `LOG_ENABLED` en `required` dans le fichier `api/lib/infrastructure/validate-environment-variables.js` et nous l'avons dé-commenté du `sample.env`

## :rainbow: Remarques
Le fichier config.js n'est pas testé et on constate qu'il peut y avoir des régressions.
Peut-être faudrait-il tester au cas par cas lorsqu'on trouve une régression (par exemple en commençant par le cas présent) ?
Cela peut être un sujet d'aprèm tech.

## :100: Pour tester

1. Récupérer la branche
2. Commenter la variable `LOG_ENABLED` dans le `.env`
4. Lancer l'api en local
5. S'assurer que le terminal renvoi une erreur car la variable est requise
6. Dé-commenter la variable et lui assigner `true`
7. Relancer l'api
8. S'assurer que les logs apparaissent
