### PR TITLE
[FEATURE] Afficher si le centre de certification est pilote certification seule dans Pix Admin (PIX-12441)

### DIFF
--- a/.husky/lint
+++ b/.husky/lint
@@ -2,7 +2,7 @@
 
 set -e
 
-npx lint-staged --cwd 1d
+npx lint-staged --cwd junior
 npx lint-staged --cwd admin
 npx lint-staged --cwd certif
 npx lint-staged --cwd mon-pix

--- a/admin/app/components/certification-centers/habilitation-tag/index.hbs
+++ b/admin/app/components/certification-centers/habilitation-tag/index.hbs
@@ -1,0 +1,4 @@
+<li aria-label={{this.ariaLabel}}>
+  <FaIcon class={{this.className}} @icon={{this.icon}} />
+  {{@label}}
+</li>

--- a/admin/app/components/certification-centers/habilitation-tag/index.js
+++ b/admin/app/components/certification-centers/habilitation-tag/index.js
@@ -1,0 +1,21 @@
+import Component from '@glimmer/component';
+
+export default class HabilitationTag extends Component {
+  get ariaLabel() {
+    const { active, label } = this.args;
+
+    return `${active ? 'Habilité' : 'Non habilité'} pour ${label}`;
+  }
+
+  get className() {
+    const { active } = this.args;
+
+    return `${active ? '' : 'non-'}granted-habilitation-icon`;
+  }
+
+  get icon() {
+    const { active } = this.args;
+
+    return `circle-${active ? 'check' : 'xmark'}`;
+  }
+}

--- a/admin/app/components/certification-centers/information-edit.hbs
+++ b/admin/app/components/certification-centers/information-edit.hbs
@@ -1,144 +1,139 @@
-<h1>Modifier un centre de certification</h1>
-<div class="certification-center-information__edit-form">
-  <form class="form" onsubmit={{this.updateCertificationCenter}}>
+<h2 class="certification-center-information__edit-title">Modifier un centre de certification</h2>
 
-    <div class="form-field">
-      <label for="name" class="field__label">Nom du centre</label>
-      {{#if (v-get this.form "name" "isInvalid")}}
-        <div class="form-field__error" aria-label="Message d'erreur du champ nom">
-          {{v-get this.form "name" "message"}}
-        </div>
-      {{/if}}
-      <Input
-        id="name"
-        @type="text"
-        class={{if (v-get this.form "name" "isInvalid") "form-control is-invalid" "form-control"}}
-        @value={{this.form.name}}
-        required={{true}}
-      />
-    </div>
+<form class="form certification-center-information__edit-form" onsubmit={{this.updateCertificationCenter}}>
 
-    <div class="form-field">
-      <PixSelect
-        @options={{this.certificationCenterTypes}}
-        @placeholder="-- Choisissez --"
-        @value={{this.form.type}}
-        @onChange={{this.selectCertificationCenterType}}
-        @errorMessage={{v-get this.form "type" "message"}}
-      >
-        <:label>Type</:label>
-        <:default as |certificationCenterType|>{{certificationCenterType.label}}</:default>
-      </PixSelect>
-    </div>
+  <label class="field-label">
+    <abbr title="obligatoire" class="mandatory-mark">*</abbr>
+    Nom du centre
+    <Input
+      id="name"
+      @type="text"
+      class={{if (v-get this.form "name" "isInvalid") "form-control is-invalid" "form-control"}}
+      @value={{this.form.name}}
+      required={{true}}
+    />
+  </label>
 
-    <div class="form-field">
-      <label for="external-id" class="field__label">Identifiant externe</label>
-      {{#if (v-get this.form "externalId" "isInvalid")}}
-        <div class="form-field__error" aria-label="Message d'erreur du champ ID externe">
-          {{v-get this.form "externalId" "message"}}
-        </div>
-      {{/if}}
-      <Input
-        id="external-id"
-        @type="text"
-        class={{if (v-get this.form "externalId" "isInvalid") "form-control is-invalid" "form-control"}}
-        @value={{this.form.externalId}}
-      />
-    </div>
+  {{#if (v-get this.form "name" "isInvalid")}}
+    <span class="error" aria-label="Message d'erreur du champ nom">
+      {{v-get this.form "name" "message"}}
+    </span>
+  {{/if}}
 
-    <div class="form-field">
-      <label for="data-protection-officer-first-name" class="field__label">Prénom du
-        <abbr title="Délégué à la protection des données">DPO</abbr></label>
-      {{#if (v-get this.form "dataProtectionOfficerFirstName" "isInvalid")}}
-        <div class="form-field__error" aria-label="Message d'erreur du champ Prénom du DPO">
-          {{v-get this.form "dataProtectionOfficerFirstName" "message"}}
-        </div>
-      {{/if}}
-      <Input
-        id="data-protection-officer-first-name"
-        @type="text"
-        class={{if
-          (v-get this.form "dataProtectionOfficerFirstName" "isInvalid")
-          "form-control is-invalid"
-          "form-control"
-        }}
-        @value={{this.form.dataProtectionOfficerFirstName}}
-      />
-    </div>
+  <PixSelect
+    @options={{this.certificationCenterTypes}}
+    @placeholder="-- Choisissez --"
+    @value={{this.form.type}}
+    @onChange={{this.selectCertificationCenterType}}
+    @errorMessage={{v-get this.form "type" "message"}}
+  >
+    <:label>Type</:label>
+    <:default as |certificationCenterType|>{{certificationCenterType.label}}</:default>
+  </PixSelect>
 
-    <div class="form-field">
-      <label for="data-protection-officer-last-name" class="field__label">Nom du
-        <abbr title="Délégué à la protection des données">DPO</abbr></label>
-      {{#if (v-get this.form "dataProtectionOfficerLastName" "isInvalid")}}
-        <div class="form-field__error" aria-label="Message d'erreur du champ Nom du DPO">
-          {{v-get this.form "dataProtectionOfficerLastName" "message"}}
-        </div>
-      {{/if}}
-      <Input
-        id="data-protection-officer-last-name"
-        @type="text"
-        class={{if
-          (v-get this.form "dataProtectionOfficerLastName" "isInvalid")
-          "form-control is-invalid"
-          "form-control"
-        }}
-        @value={{this.form.dataProtectionOfficerLastName}}
-      />
-    </div>
+  <label class="field-label">
+    Identifiant externe
+    <Input
+      id="external-id"
+      @type="text"
+      class={{if (v-get this.form "externalId" "isInvalid") "form-control is-invalid" "form-control"}}
+      @value={{this.form.externalId}}
+    />
+  </label>
 
-    <div class="form-field">
-      <label for="data-protection-officer-email" class="field__label">Adresse e-mail du
-        <abbr title="Délégué à la protection des données">DPO</abbr></label>
-      {{#if (v-get this.form "dataProtectionOfficerEmail" "isInvalid")}}
-        <div class="form-field__error" aria-label="Message d'erreur du champ Adresse e-mail du DPO">
-          {{v-get this.form "dataProtectionOfficerEmail" "message"}}
-        </div>
-      {{/if}}
-      <Input
-        id="data-protection-officer-email"
-        @type="text"
-        class={{if (v-get this.form "dataProtectionOfficerEmail" "isInvalid") "form-control is-invalid" "form-control"}}
-        @value={{this.form.dataProtectionOfficerEmail}}
-      />
-    </div>
+  {{#if (v-get this.form "externalId" "isInvalid")}}
+    <span class="error" aria-label="Message d'erreur du champ ID externe">
+      {{v-get this.form "externalId" "message"}}
+    </span>
+  {{/if}}
 
-    <div class="form-field">
-      <PixCheckbox
-        @id="isV3Pilot"
-        @size="small"
-        onChange={{this.updateIsV3Pilot}}
-        @checked={{this.form.isV3Pilot}}
-        class="form-field certification-center-information__edit-form__is-v3-pilot-checkbox"
-      >
-        <:label>{{t "components.certification-centers.is-v3-pilot-label"}}</:label>
-      </PixCheckbox>
-    </div>
+  <label class="field-label">
+    Prénom du
+    <abbr title="Délégué à la protection des données">DPO</abbr>
+    <Input
+      @type="text"
+      class={{if
+        (v-get this.form "dataProtectionOfficerFirstName" "isInvalid")
+        "form-control is-invalid"
+        "form-control"
+      }}
+      @value={{this.form.dataProtectionOfficerFirstName}}
+    />
+  </label>
 
-    <h2 class="field__label">Habilitations aux certifications complémentaires</h2>
-    <ul class="form-field certification-center-information__edit-form__habilitations-checkbox-list">
-      {{#each this.availableHabilitations as |habilitation|}}
-        <li class="habilitation-entry">
-          <Input
-            id="habilitation-checkbox__{{habilitation.id}}"
-            @type="checkbox"
-            @checked={{contains habilitation @certificationCenter.habilitations}}
-            {{on "input" (fn this.updateGrantedHabilitation habilitation)}}
-          />
-          <label class="field__label" for="habilitation-checkbox__{{habilitation.id}}">
-            {{habilitation.label}}
-          </label>
-        </li>
-      {{/each}}
-    </ul>
+  {{#if (v-get this.form "dataProtectionOfficerFirstName" "isInvalid")}}
+    <span class="error" aria-label="Message d'erreur du champ Prénom du DPO">
+      {{v-get this.form "dataProtectionOfficerFirstName" "message"}}
+    </span>
+  {{/if}}
 
-    <div class="form-actions">
-      <PixButton
-        @size="small"
-        @backgroundColor="transparent-light"
-        @isBorderVisible={{false}}
-        @triggerAction={{@toggleEditMode}}
-      >Annuler</PixButton>
-      <PixButton @type="submit" @size="small" @backgroundColor="primary">Enregistrer</PixButton>
-    </div>
-  </form>
-</div>
+  <label class="field-label">
+    Nom du
+    <abbr title="Délégué à la protection des données">DPO</abbr>
+    <Input
+      id="data-protection-officer-last-name"
+      @type="text"
+      class={{if
+        (v-get this.form "dataProtectionOfficerLastName" "isInvalid")
+        "form-control is-invalid"
+        "form-control"
+      }}
+      @value={{this.form.dataProtectionOfficerLastName}}
+    />
+  </label>
+
+  {{#if (v-get this.form "dataProtectionOfficerLastName" "isInvalid")}}
+    <span class="error" aria-label="Message d'erreur du champ Nom du DPO">
+      {{v-get this.form "dataProtectionOfficerLastName" "message"}}
+    </span>
+  {{/if}}
+
+  <label class="field-label">
+    Adresse e-mail du
+    <abbr title="Délégué à la protection des données">DPO</abbr>
+    <Input
+      @type="text"
+      class={{if (v-get this.form "dataProtectionOfficerEmail" "isInvalid") "form-control is-invalid" "form-control"}}
+      @value={{this.form.dataProtectionOfficerEmail}}
+    />
+  </label>
+
+  {{#if (v-get this.form "dataProtectionOfficerEmail" "isInvalid")}}
+    <span class="error" aria-label="Message d'erreur du champ Adresse e-mail du DPO">
+      {{v-get this.form "dataProtectionOfficerEmail" "message"}}
+    </span>
+  {{/if}}
+
+  <PixCheckbox @id="isV3Pilot" @size="small" onChange={{this.updateIsV3Pilot}} @checked={{this.form.isV3Pilot}}>
+    <:label>{{t "components.certification-centers.is-v3-pilot-label"}}</:label>
+  </PixCheckbox>
+
+  <span class="field-label">Habilitations aux certifications complémentaires</span>
+  <ul class="form-field certification-center-information__edit-form__habilitations-checkbox-list">
+    {{#each this.availableHabilitations as |habilitation|}}
+      <li class="habilitation-entry">
+        <Input
+          id="habilitation-checkbox__{{habilitation.id}}"
+          @type="checkbox"
+          @checked={{contains habilitation @certificationCenter.habilitations}}
+          {{on "input" (fn this.updateGrantedHabilitation habilitation)}}
+        />
+        <label class="field-label" for="habilitation-checkbox__{{habilitation.id}}">
+          {{habilitation.label}}
+        </label>
+      </li>
+    {{/each}}
+  </ul>
+
+  <div class="certification-center-information__action-buttons">
+    <PixButton
+      @size="small"
+      @backgroundColor="transparent-light"
+      @isBorderVisible={{true}}
+      @triggerAction={{@toggleEditMode}}
+    >
+      Annuler
+    </PixButton>
+    <PixButton @type="submit" @size="small" @backgroundColor="primary">Enregistrer</PixButton>
+  </div>
+</form>

--- a/admin/app/components/certification-centers/information-view.hbs
+++ b/admin/app/components/certification-centers/information-view.hbs
@@ -31,29 +31,19 @@
   <div class="property">
     <h2 class="field__label">{{t "pages.certification-centers.information-view.feature-habilitations.title"}}</h2>
     <ul class="certification-center-information__display__habilitations-list">
-      {{#if (eq @certificationCenter.isV3Pilot true)}}
-        <li aria-label={{concat "Habilité pour " this.isV3PilotLabel}}>
-          <FaIcon class="granted-habilitation-icon" @icon="circle-check" />
-          {{this.isV3PilotLabel}}
-        </li>
-      {{else}}
-        <li aria-label={{concat "Non habilité pour " this.isV3PilotLabel}}>
-          <FaIcon class="not-granted-habilitation-icon" @icon="circle-xmark" />
-          {{this.isV3PilotLabel}}
-        </li>
-      {{/if}}
-
-      {{#if (eq @certificationCenter.isComplementaryAlonePilot true)}}
-        <li aria-label={{concat "Habilité pour " this.isComplementaryAlonePilotLabel}}>
-          <FaIcon class="granted-habilitation-icon" @icon="circle-check" />
-          {{this.isComplementaryAlonePilotLabel}}
-        </li>
-      {{else}}
-        <li aria-label={{concat "Non habilité pour " this.isComplementaryAlonePilotLabel}}>
-          <FaIcon class="not-granted-habilitation-icon" @icon="circle-xmark" />
-          {{this.isComplementaryAlonePilotLabel}}
-        </li>
-      {{/if}}
+      {{#each this.availableFeatureHabilitations as |feature|}}
+        {{#if (eq feature.isPilot true)}}
+          <li aria-label={{concat "Habilité pour " feature.label}}>
+            <FaIcon class="granted-habilitation-icon" @icon="circle-check" />
+            {{feature.label}}
+          </li>
+        {{else}}
+          <li aria-label={{concat "Non habilité pour " feature.label}}>
+            <FaIcon class="not-granted-habilitation-icon" @icon="circle-xmark" />
+            {{feature.label}}
+          </li>
+        {{/if}}
+      {{/each}}
     </ul>
   </div>
   <div class="property">

--- a/admin/app/components/certification-centers/information-view.hbs
+++ b/admin/app/components/certification-centers/information-view.hbs
@@ -11,22 +11,49 @@
   <div class="property">
     <ul>
       <li>
-        Nom du
-        <abbr title="Délégué à la protection des données">DPO</abbr>
-        :
-        {{@certificationCenter.dataProtectionOfficerFullName}}
+        <label class="field__label">
+          Nom du
+          <abbr title="Délégué à la protection des données">DPO</abbr>
+          :
+        </label>
+        <span>{{@certificationCenter.dataProtectionOfficerFullName}}</span><br />
       </li>
       <li>
-        Adresse e-mail du
-        <abbr title="Délégué à la protection des données">DPO</abbr>
-        :
-        {{@certificationCenter.dataProtectionOfficerEmail}}
+        <label class="field__label">
+          Adresse e-mail du
+          <abbr title="Délégué à la protection des données">DPO</abbr>
+          :
+        </label>
+        <span>{{@certificationCenter.dataProtectionOfficerEmail}}</span><br />
       </li>
-      <li>
-        {{t "pages.certification-centers.information-view.is-v3-pilot"}}
-        :
-        {{if (eq @certificationCenter.isV3Pilot true) (t "common.words.yes") (t "common.words.no")}}
-      </li>
+    </ul>
+  </div>
+  <div class="property">
+    <h2 class="field__label">{{t "pages.certification-centers.information-view.feature-habilitations.title"}}</h2>
+    <ul class="certification-center-information__display__habilitations-list">
+      {{#if (eq @certificationCenter.isV3Pilot true)}}
+        <li aria-label={{concat "Habilité pour " this.isV3PilotLabel}}>
+          <FaIcon class="granted-habilitation-icon" @icon="circle-check" />
+          {{this.isV3PilotLabel}}
+        </li>
+      {{else}}
+        <li aria-label={{concat "Non habilité pour " this.isV3PilotLabel}}>
+          <FaIcon class="not-granted-habilitation-icon" @icon="circle-xmark" />
+          {{this.isV3PilotLabel}}
+        </li>
+      {{/if}}
+
+      {{#if (eq @certificationCenter.isComplementaryAlonePilot true)}}
+        <li aria-label={{concat "Habilité pour " this.isComplementaryAlonePilotLabel}}>
+          <FaIcon class="granted-habilitation-icon" @icon="circle-check" />
+          {{this.isComplementaryAlonePilotLabel}}
+        </li>
+      {{else}}
+        <li aria-label={{concat "Non habilité pour " this.isComplementaryAlonePilotLabel}}>
+          <FaIcon class="not-granted-habilitation-icon" @icon="circle-xmark" />
+          {{this.isComplementaryAlonePilotLabel}}
+        </li>
+      {{/if}}
     </ul>
   </div>
   <div class="property">

--- a/admin/app/components/certification-centers/information-view.hbs
+++ b/admin/app/components/certification-centers/information-view.hbs
@@ -1,81 +1,62 @@
-<div class="certification-center-information__display">
-  <h2 class="certification-center-information__display__name">{{@certificationCenter.name}}</h2>
-  <div class="property">
-    <label class="field__label">Type :</label>
-    <span>{{@certificationCenter.typeLabel}}</span><br />
-  </div>
-  <div class="property">
-    <label class="field__label">Identifiant externe :</label>
-    <span>{{@certificationCenter.externalId}}</span><br />
-  </div>
-  <div class="property">
-    <ul>
-      <li>
-        <label class="field__label">
-          Nom du
-          <abbr title="Délégué à la protection des données">DPO</abbr>
-          :
-        </label>
-        <span>{{@certificationCenter.dataProtectionOfficerFullName}}</span><br />
-      </li>
-      <li>
-        <label class="field__label">
-          Adresse e-mail du
-          <abbr title="Délégué à la protection des données">DPO</abbr>
-          :
-        </label>
-        <span>{{@certificationCenter.dataProtectionOfficerEmail}}</span><br />
-      </li>
-    </ul>
-  </div>
-  <div class="property">
-    <h2 class="field__label">{{t "pages.certification-centers.information-view.feature-habilitations.title"}}</h2>
-    <ul class="certification-center-information__display__habilitations-list">
-      {{#each this.availableFeatureHabilitations as |feature|}}
-        {{#if (eq feature.isPilot true)}}
-          <li aria-label={{concat "Habilité pour " feature.label}}>
-            <FaIcon class="granted-habilitation-icon" @icon="circle-check" />
-            {{feature.label}}
-          </li>
-        {{else}}
-          <li aria-label={{concat "Non habilité pour " feature.label}}>
-            <FaIcon class="not-granted-habilitation-icon" @icon="circle-xmark" />
-            {{feature.label}}
-          </li>
-        {{/if}}
-      {{/each}}
-    </ul>
-  </div>
-  <div class="property">
-    <h2 class="field__label">Habilitations aux certifications complémentaires</h2>
-    <ul class="certification-center-information__display__habilitations-list">
-      {{#each this.availableHabilitations as |habilitation|}}
-        {{#if (contains habilitation @certificationCenter.habilitations)}}
-          <li aria-label={{concat "Habilité pour " habilitation.label}}>
-            <FaIcon class="granted-habilitation-icon" @icon="circle-check" />
-            {{habilitation.label}}
-          </li>
-        {{else}}
-          <li aria-label={{concat "Non-habilité pour " habilitation.label}}>
-            <FaIcon class="not-granted-habilitation-icon" @icon="circle-xmark" />
-            {{habilitation.label}}
-          </li>
-        {{/if}}
-      {{/each}}
-    </ul>
-    <div class="certification-center-information__button-section">
-      <PixButton @size="small" @triggerAction={{@toggleEditMode}}>
-        Modifier
-      </PixButton>
+<h2 class="certification-center-information-display__name">{{@certificationCenter.name}}</h2>
 
-      <PixButtonLink
-        @backgroundColor="transparent-light"
-        @isBorderVisible={{true}}
-        @href={{this.externalURL}}
-        @size="small"
-        target="_blank"
-        rel="noopener noreferrer"
-      >Tableau de bord</PixButtonLink>
-    </div>
-  </div>
-</div>
+<dl class="certification-center-information-display__list">
+  <dt class="label">Type :</dt>
+  <dd>{{@certificationCenter.typeLabel}}</dd>
+
+  <dt class="label">Identifiant externe :</dt>
+  <dd>{{@certificationCenter.externalId}}</dd>
+
+  <dt class="label">
+    Nom du
+    <abbr title="Délégué à la protection des données">DPO</abbr>
+    :
+  </dt>
+  <dd>{{@certificationCenter.dataProtectionOfficerFullName}}</dd>
+
+  <dt class="label">
+    Adresse e-mail du
+    <abbr title="Délégué à la protection des données">DPO</abbr>
+    :
+  </dt>
+  <dd>{{@certificationCenter.dataProtectionOfficerEmail}}</dd>
+</dl>
+
+<span class="label">{{t "pages.certification-centers.information-view.feature-habilitations.title"}}</span>
+<ul class="certification-center-information-display__habilitations-list">
+  {{#each this.availableFeatureHabilitations as |feature|}}
+    <CertificationCenters::HabilitationTag @label={{feature.label}} @active={{feature.isPilot}} />
+  {{/each}}
+</ul>
+
+<div class="certification-center-information-display__divider"></div>
+
+<span class="label">Habilitations aux certifications complémentaires</span>
+<ul class="certification-center-information-display__habilitations-list">
+  {{#each this.availableHabilitations as |habilitation|}}
+    <CertificationCenters::HabilitationTag
+      @label={{habilitation.label}}
+      @active={{(contains habilitation @certificationCenter.habilitations)}}
+    />
+  {{/each}}
+</ul>
+
+<ul class="certification-center-information-display__action-buttons">
+  <li>
+    <PixButton @size="small" @triggerAction={{@toggleEditMode}}>
+      Modifier
+    </PixButton>
+  </li>
+  <li>
+    <PixButtonLink
+      @backgroundColor="transparent-light"
+      @isBorderVisible={{true}}
+      @href={{this.externalURL}}
+      @size="small"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Tableau de bord
+    </PixButtonLink>
+  </li>
+</ul>

--- a/admin/app/components/certification-centers/information-view.js
+++ b/admin/app/components/certification-centers/information-view.js
@@ -8,18 +8,24 @@ export default class InformationView extends Component {
     return this.args.availableHabilitations?.sortBy('id');
   }
 
+  get availableFeatureHabilitations() {
+    const isV3Pilot = this.args.certificationCenter.isV3Pilot;
+    const isV3PilotLabel = this.intl.t(
+      'pages.certification-centers.information-view.feature-habilitations.labels.is-v3-pilot',
+    );
+    const isComplementaryAlonePilot = this.args.certificationCenter.isComplementaryAlonePilot;
+    const isComplementaryAlonePilotLabel = this.intl.t(
+      'pages.certification-centers.information-view.feature-habilitations.labels.is-complementary-alone-pilot',
+    );
+
+    return [
+      { isPilot: isV3Pilot, label: isV3PilotLabel },
+      { isPilot: isComplementaryAlonePilot, label: isComplementaryAlonePilotLabel },
+    ];
+  }
+
   get externalURL() {
     const urlDashboardPrefix = ENV.APP.CERTIFICATION_CENTER_DASHBOARD_URL;
     return urlDashboardPrefix && urlDashboardPrefix + this.args.certificationCenter.id;
-  }
-
-  get isV3PilotLabel() {
-    return this.intl.t('pages.certification-centers.information-view.feature-habilitations.labels.is-v3-pilot');
-  }
-
-  get isComplementaryAlonePilotLabel() {
-    return this.intl.t(
-      'pages.certification-centers.information-view.feature-habilitations.labels.is-complementary-alone-pilot',
-    );
   }
 }

--- a/admin/app/components/certification-centers/information-view.js
+++ b/admin/app/components/certification-centers/information-view.js
@@ -1,7 +1,9 @@
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import ENV from 'pix-admin/config/environment';
 
 export default class InformationView extends Component {
+  @service intl;
   get availableHabilitations() {
     return this.args.availableHabilitations?.sortBy('id');
   }
@@ -9,5 +11,15 @@ export default class InformationView extends Component {
   get externalURL() {
     const urlDashboardPrefix = ENV.APP.CERTIFICATION_CENTER_DASHBOARD_URL;
     return urlDashboardPrefix && urlDashboardPrefix + this.args.certificationCenter.id;
+  }
+
+  get isV3PilotLabel() {
+    return this.intl.t('pages.certification-centers.information-view.feature-habilitations.labels.is-v3-pilot');
+  }
+
+  get isComplementaryAlonePilotLabel() {
+    return this.intl.t(
+      'pages.certification-centers.information-view.feature-habilitations.labels.is-complementary-alone-pilot',
+    );
   }
 }

--- a/admin/app/models/certification-center.js
+++ b/admin/app/models/certification-center.js
@@ -14,6 +14,7 @@ export default class CertificationCenter extends Model {
   @attr() dataProtectionOfficerLastName;
   @attr() dataProtectionOfficerEmail;
   @attr() isV3Pilot;
+  @attr() isComplementaryAlonePilot;
 
   @hasMany('complementary-certification') habilitations;
 

--- a/admin/app/styles/authenticated/certification-center/index.scss
+++ b/admin/app/styles/authenticated/certification-center/index.scss
@@ -21,6 +21,6 @@
   .error {
     padding-top: 5px;
     color: var(--pix-error-700);
-    font-size: 0.85rem;
+    font-size: 0.75rem;
   }
 }

--- a/admin/app/styles/components/certification-centers/information.scss
+++ b/admin/app/styles/components/certification-centers/information.scss
@@ -1,79 +1,39 @@
 /* stylelint-disable selector-class-pattern */
 .certification-center-information {
-  h1 {
-    padding-bottom: 16px;
-  }
 
-  &__button-section {
-    display: flex;
-    gap: 8px;
-    max-height: 60px;
-  }
+  &__edit-title{
+    @extend %pix-title-s;
 
-  &__display {
-    &__name {
-      margin-bottom: 20px;
-      font-weight: 600;
-      font-size: 1.5rem;
-    }
-
-    .property {
-      display: block;
-      padding: 0.5rem 1rem;
-      border-bottom: 0.05rem solid var(--pix-neutral-20);
-
-      &:last-child {
-        border-bottom: none;
-      }
-
-      ul {
-        padding: 0;
-        list-style: none;
-      }
-    }
+    padding-bottom: var(--pix-spacing-4x);
   }
 
   &__edit-form {
-    width: 500px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    max-width: fit-content;
   }
 
-  .field__label {
+  .field-label {
+    display: block;
+    color: var(--pix-neutral-900);
+    font-weight: var(--pix-font-medium);
+    font-size: 1rem;
+  }
+
+  .label {
+    display: block;
     color: var(--pix-neutral-800);
     font-weight: normal;
     font-size: 0.875rem;
   }
 
-  .form-field__checkbox {
-    display: flex;
-    gap: 0.5rem;
-
-    * {
-      align-self: center;
-      margin-bottom: 0;
-    }
-
-    input[type='checkbox'] {
-      width: 1rem;
-      height: 1rem;
-    }
-  }
-
-  .error {
-    padding-top: 5px;
-    color: var(--pix-error-700);
-    font-size: 0.85rem;
-  }
-
-  &__display__habilitations-list,
-  &__edit-form__habilitations-checkbox-list {
-    margin: 8px 0;
-    padding: 0;
-    list-style-type: none;
-  }
-
   &__edit-form__habilitations-checkbox-list {
     display: flex;
     flex-direction: column;
+    margin: 8px 0;
+    padding: 0;
+    list-style-type: none;
 
     .habilitation-entry {
       display: flex;
@@ -93,12 +53,29 @@
     }
   }
 
-  &__display__habilitations-list {
+  &__action-buttons {
+    display: flex;
+    gap: 8px;
+    padding-top: var(--pix-spacing-6x);
+  }
+}
+
+.certification-center-information-display {
+
+  &__action-buttons {
+    display: flex;
+    gap: 8px;
+    padding-top: var(--pix-spacing-6x);
+  }
+
+  &__name {
+    @extend %pix-title-s;
+  }
+
+  &__habilitations-list {
     display: inline-flex;
-    flex-direction: row;
     gap: 24px;
-    align-items: flex-start;
-    margin-bottom: 2rem;
+    margin: 8px 0;
 
     li {
       padding: 8px 16px;
@@ -111,7 +88,25 @@
     }
 
     .not-granted-habilitation-icon {
-      color: var(--pix-neutral-100);
+      color: var(--pix-neutral-500);
+    }
+  }
+
+  &__divider {
+    margin: var(--pix-spacing-2x) 0;
+    border-bottom: 0.05rem solid var(--pix-neutral-100);
+  }
+
+  &__list {
+    display: grid;
+    grid-template-columns: 170px auto;
+    padding: var(--pix-spacing-4x) 0 var(--pix-spacing-2x) 0;
+
+    dd, dt {
+      display: flex;
+      align-items: center;
+      padding: var(--pix-spacing-2x) 0;
+      border-bottom: 0.05rem solid var(--pix-neutral-100);
     }
   }
 }

--- a/admin/app/styles/components/certification-centers/information.scss
+++ b/admin/app/styles/components/certification-centers/information.scss
@@ -1,6 +1,5 @@
 /* stylelint-disable selector-class-pattern */
 .certification-center-information {
-
   h1 {
     padding-bottom: 16px;
   }
@@ -12,7 +11,6 @@
   }
 
   &__display {
-
     &__name {
       margin-bottom: 20px;
       font-weight: 600;
@@ -100,9 +98,13 @@
     flex-direction: row;
     gap: 24px;
     align-items: flex-start;
-    padding: 8px 16px;
-    background-color: var(--pix-neutral-20);
-    border-radius: 8px;
+    margin-bottom: 2rem;
+
+    li {
+      padding: 8px 16px;
+      background-color: var(--pix-neutral-20);
+      border-radius: 8px;
+    }
 
     .granted-habilitation-icon {
       color: var(--pix-success-700);

--- a/admin/app/styles/globals/form.scss
+++ b/admin/app/styles/globals/form.scss
@@ -76,22 +76,17 @@
   }
 }
 
-// TODO: Add this attribute in pix UI
-.pix-select select {
-  width: 100%;
-}
-
 .form-control {
   display: block;
   width: 100%;
   height: calc(1.5em + 0.75rem + 2px);
   padding: 0.375rem 0.75rem;
-  color: var(--pix-neutral-500);
+  color: var(--pix-neutral-900);
   font-size: 1rem;
   line-height: 1.5;
   background-color: var(--pix-neutral-0);
   background-clip: padding-box;
-  border: 1px solid var(--pix-neutral-100);
+  border: 1px solid var(--pix-neutral-500);
   border-radius: 0.25rem;
 }
 

--- a/admin/tests/acceptance/authenticated/certification-centers/get_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get_test.js
@@ -86,7 +86,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
     // then
     assert.dom(screen.getByLabelText('Habilité pour Pix+Edu')).exists();
     assert.dom(screen.getByLabelText('Habilité pour Pix+Surf')).exists();
-    assert.dom(screen.getByLabelText('Non-habilité pour Pix+Autre')).exists();
+    assert.dom(screen.getByLabelText('Non habilité pour Pix+Autre')).exists();
   });
 
   module('Update certification center', function () {
@@ -121,7 +121,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
       this.server.patch(`/admin/certification-centers/${certificationCenter.id}`, () => new Response({}), 204);
 
       // when
-      await fillByLabel('Nom du centre', 'nouveau nom');
+      await fillByLabel('Nom du centre', 'nouveau nom', { exact: false });
 
       await click(screen.getByRole('button', { name: 'Type' }));
       await screen.findByRole('listbox');
@@ -159,13 +159,13 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
       this.server.patch(`/admin/certification-centers/${certificationCenter.id}`, () => new Response({}), 204);
 
       // when
-      await fillByLabel('Nom du centre', 'Centre des réussites');
+      await fillByLabel('Nom du centre', 'Centre des réussites', { exact: false });
       await click(screen.getByRole('checkbox', { name: 'Pix+Surf' }));
       await clickByName('Enregistrer');
 
       // then
       assert.dom(screen.getByLabelText('Habilité pour Pix+Surf')).exists();
-      assert.dom(screen.getByLabelText('Non-habilité pour Pix+Autre')).exists();
+      assert.dom(screen.getByLabelText('Non habilité pour Pix+Autre')).exists();
       assert.dom(screen.getByText('Habilitations aux certifications complémentaires')).exists();
       assert.dom(screen.getByRole('heading', { name: 'Centre des réussites', level: 2 })).exists();
       assert.dom(screen.getByText('Centre de certification mis à jour avec succès.')).exists();

--- a/admin/tests/acceptance/authenticated/certification-centers/get_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get_test.js
@@ -138,8 +138,8 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
       assert.dom(screen.getByRole('heading', { name: 'nouveau nom', level: 2 })).exists();
       assert.dom(screen.getByText('Établissement supérieur')).exists();
       assert.dom(screen.getByText('nouvel identifiant externe')).exists();
-      assert.dom(screen.getByText('Nom du : Justin Ptipeu')).exists();
-      assert.dom(screen.getByText('Adresse e-mail du : justin.ptipeu@example.net')).exists();
+      assert.dom(screen.getByText('Justin Ptipeu')).exists();
+      assert.dom(screen.getByText('justin.ptipeu@example.net')).exists();
       assert.strictEqual(screen.getAllByTitle('Délégué à la protection des données').length, 2);
     });
 

--- a/admin/tests/integration/components/certification-centers/information-edit_test.js
+++ b/admin/tests/integration/components/certification-centers/information-edit_test.js
@@ -51,7 +51,7 @@ module('Integration | Component | certification-centers/information-edit', funct
       );
 
       // when
-      await fillByLabel('Nom du centre', '');
+      await fillByLabel('Nom du centre', '', { exact: false });
 
       // then
       assert.dom(screen.getByText('Le nom ne peut pas être vide')).exists();
@@ -64,7 +64,7 @@ module('Integration | Component | certification-centers/information-edit', funct
       );
 
       // when
-      await fillByLabel('Nom du centre', 'a'.repeat(256));
+      await fillByLabel('Nom du centre', 'a'.repeat(256), { exact: false });
 
       // then
       assert.dom(screen.getByText('La longueur du nom ne doit pas excéder 255 caractères')).exists();

--- a/admin/tests/integration/components/certification-centers/information-view_test.js
+++ b/admin/tests/integration/components/certification-centers/information-view_test.js
@@ -51,7 +51,7 @@ module('Integration | Component | certification-centers/information-view', funct
     assert.dom(screen.getByText('lucky@example.net')).exists();
     assert.strictEqual(screen.getAllByTitle('Délégué à la protection des données').length, 2);
     assert.dom(screen.getByLabelText('Habilité pour Pix+Droit')).exists();
-    assert.dom(screen.getByLabelText('Non-habilité pour Cléa')).exists();
+    assert.dom(screen.getByLabelText('Non habilité pour Cléa')).exists();
   });
 
   test('it should show button to direct user to metabase dashboard', async function (assert) {

--- a/admin/tests/integration/components/certification-centers/information-view_test.js
+++ b/admin/tests/integration/components/certification-centers/information-view_test.js
@@ -47,8 +47,8 @@ module('Integration | Component | certification-centers/information-view', funct
     assert.dom(screen.getByText('Identifiant externe :')).exists();
     assert.dom(screen.getByText('Centre SCO')).exists();
     assert.dom(screen.getByText('AX129')).exists();
-    assert.dom(screen.getByText('Nom du : Lucky Number')).exists();
-    assert.dom(screen.getByText('Adresse e-mail du : lucky@example.net')).exists();
+    assert.dom(screen.getByText('Lucky Number')).exists();
+    assert.dom(screen.getByText('lucky@example.net')).exists();
     assert.strictEqual(screen.getAllByTitle('Délégué à la protection des données').length, 2);
     assert.dom(screen.getByLabelText('Habilité pour Pix+Droit')).exists();
     assert.dom(screen.getByLabelText('Non-habilité pour Cléa')).exists();
@@ -91,7 +91,7 @@ module('Integration | Component | certification-centers/information-view', funct
       );
 
       // then
-      assert.dom(screen.getByText('Pilote certification V3 : Oui')).exists();
+      assert.dom(screen.getByLabelText('Habilité pour pilote certification V3')).exists();
     });
   });
 
@@ -114,7 +114,53 @@ module('Integration | Component | certification-centers/information-view', funct
       );
 
       // then
-      assert.dom(screen.getByText('Pilote certification V3 : Non')).exists();
+      assert.dom(screen.getByLabelText('Non habilité pour pilote certification V3')).exists();
+    });
+  });
+
+  module('certification center is complementary alone pilot', function () {
+    test('it should display that the certification center is complementary alone pilot', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const certificationCenter = store.createRecord('certification-center', {
+        type: 'SCO',
+        isComplementaryAlonePilot: true,
+      });
+      this.certificationCenter = certificationCenter;
+
+      // when
+      const screen = await render(
+        hbs`<CertificationCenters::InformationView
+  @certificationCenter={{this.certificationCenter}}
+/>`,
+      );
+
+      // then
+      assert.dom(screen.getByLabelText('Habilité pour pilote séparation Pix/Pix+')).exists();
+    });
+  });
+
+  module('certification center is NOT complementary alone pilot', function () {
+    test('it should display that the certification center is NOT complementary alone pilot', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const certificationCenter = store.createRecord('certification-center', {
+        type: 'SCO',
+        isComplementaryAlonePilot: false,
+      });
+      this.certificationCenter = certificationCenter;
+
+      // when
+      const screen = await render(
+        hbs`<CertificationCenters::InformationView
+  @certificationCenter={{this.certificationCenter}}
+/>`,
+      );
+
+      // then
+      assert.dom(screen.getByLabelText('Non habilité pour pilote séparation Pix/Pix+')).exists();
     });
   });
 });

--- a/admin/tests/unit/components/certification-centers/habilitation-tag/index_test.js
+++ b/admin/tests/unit/components/certification-centers/habilitation-tag/index_test.js
@@ -1,0 +1,31 @@
+import { setupTest } from 'ember-qunit';
+// import ENV from 'pix-admin/config/environment';
+import { module, test } from 'qunit';
+
+import createGlimmerComponent from '../../../../helpers/create-glimmer-component';
+
+module('Unit | Component | certification-centers/habilitation-tag', function (hooks) {
+  setupTest(hooks);
+
+  test('it should return the correct label, icon and classname when the center is habilited', function (assert) {
+    const component = createGlimmerComponent('component:certification-centers/habilitation-tag', {
+      active: true,
+      label: 'Mon centre bien habilité',
+    });
+
+    assert.strictEqual(component.ariaLabel, 'Habilité pour Mon centre bien habilité');
+    assert.strictEqual(component.className, 'granted-habilitation-icon');
+    assert.strictEqual(component.icon, 'circle-check');
+  });
+
+  test('it should return the correct label, icon and classname when the center is NOT habilited', function (assert) {
+    const component = createGlimmerComponent('component:certification-centers/habilitation-tag', {
+      active: false,
+      label: 'Mon centre pas habilité',
+    });
+
+    assert.strictEqual(component.ariaLabel, 'Non habilité pour Mon centre pas habilité');
+    assert.strictEqual(component.className, 'non-granted-habilitation-icon');
+    assert.strictEqual(component.icon, 'circle-xmark');
+  });
+});

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -191,7 +191,13 @@
   "pages": {
     "certification-centers": {
       "information-view": {
-        "is-v3-pilot": "V3 certification pilot"
+        "feature-habilitations": {
+          "title": "Feature habilitations:",
+          "labels": {
+            "is-complementary-alone-pilot": "Pix/Pix+ separation pilot",
+            "is-v3-pilot": "V3 certification pilot"
+          }
+        }
       },
       "notifications": {
         "failure": {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -192,7 +192,7 @@
     "certification-centers": {
       "information-view": {
         "feature-habilitations": {
-          "title": "Feature habilitations:",
+          "title": "Feature habilitations",
           "labels": {
             "is-complementary-alone-pilot": "Pix/Pix+ separation pilot",
             "is-v3-pilot": "V3 certification pilot"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -201,7 +201,13 @@
   "pages": {
     "certification-centers": {
       "information-view": {
-        "is-v3-pilot": "Pilote certification V3"
+        "feature-habilitations": {
+          "title": "Habilité aux features :",
+          "labels": {
+            "is-complementary-alone-pilot": "pilote séparation Pix/Pix+",
+            "is-v3-pilot": "pilote certification V3"
+          }
+        }
       },
       "notifications": {
         "failure": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -202,7 +202,7 @@
     "certification-centers": {
       "information-view": {
         "feature-habilitations": {
-          "title": "Habilité aux features :",
+          "title": "Habilitations aux fonctionnalités pilotes",
           "labels": {
             "is-complementary-alone-pilot": "pilote séparation Pix/Pix+",
             "is-v3-pilot": "pilote certification V3"

--- a/api/lib/domain/models/CertificationCenterForAdmin.js
+++ b/api/lib/domain/models/CertificationCenterForAdmin.js
@@ -1,3 +1,4 @@
+import { CERTIFICATION_FEATURES } from '../../../src/certification/shared/domain/constants.js';
 import { CERTIFICATION_CENTER_TYPES } from '../constants.js';
 
 class CertificationCenterForAdmin {
@@ -13,7 +14,7 @@ class CertificationCenterForAdmin {
     dataProtectionOfficerLastName,
     dataProtectionOfficerEmail,
     isV3Pilot = false,
-    isComplementaryAlonePilot = false,
+    features = [],
   } = {}) {
     this.id = id;
     this.name = name;
@@ -26,7 +27,7 @@ class CertificationCenterForAdmin {
     this.dataProtectionOfficerLastName = dataProtectionOfficerLastName;
     this.dataProtectionOfficerEmail = dataProtectionOfficerEmail;
     this.isV3Pilot = isV3Pilot;
-    this.isComplementaryAlonePilot = isComplementaryAlonePilot;
+    this.features = features;
   }
 
   get isSco() {
@@ -35,6 +36,10 @@ class CertificationCenterForAdmin {
 
   isHabilitated(key) {
     return this.habilitations.some((habilitation) => habilitation.key === key);
+  }
+
+  get isComplementaryAlonePilot() {
+    return this.features.includes(CERTIFICATION_FEATURES.CAN_REGISTER_FOR_A_COMPLEMENTARY_CERTIFICATION_ALONE.key);
   }
 }
 

--- a/api/lib/domain/models/CertificationCenterForAdmin.js
+++ b/api/lib/domain/models/CertificationCenterForAdmin.js
@@ -13,6 +13,7 @@ class CertificationCenterForAdmin {
     dataProtectionOfficerLastName,
     dataProtectionOfficerEmail,
     isV3Pilot = false,
+    isComplementaryAlonePilot = false,
   } = {}) {
     this.id = id;
     this.name = name;
@@ -25,6 +26,7 @@ class CertificationCenterForAdmin {
     this.dataProtectionOfficerLastName = dataProtectionOfficerLastName;
     this.dataProtectionOfficerEmail = dataProtectionOfficerEmail;
     this.isV3Pilot = isV3Pilot;
+    this.isComplementaryAlonePilot = isComplementaryAlonePilot;
   }
 
   get isSco() {

--- a/api/lib/infrastructure/serializers/jsonapi/certification-center-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-center-for-admin-serializer.js
@@ -32,6 +32,7 @@ const serialize = function (certificationCenters, meta) {
       'dataProtectionOfficerEmail',
       'habilitations',
       'isV3Pilot',
+      'isComplementaryAlonePilot',
     ],
     typeForAttribute: (attribute) => {
       if (attribute === 'habilitations') return 'complementary-certifications';

--- a/api/src/certification/session/domain/models/Center.js
+++ b/api/src/certification/session/domain/models/Center.js
@@ -24,8 +24,6 @@ export class Center {
   }
 
   get isComplementaryAlonePilot() {
-    return this.features.find(
-      (feature) => feature === CERTIFICATION_FEATURES.CAN_REGISTER_FOR_A_COMPLEMENTARY_CERTIFICATION_ALONE.key,
-    );
+    return this.features.includes(CERTIFICATION_FEATURES.CAN_REGISTER_FOR_A_COMPLEMENTARY_CERTIFICATION_ALONE.key);
   }
 }

--- a/api/tests/certification/session/unit/domain/models/Center_test.js
+++ b/api/tests/certification/session/unit/domain/models/Center_test.js
@@ -1,5 +1,6 @@
 import { Center } from '../../../../../../src/certification/session/domain/models/Center.js';
 import { CenterTypes } from '../../../../../../src/certification/session/domain/models/CenterTypes.js';
+import { CERTIFICATION_FEATURES } from '../../../../../../src/certification/shared/domain/constants.js';
 import { catchErrSync, domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Certification | Session | Domain | Models | Center', function () {
@@ -20,6 +21,18 @@ describe('Unit | Certification | Session | Domain | Models | Center', function (
       // when / then
       expect(center).to.be.an.instanceOf(Center);
       expect(center.hasBillingMode).is.true;
+    });
+
+    it('should return true when center is a complementary certification pilot', function () {
+      // given
+      const center = domainBuilder.certification.session.buildCenter({
+        type: CenterTypes.SUP,
+        features: [CERTIFICATION_FEATURES.CAN_REGISTER_FOR_A_COMPLEMENTARY_CERTIFICATION_ALONE.key],
+      });
+
+      // when / then
+      expect(center).to.be.an.instanceOf(Center);
+      expect(center.isComplementaryAlonePilot).is.true;
     });
 
     context('should verify center type', function () {

--- a/api/tests/integration/infrastructure/repositories/certification-center-for-admin-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-for-admin-repository_test.js
@@ -1,6 +1,7 @@
 import { NotFoundError } from '../../../../lib/domain/errors.js';
 import { CertificationCenterForAdmin } from '../../../../lib/domain/models/CertificationCenterForAdmin.js';
 import * as certificationCenterForAdminRepository from '../../../../lib/infrastructure/repositories/certification-center-for-admin-repository.js';
+import { CERTIFICATION_FEATURES } from '../../../../src/certification/shared/domain/constants.js';
 import { catchErr, databaseBuilder, domainBuilder, expect, sinon } from '../../../test-helper.js';
 
 describe('Integration | Repository | certification-center-for-admin', function () {
@@ -122,6 +123,32 @@ describe('Integration | Repository | certification-center-for-admin', function (
         const certificationCenter = await certificationCenterForAdminRepository.get(1);
 
         expect(certificationCenter).to.deepEqualInstance(expectedCertificationCenter);
+      });
+
+      context('when the certification center is a feature pilot', function () {
+        it('should return the information', async function () {
+          // given
+          const centerId = 1;
+          databaseBuilder.factory.buildCertificationCenter({
+            id: centerId,
+          });
+          const feature = databaseBuilder.factory.buildFeature({
+            key: CERTIFICATION_FEATURES.CAN_REGISTER_FOR_A_COMPLEMENTARY_CERTIFICATION_ALONE.key,
+          });
+          databaseBuilder.factory.buildCertificationCenterFeature({
+            certificationCenterId: centerId,
+            featureId: feature.id,
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const result = await certificationCenterForAdminRepository.get(centerId);
+
+          // then
+          expect(result.features).to.have.members([
+            CERTIFICATION_FEATURES.CAN_REGISTER_FOR_A_COMPLEMENTARY_CERTIFICATION_ALONE.key,
+          ]);
+        });
       });
     });
 

--- a/api/tests/tooling/domain-builder/factory/build-certification-center-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-center-for-admin.js
@@ -12,7 +12,7 @@ const buildCertificationCenterForAdmin = function ({
   dataProtectionOfficerEmail,
   habilitations = [],
   isV3Pilot,
-  isComplementaryAlonePilot,
+  features = [],
 } = {}) {
   return new CertificationCenterForAdmin({
     id,
@@ -26,7 +26,7 @@ const buildCertificationCenterForAdmin = function ({
     dataProtectionOfficerEmail,
     habilitations,
     isV3Pilot,
-    isComplementaryAlonePilot,
+    features,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/build-certification-center-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-center-for-admin.js
@@ -11,7 +11,8 @@ const buildCertificationCenterForAdmin = function ({
   dataProtectionOfficerLastName,
   dataProtectionOfficerEmail,
   habilitations = [],
-  isV3Pilot = false,
+  isV3Pilot,
+  isComplementaryAlonePilot,
 } = {}) {
   return new CertificationCenterForAdmin({
     id,
@@ -25,6 +26,7 @@ const buildCertificationCenterForAdmin = function ({
     dataProtectionOfficerEmail,
     habilitations,
     isV3Pilot,
+    isComplementaryAlonePilot,
   });
 };
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-for-admin-serializer_test.js
@@ -18,6 +18,7 @@ describe('Unit | Serializer | JSONAPI | certification-center-for-admin-serialize
           'data-protection-officer-first-name': 'Justin',
           'data-protection-officer-last-name': 'Ptipeu',
           'data-protection-officer-email': 'justin.ptipeu@example.net',
+          'is-complementary-alone-pilot': false,
         },
         relationships: {},
       },
@@ -169,6 +170,24 @@ describe('Unit | Serializer | JSONAPI | certification-center-for-admin-serialize
         ];
 
         expect(serializedCertificationCenter).to.deep.equal(certificationCenterJsonApi);
+      });
+    });
+  });
+
+  describe('when the center is for a complementary alone pilot', function () {
+    describe('#serialize', function () {
+      it('should return that the center is a complementary alone pilot into JSON API data', function () {
+        // given
+        const certificationCenter = domainBuilder.buildCertificationCenterForAdmin({
+          ...certificationCenterForAdmin,
+          isComplementaryAlonePilot: true,
+        });
+
+        // when
+        const serializedCertificationCenter = serializer.serialize(certificationCenter);
+
+        // then
+        expect(serializedCertificationCenter.data.attributes['is-complementary-alone-pilot']).to.be.true;
       });
     });
   });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-for-admin-serializer_test.js
@@ -1,4 +1,5 @@
 import * as serializer from '../../../../../lib/infrastructure/serializers/jsonapi/certification-center-for-admin-serializer.js';
+import { CERTIFICATION_FEATURES } from '../../../../../src/certification/shared/domain/constants.js';
 import { domainBuilder, expect } from '../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | certification-center-for-admin-serializer', function () {
@@ -180,7 +181,7 @@ describe('Unit | Serializer | JSONAPI | certification-center-for-admin-serialize
         // given
         const certificationCenter = domainBuilder.buildCertificationCenterForAdmin({
           ...certificationCenterForAdmin,
-          isComplementaryAlonePilot: true,
+          features: [CERTIFICATION_FEATURES.CAN_REGISTER_FOR_A_COMPLEMENTARY_CERTIFICATION_ALONE.key],
         });
 
         // when

--- a/certif/app/components/new-candidate-modal/index.hbs
+++ b/certif/app/components/new-candidate-modal/index.hbs
@@ -283,7 +283,12 @@
     >
       {{t "common.actions.close"}}
     </PixButton>
-    <PixButton @type="submit" @isLoading={{this.isLoading}} @isDisabled={{this.isLoading}} form="new-candidate-form">
+    <PixButton
+      @type="submit"
+      @isLoading={{this.isLoading}}
+      @isDisabled={{this.isLoading}}
+      form="new-candidate-form"
+    >
       {{t "pages.sessions.detail.candidates.add-modal.actions.enrol-the-candidate"}}
     </PixButton>
   </:footer>

--- a/certif/app/components/new-candidate-modal/index.hbs
+++ b/certif/app/components/new-candidate-modal/index.hbs
@@ -283,12 +283,7 @@
     >
       {{t "common.actions.close"}}
     </PixButton>
-    <PixButton
-      @type="submit"
-      @isLoading={{this.isLoading}}
-      @isDisabled={{this.isLoading}}
-      form="new-candidate-form"
-    >
+    <PixButton @type="submit" @isLoading={{this.isLoading}} @isDisabled={{this.isLoading}} form="new-candidate-form">
       {{t "pages.sessions.detail.candidates.add-modal.actions.enrol-the-candidate"}}
     </PixButton>
   </:footer>


### PR DESCRIPTION
## :unicorn: Problème
Les utilisateurs Pix Certif des centres de certification (CDC) pilotes vont avoir a gérer des candidats qui seront à inscrire à Pix coeur et Pix+ mais aussi à d’autres candidats (déjà détenteurs d’une certification Pix coeur suffisante) qui ne seront à inscrire qu'à la certification complémentaire Pix+ seule.

Certains centres sont pilotes pour tester cette fonctionnalité, mais il n’y a aucun moyen de savoir si un centre est pilote quand on va sur sa page de détails dans Admin.

## :robot: Proposition
Afficher “Pilote séparation Pix/Pix+” dans la page de détails d’Admin :

<img width="853" alt="Capture d’écran 2024-05-06 à 15 46 49" src="https://github.com/1024pix/pix/assets/11388201/a2026224-9fea-414d-a903-c4789a3cb10c">

## :rainbow: Remarques
On en a profité pour améliorer le style de ce bloc

## :100: Pour tester
- Se connecter sur Admin avec `superadmin@example.net` / `pix123`
- Aller sur la page d’un centre non Pilote (par ex, id 5000)
- Vérifier la présence de la ligne grisée  ⨯  : “Pilote séparation Pix/Pix+”
- Aller sur la page d’un centre Pilote (id 7304)
- Vérifier la présence de la ligne ✅: “Pilote séparation Pix/Pix+”