### PR TITLE
[BUGFIX] Corriger l'alignement de la tooltip des crédits (PIX-12443)

### DIFF
--- a/orga/app/components/layout/organization-places-or-credit-info.gjs
+++ b/orga/app/components/layout/organization-places-or-credit-info.gjs
@@ -27,7 +27,7 @@ export default class OrganizationPlacesOrCreditInfo extends Component {
         {{/if}}
       </div>
     {{else if this.canShowCredit}}
-      <div class="organization-places-or-credit-info hide-on-mobile">
+      <div class="organization-places-or-credit-info organization-places-or-credit-info--inline hide-on-mobile">
         <span>{{t "navigation.credits.number" count=this.currentUser.organization.credit}}</span>
 
         <PixTooltip @id="credit-info-tooltip" @position="bottom-left" @isWide={{true}} @isLight={{true}}>

--- a/orga/app/styles/components/campaign/empty-state.scss
+++ b/orga/app/styles/components/campaign/empty-state.scss
@@ -5,7 +5,7 @@
   justify-content: center;
   width: 100%;
   padding: 40px 0;
-  color: var(--pix-neutral-100);
+  color: var(--pix-neutral-500);
 
   &__text {
     display: flex;

--- a/orga/app/styles/components/layout/organization-places-or-credit-info.scss
+++ b/orga/app/styles/components/layout/organization-places-or-credit-info.scss
@@ -7,6 +7,10 @@
   color: var(--pix-neutral-900);
   font-weight: var(--pix-font-bold);
 
+  &--inline {
+    flex-direction: row;
+  }
+
   &__warning {
     color: var(--pix-error-700);
     font-weight: var(--pix-font-medium);


### PR DESCRIPTION
## :unicorn: Problème
Suite à la mise en place du header des places, l'affichage des crédits s'en trouve perturbé

## :robot: Proposition
Faire en sorte que la tooltip soit aligné avec le montant des crédits disponible

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter sur PixOrga avec une organisation n'ayant pas la feature d'activer et vérifier que la tooltip est bien sur la même ligne

Vérifier que ce n'est pas le cas pour une organization avec la feature des places en places 🥁 