### PR TITLE
[TECH] Renommer la variable emitOpsEventEachSeconds

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -116,7 +116,7 @@ const enableOpsMetrics = async function (server) {
     });
   });
 
-  oppsy.start(logging.emitOpsEventEachSeconds * 1000);
+  oppsy.start(logging.opsEventIntervalInSeconds * 1000);
   server.oppsy = oppsy;
 };
 

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -223,7 +223,7 @@ const configuration = (function () {
       enableKnexPerformanceMonitoring: toBoolean(process.env.ENABLE_KNEX_PERFORMANCE_MONITORING),
       enableLogStartingEventDispatch: toBoolean(process.env.LOG_STARTING_EVENT_DISPATCH),
       enableLogEndingEventDispatch: toBoolean(process.env.LOG_ENDING_EVENT_DISPATCH),
-      emitOpsEventEachSeconds: toBoolean(process.env.OPS_EVENT_EACH_SECONDS) || 15,
+      opsEventIntervalInSeconds: process.env.OPS_EVENT_INTERVAL_IN_SECONDS || 15,
     },
     login: {
       temporaryBlockingThresholdFailureCount: _getNumber(


### PR DESCRIPTION
## :unicorn: Problème
La variable `emitOpsEventEachSeconds`, utilisée dans la configuration du logger, n'exprime pas clairement qu'elle représente un interval en secondes. De plus, dans le fichier de configuration, on applique la fonction `toBoolean()` alors qu'il s'agit d'un entier. 

## :robot: Proposition
- Supprimer l'utilisation de la fonction `toBoolean()`
- Renommer la variable `emitOpsEventEachSeconds` en `opsEventIntervalInSeconds`

## :rainbow: Remarques
La variable n'est déclarée sur aucun environnement, c'est la valeur par défaut (15 secondes) qui est utilisée partout.