### PR TITLE
[TECH] Migrer la route GET /api/oidc/identity-providers vers src/identity-access-management (PIX-12446)

### DIFF
--- a/api/lib/application/authentication/oidc/index.js
+++ b/api/lib/application/authentication/oidc/index.js
@@ -35,23 +35,6 @@ const register = async function (server) {
     ...adminRoutes,
     {
       method: 'GET',
-      path: '/api/oidc/identity-providers',
-      config: {
-        validate: {
-          query: Joi.object({
-            audience: Joi.string().optional(),
-          }),
-        },
-        auth: false,
-        handler: oidcController.getIdentityProviders,
-        notes: [
-          'Cette route renvoie un objet contenant les informations requises par le front pour les partenaires OIDC',
-        ],
-        tags: ['api', 'oidc'],
-      },
-    },
-    {
-      method: 'GET',
       path: '/api/oidc/redirect-logout-url',
       config: {
         validate: {

--- a/api/lib/application/authentication/oidc/oidc-controller.js
+++ b/api/lib/application/authentication/oidc/oidc-controller.js
@@ -1,14 +1,7 @@
 import { PIX_ADMIN } from '../../../../src/authorization/domain/constants.js';
-import * as oidcProviderSerializer from '../../../../src/identity-access-management/infrastructure/serializers/jsonapi/oidc-identity-providers.serializer.js';
 import { oidcAuthenticationServiceRegistry, usecases } from '../../../domain/usecases/index.js';
 import * as oidcSerializer from '../../../infrastructure/serializers/jsonapi/oidc-serializer.js';
 import { BadRequestError, UnauthorizedError } from '../../http-errors.js';
-
-const getIdentityProviders = async function (request, h) {
-  const audience = request.query.audience;
-  const identityProviders = await usecases.getReadyIdentityProviders({ audience });
-  return h.response(oidcProviderSerializer.serialize(identityProviders)).code(200);
-};
 
 const getRedirectLogoutUrl = async function (
   request,
@@ -208,7 +201,6 @@ const oidcController = {
   createUser,
   findUserForReconciliation,
   getAuthorizationUrl,
-  getIdentityProviders,
   getRedirectLogoutUrl,
   reconcileUser,
   reconcileUserForAdmin,

--- a/api/src/identity-access-management/application/oidc-provider.admin.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider.admin.controller.js
@@ -30,8 +30,7 @@ async function getAllIdentityProvidersForAdmin(request, h) {
 }
 
 /**
- * @typedef OidcProviderController
- * @type {object}
+ * @typedef {Object} OidcProviderAdminController
  * @property {createInBatch} createInBatch
  * @property {getAllIdentityProvidersForAdmin} getAllIdentityProvidersForAdmin
  */

--- a/api/src/identity-access-management/application/oidc-provider.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider.controller.js
@@ -1,0 +1,14 @@
+import { usecases } from '../domain/usecases/index.js';
+import * as oidcProviderSerializer from '../infrastructure/serializers/jsonapi/oidc-identity-providers.serializer.js';
+
+async function getIdentityProviders(request, h) {
+  const audience = request.query.audience;
+  const identityProviders = await usecases.getReadyIdentityProviders({ audience });
+  return h.response(oidcProviderSerializer.serialize(identityProviders)).code(200);
+}
+
+/**
+ * @typedef {Object} OidcProviderController
+ * @property {getIdentityProviders} getIdentityProviders
+ */
+export const oidcProviderController = { getIdentityProviders };

--- a/api/src/identity-access-management/application/oidc-provider.route.js
+++ b/api/src/identity-access-management/application/oidc-provider.route.js
@@ -1,0 +1,23 @@
+import Joi from 'joi';
+
+import { oidcProviderController } from './oidc-provider.controller.js';
+
+export const oidcProviderRoutes = [
+  {
+    method: 'GET',
+    path: '/api/oidc/identity-providers',
+    config: {
+      validate: {
+        query: Joi.object({
+          audience: Joi.string().optional().default('app'),
+        }),
+      },
+      auth: false,
+      handler: (request, h) => oidcProviderController.getIdentityProviders(request, h),
+      notes: [
+        'Cette route renvoie une liste contenant les informations requises par le front pour les partenaires OIDC',
+      ],
+      tags: ['identity-access-management', 'api', 'oidc'],
+    },
+  },
+];

--- a/api/src/identity-access-management/application/routes.js
+++ b/api/src/identity-access-management/application/routes.js
@@ -1,11 +1,19 @@
 import { oidcProviderAdminRoutes } from './oidc-provider.admin.route.js';
+import { oidcProviderRoutes } from './oidc-provider.route.js';
 import { samlRoutes } from './saml.route.js';
 import { tokenRoutes } from './token.route.js';
 import { userAdminRoutes } from './user.admin.route.js';
 import { userRoutes } from './user.route.js';
 
 const register = async function (server) {
-  server.route([...oidcProviderAdminRoutes, ...samlRoutes, ...tokenRoutes, ...userRoutes, ...userAdminRoutes]);
+  server.route([
+    ...oidcProviderAdminRoutes,
+    ...oidcProviderRoutes,
+    ...samlRoutes,
+    ...tokenRoutes,
+    ...userAdminRoutes,
+    ...userRoutes,
+  ]);
 };
 
 const name = 'identity-access-management-api';

--- a/api/src/identity-access-management/domain/usecases/get-ready-identity-providers.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/get-ready-identity-providers.usecase.js
@@ -1,8 +1,17 @@
+/**
+ * @typedef {function} getReadyIdentityProviders
+ * @param {Object} params
+ * @param {string} [params.audience=app]
+ * @param {OidcAuthenticationServiceRegistry} params.oidcAuthenticationServiceRegistry
+ * @return {Promise<OidcAuthenticationService[]|null>}
+ */
 const getReadyIdentityProviders = async function ({ audience = 'app', oidcAuthenticationServiceRegistry }) {
   await oidcAuthenticationServiceRegistry.loadOidcProviderServices();
+
   if (audience === 'admin') {
     return oidcAuthenticationServiceRegistry.getReadyOidcProviderServicesForPixAdmin();
   }
+
   return oidcAuthenticationServiceRegistry.getReadyOidcProviderServices();
 };
 

--- a/api/src/identity-access-management/domain/usecases/index.js
+++ b/api/src/identity-access-management/domain/usecases/index.js
@@ -60,5 +60,6 @@ const usecases = injectDependencies(usecasesWithoutInjectedDependencies, depende
  * @type {object}
  * @property {addOidcProvider} addOidcProvider
  * @property {getAllIdentityProviders} getAllIdentityProviders
+ * @property {getReadyIdentityProviders} getReadyIdentityProviders
  */
 export { usecases };

--- a/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
@@ -1,0 +1,37 @@
+import { createServer, expect } from '../../../test-helper.js';
+
+describe('Acceptance | Identity Access Management | Application | Route | oidc-provider', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('GET /api/oidc/identity-providers', function () {
+    it('returns the list of all oidc providers with an HTTP status code 200', async function () {
+      // given
+      const options = {
+        method: 'GET',
+        url: '/api/oidc/identity-providers',
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data).to.deep.equal([
+        {
+          type: 'oidc-identity-providers',
+          id: 'oidc-example-net',
+          attributes: {
+            code: 'OIDC_EXAMPLE_NET',
+            'organization-name': 'OIDC Example',
+            'should-close-session': true,
+            source: 'oidcexamplenet',
+          },
+        },
+      ]);
+    });
+  });
+});

--- a/api/tests/identity-access-management/unit/application/oidc-provider.admin.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/oidc-provider.admin.controller.test.js
@@ -3,7 +3,7 @@ import { usecases } from '../../../../src/identity-access-management/domain/usec
 import { DomainTransaction } from '../../../../src/shared/domain/DomainTransaction.js';
 import { expect, hFake, sinon } from '../../../test-helper.js';
 
-describe('Unit | Identity Access Management | Application | Controller | Oidc', function () {
+describe('Unit | Identity Access Management | Application | Controller | oidc-provider.admin', function () {
   describe('#createInBatch', function () {
     it('returns an HTTP status code 204', async function () {
       // given

--- a/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
@@ -1,0 +1,38 @@
+import { oidcProviderController } from '../../../../src/identity-access-management/application/oidc-provider.controller.js';
+import { usecases } from '../../../../src/identity-access-management/domain/usecases/index.js';
+import { expect, hFake, sinon } from '../../../test-helper.js';
+
+describe('Unit | Identity Access Management | Application | Controller | oidc-provider', function () {
+  describe('#getIdentityProviders', function () {
+    it('returns the list of oidc identity providers', async function () {
+      // given
+      sinon.stub(usecases, 'getReadyIdentityProviders').returns([
+        {
+          code: 'SOME_OIDC_PROVIDER',
+          source: 'some_oidc_provider',
+          organizationName: 'Some OIDC Provider',
+          slug: 'some-oidc-provider',
+          shouldCloseSession: false,
+        },
+      ]);
+
+      // when
+      const response = await oidcProviderController.getIdentityProviders({ query: { audience: null } }, hFake);
+
+      // then
+      expect(usecases.getReadyIdentityProviders).to.have.been.called;
+      expect(response.statusCode).to.equal(200);
+      expect(response.source.data.length).to.equal(1);
+      expect(response.source.data).to.deep.contain({
+        type: 'oidc-identity-providers',
+        id: 'some-oidc-provider',
+        attributes: {
+          code: 'SOME_OIDC_PROVIDER',
+          source: 'some_oidc_provider',
+          'organization-name': 'Some OIDC Provider',
+          'should-close-session': false,
+        },
+      });
+    });
+  });
+});

--- a/api/tests/identity-access-management/unit/domain/usecases/get-ready-identity-providers.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/get-ready-identity-providers.usecase.test.js
@@ -1,8 +1,8 @@
-import { getReadyIdentityProviders } from '../../../../lib/domain/usecases/get-ready-identity-providers.js';
-import { PIX_ADMIN } from '../../../../src/authorization/domain/constants.js';
-import { expect, sinon } from '../../../test-helper.js';
+import { PIX_ADMIN } from '../../../../../src/authorization/domain/constants.js';
+import { getReadyIdentityProviders } from '../../../../../src/identity-access-management/domain/usecases/get-ready-identity-providers.usecase.js';
+import { expect, sinon } from '../../../../test-helper.js';
 
-describe('Unit | UseCase | get-ready-identity-providers', function () {
+describe('Unit | Identity Access Management | Domain | UseCases | get-ready-identity-providers', function () {
   let oneOidcProviderService;
   let anotherOidcProviderService;
   let oidcAuthenticationServiceRegistryStub;

--- a/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
+++ b/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
@@ -16,39 +16,6 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
     };
   });
 
-  describe('#getIdentityProviders', function () {
-    it('returns the list of oidc identity providers', async function () {
-      // given
-      sinon.stub(usecases, 'getReadyIdentityProviders').returns([
-        {
-          code: 'SOME_OIDC_PROVIDER',
-          source: 'some_oidc_provider',
-          organizationName: 'Some OIDC Provider',
-          slug: 'some-oidc-provider',
-          shouldCloseSession: false,
-        },
-      ]);
-
-      // when
-      const response = await oidcController.getIdentityProviders({ query: { audience: null } }, hFake);
-
-      // then
-      expect(usecases.getReadyIdentityProviders).to.have.been.called;
-      expect(response.statusCode).to.equal(200);
-      expect(response.source.data.length).to.equal(1);
-      expect(response.source.data).to.deep.contain({
-        type: 'oidc-identity-providers',
-        id: 'some-oidc-provider',
-        attributes: {
-          code: 'SOME_OIDC_PROVIDER',
-          source: 'some_oidc_provider',
-          'organization-name': 'Some OIDC Provider',
-          'should-close-session': false,
-        },
-      });
-    });
-  });
-
   describe('#getRedirectLogoutUrl', function () {
     it('calls the oidc authentication service retrieved from his code to generate the redirect logout url', async function () {
       // given


### PR DESCRIPTION
## :unicorn: Problème

La route `GET /api/oidc/identity-providers` est encore dans le dossier `lib`.

## :robot: Proposition

Faire la migration vers son bounded context `identity-access-management`.

## :rainbow: Remarques

Faire la review des PRs suivantes avant celle-ci :

- [x] #8851 

## :100: Pour tester

##### Pix App

1. Ouvrir un onglet sur Pix App
2. Ouvrir la console développeur sur l'onglet _Network|Réseau_
3. Constater dans l'onglet _Network|Réseau_ de la console développeur une entrée vers la route `GET /api/oidc/identity-providers`
4. Vérifier que la réponse contient bien la liste de fournisseurs d'identités disponibles et activés pour Pix App se trouvant en base de données

##### Pix Admin

1. Ouvrir un onglet sur Pix Admin
2. Ouvrir la console développeur sur l'onglet _Network|Réseau_
3. Constater dans l'onglet _Network|Réseau_ de la console développeur une entrée vers la route `GET /api/oidc/identity-providers?audience=admin`
4. Vérifier que la réponse contient bien la liste de fournisseurs d'identités disponibles et activés pour Pix Admin se trouvant en base de données