### PR TITLE
[TECH] Migrer la route GET /api/oidc/redirect-logout-url vers src/identity-access-management (PIX-12450)

### DIFF
--- a/api/lib/application/authentication/oidc/index.js
+++ b/api/lib/application/authentication/oidc/index.js
@@ -35,26 +35,6 @@ const register = async function (server) {
     ...adminRoutes,
     {
       method: 'GET',
-      path: '/api/oidc/redirect-logout-url',
-      config: {
-        validate: {
-          query: Joi.object({
-            identity_provider: Joi.string().required(),
-            logout_url_uuid: Joi.string()
-              .regex(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i)
-              .required(),
-          }),
-        },
-        handler: oidcController.getRedirectLogoutUrl,
-        notes: [
-          "Cette route reçoit un identity provider ainsi qu'une uri de redirection" +
-            " et renvoie une uri de déconnexion auprès de l'identity provider renseigné.",
-        ],
-        tags: ['api', 'oidc', 'authentication'],
-      },
-    },
-    {
-      method: 'GET',
       path: '/api/oidc/authorization-url',
       config: {
         auth: false,

--- a/api/lib/application/authentication/oidc/oidc-controller.js
+++ b/api/lib/application/authentication/oidc/oidc-controller.js
@@ -3,30 +3,6 @@ import { oidcAuthenticationServiceRegistry, usecases } from '../../../domain/use
 import * as oidcSerializer from '../../../infrastructure/serializers/jsonapi/oidc-serializer.js';
 import { BadRequestError, UnauthorizedError } from '../../http-errors.js';
 
-const getRedirectLogoutUrl = async function (
-  request,
-  h,
-  dependencies = {
-    oidcAuthenticationServiceRegistry,
-  },
-) {
-  const userId = request.auth.credentials.userId;
-  const { identity_provider: identityProvider, logout_url_uuid: logoutUrlUUID } = request.query;
-
-  await dependencies.oidcAuthenticationServiceRegistry.loadOidcProviderServices();
-  await dependencies.oidcAuthenticationServiceRegistry.configureReadyOidcProviderServiceByCode(identityProvider);
-
-  const oidcAuthenticationService = dependencies.oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({
-    identityProviderCode: identityProvider,
-  });
-  const redirectLogoutUrl = await oidcAuthenticationService.getRedirectLogoutUrl({
-    userId,
-    logoutUrlUUID,
-  });
-
-  return h.response({ redirectLogoutUrl }).code(200);
-};
-
 const findUserForReconciliation = async function (
   request,
   h,
@@ -201,7 +177,6 @@ const oidcController = {
   createUser,
   findUserForReconciliation,
   getAuthorizationUrl,
-  getRedirectLogoutUrl,
   reconcileUser,
   reconcileUserForAdmin,
 };

--- a/api/src/identity-access-management/application/oidc-provider.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider.controller.js
@@ -1,6 +1,12 @@
 import { usecases } from '../domain/usecases/index.js';
 import * as oidcProviderSerializer from '../infrastructure/serializers/jsonapi/oidc-identity-providers.serializer.js';
 
+/**
+ * @typedef {function} getIdentityProviders
+ * @param request
+ * @param h
+ * @return {Promise<*>}
+ */
 async function getIdentityProviders(request, h) {
   const audience = request.query.audience;
   const identityProviders = await usecases.getReadyIdentityProviders({ audience });
@@ -8,7 +14,27 @@ async function getIdentityProviders(request, h) {
 }
 
 /**
+ * @typedef {function} getRedirectLogoutUrl
+ * @param request
+ * @param h
+ * @return {Promise<Object>}
+ */
+async function getRedirectLogoutUrl(request, h) {
+  const userId = request.auth.credentials.userId;
+  const { identity_provider: identityProvider, logout_url_uuid: logoutUrlUUID } = request.query;
+
+  const redirectLogoutUrl = await usecases.getRedirectLogoutUrl({
+    identityProvider,
+    logoutUrlUUID,
+    userId,
+  });
+
+  return h.response({ redirectLogoutUrl }).code(200);
+}
+
+/**
  * @typedef {Object} OidcProviderController
  * @property {getIdentityProviders} getIdentityProviders
+ * @property {getRedirectLogoutUrl} getRedirectLogoutUrl
  */
-export const oidcProviderController = { getIdentityProviders };
+export const oidcProviderController = { getIdentityProviders, getRedirectLogoutUrl };

--- a/api/src/identity-access-management/application/oidc-provider.route.js
+++ b/api/src/identity-access-management/application/oidc-provider.route.js
@@ -20,4 +20,23 @@ export const oidcProviderRoutes = [
       tags: ['identity-access-management', 'api', 'oidc'],
     },
   },
+  {
+    method: 'GET',
+    path: '/api/oidc/redirect-logout-url',
+    config: {
+      validate: {
+        query: Joi.object({
+          identity_provider: Joi.string().required(),
+          logout_url_uuid: Joi.string()
+            .regex(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i)
+            .required(),
+        }),
+      },
+      handler: (request, h) => oidcProviderController.getRedirectLogoutUrl(request, h),
+      notes: [
+        "Cette route reçoit le code d'un fournisseur d'identité et renvoie une uri de déconnexion auprès du fournisseur d'identité renseigné.",
+      ],
+      tags: ['identity-access-management', 'api', 'oidc'],
+    },
+  },
 ];

--- a/api/src/identity-access-management/domain/usecases/get-redirect-logout-url.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/get-redirect-logout-url.usecase.js
@@ -1,0 +1,24 @@
+/**
+ * @typedef {function} getRedirectLogoutUrl
+ * @param {Object} params
+ * @param {string} params.identityProvider
+ * @param {string} params.logoutUrlUUID
+ * @param {string} params.userId
+ * @param {OidcAuthenticationServiceRegistry} params.oidcAuthenticationServiceRegistry
+ * @return {Promise<string>}
+ */
+async function getRedirectLogoutUrl({ identityProvider, logoutUrlUUID, userId, oidcAuthenticationServiceRegistry }) {
+  await oidcAuthenticationServiceRegistry.loadOidcProviderServices();
+  await oidcAuthenticationServiceRegistry.configureReadyOidcProviderServiceByCode(identityProvider);
+
+  const oidcAuthenticationService = oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({
+    identityProviderCode: identityProvider,
+  });
+
+  return oidcAuthenticationService.getRedirectLogoutUrl({
+    logoutUrlUUID,
+    userId,
+  });
+}
+
+export { getRedirectLogoutUrl };

--- a/api/src/identity-access-management/domain/usecases/index.js
+++ b/api/src/identity-access-management/domain/usecases/index.js
@@ -56,10 +56,10 @@ const usecasesWithoutInjectedDependencies = {
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
 
 /**
- * @typedef AuthenticationUsecases
- * @type {object}
+ * @typedef {Object} AuthenticationUsecases
  * @property {addOidcProvider} addOidcProvider
  * @property {getAllIdentityProviders} getAllIdentityProviders
  * @property {getReadyIdentityProviders} getReadyIdentityProviders
+ * @property {getRedirectLogoutUrl} getRedirectLogoutUrl
  */
 export { usecases };

--- a/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/oidc-provider.route.test.js
@@ -1,4 +1,4 @@
-import { createServer, expect } from '../../../test-helper.js';
+import { createServer, expect, generateValidRequestAuthorizationHeader } from '../../../test-helper.js';
 
 describe('Acceptance | Identity Access Management | Application | Route | oidc-provider', function () {
   let server;
@@ -32,6 +32,26 @@ describe('Acceptance | Identity Access Management | Application | Route | oidc-p
           },
         },
       ]);
+    });
+  });
+
+  describe('GET /api/oidc/redirect-logout-url', function () {
+    it('returns an object which contains the redirect logout url with HTTP status code 200', async function () {
+      // given
+      const options = {
+        method: 'GET',
+        url: '/api/oidc/redirect-logout-url?identity_provider=OIDC_EXAMPLE_NET&logout_url_uuid=86e1338f-304c-41a8-9472-89fe1b9748a1',
+        headers: { authorization: generateValidRequestAuthorizationHeader() },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.redirectLogoutUrl).to.equal(
+        'https://oidc.example.net/ea5ac20c-5076-4806-860a-b0aeb01645d4/oauth2/v2.0/logout?client_id=client',
+      );
     });
   });
 });

--- a/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/oidc-provider.controller.test.js
@@ -35,4 +35,33 @@ describe('Unit | Identity Access Management | Application | Controller | oidc-pr
       });
     });
   });
+
+  describe('#getRedirectLogoutUrl', function () {
+    it('calls the oidc authentication service retrieved from his code to generate the redirect logout url', async function () {
+      // given
+      const request = {
+        auth: { credentials: { userId: '123' } },
+        query: {
+          identity_provider: 'OIDC',
+          logout_url_uuid: '1f3dbb71-f399-4c1c-85ae-0a863c78aeea',
+        },
+      };
+
+      sinon.stub(usecases, 'getRedirectLogoutUrl').resolves('https://idp.net/oidc/logout?id_token_hint=ID_TOKEN');
+
+      // when
+      const response = await oidcProviderController.getRedirectLogoutUrl(request, hFake);
+
+      // then
+      expect(usecases.getRedirectLogoutUrl).to.have.been.calledWithExactly({
+        identityProvider: 'OIDC',
+        logoutUrlUUID: '1f3dbb71-f399-4c1c-85ae-0a863c78aeea',
+        userId: '123',
+      });
+      expect(response.statusCode).to.equal(200);
+      expect(response.source).to.deep.equal({
+        redirectLogoutUrl: 'https://idp.net/oidc/logout?id_token_hint=ID_TOKEN',
+      });
+    });
+  });
 });

--- a/api/tests/identity-access-management/unit/domain/usecases/get-redirect-logout-url.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/get-redirect-logout-url.usecase.test.js
@@ -1,0 +1,42 @@
+import { getRedirectLogoutUrl } from '../../../../../src/identity-access-management/domain/usecases/get-redirect-logout-url.usecase.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Identity Access Management | Domain | UseCases | get-redirect-logout-url', function () {
+  it('returns the generated redirect logout url', async function () {
+    // given
+    const identityProvider = 'OIDC';
+    const logoutUrlUUID = '23fbed77-5891-4779-b337-65f57cc58ddf';
+    const userId = '1';
+    const oidcAuthenticationService = {
+      getRedirectLogoutUrl: sinon.stub().returns('https://logout.url'),
+    };
+    const oidcAuthenticationServiceRegistry = {
+      loadOidcProviderServices: sinon.stub().resolves(),
+      configureReadyOidcProviderServiceByCode: sinon.stub().resolves(),
+      getOidcProviderServiceByCode: sinon.stub().returns(oidcAuthenticationService),
+    };
+
+    oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode.withArgs({
+      identityProviderCode: identityProvider,
+    });
+
+    // when
+    const logoutUrl = await getRedirectLogoutUrl({
+      identityProvider,
+      logoutUrlUUID,
+      userId,
+      oidcAuthenticationServiceRegistry,
+    });
+
+    // then
+    expect(oidcAuthenticationServiceRegistry.loadOidcProviderServices).to.have.been.calledOnce;
+    expect(oidcAuthenticationServiceRegistry.configureReadyOidcProviderServiceByCode).to.have.been.calledWithExactly(
+      identityProvider,
+    );
+    expect(oidcAuthenticationService.getRedirectLogoutUrl).to.have.been.calledWithExactly({
+      userId: '1',
+      logoutUrlUUID: '23fbed77-5891-4779-b337-65f57cc58ddf',
+    });
+    expect(logoutUrl).to.equal('https://logout.url');
+  });
+});

--- a/api/tests/integration/application/authentication/oidc/index_test.js
+++ b/api/tests/integration/application/authentication/oidc/index_test.js
@@ -5,76 +5,9 @@ import {
   DifferentExternalIdentifierError,
   UserNotFoundError,
 } from '../../../../../lib/domain/errors.js';
-import { expect, generateValidRequestAuthorizationHeader, HttpTestServer, sinon } from '../../../../test-helper.js';
+import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Application | Route | OidcRouter', function () {
-  let server;
-
-  describe('GET /api/oidc/redirect-logout-url', function () {
-    beforeEach(async function () {
-      sinon.stub(oidcController, 'getRedirectLogoutUrl').callsFake((request, h) => h.response('ok').code(200));
-      server = new HttpTestServer();
-      server.setupAuthentication();
-      await server.register(moduleUnderTest);
-    });
-
-    it('should return a response with HTTP status code 200', async function () {
-      // given & when
-      const { statusCode } = await server.requestObject({
-        method: 'GET',
-        url: '/api/oidc/redirect-logout-url?identity_provider=POLE_EMPLOI&logout_url_uuid=b45cb781-4e9a-49b6-8c7e-ff5f02e07720',
-        headers: { authorization: generateValidRequestAuthorizationHeader() },
-      });
-
-      // then
-      expect(statusCode).to.equal(200);
-    });
-
-    context('when missing required parameters', function () {
-      context('all', function () {
-        it('should return a response with HTTP status code 400', async function () {
-          // given & when
-          const { statusCode } = await server.requestObject({
-            method: 'GET',
-            url: '/api/oidc/redirect-logout-url',
-            headers: { authorization: generateValidRequestAuthorizationHeader() },
-          });
-
-          // then
-          expect(statusCode).to.equal(400);
-        });
-      });
-
-      context('identity_provider', function () {
-        it('should return a response with HTTP status code 400', async function () {
-          // given & when
-          const { statusCode } = await server.requestObject({
-            method: 'GET',
-            url: '/api/oidc/redirect-logout-url?logout_url_uuid=b45cb781-4e9a-49b6-8c7e-ff5f02e07720',
-            headers: { authorization: generateValidRequestAuthorizationHeader() },
-          });
-
-          // then
-          expect(statusCode).to.equal(400);
-        });
-      });
-
-      context('logout_url_uuid', function () {
-        it('should return a response with HTTP status code 400', async function () {
-          // given & when
-          const { statusCode } = await server.requestObject({
-            method: 'GET',
-            url: '/api/oidc/redirect-logout-url?identity_provider=POLE_EMPLOI',
-            headers: { authorization: generateValidRequestAuthorizationHeader() },
-          });
-
-          // then
-          expect(statusCode).to.equal(400);
-        });
-      });
-    });
-  });
-
   describe('POST /api/oidc/user/check-reconciliation', function () {
     context('error cases', function () {
       context('when user is not found', function () {

--- a/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
+++ b/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
@@ -16,44 +16,6 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
     };
   });
 
-  describe('#getRedirectLogoutUrl', function () {
-    it('calls the oidc authentication service retrieved from his code to generate the redirect logout url', async function () {
-      // given
-      const request = {
-        auth: { credentials: { userId: '123' } },
-        query: {
-          identity_provider: identityProvider,
-          redirect_uri: 'http://example.net/',
-          logout_url_uuid: '1f3dbb71-f399-4c1c-85ae-0a863c78aeea',
-        },
-      };
-      const oidcAuthenticationService = {
-        getRedirectLogoutUrl: sinon.stub(),
-      };
-
-      oidcAuthenticationServiceRegistryStub.getOidcProviderServiceByCode
-        .withArgs({ identityProviderCode: identityProvider })
-        .returns(oidcAuthenticationService);
-
-      const dependencies = {
-        oidcAuthenticationServiceRegistry: oidcAuthenticationServiceRegistryStub,
-      };
-
-      // when
-      await oidcController.getRedirectLogoutUrl(request, hFake, dependencies);
-
-      // then
-      expect(oidcAuthenticationServiceRegistryStub.loadOidcProviderServices).to.have.been.calledOnce;
-      expect(
-        oidcAuthenticationServiceRegistryStub.configureReadyOidcProviderServiceByCode,
-      ).to.have.been.calledWithExactly(identityProvider);
-      expect(oidcAuthenticationService.getRedirectLogoutUrl).to.have.been.calledWithExactly({
-        userId: '123',
-        logoutUrlUUID: '1f3dbb71-f399-4c1c-85ae-0a863c78aeea',
-      });
-    });
-  });
-
   describe('#getAuthorizationUrl', function () {
     it('calls oidc authentication service to generate url', async function () {
       // given


### PR DESCRIPTION
## :unicorn: Problème

La route `GET /api/oidc/redirect-logout-url` est encore dans le dossier `lib`.

## :robot: Proposition

Faire la migration vers son bounded context `identity-access-management`.

## :rainbow: Remarques

Faire la review des PRs suivantes avant celle-ci :

- [x] #8851 
- [x] #8858 

## :100: Pour tester

Faire le test de déconnexion sur tous les fournisseurs d'identité.