### PR TITLE
[FEATURE] Désactiver les champs de réponses et les embed après avoir répondu (Pix-12425)

### DIFF
--- a/1d/app/pods/components/challenge/challenge-embed-simulator/challenge-embed-simulator.scss
+++ b/1d/app/pods/components/challenge/challenge-embed-simulator/challenge-embed-simulator.scss
@@ -1,8 +1,20 @@
 .challenge-embed-simulator {
+  position: relative;
+
   &__iframe {
     position: relative;
     width: 100%;
     border: none;
+
+  }
+
+  &__overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 2;
+    width: 100%;
+    height: 100%;
   }
 }
 

--- a/1d/app/pods/components/challenge/challenge-embed-simulator/template.hbs
+++ b/1d/app/pods/components/challenge/challenge-embed-simulator/template.hbs
@@ -1,6 +1,11 @@
 {{! template-lint-disable style-concatenation no-inline-styles }}
 <div class="challenge-embed-simulator">
+  {{#if @hideSimulator}}
+    <div class="challenge-embed-simulator__overlay"></div>
+  {{/if}}
+
   <iframe
+    tabindex={{if @hideSimulator "-1"}}
     class="challenge-embed-simulator__iframe"
     src="{{@url}}"
     title="{{@title}}"

--- a/1d/app/pods/components/challenge/challenge-item-qcm/template.hbs
+++ b/1d/app/pods/components/challenge/challenge-item-qcm/template.hbs
@@ -3,7 +3,7 @@
     <PixCheckbox
       name="{{labeledCheckbox.value}}"
       @class="pix1d-checkbox"
-      disabled={{@isAnswerFieldDisabled}}
+      disabled={{@isDisabled}}
       checked={{labeledCheckbox.checked}}
       {{on "click" (fn this.checkboxClicked labeledCheckbox.value)}}
       data-test="challenge-response-proposal-selector"

--- a/1d/app/pods/components/challenge/challenge-item-qcu/template.hbs
+++ b/1d/app/pods/components/challenge/challenge-item-qcu/template.hbs
@@ -3,7 +3,7 @@
     <PixRadioButton
       name="radio"
       @value={{labeledRadio.value}}
-      disabled={{@isAnswerFieldDisabled}}
+      disabled={{@isDisabled}}
       checked={{labeledRadio.checked}}
       {{on "click" (fn this.radioClicked labeledRadio.value)}}
       data-value="{{labeledRadio.value}}"

--- a/1d/app/pods/components/challenge/challenge-item-qrocm/template.hbs
+++ b/1d/app/pods/components/challenge/challenge-item-qrocm/template.hbs
@@ -17,6 +17,7 @@
         @options={{block.options}}
         @onChange={{fn this.onSelectChange block.input}}
         @id="{{block.input}}"
+        @isDisabled={{@isDisabled}}
       >
         <:label>{{block.ariaLabel}}</:label>
       </PixSelect>
@@ -42,6 +43,7 @@
               placeholder={{block.placeholder}}
               name={{block.randomName}}
               autocomplete="nope"
+              disabled={{@isDisabled}}
               {{! To activate validation button as soon as possible }}
               {{on "keyup" (fn this.onInputChange block.input)}}
               {{! To also deal with browser dictionary auto complete }}
@@ -55,7 +57,8 @@
               name={{block.randomName}}
               autocomplete="nope"
               placeholder={{block.placeholder}}
-              ariaLabel={{block.ariaLabel}}
+              aria-label={{block.ariaLabel}}
+              disabled={{@isDisabled}}
               {{! To activate validation button as soon as possible }}
               {{on "keyup" (fn this.onInputChange block.input)}}
               {{! To also deal with browser dictionary auto complete }}
@@ -66,10 +69,11 @@
               @id="{{block.input}}"
               class="challenge-item-proposals__response challenge-item-proposals__response--number"
               name={{block.randomName}}
-              type="number"
+              @type="number"
               min="0"
               placeholder={{block.placeholder}}
               @value={{get @answerValues block.input}}
+              disabled={{@isDisabled}}
               {{! To activate validation button as soon as possible }}
               {{on "keyup" (fn this.onInputChange block.input)}}
               {{! To also deal with browser dictionary auto complete }}
@@ -77,14 +81,15 @@
             />
           {{else}}
             <PixInput
-              type="text"
+              @type="text"
               class="challenge-item-proposals__response challenge-item-proposals__response--short-text"
               @id="{{block.input}}"
               name={{block.randomName}}
               autocomplete="nope"
               placeholder={{block.placeholder}}
               @value={{get @answerValues block.input}}
-              ariaLabel={{block.ariaLabel}}
+              aria-label={{block.ariaLabel}}
+              disabled={{@isDisabled}}
               {{! To activate validation button as soon as possible }}
               {{on "keyup" (fn this.onInputChange block.input)}}
               {{! To also deal with browser dictionary auto complete }}

--- a/1d/app/pods/components/challenge/challenge-item-qrocm/template.hbs
+++ b/1d/app/pods/components/challenge/challenge-item-qrocm/template.hbs
@@ -69,7 +69,7 @@
               @id="{{block.input}}"
               class="challenge-item-proposals__response challenge-item-proposals__response--number"
               name={{block.randomName}}
-              @type="number"
+              type="number"
               min="0"
               placeholder={{block.placeholder}}
               @value={{get @answerValues block.input}}

--- a/1d/app/pods/components/challenge/challenge-item-qrocm/template.hbs
+++ b/1d/app/pods/components/challenge/challenge-item-qrocm/template.hbs
@@ -73,6 +73,7 @@
               min="0"
               placeholder={{block.placeholder}}
               @value={{get @answerValues block.input}}
+              aria-label={{block.ariaLabel}}
               disabled={{@isDisabled}}
               {{! To activate validation button as soon as possible }}
               {{on "keyup" (fn this.onInputChange block.input)}}

--- a/1d/app/pods/components/challenge/component.js
+++ b/1d/app/pods/components/challenge/component.js
@@ -26,7 +26,7 @@ export default class Challenge extends Component {
 
   @action
   setAnswerValue(value) {
-    this.answerValue = value;
+    this.answerValue = value ?? null;
   }
 
   _createActivityAnswer(challenge) {

--- a/1d/app/pods/components/challenge/component.js
+++ b/1d/app/pods/components/challenge/component.js
@@ -41,6 +41,10 @@ export default class Challenge extends Component {
     return !this.#assessmentId;
   }
 
+  get hasBeenAnswered() {
+    return this.answer !== null;
+  }
+
   @action
   async validateAnswer() {
     this.answer = this._createActivityAnswer(this.args.challenge);

--- a/1d/app/pods/components/challenge/item/template.hbs
+++ b/1d/app/pods/components/challenge/item/template.hbs
@@ -11,6 +11,7 @@
           @url={{@challenge.embedUrl}}
           @title={{@challenge.embedTitle}}
           @height={{@challenge.embedHeight}}
+          @hideSimulator={{@isDisabled}}
         />
       </div>
     {{/if}}
@@ -23,7 +24,11 @@
     {{/if}}
     {{#if (or @challenge.isQROC @challenge.isQROCM)}}
       <div class="challenge-item__qrocm">
-        <Challenge::ChallengeItemQrocm @challenge={{@challenge}} @setAnswerValue={{@setAnswerValue}} />
+        <Challenge::ChallengeItemQrocm
+          @challenge={{@challenge}}
+          @setAnswerValue={{@setAnswerValue}}
+          @isDisabled={{@isDisabled}}
+        />
       </div>
     {{/if}}
     {{#if @challenge.isQCU}}
@@ -32,6 +37,7 @@
           @challenge={{@challenge}}
           @setAnswerValue={{@setAnswerValue}}
           @assessment={{@assessment}}
+          @isDisabled={{@isDisabled}}
         />
       </div>
     {{/if}}
@@ -41,6 +47,7 @@
           @challenge={{@challenge}}
           @setAnswerValue={{@setAnswerValue}}
           @assessment={{@assessment}}
+          @isDisabled={{@isDisabled}}
         />
       </div>
     {{/if}}

--- a/1d/app/pods/components/challenge/template.hbs
+++ b/1d/app/pods/components/challenge/template.hbs
@@ -20,5 +20,6 @@
     @answerHasBeenValidated={{this.answerHasBeenValidated}}
     @activity={{@activity}}
     @resume={{this.resume}}
+    @isDisabled={{this.hasBeenAnswered}}
   />
 </div>

--- a/1d/tests/acceptance/challenge-item-qcm_test.js
+++ b/1d/tests/acceptance/challenge-item-qcm_test.js
@@ -21,7 +21,7 @@ module('Acceptance | Displaying a QCM challenge', function (hooks) {
     assert.dom(screen.getByText('Sélectionne les bonnes réponses.')).exists();
   });
 
-  test('should display answer feedback bubble if user validates after writing the right answer in input', async function (assert) {
+  test('should display answer feedback bubble and disable checkboxes if user validates after writing the right answer in input', async function (assert) {
     // when
     const screen = await visit(`/assessments/${assessment.id}/challenges`);
     await click(screen.getByRole('checkbox', { name: 'Profil 1' }));
@@ -30,6 +30,12 @@ module('Acceptance | Displaying a QCM challenge', function (hooks) {
 
     // then
     assert.dom(screen.getByText(this.intl.t('pages.challenge.messages.correct-answer'))).exists();
+    assert.dom(screen.getByRole('checkbox', { name: 'Profil 1' })).isDisabled();
+    assert.dom(screen.getByRole('checkbox', { name: 'bad-answer' })).isDisabled();
+    assert.dom(screen.getByRole('checkbox', { name: 'Profil 3' })).isDisabled();
+    assert.dom(screen.getByRole('checkbox', { name: 'Profil 4' })).isDisabled();
+    assert.dom(screen.getByRole('checkbox', { name: 'Profil 5' })).isDisabled();
+    assert.dom(screen.getByRole('checkbox', { name: 'Profil 6' })).isDisabled();
   });
 
   module('when user unselects all checkboxes', function () {

--- a/1d/tests/acceptance/challenge-item-qcu_test.js
+++ b/1d/tests/acceptance/challenge-item-qcu_test.js
@@ -21,7 +21,7 @@ module('Acceptance | Displaying a QCU challenge', function (hooks) {
     assert.dom(screen.getByText('Sélectionne la bonne réponse.')).exists();
   });
 
-  test('should display answer feedback bubble if user validates after writing the right answer in input', async function (assert) {
+  test('should display answer feedback bubble and disable radio buttons if user validates after writing the right answer in input', async function (assert) {
     // when
     const screen = await visit(`/assessments/${assessment.id}/challenges`);
     await click(screen.getByRole('radio', { name: 'Profil 1' }));
@@ -29,5 +29,11 @@ module('Acceptance | Displaying a QCU challenge', function (hooks) {
 
     // then
     assert.dom(screen.getByText(this.intl.t('pages.challenge.messages.correct-answer'))).exists();
+    assert.dom(screen.getByRole('radio', { name: 'Profil 1' })).isDisabled();
+    assert.dom(screen.getByRole('radio', { name: 'bad-answer' })).isDisabled();
+    assert.dom(screen.getByRole('radio', { name: 'Profil 3' })).isDisabled();
+    assert.dom(screen.getByRole('radio', { name: 'Profil 4' })).isDisabled();
+    assert.dom(screen.getByRole('radio', { name: 'Profil 5' })).isDisabled();
+    assert.dom(screen.getByRole('radio', { name: 'Profil 6' })).isDisabled();
   });
 });

--- a/1d/tests/acceptance/challenge-item-qroc_test.js
+++ b/1d/tests/acceptance/challenge-item-qroc_test.js
@@ -35,7 +35,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
     });
 
     module('when user removes its answer', function () {
-      test('"Je vérifie" button is enabled', async function (assert) {
+      test('"Je vérifie" button is disabled', async function (assert) {
         // when
         const screen = await visit(`/assessments/${assessment.id}/challenges`);
         await fillIn(screen.getByLabelText('Rue de :'), 'la paix');
@@ -44,6 +44,18 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
         // then
         assert.dom(screen.getByRole('button', { name: this.intl.t('pages.challenge.actions.check') })).isDisabled();
       });
+    });
+
+    test('should verify answer and disable the input', async function (assert) {
+      assessment = this.server.create('assessment');
+
+      const screen = await visit(`/assessments/${assessment.id}/challenges`);
+      const input = screen.getByLabelText('Rue de :');
+
+      await fillIn(input, 'good answer');
+      await click(screen.getByRole('button', { name: this.intl.t('pages.challenge.actions.check') }));
+      assert.dom(screen.getByText(this.intl.t('pages.challenge.messages.correct-answer'))).exists();
+      assert.dom(input).isDisabled();
     });
   });
 
@@ -62,7 +74,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
       assert.dom(input).hasValue('1990');
     });
 
-    test('should validate correct answer', async function (assert) {
+    test('should validate correct answer and disable input field', async function (assert) {
       assessment = this.server.create('assessment');
       this.server.create('challenge', 'QROCWithNumber');
 
@@ -74,6 +86,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
 
       assert.equal(this.server.schema.activityAnswers.first().value, '1990');
       assert.dom(screen.getByText(this.intl.t('pages.challenge.messages.correct-answer'))).exists();
+      assert.dom(input).isDisabled();
     });
 
     test('should validate incorrect answer', async function (assert) {
@@ -104,7 +117,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
       assert.dom(screen.getByText('Rue de :')).exists();
     });
 
-    test('should display answer feedback bubble if user validates after writing the right answer in text area', async function (assert) {
+    test('should display answer feedback bubble and disable text area if user validates after writing the right answer in text area', async function (assert) {
       // when
       const screen = await visit(`/assessments/${assessment.id}/challenges`);
 
@@ -115,6 +128,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
 
       // then
       assert.dom(screen.getByText(this.intl.t('pages.challenge.messages.correct-answer'))).exists();
+      assert.dom(textArea).isDisabled();
     });
 
     module('when user removes its answer', function () {
@@ -123,7 +137,6 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
 
         const screen = await visit(`/assessments/${assessment.id}/challenges`);
         const textArea = screen.getByLabelText('Rue de :');
-
         await fillIn(textArea, 'good-answer');
         await fillIn(textArea, '');
 
@@ -159,6 +172,23 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
 
       // then
       assert.dom('.pix-select-button').hasText('good-answer');
+    });
+
+    test('should display answer feedback bubble and disable select if user validates after selecting the right answer', async function (assert) {
+      // when
+      const screen = await visit(`/assessments/${assessment.id}/challenges`);
+
+      await clickByName('saladAriaLabel');
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'good-answer' }));
+      await click(screen.getByRole('button', { name: this.intl.t('pages.challenge.actions.check') }));
+
+      // then
+      assert.dom(screen.getByText(this.intl.t('pages.challenge.messages.correct-answer'))).exists();
+      await clickByName('saladAriaLabel');
+      const button = await screen.findByLabelText('saladAriaLabel');
+
+      assert.dom(button).hasAttribute('aria-disabled');
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Après avoir répondu et validé sa réponse, l'utilisateur avait toujours la possibilité d'interagir avec l'embed et/ou les champs de réponses (cela n'avait aucune incidence sur le résultat envoyé)

## :robot: Proposition
Rendre toute interaction avec les embed et les champs impossible, après avoir validé une réponse

## :rainbow: Remarques


## :100: Pour tester
- Aller sur pix 1d, renseigner le code `MINIPIXOU` et commencer une mission. 
- Après avoir répondu à la 1ère question, essayer de modifier la réponse