### PR TITLE
[FEATURE] Permettre l'activation de fonctionnalité en masse sur les organisations (PIX-12413)

### DIFF
--- a/admin/app/components/administration/organizations-batch-update.hbs
+++ b/admin/app/components/administration/organizations-batch-update.hbs
@@ -1,0 +1,16 @@
+<section class="page-section">
+  <header class="page-section__header">
+    <h2 class="page-section__title">{{t "components.administration.organizations-batch-update.title"}}</h2>
+  </header>
+  <p>{{t "components.administration.organizations-batch-update.description"}}</p>
+  <br />
+  <PixButtonUpload
+    @id="oidc-providers-file-upload"
+    @onChange={{this.updateOrganizationsInBatch}}
+    @backgroundColor="transparent-light"
+    @isBorderVisible={{true}}
+    accept=".csv"
+  >
+    {{t "components.administration.organizations-batch-update.upload-button"}}
+  </PixButtonUpload>
+</section>

--- a/admin/app/components/administration/organizations-batch-update.js
+++ b/admin/app/components/administration/organizations-batch-update.js
@@ -1,0 +1,52 @@
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import ENV from 'pix-admin/config/environment';
+
+export default class OrganizationsBatchUpdate extends Component {
+  @service intl;
+  @service notifications;
+  @service session;
+  @service errorResponseHandler;
+
+  @action
+  async updateOrganizationsInBatch(files) {
+    this.notifications.clearAll();
+
+    let response;
+    try {
+      const fileContent = await readFileAsText(files[0]);
+
+      const token = this.session.data.authenticated.access_token;
+      response = await window.fetch(`${ENV.APP.API_HOST}/api/admin/organizations/add-organization-features`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'text/csv',
+          Accept: 'application/json',
+        },
+        method: 'POST',
+        body: fileContent,
+      });
+      if (response.ok) {
+        this.notifications.success(
+          this.intl.t('components.administration.organizations-batch-update.notifications.success'),
+        );
+        return;
+      } else {
+        this.errorResponseHandler.notify(await response.json());
+      }
+    } catch (error) {
+      this.notifications.error(this.intl.t('common.notifications.generic-error'));
+    } finally {
+      this.isLoading = false;
+    }
+  }
+}
+
+const readFileAsText = (file) =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (event) => resolve(event.target.result);
+    reader.onerror = reject;
+    reader.readAsText(file);
+  });

--- a/admin/app/services/error-response-handler.js
+++ b/admin/app/services/error-response-handler.js
@@ -12,8 +12,12 @@ const ERROR_MESSAGES_BY_STATUS = {
   STATUS_503: 'Service momentanément indisponible',
 };
 
-const ERROR_MESSAGES_BY_CODE = {
+export const ERROR_MESSAGES_BY_CODE = {
   SENDING_EMAIL_TO_INVALID_DOMAIN: "Échec lors de l'envoi d'un e-mail car le domaine semble invalide.",
+  ALREADY_EXISTING_ORGANIZATION_FEATURE: 'Cette fonctionnalité a déjà été ajouté à cette organisation',
+  ORGANIZATION_NOT_FOUND: "Cette organisation n'existe pas",
+  FEATURE_NOT_FOUND: "Cette fonctionnalité n'existe pas",
+  FEATURE_PARAMS_NOT_PROCESSABLE: 'Les paramètres de la fonctionnalité ont un format incorrect',
 };
 
 export default class ErrorResponseHandlerService extends Service {
@@ -49,8 +53,8 @@ function _isJSONAPIError(errorResponse) {
 }
 
 function _getErrorMessageForErrorCode(errorCode) {
-  if (errorCode === 'SENDING_EMAIL_TO_INVALID_DOMAIN') {
-    return ERROR_MESSAGES_BY_CODE.SENDING_EMAIL_TO_INVALID_DOMAIN;
+  if (ERROR_MESSAGES_BY_CODE[errorCode]) {
+    return ERROR_MESSAGES_BY_CODE[errorCode];
   }
 
   return null;

--- a/admin/app/templates/authenticated/administration.hbs
+++ b/admin/app/templates/authenticated/administration.hbs
@@ -13,6 +13,8 @@
 
     <Administration::OrganizationsImport />
 
+    <Administration::OrganizationsBatchUpdate />
+
     <Administration::CampaignsImport />
 
     <Administration::SwapCampaignCodes />

--- a/admin/tests/integration/components/administration/organizations-batch-update_test.js
+++ b/admin/tests/integration/components/administration/organizations-batch-update_test.js
@@ -1,0 +1,127 @@
+import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import { triggerEvent } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import ENV from 'pix-admin/config/environment';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+const accessToken = 'An access token';
+const fileContent = 'foo';
+const file = new Blob([fileContent], { type: `valid-file` });
+
+module('Integration | Component |  administration/organizations-batch-update', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  let fetchStub;
+
+  hooks.beforeEach(function () {
+    class SessionService extends Service {
+      data = { authenticated: { access_token: accessToken } };
+    }
+    this.owner.register('service:session', SessionService);
+
+    fetchStub = sinon.stub(window, 'fetch');
+  });
+
+  hooks.afterEach(function () {
+    window.fetch.restore();
+  });
+
+  module('when import succeeds', function (hooks) {
+    hooks.beforeEach(function () {
+      fetchStub
+        .withArgs(`${ENV.APP.API_HOST}/api/admin/organizations/add-organization-features`, {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': 'text/csv',
+            Accept: 'application/json',
+          },
+          method: 'POST',
+          body: fileContent,
+        })
+        .resolves(fetchResponse({ status: 204 }));
+    });
+
+    test('it displays a success notification', async function (assert) {
+      // given
+      const notificationSuccessStub = sinon.stub();
+      class NotificationsStub extends Service {
+        success = notificationSuccessStub;
+        clearAll = sinon.stub();
+      }
+      this.owner.register('service:notifications', NotificationsStub);
+
+      // when
+      const screen = await render(hbs`<Administration::OrganizationsBatchUpdate />`);
+      const input = await screen.getByLabelText(
+        this.intl.t('components.administration.organizations-batch-update.upload-button'),
+      );
+      await triggerEvent(input, 'change', { files: [file] });
+
+      // then
+      assert.ok(true);
+      sinon.assert.calledWith(
+        notificationSuccessStub,
+        this.intl.t('components.administration.organizations-batch-update.notifications.success'),
+      );
+    });
+  });
+
+  module('when import fails', function (hooks) {
+    hooks.beforeEach(function () {
+      fetchStub
+        .withArgs(`${ENV.APP.API_HOST}/api/admin/organizations/add-organization-features`, {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': 'text/csv',
+            Accept: 'application/json',
+          },
+          method: 'POST',
+          body: fileContent,
+        })
+        .returns(
+          fetchResponse({
+            body: {
+              errors: [{ status: '412', title: "Un soucis avec l'import", code: '412', detail: 'Erreur d’import' }],
+            },
+            status: 400,
+          }),
+        );
+    });
+
+    test('it displays an error notification', async function (assert) {
+      // given
+      const file = new Blob(['foo'], { type: `valid-file` });
+      const notificationErrorStub = sinon.stub().returns();
+      class NotificationsStub extends Service {
+        error = notificationErrorStub;
+        clearAll = sinon.stub();
+      }
+      this.owner.register('service:notifications', NotificationsStub);
+
+      // when
+      const screen = await render(hbs`<Administration::OrganizationsBatchUpdate />`);
+      const input = await screen.findByLabelText(
+        this.intl.t('components.administration.organizations-batch-update.upload-button'),
+      );
+      await triggerEvent(input, 'change', { files: [file] });
+
+      // then
+      assert.ok(notificationErrorStub.called);
+    });
+  });
+});
+
+function fetchResponse({ body, status }) {
+  const mockResponse = new window.Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-type': 'application/json',
+    },
+  });
+
+  return Promise.resolve(mockResponse);
+}

--- a/admin/tests/unit/controllers/authenticated/smart-random-simulator/get-next-challenge-test.js
+++ b/admin/tests/unit/controllers/authenticated/smart-random-simulator/get-next-challenge-test.js
@@ -6,8 +6,7 @@ import sinon from 'sinon';
 module('Unit | Controller | authenticated/smart-random-simulator/get-next-challenge', function (hooks) {
   setupTest(hooks);
 
-  let controller;
-  const fetchStub = sinon.stub(window, 'fetch');
+  let controller, fetchStub;
   const returnedChallenge = {
     id: 'rec1kdnvnUagcpoYf',
     locales: ['fr', 'fr-fr'],
@@ -25,7 +24,12 @@ module('Unit | Controller | authenticated/smart-random-simulator/get-next-challe
   };
 
   hooks.beforeEach(async function () {
+    fetchStub = sinon.stub(window, 'fetch');
     controller = this.owner.lookup('controller:authenticated.smart-random-simulator.get-next-challenge');
+  });
+
+  hooks.afterEach(function () {
+    window.fetch.restore();
   });
 
   module('#skillsByTube', function () {

--- a/admin/tests/unit/services/error-response-handler_test.js
+++ b/admin/tests/unit/services/error-response-handler_test.js
@@ -108,25 +108,45 @@ module('Unit | Service | error-response-handler', function (hooks) {
   });
 
   module('with error codes', function () {
-    test('it notifies correct error for SENDING_EMAIL_TO_INVALID_DOMAIN error', function (assert) {
-      // given
-      const service = this.owner.lookup('service:error-response-handler');
-      service.notifications.error = sinon.stub();
-      const invalidDomainError = {
-        status: '400',
-        title: 'Sending email to an invalid domain',
+    [
+      {
         code: 'SENDING_EMAIL_TO_INVALID_DOMAIN',
-      };
+        message: "Échec lors de l'envoi d'un e-mail car le domaine semble invalide.",
+      },
+      {
+        code: 'ALREADY_EXISTING_ORGANIZATION_FEATURE',
+        message: 'Cette fonctionnalité a déjà été ajouté à cette organisation',
+      },
+      {
+        code: 'ORGANIZATION_NOT_FOUND',
+        message: "Cette organisation n'existe pas",
+      },
+      {
+        code: 'FEATURE_NOT_FOUND',
+        message: "Cette fonctionnalité n'existe pas",
+      },
+      {
+        code: 'FEATURE_PARAMS_NOT_PROCESSABLE',
+        message: 'Les paramètres de la fonctionnalité ont un format incorrect',
+      },
+    ].forEach(({ code, message }) => {
+      test(`it notifies correct error for code ${code}`, function (assert) {
+        // given
+        const service = this.owner.lookup('service:error-response-handler');
+        service.notifications.error = sinon.stub();
+        const invalidDomainError = {
+          status: '400',
+          title: 'Sending email to an invalid domain',
+          code,
+        };
 
-      // when
-      service.notify({ errors: [invalidDomainError] });
+        // when
+        service.notify({ errors: [invalidDomainError] });
 
-      // then
-      sinon.assert.calledWith(
-        service.notifications.error,
-        "Échec lors de l'envoi d'un e-mail car le domaine semble invalide.",
-      );
-      assert.ok(true);
+        // then
+        sinon.assert.calledWith(service.notifications.error, message);
+        assert.ok(true);
+      });
     });
   });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -41,6 +41,14 @@
         },
         "upload-button": "Import JSON file"
       },
+      "organizations-batch-update": {
+        "title": "Enable features on organizations",
+        "description": "Note: Trying to enable already existing features on organizations would produce an error.",
+        "notifications": {
+          "success": "Features have been enabled."
+        },
+        "upload-button": "Import CSV file"
+      },
       "organizations-import": {
         "title": "Mass creation of organizations",
         "description": "Existing organizations will not be changed.",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -49,6 +49,14 @@
         },
         "upload-button": "Importer un fichier JSON"
       },
+      "organizations-batch-update": {
+        "title": "Activation de fonctionnalités",
+        "description": "Note: Chercher à activer à nouveau des fonctionnalites déjà existantes sur une organisation renverrait une erreur.",
+        "notifications": {
+          "success": "Les fonctionnalités ont bien été activés."
+        },
+        "upload-button": "Importer un fichier CSV"
+      },
       "organizations-import": {
         "title": "Création en masse d'organisations",
         "description": "Les organisations déjà existantes ne seront pas modifiées.",

--- a/api/config/server-setup-error-handling.js
+++ b/api/config/server-setup-error-handling.js
@@ -5,6 +5,7 @@ import { certificationDomainErrorMappingConfiguration } from '../src/certificati
 import { devcompDomainErrorMappingConfiguration } from '../src/devcomp/application/http-error-mapper-configuration.js';
 import { evaluationDomainErrorMappingConfiguration } from '../src/evaluation/application/http-error-mapper-configuration.js';
 import { authenticationDomainErrorMappingConfiguration } from '../src/identity-access-management/application/http-error-mapper-configuration.js';
+import { organizationalEntitiesDomainErrorMappingConfiguration } from '../src/organizational-entities/application/http-error-mapper-configuration.js';
 import { prescriptionDomainErrorMappingConfiguration } from '../src/prescription/shared/application/http-error-mapper-configuration.js';
 import { schoolDomainErrorMappingConfiguration } from '../src/school/application/http-error-mapper-configuration.js';
 import { domainErrorMapper } from '../src/shared/application/domain-error-mapper.js';
@@ -13,6 +14,7 @@ import * as sharedPreResponseUtils from '../src/shared/application/pre-response-
 const setupErrorHandling = function (server) {
   const configuration = [
     ...authenticationDomainErrorMappingConfiguration,
+    ...organizationalEntitiesDomainErrorMappingConfiguration,
     ...courseDomainErrorMappingConfiguration,
     ...sessionDomainErrorMappingConfiguration,
     ...certificationDomainErrorMappingConfiguration,

--- a/api/src/organizational-entities/application/http-error-mapper-configuration.js
+++ b/api/src/organizational-entities/application/http-error-mapper-configuration.js
@@ -1,0 +1,34 @@
+import { HttpErrors } from '../../shared/application/http-errors.js';
+import { DomainErrorMappingConfiguration } from '../../shared/application/models/domain-error-mapping-configuration.js';
+import {
+  AlreadyExistingOrganizationFeatureError,
+  FeatureNotFound,
+  FeatureParamsNotProcessable,
+  OrganizationNotFound,
+  UnableToAttachChildOrganizationToParentOrganizationError,
+} from '../domain/errors.js';
+
+const organizationalEntitiesDomainErrorMappingConfiguration = [
+  {
+    name: UnableToAttachChildOrganizationToParentOrganizationError.name,
+    httpErrorFn: (error) => new HttpErrors.ConflictError(error.message, error.code, error.meta),
+  },
+  {
+    name: AlreadyExistingOrganizationFeatureError.name,
+    httpErrorFn: (error) => new HttpErrors.ConflictError(error.message, error.code, error.meta),
+  },
+  {
+    name: OrganizationNotFound.name,
+    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+  },
+  {
+    name: FeatureNotFound.name,
+    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+  },
+  {
+    name: FeatureParamsNotProcessable.name,
+    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta),
+  },
+].map((domainErrorMappingConfiguration) => new DomainErrorMappingConfiguration(domainErrorMappingConfiguration));
+
+export { organizationalEntitiesDomainErrorMappingConfiguration };

--- a/api/src/organizational-entities/application/organization-controller.js
+++ b/api/src/organizational-entities/application/organization-controller.js
@@ -9,6 +9,12 @@ const attachChildOrganization = async function (request, h) {
   return h.response().code(204);
 };
 
+const addOrganizationFeatureInBatch = async function (request, h) {
+  await usecases.addOrganizationFeatureInBatch({ filePath: request.payload.path });
+  return h.response().code(204);
+};
+
 export const organizationController = {
   attachChildOrganization,
+  addOrganizationFeatureInBatch,
 };

--- a/api/src/organizational-entities/application/routes.js
+++ b/api/src/organizational-entities/application/routes.js
@@ -1,8 +1,14 @@
 import Joi from 'joi';
 
+import { PayloadTooLargeError, sendJsonApiError } from '../../shared/application/http-errors.js';
 import { securityPreHandlers } from '../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../shared/domain/types/identifiers-type.js';
 import { organizationController } from './organization-controller.js';
+
+const ERRORS = {
+  PAYLOAD_TOO_LARGE: 'PAYLOAD_TOO_LARGE',
+};
+const TWENTY_MEGABYTES = 1048576 * 20;
 
 const register = async function (server) {
   server.route([
@@ -29,6 +35,36 @@ const register = async function (server) {
         notes: [
           "- **Cette route est restreinte aux utilisateurs authentifiés ayant un rôle SUPER_ADMIN, METIER ou SUPPORT permettant un accès à l'application d'administration de Pix**\n" +
             "- Elle permet d'attacher une organisation mère à une organisation fille",
+        ],
+      },
+    },
+    {
+      method: 'POST',
+      path: '/api/admin/organizations/add-organization-features',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        payload: {
+          maxBytes: TWENTY_MEGABYTES,
+          output: 'file',
+          failAction: (request, h) => {
+            return sendJsonApiError(
+              new PayloadTooLargeError('An error occurred, payload is too large', ERRORS.PAYLOAD_TOO_LARGE, {
+                maxSize: '20',
+              }),
+              h,
+            );
+          },
+        },
+        handler: organizationController.addOrganizationFeatureInBatch,
+        tags: ['api', 'admin', 'organizational-entities', 'organizations', 'organization-features'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant un rôle SUPER_ADMIN permettant un accès à l'application d'administration de Pix**\n" +
+            "- Elle permet d'activer une fonctionnalité à des organisations",
         ],
       },
     },

--- a/api/src/organizational-entities/domain/errors.js
+++ b/api/src/organizational-entities/domain/errors.js
@@ -12,4 +12,37 @@ class UnableToAttachChildOrganizationToParentOrganizationError extends DomainErr
   }
 }
 
-export { UnableToAttachChildOrganizationToParentOrganizationError };
+class AlreadyExistingOrganizationFeatureError extends DomainError {
+  constructor({
+    code = 'ALREADY_EXISTING_ORGANIZATION_FEATURE',
+    message = 'Unable to add feature to organization',
+    meta,
+  } = {}) {
+    super(message);
+    this.code = code;
+    this.meta = meta;
+  }
+}
+
+class OrganizationNotFound extends DomainError {
+  constructor({ code = 'ORGANIZATION_NOT_FOUND', message = 'Organization does not exist', meta } = {}) {
+    super(message);
+    this.code = code;
+    this.meta = meta;
+  }
+}
+
+class FeatureNotFound extends DomainError {
+  constructor({ code = 'FEATURE_NOT_FOUND', message = 'Feature does not exist', meta } = {}) {
+    super(message);
+    this.code = code;
+    this.meta = meta;
+  }
+}
+
+export {
+  AlreadyExistingOrganizationFeatureError,
+  FeatureNotFound,
+  OrganizationNotFound,
+  UnableToAttachChildOrganizationToParentOrganizationError,
+};

--- a/api/src/organizational-entities/domain/errors.js
+++ b/api/src/organizational-entities/domain/errors.js
@@ -40,9 +40,18 @@ class FeatureNotFound extends DomainError {
   }
 }
 
+class FeatureParamsNotProcessable extends DomainError {
+  constructor({ code = 'FEATURE_PARAMS_NOT_PROCESSABLE', message = 'Feature params are not processable', meta } = {}) {
+    super(message);
+    this.code = code;
+    this.meta = meta;
+  }
+}
+
 export {
   AlreadyExistingOrganizationFeatureError,
   FeatureNotFound,
+  FeatureParamsNotProcessable,
   OrganizationNotFound,
   UnableToAttachChildOrganizationToParentOrganizationError,
 };

--- a/api/src/organizational-entities/domain/errors.js
+++ b/api/src/organizational-entities/domain/errors.js
@@ -1,4 +1,4 @@
-import { DomainError } from '../../../lib/domain/errors.js';
+import { DomainError } from '../../shared/domain/errors.js';
 
 class UnableToAttachChildOrganizationToParentOrganizationError extends DomainError {
   constructor({

--- a/api/src/organizational-entities/domain/models/OrganizationFeature.js
+++ b/api/src/organizational-entities/domain/models/OrganizationFeature.js
@@ -1,0 +1,9 @@
+class OrganizationFeature {
+  constructor({ featureId, organizationId, params }) {
+    this.featureId = parseInt(featureId, 10);
+    this.organizationId = parseInt(organizationId, 10);
+    this.params = params ? JSON.parse(params) : null;
+  }
+}
+
+export { OrganizationFeature };

--- a/api/src/organizational-entities/domain/usecases/add-organization-feature-in-batch.js
+++ b/api/src/organizational-entities/domain/usecases/add-organization-feature-in-batch.js
@@ -1,0 +1,57 @@
+/**
+ * @typedef {import ('../usecases/index.js').OrganizationFeatureRepository} OrganizationFeatureRepository
+ */
+
+import { createReadStream } from 'node:fs';
+
+import { CsvColumn } from '../../../../lib/infrastructure/serializers/csv/csv-column.js';
+import { CsvParser } from '../../../../lib/infrastructure/serializers/csv/csv-parser.js';
+import { getDataBuffer } from '../../../prescription/learner-management/infrastructure/utils/bufferize/get-data-buffer.js';
+import { FeatureParamsNotProcessable } from '../errors.js';
+import { OrganizationFeature } from '../models/OrganizationFeature.js';
+
+const organizationFeatureCsvHeader = {
+  columns: [
+    new CsvColumn({
+      property: 'featureId',
+      name: 'Feature ID',
+      isRequired: true,
+    }),
+    new CsvColumn({
+      property: 'organizationId',
+      name: 'Organization ID',
+      isRequired: true,
+    }),
+    new CsvColumn({
+      property: 'params',
+      name: 'Params',
+      isRequired: false,
+    }),
+  ],
+};
+
+/**
+ * @param {Object} params - A parameter object.
+ * @param {string} params.featureId - feature id to add.
+ * @param {string} params.filePath - path of csv file wich contains organizations and params.
+ * @param {OrganizationFeatureRepository} params.organizationFeatureRepository - organizationRepository to use.
+ * @param {Object} params.dependencies
+ * @returns {Promise<void>}
+ */
+async function addOrganizationFeatureInBatch({ filePath, organizationFeatureRepository }) {
+  const stream = createReadStream(filePath);
+  const buffer = await getDataBuffer(stream);
+
+  const csvParser = new CsvParser(buffer, organizationFeatureCsvHeader);
+  const csvData = csvParser.parse();
+  const data = csvData.map(({ featureId, organizationId, params }) => {
+    try {
+      return new OrganizationFeature({ featureId, organizationId, params: params });
+    } catch (err) {
+      throw new FeatureParamsNotProcessable();
+    }
+  });
+  return organizationFeatureRepository.saveInBatch(data);
+}
+
+export { addOrganizationFeatureInBatch };

--- a/api/src/organizational-entities/domain/usecases/index.js
+++ b/api/src/organizational-entities/domain/usecases/index.js
@@ -3,18 +3,36 @@ import { fileURLToPath } from 'node:url';
 
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
+import * as organizationFeatureRepository from '../../infrastructure/repositories/organization-feature-repository.js';
 import * as organizationForAdminRepository from '../../infrastructure/repositories/organization-for-admin-repository.js';
 
 const path = dirname(fileURLToPath(import.meta.url));
 
-const dependencies = {
+/**
+ * @typedef {import ('../../infrastructure/repositories/organization-feature-repository.js')} OrganizationFeatureRepository
+ * @typedef {import ('../../infrastructure/repositories/organization-for-admin-repository.js')} OrganizationForAdminRepository
+ */
+
+const repositories = {
   organizationForAdminRepository,
+  organizationFeatureRepository,
 };
+
+const dependencies = Object.assign({}, repositories);
 
 const usecasesWithoutInjectedDependencies = {
   ...(await importNamedExportsFromDirectory({ path: join(path, './'), ignoredFileNames: ['index.js'] })),
 };
 
+/**
+ * @typedef OrganizationalEntitiesUsecases
+ * @property {addOrganizationFeatureInBatch} addOrganizationFeatureInBatch
+ * @property {attachChildOrganizationToOrganization} attachChildOrganizationToOrganization
+ */
+
+/**
+ * @type {OrganizationalEntitiesUsecases}
+ */
 const usecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);
 
 export { usecases };

--- a/api/src/organizational-entities/infrastructure/repositories/organization-feature-repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-feature-repository.js
@@ -1,0 +1,37 @@
+/**
+ * @module OrganizationFeatureRepository
+ */
+
+import { knex } from '../../../../db/knex-database-connection.js';
+import * as knexUtils from '../../../../src/shared/infrastructure/utils/knex-utils.js';
+import { AlreadyExistingOrganizationFeatureError, FeatureNotFound, OrganizationNotFound } from '../../domain/errors.js';
+
+/**
+ * @typedef {import('../../domain/models/OrganizationFeature.js').OrganizationFeature} OrganizationFeature
+ */
+
+const DEFAULT_BATCH_SIZE = 100;
+
+/**
+ **
+ * @param {OrganizationFeature[]} organizations
+ */
+async function saveInBatch(organizationFeatures, batchSize = DEFAULT_BATCH_SIZE) {
+  try {
+    await knex.batchInsert('organization-features', organizationFeatures, batchSize);
+  } catch (err) {
+    if (knexUtils.isUniqConstraintViolated(err)) {
+      throw new AlreadyExistingOrganizationFeatureError();
+    }
+
+    if (knexUtils.foreignKeyConstraintViolated(err) && err.constraint.includes('featureid')) {
+      throw new FeatureNotFound();
+    }
+
+    if (knexUtils.foreignKeyConstraintViolated(err) && err.constraint.includes('organizationid')) {
+      throw new OrganizationNotFound();
+    }
+  }
+}
+
+export { saveInBatch };

--- a/api/tests/organizational-entities/acceptance/add-organization-features-in-batch_test.js
+++ b/api/tests/organizational-entities/acceptance/add-organization-features-in-batch_test.js
@@ -1,0 +1,42 @@
+import iconv from 'iconv-lite';
+
+import { PIX_ADMIN } from '../../../src/authorization/domain/constants.js';
+import { createServer, databaseBuilder, expect, generateValidRequestAuthorizationHeader } from '../../test-helper.js';
+
+describe('Acceptance | Application | Organizations | POST /api/admin/organizations/add-organization-features', function () {
+  context('When a CSV  file is loaded', function () {
+    let server, feature, firstOrganization, otherOrganization;
+    beforeEach(async function () {
+      feature = databaseBuilder.factory.buildFeature({ key: 'feature', description: ' best feature ever' });
+      firstOrganization = databaseBuilder.factory.buildOrganization({ name: 'first organization', type: 'PRO' });
+      otherOrganization = databaseBuilder.factory.buildOrganization({ name: 'other organization', type: 'PRO' });
+
+      await databaseBuilder.commit();
+
+      server = await createServer();
+    });
+
+    it('should respond with a 204 - no content', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser.withRole({ role: PIX_ADMIN.ROLES.SUPER_ADMIN }).id;
+      await databaseBuilder.commit();
+
+      const input = `Feature ID;Organization ID;Params
+      ${feature.id};${firstOrganization.id};{"id": 123}
+      ${feature.id};${otherOrganization.id};{"id": 123}`;
+
+      const options = {
+        method: 'POST',
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        url: '/api/admin/organizations/add-organization-features',
+        payload: iconv.encode(input, 'UTF-8'),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+    });
+  });
+});

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-feature-repository_test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-feature-repository_test.js
@@ -1,0 +1,106 @@
+import {
+  AlreadyExistingOrganizationFeatureError,
+  FeatureNotFound,
+  OrganizationNotFound,
+} from '../../../../../src/organizational-entities/domain/errors.js';
+import { OrganizationFeature } from '../../../../../src/organizational-entities/domain/models/OrganizationFeature.js';
+import * as organizationFeatureRepository from '../../../../../src/organizational-entities/infrastructure/repositories/organization-feature-repository.js';
+import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
+import { catchErr, databaseBuilder, expect, knex } from '../../../../test-helper.js';
+
+describe('Integration | Repository | Organization-for-admin', function () {
+  let organization, feature;
+
+  beforeEach(async function () {
+    organization = databaseBuilder.factory.buildOrganization();
+    feature = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.PLACES_MANAGEMENT);
+    await databaseBuilder.commit();
+  });
+
+  describe('#saveInBatch', function () {
+    it('should add a several organization feature rows', async function () {
+      // given
+      const otherOrganization = databaseBuilder.factory.buildOrganization();
+      await databaseBuilder.commit();
+
+      const organizationFeatures = [
+        new OrganizationFeature({
+          featureId: feature.id,
+          organizationId: organization.id,
+          params: `{ "id": 123 }`,
+        }),
+        new OrganizationFeature({
+          featureId: feature.id,
+          organizationId: otherOrganization.id,
+          params: `{ "id": 456 }`,
+        }),
+      ];
+
+      // when
+      await organizationFeatureRepository.saveInBatch(organizationFeatures);
+
+      //then
+      const result = await knex('organization-features').where({
+        featureId: feature.id,
+      });
+
+      expect(result).to.have.lengthOf(2);
+      expect(result[0].featureId).to.deep.equal(organizationFeatures[0].featureId);
+      expect(result[0].organizationId).to.deep.equal(organizationFeatures[0].organizationId);
+      expect(result[0].params).to.deep.equal(organizationFeatures[0].params);
+      expect(result[1].featureId).to.deep.equal(organizationFeatures[1].featureId);
+      expect(result[1].organizationId).to.deep.equal(organizationFeatures[1].organizationId);
+      expect(result[1].params).to.deep.equal(organizationFeatures[1].params);
+    });
+
+    it('throws an error if organization feature already exists', async function () {
+      databaseBuilder.factory.buildOrganizationFeature({ organizationId: organization.id, featureId: feature.id });
+      await databaseBuilder.commit();
+
+      const organizationFeatures = [
+        new OrganizationFeature({
+          featureId: feature.id,
+          organizationId: organization.id,
+          params: `{ "id": 123 }`,
+        }),
+      ];
+
+      // when
+      const error = await catchErr(organizationFeatureRepository.saveInBatch)(organizationFeatures);
+
+      expect(error).to.be.instanceOf(AlreadyExistingOrganizationFeatureError);
+    });
+
+    it('throws an error if organization does not exists', async function () {
+      const notExistingId = 999;
+      const organizationFeatures = [
+        new OrganizationFeature({
+          featureId: feature.id,
+          organizationId: notExistingId,
+          params: `{ "id": 123 }`,
+        }),
+      ];
+
+      // when
+      const error = await catchErr(organizationFeatureRepository.saveInBatch)(organizationFeatures);
+
+      expect(error).to.be.instanceOf(OrganizationNotFound);
+    });
+
+    it('throws an error if feature does not exists', async function () {
+      const notExistingId = 999;
+      const organizationFeatures = [
+        new OrganizationFeature({
+          featureId: notExistingId,
+          organizationId: organization.id,
+          params: `{ "id": 123 }`,
+        }),
+      ];
+
+      // when
+      const error = await catchErr(organizationFeatureRepository.saveInBatch)(organizationFeatures);
+
+      expect(error).to.be.instanceOf(FeatureNotFound);
+    });
+  });
+});

--- a/api/tests/organizational-entities/unit/application/organization-controller_test.js
+++ b/api/tests/organizational-entities/unit/application/organization-controller_test.js
@@ -1,0 +1,28 @@
+import { organizationController } from '../../../../src/organizational-entities/application/organization-controller.js';
+import { usecases } from '../../../../src/organizational-entities/domain/usecases/index.js';
+import { expect, hFake, sinon } from '../../../test-helper.js';
+
+describe('Unit | Application | Organizational Entities | organization-controller', function () {
+  let filePath, request;
+
+  beforeEach(function () {
+    filePath = Symbol('filePath');
+    request = { payload: { path: filePath } };
+    sinon.stub(usecases, 'addOrganizationFeatureInBatch').resolves();
+  });
+
+  it('should call the usecase to create organization feature', async function () {
+    // given
+    hFake.request = {
+      path: '/api/admin/organizations/add-multiple-organization-features',
+    };
+
+    // when
+    await organizationController.addOrganizationFeatureInBatch(request, hFake);
+
+    // then
+    expect(usecases.addOrganizationFeatureInBatch).to.have.been.calledWithExactly({
+      filePath,
+    });
+  });
+});

--- a/api/tests/organizational-entities/unit/application/organization-route_test.js
+++ b/api/tests/organizational-entities/unit/application/organization-route_test.js
@@ -1,0 +1,30 @@
+import { organizationController } from '../../../../src/organizational-entities/application/organization-controller.js';
+import { organizationalEntitiesRoutes } from '../../../../src/organizational-entities/application/routes.js';
+import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
+import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
+
+describe('Unit | Router | organization-router', function () {
+  describe('POST /api/admin/organizations/add-organization-features', function () {
+    it('should return 204 when user can add organization features', async function () {
+      // given
+      const method = 'POST';
+      const url = '/api/admin/organizations/add-organization-features';
+      const payload = {};
+
+      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').callsFake((request, h) => h.response(true));
+
+      sinon
+        .stub(organizationController, 'addOrganizationFeatureInBatch')
+        .callsFake((request, h) => h.response('ok').code(204));
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(organizationalEntitiesRoutes[0]);
+
+      // when
+      const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+    });
+  });
+});

--- a/api/tests/organizational-entities/unit/application/organization-route_test.js
+++ b/api/tests/organizational-entities/unit/application/organization-route_test.js
@@ -1,30 +1,93 @@
 import { organizationController } from '../../../../src/organizational-entities/application/organization-controller.js';
 import { organizationalEntitiesRoutes } from '../../../../src/organizational-entities/application/routes.js';
+import {
+  AlreadyExistingOrganizationFeatureError,
+  FeatureNotFound,
+  FeatureParamsNotProcessable,
+  OrganizationNotFound,
+} from '../../../../src/organizational-entities/domain/errors.js';
 import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
 
 describe('Unit | Router | organization-router', function () {
   describe('POST /api/admin/organizations/add-organization-features', function () {
-    it('should return 204 when user can add organization features', async function () {
+    const method = 'POST';
+    const url = '/api/admin/organizations/add-organization-features';
+    const payload = {};
+
+    let httpTestServer;
+
+    beforeEach(async function () {
+      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').resolves(true);
+
+      sinon.stub(organizationController, 'addOrganizationFeatureInBatch');
+      httpTestServer = new HttpTestServer();
+      await httpTestServer.register(organizationalEntitiesRoutes[0]);
+    });
+
+    it('should return call the `checkAdminMemberHasRoleSuperAdmin` security prehandler', async function () {
       // given
-      const method = 'POST';
-      const url = '/api/admin/organizations/add-organization-features';
-      const payload = {};
+      organizationController.addOrganizationFeatureInBatch.resolves(true);
 
-      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').callsFake((request, h) => h.response(true));
+      // when
+      await httpTestServer.request(method, url, payload);
 
-      sinon
-        .stub(organizationController, 'addOrganizationFeatureInBatch')
-        .callsFake((request, h) => h.response('ok').code(204));
+      // then
+      expect(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin).to.have.been.calledOnce;
+    });
+
+    it('should return call the `addOrganizationFeatureInBatch` controller', async function () {
+      // given
+      organizationController.addOrganizationFeatureInBatch.resolves(true);
 
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(organizationalEntitiesRoutes[0]);
 
       // when
+      await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(organizationController.addOrganizationFeatureInBatch).to.have.been.calledOnce;
+    });
+
+    it('return a 422 status code when trying to add feature on non existing organization', async function () {
+      organizationController.addOrganizationFeatureInBatch.rejects(new OrganizationNotFound());
+
+      // when
       const response = await httpTestServer.request(method, url, payload);
 
       // then
-      expect(response.statusCode).to.equal(204);
+      expect(response.statusCode).to.equal(422);
+    });
+
+    it('return a 422 status code when trying to add non existing feature', async function () {
+      organizationController.addOrganizationFeatureInBatch.rejects(new FeatureNotFound());
+
+      // when
+      const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(422);
+    });
+
+    it('return a 422 status code when trying to add non processable params', async function () {
+      organizationController.addOrganizationFeatureInBatch.rejects(new FeatureParamsNotProcessable());
+
+      // when
+      const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(422);
+    });
+
+    it('return a 409 status code when trying to add already existing feature on organization', async function () {
+      organizationController.addOrganizationFeatureInBatch.rejects(new AlreadyExistingOrganizationFeatureError());
+
+      // when
+      const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(409);
     });
   });
 });

--- a/api/tests/organizational-entities/unit/domain/models/OrganizationFeature_test.js
+++ b/api/tests/organizational-entities/unit/domain/models/OrganizationFeature_test.js
@@ -1,0 +1,22 @@
+import { OrganizationFeature } from '../../../../../src/organizational-entities/domain/models/OrganizationFeature.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Domain | Models | OrganizationFeature', function () {
+  let organizationFeature, featureId, organizationId, params;
+
+  beforeEach(function () {
+    // given
+    featureId = '1';
+    organizationId = '2';
+    params = `{"id": 3}`;
+  });
+
+  describe('#constructor', function () {
+    it('should initialize an instance with given params', function () {
+      //when
+      organizationFeature = new OrganizationFeature({ featureId, organizationId, params });
+      // then
+      expect(organizationFeature).to.deep.equal({ featureId: 1, organizationId: 2, params: { id: 3 } });
+    });
+  });
+});

--- a/api/tests/organizational-entities/unit/domain/usecases/add-organization-feature-in-batch_test.js
+++ b/api/tests/organizational-entities/unit/domain/usecases/add-organization-feature-in-batch_test.js
@@ -1,0 +1,56 @@
+import { FeatureParamsNotProcessable } from '../../../../../src/organizational-entities/domain/errors.js';
+import { OrganizationFeature } from '../../../../../src/organizational-entities/domain/models/OrganizationFeature.js';
+import { addOrganizationFeatureInBatch } from '../../../../../src/organizational-entities/domain/usecases/add-organization-feature-in-batch.js';
+import { catchErr, createTempFile, expect, removeTempFile, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Domain | UseCases | add-organization-feature-in-batch', function () {
+  let organizationFeatureRepository, featureId, filePath, csvData;
+
+  beforeEach(function () {
+    featureId = 1;
+    csvData = [
+      new OrganizationFeature({ featureId, organizationId: 123, params: `{ "id": 123 }` }),
+      new OrganizationFeature({ featureId, organizationId: 456, params: `{ "id": 123 }` }),
+    ];
+
+    organizationFeatureRepository = {
+      saveInBatch: sinon.stub(),
+    };
+  });
+
+  afterEach(async function () {
+    await removeTempFile(filePath);
+  });
+
+  it('should call saveInBatch with correct paramaters', async function () {
+    // given
+    filePath = await createTempFile(
+      'test.csv',
+      `Feature ID;Organization ID;Params
+    ${featureId};123;{"id": 123}
+    ${featureId};456;{"id": 123}
+`,
+    );
+    // when
+    await addOrganizationFeatureInBatch({ filePath, organizationFeatureRepository });
+
+    expect(organizationFeatureRepository.saveInBatch).to.have.been.calledOnceWithExactly(csvData);
+  });
+
+  it('should throw a FeatureParamsNotProcessable error', async function () {
+    // given
+    filePath = await createTempFile(
+      'test.csv',
+      `Feature ID;Organization ID;Params
+    ${featureId};123;{`,
+    );
+
+    // when
+    const error = await catchErr(addOrganizationFeatureInBatch)({
+      filePath,
+      organizationFeatureRepository,
+    });
+
+    expect(error).to.be.instanceOf(FeatureParamsNotProcessable);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Nous souhaitons activer la fonctionnalité de gestion des places pour environ 300 organisations à partir du 15 mai. Il est possible d'activer cette fonctionnalité sur l'écran d'édition d'une organisation. Cependant cela est fastidieux pour un tel nombre d'organisations à la fois. 

## :robot: Proposition

On ajoute un outil dans la partie de PixAdmin accessible aux super admin pour permettre d'activer une fonctionnalité à des organisations à partir d'un fichier csv.

## :rainbow: Remarques

La team Accès va travailler sur une fonctionnalité d'édition en masse des organisations. Ces travaux pourront donc soit servir de base à cette fonctionnalité ou être ré-intégrer dedans.

## :100: Pour tester

Exemple de fichier csv : 
```
Feature ID;Organization ID;Params
1003;1002;{"id":1}
```

- Se connecter sur PixAdmin en tant que SUPER ADMIN
- Accéder à la partie administration
- Essayer d'ajouter une fonctionnalité à deux orgas (avec et sans paramètres)
- Tester les cas d'erreurs : 
  - feature non existante
  - organisation non existante
  - params json non lisible
  - feature déjà activée pour l'organisation