### PR TITLE
[FEATURE] Pix App : Arrêt du support des Elements dans les modules (PIX-12455)

### DIFF
--- a/mon-pix/app/controllers/module-preview.js
+++ b/mon-pix/app/controllers/module-preview.js
@@ -7,52 +7,61 @@ export default class ModulePreviewController extends Controller {
   @service('store') store;
 
   @tracked module = `{
-    "id": "0000000a-0000-0bcd-e000-0f0000gh0000",
-    "slug": "demo-preview-modulix",
-    "title": "Démo preview Modulix",
-    "details": {
-      "image": "https://images.pix.fr/modulix/placeholder-details.svg",
-      "description": "Découvrez la page de prévisualisation pour contribuer à Modulix !",
-      "duration": 5,
-      "level": "Débutant",
-      "objectives": [
-        "Prévisualiser un Module",
-        "Contribuer au contenu d'un Module"
-      ]
-    },
-    "transitionTexts": [
-      {
-        "content": "<p>Voici un texte de transition</p>",
-        "grainId": "1111111a-1111-1bcd-e111-1f1111gh1111"
-      }
-    ],
-    "grains": [
-      {
-        "id": "1111111a-1111-1bcd-e111-1f1111gh1111",
-        "type": "lesson",
-        "title": "Voici une leçon",
-        "elements": [
-          {
+  "id": "0000000a-0000-0bcd-e000-0f0000gh0000",
+  "slug": "demo-preview-modulix",
+  "title": "Démo preview Modulix",
+  "details": {
+    "image": "https://images.pix.fr/modulix/placeholder-details.svg",
+    "description": "Découvrez la page de prévisualisation pour contribuer à Modulix !",
+    "duration": 5,
+    "level": "Débutant",
+    "objectives": [
+      "Prévisualiser un Module",
+      "Contribuer au contenu d'un Module"
+    ]
+  },
+  "transitionTexts": [
+    {
+      "content": "<p>Voici un texte de transition</p>",
+      "grainId": "1111111a-1111-1bcd-e111-1f1111gh1111"
+    }
+  ],
+  "grains": [
+    {
+      "id": "1111111a-1111-1bcd-e111-1f1111gh1111",
+      "type": "lesson",
+      "title": "Voici une leçon",
+      "components": [
+        {
+          "type": "element",
+          "element": {
             "id": "2222222a-2222-2bcd-e222-2f2222gh2222",
             "type": "text",
             "content": "<h3>Voici une leçon</h3>"
-          },
-          {
+          }
+        },
+        {
+          "type": "element",
+          "element": {
             "id": "3333333a-3333-3bcd-e333-3f3333gh3333",
             "type": "text",
             "content": "<p>Voici un texte de leçon. Parfois, il y a des émojis pour aider à la lecture&nbsp;<span aria-hidden='true'>📚</span>️.<br>Et là, voici une image&#8239;!</p>"
-          },
-          {
+          }
+        },
+        {
+          "type": "element",
+          "element": {
             "id": "4444444a-4444-4bcd-e444-4f4444gh4444",
             "type": "image",
             "url": "https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg",
             "alt": "Dessin détaillé dans l'alternative textuelle",
             "alternativeText": "Dessin d'un ordinateur dans un univers spatial."
           }
-        ]
-      }
-    ]
-  }`;
+        }
+      ]
+    }
+  ]
+}`;
   @tracked errorMessage = null;
 
   get passage() {

--- a/mon-pix/app/pods/components/module/grain/component.js
+++ b/mon-pix/app/pods/components/module/grain/component.js
@@ -22,19 +22,15 @@ export default class ModuleGrain extends Component {
   }
 
   static getSupportedElements(grain) {
-    if (grain.components && grain.components.length > 0) {
-      return grain.components
-        .map((component) => {
-          if (component.type === 'element') {
-            return component.element;
-          } else {
-            return undefined;
-          }
-        })
-        .filter((element) => ModuleGrain.AVAILABLE_ELEMENT_TYPES.includes(element.type));
-    }
-
-    return grain.elements.filter((element) => ModuleGrain.AVAILABLE_ELEMENT_TYPES.includes(element.type));
+    return grain.components
+      .map((component) => {
+        if (component.type === 'element') {
+          return component.element;
+        } else {
+          return undefined;
+        }
+      })
+      .filter((element) => ModuleGrain.AVAILABLE_ELEMENT_TYPES.includes(element.type));
   }
 
   get displayableElements() {

--- a/mon-pix/app/pods/grain/model.js
+++ b/mon-pix/app/pods/grain/model.js
@@ -2,7 +2,6 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class Grain extends Model {
   @attr('string') title;
-  @attr({ defaultValue: () => [] }) elements;
   @attr({ defaultValue: () => [] }) components;
   @attr('string') type;
 

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-passage_test.js
@@ -9,34 +9,34 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
   setupMirage(hooks);
 
   module('when user arrive on the module passage page', function () {
-    module('with elements', function () {
-      test('should display only the first lesson grain', async function (assert) {
-        // given
-        const grains = _createDeprecatedGrains(server);
+    test('should display only the first lesson grain', async function (assert) {
+      // given
+      const grains = _createGrains(server);
 
-        server.create('module', {
-          id: 'bien-ecrire-son-adresse-mail',
-          title: 'Bien écrire son adresse mail',
-          grains,
-        });
-
-        server.create('passage', {
-          moduleId: 'bien-ecrire-son-adresse-mail',
-        });
-
-        // when
-        const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-        // then
-        assert.dom(screen.getByRole('heading', { name: grains[0].title, level: 2 })).exists();
-        assert.dom(screen.queryByRole('heading', { name: grains[1].title, level: 2 })).doesNotExist();
-        assert.dom(screen.queryByRole('heading', { name: grains[2].title, level: 2 })).doesNotExist();
-        assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists({ count: 1 });
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains,
       });
-    });
 
-    module('with components', function () {
-      test('should display only the first lesson grain', async function (assert) {
+      server.create('passage', {
+        moduleId: 'bien-ecrire-son-adresse-mail',
+      });
+
+      // when
+      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+      // then
+      assert.dom(screen.getByRole('heading', { name: grains[0].title, level: 2 })).exists();
+      assert.dom(screen.queryByRole('heading', { name: grains[1].title, level: 2 })).doesNotExist();
+      assert.dom(screen.queryByRole('heading', { name: grains[2].title, level: 2 })).doesNotExist();
+      assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists({ count: 1 });
+    });
+  });
+
+  module('when user click on continue button', function () {
+    module('when the grain displayed is not the last', function () {
+      test('should display the continue button', async function (assert) {
         // given
         const grains = _createGrains(server);
 
@@ -46,202 +46,82 @@ module('Acceptance | Module | Routes | navigateIntoTheModulePassage', function (
           grains,
         });
 
-        server.create('passage', {
-          moduleId: 'bien-ecrire-son-adresse-mail',
-        });
-
         // when
         const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
 
         // then
-        assert.dom(screen.getByRole('heading', { name: grains[0].title, level: 2 })).exists();
-        assert.dom(screen.queryByRole('heading', { name: grains[1].title, level: 2 })).doesNotExist();
-        assert.dom(screen.queryByRole('heading', { name: grains[2].title, level: 2 })).doesNotExist();
         assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists({ count: 1 });
-      });
-    });
-  });
 
-  module('when user click on continue button', function () {
-    module('when the grain displayed is not the last', function () {
-      module('with elements', function () {
-        test('should display the continue button', async function (assert) {
-          // given
-          const grains = _createDeprecatedGrains(server);
+        // when
+        await clickByName('Continuer');
 
-          server.create('module', {
-            id: 'bien-ecrire-son-adresse-mail',
-            title: 'Bien écrire son adresse mail',
-            grains,
-          });
-
-          // when
-          const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-          // then
-          assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists({ count: 1 });
-
-          // when
-          await clickByName('Continuer');
-
-          // then
-          const secondGrain = grains[1];
-          assert.dom(screen.getByRole('heading', { name: secondGrain.title, level: 2 })).exists();
-          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists();
-        });
-      });
-
-      module('with components', function () {
-        test('should display the continue button', async function (assert) {
-          // given
-          const grains = _createGrains(server);
-
-          server.create('module', {
-            id: 'bien-ecrire-son-adresse-mail',
-            title: 'Bien écrire son adresse mail',
-            grains,
-          });
-
-          // when
-          const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-          // then
-          assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists({ count: 1 });
-
-          // when
-          await clickByName('Continuer');
-
-          // then
-          const secondGrain = grains[1];
-          assert.dom(screen.getByRole('heading', { name: secondGrain.title, level: 2 })).exists();
-          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists();
-        });
+        // then
+        const secondGrain = grains[1];
+        assert.dom(screen.getByRole('heading', { name: secondGrain.title, level: 2 })).exists();
+        assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists();
       });
     });
 
     module('when the grain displayed is the last', function () {
-      module('with elements', function () {
-        test('should not display continue button', async function (assert) {
-          // given
-          const grains = _createDeprecatedGrains(server);
-
-          server.create('module', {
-            id: 'bien-ecrire-son-adresse-mail',
-            title: 'Bien écrire son adresse mail',
-            grains,
-          });
-
-          // when
-          const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-          // then
-          assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists({ count: 1 });
-
-          // when
-          await clickByName('Continuer');
-          await clickByName('Continuer');
-
-          // then
-          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
-        });
-      });
-
-      module('with components', function () {
-        test('should not display continue button', async function (assert) {
-          // given
-          const grains = _createGrains(server);
-
-          server.create('module', {
-            id: 'bien-ecrire-son-adresse-mail',
-            title: 'Bien écrire son adresse mail',
-            grains,
-          });
-
-          // when
-          const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-          // then
-          assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists({ count: 1 });
-
-          // when
-          await clickByName('Continuer');
-          await clickByName('Continuer');
-
-          // then
-          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
-        });
-      });
-    });
-
-    module('with elements', function () {
-      test('should navigate to recap page when terminate is clicked', async function (assert) {
+      test('should not display continue button', async function (assert) {
         // given
-        const text1 = {
-          id: 'elementId-1',
-          type: 'text',
-          content: 'content-1',
-        };
-        const grain1 = server.create('grain', {
-          id: 'grainId-1',
-          title: 'title grain 1',
-          elements: [text1],
-        });
+        const grains = _createGrains(server);
+
         server.create('module', {
           id: 'bien-ecrire-son-adresse-mail',
           title: 'Bien écrire son adresse mail',
-          grains: [grain1],
+          grains,
         });
 
         // when
         const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
 
         // then
-        assert.dom(screen.getByRole('button', { name: 'Terminer' })).exists({ count: 1 });
+        assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists({ count: 1 });
 
         // when
-        await clickByName('Terminer');
+        await clickByName('Continuer');
+        await clickByName('Continuer');
 
         // then
-        assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/recap');
+        assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
       });
     });
 
-    module('with components', function () {
-      test('should navigate to recap page when terminate is clicked', async function (assert) {
-        // given
-        const text1 = {
-          id: 'elementId-1',
-          type: 'text',
-          content: 'content-1',
-        };
-        const grain1 = server.create('grain', {
-          id: 'grainId-1',
-          title: 'title grain 1',
-          components: [
-            {
-              type: 'element',
-              element: text1,
-            },
-          ],
-        });
-        server.create('module', {
-          id: 'bien-ecrire-son-adresse-mail',
-          title: 'Bien écrire son adresse mail',
-          grains: [grain1],
-        });
-
-        // when
-        const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-        // then
-        assert.dom(screen.getByRole('button', { name: 'Terminer' })).exists({ count: 1 });
-
-        // when
-        await clickByName('Terminer');
-
-        // then
-        assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/recap');
+    test('should navigate to recap page when terminate is clicked', async function (assert) {
+      // given
+      const text1 = {
+        id: 'elementId-1',
+        type: 'text',
+        content: 'content-1',
+      };
+      const grain1 = server.create('grain', {
+        id: 'grainId-1',
+        title: 'title grain 1',
+        components: [
+          {
+            type: 'element',
+            element: text1,
+          },
+        ],
       });
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [grain1],
+      });
+
+      // when
+      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+      // then
+      assert.dom(screen.getByRole('button', { name: 'Terminer' })).exists({ count: 1 });
+
+      // when
+      await clickByName('Terminer');
+
+      // then
+      assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/recap');
     });
   });
 });
@@ -263,26 +143,6 @@ const text3 = {
   type: 'text',
   content: 'content-3',
 };
-function _createDeprecatedGrains(server) {
-  const grain1 = server.create('grain', {
-    id: 'grainId-1',
-    title: 'title grain 1',
-    elements: [text1],
-  });
-  const grain2 = server.create('grain', {
-    id: 'grainId-2',
-    title: 'title grain 2',
-    elements: [text2],
-  });
-  const grain3 = server.create('grain', {
-    id: 'grainId-3',
-    title: 'title grain 3',
-    elements: [text3],
-  });
-
-  return [grain1, grain2, grain3];
-}
-
 function _createGrains(server) {
   const grain1 = server.create('grain', {
     id: 'grainId-1',

--- a/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
+++ b/mon-pix/tests/acceptance/module/navigate-into-the-module-recap_test.js
@@ -11,119 +11,62 @@ module('Acceptance | Module | Routes | navigateIntoTheModuleRecap', function (ho
   setupMirage(hooks);
   setupIntl(hooks);
 
-  module('with elements', function () {
-    module('when user arrive on the module recap page', function (hooks) {
-      let screen;
-      hooks.beforeEach(async function () {
-        const grain = server.create('grain', {
-          id: 'grain1',
-          elements: [{ type: 'text' }],
-        });
-        server.create('module', {
-          id: 'bien-ecrire-son-adresse-mail',
-          title: 'Bien écrire son adresse mail',
-          grains: [grain],
-          details: {
-            image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
-            description: 'Description',
-            duration: 'duration',
-            level: 'level',
-            objectives: ['Objectif #1'],
-          },
-        });
+  module('when user arrive on the module recap page', function (hooks) {
+    let screen;
+    hooks.beforeEach(async function () {
+      const text = {
+        id: '84726001-1665-457d-8f13-4a74dc4768ea',
+        type: 'text',
+        content: '<h3>content</h3>',
+      };
 
-        screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-        await clickByName('Terminer');
+      const grain = server.create('grain', {
+        id: 'grain1',
+        components: [{ type: 'element', element: text }],
+      });
+      server.create('module', {
+        id: 'bien-ecrire-son-adresse-mail',
+        title: 'Bien écrire son adresse mail',
+        grains: [grain],
+        details: {
+          image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+          description: 'Description',
+          duration: 'duration',
+          level: 'level',
+          objectives: ['Objectif #1'],
+        },
       });
 
-      test('should include the right page title', async function (assert) {
-        // then
-        assert.ok(document.title.includes(this.intl.t('pages.modulix.recap.title')));
-        assert.ok(screen.getByRole('heading', { level: 1, name: this.intl.t('pages.modulix.recap.title') }));
-      });
-
-      test('should display the links to details button and to form builder', async function (assert) {
-        // when
-        const formLink = screen.getByRole('link', { name: this.intl.t('pages.modulix.recap.goToForm') });
-
-        // then
-        const passage = server.schema.passages.all().models[0];
-        assert.ok(formLink);
-        assert.ok(screen.getByRole('link', { name: this.intl.t('pages.modulix.recap.backToModuleDetails') }));
-        assert.strictEqual(
-          formLink.getAttribute('href'),
-          `https://form-eu.123formbuilder.com/71180/modulix-experimentation?2850087=${passage.id}`,
-        );
-      });
-
-      test('should navigate to details page by clicking on back to module details button', async function (assert) {
-        // when
-        await click(screen.getByRole('link', { name: this.intl.t('pages.modulix.recap.backToModuleDetails') }));
-
-        // then
-        assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/details');
-      });
+      screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+      await clickByName('Terminer');
     });
-  });
 
-  module('with components', function () {
-    module('when user arrive on the module recap page', function (hooks) {
-      let screen;
-      hooks.beforeEach(async function () {
-        const text = {
-          id: '84726001-1665-457d-8f13-4a74dc4768ea',
-          type: 'text',
-          content: '<h3>content</h3>',
-        };
+    test('should include the right page title', async function (assert) {
+      // then
+      assert.ok(document.title.includes(this.intl.t('pages.modulix.recap.title')));
+      assert.ok(screen.getByRole('heading', { level: 1, name: this.intl.t('pages.modulix.recap.title') }));
+    });
 
-        const grain = server.create('grain', {
-          id: 'grain1',
-          components: [{ type: 'element', element: text }],
-        });
-        server.create('module', {
-          id: 'bien-ecrire-son-adresse-mail',
-          title: 'Bien écrire son adresse mail',
-          grains: [grain],
-          details: {
-            image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
-            description: 'Description',
-            duration: 'duration',
-            level: 'level',
-            objectives: ['Objectif #1'],
-          },
-        });
+    test('should display the links to details button and to form builder', async function (assert) {
+      // when
+      const formLink = screen.getByRole('link', { name: this.intl.t('pages.modulix.recap.goToForm') });
 
-        screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-        await clickByName('Terminer');
-      });
+      // then
+      const passage = server.schema.passages.all().models[0];
+      assert.ok(formLink);
+      assert.ok(screen.getByRole('link', { name: this.intl.t('pages.modulix.recap.backToModuleDetails') }));
+      assert.strictEqual(
+        formLink.getAttribute('href'),
+        `https://form-eu.123formbuilder.com/71180/modulix-experimentation?2850087=${passage.id}`,
+      );
+    });
 
-      test('should include the right page title', async function (assert) {
-        // then
-        assert.ok(document.title.includes(this.intl.t('pages.modulix.recap.title')));
-        assert.ok(screen.getByRole('heading', { level: 1, name: this.intl.t('pages.modulix.recap.title') }));
-      });
+    test('should navigate to details page by clicking on back to module details button', async function (assert) {
+      // when
+      await click(screen.getByRole('link', { name: this.intl.t('pages.modulix.recap.backToModuleDetails') }));
 
-      test('should display the links to details button and to form builder', async function (assert) {
-        // when
-        const formLink = screen.getByRole('link', { name: this.intl.t('pages.modulix.recap.goToForm') });
-
-        // then
-        const passage = server.schema.passages.all().models[0];
-        assert.ok(formLink);
-        assert.ok(screen.getByRole('link', { name: this.intl.t('pages.modulix.recap.backToModuleDetails') }));
-        assert.strictEqual(
-          formLink.getAttribute('href'),
-          `https://form-eu.123formbuilder.com/71180/modulix-experimentation?2850087=${passage.id}`,
-        );
-      });
-
-      test('should navigate to details page by clicking on back to module details button', async function (assert) {
-        // when
-        await click(screen.getByRole('link', { name: this.intl.t('pages.modulix.recap.backToModuleDetails') }));
-
-        // then
-        assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/details');
-      });
+      // then
+      assert.strictEqual(currentURL(), '/modules/bien-ecrire-son-adresse-mail/details');
     });
   });
 });

--- a/mon-pix/tests/acceptance/module/preview_test.js
+++ b/mon-pix/tests/acceptance/module/preview_test.js
@@ -19,7 +19,7 @@ module('Acceptance | Module | Routes | Preview', function (hooks) {
 
     await fillByLabel(
       'Contenu du Module',
-      '{ "grains": [{ "id":"1", "type": "lesson", "title": "Preview", "elements": [{"type": "text", "content": "Preview du module" }] }] }',
+      '{ "grains": [{ "id":"1", "type": "lesson", "title": "Preview", "components": [{ "type": "element", "element": {"type": "text", "content": "Preview du module" }}] }] }',
     );
 
     // then

--- a/mon-pix/tests/acceptance/module/retake_completed_module_test.js
+++ b/mon-pix/tests/acceptance/module/retake_completed_module_test.js
@@ -8,163 +8,86 @@ module('Acceptance | Module | Routes | retakeCompletedModule', function (hooks) 
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  module('with elements', function () {
-    test('should reset activities when I retake a completed module', async function (assert) {
-      // given
-      const qcu = {
-        id: 'elementId-1',
-        type: 'qcu',
-        instruction: 'instruction',
-        isAnswerable: true,
-        proposals: [
-          { id: 'qcu-1-proposal-1', content: 'I am the wrong answer!' },
-          { id: 'qcu-1-proposal-2', content: 'I am the right answer!' },
-        ],
-      };
+  test('should reset activities when I retake a completed module', async function (assert) {
+    // given
+    const qcu = {
+      id: 'elementId-1',
+      type: 'qcu',
+      instruction: 'instruction',
+      isAnswerable: true,
+      proposals: [
+        { id: 'qcu-1-proposal-1', content: 'I am the wrong answer!' },
+        { id: 'qcu-1-proposal-2', content: 'I am the right answer!' },
+      ],
+    };
 
-      const grain1 = server.create('grain', {
-        id: 'grainId1',
-        title: 'title',
-        elements: [qcu],
-      });
-
-      const text = {
-        id: 'elementId-1',
-        type: 'text',
-        content: 'content-1',
-        isAnswerable: false,
-      };
-
-      const grain2 = server.create('grain', {
-        id: 'grainId2',
-        title: 'title',
-        elements: [text],
-      });
-
-      server.create('module', {
-        id: 'bien-ecrire-son-adresse-mail',
-        title: 'Bien écrire son adresse mail',
-        grains: [grain1, grain2],
-      });
-
-      server.create('correction-response', {
-        id: 'elementId-1',
-        feedback: "Bravo ! C'est la bonne réponse.",
-        status: 'ok',
-        solution: 'qcu-1-proposal-2',
-      });
-
-      // when
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-      await click(screen.getByLabelText('I am the right answer!'));
-
-      const verifyButton = screen.getByRole('button', { name: 'Vérifier' });
-      await click(verifyButton);
-
-      assert.dom(screen.queryByText("Bravo ! C'est la bonne réponse.")).exists();
-
-      const continueButton = screen.getByRole('button', { name: 'Continuer' });
-      await click(continueButton);
-
-      const terminateButton = screen.getByRole('button', { name: 'Terminer' });
-      await click(terminateButton);
-
-      const backToDetailsButton = screen.getByRole('link', { name: 'Revenir aux détails du module' });
-      await click(backToDetailsButton);
-
-      const startModuleButton = screen.getByRole('link', { name: 'Commencer le module' });
-      await click(startModuleButton);
-
-      // then
-      assert.dom(screen.queryByText("Bravo ! C'est la bonne réponse.")).doesNotExist();
-
-      assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
-      assert.dom(screen.queryByRole('button', { name: 'Passer' })).exists();
+    const grain1 = server.create('grain', {
+      id: 'grainId1',
+      title: 'title',
+      components: [
+        {
+          type: 'element',
+          element: qcu,
+        },
+      ],
     });
-  });
 
-  module('with components', function () {
-    test('should reset activities when I retake a completed module', async function (assert) {
-      // given
-      const qcu = {
-        id: 'elementId-1',
-        type: 'qcu',
-        instruction: 'instruction',
-        isAnswerable: true,
-        proposals: [
-          { id: 'qcu-1-proposal-1', content: 'I am the wrong answer!' },
-          { id: 'qcu-1-proposal-2', content: 'I am the right answer!' },
-        ],
-      };
+    const text = {
+      id: 'elementId-1',
+      type: 'text',
+      content: 'content-1',
+      isAnswerable: false,
+    };
 
-      const grain1 = server.create('grain', {
-        id: 'grainId1',
-        title: 'title',
-        components: [
-          {
-            type: 'element',
-            element: qcu,
-          },
-        ],
-      });
-
-      const text = {
-        id: 'elementId-1',
-        type: 'text',
-        content: 'content-1',
-        isAnswerable: false,
-      };
-
-      const grain2 = server.create('grain', {
-        id: 'grainId2',
-        title: 'title',
-        components: [
-          {
-            type: 'element',
-            element: text,
-          },
-        ],
-      });
-
-      server.create('module', {
-        id: 'bien-ecrire-son-adresse-mail',
-        title: 'Bien écrire son adresse mail',
-        grains: [grain1, grain2],
-      });
-
-      server.create('correction-response', {
-        id: 'elementId-1',
-        feedback: "Bravo ! C'est la bonne réponse.",
-        status: 'ok',
-        solution: 'qcu-1-proposal-2',
-      });
-
-      // when
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-      await click(screen.getByLabelText('I am the right answer!'));
-
-      const verifyButton = screen.getByRole('button', { name: 'Vérifier' });
-      await click(verifyButton);
-
-      assert.dom(screen.queryByText("Bravo ! C'est la bonne réponse.")).exists();
-
-      const continueButton = screen.getByRole('button', { name: 'Continuer' });
-      await click(continueButton);
-
-      const terminateButton = screen.getByRole('button', { name: 'Terminer' });
-      await click(terminateButton);
-
-      const backToDetailsButton = screen.getByRole('link', { name: 'Revenir aux détails du module' });
-      await click(backToDetailsButton);
-
-      const startModuleButton = screen.getByRole('link', { name: 'Commencer le module' });
-      await click(startModuleButton);
-
-      // then
-      assert.dom(screen.queryByText("Bravo ! C'est la bonne réponse.")).doesNotExist();
-
-      assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
-      assert.dom(screen.queryByRole('button', { name: 'Passer' })).exists();
+    const grain2 = server.create('grain', {
+      id: 'grainId2',
+      title: 'title',
+      components: [
+        {
+          type: 'element',
+          element: text,
+        },
+      ],
     });
+
+    server.create('module', {
+      id: 'bien-ecrire-son-adresse-mail',
+      title: 'Bien écrire son adresse mail',
+      grains: [grain1, grain2],
+    });
+
+    server.create('correction-response', {
+      id: 'elementId-1',
+      feedback: "Bravo ! C'est la bonne réponse.",
+      status: 'ok',
+      solution: 'qcu-1-proposal-2',
+    });
+
+    // when
+    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+    await click(screen.getByLabelText('I am the right answer!'));
+
+    const verifyButton = screen.getByRole('button', { name: 'Vérifier' });
+    await click(verifyButton);
+
+    assert.dom(screen.queryByText("Bravo ! C'est la bonne réponse.")).exists();
+
+    const continueButton = screen.getByRole('button', { name: 'Continuer' });
+    await click(continueButton);
+
+    const terminateButton = screen.getByRole('button', { name: 'Terminer' });
+    await click(terminateButton);
+
+    const backToDetailsButton = screen.getByRole('link', { name: 'Revenir aux détails du module' });
+    await click(backToDetailsButton);
+
+    const startModuleButton = screen.getByRole('link', { name: 'Commencer le module' });
+    await click(startModuleButton);
+
+    // then
+    assert.dom(screen.queryByText("Bravo ! C'est la bonne réponse.")).doesNotExist();
+
+    assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+    assert.dom(screen.queryByRole('button', { name: 'Passer' })).exists();
   });
 });

--- a/mon-pix/tests/acceptance/module/retry-qcm_test.js
+++ b/mon-pix/tests/acceptance/module/retry-qcm_test.js
@@ -8,269 +8,139 @@ module('Acceptance | Module | Routes | retryQcm', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  module('with elements', function () {
-    test('can retry a QCM', async function (assert) {
-      // given
-      const qcm = {
-        id: 'elementId-1',
-        type: 'qcm',
-        instruction: 'instruction',
-        proposals: [
-          { id: '1', content: 'I am the first wrong answer!' },
-          { id: '2', content: 'I am the first right answer!' },
-          { id: '3', content: 'I am the second right answer!' },
-          { id: '4', content: 'I am the second wrong answer!' },
-        ],
-      };
+  test('can retry a QCM', async function (assert) {
+    // given
+    const qcm = {
+      id: 'elementId-1',
+      type: 'qcm',
+      instruction: 'instruction',
+      proposals: [
+        { id: '1', content: 'I am the first wrong answer!' },
+        { id: '2', content: 'I am the first right answer!' },
+        { id: '3', content: 'I am the second right answer!' },
+        { id: '4', content: 'I am the second wrong answer!' },
+      ],
+    };
 
-      const grain = server.create('grain', {
-        id: 'grainId',
-        title: 'title',
-        elements: [qcm],
-      });
-
-      server.create('module', {
-        id: 'bien-ecrire-son-adresse-mail',
-        title: 'Bien écrire son adresse mail',
-        grains: [grain],
-      });
-
-      server.create('correction-response', {
-        id: 'elementId-1',
-        feedback: 'Faux',
-        status: 'ko',
-        solution: [qcm.proposals[1].id, qcm.proposals[2].id],
-      });
-
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-      const qcmVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
-      const rightAnswerCheckbox = screen.getByLabelText('I am the second right answer!');
-      const wrongAnswerCheckbox = screen.getByLabelText('I am the first wrong answer!');
-      const qcmForm = screen.getByRole('group');
-
-      await click(rightAnswerCheckbox);
-      await click(wrongAnswerCheckbox);
-      await click(qcmVerifyButton);
-
-      assert.dom(screen.getByRole('status')).exists();
-
-      // when
-      const retryButton = screen.getByRole('button', { name: 'Réessayer' });
-      await click(retryButton);
-
-      // then
-      assert.strictEqual(screen.queryByRole('status').innerText, '');
-      assert.false(qcmForm.disabled);
-      assert.false(wrongAnswerCheckbox.checked);
-      assert.false(rightAnswerCheckbox.checked);
-
-      const qcmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
-      await click(wrongAnswerCheckbox);
-      await click(rightAnswerCheckbox);
-      await click(qcmVerifyButtonCameBack);
-      assert.strictEqual(screen.queryByRole('status').innerText, 'Faux');
+    const grain = server.create('grain', {
+      id: 'grainId',
+      title: 'title',
+      components: [
+        {
+          type: 'element',
+          element: qcm,
+        },
+      ],
     });
 
-    test('after retrying a QCM, it display an error message if QCM is validated without response', async function (assert) {
-      // given
-      const qcm = {
-        id: 'elementId-1',
-        type: 'qcm',
-        instruction: 'instruction',
-        proposals: [
-          { id: '1', content: 'I am the first wrong answer!' },
-          { id: '2', content: 'I am the first right answer!' },
-          { id: '3', content: 'I am the second right answer!' },
-          { id: '4', content: 'I am the second wrong answer!' },
-        ],
-      };
-
-      const grain = server.create('grain', {
-        id: 'grainId',
-        title: 'title',
-        elements: [qcm],
-      });
-
-      server.create('module', {
-        id: 'bien-ecrire-son-adresse-mail',
-        title: 'Bien écrire son adresse mail',
-        grains: [grain],
-      });
-
-      server.create('correction-response', {
-        id: 'elementId-1',
-        feedback: 'Faux',
-        status: 'ko',
-        solution: [qcm.proposals[1].id, qcm.proposals[2].id],
-      });
-
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-      const qcmVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
-      const rightAnswerCheckbox = screen.getByLabelText('I am the second right answer!');
-      const wrongAnswerCheckbox = screen.getByLabelText('I am the first wrong answer!');
-      const qcmForm = screen.getByRole('group');
-
-      await click(rightAnswerCheckbox);
-      await click(wrongAnswerCheckbox);
-      await click(qcmVerifyButton);
-
-      assert.dom(screen.getByRole('status')).exists();
-
-      // when
-      const retryButton = screen.getByRole('button', { name: 'Réessayer' });
-      await click(retryButton);
-
-      // then
-      assert.strictEqual(screen.queryByRole('status').innerText, '');
-      assert.false(qcmForm.disabled);
-      assert.false(wrongAnswerCheckbox.checked);
-      assert.false(rightAnswerCheckbox.checked);
-
-      const qcmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
-      await click(qcmVerifyButtonCameBack);
-      const validationAlert = screen.queryAllByRole('alert')[1];
-
-      assert.strictEqual(validationAlert.innerText, 'Pour valider, sélectionnez au moins deux réponses.');
+    server.create('module', {
+      id: 'bien-ecrire-son-adresse-mail',
+      title: 'Bien écrire son adresse mail',
+      grains: [grain],
     });
+
+    server.create('correction-response', {
+      id: 'elementId-1',
+      feedback: 'Faux',
+      status: 'ko',
+      solution: [qcm.proposals[1].id, qcm.proposals[2].id],
+    });
+
+    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+    const qcmVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
+    const rightAnswerCheckbox = screen.getByLabelText('I am the second right answer!');
+    const wrongAnswerCheckbox = screen.getByLabelText('I am the first wrong answer!');
+    const qcmForm = screen.getByRole('group');
+
+    await click(rightAnswerCheckbox);
+    await click(wrongAnswerCheckbox);
+    await click(qcmVerifyButton);
+
+    assert.dom(screen.getByRole('status')).exists();
+
+    // when
+    const retryButton = screen.getByRole('button', { name: 'Réessayer' });
+    await click(retryButton);
+
+    // then
+    assert.strictEqual(screen.queryByRole('status').innerText, '');
+    assert.false(qcmForm.disabled);
+    assert.false(wrongAnswerCheckbox.checked);
+    assert.false(rightAnswerCheckbox.checked);
+
+    const qcmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
+    await click(wrongAnswerCheckbox);
+    await click(rightAnswerCheckbox);
+    await click(qcmVerifyButtonCameBack);
+    assert.strictEqual(screen.queryByRole('status').innerText, 'Faux');
   });
 
-  module('with components', function () {
-    test('can retry a QCM', async function (assert) {
-      // given
-      const qcm = {
-        id: 'elementId-1',
-        type: 'qcm',
-        instruction: 'instruction',
-        proposals: [
-          { id: '1', content: 'I am the first wrong answer!' },
-          { id: '2', content: 'I am the first right answer!' },
-          { id: '3', content: 'I am the second right answer!' },
-          { id: '4', content: 'I am the second wrong answer!' },
-        ],
-      };
+  test('after retrying a QCM, it display an error message if QCM is validated without response', async function (assert) {
+    // given
+    const qcm = {
+      id: 'elementId-1',
+      type: 'qcm',
+      instruction: 'instruction',
+      proposals: [
+        { id: '1', content: 'I am the first wrong answer!' },
+        { id: '2', content: 'I am the first right answer!' },
+        { id: '3', content: 'I am the second right answer!' },
+        { id: '4', content: 'I am the second wrong answer!' },
+      ],
+    };
 
-      const grain = server.create('grain', {
-        id: 'grainId',
-        title: 'title',
-        components: [
-          {
-            type: 'element',
-            element: qcm,
-          },
-        ],
-      });
-
-      server.create('module', {
-        id: 'bien-ecrire-son-adresse-mail',
-        title: 'Bien écrire son adresse mail',
-        grains: [grain],
-      });
-
-      server.create('correction-response', {
-        id: 'elementId-1',
-        feedback: 'Faux',
-        status: 'ko',
-        solution: [qcm.proposals[1].id, qcm.proposals[2].id],
-      });
-
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-      const qcmVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
-      const rightAnswerCheckbox = screen.getByLabelText('I am the second right answer!');
-      const wrongAnswerCheckbox = screen.getByLabelText('I am the first wrong answer!');
-      const qcmForm = screen.getByRole('group');
-
-      await click(rightAnswerCheckbox);
-      await click(wrongAnswerCheckbox);
-      await click(qcmVerifyButton);
-
-      assert.dom(screen.getByRole('status')).exists();
-
-      // when
-      const retryButton = screen.getByRole('button', { name: 'Réessayer' });
-      await click(retryButton);
-
-      // then
-      assert.strictEqual(screen.queryByRole('status').innerText, '');
-      assert.false(qcmForm.disabled);
-      assert.false(wrongAnswerCheckbox.checked);
-      assert.false(rightAnswerCheckbox.checked);
-
-      const qcmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
-      await click(wrongAnswerCheckbox);
-      await click(rightAnswerCheckbox);
-      await click(qcmVerifyButtonCameBack);
-      assert.strictEqual(screen.queryByRole('status').innerText, 'Faux');
+    const grain = server.create('grain', {
+      id: 'grainId',
+      title: 'title',
+      components: [
+        {
+          type: 'element',
+          element: qcm,
+        },
+      ],
     });
 
-    test('after retrying a QCM, it display an error message if QCM is validated without response', async function (assert) {
-      // given
-      const qcm = {
-        id: 'elementId-1',
-        type: 'qcm',
-        instruction: 'instruction',
-        proposals: [
-          { id: '1', content: 'I am the first wrong answer!' },
-          { id: '2', content: 'I am the first right answer!' },
-          { id: '3', content: 'I am the second right answer!' },
-          { id: '4', content: 'I am the second wrong answer!' },
-        ],
-      };
-
-      const grain = server.create('grain', {
-        id: 'grainId',
-        title: 'title',
-        components: [
-          {
-            type: 'element',
-            element: qcm,
-          },
-        ],
-      });
-
-      server.create('module', {
-        id: 'bien-ecrire-son-adresse-mail',
-        title: 'Bien écrire son adresse mail',
-        grains: [grain],
-      });
-
-      server.create('correction-response', {
-        id: 'elementId-1',
-        feedback: 'Faux',
-        status: 'ko',
-        solution: [qcm.proposals[1].id, qcm.proposals[2].id],
-      });
-
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-      const qcmVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
-      const rightAnswerCheckbox = screen.getByLabelText('I am the second right answer!');
-      const wrongAnswerCheckbox = screen.getByLabelText('I am the first wrong answer!');
-      const qcmForm = screen.getByRole('group');
-
-      await click(rightAnswerCheckbox);
-      await click(wrongAnswerCheckbox);
-      await click(qcmVerifyButton);
-
-      assert.dom(screen.getByRole('status')).exists();
-
-      // when
-      const retryButton = screen.getByRole('button', { name: 'Réessayer' });
-      await click(retryButton);
-
-      // then
-      assert.strictEqual(screen.queryByRole('status').innerText, '');
-      assert.false(qcmForm.disabled);
-      assert.false(wrongAnswerCheckbox.checked);
-      assert.false(rightAnswerCheckbox.checked);
-
-      const qcmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
-      await click(qcmVerifyButtonCameBack);
-      const validationAlert = screen.queryAllByRole('alert')[1];
-
-      assert.strictEqual(validationAlert.innerText, 'Pour valider, sélectionnez au moins deux réponses.');
+    server.create('module', {
+      id: 'bien-ecrire-son-adresse-mail',
+      title: 'Bien écrire son adresse mail',
+      grains: [grain],
     });
+
+    server.create('correction-response', {
+      id: 'elementId-1',
+      feedback: 'Faux',
+      status: 'ko',
+      solution: [qcm.proposals[1].id, qcm.proposals[2].id],
+    });
+
+    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+    const qcmVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
+    const rightAnswerCheckbox = screen.getByLabelText('I am the second right answer!');
+    const wrongAnswerCheckbox = screen.getByLabelText('I am the first wrong answer!');
+    const qcmForm = screen.getByRole('group');
+
+    await click(rightAnswerCheckbox);
+    await click(wrongAnswerCheckbox);
+    await click(qcmVerifyButton);
+
+    assert.dom(screen.getByRole('status')).exists();
+
+    // when
+    const retryButton = screen.getByRole('button', { name: 'Réessayer' });
+    await click(retryButton);
+
+    // then
+    assert.strictEqual(screen.queryByRole('status').innerText, '');
+    assert.false(qcmForm.disabled);
+    assert.false(wrongAnswerCheckbox.checked);
+    assert.false(rightAnswerCheckbox.checked);
+
+    const qcmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
+    await click(qcmVerifyButtonCameBack);
+    const validationAlert = screen.queryAllByRole('alert')[1];
+
+    assert.strictEqual(validationAlert.innerText, 'Pour valider, sélectionnez au moins deux réponses.');
   });
 });

--- a/mon-pix/tests/acceptance/module/retry-qcu_test.js
+++ b/mon-pix/tests/acceptance/module/retry-qcu_test.js
@@ -8,331 +8,175 @@ module('Acceptance | Module | Routes | retryQcu', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  module('with elements', function () {
-    test('can retry a QCU', async function (assert) {
-      // given
-      const qcu1 = {
-        id: 'elementId-1',
-        type: 'qcu',
-        instruction: 'instruction',
-        proposals: [
-          { id: '1', content: 'I am the wrong answer!' },
-          { id: '2', content: 'I am the right answer!' },
-        ],
-      };
-      const qcu2 = {
-        id: 'elementId-2',
-        type: 'qcu',
-        instruction: 'instruction',
-        proposals: [
-          { id: '1', content: 'Vrai' },
-          { id: '2', content: 'Faux' },
-        ],
-      };
+  test('can retry a QCU', async function (assert) {
+    // given
+    const qcu1 = {
+      id: 'elementId-1',
+      type: 'qcu',
+      instruction: 'instruction',
+      proposals: [
+        { id: '1', content: 'I am the wrong answer!' },
+        { id: '2', content: 'I am the right answer!' },
+      ],
+    };
+    const qcu2 = {
+      id: 'elementId-2',
+      type: 'qcu',
+      instruction: 'instruction',
+      proposals: [
+        { id: '1', content: 'Vrai' },
+        { id: '2', content: 'Faux' },
+      ],
+    };
 
-      const grain1 = server.create('grain', {
-        id: 'grainId1',
-        title: 'title',
-        elements: [qcu1],
-      });
-
-      const grain2 = server.create('grain', {
-        id: 'grainId2',
-        title: 'title',
-        elements: [qcu2],
-      });
-
-      server.create('module', {
-        id: 'bien-ecrire-son-adresse-mail',
-        title: 'Bien écrire son adresse mail',
-        grains: [grain1, grain2],
-      });
-
-      server.create('correction-response', {
-        id: 'elementId-1',
-        feedback: 'Faux',
-        status: 'ko',
-        solution: qcu1.proposals[1].id,
-      });
-
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-      const firstQcuVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
-      const rightAnswerRadio = screen.getByLabelText('I am the right answer!');
-      const wrongAnswerRadio = screen.getByLabelText('I am the wrong answer!');
-      const firstQcuForm = screen.getByRole('group');
-
-      await click(wrongAnswerRadio);
-      await click(firstQcuVerifyButton);
-
-      assert.dom(screen.getByRole('status')).exists();
-
-      // when
-      const retryButton = screen.getByRole('button', { name: 'Réessayer' });
-      await click(retryButton);
-
-      // then
-      assert.strictEqual(screen.queryByRole('status').innerText, '');
-      assert.false(firstQcuForm.disabled);
-      assert.false(wrongAnswerRadio.checked);
-      assert.false(rightAnswerRadio.checked);
-
-      const firstQcuVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
-      await click(wrongAnswerRadio);
-      await click(firstQcuVerifyButtonCameBack);
-      assert.strictEqual(screen.queryByRole('status').innerText, 'Faux');
+    const grain1 = server.create('grain', {
+      id: 'grainId1',
+      title: 'title',
+      components: [
+        {
+          type: 'element',
+          element: qcu1,
+        },
+      ],
     });
 
-    test('after retrying a QCU, it display an error message if QCU is validated without response', async function (assert) {
-      // given
-      const qcu1 = {
-        id: 'elementId-1',
-        type: 'qcu',
-        instruction: 'instruction',
-        proposals: [
-          { id: '1', content: 'I am the wrong answer!' },
-          { id: '2', content: 'I am the right answer!' },
-        ],
-      };
-      const qcu2 = {
-        id: 'elementId-2',
-        type: 'qcu',
-        instruction: 'instruction',
-        proposals: [
-          { id: '1', content: 'Vrai' },
-          { id: '2', content: 'Faux' },
-        ],
-      };
-
-      const grain1 = server.create('grain', {
-        id: 'grainId1',
-        title: 'title',
-        type: 'activity',
-        elements: [qcu1],
-      });
-
-      const grain2 = server.create('grain', {
-        id: 'grainId2',
-        title: 'title',
-        type: 'activity',
-        elements: [qcu2],
-      });
-
-      server.create('module', {
-        id: 'bien-ecrire-son-adresse-mail',
-        title: 'Bien écrire son adresse mail',
-        grains: [grain1, grain2],
-      });
-
-      // look at mirage
-      server.create('correction-response', {
-        id: 'elementId-1',
-        feedback: 'Faux',
-        status: 'ko',
-        solution: qcu1.proposals[1].id,
-      });
-
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-      const firstQcuVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
-      const rightAnswerRadio = screen.getByLabelText('I am the right answer!');
-      const wrongAnswerRadio = screen.getByLabelText('I am the wrong answer!');
-      const firstQcuForm = screen.getByRole('group');
-
-      await click(wrongAnswerRadio);
-      await click(firstQcuVerifyButton);
-
-      assert.dom(screen.getByRole('status')).exists();
-
-      // when
-      const retryButton = screen.getByRole('button', { name: 'Réessayer' });
-      await click(retryButton);
-
-      // then
-      assert.strictEqual(screen.queryByRole('status').innerText, '');
-      assert.false(firstQcuForm.disabled);
-      assert.false(wrongAnswerRadio.checked);
-      assert.false(rightAnswerRadio.checked);
-
-      const firstQcuVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
-      await click(firstQcuVerifyButtonCameBack);
-      const validationAlert = screen.queryAllByRole('alert')[1];
-
-      assert.strictEqual(validationAlert.innerText, 'Pour valider, sélectionnez une réponse.');
+    const grain2 = server.create('grain', {
+      id: 'grainId2',
+      title: 'title',
+      components: [
+        {
+          type: 'element',
+          element: qcu2,
+        },
+      ],
     });
+
+    server.create('module', {
+      id: 'bien-ecrire-son-adresse-mail',
+      title: 'Bien écrire son adresse mail',
+      grains: [grain1, grain2],
+    });
+
+    server.create('correction-response', {
+      id: 'elementId-1',
+      feedback: 'Faux',
+      status: 'ko',
+      solution: qcu1.proposals[1].id,
+    });
+
+    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+    const firstQcuVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
+    const rightAnswerRadio = screen.getByLabelText('I am the right answer!');
+    const wrongAnswerRadio = screen.getByLabelText('I am the wrong answer!');
+    const firstQcuForm = screen.getByRole('group');
+
+    await click(wrongAnswerRadio);
+    await click(firstQcuVerifyButton);
+
+    assert.dom(screen.getByRole('status')).exists();
+
+    // when
+    const retryButton = screen.getByRole('button', { name: 'Réessayer' });
+    await click(retryButton);
+
+    // then
+    assert.strictEqual(screen.queryByRole('status').innerText, '');
+    assert.false(firstQcuForm.disabled);
+    assert.false(wrongAnswerRadio.checked);
+    assert.false(rightAnswerRadio.checked);
+
+    const firstQcuVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
+    await click(wrongAnswerRadio);
+    await click(firstQcuVerifyButtonCameBack);
+    assert.strictEqual(screen.queryByRole('status').innerText, 'Faux');
   });
 
-  module('with components', function () {
-    test('can retry a QCU', async function (assert) {
-      // given
-      const qcu1 = {
-        id: 'elementId-1',
-        type: 'qcu',
-        instruction: 'instruction',
-        proposals: [
-          { id: '1', content: 'I am the wrong answer!' },
-          { id: '2', content: 'I am the right answer!' },
-        ],
-      };
-      const qcu2 = {
-        id: 'elementId-2',
-        type: 'qcu',
-        instruction: 'instruction',
-        proposals: [
-          { id: '1', content: 'Vrai' },
-          { id: '2', content: 'Faux' },
-        ],
-      };
+  test('after retrying a QCU, it display an error message if QCU is validated without response', async function (assert) {
+    // given
+    const qcu1 = {
+      id: 'elementId-1',
+      type: 'qcu',
+      instruction: 'instruction',
+      proposals: [
+        { id: '1', content: 'I am the wrong answer!' },
+        { id: '2', content: 'I am the right answer!' },
+      ],
+    };
+    const qcu2 = {
+      id: 'elementId-2',
+      type: 'qcu',
+      instruction: 'instruction',
+      proposals: [
+        { id: '1', content: 'Vrai' },
+        { id: '2', content: 'Faux' },
+      ],
+    };
 
-      const grain1 = server.create('grain', {
-        id: 'grainId1',
-        title: 'title',
-        components: [
-          {
-            type: 'element',
-            element: qcu1,
-          },
-        ],
-      });
-
-      const grain2 = server.create('grain', {
-        id: 'grainId2',
-        title: 'title',
-        components: [
-          {
-            type: 'element',
-            element: qcu2,
-          },
-        ],
-      });
-
-      server.create('module', {
-        id: 'bien-ecrire-son-adresse-mail',
-        title: 'Bien écrire son adresse mail',
-        grains: [grain1, grain2],
-      });
-
-      server.create('correction-response', {
-        id: 'elementId-1',
-        feedback: 'Faux',
-        status: 'ko',
-        solution: qcu1.proposals[1].id,
-      });
-
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-      const firstQcuVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
-      const rightAnswerRadio = screen.getByLabelText('I am the right answer!');
-      const wrongAnswerRadio = screen.getByLabelText('I am the wrong answer!');
-      const firstQcuForm = screen.getByRole('group');
-
-      await click(wrongAnswerRadio);
-      await click(firstQcuVerifyButton);
-
-      assert.dom(screen.getByRole('status')).exists();
-
-      // when
-      const retryButton = screen.getByRole('button', { name: 'Réessayer' });
-      await click(retryButton);
-
-      // then
-      assert.strictEqual(screen.queryByRole('status').innerText, '');
-      assert.false(firstQcuForm.disabled);
-      assert.false(wrongAnswerRadio.checked);
-      assert.false(rightAnswerRadio.checked);
-
-      const firstQcuVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
-      await click(wrongAnswerRadio);
-      await click(firstQcuVerifyButtonCameBack);
-      assert.strictEqual(screen.queryByRole('status').innerText, 'Faux');
+    const grain1 = server.create('grain', {
+      id: 'grainId1',
+      title: 'title',
+      type: 'activity',
+      components: [
+        {
+          type: 'element',
+          element: qcu1,
+        },
+      ],
     });
 
-    test('after retrying a QCU, it display an error message if QCU is validated without response', async function (assert) {
-      // given
-      const qcu1 = {
-        id: 'elementId-1',
-        type: 'qcu',
-        instruction: 'instruction',
-        proposals: [
-          { id: '1', content: 'I am the wrong answer!' },
-          { id: '2', content: 'I am the right answer!' },
-        ],
-      };
-      const qcu2 = {
-        id: 'elementId-2',
-        type: 'qcu',
-        instruction: 'instruction',
-        proposals: [
-          { id: '1', content: 'Vrai' },
-          { id: '2', content: 'Faux' },
-        ],
-      };
-
-      const grain1 = server.create('grain', {
-        id: 'grainId1',
-        title: 'title',
-        type: 'activity',
-        components: [
-          {
-            type: 'element',
-            element: qcu1,
-          },
-        ],
-      });
-
-      const grain2 = server.create('grain', {
-        id: 'grainId2',
-        title: 'title',
-        type: 'activity',
-        components: [
-          {
-            type: 'element',
-            element: qcu2,
-          },
-        ],
-      });
-
-      server.create('module', {
-        id: 'bien-ecrire-son-adresse-mail',
-        title: 'Bien écrire son adresse mail',
-        grains: [grain1, grain2],
-      });
-
-      // look at mirage
-      server.create('correction-response', {
-        id: 'elementId-1',
-        feedback: 'Faux',
-        status: 'ko',
-        solution: qcu1.proposals[1].id,
-      });
-
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-      const firstQcuVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
-      const rightAnswerRadio = screen.getByLabelText('I am the right answer!');
-      const wrongAnswerRadio = screen.getByLabelText('I am the wrong answer!');
-      const firstQcuForm = screen.getByRole('group');
-
-      await click(wrongAnswerRadio);
-      await click(firstQcuVerifyButton);
-
-      assert.dom(screen.getByRole('status')).exists();
-
-      // when
-      const retryButton = screen.getByRole('button', { name: 'Réessayer' });
-      await click(retryButton);
-
-      // then
-      assert.strictEqual(screen.queryByRole('status').innerText, '');
-      assert.false(firstQcuForm.disabled);
-      assert.false(wrongAnswerRadio.checked);
-      assert.false(rightAnswerRadio.checked);
-
-      const firstQcuVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
-      await click(firstQcuVerifyButtonCameBack);
-      const validationAlert = screen.queryAllByRole('alert')[1];
-
-      assert.strictEqual(validationAlert.innerText, 'Pour valider, sélectionnez une réponse.');
+    const grain2 = server.create('grain', {
+      id: 'grainId2',
+      title: 'title',
+      type: 'activity',
+      components: [
+        {
+          type: 'element',
+          element: qcu2,
+        },
+      ],
     });
+
+    server.create('module', {
+      id: 'bien-ecrire-son-adresse-mail',
+      title: 'Bien écrire son adresse mail',
+      grains: [grain1, grain2],
+    });
+
+    // look at mirage
+    server.create('correction-response', {
+      id: 'elementId-1',
+      feedback: 'Faux',
+      status: 'ko',
+      solution: qcu1.proposals[1].id,
+    });
+
+    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+    const firstQcuVerifyButton = screen.getByRole('button', { name: 'Vérifier' });
+    const rightAnswerRadio = screen.getByLabelText('I am the right answer!');
+    const wrongAnswerRadio = screen.getByLabelText('I am the wrong answer!');
+    const firstQcuForm = screen.getByRole('group');
+
+    await click(wrongAnswerRadio);
+    await click(firstQcuVerifyButton);
+
+    assert.dom(screen.getByRole('status')).exists();
+
+    // when
+    const retryButton = screen.getByRole('button', { name: 'Réessayer' });
+    await click(retryButton);
+
+    // then
+    assert.strictEqual(screen.queryByRole('status').innerText, '');
+    assert.false(firstQcuForm.disabled);
+    assert.false(wrongAnswerRadio.checked);
+    assert.false(rightAnswerRadio.checked);
+
+    const firstQcuVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
+    await click(firstQcuVerifyButtonCameBack);
+    const validationAlert = screen.queryAllByRole('alert')[1];
+
+    assert.strictEqual(validationAlert.innerText, 'Pour valider, sélectionnez une réponse.');
   });
 });

--- a/mon-pix/tests/acceptance/module/retry-qrocm_test.js
+++ b/mon-pix/tests/acceptance/module/retry-qrocm_test.js
@@ -8,447 +8,228 @@ module('Acceptance | Module | Routes | retryQrocm', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  module('with elements', function () {
-    test('can retry a Qrocm', async function (assert) {
-      // given
-      const qrocm1 = {
-        id: 'elementId-1',
-        type: 'qrocm',
-        instruction: 'instruction',
-        proposals: [
-          {
-            type: 'text',
-            content: '<p>Le symbole</>',
-          },
-          {
-            input: 'symbole',
-            type: 'input',
-            inputType: 'text',
-            size: 1,
-            display: 'block',
-            placeholder: '',
-            ariaLabel: 'Réponse 1',
-            defaultValue: '',
-          },
-          {
-            input: 'premiere-partie',
-            type: 'select',
-            display: 'block',
-            placeholder: '',
-            ariaLabel: 'Réponse 2',
-            defaultValue: '',
-            options: [
-              {
-                id: '1',
-                content: "l'identifiant",
-              },
-              {
-                id: '2',
-                content: "le fournisseur d'adresse mail",
-              },
-            ],
-          },
-        ],
-      };
+  test('can retry a Qrocm', async function (assert) {
+    // given
+    const qrocm1 = {
+      id: 'elementId-1',
+      type: 'qrocm',
+      instruction: 'instruction',
+      proposals: [
+        {
+          type: 'text',
+          content: '<p>Le symbole</>',
+        },
+        {
+          input: 'symbole',
+          type: 'input',
+          inputType: 'text',
+          size: 1,
+          display: 'block',
+          placeholder: '',
+          ariaLabel: 'Réponse 1',
+          defaultValue: '',
+        },
+        {
+          input: 'premiere-partie',
+          type: 'select',
+          display: 'block',
+          placeholder: '',
+          ariaLabel: 'Réponse 2',
+          defaultValue: '',
+          options: [
+            {
+              id: '1',
+              content: "l'identifiant",
+            },
+            {
+              id: '2',
+              content: "le fournisseur d'adresse mail",
+            },
+          ],
+        },
+      ],
+    };
 
-      const grain = server.create('grain', {
-        id: 'grainId',
-        title: 'title',
-        elements: [qrocm1],
-      });
-
-      server.create('module', {
-        id: 'bien-ecrire-son-adresse-mail',
-        title: 'Bien écrire son adresse mail',
-        grains: [grain],
-      });
-
-      server.create('correction-response', {
-        id: 'elementId-1',
-        feedback: 'Faux',
-        status: 'ko',
-        solution: { symbole: '@', 'premiere-partie': '2' },
-      });
-
-      // when
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-      const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
-      const qrocmForm = screen.getByRole('group');
-      const input = screen.getByLabelText('Réponse 1');
-
-      // answer input proposal
-      await fillIn(input, '#');
-      // answer select proposal
-      await clickByName('Réponse 2');
-      await screen.findByRole('listbox');
-      await click(
-        screen.queryByRole('option', {
-          name: "le fournisseur d'adresse mail",
-        }),
-      );
-
-      // submit
-      await click(verifyButton);
-
-      assert.dom(screen.getByRole('status')).exists();
-
-      // when
-      const retryButton = screen.getByRole('button', { name: 'Réessayer' });
-      await click(retryButton);
-
-      await screen.findByRole('listbox');
-
-      // then
-      assert.strictEqual(screen.queryByRole('status').innerText, '');
-      assert.false(qrocmForm.disabled);
-      assert.strictEqual(
-        screen
-          .queryByRole('option', {
-            name: "le fournisseur d'adresse mail",
-          })
-          .getAttribute('aria-selected'),
-        'false',
-      );
-      assert.strictEqual(input.value, '');
-
-      const qrocmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
-
-      // answer input proposal
-      await fillIn(input, '#');
-      // answer select proposal
-      await clickByName('Réponse 2');
-      await screen.findByRole('listbox');
-      await click(
-        screen.queryByRole('option', {
-          name: "le fournisseur d'adresse mail",
-        }),
-      );
-      await click(qrocmVerifyButtonCameBack);
-
-      assert.strictEqual(screen.queryByRole('status').innerText, 'Faux');
+    const grain = server.create('grain', {
+      id: 'grainId',
+      title: 'title',
+      components: [
+        {
+          type: 'element',
+          element: qrocm1,
+        },
+      ],
     });
 
-    test('after retrying a Qrocm, it display an error message if Qrocm is validated without response', async function (assert) {
-      // given
-      const qrocm1 = {
-        id: 'elementId-1',
-        type: 'qrocm',
-        instruction: 'instruction',
-        proposals: [
-          {
-            type: 'text',
-            content: '<p>Le symbole</>',
-          },
-          {
-            input: 'symbole',
-            type: 'input',
-            inputType: 'text',
-            size: 1,
-            display: 'block',
-            placeholder: '',
-            ariaLabel: 'Réponse 1',
-            defaultValue: '',
-          },
-          {
-            input: 'premiere-partie',
-            type: 'select',
-            display: 'block',
-            placeholder: '',
-            ariaLabel: 'Réponse 2',
-            defaultValue: '',
-            options: [
-              {
-                id: '1',
-                content: "l'identifiant",
-              },
-              {
-                id: '2',
-                content: "le fournisseur d'adresse mail",
-              },
-            ],
-          },
-        ],
-      };
-
-      const grain = server.create('grain', {
-        id: 'grainId',
-        title: 'title',
-        elements: [qrocm1],
-      });
-
-      server.create('module', {
-        id: 'bien-ecrire-son-adresse-mail',
-        title: 'Bien écrire son adresse mail',
-        grains: [grain],
-      });
-
-      server.create('correction-response', {
-        id: 'elementId-1',
-        feedback: 'Faux',
-        status: 'ko',
-        solution: { symbole: '@', 'premiere-partie': '2' },
-      });
-
-      // when
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-      const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
-      const input = screen.getByLabelText('Réponse 1');
-
-      // answer input proposal
-      await fillIn(input, '#');
-      // answer select proposal
-      await clickByName('Réponse 2');
-      await screen.findByRole('listbox');
-      await click(
-        screen.queryByRole('option', {
-          name: "le fournisseur d'adresse mail",
-        }),
-      );
-
-      // submit
-      await click(verifyButton);
-
-      assert.dom(screen.getByRole('status')).exists();
-
-      // when
-      const retryButton = screen.getByRole('button', { name: 'Réessayer' });
-      await click(retryButton);
-
-      // then
-      const qrocmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
-      await click(qrocmVerifyButtonCameBack);
-      const validationAlert = screen.queryAllByRole('alert')[1];
-
-      assert.strictEqual(validationAlert.innerText, 'Pour valider, veuillez remplir tous les champs réponse.');
+    server.create('module', {
+      id: 'bien-ecrire-son-adresse-mail',
+      title: 'Bien écrire son adresse mail',
+      grains: [grain],
     });
+
+    server.create('correction-response', {
+      id: 'elementId-1',
+      feedback: 'Faux',
+      status: 'ko',
+      solution: { symbole: '@', 'premiere-partie': '2' },
+    });
+
+    // when
+    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+    const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
+    const qrocmForm = screen.getByRole('group');
+    const input = screen.getByLabelText('Réponse 1');
+
+    // answer input proposal
+    await fillIn(input, '#');
+    // answer select proposal
+    await clickByName('Réponse 2');
+    await screen.findByRole('listbox');
+    await click(
+      screen.queryByRole('option', {
+        name: "le fournisseur d'adresse mail",
+      }),
+    );
+
+    // submit
+    await click(verifyButton);
+
+    assert.dom(screen.getByRole('status')).exists();
+
+    // when
+    const retryButton = screen.getByRole('button', { name: 'Réessayer' });
+    await click(retryButton);
+
+    await screen.findByRole('listbox');
+
+    // then
+    assert.strictEqual(screen.queryByRole('status').innerText, '');
+    assert.false(qrocmForm.disabled);
+    assert.strictEqual(
+      screen
+        .queryByRole('option', {
+          name: "le fournisseur d'adresse mail",
+        })
+        .getAttribute('aria-selected'),
+      'false',
+    );
+    assert.strictEqual(input.value, '');
+
+    const qrocmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
+
+    // answer input proposal
+    await fillIn(input, '#');
+    // answer select proposal
+    await clickByName('Réponse 2');
+    await screen.findByRole('listbox');
+    await click(
+      screen.queryByRole('option', {
+        name: "le fournisseur d'adresse mail",
+      }),
+    );
+    await click(qrocmVerifyButtonCameBack);
+
+    assert.strictEqual(screen.queryByRole('status').innerText, 'Faux');
   });
 
-  module('with components', function () {
-    test('can retry a Qrocm', async function (assert) {
-      // given
-      const qrocm1 = {
-        id: 'elementId-1',
-        type: 'qrocm',
-        instruction: 'instruction',
-        proposals: [
-          {
-            type: 'text',
-            content: '<p>Le symbole</>',
-          },
-          {
-            input: 'symbole',
-            type: 'input',
-            inputType: 'text',
-            size: 1,
-            display: 'block',
-            placeholder: '',
-            ariaLabel: 'Réponse 1',
-            defaultValue: '',
-          },
-          {
-            input: 'premiere-partie',
-            type: 'select',
-            display: 'block',
-            placeholder: '',
-            ariaLabel: 'Réponse 2',
-            defaultValue: '',
-            options: [
-              {
-                id: '1',
-                content: "l'identifiant",
-              },
-              {
-                id: '2',
-                content: "le fournisseur d'adresse mail",
-              },
-            ],
-          },
-        ],
-      };
+  test('after retrying a Qrocm, it display an error message if Qrocm is validated without response', async function (assert) {
+    // given
+    const qrocm1 = {
+      id: 'elementId-1',
+      type: 'qrocm',
+      instruction: 'instruction',
+      proposals: [
+        {
+          type: 'text',
+          content: '<p>Le symbole</>',
+        },
+        {
+          input: 'symbole',
+          type: 'input',
+          inputType: 'text',
+          size: 1,
+          display: 'block',
+          placeholder: '',
+          ariaLabel: 'Réponse 1',
+          defaultValue: '',
+        },
+        {
+          input: 'premiere-partie',
+          type: 'select',
+          display: 'block',
+          placeholder: '',
+          ariaLabel: 'Réponse 2',
+          defaultValue: '',
+          options: [
+            {
+              id: '1',
+              content: "l'identifiant",
+            },
+            {
+              id: '2',
+              content: "le fournisseur d'adresse mail",
+            },
+          ],
+        },
+      ],
+    };
 
-      const grain = server.create('grain', {
-        id: 'grainId',
-        title: 'title',
-        components: [
-          {
-            type: 'element',
-            element: qrocm1,
-          },
-        ],
-      });
-
-      server.create('module', {
-        id: 'bien-ecrire-son-adresse-mail',
-        title: 'Bien écrire son adresse mail',
-        grains: [grain],
-      });
-
-      server.create('correction-response', {
-        id: 'elementId-1',
-        feedback: 'Faux',
-        status: 'ko',
-        solution: { symbole: '@', 'premiere-partie': '2' },
-      });
-
-      // when
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-      const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
-      const qrocmForm = screen.getByRole('group');
-      const input = screen.getByLabelText('Réponse 1');
-
-      // answer input proposal
-      await fillIn(input, '#');
-      // answer select proposal
-      await clickByName('Réponse 2');
-      await screen.findByRole('listbox');
-      await click(
-        screen.queryByRole('option', {
-          name: "le fournisseur d'adresse mail",
-        }),
-      );
-
-      // submit
-      await click(verifyButton);
-
-      assert.dom(screen.getByRole('status')).exists();
-
-      // when
-      const retryButton = screen.getByRole('button', { name: 'Réessayer' });
-      await click(retryButton);
-
-      await screen.findByRole('listbox');
-
-      // then
-      assert.strictEqual(screen.queryByRole('status').innerText, '');
-      assert.false(qrocmForm.disabled);
-      assert.strictEqual(
-        screen
-          .queryByRole('option', {
-            name: "le fournisseur d'adresse mail",
-          })
-          .getAttribute('aria-selected'),
-        'false',
-      );
-      assert.strictEqual(input.value, '');
-
-      const qrocmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
-
-      // answer input proposal
-      await fillIn(input, '#');
-      // answer select proposal
-      await clickByName('Réponse 2');
-      await screen.findByRole('listbox');
-      await click(
-        screen.queryByRole('option', {
-          name: "le fournisseur d'adresse mail",
-        }),
-      );
-      await click(qrocmVerifyButtonCameBack);
-
-      assert.strictEqual(screen.queryByRole('status').innerText, 'Faux');
+    const grain = server.create('grain', {
+      id: 'grainId',
+      title: 'title',
+      components: [
+        {
+          type: 'element',
+          element: qrocm1,
+        },
+      ],
     });
 
-    test('after retrying a Qrocm, it display an error message if Qrocm is validated without response', async function (assert) {
-      // given
-      const qrocm1 = {
-        id: 'elementId-1',
-        type: 'qrocm',
-        instruction: 'instruction',
-        proposals: [
-          {
-            type: 'text',
-            content: '<p>Le symbole</>',
-          },
-          {
-            input: 'symbole',
-            type: 'input',
-            inputType: 'text',
-            size: 1,
-            display: 'block',
-            placeholder: '',
-            ariaLabel: 'Réponse 1',
-            defaultValue: '',
-          },
-          {
-            input: 'premiere-partie',
-            type: 'select',
-            display: 'block',
-            placeholder: '',
-            ariaLabel: 'Réponse 2',
-            defaultValue: '',
-            options: [
-              {
-                id: '1',
-                content: "l'identifiant",
-              },
-              {
-                id: '2',
-                content: "le fournisseur d'adresse mail",
-              },
-            ],
-          },
-        ],
-      };
-
-      const grain = server.create('grain', {
-        id: 'grainId',
-        title: 'title',
-        components: [
-          {
-            type: 'element',
-            element: qrocm1,
-          },
-        ],
-      });
-
-      server.create('module', {
-        id: 'bien-ecrire-son-adresse-mail',
-        title: 'Bien écrire son adresse mail',
-        grains: [grain],
-      });
-
-      server.create('correction-response', {
-        id: 'elementId-1',
-        feedback: 'Faux',
-        status: 'ko',
-        solution: { symbole: '@', 'premiere-partie': '2' },
-      });
-
-      // when
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-      const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
-      const input = screen.getByLabelText('Réponse 1');
-
-      // answer input proposal
-      await fillIn(input, '#');
-      // answer select proposal
-      await clickByName('Réponse 2');
-      await screen.findByRole('listbox');
-      await click(
-        screen.queryByRole('option', {
-          name: "le fournisseur d'adresse mail",
-        }),
-      );
-
-      // submit
-      await click(verifyButton);
-
-      assert.dom(screen.getByRole('status')).exists();
-
-      // when
-      const retryButton = screen.getByRole('button', { name: 'Réessayer' });
-      await click(retryButton);
-
-      // then
-      const qrocmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
-      await click(qrocmVerifyButtonCameBack);
-      const validationAlert = screen.queryAllByRole('alert')[1];
-
-      assert.strictEqual(validationAlert.innerText, 'Pour valider, veuillez remplir tous les champs réponse.');
+    server.create('module', {
+      id: 'bien-ecrire-son-adresse-mail',
+      title: 'Bien écrire son adresse mail',
+      grains: [grain],
     });
+
+    server.create('correction-response', {
+      id: 'elementId-1',
+      feedback: 'Faux',
+      status: 'ko',
+      solution: { symbole: '@', 'premiere-partie': '2' },
+    });
+
+    // when
+    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+    const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
+    const input = screen.getByLabelText('Réponse 1');
+
+    // answer input proposal
+    await fillIn(input, '#');
+    // answer select proposal
+    await clickByName('Réponse 2');
+    await screen.findByRole('listbox');
+    await click(
+      screen.queryByRole('option', {
+        name: "le fournisseur d'adresse mail",
+      }),
+    );
+
+    // submit
+    await click(verifyButton);
+
+    assert.dom(screen.getByRole('status')).exists();
+
+    // when
+    const retryButton = screen.getByRole('button', { name: 'Réessayer' });
+    await click(retryButton);
+
+    // then
+    const qrocmVerifyButtonCameBack = screen.getByRole('button', { name: 'Vérifier' });
+    await click(qrocmVerifyButtonCameBack);
+    const validationAlert = screen.queryAllByRole('alert')[1];
+
+    assert.strictEqual(validationAlert.innerText, 'Pour valider, veuillez remplir tous les champs réponse.');
   });
 });

--- a/mon-pix/tests/acceptance/module/verify-qcm_test.js
+++ b/mon-pix/tests/acceptance/module/verify-qcm_test.js
@@ -8,162 +8,85 @@ module('Acceptance | Module | Routes | verifyQcm', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  module('with elements', function () {
-    test('can validate my QCM answer', async function (assert) {
-      // given
-      const qcm1 = {
-        id: 'elementId-1',
-        type: 'qcm',
-        instruction: 'instruction',
-        proposals: [
-          { id: '1', content: 'I am one of the wrong answers!' },
-          { id: '2', content: 'I am the first right answer!' },
-          { id: '3', content: 'I am the second right answer!' },
-          { id: '4', content: 'I am one of the wrong answers!' },
-        ],
-      };
-      const qcm2 = {
-        id: 'elementId-2',
-        type: 'qcm',
-        instruction: 'instruction',
-        proposals: [
-          { id: '1', content: 'I am one of the right answers!' },
-          { id: '2', content: 'I am the first wrong answer!' },
-          { id: '3', content: 'Click Me!' },
-          { id: '4', content: 'I am the second wrong answer!' },
-        ],
-      };
+  test('can validate my QCM answer', async function (assert) {
+    // given
+    const qcm1 = {
+      id: 'elementId-1',
+      type: 'qcm',
+      instruction: 'instruction',
+      proposals: [
+        { id: '1', content: 'I am one of the wrong answers!' },
+        { id: '2', content: 'I am the first right answer!' },
+        { id: '3', content: 'I am the second right answer!' },
+        { id: '4', content: 'I am one of the wrong answers!' },
+      ],
+    };
+    const qcm2 = {
+      id: 'elementId-2',
+      type: 'qcm',
+      instruction: 'instruction',
+      proposals: [
+        { id: '1', content: 'I am one of the right answers!' },
+        { id: '2', content: 'I am the first wrong answer!' },
+        { id: '3', content: 'Click Me!' },
+        { id: '4', content: 'I am the second wrong answer!' },
+      ],
+    };
 
-      const grain = server.create('grain', {
-        id: 'grainId',
-        title: 'title',
-        elements: [qcm1, qcm2],
-      });
-
-      server.create('module', {
-        id: 'bien-ecrire-son-adresse-mail',
-        title: 'Bien écrire son adresse mail',
-        grains: [grain],
-      });
-
-      server.create('correction-response', {
-        id: 'elementId-1',
-        feedback: "Bravo ! C'est la bonne réponse.",
-        status: 'ok',
-        solution: [qcm1.proposals[1].id, qcm1.proposals[2].id],
-      });
-
-      server.create('correction-response', {
-        id: 'elementId-2',
-        feedback: 'Pas ouf',
-        status: 'ko',
-        solution: [qcm2.proposals[0].id, qcm2.proposals[2].id],
-      });
-
-      // when
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-      const allVerifyButtons = screen.getAllByRole('button', { name: 'Vérifier' });
-      const [firstQcmVerifyButton, nextQcmVerifyButton] = allVerifyButtons;
-
-      // when
-      await click(screen.getByLabelText('I am the first right answer!'));
-      await click(screen.getByLabelText('I am the second right answer!'));
-      await click(firstQcmVerifyButton);
-
-      // then
-      assert.dom(screen.getByText("Bravo ! C'est la bonne réponse.")).exists();
-
-      // when
-      await click(screen.getByLabelText('I am the first wrong answer!'));
-      await click(screen.getByLabelText('Click Me!'));
-      await click(nextQcmVerifyButton);
-
-      // then
-      assert.dom(screen.getByText('Pas ouf')).exists();
+    const grain = server.create('grain', {
+      id: 'grainId',
+      title: 'title',
+      components: [
+        {
+          type: 'element',
+          element: qcm1,
+        },
+        {
+          type: 'element',
+          element: qcm2,
+        },
+      ],
     });
-  });
 
-  module('with components', function () {
-    test('can validate my QCM answer', async function (assert) {
-      // given
-      const qcm1 = {
-        id: 'elementId-1',
-        type: 'qcm',
-        instruction: 'instruction',
-        proposals: [
-          { id: '1', content: 'I am one of the wrong answers!' },
-          { id: '2', content: 'I am the first right answer!' },
-          { id: '3', content: 'I am the second right answer!' },
-          { id: '4', content: 'I am one of the wrong answers!' },
-        ],
-      };
-      const qcm2 = {
-        id: 'elementId-2',
-        type: 'qcm',
-        instruction: 'instruction',
-        proposals: [
-          { id: '1', content: 'I am one of the right answers!' },
-          { id: '2', content: 'I am the first wrong answer!' },
-          { id: '3', content: 'Click Me!' },
-          { id: '4', content: 'I am the second wrong answer!' },
-        ],
-      };
-
-      const grain = server.create('grain', {
-        id: 'grainId',
-        title: 'title',
-        components: [
-          {
-            type: 'element',
-            element: qcm1,
-          },
-          {
-            type: 'element',
-            element: qcm2,
-          },
-        ],
-      });
-
-      server.create('module', {
-        id: 'bien-ecrire-son-adresse-mail',
-        title: 'Bien écrire son adresse mail',
-        grains: [grain],
-      });
-
-      server.create('correction-response', {
-        id: 'elementId-1',
-        feedback: "Bravo ! C'est la bonne réponse.",
-        status: 'ok',
-        solution: [qcm1.proposals[1].id, qcm1.proposals[2].id],
-      });
-
-      server.create('correction-response', {
-        id: 'elementId-2',
-        feedback: 'Pas ouf',
-        status: 'ko',
-        solution: [qcm2.proposals[0].id, qcm2.proposals[2].id],
-      });
-
-      // when
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-      const allVerifyButtons = screen.getAllByRole('button', { name: 'Vérifier' });
-      const [firstQcmVerifyButton, nextQcmVerifyButton] = allVerifyButtons;
-
-      // when
-      await click(screen.getByLabelText('I am the first right answer!'));
-      await click(screen.getByLabelText('I am the second right answer!'));
-      await click(firstQcmVerifyButton);
-
-      // then
-      assert.dom(screen.getByText("Bravo ! C'est la bonne réponse.")).exists();
-
-      // when
-      await click(screen.getByLabelText('I am the first wrong answer!'));
-      await click(screen.getByLabelText('Click Me!'));
-      await click(nextQcmVerifyButton);
-
-      // then
-      assert.dom(screen.getByText('Pas ouf')).exists();
+    server.create('module', {
+      id: 'bien-ecrire-son-adresse-mail',
+      title: 'Bien écrire son adresse mail',
+      grains: [grain],
     });
+
+    server.create('correction-response', {
+      id: 'elementId-1',
+      feedback: "Bravo ! C'est la bonne réponse.",
+      status: 'ok',
+      solution: [qcm1.proposals[1].id, qcm1.proposals[2].id],
+    });
+
+    server.create('correction-response', {
+      id: 'elementId-2',
+      feedback: 'Pas ouf',
+      status: 'ko',
+      solution: [qcm2.proposals[0].id, qcm2.proposals[2].id],
+    });
+
+    // when
+    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+    const allVerifyButtons = screen.getAllByRole('button', { name: 'Vérifier' });
+    const [firstQcmVerifyButton, nextQcmVerifyButton] = allVerifyButtons;
+
+    // when
+    await click(screen.getByLabelText('I am the first right answer!'));
+    await click(screen.getByLabelText('I am the second right answer!'));
+    await click(firstQcmVerifyButton);
+
+    // then
+    assert.dom(screen.getByText("Bravo ! C'est la bonne réponse.")).exists();
+
+    // when
+    await click(screen.getByLabelText('I am the first wrong answer!'));
+    await click(screen.getByLabelText('Click Me!'));
+    await click(nextQcmVerifyButton);
+
+    // then
+    assert.dom(screen.getByText('Pas ouf')).exists();
   });
 });

--- a/mon-pix/tests/acceptance/module/verify-qcu_test.js
+++ b/mon-pix/tests/acceptance/module/verify-qcu_test.js
@@ -8,149 +8,79 @@ module('Acceptance | Module | Routes | verifyQcu', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  module('with elements', function () {
-    test('can validate my QCU answer', async function (assert) {
-      // given
-      const qcu1 = {
-        id: 'elementId-1',
-        type: 'qcu',
-        instruction: 'instruction',
-        proposals: [
-          { id: '1', content: 'I am the wrong answer!' },
-          { id: '2', content: 'I am the right answer!' },
-        ],
-      };
-      const qcu2 = {
-        id: 'elementId-2',
-        type: 'qcu',
-        instruction: 'instruction',
-        proposals: [
-          { id: '1', content: 'Vrai' },
-          { id: '2', content: 'Faux' },
-        ],
-      };
+  test('can validate my QCU answer', async function (assert) {
+    // given
+    const qcu1 = {
+      id: 'elementId-1',
+      type: 'qcu',
+      instruction: 'instruction',
+      proposals: [
+        { id: '1', content: 'I am the wrong answer!' },
+        { id: '2', content: 'I am the right answer!' },
+      ],
+    };
+    const qcu2 = {
+      id: 'elementId-2',
+      type: 'qcu',
+      instruction: 'instruction',
+      proposals: [
+        { id: '1', content: 'Vrai' },
+        { id: '2', content: 'Faux' },
+      ],
+    };
 
-      const grain = server.create('grain', {
-        id: 'grainId',
-        title: 'title',
-        elements: [qcu1, qcu2],
-      });
-
-      server.create('module', {
-        id: 'bien-ecrire-son-adresse-mail',
-        title: 'Bien écrire son adresse mail',
-        grains: [grain],
-      });
-
-      server.create('correction-response', {
-        id: 'elementId-1',
-        feedback: "Bravo ! C'est la bonne réponse.",
-        status: 'ok',
-        solution: qcu1.proposals[1].id,
-      });
-
-      server.create('correction-response', {
-        id: 'elementId-2',
-        feedback: 'Pas ouf',
-        status: 'ko',
-        solution: qcu2.proposals[0].id,
-      });
-
-      // when
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-      const allVerifyButtons = screen.getAllByRole('button', { name: 'Vérifier' });
-      const [firstQcuVerifyButton, nextQcuVerifyButton] = allVerifyButtons;
-
-      // when
-      await click(screen.getByLabelText('I am the right answer!'));
-      await click(firstQcuVerifyButton);
-
-      // then
-      assert.dom(screen.getByText("Bravo ! C'est la bonne réponse.")).exists();
-
-      // when
-      await click(screen.getByLabelText('Faux'));
-      await click(nextQcuVerifyButton);
-
-      // then
-      assert.dom(screen.getByText('Pas ouf')).exists();
+    const grain = server.create('grain', {
+      id: 'grainId',
+      title: 'title',
+      components: [
+        {
+          type: 'element',
+          element: qcu1,
+        },
+        {
+          type: 'element',
+          element: qcu2,
+        },
+      ],
     });
-  });
-  module('with components', function () {
-    test('can validate my QCU answer', async function (assert) {
-      // given
-      const qcu1 = {
-        id: 'elementId-1',
-        type: 'qcu',
-        instruction: 'instruction',
-        proposals: [
-          { id: '1', content: 'I am the wrong answer!' },
-          { id: '2', content: 'I am the right answer!' },
-        ],
-      };
-      const qcu2 = {
-        id: 'elementId-2',
-        type: 'qcu',
-        instruction: 'instruction',
-        proposals: [
-          { id: '1', content: 'Vrai' },
-          { id: '2', content: 'Faux' },
-        ],
-      };
 
-      const grain = server.create('grain', {
-        id: 'grainId',
-        title: 'title',
-        components: [
-          {
-            type: 'element',
-            element: qcu1,
-          },
-          {
-            type: 'element',
-            element: qcu2,
-          },
-        ],
-      });
-
-      server.create('module', {
-        id: 'bien-ecrire-son-adresse-mail',
-        title: 'Bien écrire son adresse mail',
-        grains: [grain],
-      });
-
-      server.create('correction-response', {
-        id: 'elementId-1',
-        feedback: "Bravo ! C'est la bonne réponse.",
-        status: 'ok',
-        solution: qcu1.proposals[1].id,
-      });
-
-      server.create('correction-response', {
-        id: 'elementId-2',
-        feedback: 'Pas ouf',
-        status: 'ko',
-        solution: qcu2.proposals[0].id,
-      });
-
-      // when
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-      const allVerifyButtons = screen.getAllByRole('button', { name: 'Vérifier' });
-      const [firstQcuVerifyButton, nextQcuVerifyButton] = allVerifyButtons;
-
-      // when
-      await click(screen.getByLabelText('I am the right answer!'));
-      await click(firstQcuVerifyButton);
-
-      // then
-      assert.dom(screen.getByText("Bravo ! C'est la bonne réponse.")).exists();
-
-      // when
-      await click(screen.getByLabelText('Faux'));
-      await click(nextQcuVerifyButton);
-
-      // then
-      assert.dom(screen.getByText('Pas ouf')).exists();
+    server.create('module', {
+      id: 'bien-ecrire-son-adresse-mail',
+      title: 'Bien écrire son adresse mail',
+      grains: [grain],
     });
+
+    server.create('correction-response', {
+      id: 'elementId-1',
+      feedback: "Bravo ! C'est la bonne réponse.",
+      status: 'ok',
+      solution: qcu1.proposals[1].id,
+    });
+
+    server.create('correction-response', {
+      id: 'elementId-2',
+      feedback: 'Pas ouf',
+      status: 'ko',
+      solution: qcu2.proposals[0].id,
+    });
+
+    // when
+    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+    const allVerifyButtons = screen.getAllByRole('button', { name: 'Vérifier' });
+    const [firstQcuVerifyButton, nextQcuVerifyButton] = allVerifyButtons;
+
+    // when
+    await click(screen.getByLabelText('I am the right answer!'));
+    await click(firstQcuVerifyButton);
+
+    // then
+    assert.dom(screen.getByText("Bravo ! C'est la bonne réponse.")).exists();
+
+    // when
+    await click(screen.getByLabelText('Faux'));
+    await click(nextQcuVerifyButton);
+
+    // then
+    assert.dom(screen.getByText('Pas ouf')).exists();
   });
 });

--- a/mon-pix/tests/acceptance/module/verify-qrocm_test.js
+++ b/mon-pix/tests/acceptance/module/verify-qrocm_test.js
@@ -8,180 +8,92 @@ module('Acceptance | Module | Routes | verifyQrocm', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  module('with elements', function () {
-    test('can validate my QROCM answer', async function (assert) {
-      // given
-      const qrocm1 = {
-        id: 'elementId-1',
-        type: 'qrocm',
-        instruction: 'instruction',
-        proposals: [
-          {
-            type: 'text',
-            content: '<p>Le symbole</>',
-          },
-          {
-            input: 'symbole',
-            type: 'input',
-            inputType: 'text',
-            size: 1,
-            display: 'block',
-            placeholder: '',
-            ariaLabel: 'Réponse 1',
-            defaultValue: '',
-          },
-          {
-            input: 'premiere-partie',
-            type: 'select',
-            display: 'block',
-            placeholder: '',
-            ariaLabel: 'Réponse 2',
-            defaultValue: '',
-            options: [
-              {
-                id: '1',
-                content: "l'identifiant",
-              },
-              {
-                id: '2',
-                content: "le fournisseur d'adresse mail",
-              },
-            ],
-          },
-        ],
-      };
+  test('can validate my QROCM answer', async function (assert) {
+    // given
+    const qrocm1 = {
+      id: 'elementId-1',
+      type: 'qrocm',
+      instruction: 'instruction',
+      proposals: [
+        {
+          type: 'text',
+          content: '<p>Le symbole</>',
+        },
+        {
+          input: 'symbole',
+          type: 'input',
+          inputType: 'text',
+          size: 1,
+          display: 'block',
+          placeholder: '',
+          ariaLabel: 'Réponse 1',
+          defaultValue: '',
+        },
+        {
+          input: 'premiere-partie',
+          type: 'select',
+          display: 'block',
+          placeholder: '',
+          ariaLabel: 'Réponse 2',
+          defaultValue: '',
+          options: [
+            {
+              id: '1',
+              content: "l'identifiant",
+            },
+            {
+              id: '2',
+              content: "le fournisseur d'adresse mail",
+            },
+          ],
+        },
+      ],
+    };
 
-      const grain = server.create('grain', {
-        id: 'grainId',
-        title: 'title',
-        elements: [qrocm1],
-      });
-
-      server.create('module', {
-        id: 'bien-ecrire-son-adresse-mail',
-        title: 'Bien écrire son adresse mail',
-        grains: [grain],
-      });
-
-      server.create('correction-response', {
-        id: 'elementId-1',
-        feedback: "Bravo ! C'est la bonne réponse.",
-        status: 'ok',
-        solution: { symbole: '@', 'premiere-partie': '2' },
-      });
-
-      // when
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-      const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
-
-      // answer input proposal
-      await fillIn(screen.getByLabelText('Réponse 1'), '@');
-      // answer select proposal
-      await clickByName('Réponse 2');
-      await screen.findByRole('listbox');
-      await click(
-        screen.queryByRole('option', {
-          name: "le fournisseur d'adresse mail",
-        }),
-      );
-      // submit
-      await click(verifyButton);
-
-      // then
-      assert.dom(screen.getByText("Bravo ! C'est la bonne réponse.")).exists();
-      assert.notOk(screen.queryByRole('button', { name: 'Vérifier' }));
+    const grain = server.create('grain', {
+      id: 'grainId',
+      title: 'title',
+      components: [
+        {
+          type: 'element',
+          element: qrocm1,
+        },
+      ],
     });
-  });
 
-  module('with components', function () {
-    test('can validate my QROCM answer', async function (assert) {
-      // given
-      const qrocm1 = {
-        id: 'elementId-1',
-        type: 'qrocm',
-        instruction: 'instruction',
-        proposals: [
-          {
-            type: 'text',
-            content: '<p>Le symbole</>',
-          },
-          {
-            input: 'symbole',
-            type: 'input',
-            inputType: 'text',
-            size: 1,
-            display: 'block',
-            placeholder: '',
-            ariaLabel: 'Réponse 1',
-            defaultValue: '',
-          },
-          {
-            input: 'premiere-partie',
-            type: 'select',
-            display: 'block',
-            placeholder: '',
-            ariaLabel: 'Réponse 2',
-            defaultValue: '',
-            options: [
-              {
-                id: '1',
-                content: "l'identifiant",
-              },
-              {
-                id: '2',
-                content: "le fournisseur d'adresse mail",
-              },
-            ],
-          },
-        ],
-      };
-
-      const grain = server.create('grain', {
-        id: 'grainId',
-        title: 'title',
-        components: [
-          {
-            type: 'element',
-            element: qrocm1,
-          },
-        ],
-      });
-
-      server.create('module', {
-        id: 'bien-ecrire-son-adresse-mail',
-        title: 'Bien écrire son adresse mail',
-        grains: [grain],
-      });
-
-      server.create('correction-response', {
-        id: 'elementId-1',
-        feedback: "Bravo ! C'est la bonne réponse.",
-        status: 'ok',
-        solution: { symbole: '@', 'premiere-partie': '2' },
-      });
-
-      // when
-      const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
-
-      const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
-
-      // answer input proposal
-      await fillIn(screen.getByLabelText('Réponse 1'), '@');
-      // answer select proposal
-      await clickByName('Réponse 2');
-      await screen.findByRole('listbox');
-      await click(
-        screen.queryByRole('option', {
-          name: "le fournisseur d'adresse mail",
-        }),
-      );
-      // submit
-      await click(verifyButton);
-
-      // then
-      assert.dom(screen.getByText("Bravo ! C'est la bonne réponse.")).exists();
-      assert.notOk(screen.queryByRole('button', { name: 'Vérifier' }));
+    server.create('module', {
+      id: 'bien-ecrire-son-adresse-mail',
+      title: 'Bien écrire son adresse mail',
+      grains: [grain],
     });
+
+    server.create('correction-response', {
+      id: 'elementId-1',
+      feedback: "Bravo ! C'est la bonne réponse.",
+      status: 'ok',
+      solution: { symbole: '@', 'premiere-partie': '2' },
+    });
+
+    // when
+    const screen = await visit('/modules/bien-ecrire-son-adresse-mail/passage');
+
+    const verifyButton = screen.queryByRole('button', { name: 'Vérifier' });
+
+    // answer input proposal
+    await fillIn(screen.getByLabelText('Réponse 1'), '@');
+    // answer select proposal
+    await clickByName('Réponse 2');
+    await screen.findByRole('listbox');
+    await click(
+      screen.queryByRole('option', {
+        name: "le fournisseur d'adresse mail",
+      }),
+    );
+    // submit
+    await click(verifyButton);
+
+    // then
+    assert.dom(screen.getByText("Bravo ! C'est la bonne réponse.")).exists();
+    assert.notOk(screen.queryByRole('button', { name: 'Vérifier' }));
   });
 });

--- a/mon-pix/tests/integration/components/module/grain_test.js
+++ b/mon-pix/tests/integration/components/module/grain_test.js
@@ -88,140 +88,181 @@ module('Integration | Component | Module | Grain', function (hooks) {
     assert.dom(screen.getByText('leçon'));
   });
 
-  module('with elements', function () {
-    module('when element is a text', function () {
-      test('should display text element', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const textElement = {
-          content: 'element content',
-          type: 'text',
-          isAnswerable: false,
-        };
-        const grain = store.createRecord('grain', { title: 'Grain title', elements: [textElement] });
-        this.set('grain', grain);
+  module('when element is a text', function () {
+    test('should display text element', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const textElement = {
+        content: 'element content',
+        type: 'text',
+        isAnswerable: false,
+      };
+      const grain = store.createRecord('grain', {
+        title: 'Grain title',
+        components: [{ type: 'element', element: textElement }],
+      });
+      this.set('grain', grain);
 
-        // when
-        const screen = await render(hbs`
+      // when
+      const screen = await render(hbs`
             <Module::Grain @grain={{this.grain}} />`);
 
-        // then
-        assert.ok(screen.getByText('element content'));
-      });
+      // then
+      assert.ok(screen.getByText('element content'));
     });
+  });
 
-    module('when element is a qcu', function () {
-      test('should display qcu element', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const qcuElement = {
-          instruction: 'instruction',
-          proposals: ['radio1', 'radio2'],
-          type: 'qcu',
-          isAnswerable: true,
-        };
-        const grain = store.createRecord('grain', { title: 'Grain title', elements: [qcuElement] });
-        this.set('grain', grain);
-        const passage = store.createRecord('passage');
-        this.set('passage', passage);
+  module('when element is a qcu', function () {
+    test('should display qcu element', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const qcuElement = {
+        instruction: 'instruction',
+        proposals: ['radio1', 'radio2'],
+        type: 'qcu',
+        isAnswerable: true,
+      };
+      const grain = store.createRecord('grain', {
+        title: 'Grain title',
+        components: [{ type: 'element', element: qcuElement }],
+      });
+      this.set('grain', grain);
+      const passage = store.createRecord('passage');
+      this.set('passage', passage);
 
-        // when
-        const screen = await render(hbs`
+      // when
+      const screen = await render(hbs`
             <Module::Grain @grain={{this.grain}} @passage={{this.passage}} />`);
 
-        // then
-        assert.strictEqual(screen.getAllByRole('radio').length, qcuElement.proposals.length);
-      });
+      // then
+      assert.strictEqual(screen.getAllByRole('radio').length, qcuElement.proposals.length);
     });
+  });
 
-    module('when element is a qrocm', function () {
-      test('should display qrocm element', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const qrocmElement = {
-          instruction: 'Mon instruction',
-          proposals: [
-            {
-              type: 'text',
-              content: '<p>Le symbole</>',
-            },
-            {
-              input: 'symbole',
-              type: 'input',
-              inputType: 'text',
-              size: 1,
-              display: 'inline',
-              placeholder: '',
-              ariaLabel: 'Réponse 1',
-              defaultValue: '',
-            },
-            {
-              input: 'premiere-partie',
-              type: 'select',
-              display: 'inline',
-              placeholder: '',
-              ariaLabel: 'Réponse 2',
-              defaultValue: '',
-              options: [
-                {
-                  id: '1',
-                  content: "l'identifiant",
-                },
-                {
-                  id: '2',
-                  content: "le fournisseur d'adresse mail",
-                },
-              ],
-            },
-          ],
-          type: 'qrocm',
-          isAnswerable: true,
-        };
-        const grain = store.createRecord('grain', { title: 'Grain title', elements: [qrocmElement] });
-        this.set('grain', grain);
-        const passage = store.createRecord('passage');
-        this.set('passage', passage);
+  module('when element is a qrocm', function () {
+    test('should display qrocm element', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const qrocmElement = {
+        instruction: 'Mon instruction',
+        proposals: [
+          {
+            type: 'text',
+            content: '<p>Le symbole</>',
+          },
+          {
+            input: 'symbole',
+            type: 'input',
+            inputType: 'text',
+            size: 1,
+            display: 'inline',
+            placeholder: '',
+            ariaLabel: 'Réponse 1',
+            defaultValue: '',
+          },
+          {
+            input: 'premiere-partie',
+            type: 'select',
+            display: 'inline',
+            placeholder: '',
+            ariaLabel: 'Réponse 2',
+            defaultValue: '',
+            options: [
+              {
+                id: '1',
+                content: "l'identifiant",
+              },
+              {
+                id: '2',
+                content: "le fournisseur d'adresse mail",
+              },
+            ],
+          },
+        ],
+        type: 'qrocm',
+        isAnswerable: true,
+      };
+      const grain = store.createRecord('grain', {
+        title: 'Grain title',
+        components: [{ type: 'element', element: qrocmElement }],
+      });
+      this.set('grain', grain);
+      const passage = store.createRecord('passage');
+      this.set('passage', passage);
 
-        // when
-        const screen = await render(hbs`
+      // when
+      const screen = await render(hbs`
             <Module::Grain @grain={{this.grain}} @passage={{this.passage}} />`);
 
-        // then
-        assert.ok(screen);
-        assert.dom(screen.getByText('Mon instruction')).exists({ count: 1 });
-      });
+      // then
+      assert.ok(screen);
+      assert.dom(screen.getByText('Mon instruction')).exists({ count: 1 });
     });
+  });
 
-    module('when element is an image', function () {
-      test('should display image element', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const url =
-          'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg';
-        const imageElement = {
-          url,
-          alt: 'alt text',
-          alternativeText: 'alternative instruction',
-          type: 'image',
-        };
-        const grain = store.createRecord('grain', { title: 'Grain title', elements: [imageElement] });
-        this.set('grain', grain);
+  module('when element is an image', function () {
+    test('should display image element', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const url =
+        'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg';
+      const imageElement = {
+        url,
+        alt: 'alt text',
+        alternativeText: 'alternative instruction',
+        type: 'image',
+      };
+      const grain = store.createRecord('grain', {
+        title: 'Grain title',
+        components: [{ type: 'element', element: imageElement }],
+      });
+      this.set('grain', grain);
 
-        // when
-        const screen = await render(hbs`
+      // when
+      const screen = await render(hbs`
             <Module::Grain @grain={{this.grain}} />`);
 
-        // then
-        assert.ok(screen.getByRole('img', { name: 'alt text' }).hasAttribute('src', url));
+      // then
+      assert.ok(screen.getByRole('img', { name: 'alt text' }).hasAttribute('src', url));
+    });
+  });
+
+  module('when all elements are answered', function () {
+    test('should not display skip button', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const element = { type: 'qcu', isAnswerable: true };
+      const grain = store.createRecord('grain', {
+        title: 'Grain title',
+        components: [{ type: 'element', element }],
       });
+      this.set('grain', grain);
+      const passage = store.createRecord('passage');
+      this.set('passage', passage);
+
+      const correction = store.createRecord('correction-response');
+      store.createRecord('element-answer', { element, correction, passage });
+
+      // when
+      const screen = await render(hbs`
+            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
+
+      // then
+      assert
+        .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') }))
+        .doesNotExist();
     });
 
-    module('when all elements are answered', function () {
-      test('should not display skip button', async function (assert) {
+    module('when canMoveToNextGrain is true', function () {
+      test('should display continue button', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
         const element = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
+        const grain = store.createRecord('grain', {
+          title: '1st Grain title',
+          components: [{ type: 'element', element }],
+        });
+        store.createRecord('module', { grains: [grain] });
         this.set('grain', grain);
         const passage = store.createRecord('passage');
         this.set('passage', passage);
@@ -231,742 +272,275 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
         // when
         const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
+
+        // then
+        assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists();
+      });
+    });
+    module('when canMoveToNextGrain is false', function () {
+      test('should not display continue button', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = { type: 'qcu', isAnswerable: true };
+        const grain = store.createRecord('grain', {
+          title: '1st Grain title',
+          components: [{ type: 'element', element }],
+        });
+        store.createRecord('module', { grains: [grain] });
+        this.set('grain', grain);
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
+
+        // when
+        const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
+
+        // then
+        assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+      });
+    });
+  });
+
+  module('when at least one element has not been answered', function () {
+    module('when canMoveToNextGrain is true', function () {
+      test('should not display continue button', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = { type: 'qcu', isAnswerable: true };
+        const grain = store.createRecord('grain', {
+          title: 'Grain title',
+          components: [{ type: 'element', element }],
+        });
+        this.set('grain', grain);
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
+
+        // when
+        const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
+
+        // then
+        assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+      });
+
+      test('should display skip button', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = { type: 'qcu', isAnswerable: true };
+        const grain = store.createRecord('grain', {
+          title: '1st Grain title',
+          components: [{ type: 'element', element }],
+        });
+        store.createRecord('module', { grains: [grain] });
+        this.set('grain', grain);
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
+
+        // when
+        const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
+
+        // then
+        assert.dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') })).exists();
+      });
+    });
+
+    module('when canMoveToNextGrain is false', function () {
+      test('should not display continue button', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = { type: 'qcu', isAnswerable: true };
+        const grain = store.createRecord('grain', {
+          title: 'Grain title',
+          components: [{ type: 'element', element }],
+        });
+        this.set('grain', grain);
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
+
+        // when
+        const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
+
+        // then
+        assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+      });
+
+      test('should not display skip button', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const element = { type: 'qcu', isAnswerable: true };
+        const grain = store.createRecord('grain', {
+          title: 'Grain title',
+          components: [{ type: 'element', element }],
+        });
+        store.createRecord('module', { grains: [grain] });
+        this.set('grain', grain);
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
+
+        // when
+        const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
 
         // then
         assert
           .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') }))
           .doesNotExist();
       });
-
-      module('when canMoveToNextGrain is true', function () {
-        test('should display continue button', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const element = { type: 'qcu', isAnswerable: true };
-          const grain = store.createRecord('grain', { title: '1st Grain title', elements: [element] });
-          store.createRecord('module', { grains: [grain] });
-          this.set('grain', grain);
-          const passage = store.createRecord('passage');
-          this.set('passage', passage);
-
-          const correction = store.createRecord('correction-response');
-          store.createRecord('element-answer', { element, correction, passage });
-
-          // when
-          const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
-
-          // then
-          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists();
-        });
-      });
-      module('when canMoveToNextGrain is false', function () {
-        test('should not display continue button', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const element = { type: 'qcu', isAnswerable: true };
-          const grain = store.createRecord('grain', { title: '1st Grain title', elements: [element] });
-          store.createRecord('module', { grains: [grain] });
-          this.set('grain', grain);
-          const passage = store.createRecord('passage');
-          this.set('passage', passage);
-
-          // when
-          const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
-
-          // then
-          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
-        });
-      });
     });
+  });
 
-    module('when at least one element has not been answered', function () {
-      module('when canMoveToNextGrain is true', function () {
-        test('should not display continue button', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const element = { type: 'qcu', isAnswerable: true };
-          const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
-          this.set('grain', grain);
-          const passage = store.createRecord('passage');
-          this.set('passage', passage);
-
-          // when
-          const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
-
-          // then
-          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
-        });
-
-        test('should display skip button', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const element = { type: 'qcu', isAnswerable: true };
-          const grain = store.createRecord('grain', { title: '1st Grain title', elements: [element] });
-          store.createRecord('module', { grains: [grain] });
-          this.set('grain', grain);
-          const passage = store.createRecord('passage');
-          this.set('passage', passage);
-
-          // when
-          const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
-
-          // then
-          assert.dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') })).exists();
-        });
+  module('when continueAction is called', function () {
+    test('should call continueAction pass in argument', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const element = { type: 'text', isAnswerable: false };
+      const grain = store.createRecord('grain', {
+        title: '1st Grain title',
+        components: [{ type: 'element', element }],
       });
+      store.createRecord('module', { id: 'module-id', grains: [grain] });
+      this.set('grain', grain);
 
-      module('when canMoveToNextGrain is false', function () {
-        test('should not display continue button', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const element = { type: 'qcu', isAnswerable: true };
-          const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
-          this.set('grain', grain);
-          const passage = store.createRecord('passage');
-          this.set('passage', passage);
+      const stubContinueAction = sinon.stub();
+      this.set('continueAction', stubContinueAction);
 
-          // when
-          const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
-
-          // then
-          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
-        });
-
-        test('should not display skip button', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const element = { type: 'qcu', isAnswerable: true };
-          const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
-          store.createRecord('module', { grains: [grain] });
-          this.set('grain', grain);
-          const passage = store.createRecord('passage');
-          this.set('passage', passage);
-
-          // when
-          const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
-
-          // then
-          assert
-            .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') }))
-            .doesNotExist();
-        });
-      });
-    });
-
-    module('when continueAction is called', function () {
-      test('should call continueAction pass in argument', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const element = { type: 'text', isAnswerable: false };
-        const grain = store.createRecord('grain', { title: '1st Grain title', elements: [element] });
-        store.createRecord('module', { id: 'module-id', grains: [grain] });
-        this.set('grain', grain);
-
-        const stubContinueAction = sinon.stub();
-        this.set('continueAction', stubContinueAction);
-
-        // when
-        await render(
-          hbs`
+      // when
+      await render(
+        hbs`
               <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}}
                              @continueAction={{this.continueAction}} />`,
-        );
-        await clickByName('Continuer');
+      );
+      await clickByName('Continuer');
 
-        // then
-        sinon.assert.calledOnce(stubContinueAction);
-        assert.ok(true);
-      });
+      // then
+      sinon.assert.calledOnce(stubContinueAction);
+      assert.ok(true);
+    });
+  });
+
+  module('when skipAction is called', function () {
+    test('should call skipAction pass in argument', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const element = { type: 'qcu', isAnswerable: true };
+      const grain = store.createRecord('grain', { title: 'Grain title', components: [{ type: 'element', element }] });
+      store.createRecord('module', { id: 'module-id', grains: [grain] });
+      this.set('grain', grain);
+      const passage = store.createRecord('passage');
+      this.set('passage', passage);
+
+      const skipActionStub = sinon.stub();
+      this.set('skipAction', skipActionStub);
+
+      this.set('continueAction', () => {});
+
+      // when
+      await render(
+        hbs`
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}}
+                             @continueAction={{this.continueAction}} @skipAction={{this.skipAction}} @passage={{this.passage}} />`,
+      );
+      await clickByName(this.intl.t('pages.modulix.buttons.grain.skip'));
+
+      // then
+      sinon.assert.calledOnce(skipActionStub);
+      assert.ok(true);
+    });
+  });
+
+  module('when shouldDisplayTerminateButton is true', function () {
+    test('should display the terminate button', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const element = { type: 'text', isAnswerable: false };
+      const grain = store.createRecord('grain', { title: 'Grain title', components: [{ type: 'element', element }] });
+      this.set('grain', grain);
+
+      // when
+      const screen = await render(hbs`
+            <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{true}} />`);
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.terminate') })).exists();
     });
 
-    module('when skipAction is called', function () {
-      test('should call skipAction pass in argument', async function (assert) {
+    module('when terminateAction is called', function () {
+      test('should call terminateAction passed in argument', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
         const element = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
-        store.createRecord('module', { id: 'module-id', grains: [grain] });
+        const grain = store.createRecord('grain', {
+          title: 'Grain title',
+          components: [{ type: 'element', element }],
+        });
         this.set('grain', grain);
         const passage = store.createRecord('passage');
         this.set('passage', passage);
 
-        const skipActionStub = sinon.stub();
-        this.set('skipAction', skipActionStub);
-
-        this.set('continueAction', () => {});
+        const terminateActionStub = sinon.stub();
+        this.set('terminateAction', terminateActionStub);
 
         // when
         await render(
           hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}}
-                             @continueAction={{this.continueAction}} @skipAction={{this.skipAction}} @passage={{this.passage}} />`,
-        );
-        await clickByName(this.intl.t('pages.modulix.buttons.grain.skip'));
-
-        // then
-        sinon.assert.calledOnce(skipActionStub);
-        assert.ok(true);
-      });
-    });
-
-    module('when shouldDisplayTerminateButton is true', function () {
-      test('should display the terminate button', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const element = { type: 'text', isAnswerable: false };
-        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
-        this.set('grain', grain);
-
-        // when
-        const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{true}} />`);
-
-        // then
-        assert
-          .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.terminate') }))
-          .exists();
-      });
-
-      module('when terminateAction is called', function () {
-        test('should call terminateAction passed in argument', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const element = { type: 'qcu', isAnswerable: true };
-          const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
-          this.set('grain', grain);
-          const passage = store.createRecord('passage');
-          this.set('passage', passage);
-
-          const terminateActionStub = sinon.stub();
-          this.set('terminateAction', terminateActionStub);
-
-          // when
-          await render(
-            hbs`
               <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{true}}
                              @terminateAction={{this.terminateAction}} @passage={{this.passage}} />`,
-          );
-          await clickByName(this.intl.t('pages.modulix.buttons.grain.terminate'));
-
-          // then
-          sinon.assert.calledOnce(terminateActionStub);
-          assert.ok(true);
-        });
-      });
-    });
-
-    module('when shouldDisplayTerminateButton is false', function () {
-      test('should not display the terminate button', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const element = { type: 'text', isAnswerable: false };
-        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
-        this.set('grain', grain);
-
-        // when
-        const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{false}} />`);
+        );
+        await clickByName(this.intl.t('pages.modulix.buttons.grain.terminate'));
 
         // then
-        assert
-          .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.terminate') }))
-          .doesNotExist();
-      });
-    });
-
-    module('when retryElement is called', function () {
-      test('should call retryElement pass in argument', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const element = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', { title: 'Grain title', elements: [element] });
-        this.set('grain', grain);
-        const passage = store.createRecord('passage');
-        this.set('passage', passage);
-
-        const retryElementStub = sinon.stub().withArgs({ element });
-        this.set('retryElement', retryElementStub);
-
-        const correction = store.createRecord('correction-response', { status: 'ko' });
-        store.createRecord('element-answer', { element, correction, passage });
-
-        // when
-        await render(hbs`
-            <Module::Grain @grain={{this.grain}} @retryElement={{this.retryElement}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
-
-        await clickByName(this.intl.t('pages.modulix.buttons.activity.retry'));
-
-        // then
-        sinon.assert.calledOnce(retryElementStub);
+        sinon.assert.calledOnce(terminateActionStub);
         assert.ok(true);
       });
     });
   });
 
-  module('with components', function () {
-    module('when element is a text', function () {
-      test('should display text element', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const textElement = {
-          content: 'element content',
-          type: 'text',
-          isAnswerable: false,
-        };
-        const grain = store.createRecord('grain', {
-          title: 'Grain title',
-          components: [{ type: 'element', element: textElement }],
-        });
-        this.set('grain', grain);
+  module('when shouldDisplayTerminateButton is false', function () {
+    test('should not display the terminate button', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const element = { type: 'text', isAnswerable: false };
+      const grain = store.createRecord('grain', { title: 'Grain title', components: [{ type: 'element', element }] });
+      this.set('grain', grain);
 
-        // when
-        const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} />`);
-
-        // then
-        assert.ok(screen.getByText('element content'));
-      });
-    });
-
-    module('when element is a qcu', function () {
-      test('should display qcu element', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const qcuElement = {
-          instruction: 'instruction',
-          proposals: ['radio1', 'radio2'],
-          type: 'qcu',
-          isAnswerable: true,
-        };
-        const grain = store.createRecord('grain', {
-          title: 'Grain title',
-          components: [{ type: 'element', element: qcuElement }],
-        });
-        this.set('grain', grain);
-        const passage = store.createRecord('passage');
-        this.set('passage', passage);
-
-        // when
-        const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @passage={{this.passage}} />`);
-
-        // then
-        assert.strictEqual(screen.getAllByRole('radio').length, qcuElement.proposals.length);
-      });
-    });
-
-    module('when element is a qrocm', function () {
-      test('should display qrocm element', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const qrocmElement = {
-          instruction: 'Mon instruction',
-          proposals: [
-            {
-              type: 'text',
-              content: '<p>Le symbole</>',
-            },
-            {
-              input: 'symbole',
-              type: 'input',
-              inputType: 'text',
-              size: 1,
-              display: 'inline',
-              placeholder: '',
-              ariaLabel: 'Réponse 1',
-              defaultValue: '',
-            },
-            {
-              input: 'premiere-partie',
-              type: 'select',
-              display: 'inline',
-              placeholder: '',
-              ariaLabel: 'Réponse 2',
-              defaultValue: '',
-              options: [
-                {
-                  id: '1',
-                  content: "l'identifiant",
-                },
-                {
-                  id: '2',
-                  content: "le fournisseur d'adresse mail",
-                },
-              ],
-            },
-          ],
-          type: 'qrocm',
-          isAnswerable: true,
-        };
-        const grain = store.createRecord('grain', {
-          title: 'Grain title',
-          components: [{ type: 'element', element: qrocmElement }],
-        });
-        this.set('grain', grain);
-        const passage = store.createRecord('passage');
-        this.set('passage', passage);
-
-        // when
-        const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @passage={{this.passage}} />`);
-
-        // then
-        assert.ok(screen);
-        assert.dom(screen.getByText('Mon instruction')).exists({ count: 1 });
-      });
-    });
-
-    module('when element is an image', function () {
-      test('should display image element', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const url =
-          'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg';
-        const imageElement = {
-          url,
-          alt: 'alt text',
-          alternativeText: 'alternative instruction',
-          type: 'image',
-        };
-        const grain = store.createRecord('grain', {
-          title: 'Grain title',
-          components: [{ type: 'element', element: imageElement }],
-        });
-        this.set('grain', grain);
-
-        // when
-        const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} />`);
-
-        // then
-        assert.ok(screen.getByRole('img', { name: 'alt text' }).hasAttribute('src', url));
-      });
-    });
-
-    module('when all elements are answered', function () {
-      test('should not display skip button', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const element = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', {
-          title: 'Grain title',
-          components: [{ type: 'element', element }],
-        });
-        this.set('grain', grain);
-        const passage = store.createRecord('passage');
-        this.set('passage', passage);
-
-        const correction = store.createRecord('correction-response');
-        store.createRecord('element-answer', { element, correction, passage });
-
-        // when
-        const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
-
-        // then
-        assert
-          .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') }))
-          .doesNotExist();
-      });
-
-      module('when canMoveToNextGrain is true', function () {
-        test('should display continue button', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const element = { type: 'qcu', isAnswerable: true };
-          const grain = store.createRecord('grain', {
-            title: '1st Grain title',
-            components: [{ type: 'element', element }],
-          });
-          store.createRecord('module', { grains: [grain] });
-          this.set('grain', grain);
-          const passage = store.createRecord('passage');
-          this.set('passage', passage);
-
-          const correction = store.createRecord('correction-response');
-          store.createRecord('element-answer', { element, correction, passage });
-
-          // when
-          const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
-
-          // then
-          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists();
-        });
-      });
-      module('when canMoveToNextGrain is false', function () {
-        test('should not display continue button', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const element = { type: 'qcu', isAnswerable: true };
-          const grain = store.createRecord('grain', {
-            title: '1st Grain title',
-            components: [{ type: 'element', element }],
-          });
-          store.createRecord('module', { grains: [grain] });
-          this.set('grain', grain);
-          const passage = store.createRecord('passage');
-          this.set('passage', passage);
-
-          // when
-          const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
-
-          // then
-          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
-        });
-      });
-    });
-
-    module('when at least one element has not been answered', function () {
-      module('when canMoveToNextGrain is true', function () {
-        test('should not display continue button', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const element = { type: 'qcu', isAnswerable: true };
-          const grain = store.createRecord('grain', {
-            title: 'Grain title',
-            components: [{ type: 'element', element }],
-          });
-          this.set('grain', grain);
-          const passage = store.createRecord('passage');
-          this.set('passage', passage);
-
-          // when
-          const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
-
-          // then
-          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
-        });
-
-        test('should display skip button', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const element = { type: 'qcu', isAnswerable: true };
-          const grain = store.createRecord('grain', {
-            title: '1st Grain title',
-            components: [{ type: 'element', element }],
-          });
-          store.createRecord('module', { grains: [grain] });
-          this.set('grain', grain);
-          const passage = store.createRecord('passage');
-          this.set('passage', passage);
-
-          // when
-          const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
-
-          // then
-          assert.dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') })).exists();
-        });
-      });
-
-      module('when canMoveToNextGrain is false', function () {
-        test('should not display continue button', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const element = { type: 'qcu', isAnswerable: true };
-          const grain = store.createRecord('grain', {
-            title: 'Grain title',
-            components: [{ type: 'element', element }],
-          });
-          this.set('grain', grain);
-          const passage = store.createRecord('passage');
-          this.set('passage', passage);
-
-          // when
-          const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
-
-          // then
-          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
-        });
-
-        test('should not display skip button', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const element = { type: 'qcu', isAnswerable: true };
-          const grain = store.createRecord('grain', {
-            title: 'Grain title',
-            components: [{ type: 'element', element }],
-          });
-          store.createRecord('module', { grains: [grain] });
-          this.set('grain', grain);
-          const passage = store.createRecord('passage');
-          this.set('passage', passage);
-
-          // when
-          const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
-
-          // then
-          assert
-            .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') }))
-            .doesNotExist();
-        });
-      });
-    });
-
-    module('when continueAction is called', function () {
-      test('should call continueAction pass in argument', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const element = { type: 'text', isAnswerable: false };
-        const grain = store.createRecord('grain', {
-          title: '1st Grain title',
-          components: [{ type: 'element', element }],
-        });
-        store.createRecord('module', { id: 'module-id', grains: [grain] });
-        this.set('grain', grain);
-
-        const stubContinueAction = sinon.stub();
-        this.set('continueAction', stubContinueAction);
-
-        // when
-        await render(
-          hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}}
-                             @continueAction={{this.continueAction}} />`,
-        );
-        await clickByName('Continuer');
-
-        // then
-        sinon.assert.calledOnce(stubContinueAction);
-        assert.ok(true);
-      });
-    });
-
-    module('when skipAction is called', function () {
-      test('should call skipAction pass in argument', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const element = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', { title: 'Grain title', components: [{ type: 'element', element }] });
-        store.createRecord('module', { id: 'module-id', grains: [grain] });
-        this.set('grain', grain);
-        const passage = store.createRecord('passage');
-        this.set('passage', passage);
-
-        const skipActionStub = sinon.stub();
-        this.set('skipAction', skipActionStub);
-
-        this.set('continueAction', () => {});
-
-        // when
-        await render(
-          hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}}
-                             @continueAction={{this.continueAction}} @skipAction={{this.skipAction}} @passage={{this.passage}} />`,
-        );
-        await clickByName(this.intl.t('pages.modulix.buttons.grain.skip'));
-
-        // then
-        sinon.assert.calledOnce(skipActionStub);
-        assert.ok(true);
-      });
-    });
-
-    module('when shouldDisplayTerminateButton is true', function () {
-      test('should display the terminate button', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const element = { type: 'text', isAnswerable: false };
-        const grain = store.createRecord('grain', { title: 'Grain title', components: [{ type: 'element', element }] });
-        this.set('grain', grain);
-
-        // when
-        const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{true}} />`);
-
-        // then
-        assert
-          .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.terminate') }))
-          .exists();
-      });
-
-      module('when terminateAction is called', function () {
-        test('should call terminateAction passed in argument', async function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const element = { type: 'qcu', isAnswerable: true };
-          const grain = store.createRecord('grain', {
-            title: 'Grain title',
-            components: [{ type: 'element', element }],
-          });
-          this.set('grain', grain);
-          const passage = store.createRecord('passage');
-          this.set('passage', passage);
-
-          const terminateActionStub = sinon.stub();
-          this.set('terminateAction', terminateActionStub);
-
-          // when
-          await render(
-            hbs`
-              <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{true}}
-                             @terminateAction={{this.terminateAction}} @passage={{this.passage}} />`,
-          );
-          await clickByName(this.intl.t('pages.modulix.buttons.grain.terminate'));
-
-          // then
-          sinon.assert.calledOnce(terminateActionStub);
-          assert.ok(true);
-        });
-      });
-    });
-
-    module('when shouldDisplayTerminateButton is false', function () {
-      test('should not display the terminate button', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const element = { type: 'text', isAnswerable: false };
-        const grain = store.createRecord('grain', { title: 'Grain title', components: [{ type: 'element', element }] });
-        this.set('grain', grain);
-
-        // when
-        const screen = await render(hbs`
+      // when
+      const screen = await render(hbs`
             <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{false}} />`);
 
-        // then
-        assert
-          .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.terminate') }))
-          .doesNotExist();
-      });
+      // then
+      assert
+        .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.terminate') }))
+        .doesNotExist();
     });
+  });
 
-    module('when retryElement is called', function () {
-      test('should call retryElement pass in argument', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const element = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', { title: 'Grain title', components: [{ type: 'element', element }] });
-        this.set('grain', grain);
-        const passage = store.createRecord('passage');
-        this.set('passage', passage);
+  module('when retryElement is called', function () {
+    test('should call retryElement pass in argument', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const element = { type: 'qcu', isAnswerable: true };
+      const grain = store.createRecord('grain', { title: 'Grain title', components: [{ type: 'element', element }] });
+      this.set('grain', grain);
+      const passage = store.createRecord('passage');
+      this.set('passage', passage);
 
-        const retryElementStub = sinon.stub().withArgs({ element });
-        this.set('retryElement', retryElementStub);
+      const retryElementStub = sinon.stub().withArgs({ element });
+      this.set('retryElement', retryElementStub);
 
-        const correction = store.createRecord('correction-response', { status: 'ko' });
-        store.createRecord('element-answer', { element, correction, passage });
+      const correction = store.createRecord('correction-response', { status: 'ko' });
+      store.createRecord('element-answer', { element, correction, passage });
 
-        // when
-        await render(hbs`
+      // when
+      await render(hbs`
             <Module::Grain @grain={{this.grain}} @retryElement={{this.retryElement}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
-        await clickByName(this.intl.t('pages.modulix.buttons.activity.retry'));
+      await clickByName(this.intl.t('pages.modulix.buttons.activity.retry'));
 
-        // then
-        sinon.assert.calledOnce(retryElementStub);
-        assert.ok(true);
-      });
+      // then
+      sinon.assert.calledOnce(retryElementStub);
+      assert.ok(true);
     });
   });
 });

--- a/mon-pix/tests/integration/components/module/passage_test.js
+++ b/mon-pix/tests/integration/components/module/passage_test.js
@@ -18,8 +18,17 @@ module('Integration | Component | Module | Passage', function (hooks) {
       proposals: ['radio1', 'radio2'],
       type: 'qcu',
     };
-    const elements = [textElement, qcuElement];
-    const grain = store.createRecord('grain', { id: 'grainId1', elements });
+    const components = [
+      {
+        type: 'element',
+        element: textElement,
+      },
+      {
+        type: 'element',
+        element: qcuElement,
+      },
+    ];
+    const grain = store.createRecord('grain', { id: 'grainId1', components });
     const transitionTexts = [{ grainId: 'grainId1', content: 'transition text' }];
 
     const module = store.createRecord('module', { title: 'Module title', grains: [grain], transitionTexts });
@@ -48,8 +57,17 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const nonExistingElement2 = {
         type: 'non-existing-element-type',
       };
-      const elements = [nonExistingElement1, nonExistingElement2];
-      const grain = store.createRecord('grain', { id: 'grainId1', elements });
+      const components = [
+        {
+          type: 'element',
+          element: nonExistingElement1,
+        },
+        {
+          type: 'element',
+          element: nonExistingElement2,
+        },
+      ];
+      const grain = store.createRecord('grain', { id: 'grainId1', components });
 
       const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
       this.set('module', module);
@@ -71,8 +89,21 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const nonExistingElement2 = {
         type: 'non-existing-element-type',
       };
-      const elements = [nonExistingElement1, nonExistingElement2, existingElement];
-      const grain = store.createRecord('grain', { id: 'grainId1', elements });
+      const components = [
+        {
+          type: 'element',
+          element: nonExistingElement1,
+        },
+        {
+          type: 'element',
+          element: nonExistingElement2,
+        },
+        {
+          type: 'element',
+          element: existingElement,
+        },
+      ];
+      const grain = store.createRecord('grain', { id: 'grainId1', components });
 
       const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
       this.set('module', module);
@@ -88,26 +119,58 @@ module('Integration | Component | Module | Passage', function (hooks) {
     });
   });
 
-  module('with elements', function () {
-    test('should display a banner at the top of the screen for a passage', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const textElement = { content: 'content', type: 'text' };
-      const grain = store.createRecord('grain', { id: 'grainId1', elements: [textElement] });
-      const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
-      this.set('module', module);
-
-      const passage = store.createRecord('passage');
-      this.set('passage', passage);
-
-      // when
-      const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
-
-      // then
-      assert.dom(screen.getByRole('alert')).exists();
+  test('should display a banner at the top of the screen for a passage', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const textElement = { content: 'content', type: 'text' };
+    const grain = store.createRecord('grain', {
+      id: 'grainId1',
+      components: [{ type: 'element', element: textElement }],
     });
+    const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
+    this.set('module', module);
 
-    test('should display given module with more than one grain', async function (assert) {
+    const passage = store.createRecord('passage');
+    this.set('passage', passage);
+
+    // when
+    const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
+
+    // then
+    assert.dom(screen.getByRole('alert')).exists();
+  });
+
+  test('should display given module with more than one grain', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const textElement = { content: 'content', type: 'text' };
+    const qcuElement = {
+      instruction: 'instruction',
+      proposals: ['radio1', 'radio2'],
+      type: 'qcu',
+    };
+    const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: textElement }] });
+    const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: qcuElement }] });
+
+    const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+    this.set('module', module);
+
+    const passage = store.createRecord('passage');
+    this.set('passage', passage);
+
+    // when
+    const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
+
+    // then
+    assert.ok(screen.getByRole('heading', { name: module.title, level: 1 }));
+    assert.strictEqual(findAll('.element-text').length, 1);
+    assert.strictEqual(findAll('.element-qcu').length, 0);
+
+    assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists({ count: 1 });
+  });
+
+  module('when user click on skip button', function () {
+    test('should display next grain', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
       const textElement = { content: 'content', type: 'text' };
@@ -115,9 +178,10 @@ module('Integration | Component | Module | Passage', function (hooks) {
         instruction: 'instruction',
         proposals: ['radio1', 'radio2'],
         type: 'qcu',
+        isAnswerable: true,
       };
-      const grain1 = store.createRecord('grain', { elements: [textElement] });
-      const grain2 = store.createRecord('grain', { elements: [qcuElement] });
+      const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: qcuElement }] });
+      const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: textElement }] });
 
       const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
       this.set('module', module);
@@ -125,227 +189,68 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const passage = store.createRecord('passage');
       this.set('passage', passage);
 
+      await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
+
+      assert.strictEqual(findAll('.element-text').length, 0);
+
       // when
-      const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
+      await clickByName(this.intl.t('pages.modulix.buttons.grain.skip'));
 
       // then
-      assert.ok(screen.getByRole('heading', { name: module.title, level: 1 }));
       assert.strictEqual(findAll('.element-text').length, 1);
-      assert.strictEqual(findAll('.element-qcu').length, 0);
-
-      assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists({ count: 1 });
     });
 
-    module('when user click on skip button', function () {
-      test('should display next grain', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const textElement = { content: 'content', type: 'text' };
-        const qcuElement = {
-          instruction: 'instruction',
-          proposals: ['radio1', 'radio2'],
-          type: 'qcu',
-          isAnswerable: true,
-        };
-        const grain1 = store.createRecord('grain', { elements: [qcuElement] });
-        const grain2 = store.createRecord('grain', { elements: [textElement] });
+    test('should push event', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const textElement = { content: 'content', type: 'text' };
+      const qcuElement = {
+        instruction: 'instruction',
+        proposals: ['radio1', 'radio2'],
+        type: 'qcu',
+        isAnswerable: true,
+      };
+      const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: qcuElement }] });
+      const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: textElement }] });
 
-        const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
-        this.set('module', module);
+      const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+      this.set('module', module);
 
-        const passage = store.createRecord('passage');
-        this.set('passage', passage);
+      const passage = store.createRecord('passage');
+      this.set('passage', passage);
 
-        await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
+      await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
 
-        assert.strictEqual(findAll('.element-text').length, 0);
+      const metrics = this.owner.lookup('service:metrics');
+      metrics.add = sinon.stub();
 
-        // when
-        await clickByName(this.intl.t('pages.modulix.buttons.grain.skip'));
+      // when
+      await clickByName(this.intl.t('pages.modulix.buttons.grain.skip'));
 
-        // then
-        assert.strictEqual(findAll('.element-text').length, 1);
+      // then
+      sinon.assert.calledWithExactly(metrics.add, {
+        event: 'custom-event',
+        'pix-event-category': 'Modulix',
+        'pix-event-action': `Passage du module : ${module.id}`,
+        'pix-event-name': `Click sur le bouton passer du grain : ${grain1.id}`,
       });
-
-      test('should push event', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const textElement = { content: 'content', type: 'text' };
-        const qcuElement = {
-          instruction: 'instruction',
-          proposals: ['radio1', 'radio2'],
-          type: 'qcu',
-          isAnswerable: true,
-        };
-        const grain1 = store.createRecord('grain', { elements: [qcuElement] });
-        const grain2 = store.createRecord('grain', { elements: [textElement] });
-
-        const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
-        this.set('module', module);
-
-        const passage = store.createRecord('passage');
-        this.set('passage', passage);
-
-        await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
-
-        const metrics = this.owner.lookup('service:metrics');
-        metrics.add = sinon.stub();
-
-        // when
-        await clickByName(this.intl.t('pages.modulix.buttons.grain.skip'));
-
-        // then
-        sinon.assert.calledWithExactly(metrics.add, {
-          event: 'custom-event',
-          'pix-event-category': 'Modulix',
-          'pix-event-action': `Passage du module : ${module.id}`,
-          'pix-event-name': `Click sur le bouton passer du grain : ${grain1.id}`,
-        });
-        assert.ok(true);
-      });
-    });
-
-    module('when user click on continue button', function (hooks) {
-      let continueButtonName;
-      hooks.beforeEach(function () {
-        continueButtonName = this.intl.t('pages.modulix.buttons.grain.continue');
-      });
-
-      test('should display next grain', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const text1Element = { content: 'content', type: 'text' };
-        const text2Element = { content: 'content 2', type: 'text' };
-        const grain1 = store.createRecord('grain', { elements: [text1Element] });
-        const grain2 = store.createRecord('grain', { elements: [text2Element] });
-
-        const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
-        this.set('module', module);
-
-        const passage = store.createRecord('passage');
-        this.set('passage', passage);
-
-        const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
-
-        const grainsBeforeAnyAction = screen.getAllByRole('article');
-        assert.strictEqual(grainsBeforeAnyAction.length, 1);
-
-        // when
-        await clickByName(continueButtonName);
-
-        // then
-        const grainsAfterContinueAction = screen.getAllByRole('article');
-        assert.strictEqual(grainsAfterContinueAction.length, 2);
-      });
-
-      test('should give focus on the last grain when appearing', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const text1Element = { content: 'content', type: 'text' };
-        const text2Element = { content: 'content 2', type: 'text' };
-        const text3Element = { content: 'content 3', type: 'text' };
-        const grain1 = store.createRecord('grain', { elements: [text1Element] });
-        const grain2 = store.createRecord('grain', { elements: [text2Element] });
-        const grain3 = store.createRecord('grain', { elements: [text3Element] });
-
-        const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2, grain3] });
-        this.set('module', module);
-
-        const passage = store.createRecord('passage');
-        this.set('passage', passage);
-
-        const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
-
-        const grainsBeforeAnyAction = screen.getAllByRole('article');
-        assert.strictEqual(grainsBeforeAnyAction.length, 1);
-        assert.strictEqual(document.activeElement, document.body);
-
-        // when
-        await clickByName(continueButtonName);
-
-        // then
-        const grainsAfterOneContinueActions = screen.getAllByRole('article');
-        assert.strictEqual(grainsAfterOneContinueActions.length, 2);
-        const secondGrain = grainsAfterOneContinueActions.at(-1);
-        assert.strictEqual(document.activeElement, secondGrain);
-
-        // when
-        await clickByName(continueButtonName);
-
-        // then
-        const grainsAfterTwoContinueActions = screen.getAllByRole('article');
-        assert.strictEqual(grainsAfterTwoContinueActions.length, 3);
-        const thirdGrain = grainsAfterTwoContinueActions.at(-1);
-        assert.strictEqual(document.activeElement, thirdGrain);
-      });
-
-      test('should push event', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const text1Element = { content: 'content', type: 'text' };
-        const text2Element = { content: 'content 2', type: 'text' };
-        const grain1 = store.createRecord('grain', { elements: [text1Element] });
-        const grain2 = store.createRecord('grain', { elements: [text2Element] });
-
-        const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
-        this.set('module', module);
-
-        const passage = store.createRecord('passage');
-        this.set('passage', passage);
-
-        await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
-
-        const metrics = this.owner.lookup('service:metrics');
-        metrics.add = sinon.stub();
-
-        // when
-        await clickByName(continueButtonName);
-
-        // then
-        sinon.assert.calledWithExactly(metrics.add, {
-          event: 'custom-event',
-          'pix-event-category': 'Modulix',
-          'pix-event-action': `Passage du module : ${module.id}`,
-          'pix-event-name': `Click sur le bouton continuer du grain : ${grain1.id}`,
-        });
-        assert.ok(true);
-      });
+      assert.ok(true);
     });
   });
 
-  module('with components', function () {
-    test('should display a banner at the top of the screen for a passage', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const textElement = { content: 'content', type: 'text' };
-      const grain = store.createRecord('grain', {
-        id: 'grainId1',
-        components: [{ type: 'element', element: textElement }],
-      });
-      const module = store.createRecord('module', { title: 'Module title', grains: [grain] });
-      this.set('module', module);
-
-      const passage = store.createRecord('passage');
-      this.set('passage', passage);
-
-      // when
-      const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
-
-      // then
-      assert.dom(screen.getByRole('alert')).exists();
+  module('when user click on continue button', function (hooks) {
+    let continueButtonName;
+    hooks.beforeEach(function () {
+      continueButtonName = this.intl.t('pages.modulix.buttons.grain.continue');
     });
 
-    test('should display given module with more than one grain', async function (assert) {
+    test('should display next grain', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const textElement = { content: 'content', type: 'text' };
-      const qcuElement = {
-        instruction: 'instruction',
-        proposals: ['radio1', 'radio2'],
-        type: 'qcu',
-      };
-      const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: textElement }] });
-      const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: qcuElement }] });
+      const text1Element = { content: 'content', type: 'text' };
+      const text2Element = { content: 'content 2', type: 'text' };
+      const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: text1Element }] });
+      const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: text2Element }] });
 
       const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
       this.set('module', module);
@@ -353,191 +258,90 @@ module('Integration | Component | Module | Passage', function (hooks) {
       const passage = store.createRecord('passage');
       this.set('passage', passage);
 
-      // when
       const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
 
+      const grainsBeforeAnyAction = screen.getAllByRole('article');
+      assert.strictEqual(grainsBeforeAnyAction.length, 1);
+
+      // when
+      await clickByName(continueButtonName);
+
       // then
-      assert.ok(screen.getByRole('heading', { name: module.title, level: 1 }));
-      assert.strictEqual(findAll('.element-text').length, 1);
-      assert.strictEqual(findAll('.element-qcu').length, 0);
-
-      assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists({ count: 1 });
+      const grainsAfterContinueAction = screen.getAllByRole('article');
+      assert.strictEqual(grainsAfterContinueAction.length, 2);
     });
 
-    module('when user click on skip button', function () {
-      test('should display next grain', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const textElement = { content: 'content', type: 'text' };
-        const qcuElement = {
-          instruction: 'instruction',
-          proposals: ['radio1', 'radio2'],
-          type: 'qcu',
-          isAnswerable: true,
-        };
-        const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: qcuElement }] });
-        const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: textElement }] });
+    test('should give focus on the last grain when appearing', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const text1Element = { content: 'content', type: 'text' };
+      const text2Element = { content: 'content 2', type: 'text' };
+      const text3Element = { content: 'content 3', type: 'text' };
+      const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: text1Element }] });
+      const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: text2Element }] });
+      const grain3 = store.createRecord('grain', { components: [{ type: 'element', element: text3Element }] });
 
-        const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
-        this.set('module', module);
+      const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2, grain3] });
+      this.set('module', module);
 
-        const passage = store.createRecord('passage');
-        this.set('passage', passage);
+      const passage = store.createRecord('passage');
+      this.set('passage', passage);
 
-        await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
+      const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
 
-        assert.strictEqual(findAll('.element-text').length, 0);
+      const grainsBeforeAnyAction = screen.getAllByRole('article');
+      assert.strictEqual(grainsBeforeAnyAction.length, 1);
+      assert.strictEqual(document.activeElement, document.body);
 
-        // when
-        await clickByName(this.intl.t('pages.modulix.buttons.grain.skip'));
+      // when
+      await clickByName(continueButtonName);
 
-        // then
-        assert.strictEqual(findAll('.element-text').length, 1);
-      });
+      // then
+      const grainsAfterOneContinueActions = screen.getAllByRole('article');
+      assert.strictEqual(grainsAfterOneContinueActions.length, 2);
+      const secondGrain = grainsAfterOneContinueActions.at(-1);
+      assert.strictEqual(document.activeElement, secondGrain);
 
-      test('should push event', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const textElement = { content: 'content', type: 'text' };
-        const qcuElement = {
-          instruction: 'instruction',
-          proposals: ['radio1', 'radio2'],
-          type: 'qcu',
-          isAnswerable: true,
-        };
-        const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: qcuElement }] });
-        const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: textElement }] });
+      // when
+      await clickByName(continueButtonName);
 
-        const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
-        this.set('module', module);
-
-        const passage = store.createRecord('passage');
-        this.set('passage', passage);
-
-        await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
-
-        const metrics = this.owner.lookup('service:metrics');
-        metrics.add = sinon.stub();
-
-        // when
-        await clickByName(this.intl.t('pages.modulix.buttons.grain.skip'));
-
-        // then
-        sinon.assert.calledWithExactly(metrics.add, {
-          event: 'custom-event',
-          'pix-event-category': 'Modulix',
-          'pix-event-action': `Passage du module : ${module.id}`,
-          'pix-event-name': `Click sur le bouton passer du grain : ${grain1.id}`,
-        });
-        assert.ok(true);
-      });
+      // then
+      const grainsAfterTwoContinueActions = screen.getAllByRole('article');
+      assert.strictEqual(grainsAfterTwoContinueActions.length, 3);
+      const thirdGrain = grainsAfterTwoContinueActions.at(-1);
+      assert.strictEqual(document.activeElement, thirdGrain);
     });
 
-    module('when user click on continue button', function (hooks) {
-      let continueButtonName;
-      hooks.beforeEach(function () {
-        continueButtonName = this.intl.t('pages.modulix.buttons.grain.continue');
+    test('should push event', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const text1Element = { content: 'content', type: 'text' };
+      const text2Element = { content: 'content 2', type: 'text' };
+      const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: text1Element }] });
+      const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: text2Element }] });
+
+      const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
+      this.set('module', module);
+
+      const passage = store.createRecord('passage');
+      this.set('passage', passage);
+
+      await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
+
+      const metrics = this.owner.lookup('service:metrics');
+      metrics.add = sinon.stub();
+
+      // when
+      await clickByName(continueButtonName);
+
+      // then
+      sinon.assert.calledWithExactly(metrics.add, {
+        event: 'custom-event',
+        'pix-event-category': 'Modulix',
+        'pix-event-action': `Passage du module : ${module.id}`,
+        'pix-event-name': `Click sur le bouton continuer du grain : ${grain1.id}`,
       });
-
-      test('should display next grain', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const text1Element = { content: 'content', type: 'text' };
-        const text2Element = { content: 'content 2', type: 'text' };
-        const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: text1Element }] });
-        const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: text2Element }] });
-
-        const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
-        this.set('module', module);
-
-        const passage = store.createRecord('passage');
-        this.set('passage', passage);
-
-        const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
-
-        const grainsBeforeAnyAction = screen.getAllByRole('article');
-        assert.strictEqual(grainsBeforeAnyAction.length, 1);
-
-        // when
-        await clickByName(continueButtonName);
-
-        // then
-        const grainsAfterContinueAction = screen.getAllByRole('article');
-        assert.strictEqual(grainsAfterContinueAction.length, 2);
-      });
-
-      test('should give focus on the last grain when appearing', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const text1Element = { content: 'content', type: 'text' };
-        const text2Element = { content: 'content 2', type: 'text' };
-        const text3Element = { content: 'content 3', type: 'text' };
-        const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: text1Element }] });
-        const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: text2Element }] });
-        const grain3 = store.createRecord('grain', { components: [{ type: 'element', element: text3Element }] });
-
-        const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2, grain3] });
-        this.set('module', module);
-
-        const passage = store.createRecord('passage');
-        this.set('passage', passage);
-
-        const screen = await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
-
-        const grainsBeforeAnyAction = screen.getAllByRole('article');
-        assert.strictEqual(grainsBeforeAnyAction.length, 1);
-        assert.strictEqual(document.activeElement, document.body);
-
-        // when
-        await clickByName(continueButtonName);
-
-        // then
-        const grainsAfterOneContinueActions = screen.getAllByRole('article');
-        assert.strictEqual(grainsAfterOneContinueActions.length, 2);
-        const secondGrain = grainsAfterOneContinueActions.at(-1);
-        assert.strictEqual(document.activeElement, secondGrain);
-
-        // when
-        await clickByName(continueButtonName);
-
-        // then
-        const grainsAfterTwoContinueActions = screen.getAllByRole('article');
-        assert.strictEqual(grainsAfterTwoContinueActions.length, 3);
-        const thirdGrain = grainsAfterTwoContinueActions.at(-1);
-        assert.strictEqual(document.activeElement, thirdGrain);
-      });
-
-      test('should push event', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const text1Element = { content: 'content', type: 'text' };
-        const text2Element = { content: 'content 2', type: 'text' };
-        const grain1 = store.createRecord('grain', { components: [{ type: 'element', element: text1Element }] });
-        const grain2 = store.createRecord('grain', { components: [{ type: 'element', element: text2Element }] });
-
-        const module = store.createRecord('module', { title: 'Module title', grains: [grain1, grain2] });
-        this.set('module', module);
-
-        const passage = store.createRecord('passage');
-        this.set('passage', passage);
-
-        await render(hbs`<Module::Passage @module={{this.module}} @passage={{this.passage}} />`);
-
-        const metrics = this.owner.lookup('service:metrics');
-        metrics.add = sinon.stub();
-
-        // when
-        await clickByName(continueButtonName);
-
-        // then
-        sinon.assert.calledWithExactly(metrics.add, {
-          event: 'custom-event',
-          'pix-event-category': 'Modulix',
-          'pix-event-action': `Passage du module : ${module.id}`,
-          'pix-event-name': `Click sur le bouton continuer du grain : ${grain1.id}`,
-        });
-        assert.ok(true);
-      });
+      assert.ok(true);
     });
   });
 });

--- a/mon-pix/tests/integration/components/module/qcm_test.js
+++ b/mon-pix/tests/integration/components/module/qcm_test.js
@@ -124,225 +124,102 @@ module('Integration | Component | Module | QCM', function (hooks) {
     assert.dom(screen.queryByRole('alert', { name: 'Pour valider, sélectionnez une réponse.' })).doesNotExist();
   });
 
-  module('with elements', function () {
-    test('should display an ok feedback when exists', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
+  test('should display an ok feedback when exists', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
 
-      const correctionResponse = store.createRecord('correction-response', {
-        feedback: 'Good job!',
-        status: 'ok',
-        solution: ['1', '4'],
-      });
-
-      prepareDeprecatedContextRecords.call(this, store, correctionResponse);
-      this.set('submitAnswer', () => {});
-
-      // when
-      const screen = await render(
-        hbs`<Module::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
-      );
-
-      // then
-      const status = screen.getByRole('status');
-      assert.strictEqual(status.innerText, 'Good job!');
-      assert.ok(screen.getByRole('checkbox', { name: 'checkbox1', disabled: true }));
-      assert.ok(screen.getByRole('checkbox', { name: 'checkbox2', disabled: true }));
-      assert.ok(screen.getByRole('checkbox', { name: 'checkbox3', disabled: true }));
-      assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+    const correctionResponse = store.createRecord('correction-response', {
+      feedback: 'Good job!',
+      status: 'ok',
+      solution: ['1', '4'],
     });
 
-    test('should display a ko feedback when exists', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const correctionResponse = store.createRecord('correction-response', {
-        feedback: 'Too Bad!',
-        status: 'ko',
-        solution: ['1', '4'],
-      });
+    prepareContextRecords.call(this, store, correctionResponse);
+    this.set('submitAnswer', () => {});
 
-      prepareDeprecatedContextRecords.call(this, store, correctionResponse);
-      this.set('submitAnswer', () => {});
+    // when
+    const screen = await render(
+      hbs`<Module::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
+    );
 
-      // when
-      const screen = await render(
-        hbs`<Module::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
-      );
-
-      // then
-      const status = screen.getByRole('status');
-      assert.strictEqual(status.innerText, 'Too Bad!');
-      assert.ok(screen.getByRole('checkbox', { name: 'checkbox1', disabled: true }));
-      assert.ok(screen.getByRole('checkbox', { name: 'checkbox2', disabled: true }));
-      assert.ok(screen.getByRole('checkbox', { name: 'checkbox3', disabled: true }));
-      assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
-    });
-
-    test('should display retry button when a ko feedback appears', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const correctionResponse = store.createRecord('correction-response', {
-        feedback: 'Too Bad!',
-        status: 'ko',
-        solution: 'solution',
-      });
-
-      prepareDeprecatedContextRecords.call(this, store, correctionResponse);
-      this.set('submitAnswer', () => {});
-
-      // when
-      const screen = await render(
-        hbs`<Module::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
-      );
-
-      // then
-      assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).exists();
-    });
-
-    test('should not display retry button when an ok feedback appears', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const correctionResponse = store.createRecord('correction-response', {
-        feedback: 'Nice!',
-        status: 'ok',
-        solution: 'solution',
-      });
-
-      prepareDeprecatedContextRecords.call(this, store, correctionResponse);
-      this.set('submitAnswer', () => {});
-
-      // when
-      const screen = await render(
-        hbs`<Module::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
-      );
-
-      // then
-      assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).doesNotExist();
-    });
+    // then
+    const status = screen.getByRole('status');
+    assert.strictEqual(status.innerText, 'Good job!');
+    assert.ok(screen.getByRole('checkbox', { name: 'checkbox1', disabled: true }));
+    assert.ok(screen.getByRole('checkbox', { name: 'checkbox2', disabled: true }));
+    assert.ok(screen.getByRole('checkbox', { name: 'checkbox3', disabled: true }));
+    assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
   });
 
-  module('with components', function () {
-    test('should display an ok feedback when exists', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-
-      const correctionResponse = store.createRecord('correction-response', {
-        feedback: 'Good job!',
-        status: 'ok',
-        solution: ['1', '4'],
-      });
-
-      prepareContextRecords.call(this, store, correctionResponse);
-      this.set('submitAnswer', () => {});
-
-      // when
-      const screen = await render(
-        hbs`<Module::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
-      );
-
-      // then
-      const status = screen.getByRole('status');
-      assert.strictEqual(status.innerText, 'Good job!');
-      assert.ok(screen.getByRole('checkbox', { name: 'checkbox1', disabled: true }));
-      assert.ok(screen.getByRole('checkbox', { name: 'checkbox2', disabled: true }));
-      assert.ok(screen.getByRole('checkbox', { name: 'checkbox3', disabled: true }));
-      assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+  test('should display a ko feedback when exists', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const correctionResponse = store.createRecord('correction-response', {
+      feedback: 'Too Bad!',
+      status: 'ko',
+      solution: ['1', '4'],
     });
 
-    test('should display a ko feedback when exists', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const correctionResponse = store.createRecord('correction-response', {
-        feedback: 'Too Bad!',
-        status: 'ko',
-        solution: ['1', '4'],
-      });
+    prepareContextRecords.call(this, store, correctionResponse);
+    this.set('submitAnswer', () => {});
 
-      prepareContextRecords.call(this, store, correctionResponse);
-      this.set('submitAnswer', () => {});
+    // when
+    const screen = await render(
+      hbs`<Module::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
+    );
 
-      // when
-      const screen = await render(
-        hbs`<Module::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
-      );
+    // then
+    const status = screen.getByRole('status');
+    assert.strictEqual(status.innerText, 'Too Bad!');
 
-      // then
-      const status = screen.getByRole('status');
-      assert.strictEqual(status.innerText, 'Too Bad!');
+    assert.ok(screen.getByRole('checkbox', { name: 'checkbox1', disabled: true }));
+    assert.ok(screen.getByRole('checkbox', { name: 'checkbox2', disabled: true }));
+    assert.ok(screen.getByRole('checkbox', { name: 'checkbox3', disabled: true }));
+    assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+  });
 
-      assert.ok(screen.getByRole('checkbox', { name: 'checkbox1', disabled: true }));
-      assert.ok(screen.getByRole('checkbox', { name: 'checkbox2', disabled: true }));
-      assert.ok(screen.getByRole('checkbox', { name: 'checkbox3', disabled: true }));
-      assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+  test('should display retry button when a ko feedback appears', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const correctionResponse = store.createRecord('correction-response', {
+      feedback: 'Too Bad!',
+      status: 'ko',
+      solution: 'solution',
     });
 
-    test('should display retry button when a ko feedback appears', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const correctionResponse = store.createRecord('correction-response', {
-        feedback: 'Too Bad!',
-        status: 'ko',
-        solution: 'solution',
-      });
+    prepareContextRecords.call(this, store, correctionResponse);
+    this.set('submitAnswer', () => {});
 
-      prepareContextRecords.call(this, store, correctionResponse);
-      this.set('submitAnswer', () => {});
+    // when
+    const screen = await render(
+      hbs`<Module::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+    );
 
-      // when
-      const screen = await render(
-        hbs`<Module::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
-      );
+    // then
+    assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).exists();
+  });
 
-      // then
-      assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).exists();
+  test('should not display retry button when an ok feedback appears', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const correctionResponse = store.createRecord('correction-response', {
+      feedback: 'Nice!',
+      status: 'ok',
+      solution: 'solution',
     });
 
-    test('should not display retry button when an ok feedback appears', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const correctionResponse = store.createRecord('correction-response', {
-        feedback: 'Nice!',
-        status: 'ok',
-        solution: 'solution',
-      });
+    prepareContextRecords.call(this, store, correctionResponse);
+    this.set('submitAnswer', () => {});
 
-      prepareContextRecords.call(this, store, correctionResponse);
-      this.set('submitAnswer', () => {});
+    // when
+    const screen = await render(
+      hbs`<Module::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+    );
 
-      // when
-      const screen = await render(
-        hbs`<Module::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
-      );
-
-      // then
-      assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).doesNotExist();
-    });
+    // then
+    assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).doesNotExist();
   });
 });
-
-function prepareDeprecatedContextRecords(store, correctionResponse) {
-  const qcmElement = {
-    id: 'a6838f8e-05ee-42e0-9820-13a9977cf5dc',
-    instruction: 'Instruction',
-    proposals: [
-      { id: '1', content: 'checkbox1' },
-      { id: '2', content: 'checkbox2' },
-      { id: '3', content: 'checkbox3' },
-    ],
-    type: 'qcm',
-  };
-  store.createRecord('element-answer', {
-    correction: correctionResponse,
-    element: qcmElement,
-  });
-  store.createRecord('grain', { id: 'id', elements: [qcmElement] });
-  store.createRecord('element-answer', {
-    correction: correctionResponse,
-    elementId: qcmElement.id,
-  });
-  this.set('el', qcmElement);
-  this.set('correctionResponse', correctionResponse);
-}
 
 function prepareContextRecords(store, correctionResponse) {
   const qcmElement = {

--- a/mon-pix/tests/integration/components/module/qcu_test.js
+++ b/mon-pix/tests/integration/components/module/qcu_test.js
@@ -114,219 +114,99 @@ module('Integration | Component | Module | QCU', function (hooks) {
     assert.dom(screen.queryByRole('alert', { name: 'Pour valider, sélectionnez une réponse.' })).doesNotExist();
   });
 
-  module('with elements', function () {
-    test('should display an ok feedback when exists', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
+  test('should display an ok feedback when exists', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
 
-      const correctionResponse = store.createRecord('correction-response', {
-        feedback: 'Good job!',
-        status: 'ok',
-        solution: 'solution',
-      });
-
-      prepareDeprecatedContextRecords.call(this, store, correctionResponse);
-      this.set('submitAnswer', () => {});
-
-      // when
-      const screen = await render(
-        hbs`<Module::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
-      );
-
-      // then
-      const status = screen.getByRole('status');
-      assert.strictEqual(status.innerText, 'Good job!');
-      assert.ok(screen.getByRole('radio', { name: 'radio1', disabled: true }));
-      assert.ok(screen.getByRole('radio', { name: 'radio2', disabled: true }));
-      assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+    const correctionResponse = store.createRecord('correction-response', {
+      feedback: 'Good job!',
+      status: 'ok',
+      solution: 'solution',
     });
 
-    test('should display a ko feedback when exists', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const correctionResponse = store.createRecord('correction-response', {
-        feedback: 'Too Bad!',
-        status: 'ko',
-        solution: 'solution',
-      });
+    prepareContextRecords.call(this, store, correctionResponse);
+    this.set('submitAnswer', () => {});
 
-      prepareDeprecatedContextRecords.call(this, store, correctionResponse);
-      this.set('submitAnswer', () => {});
+    // when
+    const screen = await render(
+      hbs`<Module::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
+    );
 
-      // when
-      const screen = await render(
-        hbs`<Module::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
-      );
-
-      // then
-      const status = screen.getByRole('status');
-      assert.strictEqual(status.innerText, 'Too Bad!');
-      assert.ok(screen.getByRole('radio', { name: 'radio1', disabled: true }));
-      assert.ok(screen.getByRole('radio', { name: 'radio2', disabled: true }));
-      assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
-    });
-
-    test('should display retry button when a ko feedback appears', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const correctionResponse = store.createRecord('correction-response', {
-        feedback: 'Too Bad!',
-        status: 'ko',
-        solution: 'solution',
-      });
-
-      prepareDeprecatedContextRecords.call(this, store, correctionResponse);
-      this.set('submitAnswer', () => {});
-
-      // when
-      const screen = await render(
-        hbs`<Module::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
-      );
-
-      // then
-      assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).exists();
-    });
-
-    test('should not display retry button when an ok feedback appears', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const correctionResponse = store.createRecord('correction-response', {
-        feedback: 'Nice!',
-        status: 'ok',
-        solution: 'solution',
-      });
-
-      prepareDeprecatedContextRecords.call(this, store, correctionResponse);
-      this.set('submitAnswer', () => {});
-
-      // when
-      const screen = await render(
-        hbs`<Module::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
-      );
-
-      // then
-      assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).doesNotExist();
-    });
+    // then
+    const status = screen.getByRole('status');
+    assert.strictEqual(status.innerText, 'Good job!');
+    assert.ok(screen.getByRole('radio', { name: 'radio1', disabled: true }));
+    assert.ok(screen.getByRole('radio', { name: 'radio2', disabled: true }));
+    assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
   });
 
-  module('with components', function () {
-    test('should display an ok feedback when exists', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-
-      const correctionResponse = store.createRecord('correction-response', {
-        feedback: 'Good job!',
-        status: 'ok',
-        solution: 'solution',
-      });
-
-      prepareContextRecords.call(this, store, correctionResponse);
-      this.set('submitAnswer', () => {});
-
-      // when
-      const screen = await render(
-        hbs`<Module::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
-      );
-
-      // then
-      const status = screen.getByRole('status');
-      assert.strictEqual(status.innerText, 'Good job!');
-      assert.ok(screen.getByRole('radio', { name: 'radio1', disabled: true }));
-      assert.ok(screen.getByRole('radio', { name: 'radio2', disabled: true }));
-      assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+  test('should display a ko feedback when exists', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const correctionResponse = store.createRecord('correction-response', {
+      feedback: 'Too Bad!',
+      status: 'ko',
+      solution: 'solution',
     });
 
-    test('should display a ko feedback when exists', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const correctionResponse = store.createRecord('correction-response', {
-        feedback: 'Too Bad!',
-        status: 'ko',
-        solution: 'solution',
-      });
+    prepareContextRecords.call(this, store, correctionResponse);
+    this.set('submitAnswer', () => {});
 
-      prepareContextRecords.call(this, store, correctionResponse);
-      this.set('submitAnswer', () => {});
+    // when
+    const screen = await render(
+      hbs`<Module::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+    );
 
-      // when
-      const screen = await render(
-        hbs`<Module::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
-      );
+    // then
+    const status = screen.getByRole('status');
+    assert.strictEqual(status.innerText, 'Too Bad!');
+    assert.ok(screen.getByRole('radio', { name: 'radio1', disabled: true }));
+    assert.ok(screen.getByRole('radio', { name: 'radio2', disabled: true }));
+    assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+  });
 
-      // then
-      const status = screen.getByRole('status');
-      assert.strictEqual(status.innerText, 'Too Bad!');
-      assert.ok(screen.getByRole('radio', { name: 'radio1', disabled: true }));
-      assert.ok(screen.getByRole('radio', { name: 'radio2', disabled: true }));
-      assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+  test('should display retry button when a ko feedback appears', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const correctionResponse = store.createRecord('correction-response', {
+      feedback: 'Too Bad!',
+      status: 'ko',
+      solution: 'solution',
     });
 
-    test('should display retry button when a ko feedback appears', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const correctionResponse = store.createRecord('correction-response', {
-        feedback: 'Too Bad!',
-        status: 'ko',
-        solution: 'solution',
-      });
+    prepareContextRecords.call(this, store, correctionResponse);
+    this.set('submitAnswer', () => {});
 
-      prepareContextRecords.call(this, store, correctionResponse);
-      this.set('submitAnswer', () => {});
+    // when
+    const screen = await render(
+      hbs`<Module::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+    );
 
-      // when
-      const screen = await render(
-        hbs`<Module::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
-      );
+    // then
+    assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).exists();
+  });
 
-      // then
-      assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).exists();
+  test('should not display retry button when an ok feedback appears', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const correctionResponse = store.createRecord('correction-response', {
+      feedback: 'Nice!',
+      status: 'ok',
+      solution: 'solution',
     });
 
-    test('should not display retry button when an ok feedback appears', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const correctionResponse = store.createRecord('correction-response', {
-        feedback: 'Nice!',
-        status: 'ok',
-        solution: 'solution',
-      });
+    prepareContextRecords.call(this, store, correctionResponse);
+    this.set('submitAnswer', () => {});
 
-      prepareContextRecords.call(this, store, correctionResponse);
-      this.set('submitAnswer', () => {});
+    // when
+    const screen = await render(
+      hbs`<Module::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+    );
 
-      // when
-      const screen = await render(
-        hbs`<Module::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
-      );
-
-      // then
-      assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).doesNotExist();
-    });
+    // then
+    assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).doesNotExist();
   });
 });
-
-function prepareDeprecatedContextRecords(store, correctionResponse) {
-  const qcuElement = {
-    id: 'd0690f26-978c-41c3-9a21-da931857739c',
-    instruction: 'Instruction',
-    proposals: [
-      { id: '1', content: 'radio1' },
-      { id: '2', content: 'radio2' },
-    ],
-    type: 'qcu',
-  };
-  store.createRecord('element-answer', {
-    correction: correctionResponse,
-    element: qcuElement,
-  });
-  store.createRecord('grain', { id: 'id', elements: [qcuElement] });
-  store.createRecord('element-answer', {
-    correction: correctionResponse,
-    elementId: qcuElement.id,
-  });
-  this.set('el', qcuElement);
-  this.set('correctionResponse', correctionResponse);
-}
 
 function prepareContextRecords(store, correctionResponse) {
   const qcuElement = {

--- a/mon-pix/tests/integration/components/module/qrocm_test.js
+++ b/mon-pix/tests/integration/components/module/qrocm_test.js
@@ -351,227 +351,95 @@ module('Integration | Component | Module | QROCM', function (hooks) {
     });
   });
 
-  module('with elements', function () {
-    test('should display an ok feedback when exists', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
+  test('should display an ok feedback when exists', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
 
-      const correctionResponse = store.createRecord('correction-response', {
-        feedback: 'Good job!',
-        status: 'ok',
-        solution: 'solution',
-      });
-      prepareContextRecords.call(this, store, correctionResponse);
-      this.set('submitAnswer', () => {});
-
-      // when
-      const screen = await render(
-        hbs`<Module::Qrocm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
-      );
-
-      // then
-      const status = screen.getByRole('status');
-      assert.strictEqual(status.innerText, 'Good job!');
-      assert.ok(screen.getByRole('group').disabled);
-      assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+    const correctionResponse = store.createRecord('correction-response', {
+      feedback: 'Good job!',
+      status: 'ok',
+      solution: 'solution',
     });
+    prepareContextRecords.call(this, store, correctionResponse);
+    this.set('submitAnswer', () => {});
 
-    test('should display a ko feedback when exists', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const correctionResponse = store.createRecord('correction-response', {
-        feedback: 'Too Bad!',
-        status: 'ko',
-        solution: 'solution',
-      });
-      prepareContextRecords.call(this, store, correctionResponse);
-      this.set('submitAnswer', () => {});
+    // when
+    const screen = await render(
+      hbs`<Module::Qrocm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+    );
 
-      // when
-      const screen = await render(
-        hbs`<Module::Qrocm @element={{this.el}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
-      );
-
-      // then
-      const status = screen.getByRole('status');
-      assert.strictEqual(status.innerText, 'Too Bad!');
-      assert.ok(screen.getByRole('group').disabled);
-      assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
-    });
-
-    test('should display retry button when a ko feedback appears', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const correctionResponse = store.createRecord('correction-response', {
-        feedback: 'Too Bad!',
-        status: 'ko',
-        solution: 'solution',
-      });
-
-      prepareDeprecatedContextRecords.call(this, store, correctionResponse);
-      this.set('submitAnswer', () => {});
-
-      // when
-      const screen = await render(
-        hbs`<Module::Qrocm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
-      );
-
-      // then
-      assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).exists();
-    });
-
-    test('should not display retry button when an ok feedback appears', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const correctionResponse = store.createRecord('correction-response', {
-        feedback: 'Nice!',
-        status: 'ok',
-        solution: 'solution',
-      });
-
-      prepareDeprecatedContextRecords.call(this, store, correctionResponse);
-      this.set('submitAnswer', () => {});
-
-      // when
-      const screen = await render(
-        hbs`<Module::Qrocm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
-      );
-
-      // then
-      assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).doesNotExist();
-    });
+    // then
+    const status = screen.getByRole('status');
+    assert.strictEqual(status.innerText, 'Good job!');
+    assert.ok(screen.getByRole('group').disabled);
+    assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
   });
 
-  module('with components', function () {
-    test('should display an ok feedback when exists', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
+  test('should display a ko feedback when exists', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const correctionResponse = store.createRecord('correction-response', {
+      feedback: 'Too Bad!',
+      status: 'ko',
+      solution: 'solution',
+    });
+    prepareContextRecords.call(this, store, correctionResponse);
+    this.set('submitAnswer', () => {});
 
-      const correctionResponse = store.createRecord('correction-response', {
-        feedback: 'Good job!',
-        status: 'ok',
-        solution: 'solution',
-      });
-      prepareContextRecords.call(this, store, correctionResponse);
-      this.set('submitAnswer', () => {});
+    // when
+    const screen = await render(
+      hbs`<Module::Qrocm @element={{this.el}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
+    );
 
-      // when
-      const screen = await render(
-        hbs`<Module::Qrocm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
-      );
+    // then
+    const status = screen.getByRole('status');
+    assert.strictEqual(status.innerText, 'Too Bad!');
+    assert.ok(screen.getByRole('group').disabled);
+    assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+  });
 
-      // then
-      const status = screen.getByRole('status');
-      assert.strictEqual(status.innerText, 'Good job!');
-      assert.ok(screen.getByRole('group').disabled);
-      assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+  test('should display retry button when a ko feedback appears', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const correctionResponse = store.createRecord('correction-response', {
+      feedback: 'Too Bad!',
+      status: 'ko',
+      solution: 'solution',
     });
 
-    test('should display a ko feedback when exists', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const correctionResponse = store.createRecord('correction-response', {
-        feedback: 'Too Bad!',
-        status: 'ko',
-        solution: 'solution',
-      });
-      prepareContextRecords.call(this, store, correctionResponse);
-      this.set('submitAnswer', () => {});
+    prepareContextRecords.call(this, store, correctionResponse);
+    this.set('submitAnswer', () => {});
 
-      // when
-      const screen = await render(
-        hbs`<Module::Qrocm @element={{this.el}} @submitAnswer={{this.submitAnswer}} @correction={{this.correctionResponse}} />`,
-      );
+    // when
+    const screen = await render(
+      hbs`<Module::Qrocm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+    );
 
-      // then
-      const status = screen.getByRole('status');
-      assert.strictEqual(status.innerText, 'Too Bad!');
-      assert.ok(screen.getByRole('group').disabled);
-      assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
+    // then
+    assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).exists();
+  });
+
+  test('should not display retry button when an ok feedback appears', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const correctionResponse = store.createRecord('correction-response', {
+      feedback: 'Nice!',
+      status: 'ok',
+      solution: 'solution',
     });
 
-    test('should display retry button when a ko feedback appears', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const correctionResponse = store.createRecord('correction-response', {
-        feedback: 'Too Bad!',
-        status: 'ko',
-        solution: 'solution',
-      });
+    prepareContextRecords.call(this, store, correctionResponse);
+    this.set('submitAnswer', () => {});
 
-      prepareContextRecords.call(this, store, correctionResponse);
-      this.set('submitAnswer', () => {});
+    // when
+    const screen = await render(
+      hbs`<Module::Qrocm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+    );
 
-      // when
-      const screen = await render(
-        hbs`<Module::Qrocm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
-      );
-
-      // then
-      assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).exists();
-    });
-
-    test('should not display retry button when an ok feedback appears', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const correctionResponse = store.createRecord('correction-response', {
-        feedback: 'Nice!',
-        status: 'ok',
-        solution: 'solution',
-      });
-
-      prepareContextRecords.call(this, store, correctionResponse);
-      this.set('submitAnswer', () => {});
-
-      // when
-      const screen = await render(
-        hbs`<Module::Qrocm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
-      );
-
-      // then
-      assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).doesNotExist();
-    });
+    // then
+    assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).doesNotExist();
   });
 });
-
-function prepareDeprecatedContextRecords(store, correctionResponse) {
-  const qrocm = {
-    id: '994b6a96-a3c2-47ae-a461-87548ac6e02b',
-    instruction: 'Instruction',
-    proposals: [
-      {
-        input: 'premiere-partie',
-        type: 'select',
-        display: 'block',
-        placeholder: '',
-        ariaLabel: 'select-aria',
-        defaultValue: '',
-        options: [
-          {
-            id: '1',
-            content: "l'identifiant",
-          },
-          {
-            id: '2',
-            content: "le fournisseur d'adresse mail",
-          },
-        ],
-      },
-    ],
-    type: 'qrocm',
-  };
-  store.createRecord('element-answer', {
-    correction: correctionResponse,
-    element: qrocm,
-  });
-  store.createRecord('grain', { id: 'id', elements: [qrocm] });
-  store.createRecord('element-answer', {
-    correction: correctionResponse,
-    elementId: qrocm.id,
-  });
-  this.set('el', qrocm);
-  this.set('correctionResponse', correctionResponse);
-}
 
 function prepareContextRecords(store, correctionResponse) {
   const qrocm = {

--- a/mon-pix/tests/unit/components/module/grain_test.js
+++ b/mon-pix/tests/unit/components/module/grain_test.js
@@ -6,274 +6,141 @@ import createPodsComponent from '../../../helpers/create-pods-component';
 module('Unit | Component | Module | Grain', function (hooks) {
   setupTest(hooks);
 
-  module('with elements', function () {
-    module('#hasAnswerableElements', function () {
-      module('when there are answerable elements in grain', function () {
-        test('should return true', function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const qcu = { type: 'qcu', isAnswerable: true };
-          const qcm = { type: 'qcm', isAnswerable: true };
-          const qrocm = { type: 'qrocm', isAnswerable: true };
-          const text = { type: 'text', isAnswerable: false };
-          const grain = store.createRecord('grain', {
-            elements: [qcu, qcm, qrocm, text],
-          });
-          const component = createPodsComponent('module/grain', { grain });
-
-          // when
-          const hasAnswerableElements = component.hasAnswerableElements;
-
-          // then
-          assert.true(hasAnswerableElements);
+  module('#hasAnswerableElements', function () {
+    module('when there are answerable elements in grain', function () {
+      test('should return true', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const qcu = { type: 'qcu', isAnswerable: true };
+        const qcm = { type: 'qcm', isAnswerable: true };
+        const qrocm = { type: 'qrocm', isAnswerable: true };
+        const text = { type: 'text', isAnswerable: false };
+        const grain = store.createRecord('grain', {
+          components: [
+            { type: 'element', element: qcu },
+            { type: 'element', element: qcm },
+            { type: 'element', element: qrocm },
+            { type: 'element', element: text },
+          ],
         });
-      });
+        const component = createPodsComponent('module/grain', { grain });
 
-      module('when there are no answerable element in grain', function () {
-        test('should return false', function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const text = { type: 'text', isAnswerable: false };
-          const grain = store.createRecord('grain', {
-            elements: [text],
-          });
-          const component = createPodsComponent('module/grain', { grain });
+        // when
+        const hasAnswerableElements = component.hasAnswerableElements;
 
-          // when
-          const hasAnswerableElements = component.hasAnswerableElements;
-
-          // then
-          assert.false(hasAnswerableElements);
-        });
+        // then
+        assert.true(hasAnswerableElements);
       });
     });
 
-    module('#answerableElements', function () {
-      module('when there are answerable elements in elements', function () {
-        test('should return only answerable elements', function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const qcu = { type: 'qcu', isAnswerable: true };
-          const qcm = { type: 'qcm', isAnswerable: true };
-          const qrocm = { type: 'qrocm', isAnswerable: true };
-          const text = { type: 'text', isAnswerable: false };
-          const grain = store.createRecord('grain', {
-            elements: [qcu, qcm, qrocm, text],
-          });
-          const component = createPodsComponent('module/grain', { grain });
-
-          // when
-          const answerableElements = component.answerableElements;
-
-          // then
-          assert.strictEqual(answerableElements.length, 3);
-          assert.deepEqual(answerableElements, [qcu, qcm, qrocm]);
+    module('when there are no answerable element in grain', function () {
+      test('should return false', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const text = { type: 'text', isAnswerable: false };
+        const grain = store.createRecord('grain', {
+          components: [{ type: 'element', element: text }],
         });
-      });
+        const component = createPodsComponent('module/grain', { grain });
 
-      module('when there are no answerable elements in elements', function () {
-        test('should return an empty array', function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const text = { type: 'text' };
-          const grain = store.createRecord('grain', {
-            elements: [text],
-          });
-          const component = createPodsComponent('module/grain', { grain });
+        // when
+        const hasAnswerableElements = component.hasAnswerableElements;
 
-          // when
-          const answerableElements = component.answerableElements;
-
-          // then
-          assert.strictEqual(answerableElements.length, 0);
-        });
-      });
-    });
-
-    module('#allElementsAreAnswered', function () {
-      module('when all answerable elements are answered', function () {
-        test('should return true', function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const qcu = { id: 'qcu-id-1', type: 'qcu' };
-          const elementAnswer = store.createRecord('element-answer', {
-            elementId: qcu.id,
-          });
-          const passage = store.createRecord('passage', {
-            elementAnswers: [elementAnswer],
-          });
-          const grain = store.createRecord('grain', {
-            elements: [qcu],
-          });
-
-          const component = createPodsComponent('module/grain', { grain, passage });
-
-          // when
-          const allElementsAreAnswered = component.allElementsAreAnswered;
-
-          // then
-          assert.true(allElementsAreAnswered);
-        });
-      });
-
-      module('when all answerable elements are not answered', function () {
-        test('should return false', function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const qcu = { type: 'qcu', isAnswerable: true };
-          const grain = store.createRecord('grain', {
-            elements: [qcu],
-          });
-          const passage = store.createRecord('passage');
-          const component = createPodsComponent('module/grain', { grain, passage });
-
-          // when
-          const allElementsAreAnswered = component.allElementsAreAnswered;
-
-          // then
-          assert.false(allElementsAreAnswered);
-        });
+        // then
+        assert.false(hasAnswerableElements);
       });
     });
   });
 
-  module('with components', function () {
-    module('#hasAnswerableElements', function () {
-      module('when there are answerable elements in grain', function () {
-        test('should return true', function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const qcu = { type: 'qcu', isAnswerable: true };
-          const qcm = { type: 'qcm', isAnswerable: true };
-          const qrocm = { type: 'qrocm', isAnswerable: true };
-          const text = { type: 'text', isAnswerable: false };
-          const grain = store.createRecord('grain', {
-            components: [
-              { type: 'element', element: qcu },
-              { type: 'element', element: qcm },
-              { type: 'element', element: qrocm },
-              { type: 'element', element: text },
-            ],
-          });
-          const component = createPodsComponent('module/grain', { grain });
-
-          // when
-          const hasAnswerableElements = component.hasAnswerableElements;
-
-          // then
-          assert.true(hasAnswerableElements);
+  module('#answerableElements', function () {
+    module('when there are answerable elements in elements', function () {
+      test('should return only answerable elements', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const qcu = { type: 'qcu', isAnswerable: true };
+        const qcm = { type: 'qcm', isAnswerable: true };
+        const qrocm = { type: 'qrocm', isAnswerable: true };
+        const text = { type: 'text', isAnswerable: false };
+        const grain = store.createRecord('grain', {
+          components: [
+            { type: 'element', element: qcu },
+            { type: 'element', element: qcm },
+            { type: 'element', element: qrocm },
+            { type: 'element', element: text },
+          ],
         });
-      });
+        const component = createPodsComponent('module/grain', { grain });
 
-      module('when there are no answerable element in grain', function () {
-        test('should return false', function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const text = { type: 'text', isAnswerable: false };
-          const grain = store.createRecord('grain', {
-            components: [{ type: 'element', element: text }],
-          });
-          const component = createPodsComponent('module/grain', { grain });
+        // when
+        const answerableElements = component.answerableElements;
 
-          // when
-          const hasAnswerableElements = component.hasAnswerableElements;
-
-          // then
-          assert.false(hasAnswerableElements);
-        });
+        // then
+        assert.strictEqual(answerableElements.length, 3);
+        assert.deepEqual(answerableElements, [qcu, qcm, qrocm]);
       });
     });
 
-    module('#answerableElements', function () {
-      module('when there are answerable elements in elements', function () {
-        test('should return only answerable elements', function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const qcu = { type: 'qcu', isAnswerable: true };
-          const qcm = { type: 'qcm', isAnswerable: true };
-          const qrocm = { type: 'qrocm', isAnswerable: true };
-          const text = { type: 'text', isAnswerable: false };
-          const grain = store.createRecord('grain', {
-            components: [
-              { type: 'element', element: qcu },
-              { type: 'element', element: qcm },
-              { type: 'element', element: qrocm },
-              { type: 'element', element: text },
-            ],
-          });
-          const component = createPodsComponent('module/grain', { grain });
-
-          // when
-          const answerableElements = component.answerableElements;
-
-          // then
-          assert.strictEqual(answerableElements.length, 3);
-          assert.deepEqual(answerableElements, [qcu, qcm, qrocm]);
+    module('when there are no answerable elements in elements', function () {
+      test('should return an empty array', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const text = { type: 'text' };
+        const grain = store.createRecord('grain', {
+          components: [{ type: 'element', element: text }],
         });
+        const component = createPodsComponent('module/grain', { grain });
+
+        // when
+        const answerableElements = component.answerableElements;
+
+        // then
+        assert.strictEqual(answerableElements.length, 0);
       });
+    });
+  });
 
-      module('when there are no answerable elements in elements', function () {
-        test('should return an empty array', function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const text = { type: 'text' };
-          const grain = store.createRecord('grain', {
-            components: [{ type: 'element', element: text }],
-          });
-          const component = createPodsComponent('module/grain', { grain });
-
-          // when
-          const answerableElements = component.answerableElements;
-
-          // then
-          assert.strictEqual(answerableElements.length, 0);
+  module('#allElementsAreAnswered', function () {
+    module('when all answerable elements are answered', function () {
+      test('should return true', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const qcu = { id: 'qcu-id-1', type: 'qcu' };
+        const elementAnswer = store.createRecord('element-answer', {
+          elementId: qcu.id,
         });
+        const passage = store.createRecord('passage', {
+          elementAnswers: [elementAnswer],
+        });
+        const grain = store.createRecord('grain', {
+          components: [{ type: 'element', element: qcu }],
+        });
+
+        const component = createPodsComponent('module/grain', { grain, passage });
+
+        // when
+        const allElementsAreAnswered = component.allElementsAreAnswered;
+
+        // then
+        assert.true(allElementsAreAnswered);
       });
     });
 
-    module('#allElementsAreAnswered', function () {
-      module('when all answerable elements are answered', function () {
-        test('should return true', function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const qcu = { id: 'qcu-id-1', type: 'qcu' };
-          const elementAnswer = store.createRecord('element-answer', {
-            elementId: qcu.id,
-          });
-          const passage = store.createRecord('passage', {
-            elementAnswers: [elementAnswer],
-          });
-          const grain = store.createRecord('grain', {
-            components: [{ type: 'element', element: qcu }],
-          });
-
-          const component = createPodsComponent('module/grain', { grain, passage });
-
-          // when
-          const allElementsAreAnswered = component.allElementsAreAnswered;
-
-          // then
-          assert.true(allElementsAreAnswered);
+    module('when all answerable elements are not answered', function () {
+      test('should return false', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const qcu = { type: 'qcu', isAnswerable: true };
+        const grain = store.createRecord('grain', {
+          components: [{ type: 'element', element: qcu }],
         });
-      });
+        const passage = store.createRecord('passage');
+        const component = createPodsComponent('module/grain', { grain, passage });
 
-      module('when all answerable elements are not answered', function () {
-        test('should return false', function (assert) {
-          // given
-          const store = this.owner.lookup('service:store');
-          const qcu = { type: 'qcu', isAnswerable: true };
-          const grain = store.createRecord('grain', {
-            components: [{ type: 'element', element: qcu }],
-          });
-          const passage = store.createRecord('passage');
-          const component = createPodsComponent('module/grain', { grain, passage });
+        // when
+        const allElementsAreAnswered = component.allElementsAreAnswered;
 
-          // when
-          const allElementsAreAnswered = component.allElementsAreAnswered;
-
-          // then
-          assert.false(allElementsAreAnswered);
-        });
+        // then
+        assert.false(allElementsAreAnswered);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la migration de la structure des modules, nous avons supprimé côté API la notion d'`elements` pour ne garder que les `components`.
Il faut désormais faire le même travail côté front.

## :robot: Proposition
Ce travail côté front est facilité par les précédentes étapes de migration. Beaucoup de tests ont été doublé pour couvrir le cas des tableaux d'`elements` et les cas des tableaux de `components`.
Dans ce cas de figure, il suffit de supprimer les cas des tableaux d'`elements`.

À d'autres endroits des tests, la notion d'`elements` existe encore, il faut donc les remplacer par des `components`.

En dehors des tests, la logique des `elements` et des `components` est encapsulée dans la méthode `Grain.getSupportedElements` ce qui facilite notre tâche.

Il faut cependant remplacer les `elements` par des `components` dans le controller `ModulePreviewController` (ainsi que dans le test d'acceptance de la page).

## :rainbow: Remarques

## :100: Pour tester
Faire des tests de non regression sur les modules de Modulix (ex: https://app-pr8880.review.pix.fr/modules/didacticiel-modulix)
