### PR TITLE
[BUGFIX] Redonner toute la hauteur au textarea de la preview de modules (PIX-12468)

### DIFF
--- a/mon-pix/app/styles/pages/_module-preview.scss
+++ b/mon-pix/app/styles/pages/_module-preview.scss
@@ -19,6 +19,10 @@
 
         .pix-textarea {
             height: 100%;
+
+            div {
+              height: 100%;
+            }
         }
     }
 }


### PR DESCRIPTION
## :unicorn: Problème
Depuis [la version 45.0.0](https://github.com/1024pix/pix-ui/releases/tag/v45.0.0) de Pix UI, la zone de texte de la prévisualisation de modules ne prend plus toute la hauteur disponible.

## :robot: Proposition
Cela est dû au fait que dans [un des commits](https://github.com/1024pix/pix-ui/pull/568/commits/647d4fd7581eb1282cddff7a4b2371dcf399b146#diff-ede0986101162c80f725bc03917bd683d53688222194d7ee4c07dd4e2fbef6d1) de cette version 45.0.0, une `div` intermédiaire a été ajoutée dans le composant `PixTextarea` de Pix UI, ce qui casse le style CSS de notre page.
Étant donné que notre feuille de style brisait déjà le 4ème mur de Pix UI en ciblant la `div` interne `.pix-textarea`, je me suis permis d'y rajouter la nouvelle `div` introduite dans le commit cité ci-dessus.

## :rainbow: Remarques
Cette proposition de fix est loin d'être idéale car elle renforce d'autant plus la dépendance entre notre feuille de style et celle du composant venu de Pix UI.
Il faudra surement en re-discuter.

## :100: Pour tester
Vérifier sur [la review app](https://app-pr8881.review.pix.fr/modules/preview) que la zone de texte a bien repris toute la hauteur.
