### PR TITLE
[FEATURE] Utiliser l'attribut `isDisabled` des PixCheckbox et PixRadioButton (PIX-12471)

### DIFF
--- a/mon-pix/app/pods/components/module/qcm/component.js
+++ b/mon-pix/app/pods/components/module/qcm/component.js
@@ -13,6 +13,10 @@ export default class ModuleQcm extends ModuleElement {
     return [...this.selectedAnswerIds];
   }
 
+  get disableInput() {
+    return super.disableInput ? 'true' : null;
+  }
+
   resetAnswers() {
     this.selectedAnswerIds = new Set();
   }

--- a/mon-pix/app/pods/components/module/qcm/template.hbs
+++ b/mon-pix/app/pods/components/module/qcm/template.hbs
@@ -1,5 +1,5 @@
 <form class="element-qcm">
-  <fieldset disabled={{this.disableInput}}>
+  <fieldset>
     <div class="element-qcm__header">
       <legend class="element-qcm-header__direction">
         {{t "pages.modulix.qcm.direction"}}
@@ -13,7 +13,11 @@
     <div class="element-qcm__proposals">
       {{#each this.element.proposals as |proposal|}}
         <div class="element-qcm-proposals__proposal">
-          <PixCheckbox name={{this.element.id}} {{on "click" (fn this.checkboxSelected proposal.id)}}>
+          <PixCheckbox
+            name={{this.element.id}}
+            disabled={{this.disableInput}}
+            {{on "click" (fn this.checkboxSelected proposal.id)}}
+          >
             <:label>{{proposal.content}}</:label>
           </PixCheckbox>
         </div>

--- a/mon-pix/app/pods/components/module/qcm/template.hbs
+++ b/mon-pix/app/pods/components/module/qcm/template.hbs
@@ -15,7 +15,7 @@
         <div class="element-qcm-proposals__proposal">
           <PixCheckbox
             name={{this.element.id}}
-            disabled={{this.disableInput}}
+            @isDisabled={{this.disableInput}}
             {{on "click" (fn this.checkboxSelected proposal.id)}}
           >
             <:label>{{proposal.content}}</:label>

--- a/mon-pix/app/pods/components/module/qcu/component.js
+++ b/mon-pix/app/pods/components/module/qcu/component.js
@@ -22,4 +22,8 @@ export default class ModuleQcu extends ModuleElement {
   get userResponse() {
     return [this.selectedAnswerId];
   }
+
+  get disableInput() {
+    return super.disableInput ? 'true' : null;
+  }
 }

--- a/mon-pix/app/pods/components/module/qcu/template.hbs
+++ b/mon-pix/app/pods/components/module/qcu/template.hbs
@@ -1,5 +1,5 @@
 <form class="element-qcu">
-  <fieldset disabled={{this.disableInput}}>
+  <fieldset>
     <div class="element-qcu__header">
       <legend class="element-qcu-header__direction">
         {{t "pages.modulix.qcu.direction"}}
@@ -16,6 +16,7 @@
           <PixRadioButton
             name={{this.element.id}}
             @value={{proposal.id}}
+            disabled={{this.disableInput}}
             {{on "click" (fn this.radioClicked proposal.id)}}
           >
             <:label>

--- a/mon-pix/app/pods/components/module/qcu/template.hbs
+++ b/mon-pix/app/pods/components/module/qcu/template.hbs
@@ -16,7 +16,7 @@
           <PixRadioButton
             name={{this.element.id}}
             @value={{proposal.id}}
-            disabled={{this.disableInput}}
+            @isDisabled={{this.disableInput}}
             {{on "click" (fn this.radioClicked proposal.id)}}
           >
             <:label>

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -13,7 +13,7 @@
         "@1024pix/ember-matomo-tag-manager": "^2.4.3",
         "@1024pix/ember-testing-library": "^1.1.0",
         "@1024pix/eslint-config": "^1.2.12",
-        "@1024pix/pix-ui": "^45.4.1",
+        "@1024pix/pix-ui": "^45.5.0",
         "@1024pix/stylelint-config": "^5.1.12",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.2",
@@ -153,9 +153,9 @@
       "dev": true
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "45.4.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-45.4.1.tgz",
-      "integrity": "sha512-wG5kCNTf0b5cW4Y2stmwqrGuS0afE4WitG2JlNTAA7sEn7ws/jeUSFZPieNwYr5VQ8jk84iuBEYPZ56T9Qqv5A==",
+      "version": "45.5.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-45.5.0.tgz",
+      "integrity": "sha512-Ybsu/Oojyo+uzI2r/Bv383Crmtl6RTqS+565sM/QbWp/VCez9sdlUqSfHhljAUqJ2kz2MTOMxb2FyuMmtZsXwA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -45,7 +45,7 @@
     "@1024pix/ember-matomo-tag-manager": "^2.4.3",
     "@1024pix/ember-testing-library": "^1.1.0",
     "@1024pix/eslint-config": "^1.2.12",
-    "@1024pix/pix-ui": "^45.4.1",
+    "@1024pix/pix-ui": "^45.5.0",
     "@1024pix/stylelint-config": "^5.1.12",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.2",

--- a/mon-pix/tests/integration/components/module/qcm_test.js
+++ b/mon-pix/tests/integration/components/module/qcm_test.js
@@ -146,9 +146,9 @@ module('Integration | Component | Module | QCM', function (hooks) {
       // then
       const status = screen.getByRole('status');
       assert.strictEqual(status.innerText, 'Good job!');
-      assert.ok(screen.getByRole('checkbox', { name: 'checkbox1' }).disabled);
-      assert.ok(screen.getByRole('checkbox', { name: 'checkbox2' }).disabled);
-      assert.ok(screen.getByRole('checkbox', { name: 'checkbox3' }).disabled);
+      assert.ok(screen.getByRole('checkbox', { name: 'checkbox1', disabled: true }));
+      assert.ok(screen.getByRole('checkbox', { name: 'checkbox2', disabled: true }));
+      assert.ok(screen.getByRole('checkbox', { name: 'checkbox3', disabled: true }));
       assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
     });
 
@@ -172,9 +172,9 @@ module('Integration | Component | Module | QCM', function (hooks) {
       // then
       const status = screen.getByRole('status');
       assert.strictEqual(status.innerText, 'Too Bad!');
-      assert.ok(screen.getByRole('checkbox', { name: 'checkbox1' }).disabled);
-      assert.ok(screen.getByRole('checkbox', { name: 'checkbox2' }).disabled);
-      assert.ok(screen.getByRole('checkbox', { name: 'checkbox3' }).disabled);
+      assert.ok(screen.getByRole('checkbox', { name: 'checkbox1', disabled: true }));
+      assert.ok(screen.getByRole('checkbox', { name: 'checkbox2', disabled: true }));
+      assert.ok(screen.getByRole('checkbox', { name: 'checkbox3', disabled: true }));
       assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
     });
 
@@ -243,9 +243,9 @@ module('Integration | Component | Module | QCM', function (hooks) {
       // then
       const status = screen.getByRole('status');
       assert.strictEqual(status.innerText, 'Good job!');
-      assert.ok(screen.getByRole('checkbox', { name: 'checkbox1' }).disabled);
-      assert.ok(screen.getByRole('checkbox', { name: 'checkbox2' }).disabled);
-      assert.ok(screen.getByRole('checkbox', { name: 'checkbox3' }).disabled);
+      assert.ok(screen.getByRole('checkbox', { name: 'checkbox1', disabled: true }));
+      assert.ok(screen.getByRole('checkbox', { name: 'checkbox2', disabled: true }));
+      assert.ok(screen.getByRole('checkbox', { name: 'checkbox3', disabled: true }));
       assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
     });
 
@@ -269,9 +269,10 @@ module('Integration | Component | Module | QCM', function (hooks) {
       // then
       const status = screen.getByRole('status');
       assert.strictEqual(status.innerText, 'Too Bad!');
-      assert.ok(screen.getByRole('checkbox', { name: 'checkbox1' }).disabled);
-      assert.ok(screen.getByRole('checkbox', { name: 'checkbox2' }).disabled);
-      assert.ok(screen.getByRole('checkbox', { name: 'checkbox3' }).disabled);
+
+      assert.ok(screen.getByRole('checkbox', { name: 'checkbox1', disabled: true }));
+      assert.ok(screen.getByRole('checkbox', { name: 'checkbox2', disabled: true }));
+      assert.ok(screen.getByRole('checkbox', { name: 'checkbox3', disabled: true }));
       assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
     });
 

--- a/mon-pix/tests/integration/components/module/qcm_test.js
+++ b/mon-pix/tests/integration/components/module/qcm_test.js
@@ -146,7 +146,9 @@ module('Integration | Component | Module | QCM', function (hooks) {
       // then
       const status = screen.getByRole('status');
       assert.strictEqual(status.innerText, 'Good job!');
-      assert.ok(screen.getByRole('group').disabled);
+      assert.ok(screen.getByRole('checkbox', { name: 'checkbox1' }).disabled);
+      assert.ok(screen.getByRole('checkbox', { name: 'checkbox2' }).disabled);
+      assert.ok(screen.getByRole('checkbox', { name: 'checkbox3' }).disabled);
       assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
     });
 
@@ -170,7 +172,9 @@ module('Integration | Component | Module | QCM', function (hooks) {
       // then
       const status = screen.getByRole('status');
       assert.strictEqual(status.innerText, 'Too Bad!');
-      assert.ok(screen.getByRole('group').disabled);
+      assert.ok(screen.getByRole('checkbox', { name: 'checkbox1' }).disabled);
+      assert.ok(screen.getByRole('checkbox', { name: 'checkbox2' }).disabled);
+      assert.ok(screen.getByRole('checkbox', { name: 'checkbox3' }).disabled);
       assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
     });
 
@@ -239,7 +243,9 @@ module('Integration | Component | Module | QCM', function (hooks) {
       // then
       const status = screen.getByRole('status');
       assert.strictEqual(status.innerText, 'Good job!');
-      assert.ok(screen.getByRole('group').disabled);
+      assert.ok(screen.getByRole('checkbox', { name: 'checkbox1' }).disabled);
+      assert.ok(screen.getByRole('checkbox', { name: 'checkbox2' }).disabled);
+      assert.ok(screen.getByRole('checkbox', { name: 'checkbox3' }).disabled);
       assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
     });
 
@@ -263,7 +269,9 @@ module('Integration | Component | Module | QCM', function (hooks) {
       // then
       const status = screen.getByRole('status');
       assert.strictEqual(status.innerText, 'Too Bad!');
-      assert.ok(screen.getByRole('group').disabled);
+      assert.ok(screen.getByRole('checkbox', { name: 'checkbox1' }).disabled);
+      assert.ok(screen.getByRole('checkbox', { name: 'checkbox2' }).disabled);
+      assert.ok(screen.getByRole('checkbox', { name: 'checkbox3' }).disabled);
       assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
     });
 

--- a/mon-pix/tests/integration/components/module/qcu_test.js
+++ b/mon-pix/tests/integration/components/module/qcu_test.js
@@ -136,7 +136,8 @@ module('Integration | Component | Module | QCU', function (hooks) {
       // then
       const status = screen.getByRole('status');
       assert.strictEqual(status.innerText, 'Good job!');
-      assert.ok(screen.getByRole('group').disabled);
+      assert.ok(screen.getByRole('radio', { name: 'radio1' }).disabled);
+      assert.ok(screen.getByRole('radio', { name: 'radio2' }).disabled);
       assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
     });
 
@@ -160,7 +161,8 @@ module('Integration | Component | Module | QCU', function (hooks) {
       // then
       const status = screen.getByRole('status');
       assert.strictEqual(status.innerText, 'Too Bad!');
-      assert.ok(screen.getByRole('group').disabled);
+      assert.ok(screen.getByRole('radio', { name: 'radio1' }).disabled);
+      assert.ok(screen.getByRole('radio', { name: 'radio2' }).disabled);
       assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
     });
 
@@ -229,7 +231,8 @@ module('Integration | Component | Module | QCU', function (hooks) {
       // then
       const status = screen.getByRole('status');
       assert.strictEqual(status.innerText, 'Good job!');
-      assert.ok(screen.getByRole('group').disabled);
+      assert.ok(screen.getByRole('radio', { name: 'radio1' }).disabled);
+      assert.ok(screen.getByRole('radio', { name: 'radio2' }).disabled);
       assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
     });
 
@@ -253,7 +256,8 @@ module('Integration | Component | Module | QCU', function (hooks) {
       // then
       const status = screen.getByRole('status');
       assert.strictEqual(status.innerText, 'Too Bad!');
-      assert.ok(screen.getByRole('group').disabled);
+      assert.ok(screen.getByRole('radio', { name: 'radio1' }).disabled);
+      assert.ok(screen.getByRole('radio', { name: 'radio2' }).disabled);
       assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
     });
 

--- a/mon-pix/tests/integration/components/module/qcu_test.js
+++ b/mon-pix/tests/integration/components/module/qcu_test.js
@@ -136,8 +136,8 @@ module('Integration | Component | Module | QCU', function (hooks) {
       // then
       const status = screen.getByRole('status');
       assert.strictEqual(status.innerText, 'Good job!');
-      assert.ok(screen.getByRole('radio', { name: 'radio1' }).disabled);
-      assert.ok(screen.getByRole('radio', { name: 'radio2' }).disabled);
+      assert.ok(screen.getByRole('radio', { name: 'radio1', disabled: true }));
+      assert.ok(screen.getByRole('radio', { name: 'radio2', disabled: true }));
       assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
     });
 
@@ -161,8 +161,8 @@ module('Integration | Component | Module | QCU', function (hooks) {
       // then
       const status = screen.getByRole('status');
       assert.strictEqual(status.innerText, 'Too Bad!');
-      assert.ok(screen.getByRole('radio', { name: 'radio1' }).disabled);
-      assert.ok(screen.getByRole('radio', { name: 'radio2' }).disabled);
+      assert.ok(screen.getByRole('radio', { name: 'radio1', disabled: true }));
+      assert.ok(screen.getByRole('radio', { name: 'radio2', disabled: true }));
       assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
     });
 
@@ -231,8 +231,8 @@ module('Integration | Component | Module | QCU', function (hooks) {
       // then
       const status = screen.getByRole('status');
       assert.strictEqual(status.innerText, 'Good job!');
-      assert.ok(screen.getByRole('radio', { name: 'radio1' }).disabled);
-      assert.ok(screen.getByRole('radio', { name: 'radio2' }).disabled);
+      assert.ok(screen.getByRole('radio', { name: 'radio1', disabled: true }));
+      assert.ok(screen.getByRole('radio', { name: 'radio2', disabled: true }));
       assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
     });
 
@@ -256,8 +256,8 @@ module('Integration | Component | Module | QCU', function (hooks) {
       // then
       const status = screen.getByRole('status');
       assert.strictEqual(status.innerText, 'Too Bad!');
-      assert.ok(screen.getByRole('radio', { name: 'radio1' }).disabled);
-      assert.ok(screen.getByRole('radio', { name: 'radio2' }).disabled);
+      assert.ok(screen.getByRole('radio', { name: 'radio1', disabled: true }));
+      assert.ok(screen.getByRole('radio', { name: 'radio2', disabled: true }));
       assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).doesNotExist();
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Une fois soumis, nos QCU/QCM ne sont plus navigables par les utilisateurs de lecteurs d'écran.

## :robot: Proposition
Arrêter d’utiliser `disabled` à l'échelle du form et préférer les attributs `isDisabled` sur nos composants `PixCheckbox` et `PixRadioButton`.

## :rainbow: Remarques

### ⚠️ Montée de version de pix-ui inside

Pour pouvoir bénéficier correctement de la props `@isDisabled`, il a fallu que je passe la dépendance Pix UI en 45.5.0.

Autre petite remarque:

Dans Pix UI, dans [la documentation des composants](https://ui.pix.fr/?path=/docs/form-checkbox--docs#usage), c'est l'usage de l'attribut natif `disabled` qui est proposé.
```html
<PixCheckbox
  @screenReaderOnly="{{false}}"
  @isIndeterminate="{{false}}"
  @size="small"
  disabled
>
  <:label>Recevoir la newsletter</:label>
</PixCheckbox>
```
Une petite mise à jour de la doc à prévoir ?

## :100: Pour tester
Se rendre sur [le didacticiel](https://app-pr8882.review.pix.fr/modules/didacticiel-modulix)

1. Répondre à un QCU
2. Valider que les propositions sont bien _disabled_.
3. Naviguer sur l'élément avec le lecteur d'écran.

1. Répondre à un QCM
2. Valider que les propositions sont bien _disabled_.
3. Naviguer sur l'élément avec le lecteur d'écran.