### PR TITLE
[TYPO] Correction d'une petite typo dans la page de création d'une orga

### DIFF
--- a/admin/app/components/organizations/creation-form.hbs
+++ b/admin/app/components/organizations/creation-form.hbs
@@ -1,7 +1,7 @@
 <form class="admin-form" {{on "submit" @onSubmit}}>
 
   <section class="admin-form__content admin-form__content--with-counters">
-    <Card class="admin-form__card" @title="Informations générique">
+    <Card class="admin-form__card" @title="Information générique">
       <PixInput
         @id="organizationName"
         onchange={{this.handleOrganizationNameChange}}


### PR DESCRIPTION
## :unicorn: Problème
La page de création d'une orga indique `Informations générale`


## :robot: Proposition
Corrigé en enlevant le s à information.

## :rainbow: Remarques
RAS

## :100: Pour tester
Voir à la création d'une orga et observer que `Information générale` n'affiche plus de `s` en trop.
