### PR TITLE
[BUGFIX] Le texte alternatif des épreuves ne s'affichait pas si c'était null (PIX-12479)

### DIFF
--- a/mon-pix/app/components/challenge-illustration.hbs
+++ b/mon-pix/app/components/challenge-illustration.hbs
@@ -7,7 +7,7 @@
 
   <img
     src="{{@src}}"
-    alt="{{@alt}}"
+    alt="{{this.alt}}"
     class="challenge-illustration__loaded-image {{this.hiddenClass}}"
     {{on "load" this.onImageLoaded}}
   />

--- a/mon-pix/app/components/challenge-illustration.js
+++ b/mon-pix/app/components/challenge-illustration.js
@@ -5,6 +5,10 @@ export default class ChallengeIllustration extends Component {
   hiddenClass = 'challenge-illustration__loaded-image--hidden';
   displayPlaceholder = true;
 
+  get alt() {
+    return this.args.alt ?? '';
+  }
+
   @action
   onImageLoaded() {
     trySet(this, 'displayPlaceholder', false);

--- a/mon-pix/app/models/challenge.js
+++ b/mon-pix/app/models/challenge.js
@@ -11,12 +11,7 @@ export default class Challenge extends Model {
   @attr('string') embedTitle;
   @attr('string') embedHeight;
   @attr('string') format;
-  @attr('string', {
-    defaultValue() {
-      return '';
-    },
-  })
-  illustrationAlt;
+  @attr('string') illustrationAlt;
   @attr('string') illustrationUrl;
   @attr('string') instruction;
   @attr('string') alternativeInstruction;

--- a/mon-pix/tests/integration/components/challenge-illustration_test.js
+++ b/mon-pix/tests/integration/components/challenge-illustration_test.js
@@ -30,4 +30,20 @@ module('Integration | Component | challenge-illustration', function (hooks) {
     assert.dom(visibleImage).hasAttribute('src', imageSource);
     assert.dom(screen.queryByLabelText("Chargement de l'image en cours")).doesNotExist();
   });
+
+  test('should set an empty alt when illustrationAlt is null', async function (assert) {
+    // given
+    const imageSource = 'http://www.example.com/this-is-an-example.png';
+    const imageAlternativeText = null;
+
+    this.set('src', imageSource);
+    this.set('alt', imageAlternativeText);
+
+    // when
+    const screen = await render(hbs`<ChallengeIllustration @src={{this.src}} @alt={{this.alt}}/>`);
+
+    // then
+    const hiddenImage = await screen.getByAltText('');
+    assert.dom(hiddenImage).exists();
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Côté release, les textes alternatifs des illustrations des challenges sont null s'il n'y en a pas.
Côté Ember, il y a une defaultValue() qui était définie mais qui ne fonctionne que si l'alt est undefined.
Il en résulte un alt inexistant.

## :robot: Proposition
Retirer la defaultValue côté illustrationAlt (challenge model), et écrire un getter dans le component correspondant (challenge-illustration)

## :rainbow: Remarques
RAS

## :100: Pour tester
Chercher une épreuve avec une illustration et s'assurer dans la console que l'attribut alt apparaît bien même s'il n'est pas renseigné.
