### PR TITLE
[BUGFIX] Rendre visible les checkboxs dont le label est masqué sur Pix Certif (PIX-12482).

### DIFF
--- a/certif/app/components/members-list-item.hbs
+++ b/certif/app/components/members-list-item.hbs
@@ -3,9 +3,9 @@
   <td>{{@member.firstName}}</td>
   <td>
     {{#if this.isEditionMode}}
-      <div id="selectCertificationCenterRole">
+      <div class="members-list-item__container">
+
         <PixSelect
-          class="table__input"
           @screenReaderOnly={{true}}
           @hideDefaultOption={{true}}
           @placeholder="{{t 'pages.team.members.actions.select-role.label'}}"
@@ -68,7 +68,7 @@
   {{#if @shouldDisplayRefererColumn}}
     <td>
       {{#if @member.isReferer}}
-        <div class="members-list-item__is-referer">
+        <div class="members-list-item__container">
           <PixTag class="members-list-item__tag" @color="primary">
             {{t "pages.team.pix-referer"}}
           </PixTag>

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
@@ -105,20 +105,22 @@
             </div>
           </td>
           <td class="finalization-report-abort-reason">
-            <PixSelect
-              @screenReaderOnly="true"
-              @id={{concat "finalization-report-abort-reason__select" report.id}}
-              @placeholder="-- {{t 'common.actions.choose'}} --"
-              @onChange={{fn @onChangeAbortReason report}}
-              @hideDefaultOption={{true}}
-              @value={{report.abortReason}}
-              required="required"
-              @options={{this.abortOptions}}
-            >
-              <:label>{{t
-                  "pages.session-finalization.reporting.uncompleted-reports-information.table.labels.abandonment-reason-label"
-                }}</:label>
-            </PixSelect>
+            <div>
+              <PixSelect
+                @screenReaderOnly="true"
+                @id={{concat "finalization-report-abort-reason__select" report.id}}
+                @placeholder="-- {{t 'common.actions.choose'}} --"
+                @onChange={{fn @onChangeAbortReason report}}
+                @hideDefaultOption={{true}}
+                @value={{report.abortReason}}
+                required="required"
+                @options={{this.abortOptions}}
+              >
+                <:label>{{t
+                    "pages.session-finalization.reporting.uncompleted-reports-information.table.labels.abandonment-reason-label"
+                  }}</:label>
+              </PixSelect>
+            </div>
           </td>
         </tr>
       {{/each}}

--- a/certif/app/styles/components/finalize.scss
+++ b/certif/app/styles/components/finalize.scss
@@ -45,6 +45,10 @@
 
 .finalization-report-abort-reason {
 
+  div {
+    display: flex;
+  }
+
   select:invalid {
     border: var(--pix-error-700) 1px solid;
   }

--- a/certif/app/styles/components/members-list-item.scss
+++ b/certif/app/styles/components/members-list-item.scss
@@ -1,6 +1,6 @@
 .members-list-item {
 
-  &__is-referer {
+  &__container {
     display: flex;
   }
 

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-testing-library": "^1.1.0",
         "@1024pix/eslint-config": "^1.2.12",
-        "@1024pix/pix-ui": "^45.4.1",
+        "@1024pix/pix-ui": "^45.5.2",
         "@1024pix/stylelint-config": "^5.1.12",
         "@babel/eslint-parser": "^7.22.15",
         "@babel/plugin-proposal-decorators": "^7.22.15",
@@ -130,9 +130,9 @@
       "dev": true
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "45.4.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-45.4.1.tgz",
-      "integrity": "sha512-wG5kCNTf0b5cW4Y2stmwqrGuS0afE4WitG2JlNTAA7sEn7ws/jeUSFZPieNwYr5VQ8jk84iuBEYPZ56T9Qqv5A==",
+      "version": "45.5.2",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-45.5.2.tgz",
+      "integrity": "sha512-J5xnlvfgIUA1zr1zQUN9NI7fWN+/w6PibhZvSK+Y+rZWBbdesl7fqoFS+8C+sVsrp08j8StoTS2IEYJYClBMCg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@1024pix/ember-testing-library": "^1.1.0",
     "@1024pix/eslint-config": "^1.2.12",
-    "@1024pix/pix-ui": "^45.4.1",
+    "@1024pix/pix-ui": "^45.5.2",
     "@1024pix/stylelint-config": "^5.1.12",
     "@babel/eslint-parser": "^7.22.15",
     "@babel/plugin-proposal-decorators": "^7.22.15",


### PR DESCRIPTION
## :unicorn: Problème
La version [45.4.1](https://github.com/1024pix/pix-ui/compare/v45.4.0...v45.4.1) de Pix UI a introduit un bug dans les checkboxs dont les labels sont masqué en screen-reader-only.

![Capture d’écran 2024-05-13 à 14 36 45](https://github.com/1024pix/pix/assets/58915422/47b5acb2-a136-4466-814d-4080777d9f25)


## :robot: Proposition
[Une correction a été apporté dans la nouvelle version de Pix UI](https://github.com/1024pix/pix-ui/pull/632). Mettre à jour la version sur Pix Certif

## :100: Pour tester
- Se connecter avec Pix Certif avec certif-sco@example.net
- Créer une session
- Aller dans l'onglet Candidats et ajouter un candidat
- Constater que les checkbox sont de nouveau visibles
- Sélectionner des candidats et valider pour constater la non régression des checkboxs
- (si vous voulez vérifier d'autres checkbox dans l'application => finaliser une session ou inviter un membre pour accéder à la double mire)


- dans l'onglet équipe, petite correction sur le select pour qu'il soit aligné. Vérifier que c'est ok.
<img width="554" alt="Capture d’écran 2024-05-13 à 16 22 23" src="https://github.com/1024pix/pix/assets/58915422/06e9a460-080f-42e7-aace-9f64d80c054b">
