### PR TITLE
[BUGFIX] Ne plus envoyer le hasComplementaryReferential lors de l'ajout d'un candidat avec certification complémentaire sur Pix Certif (PIX-12491).

### DIFF
--- a/certif/app/serializers/certification-candidate.js
+++ b/certif/app/serializers/certification-candidate.js
@@ -1,0 +1,11 @@
+import JSONAPISerializer from '@ember-data/serializer/json-api';
+
+export default class CertificationCandidateSerializer extends JSONAPISerializer {
+  serialize(...args) {
+    const json = super.serialize(...args);
+
+    delete json.data.attributes['complementary-certification']?.hasComplementaryReferential;
+
+    return json;
+  }
+}

--- a/certif/app/serializers/certification-candidate.js
+++ b/certif/app/serializers/certification-candidate.js
@@ -1,6 +1,10 @@
 import JSONAPISerializer from '@ember-data/serializer/json-api';
 
 export default class CertificationCandidateSerializer extends JSONAPISerializer {
+  // This bypasses extractErrors emberData behavior which relies on the property being a function.
+  // This should not be needed after upgrading to ember-data v5
+  extractErrors = false;
+
   serialize(...args) {
     const json = super.serialize(...args);
 

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -455,7 +455,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
                     },
                   ],
                 }),
-                422,
+                400,
               );
 
               // when

--- a/certif/tests/unit/serializers/certification-candidate_test.js
+++ b/certif/tests/unit/serializers/certification-candidate_test.js
@@ -1,0 +1,43 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Serializer | certification-candidate', function (hooks) {
+  setupTest(hooks);
+
+  test('should serialize a certification candidate', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const serializer = this.owner.lookup('serializer:certification-candidate');
+    const record = store.createRecord('certification-candidate', {
+      firstName: 'Alain',
+      lastName: 'Cendy',
+      birthCity: 'Eu',
+      birthCountry: 'France',
+      email: 'alaincendy@example.net',
+      resultRecipientEmail: 'test@example.net',
+      externalId: '12345',
+      birthdate: '2000-12-25',
+      extraTimePercentage: 0.1,
+      birthInseeCode: 76255,
+      birthPostalCode: 76260,
+      sex: 'F',
+      complementaryCertification: { key: 'COMP', label: 'complémentaire', hasComplementaryReferential: true },
+    });
+    const snapshot = record._createSnapshot();
+
+    const json = serializer.serialize(snapshot);
+
+    assert.strictEqual(json.data.attributes['first-name'], 'Alain');
+    assert.strictEqual(json.data.attributes['last-name'], 'Cendy');
+    assert.strictEqual(json.data.attributes['birth-city'], 'Eu');
+    assert.strictEqual(json.data.attributes['birth-country'], 'France');
+    assert.strictEqual(json.data.attributes.email, 'alaincendy@example.net');
+    assert.strictEqual(json.data.attributes['result-recipient-email'], 'test@example.net');
+    assert.strictEqual(json.data.attributes['external-id'], '12345');
+    assert.strictEqual(json.data.attributes.birthdate, '2000-12-25');
+    assert.strictEqual(json.data.attributes['extra-time-percentage'], 0.1);
+    assert.strictEqual(json.data.attributes['birth-insee-code'], '76255');
+    assert.strictEqual(json.data.attributes['birth-postal-code'], '76260');
+    assert.strictEqual(json.data.attributes.sex, 'F');
+    assert.deepEqual(json.data.attributes['complementary-certification'], { key: 'COMP', label: 'complémentaire' });
+  });
+});

--- a/certif/tests/unit/serializers/certification-candidate_test.js
+++ b/certif/tests/unit/serializers/certification-candidate_test.js
@@ -20,7 +20,6 @@ module('Unit | Serializer | certification-candidate', function (hooks) {
       birthInseeCode: 76255,
       birthPostalCode: 76260,
       sex: 'F',
-      complementaryCertification: { key: 'COMP', label: 'complémentaire', hasComplementaryReferential: true },
     });
     const snapshot = record._createSnapshot();
 
@@ -38,6 +37,20 @@ module('Unit | Serializer | certification-candidate', function (hooks) {
     assert.strictEqual(json.data.attributes['birth-insee-code'], '76255');
     assert.strictEqual(json.data.attributes['birth-postal-code'], '76260');
     assert.strictEqual(json.data.attributes.sex, 'F');
-    assert.deepEqual(json.data.attributes['complementary-certification'], { key: 'COMP', label: 'complémentaire' });
+    assert.strictEqual(json.data.attributes['complementary-certification'], undefined);
+  });
+
+  module('when there is a complementary certification', function () {
+    test('should serialize a certification candidate', function (assert) {
+      const store = this.owner.lookup('service:store');
+      const serializer = this.owner.lookup('serializer:certification-candidate');
+      const record = store.createRecord('certification-candidate', {
+        complementaryCertification: { key: 'COMP', label: 'complémentaire', hasComplementaryReferential: true },
+      });
+      const snapshot = record._createSnapshot();
+
+      const json = serializer.serialize(snapshot);
+      assert.deepEqual(json.data.attributes['complementary-certification'], { key: 'COMP', label: 'complémentaire' });
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Un bug a été introduit lors de l'ajout d'un candidat via la modale sur Pix Certif. Il n'est plus possible d'effectuer un ajout lorsqu'on ajoute une certification complémentaire à ce dernier.
Un attribut hasComplementaryReferential s'est glissé dans l'envoi de données, et le joi de l'API jette l'appel.

## :robot: Proposition
Ne plus envoyer cet attribut via la création d'un serializer coté front.

## :100: Pour tester
- Se connecter sur certif avec certif-pro@example.net
- Aller sur une session et ajouter un candidat via la modale AVEC une complémentaire et constater que ça fonctionne ne nouveau !
