### PR TITLE
[BUGFIX] Enchainement effectif des étapes d'une mission (PIX-12489)

### DIFF
--- a/api/src/school/domain/services/init-mission-activity.js
+++ b/api/src/school/domain/services/init-mission-activity.js
@@ -32,7 +32,7 @@ export async function initMissionActivity({
     assessmentId,
     level: activityInfo.level,
     status: Activity.status.STARTED,
-    stepIndex: 0,
+    stepIndex: activityInfo.stepIndex,
     alternativeVersion,
   });
 

--- a/api/src/school/domain/usecases/get-next-challenge.js
+++ b/api/src/school/domain/usecases/get-next-challenge.js
@@ -19,7 +19,7 @@ export async function getNextChallenge({
   const answers = await activityAnswerRepository.findByActivity(activity.id);
 
   const challengeId = mission.getChallengeId({
-    activityInfo: new ActivityInfo({ level: activity.level, stepIndex: 0 }),
+    activityInfo: new ActivityInfo({ level: activity.level, stepIndex: activity.stepIndex }),
     challengeIndex: answers.length,
     alternativeVersion: activity.alternativeVersion,
   });

--- a/junior/app/modifiers/did-render.js
+++ b/junior/app/modifiers/did-render.js
@@ -1,0 +1,10 @@
+import { modifier } from 'ember-modifier';
+
+/**
+ * did-render is a modifier that executes the fn function passed as first arg
+ * each time the component is rendered
+ **/
+export default modifier(function (element, args) {
+  const [fn, ...positional] = args;
+  fn(element, positional);
+});

--- a/junior/app/pods/components/challenge/challenge-item-qrocm/component.js
+++ b/junior/app/pods/components/challenge/challenge-item-qrocm/component.js
@@ -8,8 +8,8 @@ import generateRandomString from '../../../../utils/generate-random-string';
 export default class ChallengeItemQrocm extends Component {
   @tracked answerValues;
 
-  constructor() {
-    super(...arguments);
+  @action
+  resetAnswerValues() {
     this.answerValues = this.#extractProposals();
   }
 

--- a/junior/app/pods/components/challenge/challenge-item-qrocm/template.hbs
+++ b/junior/app/pods/components/challenge/challenge-item-qrocm/template.hbs
@@ -1,4 +1,4 @@
-<div class="challenge-item-proposals">
+<div {{did-render this.resetAnswerValues}} class="challenge-item-proposals">
   {{#each this.proposalBlocks as |block|}}
     {{#if block.showText}}
       <Markdown::MarkdownToHtml


### PR DESCRIPTION
## :unicorn: Problème
Lorsque 2 QROCM se suivent, les infos du précédent continuaient d'être injecté, bloquant ainsi la progression de l'utilisateur. 
## :robot: Proposition
Ajouter une méthode dans le cycle de vie du composant pour purge les anciennes réponses.

## :100: Pour tester
Se connecter sur la RA, choisir la mission donnée personnelle, et lorsque que 2 QROCM se suivent, si vous avez réussi. 
Le parcours devrait continuer normalement sans erreurs dans la console. 