### PR TITLE
[TECH] découpe le use case d'import de learner sup (Pix-11942)

### DIFF
--- a/api/src/prescription/learner-management/application/sup-organization-management-controller.js
+++ b/api/src/prescription/learner-management/application/sup-organization-management-controller.js
@@ -19,11 +19,15 @@ const importSupOrganizationLearners = async function (
   let warnings;
 
   try {
-    warnings = await usecases.importSupOrganizationLearners({
+    await usecases.uploadCsvFile({
       payload: request.payload,
       organizationId,
-      i18n: request.i18n,
       userId: authenticatedUserId,
+      i18n: request.i18n,
+    });
+    warnings = await usecases.importSupOrganizationLearners({
+      organizationId,
+      i18n: request.i18n,
     });
   } finally {
     try {

--- a/api/src/prescription/learner-management/application/sup-organization-management-controller.js
+++ b/api/src/prescription/learner-management/application/sup-organization-management-controller.js
@@ -25,6 +25,10 @@ const importSupOrganizationLearners = async function (
       userId: authenticatedUserId,
       i18n: request.i18n,
     });
+    await usecases.validateSupCsvFile({
+      organizationId,
+      i18n: request.i18n,
+    });
     warnings = await usecases.importSupOrganizationLearners({
       organizationId,
       i18n: request.i18n,

--- a/api/src/prescription/learner-management/domain/usecases/import-sup-organization-learners.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-sup-organization-learners.js
@@ -1,45 +1,21 @@
-import { createReadStream } from 'node:fs';
-
 import { SupOrganizationLearnerParser } from '../../infrastructure/serializers/csv/sup-organization-learner-parser.js';
 import { getDataBuffer } from '../../infrastructure/utils/bufferize/get-data-buffer.js';
 import { AggregateImportError } from '../errors.js';
-import { OrganizationImport } from '../models/OrganizationImport.js';
 
 const importSupOrganizationLearners = async function ({
-  payload,
-  userId,
   organizationId,
   i18n,
   supOrganizationLearnerRepository,
   organizationImportRepository,
   importStorage,
-  dependencies = { createReadStream },
 }) {
-  let organizationImport = OrganizationImport.create({ organizationId, createdBy: userId });
-  let filename;
-  let encoding;
+  let organizationImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
   const errors = [];
   let learnersData, warningsData;
 
-  // Sending File
-  try {
-    filename = await importStorage.sendFile({ filepath: payload.path });
-
-    const readableStreamEncoding = dependencies.createReadStream(payload.path);
-    const bufferEncoding = await getDataBuffer(readableStreamEncoding);
-    const parserEncoding = SupOrganizationLearnerParser.create(bufferEncoding, organizationId, i18n);
-    encoding = parserEncoding.getFileEncoding();
-  } catch (error) {
-    errors.push(error);
-    throw error;
-  } finally {
-    organizationImport.upload({ filename, encoding, errors });
-    await organizationImportRepository.save(organizationImport);
-  }
-
   // Reading File
   try {
-    const readableStream = await importStorage.readFile({ filename });
+    const readableStream = await importStorage.readFile({ filename: organizationImport.filename });
 
     const buffer = await getDataBuffer(readableStream);
     const parser = SupOrganizationLearnerParser.create(buffer, organizationId, i18n);
@@ -56,13 +32,14 @@ const importSupOrganizationLearners = async function ({
     }
     throw error;
   } finally {
-    organizationImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
     organizationImport.validate({ errors, warnings: warningsData });
     await organizationImportRepository.save(organizationImport);
-    await importStorage.deleteFile({ filename });
+    await importStorage.deleteFile({ filename: organizationImport.filename });
   }
 
   // Insert Data
+  organizationImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
+
   try {
     await supOrganizationLearnerRepository.addStudents(learnersData);
 
@@ -71,7 +48,6 @@ const importSupOrganizationLearners = async function ({
     errors.push(error);
     throw error;
   } finally {
-    organizationImport = await organizationImportRepository.getLastByOrganizationId(organizationId);
     organizationImport.process({ errors });
     await organizationImportRepository.save(organizationImport);
   }

--- a/api/src/prescription/learner-management/domain/usecases/upload-csv-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/upload-csv-file.js
@@ -1,0 +1,37 @@
+import { createReadStream } from 'node:fs';
+
+import { SupOrganizationLearnerParser } from '../../infrastructure/serializers/csv/sup-organization-learner-parser.js';
+import { getDataBuffer } from '../../infrastructure/utils/bufferize/get-data-buffer.js';
+import { OrganizationImport } from '../models/OrganizationImport.js';
+
+const uploadCsvFile = async function ({
+  payload,
+  userId,
+  organizationId,
+  i18n,
+  organizationImportRepository,
+  importStorage,
+}) {
+  const organizationImport = OrganizationImport.create({ organizationId, createdBy: userId });
+  let filename;
+  let encoding;
+  const errors = [];
+
+  // Sending File
+  try {
+    filename = await importStorage.sendFile({ filepath: payload.path });
+
+    const readableStreamEncoding = createReadStream(payload.path);
+    const bufferEncoding = await getDataBuffer(readableStreamEncoding);
+    const parserEncoding = SupOrganizationLearnerParser.create(bufferEncoding, organizationId, i18n);
+    encoding = parserEncoding.getFileEncoding();
+  } catch (error) {
+    errors.push(error);
+    throw error;
+  } finally {
+    organizationImport.upload({ filename, encoding, errors });
+    await organizationImportRepository.save(organizationImport);
+  }
+};
+
+export { uploadCsvFile };

--- a/api/tests/prescription/learner-management/unit/application/sup-organization-management-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/sup-organization-management-controller_test.js
@@ -24,6 +24,7 @@ describe('Unit | Controller | sup-organization-management-controller', function 
     serializedResponse = Symbol('serializedResponse');
     userId = Symbol('userId');
 
+    sinon.stub(usecases, 'uploadCsvFile');
     sinon.stub(usecases, 'importSupOrganizationLearners');
     sinon.stub(usecases, 'replaceSupOrganizationLearners');
     supOrganizationLearnerWarningSerializerStub = { serialize: sinon.stub() };
@@ -32,7 +33,7 @@ describe('Unit | Controller | sup-organization-management-controller', function 
   });
 
   context('#importSupOrganizationLearners', function () {
-    it('should call importSupOrganizationLearners usecase and return 200', async function () {
+    it('should call uploadCsvFile and importSupOrganizationLearners usecase and return 200', async function () {
       const params = { id: organizationId };
       const request = {
         auth: { credentials: { userId } },
@@ -40,10 +41,10 @@ describe('Unit | Controller | sup-organization-management-controller', function 
         params,
         i18n,
       };
+      usecases.uploadCsvFile.rejects().withArgs({ userId, organizationId, payload: request.payload, i18n }).resolves();
       usecases.importSupOrganizationLearners
+        .rejects()
         .withArgs({
-          userId,
-          payload: request.payload,
           organizationId,
           i18n,
         })
@@ -75,10 +76,9 @@ describe('Unit | Controller | sup-organization-management-controller', function 
         params,
         i18n,
       };
+      usecases.uploadCsvFile.withArgs({ userId, payload: request.payload, organizationId, i18n }).resolves();
       usecases.importSupOrganizationLearners
         .withArgs({
-          userId,
-          payload: request.payload,
           organizationId,
           i18n,
         })

--- a/api/tests/prescription/learner-management/unit/application/sup-organization-management-controller_test.js
+++ b/api/tests/prescription/learner-management/unit/application/sup-organization-management-controller_test.js
@@ -25,6 +25,7 @@ describe('Unit | Controller | sup-organization-management-controller', function 
     userId = Symbol('userId');
 
     sinon.stub(usecases, 'uploadCsvFile');
+    sinon.stub(usecases, 'validateSupCsvFile');
     sinon.stub(usecases, 'importSupOrganizationLearners');
     sinon.stub(usecases, 'replaceSupOrganizationLearners');
     supOrganizationLearnerWarningSerializerStub = { serialize: sinon.stub() };
@@ -33,7 +34,7 @@ describe('Unit | Controller | sup-organization-management-controller', function 
   });
 
   context('#importSupOrganizationLearners', function () {
-    it('should call uploadCsvFile and importSupOrganizationLearners usecase and return 200', async function () {
+    it('should call uploadCsvFile, validateSupCsvFile and importSupOrganizationLearners usecase and return 200', async function () {
       const params = { id: organizationId };
       const request = {
         auth: { credentials: { userId } },
@@ -42,6 +43,7 @@ describe('Unit | Controller | sup-organization-management-controller', function 
         i18n,
       };
       usecases.uploadCsvFile.rejects().withArgs({ userId, organizationId, payload: request.payload, i18n }).resolves();
+      usecases.validateSupCsvFile.rejects().withArgs({ organizationId, i18n }).resolves();
       usecases.importSupOrganizationLearners
         .rejects()
         .withArgs({
@@ -62,6 +64,13 @@ describe('Unit | Controller | sup-organization-management-controller', function 
       });
 
       // then
+      expect(
+        sinon.assert.callOrder(
+          usecases.uploadCsvFile,
+          usecases.validateSupCsvFile,
+          usecases.importSupOrganizationLearners,
+        ),
+      ).to.not.throws;
       expect(response.statusCode).to.be.equal(200);
       expect(response.source).to.be.equal(serializedResponse);
 

--- a/api/tests/prescription/learner-management/unit/domain/usecases/import-sup-organization-learners_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/import-sup-organization-learners_test.js
@@ -1,11 +1,7 @@
-import { Readable } from 'node:stream';
-
-import iconv from 'iconv-lite';
-
 import { OrganizationImport } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationImport.js';
 import { importSupOrganizationLearners } from '../../../../../../src/prescription/learner-management/domain/usecases/import-sup-organization-learners.js';
 import { SupOrganizationLearnerImportHeader } from '../../../../../../src/prescription/learner-management/infrastructure/serializers/csv/sup-organization-learner-import-header.js';
-import { catchErr, expect, sinon } from '../../../../../test-helper.js';
+import { catchErr, expect, sinon, toStream } from '../../../../../test-helper.js';
 import { getI18n } from '../../../../../tooling/i18n/i18n.js';
 const i18n = getI18n();
 
@@ -15,68 +11,44 @@ const supOrganizationLearnerImportHeader = new SupOrganizationLearnerImportHeade
 
 describe('Unit | UseCase | ImportSupOrganizationLearner', function () {
   const organizationId = 1234;
-  let organizationImportRepositoryStub, supOrganizationLearnerRepositoryStub, importStorageStub, payload, filename;
+  let organizationImport, organizationImportRepositoryStub, supOrganizationLearnerRepositoryStub, importStorageStub;
 
   beforeEach(function () {
-    filename = Symbol('file.csv');
-    payload = { path: filename };
+    organizationImport = new OrganizationImport({
+      filename: 'file.csv',
+      organizationId,
+      createdBy: 2,
+      encoding: 'utf-8',
+    });
 
-    supOrganizationLearnerRepositoryStub = { addStudents: sinon.stub() };
-    supOrganizationLearnerRepositoryStub.addStudents.resolves();
-
-    importStorageStub = {
-      sendFile: sinon.stub(),
-      readFile: sinon.stub(),
-      deleteFile: sinon.stub(),
-    };
+    supOrganizationLearnerRepositoryStub = { addStudents: sinon.stub().resolves() };
 
     organizationImportRepositoryStub = {
       getLastByOrganizationId: sinon.stub(),
       save: sinon.stub(),
     };
 
-    organizationImportRepositoryStub.getLastByOrganizationId.callsFake(
-      () => new OrganizationImport({ organizationId, createdBy: 2, encoding: 'utf-8' }),
-    );
+    importStorageStub = {
+      readFile: sinon.stub(),
+      deleteFile: sinon.stub(),
+    };
   });
 
   context('when there is no errors', function () {
-    beforeEach(function () {
-      importStorageStub.sendFile.withArgs({ filepath: payload.path }).resolves(filename);
-    });
-
-    it('parses the csv received and creates the SupOrganizationLearner', async function () {
+    it('add students from csv fivle', async function () {
       const input = `${supOrganizationLearnerImportHeader}
           Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;12346;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;
           O-Ren;;;Ishii;Cottonmouth;01/01/1980;ishii@example.net;789;Assassination Squad;Bill;Deadly Viper Assassination Squad;DUT;;
       `.trim();
-
-      importStorageStub.readFile.withArgs({ filename }).resolves(
-        new Readable({
-          read() {
-            this.push(iconv.encode(input, 'utf8'));
-            this.push(null);
-          },
-        }),
-      );
+      organizationImportRepositoryStub.getLastByOrganizationId.withArgs(organizationId).resolves(organizationImport);
+      importStorageStub.readFile.withArgs({ filename: organizationImport.filename }).resolves(toStream(input));
 
       await importSupOrganizationLearners({
-        payload,
-        organizationId: 2,
+        organizationId,
         i18n,
-        importStorage: importStorageStub,
         supOrganizationLearnerRepository: supOrganizationLearnerRepositoryStub,
         organizationImportRepository: organizationImportRepositoryStub,
-        dependencies: {
-          createReadStream: sinon.stub().returns(
-            new Readable({
-              read() {
-                this.push(iconv.encode(input, 'utf8'));
-                this.push(null);
-              },
-            }),
-          ),
-        },
+        importStorage: importStorageStub,
       });
 
       expect(supOrganizationLearnerRepositoryStub.addStudents).to.have.been.calledWithExactly([
@@ -94,7 +66,7 @@ describe('Unit | UseCase | ImportSupOrganizationLearner', function () {
           educationalTeam: 'Hattori Hanzo',
           group: 'Deadly Viper Assassination Squad',
           studyScheme: 'Non reconnu',
-          organizationId: 2,
+          organizationId,
         },
         {
           firstName: 'O-Ren',
@@ -110,7 +82,7 @@ describe('Unit | UseCase | ImportSupOrganizationLearner', function () {
           educationalTeam: 'Bill',
           group: 'Deadly Viper Assassination Squad',
           studyScheme: 'Non reconnu',
-          organizationId: 2,
+          organizationId,
         },
       ]);
     });
@@ -119,33 +91,15 @@ describe('Unit | UseCase | ImportSupOrganizationLearner', function () {
       const input = `${supOrganizationLearnerImportHeader}
               Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;BAD;BAD;
           `.trim();
-
-      importStorageStub.readFile.withArgs({ filename }).resolves(
-        new Readable({
-          read() {
-            this.push(iconv.encode(input, 'utf8'));
-            this.push(null);
-          },
-        }),
-      );
+      organizationImportRepositoryStub.getLastByOrganizationId.withArgs(organizationId).resolves(organizationImport);
+      importStorageStub.readFile.withArgs({ filename: organizationImport.filename }).resolves(toStream(input));
 
       const warnings = await importSupOrganizationLearners({
-        payload,
-        importStorage: importStorageStub,
-        organizationId: 2,
+        organizationId,
         i18n,
+        importStorage: importStorageStub,
         supOrganizationLearnerRepository: supOrganizationLearnerRepositoryStub,
         organizationImportRepository: organizationImportRepositoryStub,
-        dependencies: {
-          createReadStream: sinon.stub().returns(
-            new Readable({
-              read() {
-                this.push(iconv.encode(input, 'utf8'));
-                this.push(null);
-              },
-            }),
-          ),
-        },
       });
 
       expect(warnings).to.deep.equal([
@@ -158,36 +112,18 @@ describe('Unit | UseCase | ImportSupOrganizationLearner', function () {
       const input = `${supOrganizationLearnerImportHeader}
               Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;
           `.trim();
-
-      importStorageStub.readFile.withArgs({ filename }).resolves(
-        new Readable({
-          read() {
-            this.push(iconv.encode(input, 'utf8'));
-            this.push(null);
-          },
-        }),
-      );
+      organizationImportRepositoryStub.getLastByOrganizationId.withArgs(organizationId).resolves(organizationImport);
+      importStorageStub.readFile.withArgs({ filename: organizationImport.filename }).resolves(toStream(input));
 
       await importSupOrganizationLearners({
-        payload,
-        importStorage: importStorageStub,
-        organizationId: 2,
+        organizationId,
         i18n,
+        importStorage: importStorageStub,
         supOrganizationLearnerRepository: supOrganizationLearnerRepositoryStub,
         organizationImportRepository: organizationImportRepositoryStub,
-        dependencies: {
-          createReadStream: sinon.stub().returns(
-            new Readable({
-              read() {
-                this.push(iconv.encode(input, 'utf8'));
-                this.push(null);
-              },
-            }),
-          ),
-        },
       });
 
-      expect(importStorageStub.deleteFile).to.have.been.calledWithExactly({ filename: payload.path });
+      expect(importStorageStub.deleteFile).to.have.been.calledWithExactly({ filename: organizationImport.filename });
     });
   });
 
@@ -195,170 +131,89 @@ describe('Unit | UseCase | ImportSupOrganizationLearner', function () {
     describe('success case', function () {
       it('should save uploaded, validated and imported state each after each', async function () {
         // given
-        importStorageStub.sendFile.withArgs({ filepath: payload.path }).resolves(filename);
+        organizationImportRepositoryStub.getLastByOrganizationId
+          .withArgs(organizationId)
+          // we create a new instance for each call so save spies will store different
+          // args object
+          .callsFake(() => new OrganizationImport({ ...organizationImport }));
 
-        const csv = `${supOrganizationLearnerImportHeader}
+        const csvContent = `${supOrganizationLearnerImportHeader}
         Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;BAD;BAD;
         `.trim();
 
-        importStorageStub.readFile.withArgs({ filename }).resolves(
-          new Readable({
-            read() {
-              this.push(iconv.encode(csv, 'utf8'));
-              this.push(null);
-            },
-          }),
-        );
+        importStorageStub.readFile.withArgs({ filename: organizationImport.filename }).resolves(toStream(csvContent));
 
         // when
         await importSupOrganizationLearners({
           organizationId,
-          payload,
-          supOrganizationLearnerRepository: supOrganizationLearnerRepositoryStub,
-          importStorage: importStorageStub,
-          organizationImportRepository: organizationImportRepositoryStub,
-          dependencies: {
-            createReadStream: sinon.stub().returns(
-              new Readable({
-                read() {
-                  this.push(iconv.encode(csv, 'utf8'));
-                  this.push(null);
-                },
-              }),
-            ),
-          },
           i18n,
+          supOrganizationLearnerRepository: supOrganizationLearnerRepositoryStub,
+          organizationImportRepository: organizationImportRepositoryStub,
+          importStorage: importStorageStub,
         });
 
         // then
+        const firstCallArg = organizationImportRepositoryStub.save.firstCall.firstArg;
+        const secondCallArg = organizationImportRepositoryStub.save.secondCall.firstArg;
 
-        const firstSaveCall = organizationImportRepositoryStub.save.getCall(0).args[0];
-        const secondSaveCall = organizationImportRepositoryStub.save.getCall(1).args[0];
-        const thirdSaveCall = organizationImportRepositoryStub.save.getCall(2).args[0];
-
-        expect(firstSaveCall.status).to.equal('UPLOADED');
-        expect(secondSaveCall.status).to.equal('VALIDATED');
-        expect(thirdSaveCall.status).to.equal('IMPORTED');
+        expect(firstCallArg.status).to.equal('VALIDATED');
+        expect(secondCallArg.status).to.equal('IMPORTED');
       });
     });
 
     describe('errors case', function () {
-      describe('when there is an upload error', function () {
-        it('should save UPLOAD_ERROR status', async function () {
-          // given
-          const csv = `${supOrganizationLearnerImportHeader}`;
-          importStorageStub.sendFile.withArgs({ filepath: filename }).rejects();
+      beforeEach(function () {
+        organizationImportRepositoryStub.getLastByOrganizationId
+          .withArgs(organizationId)
+          // we create a new instance for each call so save spies will store different
+          // args object
+          .callsFake(() => new OrganizationImport({ ...organizationImport }));
 
-          // when
-          await catchErr(importSupOrganizationLearners)({
-            organizationId,
-            payload,
-            supOrganizationLearnerRepository: supOrganizationLearnerRepositoryStub,
-            importStorage: importStorageStub,
-            organizationImportRepository: organizationImportRepositoryStub,
-            dependencies: {
-              createReadStream: sinon.stub().returns(
-                new Readable({
-                  read() {
-                    this.push(iconv.encode(csv, 'utf8'));
-                    this.push(null);
-                  },
-                }),
-              ),
-            },
-            i18n,
-          });
-
-          // then
-
-          expect(organizationImportRepositoryStub.save.getCall(0).args[0].status).to.equal('UPLOAD_ERROR');
-        });
+        const csvContent = `${supOrganizationLearnerImportHeader}
+          Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;BAD;BAD;
+          `.trim();
+        importStorageStub.readFile.withArgs({ filename: organizationImport.filename }).resolves(toStream(csvContent));
       });
 
       describe('when there is an validation error', function () {
         it('should save VALIDATION_ERROR status', async function () {
           // given
-          importStorageStub.sendFile.withArgs({ filepath: filename }).resolves(filename);
-          const csv = `${supOrganizationLearnerImportHeader}
+          const csvContent = `${supOrganizationLearnerImportHeader}
           Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;BAD;BAD;
           Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;BAD;BAD;
           `.trim();
+          importStorageStub.readFile.withArgs({ filename: organizationImport.filename }).resolves(toStream(csvContent));
 
-          importStorageStub.readFile.withArgs({ filename }).resolves(
-            new Readable({
-              read() {
-                this.push(iconv.encode(csv, 'utf8'));
-                this.push(null);
-              },
-            }),
-          );
           // when
           await catchErr(importSupOrganizationLearners)({
             organizationId,
-            payload,
-            supOrganizationLearnerRepository: supOrganizationLearnerRepositoryStub,
-            importStorage: importStorageStub,
-            organizationImportRepository: organizationImportRepositoryStub,
-            dependencies: {
-              createReadStream: sinon.stub().returns(
-                new Readable({
-                  read() {
-                    this.push(iconv.encode(csv, 'utf8'));
-                    this.push(null);
-                  },
-                }),
-              ),
-            },
             i18n,
+            supOrganizationLearnerRepository: supOrganizationLearnerRepositoryStub,
+            organizationImportRepository: organizationImportRepositoryStub,
+            importStorage: importStorageStub,
           });
 
           // then
-          expect(organizationImportRepositoryStub.save.getCall(1).args[0].status).to.equal('VALIDATION_ERROR');
+          expect(organizationImportRepositoryStub.save.firstCall.firstArg.status).to.equal('VALIDATION_ERROR');
         });
       });
 
       describe('when there is an import error', function () {
         it('should save IMPORT_ERROR status', async function () {
           // given
-          importStorageStub.sendFile.withArgs({ filepath: filename }).resolves(filename);
-
-          const csv = `${supOrganizationLearnerImportHeader}
-          Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;BAD;BAD;
-          `.trim();
-
-          importStorageStub.readFile.withArgs({ filename }).resolves(
-            new Readable({
-              read() {
-                this.push(iconv.encode(csv, 'utf8'));
-                this.push(null);
-              },
-            }),
-          );
           supOrganizationLearnerRepositoryStub.addStudents.rejects('errors');
 
           // when
           await catchErr(importSupOrganizationLearners)({
             organizationId,
-            payload,
-            supOrganizationLearnerRepository: supOrganizationLearnerRepositoryStub,
-            importStorage: importStorageStub,
-            organizationImportRepository: organizationImportRepositoryStub,
-            dependencies: {
-              createReadStream: sinon.stub().returns(
-                new Readable({
-                  read() {
-                    this.push(iconv.encode(csv, 'utf8'));
-                    this.push(null);
-                  },
-                }),
-              ),
-            },
             i18n,
+            supOrganizationLearnerRepository: supOrganizationLearnerRepositoryStub,
+            organizationImportRepository: organizationImportRepositoryStub,
+            importStorage: importStorageStub,
           });
 
           // then
-
-          expect(organizationImportRepositoryStub.save.getCall(2).args[0].status).to.equal('IMPORT_ERROR');
+          expect(organizationImportRepositoryStub.save.secondCall.args[0].status).to.equal('IMPORT_ERROR');
         });
       });
     });

--- a/api/tests/prescription/learner-management/unit/domain/usecases/upload-csv-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/upload-csv-file_test.js
@@ -1,0 +1,106 @@
+import { IMPORT_STATUSES } from '../../../../../../src/prescription/learner-management/domain/constants.js';
+import { OrganizationImport } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationImport.js';
+import { uploadCsvFile } from '../../../../../../src/prescription/learner-management/domain/usecases/upload-csv-file.js';
+import { SupOrganizationLearnerImportHeader } from '../../../../../../src/prescription/learner-management/infrastructure/serializers/csv/sup-organization-learner-import-header.js';
+import { catchErr, createTempFile, expect, removeTempFile, sinon } from '../../../../../test-helper.js';
+import { getI18n } from '../../../../../tooling/i18n/i18n.js';
+
+const i18n = getI18n();
+const supOrganizationLearnerImportHeader = new SupOrganizationLearnerImportHeader(i18n).columns
+  .map((column) => column.name)
+  .join(';');
+
+describe('Unit | UseCase | ImportSupOrganizationLearner', function () {
+  const organizationId = 1;
+  const userId = 2;
+  let timer, fakeDate, organizationImportRepositoryStub, importStorageStub, payload, filepath, s3Filename;
+
+  beforeEach(async function () {
+    s3Filename = Symbol('filename');
+    filepath = await createTempFile(
+      'file.csv',
+      `${supOrganizationLearnerImportHeader}
+    Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;12346;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;
+    O-Ren;;;Ishii;Cottonmouth;01/01/1980;ishii@example.net;789;Assassination Squad;Bill;Deadly Viper Assassination Squad;DUT;;`,
+    );
+    payload = { path: filepath };
+    fakeDate = new Date('2019-01-10');
+    timer = sinon.useFakeTimers({
+      now: fakeDate,
+      toFake: ['Date'],
+    });
+
+    importStorageStub = {
+      sendFile: sinon.stub(),
+    };
+
+    organizationImportRepositoryStub = {
+      save: sinon.stub(),
+    };
+  });
+
+  afterEach(async function () {
+    timer.restore();
+    await removeTempFile(filepath);
+  });
+
+  context('when there is no errors', function () {
+    it('save import state in database', async function () {
+      // given
+      importStorageStub.sendFile.withArgs({ filepath: payload.path }).resolves(s3Filename);
+
+      // when
+      await uploadCsvFile({
+        payload,
+        userId,
+        organizationId,
+        i18n,
+        organizationImportRepository: organizationImportRepositoryStub,
+        importStorage: importStorageStub,
+      });
+
+      // then
+      expect(organizationImportRepositoryStub.save).to.have.been.calledOnce;
+      expect(organizationImportRepositoryStub.save.firstCall.args[0]).to.deep.equals(
+        new OrganizationImport({
+          organizationId,
+          createdBy: userId,
+          createdAt: fakeDate,
+          updatedAt: fakeDate,
+          encoding: 'utf-8',
+          filename: s3Filename,
+          status: IMPORT_STATUSES.UPLOADED,
+        }),
+      );
+    });
+  });
+  context('when there is an upload error', function () {
+    it('save UPLOAD_ERROR state in database', async function () {
+      // given
+      importStorageStub.sendFile.withArgs({ filepath: payload.path }).rejects();
+
+      // when
+      const error = await catchErr(uploadCsvFile)({
+        payload,
+        userId,
+        organizationId,
+        i18n,
+        organizationImportRepository: organizationImportRepositoryStub,
+        importStorage: importStorageStub,
+      });
+
+      // then
+      expect(organizationImportRepositoryStub.save).to.have.been.calledOnce;
+      expect(organizationImportRepositoryStub.save.firstCall.args[0]).to.deep.equals(
+        new OrganizationImport({
+          organizationId,
+          createdBy: userId,
+          createdAt: fakeDate,
+          errors: [error],
+          status: IMPORT_STATUSES.UPLOAD_ERROR,
+          updatedAt: fakeDate,
+        }),
+      );
+    });
+  });
+});

--- a/api/tests/prescription/learner-management/unit/domain/usecases/valide-sup-csv-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/valide-sup-csv-file_test.js
@@ -1,0 +1,90 @@
+import { OrganizationImport } from '../../../../../../src/prescription/learner-management/domain/models/OrganizationImport.js';
+import { validateSupCsvFile } from '../../../../../../src/prescription/learner-management/domain/usecases/validate-sup-csv-file.js';
+import { SupOrganizationLearnerImportHeader } from '../../../../../../src/prescription/learner-management/infrastructure/serializers/csv/sup-organization-learner-import-header.js';
+import { catchErr, expect, sinon, toStream } from '../../../../../test-helper.js';
+import { getI18n } from '../../../../../tooling/i18n/i18n.js';
+
+const i18n = getI18n();
+
+const supOrganizationLearnerImportHeader = new SupOrganizationLearnerImportHeader(i18n).columns
+  .map((column) => column.name)
+  .join(';');
+
+describe('Unit | UseCase | ImportSupOrganizationLearner', function () {
+  const organizationId = 1234;
+  let organizationImport, organizationImportRepositoryStub, importStorageStub;
+
+  beforeEach(function () {
+    organizationImport = new OrganizationImport({
+      filename: 'file.csv',
+      organizationId,
+      createdBy: 2,
+      encoding: 'utf-8',
+    });
+
+    organizationImportRepositoryStub = {
+      getLastByOrganizationId: sinon.stub(),
+      save: sinon.stub(),
+    };
+
+    importStorageStub = {
+      readFile: sinon.stub(),
+      deleteFile: sinon.stub(),
+    };
+  });
+
+  context('when there is no errors', function () {
+    it('should save validated state', async function () {
+      // given
+      organizationImportRepositoryStub.getLastByOrganizationId.withArgs(organizationId).resolves(organizationImport);
+
+      const csvContent = `${supOrganizationLearnerImportHeader}
+      Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;BAD;BAD;
+      `.trim();
+
+      importStorageStub.readFile.withArgs({ filename: organizationImport.filename }).resolves(toStream(csvContent));
+
+      // when
+      await validateSupCsvFile({
+        organizationId,
+        i18n,
+        organizationImportRepository: organizationImportRepositoryStub,
+        importStorage: importStorageStub,
+      });
+
+      // then
+      expect(organizationImportRepositoryStub.save).to.have.been.calledOnceWithExactly(organizationImport);
+    });
+  });
+
+  context('when there is errors', function () {
+    beforeEach(function () {
+      organizationImportRepositoryStub.getLastByOrganizationId.withArgs(organizationId).resolves(organizationImport);
+
+      const csvContent = `${supOrganizationLearnerImportHeader}
+          Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;BAD;BAD;
+          `.trim();
+      importStorageStub.readFile.withArgs({ filename: organizationImport.filename }).resolves(toStream(csvContent));
+    });
+
+    it('should save VALIDATION_ERROR status', async function () {
+      // given
+      const csvContent = `${supOrganizationLearnerImportHeader}
+          Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;BAD;BAD;
+          Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;BAD;BAD;
+          `.trim();
+      importStorageStub.readFile.withArgs({ filename: organizationImport.filename }).resolves(toStream(csvContent));
+
+      // when
+      await catchErr(validateSupCsvFile)({
+        organizationId,
+        i18n,
+        organizationImportRepository: organizationImportRepositoryStub,
+        importStorage: importStorageStub,
+      });
+
+      // then
+      expect(organizationImportRepositoryStub.save.firstCall.firstArg.status).to.equal('VALIDATION_ERROR');
+    });
+  });
+});

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -2,6 +2,7 @@
 /* eslint-disable n/no-unpublished-import */
 import 'dayjs/locale/fr.js';
 
+import { Readable } from 'node:stream';
 import * as url from 'node:url';
 
 import { Assertion, AssertionError, expect, use as chaiUse, util as chaiUtil } from 'chai';
@@ -10,6 +11,7 @@ import chaiSorted from 'chai-sorted';
 import dayjs from 'dayjs';
 import localizedFormat from 'dayjs/plugin/localizedFormat.js';
 import * as dotenv from 'dotenv';
+import iconv from 'iconv-lite';
 import _ from 'lodash';
 import MockDate from 'mockdate';
 import nock from 'nock';
@@ -73,6 +75,15 @@ after(function () {
 });
 
 /* eslint-enable mocha/no-top-level-hooks */
+
+function toStream(data, encoding = 'utf8') {
+  return new Readable({
+    read() {
+      this.push(iconv.encode(data, encoding));
+      this.push(null);
+    },
+  });
+}
 
 function generateValidRequestAuthorizationHeader(userId = 1234, source = 'pix') {
   const accessToken = tokenService.createAccessTokenFromUser(userId, source).accessToken;
@@ -304,4 +315,5 @@ export {
   sinon,
   streamToPromise,
   testErr,
+  toStream,
 };


### PR DESCRIPTION
## :unicorn: Problème
On souhaite basculer nos import en asynchrone pour faciliter le travail des captains en cas de charge. Pour cela, nous avons besoin de séparer les étapes de envoi / validation  / import 

## :robot: Proposition
On découpe le usecase principal en 3 usecase

## :rainbow: Remarques
On profite du découpage pour simplifier un peu les tests

## :100: Pour tester
Se connecter sur orga avec `sup-orga@example.net`
faire un import de fichier sup
constater le succès / echec
