### PR TITLE
[TECH] Parallélise l'exécution des tests d'acceptance de l'API sur la CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -414,7 +414,7 @@ jobs:
           name: Test
           command: |
             circleci tests glob 'tests/**/acceptance/**/*test.js' |
-            circleci tests split |
+            circleci tests split --split-by=filesize |
             xargs npm run test:api:path --
           environment:
             NODE_ENV: test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -400,6 +400,7 @@ jobs:
     executor:
       name: node-redis-postgres-s3-docker
     working_directory: ~/pix/api
+    parallelism: 3
     steps:
       - attach_workspace:
           at: ~/pix
@@ -411,7 +412,10 @@ jobs:
             TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci_acceptance
       - run:
           name: Test
-          command: npm run test:api:acceptance
+          command: |
+            circleci tests glob 'tests/**/acceptance/**/*test.js' |
+            circleci tests split |
+            xargs npm run test:api:path --
           environment:
             NODE_ENV: test
             TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci_acceptance


### PR DESCRIPTION
## :egg: Problème
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Le job `api_acceptance_test` est un des plus longs jobs.

## :bowl_with_spoon: Proposition
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
On utilise les fonctionnalités offertes par CircleCI, notamment les deux commandes suivantes.
`circleci tests glob` qui permet de lister tous les fichiers de tests à exécuter.
`circleci tests split` qui permet d'exécuter les tests répartis sur les différents conteneurs.

En configurant la parallélisation à 3 conteneurs, les 919 tests d'acceptance sont exécutés en 2m 9s contre 3m 56s sans parallélisation.

## :milk_glass: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->
En jouant avec les options de `circleci tests split` on peut éventuellement mieux répartir les tests.
On pourrait surement paralléliser l'exécution des tests e2e également.

## :butter: Pour tester

Admirer la vitesse du job `api_acceptance_test`.
