### PR TITLE
[TECH] Utiliser le composant Pixtoggle pour filtrer les campagnes que l'on souhaite voir (PIX-10467)

### DIFF
--- a/orga/app/components/campaign/filter/campaign-filters.hbs
+++ b/orga/app/components/campaign/filter/campaign-filters.hbs
@@ -24,32 +24,13 @@
     />
   {{/unless}}
 
-  <div role="radiogroup" class="campaign-filters__type">
-    <input
-      id="ongoing-campaigns"
-      type="radio"
-      class="campaign-filters__radio"
-      checked={{not this.isArchived}}
-      {{on "click" (fn @onFilter "status" null)}}
-    />
-    <label
-      for="ongoing-campaigns"
-      class="campaign-filters__tab {{unless this.isArchived 'campaign-filters__tab--active'}}"
-    >
-      {{t "pages.campaigns-list.action.ongoing.label"}}
-    </label>
-    <input
-      id="archived-campaigns"
-      type="radio"
-      class="campaign-filters__radio"
-      checked={{this.isArchived}}
-      {{on "click" (fn @onFilter "status" "archived")}}
-    />
-    <label
-      for="archived-campaigns"
-      class="campaign-filters__tab {{if this.isArchived 'campaign-filters__tab--active'}}"
-    >
-      {{t "pages.campaigns-list.action.archived.label"}}
-    </label>
-  </div>
+  <PixToggle
+    @onLabel={{t "pages.campaigns-list.action.campaign.ongoing"}}
+    @offLabel={{t "pages.campaigns-list.action.campaign.archived"}}
+    @toggled={{this.isToggleSwitched}}
+    @onChange={{this.onToggle}}
+    @screenReaderOnly={{true}}
+  >
+    <:label>{{t "pages.campaigns-list.action.campaign.label"}}</:label>
+  </PixToggle>
 </PixFilterBanner>

--- a/orga/app/components/campaign/filter/campaign-filters.js
+++ b/orga/app/components/campaign/filter/campaign-filters.js
@@ -1,8 +1,9 @@
+import { action } from '@ember/object';
 import Component from '@glimmer/component';
 
 export default class CampaignFilters extends Component {
-  get isArchived() {
-    return this.args.statusFilter === 'archived';
+  get isToggleSwitched() {
+    return this.args.statusFilter !== 'archived';
   }
 
   get isClearFiltersButtonDisabled() {
@@ -11,5 +12,11 @@ export default class CampaignFilters extends Component {
       !this.args.statusFilter &&
       (this.args.listOnlyCampaignsOfCurrentUser || !this.args.ownerNameFilter)
     );
+  }
+
+  @action
+  onToggle() {
+    const status = this.isToggleSwitched ? 'archived' : null;
+    this.args.onFilter('status', status);
   }
 }

--- a/orga/tests/acceptance/campaign-list-all-campaigns_test.js
+++ b/orga/tests/acceptance/campaign-list-all-campaigns_test.js
@@ -230,13 +230,12 @@ module('Acceptance | campaigns/all-campaigns', function (hooks) {
           // when
           await fillByLabel('Rechercher une campagne', campaignName1);
           await fillByLabel('Rechercher un propriétaire', owner.firstName);
-          await clickByName('Archivées');
+          await clickByName(this.intl.t('pages.campaigns-list.action.campaign.label'));
           await clickByName(this.intl.t('pages.campaigns-list.filter.clear'));
 
           //then
           assert.ok(screen.getByLabelText(this.intl.t('pages.campaigns-list.filter.by-owner')));
           assert.ok(screen.getByLabelText(this.intl.t('pages.campaigns-list.filter.by-name')));
-          assert.dom(screen.getByText('Actives')).hasClass('campaign-filters__tab--active');
           assert.deepEqual(currentURL(), '/campagnes/toutes');
         });
       });

--- a/orga/tests/acceptance/campaign-list-my-campaigns_test.js
+++ b/orga/tests/acceptance/campaign-list-my-campaigns_test.js
@@ -158,12 +158,11 @@ module('Acceptance | /campaigns/list/my-campaigns ', function (hooks) {
 
             // when
             await fillByLabel('Rechercher une campagne', 'ma super campagne');
-            await clickByName('Archivées');
+            await clickByName(this.intl.t('pages.campaigns-list.action.campaign.label'));
             await clickByName(this.intl.t('pages.campaigns-list.filter.clear'));
 
             //then
             assert.ok(screen.getByPlaceholderText(this.intl.t('pages.campaigns-list.filter.by-name')));
-            assert.dom(screen.getByText('Actives')).hasClass('campaign-filters__tab--active');
             assert.deepEqual(currentURL(), '/campagnes/les-miennes');
           });
         });

--- a/orga/tests/integration/components/campaign/filter/campaign-filters_test.js
+++ b/orga/tests/integration/components/campaign/filter/campaign-filters_test.js
@@ -27,8 +27,7 @@ module('Integration | Component | Campaign::Filter::CampaignFilters', function (
     assert.dom(screen.getByText(this.intl.t('pages.campaigns-list.filter.title'))).exists();
     assert.dom(screen.getByLabelText(this.intl.t('pages.campaigns-list.filter.by-name'))).exists();
     assert.dom(screen.getByLabelText(this.intl.t('pages.campaigns-list.filter.by-owner'))).exists();
-    assert.dom(screen.getByLabelText(this.intl.t('pages.campaigns-list.action.archived.label'))).exists();
-    assert.dom(screen.getByLabelText(this.intl.t('pages.campaigns-list.action.ongoing.label'))).exists();
+    assert.dom(screen.getByLabelText(this.intl.t('pages.campaigns-list.action.campaign.label'))).exists();
     assert.dom(screen.getByText(this.intl.t('pages.campaigns-list.filter.results', { total: 1 }))).exists();
   });
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -652,13 +652,12 @@
     "campaigns-list": {
       "title": "Campaigns",
       "action": {
-        "archived": {
-          "label": "Archived"
+        "campaign": {
+          "archived": "Archived",
+          "label": "Show on ongoing or archived campaigns",
+          "ongoing": "Ongoing"
         },
-        "create": "Create a campaign",
-        "ongoing": {
-          "label": "Ongoing"
-        }
+        "create": "Create a campaign"
       },
       "filter": {
         "title": "Filters",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -652,13 +652,12 @@
     "campaigns-list": {
       "title": "Campagnes",
       "action": {
-        "archived": {
-          "label": "Archivées"
+        "campaign": {
+          "archived": "Archivées",
+          "label": "Afficher les campagnes actives ou archivées",
+          "ongoing": "Actives"
         },
-        "create": "Créer une campagne",
-        "ongoing": {
-          "label": "Actives"
-        }
+        "create": "Créer une campagne"
       },
       "filter": {
         "title": "Filtres",


### PR DESCRIPTION
## :unicorn: Problème
Nous avons un composant dans le design system pour avoir un toggle, or actuellement sur PixOrga, nous utilisons le toggle custom lorsque 🎵 celui là n'existez pas 🎵 .

## :robot: Proposition
Utiliser le composant PixToggle

## :rainbow: Remarques
* Ce qui me chagrinne dans ce ticket, c'est qu'à mon sens le PixToggle n'est pas accessible en l'état. ( mais quand nous le rendrons accessible sur PixUI. ce sera automatiquement reporté içi) 
* Il faut  revoir la traduction du label du PixToggle
* le sizing du toggle est assez étrange

## :100: Pour tester
Aller sur PixOrga et vérifier que l'on peut toujours filtrer sur les campagnes actives/archiver