### PR TITLE
[FEATURE] Ajout du support de Typescript sur PixOrga (PIX-12474)

### DIFF
--- a/orga/app/app.js
+++ b/orga/app/app.js
@@ -22,3 +22,7 @@ library.add(fapixTachometer, fapixPersonExport, fapixInboxIn, fapixTicket);
 dom.watch();
 
 loadInitializers(App, config.modulePrefix);
+
+/**
+ * @typedef {import('ember-source/types')} EmberTypes
+ */


### PR DESCRIPTION
## :unicorn: Problème


## :robot: Proposition
Suite aux récentes montée de version d'Ember sur Pix Orga, on à maintenant la possibilité d'ajouter le support de typescript dans Ember.
Même si actuellement nous ne developpons pas en TS, cet ajout permet de bénéficier d'une doc sur les features d'ember plus complète ainsi que de l'auto import depuis les fichiers js. 
Je mets des captures d'écran avant/aprés : 

### Pour la doc
AVANT (sur VSCODE ou VIM) : 
![image](https://github.com/1024pix/pix/assets/101280231/66bda376-89da-42c5-b96b-d41cec9aceae)

APRES : 
![image](https://github.com/1024pix/pix/assets/101280231/b6af8dbd-11ba-4781-b17d-d499dff6ceba)

### Pour l'auto-import : 
AVANT : 
![image](https://github.com/1024pix/pix/assets/101280231/24b0a40f-209a-4088-897e-e7382e786952)

APRES : 
![image](https://github.com/1024pix/pix/assets/101280231/10bea3b6-819b-417f-b64d-d29ad06504b1)


## :rainbow: Remarques
Documentation Ember 5.1 : https://blog.emberjs.com/stable-typescript-types-in-ember-5-1/

## :100: Pour tester
Refaire les manip des screens ci dessus : 

- Hover une méthode native d'ember et voir affiché la doc plus complète
- Faire (par exemple) un @action et voir apparaitre l'auto import
- 🐈‍⬛ 