### PR TITLE
[FEATURE] Supprimer la colonne "grainId" de la table "element-answers" (PIX-12459)

### DIFF
--- a/api/db/migrations/20240515132133_remove_grainId_from_element_answers.js
+++ b/api/db/migrations/20240515132133_remove_grainId_from_element_answers.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'element-answers';
+const COLUMN_NAME = 'grainId';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/src/devcomp/domain/usecases/verify-and-save-answer.js
+++ b/api/src/devcomp/domain/usecases/verify-and-save-answer.js
@@ -26,7 +26,6 @@ async function verifyAndSaveAnswer({
   return await elementAnswerRepository.save({
     passageId,
     elementId,
-    grainId: grain.id,
     value: element.userResponse,
     correction,
   });

--- a/api/src/devcomp/infrastructure/repositories/element-answer-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/element-answer-repository.js
@@ -1,11 +1,10 @@
 import { knex } from '../../../../db/knex-database-connection.js';
-import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { ElementAnswer } from '../../domain/models/ElementAnswer.js';
 
 const save = async function ({
   passageId,
   elementId,
-  grainId,
   value,
   correction,
   domainTransaction = DomainTransaction.emptyTransaction(),
@@ -15,7 +14,6 @@ const save = async function ({
     .insert({
       passageId,
       elementId,
-      grainId,
       value,
       status: correction.status.status,
       createdAt: new Date(),

--- a/api/tests/devcomp/integration/repositories/element-answer-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/element-answer-repository_test.js
@@ -23,7 +23,6 @@ describe('Integration | DevComp | Repositories | ElementAnswerRepository', funct
 
       const passageId = passage.id,
         elementId = 'elementId',
-        grainId = 'grainId',
         value = 'val',
         correction = { status: AnswerStatus.OK, feedback: Symbol('feedback'), solution: Symbol('solution') };
 
@@ -31,7 +30,6 @@ describe('Integration | DevComp | Repositories | ElementAnswerRepository', funct
       const returnedElementAnswer = await elementAnswerRepository.save({
         passageId,
         elementId,
-        grainId,
         value,
         correction,
       });
@@ -48,7 +46,6 @@ describe('Integration | DevComp | Repositories | ElementAnswerRepository', funct
 
       const persistedElementAnswer = await knex('element-answers').where({ id: returnedElementAnswer.id }).first();
       expect(persistedElementAnswer.passageId).to.equal(passageId);
-      expect(persistedElementAnswer.grainId).to.equal(grainId);
       expect(persistedElementAnswer.elementId).to.equal(elementId);
       expect(persistedElementAnswer.value).to.equal(value);
       expect(persistedElementAnswer.status).to.equal(correction.status.status);

--- a/api/tests/devcomp/unit/domain/usecases/verify-and-save-answer_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/verify-and-save-answer_test.js
@@ -93,7 +93,6 @@ describe('Unit | Devcomp | Domain | UseCases | verify-and-save-answer', function
           .withArgs({
             passageId,
             elementId,
-            grainId: grain.id,
             value: element.userResponse,
             correction: correction,
           })


### PR DESCRIPTION
## :unicorn: Problème
Cette information n'est pas utilisée par l'équipe métier, nous n'avons donc pas le besoin de l'enregistrer.

## :robot: Proposition
Faire une migration pour supprimer la colonne `grainId` de la table `element-anwers` de la BDD.

## :rainbow: Remarques
On a choisi de mettre la colonne à `nullable` dans le down de la migration, sinon le rollback ne fonctionne pas dans le cas où il y a déjà des données dans la BDD.

## :100: Pour tester
**En local :**

1. Dans le dossier `api` lancer la commande `npm run db:migrate`
2. Dans votre BDD, vérifiez que la colonne `grainId` de la table `element-anwers` n'existe plus
3. Lancer Pix App et aller sur le module `didacticiel-modulix`
4. Répondez aux questions et assurez vous que lorsque vous cliquez sur le bouton `Vérifiez` il n'y a pas d'erreur
5. Ensuite retournez dans votre terminal et exécutez la commande `npm run db:rollback:latest`
6. Retourner dans votre BDD et vérifiez que la colonne `grainId` de la table `element-anwers` est à nouveau présente


**Sur la RA :**  

1. Vérifiez qu'il n'y a pas de regression en allant sur le module `didacticiel-modulix`
2. Répondez aux questions et assurez vous que lorsque vous cliquez sur le bouton `Vérifiez` il n'y a pas d'erreur