### PR TITLE
[TECH] Supprimer toutes les références au statut "partially" (PIX-11417)

### DIFF
--- a/admin/app/components/certifications/certification/details-v3.js
+++ b/admin/app/components/certifications/certification/details-v3.js
@@ -49,11 +49,6 @@ const answerStatusMap = [
     color: secondaryColor,
   },
   {
-    value: AnswerStatus.PARTIALLY,
-    label: 'pages.certifications.certification.details.v3.answer-status.partially-ok',
-    color: secondaryColor,
-  },
-  {
     value: AnswerStatus.UNIMPLEMENTED,
     label: 'pages.certifications.certification.details.v3.answer-status.unimplemented',
     color: secondaryColor,

--- a/admin/app/components/certifications/details-answer.js
+++ b/admin/app/components/certifications/details-answer.js
@@ -4,7 +4,6 @@ import { tracked } from '@glimmer/tracking';
 const options = [
   { value: 'ok', label: 'Succès' },
   { value: 'ko', label: 'Échec' },
-  { value: 'partially', label: 'Succès partiel' },
   { value: 'timedout', label: 'Temps écoulé' },
   { value: 'focusedOut', label: 'Focus échoué' },
   { value: 'aband', label: 'Passée' },

--- a/admin/app/components/smart-random-simulator/smart-random-params.js
+++ b/admin/app/components/smart-random-simulator/smart-random-params.js
@@ -69,7 +69,7 @@ export default class SmartRandomParams extends Component {
     answers: Joi.array()
       .items({
         id: Joi.number().required(),
-        result: Joi.string().valid('ok', 'ko', 'aband', 'timedout', 'focusedOut', 'partially').required(),
+        result: Joi.string().valid('ok', 'ko', 'aband', 'timedout', 'focusedOut').required(),
         challengeId: Joi.string().required(),
       })
       .required(),

--- a/admin/app/models/certification-challenges-for-administration.js
+++ b/admin/app/models/certification-challenges-for-administration.js
@@ -6,7 +6,6 @@ export const AnswerStatus = {
   ABAND: 'aband',
   TIMEDOUT: 'timedout',
   FOCUSEDOUT: 'focusedOut',
-  PARTIALLY: 'partially',
   UNIMPLEMENTED: 'unimplemented',
 };
 export default class CertificationChallengesForAdministration extends Model {

--- a/admin/tests/integration/components/certifications/certification/details-v3_test.js
+++ b/admin/tests/integration/components/certifications/certification/details-v3_test.js
@@ -73,17 +73,6 @@ const answers = [
     skillName: '@rec124',
   },
   {
-    id: 7,
-    questionNumber: '6',
-    answerStatus: 'partially',
-    answerStatusName: 'Partiellement OK',
-    validatedLiveAlert: false,
-    answeredAt: new Date('2020-01-01T17:13:00Z'),
-    competenceName: 'Aiguiser les couteaux',
-    competenceIndex: '1.3',
-    skillName: '@rec124',
-  },
-  {
     id: 8,
     questionNumber: '7',
     answerStatus: 'unimplemented',

--- a/admin/tests/integration/components/certifications/details-answer_test.js
+++ b/admin/tests/integration/components/certifications/details-answer_test.js
@@ -10,7 +10,7 @@ module('Integration | Component | certifications/details-answer', function (hook
     skill: '@skill6',
     challengeId: 'rec1234',
     order: 5,
-    result: 'partially',
+    result: 'ko',
     isNeutralized: false,
     value: 'coucou',
   };
@@ -25,7 +25,7 @@ module('Integration | Component | certifications/details-answer', function (hook
     const screen = await render(hbs`<Certifications::DetailsAnswer @answer={{this.answer}} />`);
 
     // then
-    assert.dom(screen.getByText('Succès partiel')).exists();
+    assert.dom(screen.getByText('Échec')).exists();
   });
 
   test('init answer displayed status with neutralized label when challenge is neutralized', async function (assert) {
@@ -55,7 +55,7 @@ module('Integration | Component | certifications/details-answer', function (hook
     assert.dom(screen.getByText('@skill6')).exists();
     assert.dom(screen.getByText('rec1234')).exists();
     assert.dom(screen.getByText('coucou')).exists();
-    assert.dom(screen.getByText('Succès partiel')).exists();
+    assert.dom(screen.getByText('Échec')).exists();
   });
 
   module('when challenge has been skipped automatically', function () {

--- a/admin/tests/integration/components/certifications/details-competence_test.js
+++ b/admin/tests/integration/components/certifications/details-competence_test.js
@@ -29,7 +29,7 @@ module('Integration | Component | certifications/details-competence', function (
 
   test('it renders', async function (assert) {
     // given
-    this.set('competenceData', competence('ok', 'ko', 'partially'));
+    this.set('competenceData', competence('ok', 'ko'));
 
     // when
     const screen = await render(

--- a/admin/tests/unit/components/certifications/certification/details-v3_test.js
+++ b/admin/tests/unit/components/certifications/certification/details-v3_test.js
@@ -32,11 +32,6 @@ module('Unit | Component | certifications/certification/details-v3', function (h
       color: 'secondary',
     },
     {
-      value: 'partially',
-      label: 'pages.certifications.certification.details.v3.answer-status.partially-ok',
-      color: 'secondary',
-    },
-    {
       value: 'unimplemented',
       label: 'pages.certifications.certification.details.v3.answer-status.unimplemented',
       color: 'secondary',

--- a/admin/tests/unit/components/certifications/details-competence_test.js
+++ b/admin/tests/unit/components/certifications/details-competence_test.js
@@ -49,10 +49,10 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
   test('it should retrieve answers from competence', async function (assert) {
     // when
     component.args = {
-      competence: competence('ok', 'partially', 'ko'),
+      competence: competence('ok', 'aband', 'ko'),
     };
 
     // then
-    assert.deepEqual(component.answers, [answer('ok'), answer('partially'), answer('ko')]);
+    assert.deepEqual(component.answers, [answer('ok'), answer('aband'), answer('ko')]);
   });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -234,7 +234,6 @@
               "focused-out": "Focus out",
               "ko": "KO",
               "ok": "OK",
-              "partially-ok": "Partially OK",
               "timedout": "Time out",
               "unimplemented": "Not implemented",
               "validated-live-alert": "Report validated"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -244,7 +244,6 @@
               "focused-out": "Focus out",
               "ko": "KO",
               "ok": "OK",
-              "partially-ok": "Partiellement OK",
               "timedout": "Temps écoulé",
               "unimplemented": "Non implémentée",
               "validated-live-alert": "Signalement validé"

--- a/api/lib/domain/models/AnswerCollectionForScoring.js
+++ b/api/lib/domain/models/AnswerCollectionForScoring.js
@@ -67,8 +67,6 @@ class AnswerCollectionForScoring {
       if (!challengeWithAnswer.isNeutralized()) {
         if (challengesWithAnswersForCompetence.length < 3 && challengeWithAnswer.isAFullyCorrectQROCMdep()) {
           nbOfCorrectAnswers += 2;
-        } else if (challengesWithAnswersForCompetence.length < 3 && challengeWithAnswer.isAPartiallyCorrectQROCMdep()) {
-          nbOfCorrectAnswers += 1;
         } else if (challengeWithAnswer.isCorrect()) {
           nbOfCorrectAnswers += 1;
         }
@@ -121,10 +119,6 @@ class ChallengeWithAnswer {
 
   isAFullyCorrectQROCMdep() {
     return this.isQROCMdep() && this.isCorrect();
-  }
-
-  isAPartiallyCorrectQROCMdep() {
-    return this.isQROCMdep() && Boolean(this._answer) && this._answer.isPartially();
   }
 
   isNeutralized() {

--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -91,13 +91,13 @@ class CertificationAssessment {
     this.endedAt = now;
   }
 
-  neutralizeChallengeByNumberIfKoOrSkippedOrPartially(questionNumber) {
+  neutralizeChallengeByNumberIfKoOrSkipped(questionNumber) {
     const toBeNeutralizedChallengeAnswer = this.getAnswerByQuestionNumber(questionNumber);
     if (!toBeNeutralizedChallengeAnswer) {
       return NeutralizationAttempt.failure(questionNumber);
     }
 
-    if (_isAnswerKoOrSkippedOrPartially(toBeNeutralizedChallengeAnswer.result.status)) {
+    if (_isAnswerKoOrSkipped(toBeNeutralizedChallengeAnswer.result.status)) {
       const challengeToBeNeutralized = _.find(this.certificationChallenges, {
         challengeId: toBeNeutralizedChallengeAnswer.challengeId,
       });
@@ -184,11 +184,10 @@ class CertificationAssessment {
   }
 }
 
-function _isAnswerKoOrSkippedOrPartially(answerStatus) {
+function _isAnswerKoOrSkipped(answerStatus) {
   const isKo = AnswerStatus.isKO(answerStatus);
   const isSkipped = AnswerStatus.isSKIPPED(answerStatus);
-  const isPartially = AnswerStatus.isPARTIALLY(answerStatus);
-  return isKo || isSkipped || isPartially;
+  return isKo || isSkipped;
 }
 
 CertificationAssessment.states = states;

--- a/api/lib/domain/models/CertificationIssueReportResolutionStrategies.js
+++ b/api/lib/domain/models/CertificationIssueReportResolutionStrategies.js
@@ -175,8 +175,7 @@ export {
 
 function _neutralizeAndResolve(certificationAssessment, certificationIssueReportRepository, certificationIssueReport) {
   const questionNumber = certificationIssueReport.questionNumber;
-  const neutralizationAttempt =
-    certificationAssessment.neutralizeChallengeByNumberIfKoOrSkippedOrPartially(questionNumber);
+  const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkipped(questionNumber);
   if (neutralizationAttempt.hasSucceeded()) {
     return _resolveWithQuestionNeutralized(certificationIssueReportRepository, certificationIssueReport);
   } else if (neutralizationAttempt.wasSkipped()) {

--- a/api/lib/infrastructure/adapters/answer-status-json-api-adapter.js
+++ b/api/lib/infrastructure/adapters/answer-status-json-api-adapter.js
@@ -1,7 +1,6 @@
 const UNIMPLEMENTED = 'unimplemented';
 const TIMEDOUT = 'timedout';
 const FOCUSEDOUT = 'focusedOut';
-const PARTIALLY = 'partially';
 const SKIPPED = 'aband';
 const OK = 'ok';
 const KO = 'ko';
@@ -14,8 +13,6 @@ const AnswerStatusJsonApiAdapter = {
       return KO;
     } else if (answerStatus.isSKIPPED()) {
       return SKIPPED;
-    } else if (answerStatus.isPARTIALLY()) {
-      return PARTIALLY;
     } else if (answerStatus.isTIMEDOUT()) {
       return TIMEDOUT;
     } else if (answerStatus.isFOCUSEDOUT()) {

--- a/api/src/evaluation/application/smart-random-simulator/index.js
+++ b/api/src/evaluation/application/smart-random-simulator/index.js
@@ -59,7 +59,6 @@ const register = async function (server) {
                         AnswerStatus.statuses.KO,
                         AnswerStatus.statuses.SKIPPED,
                         AnswerStatus.statuses.FOCUSEDOUT,
-                        AnswerStatus.statuses.PARTIALLY,
                       )
                       .required(),
                     challengeId: identifiersType.challengeId,

--- a/api/src/evaluation/domain/models/Answer.js
+++ b/api/src/evaluation/domain/models/Answer.js
@@ -32,10 +32,6 @@ class Answer {
     return this.result.isOK();
   }
 
-  isPartially() {
-    return this.result.isPARTIALLY();
-  }
-
   get binaryOutcome() {
     return AnswerStatus.isOK(this.result) ? 1 : 0;
   }

--- a/api/src/shared/domain/models/AnswerStatus.js
+++ b/api/src/shared/domain/models/AnswerStatus.js
@@ -4,7 +4,6 @@ const statuses = {
   SKIPPED: 'aband',
   TIMEDOUT: 'timedout',
   FOCUSEDOUT: 'focusedOut',
-  PARTIALLY: 'partially',
   UNIMPLEMENTED: 'unimplemented',
 };
 
@@ -34,9 +33,6 @@ class AnswerStatus {
   isFOCUSEDOUT() {
     return this.status === statuses.FOCUSEDOUT;
   }
-  isPARTIALLY() {
-    return this.status === statuses.PARTIALLY;
-  }
   isUNIMPLEMENTED() {
     return this.status === statuses.UNIMPLEMENTED;
   }
@@ -57,9 +53,6 @@ class AnswerStatus {
   static get FOCUSEDOUT() {
     return new AnswerStatus({ status: statuses.FOCUSEDOUT });
   }
-  static get PARTIALLY() {
-    return new AnswerStatus({ status: statuses.PARTIALLY });
-  }
   static get UNIMPLEMENTED() {
     return new AnswerStatus({ status: statuses.UNIMPLEMENTED });
   }
@@ -76,9 +69,6 @@ class AnswerStatus {
   }
   static isSKIPPED(otherResult) {
     return AnswerStatus.from(otherResult).isSKIPPED();
-  }
-  static isPARTIALLY(otherResult) {
-    return AnswerStatus.from(otherResult).isPARTIALLY();
   }
   static isFOCUSEDOUT(otherResult) {
     return AnswerStatus.from(otherResult).isFOCUSEDOUT();

--- a/api/src/shared/infrastructure/adapters/answer-status-database-adapter.js
+++ b/api/src/shared/infrastructure/adapters/answer-status-database-adapter.js
@@ -2,7 +2,6 @@ import { AnswerStatus } from '../../../shared/domain/models/AnswerStatus.js';
 
 const UNIMPLEMENTED = 'unimplemented';
 const TIMEDOUT = 'timedout';
-const PARTIALLY = 'partially';
 const SKIPPED = 'aband';
 const FOCUSEDOUT = 'focusedOut';
 const OK = 'ok';
@@ -19,8 +18,6 @@ const toSQLString = function (answerStatus) {
     return KO;
   } else if (answerStatus.isSKIPPED()) {
     return SKIPPED;
-  } else if (answerStatus.isPARTIALLY()) {
-    return PARTIALLY;
   } else if (answerStatus.isTIMEDOUT()) {
     return TIMEDOUT;
   } else if (answerStatus.isFOCUSEDOUT()) {
@@ -35,8 +32,6 @@ const fromSQLString = function (answerStatusString) {
     return AnswerStatus.OK;
   } else if (answerStatusString === KO) {
     return AnswerStatus.KO;
-  } else if (answerStatusString === PARTIALLY) {
-    return AnswerStatus.PARTIALLY;
   } else if (answerStatusString === TIMEDOUT) {
     return AnswerStatus.TIMEDOUT;
   } else if (answerStatusString === SKIPPED) {

--- a/api/tests/devcomp/unit/domain/models/validator/AnswerStatus_test.js
+++ b/api/tests/devcomp/unit/domain/models/validator/AnswerStatus_test.js
@@ -28,7 +28,7 @@ describe('Unit | Devcomp | Domain | Models | Validator | AnswerStatus', function
       expect(AnswerStatus.UNIMPLEMENTED.isUNIMPLEMENTED()).to.be.true;
     });
 
-    it('should be false with AnswerStatuses OK, KO, SKIPPED, PARTIALLY, FOCUSEDOUT and TIMEDOUT', function () {
+    it('should be false with AnswerStatuses OK, KO, SKIPPED, FOCUSEDOUT and TIMEDOUT', function () {
       expect(AnswerStatus.OK.isUNIMPLEMENTED()).to.be.false;
       expect(AnswerStatus.KO.isUNIMPLEMENTED()).to.be.false;
     });

--- a/api/tests/evaluation/unit/domain/models/Answer_test.js
+++ b/api/tests/evaluation/unit/domain/models/Answer_test.js
@@ -58,24 +58,6 @@ describe('Unit | Domain | Models | Answer', function () {
     });
   });
 
-  describe('isPartially', function () {
-    it('should return true if answer is partially', function () {
-      // given
-      const answer = new Answer({ result: 'partially' });
-
-      // when
-      expect(answer.isPartially()).to.be.true;
-    });
-
-    it('should return false if answer is different than partially', function () {
-      // given
-      const answer = new Answer({ result: 'notok' });
-
-      // when
-      expect(answer.isPartially()).to.be.false;
-    });
-  });
-
   describe('#maxDifficulty', function () {
     it('should exist', function () {
       // given

--- a/api/tests/shared/unit/domain/models/AnswerStatus_test.js
+++ b/api/tests/shared/unit/domain/models/AnswerStatus_test.js
@@ -7,10 +7,9 @@ describe('AnswerStatus', function () {
       expect(AnswerStatus.OK.isOK()).to.be.true;
     });
 
-    it('should be false with AnswerStatuses KO, SKIPPED, PARTIALLY, TIMEDOUT, FOCUSEDOUT and UNIMPLEMENTED', function () {
+    it('should be false with AnswerStatuses KO, SKIPPED, TIMEDOUT, FOCUSEDOUT and UNIMPLEMENTED', function () {
       expect(AnswerStatus.KO.isOK()).to.be.false;
       expect(AnswerStatus.SKIPPED.isOK()).to.be.false;
-      expect(AnswerStatus.PARTIALLY.isOK()).to.be.false;
       expect(AnswerStatus.TIMEDOUT.isOK()).to.be.false;
       expect(AnswerStatus.FOCUSEDOUT.isOK()).to.be.false;
       expect(AnswerStatus.UNIMPLEMENTED.isOK()).to.be.false;
@@ -22,10 +21,9 @@ describe('AnswerStatus', function () {
       expect(AnswerStatus.KO.isKO()).to.be.true;
     });
 
-    it('should be false with AnswerStatuses OK, SKIPPED, PARTIALLY, TIMEDOUT, FOCUSEDOUT and UNIMPLEMENTED', function () {
+    it('should be false with AnswerStatuses OK, SKIPPED, TIMEDOUT, FOCUSEDOUT and UNIMPLEMENTED', function () {
       expect(AnswerStatus.OK.isKO()).to.be.false;
       expect(AnswerStatus.SKIPPED.isKO()).to.be.false;
-      expect(AnswerStatus.PARTIALLY.isKO()).to.be.false;
       expect(AnswerStatus.TIMEDOUT.isKO()).to.be.false;
       expect(AnswerStatus.FOCUSEDOUT.isKO()).to.be.false;
       expect(AnswerStatus.UNIMPLEMENTED.isKO()).to.be.false;
@@ -37,28 +35,12 @@ describe('AnswerStatus', function () {
       expect(AnswerStatus.SKIPPED.isSKIPPED()).to.be.true;
     });
 
-    it('should be false with AnswerStatuses OK, KO, PARTIALLY, TIMEDOUT, FOCUSEDOUT and UNIMPLEMENTED', function () {
+    it('should be false with AnswerStatuses OK, KO, TIMEDOUT, FOCUSEDOUT and UNIMPLEMENTED', function () {
       expect(AnswerStatus.OK.isSKIPPED()).to.be.false;
       expect(AnswerStatus.KO.isSKIPPED()).to.be.false;
-      expect(AnswerStatus.PARTIALLY.isSKIPPED()).to.be.false;
       expect(AnswerStatus.TIMEDOUT.isSKIPPED()).to.be.false;
       expect(AnswerStatus.FOCUSEDOUT.isSKIPPED()).to.be.false;
       expect(AnswerStatus.UNIMPLEMENTED.isSKIPPED()).to.be.false;
-    });
-  });
-
-  context('AnswerStatus#isPARTIALLY', function () {
-    it('should be true with AnswerStatus.PARTIALLY', function () {
-      expect(AnswerStatus.PARTIALLY.isPARTIALLY()).to.be.true;
-    });
-
-    it('should be false with AnswerStatuses OK, KO, SKIPPED, TIMEDOUT, FOCUSEDOUTand UNIMPLEMENTED', function () {
-      expect(AnswerStatus.OK.isPARTIALLY()).to.be.false;
-      expect(AnswerStatus.KO.isPARTIALLY()).to.be.false;
-      expect(AnswerStatus.SKIPPED.isPARTIALLY()).to.be.false;
-      expect(AnswerStatus.TIMEDOUT.isPARTIALLY()).to.be.false;
-      expect(AnswerStatus.FOCUSEDOUT.isPARTIALLY()).to.be.false;
-      expect(AnswerStatus.UNIMPLEMENTED.isPARTIALLY()).to.be.false;
     });
   });
 
@@ -67,11 +49,10 @@ describe('AnswerStatus', function () {
       expect(AnswerStatus.TIMEDOUT.isTIMEDOUT()).to.be.true;
     });
 
-    it('should be false with AnswerStatuses OK, KO, SKIPPED, PARTIALLY, FOCUSEDOUT and UNIMPLEMENTED', function () {
+    it('should be false with AnswerStatuses OK, KO, SKIPPED, FOCUSEDOUT and UNIMPLEMENTED', function () {
       expect(AnswerStatus.OK.isTIMEDOUT()).to.be.false;
       expect(AnswerStatus.KO.isTIMEDOUT()).to.be.false;
       expect(AnswerStatus.SKIPPED.isTIMEDOUT()).to.be.false;
-      expect(AnswerStatus.PARTIALLY.isTIMEDOUT()).to.be.false;
       expect(AnswerStatus.FOCUSEDOUT.isTIMEDOUT()).to.be.false;
       expect(AnswerStatus.UNIMPLEMENTED.isTIMEDOUT()).to.be.false;
     });
@@ -82,11 +63,10 @@ describe('AnswerStatus', function () {
       expect(AnswerStatus.UNIMPLEMENTED.isUNIMPLEMENTED()).to.be.true;
     });
 
-    it('should be false with AnswerStatuses OK, KO, SKIPPED, PARTIALLY, FOCUSEDOUT and TIMEDOUT', function () {
+    it('should be false with AnswerStatuses OK, KO, SKIPPED, FOCUSEDOUT and TIMEDOUT', function () {
       expect(AnswerStatus.OK.isUNIMPLEMENTED()).to.be.false;
       expect(AnswerStatus.KO.isUNIMPLEMENTED()).to.be.false;
       expect(AnswerStatus.SKIPPED.isUNIMPLEMENTED()).to.be.false;
-      expect(AnswerStatus.PARTIALLY.isUNIMPLEMENTED()).to.be.false;
       expect(AnswerStatus.TIMEDOUT.isUNIMPLEMENTED()).to.be.false;
       expect(AnswerStatus.FOCUSEDOUT.isUNIMPLEMENTED()).to.be.false;
     });
@@ -97,10 +77,9 @@ describe('AnswerStatus', function () {
       expect(AnswerStatus.OK.isFailed()).to.be.false;
     });
 
-    it('should be true with AnswerStatuses KO, SKIPPED, PARTIALLY, TIMEDOUT, FOCUSEDOUT and UNIMPLEMENTED', function () {
+    it('should be true with AnswerStatuses KO, SKIPPED, TIMEDOUT, FOCUSEDOUT and UNIMPLEMENTED', function () {
       expect(AnswerStatus.KO.isFailed()).to.be.true;
       expect(AnswerStatus.SKIPPED.isFailed()).to.be.true;
-      expect(AnswerStatus.PARTIALLY.isFailed()).to.be.true;
       expect(AnswerStatus.TIMEDOUT.isFailed()).to.be.true;
       expect(AnswerStatus.FOCUSEDOUT.isFailed()).to.be.true;
       expect(AnswerStatus.UNIMPLEMENTED.isFailed()).to.be.true;
@@ -112,11 +91,10 @@ describe('AnswerStatus', function () {
       expect(AnswerStatus.FOCUSEDOUT.isFOCUSEDOUT()).to.be.true;
     });
 
-    it('should be false with AnswerStatuses OK, KO, SKIPPED, PARTIALLY, TIMEDOUT and UNIMPLEMENTED', function () {
+    it('should be false with AnswerStatuses OK, KO, SKIPPED, TIMEDOUT and UNIMPLEMENTED', function () {
       expect(AnswerStatus.OK.isFOCUSEDOUT()).to.be.false;
       expect(AnswerStatus.KO.isFOCUSEDOUT()).to.be.false;
       expect(AnswerStatus.SKIPPED.isFOCUSEDOUT()).to.be.false;
-      expect(AnswerStatus.PARTIALLY.isFOCUSEDOUT()).to.be.false;
       expect(AnswerStatus.TIMEDOUT.isFOCUSEDOUT()).to.be.false;
       expect(AnswerStatus.UNIMPLEMENTED.isFOCUSEDOUT()).to.be.false;
     });

--- a/api/tests/unit/domain/models/AnswerCollectionForScoring_test.js
+++ b/api/tests/unit/domain/models/AnswerCollectionForScoring_test.js
@@ -194,27 +194,6 @@ describe('Unit | Domain | Models | AnswerCollectionForScoring', function () {
       expect(numberOfCorrectAnswers).to.equal(3);
     });
 
-    it('counts QROCMDeps as 0 when partially correct', function () {
-      // given
-      const challenge1 = _buildDecoratedCertificationChallenge({ challengeId: 'chal1', type: 'QCM' });
-      const qROCMDepChallenge2 = _buildDecoratedCertificationChallenge({ challengeId: 'chal2', type: 'QROCM-dep' });
-      const answer1 = domainBuilder.buildAnswer({ challengeId: challenge1.challengeId, result: AnswerStatus.OK });
-      const qROCMDepAnswer2 = domainBuilder.buildAnswer({
-        challengeId: qROCMDepChallenge2.challengeId,
-        result: AnswerStatus.PARTIALLY,
-      });
-      const answerCollection = AnswerCollectionForScoring.from({
-        answers: [answer1, qROCMDepAnswer2],
-        challenges: [challenge1, qROCMDepChallenge2],
-      });
-
-      // when
-      const numberOfCorrectAnswers = answerCollection.numberOfCorrectAnswers();
-
-      // then
-      expect(numberOfCorrectAnswers).to.equal(1);
-    });
-
     it('counts QROCMDeps as 1 when fully correct', function () {
       // given
       const challenge1 = _buildDecoratedCertificationChallenge({ challengeId: 'chal1', type: 'QCM' });
@@ -605,51 +584,6 @@ describe('Unit | Domain | Models | AnswerCollectionForScoring', function () {
 
       // then
       expect(numberOfCorrectAnswers).to.equal(3);
-    });
-
-    it('counts QROCMDeps as 1 when partially correct for given competence', function () {
-      // given
-      const aCompetenceId = 'recIdOfACompetence';
-      const anotherCompetenceId = 'recIdOfAnotherCompetence';
-      const challenge1 = _buildDecoratedCertificationChallenge({
-        challengeId: 'chal1',
-        competenceId: aCompetenceId,
-        type: 'QCM',
-      });
-      const qROCMDepChallenge2 = _buildDecoratedCertificationChallenge({
-        challengeId: 'chal2',
-        competenceId: aCompetenceId,
-        type: 'QROCM-dep',
-      });
-      const answer1 = domainBuilder.buildAnswer({ challengeId: challenge1.challengeId, result: AnswerStatus.OK });
-      const qROCMDepAnswer2 = domainBuilder.buildAnswer({
-        challengeId: qROCMDepChallenge2.challengeId,
-        result: AnswerStatus.PARTIALLY,
-      });
-
-      const challenge3 = _buildDecoratedCertificationChallenge({
-        challengeId: 'chal3',
-        competenceId: anotherCompetenceId,
-        type: 'QCM',
-      });
-      const challenge4 = _buildDecoratedCertificationChallenge({
-        challengeId: 'chal4',
-        competenceId: anotherCompetenceId,
-        type: 'QCM',
-      });
-      const answer3 = domainBuilder.buildAnswer({ challengeId: challenge3.challengeId, result: AnswerStatus.KO });
-      const answer4 = domainBuilder.buildAnswer({ challengeId: challenge4.challengeId, result: AnswerStatus.KO });
-
-      const answerCollection = AnswerCollectionForScoring.from({
-        answers: [answer1, qROCMDepAnswer2, answer3, answer4],
-        challenges: [challenge1, qROCMDepChallenge2, challenge3, challenge4],
-      });
-
-      // when
-      const numberOfCorrectAnswers = answerCollection.numberOfCorrectAnswersForCompetence(aCompetenceId);
-
-      // then
-      expect(numberOfCorrectAnswers).to.equal(2);
     });
 
     it('counts 2 QROCMDeps as 3 correct answers when fully correct for given competence', function () {

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -272,7 +272,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
     });
   });
 
-  describe('#neutralizeChallengeByNumberIfKoOrSkippedOrPartially', function () {
+  describe('#neutralizeChallengeByNumberIfKoOrSkipped', function () {
     it('should neutralize the challenge when the answer is ko', function () {
       // given
       const challengeKoToBeNeutralized = domainBuilder.buildCertificationChallengeWithType({
@@ -299,7 +299,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
       });
 
       // when
-      const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkippedOrPartially(1);
+      const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkipped(1);
 
       // then
       expect(challengeKoToBeNeutralized.isNeutralized).to.be.true;
@@ -332,47 +332,14 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
       });
 
       // when
-      const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkippedOrPartially(1);
+      const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkipped(1);
 
       // then
       expect(challengeSkippedToBeNeutralized.isNeutralized).to.be.true;
       expect(neutralizationAttempt).to.deep.equal(NeutralizationAttempt.neutralized(1));
     });
 
-    it('should neutralize the challenge when the answer is partially answered', function () {
-      // given
-      const challengeSkippedToBeNeutralized = domainBuilder.buildCertificationChallengeWithType({
-        challengeId: 'rec3',
-        isNeutralized: false,
-      });
-
-      const certificationAssessment = domainBuilder.buildCertificationAssessment({
-        id: 123,
-        userId: 123,
-        certificationCourseId: 123,
-        createdAt: new Date('2020-01-01'),
-        completedAt: new Date('2020-01-01'),
-        state: CertificationAssessment.states.STARTED,
-        version: 2,
-        certificationChallenges: [challengeSkippedToBeNeutralized],
-        certificationAnswersByDate: [
-          domainBuilder.buildAnswer({
-            challengeId: challengeSkippedToBeNeutralized.challengeId,
-            result: AnswerStatus.PARTIALLY.status,
-            assessmentId: CertificationAssessment.id,
-          }),
-        ],
-      });
-
-      // when
-      const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkippedOrPartially(1);
-
-      // then
-      expect(challengeSkippedToBeNeutralized.isNeutralized).to.be.true;
-      expect(neutralizationAttempt).to.deep.equal(NeutralizationAttempt.neutralized(1));
-    });
-
-    it('should not neutralize the challenge when the answer is neither skipped nor ko nor partially', function () {
+    it('should not neutralize the challenge when the answer is neither skipped nor ko', function () {
       // given
       const challengeNotToBeNeutralized = domainBuilder.buildCertificationChallengeWithType({
         challengeId: 'rec3',
@@ -398,7 +365,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
       });
 
       // when
-      const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkippedOrPartially(1);
+      const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkipped(1);
 
       // then
       expect(challengeNotToBeNeutralized.isNeutralized).to.be.false;
@@ -434,7 +401,7 @@ describe('Unit | Domain | Models | CertificationAssessment', function () {
       });
 
       // when
-      const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkippedOrPartially(66);
+      const neutralizationAttempt = certificationAssessment.neutralizeChallengeByNumberIfKoOrSkipped(66);
 
       // then
       expect(neutralizationAttempt).to.deep.equal(NeutralizationAttempt.failure(66));

--- a/api/tests/unit/domain/services/scoring/scoring-certification-service_test.js
+++ b/api/tests/unit/domain/services/scoring/scoring-certification-service_test.js
@@ -1151,50 +1151,6 @@ describe('Unit | Service | Certification Result Service', function () {
           // then
           expect(certificationAssessmentScore.competenceMarks).to.deep.equal(expectedCertifiedCompetences);
         });
-
-        it('should compute the result of QROCM-dep as only one OK because result is partially right', async function () {
-          // given
-          certificationAssessment.certificationAnswersByDate = _.map(
-            [
-              { challengeId: 'challenge_A_for_competence_5', result: 'ok' },
-              { challengeId: 'challenge_B_for_competence_5', result: 'partially' },
-              { challengeId: 'challenge_A_for_competence_6', result: 'ko' },
-              { challengeId: 'challenge_B_for_competence_6', result: 'ok' },
-              { challengeId: 'challenge_C_for_competence_6', result: 'ok' },
-            ],
-            domainBuilder.buildAnswer,
-          );
-
-          const expectedCertifiedCompetences = [
-            domainBuilder.buildCompetenceMark({
-              competence_code: '5.5',
-              area_code: '5',
-              competenceId: 'competence_5',
-              level: 4,
-              score: 40,
-            }),
-            domainBuilder.buildCompetenceMark({
-              competence_code: '6.6',
-              area_code: '6',
-              competenceId: 'competence_6',
-              level: 2,
-              score: 28,
-            }),
-          ];
-
-          // when
-          const certificationAssessmentScore = await scoringCertificationService.calculateCertificationAssessmentScore({
-            certificationAssessment,
-            continueOnError,
-            dependencies: {
-              areaRepository,
-              placementProfileService,
-            },
-          });
-
-          // then
-          expect(certificationAssessmentScore.competenceMarks).to.deep.equal(expectedCertifiedCompetences);
-        });
       });
 
       context('when there are challenges for non-certifiable competences', function () {

--- a/api/tests/unit/infrastructure/adapters/answer-status-database-adapter_test.js
+++ b/api/tests/unit/infrastructure/adapters/answer-status-database-adapter_test.js
@@ -16,12 +16,6 @@ describe('AnswerStatusDatabaseAdapter', function () {
       expect(result).to.equals('ko');
     });
 
-    it('should convert AnswerStatus.PARTIALLY to "partially"', function () {
-      const answerStatus = AnswerStatus.PARTIALLY;
-      const result = AnswerStatusDatabaseAdapter.adapt(answerStatus);
-      expect(result).to.equals('partially');
-    });
-
     it('should convert AnswerStatus.TIMEDOUT to "timedout"', function () {
       const answerStatus = AnswerStatus.TIMEDOUT;
       const result = AnswerStatusDatabaseAdapter.adapt(answerStatus);
@@ -60,12 +54,6 @@ describe('AnswerStatusDatabaseAdapter', function () {
       expect(result).to.equals('ko');
     });
 
-    it('should convert AnswerStatus.PARTIALLY to "partially"', function () {
-      const answerStatus = AnswerStatus.PARTIALLY;
-      const result = AnswerStatusDatabaseAdapter.toSQLString(answerStatus);
-      expect(result).to.equals('partially');
-    });
-
     it('should convert AnswerStatus.TIMEDOUT to "timedout"', function () {
       const answerStatus = AnswerStatus.TIMEDOUT;
       const result = AnswerStatusDatabaseAdapter.toSQLString(answerStatus);
@@ -102,12 +90,6 @@ describe('AnswerStatusDatabaseAdapter', function () {
       const answerStatusString = 'ko';
       const result = AnswerStatusDatabaseAdapter.fromSQLString(answerStatusString);
       expect(result.isKO()).to.be.true;
-    });
-
-    it('should convert "partially" to AnswerStatus.PARTIALLY', function () {
-      const answerStatusString = 'partially';
-      const result = AnswerStatusDatabaseAdapter.fromSQLString(answerStatusString);
-      expect(result.isPARTIALLY()).to.be.true;
     });
 
     it('should convert "timedout" to AnswerStatus.TIMEDOUT', function () {

--- a/api/tests/unit/infrastructure/adapters/answer-status-json-api-adapter_test.js
+++ b/api/tests/unit/infrastructure/adapters/answer-status-json-api-adapter_test.js
@@ -16,12 +16,6 @@ describe('AnswerStatusJsonApiAdapter', function () {
       expect(result).to.equals('ko');
     });
 
-    it('should convert AnswerStatus.PARTIALLY to "partially"', function () {
-      const answerStatus = AnswerStatus.PARTIALLY;
-      const result = AnswerStatusJsonApiAdapter.adapt(answerStatus);
-      expect(result).to.equals('partially');
-    });
-
     it('should convert AnswerStatus.TIMEDOUT to "timedout"', function () {
       const answerStatus = AnswerStatus.TIMEDOUT;
       const result = AnswerStatusJsonApiAdapter.adapt(answerStatus);

--- a/mon-pix/app/components/comparison-window.js
+++ b/mon-pix/app/components/comparison-window.js
@@ -5,7 +5,6 @@ const TEXT_FOR_RESULT = {
   ok: { status: 'ok' },
   ko: { status: 'ko' },
   aband: { status: 'aband' },
-  partially: { status: 'partially' },
   timedout: { status: 'timedout' },
   focusedOut: { status: 'ko' },
   okAutoReply: { status: 'ok' },

--- a/mon-pix/app/utils/result-icon.js
+++ b/mon-pix/app/utils/result-icon.js
@@ -15,10 +15,6 @@ const resultIcons = {
     icon: 'circle-xmark',
     color: 'grey',
   },
-  partially: {
-    icon: 'circle-check',
-    color: 'orange',
-  },
   timedout: {
     icon: 'circle-xmark',
     color: 'red',

--- a/mon-pix/tests/integration/components/result-item-campaign_test.js
+++ b/mon-pix/tests/integration/components/result-item-campaign_test.js
@@ -87,7 +87,6 @@ module('Integration | Component | result-item', function (hooks) {
       { status: 'ok', color: 'green' },
       { status: 'ko', color: 'red' },
       { status: 'aband', color: 'grey' },
-      { status: 'partially', color: 'orange' },
       { status: 'timedout', color: 'red' },
     ].forEach(function (data) {
       test(`should display a relevant result icon when the result of the answer is "${data.status}"`, async function (assert) {

--- a/mon-pix/tests/unit/components/comparison-window_test.js
+++ b/mon-pix/tests/unit/components/comparison-window_test.js
@@ -149,12 +149,6 @@ module('Unit | Component | comparison-window', function (hooks) {
         expectedTooltip: 'Sans réponse',
       },
       {
-        validationStatus: 'partially',
-        result: 'partially',
-        expectedTitle: 'Vous avez donné une réponse partielle',
-        expectedTooltip: 'Réponse partielle',
-      },
-      {
         validationStatus: 'timedout',
         result: 'timedout',
         expectedTitle: 'Vous avez dépassé le temps imparti',

--- a/mon-pix/tests/unit/components/result-item_test.js
+++ b/mon-pix/tests/unit/components/result-item_test.js
@@ -47,7 +47,6 @@ module('Unit | Component | result-item-component', function (hooks) {
       { result: 'ok', expectedColor: 'green', expectedIcon: 'circle-check' },
       { result: 'ko', expectedColor: 'red', expectedIcon: 'circle-xmark' },
       { result: 'timedout', expectedColor: 'red', expectedIcon: 'circle-xmark' },
-      { result: 'partially', expectedColor: 'orange', expectedIcon: 'circle-check' },
       { result: 'aband', expectedColor: 'grey', expectedIcon: 'circle-xmark' },
     ].forEach((data) => {
       test(`should return a ${data.expectedColor} ${data.expectedIcon} icon when answer provided has a ${data.result} result`, function (assert) {
@@ -69,7 +68,6 @@ module('Unit | Component | result-item-component', function (hooks) {
       { result: 'ok', expectedTooltip: 'Réponse correcte' },
       { result: 'ko', expectedTooltip: 'Réponse incorrecte' },
       { result: 'timedout', expectedTooltip: 'Temps dépassé' },
-      { result: 'partially', expectedTooltip: 'Réponse partielle' },
       { result: 'aband', expectedTooltip: 'Sans réponse' },
     ].forEach((data) => {
       test(`should return a tooltip text equal to ${data.expectedTooltip}`, function (assert) {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -842,10 +842,6 @@
           "title": "You correctly answered the question",
           "tooltip": "Question answered correctly "
         },
-        "partially": {
-          "title": "You gave an incomplete answer",
-          "tooltip": "Incomplete answer"
-        },
         "solutions": {
           "end": "or...",
           "or": "or"
@@ -1377,7 +1373,6 @@
       },
       "ko": "Incorrect answer",
       "ok": "Correct answer",
-      "partially": "Incomplete answer",
       "timedout": "Out of time"
     },
     "send-profile": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -842,10 +842,6 @@
           "title": "Ha superado la prueba",
           "tooltip": "Prueba superada"
         },
-        "partially": {
-          "title": "Ha dado una respuesta parcial",
-          "tooltip": "Respuesta parcial"
-        },
         "solutions": {
           "end": "o...",
           "or": "o"
@@ -1377,7 +1373,6 @@
       },
       "ko": "Respuesta incorrecta",
       "ok": "Respuesta correcta",
-      "partially": "Respuesta parcial",
       "timedout": "Tiempo muerto"
     },
     "send-profile": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -842,10 +842,6 @@
           "title": "Vous avez réussi l’épreuve",
           "tooltip": "Épreuve réussie"
         },
-        "partially": {
-          "title": "Vous avez donné une réponse partielle",
-          "tooltip": "Réponse partielle"
-        },
         "solutions": {
           "end": "ou...",
           "or": "ou"
@@ -1377,7 +1373,6 @@
       },
       "ko": "Réponse incorrecte",
       "ok": "Réponse correcte",
-      "partially": "Réponse partielle",
       "timedout": "Temps dépassé"
     },
     "send-profile": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -842,10 +842,6 @@
           "title": "Je bent geslaagd voor de test",
           "tooltip": "Geslaagde test"
         },
-        "partially": {
-          "title": "Je hebt een gedeeltelijk antwoord gegeven",
-          "tooltip": "Gedeeltelijke reactie"
-        },
         "solutions": {
           "end": "of...",
           "or": "of"
@@ -1377,7 +1373,6 @@
       },
       "ko": "Onjuist antwoord",
       "ok": "Juist antwoord",
-      "partially": "Gedeeltelijke reactie",
       "timedout": "Time-out"
     },
     "send-profile": {


### PR DESCRIPTION
## :unicorn: Problème
Autrefois les "answers" pouvaient avoir un "result" égal à "partially". Ce type de résultat n'est plus utilisé depuis au moins 2021. Cependant le code référence et prévoit toujours ce type de résultat. 

## :robot: Proposition
Oblitérer toute référence à ce "result" dans le code. 

## :100: Pour tester
Tests au vert
