### PR TITLE
[FEATURE] Active l'import élève pour les établissement scolaire du premier degré (PIX-12338).

### DIFF
--- a/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
+++ b/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
@@ -75,7 +75,7 @@ class OrganizationForAdmin {
     }
     if (this.type === 'SCO-1D') {
       this.features[ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT.key] = true;
-      this.features[ORGANIZATION_FEATURE.LEARNER_IMPORT.key] = true;
+      this.features[ORGANIZATION_FEATURE.LEARNER_IMPORT.key] = ORGANIZATION_FEATURE.LEARNER_IMPORT.FORMAT.ONDE;
     }
     this.tagsToAdd = [];
     this.tagsToRemove = [];

--- a/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
+++ b/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
@@ -75,6 +75,7 @@ class OrganizationForAdmin {
     }
     if (this.type === 'SCO-1D') {
       this.features[ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT.key] = true;
+      this.features[ORGANIZATION_FEATURE.LEARNER_IMPORT.key] = true;
     }
     this.tagsToAdd = [];
     this.tagsToRemove = [];

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin-repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin-repository.js
@@ -116,6 +116,7 @@ const save = async function (organization) {
   const data = _.pick(organization, ['name', 'type', 'documentationUrl', 'credit', 'createdBy']);
   const [organizationCreated] = await knex(ORGANIZATIONS_TABLE_NAME).returning('*').insert(data);
   const savedOrganization = _toDomain(organizationCreated);
+
   if (!_.isEmpty(savedOrganization.features)) {
     await _enableFeatures(knex, savedOrganization.features, savedOrganization.id);
   }

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin-repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin-repository.js
@@ -5,6 +5,7 @@ import { MissingAttributesError, NotFoundError } from '../../../../lib/domain/er
 import { OrganizationInvitation } from '../../../../lib/domain/models/OrganizationInvitation.js';
 import { Tag } from '../../../../lib/domain/models/Tag.js';
 import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
+import { ORGANIZATION_FEATURE } from '../../../shared/domain/constants.js';
 import { OrganizationForAdmin } from '../../domain/models/OrganizationForAdmin.js';
 
 const ORGANIZATIONS_TABLE_NAME = 'organizations';
@@ -172,6 +173,7 @@ async function _disableFeatures(knexConn, features, organizationId) {
 
 async function _enableFeatures(knexConn, featuresToEnable, organizationId) {
   const features = await knexConn('features');
+  const importFormats = await knexConn('organization-learner-import-formats').select('name', 'id');
 
   await knexConn('organization-features')
     .insert(
@@ -180,10 +182,18 @@ async function _enableFeatures(knexConn, featuresToEnable, organizationId) {
         .map((key) => ({
           organizationId,
           featureId: features.find((feature) => feature.key === key).id,
+          params: _paramsForFeature(importFormats, key, featuresToEnable[key]),
         })),
     )
     .onConflict()
     .ignore();
+}
+
+function _paramsForFeature(importFormats, key, value) {
+  if (key === ORGANIZATION_FEATURE.LEARNER_IMPORT.key) {
+    const learnerImportFormat = importFormats.find(({ name }) => name === value);
+    return { organizationLearnerImportFormatId: learnerImportFormat.id };
+  }
 }
 
 async function _removeTags(knexConn, organizationTags) {

--- a/api/src/shared/domain/constants.js
+++ b/api/src/shared/domain/constants.js
@@ -18,6 +18,9 @@ const ORGANIZATION_FEATURE = {
   LEARNER_IMPORT: {
     key: 'LEARNER_IMPORT',
     description: "Permet l'import de participants sur PixOrga",
+    FORMAT: {
+      ONDE: 'ONDE',
+    },
   },
   PLACES_MANAGEMENT: {
     key: 'PLACES_MANAGEMENT',

--- a/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
+++ b/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
@@ -25,13 +25,11 @@ const { omit } = lodash;
 
 describe('Integration | UseCases | create-organizations-with-tags-and-target-profiles', function () {
   let missionFeature;
-  let learnerImportFeature;
   let userId;
 
   beforeEach(async function () {
     databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY);
     missionFeature = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT);
-    learnerImportFeature = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.LEARNER_IMPORT);
     userId = databaseBuilder.factory.buildUser().id;
     await databaseBuilder.commit();
   });

--- a/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
+++ b/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
@@ -737,12 +737,12 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
 
       // then
       const savedOrganizationFeatures = await knex('organization-features');
-      expect(savedOrganizationFeatures.length).to.equal(2);
+      //TODO organization create with batch, see https://1024pix.atlassian.net/jira/software/c/projects/PIX/boards/107?selectedIssue=PIX-12563
+      expect(savedOrganizationFeatures.length).to.equal(1);
       const savedOrganizationFeatureIds = savedOrganizationFeatures.map(
         (organizationFeature) => organizationFeature.featureId,
       );
       expect(savedOrganizationFeatureIds).to.include(missionFeature.id);
-      expect(savedOrganizationFeatureIds).to.include(learnerImportFeature.id);
     });
 
     it('should create schools associated to organizations', async function () {

--- a/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
+++ b/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
@@ -25,11 +25,13 @@ const { omit } = lodash;
 
 describe('Integration | UseCases | create-organizations-with-tags-and-target-profiles', function () {
   let missionFeature;
+  let learnerImportFeature;
   let userId;
 
   beforeEach(async function () {
     databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY);
     missionFeature = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT);
+    learnerImportFeature = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.LEARNER_IMPORT);
     userId = databaseBuilder.factory.buildUser().id;
     await databaseBuilder.commit();
   });
@@ -735,8 +737,12 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
 
       // then
       const savedOrganizationFeatures = await knex('organization-features');
-      expect(savedOrganizationFeatures.length).to.equal(1);
-      expect(savedOrganizationFeatures[0].featureId).to.equal(missionFeature.id);
+      expect(savedOrganizationFeatures.length).to.equal(2);
+      const savedOrganizationFeatureIds = savedOrganizationFeatures.map(
+        (organizationFeature) => organizationFeature.featureId,
+      );
+      expect(savedOrganizationFeatureIds).to.include(missionFeature.id);
+      expect(savedOrganizationFeatureIds).to.include(learnerImportFeature.id);
     });
 
     it('should create schools associated to organizations', async function () {

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin-repository_test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin-repository_test.js
@@ -477,6 +477,9 @@ describe('Integration | Repository | Organization-for-admin', function () {
           ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT,
         ).id;
         const learnerImportFeatureId = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.LEARNER_IMPORT).id;
+        const organizationLearnerImportOndeFormat = databaseBuilder.factory.buildOrganizationLearnerImportFormat({
+          name: 'ONDE',
+        });
 
         await databaseBuilder.commit();
 
@@ -488,16 +491,24 @@ describe('Integration | Repository | Organization-for-admin', function () {
 
         const savedOrganization = await organizationForAdminRepository.save(organization);
 
-        const savedOrganizationFeature = await knex('organization-features').where({
+        const savedOrganizationFeatures = await knex('organization-features').where({
           organizationId: savedOrganization.id,
         });
 
-        expect(savedOrganizationFeature.length).to.equal(2);
-        const savedOrganizationFeatureIds = savedOrganizationFeature.map(
+        expect(savedOrganizationFeatures.length).to.equal(2);
+        const savedOrganizationFeatureIds = savedOrganizationFeatures.map(
           (organizationFeature) => organizationFeature.featureId,
         );
         expect(savedOrganizationFeatureIds).to.include(missionManagementFeatureId);
         expect(savedOrganizationFeatureIds).to.include(learnerImportFeatureId);
+
+        const learnerImportFeatureParams = savedOrganizationFeatures.find((organizationFeature) => {
+          return organizationFeature.featureId == learnerImportFeatureId;
+        }).params;
+
+        expect(learnerImportFeatureParams).to.deep.equal({
+          organizationLearnerImportFormatId: organizationLearnerImportOndeFormat.id,
+        });
       });
     });
   });

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin-repository_test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin-repository_test.js
@@ -471,9 +471,12 @@ describe('Integration | Repository | Organization-for-admin', function () {
     });
 
     context('when the organization type is SCO-1D', function () {
-      it('adds mission_management feature to the organization', async function () {
+      it('adds mission_management and learner_import features to the organization', async function () {
         const superAdminUserId = databaseBuilder.factory.buildUser().id;
-        const featureId = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT).id;
+        const missionManagementFeatureId = databaseBuilder.factory.buildFeature(
+          ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT,
+        ).id;
+        const learnerImportFeatureId = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.LEARNER_IMPORT).id;
 
         await databaseBuilder.commit();
 
@@ -483,15 +486,18 @@ describe('Integration | Repository | Organization-for-admin', function () {
           createdBy: superAdminUserId,
         });
 
-        // when
         const savedOrganization = await organizationForAdminRepository.save(organization);
 
         const savedOrganizationFeature = await knex('organization-features').where({
           organizationId: savedOrganization.id,
         });
 
-        expect(savedOrganizationFeature.length).to.equal(1);
-        expect(savedOrganizationFeature[0].featureId).to.equal(featureId);
+        expect(savedOrganizationFeature.length).to.equal(2);
+        const savedOrganizationFeatureIds = savedOrganizationFeature.map(
+          (organizationFeature) => organizationFeature.featureId,
+        );
+        expect(savedOrganizationFeatureIds).to.include(missionManagementFeatureId);
+        expect(savedOrganizationFeatureIds).to.include(learnerImportFeatureId);
       });
     });
   });

--- a/api/tests/unit/domain/models/organizations-administration/OrganizationForAdmin_test.js
+++ b/api/tests/unit/domain/models/organizations-administration/OrganizationForAdmin_test.js
@@ -41,17 +41,26 @@ describe('Unit | Domain | Models | OrganizationForAdmin', function () {
     });
     context('for SCO-1D organizations', function () {
       it('should build an OrganizationForAdmin with MISSIONS_MANAGEMENT feature', function () {
-        // given
         const expectedOrganization = domainBuilder.buildOrganizationForAdmin({
           type: 'SCO-1D',
         });
 
-        // when
         const organization = new OrganizationForAdmin(expectedOrganization);
 
-        // then
-        expect(organization.features).to.deep.equal({
+        expect(organization.features).to.include({
           [ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT.key]: true,
+        });
+      });
+
+      it('should build an OrganizationForAdmin with LEARNER-IMPORT feature', function () {
+        const expectedOrganization = domainBuilder.buildOrganizationForAdmin({
+          type: 'SCO-1D',
+        });
+
+        const organization = new OrganizationForAdmin(expectedOrganization);
+
+        expect(organization.features).to.include({
+          [ORGANIZATION_FEATURE.LEARNER_IMPORT.key]: true,
         });
       });
     });

--- a/api/tests/unit/domain/models/organizations-administration/OrganizationForAdmin_test.js
+++ b/api/tests/unit/domain/models/organizations-administration/OrganizationForAdmin_test.js
@@ -60,7 +60,7 @@ describe('Unit | Domain | Models | OrganizationForAdmin', function () {
         const organization = new OrganizationForAdmin(expectedOrganization);
 
         expect(organization.features).to.include({
-          [ORGANIZATION_FEATURE.LEARNER_IMPORT.key]: true,
+          [ORGANIZATION_FEATURE.LEARNER_IMPORT.key]: 'ONDE',
         });
       });
     });

--- a/orga/app/templates/authenticated/missions/list.hbs
+++ b/orga/app/templates/authenticated/missions/list.hbs
@@ -5,9 +5,9 @@
   <br />
   {{#if @model.isAdminOfTheCurrentOrganization}}
     {{t "pages.missions.list.banner.admin.abstract"}}
-    <LinkTo @route="authenticated.import-organization-participants">
-      {{t "pages.missions.list.banner.admin.import-text"}}
-    </LinkTo>
+    <LinkTo @route="authenticated.import-organization-participants">{{t
+        "pages.missions.list.banner.admin.import-text"
+      }}</LinkTo>
     {{t "pages.missions.list.banner.admin.info"}}
   {{else}}
     {{t "pages.missions.list.banner.non-admin.abstract"}}


### PR DESCRIPTION
## :unicorn: Problème

Lorsque l'ont crée une organisation de type SCO-1D, nous n'avons pas le droit de faire un import élève.

## :robot: Proposition

Ajouter l'autorisation d'import élève au moment de la création d'une organisation SCO-1D

## :rainbow: Remarques


## :100: Pour tester

- Créer une organisation de type SCO-1D dans pix-admin
- ajouter un administrateur
- Se connecter avec l'administrateur en question sur Pix Orga
- Vérifier que l'on peut importer des élèves.
