### PR TITLE
wip: test new @ember/debug warn method in PixCheckbox @isDisabled

### DIFF
--- a/mon-pix/app/components/signup-form.hbs
+++ b/mon-pix/app/components/signup-form.hbs
@@ -83,7 +83,11 @@
       </div>
 
       <div class="signup-form__cgu-container">
-        <PixCheckbox {{on "change" this.onCguCheckboxChange}} aria-describedby="sign-up-cgu-error-message">
+        <PixCheckbox
+          {{on "change" this.onCguCheckboxChange}}
+          aria-describedby="sign-up-cgu-error-message"
+          @isDisabled="true"
+        >
           <:label>
             {{t
               "common.cgu.message"

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -13,7 +13,7 @@
         "@1024pix/ember-matomo-tag-manager": "^2.4.3",
         "@1024pix/ember-testing-library": "^1.1.0",
         "@1024pix/eslint-config": "^1.2.12",
-        "@1024pix/pix-ui": "^45.5.0",
+        "@1024pix/pix-ui": "github:1024pix/pix-ui#improve-checkbox-radio-disabled-docs",
         "@1024pix/stylelint-config": "^5.1.13",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.2",
@@ -153,9 +153,8 @@
       "dev": true
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "45.5.2",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-45.5.2.tgz",
-      "integrity": "sha512-J5xnlvfgIUA1zr1zQUN9NI7fWN+/w6PibhZvSK+Y+rZWBbdesl7fqoFS+8C+sVsrp08j8StoTS2IEYJYClBMCg==",
+      "version": "46.0.2",
+      "resolved": "git+ssh://git@github.com/1024pix/pix-ui.git#2e02e5026a49750da0754631de819ee530e66575",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -170,7 +169,7 @@
         "ember-truth-helpers": "^4.0.0"
       },
       "engines": {
-        "node": "^20.12.2"
+        "node": "^20.13.0"
       }
     },
     "node_modules/@1024pix/stylelint-config": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -45,7 +45,7 @@
     "@1024pix/ember-matomo-tag-manager": "^2.4.3",
     "@1024pix/ember-testing-library": "^1.1.0",
     "@1024pix/eslint-config": "^1.2.12",
-    "@1024pix/pix-ui": "^45.5.0",
+    "@1024pix/pix-ui": "github:1024pix/pix-ui#improve-checkbox-radio-disabled-docs",
     "@1024pix/stylelint-config": "^5.1.13",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.2",


### PR DESCRIPTION
Branché avec https://github.com/1024pix/pix-ui/pull/638

En local (dev) sur mon-pix, [la page d'inscription](http://localhost:4200/inscription) j'ai un warning dans la console

<img width="960" alt="image" src="https://github.com/1024pix/pix/assets/5855339/bfed6d95-49e4-4f9e-aa69-84faa7b43dd8">


[En RA](https://app-pr8940.review.pix.fr/inscription), ça ne doit pas être le cas car la variable d'environnement `NODE_ENV` est settée à `production` sur les RA.

<img width="960" alt="image" src="https://github.com/1024pix/pix/assets/5855339/c4060067-83f4-4f46-926b-c37a694481e7">
