### PR TITLE
[FEATURE] Rattrapage de la feature "LEARNER_IMPORT" pour les organisation sco-1d (PIX-12339).

### DIFF
--- a/api/db/migrations/20240515151525_add-unicity-constraint-on-import-format-name.js
+++ b/api/db/migrations/20240515151525_add-unicity-constraint-on-import-format-name.js
@@ -1,0 +1,25 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/DEV/pages/2153512965/Cr+er+une+migration
+
+// If your migrations target `answers` or `knowledge-elements`
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+const TABLE_NAME = 'organization-learner-import-formats';
+const COLUMN_NAME = 'name';
+
+const up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.unique(COLUMN_NAME);
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, function (table) {
+    table.dropUnique(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/db/migrations/20240515151526_add-learner-import-to-sco-1d-organisation.js
+++ b/api/db/migrations/20240515151526_add-learner-import-to-sco-1d-organisation.js
@@ -1,0 +1,34 @@
+const up = async function (knex) {
+  const [feature] = await knex.select('id').from('features').where({ key: 'LEARNER_IMPORT' }).limit(1);
+  const organizationIdsSco1d = await knex.select('id').from('organizations').where({ type: 'SCO-1D' });
+  const [organizationLearnerImportFormat] = await knex
+    .select('id')
+    .from('organization-learner-import-formats')
+    .where({ name: 'ONDE' })
+    .limit(1);
+
+  for await (const organization of organizationIdsSco1d) {
+    await knex('organization-features')
+      .insert({
+        organizationId: organization.id,
+        featureId: feature.id,
+        params: { organizationLearnerImportFormatId: organizationLearnerImportFormat.id },
+      })
+      .onConflict()
+      .ignore();
+  }
+};
+
+const down = async function (knex) {
+  const [feature] = await knex.select('id').from('features').where({ key: 'LEARNER_IMPORT' }).limit(1);
+  const organizationIdsSco1d = await knex.select('id').from('organizations').where({ type: 'SCO-1D' });
+
+  for await (const organization of organizationIdsSco1d) {
+    await knex('organization-features').del().where({
+      organizationId: organization.id,
+      featureId: feature.id,
+    });
+  }
+};
+
+export { down, up };

--- a/api/db/seeds/data/team-prescription/build-organization-learner-import-formats.js
+++ b/api/db/seeds/data/team-prescription/build-organization-learner-import-formats.js
@@ -4,7 +4,7 @@ import { ONDE_IMPORT_FORMAT_ID } from '../common/constants.js';
 export async function buildOrganizationLearnerImportFormat(databaseBuilder) {
   await databaseBuilder.factory.buildOrganizationLearnerImportFormat({
     id: ONDE_IMPORT_FORMAT_ID,
-    name: 'ONDE-seed',
+    name: 'ONDE',
     fileType: 'csv',
     config: {
       acceptedEncoding: ['utf8'],


### PR DESCRIPTION
## :unicorn: Problème
Les organisations SCO-1d n'ont pas la possibilité d'importer des élèves

## :robot: Proposition
Ajouter aux organisations le droit d'importer des élèves

## :100: Pour tester
Créer une organisation sur pix admin, puis ajouter un utilisateur lié à cette orga.
Il faut se connecter avec cette utilisateur sur pix Orga. 
Sur l'onglet missions, cliquez sur le lien "importer les élèves".
Normalement une nouvelle page devrait s'afficher !