### PR TITLE
[POC] Déconnecter la session du fournisseur d'identité en cas d'erreur lors de la connexion (PIX-12531)

### DIFF
--- a/api/src/identity-access-management/application/oidc-provider.controller.js
+++ b/api/src/identity-access-management/application/oidc-provider.controller.js
@@ -51,9 +51,31 @@ async function getRedirectLogoutUrl(request, h) {
 }
 
 /**
+ * @typedef {function} getUnauthenticatedRedirectLogoutUrl
+ * @param request
+ * @param h
+ * @return {Promise<Object>}
+ */
+async function getUnauthenticatedRedirectLogoutUrl(request, h) {
+  const { identity_provider: identityProvider, id_token_hint: idTokenHint } = request.query;
+
+  const redirectLogoutUrl = await usecases.getUnauthenticatedRedirectLogoutUrl({
+    identityProvider,
+    idTokenHint,
+  });
+
+  return h.response({ redirectLogoutUrl }).code(200);
+}
+
+/**
  * @typedef {Object} OidcProviderController
  * @property {getAuthorizationUrl} getAuthorizationUrl
  * @property {getIdentityProviders} getIdentityProviders
  * @property {getRedirectLogoutUrl} getRedirectLogoutUrl
  */
-export const oidcProviderController = { getAuthorizationUrl, getIdentityProviders, getRedirectLogoutUrl };
+export const oidcProviderController = {
+  getAuthorizationUrl,
+  getIdentityProviders,
+  getRedirectLogoutUrl,
+  getUnauthenticatedRedirectLogoutUrl,
+};

--- a/api/src/identity-access-management/application/oidc-provider.route.js
+++ b/api/src/identity-access-management/application/oidc-provider.route.js
@@ -41,6 +41,24 @@ export const oidcProviderRoutes = [
   },
   {
     method: 'GET',
+    path: '/api/oidc/unauthenticated-redirect-logout-url',
+    config: {
+      validate: {
+        query: Joi.object({
+          identity_provider: Joi.string().required(),
+          id_token_hint: Joi.string().required(),
+        }),
+      },
+      auth: false,
+      handler: (request, h) => oidcProviderController.getUnauthenticatedRedirectLogoutUrl(request, h),
+      notes: [
+        "Cette route reçoit le code d'un fournisseur d'identité et renvoie une uri de déconnexion auprès du fournisseur d'identité renseigné.",
+      ],
+      tags: ['identity-access-management', 'api', 'oidc'],
+    },
+  },
+  {
+    method: 'GET',
     path: '/api/oidc/authorization-url',
     config: {
       auth: false,

--- a/api/src/identity-access-management/domain/usecases/get-unauthenticated-redirect-logout-url.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/get-unauthenticated-redirect-logout-url.usecase.js
@@ -1,0 +1,26 @@
+/**
+ * @typedef {function} getUnauthenticatedRedirectLogoutUrl
+ * @param {Object} params
+ * @param {string} params.identityProvider
+ * @param {string} params.idTokenHint
+ * @param {OidcAuthenticationServiceRegistry} params.oidcAuthenticationServiceRegistry
+ * @return {Promise<string>}
+ */
+async function getUnauthenticatedRedirectLogoutUrl({
+  identityProvider,
+  idTokenHint,
+  oidcAuthenticationServiceRegistry,
+}) {
+  await oidcAuthenticationServiceRegistry.loadOidcProviderServices();
+  await oidcAuthenticationServiceRegistry.configureReadyOidcProviderServiceByCode(identityProvider);
+
+  const oidcAuthenticationService = oidcAuthenticationServiceRegistry.getOidcProviderServiceByCode({
+    identityProviderCode: identityProvider,
+  });
+
+  return oidcAuthenticationService.getUnauthenticatedRedirectLogoutUrl({
+    idTokenHint,
+  });
+}
+
+export { getUnauthenticatedRedirectLogoutUrl };

--- a/api/src/identity-access-management/domain/usecases/index.js
+++ b/api/src/identity-access-management/domain/usecases/index.js
@@ -62,5 +62,6 @@ const usecases = injectDependencies(usecasesWithoutInjectedDependencies, depende
  * @property {getAuthorizationUrl} getAuthorizationUrl
  * @property {getReadyIdentityProviders} getReadyIdentityProviders
  * @property {getRedirectLogoutUrl} getRedirectLogoutUrl
+ * @property {getUnauthorizedRedirectLogoutUrl} getUnauthorizedRedirectLogoutUrl
  */
 export { usecases };

--- a/mon-pix/app/controllers/error.js
+++ b/mon-pix/app/controllers/error.js
@@ -1,0 +1,14 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import fetch from 'fetch';
+
+export default class ErrorController extends Controller {
+  @action
+  async disconnectOidcProviderSession() {
+    const response = await fetch(this.disconnectAndRetryUrl);
+
+    const { redirectLogoutUrl } = await response.json();
+
+    window.location.replace(redirectLogoutUrl);
+  }
+}

--- a/mon-pix/app/routes/error.js
+++ b/mon-pix/app/routes/error.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import get from 'lodash/get';
+import ENV from 'mon-pix/config/environment';
 import { ApplicationError } from 'mon-pix/errors/application-error';
 import JSONApiError from 'mon-pix/errors/json-api-error';
 
@@ -27,7 +28,11 @@ export default class ErrorRoute extends Route {
       controller.errorMessage = error.message;
       controller.errorStatus = error.status;
       controller.errorTitle = error.title;
+      if (error.code === 'USER_INFO_MISSING_FIELDS') {
+        const { identityProviderCode, idToken } = error.meta;
 
+        controller.disconnectAndRetryUrl = `${ENV.APP.API_HOST}/api/oidc/unauthenticated-redirect-logout-url?identity_provider=${identityProviderCode}&id_token_hint=${idToken}`;
+      }
       if (error.shortCode) {
         controller.errorStatus += ` (${error.shortCode})`;
       }

--- a/mon-pix/app/templates/error.hbs
+++ b/mon-pix/app/templates/error.hbs
@@ -9,8 +9,7 @@
     <div class="error-page__main-content">
       <h1 class="error-page-main-content__title">{{t "pages.error.first-title"}}</h1>
       {{t "pages.error.content-text" htmlSafe=true}}
-      <LinkTo @route="authentication.login" class="button button--extra-big button--link error-page__index-link">
-        {{t "navigation.back-to-homepage"}}</LinkTo>
+      <PixButton @triggerAction={{this.disconnectOidcProviderSession}}> {{t "navigation.disconnect-and-back-to-homepage"}} </PixButton>
     </div>
     <div class="error-page__error">
       <p class="error-page__error-title">{{this.errorTitle}}</p>

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -111,6 +111,7 @@
   },
   "navigation": {
     "back-to-homepage": "Return to homepage",
+    "disconnect-and-back-to-homepage": "Se déconnecter et réessayer",
     "back-to-profile": "Return to profile",
     "copyrights": "©",
     "error": "Error",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -111,6 +111,7 @@
   },
   "navigation": {
     "back-to-homepage": "Volver a la página de inicio",
+    "disconnect-and-back-to-homepage": "Se déconnecter et réessayer",
     "back-to-profile": "Volver al perfil",
     "copyrights": "©",
     "error": "Error",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -111,6 +111,7 @@
   },
   "navigation": {
     "back-to-homepage": "Revenir à la page d’accueil",
+    "disconnect-and-back-to-homepage": "Se déconnecter et réessayer",
     "back-to-profile": "Revenir au profil",
     "copyrights": "©",
     "error": "Erreur",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -111,6 +111,7 @@
   },
   "navigation": {
     "back-to-homepage": "Terug naar de startpagina",
+    "disconnect-and-back-to-homepage": "Se déconnecter et réessayer",
     "back-to-profile": "Terug naar profiel",
     "copyrights": "©",
     "error": "Fout",


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un utilisateur se connecte avec son fournisseur d'identité sans avoir les claims requis, il arrive sur une page Oups d'erreur avec la liste des claims manquant.

Il reste connecté sur le fournisseur d'identité sans être connecté chez Pix. Ce qui peut poser problème s'il veut recommencer.

## :robot: Proposition
Déconnecter la session de l'utilisateur du fournisseur d'identité. 

## :rainbow: Remarques
- Un claim `doubidou` a été ajouté pour pouvoir tester ce scénario sur n'importe quel fournisseur d'identité

## :100: Pour tester (en local)
- Se connecter avec un fournisseur d'identité.
- Vérifier qu'on tombe bien sur la page Oups avec comme message d'erreur le claim `doubidou` manquant. 
- Cliquer sur le bouton `Se déconnecter et réessayer`
- Vérifier que la redirection vers la page de déconnexion du fournisseur d'identité est bien effectuée 😄 