### PR TITLE
[BUGFIX] Passer à l'étape suivante même lorsque le didacticiel a été joué (Pix-12548)

### DIFF
--- a/api/src/school/domain/services/get-next-activity-info.js
+++ b/api/src/school/domain/services/get-next-activity-info.js
@@ -49,17 +49,21 @@ function _lastActivity(activities) {
   return activities[0];
 }
 
-function _hasValidatedTheMissionUsingTutorial(lastActivity, activities) {
-  return lastActivity.isValidation && _hasAlreadyDoneActivity(activities, TUTORIAL);
+function _hasValidatedTheMissionUsingTutorialInFinalStep(lastActivity, currentStepActivities, stepCount) {
+  return _hasValidatedTheMission(lastActivity, stepCount) && _hasAlreadyDoneActivity(currentStepActivities, TUTORIAL);
+}
+
+function _hasValidatedTheMission(lastActivity, stepCount) {
+  return lastActivity.isValidation && lastActivity.stepIndex === stepCount - 1;
 }
 
 /**
- * @param {[Activity]} activities
+ * @param {[Activity]} currentStepActivities
  * @param {Activity} lastActivity
  * @param {number} stepCount
  */
-function _getNextActivityInfoAfterSuccess(activities, lastActivity, stepCount) {
-  if (_hasValidatedTheMissionUsingTutorial(lastActivity, activities)) {
+function _getNextActivityInfoAfterSuccess(currentStepActivities, lastActivity, stepCount) {
+  if (_hasValidatedTheMissionUsingTutorialInFinalStep(lastActivity, currentStepActivities, stepCount)) {
     return END_OF_MISSION;
   }
   const nextActivityLevel = lastActivity.higherLevel;

--- a/api/tests/school/unit/domain/services/get-next-activity-info_test.js
+++ b/api/tests/school/unit/domain/services/get-next-activity-info_test.js
@@ -199,6 +199,17 @@ describe('Unit | Domain | Pix Junior | get next activity info', function () {
       stepCount: 1,
       expectedActivityInfo: END_OF_MISSION,
     },
+    {
+      activities: [
+        '0:VALIDATION:FAILED',
+        '0:TRAINING:FAILED',
+        '0:TUTORIAL:SUCCEEDED',
+        '0:TRAINING:SUCCEEDED',
+        '0:VALIDATION:SUCCEEDED',
+      ],
+      stepCount: 2,
+      expectedActivityInfo: '1:VALIDATION',
+    },
   ].forEach(({ activities, stepCount, expectedActivityInfo }) => {
     // eslint-disable-next-line mocha/no-setup-in-describe
     context(`when activities flow is ${JSON.stringify(activities)} in a ${stepCount} steps mission`, function () {


### PR DESCRIPTION
## :unicorn: Problème
Si l'élève a validé la 1ère étape d'une mission en étant passé par le didacticiel, il n’est pas redirigé sur l'étape suivante, mais termine la mission prématurément.

## :robot: Proposition
Celui-ci doit être redirigé vers l’activité de validation de l'étape suivante.

## :100: Pour tester
Jouer une mission à 2 étapes. Echouer jusqu'au didacticiel sur la 1ère étape, puis réussir l'entraînement et la validation. La 1ère épreuve de validation de la 2nde étape est alors proposée.
