### PR TITLE
[FEATURE]  Changement de style dans des page resume/result des missions (Pix-12568)

### DIFF
--- a/junior/app/pods/assessment/results/template.hbs
+++ b/junior/app/pods/assessment/results/template.hbs
@@ -10,12 +10,11 @@
     />
 
     <div class="mission-page__details">
-      <p class="details-list__title">{{t "pages.missions.end-page.details-list"}}</p>
+      <p class="details-list__title details-list__title--big">{{t "pages.missions.end-page.details-list"}}</p>
       <ul class="details-list">
         {{#each this.validatedObjectives as |element|}}
-          <li class="details-list__item">
-            <img src="/images/icons/objectif.svg" alt="" />
-            <Markdown::MarkdownToHtml @markdown={{element}} />
+          <li>
+            <Markdown::MarkdownToHtml @markdown={{element}} class="details-list__item" />
           </li>
         {{/each}}
       </ul>

--- a/junior/app/pods/identified/missions/mission/mission.scss
+++ b/junior/app/pods/identified/missions/mission/mission.scss
@@ -40,7 +40,6 @@
     ul {
       margin-left: 30px;
       list-style-type: disc;
-
     }
 
     .details-list {

--- a/junior/app/pods/identified/missions/mission/mission.scss
+++ b/junior/app/pods/identified/missions/mission/mission.scss
@@ -37,6 +37,12 @@
       text-decoration: underline;
     }
 
+    ul {
+      margin-left: 30px;
+      list-style-type: disc;
+
+    }
+
     .details-list {
 
       &__title {

--- a/junior/app/pods/identified/missions/mission/template.hbs
+++ b/junior/app/pods/identified/missions/mission/template.hbs
@@ -15,9 +15,8 @@
       <p class="details-list__title details-list__title--big">{{t "pages.missions.start-page.purpose-title"}}</p>
       <ul class="details-list">
         {{#each this.learningObjectives as |element|}}
-          <li class="details-list__item">
-            <FaIcon @icon="arrow-right" class="icon" />
-            <Markdown::MarkdownToHtml @markdown={{element}} />
+          <li>
+            <Markdown::MarkdownToHtml @markdown={{element}} class="details-list__item" />
           </li>
         {{/each}}
       </ul>

--- a/junior/translations/fr.json
+++ b/junior/translations/fr.json
@@ -44,7 +44,7 @@
       "end-page": {
         "congratulations": "Bravo ! <br> Tu as terminé ta mission !",
         "back-to-missions": "Voir d'autres missions",
-        "details-list": "Tu as pu validé les notions suivantes:"
+        "details-list": "Tu as pu travailler :"
       }
     },
     "error": {


### PR DESCRIPTION
## :unicorn: Problème

La notation des objectifs étaient affichés comme validés quoi qu'il arrive.
Le style ne rendait pas lisible les éléments.


## :robot: Proposition
Ne plus afficher la réussite des objectifs.
Changer le style, pour homogénéiser les puces dans les listes.


## :100: Pour tester
Réaliser un parcourt et observer au début de la mission, et à sa fin, les page de récapitulatif.

![Capture d’écran du 2024-05-17 15-44-30](https://github.com/1024pix/pix/assets/62065031/1b121bee-d042-4a1d-8dfa-68af9dea6aa0)

![Capture d’écran du 2024-05-17 15-44-34](https://github.com/1024pix/pix/assets/62065031/bd89d162-62e2-4f1c-81fb-76ab66eb1cbd)

