### PR TITLE
[TECH] Ajouter des configurations pour exécuter les tests sur Webstorm

### DIFF
--- a/.run/Acceptance _ Pix Api.run.xml
+++ b/.run/Acceptance _ Pix Api.run.xml
@@ -1,0 +1,31 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Acceptance | Pix Api" type="mocha-javascript-test-runner">
+    <node-interpreter>project</node-interpreter>
+    <node-options />
+    <mocha-package>$PROJECT_DIR$/api/node_modules/mocha</mocha-package>
+    <working-directory>$PROJECT_DIR$/api</working-directory>
+    <pass-parent-env>true</pass-parent-env>
+    <envs>
+      <env name="NODE_ENV" value="test" />
+      <env name="TEST_DATABASE_URL" value="postgresql://postgres@localhost/pix_acceptance_test" />
+    </envs>
+    <ui>bdd</ui>
+    <extra-mocha-options>--exit --recursive</extra-mocha-options>
+    <test-kind>PATTERN</test-kind>
+    <test-pattern>tests/**/acceptance/**/*test.js</test-pattern>
+    <method v="2">
+      <option name="NpmBeforeRunTask" enabled="true">
+        <package-json value="$PROJECT_DIR$/api/package.json" />
+        <command value="run" />
+        <scripts>
+          <script value="db:prepare" />
+        </scripts>
+        <node-interpreter value="project" />
+        <envs>
+          <env name="NODE_ENV" value="test" />
+          <env name="TEST_DATABASE_URL" value="postgresql://postgres@localhost/pix_acceptance_test" />
+        </envs>
+      </option>
+    </method>
+  </configuration>
+</component>

--- a/.run/Integration _ Pix Api.run.xml
+++ b/.run/Integration _ Pix Api.run.xml
@@ -1,0 +1,31 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Integration | Pix Api" type="mocha-javascript-test-runner">
+    <node-interpreter>project</node-interpreter>
+    <node-options />
+    <mocha-package>$PROJECT_DIR$/api/node_modules/mocha</mocha-package>
+    <working-directory>$PROJECT_DIR$/api</working-directory>
+    <pass-parent-env>true</pass-parent-env>
+    <envs>
+      <env name="NODE_ENV" value="test" />
+      <env name="TEST_DATABASE_URL" value="postgresql://postgres@localhost/pix_integration_test" />
+    </envs>
+    <ui>bdd</ui>
+    <extra-mocha-options>--exit --recursive</extra-mocha-options>
+    <test-kind>PATTERN</test-kind>
+    <test-pattern>tests/**/integration/**/*test.js</test-pattern>
+    <method v="2">
+      <option name="NpmBeforeRunTask" enabled="true">
+        <package-json value="$PROJECT_DIR$/api/package.json" />
+        <command value="run" />
+        <scripts>
+          <script value="db:prepare" />
+        </scripts>
+        <node-interpreter value="project" />
+        <envs>
+          <env name="NODE_ENV" value="test" />
+          <env name="TEST_DATABASE_URL" value="postgresql://postgres@localhost/pix_integration_test" />
+        </envs>
+      </option>
+    </method>
+  </configuration>
+</component>

--- a/.run/Pix Api Tests.run.xml
+++ b/.run/Pix Api Tests.run.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Pix Api Tests" type="CompoundRunConfigurationType">
+    <toRun name="Acceptance | Pix Api" type="mocha-javascript-test-runner" />
+    <toRun name="Integration | Pix Api" type="mocha-javascript-test-runner" />
+    <toRun name="Unit | Pix Api" type="mocha-javascript-test-runner" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Unit _ Pix Api.run.xml
+++ b/.run/Unit _ Pix Api.run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Unit | Pix Api" type="mocha-javascript-test-runner">
+    <node-interpreter>project</node-interpreter>
+    <node-options />
+    <mocha-package>$PROJECT_DIR$/api/node_modules/mocha</mocha-package>
+    <working-directory>$PROJECT_DIR$/api</working-directory>
+    <pass-parent-env>true</pass-parent-env>
+    <envs>
+      <env name="NODE_ENV" value="test" />
+      <env name="TEST_DATABASE_URL" value="postgres://should.not.reach.db.in.unit.tests" />
+      <env name="REDIS_URL" value="" />
+    </envs>
+    <ui>bdd</ui>
+    <extra-mocha-options>--exit --recursive</extra-mocha-options>
+    <test-kind>PATTERN</test-kind>
+    <test-pattern>tests/**/unit/**/*test.js</test-pattern>
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
## :unicorn: Problème

Il n'y a pas de configurations sur Webstorm pour exécuter tous les tests, ou tous les tests unitaires, d'intégration ou d'acceptance.

## :robot: Proposition

Ajouter les configurations d'exécution suivantes pour Webstorm dans le dossier `/.run` :

- **Unit | Pix Api** - _Mocha run configuration_
- **Integration | Pix Api** - _Mocha run configuration_
- **Acceptance | Pix Api** - _Mocha run configuration_
- **Pix Api Tests** - _Compound run configuration_

## :rainbow: Remarques

Webstorm devrait prendre en compte automatiquement les nouveaux fichiers qui sont ajoutés dans le dossier `/.run`. Donc, si vous êtes sur cette PR, vous devriez voir dans la liste des configurations sur Webstorm les 4 nouvelles configurations.

Les configurations pour l'intégration et l'acceptance ont doivent exécuter une configuration d'exécution de type `npm script` avant d'être exécuté. Cette configuration est la préparation de la base de données. Cette préparation utilisera `pix_integration_test` pour les tests d'intégration et `pix_acceptance_test` pour les tests d'acceptance.

Le faite d'utiliser une base de données différentes pour integration et acceptance permet également de créer une configuration d'exécution dite `compound`. Cette configuration permet d'exécuter les configurations d'exécution des tests en parallèle.

## :100: Pour tester

- ✅ CI
- Exécuter les différentes configurations sur votre machine
