### PR TITLE
[BUGFIX] Corriger l'affichage des inputs dans la modale de gestion du compte de l'élève sur Pix Orga (PIX-12469)

### DIFF
--- a/orga/app/components/sco-organization-participant/manage-authentication-method-modal.hbs
+++ b/orga/app/components/sco-organization-participant/manage-authentication-method-modal.hbs
@@ -44,12 +44,7 @@
                     }}</:label>
                 </PixInput>
                 {{#if (is-clipboard-supported)}}
-                  <PixTooltip
-                    @id="copy-email-tooltip"
-                    @position="top"
-                    @isInline={{true}}
-                    class="manage-authentication-window__tooltip"
-                  >
+                  <PixTooltip @id="copy-email-tooltip" @position="top" @isInline={{true}}>
                     <:triggerElement>
                       <CopyButton
                         @text={{@student.email}}
@@ -59,7 +54,7 @@
                           'pages.sco-organization-participants.manage-authentication-method-modal.section.email.copy'
                         }}"
                         aria-describedby="copy-email-tooltip"
-                        class="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey manage-authentication-window__clipboard-button"
+                        class="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey"
                       >
                         <FaIcon @icon="copy" @prefix="far" />
                       </CopyButton>
@@ -103,12 +98,7 @@
                       }}</:label>
                   </PixInput>
                   {{#if (is-clipboard-supported)}}
-                    <PixTooltip
-                      @id="copy-username-tooltip"
-                      @position="top"
-                      @isInline={{true}}
-                      class="manage-authentication-window__tooltip"
-                    >
+                    <PixTooltip @id="copy-username-tooltip" @position="top" @isInline={{true}}>
                       <:triggerElement>
                         <CopyButton
                           @text={{@student.username}}
@@ -118,7 +108,7 @@
                             "pages.sco-organization-participants.manage-authentication-method-modal.section.username.copy"
                           }}
                           aria-describedby="copy-username-tooltip"
-                          class="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey manage-authentication-window__clipboard-button"
+                          class="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey"
                         >
                           <FaIcon @icon="copy" @prefix="far" />
                         </CopyButton>
@@ -147,12 +137,7 @@
                       }}</:label>
                   </PixInput>
                   {{#if (is-clipboard-supported)}}
-                    <PixTooltip
-                      @id="copy-password-tooltip"
-                      @position="top"
-                      @isInline={{true}}
-                      class="manage-authentication-window__tooltip"
-                    >
+                    <PixTooltip @id="copy-password-tooltip" @position="top" @isInline={{true}}>
                       <:triggerElement>
                         <CopyButton
                           @text={{this.generatedPassword}}
@@ -162,7 +147,7 @@
                             "pages.sco-organization-participants.manage-authentication-method-modal.section.password.copy"
                           }}
                           aria-describedby="copy-password-tooltip"
-                          class="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey manage-authentication-window__clipboard-button"
+                          class="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey"
                         >
                           <FaIcon @icon="copy" @prefix="far" class="fa-inverse" />
                         </CopyButton>

--- a/orga/app/styles/components/manage-authentication-method-modal.scss
+++ b/orga/app/styles/components/manage-authentication-method-modal.scss
@@ -32,22 +32,16 @@
   }
 
   &__clipboard {
+    display: flex;
+    gap: var(--pix-spacing-4x);
+
+    .pix-input {
+      width: 100%;
+    }
+
     input {
       box-sizing: border-box;
-      width: 85%;
       background-color: var(--pix-neutral-20);
-    }
-  }
-
-  &__clipboard-button {
-    margin: -10px 6px 0 6px;
-  }
-
-  &__tooltip {
-    display: inline-block;
-
-    .pix-tooltip__content {
-      margin-bottom: 6px;
     }
   }
 


### PR DESCRIPTION
## :unicorn: Problème
Dans la fenêtre “Gestion du compte Pix de l'élève”, les champs “Identifiant” et “email” sont tronqués. Sur l’identifiant spécifiquement, il est impossible de lire l’identifiant au complet. Même si la fonctionnalité “Copier” existe, en pratique, le professeur préfère dicter l’identifiant à l’oral ce qui est impossible dans la configuration.

![image](https://github.com/1024pix/pix/assets/11760574/4123c2bb-2097-41cf-bdfa-71dac6083d2f)

## :robot: Proposition

Agrandir l’input jusqu’au bout et aligner le bouton “copier”.


## :rainbow: Remarques
RAS

## :100: Pour tester 
- Se connecter sur la RA de Pix Orga avec le compte allorga@example.net
- Vérifier que vous êtes bien connecté sur l'organisation `Collège House of the Dragon`
- Aller sur l'onglet Elèves
- Cliquer, sur la ligne correspondant à l'élève Eliza Delajungle, sur l'icône _Afficher les actions_
- Sélectionner l'option _Gérer le compte_.
- Vérifier que les champs input correspondant à l'adresse email et identifiant sont bien agrandis
- Vérifier que les boutons `copier` sont aussi bien alignés avec l'input 😄 