### PR TITLE
[TECH] Améliorer l'orchestration du usecase `verifyAndSaveAnswer` (PIX-12456)

### DIFF
--- a/api/src/devcomp/domain/usecases/verify-and-save-answer.js
+++ b/api/src/devcomp/domain/usecases/verify-and-save-answer.js
@@ -6,7 +6,7 @@ async function verifyAndSaveAnswer({
   elementId,
   passageId,
   passageRepository,
-  moduleRepository,
+  elementRepository,
   elementAnswerRepository,
 }) {
   const passage = await _getPassage({ passageId, passageRepository });
@@ -14,10 +14,7 @@ async function verifyAndSaveAnswer({
     throw new PassageTerminatedError();
   }
 
-  const module = await moduleRepository.getBySlugForVerification({ slug: passage.moduleId });
-
-  const grain = module.getGrainByElementId(elementId);
-  const element = grain.getElementById(elementId);
+  const element = await elementRepository.getByIdForAnswerVerification({ moduleId: passage.moduleId, elementId });
 
   element.setUserResponse(userResponse);
 

--- a/api/src/devcomp/infrastructure/repositories/element-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/element-repository.js
@@ -1,0 +1,29 @@
+import { NotFoundError } from '../../../shared/domain/errors.js';
+import { LearningContentResourceNotFound } from '../../../shared/infrastructure/datasources/learning-content/LearningContentResourceNotFound.js';
+import { Module } from '../../domain/models/module/Module.js';
+
+async function getByIdForAnswerVerification({ moduleId, elementId, moduleDatasource }) {
+  let moduleData;
+  try {
+    moduleData = await moduleDatasource.getBySlug(moduleId);
+  } catch (e) {
+    if (e instanceof LearningContentResourceNotFound) {
+      throw new NotFoundError();
+    }
+    throw e;
+  }
+
+  const foundElement = moduleData.grains
+    .flatMap(({ components }) => components)
+    .find((component) => component.type === 'element' && component.element.id === elementId);
+
+  if (foundElement === undefined) {
+    throw new NotFoundError();
+  }
+
+  const module = Module.toDomainForVerification(moduleData);
+  const grain = module.getGrainByElementId(elementId);
+  return grain.getElementById(elementId);
+}
+
+export { getByIdForAnswerVerification };

--- a/api/src/devcomp/infrastructure/repositories/index.js
+++ b/api/src/devcomp/infrastructure/repositories/index.js
@@ -1,6 +1,7 @@
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import moduleDatasource from '../datasources/learning-content/module-datasource.js';
 import * as elementAnswerRepository from './element-answer-repository.js';
+import * as elementRepository from './element-repository.js';
 import * as moduleRepository from './module-repository.js';
 import * as passageRepository from './passage-repository.js';
 import * as trainingRepository from './training-repository.js';
@@ -12,6 +13,7 @@ import * as userSavedTutorialRepository from './user-saved-tutorial-repository.j
 
 const repositoriesWithoutInjectedDependencies = {
   elementAnswerRepository,
+  elementRepository,
   moduleRepository,
   passageRepository,
   trainingRepository,

--- a/api/tests/devcomp/integration/repositories/element-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/element-repository_test.js
@@ -1,0 +1,84 @@
+import { QCUForAnswerVerification } from '../../../../src/devcomp/domain/models/element/QCU-for-answer-verification.js';
+import moduleDatasource from '../../../../src/devcomp/infrastructure/datasources/learning-content/module-datasource.js';
+import * as elementRepository from '../../../../src/devcomp/infrastructure/repositories/element-repository.js';
+import { NotFoundError } from '../../../../src/shared/domain/errors.js';
+import { catchErr, expect } from '../../../test-helper.js';
+
+describe('Integration | DevComp | Repositories | ElementRepository', function () {
+  describe('#getByIdForAnswerVerification', function () {
+    it('should return the element', async function () {
+      // given
+      const moduleId = 'didacticiel-modulix';
+      const elementId = '71de6394-ff88-4de3-8834-a40057a50ff4';
+      const element = new QCUForAnswerVerification({
+        id: elementId,
+        type: 'qcu',
+        instruction: '<p>Pix évalue 16 compétences numériques différentes.</p>',
+        proposals: [
+          {
+            id: '1',
+            content: 'Vrai',
+          },
+          {
+            id: '2',
+            content: 'Faux',
+          },
+        ],
+        feedbacks: {
+          valid: '<p>Correct&#8239;! Ces 16 compétences sont rangées dans 5 domaines.</p>',
+          invalid: '<p>Incorrect. Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>️!</p>',
+        },
+        solution: '1',
+      });
+
+      // when
+      const foundElement = await elementRepository.getByIdForAnswerVerification({
+        moduleId,
+        elementId,
+        moduleDatasource,
+      });
+
+      // then
+      expect(foundElement).to.be.instanceof(QCUForAnswerVerification);
+      expect(foundElement).to.deep.equal(element);
+    });
+
+    describe('errors', function () {
+      describe('when module id is not found', function () {
+        it('should throw a NotFoundError', async function () {
+          // given
+          const nonExistingModuleId = 'dresser-des-pokemons';
+          const elementId = '67b68f2a-349d-4df7-90a5-c9f5dc930a1a';
+
+          // when
+          const error = await catchErr(elementRepository.getByIdForAnswerVerification)({
+            moduleId: nonExistingModuleId,
+            elementId,
+            moduleDatasource,
+          });
+
+          // then
+          expect(error).to.be.instanceOf(NotFoundError);
+        });
+      });
+
+      describe('when element id is not found', function () {
+        it('should throw a NotFoundError', async function () {
+          // given
+          const moduleId = 'adresse-ip-publique-et-vous';
+          const nonExistingElementId = '12';
+
+          // when
+          const error = await catchErr(elementRepository.getByIdForAnswerVerification)({
+            moduleId,
+            elementId: nonExistingElementId,
+            moduleDatasource,
+          });
+
+          // then
+          expect(error).to.be.instanceOf(NotFoundError);
+        });
+      });
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/usecases/verify-and-save-answer_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/verify-and-save-answer_test.js
@@ -28,7 +28,7 @@ describe('Unit | Devcomp | Domain | UseCases | verify-and-save-answer', function
         const elementId = Symbol('elementId');
         const passageId = Symbol('passageId');
         const userResponse = Symbol('userResponse');
-        const moduleRepository = {};
+        const elementRepository = {};
         const elementAnswerRepository = {};
 
         const passageRepository = {
@@ -43,7 +43,7 @@ describe('Unit | Devcomp | Domain | UseCases | verify-and-save-answer', function
           elementId,
           passageId,
           passageRepository,
-          moduleRepository,
+          elementRepository,
           elementAnswerRepository,
         });
 
@@ -65,11 +65,9 @@ describe('Unit | Devcomp | Domain | UseCases | verify-and-save-answer', function
         const moduleId = Symbol('moduleId');
         passageRepository.get.withArgs({ passageId }).resolves({ moduleId });
 
-        const moduleRepository = {
-          getBySlugForVerification: sinon.stub(),
+        const elementRepository = {
+          getByIdForAnswerVerification: sinon.stub(),
         };
-
-        const module = { getGrainByElementId: sinon.stub() };
 
         const element = {
           userResponse: Symbol('UserResponse'),
@@ -80,11 +78,7 @@ describe('Unit | Devcomp | Domain | UseCases | verify-and-save-answer', function
         element.setUserResponse.withArgs(userResponse).returns();
         element.assess.withArgs().returns(correction);
 
-        const grain = { id: 'grain-id', getElementById: sinon.stub() };
-        grain.getElementById.withArgs(elementId).returns(element);
-        module.getGrainByElementId.withArgs(elementId).returns(grain);
-
-        moduleRepository.getBySlugForVerification.withArgs({ slug: moduleId }).resolves(module);
+        elementRepository.getByIdForAnswerVerification.withArgs({ moduleId, elementId }).resolves(element);
 
         const elementAnswerRepository = {
           save: sinon.stub(),
@@ -104,7 +98,7 @@ describe('Unit | Devcomp | Domain | UseCases | verify-and-save-answer', function
           elementId,
           passageId,
           passageRepository,
-          moduleRepository,
+          elementRepository,
           elementAnswerRepository,
         });
 


### PR DESCRIPTION
## :unicorn: Problème
Jusque là notre usecase `verifyAndSaveAnswer` récupérait un `Element` `forAnswerVerification` en récupérant un `Module` `forAnswerVerification` avant de boucler dessus en passant par le grain.
Depuis la précédente étape de migration vers les `Components`, nous n'utilisons plus l'id du `Grain`.

## :robot: Proposition
Nous pouvons donc désormais simplifier la logique du usecase en récupérant directement un `Element` `forAnswerVerification` sans passer par le `Module` et ses grains.
Nous avons donc implémenté un `ElementRepository` qui va retourner `Element` `forAnswerVerification`.

## :rainbow: Remarques
Étant donné la prochaine tâche de refactor, nous pourrons en profiter pour simplifier encore plus la logique du repository.

## :100: Pour tester
La CI passe.
Il n'y a pas de régression lors d'une vérification de question via par exemple [le didacticiel](https://app-pr8975.review.pix.fr/modules/didacticiel-modulix).
