### PR TITLE
[FEATURE] Enchainer les activités après le didacticiel (PIX-12566).

### DIFF
--- a/api/src/school/domain/models/Activity.js
+++ b/api/src/school/domain/models/Activity.js
@@ -41,6 +41,10 @@ class Activity {
     return this.level === levels.TRAINING;
   }
 
+  get isTutorial() {
+    return this.level === levels.TUTORIAL;
+  }
+
   get isSucceeded() {
     return this.status === status.SUCCEEDED;
   }

--- a/api/src/school/domain/services/get-next-activity-info.js
+++ b/api/src/school/domain/services/get-next-activity-info.js
@@ -26,7 +26,7 @@ export function getNextActivityInfo({ activities, stepCount }) {
   if (_hasRunActivityLevel3Times(currentStepActivities, TRAINING) && lastActivity.isFailedOrSkipped) {
     return END_OF_MISSION;
   }
-  if (lastActivity.isSucceeded) {
+  if (lastActivity.isSucceeded || lastActivity.isTutorial) {
     return _getNextActivityInfoAfterSuccess(currentStepActivities, lastActivity, stepCount);
   }
   if (lastActivity.isFailedOrSkipped) {

--- a/api/tests/school/integration/domain/services/update-current-activity_test.js
+++ b/api/tests/school/integration/domain/services/update-current-activity_test.js
@@ -9,101 +9,275 @@ import { databaseBuilder, expect, knex, mockLearningContent } from '../../../../
 import * as learningContentBuilder from '../../../../tooling/learning-content-builder/index.js';
 
 describe('Integration | UseCase | update current activity', function () {
-  context('when last answer is ko', function () {
-    it('should update current activity with FAILED status', async function () {
-      const { assessmentId, missionId } = databaseBuilder.factory.buildMissionAssessment();
-      const { id: activityId } = databaseBuilder.factory.buildActivity({
-        assessmentId,
-        status: Activity.status.STARTED,
-        stepIndex: 0,
-      });
-      databaseBuilder.factory.buildActivityAnswer({
-        activityId,
-        challengeId: 'va_challenge_id',
-        result: AnswerStatus.statuses.KO,
-      });
-
-      mockLearningContent({
-        missions: [
-          learningContentBuilder.buildMission({
-            id: missionId,
-            content: {
-              steps: [
-                {
-                  validationChallenges: [['va_challenge_id'], ['va_next_challenge_id']],
-                },
-              ],
-            },
-          }),
-        ],
-      });
-
-      await databaseBuilder.commit();
-
-      const currentActivity = await updateCurrentActivity({
-        assessmentId,
-        activityRepository,
-        activityAnswerRepository,
-        missionAssessmentRepository,
-        missionRepository,
-      });
-
-      const activities = await knex('activities').where({ assessmentId });
-      expect(activities.length).to.equal(1);
-      expect(activities[0].status).to.equal(Activity.status.FAILED);
-      expect(currentActivity.status).equals(Activity.status.FAILED);
-    });
-  });
-  context('when last answer is ok', function () {
+  context('when activity level is tutorial', function () {
     context('when activity is not finished', function () {
-      it('should not update current activity status', async function () {
-        const { assessmentId, missionId } = databaseBuilder.factory.buildMissionAssessment();
-        const { id: activityId } = databaseBuilder.factory.buildActivity({
-          assessmentId,
-          level: Activity.levels.VALIDATION,
-          status: Activity.status.STARTED,
-          stepIndex: 0,
-        });
-        databaseBuilder.factory.buildActivityAnswer({
-          activityId,
-          challengeId: 'va_challenge_id',
-          result: AnswerStatus.statuses.OK,
-        });
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      [
+        // eslint-disable-next-line mocha/no-setup-in-describe
+        { message: 'correctly answered', result: AnswerStatus.statuses.OK },
+        // eslint-disable-next-line mocha/no-setup-in-describe
+        { message: 'wrongly answered', result: AnswerStatus.statuses.KO },
+        // eslint-disable-next-line mocha/no-setup-in-describe
+        { message: 'skipped', result: AnswerStatus.statuses.SKIPPED },
+      ].forEach(({ message, result }) =>
+        it(`should not update current activity status when challenge is ${message}`, async function () {
+          const { assessmentId, missionId } = databaseBuilder.factory.buildMissionAssessment();
+          const { id: activityId } = databaseBuilder.factory.buildActivity({
+            assessmentId,
+            level: Activity.levels.TUTORIAL,
+            status: Activity.status.STARTED,
+            stepIndex: 0,
+          });
+          databaseBuilder.factory.buildActivityAnswer({
+            activityId,
+            challengeId: 'di_challenge_id',
+            result,
+          });
 
-        await databaseBuilder.commit();
+          await databaseBuilder.commit();
 
-        mockLearningContent({
-          missions: [
-            learningContentBuilder.buildMission({
-              id: missionId,
-              content: {
-                steps: [
-                  {
-                    validationChallenges: [['va_challenge_id'], ['va_next_challenge_id']],
-                  },
-                ],
-              },
-            }),
-          ],
-        });
+          mockLearningContent({
+            missions: [
+              learningContentBuilder.buildMission({
+                id: missionId,
+                content: {
+                  steps: [
+                    {
+                      tutorialChallenges: [['di_challenge_id'], ['di_next_challenge_id']],
+                    },
+                  ],
+                },
+              }),
+            ],
+          });
 
-        const currentActivity = await updateCurrentActivity({
-          assessmentId,
-          activityRepository,
-          activityAnswerRepository,
-          missionAssessmentRepository,
-          missionRepository,
-        });
+          const currentActivity = await updateCurrentActivity({
+            assessmentId,
+            activityRepository,
+            activityAnswerRepository,
+            missionAssessmentRepository,
+            missionRepository,
+          });
 
-        const activities = await knex('activities').where({ assessmentId });
-        expect(activities.length).to.equal(1);
-        expect(activities[0].status).to.equal(Activity.status.STARTED);
-        expect(currentActivity.status).equals(Activity.status.STARTED);
-      });
+          const activities = await knex('activities').where({ assessmentId });
+          expect(activities.length).to.equal(1);
+          expect(activities[0].status).to.equal(Activity.status.STARTED);
+          expect(currentActivity.status).equals(Activity.status.STARTED);
+        }),
+      );
     });
 
     context('when activity is finished', function () {
-      it('should update current activity with SUCCEEDED status', async function () {
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      [
+        // eslint-disable-next-line mocha/no-setup-in-describe
+        { message: 'correctly answered', result: AnswerStatus.statuses.OK },
+        // eslint-disable-next-line mocha/no-setup-in-describe
+        { message: 'wrongly answered', result: AnswerStatus.statuses.KO },
+        // eslint-disable-next-line mocha/no-setup-in-describe
+        { message: 'skipped', result: AnswerStatus.statuses.SKIPPED },
+      ].forEach(({ message, result }) =>
+        it(`should update current activity with SUCCEEDED status when challenge is ${message}`, async function () {
+          const { assessmentId, missionId } = databaseBuilder.factory.buildMissionAssessment();
+          const { id: activityId } = databaseBuilder.factory.buildActivity({
+            assessmentId,
+            level: Activity.levels.TUTORIAL,
+            status: Activity.status.STARTED,
+            stepIndex: 0,
+          });
+          databaseBuilder.factory.buildActivityAnswer({
+            activityId,
+            challengeId: 'di_challenge_id',
+            result,
+          });
+          databaseBuilder.factory.buildActivityAnswer({
+            activityId,
+            challengeId: 'di_next_challenge_id',
+            result,
+          });
+
+          await databaseBuilder.commit();
+
+          mockLearningContent({
+            missions: [
+              learningContentBuilder.buildMission({
+                id: missionId,
+                content: {
+                  steps: [
+                    {
+                      tutorialChallenges: [['di_challenge_id'], ['di_next_challenge_id']],
+                    },
+                  ],
+                },
+              }),
+            ],
+          });
+
+          const currentActivity = await updateCurrentActivity({
+            assessmentId,
+            activityRepository,
+            activityAnswerRepository,
+            missionAssessmentRepository,
+            missionRepository,
+          });
+
+          const activities = await knex('activities').where({ assessmentId });
+          expect(activities.length).to.equal(1);
+          expect(activities[0].status).to.equal(Activity.status.SUCCEEDED);
+          expect(currentActivity.status).equals(Activity.status.SUCCEEDED);
+        }),
+      );
+    });
+  });
+  context('when activity level is not tutorial', function () {
+    context('when last answer is ko', function () {
+      it('should update current activity with FAILED status', async function () {
+        const { assessmentId, missionId } = databaseBuilder.factory.buildMissionAssessment();
+        const { id: activityId } = databaseBuilder.factory.buildActivity({
+          assessmentId,
+          status: Activity.status.STARTED,
+          level: Activity.levels.VALIDATION,
+          stepIndex: 0,
+        });
+        databaseBuilder.factory.buildActivityAnswer({
+          activityId,
+          challengeId: 'va_challenge_id',
+          result: AnswerStatus.statuses.KO,
+        });
+
+        mockLearningContent({
+          missions: [
+            learningContentBuilder.buildMission({
+              id: missionId,
+              content: {
+                steps: [
+                  {
+                    validationChallenges: [['va_challenge_id'], ['va_next_challenge_id']],
+                  },
+                ],
+              },
+            }),
+          ],
+        });
+
+        await databaseBuilder.commit();
+
+        const currentActivity = await updateCurrentActivity({
+          assessmentId,
+          activityRepository,
+          activityAnswerRepository,
+          missionAssessmentRepository,
+          missionRepository,
+        });
+
+        const activities = await knex('activities').where({ assessmentId });
+        expect(activities.length).to.equal(1);
+        expect(activities[0].status).to.equal(Activity.status.FAILED);
+        expect(currentActivity.status).equals(Activity.status.FAILED);
+      });
+    });
+    context('when last answer is ok', function () {
+      context('when activity is not finished', function () {
+        it('should not update current activity status', async function () {
+          const { assessmentId, missionId } = databaseBuilder.factory.buildMissionAssessment();
+          const { id: activityId } = databaseBuilder.factory.buildActivity({
+            assessmentId,
+            level: Activity.levels.VALIDATION,
+            status: Activity.status.STARTED,
+            stepIndex: 0,
+          });
+          databaseBuilder.factory.buildActivityAnswer({
+            activityId,
+            challengeId: 'va_challenge_id',
+            result: AnswerStatus.statuses.OK,
+          });
+
+          await databaseBuilder.commit();
+
+          mockLearningContent({
+            missions: [
+              learningContentBuilder.buildMission({
+                id: missionId,
+                content: {
+                  steps: [
+                    {
+                      validationChallenges: [['va_challenge_id'], ['va_next_challenge_id']],
+                    },
+                  ],
+                },
+              }),
+            ],
+          });
+
+          const currentActivity = await updateCurrentActivity({
+            assessmentId,
+            activityRepository,
+            activityAnswerRepository,
+            missionAssessmentRepository,
+            missionRepository,
+          });
+
+          const activities = await knex('activities').where({ assessmentId });
+          expect(activities.length).to.equal(1);
+          expect(activities[0].status).to.equal(Activity.status.STARTED);
+          expect(currentActivity.status).equals(Activity.status.STARTED);
+        });
+      });
+
+      context('when activity is finished', function () {
+        it('should update current activity with SUCCEEDED status', async function () {
+          const { assessmentId, missionId } = databaseBuilder.factory.buildMissionAssessment();
+          const { id: activityId } = databaseBuilder.factory.buildActivity({
+            assessmentId,
+            level: Activity.levels.VALIDATION,
+            status: Activity.status.STARTED,
+            stepIndex: 0,
+          });
+          databaseBuilder.factory.buildActivityAnswer({
+            activityId,
+            challengeId: 'va_challenge_id',
+            result: AnswerStatus.statuses.OK,
+          });
+          databaseBuilder.factory.buildActivityAnswer({
+            activityId,
+            challengeId: 'va_next_challenge_id',
+            result: AnswerStatus.statuses.OK,
+          });
+
+          await databaseBuilder.commit();
+
+          mockLearningContent({
+            missions: [
+              learningContentBuilder.buildMission({
+                id: missionId,
+                content: {
+                  steps: [
+                    {
+                      validationChallenges: [['va_challenge_id'], ['va_next_challenge_id']],
+                    },
+                  ],
+                },
+              }),
+            ],
+          });
+
+          const currentActivity = await updateCurrentActivity({
+            assessmentId,
+            activityRepository,
+            activityAnswerRepository,
+            missionAssessmentRepository,
+            missionRepository,
+          });
+
+          const activities = await knex('activities').where({ assessmentId });
+          expect(activities.length).to.equal(1);
+          expect(activities[0].status).to.equal(Activity.status.SUCCEEDED);
+          expect(currentActivity.status).equals(Activity.status.SUCCEEDED);
+        });
+      });
+    });
+    context('when challenge has been skipped', function () {
+      it('should update current activity with SKIPPED status', async function () {
         const { assessmentId, missionId } = databaseBuilder.factory.buildMissionAssessment();
         const { id: activityId } = databaseBuilder.factory.buildActivity({
           assessmentId,
@@ -114,14 +288,8 @@ describe('Integration | UseCase | update current activity', function () {
         databaseBuilder.factory.buildActivityAnswer({
           activityId,
           challengeId: 'va_challenge_id',
-          result: AnswerStatus.statuses.OK,
+          result: AnswerStatus.statuses.SKIPPED,
         });
-        databaseBuilder.factory.buildActivityAnswer({
-          activityId,
-          challengeId: 'va_next_challenge_id',
-          result: AnswerStatus.statuses.OK,
-        });
-
         await databaseBuilder.commit();
 
         mockLearningContent({
@@ -149,54 +317,9 @@ describe('Integration | UseCase | update current activity', function () {
 
         const activities = await knex('activities').where({ assessmentId });
         expect(activities.length).to.equal(1);
-        expect(activities[0].status).to.equal(Activity.status.SUCCEEDED);
-        expect(currentActivity.status).equals(Activity.status.SUCCEEDED);
+        expect(activities[0].status).to.equal(Activity.status.SKIPPED);
+        expect(currentActivity.status).equals(Activity.status.SKIPPED);
       });
-    });
-  });
-  context('when challenge has been skipped', function () {
-    it('should update current activity with SKIPPED status', async function () {
-      const { assessmentId, missionId } = databaseBuilder.factory.buildMissionAssessment();
-      const { id: activityId } = databaseBuilder.factory.buildActivity({
-        assessmentId,
-        level: Activity.levels.VALIDATION,
-        status: Activity.status.STARTED,
-        stepIndex: 0,
-      });
-      databaseBuilder.factory.buildActivityAnswer({
-        activityId,
-        challengeId: 'va_challenge_id',
-        result: AnswerStatus.statuses.SKIPPED,
-      });
-      await databaseBuilder.commit();
-
-      mockLearningContent({
-        missions: [
-          learningContentBuilder.buildMission({
-            id: missionId,
-            content: {
-              steps: [
-                {
-                  validationChallenges: [['va_challenge_id'], ['va_next_challenge_id']],
-                },
-              ],
-            },
-          }),
-        ],
-      });
-
-      const currentActivity = await updateCurrentActivity({
-        assessmentId,
-        activityRepository,
-        activityAnswerRepository,
-        missionAssessmentRepository,
-        missionRepository,
-      });
-
-      const activities = await knex('activities').where({ assessmentId });
-      expect(activities.length).to.equal(1);
-      expect(activities[0].status).to.equal(Activity.status.SKIPPED);
-      expect(currentActivity.status).equals(Activity.status.SKIPPED);
     });
   });
 });

--- a/api/tests/school/unit/domain/models/Activity_test.js
+++ b/api/tests/school/unit/domain/models/Activity_test.js
@@ -9,26 +9,30 @@ describe('Unit | domain | Activity', function () {
       isDare: true,
       isValidation: false,
       isTraining: false,
+      isTutorial: false,
     },
     {
       level: Activity.levels.VALIDATION,
       isDare: false,
       isValidation: true,
       isTraining: false,
+      isTutorial: false,
     },
     {
       level: Activity.levels.TUTORIAL,
       isDare: false,
       isValidation: false,
       isTraining: false,
+      isTutorial: true,
     },
     {
       level: Activity.levels.TRAINING,
       isDare: false,
       isValidation: false,
       isTraining: true,
+      isTutorial: false,
     },
-  ].forEach(function ({ level, isDare, isValidation, isTraining }) {
+  ].forEach(function ({ level, isDare, isValidation, isTraining, isTutorial }) {
     it(`isDare should return ${isDare} when activity is ${level} level`, function () {
       const activity = new Activity({ level });
       expect(activity.isDare).to.equal(isDare);
@@ -42,6 +46,11 @@ describe('Unit | domain | Activity', function () {
     it(`isTraining should return ${isTraining} when activity is ${level} level`, function () {
       const activity = new Activity({ level });
       expect(activity.isTraining).to.equal(isTraining);
+    });
+
+    it(`isTutorial should return ${isTutorial} when activity is ${level} level`, function () {
+      const activity = new Activity({ level });
+      expect(activity.isTutorial).to.equal(isTutorial);
     });
   });
   /* eslint-enable mocha/no-setup-in-describe */

--- a/api/tests/school/unit/domain/services/get-next-activity-info_test.js
+++ b/api/tests/school/unit/domain/services/get-next-activity-info_test.js
@@ -75,6 +75,11 @@ describe('Unit | Domain | Pix Junior | get next activity info', function () {
       expectedActivityInfo: '0:TRAINING',
     },
     {
+      activities: ['0:VALIDATION:FAILED', '0:TRAINING:FAILED', '0:TUTORIAL:FAILED'],
+      stepCount: 1,
+      expectedActivityInfo: '0:TRAINING',
+    },
+    {
       activities: ['0:VALIDATION:FAILED', '0:TRAINING:SUCCEEDED', '0:VALIDATION:FAILED'],
       stepCount: 1,
       expectedActivityInfo: '0:TUTORIAL',
@@ -87,7 +92,7 @@ describe('Unit | Domain | Pix Junior | get next activity info', function () {
     {
       activities: ['0:VALIDATION:FAILED', '0:TRAINING:FAILED', '0:TUTORIAL:SKIPPED'],
       stepCount: 1,
-      expectedActivityInfo: '0:TUTORIAL',
+      expectedActivityInfo: '0:TRAINING',
     },
     {
       activities: ['0:VALIDATION:SUCCEEDED', '1:VALIDATION:FAILED', '1:TRAINING:FAILED', '1:TUTORIAL:SUCCEEDED'],


### PR DESCRIPTION
## :unicorn: Problème

Si un élève échoue une épreuve du didacticiel, l'activité de didacticiel est considérée comme échouée.
On ne souhaite plus ce comportement et l'on préfère poursuivre le didacticiel quel que soit le résultat de l'épreuve.

## :robot: Proposition

L'activité de didacticiel doit être poursuivie jusqu'au bout quelque soit les réponses données aux épreuves. L'activité sera toujours indiquée comme réussie.

## :rainbow: Remarques

Merci les tests de `get-next-activity-info` 😃 

## :100: Pour tester

Faire une mission en échouant les premières épreuves pour afficher le didacticiel.
Vérifier que même en cas d'échec sur une épreuve de didacticiel, toutes les épreuves du didacticiel sont proposées à l'élève. Lorsque toutes les épreuves ont été jouées, l'élève passe alors systématiquement à l'entraînement.
