### PR TITLE
[FEATURE] Englober les signalements dans la zone de focus (PIX-12025)

### DIFF
--- a/mon-pix/app/components/challenge/item.hbs
+++ b/mon-pix/app/components/challenge/item.hbs
@@ -1,10 +1,7 @@
 <article
-  class="rounded-panel rounded-panel--no-margin-bottom challenge-item
-    {{if @isFocusedChallengeAndUserHasFocusedOutOfChallenge 'challenge-item--focused'}}"
-  data-challenge-id="{{@challenge.id}}"
-  {{on "mouseenter" this.hideOutOfFocusBorder}}
-  {{on "mouseleave" this.showOutOfFocusBorder}}
+  class="rounded-panel rounded-panel--no-margin-bottom challenge-item"
   {{will-destroy this.clearFocusOutEventListener}}
+  data-challenge-id="{{@challenge.id}}"
   role="article"
 >
   <ChallengeStatement @challenge={{@challenge}} @assessment={{@assessment}} />

--- a/mon-pix/app/components/challenge/item.js
+++ b/mon-pix/app/components/challenge/item.js
@@ -42,30 +42,6 @@ export default class Item extends Component {
     return ensureSafeComponent(result, this);
   }
 
-  @action
-  hideOutOfFocusBorder() {
-    if (this.isFocusedChallenge) {
-      this.args.onFocusIntoChallenge();
-    }
-  }
-
-  @action
-  showOutOfFocusBorder(event) {
-    if (this.isFocusedChallenge && !this.args.answer) {
-      // linked to a Firefox issue where the mouseleave is triggered
-      // when hovering the select options on mouse navigation
-      // see: https://stackoverflow.com/questions/46831247/select-triggers-mouseleave-event-on-parent-element-in-mozilla-firefox
-      if (this.shouldPreventFirefoxSelectMouseLeaveBehavior(event)) {
-        return;
-      }
-      this.args.onFocusOutOfChallenge();
-    }
-  }
-
-  shouldPreventFirefoxSelectMouseLeaveBehavior(event) {
-    return event.relatedTarget === null;
-  }
-
   _setFocusOutEventListener() {
     document.addEventListener(FOCUSEDOUT_EVENT_NAME, this._focusedoutListener);
 

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -9,6 +9,7 @@ const timedOutPageTitle = 'pages.challenge.title.timed-out';
 const focusedPageTitle = 'pages.challenge.title.focused';
 const focusedOutPageTitle = 'pages.challenge.title.focused-out';
 import isInteger from 'lodash/isInteger';
+import ENV from 'mon-pix/config/environment';
 
 export default class ChallengeController extends Controller {
   queryParams = ['newLevel', 'competenceLeveled', 'challengeId'];
@@ -75,6 +76,30 @@ export default class ChallengeController extends Controller {
     return this.model.challenge.focused && !this.hasConfirmedFocusChallengeWarningScreen;
   }
 
+  get isFocusedChallenge() {
+    return ENV.APP.FT_FOCUS_CHALLENGE_ENABLED && this.model.challenge.focused;
+  }
+
+  @action
+  hideOutOfFocusBorder() {
+    if (this.isFocusedChallenge) {
+      this.setFocusedOutOfChallenge(false);
+    }
+  }
+
+  @action
+  showOutOfFocusBorder(event) {
+    if (this.isFocusedChallenge && !this.model.answer) {
+      // linked to a Firefox issue where the mouseleave is triggered
+      // when hovering the select options on mouse navigation
+      // see: https://stackoverflow.com/questions/46831247/select-triggers-mouseleave-event-on-parent-element-in-mozilla-firefox
+      if (this.shouldPreventFirefoxSelectMouseLeaveBehavior(event)) {
+        return;
+      }
+      this.setFocusedOutOfChallenge(true);
+    }
+  }
+
   @action
   setFocusedOutOfChallenge(value) {
     this.hasFocusedOutOfChallenge = value;
@@ -89,6 +114,10 @@ export default class ChallengeController extends Controller {
         challengeId: this.model.challenge.id,
       },
     });
+  }
+
+  shouldPreventFirefoxSelectMouseLeaveBehavior(event) {
+    return event.relatedTarget === null;
   }
 
   get isFocusedCertificationChallengeWithoutAnswer() {

--- a/mon-pix/app/styles/components/_challenge-item.scss
+++ b/mon-pix/app/styles/components/_challenge-item.scss
@@ -1,12 +1,5 @@
 .challenge-item {
   padding: $pix-spacing-xxs;
-
-  &--focused {
-    z-index: 1;
-    border-radius: 10px;
-    outline: 3px dashed $pix-neutral-70;
-    outline-offset: -3px;
-  }
 }
 
 .challenge-response {

--- a/mon-pix/app/styles/pages/_challenge.scss
+++ b/mon-pix/app/styles/pages/_challenge.scss
@@ -39,17 +39,7 @@
     margin-bottom: 73px;
   }
 
-  &__focused-out-overlay {
-    position: fixed;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    display: block;
-    width: 100%;
-    height: 100%;
-    background-color: rgb(0 0 0 / 50%);
-  }
+
 
   &__feedback {
     z-index: 1;
@@ -119,4 +109,24 @@
     line-height: 1.375rem;
     letter-spacing: 0.009rem;
   }
+}
+
+.focus-zone-warning--triggered{
+  z-index: 1;
+  background-color: $pix-neutral-20;
+  border-radius: 5px;
+  outline: 5px dashed $pix-shades-100;
+  outline-offset: -5px;
+}
+
+.focus-zone-warning__overlay {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: block;
+  width: 100%;
+  height: 100%;
+  background-color: rgb(0 0 0 / 50%);
 }

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -18,9 +18,6 @@
 {{/if}}
 
 <div class="background-banner-wrapper challenge">
-  {{#if this.isFocusedChallengeAndUserHasFocusedOutOfChallenge}}
-    <div class="challenge__focused-out-overlay"></div>
-  {{/if}}
 
   <div class="challenge__banner">
     {{#if @model.assessment.isCertification}}
@@ -51,30 +48,45 @@
     {{/if}}
 
     {{#if this.displayChallenge}}
-      <Challenge::Item
-        @challenge={{@model.challenge}}
-        @assessment={{@model.assessment}}
-        @answer={{@model.answer}}
-        @timeoutChallenge={{this.timeoutChallenge}}
-        @resetAllChallengeInfo={{this.resetAllChallengeInfo}}
-        @resetChallengeInfoOnResume={{this.resetChallengeInfoOnResume}}
-        @onFocusIntoChallenge={{fn this.setFocusedOutOfChallenge false}}
-        @onFocusOutOfChallenge={{fn this.setFocusedOutOfChallenge true}}
-        @onFocusOutOfWindow={{this.focusedOutOfWindow}}
-        @hasFocusedOutOfWindow={{this.hasFocusedOutOfWindow}}
-        @isFocusedChallengeAndUserHasFocusedOutOfChallenge={{this.isFocusedChallengeAndUserHasFocusedOutOfChallenge}}
-      />
-    {{/if}}
-  </main>
-  {{#if this.displayChallenge}}
-    <div class="challenge__feedback" role="complementary">
-      {{#if (eq @model.assessment.certificationCourse.version 3)}}
-        <FeedbackPanelV3 @submitLiveAlert={{this.submitLiveAlert}} @assessment={{@model.assessment}} />
-      {{else}}
-        <FeedbackPanel @assessment={{@model.assessment}} @challenge={{@model.challenge}} />
+
+      <div
+        class="focus-zone-warning
+          {{if this.isFocusedChallengeAndUserHasFocusedOutOfChallenge 'focus-zone-warning--triggered'}}"
+        data-challenge-id="{{@challenge.id}}"
+        {{on "mouseenter" this.hideOutOfFocusBorder}}
+        {{on "mouseleave" this.showOutOfFocusBorder}}
+      >
+
+        <Challenge::Item
+          @challenge={{@model.challenge}}
+          @assessment={{@model.assessment}}
+          @answer={{@model.answer}}
+          @timeoutChallenge={{this.timeoutChallenge}}
+          @resetAllChallengeInfo={{this.resetAllChallengeInfo}}
+          @resetChallengeInfoOnResume={{this.resetChallengeInfoOnResume}}
+          @onFocusIntoChallenge={{fn this.setFocusedOutOfChallenge false}}
+          @onFocusOutOfChallenge={{fn this.setFocusedOutOfChallenge true}}
+          @onFocusOutOfWindow={{this.focusedOutOfWindow}}
+          @hasFocusedOutOfWindow={{this.hasFocusedOutOfWindow}}
+          @isFocusedChallengeAndUserHasFocusedOutOfChallenge={{this.isFocusedChallengeAndUserHasFocusedOutOfChallenge}}
+        />
+
+        <div class="challenge__feedback" role="complementary">
+          {{#if (eq @model.assessment.certificationCourse.version 3)}}
+            <FeedbackPanelV3 @submitLiveAlert={{this.submitLiveAlert}} @assessment={{@model.assessment}} />
+          {{else}}
+            <FeedbackPanel @assessment={{@model.assessment}} @challenge={{@model.challenge}} />
+          {{/if}}
+        </div>
+      </div>
+
+      {{#if this.isFocusedChallengeAndUserHasFocusedOutOfChallenge}}
+        <div class="focus-zone-warning__overlay" />
       {{/if}}
-    </div>
-  {{/if}}
+
+    {{/if}}
+
+  </main>
 
   {{#if @model.challenge.focused}}
     <div

--- a/mon-pix/tests/acceptance/challenge-item_test.js
+++ b/mon-pix/tests/acceptance/challenge-item_test.js
@@ -50,15 +50,15 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
               assert.dom('.tooltip-tag__information').exists();
             });
 
-            test('should display an info alert with dashed border and overlay', async function (assert) {
+            test('should display an info alert with dashed border and overlay ', async function (assert) {
               // when
-              const challengeItem = find('.challenge-item');
-              await triggerEvent(challengeItem, 'mouseleave', { relatedTarget: challengeItem });
+              const focusZone = find('.focus-zone-warning');
+              await triggerEvent(focusZone, 'mouseleave', { relatedTarget: focusZone });
 
               // then
               assert.dom('.challenge__info-alert--show').exists();
-              assert.dom('.challenge-item--focused').exists();
-              assert.dom('.challenge__focused-out-overlay').exists();
+              assert.dom('.focus-zone-warning--triggered').exists();
+              assert.dom('.focus-zone-warning__overlay').exists();
             });
 
             module('when user closes tooltip', function (hooks) {
@@ -94,23 +94,23 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
 
               test('should display an info alert with dashed border and overlay', async function (assert) {
                 // when
-                const challengeItem = find('.challenge-item');
-                await triggerEvent(challengeItem, 'mouseleave', { relatedTarget: challengeItem });
+                const focusZone = find('.focus-zone-warning');
+                await triggerEvent(focusZone, 'mouseleave', { relatedTarget: focusZone });
 
                 // then
                 assert.dom('.challenge__info-alert--could-show').exists();
-                assert.dom('.challenge-item--focused').exists();
-                assert.dom('.challenge__focused-out-overlay').exists();
+                assert.dom('.focus-zone-warning--triggered').exists();
+                assert.dom('.focus-zone-warning__overlay').exists();
               });
 
               test('should display only the warning alert when it has been triggered', async function (assert) {
                 // given
-                const challengeItem = find('.challenge-item');
-                await triggerEvent(challengeItem, 'mouseleave', { relatedTarget: challengeItem });
+                const focusZone = find('.focus-zone-warning');
+                await triggerEvent(focusZone, 'mouseleave', { relatedTarget: focusZone });
 
                 assert.dom('.challenge__info-alert--could-show').exists();
-                assert.dom('.challenge-item--focused').exists();
-                assert.dom('.challenge__focused-out-overlay').exists();
+                assert.dom('.focus-zone-warning--triggered').exists();
+                assert.dom('.focus-zone-warning__overlay').exists();
 
                 // when
                 await triggerEvent(document, 'focusedout');
@@ -118,8 +118,8 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
                 // then
                 assert.dom('.challenge__info-alert--could-show').doesNotExist();
                 assert.dom('[data-test="alert-message-focused-out-of-window"]').exists();
-                assert.dom('.challenge-item--focused').exists();
-                assert.dom('.challenge__focused-out-overlay').exists();
+                assert.dom('.focus-zone-warning--triggered').exists();
+                assert.dom('.focus-zone-warning__overlay').exists();
               });
             });
           });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement dans une épreuve focus, nous affichons un avertissement si l'utilisateur sort de la zone de l'épreuve.
Or s'il a un souci sur l'épreuve et veut effectuer un signalement il doit sortir de cette zone. 
Cela déclenche l'avertissement et en plus "masque" la zone de signalement qu'il veut utiliser.

## :robot: Proposition
Pour éviter cela, on propose d'agrandir cette zone réactive qui du coup englobe l'épreuve et la partie signalement.

## :rainbow: Remarques
Je n'ai pas respecté le design, je n'ai pas ajouté de padding dans la zone de focus. Ce sera toujours possible de le faire dans un second temps.

## :100: Pour tester
- Se rendre sur une [épreuve focus](https://app-pr8993.review.pix.fr/challenges/challenge1TI4FJyZthTpBx/preview)
- S'assurer qu'il est désormais possible de procéder à un signalement sans déclencher l'avertissement.
- S'assurer que le design est (a peu près) conforme à ce qui était attendu 
