### PR TITLE
[FEATURE] Afficher un sélecteur de participation (PIX-11643)

### DIFF
--- a/orga/app/adapters/available-campaign-participation.js
+++ b/orga/app/adapters/available-campaign-participation.js
@@ -1,0 +1,11 @@
+import ApplicationAdapter from './application';
+
+export default class availableCampaignParticipationAdapter extends ApplicationAdapter {
+  urlForQuery(query) {
+    const { campaignId, organizationLearnerId } = query;
+    delete query.campaignId;
+    delete query.organizationLearnerId;
+
+    return `${this.host}/${this.namespace}/campaigns/${campaignId}/organization-learners/${organizationLearnerId}/participations`;
+  }
+}

--- a/orga/app/components/participant/assessment/header.hbs
+++ b/orga/app/components/participant/assessment/header.hbs
@@ -13,8 +13,18 @@
 </header>
 
 <section class="panel panel--header">
-  <header class="panel-header__headline">
+  <header class="panel-header__headline panel-header__headline--with-right-content">
     <h2 class="panel-header-title">{{@campaign.name}}</h2>
+    {{#if @campaign.multipleSendings}}
+      <PixSelect
+        @options={{this.participationsListOptions}}
+        @inlineLabel="true"
+        @value={{this.selectedParticipation.value}}
+        @onChange={{this.selectAParticipation}}
+      >
+        <:label>{{t "pages.assessment-individual-results.participation-selector"}}</:label>
+      </PixSelect>
+    {{/if}}
   </header>
 
   <div class="panel-header__body">

--- a/orga/app/components/participant/assessment/header.js
+++ b/orga/app/components/participant/assessment/header.js
@@ -1,12 +1,16 @@
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import dayjs from 'dayjs';
 
 export default class Header extends Component {
   @service intl;
   @service currentUser;
+  @service router;
 
   get displayBadges() {
     const { campaign, participation } = this.args;
+
     return campaign.hasBadges && participation.badges.length > 0;
   }
 
@@ -34,5 +38,44 @@ export default class Header extends Component {
 
   get percentage() {
     return Math.round(this.args.participation.masteryRate * 100);
+  }
+
+  get participationsListOptions() {
+    let participationNumber = 0;
+    const options = this.args.allParticipations.map((participation) => {
+      participationNumber++;
+
+      let category;
+      let label = this.intl.t('pages.assessment-individual-results.participation-label', { participationNumber });
+
+      if (participation.sharedAt) {
+        const participationDate = dayjs(participation.sharedAt).format('DD/MM/YYYY');
+        label = `${label} - ${participationDate}`;
+      }
+
+      if (participation.status === 'SHARED') {
+        category = `— ${this.intl.t('pages.assessment-individual-results.participation-shared')} —`;
+      } else if (participation.status === 'TO_SHARE') {
+        category = `— ${this.intl.t('pages.assessment-individual-results.participation-to-share')} —`;
+      }
+
+      return {
+        id: participationNumber,
+        value: participation.id,
+        label,
+        category,
+      };
+    });
+
+    return options;
+  }
+
+  get selectedParticipation() {
+    return this.participationsListOptions.find((participation) => participation.value === this.args.participation.id);
+  }
+
+  @action
+  selectAParticipation(participationId) {
+    this.router.transitionTo('authenticated.campaigns.participant-assessment', this.args.campaign.id, participationId);
   }
 }

--- a/orga/app/components/participant/assessment/header.js
+++ b/orga/app/components/participant/assessment/header.js
@@ -5,10 +5,6 @@ export default class Header extends Component {
   @service intl;
   @service currentUser;
 
-  get organization() {
-    return this.currentUser.organization;
-  }
-
   get displayBadges() {
     const { campaign, participation } = this.args;
     return campaign.hasBadges && participation.badges.length > 0;

--- a/orga/app/models/available-campaign-participation.js
+++ b/orga/app/models/available-campaign-participation.js
@@ -1,0 +1,6 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class availableCampaignParticipation extends Model {
+  @attr('date') sharedAt;
+  @attr('string') status;
+}

--- a/orga/app/routes/authenticated/campaigns/participant-assessment.js
+++ b/orga/app/routes/authenticated/campaigns/participant-assessment.js
@@ -9,12 +9,21 @@ export default class AssessmentRoute extends Route {
   async model(params) {
     try {
       const { campaign_id: campaignId, campaign_participation_id: campaignParticipationId } = params;
+
+      const campaignAssessmentParticipation = await this.store.queryRecord('campaign-assessment-participation', {
+        campaignId,
+        campaignParticipationId,
+      });
+
+      const availableCampaignParticipations = await this.store.query('available-campaign-participation', {
+        campaignId,
+        organizationLearnerId: campaignAssessmentParticipation.organizationLearnerId,
+      });
+
       return await RSVP.hash({
         campaign: this.store.findRecord('campaign', campaignId),
-        campaignAssessmentParticipation: this.store.queryRecord('campaign-assessment-participation', {
-          campaignId,
-          campaignParticipationId,
-        }),
+        campaignAssessmentParticipation,
+        availableCampaignParticipations,
       });
     } catch (error) {
       this.send('error', error, this.router.replaceWith('not-found', params.campaign_id));

--- a/orga/app/styles/globals/panels.scss
+++ b/orga/app/styles/globals/panels.scss
@@ -28,6 +28,10 @@
   .panel-header-title {
     margin: 0;
   }
+
+  &--with-right-content {
+    justify-content: space-between;
+  }
 }
 
 .panel-header__body {
@@ -94,7 +98,6 @@
 }
 
 .navbar {
-  display: flex;
   display: flex;
   width: 100%;
   min-height: 60px;

--- a/orga/app/templates/authenticated/campaigns/participant-assessment.hbs
+++ b/orga/app/templates/authenticated/campaigns/participant-assessment.hbs
@@ -4,6 +4,7 @@
   <Participant::Assessment::Header
     @campaign={{@model.campaign}}
     @participation={{@model.campaignAssessmentParticipation}}
+    @allParticipations={{@model.availableCampaignParticipations}}
   />
 
   <Participant::Assessment::Tabs

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -457,6 +457,10 @@ function routes() {
     return schema.campaignAssessmentParticipations.findBy({ ...request.params });
   });
 
+  this.get('/campaigns/:campaignId/organization-learners/:organizationLearnerId/participations', (schema) => {
+    return schema.availableCampaignParticipations.all();
+  });
+
   this.get('/campaigns/:campaignId/assessment-participations/:id/results', (schema, request) => {
     return schema.campaignAssessmentParticipationResults.findBy({ ...request.params });
   });

--- a/orga/tests/integration/components/participant/assessment/header_test.js
+++ b/orga/tests/integration/components/participant/assessment/header_test.js
@@ -29,7 +29,7 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
     );
 
     // then
-    assert.dom(screen.getByText('Jean La fripouille')).exists();
+    assert.ok(screen.getByText('Jean La fripouille'));
   });
 
   module('participation selector', function () {
@@ -161,7 +161,7 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
       hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
     );
 
-    assert.dom(screen.getByText('01 janv. 2020')).exists();
+    assert.ok(screen.getByText('01 janv. 2020'));
   });
 
   test('it displays campaign participation progression', async function (assert) {
@@ -172,8 +172,8 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
       hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
     );
 
-    assert.dom(screen.getByText(this.intl.t('pages.assessment-individual-results.progression'))).exists();
-    assert.dom(screen.getByText('75 %')).exists();
+    assert.ok(screen.getByText(this.intl.t('pages.assessment-individual-results.progression')));
+    assert.ok(screen.getByText('75 %'));
   });
 
   module('is shared', function () {
@@ -190,8 +190,8 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
           hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
         );
 
-        assert.dom(screen.getByText(this.intl.t('pages.campaign-individual-results.shared-date'))).exists();
-        assert.dom(screen.getByText('02 janv. 2020')).exists();
+        assert.ok(screen.getByText(this.intl.t('pages.campaign-individual-results.shared-date')));
+        assert.ok(screen.getByText('02 janv. 2020'));
       });
     });
 
@@ -204,7 +204,7 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
           hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
         );
 
-        assert.dom(screen.queryByText(this.intl.t('pages.campaign-individual-results.shared-date'))).doesNotExist();
+        assert.notOk(screen.queryByText(this.intl.t('pages.campaign-individual-results.shared-date')));
       });
     });
   });
@@ -222,8 +222,8 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
           hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
         );
 
-        assert.dom(screen.getByText('identifiant de l’élève')).exists();
-        assert.dom(screen.getByText('i12345')).exists();
+        assert.ok(screen.getByText('identifiant de l’élève'));
+        assert.ok(screen.getByText('i12345'));
       });
     });
     module('when the external id is not present', function () {
@@ -238,7 +238,7 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
           hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
         );
 
-        assert.dom(screen.queryByText('identifiant de l’élève')).doesNotExist();
+        assert.notOk(screen.queryByText('identifiant de l’élève'));
       });
     });
   });
@@ -253,10 +253,10 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
           hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
         );
 
-        assert.dom(screen.queryByText(this.intl.t('pages.assessment-individual-results.progression'))).doesNotExist();
-        assert
-          .dom(screen.queryByText(this.intl.t('common.result.percentage', { value: this.participation.progression })))
-          .doesNotExist();
+        assert.notOk(screen.queryByText(this.intl.t('pages.assessment-individual-results.progression')));
+        assert.notOk(
+          screen.queryByText(this.intl.t('common.result.percentage', { value: this.participation.progression })),
+        );
       });
 
       module('when the campaign has stages', function () {
@@ -279,8 +279,8 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
             hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
           );
 
-          assert.dom(screen.queryByLabelText(this.intl.t('pages.assessment-individual-results.result'))).exists();
-          assert.dom(screen.getByText(this.intl.t('common.result.stages', { count: 1, total: 2 }))).exists();
+          assert.ok(screen.queryByLabelText(this.intl.t('pages.assessment-individual-results.result')));
+          assert.ok(screen.getByText(this.intl.t('common.result.stages', { count: 1, total: 2 })));
         });
       });
 
@@ -295,7 +295,7 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
 
           // We should keep getAllByText instead of getByText because in the ci the npm run test fails.
           // It finds two occurences instead of one for some reason related to a nbsp; not being present in this context.
-          assert.dom(screen.getAllByText('65%')[0]).exists();
+          assert.ok(screen.getAllByText('65%')[0]);
         });
       });
 
@@ -323,7 +323,7 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
             hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
           );
 
-          assert.dom(screen.queryByLabelText(this.intl.t('pages.assessment-individual-results.badges'))).doesNotExist();
+          assert.notOk(screen.queryByLabelText(this.intl.t('pages.assessment-individual-results.badges')));
         });
       });
 
@@ -335,7 +335,7 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
           const screen = await render(
             hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
           );
-          assert.dom(screen.queryByLabelText(this.intl.t('pages.assessment-individual-results.badges'))).doesNotExist();
+          assert.notOk(screen.queryByLabelText(this.intl.t('pages.assessment-individual-results.badges')));
         });
       });
     });
@@ -349,7 +349,7 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
           hbs`<Participant::Assessment::Header @participation={{this.participation}} @campaign={{this.campaign}} />`,
         );
 
-        assert.dom(screen.queryByLabelText(this.intl.t('pages.assessment-individual-results.result'))).doesNotExist();
+        assert.notOk(screen.queryByLabelText(this.intl.t('pages.assessment-individual-results.result')));
       });
     });
   });

--- a/orga/tests/unit/adapters/available-campaign-participation_test.js
+++ b/orga/tests/unit/adapters/available-campaign-participation_test.js
@@ -1,0 +1,27 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { resolve } from 'rsvp';
+
+module('Unit | Adapters | AvailableCampaignParticipation', function (hooks) {
+  setupTest(hooks);
+
+  let adapter;
+
+  hooks.beforeEach(function () {
+    adapter = this.owner.lookup('adapter:available-campaign-participation');
+    const ajaxStub = () => resolve();
+    adapter.ajax = ajaxStub;
+  });
+
+  module('#urlForQuery', function () {
+    test('should build url with campaign id and organization learner id', async function (assert) {
+      // when
+      const query = { campaignId: 1, organizationLearnerId: 2 };
+      const url = await adapter.urlForQuery(query);
+
+      // then
+      assert.true(url.endsWith(`/campaigns/1/organization-learners/2/participations`));
+      assert.strictEqual(query.campaignId, undefined);
+    });
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -317,6 +317,10 @@
       "title": "Results of {firstName} {lastName}",
       "badges": "Thematic results",
       "breadcrumb-current-page-label": "Participation of {firstName} {lastName}",
+      "participation-label": "Participation #{participationNumber}",
+      "participation-selector": "Select a participation",
+      "participation-shared": "Submitted results",
+      "participation-to-share": "Results to submit",
       "progression": "Progression",
       "result": "Result",
       "tab": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -317,6 +317,10 @@
       "title": "Résultats de {firstName} {lastName}",
       "badges": "Résultats Thématiques",
       "breadcrumb-current-page-label": "Participation de {firstName} {lastName}",
+      "participation-label": "Participation #{participationNumber}",
+      "participation-selector": "Choisir une participation",
+      "participation-shared": "Résultats envoyés",
+      "participation-to-share": "Résultats non-envoyés",
       "progression": "Avancement",
       "result": "Résultat",
       "tab": {


### PR DESCRIPTION
## :unicorn: Problème
Nous avons permis de voir le nombre de participations d’un participant à une campagne à envoi multiple et de conserver le dernier résultat partagé. 
Nous souhaitons également permettre au prescripteur de visualiser les résultats de toutes les participations d’un participant à une campagne d'évaluation. 


## :robot: Proposition
Afficher un sélecteur de participation (page résultats évaluation)
On numérote les participations et on affiche la date de partage lorsqu’elle a été partagée
On trie les participations en 2 catégories : résultats non-envoyés et résultats envoyés (cf maquette)

Comportement en fonction de l’origine du prescripteur : 
- si je viens de l’onglet activité ou du détail d'un participant → j’arrive sur la dernière participation, peu importe son statut
- si je viens de l’onglet résultats → j’arrive sur la dernière participation partagée

## :rainbow: Remarques
2 mini commits BSR dans ce ticket

## :100: Pour tester
- se connecter en tant que orga pro (car c'est la que les seeds sont présentes)
- voir une campagne à envoi multiple
- se rendre sur les participations à cette campagne
- remarquer la présence du sélecteur quand le participant a plusieurs participation OU même une seule participation
- remarquer que les options sont bien catégorisées en partagées et non-partagées
- Vérifier que, au clique, cela nous redirige bien vers la bonne participation
- Vérifier la correspondance avec la maquette
- Et tada quoi 🎉 