### PR TITLE
[BUGFIX] met à jour la date dans la banniere d'info sur orga (Pix-12533)

### DIFF
--- a/orga/app/components/banner/information.gjs
+++ b/orga/app/components/banner/information.gjs
@@ -27,11 +27,15 @@ export default class InformationBanner extends Component {
     return this.currentUser.isSCOManagingStudents && timeToDisplay.includes(actualMonth);
   }
 
+  get year() {
+    return this.dayjs.self().format('YYYY');
+  }
+
   <template>
     {{#if this.displayNewYearOrganizationLearnersImportBanner}}
       <NewYearBanner />
     {{else if this.displayCertificationBanner}}
-      <CertificationBanner />
+      <CertificationBanner @year={{this.year}} />
     {{/if}}
   </template>
 }
@@ -54,6 +58,7 @@ const CertificationBanner = <template>
       documentationLink="https://view.genial.ly/62cd67b161c1e3001759e818?idSlide=0f1b3413-7fef-4c97-b890-675c5bafbe93"
       linkClasses="link link--banner link--bold link--underlined"
       htmlSafe=true
+      year=@year
     }}
   </PixBanner>
 </template>;

--- a/orga/tests/integration/components/banner/information_test.gjs
+++ b/orga/tests/integration/components/banner/information_test.gjs
@@ -1,6 +1,6 @@
 import { render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
-import { hbs } from 'ember-cli-htmlbars';
+import Information from 'pix-orga/components/banner/information';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -23,7 +23,7 @@ module('Integration | Component | Banner::Information', function (hooks) {
           this.owner.register('service:current-user', CurrentUserStub);
 
           // when
-          const screen = await render(hbs`<Banner::Information />`);
+          const screen = await render(<template><Information /></template>);
 
           // then
           const link = screen.getByRole('link', { name: 'Plus d’info' });
@@ -39,7 +39,7 @@ module('Integration | Component | Banner::Information', function (hooks) {
           this.owner.register('service:current-user', CurrentUserStub);
 
           // when
-          const screen = await render(hbs`<Banner::Information />`);
+          const screen = await render(<template><Information /></template>);
 
           // then
           const link = screen.getByRole('link', { name: 'importer' });
@@ -60,7 +60,7 @@ module('Integration | Component | Banner::Information', function (hooks) {
         this.owner.register('service:current-user', CurrentUserStub);
 
         // when
-        const screen = await render(hbs`<Banner::Information />`);
+        const screen = await render(<template><Information /></template>);
 
         const link = screen.queryByRole('link', { name: 'importer' });
         // then
@@ -79,7 +79,7 @@ module('Integration | Component | Banner::Information', function (hooks) {
         this.owner.register('service:current-user', CurrentUserStub);
 
         // when
-        await render(hbs`<Banner::Information />`);
+        await render(<template><Information /></template>);
 
         // then
         assert.dom('.pix-banner').doesNotExist();
@@ -93,7 +93,7 @@ module('Integration | Component | Banner::Information', function (hooks) {
 
       hooks.beforeEach(function () {
         dayjs = this.owner.lookup('service:dayjs');
-        sinon.stub(dayjs.self.prototype, 'format').returns('04');
+        sinon.stub(dayjs.self.prototype, 'format').withArgs('MM').returns('04').withArgs('YYYY').returns('2001');
       });
 
       hooks.afterEach(function () {
@@ -106,13 +106,22 @@ module('Integration | Component | Banner::Information', function (hooks) {
           organization = { isSco: true };
           isSCOManagingStudents = true;
         }
+        test('should render the current year', async function (assert) {
+          // given
+          this.owner.register('service:current-user', CurrentUserStub);
 
+          // when
+          const screen = await render(<template><Information /></template>);
+
+          // then
+          assert.ok(screen.getByText(/2001/));
+        });
         test('should render the info link for finalize certification session', async function (assert) {
           // given
           this.owner.register('service:current-user', CurrentUserStub);
 
           // when
-          const screen = await render(hbs`<Banner::Information />`);
+          const screen = await render(<template><Information /></template>);
 
           const link = screen.getByRole('link', { name: 'finaliser les sessions dans Pix Certif' });
 
@@ -135,52 +144,12 @@ module('Integration | Component | Banner::Information', function (hooks) {
           this.owner.register('service:current-user', CurrentUserStub);
 
           // when
-          await render(hbs`<Banner::Information />`);
+          await render(<template><Information /></template>);
 
           // then
           assert.dom('.pix-banner').doesNotExist();
         });
       });
     });
-
-    module(
-      'when prescriber’s organization is of type SCO that manages students and it is not certification period',
-      function () {
-        class CurrentUserStub extends Service {
-          prescriber = { areNewYearOrganizationLearnersImported: false };
-          organization = { isSco: true };
-          isSCOManagingStudents = true;
-        }
-
-        test('should render the more info link', async function (assert) {
-          // given
-          this.owner.register('service:current-user', CurrentUserStub);
-
-          // when
-          const screen = await render(hbs`<Banner::Information />`);
-
-          // then
-          const link = screen.getByRole('link', { name: 'Plus d’info' });
-
-          assert.strictEqual(
-            link.href,
-            'https://view.genial.ly/62cd67b161c1e3001759e818?idSlide=e11f61b2-3047-4be3-9a4d-dd9e7cc698ba',
-          );
-        });
-
-        test('should render the import link banner', async function (assert) {
-          // given
-          this.owner.register('service:current-user', CurrentUserStub);
-
-          // when
-          const screen = await render(hbs`<Banner::Information />`);
-
-          // then
-          const link = screen.getByRole('link', { name: 'importer' });
-
-          assert.dom(link).exists();
-        });
-      },
-    );
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -55,7 +55,7 @@
   },
   "banners": {
     "certification": {
-      "message": "'<strong>'Certifications :'</strong>' n’oubliez pas de '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'finaliser les sessions dans Pix Certif'</a>' puis de télécharger les attestations ici via l'onglet “Certifications” avant la rentrée 2023."
+      "message": "'<strong>'Certifications :'</strong>' n’oubliez pas de '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'finaliser les sessions dans Pix Certif'</a>' puis de télécharger les attestations ici via l'onglet “Certifications” avant la rentrée {year}."
     },
     "import": {
       "message": "The administrator can download certification results and '<'a href=\"/import-participants\" class=\"{linkClasses}\"'>'import'</a>' the students database to create back-to-school campaigns by year level. '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'Learn more'</a>'"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -55,7 +55,7 @@
   },
   "banners": {
     "certification": {
-      "message": "'<strong>'Certifications :'</strong>' n’oubliez pas de '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'finaliser les sessions dans Pix Certif'</a>' puis de télécharger les attestations ici via l'onglet “Certifications” avant la rentrée 2023."
+      "message": "'<strong>'Certifications :'</strong>' n’oubliez pas de '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'finaliser les sessions dans Pix Certif'</a>' puis de télécharger les attestations ici via l'onglet “Certifications” avant la rentrée {year}."
     },
     "import": {
       "message": "L'administrateur peut télécharger les résultats de certification et '<'a href=\"/import-participants\" class=\"{linkClasses}\"'>'importer'</a>' la base élèves, afin de créer les campagnes de rentrée par niveau. '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'Plus d’info'</a>'"


### PR DESCRIPTION
## :unicorn: Problème
Il y a un bandeau d’information dans l'onglet "Certifications" de Pix Orga (SCO, is managing students) qui indique de télécharger les attestations avant la rentrée. La date indiquée est celle de la rentrée 2023 et se trouve dans un fichier de traduction. cela implique de faire une pr pour modifier cette date chaque année.

## :robot: Proposition
Rendre la date dynamique pour éviter d'avoir à modifier des fichiers de traductions chaque année

## :rainbow: Remarques
~~Petit refacto en gjs au passage~~ yvo était déjà passé par là :)

## :100: Pour tester

- Se connecter avec une orga sco sur orga
- voir le bandeau et la date à jour
