### PR TITLE
[BUGFIX] Unifier les status et score sur la page de détails admin pour les certif v3 (PIX-12061)

### DIFF
--- a/api/src/certification/course/infrastructure/repositories/v3-certification-course-details-for-administration-repository.js
+++ b/api/src/certification/course/infrastructure/repositories/v3-certification-course-details-for-administration-repository.js
@@ -39,7 +39,16 @@ const getV3DetailsByCertificationCourseId = async function ({ certificationCours
     })
     .from('certification-courses')
     .leftJoin('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
-    .leftJoin('assessment-results', 'assessments.id', 'assessment-results.assessmentId')
+    .leftJoin(
+      'certification-courses-last-assessment-results',
+      'certification-courses.id',
+      'certification-courses-last-assessment-results.certificationCourseId',
+    )
+    .leftJoin(
+      'assessment-results',
+      'assessment-results.id',
+      'certification-courses-last-assessment-results.lastAssessmentResultId',
+    )
     .where({
       'certification-courses.id': certificationCourseId,
     })

--- a/api/tests/certification/course/integration/infrastructure/repositories/v3-certification-course-details-for-administration-repository_test.js
+++ b/api/tests/certification/course/integration/infrastructure/repositories/v3-certification-course-details-for-administration-repository_test.js
@@ -11,7 +11,7 @@ import { databaseBuilder, domainBuilder, expect } from '../../../../../test-help
 
 describe('Integration | Infrastructure | Repository | v3-certification-course-details-for-administration', function () {
   describe('#getV3DetailsByCertificationCourseId', function () {
-    it('should return all challenges by certification course id', async function () {
+    it('should return all challenges by certification course id and last assessment result', async function () {
       // given
       const certificationCourseId = 123;
       const challengeId = 'recCHAL456';
@@ -43,12 +43,28 @@ describe('Integration | Infrastructure | Repository | v3-certification-course-de
         certificationCourseId,
         state: assessmentState,
       });
+
       databaseBuilder.factory.buildAssessmentResult({
+        pixScore: 50,
+        certificationCourseId,
+        assessmentId,
+        assessmentResultStatus,
+        createdAt: new Date('2020-01-01'),
+      });
+
+      const lastAssessmentResultId = databaseBuilder.factory.buildAssessmentResult({
         pixScore,
         certificationCourseId,
         assessmentId,
         assessmentResultStatus,
+        createdAt: new Date('2024-01-01'),
+      }).id;
+
+      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+        certificationCourseId,
+        lastAssessmentResultId,
       });
+
       const { maximumAssessmentLength: numberOfChallenges } = databaseBuilder.factory.buildFlashAlgorithmConfiguration({
         maximumAssessmentLength: 1,
         createdAt: flashAlgorithmConfigurationCreationDate,


### PR DESCRIPTION
## :unicorn: Problème
En prod, une certification v3 a été rejetée, puis on a annuler le rejet, afin de regénérer un scoring

Résultat obtenu : le statut de la certif est différent dans Pix admin selon l’onglet sur lequel on se place : 

Onglet “Informations” : le statut de la certif est à “Validée”

Onglet “Détails”, la certif est indiquée comme “Rejetée”

Résultat attendu : on devrait avoir le même statut sur les 2 onglets

## :robot: Proposition
Fixer la différence d'informations affichées entre la page de détail et d'information d'une certification V3

## :rainbow: Remarques
Sur la page de détail, les infos remontées ne se basaient pas sur le "certification-courses-last-assessment-result". On utilisait le .first() sans pour autant trier les assessment results par date ou id.

## :100: Pour tester

- Passer un certification V3
- Dans Admin, la rejetter, puis la dé rejetter
- Constater maintenant que les informations ( Score et Status ) dans l'onglet "Informations" et "Détails" son identiques