### PR TITLE
[FEATURE] Ne pas jouer deux fois le didacticiel (PIX-12571).

### DIFF
--- a/api/src/school/domain/services/get-next-activity-info.js
+++ b/api/src/school/domain/services/get-next-activity-info.js
@@ -81,6 +81,9 @@ function _getNextActivityInfoAfterSuccess(currentStepActivities, lastActivity, s
 }
 
 function _getNextActivityInfoOnFailure(activities, lastActivity) {
+  if ((lastActivity.isTraining || lastActivity.isValidation) && _hasAlreadyDoneActivity(activities, TUTORIAL)) {
+    return END_OF_MISSION;
+  }
   if (lastActivity.isValidation && _neverDoneActivity(activities, TRAINING)) {
     return new ActivityInfo({ stepIndex: lastActivity.stepIndex, level: TRAINING });
   }

--- a/api/tests/school/unit/domain/services/get-next-activity-info_test.js
+++ b/api/tests/school/unit/domain/services/get-next-activity-info_test.js
@@ -130,7 +130,7 @@ describe('Unit | Domain | Pix Junior | get next activity info', function () {
     {
       activities: ['0:VALIDATION:FAILED', '0:TRAINING:FAILED', '0:TUTORIAL:SUCCEEDED', '0:TRAINING:FAILED'],
       stepCount: 1,
-      expectedActivityInfo: '0:TUTORIAL',
+      expectedActivityInfo: END_OF_MISSION,
     },
     {
       activities: ['0:VALIDATION:FAILED', '0:TRAINING:SUCCEEDED', '0:VALIDATION:SUCCEEDED', '1:VALIDATION:FAILED'],
@@ -145,7 +145,7 @@ describe('Unit | Domain | Pix Junior | get next activity info', function () {
     {
       activities: ['0:VALIDATION:FAILED', '0:TRAINING:FAILED', '0:TUTORIAL:SUCCEEDED', '0:TRAINING:SKIPPED'],
       stepCount: 1,
-      expectedActivityInfo: '0:TUTORIAL',
+      expectedActivityInfo: END_OF_MISSION,
     },
     {
       activities: ['0:VALIDATION:FAILED', '0:TRAINING:SUCCEEDED', '0:VALIDATION:SUCCEEDED', '-:CHALLENGE:SKIPPED'],
@@ -159,8 +159,6 @@ describe('Unit | Domain | Pix Junior | get next activity info', function () {
         '0:TUTORIAL:SUCCEEDED',
         '0:TRAINING:SUCCEEDED',
         '0:VALIDATION:FAILED',
-        '0:TUTORIAL:SUCCEEDED',
-        '0:TRAINING:FAILED',
       ],
       stepCount: 1,
       expectedActivityInfo: END_OF_MISSION,
@@ -171,35 +169,7 @@ describe('Unit | Domain | Pix Junior | get next activity info', function () {
         '0:TRAINING:FAILED',
         '0:TUTORIAL:SUCCEEDED',
         '0:TRAINING:SUCCEEDED',
-        '0:VALIDATION:FAILED',
-        '0:TUTORIAL:SUCCEEDED',
-        '0:TRAINING:SUCCEEDED',
-        '0:VALIDATION:SUCCEEDED',
-      ],
-      stepCount: 1,
-      expectedActivityInfo: END_OF_MISSION,
-    },
-    {
-      activities: [
-        '0:VALIDATION:FAILED',
-        '0:TRAINING:FAILED',
-        '0:TUTORIAL:SUCCEEDED',
-        '0:TRAINING:SUCCEEDED',
-        '0:VALIDATION:FAILED',
-        '0:TUTORIAL:SUCCEEDED',
-        '0:TRAINING:FAILED',
-      ],
-      stepCount: 1,
-      expectedActivityInfo: END_OF_MISSION,
-    },
-    {
-      activities: [
-        '0:VALIDATION:FAILED',
-        '0:TRAINING:FAILED',
-        '0:TUTORIAL:SUCCEEDED',
-        '0:TRAINING:FAILED',
-        '0:TUTORIAL:SUCCEEDED',
-        '0:TRAINING:SKIPPED',
+        '0:VALIDATION:SKIPPED',
       ],
       stepCount: 1,
       expectedActivityInfo: END_OF_MISSION,


### PR DESCRIPTION
## :unicorn: Problème
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Actuellement, lorsque l'élève échoue après une épreuve de validation ou d'entraînement une seconde fois, il se voit proposer le didacticiel une nouvelle fois.

## :robot: Proposition
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
En cas d'échec à une épreuve de validation ou d'entraînement, on vérifie qu'il n'a pas déjà joué le didacticiel. Sinon on termine la mission.

## :rainbow: Remarques
RAS

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
Echouer les épreuves de validation et d'entraînement.
Après le didacticiel, échouer l'épreuve d'entraînement.
Vérifier que la page fin de mission s'affiche.

Echouer les épreuves de validation et d'entraînement.
Après le didacticiel, réussir l'épreuve d'entraînement, puis échouer l'épreuve de validation.
Vérifier que la page fin de mission s'affiche.
