### PR TITLE
[FEATURE] Passe le défi si un didactiel a été vu dans une des missions (PIX-12593)

### DIFF
--- a/api/src/school/domain/services/get-next-activity-info.js
+++ b/api/src/school/domain/services/get-next-activity-info.js
@@ -27,7 +27,12 @@ export function getNextActivityInfo({ activities, stepCount }) {
     return END_OF_MISSION;
   }
   if (lastActivity.isSucceeded || lastActivity.isTutorial) {
-    return _getNextActivityInfoAfterSuccess(currentStepActivities, lastActivity, stepCount);
+    return _getNextActivityInfoAfterSuccess(
+      currentStepActivities,
+      lastActivity,
+      stepCount,
+      _hasAlreadyDoneActivity(activities, TUTORIAL),
+    );
   }
   if (lastActivity.isFailedOrSkipped) {
     return _getNextActivityInfoOnFailure(currentStepActivities, lastActivity);
@@ -49,8 +54,8 @@ function _lastActivity(activities) {
   return activities[0];
 }
 
-function _hasValidatedTheMissionUsingTutorialInFinalStep(lastActivity, currentStepActivities, stepCount) {
-  return _hasValidatedTheMission(lastActivity, stepCount) && _hasAlreadyDoneActivity(currentStepActivities, TUTORIAL);
+function _hasValidatedTheMissionUsingTutorial(lastActivity, stepCount, hasAlreadyDoneTutorial) {
+  return _hasValidatedTheMission(lastActivity, stepCount) && hasAlreadyDoneTutorial;
 }
 
 function _hasValidatedTheMission(lastActivity, stepCount) {
@@ -62,8 +67,8 @@ function _hasValidatedTheMission(lastActivity, stepCount) {
  * @param {Activity} lastActivity
  * @param {number} stepCount
  */
-function _getNextActivityInfoAfterSuccess(currentStepActivities, lastActivity, stepCount) {
-  if (_hasValidatedTheMissionUsingTutorialInFinalStep(lastActivity, currentStepActivities, stepCount)) {
+function _getNextActivityInfoAfterSuccess(currentStepActivities, lastActivity, stepCount, hasAlreadyDoneTutorial) {
+  if (_hasValidatedTheMissionUsingTutorial(lastActivity, stepCount, hasAlreadyDoneTutorial)) {
     return END_OF_MISSION;
   }
   const nextActivityLevel = lastActivity.higherLevel;

--- a/api/tests/school/unit/domain/services/get-next-activity-info_test.js
+++ b/api/tests/school/unit/domain/services/get-next-activity-info_test.js
@@ -125,7 +125,18 @@ describe('Unit | Domain | Pix Junior | get next activity info', function () {
         '1:VALIDATION:SUCCEEDED',
       ],
       stepCount: 2,
-      expectedActivityInfo: '-:CHALLENGE',
+      expectedActivityInfo: END_OF_MISSION,
+    },
+    {
+      activities: [
+        '0:VALIDATION:FAILED',
+        '0:TRAINING:SUCCEEDED',
+        '1:VALIDATION:FAILED',
+        '1:TUTORIAL:SUCCEEDED',
+        '1:VALIDATION:SUCCEEDED',
+      ],
+      stepCount: 2,
+      expectedActivityInfo: END_OF_MISSION,
     },
     {
       activities: ['0:VALIDATION:FAILED', '0:TRAINING:FAILED', '0:TUTORIAL:SUCCEEDED', '0:TRAINING:FAILED'],


### PR DESCRIPTION
## :unicorn: Problème

l'élève passe par le défi, même s'il a vu un didacticiel.

## :robot: Proposition

Ne pas voir le défi si un didacticiel a été vu au cours d'une des missions.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

- Échouer à la validation
- Réussir le didacticiel
- Réussir l'entrainement
- Réussir la validation

Ne pas voir le défi

Même opération, mais en voyant le didacticiel sur la deuxième mission.
