### PR TITLE
[FEATURE] Ajouter un stepper dans le referentiel de Modulix (PIX-12619)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -40,6 +40,32 @@
   ],
   "grains": [
     {
+      "id": "47cd065b-dbf2-4adc-b5c3-02fb69cb9ec2",
+      "type": "activity",
+      "title": "Test Stepper",
+      "components": [
+        {
+          "type": "stepper",
+          "steps": [
+            {
+              "elements": [{
+                "id": "342183f7-af51-4e4e-ab4c-ebed1e195063",
+                "type": "text",
+                "content": "<p>À la fin de cette vidéo, une question sera posée sur les compétences Pix.</p>"
+              }]
+            },
+            {
+              "elements": [{
+                "id": "342183f7-af51-4e4e-ab4c-ebed1e195063",
+                "type": "text",
+                "content": "<p>À la fin de cette vidéo, une question sera posée sur les compétences Pix.</p>"
+              }]
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "f312c33d-e7c9-4a69-9ba0-913957b8f7dd",
       "type": "lesson",
       "title": "Voici une leçon",

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module.js
@@ -34,14 +34,33 @@ const elementSchema = Joi.alternatives().conditional('.type', {
   ],
 });
 
+const componentElementSchema = Joi.object({
+  type: Joi.string().valid('element').required(),
+  element: elementSchema.required(),
+});
+
+const componentStepperSchema = Joi.object({
+  type: Joi.string().valid('stepper').required(),
+  steps: Joi.array()
+    .items(
+      Joi.object({
+        elements: Joi.array().items(elementSchema).required(),
+      }),
+    )
+    .min(2)
+    .required(),
+});
+
 const grainSchema = Joi.object({
   id: uuidSchema,
   type: Joi.string().valid('lesson', 'activity').required(),
   title: htmlNotAllowedSchema.required(),
   components: Joi.array().items(
-    Joi.object({
-      type: Joi.string().valid('element').required(),
-      element: elementSchema.required(),
+    Joi.alternatives().conditional('.type', {
+      switch: [
+        { is: 'element', then: componentElementSchema },
+        { is: 'stepper', then: componentStepperSchema },
+      ],
     }),
   ),
 }).required();


### PR DESCRIPTION
## :unicorn: Problème
En tant qu’utilisateur je souhaite que les éléments (QCU par ex) soit affichés 1 par 1 afin que la navigation soit plus fluide lors de mon passage de module

## :robot: Proposition
Ajout d’un stepper dans le module didacticiel-modulix

## :rainbow: Remarques
RAS

## :100: Pour tester
CI Vert
Pas regression côté front
