### PR TITLE
[FEATURE] Ajouter une API interne pour récupérer la liste des features d'une organisation (PIX-12558)

### DIFF
--- a/api/src/organizational-entities/application/api/OrganizationFeatureItemDTO.js
+++ b/api/src/organizational-entities/application/api/OrganizationFeatureItemDTO.js
@@ -1,0 +1,6 @@
+export class OrganizationFeatureItemDTO {
+  constructor({ name, params }) {
+    this.name = name;
+    this.params = params;
+  }
+}

--- a/api/src/organizational-entities/application/api/organization-features-api.js
+++ b/api/src/organizational-entities/application/api/organization-features-api.js
@@ -1,0 +1,19 @@
+import { usecases } from '../../domain/usecases/index.js';
+import { OrganizationFeatureItemDTO } from './OrganizationFeatureItemDTO.js';
+
+/**
+ * @module OrganizationFeaturesApi
+ */
+
+/**
+ * @function
+ * @name getAllFeaturesFromOrganization
+ *
+ * @param {number} organizationId
+ * @returns {Promise<Array<OrganizationFeatureItemDTO>>}
+ */
+export const getAllFeaturesFromOrganization = async (organizationId) => {
+  const organizationFeatures = await usecases.findOrganizationFeatures({ organizationId });
+
+  return organizationFeatures.map((organizationFeature) => new OrganizationFeatureItemDTO(organizationFeature));
+};

--- a/api/src/organizational-entities/domain/models/OrganizationFeatureItem.js
+++ b/api/src/organizational-entities/domain/models/OrganizationFeatureItem.js
@@ -1,0 +1,6 @@
+export class OrganizationFeatureItem {
+  constructor({ key, params }) {
+    this.name = key;
+    this.params = params;
+  }
+}

--- a/api/src/organizational-entities/domain/usecases/find-organization-features.js
+++ b/api/src/organizational-entities/domain/usecases/find-organization-features.js
@@ -1,0 +1,16 @@
+/**
+ * @typedef {import ('./index.js').OrganizationFeatureRepository} OrganizationFeatureRepository
+ */
+/**
+ * @typedef {import ('../models/OrganizationFeatureItem.js')} OrganizationFeatureItem
+ */
+
+/**
+ * @param {Object} params - A parameter object.
+ * @param {string} params.organizationId - feature id to add.
+ * @param {OrganizationFeatureRepository} params.organizationFeatureRepository - organizationRepository to use.
+ * @returns {Promise<OrganizationFeatureItem>}
+ */
+export const findOrganizationFeatures = async function ({ organizationId, organizationFeatureRepository }) {
+  return organizationFeatureRepository.findAllOrganizationFeaturesFromOrganizationId({ organizationId });
+};

--- a/api/src/organizational-entities/infrastructure/repositories/organization-feature-repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-feature-repository.js
@@ -1,13 +1,16 @@
 /**
  * @module OrganizationFeatureRepository
  */
-
 import { knex } from '../../../../db/knex-database-connection.js';
 import * as knexUtils from '../../../../src/shared/infrastructure/utils/knex-utils.js';
 import { AlreadyExistingOrganizationFeatureError, FeatureNotFound, OrganizationNotFound } from '../../domain/errors.js';
+import { OrganizationFeatureItem } from '../../domain/models/OrganizationFeatureItem.js';
 
 /**
  * @typedef {import('../../domain/models/OrganizationFeature.js').OrganizationFeature} OrganizationFeature
+ */
+/**
+ * @typedef {import('../../domain/models/OrganizationFeatureItem.js').OrganizationFeatureItem} OrganizationFeatureItem
  */
 
 const DEFAULT_BATCH_SIZE = 100;
@@ -34,4 +37,27 @@ async function saveInBatch(organizationFeatures, batchSize = DEFAULT_BATCH_SIZE)
   }
 }
 
-export { saveInBatch };
+/**
+ * @typedef GetOrganizationFeaturePayload
+ * @type {object}
+ * @property {number} organizationId
+ */
+
+/**
+ * @function
+ * @name findAllOrganizationFeaturesFromOrganizationId
+ *
+ * @param {GetOrganizationFeaturePayload} payload
+ * @returns {Promise<OrganizationFeatureItem>}
+ */
+async function findAllOrganizationFeaturesFromOrganizationId({ organizationId }) {
+  const organizationFeatures = await knex
+    .select('key', 'params')
+    .from('organization-features')
+    .join('features', 'features.id', 'organization-features.featureId')
+    .where({ organizationId });
+
+  return organizationFeatures.map((organizationFeature) => new OrganizationFeatureItem(organizationFeature));
+}
+
+export { findAllOrganizationFeaturesFromOrganizationId, saveInBatch };

--- a/api/tests/organizational-entities/acceptance/api/organization-features-api_test.js
+++ b/api/tests/organizational-entities/acceptance/api/organization-features-api_test.js
@@ -1,0 +1,20 @@
+import * as organizationFeatureApi from '../../../../src/organizational-entities/application/api/organization-features-api.js';
+import { databaseBuilder, expect } from '../../../test-helper.js';
+
+describe('Acceptance | Organizational Entities | Application | organization-features-api', function () {
+  it('should not fail', async function () {
+    //given
+    const organizationId = databaseBuilder.factory.buildOrganization().id;
+    const featureId = databaseBuilder.factory.buildFeature({ key: 'my_feature' }).id;
+
+    databaseBuilder.factory.buildOrganizationFeature({ featureId, organizationId });
+
+    await databaseBuilder.commit();
+
+    // when
+    const result = await organizationFeatureApi.getAllFeaturesFromOrganization(organizationId);
+
+    // then
+    expect(result).to.be.ok;
+  });
+});

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-feature-repository_test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-feature-repository_test.js
@@ -4,20 +4,21 @@ import {
   OrganizationNotFound,
 } from '../../../../../src/organizational-entities/domain/errors.js';
 import { OrganizationFeature } from '../../../../../src/organizational-entities/domain/models/OrganizationFeature.js';
+import { OrganizationFeatureItem } from '../../../../../src/organizational-entities/domain/models/OrganizationFeatureItem.js';
 import * as organizationFeatureRepository from '../../../../../src/organizational-entities/infrastructure/repositories/organization-feature-repository.js';
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/domain/constants.js';
 import { catchErr, databaseBuilder, expect, knex } from '../../../../test-helper.js';
 
 describe('Integration | Repository | Organization-for-admin', function () {
-  let organization, feature;
-
-  beforeEach(async function () {
-    organization = databaseBuilder.factory.buildOrganization();
-    feature = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.PLACES_MANAGEMENT);
-    await databaseBuilder.commit();
-  });
-
   describe('#saveInBatch', function () {
+    let organization, feature;
+
+    beforeEach(async function () {
+      organization = databaseBuilder.factory.buildOrganization();
+      feature = databaseBuilder.factory.buildFeature(ORGANIZATION_FEATURE.PLACES_MANAGEMENT);
+      await databaseBuilder.commit();
+    });
+
     it('should add a several organization feature rows', async function () {
       // given
       const otherOrganization = databaseBuilder.factory.buildOrganization();
@@ -101,6 +102,98 @@ describe('Integration | Repository | Organization-for-admin', function () {
       const error = await catchErr(organizationFeatureRepository.saveInBatch)(organizationFeatures);
 
       expect(error).to.be.instanceOf(FeatureNotFound);
+    });
+  });
+
+  describe('#findAllOrganizationFeaturesFromOrganizationId', function () {
+    let organization, otherOrganization, featureOne, featureTwo, featureThree;
+
+    beforeEach(async function () {
+      organization = databaseBuilder.factory.buildOrganization();
+      otherOrganization = databaseBuilder.factory.buildOrganization();
+
+      featureOne = databaseBuilder.factory.buildFeature({
+        key: 'AWESOME_FIRST_FEATURE',
+      });
+
+      featureTwo = databaseBuilder.factory.buildFeature({
+        key: 'AWESOME_SECOND_FEATURE',
+      });
+
+      featureThree = databaseBuilder.factory.buildFeature({
+        key: 'AWESOME_THIRD_FEATURE',
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    it('should list all feature from an organization', async function () {
+      databaseBuilder.factory.buildOrganizationFeature({ organizationId: organization.id, featureId: featureOne.id });
+      databaseBuilder.factory.buildOrganizationFeature({
+        organizationId: organization.id,
+        featureId: featureThree.id,
+      });
+      databaseBuilder.factory.buildOrganizationFeature({
+        organizationId: otherOrganization.id,
+        featureId: featureTwo.id,
+      });
+
+      await databaseBuilder.commit();
+
+      const results = await organizationFeatureRepository.findAllOrganizationFeaturesFromOrganizationId({
+        organizationId: organization.id,
+      });
+
+      expect(results).lengthOf(2);
+      expect(results[0]).instanceOf(OrganizationFeatureItem);
+      expect(results.map((result) => result.name)).to.have.members([featureOne.key, featureThree.key]);
+    });
+
+    it('should return an empty list from an organization', async function () {
+      const results = await organizationFeatureRepository.findAllOrganizationFeaturesFromOrganizationId({
+        organizationId: organization.id,
+      });
+
+      expect(results).lengthOf(0);
+    });
+
+    it('should return null params when not defined', async function () {
+      databaseBuilder.factory.buildOrganizationFeature({ organizationId: organization.id, featureId: featureOne.id });
+
+      await databaseBuilder.commit();
+
+      const results = await organizationFeatureRepository.findAllOrganizationFeaturesFromOrganizationId({
+        organizationId: organization.id,
+      });
+
+      expect(results[0].params).to.be.null;
+    });
+
+    it('should return params when defined', async function () {
+      const featureParams = ['this is my extraParams', 'its AWESOME'];
+      databaseBuilder.factory.buildOrganizationFeature({
+        organizationId: organization.id,
+        featureId: featureOne.id,
+        params: JSON.stringify(featureParams),
+      });
+
+      await databaseBuilder.commit();
+
+      const results = await organizationFeatureRepository.findAllOrganizationFeaturesFromOrganizationId({
+        organizationId: organization.id,
+      });
+
+      expect(results[0].params).to.be.deep.equal(featureParams);
+    });
+
+    it('should return empty arry when no feature detected', async function () {
+      // when
+      const results = await organizationFeatureRepository.findAllOrganizationFeaturesFromOrganizationId({
+        organizationId: organization.id,
+      });
+
+      // then
+      expect(results).to.be.lengthOf(0);
     });
   });
 });

--- a/api/tests/organizational-entities/unit/application/api/organization-features-api_test.js
+++ b/api/tests/organizational-entities/unit/application/api/organization-features-api_test.js
@@ -1,0 +1,26 @@
+import * as organizationEntitiesApi from '../../../../../src/organizational-entities/application/api/organization-features-api.js';
+import { OrganizationFeatureItem } from '../../../../../src/organizational-entities/domain/models/OrganizationFeatureItem.js';
+import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Organizational Entities | Application | API | organization-features-api', function () {
+  describe('#getAllFeaturesFromOrganization', function () {
+    it('should return OrganizationFeature configuration from organization', async function () {
+      // given
+      const organizationId = Symbol('organizationId');
+
+      const getOrganizationFeatures = sinon.stub(usecases, 'findOrganizationFeatures');
+      getOrganizationFeatures
+        .withArgs({
+          organizationId,
+        })
+        .resolves([{}]);
+
+      // when
+      const result = await organizationEntitiesApi.getAllFeaturesFromOrganization(organizationId);
+
+      // then
+      expect(result[0]).not.to.be.instanceOf(OrganizationFeatureItem);
+    });
+  });
+});

--- a/api/tests/organizational-entities/unit/domain/usecases/find-organization-features_test.js
+++ b/api/tests/organizational-entities/unit/domain/usecases/find-organization-features_test.js
@@ -1,0 +1,27 @@
+import { findOrganizationFeatures } from '../../../../../src/organizational-entities/domain/usecases/find-organization-features.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Organizational Entities | Domain | UseCases | find-organization-features', function () {
+  let organizationFeatureRepository;
+
+  beforeEach(function () {
+    organizationFeatureRepository = {
+      findAllOrganizationFeaturesFromOrganizationId: sinon.stub(),
+    };
+  });
+
+  it('should call findAllOrganizationFeaturesFromOrganizationId with correct paramaters', async function () {
+    // given
+    const organizationId = Symbol('organizationId');
+
+    // when
+    await findOrganizationFeatures({ organizationId, organizationFeatureRepository });
+
+    // then
+    expect(
+      organizationFeatureRepository.findAllOrganizationFeaturesFromOrganizationId,
+    ).to.have.been.calledOnceWithExactly({
+      organizationId,
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Pour permettre la réconciliation d'un learner avec sa campagne dans le cadre d'un import à format il nous est impossible de connaitre à l'heure actuel si elle existe.
Etant du Bounded Context Acces, nous ne pouvons récupérer cela sauvagement

## :robot: Proposition
Ajouter une API interne qui permet dans le cas d'un accès à une campagne ayant une organization avec import . de définir les champs à afficher pour la réconciliation

## :rainbow: Remarques
RAS

## :100: Pour tester
CI au vert ✅ 