### PR TITLE
[FEATURE] Ajouter les modèles liés au Stepper (PIX-12620)

### DIFF
--- a/api/src/devcomp/domain/models/component/ComponentElement.js
+++ b/api/src/devcomp/domain/models/component/ComponentElement.js
@@ -1,4 +1,4 @@
-import { assertNotNullOrUndefined } from '../../../shared/domain/models/asserts.js';
+import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
 
 class ComponentElement {
   constructor({ element }) {

--- a/api/src/devcomp/domain/models/component/ComponentStepper.js
+++ b/api/src/devcomp/domain/models/component/ComponentStepper.js
@@ -1,0 +1,19 @@
+import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+
+class ComponentStepper {
+  constructor({ steps }) {
+    assertNotNullOrUndefined(steps, 'Steps are required for a componentStepper');
+    this.#assertStepsAreAnArray(steps);
+
+    this.steps = steps;
+    this.type = 'stepper';
+  }
+
+  #assertStepsAreAnArray(steps) {
+    if (!Array.isArray(steps)) {
+      throw new Error('Steps should be an array');
+    }
+  }
+}
+
+export { ComponentStepper };

--- a/api/src/devcomp/domain/models/component/Step.js
+++ b/api/src/devcomp/domain/models/component/Step.js
@@ -1,0 +1,21 @@
+import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+
+class Step {
+  constructor({ elements }) {
+    assertNotNullOrUndefined(elements, 'A step should contain elements');
+    this.#assertElementsNotEmpty(elements);
+
+    this.elements = elements;
+  }
+
+  #assertElementsNotEmpty(elements) {
+    if (!Array.isArray(elements)) {
+      throw new Error('step.elements should be an array');
+    }
+    if (elements.length === 0) {
+      throw new Error('A step should contain at least one element');
+    }
+  }
+}
+
+export { Step };

--- a/api/src/devcomp/domain/models/module/Module.js
+++ b/api/src/devcomp/domain/models/module/Module.js
@@ -135,7 +135,7 @@ class Module {
             title: grain.title,
             type: grain.type,
             components: grain.components
-              .map((component) => {
+              .flatMap((component) => {
                 if (component.type === 'element') {
                   const element = Module.#mapElementForVerification(component.element);
                   if (element) {
@@ -143,6 +143,22 @@ class Module {
                   } else {
                     return undefined;
                   }
+                } else if (component.type === 'stepper') {
+                  return component.steps.flatMap((step) => {
+                    return step.elements
+                      .flatMap((element) => {
+                        const domainElement = Module.#mapElementForVerification(element);
+                        if (domainElement) {
+                          return domainElement;
+                        } else {
+                          return undefined;
+                        }
+                      })
+                      .filter((element) => element !== undefined)
+                      .map((element) => {
+                        return new ComponentElement({ element });
+                      });
+                  });
                 } else {
                   logger.warn({
                     event: 'module_component_type_unknown',

--- a/api/src/devcomp/domain/models/module/Module.js
+++ b/api/src/devcomp/domain/models/module/Module.js
@@ -6,7 +6,7 @@ import { BlockInput } from '../block/BlockInput.js';
 import { BlockSelect } from '../block/BlockSelect.js';
 import { BlockSelectOption } from '../block/BlockSelectOption.js';
 import { BlockText } from '../block/BlockText.js';
-import { ComponentElement } from '../ComponentElement.js';
+import { ComponentElement } from '../component/ComponentElement.js';
 import { Image } from '../element/Image.js';
 import { QCM } from '../element/QCM.js';
 import { QCMForAnswerVerification } from '../element/QCM-for-answer-verification.js';

--- a/api/src/devcomp/domain/models/module/Module.js
+++ b/api/src/devcomp/domain/models/module/Module.js
@@ -57,36 +57,38 @@ class Module {
             type: grain.type,
             components: grain.components
               .map((component) => {
-                if (component.type === 'element') {
-                  const element = Module.#mapElement(component.element);
-                  if (element) {
-                    return new ComponentElement({ element });
-                  } else {
-                    return undefined;
+                switch (component.type) {
+                  case 'element': {
+                    const element = Module.#mapElement(component.element);
+                    if (element) {
+                      return new ComponentElement({ element });
+                    } else {
+                      return undefined;
+                    }
                   }
-                } else if (component.type === 'stepper') {
-                  return new ComponentStepper({
-                    steps: component.steps.map((step) => {
-                      return new Step({
-                        elements: step.elements
-                          .map((element) => {
-                            const domainElement = Module.#mapElement(element);
-                            if (domainElement) {
-                              return domainElement;
-                            } else {
-                              return undefined;
-                            }
-                          })
-                          .filter((element) => element !== undefined),
-                      });
-                    }),
-                  });
-                } else {
-                  logger.warn({
-                    event: 'module_component_type_unknown',
-                    message: `Component inconnu: ${component.type}`,
-                  });
-                  return undefined;
+                  case 'stepper':
+                    return new ComponentStepper({
+                      steps: component.steps.map((step) => {
+                        return new Step({
+                          elements: step.elements
+                            .map((element) => {
+                              const domainElement = Module.#mapElement(element);
+                              if (domainElement) {
+                                return domainElement;
+                              } else {
+                                return undefined;
+                              }
+                            })
+                            .filter((element) => element !== undefined),
+                        });
+                      }),
+                    });
+                  default:
+                    logger.warn({
+                      event: 'module_component_type_unknown',
+                      message: `Component inconnu: ${component.type}`,
+                    });
+                    return undefined;
                 }
               })
               .filter((component) => component !== undefined),
@@ -136,35 +138,37 @@ class Module {
             type: grain.type,
             components: grain.components
               .flatMap((component) => {
-                if (component.type === 'element') {
-                  const element = Module.#mapElementForVerification(component.element);
-                  if (element) {
-                    return new ComponentElement({ element });
-                  } else {
-                    return undefined;
+                switch (component.type) {
+                  case 'element': {
+                    const element = Module.#mapElementForVerification(component.element);
+                    if (element) {
+                      return new ComponentElement({ element });
+                    } else {
+                      return undefined;
+                    }
                   }
-                } else if (component.type === 'stepper') {
-                  return component.steps.flatMap((step) => {
-                    return step.elements
-                      .flatMap((element) => {
-                        const domainElement = Module.#mapElementForVerification(element);
-                        if (domainElement) {
-                          return domainElement;
-                        } else {
-                          return undefined;
-                        }
-                      })
-                      .filter((element) => element !== undefined)
-                      .map((element) => {
-                        return new ComponentElement({ element });
-                      });
-                  });
-                } else {
-                  logger.warn({
-                    event: 'module_component_type_unknown',
-                    message: `Component inconnu: ${component.type}`,
-                  });
-                  return undefined;
+                  case 'stepper':
+                    return component.steps.flatMap((step) => {
+                      return step.elements
+                        .flatMap((element) => {
+                          const domainElement = Module.#mapElementForVerification(element);
+                          if (domainElement) {
+                            return domainElement;
+                          } else {
+                            return undefined;
+                          }
+                        })
+                        .filter((element) => element !== undefined)
+                        .map((element) => {
+                          return new ComponentElement({ element });
+                        });
+                    });
+                  default:
+                    logger.warn({
+                      event: 'module_component_type_unknown',
+                      message: `Component inconnu: ${component.type}`,
+                    });
+                    return undefined;
                 }
               })
               .filter((component) => component !== undefined),

--- a/api/src/devcomp/domain/models/module/Module.js
+++ b/api/src/devcomp/domain/models/module/Module.js
@@ -7,6 +7,8 @@ import { BlockSelect } from '../block/BlockSelect.js';
 import { BlockSelectOption } from '../block/BlockSelectOption.js';
 import { BlockText } from '../block/BlockText.js';
 import { ComponentElement } from '../component/ComponentElement.js';
+import { ComponentStepper } from '../component/ComponentStepper.js';
+import { Step } from '../component/Step.js';
 import { Image } from '../element/Image.js';
 import { QCM } from '../element/QCM.js';
 import { QCMForAnswerVerification } from '../element/QCM-for-answer-verification.js';
@@ -62,6 +64,23 @@ class Module {
                   } else {
                     return undefined;
                   }
+                } else if (component.type === 'stepper') {
+                  return new ComponentStepper({
+                    steps: component.steps.map((step) => {
+                      return new Step({
+                        elements: step.elements
+                          .map((element) => {
+                            const domainElement = Module.#mapElement(element);
+                            if (domainElement) {
+                              return domainElement;
+                            } else {
+                              return undefined;
+                            }
+                          })
+                          .filter((element) => element !== undefined),
+                      });
+                    }),
+                  });
                 } else {
                   logger.warn({
                     event: 'module_component_type_unknown',

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
@@ -15,7 +15,7 @@ function serialize(module) {
             id: grain.id,
             title: grain.title,
             type: grain.type,
-            components: grain.components,
+            components: grain.components.filter((component) => component.type === 'element'),
           };
         }),
       };

--- a/api/tests/devcomp/unit/domain/models/component/ComponentElement_test.js
+++ b/api/tests/devcomp/unit/domain/models/component/ComponentElement_test.js
@@ -1,7 +1,7 @@
-import { ComponentElement } from '../../../../../src/devcomp/domain/models/ComponentElement.js';
-import { expect } from '../../../../test-helper.js';
+import { ComponentElement } from '../../../../../../src/devcomp/domain/models/component/ComponentElement.js';
+import { expect } from '../../../../../test-helper.js';
 
-describe('Unit | Devcomp | Domain | Models | ComponentElement', function () {
+describe('Unit | Devcomp | Domain | Models | Component | ComponentElement', function () {
   describe('#constructor', function () {
     it('should create a componentElement', function () {
       // given

--- a/api/tests/devcomp/unit/domain/models/component/ComponentStepper_test.js
+++ b/api/tests/devcomp/unit/domain/models/component/ComponentStepper_test.js
@@ -1,0 +1,35 @@
+import { ComponentStepper } from '../../../../../../src/devcomp/domain/models/component/ComponentStepper.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | Component | ComponentStepper', function () {
+  describe('#constructor', function () {
+    it('should create a componentStepper', function () {
+      // given
+      const steps = [{ elements: 'toto' }, { elements: 'foo' }];
+      const type = 'stepper';
+
+      // when
+      const componentStepper = new ComponentStepper({ steps });
+
+      // then
+      expect(componentStepper.steps).to.equal(steps);
+      expect(componentStepper.type).to.equal(type);
+    });
+  });
+
+  describe('if a componentStepper does not have steps', function () {
+    it('should throw an error', function () {
+      expect(() => new ComponentStepper({})).to.throw('Steps are required for a componentStepper');
+    });
+  });
+
+  describe('when a componentStepper does not have an array of Steps', function () {
+    it('should throw an error', function () {
+      // given
+      const steps = 'steps';
+
+      // when/then
+      expect(() => new ComponentStepper({ steps })).to.throw('Steps should be an array');
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/models/component/Step_test.js
+++ b/api/tests/devcomp/unit/domain/models/component/Step_test.js
@@ -1,0 +1,38 @@
+import { Step } from '../../../../../../src/devcomp/domain/models/component/Step.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | Component | Step', function () {
+  describe('#constructor', function () {
+    it('should create a step', function () {
+      // given
+      const elements = [{ id: Symbol('toto') }];
+
+      // when
+      const step = new Step({ elements });
+
+      // then
+      expect(step.elements).to.equal(elements);
+    });
+  });
+
+  describe('when a step does not have elements', function () {
+    it('should throw an error', function () {
+      // when/then
+      expect(() => new Step({})).to.throw('A step should contain elements');
+    });
+  });
+
+  describe('when the elements of a Step is not a list', function () {
+    it('should throw an error', function () {
+      // when/then
+      expect(() => new Step({ elements: 'not a list' })).to.throw('step.elements should be an array');
+    });
+  });
+
+  describe('when a step has an empty list of elements', function () {
+    it('should throw an error', function () {
+      // when/then
+      expect(() => new Step({ elements: [] })).to.throw('A step should contain at least one element');
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/models/module/Module_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/Module_test.js
@@ -1,4 +1,6 @@
 import { ModuleInstantiationError } from '../../../../../../src/devcomp/domain/errors.js';
+import { ComponentStepper } from '../../../../../../src/devcomp/domain/models/component/ComponentStepper.js';
+import { Step } from '../../../../../../src/devcomp/domain/models/component/Step.js';
 import { Image } from '../../../../../../src/devcomp/domain/models/element/Image.js';
 import { QCM } from '../../../../../../src/devcomp/domain/models/element/QCM.js';
 import { QCMForAnswerVerification } from '../../../../../../src/devcomp/domain/models/element/QCM-for-answer-verification.js';
@@ -281,330 +283,859 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
       }
     });
 
-    it('should instantiate a Module with a ComponentElement which contains an Image Element', function () {
-      // given
-      const moduleData = {
-        id: '6282925d-4775-4bca-b513-4c3009ec5886',
-        slug: 'title',
-        title: 'title',
-        details: {
-          image: 'https://images.pix.fr/modulix/placeholder-details.svg',
-          description: 'Description',
-          duration: 5,
-          level: 'Débutant',
-          objectives: ['Objective 1'],
-        },
-        grains: [
-          {
-            id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-            type: 'lesson',
-            title: 'title',
-            components: [
-              {
-                type: 'element',
-                element: {
-                  id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
-                  type: 'image',
-                  url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg',
-                  alt: 'Alternative',
-                  alternativeText: 'Alternative textuelle',
-                },
-              },
-            ],
+    describe('With ComponentElement', function () {
+      it('should instantiate a Module with a ComponentElement which contains an Image Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
           },
-        ],
-      };
-
-      // when
-      const module = Module.toDomain(moduleData);
-
-      // then
-      expect(module.grains[0].components[0].element).to.be.an.instanceOf(Image);
-    });
-
-    it('should instantiate a Module with a ComponentElement which contains a Text Element', function () {
-      // given
-      const moduleData = {
-        id: '6282925d-4775-4bca-b513-4c3009ec5886',
-        slug: 'title',
-        title: 'title',
-        details: {
-          image: 'https://images.pix.fr/modulix/placeholder-details.svg',
-          description: 'Description',
-          duration: 5,
-          level: 'Débutant',
-          objectives: ['Objective 1'],
-        },
-        grains: [
-          {
-            id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-            type: 'lesson',
-            title: 'title',
-            components: [
-              {
-                type: 'element',
-                element: {
-                  id: '84726001-1665-457d-8f13-4a74dc4768ea',
-                  type: 'text',
-                  content: '<h3>Content</h3>',
-                },
-              },
-            ],
-          },
-        ],
-      };
-
-      // when
-      const module = Module.toDomain(moduleData);
-
-      // then
-      expect(module.grains[0].components[0].element).to.be.an.instanceOf(Text);
-    });
-
-    it('should instantiate a Module with a ComponentElement which contains a Video Element', function () {
-      // given
-      const moduleData = {
-        id: '6282925d-4775-4bca-b513-4c3009ec5886',
-        slug: 'title',
-        title: 'title',
-        details: {
-          image: 'https://images.pix.fr/modulix/placeholder-details.svg',
-          description: 'Description',
-          duration: 5,
-          level: 'Débutant',
-          objectives: ['Objective 1'],
-        },
-        grains: [
-          {
-            id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-            type: 'lesson',
-            title: 'title',
-            components: [
-              {
-                type: 'element',
-                element: {
-                  id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
-                  type: 'video',
-                  title: 'Le format des adress mail',
-                  url: 'https://videos.pix.fr/modulix/chat_animation_2.webm',
-                  subtitles: 'Insert subtitles here',
-                  transcription: 'Insert transcription here',
-                },
-              },
-            ],
-          },
-        ],
-      };
-
-      // when
-      const module = Module.toDomain(moduleData);
-
-      // then
-      expect(module.grains[0].components[0].element).to.be.an.instanceOf(Video);
-    });
-
-    it('should instantiate a Module with a ComponentElement which contains a QCU Element', function () {
-      // given
-      const moduleData = {
-        id: '6282925d-4775-4bca-b513-4c3009ec5886',
-        slug: 'title',
-        title: 'title',
-        details: {
-          image: 'https://images.pix.fr/modulix/placeholder-details.svg',
-          description: 'Description',
-          duration: 5,
-          level: 'Débutant',
-          objectives: ['Objective 1'],
-        },
-        grains: [
-          {
-            id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-            type: 'lesson',
-            title: 'title',
-            components: [
-              {
-                type: 'element',
-                element: {
-                  id: 'ba78dead-a806-4954-b408-e8ef28d28fab',
-                  type: 'qcu',
-                  instruction: '<p>L’adresse mail M3g4Cool1415@gmail.com est correctement écrite ?</p>',
-                  proposals: [
-                    {
-                      id: '1',
-                      content: 'Vrai',
-                    },
-                    {
-                      id: '2',
-                      content: 'Faux',
-                    },
-                  ],
-                  feedbacks: {
-                    valid:
-                      '<p>On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>',
-                    invalid:
-                      '<p>On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>',
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              components: [
+                {
+                  type: 'element',
+                  element: {
+                    id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
+                    type: 'image',
+                    url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg',
+                    alt: 'Alternative',
+                    alternativeText: 'Alternative textuelle',
                   },
-                  solution: '1',
                 },
-              },
-            ],
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = Module.toDomain(moduleData);
+
+        // then
+        expect(module.grains[0].components[0].element).to.be.an.instanceOf(Image);
+      });
+
+      it('should instantiate a Module with a ComponentElement which contains a Text Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
           },
-        ],
-      };
-
-      // when
-      const module = Module.toDomain(moduleData);
-
-      // then
-      expect(module.grains[0].components[0].element).to.be.an.instanceOf(QCU);
-    });
-
-    it('should instantiate a Module with a ComponentElement which contains a QCM Element', function () {
-      // given
-      const moduleData = {
-        id: '6282925d-4775-4bca-b513-4c3009ec5886',
-        slug: 'title',
-        title: 'title',
-        details: {
-          image: 'https://images.pix.fr/modulix/placeholder-details.svg',
-          description: 'Description',
-          duration: 5,
-          level: 'Débutant',
-          objectives: ['Objective 1'],
-        },
-        grains: [
-          {
-            id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-            type: 'lesson',
-            title: 'title',
-            components: [
-              {
-                type: 'element',
-                element: {
-                  id: '30701e93-1b4d-4da4-b018-fa756c07d53f',
-                  type: 'qcm',
-                  instruction: '<p>Quels sont les 3 piliers de Pix ?</p>',
-                  proposals: [
-                    {
-                      id: '1',
-                      content: 'Evaluer ses connaissances et savoir-faire sur 16 compétences du numérique',
-                    },
-                    {
-                      id: '2',
-                      content: 'Développer son savoir-faire sur les jeux de type TPS',
-                    },
-                    {
-                      id: '3',
-                      content: 'Développer ses compétences numériques',
-                    },
-                    {
-                      id: '4',
-                      content: 'Certifier ses compétences Pix',
-                    },
-                    {
-                      id: '5',
-                      content: 'Evaluer ses compétences de logique et compréhension mathématique',
-                    },
-                  ],
-                  feedbacks: {
-                    valid: '<p>Correct ! Vous nous avez bien cernés :)</p>',
-                    invalid: '<p>Et non ! Pix sert à évaluer, certifier et développer ses compétences numériques.',
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              components: [
+                {
+                  type: 'element',
+                  element: {
+                    id: '84726001-1665-457d-8f13-4a74dc4768ea',
+                    type: 'text',
+                    content: '<h3>Content</h3>',
                   },
-                  solutions: ['1', '3', '4'],
                 },
-              },
-            ],
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = Module.toDomain(moduleData);
+
+        // then
+        expect(module.grains[0].components[0].element).to.be.an.instanceOf(Text);
+      });
+
+      it('should instantiate a Module with a ComponentElement which contains a Video Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
           },
-        ],
-      };
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              components: [
+                {
+                  type: 'element',
+                  element: {
+                    id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
+                    type: 'video',
+                    title: 'Le format des adress mail',
+                    url: 'https://videos.pix.fr/modulix/chat_animation_2.webm',
+                    subtitles: 'Insert subtitles here',
+                    transcription: 'Insert transcription here',
+                  },
+                },
+              ],
+            },
+          ],
+        };
 
-      // when
-      const module = Module.toDomain(moduleData);
+        // when
+        const module = Module.toDomain(moduleData);
 
-      // then
-      expect(module.grains[0].components[0].element).to.be.an.instanceOf(QCM);
+        // then
+        expect(module.grains[0].components[0].element).to.be.an.instanceOf(Video);
+      });
+
+      it('should instantiate a Module with a ComponentElement which contains a QCU Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              components: [
+                {
+                  type: 'element',
+                  element: {
+                    id: 'ba78dead-a806-4954-b408-e8ef28d28fab',
+                    type: 'qcu',
+                    instruction: '<p>L’adresse mail M3g4Cool1415@gmail.com est correctement écrite ?</p>',
+                    proposals: [
+                      {
+                        id: '1',
+                        content: 'Vrai',
+                      },
+                      {
+                        id: '2',
+                        content: 'Faux',
+                      },
+                    ],
+                    feedbacks: {
+                      valid:
+                        '<p>On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>',
+                      invalid:
+                        '<p>On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>',
+                    },
+                    solution: '1',
+                  },
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = Module.toDomain(moduleData);
+
+        // then
+        expect(module.grains[0].components[0].element).to.be.an.instanceOf(QCU);
+      });
+
+      it('should instantiate a Module with a ComponentElement which contains a QCM Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              components: [
+                {
+                  type: 'element',
+                  element: {
+                    id: '30701e93-1b4d-4da4-b018-fa756c07d53f',
+                    type: 'qcm',
+                    instruction: '<p>Quels sont les 3 piliers de Pix ?</p>',
+                    proposals: [
+                      {
+                        id: '1',
+                        content: 'Evaluer ses connaissances et savoir-faire sur 16 compétences du numérique',
+                      },
+                      {
+                        id: '2',
+                        content: 'Développer son savoir-faire sur les jeux de type TPS',
+                      },
+                      {
+                        id: '3',
+                        content: 'Développer ses compétences numériques',
+                      },
+                      {
+                        id: '4',
+                        content: 'Certifier ses compétences Pix',
+                      },
+                      {
+                        id: '5',
+                        content: 'Evaluer ses compétences de logique et compréhension mathématique',
+                      },
+                    ],
+                    feedbacks: {
+                      valid: '<p>Correct ! Vous nous avez bien cernés :)</p>',
+                      invalid: '<p>Et non ! Pix sert à évaluer, certifier et développer ses compétences numériques.',
+                    },
+                    solutions: ['1', '3', '4'],
+                  },
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = Module.toDomain(moduleData);
+
+        // then
+        expect(module.grains[0].components[0].element).to.be.an.instanceOf(QCM);
+      });
+
+      it('should instantiate a Module with a ComponentElement which contains a QROCM Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              components: [
+                {
+                  type: 'element',
+                  element: {
+                    id: '98c51fa7-03b7-49b1-8c5e-49341d35909c',
+                    type: 'qrocm',
+                    instruction:
+                      "<p>Pour être sûr que tout est clair, complétez le texte ci-dessous <span aria-hidden='true'>🧩</span></p><p>Si vous avez besoin d’aide, revenez en arrière <span aria-hidden='true'>⬆️</span></p>",
+                    proposals: [
+                      {
+                        type: 'text',
+                        content: '<p>Le symbole</>',
+                      },
+                      {
+                        input: 'symbole',
+                        type: 'input',
+                        inputType: 'text',
+                        size: 1,
+                        display: 'inline',
+                        placeholder: '',
+                        ariaLabel: 'Réponse 1',
+                        defaultValue: '',
+                        tolerances: ['t1'],
+                        solutions: ['@'],
+                      },
+                      {
+                        input: 'premiere-partie',
+                        type: 'select',
+                        display: 'inline',
+                        placeholder: '',
+                        ariaLabel: 'Réponse 2',
+                        defaultValue: '',
+                        tolerances: [],
+                        options: [
+                          {
+                            id: '1',
+                            content: "l'identifiant",
+                          },
+                          {
+                            id: '2',
+                            content: "le fournisseur d'adresse mail",
+                          },
+                        ],
+                        solutions: ['1'],
+                      },
+                    ],
+                    feedbacks: {
+                      valid: '<p>Bravo ! 🎉 </p>',
+                      invalid: "<p class='pix-list-inline'>Et non !</p>",
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = Module.toDomain(moduleData);
+
+        // then
+        expect(module.grains[0].components[0].element).to.be.an.instanceOf(QROCM);
+      });
     });
 
-    it('should instantiate a Module with a ComponentElement which contains a QROCM Element', function () {
-      // given
-      const moduleData = {
-        id: '6282925d-4775-4bca-b513-4c3009ec5886',
-        slug: 'title',
-        title: 'title',
-        details: {
-          image: 'https://images.pix.fr/modulix/placeholder-details.svg',
-          description: 'Description',
-          duration: 5,
-          level: 'Débutant',
-          objectives: ['Objective 1'],
-        },
-        grains: [
-          {
-            id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-            type: 'lesson',
-            title: 'title',
-            components: [
-              {
-                type: 'element',
-                element: {
-                  id: '98c51fa7-03b7-49b1-8c5e-49341d35909c',
-                  type: 'qrocm',
-                  instruction:
-                    "<p>Pour être sûr que tout est clair, complétez le texte ci-dessous <span aria-hidden='true'>🧩</span></p><p>Si vous avez besoin d’aide, revenez en arrière <span aria-hidden='true'>⬆️</span></p>",
-                  proposals: [
+    describe('With ComponentStepper', function () {
+      it('should instantiate a Module with a ComponentStepper which contains an Image Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              components: [
+                {
+                  type: 'stepper',
+                  steps: [
                     {
-                      type: 'text',
-                      content: '<p>Le symbole</>',
-                    },
-                    {
-                      input: 'symbole',
-                      type: 'input',
-                      inputType: 'text',
-                      size: 1,
-                      display: 'inline',
-                      placeholder: '',
-                      ariaLabel: 'Réponse 1',
-                      defaultValue: '',
-                      tolerances: ['t1'],
-                      solutions: ['@'],
-                    },
-                    {
-                      input: 'premiere-partie',
-                      type: 'select',
-                      display: 'inline',
-                      placeholder: '',
-                      ariaLabel: 'Réponse 2',
-                      defaultValue: '',
-                      tolerances: [],
-                      options: [
+                      elements: [
                         {
-                          id: '1',
-                          content: "l'identifiant",
-                        },
-                        {
-                          id: '2',
-                          content: "le fournisseur d'adresse mail",
+                          id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
+                          type: 'image',
+                          url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg',
+                          alt: "Dessin détaillé dans l'alternative textuelle",
+                          alternativeText: "Dessin d'un ordinateur dans un univers spatial.",
                         },
                       ],
-                      solutions: ['1'],
                     },
                   ],
-                  feedbacks: {
-                    valid: '<p>Bravo ! 🎉 </p>',
-                    invalid: "<p class='pix-list-inline'>Et non !</p>",
-                  },
                 },
-              },
-            ],
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = Module.toDomain(moduleData);
+
+        // then
+        expect(module.grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
+        expect(module.grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
+        expect(module.grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Image);
+      });
+
+      it('should instantiate a Module with a ComponentStepper which contains a Text Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
           },
-        ],
-      };
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              components: [
+                {
+                  type: 'stepper',
+                  steps: [
+                    {
+                      elements: [
+                        {
+                          id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                          type: 'text',
+                          content: '<p>À la fin de cette vidéo, une question sera posée sur les compétences Pix.</p>',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
 
-      // when
-      const module = Module.toDomain(moduleData);
+        // when
+        const module = Module.toDomain(moduleData);
 
-      // then
-      expect(module.grains[0].components[0].element).to.be.an.instanceOf(QROCM);
+        // then
+        expect(module.grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
+        expect(module.grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
+        expect(module.grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Text);
+      });
+
+      it('should instantiate a Module with a ComponentStepper which contains a Video Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              components: [
+                {
+                  type: 'stepper',
+                  steps: [
+                    {
+                      elements: [
+                        {
+                          id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
+                          type: 'video',
+                          title: 'Vidéo de présentation de Pix',
+                          url: 'https://videos.pix.fr/modulix/didacticiel/presentation.mp4',
+                          subtitles: '',
+                          transcription:
+                            '<p>Le numérique évolue en permanence, vos compétences aussi, pour travailler, communiquer et s\'informer, se déplacer, réaliser des démarches, un enjeu tout au long de la vie.</p><p>Sur <a href="https://pix.fr" target="blank">pix.fr</a>, testez-vous et cultivez vos compétences numériques.</p><p>Les tests Pix sont personnalisés, les questions s\'adaptent à votre niveau, réponse après réponse.</p><p>Évaluez vos connaissances et savoir-faire sur 16 compétences, dans 5 domaines, sur 5 niveaux de débutants à confirmer, avec des mises en situation ludiques, recherches en ligne, manipulation de fichiers et de données, culture numérique...</p><p>Allez à votre rythme, vous pouvez arrêter et reprendre quand vous le voulez.</p><p>Toutes les 5 questions, découvrez vos résultats et progressez grâce aux astuces et aux tutos.</p><p>En relevant les défis Pix, vous apprendrez de nouvelles choses et aurez envie d\'aller plus loin.</p><p>Vous pensez pouvoir faire mieux&#8239;?</p><p>Retentez les tests et améliorez votre score.</p><p>Faites reconnaître officiellement votre niveau en passant la certification Pix, reconnue par l\'État et le monde professionnel.</p><p>Pix&nbsp;: le service public en ligne pour évaluer, développer et certifier ses compétences numériques.</p>',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = Module.toDomain(moduleData);
+
+        // then
+        expect(module.grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
+        expect(module.grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
+        expect(module.grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Video);
+      });
+
+      it('should instantiate a Module with a ComponentStepper which contains a QCU Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              components: [
+                {
+                  type: 'stepper',
+                  steps: [
+                    {
+                      elements: [
+                        {
+                          id: '71de6394-ff88-4de3-8834-a40057a50ff4',
+                          type: 'qcu',
+                          instruction: '<p>Pix évalue 16 compétences numériques différentes.</p>',
+                          proposals: [
+                            {
+                              id: '1',
+                              content: 'Vrai',
+                            },
+                            {
+                              id: '2',
+                              content: 'Faux',
+                            },
+                          ],
+                          feedbacks: {
+                            valid: '<p>Correct&#8239;! Ces 16 compétences sont rangées dans 5 domaines.</p>',
+                            invalid:
+                              '<p>Incorrect. Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>️!</p>',
+                          },
+                          solution: '1',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = Module.toDomain(moduleData);
+
+        // then
+        expect(module.grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
+        expect(module.grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
+        expect(module.grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(QCU);
+      });
+
+      it('should instantiate a Module with a ComponentStepper which contains a QCM Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              components: [
+                {
+                  type: 'stepper',
+                  steps: [
+                    {
+                      elements: [
+                        {
+                          id: '30701e93-1b4d-4da4-b018-fa756c07d53f',
+                          type: 'qcm',
+                          instruction: '<p>Quels sont les 3 piliers de Pix&#8239;?</p>',
+                          proposals: [
+                            {
+                              id: '1',
+                              content: 'Evaluer ses connaissances et savoir-faire sur 16 compétences du numérique',
+                            },
+                            {
+                              id: '2',
+                              content: 'Développer son savoir-faire sur les jeux de type TPS',
+                            },
+                            {
+                              id: '3',
+                              content: 'Développer ses compétences numériques',
+                            },
+                            {
+                              id: '4',
+                              content: 'Certifier ses compétences Pix',
+                            },
+                            {
+                              id: '5',
+                              content: 'Evaluer ses compétences de logique et compréhension mathématique',
+                            },
+                          ],
+                          feedbacks: {
+                            valid: '<p>Correct&#8239;! Vous nous avez bien cernés&nbsp;:)</p>',
+                            invalid:
+                              '<p>Et non&#8239;! Pix sert à évaluer, certifier et développer ses compétences numériques.</p>',
+                          },
+                          solutions: ['1', '3', '4'],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = Module.toDomain(moduleData);
+
+        // then
+        expect(module.grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
+        expect(module.grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
+        expect(module.grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(QCM);
+      });
+
+      it('should instantiate a Module with a ComponentStepper which contains a QROCM Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              components: [
+                {
+                  type: 'stepper',
+                  steps: [
+                    {
+                      elements: [
+                        {
+                          id: 'c23436d4-6261-49f1-b50d-13a547529c29',
+                          type: 'qrocm',
+                          instruction: '<p>Compléter le texte suivant :</p>',
+                          proposals: [
+                            {
+                              type: 'text',
+                              content: '<span>Pix est un</span>',
+                            },
+                            {
+                              input: 'pix-name',
+                              type: 'input',
+                              inputType: 'text',
+                              size: 10,
+                              display: 'inline',
+                              placeholder: '',
+                              ariaLabel: 'Mot à trouver',
+                              defaultValue: '',
+                              tolerances: ['t1', 't3'],
+                              solutions: ['Groupement'],
+                            },
+                            {
+                              type: 'text',
+                              content: "<span>d'intérêt public qui a été créée en</span>",
+                            },
+                            {
+                              input: 'pix-birth',
+                              type: 'input',
+                              inputType: 'text',
+                              size: 10,
+                              display: 'inline',
+                              placeholder: '',
+                              ariaLabel: 'Année à trouver',
+                              defaultValue: '',
+                              tolerances: [],
+                              solutions: ['2016'],
+                            },
+                          ],
+                          feedbacks: {
+                            valid:
+                              '<p>Correct&#8239;! vous nous connaissez bien&nbsp;<span aria-hidden="true">🎉</span></p>',
+                            invalid: '<p>Incorrect&#8239;! vous y arriverez la prochaine fois&#8239;!</p>',
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = Module.toDomain(moduleData);
+
+        // then
+        expect(module.grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
+        expect(module.grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
+        expect(module.grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(QROCM);
+      });
+
+      it('should filter out unknown element type', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              components: [
+                {
+                  type: 'stepper',
+                  steps: [
+                    {
+                      elements: [
+                        {
+                          id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                          type: 'text',
+                          content: '<p>À la fin de cette vidéo, une question sera posée sur les compétences Pix.</p>',
+                        },
+                        {
+                          id: '16ad694a-848f-456d-95a6-c488350c3ed7',
+                          type: 'unknown',
+                          content: 'Should not be added to the grain',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = Module.toDomain(moduleData);
+
+        // then
+        expect(module.grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
+        expect(module.grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
+        expect(module.grains[0].components[0].steps[0].elements).to.have.length(1);
+        expect(module.grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Text);
+      });
+
+      it('should filter out steps with only unknown element type', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              components: [
+                {
+                  type: 'stepper',
+                  steps: [
+                    {
+                      elements: [
+                        {
+                          id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                          type: 'text',
+                          content: '<p>À la fin de cette vidéo, une question sera posée sur les compétences Pix.</p>',
+                        },
+                      ],
+                    },
+                    {
+                      elements: [
+                        {
+                          id: '16ad694a-848f-456d-95a6-c488350c3ed7',
+                          type: 'unknown',
+                          content: 'Should not be added to the grain',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const error = catchErrSync(Module.toDomain)(moduleData);
+
+        // then
+        expect(error).to.be.an.instanceOf(ModuleInstantiationError);
+        expect(error.message).to.deep.equal('A step should contain at least one element');
+      });
+
+      it('should filter out stepper with only unknown element type', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              components: [
+                {
+                  type: 'stepper',
+                  steps: [
+                    {
+                      elements: [
+                        {
+                          id: '16ad694a-848f-456d-95a6-c488350c3ed7',
+                          type: 'unknown',
+                          content: 'Should not be added to the grain',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const error = catchErrSync(Module.toDomain)(moduleData);
+
+        // then
+        expect(error).to.be.an.instanceOf(ModuleInstantiationError);
+        expect(error.message).to.deep.equal('A step should contain at least one element');
+      });
     });
 
     it('should filter out unknown component types', function () {

--- a/api/tests/devcomp/unit/domain/models/module/Module_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/Module_test.js
@@ -1290,254 +1290,256 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
     });
 
     describe('with answerable elements', function () {
-      it('should instantiate a Module with components', function () {
-        // given
-        const feedbacks = { valid: 'valid', invalid: 'invalid' };
-        const proposals = [
-          { id: '1', content: 'toto' },
-          { id: '2', content: 'foo' },
-        ];
+      describe('with ComponentElement', function () {
+        it('should instantiate a Module with components', function () {
+          // given
+          const feedbacks = { valid: 'valid', invalid: 'invalid' };
+          const proposals = [
+            { id: '1', content: 'toto' },
+            { id: '2', content: 'foo' },
+          ];
 
-        const moduleData = {
-          id: '6282925d-4775-4bca-b513-4c3009ec5886',
-          slug: 'title',
-          title: 'title',
-          details: {
-            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
-            description: 'Description',
-            duration: 5,
-            level: 'Débutant',
-            objectives: ['Objective 1'],
-          },
-          grains: [
-            {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
-                {
-                  type: 'element',
-                  element: {
-                    id: '123',
-                    instruction: 'instruction',
-                    locales: ['fr-FR'],
-                    proposals,
-                    feedbacks,
-                    type: 'qcu',
-                    solution: proposals[0].id,
-                  },
-                },
-              ],
+          const moduleData = {
+            id: '6282925d-4775-4bca-b513-4c3009ec5886',
+            slug: 'title',
+            title: 'title',
+            details: {
+              image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+              description: 'Description',
+              duration: 5,
+              level: 'Débutant',
+              objectives: ['Objective 1'],
             },
-          ],
-        };
-
-        // when
-        const module = Module.toDomainForVerification(moduleData);
-
-        // then
-        expect(module).to.be.an.instanceOf(Module);
-        expect(module.grains).not.to.be.empty;
-        for (const grain of module.grains) {
-          expect(grain.components).not.to.be.empty;
-        }
-      });
-
-      it('should instantiate a Module with a ComponentElement with contains a QCUForAnswerVerification Element', function () {
-        // given
-        const feedbacks = { valid: 'valid', invalid: 'invalid' };
-        const proposals = [
-          { id: '1', content: 'toto' },
-          { id: '2', content: 'foo' },
-        ];
-
-        const moduleData = {
-          id: '6282925d-4775-4bca-b513-4c3009ec5886',
-          slug: 'title',
-          title: 'title',
-          details: {
-            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
-            description: 'Description',
-            duration: 5,
-            level: 'Débutant',
-            objectives: ['Objective 1'],
-          },
-          grains: [
-            {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
-                {
-                  type: 'element',
-                  element: {
-                    id: '123',
-                    instruction: 'instruction',
-                    locales: ['fr-FR'],
-                    proposals,
-                    feedbacks,
-                    type: 'qcu',
-                    solution: proposals[0].id,
-                  },
-                },
-              ],
-            },
-          ],
-        };
-
-        // when
-        const module = Module.toDomainForVerification(moduleData);
-
-        // then
-        expect(module.grains[0].components[0].element).to.be.an.instanceOf(QCUForAnswerVerification);
-      });
-
-      it('should instantiate a Module with a ComponentElement with contains a QCMForAnswerVerification Element', function () {
-        // given
-        const moduleData = {
-          id: '6282925d-4775-4bca-b513-4c3009ec5886',
-          slug: 'title',
-          title: 'title',
-          details: {
-            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
-            description: 'Description',
-            duration: 5,
-            level: 'Débutant',
-            objectives: ['Objective 1'],
-          },
-          grains: [
-            {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
-                {
-                  type: 'element',
-                  element: {
-                    id: '30701e93-1b4d-4da4-b018-fa756c07d53f',
-                    type: 'qcm',
-                    instruction: '<p>Quels sont les 3 piliers de Pix ?</p>',
-                    proposals: [
-                      {
-                        id: '1',
-                        content: 'Evaluer ses connaissances et savoir-faire sur 16 compétences du numérique',
-                      },
-                      {
-                        id: '2',
-                        content: 'Développer son savoir-faire sur les jeux de type TPS',
-                      },
-                      {
-                        id: '3',
-                        content: 'Développer ses compétences numériques',
-                      },
-                      {
-                        id: '4',
-                        content: 'Certifier ses compétences Pix',
-                      },
-                      {
-                        id: '5',
-                        content: 'Evaluer ses compétences de logique et compréhension mathématique',
-                      },
-                    ],
-                    feedbacks: {
-                      valid: '<p>Correct ! Vous nous avez bien cernés :)</p>',
-                      invalid: '<p>Et non ! Pix sert à évaluer, certifier et développer ses compétences numériques.',
-                    },
-                    solutions: ['1', '3', '4'],
-                  },
-                },
-              ],
-            },
-          ],
-        };
-
-        // when
-        const module = Module.toDomainForVerification(moduleData);
-
-        // then
-        expect(module.grains[0].components[0].element).to.be.an.instanceOf(QCMForAnswerVerification);
-      });
-
-      it('should instantiate a Module with a ComponentElement with contains a QROCMForAnswerVerification Element', function () {
-        // given
-        const moduleData = {
-          id: '6282925d-4775-4bca-b513-4c3009ec5886',
-          slug: 'title',
-          title: 'title',
-          details: {
-            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
-            description: 'Description',
-            duration: 5,
-            level: 'Débutant',
-            objectives: ['Objective 1'],
-          },
-          grains: [
-            {
-              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
-              type: 'lesson',
-              title: 'title',
-              components: [
-                {
-                  type: 'element',
-                  element: {
-                    id: '98c51fa7-03b7-49b1-8c5e-49341d35909c',
-                    type: 'qrocm',
-                    instruction:
-                      "<p>Pour être sûr que tout est clair, complétez le texte ci-dessous <span aria-hidden='true'>🧩</span></p><p>Si vous avez besoin d’aide, revenez en arrière <span aria-hidden='true'>⬆️</span></p>",
-                    proposals: [
-                      {
-                        type: 'text',
-                        content: '<p>Le symbole</>',
-                      },
-                      {
-                        input: 'symbole',
-                        type: 'input',
-                        inputType: 'text',
-                        size: 1,
-                        display: 'inline',
-                        placeholder: '',
-                        ariaLabel: 'Réponse 1',
-                        defaultValue: '',
-                        tolerances: ['t1'],
-                        solutions: ['@'],
-                      },
-                      {
-                        input: 'premiere-partie',
-                        type: 'select',
-                        display: 'inline',
-                        placeholder: '',
-                        ariaLabel: 'Réponse 2',
-                        defaultValue: '',
-                        tolerances: [],
-                        options: [
-                          {
-                            id: '1',
-                            content: "l'identifiant",
-                          },
-                          {
-                            id: '2',
-                            content: "le fournisseur d'adresse mail",
-                          },
-                        ],
-                        solutions: ['1'],
-                      },
-                    ],
-                    feedbacks: {
-                      valid: '<p>Bravo ! 🎉 </p>',
-                      invalid: "<p class='pix-list-inline'>Et non !</p>",
+            grains: [
+              {
+                id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                type: 'lesson',
+                title: 'title',
+                components: [
+                  {
+                    type: 'element',
+                    element: {
+                      id: '123',
+                      instruction: 'instruction',
+                      locales: ['fr-FR'],
+                      proposals,
+                      feedbacks,
+                      type: 'qcu',
+                      solution: proposals[0].id,
                     },
                   },
-                },
-              ],
+                ],
+              },
+            ],
+          };
+
+          // when
+          const module = Module.toDomainForVerification(moduleData);
+
+          // then
+          expect(module).to.be.an.instanceOf(Module);
+          expect(module.grains).not.to.be.empty;
+          for (const grain of module.grains) {
+            expect(grain.components).not.to.be.empty;
+          }
+        });
+
+        it('should instantiate a Module with a ComponentElement with contains a QCUForAnswerVerification Element', function () {
+          // given
+          const feedbacks = { valid: 'valid', invalid: 'invalid' };
+          const proposals = [
+            { id: '1', content: 'toto' },
+            { id: '2', content: 'foo' },
+          ];
+
+          const moduleData = {
+            id: '6282925d-4775-4bca-b513-4c3009ec5886',
+            slug: 'title',
+            title: 'title',
+            details: {
+              image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+              description: 'Description',
+              duration: 5,
+              level: 'Débutant',
+              objectives: ['Objective 1'],
             },
-          ],
-        };
+            grains: [
+              {
+                id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                type: 'lesson',
+                title: 'title',
+                components: [
+                  {
+                    type: 'element',
+                    element: {
+                      id: '123',
+                      instruction: 'instruction',
+                      locales: ['fr-FR'],
+                      proposals,
+                      feedbacks,
+                      type: 'qcu',
+                      solution: proposals[0].id,
+                    },
+                  },
+                ],
+              },
+            ],
+          };
 
-        // when
-        const module = Module.toDomainForVerification(moduleData);
+          // when
+          const module = Module.toDomainForVerification(moduleData);
 
-        // then
-        expect(module.grains[0].components[0].element).to.be.an.instanceOf(QROCMForAnswerVerification);
+          // then
+          expect(module.grains[0].components[0].element).to.be.an.instanceOf(QCUForAnswerVerification);
+        });
+
+        it('should instantiate a Module with a ComponentElement with contains a QCMForAnswerVerification Element', function () {
+          // given
+          const moduleData = {
+            id: '6282925d-4775-4bca-b513-4c3009ec5886',
+            slug: 'title',
+            title: 'title',
+            details: {
+              image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+              description: 'Description',
+              duration: 5,
+              level: 'Débutant',
+              objectives: ['Objective 1'],
+            },
+            grains: [
+              {
+                id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                type: 'lesson',
+                title: 'title',
+                components: [
+                  {
+                    type: 'element',
+                    element: {
+                      id: '30701e93-1b4d-4da4-b018-fa756c07d53f',
+                      type: 'qcm',
+                      instruction: '<p>Quels sont les 3 piliers de Pix ?</p>',
+                      proposals: [
+                        {
+                          id: '1',
+                          content: 'Evaluer ses connaissances et savoir-faire sur 16 compétences du numérique',
+                        },
+                        {
+                          id: '2',
+                          content: 'Développer son savoir-faire sur les jeux de type TPS',
+                        },
+                        {
+                          id: '3',
+                          content: 'Développer ses compétences numériques',
+                        },
+                        {
+                          id: '4',
+                          content: 'Certifier ses compétences Pix',
+                        },
+                        {
+                          id: '5',
+                          content: 'Evaluer ses compétences de logique et compréhension mathématique',
+                        },
+                      ],
+                      feedbacks: {
+                        valid: '<p>Correct ! Vous nous avez bien cernés :)</p>',
+                        invalid: '<p>Et non ! Pix sert à évaluer, certifier et développer ses compétences numériques.',
+                      },
+                      solutions: ['1', '3', '4'],
+                    },
+                  },
+                ],
+              },
+            ],
+          };
+
+          // when
+          const module = Module.toDomainForVerification(moduleData);
+
+          // then
+          expect(module.grains[0].components[0].element).to.be.an.instanceOf(QCMForAnswerVerification);
+        });
+
+        it('should instantiate a Module with a ComponentElement with contains a QROCMForAnswerVerification Element', function () {
+          // given
+          const moduleData = {
+            id: '6282925d-4775-4bca-b513-4c3009ec5886',
+            slug: 'title',
+            title: 'title',
+            details: {
+              image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+              description: 'Description',
+              duration: 5,
+              level: 'Débutant',
+              objectives: ['Objective 1'],
+            },
+            grains: [
+              {
+                id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                type: 'lesson',
+                title: 'title',
+                components: [
+                  {
+                    type: 'element',
+                    element: {
+                      id: '98c51fa7-03b7-49b1-8c5e-49341d35909c',
+                      type: 'qrocm',
+                      instruction:
+                        "<p>Pour être sûr que tout est clair, complétez le texte ci-dessous <span aria-hidden='true'>🧩</span></p><p>Si vous avez besoin d’aide, revenez en arrière <span aria-hidden='true'>⬆️</span></p>",
+                      proposals: [
+                        {
+                          type: 'text',
+                          content: '<p>Le symbole</>',
+                        },
+                        {
+                          input: 'symbole',
+                          type: 'input',
+                          inputType: 'text',
+                          size: 1,
+                          display: 'inline',
+                          placeholder: '',
+                          ariaLabel: 'Réponse 1',
+                          defaultValue: '',
+                          tolerances: ['t1'],
+                          solutions: ['@'],
+                        },
+                        {
+                          input: 'premiere-partie',
+                          type: 'select',
+                          display: 'inline',
+                          placeholder: '',
+                          ariaLabel: 'Réponse 2',
+                          defaultValue: '',
+                          tolerances: [],
+                          options: [
+                            {
+                              id: '1',
+                              content: "l'identifiant",
+                            },
+                            {
+                              id: '2',
+                              content: "le fournisseur d'adresse mail",
+                            },
+                          ],
+                          solutions: ['1'],
+                        },
+                      ],
+                      feedbacks: {
+                        valid: '<p>Bravo ! 🎉 </p>',
+                        invalid: "<p class='pix-list-inline'>Et non !</p>",
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          };
+
+          // when
+          const module = Module.toDomainForVerification(moduleData);
+
+          // then
+          expect(module.grains[0].components[0].element).to.be.an.instanceOf(QROCMForAnswerVerification);
+        });
       });
     });
 

--- a/api/tests/devcomp/unit/domain/models/module/Module_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/Module_test.js
@@ -143,49 +143,6 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
         expect(error).to.be.instanceOf(NotFoundError);
       });
     });
-
-    // eslint-disable-next-line mocha/no-skipped-tests
-    describe.skip('Skip those tests, we keep them in order to discuss with business', function () {
-      describe('given a module being created', function () {
-        describe('given a module with less than two grains', function () {
-          // On permet des tests vides tant qu'on n'a pas validé le comportement attendu avec le métier
-          // eslint-disable-next-line no-empty-function
-          it('should throw error', function () {});
-        });
-
-        describe('given a module with two grains which are the same', function () {
-          // On permet des tests vides tant qu'on n'a pas validé le comportement attendu avec le métier
-          // eslint-disable-next-line no-empty-function
-          it('should throw an error', function () {});
-        });
-
-        describe('a grain already associated to another module', function () {
-          // On permet des tests vides tant qu'on n'a pas validé le comportement attendu avec le métier
-          // eslint-disable-next-line no-empty-function
-          it('will not throw an error', function () {});
-        });
-      });
-
-      describe('given a published module', function () {
-        describe('given a module with less than two grains', function () {
-          // On permet des tests vides tant qu'on n'a pas validé le comportement attendu avec le métier
-          // eslint-disable-next-line no-empty-function
-          it('should throw error', function () {});
-        });
-
-        describe('if a module does not have a description', function () {
-          // On permet des tests vides tant qu'on n'a pas validé le comportement attendu avec le métier
-          // eslint-disable-next-line no-empty-function
-          it('should throw an error', function () {});
-        });
-
-        describe('given a module with two grains which are the same', function () {
-          // On permet des tests vides tant qu'on n'a pas validé le comportement attendu avec le métier
-          // eslint-disable-next-line no-empty-function
-          it('should throw an error', function () {});
-        });
-      });
-    });
   });
 
   describe('#toDomain', function () {

--- a/api/tests/devcomp/unit/domain/models/module/Module_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/Module_test.js
@@ -1541,6 +1541,283 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
           expect(module.grains[0].components[0].element).to.be.an.instanceOf(QROCMForAnswerVerification);
         });
       });
+
+      describe('with ComponentStepper', function () {
+        it('should instantiate a Module with components', function () {
+          // given
+          const feedbacks = { valid: 'valid', invalid: 'invalid' };
+          const proposals = [
+            { id: '1', content: 'toto' },
+            { id: '2', content: 'foo' },
+          ];
+
+          const moduleData = {
+            id: '6282925d-4775-4bca-b513-4c3009ec5886',
+            slug: 'title',
+            title: 'title',
+            details: {
+              image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+              description: 'Description',
+              duration: 5,
+              level: 'Débutant',
+              objectives: ['Objective 1'],
+            },
+            grains: [
+              {
+                id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                type: 'lesson',
+                title: 'title',
+                components: [
+                  {
+                    type: 'stepper',
+                    steps: [
+                      {
+                        elements: [
+                          {
+                            id: '123',
+                            instruction: 'instruction',
+                            locales: ['fr-FR'],
+                            proposals,
+                            feedbacks,
+                            type: 'qcu',
+                            solution: proposals[0].id,
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          };
+
+          // when
+          const module = Module.toDomainForVerification(moduleData);
+
+          // then
+          expect(module).to.be.an.instanceOf(Module);
+          expect(module.grains).not.to.be.empty;
+          for (const grain of module.grains) {
+            expect(grain.components).not.to.be.empty;
+          }
+        });
+
+        it('should instantiate a Module with a ComponentStepper with contains a QCUForAnswerVerification Element', function () {
+          // given
+          const feedbacks = { valid: 'valid', invalid: 'invalid' };
+          const proposals = [
+            { id: '1', content: 'toto' },
+            { id: '2', content: 'foo' },
+          ];
+
+          const moduleData = {
+            id: '6282925d-4775-4bca-b513-4c3009ec5886',
+            slug: 'title',
+            title: 'title',
+            details: {
+              image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+              description: 'Description',
+              duration: 5,
+              level: 'Débutant',
+              objectives: ['Objective 1'],
+            },
+            grains: [
+              {
+                id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                type: 'lesson',
+                title: 'title',
+                components: [
+                  {
+                    type: 'stepper',
+                    steps: [
+                      {
+                        elements: [
+                          {
+                            id: '123',
+                            instruction: 'instruction',
+                            locales: ['fr-FR'],
+                            proposals,
+                            feedbacks,
+                            type: 'qcu',
+                            solution: proposals[0].id,
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          };
+
+          // when
+          const module = Module.toDomainForVerification(moduleData);
+
+          // then
+          expect(module.grains[0].components[0].element).to.be.an.instanceOf(QCUForAnswerVerification);
+        });
+
+        it('should instantiate a Module with a ComponentStepper with contains a QCMForAnswerVerification Element', function () {
+          // given
+          const moduleData = {
+            id: '6282925d-4775-4bca-b513-4c3009ec5886',
+            slug: 'title',
+            title: 'title',
+            details: {
+              image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+              description: 'Description',
+              duration: 5,
+              level: 'Débutant',
+              objectives: ['Objective 1'],
+            },
+            grains: [
+              {
+                id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                type: 'lesson',
+                title: 'title',
+                components: [
+                  {
+                    type: 'stepper',
+                    steps: [
+                      {
+                        elements: [
+                          {
+                            id: '30701e93-1b4d-4da4-b018-fa756c07d53f',
+                            type: 'qcm',
+                            instruction: '<p>Quels sont les 3 piliers de Pix ?</p>',
+                            proposals: [
+                              {
+                                id: '1',
+                                content: 'Evaluer ses connaissances et savoir-faire sur 16 compétences du numérique',
+                              },
+                              {
+                                id: '2',
+                                content: 'Développer son savoir-faire sur les jeux de type TPS',
+                              },
+                              {
+                                id: '3',
+                                content: 'Développer ses compétences numériques',
+                              },
+                              {
+                                id: '4',
+                                content: 'Certifier ses compétences Pix',
+                              },
+                              {
+                                id: '5',
+                                content: 'Evaluer ses compétences de logique et compréhension mathématique',
+                              },
+                            ],
+                            feedbacks: {
+                              valid: '<p>Correct ! Vous nous avez bien cernés :)</p>',
+                              invalid:
+                                '<p>Et non ! Pix sert à évaluer, certifier et développer ses compétences numériques.',
+                            },
+                            solutions: ['1', '3', '4'],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          };
+
+          // when
+          const module = Module.toDomainForVerification(moduleData);
+
+          // then
+          expect(module.grains[0].components[0].element).to.be.an.instanceOf(QCMForAnswerVerification);
+        });
+
+        it('should instantiate a Module with a ComponentStepper with contains a QROCMForAnswerVerification Element', function () {
+          // given
+          const moduleData = {
+            id: '6282925d-4775-4bca-b513-4c3009ec5886',
+            slug: 'title',
+            title: 'title',
+            details: {
+              image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+              description: 'Description',
+              duration: 5,
+              level: 'Débutant',
+              objectives: ['Objective 1'],
+            },
+            grains: [
+              {
+                id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+                type: 'lesson',
+                title: 'title',
+                components: [
+                  {
+                    type: 'stepper',
+                    steps: [
+                      {
+                        elements: [
+                          {
+                            id: '98c51fa7-03b7-49b1-8c5e-49341d35909c',
+                            type: 'qrocm',
+                            instruction:
+                              "<p>Pour être sûr que tout est clair, complétez le texte ci-dessous <span aria-hidden='true'>🧩</span></p><p>Si vous avez besoin d’aide, revenez en arrière <span aria-hidden='true'>⬆️</span></p>",
+                            proposals: [
+                              {
+                                type: 'text',
+                                content: '<p>Le symbole</>',
+                              },
+                              {
+                                input: 'symbole',
+                                type: 'input',
+                                inputType: 'text',
+                                size: 1,
+                                display: 'inline',
+                                placeholder: '',
+                                ariaLabel: 'Réponse 1',
+                                defaultValue: '',
+                                tolerances: ['t1'],
+                                solutions: ['@'],
+                              },
+                              {
+                                input: 'premiere-partie',
+                                type: 'select',
+                                display: 'inline',
+                                placeholder: '',
+                                ariaLabel: 'Réponse 2',
+                                defaultValue: '',
+                                tolerances: [],
+                                options: [
+                                  {
+                                    id: '1',
+                                    content: "l'identifiant",
+                                  },
+                                  {
+                                    id: '2',
+                                    content: "le fournisseur d'adresse mail",
+                                  },
+                                ],
+                                solutions: ['1'],
+                              },
+                            ],
+                            feedbacks: {
+                              valid: '<p>Bravo ! 🎉 </p>',
+                              invalid: "<p class='pix-list-inline'>Et non !</p>",
+                            },
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          };
+
+          // when
+          const module = Module.toDomainForVerification(moduleData);
+
+          // then
+          expect(module.grains[0].components[0].element).to.be.an.instanceOf(QROCMForAnswerVerification);
+        });
+      });
     });
 
     describe('without answerable elements', function () {

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -2,6 +2,8 @@ import { BlockInput } from '../../../../../../src/devcomp/domain/models/block/Bl
 import { BlockSelect } from '../../../../../../src/devcomp/domain/models/block/BlockSelect.js';
 import { BlockSelectOption } from '../../../../../../src/devcomp/domain/models/block/BlockSelectOption.js';
 import { BlockText } from '../../../../../../src/devcomp/domain/models/block/BlockText.js';
+import { ComponentElement } from '../../../../../../src/devcomp/domain/models/component/ComponentElement.js';
+import { ComponentStepper } from '../../../../../../src/devcomp/domain/models/component/ComponentStepper.js';
 import { Image } from '../../../../../../src/devcomp/domain/models/element/Image.js';
 import { QCM } from '../../../../../../src/devcomp/domain/models/element/QCM.js';
 import { QCU } from '../../../../../../src/devcomp/domain/models/element/QCU.js';
@@ -138,17 +140,66 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
 
 function getComponents() {
   return [
-    { type: 'element', element: new Text({ id: '1', content: 'toto' }) },
-    {
-      type: 'element',
+    new ComponentStepper({
+      steps: [
+        {
+          elements: [
+            {
+              id: 'c23436d4-6261-49f1-b50d-13a547529c29',
+              type: 'qrocm',
+              instruction: '<p>Compléter le texte suivant :</p>',
+              proposals: [
+                {
+                  type: 'text',
+                  content: '<span>Pix est un</span>',
+                },
+                {
+                  input: 'pix-name',
+                  type: 'input',
+                  inputType: 'text',
+                  size: 10,
+                  display: 'inline',
+                  placeholder: '',
+                  ariaLabel: 'Mot à trouver',
+                  defaultValue: '',
+                  tolerances: ['t1', 't3'],
+                  solutions: ['Groupement'],
+                },
+                {
+                  type: 'text',
+                  content: "<span>d'intérêt public qui a été créée en</span>",
+                },
+                {
+                  input: 'pix-birth',
+                  type: 'input',
+                  inputType: 'text',
+                  size: 10,
+                  display: 'inline',
+                  placeholder: '',
+                  ariaLabel: 'Année à trouver',
+                  defaultValue: '',
+                  tolerances: [],
+                  solutions: ['2016'],
+                },
+              ],
+              feedbacks: {
+                valid: '<p>Correct&#8239;! vous nous connaissez bien&nbsp;<span aria-hidden="true">🎉</span></p>',
+                invalid: '<p>Incorrect&#8239;! vous y arriverez la prochaine fois&#8239;!</p>',
+              },
+            },
+          ],
+        },
+      ],
+    }),
+    new ComponentElement({ element: new Text({ id: '1', content: 'toto' }) }),
+    new ComponentElement({
       element: new QCU({
         id: '2',
         proposals: [{ id: 'a1b2c3d4-e5f6-7g8h-9i0j-k1l2m3n4o5p6', content: 'toto' }],
         instruction: 'hello',
       }),
-    },
-    {
-      type: 'element',
+    }),
+    new ComponentElement({
       element: new QCM({
         id: '2000',
         proposals: [
@@ -158,9 +209,8 @@ function getComponents() {
         ],
         instruction: 'hello',
       }),
-    },
-    {
-      type: 'element',
+    }),
+    new ComponentElement({
       element: new QROCM({
         id: '100',
         instruction: '',
@@ -201,10 +251,11 @@ function getComponents() {
           }),
         ],
       }),
-    },
-    { type: 'element', element: new Image({ id: '3', url: 'url', alt: 'alt', alternativeText: 'alternativeText' }) },
-    {
-      type: 'element',
+    }),
+    new ComponentElement({
+      element: new Image({ id: '3', url: 'url', alt: 'alt', alternativeText: 'alternativeText' }),
+    }),
+    new ComponentElement({
       element: new Video({
         id: '4',
         title: 'title',
@@ -212,7 +263,7 @@ function getComponents() {
         subtitles: 'subtitles',
         transcription: 'transcription',
       }),
-    },
+    }),
   ];
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Maintenant que nous avons ajouté un premier _Stepper_ dans le référentiel du module "Didacticiel Modulix", nous souhaitons que ce type de donnée soit pris en compte dans notre domaine.

## :robot: Proposition

- Ajout des modèles `ComponentStepper` et `Step` dans le domaine.
- Mapping des `ComponentStepper` lors du `Module.toDomain`.
- Mapping des `ComponentStepper` lors du `Module.toDomainForAnswerVerification`.

## :rainbow: Remarques
Pour la vérification, on a fait le choix de mapper les components de type "stepper" vers des `ComponentElement` pour toujours manipuler la même structure de données.

Ça pourrait nous servir si on souhaite un jour simplifier davantage cette structure, notamment car les `components` et le `element` ne servent à rien (pour l'instant) lors de la vérif.

## :100: Pour tester
CI 🍏 

Didacticiel toujours accessible