### PR TITLE
[TECH] Éviter l'existance constante d'une raison d'abandon dans la gestion du scoring V3 (PIX-12629).

### DIFF
--- a/api/lib/domain/services/scoring/scoring-certification-service.js
+++ b/api/lib/domain/services/scoring/scoring-certification-service.js
@@ -6,7 +6,6 @@ import { CertificationAssessmentHistory } from '../../../../src/certification/sc
 import { CertificationAssessmentScore } from '../../../../src/certification/scoring/domain/models/CertificationAssessmentScore.js';
 import { CertificationAssessmentScoreV3 } from '../../../../src/certification/scoring/domain/models/CertificationAssessmentScoreV3.js';
 import { AssessmentResultFactory } from '../../../../src/certification/scoring/domain/models/factories/AssessmentResultFactory.js';
-import { ABORT_REASONS } from '../../../../src/certification/shared/domain/models/CertificationCourse.js';
 import { CertificationVersion } from '../../../../src/certification/shared/domain/models/CertificationVersion.js';
 import * as scoringService from '../../../../src/evaluation/domain/services/scoring/scoring-service.js';
 import { config } from '../../../../src/shared/config.js';
@@ -78,9 +77,7 @@ const handleV3CertificationScoring = async function ({
 
   const certificationCourse = await certificationCourseRepository.get({ id: certificationCourseId });
 
-  const abortReason = certificationCourse.isAbortReasonCandidateRelated()
-    ? ABORT_REASONS.CANDIDATE
-    : ABORT_REASONS.TECHNICAL;
+  const abortReason = certificationCourse.getAbortReason();
 
   const configuration = await flashAlgorithmConfigurationRepository.getMostRecentBeforeDate(
     certificationCourse.getStartDate(),

--- a/api/src/certification/shared/domain/models/CertificationCourse.js
+++ b/api/src/certification/shared/domain/models/CertificationCourse.js
@@ -1,9 +1,11 @@
 import JoiDate from '@joi/date';
 import BaseJoi from 'joi';
 import _ from 'lodash';
-const Joi = BaseJoi.extend(JoiDate);
+
 import { EntityValidationError } from '../../../../shared/domain/errors.js';
 import { CertificationVersion } from './CertificationVersion.js';
+
+const Joi = BaseJoi.extend(JoiDate);
 
 export const ABORT_REASONS = {
   CANDIDATE: 'candidate',
@@ -234,6 +236,10 @@ class CertificationCourse {
 
   doesBelongTo(userId) {
     return this._userId === userId;
+  }
+
+  getAbortReason() {
+    return this._abortReason;
   }
 
   getId() {


### PR DESCRIPTION
## :unicorn: Problème
Dans la gestion du scoring v3, nous nous sommes aperçu qu'une erreur d'implémentation conduisait à définir constamment une raison d'abandon. (Voir fichier `scoring-certification-service.js`) 
![Capture d’écran 2024-05-23 à 14 27 22](https://github.com/1024pix/pix/assets/152303583/389318e7-89ef-4434-be96-4e091fc08a1a)

Or il peut ne pas en avoir, et ceci peut avoir un effet de bord sur la suite du scoring, notamment sur la gestion le statut du résultat.

## :robot: Proposition
Ne plus calculer la raison de l'abandon et la récupérer directement dans le `certificationCourse` via un getter.

## :rainbow: Remarques
Il n'y a pas de tests ajoutés, le bon fonctionnement de ce fix est garanti par les tests déjà existants. Nous avons pu constater que les simples getters (sans logiques) ne sont pas testés dans les tests de model (voir fichier `certificationCourse_test.js`).

## :100: Pour tester
Il convient de tester qu'il n'y a pas de régression sur la gestion du statut d'une certification :
1. Passer une certification V3
2. Répondre à une question seulement (la passer suffit)
3. Finaliser la session du candidat en précisant un raison d'abandon candidat ("Abandon: manque de temps...")
4. **Vérifier sur Admin** que le statut de la certification est bien à `Rejetée`.