### PR TITLE
[BUGFIX] [Admin] Gérer le cas des imports OIDC Providers suivants qui produisent des 500 (PIX-12333)

### DIFF
--- a/admin/app/components/administration/organizations-batch-update.hbs
+++ b/admin/app/components/administration/organizations-batch-update.hbs
@@ -5,7 +5,7 @@
   <p>{{t "components.administration.organizations-batch-update.description"}}</p>
   <br />
   <PixButtonUpload
-    @id="oidc-providers-file-upload"
+    @id="organizations-batch-update-file-upload"
     @onChange={{this.updateOrganizationsInBatch}}
     @variant="secondary"
     accept=".csv"

--- a/api/src/identity-access-management/domain/usecases/add-oidc-provider.js
+++ b/api/src/identity-access-management/domain/usecases/add-oidc-provider.js
@@ -1,4 +1,5 @@
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+
 /**
  * @typedef {import ('../usecases/index.js').OidcProviderRepository} OidcProviderRepository
  */


### PR DESCRIPTION
## :unicorn: Problème

Dans Pix Admin quand on importe un OIDC Provider (action rendue disponible par #8734) déjà existant dans Pix Admin cela produit une erreur `500`.

## :robot: Proposition

Gérer le cas d'un enregistrement déjà existant dans la fonction `create` de l'`oidc-provider-repository`.

## :rainbow: Remarques

Cette PR corrige une régression introduite par l'organizations-batch-update qui avait cassé l'import d'OIDC Providers depuis Pix Admin à cause d'un `id` HTML dupliqué par erreur.

L'erreur renvoyée par Pix Api est une erreur `400` alors qu'une erreur `409 Conflict` eût été plus indiquée. Mais cela vient du `api/src/shared/application/error-manager.js` qu'il faudra faire évoluer dans une autre PR. Cela n'a pas été fait dans cette PR-ci pour accélérer au maximum la livraison des correctifs contenus dans cette PR-ci.

## :100: Pour tester

1. Se connecter à Pix Admin
2. Aller dans la section Import d’OIDC Providers et y soumettre un fichier JSON contenant les propriétés d'un OIDC Provider n'existant pas encore, par exemple :

```json
[
    {
        "identityProvider": "GAGACONNECT",
        "organizationName": "Gaga Connect",
        "scope": "openid profile email",
        "slug": "gaga-connect",
        "source": "gagaconnect",
        "clientId": "__CLIENT_ID__",
        "clientSecret": "__CLIENT_SECRET__",
        "accessTokenLifespan": "4h",
        "claimsToStore": "email",
        "enabled": true,
        "enabledForPixAdmin": false,
        "openidConfigurationUrl": "https://gaga.example.net/.well-known/openid-configuration",
        "redirectUri": "https://app.dev.pix.org/connexion/gaga-connect"
    }
]
```

3. Constater que l'opération affiche une notification de succès (en vert dans Pix Admin) et crée bien l'OIDC Provider en base de données
4. Réimporter dans Pix Admin le même fichier JSON
5. Constater que l'opération affiche une notification d'erreur (en rouge dans Pix Admin) avec une requête HTTP avec un status code de la famille 4xx et non 500.

ℹ️ Il faut que l'API soit redémarrée pour que les nouveaux SSO OIDC apparaissent dans les listes de choix de SSO OIDC dans Pix Admin. C'est une des limitations de l'industrialisation v0. Nous avons envisagé la mise à jour à chaud de l'utilisation des SSO, mais dans une version d'industrialisation très ultérieure.