### PR TITLE
[FEATURES] Avoir uniquement un bouton "Je continue" pour les activités "leçon" (PIX-12567)

### DIFF
--- a/junior/app/pods/components/challenge/challenge-actions/template.hbs
+++ b/junior/app/pods/components/challenge/challenge-actions/template.hbs
@@ -1,5 +1,5 @@
 <div class="challenge-actions">
-  {{#unless this.hideSkipButton}}
+  {{#unless (or this.hideSkipButton @isLesson)}}
     <PixButton class="pix1d-button pix1d-button--skip" @triggerAction={{@skipChallenge}} @shape="rounded" @size="big">
       <span>
         {{t "pages.challenge.actions.skip"}}
@@ -11,6 +11,19 @@
       class="pix1d-button pix1d-button--success"
       @iconAfter="arrow-right"
       @triggerAction={{@nextAction}}
+      @shape="rounded"
+      @size="big"
+    >
+      <span>
+        {{t "pages.challenge.actions.continue"}}
+      </span>
+    </PixButton>
+  {{else if @isLesson}}
+    <PixButton
+      class="pix1d-button"
+      @iconAfter="arrow-right"
+      @isDisabled={{@disableLessonButton}}
+      @triggerAction={{@skipChallenge}}
       @shape="rounded"
       @size="big"
     >

--- a/junior/app/pods/components/challenge/component.js
+++ b/junior/app/pods/components/challenge/component.js
@@ -14,6 +14,10 @@ export default class Challenge extends Component {
     return this.answerValue === null || this.answerValue === '';
   }
 
+  get disableLessonButton() {
+    return this.args.challenge.hasValidEmbedDocument ? this.answerValue === null || this.answerValue === '' : false;
+  }
+
   get robotMood() {
     if (this.answer?.result === 'ok') {
       return 'happy';

--- a/junior/app/pods/components/challenge/item/integration_test.js
+++ b/junior/app/pods/components/challenge/item/integration_test.js
@@ -60,7 +60,7 @@ module('Integration | Component | challenge', function (hooks) {
     assert.dom('.challenge-item__qcm').exists();
   });
 
-  test('display image, embed and qroc', async function (assert) {
+  test('displays image, embed and qroc', async function (assert) {
     this.set('challenge', {
       hasValidEmbedDocument: true,
       autoReply: false,
@@ -75,5 +75,19 @@ module('Integration | Component | challenge', function (hooks) {
     assert.dom('.challenge-item__image').exists();
     assert.dom('.challenge-item__embed').exists();
     assert.dom('.challenge-item__qrocm').exists();
+  });
+
+  test('displays lesson', async function (assert) {
+    this.set('challenge', {
+      hasValidEmbedDocument: true,
+      autoReply: false,
+      focused: true,
+    });
+    this.set('assessment', {});
+
+    const screen = await render(hbs`<Challenge::Item @challenge={{this.challenge}} @assessment={{this.assessment}} />`);
+
+    assert.dom(screen.getByRole('button', { name: this.intl.t('pages.challenge.actions.continue') })).exists();
+    assert.dom(screen.queryByRole('button', { name: this.intl.t('pages.challenge.actions.skip') })).doesNotExist();
   });
 });

--- a/junior/app/pods/components/challenge/item/template.hbs
+++ b/junior/app/pods/components/challenge/item/template.hbs
@@ -57,7 +57,9 @@
         @skipChallenge={{@skipChallenge}}
         @level={{@activity.level}}
         @nextAction={{@resume}}
+        @isLesson={{@challenge.focused}}
         @disableCheckButton={{@disableCheckButton}}
+        @disableLessonButton={{@disableLessonButton}}
         @answerHasBeenValidated={{@answerHasBeenValidated}}
       />
     </div>

--- a/junior/app/pods/components/challenge/template.hbs
+++ b/junior/app/pods/components/challenge/template.hbs
@@ -8,7 +8,6 @@
     {{#if (eq this.answer.result "ko")}}
       <Bubble @message={{t "pages.challenge.messages.wrong-answer"}} @color="error" aria-live="polite" />
     {{/if}}
-
   </RobotDialog>
   <Challenge::Item
     @setAnswerValue={{this.setAnswerValue}}
@@ -17,6 +16,7 @@
     @challenge={{@challenge}}
     @assessment={{@assessment}}
     @disableCheckButton={{this.disableCheckButton}}
+    @disableLessonButton={{this.disableLessonButton}}
     @answerHasBeenValidated={{this.answerHasBeenValidated}}
     @activity={{@activity}}
     @resume={{this.resume}}

--- a/junior/mirage/factories/challenge.js
+++ b/junior/mirage/factories/challenge.js
@@ -8,6 +8,11 @@ export default Factory.extend({
   embedTitle: 'Applications',
   proposals: 'Rue de : ${Rue#}',
   autoReply: false,
+  focused: false,
+
+  lesson: trait({
+    focused: true,
+  }),
 
   QROCWithTextArea: trait({
     format: 'paragraphe',

--- a/junior/tests/acceptance/lesson-workflow_test.js
+++ b/junior/tests/acceptance/lesson-workflow_test.js
@@ -1,0 +1,37 @@
+import { visit } from '@1024pix/ember-testing-library';
+// import { click } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+
+import { setupApplicationTest } from '../helpers';
+
+module('Acceptance | Lesson workflow', function (hooks) {
+  setupApplicationTest(hooks);
+  module('when user click on continue button', function () {
+    // test('redirects to next challenge', async function (assert) {
+    //   const assessment = this.server.create('assessment');
+    //   this.server.create('challenge', 'lesson', {
+    //     timer: 0,
+    //   });
+    //   this.server.create('challenge', {
+    //     id: 2,
+    //     instruction: 'Nouvelle instruction',
+    //   });
+    //   // when
+    //   const screen = await visit(`/assessments/${assessment.id}/challenges`);
+    //   await click(screen.getByRole('button', { name: this.intl.t('pages.challenge.actions.continue') }));
+    //
+    //   // then
+    //   assert.dom(screen.getByText('Nouvelle instruction')).exists();
+    // });
+
+    test('should disabled button for pass during a short time', async function (assert) {
+      const assessment = this.server.create('assessment');
+      this.server.create('challenge', 'lesson');
+      // when
+      const screen = await visit(`/assessments/${assessment.id}/challenges`);
+
+      // then
+      assert.dom(screen.getByRole('button', { name: this.intl.t('pages.challenge.actions.continue') })).isDisabled();
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'une activité de type leçon est affichée. Il n'y à pas de question proposée à l'utilisateur et donc aucune réponse à valider.
L'utilisateur doit donc cliquer 2 fois pour passer à la prochaine "épreuve". 

## :robot: Proposition
Fusionner les 2 boutons pour n'avoir qu'un seul clic à faire. 

## :100: Pour tester
Lancer une mission.
Échouer pour arriver à une leçon.
		- S'il s'agit d'un embed, il ne doit y avoir que le bouton "Je continue". Celui-ci doit être disabled au début puis être enable par l'embed  (ex: vidéo au bout de 30 secondes)
		- Pour le reste il ne doit y avoir qu'un seul clic (bouton "Je continue") pour passer à l'épreuve suivante
