### PR TITLE
[FEATURE] Envoyer le composant stepper vers le client (PIX-12621).

### DIFF
--- a/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/module-serializer.js
@@ -15,7 +15,7 @@ function serialize(module) {
             id: grain.id,
             title: grain.title,
             type: grain.type,
-            components: grain.components.filter((component) => component.type === 'element'),
+            components: grain.components,
           };
         }),
       };

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -139,55 +139,51 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | ModuleSerial
 });
 
 function getComponents() {
+  const qrocmElement = new QROCM({
+    id: '100',
+    instruction: '',
+    locales: ['fr-FR'],
+    proposals: [
+      new BlockText({
+        content: '<p>Adresse mail de Naomi : ${email}</p>',
+      }),
+      new BlockInput({
+        input: 'email',
+        inputType: 'text',
+        size: 10,
+        display: 'inline',
+        placeholder: '',
+        ariaLabel: 'Adresse mail de Naomi',
+        defaultValue: '',
+        tolerances: [],
+        solutions: ['naomizao@yahoo.com', 'naomizao@yahoo.fr'],
+      }),
+      new BlockSelect({
+        input: 'seconde-partie',
+        display: 'inline',
+        placeholder: '',
+        ariaLabel: 'Réponse 3',
+        defaultValue: '',
+        tolerances: [],
+        options: [
+          new BlockSelectOption({
+            id: '1',
+            content: "l'identifiant",
+          }),
+          new BlockSelectOption({
+            id: '2',
+            content: "le fournisseur d'adresse mail",
+          }),
+        ],
+        solutions: ['2'],
+      }),
+    ],
+  });
   return [
     new ComponentStepper({
       steps: [
         {
-          elements: [
-            {
-              id: 'c23436d4-6261-49f1-b50d-13a547529c29',
-              type: 'qrocm',
-              instruction: '<p>Compléter le texte suivant :</p>',
-              proposals: [
-                {
-                  type: 'text',
-                  content: '<span>Pix est un</span>',
-                },
-                {
-                  input: 'pix-name',
-                  type: 'input',
-                  inputType: 'text',
-                  size: 10,
-                  display: 'inline',
-                  placeholder: '',
-                  ariaLabel: 'Mot à trouver',
-                  defaultValue: '',
-                  tolerances: ['t1', 't3'],
-                  solutions: ['Groupement'],
-                },
-                {
-                  type: 'text',
-                  content: "<span>d'intérêt public qui a été créée en</span>",
-                },
-                {
-                  input: 'pix-birth',
-                  type: 'input',
-                  inputType: 'text',
-                  size: 10,
-                  display: 'inline',
-                  placeholder: '',
-                  ariaLabel: 'Année à trouver',
-                  defaultValue: '',
-                  tolerances: [],
-                  solutions: ['2016'],
-                },
-              ],
-              feedbacks: {
-                valid: '<p>Correct&#8239;! vous nous connaissez bien&nbsp;<span aria-hidden="true">🎉</span></p>',
-                invalid: '<p>Incorrect&#8239;! vous y arriverez la prochaine fois&#8239;!</p>',
-              },
-            },
-          ],
+          elements: [qrocmElement],
         },
       ],
     }),
@@ -211,46 +207,7 @@ function getComponents() {
       }),
     }),
     new ComponentElement({
-      element: new QROCM({
-        id: '100',
-        instruction: '',
-        locales: ['fr-FR'],
-        proposals: [
-          new BlockText({
-            content: '<p>Adresse mail de Naomi : ${email}</p>',
-          }),
-          new BlockInput({
-            input: 'email',
-            inputType: 'text',
-            size: 10,
-            display: 'inline',
-            placeholder: '',
-            ariaLabel: 'Adresse mail de Naomi',
-            defaultValue: '',
-            tolerances: [],
-            solutions: ['naomizao@yahoo.com', 'naomizao@yahoo.fr'],
-          }),
-          new BlockSelect({
-            input: 'seconde-partie',
-            display: 'inline',
-            placeholder: '',
-            ariaLabel: 'Réponse 3',
-            defaultValue: '',
-            tolerances: [],
-            options: [
-              new BlockSelectOption({
-                id: '1',
-                content: "l'identifiant",
-              }),
-              new BlockSelectOption({
-                id: '2',
-                content: "le fournisseur d'adresse mail",
-              }),
-            ],
-            solutions: ['2'],
-          }),
-        ],
-      }),
+      element: qrocmElement,
     }),
     new ComponentElement({
       element: new Image({ id: '3', url: 'url', alt: 'alt', alternativeText: 'alternativeText' }),
@@ -268,7 +225,60 @@ function getComponents() {
 }
 
 function getAttributesComponents() {
+  const expectedQrocm = {
+    id: '100',
+    instruction: '',
+    isAnswerable: true,
+    locales: ['fr-FR'],
+    proposals: [
+      {
+        content: '<p>Adresse mail de Naomi : ${email}</p>',
+        type: 'text',
+      },
+      {
+        ariaLabel: 'Adresse mail de Naomi',
+        defaultValue: '',
+        display: 'inline',
+        input: 'email',
+        inputType: 'text',
+        placeholder: '',
+        size: 10,
+        solutions: ['naomizao@yahoo.com', 'naomizao@yahoo.fr'],
+        tolerances: [],
+        type: 'input',
+      },
+      {
+        ariaLabel: 'Réponse 3',
+        defaultValue: '',
+        display: 'inline',
+        input: 'seconde-partie',
+        options: [
+          {
+            content: "l'identifiant",
+            id: '1',
+          },
+          {
+            content: "le fournisseur d'adresse mail",
+            id: '2',
+          },
+        ],
+        placeholder: '',
+        solutions: ['2'],
+        tolerances: [],
+        type: 'select',
+      },
+    ],
+    type: 'qrocm',
+  };
   return [
+    {
+      type: 'stepper',
+      steps: [
+        {
+          elements: [expectedQrocm],
+        },
+      ],
+    },
     {
       type: 'element',
       element: {
@@ -320,51 +330,7 @@ function getAttributesComponents() {
     },
     {
       type: 'element',
-      element: {
-        id: '100',
-        instruction: '',
-        isAnswerable: true,
-        locales: ['fr-FR'],
-        proposals: [
-          {
-            content: '<p>Adresse mail de Naomi : ${email}</p>',
-            type: 'text',
-          },
-          {
-            ariaLabel: 'Adresse mail de Naomi',
-            defaultValue: '',
-            display: 'inline',
-            input: 'email',
-            inputType: 'text',
-            placeholder: '',
-            size: 10,
-            solutions: ['naomizao@yahoo.com', 'naomizao@yahoo.fr'],
-            tolerances: [],
-            type: 'input',
-          },
-          {
-            ariaLabel: 'Réponse 3',
-            defaultValue: '',
-            display: 'inline',
-            input: 'seconde-partie',
-            options: [
-              {
-                content: "l'identifiant",
-                id: '1',
-              },
-              {
-                content: "le fournisseur d'adresse mail",
-                id: '2',
-              },
-            ],
-            placeholder: '',
-            solutions: ['2'],
-            tolerances: [],
-            type: 'select',
-          },
-        ],
-        type: 'qrocm',
-      },
+      element: expectedQrocm,
     },
     {
       type: 'element',

--- a/mon-pix/app/pods/components/module/grain/component.js
+++ b/mon-pix/app/pods/components/module/grain/component.js
@@ -30,7 +30,9 @@ export default class ModuleGrain extends Component {
           return undefined;
         }
       })
-      .filter((element) => ModuleGrain.AVAILABLE_ELEMENT_TYPES.includes(element.type));
+      .filter((element) => {
+        return element !== undefined && ModuleGrain.AVAILABLE_ELEMENT_TYPES.includes(element.type);
+      });
   }
 
   get displayableElements() {

--- a/mon-pix/tests/unit/components/module/grain_test.js
+++ b/mon-pix/tests/unit/components/module/grain_test.js
@@ -144,4 +144,45 @@ module('Unit | Component | Module | Grain', function (hooks) {
       });
     });
   });
+
+  module('#displayableElements', function () {
+    module('when component.type is supported', function () {
+      test('should return the displayable element', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const qcu = { id: 'qcu-id-1', type: 'qcu' };
+        const grain = store.createRecord('grain', {
+          components: [{ type: 'element', element: qcu }],
+        });
+
+        const component = createPodsComponent('module/grain', { grain });
+
+        // when
+        const displayableElements = component.displayableElements;
+
+        // then
+        assert.strictEqual(displayableElements.length, 1);
+        assert.strictEqual(displayableElements[0], qcu);
+      });
+    });
+
+    module('when component.type is not supported', function () {
+      test('should return an empty array', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const qcu = { id: 'qcu-id-1', type: 'qcu' };
+        const grain = store.createRecord('grain', {
+          components: [{ type: 'toto', element: qcu }],
+        });
+
+        const component = createPodsComponent('module/grain', { grain });
+
+        // when
+        const displayableElements = component.displayableElements;
+
+        // then
+        assert.strictEqual(displayableElements.length, 0);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Nous avons un model `ComponentStepper` dans notre API qui est pas disponible côté client. 

## :robot: Proposition
Ajout du component Stepper dans le `module-serializer`.

## :rainbow: Remarques
Nous avons mis à jour la méthode static `getSupportedElements()` dans le front de `mon-pix` pour corriger l'affichage des éléments inconnus. Et nous avons ajouté des tests permettant de s'assurer qu'on n'essaye pas d'afficher des éléments `undefined`. 

## :100: Pour tester
CI pass 

Cote front:
- Verifier que le [didacticiel](https://app-pr9043.review.pix.fr/modules/didacticiel-modulix/passage) affiche pas les `Stepper`
- Verifier que les elements existants s'affiche correctement.

Cote API:
- verifier que [le route](https://api-pr9043.review.pix.fr/api/modules/didacticiel-modulix) envoi le partie `Stepper` (faire un Ctrl+F `Stepper` et verifier qu'il envoi le bon donne)
