### PR TITLE
[FEATURE] Modification du wording de la modale lors du remplacement à l’import SUP (PIX-10092)

### DIFF
--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1298,7 +1298,7 @@
         "title": "Are you sure you want to overwrite the existing students?",
         "confirm": "Yes, overwrite",
         "confirmation-checkbox": "I have fully understood the effect of this action",
-        "footer-content": "Existing students in the application and included in the new import will not be affected.",
+        "footer-content": "Existing students in the application and included in the new import will not be deleted and will be updated if necessary.",
         "last-warning": "Please note that this action is irreversible, students who are not included in the new import will be deleted from Pix Orga.",
         "main-content": "All of their campaign participations will be deleted. This will have an impact on the results and analytics of your campaigns. They will no longer be able to take part in any previous campaigns. However, they will still be able to take part in new campaigns."
       },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1298,7 +1298,7 @@
         "title": "Êtes-vous sûr(e) de vouloir remplacer les étudiants existants ?",
         "confirm": "Oui, je remplace",
         "confirmation-checkbox": "Je confirme avoir bien compris les impacts",
-        "footer-content": "Les étudiants existants dans l’application et présents dans le nouvel import ne seront pas modifiés.",
+        "footer-content": "Les étudiants existants dans l'application et présents dans le nouvel import ne seront pas supprimés et seront mis à jour si nécessaire.",
         "last-warning": "Attention, cette action est irréversible. Les étudiants non présents dans le nouvel import vont être supprimés de Pix Orga.",
         "main-content": "Toutes leurs participations aux campagnes seront supprimées. Cela impactera donc les résultats et analyses des campagnes qu’ils ont réalisées. Ils ne pourront plus participer aux campagnes auxquelles ils avaient participé par le passé. Cependant, ils pourront participer à de nouvelles campagnes."
       },


### PR DESCRIPTION
## :unicorn: Problème
Le wording actuel est un peu trompeur car on dit “Les étudiants existants dans l'application et présents dans le nouvel import ne seront pas modifiés.” alors que les étudiants sont bien maj lorsqu’ils sont présents dans l’orga et dans le nouveau fichier d’import.

## :robot: Proposition
Modifier les wordings :
FR : Les étudiants existants dans l'application et présents dans le nouvel import ne seront pas supprimés et seront mis à jour si nécessaire. 
EN : Existing students in the application and included in the new import will not be deleted and will be updated if necessary.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- Se connecter à PixOrga avec le compte SUP
- Faire un import avec remplacement 
- vérifier la modif de la modale 🎉 
(et tout pareil en anglais)
