### PR TITLE
[BUGFIX] recharge les places  lorsque le prescrit change d'organisation (PIX-12653)

### DIFF
--- a/orga/app/components/layout/topbar.hbs
+++ b/orga/app/components/layout/topbar.hbs
@@ -1,4 +1,4 @@
 <div class="topbar">
   <Layout::OrganizationPlacesOrCreditInfo @placesCount={{@placesCount}} />
-  <Layout::UserLoggedMenu class="topbar__user-logged-menu" />
+  <Layout::UserLoggedMenu class="topbar__user-logged-menu" @reloadPlaceStatistics={{@reloadPlaceStatistics}} />
 </div>

--- a/orga/app/components/layout/user-logged-menu.js
+++ b/orga/app/components/layout/user-logged-menu.js
@@ -56,6 +56,7 @@ export default class UserLoggedMenu extends Component {
     this.router.replaceWith('authenticated', { queryParams });
 
     await this.currentUser.load();
+    this.args.reloadPlaceStatistics();
 
     this.closeMenu();
   }

--- a/orga/app/controllers/authenticated.js
+++ b/orga/app/controllers/authenticated.js
@@ -1,0 +1,13 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+export default class AuthenticatedController extends Controller {
+  @service currentUser;
+  @service store;
+
+  @action
+  reloadPlaceStatistics() {
+    this.send('refreshModel');
+  }
+}

--- a/orga/app/routes/authenticated.js
+++ b/orga/app/routes/authenticated.js
@@ -1,3 +1,4 @@
+import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import get from 'lodash/get';
@@ -27,5 +28,10 @@ export default class AuthenticatedRoute extends Route {
         organizationId: this.currentUser.organization.id,
       });
     } else return null;
+  }
+
+  @action
+  refreshModel() {
+    this.refresh();
   }
 }

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -15,7 +15,9 @@ export default class CurrentUserService extends Service {
   async load() {
     if (this.session.isAuthenticated) {
       try {
-        this.prescriber = await this.store.findRecord('prescriber', this.session.data.authenticated.user_id);
+        this.prescriber = await this.store.findRecord('prescriber', this.session.data.authenticated.user_id, {
+          reload: true,
+        });
         this.memberships = await this.prescriber.memberships;
         const userOrgaSettings = await this.prescriber.userOrgaSettings;
         const membership = await this._getMembershipByUserOrgaSettings(this.memberships.slice(), userOrgaSettings);

--- a/orga/app/templates/authenticated.hbs
+++ b/orga/app/templates/authenticated.hbs
@@ -3,7 +3,7 @@
 
   <div class="main-content">
     <header>
-      <Layout::Topbar @placesCount={{@model.available}} />
+      <Layout::Topbar @placesCount={{@model.available}} @reloadPlaceStatistics={{this.reloadPlaceStatistics}} />
     </header>
 
     <main class="main-content__body page">

--- a/orga/tests/integration/components/layout/user-logged-menu_test.js
+++ b/orga/tests/integration/components/layout/user-logged-menu_test.js
@@ -95,6 +95,8 @@ module('Integration | Component | Layout::UserLoggedMenu', function (hooks) {
 
   test('should redirect to authenticated route before reload the current user', async function (assert) {
     const replaceWithStub = sinon.stub();
+    const reloadPlaceStatistics = sinon.stub();
+
     class RouterStub extends Service {
       replaceWith = replaceWithStub;
       currentRoute = { queryParams: [] };
@@ -105,15 +107,15 @@ module('Integration | Component | Layout::UserLoggedMenu', function (hooks) {
         return { save() {} };
       }
     }
-
+    this.set('reloadPlaceStatistics', reloadPlaceStatistics);
     this.owner.register('service:router', RouterStub);
     this.owner.register('service:store', StoreStub);
 
-    const screen = await render(hbs`<Layout::UserLoggedMenu />`);
+    const screen = await render(hbs`<Layout::UserLoggedMenu @reloadPlaceStatistics={{this.reloadPlaceStatistics}} />`);
     await clickByName('Ouvrir le menu utilisateur');
     await click(screen.getByRole('button', { name: `${organization2.name} (${organization2.externalId})` }));
 
     sinon.assert.callOrder(replaceWithStub, loadStub);
-    assert.ok(true);
+    assert.ok(reloadPlaceStatistics.calledOnce);
   });
 });

--- a/orga/tests/unit/controllers/authenticated_test.js
+++ b/orga/tests/unit/controllers/authenticated_test.js
@@ -1,0 +1,18 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Controller | authenticated', function (hooks) {
+  setupTest(hooks);
+
+  test('should call send method', async function (assert) {
+    // given
+    const controller = this.owner.lookup('controller:authenticated');
+    controller.send = sinon.stub();
+
+    // when
+    controller.reloadPlaceStatistics();
+    // then
+    assert.true(controller.send.calledWithExactly('refreshModel'));
+  });
+});

--- a/orga/tests/unit/routes/authenticated_test.js
+++ b/orga/tests/unit/routes/authenticated_test.js
@@ -124,4 +124,18 @@ module('Unit | Route | authenticated', function (hooks) {
       assert.notOk(queryRecordStub.calledWithExactly('organization-place-statistic', { organizationId }));
     });
   });
+
+  module('refreshModel', function () {
+    test('should call refresh', async function (assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated');
+      route.refresh = sinon.stub();
+
+      // when
+      route.refreshModel();
+
+      // then
+      assert.ok(route.refresh.called);
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Nous avons implémenté l’affichage du compteur de place dans le bandeau en haut du site orga. Dans le cas d’un utilisateur qui gère plusieurs orga, ce compteur ne se met pas à jour lorsqu’on change d’orga.

## :robot: Proposition
le compteur de place affiche le bon nombre de place

## :rainbow: Remarques
petite migration du composant en gjs :sparkles: 

## :100: Pour tester
### pre-requis
Sur admin, ajouter comme membre pro-orga@example.net sur 1 orga avec des places et sur une orga sans place 

- Se connecter en tant que pro-orga
- Changer d'orga 
- constater que l'affichage des places se mettent bien à jour
