### PR TITLE
[BUGFIX] Chercher les certification-challenges par date de création pour le scoring V3 (PIX-12671).

### DIFF
--- a/api/src/certification/scoring/infrastructure/repositories/certification-challenge-for-scoring-repository.js
+++ b/api/src/certification/scoring/infrastructure/repositories/certification-challenge-for-scoring-repository.js
@@ -9,7 +9,8 @@ export const getByCertificationCourseId = async ({ certificationCourseId }) => {
       difficulty: 'difficulty',
       certificationChallengeId: 'id',
     })
-    .where({ courseId: certificationCourseId });
+    .where({ courseId: certificationCourseId })
+    .orderBy('createdAt', 'asc');
 
   return _toDomain(certificationChallengesForScoringDTO);
 };

--- a/api/tests/certification/scoring/integration/infrastructure/repositories/certification-challenge-for-scoring-repository_test.js
+++ b/api/tests/certification/scoring/integration/infrastructure/repositories/certification-challenge-for-scoring-repository_test.js
@@ -26,14 +26,24 @@ describe('Integration | Infrastructure | Repository | CertificationChallengeForS
       });
     });
 
-    describe('when there are 2 challenges', function () {
-      it('should return all certification challenges for scoring for the certification course', async function () {
+    describe('when there are 2 or more challenges', function () {
+      it('should return all certification challenges for scoring for the certification course ordered by creation date', async function () {
         databaseBuilder.factory.buildCertificationChallenge({
           id: 1,
           challengeId: 'challenge_id_1',
           courseId: certificationCourseId,
           discriminant: 1.1,
           difficulty: 1,
+          createdAt: new Date('2020-01-01T00:00:00Z'),
+        });
+
+        databaseBuilder.factory.buildCertificationChallenge({
+          id: 3,
+          challengeId: 'challenge_id_3',
+          courseId: certificationCourseId,
+          discriminant: 1.2,
+          difficulty: 1,
+          createdAt: new Date('2020-01-03T00:00:00Z'),
         });
 
         databaseBuilder.factory.buildCertificationChallenge({
@@ -42,14 +52,18 @@ describe('Integration | Infrastructure | Repository | CertificationChallengeForS
           courseId: certificationCourseId,
           discriminant: 1.2,
           difficulty: 1,
+          createdAt: new Date('2020-01-02T00:00:00Z'),
         });
 
         await databaseBuilder.commit();
 
         const challenges = await getByCertificationCourseId({ certificationCourseId });
 
-        expect(challenges.length).to.equal(2);
+        expect(challenges.length).to.equal(3);
         expect(challenges[0]).to.be.instanceOf(CertificationChallengeForScoring);
+        expect(challenges[0].id).to.equal('challenge_id_1');
+        expect(challenges[1].id).to.equal('challenge_id_2');
+        expect(challenges[2].id).to.equal('challenge_id_3');
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème

Lors du scoring d’une certification, les certification-challenges récupérés dans le repository et sur lesquels on se base pour matcher avec les réponses du candidat, ne sont pas triés.

Ce manque de tri fait que le matching entre les answers et les certification-challenges que l’on retrouve dans la création de l’historique créée des erreurs puisque l’on se base sur l’index des deux tableaux pour réaliser l’opération.

## :robot: Proposition

Récupérer les certification-challenges par date de création comme cela est déjà fait pour les answers du candidat.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

- Créer une session V3 (`certifv3@example.net`) et y inscrire un candidat.
- Passer et terminer le test avec `certifiable-contenu-user@example.net`
- Vérifier en console (grâce au dernier commit qui sera supprimé avant merge) que les answers et les challenges correspondent.
