### PR TITLE
[TECH] Deplacer PickChallengeService vers Evaluation (PIX-12657)

### DIFF
--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -5,6 +5,7 @@ import _ from 'lodash';
 import * as complementaryCertificationBadgesRepository from '../../../src/certification/complementary-certification/infrastructure/repositories/complementary-certification-badge-repository.js';
 import * as flashAlgorithmService from '../../../src/certification/flash-certification/domain/services/algorithm-methods/flash.js';
 import * as flashAlgorithmConfigurationRepository from '../../../src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js';
+import { scoringDegradationService } from '../../../src/certification/scoring/domain/services/scoring-degradation-service.js';
 import * as certificationAssessmentHistoryRepository from '../../../src/certification/scoring/infrastructure/repositories/certification-assessment-history-repository.js';
 import * as certificationChallengeForScoringRepository from '../../../src/certification/scoring/infrastructure/repositories/certification-challenge-for-scoring-repository.js';
 import * as scoringConfigurationRepository from '../../../src/certification/scoring/infrastructure/repositories/scoring-configuration-repository.js';
@@ -14,7 +15,6 @@ import * as certificationAssessmentRepository from '../../../src/certification/s
 import * as certificationCenterRepository from '../../../src/certification/shared/infrastructure/repositories/certification-center-repository.js';
 import * as certificationCourseRepository from '../../../src/certification/shared/infrastructure/repositories/certification-course-repository.js';
 import * as certificationIssueReportRepository from '../../../src/certification/shared/infrastructure/repositories/certification-issue-report-repository.js';
-import { scoringDegradationService } from '../../../src/domain/services/scoring/scoring-degradation-service.js';
 import * as answerRepository from '../../../src/shared/infrastructure/repositories/answer-repository.js';
 import * as assessmentRepository from '../../../src/shared/infrastructure/repositories/assessment-repository.js';
 import * as assessmentResultRepository from '../../../src/shared/infrastructure/repositories/assessment-result-repository.js';

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -18,7 +18,6 @@ import * as certificationCpfCityRepository from '../../../src/certification/enro
 import * as certificationCpfCountryRepository from '../../../src/certification/enrolment/infrastructure/repositories/certification-cpf-country-repository.js';
 import * as sessionEnrolmentRepository from '../../../src/certification/enrolment/infrastructure/repositories/session-repository.js';
 import * as flashAlgorithmService from '../../../src/certification/flash-certification/domain/services/algorithm-methods/flash.js';
-import { pickChallengeService } from '../../../src/certification/flash-certification/domain/services/pick-challenge-service.js';
 import * as flashAlgorithmConfigurationRepository from '../../../src/certification/flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js';
 import * as certificationOfficerRepository from '../../../src/certification/session-management/infrastructure/repositories/certification-officer-repository.js';
 import * as finalizedSessionRepository from '../../../src/certification/session-management/infrastructure/repositories/finalized-session-repository.js';
@@ -37,6 +36,7 @@ import * as userSavedTutorialRepository from '../../../src/devcomp/infrastructur
 import * as algorithmDataFetcherService from '../../../src/evaluation/domain/services/algorithm-methods/data-fetcher.js';
 import * as smartRandom from '../../../src/evaluation/domain/services/algorithm-methods/smart-random.js';
 import { getCompetenceLevel } from '../../../src/evaluation/domain/services/get-competence-level.js';
+import { pickChallengeService } from '../../../src/evaluation/domain/services/pick-challenge-service.js';
 import * as scorecardService from '../../../src/evaluation/domain/services/scorecard-service.js';
 import * as stageAndStageAcquisitionComparisonService from '../../../src/evaluation/domain/services/stages/stage-and-stage-acquisition-comparison-service.js';
 import * as badgeRepository from '../../../src/evaluation/infrastructure/repositories/badge-repository.js';

--- a/api/src/certification/course/domain/usecases/index.js
+++ b/api/src/certification/course/domain/usecases/index.js
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import * as certificationResultRepository from '../../../../../lib/infrastructure/repositories/certification-result-repository.js';
 import * as competenceMarkRepository from '../../../../../lib/infrastructure/repositories/competence-mark-repository.js';
+import * as pickChallengeService from '../../../../evaluation/domain/services/pick-challenge-service.js';
 import * as answerRepository from '../../../../shared/infrastructure/repositories/answer-repository.js';
 import * as assessmentResultRepository from '../../../../shared/infrastructure/repositories/assessment-result-repository.js';
 import * as challengeRepository from '../../../../shared/infrastructure/repositories/challenge-repository.js';
@@ -11,7 +12,6 @@ import * as competenceRepository from '../../../../shared/infrastructure/reposit
 import { injectDependencies } from '../../../../shared/infrastructure/utils/dependency-injection.js';
 import { importNamedExportsFromDirectory } from '../../../../shared/infrastructure/utils/import-named-exports-from-directory.js';
 import * as flashAlgorithmService from '../../../flash-certification/domain/services/algorithm-methods/flash.js';
-import * as pickChallengeService from '../../../flash-certification/domain/services/pick-challenge-service.js';
 import * as flashAlgorithmConfigurationRepository from '../../../flash-certification/infrastructure/repositories/flash-algorithm-configuration-repository.js';
 import * as certificationChallengeLiveAlertRepository from '../../../shared/infrastructure/repositories/certification-challenge-live-alert-repository.js';
 import * as certificationChallengeRepository from '../../../shared/infrastructure/repositories/certification-challenge-repository.js';

--- a/api/src/certification/flash-certification/application/scenario-simulator-controller.js
+++ b/api/src/certification/flash-certification/application/scenario-simulator-controller.js
@@ -8,8 +8,8 @@ import { scenarioSimulatorBatchSerializer } from '../../../../lib/infrastructure
 import { random } from '../../../../lib/infrastructure/utils/random.js';
 import { extractLocaleFromRequest } from '../../../../lib/infrastructure/utils/request-response-utils.js';
 import { parseCsv } from '../../../../scripts/helpers/csvHelpers.js';
+import { pickChallengeService } from '../../../evaluation/domain/services/pick-challenge-service.js';
 import { FlashAssessmentSuccessRateHandler } from '../domain/models/FlashAssessmentSuccessRateHandler.js';
-import { pickChallengeService } from '../domain/services/pick-challenge-service.js';
 import { usecases } from '../domain/usecases/index.js';
 
 async function simulateFlashAssessmentScenario(

--- a/api/src/certification/scoring/domain/services/scoring-degradation-service.js
+++ b/api/src/certification/scoring/domain/services/scoring-degradation-service.js
@@ -1,7 +1,7 @@
-import { AnswerStatus, AssessmentSimulator } from '../../../../lib/domain/models/index.js';
-import { pickAnswerStatusService } from '../../../../lib/domain/services/pick-answer-status-service.js';
-import { AssessmentSimulatorSingleMeasureStrategy } from '../../../certification/flash-certification/domain/models/AssessmentSimulatorSingleMeasureStrategy.js';
-import { pickChallengeService } from '../../../certification/flash-certification/domain/services/pick-challenge-service.js';
+import { AnswerStatus, AssessmentSimulator } from '../../../../../lib/domain/models/index.js';
+import { pickAnswerStatusService } from '../../../../../lib/domain/services/pick-answer-status-service.js';
+import { AssessmentSimulatorSingleMeasureStrategy } from '../../../flash-certification/domain/models/AssessmentSimulatorSingleMeasureStrategy.js';
+import { pickChallengeService } from '../../../flash-certification/domain/services/pick-challenge-service.js';
 
 const downgradeCapacity = ({
   algorithm,

--- a/api/src/certification/scoring/domain/services/scoring-degradation-service.js
+++ b/api/src/certification/scoring/domain/services/scoring-degradation-service.js
@@ -1,7 +1,7 @@
 import { AnswerStatus, AssessmentSimulator } from '../../../../../lib/domain/models/index.js';
 import { pickAnswerStatusService } from '../../../../../lib/domain/services/pick-answer-status-service.js';
+import { pickChallengeService } from '../../../../evaluation/domain/services/pick-challenge-service.js';
 import { AssessmentSimulatorSingleMeasureStrategy } from '../../../flash-certification/domain/models/AssessmentSimulatorSingleMeasureStrategy.js';
-import { pickChallengeService } from '../../../flash-certification/domain/services/pick-challenge-service.js';
 
 const downgradeCapacity = ({
   algorithm,

--- a/api/src/evaluation/domain/services/pick-challenge-service.js
+++ b/api/src/evaluation/domain/services/pick-challenge-service.js
@@ -1,7 +1,7 @@
 import hashInt from 'hash-int';
 
-import { config } from '../../../../../lib/config.js';
-import { random } from '../../../../../lib/infrastructure/utils/random.js';
+import { config } from '../../../../lib/config.js';
+import { random } from '../../../../lib/infrastructure/utils/random.js';
 const NON_EXISTING_ITEM = null;
 const VALIDATED_STATUS = 'validé';
 

--- a/api/src/evaluation/domain/usecases/index.js
+++ b/api/src/evaluation/domain/usecases/index.js
@@ -6,7 +6,6 @@ import * as campaignParticipationRepository from '../../../../lib/infrastructure
 import * as campaignRepository from '../../../../lib/infrastructure/repositories/campaign-repository.js';
 import * as knowledgeElementRepository from '../../../../lib/infrastructure/repositories/knowledge-element-repository.js';
 import * as targetProfileRepository from '../../../../lib/infrastructure/repositories/target-profile-repository.js';
-import { pickChallengeService } from '../../../certification/flash-certification/domain/services/pick-challenge-service.js';
 import * as answerRepository from '../../../shared/infrastructure/repositories/answer-repository.js';
 import * as areaRepository from '../../../shared/infrastructure/repositories/area-repository.js';
 import * as assessmentRepository from '../../../shared/infrastructure/repositories/assessment-repository.js';
@@ -25,6 +24,7 @@ import * as stageCollectionForTargetProfileRepository from '../../infrastructure
 import * as stageRepository from '../../infrastructure/repositories/stage-repository.js';
 import * as smartRandomService from '../services/algorithm-methods/smart-random.js';
 import { getCompetenceLevel } from '../services/get-competence-level.js';
+import { pickChallengeService } from '../services/pick-challenge-service.js';
 import * as scorecardService from '../services/scorecard-service.js';
 
 const path = dirname(fileURLToPath(import.meta.url));

--- a/api/tests/certification/flash-certification/integration/application/scenario-simulator-controller_test.js
+++ b/api/tests/certification/flash-certification/integration/application/scenario-simulator-controller_test.js
@@ -1,8 +1,8 @@
 import { pickAnswerStatusService } from '../../../../../lib/domain/services/pick-answer-status-service.js';
 import { random } from '../../../../../lib/infrastructure/utils/random.js';
 import * as moduleUnderTest from '../../../../../src/certification/flash-certification/application/scenario-simulator-route.js';
-import { pickChallengeService } from '../../../../../src/certification/flash-certification/domain/services/pick-challenge-service.js';
 import { usecases } from '../../../../../src/certification/flash-certification/domain/usecases/index.js';
+import { pickChallengeService } from '../../../../../src/evaluation/domain/services/pick-challenge-service.js';
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { domainBuilder, expect, HttpTestServer, parseJsonStream, sinon } from '../../../../test-helper.js';
 

--- a/api/tests/certification/scoring/unit/domain/services/scoring-degradation-service_test.js
+++ b/api/tests/certification/scoring/unit/domain/services/scoring-degradation-service_test.js
@@ -1,5 +1,5 @@
 import * as flashAlgorithmService from '../../../../../../src/certification/flash-certification/domain/services/algorithm-methods/flash.js';
-import { scoringDegradationService } from '../../../../../../src/domain/services/scoring/scoring-degradation-service.js';
+import { scoringDegradationService } from '../../../../../../src/certification/scoring/domain/services/scoring-degradation-service.js';
 import { domainBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Unit | Domain | services | scoringDegradationService', function () {

--- a/api/tests/evaluation/unit/domain/services/pick-challenge-service_test.js
+++ b/api/tests/evaluation/unit/domain/services/pick-challenge-service_test.js
@@ -1,6 +1,6 @@
-import { pickChallengeService } from '../../../../../../src/certification/flash-certification/domain/services/pick-challenge-service.js';
-import { LOCALE } from '../../../../../../src/shared/domain/constants.js';
-import { domainBuilder, expect } from '../../../../../test-helper.js';
+import { pickChallengeService } from '../../../../../src/evaluation/domain/services/pick-challenge-service.js';
+import { LOCALE } from '../../../../../src/shared/domain/constants.js';
+import { domainBuilder, expect } from '../../../../test-helper.js';
 
 const { ENGLISH_SPOKEN, FRENCH_FRANCE, FRENCH_SPOKEN } = LOCALE;
 


### PR DESCRIPTION
## :unicorn: Problème
Le service pickChallengeService est utilisé par certification et evaluation. Il a ete cree par/pour la certification mais son utilisation est plus large

## :robot: Proposition
Le deplacer dans le contexte `evaluation`

## :rainbow: Remarques
- On deplace scoring-degradation-service qui n'est pas au bon endroit

## :100: Pour tester
A definir 😇
