### PR TITLE
[BUGFIX] Retire l'icône de suppression de signalement effectué en live lors d'une certif V3 (PIX-12655).

### DIFF
--- a/api/src/certification/session-management/infrastructure/serializers/session-serializer.js
+++ b/api/src/certification/session-management/infrastructure/serializers/session-serializer.js
@@ -17,6 +17,7 @@ const serialize = function ({ session, hasSupervisorAccess, hasSomeCleaAcquired 
     'certificationReports',
     'hasSupervisorAccess',
     'hasSomeCleaAcquired',
+    'version',
   ];
   return new Serializer('session-management', {
     transform(record) {
@@ -52,6 +53,7 @@ const deserialize = function (json) {
     examinerGlobalComment: attributes['examiner-global-comment'],
     hasIncident: attributes['has-incident'],
     hasJoiningIssue: attributes['has-joining-issue'],
+    version: attributes['version'],
   });
 
   if (_.isEmpty(_.trim(result.examinerGlobalComment))) {

--- a/api/tests/certification/session-management/unit/infrastructure/serializers/session-serializer_test.js
+++ b/api/tests/certification/session-management/unit/infrastructure/serializers/session-serializer_test.js
@@ -21,6 +21,7 @@ describe('Unit | Certification | session-management | Serializer | session-seria
             'finalized-at': new Date('2020-02-17T14:23:56Z'),
             'results-sent-to-prescriber-at': new Date('2020-02-20T14:23:56Z'),
             'published-at': new Date('2020-02-21T14:23:56Z'),
+            version: 3,
           },
           relationships: {
             'certification-reports': {
@@ -39,6 +40,7 @@ describe('Unit | Certification | session-management | Serializer | session-seria
         finalizedAt: new Date('2020-02-17T14:23:56Z'),
         resultsSentToPrescriberAt: new Date('2020-02-20T14:23:56Z'),
         publishedAt: new Date('2020-02-21T14:23:56Z'),
+        version: 3,
       });
     });
 
@@ -100,6 +102,7 @@ describe('Unit | Certification | session-management | Serializer | session-seria
           'has-joining-issue': true,
           'finalized-at': new Date('2020-02-17T14:23:56Z'),
           'results-sent-to-prescriber-at': new Date('2020-02-20T14:23:56Z'),
+          version: 3,
         },
         relationships: {
           certifications: {
@@ -130,6 +133,7 @@ describe('Unit | Certification | session-management | Serializer | session-seria
       expect(session.examinerGlobalComment).to.equal('It was a fine session my dear');
       expect(session.hasIncident).to.be.true;
       expect(session.hasJoiningIssue).to.be.true;
+      expect(session.version).to.equal(3);
     });
 
     // eslint-disable-next-line mocha/no-setup-in-describe


### PR DESCRIPTION
## :unicorn: Problème

Suite à  la PR #7988 et possiblement à la migration des bounded contextes, il s'avère que l'icône de suppression est encore visible pour les live-alerts de catégorie E1-E12 dans le cas où la session n'est pas terminée par le candidat.

## :robot: Proposition

Ajouter la version au serializer de `session-management` qui ne contenait pas la propriété.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

Créer une session dans un CDC pilote certif v3 et inscrire un candidat
Lancer la certification et signaler un problème 
Depuis l’ES, valider le signalement
Dans pix certif, ouvrir la page de finalisation
Cliquer sur “signalement”

Résultat attendu : l’icône de devrait pas être visible car pas possible de supprimer un signalement fait en direct pendant la session
