### PR TITLE
[BUGFIX] Corriger l'envoi de signalement depuis la correction d'une épreuve

### DIFF
--- a/mon-pix/app/components/feedback-panel.js
+++ b/mon-pix/app/components/feedback-panel.js
@@ -97,8 +97,8 @@ export default class FeedbackPanel extends Component {
     const feedback = this.store.createRecord('feedback', {
       content: this.content || '',
       category,
-      assessment: this.args.assessment,
-      challenge: this.args.challenge,
+      assessment: await this.args.assessment,
+      challenge: await this.args.challenge,
       answer: get(this.args, 'answer.value', null),
     });
 

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -106,4 +106,6 @@ function routes() {
   this.get('/certification-candidates/:id/subscriptions', getCertificationCandidatesSubscriptions);
 
   this.get('/certification-courses/:id');
+
+  this.post('/feedbacks');
 }

--- a/mon-pix/tests/acceptance/compare-answer-solution_test.js
+++ b/mon-pix/tests/acceptance/compare-answer-solution_test.js
@@ -1,11 +1,15 @@
-import { visit } from '@1024pix/ember-testing-library';
+import { clickByText, visit } from '@1024pix/ember-testing-library';
 import { click, findAll } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
+import { clickByLabel } from '../helpers/click-by-label';
+import setupIntl from '../helpers/setup-intl';
+
 module('Compare answers and solutions for QCM questions', function (hooks) {
   setupApplicationTest(hooks);
+  setupIntl(hooks);
   setupMirage(hooks);
   let assessment;
 
@@ -75,6 +79,29 @@ module('Compare answers and solutions for QCM questions', function (hooks) {
 
       assert.dom('.pix-modal__overlay--hidden .comparison-window').doesNotExist();
       assert.dom('.pix-modal__overlay .comparison-window').exists();
+    });
+
+    test('should be able to send a feedback', async function (assert) {
+      // given
+      await visit(`/assessments/${assessment.id}/results`);
+      await click('.result-item__correction-button');
+
+      // when
+      await clickByText(this.intl.t('pages.challenge.feedback-panel.actions.open-close'));
+
+      await clickByLabel(this.intl.t('pages.challenge.feedback-panel.form.fields.detail-selection.aria-first'));
+      await clickByText(this.intl.t('pages.challenge.feedback-panel.form.fields.category-selection.options.question'));
+
+      await clickByLabel(this.intl.t('pages.challenge.feedback-panel.form.fields.detail-selection.aria-secondary'));
+      await clickByText(
+        this.intl.t('pages.challenge.feedback-panel.form.fields.detail-selection.options.question-not-understood'),
+      );
+
+      await clickByText(this.intl.t('pages.challenge.feedback-panel.form.actions.submit'));
+      await clickByText(this.intl.t('common.actions.validate'));
+
+      // then
+      assert.dom('.feedback-panel__view--mercix').exists();
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix App, depuis la montée de version d'Ember-data, l'envoi de signalement depuis la modale de correction d'une épreuve n'est pas possible.

## :robot: Proposition
Prendre en compte les dépréciations venues avec ember-data v5.

## :rainbow: Remarques
Testing library n'a pas été utilisé dans tout le test, le fichier complet est à revoir en réalité mais je n'avais pas le temps.

## :100: Pour tester
- Sur Pix App, passer des épreuves jusqu'à un checkpoint
- Au checkpoint, regarder les réponses et tutos d'une épreuve
- Faire un signalement