### PR TITLE
[FEATURE] Découper les feedbacks de constat et de diagnostique - v0 (PIX-9783)

### DIFF
--- a/api/src/devcomp/domain/models/validator/ValidatorQCM.js
+++ b/api/src/devcomp/domain/models/validator/ValidatorQCM.js
@@ -1,4 +1,4 @@
-import * as solutionServiceQCM from '../../services/solution-service-qcm.js';
+import solutionServiceQCM from '../../services/solution-service-qcm.js';
 import { Validation } from './Validation.js';
 import { Validator } from './Validator.js';
 

--- a/api/src/devcomp/domain/models/validator/ValidatorQCU.js
+++ b/api/src/devcomp/domain/models/validator/ValidatorQCU.js
@@ -1,4 +1,4 @@
-import * as solutionServiceQCU from '../../services/solution-service-qcu.js';
+import solutionServiceQCU from '../../services/solution-service-qcu.js';
 import { Validation } from './Validation.js';
 import { Validator } from './Validator.js';
 

--- a/api/src/devcomp/domain/models/validator/ValidatorQROCMInd.js
+++ b/api/src/devcomp/domain/models/validator/ValidatorQROCMInd.js
@@ -1,4 +1,4 @@
-import * as solutionServiceQROCMInd from '../../services/solution-service-qrocm-ind.js';
+import solutionServiceQROCMInd from '../../services/solution-service-qrocm-ind.js';
 import { Validation } from './Validation.js';
 import { Validator } from './Validator.js';
 

--- a/api/src/devcomp/domain/services/solution-service-qcm.js
+++ b/api/src/devcomp/domain/services/solution-service-qcm.js
@@ -10,4 +10,4 @@ const match = function (answers, solutions) {
   return AnswerStatus.KO;
 };
 
-export { match };
+export default { match };

--- a/api/src/devcomp/domain/services/solution-service-qcu.js
+++ b/api/src/devcomp/domain/services/solution-service-qcu.js
@@ -7,4 +7,4 @@ const match = function (answer, solution) {
   return AnswerStatus.KO;
 };
 
-export { match };
+export default { match };

--- a/api/src/devcomp/domain/services/solution-service-qrocm-ind.js
+++ b/api/src/devcomp/domain/services/solution-service-qrocm-ind.js
@@ -134,7 +134,7 @@ function _formatResult(resultDetails) {
   return AnswerStatus.OK;
 }
 
-export {
+export default {
   _applyTolerancesToAnswers,
   _applyTolerancesToSolutions,
   _areAnswersComparableToSolutions,

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
@@ -88,8 +88,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct.</p>",
-              "invalid": "<p>Incorrect. La page indique à côté de la localisation que c'est <strong>d'après votre adresse IP.</strong></p>"
+              "valid": "<span class=\"feedback__state\">Correct.</span>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p>La page indique à côté de la localisation que c'est <strong>d'après votre adresse IP.</strong></p>"
             },
             "solution": "2"
           }
@@ -148,8 +148,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct. L'adresse IP publique est l’équivalent d’une adresse postale pour identifier où est une personne.</p>",
-              "invalid": "<p>Incorrect. Vous pensez peut-être plutôt à l'adresse <strong>web</strong> ou l'adresse <strong>mail</strong>.<br>Vous pouvez remonter voir la vidéo.<span aria-hidden=\"true\">👆</span>️</p>"
+              "valid": "<span class=\"feedback__state\">Correct</span>.<p>L'adresse IP publique est l’équivalent d’une adresse postale pour identifier où est une personne.</p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect</span>.<p>Vous pensez peut-être plutôt à l'adresse <strong>web</strong> ou l'adresse <strong>mail</strong>.<br>Vous pouvez remonter voir la vidéo.<span aria-hidden=\"true\">👆</span>️</p>"
             },
             "solution": "1"
           }
@@ -194,8 +194,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct. Les plages d’adresses IP sont réparties dans 5 grandes régions du monde puis partagées dans chaque pays.</p>",
-              "invalid": "<p>Incorrect. Les plages d’adresses IP sont réparties dans 5 grandes régions du monde puis partagées dans chaque pays. Elles sont donc <strong>localisées</strong>.</p>"
+              "valid": "<span class=\"feedback__state\">Correct.</span><p>Les plages d’adresses IP sont réparties dans 5 grandes régions du monde puis partagées dans chaque pays.</p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect</span><p>Les plages d’adresses IP sont réparties dans 5 grandes régions du monde puis partagées dans chaque pays. Elles sont donc <strong>localisées</strong>.</p>"
             },
             "solution": "1"
           }
@@ -225,8 +225,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct. Il s’agit par exemple de l’adresse IP publique de votre box internet si vous êtes chez vous ou celle du réseau de votre employeur au travail.</p>",
-              "invalid": "<p>Incorrect. Il s’agit par exemple de l’adresse IP publique de votre box internet si vous êtes chez vous ou celle du réseau de votre employeur au travail.</p>"
+              "valid": "<span class=\"feedback__state\">Correct.</span><p>Il s’agit par exemple de l’adresse IP publique de votre box internet si vous êtes chez vous ou celle du réseau de votre employeur au travail.</p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p>Il s’agit par exemple de l’adresse IP publique de votre box internet si vous êtes chez vous ou celle du réseau de votre employeur au travail.</p>"
             },
             "solution": "1"
           }
@@ -256,8 +256,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct. Au mieux, avec une adresse IP publique, on peut connaître votre pays ou votre ville. Si besoin, les autorités peuvent cependant accéder à plus d'informations dans un cadre prévu par la loi.</p>",
-              "invalid": "<p>Incorrect. Une adresse IP publique permet d'identifier un pays, voire une ville de connexion, mais difficile d’en savoir plus&#8239;!</p>"
+              "valid": "<span class=\"feedback__state\">Correct.</span><p> Au mieux, avec une adresse IP publique, on peut connaître votre pays ou votre ville. Si besoin, les autorités peuvent cependant accéder à plus d'informations dans un cadre prévu par la loi.</p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Une adresse IP publique permet d'identifier un pays, voire une ville de connexion, mais difficile d’en savoir plus&#8239;!</p>"
             },
             "solution": "2"
           }
@@ -287,8 +287,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct. C’est effectivement le point d’accès internet qui détermine l’adresse IP publique.</p>",
-              "invalid": "<p>Incorrect. Il n'y a pas plusieurs adresses IP publiques pour un même point d'accès internet. L'adresse est unique. </p>"
+              "valid": "<span class=\"feedback__state\">Correct.</span><p> C’est effectivement le point d’accès internet qui détermine l’adresse IP publique.</p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Il n'y a pas plusieurs adresses IP publiques pour un même point d'accès internet. L'adresse est unique. </p>"
             },
             "solution": "1"
           }
@@ -344,8 +344,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct.&nbsp;<span aria-hidden=\"true\">🎉</span></p>",
-              "invalid": "<p>Incorrect. Pour réussir, utilisez un site internet dédié. Pour le trouver, faites une recherche sur internet avec les mots-clés \"localisation adresse IP\".</p>"
+              "valid": "<span class=\"feedback__state\">Correct.&nbsp;<span aria-hidden=\"true\">🎉</span></span>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p>Pour réussir, utilisez un site internet dédié. Pour le trouver, faites une recherche sur internet avec les mots-clés \"localisation adresse IP\".</p>"
             }
           }
         },
@@ -430,8 +430,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct.&nbsp;<span aria-hidden=\"true\">🎉</span></p>",
-              "invalid": "<p>Incorrect. L'adresse IP privée (locale) est visible uniquement par les appareils du réseau local.</p>"
+              "valid": "<span class=\"feedback__state\">Correct.&nbsp;<span aria-hidden=\"true\">🎉</span></span>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> L'adresse IP privée (locale) est visible uniquement par les appareils du réseau local.</p>"
             },
             "solution": "1"
           }
@@ -461,8 +461,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct.&nbsp;<span aria-hidden=\"true\">🎉</span></p>",
-              "invalid": "<p>Incorrect. L'adresse IP publique permet les échanges entre une box internet et les sites visités.</p>"
+              "valid": "<span class=\"feedback__state\">Correct.&nbsp;<span aria-hidden=\"true\">🎉</span></span>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> L'adresse IP publique permet les échanges entre une box internet et les sites visités.</p>"
             },
             "solution": "2"
           }
@@ -492,8 +492,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct.&nbsp;<span aria-hidden=\"true\">🎉</span></p>",
-              "invalid": "<p>Incorrect. L'adresse IP publique est spécifique à la box internet, pas aux appareils qui y sont connectés.</p>"
+              "valid": "<span class=\"feedback__state\">Correct.&nbsp;<span aria-hidden=\"true\">🎉</span></span>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> L'adresse IP publique est spécifique à la box internet, pas aux appareils qui y sont connectés.</p>"
             },
             "solution": "2"
           }
@@ -523,7 +523,7 @@
             ],
             "feedbacks": {
               "valid": "<p> Pour vérifier votre réponse, suivez le lien vers <a href=\"https://monip.org/\" target=\"_blank\">https://monip.org/</a>.</p>",
-              "invalid": "<p>Suivez le lien vers <a href=\"https://monip.org/\" target=\"_blank\">https://monip.org/</a> pour la trouver.</p>"
+              "invalid": "<p> Suivez le lien vers <a href=\"https://monip.org/\" target=\"_blank\">https://monip.org/</a> pour la trouver.</p>"
             },
             "solution": "1"
           }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -183,8 +183,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct.&nbsp;<span aria-hidden=\"true\">🎉</span></p>",
-              "invalid": "<p>Incorrect. Cherchez le symbole @ sur votre clavier pour pouvoir l'écrire.</p>"
+              "valid": "<span class=\"feedback__state\">Correct.&nbsp;<span aria-hidden=\"true\">🎉</span></span>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p>Cherchez le symbole @ sur votre clavier pour pouvoir l'écrire.</p>"
             }
           }
         },
@@ -253,8 +253,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span>&nbsp;Vous avez retrouvé le bon format d’une adresse mail.</p>",
-              "invalid": "<p>Incorrect&#8239;! Pour avoir de l’aide, revenez en arrière.&nbsp;<span aria-hidden=\"true\">👆</span></p>"
+              "valid": "<span class=\"feedback__state\">Correct&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span></span><p>Vous avez retrouvé le bon format d’une adresse mail.</p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect&#8239;!</span><p>Pour avoir de l’aide, revenez en arrière.&nbsp;<span aria-hidden=\"true\">👆</span></p>"
             }
           }
         }
@@ -329,8 +329,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Et oui&#8239;! Cette adresse est correctement écrite. On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>",
-              "invalid": "<p>Et si&#8239;! Cette adresse est correctement écrite. On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>"
+              "valid": "<span class=\"feedback__state\">Et oui&#8239;!</span><p>Cette adresse est correctement écrite. On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>",
+              "invalid": "<span class=\"feedback__state\">Et si&#8239;!</span><p>Cette adresse est correctement écrite. On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>"
             },
             "solution": "1"
           }
@@ -391,7 +391,7 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Bien vu&#8239;! Google n’est effectivement pas le seul fournisseur d’adresse mail. Il y en énormément, vous avez peut-être déjà vu des adresses de chez</p><ul><li>Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>La Poste (laposte.net).</li></ul>",
+              "valid": "<span class=\"feedback__state\">Bien vu&#8239;!</span><p>Google n’est effectivement pas le seul fournisseur d’adresse mail. Il y en énormément, vous avez peut-être déjà vu des adresses de chez</p><ul><li>Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>La Poste (laposte.net).</li></ul>",
               "invalid": "<p>Il y a d’autres fournisseurs d’adresses mails que Google (gmail.com).</p><p>Il y en a énormément, vous avez peut-être déjà vu des adresses de chez</p><ul><li>Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>La Poste (laposte.net).</li></ul>"
             },
             "solution": "2"
@@ -444,8 +444,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct.&nbsp;<span aria-hidden=\"true\">🎉</span> Tout est dans l'ordre&nbsp;: l'identifiant, l'arobase puis le fournisseur d'adresse mail</p>",
-              "invalid": "<p> Incorrect. Pour réussir la prochaine fois, utilisez les indices ci-dessous&nbsp;<span aria-hidden=\"true\">👇</span> </p>"
+              "valid": "<span class=\"feedback__state\">Correct.&nbsp;<span aria-hidden=\"true\">🎉</span></span><p>Tout est dans l'ordre&nbsp;: l'identifiant, l'arobase puis le fournisseur d'adresse mail</p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p>Pour réussir la prochaine fois, utilisez les indices ci-dessous&nbsp;<span aria-hidden=\"true\">👇</span> </p>"
             }
           }
         },

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -298,8 +298,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p class=\"pix-list-inline\">Oui, aucun problème&#8239;! Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>",
-              "invalid": "<p class=\"pix-list-inline\">Et si&#8239;! Les chiffres sont autorisés dans l’identifiant d’une adresse mail. Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>"
+              "valid": "<span class=\"feedback__state\">Oui, aucun problème&#8239;!</span><p class=\"pix-list-inline\">Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>",
+              "invalid": "<span class=\"feedback__state\">Et si&#8239;!</span><p class=\"pix-list-inline\">Les chiffres sont autorisés dans l’identifiant d’une adresse mail. Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>"
             },
             "solution": "1"
           }
@@ -360,8 +360,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Il faut pouvoir séparer l’identifiant et le fournisseur d’adresse. Il y a donc un seul symbole @ entre les deux.</p>",
-              "invalid": "<p>Il faut pouvoir séparer l’identifiant et le fournisseur d’adresse. Il y a donc un seul symbole @ entre les deux.</p>"
+              "valid": "<span class=\"feedback__state\">Correct&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span></span><p>Il faut pouvoir séparer l’identifiant et le fournisseur d’adresse. Il y a donc un seul symbole @ entre les deux.</p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect&#8239;!</span><p>Il faut pouvoir séparer l’identifiant et le fournisseur d’adresse. Il y a donc un seul symbole @ entre les deux.</p>"
             },
             "solution": "1"
           }
@@ -392,7 +392,7 @@
             ],
             "feedbacks": {
               "valid": "<span class=\"feedback__state\">Bien vu&#8239;!</span><p>Google n’est effectivement pas le seul fournisseur d’adresse mail. Il y en énormément, vous avez peut-être déjà vu des adresses de chez</p><ul><li>Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>La Poste (laposte.net).</li></ul>",
-              "invalid": "<p>Il y a d’autres fournisseurs d’adresses mails que Google (gmail.com).</p><p>Il y en a énormément, vous avez peut-être déjà vu des adresses de chez</p><ul><li>Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>La Poste (laposte.net).</li></ul>"
+              "invalid": "<span class=\"feedback__state\">Incorrect&#8239;!</span><p>Il y a d’autres fournisseurs d’adresses mails que Google (gmail.com).</p><p>Il y en a énormément, vous avez peut-être déjà vu des adresses de chez</p><ul><li>Microsoft (hotmail.com)</li><li>Free (free.fr)</li><li>La Poste (laposte.net).</li></ul>"
             },
             "solution": "2"
           }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -298,8 +298,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<span class=\"feedback__state\">Oui, aucun problème&#8239;!</span><p class=\"pix-list-inline\">Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>",
-              "invalid": "<span class=\"feedback__state\">Et si&#8239;!</span><p class=\"pix-list-inline\">Les chiffres sont autorisés dans l’identifiant d’une adresse mail. Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>"
+              "valid": "<p class=\"feedback__state\">Oui, aucun problème&#8239;!</p><p class=\"pix-list-inline\">Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>",
+              "invalid": "<p class=\"feedback__state\">Et si&#8239;!</p><p class=\"pix-list-inline\">Les chiffres sont autorisés dans l’identifiant d’une adresse mail. Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>"
             },
             "solution": "1"
           }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -146,8 +146,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct&#8239;! Ces 16 compétences sont rangées dans 5 domaines.</p>",
-              "invalid": "<p>Incorrect. Retourner voir la vidéo si besoin&nbsp;<span aria-hidden=\"true\">👆</span>️!</p>"
+              "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden=\"true\">👆</span>️!</p>"
             },
             "solution": "1"
           }
@@ -188,8 +188,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct&#8239;! Vous nous avez bien cernés&nbsp;:)</p>",
-              "invalid": "<p>Et non&#8239;! Pix sert à évaluer, certifier et développer ses compétences numériques.</p>"
+              "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p>Vous nous avez bien cernés&nbsp;:)</p>",
+              "invalid": "<span class=\"feedback__state\">Et non&#8239;!</span><p> Pix sert à évaluer, certifier et développer ses compétences numériques.</p>"
             },
             "solutions": ["1", "3", "4"]
           }
@@ -222,8 +222,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct&#8239;! Vous avez bien remonté la page</p>",
-              "invalid": "<p>Incorrect. Remonter la page pour retrouver le premier mot&#8239;!</p>"
+              "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p> Vous avez bien remonté la page</p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Remonter la page pour retrouver le premier mot&#8239;!</p>"
             },
             "solution": "2"
           }
@@ -276,8 +276,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct&#8239;! vous nous connaissez bien&nbsp;<span aria-hidden=\"true\">🎉</span></p>",
-              "invalid": "<p>Incorrect&#8239;! vous y arriverez la prochaine fois&#8239;!</p>"
+              "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p> vous nous connaissez bien&nbsp;<span aria-hidden=\"true\">🎉</span></p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect&#8239;!</span><p> vous y arriverez la prochaine fois&#8239;!</p>"
             }
           }
         }
@@ -309,8 +309,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct&#8239;! vous êtes prêt à explorer&nbsp;<span aria-hidden=\"true\">🎉</span></p>",
-              "invalid": "<p>Incorrect&#8239;! vous y arriverez la prochaine fois&#8239;!</p>"
+              "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p> Vous êtes prêt à explorer&nbsp;<span aria-hidden=\"true\">🎉</span></p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect&#8239;!</span><p> Vous y arriverez la prochaine fois&#8239;!</p>"
             }
           }
         }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
@@ -76,8 +76,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Bien vu&#8239;! C'est le titre d'un <a href=\"https://www.sciencesetavenir.fr/sante/cerveau-et-psy/a-huit-mois-un-bebe-comprend-deja-la-notion-d-outil-y-compris-les-nouvelles-technologies_176388\" target=\"_blank\">article du magazine Sciences et Avenir</a>.</p>",
-              "invalid": "<p>Et pourtant, c'est vrai&#8239;! C'est le titre d'un <a href=\"https://www.sciencesetavenir.fr/sante/cerveau-et-psy/a-huit-mois-un-bebe-comprend-deja-la-notion-d-outil-y-compris-les-nouvelles-technologies_176388\" target=\"_blank\">article du magazine Sciences et Avenir</a>.</p>"
+              "valid": "<span class=\"feedback__state\">Bien vu&#8239;!</span><p>C'est le titre d'un <a href=\"https://www.sciencesetavenir.fr/sante/cerveau-et-psy/a-huit-mois-un-bebe-comprend-deja-la-notion-d-outil-y-compris-les-nouvelles-technologies_176388\" target=\"_blank\">article du magazine Sciences et Avenir</a>.</p>",
+              "invalid": "<span class=\"feedback__state\">Et pourtant, c'est vrai&#8239;!</span><p> C'est le titre d'un <a href=\"https://www.sciencesetavenir.fr/sante/cerveau-et-psy/a-huit-mois-un-bebe-comprend-deja-la-notion-d-outil-y-compris-les-nouvelles-technologies_176388\" target=\"_blank\">article du magazine Sciences et Avenir</a>.</p>"
             },
             "solution": "1"
           }
@@ -117,8 +117,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Bravo&#8239;! C'est le titre d'un <a href=\"https://www.slate.fr/story/252022/san-francisco-navettes-sans-conducteurs-autonomes\" target=\"_blank\">article de Slate</a>.</p>",
-              "invalid": "<p>Et pourtant, c'est vrai&#8239;! C'est le titre d'un <a href=\"https://www.slate.fr/story/252022/san-francisco-navettes-sans-conducteurs-autonomes\" target=\"_blank\">article de Slate</a>.</p>"
+              "valid": "<span class=\"feedback__state\">Bravo&#8239;!</span><p> C'est le titre d'un <a href=\"https://www.slate.fr/story/252022/san-francisco-navettes-sans-conducteurs-autonomes\" target=\"_blank\">article de Slate</a>.</p>",
+              "invalid": "<span class=\"feedback__state\">Et pourtant, c'est vrai&#8239;!</span><p> C'est le titre d'un <a href=\"https://www.slate.fr/story/252022/san-francisco-navettes-sans-conducteurs-autonomes\" target=\"_blank\">article de Slate</a>.</p>"
             },
             "solution": "1"
           }
@@ -158,8 +158,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Oui, c'est une fake news&#8239;! C'est le titre d'un <a href=\"https://www.legorafi.fr/2017/03/27/le-professeur-de-techno-forcait-ses-eleves-a-construire-des-porte-cles-lumineux-quil-revendait-sur-les-marches/\" target=\"_blank\">article <strong>parodique</strong> du Gorafi</a>.</p>",
-              "invalid": "<p>Attention, c'est une fake news&#8239;! C'est le titre d'un <a href=\"https://www.legorafi.fr/2017/03/27/le-professeur-de-techno-forcait-ses-eleves-a-construire-des-porte-cles-lumineux-quil-revendait-sur-les-marches/\" target=\"_blank\">article <strong>parodique</strong> du Gorafi</a>.</p>"
+              "valid": "<span class=\"feedback__state\">Oui, c'est une fake news&#8239;!</span><p> C'est le titre d'un <a href=\"https://www.legorafi.fr/2017/03/27/le-professeur-de-techno-forcait-ses-eleves-a-construire-des-porte-cles-lumineux-quil-revendait-sur-les-marches/\" target=\"_blank\">article <strong>parodique</strong> du Gorafi</a>.</p>",
+              "invalid": "<span class=\"feedback__state\">Attention, c'est une fake news&#8239;!</span><p> C'est le titre d'un <a href=\"https://www.legorafi.fr/2017/03/27/le-professeur-de-techno-forcait-ses-eleves-a-construire-des-porte-cles-lumineux-quil-revendait-sur-les-marches/\" target=\"_blank\">article <strong>parodique</strong> du Gorafi</a>.</p>"
             },
             "solution": "2"
           }
@@ -226,8 +226,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct. C'est une opinion, c'est-à-dire un point de vue exprimé.</p>",
-              "invalid": "<p>Incorrect. C'est une opinion, c'est-à-dire un point de vue exprimé.</p>"
+              "valid": "<span class=\"feedback__state\">Correct.</span><p> C'est une opinion, c'est-à-dire un point de vue exprimé.</p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> C'est une opinion, c'est-à-dire un point de vue exprimé.</p>"
             },
             "solution": "1"
           }
@@ -261,8 +261,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct. C'est un détail, c'est un fait qui n'est pas intéressant pour les gens.</p>",
-              "invalid": "<p>Incorrect. C'est un détail, c'est un fait qui n'est pas intéressant pour les gens.</p>"
+              "valid": "<span class=\"feedback__state\">Correct.</span><p> C'est un détail, c'est un fait qui n'est pas intéressant pour les gens.</p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> C'est un détail, c'est un fait qui n'est pas intéressant pour les gens.</p>"
             },
             "solution": "3"
           }
@@ -296,8 +296,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct. Ce qu'a entendu Yann n'est soutenu par aucune source. C'est donc une rumeur.</p>",
-              "invalid": "<p>Incorrect. Ce qu'a entendu Yann n'est soutenu par aucune source. C'est donc une rumeur.</p>"
+              "valid": "<span class=\"feedback__state\">Correct.</span><p> Ce qu'a entendu Yann n'est soutenu par aucune source. C'est donc une rumeur.</p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Ce qu'a entendu Yann n'est soutenu par aucune source. C'est donc une rumeur.</p>"
             },
             "solution": "2"
           }
@@ -385,8 +385,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct. Tous ces éléments permettent de vérifier une information. </p>",
-              "invalid": "<p>Incorrect. Retournez voir la leçon ci-dessus si besoin&nbsp;<span aria-hidden=\"true\">⬆</span>️!</p>"
+              "valid": "<span class=\"feedback__state\">Correct.</span><p> Tous ces éléments permettent de vérifier une information. </p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Retournez voir la leçon ci-dessus si besoin&nbsp;<span aria-hidden=\"true\">⬆</span>️!</p>"
             },
             "solutions": [
               "2",
@@ -441,8 +441,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct. FanDuRealMadrid annonce la venue de Mbappé dans son club favori alors que l’article utilisé comme source ne l’annonce pas du tout&#8239;!</p>",
-              "invalid": "<p>Incorrect. L’article utilisé comme source n’annonce pas du tout la venue de Mbappé. Ce fan a sûrement été influencé par ses envies.</p>"
+              "valid": "<span class=\"feedback__state\">Correct.</span><p> FanDuRealMadrid annonce la venue de Mbappé dans son club favori alors que l’article utilisé comme source ne l’annonce pas du tout&#8239;!</p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> L’article utilisé comme source n’annonce pas du tout la venue de Mbappé. Ce fan a sûrement été influencé par ses envies.</p>"
             },
             "solution": "1"
           }
@@ -486,8 +486,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct. Il faudrait que Jean-Eude précise l’étude qui donne ce résultat pour pouvoir vérifier l’information.</p>",
-              "invalid": "<p>Incorrect. Pour partager sa source, il faudrait que Jean-Eude précise l’étude qui partage ce résultat. </p>"
+              "valid": "<span class=\"feedback__state\">Correct.</span><p> Il faudrait que Jean-Eude précise l’étude qui donne ce résultat pour pouvoir vérifier l’information.</p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Pour partager sa source, il faudrait que Jean-Eude précise l’étude qui partage ce résultat. </p>"
             },
             "solution": "3"
           }
@@ -539,8 +539,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct. La publication de Stéphanie date de 2023 alors que l’article utilisé comme source date de 2021.</p>",
-              "invalid": "<p>Incorrect. En regardant l'article, on voit qu'il a été publié en 2021. Le message de Stéphanie date de 2023, la date de l'information est donc erronée.</p>"
+              "valid": "<span class=\"feedback__state\">Correct.</span><p> La publication de Stéphanie date de 2023 alors que l’article utilisé comme source date de 2021.</p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> En regardant l'article, on voit qu'il a été publié en 2021. Le message de Stéphanie date de 2023, la date de l'information est donc erronée.</p>"
             },
             "solution": "2"
           }
@@ -620,8 +620,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct. Plusieurs indices, comme l'absence de source ou le code promotionnel, poussent à vouloir en savoir plus avant de tester ou de partager ces astuces.</p>",
-              "invalid": "<p>Incorrect. Plusieurs indices, comme l'absence de source ou le code promotionnel, poussent à vouloir en savoir plus avant de tester ou de partager ces astuces.</p>"
+              "valid": "<span class=\"feedback__state\">Correct.</span><p> Plusieurs indices, comme l'absence de source ou le code promotionnel, poussent à vouloir en savoir plus avant de tester ou de partager ces astuces.</p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Plusieurs indices, comme l'absence de source ou le code promotionnel, poussent à vouloir en savoir plus avant de tester ou de partager ces astuces.</p>"
             },
             "solutions": [
               "2",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/mots-de-passe-securises.json
@@ -101,8 +101,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Bien vu&#8239;! Voici la liste des 5 mots de passe les plus utilisés&nbsp;: 123456&#8239;; 123456789&#8239;; azerty&#8239;; 1234561&#8239;; qwerty.<br>Ce sont donc de mauvais mots de passe.</p>",
-              "invalid": "<p>Dommage&#8239;! Voici la liste des 5 mots de passe les plus utilisés&nbsp;: 123456&#8239;; 123456789&#8239;; azerty&#8239;; 1234561&#8239;; qwerty.<br>Ce sont donc de mauvais mots de passe.</p>"
+              "valid": "<span class=\"feedback__state\">Bien vu&#8239;!</span><p> Voici la liste des 5 mots de passe les plus utilisés&nbsp;: 123456&#8239;; 123456789&#8239;; azerty&#8239;; 1234561&#8239;; qwerty.<br>Ce sont donc de mauvais mots de passe.</p>",
+              "invalid": "<span class=\"feedback__state\">Dommage&#8239;!</span><p> Voici la liste des 5 mots de passe les plus utilisés&nbsp;: 123456&#8239;; 123456789&#8239;; azerty&#8239;; 1234561&#8239;; qwerty.<br>Ce sont donc de mauvais mots de passe.</p>"
             }
           }
         }
@@ -224,8 +224,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct. C’est un <strong>mot de passe faible</strong>, c’est-à-dire  facile à trouver.</p>",
-              "invalid": "<p>Incorrect. Plusieurs réponses sont possibles. Avez-vous utilisé la date de naissance d’Austin, par exemple 151184&#8239;? Et utilisé le prénom de son fils Bill&#8239;?</p>"
+              "valid": "<span class=\"feedback__state\">Correct.</span><p> C’est un <strong>mot de passe faible</strong>, c’est-à-dire  facile à trouver.</p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Plusieurs réponses sont possibles. Avez-vous utilisé la date de naissance d’Austin, par exemple 151184&#8239;? Et utilisé le prénom de son fils Bill&#8239;?</p>"
             }
           }
         }
@@ -308,8 +308,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span> </p>",
-              "invalid": "<p>Incorrect&#8239;!</p>"
+              "valid": "<span class=\"feedback__state\">Correct&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span></span>",
+              "invalid": "<span class=\"feedback__state\">Incorrect&#8239;!</span>"
             },
             "solution": "1"
           }
@@ -339,8 +339,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span> </p>",
-              "invalid": "<p>Incorrect&#8239;!</p>"
+              "valid": "<span class=\"feedback__state\">Correct&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span> </span>",
+              "invalid": "<span class=\"feedback__state\">Incorrect&#8239;!</span>"
             },
             "solution": "2"
           }
@@ -370,8 +370,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span> </p>",
-              "invalid": "<p>Incorrect&#8239;!</p>"
+              "valid": "<span class=\"feedback__state\">Correct&#8239;!&nbsp;<span aria-hidden=\"true\">🎉</span> </span>",
+              "invalid": "<span class=\"feedback__state\">Incorrect&#8239;!</span>"
             },
             "solution": "1"
           }
@@ -455,8 +455,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct. Un mot de passe long est plus solide. Se servir d'une phrase permet de mieux s'en souvenir. </p>",
-              "invalid": "<p>Incorrect. Un mot de passe long est plus solide. Se servir d'une phrase permet de mieux s'en souvenir.</p>"
+              "valid": "<span class=\"feedback__state\">Correct.</span><p> Un mot de passe long est plus solide. Se servir d'une phrase permet de mieux s'en souvenir. </p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Un mot de passe long est plus solide. Se servir d'une phrase permet de mieux s'en souvenir.</p>"
             },
             "solutions": [
               "1",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/ports-connexions-essentiels.json
@@ -256,8 +256,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Oui&#8239;! cette souris filaire se branche à un port USB.</p>",
-              "invalid": "<p>Attention&#8239;! Regardez bien l’extrémité du fil de cette souris. Elle se branche à un port USB.</p>"
+              "valid": "<span class=\"feedback__state\">Oui&#8239;!</span><p> cette souris filaire se branche à un port USB.</p>",
+              "invalid": "<span class=\"feedback__state\">Attention&#8239;!</span><p> Regardez bien l’extrémité du fil de cette souris. Elle se branche à un port USB.</p>"
             },
             "solution": "1"
           }
@@ -297,8 +297,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct&#8239;! Ce casque audio ne se branche pas à un port USB. Il se branche à un port jack.</p>",
-              "invalid": "<p>Attention&#8239;! Regardez bien l’extrémité du fil de ce casque audio. Il ne se branche pas en USB.</p>"
+              "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p> Ce casque audio ne se branche pas à un port USB. Il se branche à un port jack.</p>",
+              "invalid": "<span class=\"feedback__state\">Attention&#8239;!</span><p> Regardez bien l’extrémité du fil de ce casque audio. Il ne se branche pas en USB.</p>"
             },
             "solution": "2"
           }
@@ -338,8 +338,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Bien vu&#8239;! Ce symbole peut changer un peu sur des ports USB plus récents.</p>",
-              "invalid": "<p>Et si&#8239;! Retenez ce symbole, il vous aidera à trouver les branchements USB.</p>"
+              "valid": "<span class=\"feedback__state\">Bien vu&#8239;!</span><p> Ce symbole peut changer un peu sur des ports USB plus récents.</p>",
+              "invalid": "<span class=\"feedback__state\">Et si&#8239;!</span><p> Retenez ce symbole, il vous aidera à trouver les branchements USB.</p>"
             },
             "solution": "1"
           }
@@ -579,8 +579,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct. Vous avez bien identifié le port USB.</p>",
-              "invalid": "<p>Incorrect. Remontez voir les différents ports pour trouver le port <strong>USB</strong>.</p>"
+              "valid": "<span class=\"feedback__state\">Correct.</span><p> Vous avez bien identifié le port USB.</p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Remontez voir les différents ports pour trouver le port <strong>USB</strong>.</p>"
             },
             "solution": "4"
           }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
@@ -92,8 +92,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct&#8239;!</p>",
-              "invalid": "<p>Incorrect. La construction permanente et les différentes langues de Wikipédia sont symbolisées prioritairement à travers ce logo.</p>"
+              "valid": "<span class=\"feedback__state\">Correct&#8239;!</span>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> La construction permanente et les différentes langues de Wikipédia sont symbolisées prioritairement à travers ce logo.</p>"
             },
             "solutions": ["1", "4"]
           }
@@ -213,8 +213,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct. Vous avez bien identifié les principes de Wikipédia. </p>",
-              "invalid": "<p>Incorrect. Remonter la page pour relire la leçon.&nbsp;<span aria-hidden=\"true\">⬆</span>️</p>"
+              "valid": "<span class=\"feedback__state\">Correct.</span><p> Vous avez bien identifié les principes de Wikipédia. </p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Remonter la page pour relire la leçon.&nbsp;<span aria-hidden=\"true\">⬆</span>️</p>"
             },
             "solutions": ["1", "3", "4"]
           }
@@ -251,8 +251,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct. Il y a une représentation inégale entre ces langues&nbsp;: on compte environ 7 millions d’articles en anglais, 2 millions en français et 7 000 en tibétain.</p>",
-              "invalid": "<p>Incorrect. La réponse est 250.<br>Il y a une représentation inégale entre ces langues&nbsp;: on compte environ 7 millions d’articles en anglais, 2 millions en français et 7 000 en tibétain.</p>"
+              "valid": "<span class=\"feedback__state\">Correct.</span><p> Il y a une représentation inégale entre ces langues&nbsp;: on compte environ 7 millions d’articles en anglais, 2 millions en français et 7 000 en tibétain.</p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> La réponse est 250.<br>Il y a une représentation inégale entre ces langues&nbsp;: on compte environ 7 millions d’articles en anglais, 2 millions en français et 7 000 en tibétain.</p>"
             },
             "solution": "2"
           }
@@ -285,8 +285,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Oui. Wikipédia est géré par une association à but non lucratif, financé par des donations d’utilisateurs.</p>",
-              "invalid": "<p>Incorrect. Dans ce cas, le principe de neutralité ne serait pas respecté. Wikipédia est géré par une association à but non lucratif, financé par des donations d’utilisateurs.</p>"
+              "valid": "<span class=\"feedback__state\">Oui, c'est correct.</span><p> Wikipédia est géré par une association à but non lucratif, financé par des donations d’utilisateurs.</p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Dans ce cas, le principe de neutralité ne serait pas respecté. Wikipédia est géré par une association à but non lucratif, financé par des donations d’utilisateurs.</p>"
             },
             "solution": "3"
           }
@@ -365,8 +365,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct&#8239;!</p>",
-              "invalid": "<p>Incorrect.</p>"
+              "valid": "<span class=\"feedback__state\">Correct&#8239;!</span>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span>"
             }
           }
         },
@@ -403,8 +403,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct&#8239;!</p>",
-              "invalid": "<p>Incorrect.</p>"
+              "valid": "<span class=\"feedback__state\">Correct&#8239;!</span>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span>"
             }
           }
         },
@@ -453,8 +453,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct&#8239;!</p>",
-              "invalid": "<p>Incorrect.</p>"
+              "valid": "<span class=\"feedback__state\">Correct&#8239;!</span>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span>"
             }
           }
         }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
@@ -197,8 +197,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct. La source d'une information est la personne <strong>témoin</strong> de l'information.</p>",
-              "invalid": "<p>Incorrect. La date ou le moyen de partage ne sont pas la source d'une information.</p>"
+              "valid": "<span class=\"feedback__state\">Correct.</span><p> La source d'une information est la personne <strong>témoin</strong> de l'information.</p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> La date ou le moyen de partage ne sont pas la source d'une information.</p>"
             },
             "solution": "3"
           }
@@ -258,8 +258,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Oui, la professeure Saturne explique qu'il n'y avait pas de soucoupe volante. Son équipe et elle ont pu observer l'aurore boréale au télescope.</p>",
-              "invalid": "<p>Incorrect. Madame Sarah n'est pas présente et le journaliste Dupont écoute le témoignage de la professeure Saturne.</p>"
+              "valid": "<span class=\"feedback__state\">Oui,c'est correct.</span><p> la professeure Saturne explique qu'il n'y avait pas de soucoupe volante. Son équipe et elle ont pu observer l'aurore boréale au télescope.</p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Madame Sarah n'est pas présente et le journaliste Dupont écoute le témoignage de la professeure Saturne.</p>"
             },
             "solution": "2"
           }
@@ -381,8 +381,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct. Les publications de JournalDeBlagues ont pour objectif de faire rire.</p>",
-              "invalid": "<p>Incorrect. Les publications de JournalDeBlagues ont pour objectif de faire rire.</p>"
+              "valid": "<span class=\"feedback__state\">Correct.</span><p> Les publications de JournalDeBlagues ont pour objectif de faire rire.</p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Les publications de JournalDeBlagues ont pour objectif de faire rire.</p>"
             },
             "solution": "2"
           }
@@ -426,8 +426,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct. Ce journal est reconnu et vérifie les informations qu’il publie. Ces informations sont donc très souvent vraies.</p>",
-              "invalid": "<p>Incorrect. Ce journal est reconnu et vérifie les informations qu’il publie. Ces informations sont donc très souvent vraies.</p>"
+              "valid": "<span class=\"feedback__state\">Correct.</span><p> Ce journal est reconnu et vérifie les informations qu’il publie. Ces informations sont donc très souvent vraies.</p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Ce journal est reconnu et vérifie les informations qu’il publie. Ces informations sont donc très souvent vraies.</p>"
             },
             "solution": "1"
           }
@@ -471,8 +471,8 @@
               }
             ],
             "feedbacks": {
-              "valid": "<p>Correct. L’auteur présente des informations fausses ou incomplètes et qui servent ses intérêts. Il n’est pas neutre ou expert.</p>",
-              "invalid": "<p>Incorrect. L’auteur présente des informations fausses ou incomplètes et qui servent ses intérêts. Il n’est pas neutre ou expert.</p>"
+              "valid": "<span class=\"feedback__state\">Correct.</span><p> L’auteur présente des informations fausses ou incomplètes et qui servent ses intérêts. Il n’est pas neutre ou expert.</p>",
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> L’auteur présente des informations fausses ou incomplètes et qui servent ses intérêts. Il n’est pas neutre ou expert.</p>"
             },
             "solution": "3"
           }

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -107,7 +107,7 @@ describe('Acceptance | Controller | passage-controller', function () {
           userResponse: [{ input: 'email', answer: 'naomizao457@yahoo.com' }],
           expectedUserResponseValue: { email: 'naomizao457@yahoo.com' },
           expectedFeedback:
-            "<p>Correct.&nbsp;<span aria-hidden=\"true\">🎉</span> Tout est dans l'ordre&nbsp;: l'identifiant, l'arobase puis le fournisseur d'adresse mail</p>",
+            '<span class="feedback__state">Correct.&nbsp;<span aria-hidden="true">🎉</span></span><p>Tout est dans l\'ordre&nbsp;: l\'identifiant, l\'arobase puis le fournisseur d\'adresse mail</p>',
           expectedSolution: {
             email: ['naomizao457@yahoo.com', 'naomizao457@yahoo.fr'],
           },

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -97,7 +97,7 @@ describe('Acceptance | Controller | passage-controller', function () {
           userResponse: ['1'],
           expectedUserResponseValue: '1',
           expectedFeedback:
-            '<p class="pix-list-inline">Oui, aucun problème&#8239;! Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>',
+            '<p class="feedback__state">Oui, aucun problème&#8239;!</p><p class="pix-list-inline">Seuls certains caractères sont interdits, comme</p><ul><li>é</li><li>â</li><li>&amp;</li><li>@</li><li>$</li><li>*</li><li>€</li><li>£</li><li>etc.</li></ul>',
           expectedSolution: '1',
         },
         {

--- a/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/passages/passage-controller_test.js
@@ -118,7 +118,8 @@ describe('Acceptance | Controller | passage-controller', function () {
           elementId: '30701e93-1b4d-4da4-b018-fa756c07d53f',
           userResponse: ['1', '3', '4'],
           expectedUserResponseValue: ['1', '3', '4'],
-          expectedFeedback: '<p>Correct&#8239;! Vous nous avez bien cernés&nbsp;:)</p>',
+          expectedFeedback:
+            '<span class="feedback__state">Correct&#8239;!</span><p>Vous nous avez bien cernés&nbsp;:)</p>',
           expectedSolution: ['1', '3', '4'],
         },
       ];

--- a/api/tests/devcomp/integration/repositories/element-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/element-repository_test.js
@@ -25,8 +25,10 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
           },
         ],
         feedbacks: {
-          valid: '<p>Correct&#8239;! Ces 16 compétences sont rangées dans 5 domaines.</p>',
-          invalid: '<p>Incorrect. Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>️!</p>',
+          valid:
+            '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
+          invalid:
+            '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>️!</p>',
         },
         solution: '1',
       });

--- a/api/tests/devcomp/integration/repositories/element-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/element-repository_test.js
@@ -2,7 +2,7 @@ import { QCUForAnswerVerification } from '../../../../src/devcomp/domain/models/
 import moduleDatasource from '../../../../src/devcomp/infrastructure/datasources/learning-content/module-datasource.js';
 import * as elementRepository from '../../../../src/devcomp/infrastructure/repositories/element-repository.js';
 import { NotFoundError } from '../../../../src/shared/domain/errors.js';
-import { catchErr, expect } from '../../../test-helper.js';
+import { catchErr, expect, sinon } from '../../../test-helper.js';
 
 describe('Integration | DevComp | Repositories | ElementRepository', function () {
   describe('#getByIdForAnswerVerification', function () {
@@ -32,12 +32,61 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
         },
         solution: '1',
       });
+      const moduleDatasourceStub = {
+        getBySlug: sinon.stub(),
+      };
+      moduleDatasourceStub.getBySlug.withArgs(moduleId).resolves({
+        id: '6282925d-4775-4bca-b513-4c3009ec5886',
+        slug: 'didacticiel-modulix',
+        title: 'Didacticiel Modulix',
+        details: {
+          image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+          description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',
+          duration: 5,
+          level: 'Débutant',
+          objectives: ['Naviguer dans Modulix', 'Découvrir les leçons et les activités'],
+        },
+        grains: [
+          {
+            id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+            type: 'lesson',
+            title: 'Voici une leçon',
+            components: [
+              {
+                type: 'element',
+                element: {
+                  id: '71de6394-ff88-4de3-8834-a40057a50ff4',
+                  type: 'qcu',
+                  instruction: '<p>Pix évalue 16 compétences numériques différentes.</p>',
+                  proposals: [
+                    {
+                      id: '1',
+                      content: 'Vrai',
+                    },
+                    {
+                      id: '2',
+                      content: 'Faux',
+                    },
+                  ],
+                  feedbacks: {
+                    valid:
+                      '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
+                    invalid:
+                      '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>️!</p>',
+                  },
+                  solution: '1',
+                },
+              },
+            ],
+          },
+        ],
+      });
 
       // when
       const foundElement = await elementRepository.getByIdForAnswerVerification({
         moduleId,
         elementId,
-        moduleDatasource,
+        moduleDatasource: moduleDatasourceStub,
       });
 
       // then

--- a/api/tests/devcomp/unit/domain/services/solution-service-qcm_test.js
+++ b/api/tests/devcomp/unit/domain/services/solution-service-qcm_test.js
@@ -1,5 +1,5 @@
 import { AnswerStatus } from '../../../../../src/devcomp/domain/models/validator/AnswerStatus.js';
-import * as service from '../../../../../src/devcomp/domain/services/solution-service-qcm.js';
+import service from '../../../../../src/devcomp/domain/services/solution-service-qcm.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Services | SolutionServiceQCM ', function () {

--- a/api/tests/devcomp/unit/domain/services/solution-service-qcu_test.js
+++ b/api/tests/devcomp/unit/domain/services/solution-service-qcu_test.js
@@ -1,5 +1,5 @@
 import { AnswerStatus } from '../../../../../src/devcomp/domain/models/validator/AnswerStatus.js';
-import * as service from '../../../../../src/devcomp/domain/services/solution-service-qcu.js';
+import service from '../../../../../src/devcomp/domain/services/solution-service-qcu.js';
 import { expect } from '../../../../test-helper.js';
 
 describe('Unit | Devcomp | Domain | Services | SolutionServiceQCU ', function () {

--- a/api/tests/devcomp/unit/domain/services/solution-service-qrocm-ind_test.js
+++ b/api/tests/devcomp/unit/domain/services/solution-service-qrocm-ind_test.js
@@ -1,4 +1,4 @@
-import * as service from '../../../../../src/devcomp/domain/services/solution-service-qrocm-ind.js';
+import service from '../../../../../src/devcomp/domain/services/solution-service-qrocm-ind.js';
 import { AnswerStatus } from '../../../../../src/shared/domain/models/AnswerStatus.js';
 import { catchErr, expect } from '../../../../test-helper.js';
 

--- a/mon-pix/app/components/module/element/module-element.js
+++ b/mon-pix/app/components/module/element/module-element.js
@@ -10,8 +10,8 @@ export default class ModuleElement extends Component {
     return this.args.element;
   }
 
-  get feedbackType() {
-    return this.correction?.isOk ? 'success' : 'error';
+  get answerIsValid() {
+    return this.correction?.isOk;
   }
 
   get disableInput() {

--- a/mon-pix/app/components/module/element/qcm.hbs
+++ b/mon-pix/app/components/module/element/qcm.hbs
@@ -47,9 +47,9 @@
 
   <div class="element-qcm__feedback" role="status" tabindex="-1">
     {{#if this.shouldDisplayFeedback}}
-      <PixMessage @type={{this.feedbackType}} @withIcon={{true}} class="element-qcm-feedback__message">
+      <Modulix::Feedback @answerIsValid={{this.answerIsValid}}>
         {{html-unsafe this.correction.feedback}}
-      </PixMessage>
+      </Modulix::Feedback>
     {{/if}}
   </div>
 

--- a/mon-pix/app/components/module/element/qcu.hbs
+++ b/mon-pix/app/components/module/element/qcu.hbs
@@ -50,9 +50,9 @@
 
   <div class="element-qcu__feedback" role="status" tabindex="-1">
     {{#if this.shouldDisplayFeedback}}
-      <PixMessage @type={{this.feedbackType}} @withIcon={{true}} class="element-qcu-feedback__message">
+      <Modulix::Feedback @answerIsValid={{this.answerIsValid}}>
         {{html-unsafe this.correction.feedback}}
-      </PixMessage>
+      </Modulix::Feedback>
     {{/if}}
   </div>
 

--- a/mon-pix/app/components/module/element/qrocm.hbs
+++ b/mon-pix/app/components/module/element/qrocm.hbs
@@ -79,9 +79,9 @@
 
   <div class="element-qrocm__feedback" role="status" tabindex="-1">
     {{#if this.shouldDisplayFeedback}}
-      <PixMessage @type={{this.feedbackType}} @withIcon={{true}} class="element-qrocm-feedback__message">
+      <Modulix::Feedback @answerIsValid={{this.answerIsValid}}>
         {{html-unsafe this.correction.feedback}}
-      </PixMessage>
+      </Modulix::Feedback>
     {{/if}}
   </div>
 

--- a/mon-pix/app/components/modulix/feedback.gjs
+++ b/mon-pix/app/components/modulix/feedback.gjs
@@ -1,0 +1,15 @@
+import Component from '@glimmer/component';
+import PixMessage from '@1024pix/pix-ui/components/pix-message';
+import { htmlUnsafe } from 'mon-pix/helpers/html-unsafe';
+
+export default class ModulixFeedback extends Component {
+  get type() {
+    return this.args.answerIsValid ? 'success' : 'error';
+  }
+
+  <template>
+    <PixMessage @type={{this.type}} @withIcon={{true}} class="element-qcm-feedback__message">
+      {{yield}}
+    </PixMessage>
+  </template>
+}

--- a/mon-pix/app/components/modulix/feedback.gjs
+++ b/mon-pix/app/components/modulix/feedback.gjs
@@ -1,6 +1,4 @@
 import Component from '@glimmer/component';
-import PixMessage from '@1024pix/pix-ui/components/pix-message';
-import { htmlUnsafe } from 'mon-pix/helpers/html-unsafe';
 
 export default class ModulixFeedback extends Component {
   get type() {
@@ -8,8 +6,8 @@ export default class ModulixFeedback extends Component {
   }
 
   <template>
-    <PixMessage @type={{this.type}} @withIcon={{true}} class="element-qcm-feedback__message">
+    <div class="feedback feedback--{{this.type}}">
       {{yield}}
-    </PixMessage>
+    </div>
   </template>
 }

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -121,6 +121,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @import 'components/pix-toggle';
 @import 'components/skip-link';
 @import 'components/campaigns/assessment/skill-review/share-badge-icons';
+@import 'components/modulix/feedback';
 
 /* pages */
 @import 'pages/assessment-results';

--- a/mon-pix/app/styles/components/modulix/_feedback.scss
+++ b/mon-pix/app/styles/components/modulix/_feedback.scss
@@ -1,0 +1,14 @@
+.feedback {
+  &--success {
+    --modulix-feedback-state-color: var(--pix-success-700);
+  }
+
+  &--error {
+    --modulix-feedback-state-color: var(--pix-error-700);
+  }
+
+  &__state {
+    color: var(--modulix-feedback-state-color);
+    font-weight: var(--pix-font-bold);
+  }
+}

--- a/mon-pix/tests/unit/components/module/qcm_test.js
+++ b/mon-pix/tests/unit/components/module/qcm_test.js
@@ -1,0 +1,56 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+
+module('Unit | Component | Module | QCM', function (hooks) {
+  setupTest(hooks);
+
+  module('#answerIsValid', function () {
+    module('When correction status is ko', function () {
+      test('should be error', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const correctionResponse = store.createRecord('correction-response', { status: 'ko' });
+        const qcmElement = { id: '994b6a96-a3c2-47ae-a461-87548ac6e02b' };
+        store.createRecord('element-answer', {
+          correction: correctionResponse,
+          element: qcmElement,
+        });
+        const component = createGlimmerComponent('module/element/qcm', {
+          qcm: qcmElement,
+          correction: correctionResponse,
+        });
+
+        // when
+        const answerIsValid = component.answerIsValid;
+
+        // then
+        assert.false(answerIsValid);
+      });
+    });
+
+    module('When correction status is ok', function () {
+      test('should be success', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const correctionResponse = store.createRecord('correction-response', { status: 'ok' });
+        const qcmElement = { id: 'qcm-id' };
+        store.createRecord('element-answer', {
+          correction: correctionResponse,
+          elementId: qcmElement.id,
+        });
+        const component = createGlimmerComponent('module/element/qcm', {
+          qcm: qcmElement,
+          correction: correctionResponse,
+        });
+
+        // when
+        const answerIsValid = component.answerIsValid;
+
+        // then
+        assert.true(answerIsValid);
+      });
+    });
+  });
+});

--- a/mon-pix/tests/unit/components/module/qcu_test.js
+++ b/mon-pix/tests/unit/components/module/qcu_test.js
@@ -6,7 +6,7 @@ import createGlimmerComponent from '../../../helpers/create-glimmer-component';
 module('Unit | Component | Module | QCU', function (hooks) {
   setupTest(hooks);
 
-  module('#feedbackType', function () {
+  module('#answerIsValid', function () {
     module('When correction status is ko', function () {
       test('should be error', async function (assert) {
         // given
@@ -23,10 +23,10 @@ module('Unit | Component | Module | QCU', function (hooks) {
         });
 
         // when
-        const feedbackType = component.feedbackType;
+        const answerIsValid = component.answerIsValid;
 
         // then
-        assert.strictEqual(feedbackType, 'error');
+        assert.false(answerIsValid);
       });
     });
 
@@ -46,10 +46,10 @@ module('Unit | Component | Module | QCU', function (hooks) {
         });
 
         // when
-        const feedbackType = component.feedbackType;
+        const answerIsValid = component.answerIsValid;
 
         // then
-        assert.strictEqual(feedbackType, 'success');
+        assert.true(answerIsValid);
       });
     });
   });

--- a/mon-pix/tests/unit/components/module/qrocm_test.js
+++ b/mon-pix/tests/unit/components/module/qrocm_test.js
@@ -1,0 +1,56 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+
+module('Unit | Component | Module | QROCM', function (hooks) {
+  setupTest(hooks);
+
+  module('#answerIsValid', function () {
+    module('When correction status is ko', function () {
+      test('should be error', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const correctionResponse = store.createRecord('correction-response', { status: 'ko' });
+        const qrocmElement = { id: '994b6a96-a3c2-47ae-a461-87548ac6e02b' };
+        store.createRecord('element-answer', {
+          correction: correctionResponse,
+          element: qrocmElement,
+        });
+        const component = createGlimmerComponent('module/element/qrocm', {
+          qrocm: qrocmElement,
+          correction: correctionResponse,
+        });
+
+        // when
+        const answerIsValid = component.answerIsValid;
+
+        // then
+        assert.false(answerIsValid);
+      });
+    });
+
+    module('When correction status is ok', function () {
+      test('should be success', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const correctionResponse = store.createRecord('correction-response', { status: 'ok' });
+        const qrocmElement = { id: 'qrocm-id' };
+        store.createRecord('element-answer', {
+          correction: correctionResponse,
+          elementId: qrocmElement.id,
+        });
+        const component = createGlimmerComponent('module/element/qrocm', {
+          qrocm: qrocmElement,
+          correction: correctionResponse,
+        });
+
+        // when
+        const answerIsValid = component.answerIsValid;
+
+        // then
+        assert.true(answerIsValid);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Les feedbacks après qu'un utilisateur réponde à un élément sont englobés dans un [`PixMessage`](https://ui.pix.fr/?path=/docs/notification-message--docs) un peu imposant.

## :robot: Proposition
Une toute petite première étape pour ne pas impacter le modèle de données est de bien se synchroniser avec le contenu et séparer sémantiquement ces deux informations dans le "réferentiel" Modulix.

On permet ainsi l'usage d'une classe CSS `feedback__state` par l'équipe Contenu, qui met en avant le feedback de "constat" (OK/KO). Le feedback de diagnostic ne nécessite pas d'usage de classe CSS. On souhaite laisser la liberté de choisir le contenu textuel du feedback.

## :rainbow: Remarques
Les feedbacks "techniques" de type "Le champ de réponse n'a pas été rempli" n'ont pas été revus.

## :100: Pour tester
### Dev 
CI 🍏 
Nouveau visuel pour les feedbacks.
Pas de régression.

### Contenus
Tous les modules doivent avoir migré : 
- [x] https://app-pr9060.review.pix.fr/modules/bien-ecrire-son-adresse-mail/passage
- [x] https://app-pr9060.review.pix.fr/modules/adresse-ip-publique-et-vous/passage
- [x] https://app-pr9060.review.pix.fr/modules/didacticiel-modulix/passage
- [x] https://app-pr9060.review.pix.fr/modules/distinguer-vrai-faux-sur-internet/passage
- [x] https://app-pr9060.review.pix.fr/modules/mots-de-passe-securises/passage
- [x] https://app-pr9060.review.pix.fr/modules/ports-connexions-essentiels/passage
- [x] https://app-pr9060.review.pix.fr/modules/principes-fondateurs-wikipedia/passage
- [x] https://app-pr9060.review.pix.fr/modules/sources-informations/passage