### PR TITLE
[FEATURES] Ajout d'un label informatif pour les QCU / QCM (Pix-12592)

### DIFF
--- a/junior/app/pods/components/challenge/challenge-item-qcm/template.hbs
+++ b/junior/app/pods/components/challenge/challenge-item-qcm/template.hbs
@@ -1,4 +1,5 @@
 <div class="challenge-item-proposals__qcm-checkboxes">
+  <p class="challenge-item-proposals__qcm-checkboxes__hint">{{t "pages.challenge.qcm-hint"}}</p>
   {{#each this.labeledCheckboxes as |labeledCheckbox|}}
     <PixCheckbox
       name="{{labeledCheckbox.value}}"

--- a/junior/app/pods/components/challenge/challenge-item-qcu/template.hbs
+++ b/junior/app/pods/components/challenge/challenge-item-qcu/template.hbs
@@ -1,4 +1,5 @@
 <div class="challenge-item-proposals__qcu-radios">
+  <p class="challenge-item-proposals__qcu-radios__hint">{{t "pages.challenge.qcu-hint"}}</p>
   {{#each this.labeledRadios as |labeledRadio|}}
     <PixRadioButton
       name="radio"

--- a/junior/app/pods/components/challenge/item/challenge-item-proposals.scss
+++ b/junior/app/pods/components/challenge/item/challenge-item-proposals.scss
@@ -31,6 +31,13 @@
     display: flex;
     flex-direction: column;
     width: 100%;
+
+    &__hint {
+      margin-bottom: 10px;
+      color: var(--pix-neutral-700);
+      font-size: 16px;
+      text-align: start;
+    }
   }
 }
 

--- a/junior/translations/fr.json
+++ b/junior/translations/fr.json
@@ -14,7 +14,10 @@
       "messages": {
         "correct-answer": "Bien joué, tu as répondu correctement !",
         "wrong-answer": "Mauvaise réponse. Tu peux passer à la suite."
-      }
+      },
+        "qcu-hint": "Sélectionne une seule réponse.",
+        "qcm-hint": "Sélectionne plusieurs réponses."
+
     },
     "home": {
       "page-title": "Page d'accueil",


### PR DESCRIPTION
## :unicorn: Problème
Les utilisateurs ont du mal à différencier les QCU et QCM.

## :robot: Proposition
Ajouter un label pour informer du nombre de réponse à sélectionner.

## :100: Pour tester
Lancer la RA et tomber sur un QCU ou QCM et voir une petite phrase en haut du challenge qui informe du nombre de réponse

Pour tester en RA :
QCM : https://junior-pr9061.review.pix.fr/challenges/reco3jUKgbjd7RmYu/preview
QCU : https://junior-pr9061.review.pix.fr/challenges/challenge18EjFM4ZjSxa8i/preview