### PR TITLE
[TECH] Remettre la version 14.11 de postgres

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ executors:
         type: string
     docker:
       - image: cimg/node:<<parameters.node-version>>
-      - image: postgres:14.12-alpine
+      - image: postgres:14.11-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
@@ -70,7 +70,7 @@ executors:
         type: string
     docker:
       - image: cimg/node:<<parameters.node-version>>-browsers
-      - image: postgres:14.12-alpine
+      - image: postgres:14.11-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
@@ -84,7 +84,7 @@ executors:
         type: string
     docker:
       - image: cimg/node:<<parameters.node-version>>
-      - image: postgres:14.12-alpine
+      - image: postgres:14.11-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:14.12-alpine
+    image: postgres:14.11-alpine
     container_name: pix-api-postgres
     ports:
       - '${PIX_DATABASE_PORT:-5432}:5432'

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -4,7 +4,7 @@ version: '3'
 services:
 
   postgres:
-    image: postgres:14.12-alpine
+    image: postgres:14.11-alpine
     container_name: pix-api-postgres
     ports:
       - '${PIX_DATABASE_PORT:-5432}:5432'

--- a/high-level-tests/e2e/docker-compose.yaml
+++ b/high-level-tests/e2e/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   postgres:
-    image: postgres:14.12-alpine
+    image: postgres:14.11-alpine
     container_name: pix-e2e-postgres
     environment:
       POSTGRES_DB: pix

--- a/scalingo.json
+++ b/scalingo.json
@@ -25,7 +25,7 @@
     {
       "plan": "postgresql:postgresql-sandbox",
       "options": {
-        "version": "14.12"
+        "version": "14.11"
       }
     },
     {


### PR DESCRIPTION
## :unicorn: Problème
La PR de [renovate](https://github.com/1024pix/pix/pull/9024) a monté la version de postgres en 14.12. Cependant, cette version n'est pas encore proposée par Scalingo et empêche le déploiement des RA.

## :robot: Proposition
Remettre la version 14.11

## :rainbow: Remarques
Dans un soucis d'uniformisation, la version a été modifié aussi pour la CI et les docker locaux.