### PR TITLE
[TECH] Récupération de la version de certification dans le modèle (PIX-11689).

### DIFF
--- a/api/lib/domain/events/handle-auto-jury.js
+++ b/api/lib/domain/events/handle-auto-jury.js
@@ -1,6 +1,5 @@
 import bluebird from 'bluebird';
 
-import { CertificationVersion } from '../../../src/certification/shared/domain/models/CertificationVersion.js';
 import { CertificationIssueReportResolutionAttempt } from '../models/CertificationIssueReportResolutionAttempt.js';
 import { CertificationIssueReportResolutionStrategies } from '../models/CertificationIssueReportResolutionStrategies.js';
 import { CertificationAssessment } from '../models/index.js';
@@ -101,7 +100,7 @@ async function _handleAutoJuryV2({
 }
 
 function _areV3CertificationCourses(certificationCourses) {
-  return certificationCourses[0].getVersion() === CertificationVersion.V3;
+  return certificationCourses[0].isV3();
 }
 
 async function _handleAutoJuryV3({ certificationCourses, certificationAssessmentRepository, event }) {

--- a/api/lib/domain/events/handle-certification-rescoring.js
+++ b/api/lib/domain/events/handle-certification-rescoring.js
@@ -41,7 +41,7 @@ async function handleCertificationRescoring({
     certificationCourseId: event.certificationCourseId,
   });
 
-  if (certificationAssessment.version === CertificationVersion.V3) {
+  if (CertificationVersion.isV3(certificationAssessment.version)) {
     return _handleV3CertificationScoring({
       certificationAssessment,
       event,

--- a/api/lib/domain/events/handle-certification-scoring.js
+++ b/api/lib/domain/events/handle-certification-scoring.js
@@ -33,7 +33,7 @@ async function handleCertificationScoring({
 
   const certificationAssessment = await certificationAssessmentRepository.get(event.assessmentId);
 
-  if (certificationAssessment.version === CertificationVersion.V3) {
+  if (CertificationVersion.isV3(certificationAssessment.version)) {
     return _handleV3CertificationScoring({
       certificationAssessment,
       locale: event.locale,

--- a/api/lib/domain/services/placement-profile-service.js
+++ b/api/lib/domain/services/placement-profile-service.js
@@ -1,7 +1,10 @@
 import bluebird from 'bluebird';
 import _ from 'lodash';
 
-import { CertificationVersion } from '../../../src/certification/shared/domain/models/CertificationVersion.js';
+import {
+  CERTIFICATION_VERSIONS,
+  CertificationVersion,
+} from '../../../src/certification/shared/domain/models/CertificationVersion.js';
 import * as scoringService from '../../../src/evaluation/domain/services/scoring/scoring-service.js';
 import * as assessmentRepository from '../../../src/shared/infrastructure/repositories/assessment-repository.js';
 import * as assessmentResultRepository from '../../../src/shared/infrastructure/repositories/assessment-result-repository.js';
@@ -15,12 +18,12 @@ import { UserCompetence } from '../models/UserCompetence.js';
 async function getPlacementProfile({
   userId,
   limitDate,
-  version = CertificationVersion.V2,
+  version = CERTIFICATION_VERSIONS.V2,
   allowExcessPixAndLevels = true,
   locale,
 }) {
   const pixCompetences = await competenceRepository.listPixCompetencesOnly({ locale });
-  if (version !== CertificationVersion.V1) {
+  if (!CertificationVersion.isV1(version)) {
     return _generatePlacementProfile({
       userId,
       profileDate: limitDate,

--- a/api/lib/domain/services/scoring/scoring-certification-service.js
+++ b/api/lib/domain/services/scoring/scoring-certification-service.js
@@ -6,7 +6,7 @@ import { CertificationAssessmentHistory } from '../../../../src/certification/sc
 import { CertificationAssessmentScore } from '../../../../src/certification/scoring/domain/models/CertificationAssessmentScore.js';
 import { CertificationAssessmentScoreV3 } from '../../../../src/certification/scoring/domain/models/CertificationAssessmentScoreV3.js';
 import { AssessmentResultFactory } from '../../../../src/certification/scoring/domain/models/factories/AssessmentResultFactory.js';
-import { CertificationVersion } from '../../../../src/certification/shared/domain/models/CertificationVersion.js';
+import { CERTIFICATION_VERSIONS } from '../../../../src/certification/shared/domain/models/CertificationVersion.js';
 import * as scoringService from '../../../../src/evaluation/domain/services/scoring/scoring-service.js';
 import { config } from '../../../../src/shared/config.js';
 import { AssessmentResult } from '../../../../src/shared/domain/models/AssessmentResult.js';
@@ -32,7 +32,7 @@ const calculateCertificationAssessmentScore = async function ({
   const testedCompetences = await _getTestedCompetences({
     userId: certificationAssessment.userId,
     limitDate: certificationAssessment.createdAt,
-    version: CertificationVersion.V2,
+    version: CERTIFICATION_VERSIONS.V2,
     placementProfileService: dependencies.placementProfileService,
   });
 

--- a/api/lib/domain/usecases/get-certification-details.js
+++ b/api/lib/domain/usecases/get-certification-details.js
@@ -1,4 +1,4 @@
-import { CertificationVersion } from '../../../src/certification/shared/domain/models/CertificationVersion.js';
+import { CERTIFICATION_VERSIONS } from '../../../src/certification/shared/domain/models/CertificationVersion.js';
 import { CertificationDetails } from '../read-models/CertificationDetails.js';
 
 const getCertificationDetails = async function ({
@@ -39,7 +39,7 @@ async function _computeCertificationDetailsOnTheFly(
   const placementProfile = await placementProfileService.getPlacementProfile({
     userId: certificationAssessment.userId,
     limitDate: certificationAssessment.createdAt,
-    version: CertificationVersion.V2,
+    version: CERTIFICATION_VERSIONS.V2,
     allowExcessPixAndLevels: false,
   });
 
@@ -58,7 +58,7 @@ async function _retrievePersistedCertificationDetails(
   const placementProfile = await placementProfileService.getPlacementProfile({
     userId: certificationAssessment.userId,
     limitDate: certificationAssessment.createdAt,
-    version: CertificationVersion.V2,
+    version: CERTIFICATION_VERSIONS.V2,
     allowExcessPixAndLevels: false,
   });
 

--- a/api/lib/domain/usecases/link-user-to-session-certification-candidate.js
+++ b/api/lib/domain/usecases/link-user-to-session-certification-candidate.js
@@ -30,7 +30,7 @@ const linkUserToSessionCertificationCandidate = async function ({
 }) {
   const session = await sessionEnrolmentRepository.get({ id: sessionId });
 
-  if (session.version === CertificationVersion.V3) {
+  if (CertificationVersion.isV3(session.version)) {
     const user = await userRepository.get(userId);
     const isUserLanguageValid = _validateUserLanguage(languageService, user.lang);
 

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -72,7 +72,7 @@ const retrieveLastOrCreateCertificationCourse = async function ({
   const { version } = session;
 
   let lang;
-  if (version === CertificationVersion.V3) {
+  if (CertificationVersion.isV3(version)) {
     const user = await userRepository.get(userId);
     const isUserLanguageValid = _validateUserLanguage(languageService, user.lang);
 
@@ -222,7 +222,7 @@ async function _startNewCertification({
   );
 
   let challengesForPixCertification = [];
-  if (version !== CertificationVersion.V3) {
+  if (!CertificationVersion.isV3(version)) {
     challengesForPixCertification = await certificationChallengesService.pickCertificationChallenges(
       placementProfile,
       locale,

--- a/api/lib/infrastructure/repositories/sessions/session-for-supervising-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-for-supervising-repository.js
@@ -104,7 +104,7 @@ function _toDomain(results) {
   const certificationCandidates = results.certificationCandidates
     .filter((candidate) => candidate?.id !== null)
     .map((candidate) =>
-      results.version === CertificationVersion.V3
+      CertificationVersion.isV3(results.version)
         ? _buildCertificationCandidateForSupervisingV3(candidate)
         : _buildCertificationCandidateForSupervising(candidate),
     );

--- a/api/src/certification/enrolment/domain/models/SessionEnrolment.js
+++ b/api/src/certification/enrolment/domain/models/SessionEnrolment.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 
 import { config } from '../../../../shared/config.js';
 import { SESSION_STATUSES } from '../../../shared/domain/constants.js';
-import { CertificationVersion } from '../../../shared/domain/models/CertificationVersion.js';
+import { CERTIFICATION_VERSIONS } from '../../../shared/domain/models/CertificationVersion.js';
 
 const availableCharactersForPasswordGeneration =
   `${config.availableCharacterForCode.numbers}${config.availableCharacterForCode.letters}`.split('');
@@ -22,7 +22,7 @@ class SessionEnrolment {
     certificationCandidates,
     certificationCenterId,
     supervisorPassword = SessionEnrolment.generateSupervisorPassword(),
-    version = CertificationVersion.V2,
+    version = CERTIFICATION_VERSIONS.V2,
     createdBy,
     finalizedAt,
   } = {}) {

--- a/api/src/certification/enrolment/domain/usecases/create-session.js
+++ b/api/src/certification/enrolment/domain/usecases/create-session.js
@@ -5,7 +5,7 @@
  * @typedef {import ("./index.js").SessionCodeService} SessionCodeService
  */
 
-import { CertificationVersion } from '../../../shared/domain/models/CertificationVersion.js';
+import { CERTIFICATION_VERSIONS } from '../../../shared/domain/models/CertificationVersion.js';
 import { SessionEnrolment } from '../models/SessionEnrolment.js';
 
 /**
@@ -31,7 +31,7 @@ const createSession = async function ({
   const { isV3Pilot, name: certificationCenterName } = await certificationCenterRepository.get({
     id: certificationCenterId,
   });
-  const version = isV3Pilot ? CertificationVersion.V3 : CertificationVersion.V2;
+  const version = isV3Pilot ? CERTIFICATION_VERSIONS.V3 : CERTIFICATION_VERSIONS.V2;
 
   const domainSession = new SessionEnrolment({
     ...session,

--- a/api/src/certification/enrolment/domain/usecases/create-sessions.js
+++ b/api/src/certification/enrolment/domain/usecases/create-sessions.js
@@ -7,7 +7,7 @@ import bluebird from 'bluebird';
 import { NotFoundError } from '../../../../../lib/domain/errors.js';
 import { CertificationCandidate } from '../../../../../lib/domain/models/index.js';
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { CertificationVersion } from '../../../shared/domain/models/CertificationVersion.js';
+import { CERTIFICATION_VERSIONS } from '../../../shared/domain/models/CertificationVersion.js';
 import { SessionEnrolment } from '../models/SessionEnrolment.js';
 
 /**
@@ -80,7 +80,7 @@ function _hasCandidates(certificationCandidates) {
 async function _saveNewSessionReturningId({ sessionRepository, sessionDTO, domainTransaction, isV3Pilot }) {
   const sessionToSave = new SessionEnrolment({
     ...sessionDTO,
-    version: isV3Pilot ? CertificationVersion.V3 : CertificationVersion.V2,
+    version: isV3Pilot ? CERTIFICATION_VERSIONS.V3 : CERTIFICATION_VERSIONS.V2,
   });
   return await sessionRepository.save({ session: sessionToSave, domainTransaction });
 }

--- a/api/src/certification/enrolment/domain/validators/session-validator.js
+++ b/api/src/certification/enrolment/domain/validators/session-validator.js
@@ -6,7 +6,7 @@ import { types } from '../../../../../lib/domain/models/CertificationCenter.js';
 import { EntityValidationError } from '../../../../../src/shared/domain/errors.js';
 import { identifiersType } from '../../../../shared/domain/types/identifiers-type.js';
 import { SESSION_STATUSES } from '../../../shared/domain/constants.js';
-import { CertificationVersion } from '../../../shared/domain/models/CertificationVersion.js';
+import { CERTIFICATION_VERSIONS } from '../../../shared/domain/models/CertificationVersion.js';
 
 const Joi = BaseJoi.extend(JoiDate);
 
@@ -88,7 +88,7 @@ const sessionFiltersValidationSchema = Joi.object({
   certificationCenterName: Joi.string().trim().optional(),
   certificationCenterExternalId: Joi.string().trim().optional(),
   certificationCenterType: Joi.string().trim().valid(types.SUP, types.SCO, types.PRO).optional(),
-  version: Joi.number().valid(CertificationVersion.V2, CertificationVersion.V3).optional(),
+  version: Joi.number().valid(CERTIFICATION_VERSIONS.V2, CERTIFICATION_VERSIONS.V3).optional(),
 });
 
 const validate = function (session) {

--- a/api/src/certification/session-management/domain/models/SessionManagement.js
+++ b/api/src/certification/session-management/domain/models/SessionManagement.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 
 import { SESSION_STATUSES } from '../../../shared/domain/constants.js';
-import { CertificationVersion } from '../../../shared/domain/models/CertificationVersion.js';
+import { CERTIFICATION_VERSIONS } from '../../../shared/domain/models/CertificationVersion.js';
 
 const NO_EXAMINER_GLOBAL_COMMENT = null;
 
@@ -26,7 +26,7 @@ class SessionManagement {
     certificationCenterId,
     assignedCertificationOfficerId,
     supervisorPassword,
-    version = CertificationVersion.V2,
+    version = CERTIFICATION_VERSIONS.V2,
     createdBy,
   } = {}) {
     this.id = id;

--- a/api/src/certification/shared/domain/models/CertificationCourse.js
+++ b/api/src/certification/shared/domain/models/CertificationCourse.js
@@ -3,7 +3,7 @@ import BaseJoi from 'joi';
 import _ from 'lodash';
 
 import { EntityValidationError } from '../../../../shared/domain/errors.js';
-import { CertificationVersion } from './CertificationVersion.js';
+import { CERTIFICATION_VERSIONS, CertificationVersion } from './CertificationVersion.js';
 
 const Joi = BaseJoi.extend(JoiDate);
 
@@ -39,7 +39,7 @@ class CertificationCourse {
     abortReason,
     complementaryCertificationCourses = [],
     numberOfChallenges,
-    version = CertificationVersion.V2,
+    version = CERTIFICATION_VERSIONS.V2,
     isRejectedForFraud = false,
     lang,
   } = {}) {
@@ -275,7 +275,7 @@ class CertificationCourse {
   }
 
   isV3() {
-    return this._version === CertificationVersion.V3;
+    return CertificationVersion.isV3(this._version);
   }
 
   static isLanguageAvailableForV3Certification(languageService, candidateLanguage) {

--- a/api/src/certification/shared/domain/models/CertificationVersion.js
+++ b/api/src/certification/shared/domain/models/CertificationVersion.js
@@ -1,5 +1,15 @@
-export const CertificationVersion = {
+export const CERTIFICATION_VERSIONS = {
   V1: 1,
   V2: 2,
   V3: 3,
 };
+
+export class CertificationVersion {
+  static isV3(version) {
+    return version === CERTIFICATION_VERSIONS.V3;
+  }
+
+  static isV1(version) {
+    return version === CERTIFICATION_VERSIONS.V1;
+  }
+}

--- a/api/src/shared/application/assessments/assessment-controller.js
+++ b/api/src/shared/application/assessments/assessment-controller.js
@@ -202,7 +202,7 @@ async function _getChallengeByAssessmentType({ assessment, request, dependencies
       certificationCourseId: assessment.certificationCourseId,
     });
 
-    if (certificationCourseVersion === CertificationVersion.V3) {
+    if (CertificationVersion.isV3(certificationCourseVersion)) {
       return dependencies.usecases.getNextChallengeForV3Certification({ assessment, locale });
     } else {
       return dependencies.usecases.getNextChallengeForV2Certification({ assessment, locale });

--- a/api/tests/acceptance/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-courses/certification-course-controller_test.js
@@ -3,7 +3,10 @@ import { CertificationAssessment } from '../../../../lib/domain/models/Certifica
 import { ComplementaryCertificationCourseResult } from '../../../../lib/domain/models/ComplementaryCertificationCourseResult.js';
 import { KnowledgeElement } from '../../../../lib/domain/models/KnowledgeElement.js';
 import { CertificationIssueReportCategory } from '../../../../src/certification/shared/domain/models/CertificationIssueReportCategory.js';
-import { CertificationVersion } from '../../../../src/certification/shared/domain/models/CertificationVersion.js';
+import {
+  CERTIFICATION_VERSIONS,
+  CertificationVersion,
+} from '../../../../src/certification/shared/domain/models/CertificationVersion.js';
 import { AutoJuryCommentKeys } from '../../../../src/certification/shared/domain/models/JuryComment.js';
 import {
   createServer,
@@ -699,13 +702,13 @@ describe('Acceptance | API | Certification Course', function () {
           // then
           const certificationCourses = await knex('certification-courses').where({ userId, sessionId });
           expect(certificationCourses).to.have.length(1);
-          expect(certificationCourses[0].version).to.equal(CertificationVersion.V2);
+          expect(certificationCourses[0].version).to.equal(CERTIFICATION_VERSIONS.V2);
         });
 
         context('when the session is v3', function () {
           it('should have created a v3 certification course without any challenges', async function () {
             // given
-            const { options, userId, sessionId } = _createRequestOptions({ version: CertificationVersion.V3 });
+            const { options, userId, sessionId } = _createRequestOptions({ version: CERTIFICATION_VERSIONS.V3 });
             _createNonExistingCertifCourseSetup({ learningContent, userId, sessionId });
             await databaseBuilder.commit();
 
@@ -714,7 +717,7 @@ describe('Acceptance | API | Certification Course', function () {
 
             // then
             const [certificationCourse] = await knex('certification-courses').where({ userId, sessionId });
-            expect(certificationCourse.version).to.equal(CertificationVersion.V3);
+            expect(certificationCourse.version).to.equal(CERTIFICATION_VERSIONS.V3);
             expect(response.result.data.attributes).to.include({
               'nb-challenges': config.v3Certification.numberOfChallengesPerCourse,
             });
@@ -796,7 +799,7 @@ describe('Acceptance | API | Certification Course', function () {
       it('should retrieve the already existing V2 certification course', async function () {
         // given
         const { options, userId, sessionId } = _createRequestOptions();
-        _createExistingCertifCourseSetup({ userId, sessionId, version: CertificationVersion.V2 });
+        _createExistingCertifCourseSetup({ userId, sessionId, version: CERTIFICATION_VERSIONS.V2 });
         await databaseBuilder.commit();
 
         // when
@@ -809,14 +812,14 @@ describe('Acceptance | API | Certification Course', function () {
         });
         expect(otherCertificationCourses).to.have.length(0);
         expect(certificationCourse.id + '').to.equal(response.result.data.id);
-        expect(certificationCourse.version).to.equal(CertificationVersion.V2);
+        expect(certificationCourse.version).to.equal(CERTIFICATION_VERSIONS.V2);
       });
 
       context('when the session is v3', function () {
         it('should retrieve the already existing V3 certification course', async function () {
           // given
-          const { options, userId, sessionId } = _createRequestOptions({ version: CertificationVersion.V3 });
-          _createExistingCertifCourseSetup({ userId, sessionId, version: CertificationVersion.V3 });
+          const { options, userId, sessionId } = _createRequestOptions({ version: CERTIFICATION_VERSIONS.V3 });
+          _createExistingCertifCourseSetup({ userId, sessionId, version: CERTIFICATION_VERSIONS.V3 });
           await databaseBuilder.commit();
 
           // when
@@ -824,7 +827,7 @@ describe('Acceptance | API | Certification Course', function () {
 
           // then
           const [certificationCourse] = await knex('certification-courses').where({ userId, sessionId });
-          expect(certificationCourse.version).to.equal(CertificationVersion.V3);
+          expect(certificationCourse.version).to.equal(CERTIFICATION_VERSIONS.V3);
         });
       });
     });
@@ -980,9 +983,9 @@ describe('Acceptance | API | Certification Course', function () {
 });
 
 function _createRequestOptions(
-  { locale = 'fr-fr', version = CertificationVersion.V2 } = { locale: 'fr-fr', version: CertificationVersion.V2 },
+  { locale = 'fr-fr', version = CERTIFICATION_VERSIONS.V2 } = { locale: 'fr-fr', version: CERTIFICATION_VERSIONS.V2 },
 ) {
-  const isV3Pilot = version === CertificationVersion.V3;
+  const isV3Pilot = CertificationVersion.isV3(version);
   const userId = databaseBuilder.factory.buildUser().id;
   const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({ isV3Pilot }).id;
   const sessionId = databaseBuilder.factory.buildSession({ accessCode: '123', certificationCenterId, version }).id;

--- a/api/tests/certification/course/integration/infrastructure/repositories/certification-version-repository_test.js
+++ b/api/tests/certification/course/integration/infrastructure/repositories/certification-version-repository_test.js
@@ -1,5 +1,5 @@
 import * as certificationVersionRepository from '../../../../../../src/certification/course/infrastructure/repositories/certification-version-repository.js';
-import { CertificationVersion } from '../../../../../../src/certification/shared/domain/models/CertificationVersion.js';
+import { CERTIFICATION_VERSIONS } from '../../../../../../src/certification/shared/domain/models/CertificationVersion.js';
 import { databaseBuilder, expect } from '../../../../../test-helper.js';
 
 describe('Certification | Course | Integration | Repository | course-assessment-result', function () {
@@ -17,7 +17,7 @@ describe('Certification | Course | Integration | Repository | course-assessment-
       });
 
       // then
-      expect(certificationVersion).to.equal(CertificationVersion.V2);
+      expect(certificationVersion).to.equal(CERTIFICATION_VERSIONS.V2);
     });
   });
 });

--- a/api/tests/certification/course/unit/domain/usecases/get-next-challenge-for-v3-certification_test.js
+++ b/api/tests/certification/course/unit/domain/usecases/get-next-challenge-for-v3-certification_test.js
@@ -1,6 +1,6 @@
 import { AssessmentEndedError } from '../../../../../../lib/domain/errors.js';
 import { getNextChallengeForV3Certification } from '../../../../../../src/certification/course/domain/usecases/get-next-challenge-for-v3-certification.js';
-import { CertificationVersion } from '../../../../../../src/certification/shared/domain/models/CertificationVersion.js';
+import { CERTIFICATION_VERSIONS } from '../../../../../../src/certification/shared/domain/models/CertificationVersion.js';
 import { config } from '../../../../../../src/shared/config.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
@@ -54,7 +54,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-v3-certification', 
         // given
         const nextChallengeToAnswer = domainBuilder.buildChallenge();
         const v3CertificationCourse = domainBuilder.buildCertificationCourse({
-          version: CertificationVersion.V3,
+          version: CERTIFICATION_VERSIONS.V3,
         });
         const assessment = domainBuilder.buildAssessment();
         const locale = 'fr-FR';
@@ -130,7 +130,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-v3-certification', 
           const locale = 'fr-FR';
 
           const v3CertificationCourse = domainBuilder.buildCertificationCourse({
-            version: CertificationVersion.V3,
+            version: CERTIFICATION_VERSIONS.V3,
           });
           const assessment = domainBuilder.buildAssessment();
 
@@ -183,7 +183,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-v3-certification', 
         const skill = domainBuilder.buildSkill({ id: 'skill1' });
 
         const v3CertificationCourse = domainBuilder.buildCertificationCourse({
-          version: CertificationVersion.V3,
+          version: CERTIFICATION_VERSIONS.V3,
         });
         const assessment = domainBuilder.buildAssessment();
 
@@ -272,7 +272,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-v3-certification', 
         const secondSkill = domainBuilder.buildSkill({ id: 'skill2' });
 
         const v3CertificationCourse = domainBuilder.buildCertificationCourse({
-          version: CertificationVersion.V3,
+          version: CERTIFICATION_VERSIONS.V3,
         });
         const assessment = domainBuilder.buildAssessment();
 
@@ -369,7 +369,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-v3-certification', 
         const answeredChallenge = domainBuilder.buildChallenge();
         const answer = domainBuilder.buildAnswer({ challengeId: answeredChallenge.id });
         const v3CertificationCourse = domainBuilder.buildCertificationCourse({
-          version: CertificationVersion.V3,
+          version: CERTIFICATION_VERSIONS.V3,
         });
         const assessment = domainBuilder.buildAssessment();
         const locale = 'fr-FR';
@@ -471,7 +471,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-v3-certification', 
             });
 
             const v3CertificationCourse = domainBuilder.buildCertificationCourse({
-              version: CertificationVersion.V3,
+              version: CERTIFICATION_VERSIONS.V3,
             });
 
             flashAlgorithmConfigurationRepository.getMostRecentBeforeDate.reset();

--- a/api/tests/certification/enrolment/unit/domain/usecases/create-sessions_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/create-sessions_test.js
@@ -3,7 +3,7 @@ import { CertificationCenter } from '../../../../../../lib/domain/models/Certifi
 import { DomainTransaction } from '../../../../../../lib/infrastructure/DomainTransaction.js';
 import { SessionEnrolment } from '../../../../../../src/certification/enrolment/domain/models/SessionEnrolment.js';
 import { createSessions } from '../../../../../../src/certification/enrolment/domain/usecases/create-sessions.js';
-import { CertificationVersion } from '../../../../../../src/certification/shared/domain/models/CertificationVersion.js';
+import { CERTIFICATION_VERSIONS } from '../../../../../../src/certification/shared/domain/models/CertificationVersion.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | UseCase | sessions-mass-import | create-sessions', function () {
@@ -183,7 +183,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
           // then
           const expectedSession = new SessionEnrolment({
             ...temporaryCachedSessions[0],
-            version: CertificationVersion.V3,
+            version: CERTIFICATION_VERSIONS.V3,
             createdBy: sessionCreatorId,
           });
           expect(sessionRepository.save).to.have.been.calledOnceWith({ session: expectedSession, domainTransaction });
@@ -231,7 +231,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
           // then
           const expectedSession = new SessionEnrolment({
             ...temporaryCachedSessions[0],
-            version: CertificationVersion.V2,
+            version: CERTIFICATION_VERSIONS.V2,
             createdBy: sessionCreatorId,
           });
           expect(sessionRepository.save).to.have.been.calledOnceWith({ session: expectedSession, domainTransaction });

--- a/api/tests/certification/shared/integration/infrastructure/repositories/certification-challenge-repository_test.js
+++ b/api/tests/certification/shared/integration/infrastructure/repositories/certification-challenge-repository_test.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 
 import { AssessmentEndedError } from '../../../../../../lib/domain/errors.js';
 import { CertificationChallenge } from '../../../../../../lib/domain/models/CertificationChallenge.js';
-import { CertificationVersion } from '../../../../../../src/certification/shared/domain/models/CertificationVersion.js';
+import { CERTIFICATION_VERSIONS } from '../../../../../../src/certification/shared/domain/models/CertificationVersion.js';
 import * as certificationChallengeRepository from '../../../../../../src/certification/shared/infrastructure/repositories/certification-challenge-repository.js';
 import { databaseBuilder, domainBuilder, expect } from '../../../../../test-helper.js';
 
@@ -135,7 +135,7 @@ describe('Integration | Repository | Certification Challenge', function () {
         const userId = databaseBuilder.factory.buildUser({}).id;
         certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
           userId,
-          version: CertificationVersion.V3,
+          version: CERTIFICATION_VERSIONS.V3,
         }).id;
         challengeId = databaseBuilder.factory.buildCertificationChallenge({
           challengeId: 'recChallenge1',
@@ -171,7 +171,7 @@ describe('Integration | Repository | Certification Challenge', function () {
         const userId = databaseBuilder.factory.buildUser({}).id;
         certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
           userId,
-          version: CertificationVersion.V3,
+          version: CERTIFICATION_VERSIONS.V3,
         }).id;
 
         const answeredChallenge = databaseBuilder.factory.buildCertificationChallenge({

--- a/api/tests/certification/shared/unit/domain/models/CertificationCourse_test.js
+++ b/api/tests/certification/shared/unit/domain/models/CertificationCourse_test.js
@@ -1,5 +1,5 @@
 import { CertificationCourse } from '../../../../../../src/certification/shared/domain/models/CertificationCourse.js';
-import { CertificationVersion } from '../../../../../../src/certification/shared/domain/models/CertificationVersion.js';
+import { CERTIFICATION_VERSIONS } from '../../../../../../src/certification/shared/domain/models/CertificationVersion.js';
 import { EntityValidationError } from '../../../../../../src/shared/domain/errors.js';
 import * as languageService from '../../../../../../src/shared/domain/services/language-service.js';
 import { domainBuilder, expect } from '../../../../../test-helper.js';
@@ -327,7 +327,7 @@ describe('Unit | Domain | Models | CertificationCourse', function () {
         // given
         const numberOfChallenges = 5;
         const certificationCourse = domainBuilder.buildCertificationCourse({
-          version: CertificationVersion.V3,
+          version: CERTIFICATION_VERSIONS.V3,
           numberOfChallenges,
         });
 
@@ -345,7 +345,7 @@ describe('Unit | Domain | Models | CertificationCourse', function () {
         const numberOfChallenges = 5;
         const challenges = generateChallengeList({ length: numberOfChallenges });
         const certificationCourse = domainBuilder.buildCertificationCourse({
-          version: CertificationVersion.V2,
+          version: CERTIFICATION_VERSIONS.V2,
           challenges,
         });
 

--- a/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
@@ -4,7 +4,7 @@ import { NotFoundError } from '../../../../../lib/domain/errors.js';
 import { SessionForSupervising } from '../../../../../lib/domain/read-models/SessionForSupervising.js';
 import * as sessionForSupervisingRepository from '../../../../../lib/infrastructure/repositories/sessions/session-for-supervising-repository.js';
 import { CertificationChallengeLiveAlertStatus } from '../../../../../src/certification/shared/domain/models/CertificationChallengeLiveAlert.js';
-import { CertificationVersion } from '../../../../../src/certification/shared/domain/models/CertificationVersion.js';
+import { CERTIFICATION_VERSIONS } from '../../../../../src/certification/shared/domain/models/CertificationVersion.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import { catchErr, databaseBuilder, expect } from '../../../../test-helper.js';
 
@@ -236,7 +236,7 @@ describe('Integration | Repository | SessionForSupervising', function () {
         // given
         databaseBuilder.factory.buildCertificationCenter({ name: 'Toto', id: 1234 });
         const session = databaseBuilder.factory.buildSession({
-          version: CertificationVersion.V3,
+          version: CERTIFICATION_VERSIONS.V3,
           address: 'centre de certification 1',
           certificationCenter: 'Tour Gamma',
           room: 'Salle A',
@@ -271,7 +271,7 @@ describe('Integration | Repository | SessionForSupervising', function () {
         // given
         databaseBuilder.factory.buildCertificationCenter({ name: 'Toto', id: 1234 });
         const session = databaseBuilder.factory.buildSession({
-          version: CertificationVersion.V3,
+          version: CERTIFICATION_VERSIONS.V3,
           certificationCenter: 'Tour Gamma',
           room: 'Salle A',
           examiner: 'Monsieur Examinateur',
@@ -312,7 +312,7 @@ describe('Integration | Repository | SessionForSupervising', function () {
         });
 
         const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
-          version: CertificationVersion.V3,
+          version: CERTIFICATION_VERSIONS.V3,
           userId: 12345,
           sessionId: session.id,
           createdAt: new Date('2022-10-19T13:37:00Z'),

--- a/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
+++ b/api/tests/shared/acceptance/application/assessments/assessment-controller-get-next-challenge-for-certification_test.js
@@ -1,4 +1,4 @@
-import { CertificationVersion } from '../../../../../src/certification/shared/domain/models/CertificationVersion.js';
+import { CERTIFICATION_VERSIONS } from '../../../../../src/certification/shared/domain/models/CertificationVersion.js';
 import { Assessment } from '../../../../../src/shared/domain/models/Assessment.js';
 import {
   createServer,
@@ -87,12 +87,12 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
           const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({ isV3Pilot: true }).id;
           const sessionId = databaseBuilder.factory.buildSession({
             certificationCenterId,
-            version: CertificationVersion.V3,
+            version: CERTIFICATION_VERSIONS.V3,
           }).id;
           databaseBuilder.factory.buildFlashAlgorithmConfiguration();
           const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
             isPublished: false,
-            version: CertificationVersion.V3,
+            version: CERTIFICATION_VERSIONS.V3,
             userId,
             sessionId,
           }).id;
@@ -151,7 +151,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
           const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({ isV3Pilot: true }).id;
           const sessionId = databaseBuilder.factory.buildSession({
             certificationCenterId,
-            version: CertificationVersion.V3,
+            version: CERTIFICATION_VERSIONS.V3,
           }).id;
           databaseBuilder.factory.buildCertificationCandidate({
             userId: user.id,
@@ -159,7 +159,7 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-for-certif
           });
           const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
             isPublished: false,
-            version: CertificationVersion.V3,
+            version: CERTIFICATION_VERSIONS.V3,
             userId: user.id,
             sessionId,
           }).id;

--- a/api/tests/tooling/domain-builder/factory/build-jury-certification.js
+++ b/api/tests/tooling/domain-builder/factory/build-jury-certification.js
@@ -1,5 +1,5 @@
 import { JuryCertification } from '../../../../lib/domain/models/JuryCertification.js';
-import { CertificationVersion } from '../../../../src/certification/shared/domain/models/CertificationVersion.js';
+import { CERTIFICATION_VERSIONS } from '../../../../src/certification/shared/domain/models/CertificationVersion.js';
 import { JuryComment, JuryCommentContexts } from '../../../../src/certification/shared/domain/models/JuryComment.js';
 import { buildCertificationIssueReport } from './build-certification-issue-report.js';
 import { buildCompetenceMark } from './build-competence-mark.js';
@@ -33,7 +33,7 @@ const buildJuryCertification = function ({
   certificationIssueReports = [buildCertificationIssueReport()],
   commonComplementaryCertificationCourseResult,
   complementaryCertificationCourseResultWithExternal,
-  version = CertificationVersion.V2,
+  version = CERTIFICATION_VERSIONS.V2,
 } = {}) {
   return new JuryCertification({
     certificationCourseId,

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -6,7 +6,7 @@ import { ChallengeNeutralized } from '../../../../lib/domain/events/ChallengeNeu
 import { _forTestOnly } from '../../../../lib/domain/events/index.js';
 import { AssessmentResult, CertificationAssessment, CertificationResult } from '../../../../lib/domain/models/index.js';
 import { ABORT_REASONS } from '../../../../src/certification/shared/domain/models/CertificationCourse.js';
-import { CertificationVersion } from '../../../../src/certification/shared/domain/models/CertificationVersion.js';
+import { CERTIFICATION_VERSIONS } from '../../../../src/certification/shared/domain/models/CertificationVersion.js';
 import { domainBuilder, expect, sinon } from '../../../test-helper.js';
 
 const { handleCertificationRescoring } = _forTestOnly.handlers;
@@ -54,7 +54,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         it('should save the score with a rejected status', async function () {
           // given
           const certificationAssessment = domainBuilder.buildCertificationAssessment({
-            version: CertificationVersion.V3,
+            version: CERTIFICATION_VERSIONS.V3,
           });
           const abortedCertificationCourse = domainBuilder.buildCertificationCourse({
             abortReason: ABORT_REASONS.CANDIDATE,
@@ -90,7 +90,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         it('should save the score with a rejected status and cancel the certification course', async function () {
           // given
           const certificationAssessment = domainBuilder.buildCertificationAssessment({
-            version: CertificationVersion.V3,
+            version: CERTIFICATION_VERSIONS.V3,
           });
 
           const abortedCertificationCourse = domainBuilder.buildCertificationCourse({
@@ -141,7 +141,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           // given
           const certificationCourseStartDate = new Date('2022-01-01');
           const certificationAssessment = domainBuilder.buildCertificationAssessment({
-            version: CertificationVersion.V3,
+            version: CERTIFICATION_VERSIONS.V3,
           });
 
           const abortedCertificationCourse = domainBuilder.buildCertificationCourse({
@@ -182,7 +182,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
         // given
         const certificationCourseStartDate = new Date('2022-01-01');
         const certificationAssessment = domainBuilder.buildCertificationAssessment({
-          version: CertificationVersion.V3,
+          version: CERTIFICATION_VERSIONS.V3,
         });
 
         const abortedCertificationCourse = domainBuilder.buildCertificationCourse({
@@ -220,7 +220,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', function () 
           const certificationCourseStartDate = new Date('2022-01-01');
           // given
           const certificationAssessment = domainBuilder.buildCertificationAssessment({
-            version: CertificationVersion.V3,
+            version: CERTIFICATION_VERSIONS.V3,
           });
 
           const abortedCertificationCourse = domainBuilder.buildCertificationCourse({

--- a/api/tests/unit/domain/services/scoring/scoring-certification-service_test.js
+++ b/api/tests/unit/domain/services/scoring/scoring-certification-service_test.js
@@ -11,7 +11,7 @@ import { CertificationCourse, CertificationResult } from '../../../../../lib/dom
 import * as scoringCertificationService from '../../../../../lib/domain/services/scoring/scoring-certification-service.js';
 import { CertificationChallengeForScoring } from '../../../../../src/certification/scoring/domain/models/CertificationChallengeForScoring.js';
 import { ABORT_REASONS } from '../../../../../src/certification/shared/domain/models/CertificationCourse.js';
-import { CertificationVersion } from '../../../../../src/certification/shared/domain/models/CertificationVersion.js';
+import { CERTIFICATION_VERSIONS } from '../../../../../src/certification/shared/domain/models/CertificationVersion.js';
 import { AutoJuryCommentKeys } from '../../../../../src/certification/shared/domain/models/JuryComment.js';
 import { config } from '../../../../../src/shared/config.js';
 import { AssessmentResult, status } from '../../../../../src/shared/domain/models/AssessmentResult.js';
@@ -2789,7 +2789,7 @@ describe('Unit | Service | Certification Result Service', function () {
           it('should save the score with a rejected status', async function () {
             // given
             const certificationAssessment = domainBuilder.buildCertificationAssessment({
-              version: CertificationVersion.V3,
+              version: CERTIFICATION_VERSIONS.V3,
             });
 
             const abortedCertificationCourse = domainBuilder.buildCertificationCourse({
@@ -2910,7 +2910,7 @@ describe('Unit | Service | Certification Result Service', function () {
           it('should save the score with a rejected status and cancel the certification course', async function () {
             // given
             const certificationAssessment = domainBuilder.buildCertificationAssessment({
-              version: CertificationVersion.V3,
+              version: CERTIFICATION_VERSIONS.V3,
             });
 
             const abortedCertificationCourse = domainBuilder.buildCertificationCourse({
@@ -3033,7 +3033,7 @@ describe('Unit | Service | Certification Result Service', function () {
             // given
             const certificationCourseStartDate = new Date('2022-01-01');
             const certificationAssessment = domainBuilder.buildCertificationAssessment({
-              version: CertificationVersion.V3,
+              version: CERTIFICATION_VERSIONS.V3,
             });
 
             const abortedCertificationCourse = domainBuilder.buildCertificationCourse({
@@ -3155,7 +3155,7 @@ describe('Unit | Service | Certification Result Service', function () {
           // given
           const certificationCourseStartDate = new Date('2022-01-01');
           const certificationAssessment = domainBuilder.buildCertificationAssessment({
-            version: CertificationVersion.V3,
+            version: CERTIFICATION_VERSIONS.V3,
           });
 
           const abortedCertificationCourse = domainBuilder.buildCertificationCourse({
@@ -3286,7 +3286,7 @@ describe('Unit | Service | Certification Result Service', function () {
             const certificationCourseStartDate = new Date('2022-01-01');
             // given
             const certificationAssessment = domainBuilder.buildCertificationAssessment({
-              version: CertificationVersion.V3,
+              version: CERTIFICATION_VERSIONS.V3,
             });
 
             const abortedCertificationCourse = domainBuilder.buildCertificationCourse({
@@ -3406,7 +3406,7 @@ describe('Unit | Service | Certification Result Service', function () {
             const certificationCourseStartDate = new Date('2022-01-01');
             // given
             const certificationAssessment = domainBuilder.buildCertificationAssessment({
-              version: CertificationVersion.V3,
+              version: CERTIFICATION_VERSIONS.V3,
             });
 
             const abortedCertificationCourse = domainBuilder.buildCertificationCourse({


### PR DESCRIPTION
## :unicorn: Problème

La récupération de la version de la session se fait dans la codebase au travers d'égalités du type 
`certification.version === CertificationVersion.V3`

## :robot: Proposition

Remplacement de cette égalité par une propriété dans la classe CertificationVersion.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

- Tests verts
- Créer une session de certification V3, la passer, la finaliser et la publier. Vérifier qu'il n'y ait pas de régression.
