### PR TITLE
[FEATURE][ADMIN] Permettre la copie de l'adresse e-mail et de l'identifiant via un bouton (PIX-12636)

### DIFF
--- a/admin/app/components/users/user-overview.hbs
+++ b/admin/app/components/users/user-overview.hbs
@@ -129,10 +129,36 @@
             </li>
           </ul>
           <ul class="user-detail-personal-information-section__infogroup">
-            <li class="user-detail-personal-information-section__user-informations">Adresse e-mail :
-              {{@user.email}}</li>
-            <li class="user-detail-personal-information-section__user-informations">Identifiant :
-              {{@user.username}}</li>
+            <li class="user-detail-personal-information-section__user-informations flex space-between gap-4x">
+              <span>Adresse e-mail : {{@user.email}}</span>
+              <span>
+                {{#if (is-clipboard-supported)}}
+                  <CopyButton
+                    @text={{@user.email}}
+                    aria-label="{{t 'components.users.user-detail-personal-information.actions.copy-email'}}"
+                    aria-describedby="copy-user-email"
+                    class="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey"
+                  >
+                    <FaIcon @icon="copy" @prefix="far" />
+                  </CopyButton>
+                {{/if}}
+              </span>
+            </li>
+            <li class="user-detail-personal-information-section__user-informations flex space-between gap-4x">
+              <span>Identifiant : {{@user.username}}</span>
+              <span>
+                {{#if (is-clipboard-supported)}}
+                  <CopyButton
+                    @text={{@user.username}}
+                    aria-label="{{t 'components.users.user-detail-personal-information.actions.copy-username'}}"
+                    aria-describedby="copy-user-id"
+                    class="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey"
+                  >
+                    <FaIcon @icon="copy" @prefix="far" />
+                  </CopyButton>
+                {{/if}}
+              </span>
+            </li>
           </ul>
           <ul class="user-detail-personal-information-section__infogroup">
             <li class="user-detail-personal-information-section__user-informations">CGU Pix App validé :

--- a/admin/app/components/users/user-overview.hbs
+++ b/admin/app/components/users/user-overview.hbs
@@ -132,30 +132,34 @@
             <li class="user-detail-personal-information-section__user-informations flex space-between gap-4x">
               <span>Adresse e-mail : {{@user.email}}</span>
               <span>
-                {{#if (is-clipboard-supported)}}
-                  <CopyButton
-                    @text={{@user.email}}
-                    aria-label="{{t 'components.users.user-detail-personal-information.actions.copy-email'}}"
-                    aria-describedby="copy-user-email"
-                    class="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey"
-                  >
+                {{#if @user.email}}
+                  {{#if (is-clipboard-supported)}}
+                    <CopyButton
+                      @text={{@user.email}}
+                      aria-label="{{t 'components.users.user-detail-personal-information.actions.copy-email'}}"
+                      aria-describedby="copy-user-email"
+                      class="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey"
+                    >
                     <FaIcon @icon="copy" @prefix="far" />
                   </CopyButton>
+                  {{/if}}
                 {{/if}}
               </span>
             </li>
             <li class="user-detail-personal-information-section__user-informations flex space-between gap-4x">
               <span>Identifiant : {{@user.username}}</span>
               <span>
-                {{#if (is-clipboard-supported)}}
-                  <CopyButton
-                    @text={{@user.username}}
-                    aria-label="{{t 'components.users.user-detail-personal-information.actions.copy-username'}}"
-                    aria-describedby="copy-user-id"
-                    class="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey"
-                  >
+                {{#if @user.username}}
+                  {{#if (is-clipboard-supported)}}
+                    <CopyButton
+                      @text={{@user.username}}
+                      aria-label="{{t 'components.users.user-detail-personal-information.actions.copy-username'}}"
+                      aria-describedby="copy-user-id"
+                      class="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey"
+                    >
                     <FaIcon @icon="copy" @prefix="far" />
                   </CopyButton>
+                  {{/if}}
                 {{/if}}
               </span>
             </li>

--- a/admin/app/components/users/user-overview.hbs
+++ b/admin/app/components/users/user-overview.hbs
@@ -134,14 +134,19 @@
               <span>
                 {{#if @user.email}}
                   {{#if (is-clipboard-supported)}}
-                    <CopyButton
-                      @text={{@user.email}}
-                      aria-label="{{t 'components.users.user-detail-personal-information.actions.copy-email'}}"
-                      aria-describedby="copy-user-email"
-                      class="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey"
-                    >
-                    <FaIcon @icon="copy" @prefix="far" />
-                  </CopyButton>
+                    <PixTooltip @id="copy-email-tooltip" @position="top" @isInline={{true}}>
+                      <:triggerElement>
+                        <CopyButton
+                          @text={{@user.email}}
+                          aria-label="{{t 'components.users.user-detail-personal-information.actions.copy-email'}}"
+                          aria-describedby="copy-user-email"
+                          class="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey"
+                        >
+                          <FaIcon @icon="copy" @prefix="far" />
+                        </CopyButton>
+                      </:triggerElement>
+                      <:tooltip>{{this.tooltipTextEmail}}</:tooltip>
+                    </PixTooltip>
                   {{/if}}
                 {{/if}}
               </span>
@@ -151,14 +156,19 @@
               <span>
                 {{#if @user.username}}
                   {{#if (is-clipboard-supported)}}
-                    <CopyButton
-                      @text={{@user.username}}
-                      aria-label="{{t 'components.users.user-detail-personal-information.actions.copy-username'}}"
-                      aria-describedby="copy-user-id"
-                      class="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey"
-                    >
-                    <FaIcon @icon="copy" @prefix="far" />
-                  </CopyButton>
+                    <PixTooltip @id="copy-username-tooltip" @position="top" @isInline={{true}}>
+                      <:triggerElement>
+                        <CopyButton
+                          @text={{@user.username}}
+                          aria-label="{{t 'components.users.user-detail-personal-information.actions.copy-username'}}"
+                          aria-describedby="copy-user-id"
+                          class="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey"
+                        >
+                          <FaIcon @icon="copy" @prefix="far" />
+                        </CopyButton>
+                      </:triggerElement>
+                      <:tooltip>{{this.tooltipTextUsername}}</:tooltip>
+                    </PixTooltip>
                   {{/if}}
                 {{/if}}
               </span>

--- a/admin/app/components/users/user-overview.js
+++ b/admin/app/components/users/user-overview.js
@@ -7,6 +7,7 @@ import ENV from 'pix-admin/config/environment';
 
 export default class UserOverview extends Component {
   @service accessControl;
+  @service intl;
   @service notifications;
   @service references;
   @service store;
@@ -16,6 +17,8 @@ export default class UserOverview extends Component {
 
   languages = this.references.availableLanguages;
   locales = this.references.availableLocales;
+  tooltipTextEmail = this.intl.t('components.users.user-detail-personal-information.actions.copy-email');
+  tooltipTextUsername = this.intl.t('components.users.user-detail-personal-information.actions.copy-username');
 
   constructor() {
     super(...arguments);

--- a/admin/app/styles/globals/global.scss
+++ b/admin/app/styles/globals/global.scss
@@ -64,3 +64,15 @@ a.pix-button {
   justify-content: flex-end;
   padding: 0.75rem;
 }
+
+.flex {
+  display: flex;
+
+  &.space-between {
+    justify-content: space-between;
+  }
+
+  &.gap-4x {
+    gap: var(--pix-spacing-4x);
+  }
+}

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -35,6 +35,7 @@
         "ember-cli": "^5.3.0",
         "ember-cli-app-version": "^6.0.0",
         "ember-cli-babel": "^8.0.0",
+        "ember-cli-clipboard": "^1.1.0",
         "ember-cli-dependency-checker": "^3.3.1",
         "ember-cli-htmlbars": "^6.1.1",
         "ember-cli-inject-live-reload": "^2.1.0",
@@ -19289,6 +19290,17 @@
         "node": ">= 10"
       }
     },
+    "node_modules/clipboard": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
+      "integrity": "sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==",
+      "dev": true,
+      "dependencies": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "dev": true,
@@ -20333,6 +20345,12 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "dev": true
+    },
     "node_modules/delegates": {
       "version": "1.0.0",
       "dev": true,
@@ -21113,6 +21131,764 @@
       "version": "3.1.2",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/core": "^7.3.4",
+        "object-assign": "4.1.1",
+        "rsvp": "^4.8.4"
+      }
+    },
+    "node_modules/ember-arg-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ember-arg-types/-/ember-arg-types-1.1.0.tgz",
+      "integrity": "sha512-hWpUz0eiNkWzi3FgHW5QU6LyCDyUlTWwuIROHluEKZoa9m6LJVXbb/EVFgIG3FkAib6a5Ie00WvkXEZFXxh3+A==",
+      "dev": true,
+      "dependencies": {
+        "@embroider/macros": "^1.8.1",
+        "ember-auto-import": "^2.4.2",
+        "ember-cli-babel": "^7.26.11",
+        "ember-cli-typescript": "^5.1.1",
+        "ember-get-config": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": "14.* || >= 16"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/@babel/runtime": {
+      "version": "7.12.18",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
+      "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/@types/fs-extra": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
+      "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/async-disk-cache": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.5.tgz",
+      "integrity": "sha512-VZpqfR0R7CEOJZ/0FOTgWq70lCrZyS1rkI8PXugDUkTKyyAUgZ2zQ09gLhMkEn+wN8LYeUTPxZdXtlX/kmbXKQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^2.1.3",
+        "heimdalljs": "^0.2.3",
+        "istextorbinary": "2.1.0",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^2.5.3",
+        "rsvp": "^3.0.18",
+        "username-sync": "^1.0.2"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/async-disk-cache/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/async-disk-cache/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/async-disk-cache/node_modules/rsvp": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+      "dev": true,
+      "engines": {
+        "node": "0.12.* || 4.* || 6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/babel-plugin-module-resolver": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz",
+      "integrity": "sha512-tjR0GvSndzPew/Iayf4uICWZqjBwnlMWjSx6brryfQ81F9rxBVqwDJtFCV8oOs0+vJeefK9TmdZtkIFdFe1UnA==",
+      "dev": true,
+      "dependencies": {
+        "find-babel-config": "^1.1.0",
+        "glob": "^7.1.2",
+        "pkg-up": "^2.0.0",
+        "reselect": "^3.0.1",
+        "resolve": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/broccoli-babel-transpiler": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-7.8.1.tgz",
+      "integrity": "sha512-6IXBgfRt7HZ61g67ssBc6lBb3Smw3DPZ9dEYirgtvXWpRZ2A9M22nxy6opEwJDgDJzlu/bB7ToppW33OFkA1gA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.12.0",
+        "@babel/polyfill": "^7.11.5",
+        "broccoli-funnel": "^2.0.2",
+        "broccoli-merge-trees": "^3.0.2",
+        "broccoli-persistent-filter": "^2.2.1",
+        "clone": "^2.1.2",
+        "hash-for-dep": "^1.4.7",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.9",
+        "json-stable-stringify": "^1.0.1",
+        "rsvp": "^4.8.4",
+        "workerpool": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/broccoli-funnel": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+      "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+      "dev": true,
+      "dependencies": {
+        "array-equal": "^1.0.0",
+        "blank-object": "^1.0.1",
+        "broccoli-plugin": "^1.3.0",
+        "debug": "^2.2.0",
+        "fast-ordered-set": "^1.0.0",
+        "fs-tree-diff": "^0.5.3",
+        "heimdalljs": "^0.2.0",
+        "minimatch": "^3.0.0",
+        "mkdirp": "^0.5.0",
+        "path-posix": "^1.0.0",
+        "rimraf": "^2.4.3",
+        "symlink-or-copy": "^1.0.0",
+        "walk-sync": "^0.3.1"
+      },
+      "engines": {
+        "node": "^4.5 || 6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/broccoli-funnel/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/broccoli-funnel/node_modules/fs-tree-diff": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
+      "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
+      "dev": true,
+      "dependencies": {
+        "heimdalljs-logger": "^0.1.7",
+        "object-assign": "^4.1.0",
+        "path-posix": "^1.0.0",
+        "symlink-or-copy": "^1.1.8"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/broccoli-funnel/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/broccoli-merge-trees": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
+      "integrity": "sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==",
+      "dev": true,
+      "dependencies": {
+        "broccoli-plugin": "^1.3.0",
+        "merge-trees": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/broccoli-persistent-filter": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-2.3.1.tgz",
+      "integrity": "sha512-hVsmIgCDrl2NFM+3Gs4Cr2TA6UPaIZip99hN8mtkaUPgM8UeVnCbxelCvBjUBHo0oaaqP5jzqqnRVvb568Yu5g==",
+      "dev": true,
+      "dependencies": {
+        "async-disk-cache": "^1.2.1",
+        "async-promise-queue": "^1.0.3",
+        "broccoli-plugin": "^1.0.0",
+        "fs-tree-diff": "^2.0.0",
+        "hash-for-dep": "^1.5.0",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "mkdirp": "^0.5.1",
+        "promise-map-series": "^0.2.1",
+        "rimraf": "^2.6.1",
+        "rsvp": "^4.7.0",
+        "symlink-or-copy": "^1.0.1",
+        "sync-disk-cache": "^1.3.3",
+        "walk-sync": "^1.0.0"
+      },
+      "engines": {
+        "node": "6.* || >= 8.*"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/broccoli-persistent-filter/node_modules/matcher-collection": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
+      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^3.0.2"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/broccoli-persistent-filter/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/broccoli-persistent-filter/node_modules/walk-sync": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
+      "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "^3.0.3",
+        "ensure-posix-path": "^1.1.0",
+        "matcher-collection": "^1.1.1"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/broccoli-plugin": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
+      "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
+      "dev": true,
+      "dependencies": {
+        "promise-map-series": "^0.2.1",
+        "quick-temp": "^0.1.3",
+        "rimraf": "^2.3.4",
+        "symlink-or-copy": "^1.1.8"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/broccoli-plugin/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/broccoli-source": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-2.1.2.tgz",
+      "integrity": "sha512-1lLayO4wfS0c0Sj50VfHJXNWf94FYY0WUhxj0R77thbs6uWI7USiOWFqQV5dRmhAJnoKaGN4WyLGQbgjgiYFwQ==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/editions": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/ember-cli-babel": {
+      "version": "7.26.11",
+      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz",
+      "integrity": "sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.12.0",
+        "@babel/helper-compilation-targets": "^7.12.0",
+        "@babel/plugin-proposal-class-properties": "^7.16.5",
+        "@babel/plugin-proposal-decorators": "^7.13.5",
+        "@babel/plugin-proposal-private-methods": "^7.16.5",
+        "@babel/plugin-proposal-private-property-in-object": "^7.16.5",
+        "@babel/plugin-transform-modules-amd": "^7.13.0",
+        "@babel/plugin-transform-runtime": "^7.13.9",
+        "@babel/plugin-transform-typescript": "^7.13.0",
+        "@babel/polyfill": "^7.11.5",
+        "@babel/preset-env": "^7.16.5",
+        "@babel/runtime": "7.12.18",
+        "amd-name-resolver": "^1.3.1",
+        "babel-plugin-debug-macros": "^0.3.4",
+        "babel-plugin-ember-data-packages-polyfill": "^0.1.2",
+        "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
+        "babel-plugin-module-resolver": "^3.2.0",
+        "broccoli-babel-transpiler": "^7.8.0",
+        "broccoli-debug": "^0.6.4",
+        "broccoli-funnel": "^2.0.2",
+        "broccoli-source": "^2.1.2",
+        "calculate-cache-key-for-tree": "^2.0.0",
+        "clone": "^2.1.2",
+        "ember-cli-babel-plugin-helpers": "^1.1.1",
+        "ember-cli-version-checker": "^4.1.0",
+        "ensure-posix-path": "^1.0.2",
+        "fixturify-project": "^1.10.0",
+        "resolve-package-path": "^3.1.0",
+        "rimraf": "^3.0.1",
+        "semver": "^5.5.0"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/ember-cli-babel/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/ember-cli-typescript": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.3.0.tgz",
+      "integrity": "sha512-gFA+ZwmsvvFwo2Jz/B9GMduEn+fPoGb69qWGP0Tp3+Tu5xypDtIKVSZ5086I3Cr19cLXD4HkrOR3YQvdUKzAkQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-to-html": "^0.6.15",
+        "broccoli-stew": "^3.0.0",
+        "debug": "^4.0.0",
+        "execa": "^4.0.0",
+        "fs-extra": "^9.0.1",
+        "resolve": "^1.5.0",
+        "rsvp": "^4.8.1",
+        "semver": "^7.3.2",
+        "stagehand": "^1.0.0",
+        "walk-sync": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 12.*"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/ember-cli-typescript/node_modules/semver": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/ember-cli-typescript/node_modules/walk-sync": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "^3.0.3",
+        "ensure-posix-path": "^1.1.0",
+        "matcher-collection": "^2.0.0",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/ember-cli-version-checker": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-4.1.1.tgz",
+      "integrity": "sha512-bzEWsTMXUGEJfxcAGWPe6kI7oHEGD3jaxUWDYPTqzqGhNkgPwXTBgoWs9zG1RaSMaOPFnloWuxRcoHi4TrYS3Q==",
+      "dev": true,
+      "dependencies": {
+        "resolve-package-path": "^2.0.0",
+        "semver": "^6.3.0",
+        "silent-error": "^1.1.1"
+      },
+      "engines": {
+        "node": "8.* || 10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/ember-cli-version-checker/node_modules/resolve-package-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-2.0.0.tgz",
+      "integrity": "sha512-/CLuzodHO2wyyHTzls5Qr+EFeG6RcW4u6//gjYvUfcfyuplIX1SSccU+A5A9A78Gmezkl3NBkFAMxLbzTY9TJA==",
+      "dev": true,
+      "dependencies": {
+        "path-root": "^0.1.1",
+        "resolve": "^1.13.1"
+      },
+      "engines": {
+        "node": "8.* || 10.* || >= 12"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/execa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/find-babel-config": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.2.tgz",
+      "integrity": "sha512-oK59njMyw2y3yxto1BCfVK7MQp/OYf4FleHu0RgosH3riFJ1aOuo/7naLDLAObfrgn3ueFhw5sAT/cp0QuJI3Q==",
+      "dev": true,
+      "dependencies": {
+        "json5": "^1.0.2",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/fixturify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fixturify/-/fixturify-1.3.0.tgz",
+      "integrity": "sha512-tL0svlOy56pIMMUQ4bU1xRe6NZbFSa/ABTWMxW2mH38lFGc9TrNAKWcMBQ7eIjo3wqSS8f2ICabFaatFyFmrVQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/fs-extra": "^5.0.5",
+        "@types/minimatch": "^3.0.3",
+        "@types/rimraf": "^2.0.2",
+        "fs-extra": "^7.0.1",
+        "matcher-collection": "^2.0.0"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/fixturify-project": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/fixturify-project/-/fixturify-project-1.10.0.tgz",
+      "integrity": "sha512-L1k9uiBQuN0Yr8tA9Noy2VSQ0dfg0B8qMdvT7Wb5WQKc7f3dn3bzCbSrqlb+etLW+KDV4cBC7R1OvcMg3kcxmA==",
+      "dev": true,
+      "dependencies": {
+        "fixturify": "^1.2.0",
+        "tmp": "^0.0.33"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/fixturify/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.12.0"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/istextorbinary": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
+      "integrity": "sha512-kT1g2zxZ5Tdabtpp9VSdOzW9lb6LXImyWbzbQeTxoRtHhurC9Ej9Wckngr2+uepPL09ky/mJHmN9jeJPML5t6A==",
+      "dev": true,
+      "dependencies": {
+        "binaryextensions": "1 || 2",
+        "editions": "^1.1.1",
+        "textextensions": "1 || 2"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
+    },
+    "node_modules/ember-arg-types/node_modules/p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+      "integrity": "sha512-fjAPuiws93rm7mPUu21RdBnkeZNrbfCFCwfAhPWY+rR3zG0ubpe5cEReHOw5fIbfmsxEV/g2kSxGTATY3Bpnwg==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true
+    },
+    "node_modules/ember-arg-types/node_modules/reselect": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
+      "integrity": "sha512-b/6tFZCmRhtBMa4xGqiiRp9jh9Aqi2A687Lo265cN0/QohJQEBPiQ52f4QB6i0eF3yp3hmLL21LSGBcML2dlxA==",
+      "dev": true
+    },
+    "node_modules/ember-arg-types/node_modules/resolve-package-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
+      "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
+      "dev": true,
+      "dependencies": {
+        "path-root": "^0.1.1",
+        "resolve": "^1.17.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/sync-disk-cache": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-1.3.4.tgz",
+      "integrity": "sha512-GlkGeM81GPPEKz/lH7QUTbvqLq7K/IUTuaKDSMulP9XQ42glqNJIN/RKgSOw4y8vxL1gOVvj+W7ruEO4s36eCw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^2.1.3",
+        "heimdalljs": "^0.2.3",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^2.2.8",
+        "username-sync": "^1.0.2"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/sync-disk-cache/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/sync-disk-cache/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/walk-sync": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
+      "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
+      "dev": true,
+      "dependencies": {
+        "ensure-posix-path": "^1.0.0",
+        "matcher-collection": "^1.0.0"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/walk-sync/node_modules/matcher-collection": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
+      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^3.0.2"
+      }
+    },
+    "node_modules/ember-arg-types/node_modules/workerpool": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-3.1.2.tgz",
+      "integrity": "sha512-WJFA0dGqIK7qj7xPTqciWBH5DlJQzoPjsANvc3Y4hNB0SScT+Emjvt0jPPkDBUjBNngX1q9hHgt1Gfwytu6pug==",
+      "dev": true,
       "dependencies": {
         "@babel/core": "^7.3.4",
         "object-assign": "4.1.1",
@@ -23176,6 +23952,653 @@
       "version": "4.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ember-cli-clipboard": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-clipboard/-/ember-cli-clipboard-1.1.0.tgz",
+      "integrity": "sha512-gqFMeLCMe7OKP8rtZluV3BsP03bnjqD/f1QQLdOB9gAbdiHzMIAbwIA/RhccGtGQgy5AlnxkkQ+7j/h6UDluPQ==",
+      "dev": true,
+      "dependencies": {
+        "@embroider/macros": "^1.10.0",
+        "clipboard": "^2.0.11",
+        "ember-arg-types": "^1.0.0",
+        "ember-auto-import": "^2.4.2",
+        "ember-cli-babel": "^7.26.11",
+        "ember-cli-htmlbars": "^6.1.0",
+        "ember-modifier": "^3.2.7 || ^4.1.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": "14.* || >= 16"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/@babel/runtime": {
+      "version": "7.12.18",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
+      "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/@types/fs-extra": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
+      "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/async-disk-cache": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.5.tgz",
+      "integrity": "sha512-VZpqfR0R7CEOJZ/0FOTgWq70lCrZyS1rkI8PXugDUkTKyyAUgZ2zQ09gLhMkEn+wN8LYeUTPxZdXtlX/kmbXKQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^2.1.3",
+        "heimdalljs": "^0.2.3",
+        "istextorbinary": "2.1.0",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^2.5.3",
+        "rsvp": "^3.0.18",
+        "username-sync": "^1.0.2"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/async-disk-cache/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/async-disk-cache/node_modules/rsvp": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+      "dev": true,
+      "engines": {
+        "node": "0.12.* || 4.* || 6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/babel-plugin-module-resolver": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz",
+      "integrity": "sha512-tjR0GvSndzPew/Iayf4uICWZqjBwnlMWjSx6brryfQ81F9rxBVqwDJtFCV8oOs0+vJeefK9TmdZtkIFdFe1UnA==",
+      "dev": true,
+      "dependencies": {
+        "find-babel-config": "^1.1.0",
+        "glob": "^7.1.2",
+        "pkg-up": "^2.0.0",
+        "reselect": "^3.0.1",
+        "resolve": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/broccoli-babel-transpiler": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-7.8.1.tgz",
+      "integrity": "sha512-6IXBgfRt7HZ61g67ssBc6lBb3Smw3DPZ9dEYirgtvXWpRZ2A9M22nxy6opEwJDgDJzlu/bB7ToppW33OFkA1gA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.12.0",
+        "@babel/polyfill": "^7.11.5",
+        "broccoli-funnel": "^2.0.2",
+        "broccoli-merge-trees": "^3.0.2",
+        "broccoli-persistent-filter": "^2.2.1",
+        "clone": "^2.1.2",
+        "hash-for-dep": "^1.4.7",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.9",
+        "json-stable-stringify": "^1.0.1",
+        "rsvp": "^4.8.4",
+        "workerpool": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/broccoli-funnel": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+      "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+      "dev": true,
+      "dependencies": {
+        "array-equal": "^1.0.0",
+        "blank-object": "^1.0.1",
+        "broccoli-plugin": "^1.3.0",
+        "debug": "^2.2.0",
+        "fast-ordered-set": "^1.0.0",
+        "fs-tree-diff": "^0.5.3",
+        "heimdalljs": "^0.2.0",
+        "minimatch": "^3.0.0",
+        "mkdirp": "^0.5.0",
+        "path-posix": "^1.0.0",
+        "rimraf": "^2.4.3",
+        "symlink-or-copy": "^1.0.0",
+        "walk-sync": "^0.3.1"
+      },
+      "engines": {
+        "node": "^4.5 || 6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/broccoli-funnel/node_modules/fs-tree-diff": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
+      "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
+      "dev": true,
+      "dependencies": {
+        "heimdalljs-logger": "^0.1.7",
+        "object-assign": "^4.1.0",
+        "path-posix": "^1.0.0",
+        "symlink-or-copy": "^1.1.8"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/broccoli-funnel/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/broccoli-merge-trees": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
+      "integrity": "sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==",
+      "dev": true,
+      "dependencies": {
+        "broccoli-plugin": "^1.3.0",
+        "merge-trees": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/broccoli-persistent-filter": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-2.3.1.tgz",
+      "integrity": "sha512-hVsmIgCDrl2NFM+3Gs4Cr2TA6UPaIZip99hN8mtkaUPgM8UeVnCbxelCvBjUBHo0oaaqP5jzqqnRVvb568Yu5g==",
+      "dev": true,
+      "dependencies": {
+        "async-disk-cache": "^1.2.1",
+        "async-promise-queue": "^1.0.3",
+        "broccoli-plugin": "^1.0.0",
+        "fs-tree-diff": "^2.0.0",
+        "hash-for-dep": "^1.5.0",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "mkdirp": "^0.5.1",
+        "promise-map-series": "^0.2.1",
+        "rimraf": "^2.6.1",
+        "rsvp": "^4.7.0",
+        "symlink-or-copy": "^1.0.1",
+        "sync-disk-cache": "^1.3.3",
+        "walk-sync": "^1.0.0"
+      },
+      "engines": {
+        "node": "6.* || >= 8.*"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/broccoli-persistent-filter/node_modules/matcher-collection": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
+      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^3.0.2"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/broccoli-persistent-filter/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/broccoli-persistent-filter/node_modules/walk-sync": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
+      "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "^3.0.3",
+        "ensure-posix-path": "^1.1.0",
+        "matcher-collection": "^1.1.1"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/broccoli-plugin": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
+      "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
+      "dev": true,
+      "dependencies": {
+        "promise-map-series": "^0.2.1",
+        "quick-temp": "^0.1.3",
+        "rimraf": "^2.3.4",
+        "symlink-or-copy": "^1.1.8"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/broccoli-plugin/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/broccoli-source": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-2.1.2.tgz",
+      "integrity": "sha512-1lLayO4wfS0c0Sj50VfHJXNWf94FYY0WUhxj0R77thbs6uWI7USiOWFqQV5dRmhAJnoKaGN4WyLGQbgjgiYFwQ==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/editions": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/ember-cli-babel": {
+      "version": "7.26.11",
+      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz",
+      "integrity": "sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.12.0",
+        "@babel/helper-compilation-targets": "^7.12.0",
+        "@babel/plugin-proposal-class-properties": "^7.16.5",
+        "@babel/plugin-proposal-decorators": "^7.13.5",
+        "@babel/plugin-proposal-private-methods": "^7.16.5",
+        "@babel/plugin-proposal-private-property-in-object": "^7.16.5",
+        "@babel/plugin-transform-modules-amd": "^7.13.0",
+        "@babel/plugin-transform-runtime": "^7.13.9",
+        "@babel/plugin-transform-typescript": "^7.13.0",
+        "@babel/polyfill": "^7.11.5",
+        "@babel/preset-env": "^7.16.5",
+        "@babel/runtime": "7.12.18",
+        "amd-name-resolver": "^1.3.1",
+        "babel-plugin-debug-macros": "^0.3.4",
+        "babel-plugin-ember-data-packages-polyfill": "^0.1.2",
+        "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
+        "babel-plugin-module-resolver": "^3.2.0",
+        "broccoli-babel-transpiler": "^7.8.0",
+        "broccoli-debug": "^0.6.4",
+        "broccoli-funnel": "^2.0.2",
+        "broccoli-source": "^2.1.2",
+        "calculate-cache-key-for-tree": "^2.0.0",
+        "clone": "^2.1.2",
+        "ember-cli-babel-plugin-helpers": "^1.1.1",
+        "ember-cli-version-checker": "^4.1.0",
+        "ensure-posix-path": "^1.0.2",
+        "fixturify-project": "^1.10.0",
+        "resolve-package-path": "^3.1.0",
+        "rimraf": "^3.0.1",
+        "semver": "^5.5.0"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/ember-cli-babel/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/ember-cli-version-checker": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-4.1.1.tgz",
+      "integrity": "sha512-bzEWsTMXUGEJfxcAGWPe6kI7oHEGD3jaxUWDYPTqzqGhNkgPwXTBgoWs9zG1RaSMaOPFnloWuxRcoHi4TrYS3Q==",
+      "dev": true,
+      "dependencies": {
+        "resolve-package-path": "^2.0.0",
+        "semver": "^6.3.0",
+        "silent-error": "^1.1.1"
+      },
+      "engines": {
+        "node": "8.* || 10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/ember-cli-version-checker/node_modules/resolve-package-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-2.0.0.tgz",
+      "integrity": "sha512-/CLuzodHO2wyyHTzls5Qr+EFeG6RcW4u6//gjYvUfcfyuplIX1SSccU+A5A9A78Gmezkl3NBkFAMxLbzTY9TJA==",
+      "dev": true,
+      "dependencies": {
+        "path-root": "^0.1.1",
+        "resolve": "^1.13.1"
+      },
+      "engines": {
+        "node": "8.* || 10.* || >= 12"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/find-babel-config": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.2.tgz",
+      "integrity": "sha512-oK59njMyw2y3yxto1BCfVK7MQp/OYf4FleHu0RgosH3riFJ1aOuo/7naLDLAObfrgn3ueFhw5sAT/cp0QuJI3Q==",
+      "dev": true,
+      "dependencies": {
+        "json5": "^1.0.2",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/fixturify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fixturify/-/fixturify-1.3.0.tgz",
+      "integrity": "sha512-tL0svlOy56pIMMUQ4bU1xRe6NZbFSa/ABTWMxW2mH38lFGc9TrNAKWcMBQ7eIjo3wqSS8f2ICabFaatFyFmrVQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/fs-extra": "^5.0.5",
+        "@types/minimatch": "^3.0.3",
+        "@types/rimraf": "^2.0.2",
+        "fs-extra": "^7.0.1",
+        "matcher-collection": "^2.0.0"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/fixturify-project": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/fixturify-project/-/fixturify-project-1.10.0.tgz",
+      "integrity": "sha512-L1k9uiBQuN0Yr8tA9Noy2VSQ0dfg0B8qMdvT7Wb5WQKc7f3dn3bzCbSrqlb+etLW+KDV4cBC7R1OvcMg3kcxmA==",
+      "dev": true,
+      "dependencies": {
+        "fixturify": "^1.2.0",
+        "tmp": "^0.0.33"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/istextorbinary": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
+      "integrity": "sha512-kT1g2zxZ5Tdabtpp9VSdOzW9lb6LXImyWbzbQeTxoRtHhurC9Ej9Wckngr2+uepPL09ky/mJHmN9jeJPML5t6A==",
+      "dev": true,
+      "dependencies": {
+        "binaryextensions": "1 || 2",
+        "editions": "^1.1.1",
+        "textextensions": "1 || 2"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
+    },
+    "node_modules/ember-cli-clipboard/node_modules/p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+      "integrity": "sha512-fjAPuiws93rm7mPUu21RdBnkeZNrbfCFCwfAhPWY+rR3zG0ubpe5cEReHOw5fIbfmsxEV/g2kSxGTATY3Bpnwg==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true
+    },
+    "node_modules/ember-cli-clipboard/node_modules/reselect": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
+      "integrity": "sha512-b/6tFZCmRhtBMa4xGqiiRp9jh9Aqi2A687Lo265cN0/QohJQEBPiQ52f4QB6i0eF3yp3hmLL21LSGBcML2dlxA==",
+      "dev": true
+    },
+    "node_modules/ember-cli-clipboard/node_modules/resolve-package-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
+      "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
+      "dev": true,
+      "dependencies": {
+        "path-root": "^0.1.1",
+        "resolve": "^1.17.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/sync-disk-cache": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-1.3.4.tgz",
+      "integrity": "sha512-GlkGeM81GPPEKz/lH7QUTbvqLq7K/IUTuaKDSMulP9XQ42glqNJIN/RKgSOw4y8vxL1gOVvj+W7ruEO4s36eCw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^2.1.3",
+        "heimdalljs": "^0.2.3",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^2.2.8",
+        "username-sync": "^1.0.2"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/sync-disk-cache/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/walk-sync": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
+      "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
+      "dev": true,
+      "dependencies": {
+        "ensure-posix-path": "^1.0.0",
+        "matcher-collection": "^1.0.0"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/walk-sync/node_modules/matcher-collection": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
+      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^3.0.2"
+      }
+    },
+    "node_modules/ember-cli-clipboard/node_modules/workerpool": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-3.1.2.tgz",
+      "integrity": "sha512-WJFA0dGqIK7qj7xPTqciWBH5DlJQzoPjsANvc3Y4hNB0SScT+Emjvt0jPPkDBUjBNngX1q9hHgt1Gfwytu6pug==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.3.4",
+        "object-assign": "4.1.1",
+        "rsvp": "^4.8.4"
+      }
     },
     "node_modules/ember-cli-dependency-checker": {
       "version": "3.3.2",
@@ -41057,6 +42480,15 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
+      "dev": true,
+      "dependencies": {
+        "delegate": "^3.1.2"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "dev": true,
@@ -43024,6 +44456,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/loud-rejection": {
@@ -45853,6 +47297,23 @@
         "node": "10.* || >= 12.*"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
+    },
     "node_modules/proper-lockfile": {
       "version": "4.1.2",
       "dev": true,
@@ -47108,6 +48569,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA==",
+      "dev": true
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -49290,6 +50757,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "dev": true
     },
     "node_modules/tiny-glob": {
       "version": "0.2.9",

--- a/admin/package.json
+++ b/admin/package.json
@@ -66,6 +66,7 @@
     "ember-cli": "^5.3.0",
     "ember-cli-app-version": "^6.0.0",
     "ember-cli-babel": "^8.0.0",
+    "ember-cli-clipboard": "^1.1.0",
     "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-htmlbars": "^6.1.1",
     "ember-cli-inject-live-reload": "^2.1.0",

--- a/admin/tests/integration/components/users/user-overview_test.js
+++ b/admin/tests/integration/components/users/user-overview_test.js
@@ -2,12 +2,13 @@ import { clickByName, render, waitFor } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | users | user-overview', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   module('when the admin member has access to users actions scope', function (hooks) {
     class AccessControlStub extends Service {
@@ -93,6 +94,64 @@ module('Integration | Component | users | user-overview', function (hooks) {
           assert.dom(screen.getByText(`Langue : ${expected.lang}`)).exists();
           assert.dom(screen.getByText(`Locale : ${expected.locale}`)).exists();
           assert.dom(screen.getByText('Date de création :')).exists();
+        });
+      });
+
+      module('copy feature', function () {
+        module('when information is provided', function () {
+          test('displays copy button after the user e-mail', async function (assert) {
+            // given
+            const email = 'pat.ate@example.net';
+            const store = this.owner.lookup('service:store');
+            const user = store.createRecord('user', {
+              firstName: 'Pat',
+              lastName: 'Ate',
+              email,
+              lang: 'fr',
+              locale: 'fr-FR',
+              createdAt: new Date('2021-12-10'),
+            });
+            this.set('user', user);
+
+            // when
+            const screen = await render(hbs`<Users::UserOverview @user={{this.user}} />`);
+
+            // then
+            assert.ok(
+              screen
+                .getByRole('button', {
+                  name: this.intl.t('components.users.user-detail-personal-information.actions.copy-email'),
+                })
+                .hasAttribute('data-clipboard-text', email),
+            );
+          });
+
+          test('displays copy button after the user ID', async function (assert) {
+            // given
+            const username = 'mouss.tique';
+            const store = this.owner.lookup('service:store');
+            const user = store.createRecord('user', {
+              firstName: 'Mouss',
+              lastName: 'Tique',
+              username,
+              lang: 'fr',
+              locale: 'fr-FR',
+              createdAt: new Date('2021-12-10'),
+            });
+            this.set('user', user);
+
+            // when
+            const screen = await render(hbs`<Users::UserOverview @user={{this.user}} />`);
+
+            // then
+            assert.ok(
+              screen
+                .getByRole('button', {
+                  name: this.intl.t('components.users.user-detail-personal-information.actions.copy-username'),
+                })
+                .hasAttribute('data-clipboard-text', username),
+            );
+          });
         });
       });
 
@@ -438,8 +497,6 @@ module('Integration | Component | users | user-overview', function (hooks) {
           .exists();
       });
 
-      // TODO Fix arai-hidden PixUI Modal before this test pass
-      test.skip('should close the modal to cancel action', async function (assert) {
       // TODO Fix aria-hidden PixUI Modal before this test pass
       test.skip('closes the modal to cancel action', async function (assert) {
         // given

--- a/admin/tests/integration/components/users/user-overview_test.js
+++ b/admin/tests/integration/components/users/user-overview_test.js
@@ -9,7 +9,7 @@ import sinon from 'sinon';
 module('Integration | Component | users | user-overview', function (hooks) {
   setupRenderingTest(hooks);
 
-  module('When the admin member has access to users actions scope', function (hooks) {
+  module('when the admin member has access to users actions scope', function (hooks) {
     class AccessControlStub extends Service {
       hasAccessToUsersActionsScope = true;
     }
@@ -18,8 +18,8 @@ module('Integration | Component | users | user-overview', function (hooks) {
       this.owner.register('service:access-control', AccessControlStub);
     });
 
-    module('When the admin look at user details', function () {
-      test('should display the update button', async function (assert) {
+    module('when the admin look at user details', function () {
+      test('displays the update button', async function (assert) {
         // given
         this.set('user', {
           firstName: 'John',
@@ -35,7 +35,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
         assert.dom(screen.getByRole('button', { name: 'Modifier' })).exists();
       });
 
-      test('should display user’s information', async function (assert) {
+      test('displays user’s information', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
         const user = store.createRecord('user', {
@@ -97,8 +97,8 @@ module('Integration | Component | users | user-overview', function (hooks) {
       });
 
       module('terms of service', function () {
-        module('should display yes by application', function () {
-          test('should display "OUI" with date when user accepted Pix App terms of service', async function (assert) {
+        module('displays yes by application', function () {
+          test('displays "OUI" with date when user accepted Pix App terms of service', async function (assert) {
             // given
             this.set('user', { cgu: true, lastTermsOfServiceValidatedAt: new Date('2021-12-10') });
 
@@ -109,7 +109,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
             assert.dom(screen.getByText('CGU Pix App validé : OUI, le 10/12/2021')).exists();
           });
 
-          test('should display "OUI" with date when user accepted Pix Orga terms of service', async function (assert) {
+          test('displays "OUI" with date when user accepted Pix Orga terms of service', async function (assert) {
             // given
             this.set('user', {
               pixOrgaTermsOfServiceAccepted: true,
@@ -123,7 +123,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
             assert.dom(screen.getByText('CGU Pix Orga validé : OUI, le 14/12/2021')).exists();
           });
 
-          test('should display "OUI" with date when user accepted Pix Certif terms of service', async function (assert) {
+          test('displays "OUI" with date when user accepted Pix Certif terms of service', async function (assert) {
             // given
             this.set('user', {
               pixCertifTermsOfServiceAccepted: true,
@@ -138,7 +138,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
           });
         });
 
-        test('should display "NON" when user not accepted Pix App terms of service', async function (assert) {
+        test('displays "NON" when user not accepted Pix App terms of service', async function (assert) {
           // given
           this.set('user', { pixCertifTermsOfServiceAccepted: true, pixOrgaTermsOfServiceAccepted: true, cgu: false });
 
@@ -149,7 +149,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
           assert.dom(screen.getByText('CGU Pix App validé : NON')).exists();
         });
 
-        test('should display "NON" when user not accepted Pix Orga terms of service', async function (assert) {
+        test('displays "NON" when user not accepted Pix Orga terms of service', async function (assert) {
           // given
           this.set('user', { pixCertifTermsOfServiceAccepted: true, pixOrgaTermsOfServiceAccepted: false, cgu: true });
 
@@ -160,7 +160,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
           assert.dom(screen.getByText('CGU Pix Orga validé : NON')).exists();
         });
 
-        test('should display "NON" when user not accepted Pix Certif terms of service and "OUI" with no date when terms of service for an app are validated but no date provided', async function (assert) {
+        test('displays "NON" when user not accepted Pix Certif terms of service and "OUI" with no date when terms of service for an app are validated but no date provided', async function (assert) {
           // given
           this.set('user', { pixCertifTermsOfServiceAccepted: false, pixOrgaTermsOfServiceAccepted: true, cgu: true });
 
@@ -186,7 +186,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
           clock.restore();
         });
 
-        test('should only display failure count if user is not blocked', async function (assert) {
+        test('displays failure count if user is not blocked', async function (assert) {
           // given
           const store = this.owner.lookup('service:store');
           const userLogin = store.createRecord('user-login', {
@@ -206,7 +206,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
           assert.dom(screen.getByText('Nombre de tentatives de connexion en erreur : 0')).exists();
         });
 
-        test('should display dates when user is temporarily blocked', async function (assert) {
+        test('displays dates when user is temporarily blocked', async function (assert) {
           // given
           const store = this.owner.lookup('service:store');
           const userLogin = store.createRecord('user-login', {
@@ -228,7 +228,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
           assert.dom(screen.queryByText('Utilisateur totalement bloqué le :')).doesNotExist();
         });
 
-        test('should display dates when user is blocked', async function (assert) {
+        test('displays dates when user is blocked', async function (assert) {
           // given
           const store = this.owner.lookup('service:store');
           const userLogin = store.createRecord('user-login', {
@@ -324,7 +324,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
       });
 
       module('when user has an email only', function () {
-        test('should display user’s email in edit mode', async function (assert) {
+        test('displays user’s email in edit mode', async function (assert) {
           // given
           this.set('user', user);
 
@@ -336,7 +336,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
           assert.dom(screen.getByRole('textbox', { name: 'Adresse e-mail :' })).hasValue(this.user.email);
         });
 
-        test('should not display username in edit mode', async function (assert) {
+        test('does not display username in edit mode', async function (assert) {
           // given
           this.set('user', user);
 
@@ -350,7 +350,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
       });
 
       module('when user has a username only', function () {
-        test('should display user’s username in edit mode', async function (assert) {
+        test('displays user’s username in edit mode', async function (assert) {
           // given
           const user = EmberObject.create({
             lastName: 'Harry',
@@ -368,7 +368,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
           assert.dom(screen.getByRole('textbox', { name: 'Identifiant :' })).hasValue(this.user.username);
         });
 
-        test('should display email', async function (assert) {
+        test('displays email', async function (assert) {
           // given
           const user = EmberObject.create({
             lastName: 'Harry',
@@ -388,7 +388,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
       });
 
       module('when user has no username and no email', function () {
-        test('should not display email', async function (assert) {
+        test('does not display email', async function (assert) {
           // given
           const user = EmberObject.create({
             lastName: 'Harry',
@@ -420,7 +420,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
         });
       });
 
-      test('should show modal', async function (assert) {
+      test('shows modal', async function (assert) {
         // given
         this.set('user', user);
         const screen = await render(hbs`<Users::UserOverview @user={{this.user}} />`);
@@ -440,6 +440,8 @@ module('Integration | Component | users | user-overview', function (hooks) {
 
       // TODO Fix arai-hidden PixUI Modal before this test pass
       test.skip('should close the modal to cancel action', async function (assert) {
+      // TODO Fix aria-hidden PixUI Modal before this test pass
+      test.skip('closes the modal to cancel action', async function (assert) {
         // given
         this.set('user', user);
         const screen = await render(hbs`<Users::UserOverview @user={{this.user}} />`);
@@ -455,7 +457,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
         assert.dom(screen.queryByRole('button', { name: 'Annuler' })).doesNotExist();
       });
 
-      test('should display an anonymisation message with the full name of the admin member', async function (assert) {
+      test('displays an anonymisation message with the full name of the admin member', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
         const user = store.createRecord('user', { hasBeenAnonymised: true, anonymisedByFullName: 'Laurent Gina' });
@@ -468,7 +470,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
         assert.dom(screen.getByText('Utilisateur anonymisé par Laurent Gina.')).exists();
       });
 
-      test('should disable action buttons "Modifier" and "Anonymiser cet utilisateur"', async function (assert) {
+      test('disables action buttons "Modifier" and "Anonymiser cet utilisateur"', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
         const user = store.createRecord('user', { hasBeenAnonymised: true, anonymisedByFullName: 'Laurent Gina' });
@@ -483,7 +485,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
       });
 
       module('When the admin member who anonymised the user is not set in database', function () {
-        test('should display an anonymisation message', async function (assert) {
+        test('displays an anonymisation message', async function (assert) {
           // given
           const store = this.owner.lookup('service:store');
           const user = store.createRecord('user', { hasBeenAnonymised: true, anonymisedByFullName: null });
@@ -500,7 +502,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
   });
 
   module('When the admin member does not have access to users actions scope', function () {
-    test('it should not be able to see action buttons "Modifier" and "Anonymiser cet utilisateur"', async function (assert) {
+    test('does not display the action buttons "Modifier" and "Anonymiser cet utilisateur"', async function (assert) {
       // given
       class AccessControlStub extends Service {
         hasAccessToUsersActionsScope = false;

--- a/admin/tests/integration/components/users/user-overview_test.js
+++ b/admin/tests/integration/components/users/user-overview_test.js
@@ -1,6 +1,7 @@
 import { clickByName, render, waitFor } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
+import { triggerEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -126,6 +127,35 @@ module('Integration | Component | users | user-overview', function (hooks) {
             );
           });
 
+          test('displays tooltip on copy user e-mail button hover', async function (assert) {
+            // given
+            const email = 'pat.ate@example.net';
+            const store = this.owner.lookup('service:store');
+            const user = store.createRecord('user', {
+              firstName: 'Pat',
+              lastName: 'Ate',
+              email,
+              lang: 'fr',
+              locale: 'fr-FR',
+              createdAt: new Date('2021-12-10'),
+            });
+            this.set('user', user);
+
+            // when
+            const screen = await render(hbs`<Users::UserOverview @user={{this.user}} />`);
+            const copyButton = await screen.getByRole('button', {
+              name: this.intl.t('components.users.user-detail-personal-information.actions.copy-email'),
+            });
+            await triggerEvent(copyButton, 'mouseenter');
+
+            // then
+            assert
+              .dom(
+                screen.getByText(this.intl.t('components.users.user-detail-personal-information.actions.copy-email')),
+              )
+              .exists();
+          });
+
           test('displays copy button after the user ID', async function (assert) {
             // given
             const username = 'mouss.tique';
@@ -151,6 +181,37 @@ module('Integration | Component | users | user-overview', function (hooks) {
                 })
                 .hasAttribute('data-clipboard-text', username),
             );
+          });
+
+          test('displays tooltip on copy username button hover', async function (assert) {
+            // given
+            const username = 'mouss.tique';
+            const store = this.owner.lookup('service:store');
+            const user = store.createRecord('user', {
+              firstName: 'Mouss',
+              lastName: 'Tique',
+              username,
+              lang: 'fr',
+              locale: 'fr-FR',
+              createdAt: new Date('2021-12-10'),
+            });
+            this.set('user', user);
+
+            // when
+            const screen = await render(hbs`<Users::UserOverview @user={{this.user}} />`);
+            const copyButton = await screen.getByRole('button', {
+              name: this.intl.t('components.users.user-detail-personal-information.actions.copy-username'),
+            });
+            await triggerEvent(copyButton, 'mouseenter');
+
+            // then
+            assert
+              .dom(
+                screen.getByText(
+                  this.intl.t('components.users.user-detail-personal-information.actions.copy-username'),
+                ),
+              )
+              .exists();
           });
         });
 

--- a/admin/tests/integration/components/users/user-overview_test.js
+++ b/admin/tests/integration/components/users/user-overview_test.js
@@ -153,6 +153,60 @@ module('Integration | Component | users | user-overview', function (hooks) {
             );
           });
         });
+
+        module('when information is not provided', function () {
+          test('does not display copy button after the user e-mail', async function (assert) {
+            // given
+            const store = this.owner.lookup('service:store');
+            const user = store.createRecord('user', {
+              firstName: 'Pat',
+              lastName: 'Ate',
+              username: 'pat.ate',
+              lang: 'fr',
+              locale: 'fr-FR',
+              createdAt: new Date('2021-12-10'),
+            });
+            this.set('user', user);
+
+            // when
+            const screen = await render(hbs`<Users::UserOverview @user={{this.user}} />`);
+
+            // then
+            assert
+              .dom(
+                screen.queryByRole('button', {
+                  name: this.intl.t('components.users.user-detail-personal-information.actions.copy-email'),
+                }),
+              )
+              .doesNotExist();
+          });
+
+          test('does not display copy button after the user ID', async function (assert) {
+            // given
+            const store = this.owner.lookup('service:store');
+            const user = store.createRecord('user', {
+              firstName: 'Mouss',
+              lastName: 'Tique',
+              email: 'mouss.tique@example.net',
+              lang: 'fr',
+              locale: 'fr-FR',
+              createdAt: new Date('2021-12-10'),
+            });
+            this.set('user', user);
+
+            // when
+            const screen = await render(hbs`<Users::UserOverview @user={{this.user}} />`);
+
+            // then
+            assert
+              .dom(
+                screen.queryByRole('button', {
+                  name: this.intl.t('components.users.user-detail-personal-information.actions.copy-username'),
+                }),
+              )
+              .doesNotExist();
+          });
+        });
       });
 
       module('terms of service', function () {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -190,9 +190,14 @@
         }
       },
       "user-detail-personal-information": {
+        "actions": {
+          "copy-email": "Copy user e-mail address",
+          "copy-username": "Copy user id"
+        },
         "authentication-method": {
           "should-change-password-status": "Temporary password :"
-        }
+        },
+        "copied": "Copied!"
       }
     }
   },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -200,9 +200,14 @@
         }
       },
       "user-detail-personal-information": {
+        "actions": {
+          "copy-email": "Copier l’adresse e-mail",
+          "copy-username": "Copier l’identifiant"
+        },
         "authentication-method": {
           "should-change-password-status": "Mot de passe temporaire :"
-        }
+        },
+        "copied": "Copié !"
       }
     }
   },


### PR DESCRIPTION
## :unicorn: Problème

Les membres du support doivent sélectionner l'adresse e-mail ou l'identifiant d'un compte utilisateur via la souris. Cela peut entraîner une perte d'information, donc refaire la même manipulation, ou ajouter un caractère en trop dans le contenu copié.

Pour faciliter et améliorer l'expérience d'utilisation pour les membres du support, il faudrait ajouter un bouton `Copier` pour les informations suivantes : **adresse e-mail** et **identifiant**.

## :robot: Proposition

Ajouter un bouton `Copier` après l'adresse-email et l'identifiant. Ce bouton doit s'afficher uniquement si la donnée est présente. Dans le cas contraire, ne rien afficher.

## :rainbow: Remarques

RAS

## :100: Pour tester

1. Se connecter à Pix Admin https://admin-pr9075.review.pix.fr/
2. Aller sur la page de détails d'un compte utilisateur (ex: Prénom - James)
3. Constater l'affichage de bouton `Copier` à droite des lignes concernant l'adresse e-mail et l'identifiant du compte utilisateur
4. Cliquer sur l'un des boutons
5. Coller le contenu copié
6. Constater que le contenu a bien été copié