### PR TITLE
[TECH] configuration pour le TMS Phrase

### DIFF
--- a/.phrase.yml
+++ b/.phrase.yml
@@ -5,73 +5,61 @@ phrase:
     - file: ./mon-pix/translations/fr.json
       project_id: "9ca9a54c81b5a85168c8df3d6953a49e"
       params:
-        update_translations: true
         locale_id: 'fr'
 
     - file: ./mon-pix/translations/en.json
       project_id: "9ca9a54c81b5a85168c8df3d6953a49e"
       params:
-        update_translations: true
         locale_id: 'en'
 
     - file: ./orga/translations/fr.json
       project_id: "93a23f4b74a86dbb53244134fb21ef43"
       params:
-        update_translations: true
         locale_id: 'fr'
 
     - file: ./orga/translations/en.json
       project_id: "93a23f4b74a86dbb53244134fb21ef43"
       params:
-        update_translations: true
         locale_id: 'en'
 
     - file: ./certif/translations/fr.json
       project_id: "3371843f0a06e47d0fba1374b19b439c"
       params:
-        update_translations: true
         locale_id: 'fr'
 
     - file: ./certif/translations/en.json
       project_id: "3371843f0a06e47d0fba1374b19b439c"
       params:
-        update_translations: true
         locale_id: 'en'
 
     - file: ./admin/translations/fr.json
       project_id: "0e242bea62d0ac0d989d082b8d1d96d7"
       params:
-        update_translations: true
         locale_id: 'fr'
 
     - file: ./admin/translations/en.json
       project_id: "0e242bea62d0ac0d989d082b8d1d96d7"
       params:
-        update_translations: true
         locale_id: 'en'
 
     - file: ./1d/translations/fr.json
       project_id: "dd99bbfc9e880398e292a808e7013896"
       params:
-        update_translations: true
         locale_id: 'fr'
 
     - file: ./1d/translations/en.json
       project_id: "dd99bbfc9e880398e292a808e7013896"
       params:
-        update_translations: true
         locale_id: 'en'
 
     - file: ./api/translations/fr.json
       project_id: "88f30f82bdab4e25ac5e57b6663a941a"
       params:
-        update_translations: true
         locale_id: 'fr'
 
     - file: ./api/translations/en.json
       project_id: "88f30f82bdab4e25ac5e57b6663a941a"
       params:
-        update_translations: true
         locale_id: 'en'
 
   pull:

--- a/.phrase.yml
+++ b/.phrase.yml
@@ -42,12 +42,12 @@ phrase:
       params:
         locale_id: 'en'
 
-    - file: ./1d/translations/fr.json
+    - file: ./junior/translations/fr.json
       project_id: "dd99bbfc9e880398e292a808e7013896"
       params:
         locale_id: 'fr'
 
-    - file: ./1d/translations/en.json
+    - file: ./junior/translations/en.json
       project_id: "dd99bbfc9e880398e292a808e7013896"
       params:
         locale_id: 'en'

--- a/.phrase.yml
+++ b/.phrase.yml
@@ -86,26 +86,6 @@ phrase:
        params:
          locale_id: 'es'
 
-     - file: ./orga/translations/nl.json
-       project_id: "93a23f4b74a86dbb53244134fb21ef43"
-       params:
-         locale_id: 'nl'
-
-     - file: ./certif/translations/nl.json
-       project_id: "3371843f0a06e47d0fba1374b19b439c"
-       params:
-         locale_id: 'nl'
-
-     - file: ./admin/translations/nl.json
-       project_id: "0e242bea62d0ac0d989d082b8d1d96d7"
-       params:
-         locale_id: 'nl'
-
-     - file: ./1d/translations/nl.json
-       project_id: "dd99bbfc9e880398e292a808e7013896"
-       params:
-         locale_id: 'nl'
-
      - file: ./api/translations/nl.json
        project_id: "88f30f82bdab4e25ac5e57b6663a941a"
        params:


### PR DESCRIPTION
## :unicorn: Problème

L’usage local de Phrase affiche des erreurs. La console finit en erreur avec un code exit 1 
et cela termine le CLI dans son pull

![image](https://github.com/1024pix/pix/assets/170271/7e83a31a-18fa-458b-8856-f6f108e3b713)

## :robot: Proposition

* Ne conserver que la configuration qui existe bien côté Phrase
  * Enlèves les codes exit 1
  * Permet aux développeurs de savoir de manière effective les langues configurées côté Phrase pour telle ou telle appli en regardant le .phrase.yml

* Supprimer update_translations: true
  * Pour éviter un écrasement malheureux par un dev de traductions validées par les traducteurs sur Phrase
    * les jetons d’authent comportant par défaut les droits “write”
  * Faire de Phrase la source de vérité en terme de traduction, car c’est là que les traducteurs travaillent
    * Note : **il sera toujours possible de push avec overwrite via CLI** ce ne sera juste plus le comportement par défaut
    * Les **nouvelles** clés pourront être push avec le paramètre à faux

Source : https://support.phrase.com/hc/fr/articles/5784118494492-Modifier-le-fichier-de-configuration-CLI-Strings#:~:text=Update_translations%20est%20d%C3%A9fini%20sur%20faux,remplace%20tout%20contenu%20d%C3%A9j%C3%A0%20pr%C3%A9sent.

> Update_translations est défini sur faux, donc seules les nouvelles clés et traductions sont importées. S ' il est défini sur vrai, le client importe également les modifications locales apportées aux traductions existantes et remplace tout contenu déjà présent.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

* Avoir suivi la procédure d'installation du CLI, suivre par exemple [le tutoriel Pix sur Confluence](https://1024pix.atlassian.net/wiki/spaces/PROD/pages/4190339074/I18n+-+Maintenance+d+une+langue), ou bien les instructions [sur Phrase](https://support.phrase.com/hc/en-us/articles/5784093863964-CLI-Installation-Strings)
* Lancer la commande ` phrase --config .phrase.yml -t $PHRASE_TOKEN pull` depuis la racine du projet Pix
* Vérifier que la commande fonctionne et ne termine pas en erreur
