### PR TITLE
[TECH] Ajout d'un feature toggle pour les écrans d'informations de certif V3 (PIX-11844).

### DIFF
--- a/api/lib/infrastructure/validate-environment-variables.js
+++ b/api/lib/infrastructure/validate-environment-variables.js
@@ -30,6 +30,7 @@ const schema = Joi.object({
   NODE_ENV: Joi.string().optional().valid('development', 'test', 'production'),
   FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE: Joi.string().optional().valid('true', 'false'),
   FT_ENABLE_PIX_PLUS_LOWER_LEVEL: Joi.string().optional().valid('true', 'false'),
+  FT_ENABLE_V3_INFO_SCREENS: Joi.string().optional().valid('true', 'false'),
   POLE_EMPLOI_CLIENT_ID: Joi.string().optional(),
   POLE_EMPLOI_CLIENT_SECRET: Joi.string().optional(),
   POLE_EMPLOI_TOKEN_URL: Joi.string().uri().optional(),

--- a/api/sample.env
+++ b/api/sample.env
@@ -724,6 +724,13 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: false
 # FT_ENABLE_PIX_PLUS_LOWER_LEVEL=false
 
+# Displays the V3 certification pre-test information screens
+#
+# presence: optional
+# type: boolean
+# default: false
+# FT_ENABLE_V3_INFO_SCREENS=false
+
 # Enable the verification of the scope in certification tokens
 #
 # presence: optional

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -183,6 +183,7 @@ const configuration = (function () {
       scoAccountRecoveryKeyLifetimeMinutes: process.env.SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES,
     },
     featureToggles: {
+      areV3InfoScreensEnabled: toBoolean(process.env.FT_ENABLE_V3_INFO_SCREENS),
       isAlwaysOkValidateNextChallengeEndpointEnabled: toBoolean(
         process.env.FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT,
       ),

--- a/api/tests/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -20,6 +20,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
           id: '0',
           type: 'feature-toggles',
           attributes: {
+            'are-v3-info-screens-enabled': false,
             'is-always-ok-validate-next-challenge-endpoint-enabled': false,
             'is-pix1d-enabled': true,
             'is-pix-plus-lower-lever-enabled': false,


### PR DESCRIPTION
## :unicorn: Problème

Dans le cadre de la nouvelle certif, nous allons mettre à disposition des candidats des écrans d’instruction afin de leur donner des infos sur le test qu’ils vont passer.

Afin d’avancer étape par étape dans le développement, tous les écrans ne seront pas développés au même moment, mais nous souhaitons mettre à dispo ces écrans aux candidat que lorsqu’ils seront complets.

## :robot: Proposition

Ajout d'un nouveau feature toggle.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

Tests au vert.
