### PR TITLE
[BUGFIX] Numéroter les participations dans le bon ordre dans le selecteur de participation (pix-12713)

### DIFF
--- a/orga/app/components/participant/assessment/header.hbs
+++ b/orga/app/components/participant/assessment/header.hbs
@@ -18,9 +18,10 @@
     {{#if @campaign.multipleSendings}}
       <PixSelect
         @options={{this.participationsListOptions}}
-        @inlineLabel="true"
         @value={{this.selectedParticipation.value}}
         @onChange={{this.selectAParticipation}}
+        @inlineLabel={{true}}
+        @hideDefaultOption={{true}}
       >
         <:label>{{t "pages.assessment-individual-results.participation-selector"}}</:label>
       </PixSelect>

--- a/orga/app/components/participant/assessment/header.js
+++ b/orga/app/components/participant/assessment/header.js
@@ -41,10 +41,9 @@ export default class Header extends Component {
   }
 
   get participationsListOptions() {
-    let participationNumber = 0;
-    const options = this.args.allParticipations.map((participation) => {
-      participationNumber++;
+    let participationNumber = this.args.allParticipations.length;
 
+    const options = this.args.allParticipations.map((participation) => {
       let category;
       let label = this.intl.t('pages.assessment-individual-results.participation-label', { participationNumber });
 
@@ -55,12 +54,13 @@ export default class Header extends Component {
 
       if (participation.status === 'SHARED') {
         category = `— ${this.intl.t('pages.assessment-individual-results.participation-shared')} —`;
-      } else if (participation.status === 'TO_SHARE') {
-        category = `— ${this.intl.t('pages.assessment-individual-results.participation-to-share')} —`;
+      } else {
+        category = `— ${this.intl.t('pages.assessment-individual-results.participation-not-shared')} —`;
       }
 
+      participationNumber--;
+
       return {
-        id: participationNumber,
         value: participation.id,
         label,
         category,

--- a/orga/tests/integration/components/participant/assessment/header_test.js
+++ b/orga/tests/integration/components/participant/assessment/header_test.js
@@ -97,7 +97,7 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
         );
         assert.ok(
           within(screen.getByRole('listbox')).getByText(
-            this.intl.t('pages.assessment-individual-results.participation-to-share'),
+            this.intl.t('pages.assessment-individual-results.participation-not-shared'),
             { exact: false },
           ),
         );
@@ -138,7 +138,7 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
         await screen.findByRole('listbox');
         await click(
           screen.getByRole('option', {
-            name: `${this.intl.t('pages.assessment-individual-results.participation-label', { participationNumber: 2 })} - 02/01/2020`,
+            name: `${this.intl.t('pages.assessment-individual-results.participation-label', { participationNumber: 1 })} - 02/01/2020`,
           }),
         );
 

--- a/orga/tests/unit/components/participant/assessment/header_test.js
+++ b/orga/tests/unit/components/participant/assessment/header_test.js
@@ -1,0 +1,55 @@
+import { module, test } from 'qunit';
+
+import createGlimmerComponent from '../../../../helpers/create-glimmer-component';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Unit | Component | Participant | Assessment | Header', (hooks) => {
+  setupIntlRenderingTest(hooks);
+
+  let component;
+
+  hooks.beforeEach(function () {
+    component = createGlimmerComponent('component:participant/assessment/header');
+  });
+
+  module('get participationsListOptions', () => {
+    test('should return options numbered catergorized', function (assert) {
+      // given
+      component.args.allParticipations = [
+        {
+          id: '93714',
+          sharedAt: null,
+          status: 'STARTED',
+        },
+        {
+          id: '93331',
+          sharedAt: null,
+          status: 'TO_SHARE',
+        },
+        {
+          id: '92990',
+          sharedAt: '2024-06-10T13:57:01.267Z',
+          status: 'SHARED',
+        },
+        {
+          id: '92450',
+          sharedAt: '2023-09-29T13:57:01.267Z',
+          status: 'SHARED',
+        },
+      ];
+
+      const expectedResult = [
+        { category: '— Résultats non-envoyés —', label: 'Participation #4', value: '93714' },
+        { category: '— Résultats non-envoyés —', label: 'Participation #3', value: '93331' },
+        { category: '— Résultats envoyés —', label: 'Participation #2 - 10/06/2024', value: '92990' },
+        { category: '— Résultats envoyés —', label: 'Participation #1 - 29/09/2023', value: '92450' },
+      ];
+
+      // when
+      const result = component.participationsListOptions;
+
+      // then
+      assert.deepEqual(result, expectedResult);
+    });
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -318,9 +318,9 @@
       "badges": "Thematic results",
       "breadcrumb-current-page-label": "Participation of {firstName} {lastName}",
       "participation-label": "Participation #{participationNumber}",
+      "participation-not-shared": "Results to submit",
       "participation-selector": "Select a participation",
       "participation-shared": "Submitted results",
-      "participation-to-share": "Results to submit",
       "progression": "Progression",
       "result": "Result",
       "tab": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -318,9 +318,9 @@
       "badges": "Résultats Thématiques",
       "breadcrumb-current-page-label": "Participation de {firstName} {lastName}",
       "participation-label": "Participation #{participationNumber}",
+      "participation-not-shared": "Résultats non-envoyés",
       "participation-selector": "Choisir une participation",
       "participation-shared": "Résultats envoyés",
-      "participation-to-share": "Résultats non-envoyés",
       "progression": "Avancement",
       "result": "Résultat",
       "tab": {


### PR DESCRIPTION
## :unicorn: Problème
Les participations ne sont pas numérotées dans le bon ordre
Les participations avec le status Started ne sont pas catégorisées
Il faut cacher l'option par défaut non renseigné du composant select
## :robot: Proposition
- Numéroter les participations dans le bon ordre
- Catégoriser les participations non shared
- Cacher l'option par défaut non renseigné du composant select

## :rainbow: Remarques
Voilà

## :100: Pour tester
- Refaire comme dans la PR précédente
- Vérifier l'ordre, les status et la non présence d'option vide en haut du selecteur