### PR TITLE
[BUGFIX] Forcer la locale fr pour les icônes d'étape du didacticiel (PIX-12447).

### DIFF
--- a/mon-pix/app/routes/campaigns/assessment/tutorial.js
+++ b/mon-pix/app/routes/campaigns/assessment/tutorial.js
@@ -26,7 +26,9 @@ export default class TutorialRoute extends Route {
     this.campaignCode = this.paramsFor('campaigns').code;
     return {
       title: this.intl.t(`pages.tutorial.pages.page${this.tutorialPageId}.title`),
-      icon: this.intl.t(`pages.tutorial.pages.page${this.tutorialPageId}.icon`),
+      icon: this.intl.t(`pages.tutorial.pages.page${this.tutorialPageId}.icon`, {
+        locale: 'fr',
+      }),
       explanation: this.intl.t(`pages.tutorial.pages.page${this.tutorialPageId}.explanation`),
       showNextButton: this.tutorialPageId < this.tutorialPageCount - 1,
       paging: this._setupPaging(this.tutorialPageCount, this.tutorialPageId),


### PR DESCRIPTION
## :unicorn: Problème

Avec l'automatisation de traductions, les clés dédiées à des icônes sont aussi traduites.
Or, dans les pages de didacticiel, on veut toujours utiliser la même icône, peu importe la langue de l'utilisateur.

## :robot: Proposition

Dans le code, forcer la langue `fr` pour les sources de ces icônes.

## :100: Pour tester

- Vérifier en RA que les icônes s'affichent bien
