### PR TITLE
[BUGFIX] Interdire les actions utilisateurs pendant la transition entre épreuves (PIX-12658).

### DIFF
--- a/junior/app/pods/assessment/challenge-loading/template.hbs
+++ b/junior/app/pods/assessment/challenge-loading/template.hbs
@@ -1,0 +1,3 @@
+<div class="loading-page">
+  <div class="loader"></div>
+</div>

--- a/junior/app/pods/assessment/challenge/controller.js
+++ b/junior/app/pods/assessment/challenge/controller.js
@@ -1,0 +1,3 @@
+import Controller from '@ember/controller';
+
+export default class Challenge extends Controller {}

--- a/junior/app/pods/assessment/challenge/route.js
+++ b/junior/app/pods/assessment/challenge/route.js
@@ -1,3 +1,4 @@
+import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
@@ -20,5 +21,13 @@ export default class ChallengeRoute extends Route {
     }
     const activity = await this.store.queryRecord('activity', { assessmentId: assessment.id });
     return { assessment, challenge, activity };
+  }
+
+  @action
+  loading(_transition, _originRoute) {
+    // eslint-disable-next-line ember/no-controller-access-in-routes
+    const controller = this.controllerFor('assessment.challenge');
+    controller.set('currentlyLoading', true);
+    return true;
   }
 }

--- a/junior/app/pods/components/challenge/component.js
+++ b/junior/app/pods/components/challenge/component.js
@@ -83,6 +83,6 @@ export default class Challenge extends Component {
     this.answerValue = null;
     this.answer = null;
 
-    this.router.transitionTo('assessment.resume');
+    this.router.replaceWith('assessment.resume');
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Lors des transitions entre épreuves, l'interface redevient active (notamment le bouton `Je vérifie`) ce qui peut être très perturbant pour l'utilisateur.


## :robot: Proposition
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
On ajoute une page de chargement propre aux épreuves.


## :rainbow: Remarques
On a beaucoup cherché et peu trouvé.
On a testé de réagir sur changement d'attributs du composant `Challenge` mais sans succès.
On a testé d'activer la page de loading générale mais sans succès.
On a donc fini avec une page de loading spécifique `challenge-loading` qui est un simple spinner pour le moment.

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
Se rendre sur une épreuve.
Valider l'épreuve.
Dégrader sa connexion réseau (par exemple `Good 2G` sur Firefox ou `Slow 3G` sur Chrome).
Cliquer sur `Je continue`.
Constater l'affichage d'un spinner.
Constater qu'il n'est plus possible d'accéder aux éléments de l'interface.