### PR TITLE
[BUGFIX] Import en masse de session KO pour l'inscription aux complémentaires (PIX-12718).

### DIFF
--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -167,20 +167,24 @@ class CertificationCandidate {
     this.sessionId = sessionId;
     this.userId = userId;
     this.organizationLearnerId = organizationLearnerId;
-    this.complementaryCertification = complementaryCertification;
     this.billingMode = billingMode;
     this.prepaymentCode = prepaymentCode;
-  }
 
-  get complementaryCertification() {
-    return this.#complementaryCertification;
-  }
+    Object.defineProperty(this, 'complementaryCertification', {
+      enumerable: true,
+      get: function () {
+        return this.#complementaryCertification;
+      },
 
-  set complementaryCertification(complementaryCertification) {
-    this.#complementaryCertification = complementaryCertification;
-    if (complementaryCertification?.id) {
-      this.#subscriptions?.add(SubscriptionTypes.COMPLEMENTARY);
-    }
+      set: function (complementaryCertification) {
+        this.#complementaryCertification = complementaryCertification;
+        if (complementaryCertification?.id) {
+          this.#subscriptions?.add(SubscriptionTypes.COMPLEMENTARY);
+        }
+      },
+    });
+
+    this.complementaryCertification = complementaryCertification;
   }
 
   get subscriptions() {

--- a/api/tests/unit/domain/models/CertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidate_test.js
@@ -61,9 +61,9 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         prepaymentCode: null,
         resultRecipientEmail: undefined,
         sex: undefined,
+        complementaryCertification: null,
       });
 
-      expect(certificationCandidate.complementaryCertification).to.be.null;
       expect(certificationCandidate.subscriptions).to.deepEqualArray([SubscriptionTypes.CORE]);
     });
   });

--- a/api/tests/unit/domain/models/CertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidate_test.js
@@ -19,52 +19,108 @@ const translate = i18n.__;
 
 describe('Unit | Domain | Models | Certification Candidate', function () {
   describe('constructor', function () {
-    it('should build a Certification Candidate', function () {
-      // given
-      const rawData = {
-        firstName: 'Jean-Pierre',
-        lastName: 'Foucault',
-        birthCity: 'Marseille',
-        birthProvinceCode: '13',
-        birthCountry: 'France',
-        externalId: 'QVGDM',
-        email: 'jp@fou.cau',
-        birthdate: '1940-05-05',
-        extraTimePercentage: 0.3,
-        sessionId: 1,
-        userId: 2,
-      };
+    describe('when there is no complementary certification', function () {
+      it('should build a Certification Candidate', function () {
+        // given
+        const rawData = {
+          firstName: 'Jean-Pierre',
+          lastName: 'Foucault',
+          birthCity: 'Marseille',
+          birthProvinceCode: '13',
+          birthCountry: 'France',
+          externalId: 'QVGDM',
+          email: 'jp@fou.cau',
+          birthdate: '1940-05-05',
+          extraTimePercentage: 0.3,
+          sessionId: 1,
+          userId: 2,
+        };
 
-      // when
-      const certificationCandidate = new CertificationCandidate(rawData);
+        // when
+        const certificationCandidate = new CertificationCandidate(rawData);
 
-      // then
-      expect(certificationCandidate).to.deep.equal({
-        id: undefined,
-        firstName: 'Jean-Pierre',
-        lastName: 'Foucault',
-        birthCity: 'Marseille',
-        birthProvinceCode: '13',
-        birthCountry: 'France',
-        externalId: 'QVGDM',
-        email: 'jp@fou.cau',
-        birthdate: '1940-05-05',
-        extraTimePercentage: 0.3,
-        sessionId: 1,
-        userId: 2,
-        authorizedToStart: undefined,
-        billingMode: null,
-        birthINSEECode: undefined,
-        birthPostalCode: undefined,
-        createdAt: undefined,
-        organizationLearnerId: null,
-        prepaymentCode: null,
-        resultRecipientEmail: undefined,
-        sex: undefined,
-        complementaryCertification: null,
+        // then
+        expect(certificationCandidate).to.deep.equal({
+          id: undefined,
+          firstName: 'Jean-Pierre',
+          lastName: 'Foucault',
+          birthCity: 'Marseille',
+          birthProvinceCode: '13',
+          birthCountry: 'France',
+          externalId: 'QVGDM',
+          email: 'jp@fou.cau',
+          birthdate: '1940-05-05',
+          extraTimePercentage: 0.3,
+          sessionId: 1,
+          userId: 2,
+          authorizedToStart: undefined,
+          billingMode: null,
+          birthINSEECode: undefined,
+          birthPostalCode: undefined,
+          createdAt: undefined,
+          organizationLearnerId: null,
+          prepaymentCode: null,
+          resultRecipientEmail: undefined,
+          sex: undefined,
+          complementaryCertification: null,
+        });
+
+        expect(certificationCandidate.subscriptions).to.deepEqualArray([SubscriptionTypes.CORE]);
       });
+    });
 
-      expect(certificationCandidate.subscriptions).to.deepEqualArray([SubscriptionTypes.CORE]);
+    describe('when there is a complementary certification', function () {
+      it('should build a Certification Candidate', function () {
+        // given
+        const rawData = {
+          firstName: 'Jean-Pierre',
+          lastName: 'Foucault',
+          birthCity: 'Marseille',
+          birthProvinceCode: '13',
+          birthCountry: 'France',
+          externalId: 'QVGDM',
+          email: 'jp@fou.cau',
+          birthdate: '1940-05-05',
+          extraTimePercentage: 0.3,
+          sessionId: 1,
+          userId: 2,
+          complementaryCertification: { id: 99 },
+        };
+
+        // when
+        const certificationCandidate = new CertificationCandidate(rawData);
+
+        // then
+        expect(certificationCandidate).to.deep.equal({
+          id: undefined,
+          firstName: 'Jean-Pierre',
+          lastName: 'Foucault',
+          birthCity: 'Marseille',
+          birthProvinceCode: '13',
+          birthCountry: 'France',
+          externalId: 'QVGDM',
+          email: 'jp@fou.cau',
+          birthdate: '1940-05-05',
+          extraTimePercentage: 0.3,
+          sessionId: 1,
+          userId: 2,
+          authorizedToStart: undefined,
+          billingMode: null,
+          birthINSEECode: undefined,
+          birthPostalCode: undefined,
+          createdAt: undefined,
+          organizationLearnerId: null,
+          prepaymentCode: null,
+          resultRecipientEmail: undefined,
+          sex: undefined,
+          complementaryCertification: { id: 99 },
+        });
+
+        expect(certificationCandidate.subscriptions).to.deepEqualArray([
+          SubscriptionTypes.CORE,
+          SubscriptionTypes.COMPLEMENTARY,
+        ]);
+      });
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème

Lors de l’import en masse de session, le choix de complémentaire ne s’enregistre pas

## :robot: Proposition

Lors de la serialisation de l’objet des session vers Redis, on utilise le spread operator qui réalise un shallow clone, qui ne prends en compte que les data properties et donc pas les accessors properties.

Le but de cette PR est de fournir une solution qui rétabli la fonctionnalité en production. Une étude + approfondie sera menée sur le sujet après.

## :rainbow: Remarques

L'origine du soucis vient du fait que l'usage de getter / setter en JS fait passer une property de "data propoerty" à "accessor property".
Voici une source qui peut être intéressant pour ne lire un peu + là-dessus : https://jscurious.com/object-defineproperty-method-in-javascript/

## :100: Pour tester

⚠️ Bien être vigilant sur la partie complémentaire

* Sur Pix Certif avec certif-pro@example.net , réaliser un import de sessions en masse via CSV
  * Créer au moins deux sessions
  * Mixer dans les sessions des candidats avec et sans complémentaire 
* Réaliser des tests de non régression, avec et sans complémentaires sur
  * Inscription candidat via modale
  * Inscription via ODS
