### PR TITLE
[FEATURE] Récupération de la version de la session après réconciliation (PIX-11842).

### DIFF
--- a/api/lib/domain/read-models/CertificationCandidateSubscription.js
+++ b/api/lib/domain/read-models/CertificationCandidateSubscription.js
@@ -1,9 +1,10 @@
 class CertificationCandidateSubscription {
-  constructor({ id, sessionId, eligibleSubscription, nonEligibleSubscription }) {
+  constructor({ id, sessionId, eligibleSubscription, nonEligibleSubscription, sessionVersion }) {
     this.id = id;
     this.sessionId = sessionId;
     this.eligibleSubscription = eligibleSubscription;
     this.nonEligibleSubscription = nonEligibleSubscription;
+    this.sessionVersion = sessionVersion;
   }
 }
 

--- a/api/lib/domain/usecases/get-certification-candidate-subscription.js
+++ b/api/lib/domain/usecases/get-certification-candidate-subscription.js
@@ -5,9 +5,12 @@ const getCertificationCandidateSubscription = async function ({
   certificationBadgesService,
   certificationCandidateRepository,
   certificationCenterRepository,
+  sessionRepository,
 }) {
   const certificationCandidate =
     await certificationCandidateRepository.getWithComplementaryCertification(certificationCandidateId);
+
+  const sessionVersion = await sessionRepository.getVersion({ id: certificationCandidate.sessionId });
 
   if (!certificationCandidate.complementaryCertification) {
     return new CertificationCandidateSubscription({
@@ -15,6 +18,7 @@ const getCertificationCandidateSubscription = async function ({
       sessionId: certificationCandidate.sessionId,
       eligibleSubscription: null,
       nonEligibleSubscription: null,
+      sessionVersion,
     });
   }
 
@@ -46,6 +50,7 @@ const getCertificationCandidateSubscription = async function ({
     sessionId: certificationCandidate.sessionId,
     eligibleSubscription,
     nonEligibleSubscription,
+    sessionVersion,
   });
 };
 

--- a/api/lib/infrastructure/serializers/jsonapi/certification-candidate-subscription-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-candidate-subscription-serializer.js
@@ -4,7 +4,7 @@ const { Serializer } = jsonapiSerializer;
 
 const serialize = function (certificationCandidateSubscription) {
   return new Serializer('certification-candidate-subscription', {
-    attributes: ['sessionId', 'eligibleSubscription', 'nonEligibleSubscription'],
+    attributes: ['sessionId', 'eligibleSubscription', 'nonEligibleSubscription', 'sessionVersion'],
   }).serialize(certificationCandidateSubscription);
 };
 

--- a/api/src/certification/session-management/infrastructure/repositories/session-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/session-repository.js
@@ -15,6 +15,14 @@ const get = async function ({ id }) {
   return new SessionManagement({ ...foundSession });
 };
 
+const getVersion = async function ({ id }) {
+  const result = await knex.select('version').from('sessions').where({ id }).first();
+  if (!result) {
+    throw new NotFoundError("La session n'existe pas ou son accès est restreint");
+  }
+  return result.version;
+};
+
 const isFinalized = async function ({ id }) {
   const session = await knex.select('id').from('sessions').where({ id }).whereNotNull('finalizedAt').first();
   return Boolean(session);
@@ -153,6 +161,7 @@ export {
   finalize,
   flagResultsAsSentToPrescriber,
   get,
+  getVersion,
   getWithCertificationCandidates,
   hasNoStartedCertification,
   hasSomeCleaAcquired,

--- a/api/tests/acceptance/application/certification-candidates/certification-candidates-controller_test.js
+++ b/api/tests/acceptance/application/certification-candidates/certification-candidates-controller_test.js
@@ -230,6 +230,7 @@ describe('Acceptance | API | Certifications candidates', function () {
         type: 'certification-candidate-subscriptions',
         attributes: {
           'session-id': session.id,
+          'session-version': session.version,
           'eligible-subscription': null,
           'non-eligible-subscription': {
             id: cleaComplementaryCertification.id,

--- a/api/tests/certification/session-management/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/certification/session-management/integration/infrastructure/repositories/session-repository_test.js
@@ -62,6 +62,34 @@ describe('Integration | Repository | Certification | session | SessionManagement
     });
   });
 
+  describe('#getVersion', function () {
+    let session;
+
+    beforeEach(async function () {
+      // given
+      session = databaseBuilder.factory.buildSession({
+        version: 3,
+      });
+      await databaseBuilder.commit();
+    });
+
+    it('should the version of the session if it exists', async function () {
+      // when
+      const version = await sessionRepository.getVersion({ id: session.id });
+
+      // then
+      expect(version).to.equal(3);
+    });
+
+    it('should return a Not found error when no session was found', async function () {
+      // when
+      const error = await catchErr(sessionRepository.getVersion)({ id: 2 });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
+  });
+
   describe('#isFinalized', function () {
     let finalizedSessionId;
     let notFinalizedSessionId;

--- a/api/tests/tooling/domain-builder/factory/build-certification-candidate-subscription.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-candidate-subscription.js
@@ -5,12 +5,14 @@ const buildCertificationCandidateSubscription = function ({
   sessionId = 1234,
   eligibleSubscription = null,
   nonEligibleSubscription = null,
+  sessionVersion = 2,
 } = {}) {
   return new CertificationCandidateSubscription({
     id,
     sessionId,
     eligibleSubscription,
     nonEligibleSubscription,
+    sessionVersion,
   });
 };
 

--- a/api/tests/unit/domain/usecases/get-certification-candidate-subscription_test.js
+++ b/api/tests/unit/domain/usecases/get-certification-candidate-subscription_test.js
@@ -5,6 +5,7 @@ describe('Unit | UseCase | get-certification-candidate-subscription', function (
   let certificationBadgesService;
   let certificationCandidateRepository;
   let certificationCenterRepository;
+  let sessionRepository;
 
   beforeEach(function () {
     certificationBadgesService = {
@@ -16,6 +17,10 @@ describe('Unit | UseCase | get-certification-candidate-subscription', function (
 
     certificationCenterRepository = {
       getBySessionId: sinon.stub(),
+    };
+
+    sessionRepository = {
+      getVersion: sinon.stub(),
     };
   });
 
@@ -52,6 +57,8 @@ describe('Unit | UseCase | get-certification-candidate-subscription', function (
           .withArgs(certificationCandidateId)
           .resolves(candidateWithComplementaryCertification);
 
+        sessionRepository.getVersion.withArgs({ id: sessionId }).resolves(2);
+
         certificationCenterRepository.getBySessionId.withArgs({ sessionId }).resolves(certificationCenter);
 
         certificationBadgesService.findStillValidBadgeAcquisitions
@@ -64,6 +71,7 @@ describe('Unit | UseCase | get-certification-candidate-subscription', function (
           certificationBadgesService,
           certificationCandidateRepository,
           certificationCenterRepository,
+          sessionRepository,
         });
 
         // then
@@ -73,6 +81,7 @@ describe('Unit | UseCase | get-certification-candidate-subscription', function (
             sessionId,
             eligibleSubscription: null,
             nonEligibleSubscription: null,
+            sessionVersion: 2,
           }),
         );
       });
@@ -111,6 +120,8 @@ describe('Unit | UseCase | get-certification-candidate-subscription', function (
           .withArgs(certificationCandidateId)
           .resolves(candidateWithoutComplementaryCertification);
 
+        sessionRepository.getVersion.withArgs({ id: sessionId }).resolves(2);
+
         certificationCenterRepository.getBySessionId.withArgs({ sessionId }).resolves(certificationCenter);
 
         certificationBadgesService.findStillValidBadgeAcquisitions
@@ -123,6 +134,7 @@ describe('Unit | UseCase | get-certification-candidate-subscription', function (
           certificationBadgesService,
           certificationCandidateRepository,
           certificationCenterRepository,
+          sessionRepository,
         });
 
         // then
@@ -132,6 +144,7 @@ describe('Unit | UseCase | get-certification-candidate-subscription', function (
             sessionId,
             eligibleSubscription: null,
             nonEligibleSubscription: null,
+            sessionVersion: 2,
           }),
         );
       });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-candidate-subscription-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-candidate-subscription-serializer_test.js
@@ -11,6 +11,7 @@ describe('Unit | Serializer | JSONAPI | certification-candidate-subscription-ser
           key: 'FIRST_COMPLEMENTARY',
           label: 'First Complementary Certification',
         }),
+        sessionVersion: 2,
 
         nonEligibleSubscription: domainBuilder.buildComplementaryCertification({
           key: 'SECOND_COMPLEMENTARY',
@@ -34,6 +35,7 @@ describe('Unit | Serializer | JSONAPI | certification-candidate-subscription-ser
               label: 'Second Complementary Certification',
             },
             'session-id': 456,
+            'session-version': 2,
           },
         },
       };

--- a/mon-pix/app/components/certification-information.hbs
+++ b/mon-pix/app/components/certification-information.hbs
@@ -1,0 +1,7 @@
+<section class="certification-starter">
+  <h2 class="certification-start-page__title">{{t "pages.certification-information.screens.first.title"}}</h2>
+  <p>{{t "pages.certification-information.screens.first.how"}}</p>
+  <div>
+    {{t "pages.certification-information.screens.first.text" htmlSafe=true}}
+  </div>
+</section>

--- a/mon-pix/app/models/certification-candidate-subscription.js
+++ b/mon-pix/app/models/certification-candidate-subscription.js
@@ -9,4 +9,8 @@ export default class CertificationCandidateSubscription extends Model {
   get hasSubscription() {
     return this.eligibleSubscription || this.nonEligibleSubscription;
   }
+
+  get isSessionVersion3() {
+    return this.sessionVersion === 3;
+  }
 }

--- a/mon-pix/app/models/certification-candidate-subscription.js
+++ b/mon-pix/app/models/certification-candidate-subscription.js
@@ -4,6 +4,7 @@ export default class CertificationCandidateSubscription extends Model {
   @attr sessionId;
   @attr eligibleSubscription;
   @attr nonEligibleSubscription;
+  @attr sessionVersion;
 
   get hasSubscription() {
     return this.eligibleSubscription || this.nonEligibleSubscription;

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -1,5 +1,6 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
+  @attr areV3InfoScreensEnabled;
   @attr('boolean') isTextToSpeechButtonEnabled;
 }

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -42,6 +42,7 @@ Router.map(function () {
 
     this.route('certifications', function () {
       this.route('join', { path: '/' });
+      this.route('information', { path: '/informations' });
       this.route('start', { path: '/candidat/:certification_candidate_id' });
       this.route('resume', { path: '/:certification_course_id' });
       this.route('results', { path: '/:certification_id/results' });

--- a/mon-pix/app/routes/authenticated/certifications/start.js
+++ b/mon-pix/app/routes/authenticated/certifications/start.js
@@ -3,8 +3,22 @@ import { service } from '@ember/service';
 
 export default class StartRoute extends Route {
   @service store;
+  @service router;
+  @service featureToggles;
 
-  model(params) {
-    return this.store.findRecord('certification-candidate-subscription', params.certification_candidate_id);
+  async model(params) {
+    const certificationCandidateSubscription = await this.store.findRecord(
+      'certification-candidate-subscription',
+      params.certification_candidate_id,
+    );
+
+    if (
+      certificationCandidateSubscription.isSessionVersion3 &&
+      this.featureToggles.featureToggles.areV3InfoScreensEnabled
+    ) {
+      this.router.replaceWith('authenticated.certifications.information');
+    }
+
+    return certificationCandidateSubscription;
   }
 }

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -152,3 +152,4 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @import 'pages/connection-methods';
 @import 'pages/language';
 @import 'pages/existing-campagne';
+@import 'pages/certification-information';

--- a/mon-pix/app/styles/pages/_certification-information.scss
+++ b/mon-pix/app/styles/pages/_certification-information.scss
@@ -1,0 +1,9 @@
+.certification-information {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 100vh;
+  background: $pix-primary-certif-gradient;
+}

--- a/mon-pix/app/templates/authenticated/certifications/information.hbs
+++ b/mon-pix/app/templates/authenticated/certifications/information.hbs
@@ -1,0 +1,9 @@
+{{page-title (t "pages.certification-information.title")}}
+
+<main class="certification-information">
+  <PixBackgroundHeader id="main">
+    <PixBlock @shadow="heavy" class="certification-start-page__block">
+      <CertificationInformation />
+    </PixBlock>
+  </PixBackgroundHeader>
+</main>

--- a/mon-pix/tests/unit/routes/authenticated/certifications/start_test.js
+++ b/mon-pix/tests/unit/routes/authenticated/certifications/start_test.js
@@ -1,0 +1,150 @@
+import Service from '@ember/service';
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | Certification | Start', function (hooks) {
+  setupTest(hooks);
+
+  module('#model', function () {
+    module('when session is V3 and toggle is enabled', function () {
+      test('should redirect to certification information page', async function (assert) {
+        // given
+        const certificationCandidateId = 'certification-candidate-id';
+        const params = { certification_candidate_id: certificationCandidateId };
+        const store = this.owner.lookup('service:store');
+
+        const certificationCandidateSubscription = store.createRecord('certification-candidate-subscription', {
+          id: certificationCandidateId,
+          sessionId: 1234,
+          sessionVersion: 3,
+        });
+        const featureToggles = Object.create({
+          featureToggles: {
+            areV3InfoScreensEnabled: true,
+          },
+        });
+
+        const findRecordStub = sinon.stub().returns(certificationCandidateSubscription);
+        const storeStub = Service.create({ findRecord: findRecordStub });
+
+        const route = this.owner.lookup('route:authenticated/certifications.start');
+        route.set('store', storeStub);
+        route.set('featureToggles', featureToggles);
+        route.router = { replaceWith: sinon.stub() };
+
+        // when
+        await route.model(params);
+
+        // then
+        sinon.assert.calledWith(route.router.replaceWith, 'authenticated.certifications.information');
+        assert.ok(true);
+      });
+    });
+
+    module('when session is V3 and toggle is not enabled', function () {
+      test('should not redirect to certification information page', async function (assert) {
+        // given
+        const certificationCandidateId = 'certification-candidate-id';
+        const params = { certification_candidate_id: certificationCandidateId };
+        const store = this.owner.lookup('service:store');
+
+        const certificationCandidateSubscription = store.createRecord('certification-candidate-subscription', {
+          id: certificationCandidateId,
+          sessionId: 1234,
+          sessionVersion: 3,
+        });
+        const featureToggles = Object.create({
+          featureToggles: {
+            areV3InfoScreensEnabled: false,
+          },
+        });
+
+        const findRecordStub = sinon.stub().returns(certificationCandidateSubscription);
+        const storeStub = Service.create({ findRecord: findRecordStub });
+
+        const route = this.owner.lookup('route:authenticated/certifications.start');
+        route.set('store', storeStub);
+        route.set('featureToggles', featureToggles);
+        route.router = { replaceWith: sinon.stub() };
+
+        // when
+        const model = await route.model(params);
+
+        // then
+        sinon.assert.notCalled(route.router.replaceWith);
+        assert.strictEqual(model, certificationCandidateSubscription);
+      });
+    });
+
+    module('when session is not V3 and toggle is enabled', function () {
+      test('should not redirect to certification information page', async function (assert) {
+        // given
+        const certificationCandidateId = 'certification-candidate-id';
+        const params = { certification_candidate_id: certificationCandidateId };
+        const store = this.owner.lookup('service:store');
+
+        const certificationCandidateSubscription = store.createRecord('certification-candidate-subscription', {
+          id: certificationCandidateId,
+          sessionId: 1234,
+          sessionVersion: 2,
+        });
+        const featureToggles = Object.create({
+          featureToggles: {
+            areV3InfoScreensEnabled: true,
+          },
+        });
+
+        const findRecordStub = sinon.stub().returns(certificationCandidateSubscription);
+        const storeStub = Service.create({ findRecord: findRecordStub });
+
+        const route = this.owner.lookup('route:authenticated/certifications.start');
+        route.set('store', storeStub);
+        route.set('featureToggles', featureToggles);
+        route.router = { replaceWith: sinon.stub() };
+
+        // when
+        const model = await route.model(params);
+
+        // then
+        sinon.assert.notCalled(route.router.replaceWith);
+        assert.strictEqual(model, certificationCandidateSubscription);
+      });
+    });
+
+    module('when session is not V3 and toggle is not enabled', function () {
+      test('should not redirect to certification information page', async function (assert) {
+        // given
+        const certificationCandidateId = 'certification-candidate-id';
+        const params = { certification_candidate_id: certificationCandidateId };
+        const store = this.owner.lookup('service:store');
+
+        const certificationCandidateSubscription = store.createRecord('certification-candidate-subscription', {
+          id: certificationCandidateId,
+          sessionId: 1234,
+          sessionVersion: 2,
+        });
+        const featureToggles = Object.create({
+          featureToggles: {
+            areV3InfoScreensEnabled: false,
+          },
+        });
+
+        const findRecordStub = sinon.stub().returns(certificationCandidateSubscription);
+        const storeStub = Service.create({ findRecord: findRecordStub });
+
+        const route = this.owner.lookup('route:authenticated/certifications.start');
+        route.set('store', storeStub);
+        route.set('featureToggles', featureToggles);
+        route.router = { replaceWith: sinon.stub() };
+
+        // when
+        const model = await route.model(params);
+
+        // then
+        sinon.assert.notCalled(route.router.replaceWith);
+        assert.strictEqual(model, certificationCandidateSubscription);
+      });
+    });
+  });
+});

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -427,6 +427,16 @@
         "step-2": "You will be able to download and share your certificate of achievement or provide the verification code to be used on the Pix website."
       }
     },
+    "certification-information": {
+      "title": "information",
+      "screens": {
+        "first": {
+          "title": "Bienvenue à la certification Pix",
+          "how": "Comment fonctionne le test de certification ?",
+          "text": "Il s'agit d'un test adaptatif. C’est-à-dire, que votre capacité à répondre correctement (ou non) aux questions détermine en temps réel la difficulté des questions suivantes. <br/> <br/>Si vous ne savez pas répondre à une question, vous avez la possibilité de “passer” cette question. Les questions passées seront considérées comme échouées et ne vous seront pas proposées à nouveau.<br/><br/>Il est important d'aller jusqu'au bout du test, et donc de bien gérer votre temps. Une pénalité tenant compte du nombre de questions restantes sera appliquée."
+        }
+      }
+    },
     "certification-joiner": {
       "title": "Join a certification session",
       "congratulation-banner": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -496,6 +496,16 @@
       "flag-alt": "Bandera",
       "title": "Prueba finalizada"
     },
+    "certification-information": {
+      "title": "information",
+      "screens": {
+        "first": {
+          "title": "Bienvenue à la certification Pix",
+          "how": "Comment fonctionne le test de certification ?",
+          "text": "Il s'agit d'un test adaptatif. C’est-à-dire, que votre capacité à répondre correctement (ou non) aux questions détermine en temps réel la difficulté des questions suivantes. <br/> <br/>Si vous ne savez pas répondre à une question, vous avez la possibilité de “passer” cette question. Les questions passées seront considérées comme échouées et ne vous seront pas proposées à nouveau.<br/><br/>Il est important d'aller jusqu'au bout du test, et donc de bien gérer votre temps. Une pénalité tenant compte du nombre de questions restantes sera appliquée."
+        }
+      }
+    },
     "certification-start": {
       "access-code": "Código de acceso comunicado por el supervisor",
       "actions": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -427,6 +427,16 @@
         "step-2": "Vous pourrez télécharger votre attestation de certification et la partager, ou encore communiquer le code de vérification à utiliser sur le site de Pix."
       }
     },
+    "certification-information": {
+      "title": "information",
+      "screens": {
+        "first": {
+          "title": "Bienvenue à la certification Pix",
+          "how": "Comment fonctionne le test de certification ?",
+          "text": "Il s'agit d'un test adaptatif. C’est-à-dire, que votre capacité à répondre correctement (ou non) aux questions détermine en temps réel la difficulté des questions suivantes. <br/> <br/>Si vous ne savez pas répondre à une question, vous avez la possibilité de “passer” cette question. Les questions passées seront considérées comme échouées et ne vous seront pas proposées à nouveau.<br/><br/>Il est important d'aller jusqu'au bout du test, et donc de bien gérer votre temps. Une pénalité tenant compte du nombre de questions restantes sera appliquée."
+        }
+      }
+    },
     "certification-joiner": {
       "title": "Rejoindre une session de certification",
       "congratulation-banner": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -496,6 +496,16 @@
       "flag-alt": "Vlag",
       "title": "Test voltooid"
     },
+    "certification-information": {
+      "title": "information",
+      "screens": {
+        "first": {
+          "title": "Bienvenue à la certification Pix",
+          "how": "Comment fonctionne le test de certification ?",
+          "text": "Il s'agit d'un test adaptatif. C’est-à-dire, que votre capacité à répondre correctement (ou non) aux questions détermine en temps réel la difficulté des questions suivantes. <br/> <br/>Si vous ne savez pas répondre à une question, vous avez la possibilité de “passer” cette question. Les questions passées seront considérées comme échouées et ne vous seront pas proposées à nouveau.<br/><br/>Il est important d'aller jusqu'au bout du test, et donc de bien gérer votre temps. Une pénalité tenant compte du nombre de questions restantes sera appliquée."
+        }
+      }
+    },
     "certification-start": {
       "access-code": "Toegangscode gegeven door de supervisor",
       "actions": {


### PR DESCRIPTION
## :unicorn: Problème

Dans le cadre de la nouvelle certif, nous allons mettre à disposition des candidats des écrans d’instruction afin de leur donner des infos sur le test qu’ils vont passer.

Ces écrans d’instruction sont spécifiques à la nouvelle certif et ne doivent pas être affichés pour la certif v2. Or, on ne récupère actuellement pas la version de la session après qu’un candidat ait rejoint une session

## :robot: Proposition

Récupérer la version de la session au moment de la réconciliation pour afficher les écrans d'instructions avant l'insertion du mot de passe de certif (et ainsi ne pas empiéter sur le temps de certification pour la lecture des consignes)

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

- Créer une session V3 avec `certifv3@example.net` et ajouter un candidat
- Se réconcilier avec `certifiable-contenu-user@example.net` et vérifier que l'on obtient bien le premier écran d'instruction
- Créer une session V2 avec `certif-pro@example.net` et ajouter un candidat
- Se réconcilier avec `certifiable-contenu-user@example.net` et vérifier que l'on obtient la page d'entrée de mot de passe de session
