### PR TITLE
[FEATURE] Ajouter le chargement d'une campagne dans le simulateur Smart Random (PIX-12731)

### DIFF
--- a/admin/app/components/smart-random-simulator/current-challenge.hbs
+++ b/admin/app/components/smart-random-simulator/current-challenge.hbs
@@ -28,15 +28,15 @@
 
   <div class="current-challenge__actions">
 
-    <PixButton @variant="error" @size="large" @triggerAction={{@failCurrentChallenge}}>
+    <PixButton @variant="error" @triggerAction={{@failCurrentChallenge}}>
       Rater l'épreuve
     </PixButton>
 
-    <PixButton @variant="success" @size="large" @triggerAction={{@succeedCurrentChallenge}}>
+    <PixButton @variant="success" @triggerAction={{@succeedCurrentChallenge}}>
       Réussir l'épreuve
     </PixButton>
 
-    <PixButton @variant="tertiary" @size="large" @triggerAction={{@reset}}>
+    <PixButton @variant="secondary" @triggerAction={{@reset}}>
       Redémarrer la simulation
     </PixButton>
 

--- a/admin/app/components/smart-random-simulator/previous-challenges.hbs
+++ b/admin/app/components/smart-random-simulator/previous-challenges.hbs
@@ -1,12 +1,14 @@
-<Card class="admin-form__card previous-challenges" @title="Précédentes épreuves">
-  <div class="previous-challenges__container">
-    {{#each @challenges as |challenge index|}}
-      <div class="previous-challenges__result {{challenge.result}}">
-        <p class="previous-challenges__result__count">Épreuve {{this.incrementIndex index}}</p>
-        <h2>{{challenge.skill.name}}</h2>
-        <p class="previous-challenges__result__focused">Focus : {{if challenge.focused "Oui" "Non"}}</p>
-        <p class="previous-challenges__result__timed">Temps imparti: {{if challenge.timer "Oui" "Non"}}</p>
-      </div>
-    {{/each}}
-  </div>
-</Card>
+<section class="admin-form__content">
+  <Card class="admin-form__card previous-challenges" @title="Précédentes épreuves">
+    <div class="previous-challenges__container">
+      {{#each @challenges as |challenge index|}}
+        <div class="previous-challenges__result {{challenge.result}}">
+          <p class="previous-challenges__result__count">Épreuve {{this.incrementIndex index}}</p>
+          <h2>{{challenge.skill.name}}</h2>
+          <p class="previous-challenges__result__focused">Focus : {{if challenge.focused "Oui" "Non"}}</p>
+          <p class="previous-challenges__result__timed">Temps imparti: {{if challenge.timer "Oui" "Non"}}</p>
+        </div>
+      {{/each}}
+    </div>
+  </Card>
+</section>

--- a/admin/app/components/smart-random-simulator/smart-random-params.hbs
+++ b/admin/app/components/smart-random-simulator/smart-random-params.hbs
@@ -14,6 +14,7 @@
           @placeholder="12345"
           @value={{this.campaignId}}
           {{on "change" this.updateCampaignIdValue}}
+          type="number"
         />
 
         <PixButton @triggerAction={{this.loadCampaignParams}} @size="small">

--- a/admin/app/components/smart-random-simulator/smart-random-params.hbs
+++ b/admin/app/components/smart-random-simulator/smart-random-params.hbs
@@ -1,7 +1,26 @@
 <form class="admin-form">
-  <section class="admin-form__content admin-form__content--with-counters">
+  <section class="admin-form__content">
 
     <Card class="admin-form__card" @title="Évaluation (campagne ou positionnement)">
+
+      <div class="load-campaign-params">
+
+        <p>
+          Charger les paramètres depuis un identifiant de campagne :
+        </p>
+
+        <PixInput
+          @id="campaignId"
+          @placeholder="12345"
+          @value={{this.campaignId}}
+          {{on "change" this.updateCampaignIdValue}}
+        />
+
+        <PixButton @triggerAction={{this.loadCampaignParams}} @size="small">
+          Charger
+        </PixButton>
+      </div>
+
       <PixTextarea
         @id="skills"
         @value={{fn this.stringify @skills}}

--- a/admin/app/components/smart-random-simulator/smart-random-params.js
+++ b/admin/app/components/smart-random-simulator/smart-random-params.js
@@ -5,6 +5,7 @@ import Joi from 'joi';
 
 export default class SmartRandomParams extends Component {
   @tracked errors = {};
+  @tracked campaignId = 1;
 
   acceptedLocales = [
     { value: 'en', label: 'en' },
@@ -12,7 +13,6 @@ export default class SmartRandomParams extends Component {
     { value: 'fr-fr', label: 'fr-fr' },
     { value: 'nl', label: 'nl' },
   ];
-
   skillsExample = [{ id: 'skillId', name: '@requete2', difficulty: 3 }];
   challengesExample = [
     {
@@ -21,7 +21,6 @@ export default class SmartRandomParams extends Component {
       locales: ['fr-fr'],
     },
   ];
-
   knowledgeElementsExample = [
     {
       id: 'rec1xAgCoZux1Lxq8',
@@ -105,7 +104,16 @@ export default class SmartRandomParams extends Component {
     this.args.updateParametersValue(key, event.target.value);
   }
 
+  @action
+  updateCampaignIdValue(event) {
+    this.campaignId = event.target.value;
+  }
+
   @action updateLocaleValue(value) {
     this.args.updateParametersValue('locale', value);
+  }
+
+  @action loadCampaignParams() {
+    this.args.loadCampaignParams(this.campaignId);
   }
 }

--- a/admin/app/components/smart-random-simulator/start.hbs
+++ b/admin/app/components/smart-random-simulator/start.hbs
@@ -1,5 +1,5 @@
 <section class="start">
-  <PixButton @variant="failure" @size="large" @triggerAction={{@startAssessment}}>
+  <PixButton @variant="primary" @triggerAction={{@startAssessment}}>
     Démarrer la simulation
   </PixButton>
 </section>

--- a/admin/app/controllers/authenticated/smart-random-simulator/get-next-challenge.js
+++ b/admin/app/controllers/authenticated/smart-random-simulator/get-next-challenge.js
@@ -4,6 +4,7 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 const GET_NEXT_CHALLENGE_API_ROUTE = '/api/admin/smart-random-simulator/get-next-challenge';
+const GET_CAMPAIGN_PARAMS_API_ROUTE = '/api/admin/smart-random-simulator/campaign-parameters';
 
 const ANSWER_STATUSES = { OK: 'ok', KO: 'ko' };
 const KNOWLEDGE_ELEMENTS_STATUSES = { VALIDATED: 'validated', INVALIDATED: 'invalidated' };
@@ -59,6 +60,32 @@ export default class SmartRandomSimulator extends Controller {
   @action
   selectDisplayedStepIndex(value) {
     this.displayedStepIndex = value;
+  }
+
+  @action
+  async loadCampaignParams(campaignId) {
+    const apiResponse = await window.fetch(`${GET_CAMPAIGN_PARAMS_API_ROUTE}/${this.locale}/${campaignId}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.session.data.authenticated.access_token}`,
+      },
+    });
+
+    if (apiResponse.status === 200) {
+      const responseBody = await apiResponse.json();
+      this.skills = responseBody.skills;
+      this.challenges = responseBody.challenges;
+      this.notifications.success(
+        `Données chargées: ${this.skills.length} compétences et ${this.challenges.length} challenges`,
+      );
+      return;
+    }
+
+    const response = await apiResponse.json();
+    response.errors.map(({ detail }) => {
+      this.notifications.error(detail);
+    });
   }
 
   get previousChallenges() {

--- a/admin/app/styles/authenticated/smart-random-simulator/get-next-challenge.scss
+++ b/admin/app/styles/authenticated/smart-random-simulator/get-next-challenge.scss
@@ -2,6 +2,22 @@
   display: flex;
   flex-direction: row;
 
+  .load-campaign-params{
+    display: flex;
+    flex-direction: row;
+    gap: var(--pix-spacing-4x);
+    align-items: center;
+    justify-content: left;
+    margin-right: 20px;
+
+    p{
+      display: block;
+      color: var(--pix-neutral-900);
+      font-weight: var(--pix-font-medium);
+      line-height: 1.5;
+    }
+  }
+
   section {
     position: relative;
     width: 100%;

--- a/admin/app/templates/authenticated/smart-random-simulator/get-next-challenge.hbs
+++ b/admin/app/templates/authenticated/smart-random-simulator/get-next-challenge.hbs
@@ -16,6 +16,7 @@
         @challenges={{this.challenges}}
         @locale={{this.locale}}
         @assessmentId={{this.assessmentId}}
+        @loadCampaignParams={{this.loadCampaignParams}}
         @updateParametersValue={{this.updateParametersValue}}
       />
 

--- a/api/src/evaluation/application/smart-random-simulator/index.js
+++ b/api/src/evaluation/application/smart-random-simulator/index.js
@@ -12,98 +12,128 @@ const skillValidationObject = Joi.object({
   name: Joi.string().required(),
 });
 
-const register = async function (server) {
-  server.route([
-    {
-      method: 'POST',
-      path: '/api/admin/smart-random-simulator/get-next-challenge',
-      config: {
-        pre: [
-          {
-            method: (request, h) =>
-              securityPreHandlers.hasAtLeastOneAccessOf([
-                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-                securityPreHandlers.checkAdminMemberHasRoleMetier,
-                securityPreHandlers.checkAdminMemberHasRoleCertif,
-              ])(request, h),
-            assign: 'hasAuthorizationToAccessAdminScope',
-          },
-        ],
-        validate: {
-          payload: Joi.object({
-            data: {
-              attributes: {
-                knowledgeElements: Joi.array()
-                  .items({
-                    source: Joi.string()
-                      .valid(KnowledgeElement.SourceType.DIRECT, KnowledgeElement.SourceType.INFERRED)
-                      .required(),
-                    status: Joi.string()
-                      .valid(
-                        KnowledgeElement.StatusType.VALIDATED,
-                        KnowledgeElement.StatusType.INVALIDATED,
-                        KnowledgeElement.StatusType.RESET,
-                      )
-                      .required(),
-                    answerId: identifiersType.answerId,
-                    skillId: identifiersType.skillId,
-                  })
+const getNextChallengeRoute = {
+  method: 'POST',
+  path: '/api/admin/smart-random-simulator/get-next-challenge',
+  config: {
+    pre: [
+      {
+        method: (request, h) =>
+          securityPreHandlers.hasAtLeastOneAccessOf([
+            securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+            securityPreHandlers.checkAdminMemberHasRoleSupport,
+            securityPreHandlers.checkAdminMemberHasRoleMetier,
+            securityPreHandlers.checkAdminMemberHasRoleCertif,
+          ])(request, h),
+        assign: 'hasAuthorizationToAccessAdminScope',
+      },
+    ],
+    validate: {
+      payload: Joi.object({
+        data: {
+          attributes: {
+            knowledgeElements: Joi.array()
+              .items({
+                source: Joi.string()
+                  .valid(KnowledgeElement.SourceType.DIRECT, KnowledgeElement.SourceType.INFERRED)
                   .required(),
-                answers: Joi.array()
-                  .items({
-                    id: Joi.number().required(),
-                    result: Joi.string()
-                      .valid(
-                        AnswerStatus.statuses.OK,
-                        AnswerStatus.statuses.KO,
-                        AnswerStatus.statuses.SKIPPED,
-                        AnswerStatus.statuses.FOCUSEDOUT,
-                      )
-                      .required(),
-                    challengeId: identifiersType.challengeId,
-                  })
+                status: Joi.string()
+                  .valid(
+                    KnowledgeElement.StatusType.VALIDATED,
+                    KnowledgeElement.StatusType.INVALIDATED,
+                    KnowledgeElement.StatusType.RESET,
+                  )
                   .required(),
-                skills: Joi.array().items(skillValidationObject).min(1).required(),
-                challenges: Joi.array()
-                  .items({
-                    id: identifiersType.challengeId,
-                    skill: skillValidationObject.required(),
-                    timer: Joi.number().integer(),
-                    focused: Joi.boolean().optional(),
-                    locales: Joi.array()
-                      .items(
-                        Joi.string().valid(
-                          LOCALE.FRENCH_FRANCE,
-                          LOCALE.FRENCH_SPOKEN,
-                          LOCALE.ENGLISH_SPOKEN,
-                          LOCALE.DUTCH_SPOKEN,
-                        ),
-                      )
-                      .required(),
-                  })
-                  .min(1)
+                answerId: identifiersType.answerId,
+                skillId: identifiersType.skillId,
+              })
+              .required(),
+            answers: Joi.array()
+              .items({
+                id: Joi.number().required(),
+                result: Joi.string()
+                  .valid(
+                    AnswerStatus.statuses.OK,
+                    AnswerStatus.statuses.KO,
+                    AnswerStatus.statuses.SKIPPED,
+                    AnswerStatus.statuses.FOCUSEDOUT,
+                  )
                   .required(),
-                locale: Joi.string()
-                  .valid(LOCALE.FRENCH_FRANCE, LOCALE.FRENCH_SPOKEN, LOCALE.ENGLISH_SPOKEN, LOCALE.DUTCH_SPOKEN)
+                challengeId: identifiersType.challengeId,
+              })
+              .required(),
+            skills: Joi.array().items(skillValidationObject).min(1).required(),
+            challenges: Joi.array()
+              .items({
+                id: identifiersType.challengeId,
+                skill: skillValidationObject.required(),
+                timer: Joi.number().integer(),
+                focused: Joi.boolean().optional(),
+                locales: Joi.array()
+                  .items(
+                    Joi.string().valid(
+                      LOCALE.FRENCH_FRANCE,
+                      LOCALE.FRENCH_SPOKEN,
+                      LOCALE.ENGLISH_SPOKEN,
+                      LOCALE.DUTCH_SPOKEN,
+                    ),
+                  )
                   .required(),
-                assessmentId: identifiersType.assessmentId,
-              },
-            },
-          }),
-          options: {
-            allowUnknown: true,
+              })
+              .min(1)
+              .required(),
+            locale: Joi.string()
+              .valid(LOCALE.FRENCH_FRANCE, LOCALE.FRENCH_SPOKEN, LOCALE.ENGLISH_SPOKEN, LOCALE.DUTCH_SPOKEN)
+              .required(),
+            assessmentId: identifiersType.assessmentId,
           },
         },
-        handler: smartRandomSimulatorController.getNextChallenge,
-        notes: [
-          '- **Route nécessitant une authentification**\n' +
-            "- Cette route permet d'appeler le simulateur d'algorithme de sélection des épreuves Smart Random.",
-        ],
-        tags: ['api', 'admin', 'smart-random-simulator'],
+      }),
+      options: {
+        allowUnknown: true,
       },
     },
-  ]);
+    handler: smartRandomSimulatorController.getNextChallenge,
+    notes: [
+      '- **Route nécessitant une authentification**\n' +
+        "- Cette route permet d'appeler le simulateur d'algorithme de sélection des épreuves Smart Random.",
+    ],
+    tags: ['api', 'admin', 'smart-random-simulator'],
+  },
+};
+
+const getCampaignParametersRoute = {
+  method: 'GET',
+  path: '/api/admin/smart-random-simulator/campaign-parameters/{locale}/{campaignId}',
+  config: {
+    pre: [
+      {
+        method: (request, h) =>
+          securityPreHandlers.hasAtLeastOneAccessOf([securityPreHandlers.checkAdminMemberHasRoleSuperAdmin])(
+            request,
+            h,
+          ),
+        assign: 'hasAuthorizationToAccessAdminScope',
+      },
+    ],
+    validate: {
+      params: Joi.object({
+        locale: Joi.string()
+          .required()
+          .valid(...[LOCALE.ENGLISH_SPOKEN, LOCALE.FRENCH_FRANCE, LOCALE.FRENCH_SPOKEN, LOCALE.DUTCH_SPOKEN]),
+        campaignId: Joi.string().required(),
+      }),
+    },
+    handler: smartRandomSimulatorController.getInputValuesForCampaign,
+    notes: [
+      '- **Route nécessitant une authentification**\n' +
+        "- Cette route permet de récupérer les données d'entrée d'une campagne pour nourrir le simulateur",
+    ],
+    tags: ['api', 'admin', 'smart-random-simulator'],
+  },
+};
+const register = async function (server) {
+  server.route([getNextChallengeRoute, getCampaignParametersRoute]);
 };
 
 const name = 'smart-random-simulator-api';

--- a/api/src/evaluation/application/smart-random-simulator/smart-random-simulator-controller.js
+++ b/api/src/evaluation/application/smart-random-simulator/smart-random-simulator-controller.js
@@ -11,5 +11,12 @@ const getNextChallenge = async function (
 
   return evaluationUsecases.getNextChallengeForSimulator({ simulationParameters: deserializedPayload });
 };
-const smartRandomSimulatorController = { getNextChallenge };
+
+const getInputValuesForCampaign = async function (request) {
+  const campaignId = request.params.campaignId;
+  const locale = request.params.locale;
+  return evaluationUsecases.getCampaignParametersForSimulator({ campaignId, locale });
+};
+
+const smartRandomSimulatorController = { getNextChallenge, getInputValuesForCampaign };
 export { smartRandomSimulatorController };

--- a/api/src/evaluation/domain/usecases/get-campaign-parameters-for-simulator.js
+++ b/api/src/evaluation/domain/usecases/get-campaign-parameters-for-simulator.js
@@ -1,0 +1,25 @@
+const getCampaignParametersForSimulator = async function ({
+  campaignId,
+  locale,
+  campaignRepository,
+  challengeRepository,
+}) {
+  const skills = await campaignRepository.findSkills({ campaignId });
+  const challenges = await challengeRepository.findOperativeBySkills(skills, locale);
+  const sanitizedChallenges = challenges.map((challenge) => ({
+    id: challenge.id,
+    format: challenge.format,
+    instruction: challenge.instruction.slice(0, 130),
+    status: challenge.status,
+    timer: challenge.timer,
+    type: challenge.type,
+    locales: challenge.locales,
+    skill: challenge.skill,
+    focused: challenge.focused,
+    difficulty: challenge.difficulty,
+    responsive: challenge.responsive,
+  }));
+  return { skills, challenges: sanitizedChallenges };
+};
+
+export { getCampaignParametersForSimulator };

--- a/api/src/evaluation/domain/usecases/index.js
+++ b/api/src/evaluation/domain/usecases/index.js
@@ -6,6 +6,7 @@ import * as campaignParticipationRepository from '../../../../lib/infrastructure
 import * as campaignRepository from '../../../../lib/infrastructure/repositories/campaign-repository.js';
 import * as knowledgeElementRepository from '../../../../lib/infrastructure/repositories/knowledge-element-repository.js';
 import * as targetProfileRepository from '../../../../lib/infrastructure/repositories/target-profile-repository.js';
+import * as challengeRepository from '../../../../src/shared/infrastructure/repositories/challenge-repository.js';
 import * as answerRepository from '../../../shared/infrastructure/repositories/answer-repository.js';
 import * as areaRepository from '../../../shared/infrastructure/repositories/area-repository.js';
 import * as assessmentRepository from '../../../shared/infrastructure/repositories/assessment-repository.js';
@@ -43,6 +44,7 @@ const dependencies = {
   badgeCriteriaRepository,
   campaignRepository,
   campaignParticipationRepository,
+  challengeRepository,
   competenceEvaluationRepository,
   competenceRepository,
   feedbackRepository,

--- a/api/tests/evaluation/integration/domain/usecases/get-campaign-parameters-for-simulator_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/get-campaign-parameters-for-simulator_test.js
@@ -1,0 +1,51 @@
+import { evaluationUsecases } from '../../../../../src/evaluation/domain/usecases/index.js';
+import {
+  databaseBuilder,
+  domainBuilder,
+  expect,
+  learningContentBuilder,
+  mockLearningContent,
+} from '../../../../test-helper.js';
+
+function buildLearningContent() {
+  const learningContent = domainBuilder.buildCampaignLearningContent.withSimpleContent();
+  const learningContentObjects = learningContentBuilder([learningContent]);
+  mockLearningContent(learningContentObjects);
+}
+
+describe('Integration | Domain | UseCases | get-campaign-parameters-for-simulator', function () {
+  it('should return skills and challenges', async function () {
+    // given
+    const campaignId = 100000;
+
+    databaseBuilder.factory.buildCampaign({ id: campaignId });
+    databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'skillId' });
+
+    await databaseBuilder.commit();
+    buildLearningContent();
+
+    // when
+    const result = await evaluationUsecases.getCampaignParametersForSimulator({
+      campaignId,
+      locale: 'fr',
+    });
+
+    // then
+    expect(result).to.deep.equal({
+      skills: [
+        {
+          id: 'skillId',
+          name: '@sau6',
+          pixValue: 3,
+          competenceId: 'competenceId',
+          tutorialIds: [],
+          learningMoreTutorialIds: [],
+          tubeId: 'tubeId',
+          version: 1,
+          difficulty: undefined,
+        },
+      ],
+      challenges: [],
+    });
+  });
+});

--- a/api/tests/evaluation/unit/domain/usecases/get-campaign-parameters-for-simulator_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/get-campaign-parameters-for-simulator_test.js
@@ -1,0 +1,83 @@
+import { getCampaignParametersForSimulator } from '../../../../../src/evaluation/domain/usecases/get-campaign-parameters-for-simulator.js';
+import { expect, sinon } from '../../../../test-helper.js';
+import { buildChallenge } from '../../../../tooling/domain-builder/factory/index.js';
+
+describe('Unit | UseCase | get-campaign-parameters-for-simulator', function () {
+  describe('#getCampaignParametersForSimulator', function () {
+    let campaignRepository;
+    let challengeRepository;
+
+    beforeEach(function () {
+      campaignRepository = {
+        findSkills: sinon.stub(),
+      };
+
+      challengeRepository = {
+        findOperativeBySkills: sinon.stub(),
+      };
+    });
+
+    it('should return skills and sanitized challenges', function () {
+      const campaignSKills = Symbol('campaignSkills');
+      const challenges = [
+        buildChallenge({ id: 'rec1' }),
+        buildChallenge({
+          id: 'rec2',
+          instruction:
+            'Des instructions qui devraient être tronquées à partir de 160 caractères pour éviter le spoil, des instructions qui devraient être tronquées à partir de 160 caractères pour éviter le spoil',
+        }),
+      ];
+
+      // given
+      campaignRepository.findSkills
+        .withArgs({
+          campaignId: 12,
+        })
+        .resolves(campaignSKills);
+
+      challengeRepository.findOperativeBySkills.withArgs(campaignSKills, 'fr').resolves(challenges);
+
+      // when
+      const result = getCampaignParametersForSimulator({
+        campaignId: 12,
+        locale: 'fr',
+        campaignRepository,
+        challengeRepository,
+      });
+
+      // then
+      return expect(result).to.eventually.deep.equal({
+        skills: campaignSKills,
+        challenges: [
+          {
+            id: 'rec1',
+            format: 'petit',
+            instruction: 'Des instructions',
+            status: 'validé',
+            timer: undefined,
+            type: 'QCM',
+            locales: ['fr'],
+            skill: challenges[0].skill,
+            focused: false,
+            difficulty: 0,
+            responsive: 'Smartphone/Tablette',
+          },
+          {
+            id: 'rec2',
+            format: 'petit',
+            instruction:
+              'Des instructions qui devraient être tronquées à partir de 160 caractères pour éviter le spoil, des instructions qui devraient être',
+            status: 'validé',
+            timer: undefined,
+            type: 'QCM',
+            locales: ['fr'],
+            skill: challenges[1].skill,
+            focused: false,
+            difficulty: 0,
+            responsive: 'Smartphone/Tablette',
+          },
+        ],
+      });
+    });
+  });
+});

--- a/api/tests/evaluation/unit/domain/usecases/get-campaign-parameters-for-simulator_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/get-campaign-parameters-for-simulator_test.js
@@ -24,7 +24,7 @@ describe('Unit | UseCase | get-campaign-parameters-for-simulator', function () {
         buildChallenge({
           id: 'rec2',
           instruction:
-            'Des instructions qui devraient être tronquées à partir de 160 caractères pour éviter le spoil, des instructions qui devraient être tronquées à partir de 160 caractères pour éviter le spoil',
+            'Des instructions qui devraient être tronquées à partir de 130 caractères pour éviter le spoil, des instructions qui devraient être tronquées à partir de 130 caractères pour éviter le spoil',
         }),
       ];
 
@@ -66,7 +66,7 @@ describe('Unit | UseCase | get-campaign-parameters-for-simulator', function () {
             id: 'rec2',
             format: 'petit',
             instruction:
-              'Des instructions qui devraient être tronquées à partir de 160 caractères pour éviter le spoil, des instructions qui devraient être',
+              'Des instructions qui devraient être tronquées à partir de 130 caractères pour éviter le spoil, des instructions qui devraient être',
             status: 'validé',
             timer: undefined,
             type: 'QCM',


### PR DESCRIPTION
## :unicorn: Problème
Actuellement dans le simulateur, il faut renseigner les données de la campagne à la main, ce qui est fort peu commode.

## :robot: Proposition
Ajouter une fonctionnalité qui permette de charger les acquis et challenges d'une campagne à partir d'un identifiant.

## :100: Pour tester

- Créer un profil cible sur PIX admin
- Créer une campagne sur PIX orga ( ou un parcours autonome sur PIX admin ) 
- Accéder au simulateur sur l'admin
- Renseigner l'identifiant de la campagne précédemment créée
- Vérifier que les données sont correctement chargées dans l'interface