### PR TITLE
[BUGFIX] Ne pas prendre en compte les learner supprimés lors de la réconciliation SUP (PIX-12734)

### DIFF
--- a/api/src/prescription/learner-management/infrastructure/repositories/sup-organization-learner-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/sup-organization-learner-repository.js
@@ -26,7 +26,7 @@ const updateStudentNumber = async function (studentId, studentNumber) {
 };
 
 const findOneByStudentNumberAndBirthdate = async function ({ organizationId, studentNumber, birthdate }) {
-  const organizationLearner = await knex('organization-learners')
+  const organizationLearner = await knex('view-active-organization-learners')
     .where('organizationId', organizationId)
     .where('birthdate', birthdate)
     .where('isDisabled', false)
@@ -37,8 +37,9 @@ const findOneByStudentNumberAndBirthdate = async function ({ organizationId, stu
 };
 
 const findOneByStudentNumber = async function ({ organizationId, studentNumber }) {
-  const organizationLearner = await knex('organization-learners')
+  const organizationLearner = await knex('view-active-organization-learners')
     .where('organizationId', organizationId)
+    .where('isDisabled', false)
     .whereRaw('LOWER(?)=LOWER(??)', [studentNumber, 'studentNumber'])
     .first();
 


### PR DESCRIPTION
## :unicorn: Problème
Certains learner supprimé d'une même orga, même après avoir été rajouté ne peuvent plus rejoindre leur organizations. 
Il s'avère que nous n'utilisions pas la vue qui permet d'exclure les learner deleted sur ces deux endpoints

## :robot: Proposition
Utiliser la view pour exclure automatiquement les learners "deleted", et filtrer sur les learners actif seulement

## :rainbow: Remarques
ajout de tests pour ces cas

## :100: Pour tester
Faire un import SUP,  
Se reconcilier sur une campagne
Supprimer un learner reconcilié
Réimporter la liste des learner pour faire reapparaitre un nouveau learner de celui supprimé
Tenter de rejoindre une autre campagne et normalement, ça fonctionne