### PR TITLE
[TECH] Monter la version d'`eslint` minimum du dossier racine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@1024pix/eslint-config": "^1.3.1",
-        "eslint": "^8.46.0",
+        "eslint": "^8.57.0",
         "eslint-plugin-mocha": "^10.0.0",
         "husky": "^9.0.0",
         "lint-staged": "^15.0.0"

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   },
   "devDependencies": {
     "@1024pix/eslint-config": "^1.3.1",
-    "eslint": "^8.46.0",
+    "eslint": "^8.57.0",
     "eslint-plugin-mocha": "^10.0.0",
     "husky": "^9.0.0",
     "lint-staged": "^15.0.0"


### PR DESCRIPTION
## :unicorn: Problème
Notre `package.json` à la racine laisse la place pour une version trop ancienne d'eslint avec la migration en cours (déjà faite sur l'API).

## :robot: Proposition
Monter de version minimum pour ne pas avoir de conflit avec la config API.

Un `npm ci` à la racine sera nécessaire.

## :rainbow: Remarques
La v8.56.0 met en place le support de la flat config, j'ai pris la dernière version de la v8 histoire que ce soit fait.

## :100: Pour tester
CI 🆗 