### PR TITLE
[FEATURE] Ajoute les colonnes deletedBy et deletedAt sur la table campaigns (PIX-12688).

### DIFF
--- a/api/db/migrations/20240530060847_add-deleted-at-deleted-by-on-campaigns.js
+++ b/api/db/migrations/20240530060847_add-deleted-at-deleted-by-on-campaigns.js
@@ -1,0 +1,19 @@
+const TABLE_NAME = 'campaigns';
+const DELETEDAT_COLUMN = 'deletedAt';
+const DELETEDBY_COLUMN = 'deletedBy';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, async (table) => {
+    table.dateTime(DELETEDAT_COLUMN).nullable();
+    table.bigInteger(DELETEDBY_COLUMN).index().references('users.id').nullable();
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, async (table) => {
+    table.dropColumn(DELETEDAT_COLUMN);
+    table.dropColumn(DELETEDBY_COLUMN);
+  });
+};
+
+export { down, up };

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -24,7 +24,7 @@ const getCodeOfLastParticipationToProfilesCollectionCampaignForUser = async func
     .select('campaigns.code')
     .join('campaigns', 'campaigns.id', 'campaignId')
     .where({ userId })
-    .whereNull('deletedAt')
+    .whereNull('campaign-participations.deletedAt')
     .whereNull('archivedAt')
     .andWhere({ status: TO_SHARE })
     .andWhere({ 'campaigns.type': CampaignTypes.PROFILES_COLLECTION })

--- a/api/tests/prescription/campaign/integration/domain/usecases/update-campaign-details_test.js
+++ b/api/tests/prescription/campaign/integration/domain/usecases/update-campaign-details_test.js
@@ -2,6 +2,7 @@ import {
   IsForAbsoluteNoviceUpdateError,
   MultipleSendingsUpdateError,
 } from '../../../../../../src/prescription/campaign/domain/errors.js';
+import { Campaign } from '../../../../../../src/prescription/campaign/domain/models/Campaign.js';
 import { usecases } from '../../../../../../src/prescription/campaign/domain/usecases/index.js';
 import { CampaignParticipationStatuses } from '../../../../../../src/prescription/shared/domain/constants.js';
 import { catchErr, databaseBuilder, expect, knex, mockLearningContent } from '../../../../../test-helper.js';
@@ -54,7 +55,7 @@ describe('Integration | UseCases | update-campaign-details', function () {
       customResultPageButtonText: 'new result button text',
       customResultPageButtonUrl: 'http://some.url.com',
     };
-    const expectedCampaign = { ...campaign, ...campaignAttributes };
+    const expectedCampaign = new Campaign({ ...campaign, ...campaignAttributes });
 
     await usecases.updateCampaignDetails({
       campaignId,
@@ -62,7 +63,7 @@ describe('Integration | UseCases | update-campaign-details', function () {
     });
 
     const actualCampaign = await knex.select('*').from('campaigns').first();
-    expect(actualCampaign).to.deep.equal(expectedCampaign);
+    expect(new Campaign(actualCampaign)).to.deep.equal(expectedCampaign);
   });
 
   describe('#multipleSendings', function () {


### PR DESCRIPTION
## :unicorn: Problème

Dans le cadre de l'Epix "Suppression des campagnes", nous voulons rendre les campagnes supprimables pour différents besoins (gestion des places, vider les espaces PixOrga, l'anonymisation des données, ...). Pour de multiples raisons, nous ne pouvons pas faire de suppression physique (légal, stats, ...) des données. 

## :robot: Proposition

Ajout les colonnes deletedBy et deletedAt sur la table campaigns pour implémenter une suppression logique.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
Pas de tests
