### PR TITLE
[FEATURE] Ajouter le suffixe "%" pour les paliers par seuil (PIX-11911).

### DIFF
--- a/admin/app/components/target-profiles/stages/new-stage.hbs
+++ b/admin/app/components/target-profiles/stages/new-stage.hbs
@@ -15,19 +15,22 @@
           @id={{concat "threshold-" @index}}
         />
       {{else}}
-        <PixInput
-          @id={{concat "threshold-" @index}}
-          @errorMessage="Le seuil est invalide"
-          @validationStatus={{this.thresholdStatus}}
-          @requiredLabel="Champ obligatoire"
-          type="number"
-          @value={{this.threshold}}
-          readonly={{@stage.isZeroStage}}
-          @screenReaderOnly={{true}}
-          {{on "focusout" this.checkThresholdValidity}}
-        >
-          <:label>Seuil du palier</:label>
-        </PixInput>
+        <div class="table__cell--percentage">
+          <PixInput
+            @id={{concat "threshold-" @index}}
+            @errorMessage="Le seuil est invalide"
+            @validationStatus={{this.thresholdStatus}}
+            @requiredLabel="Champ obligatoire"
+            type="number"
+            @value={{this.threshold}}
+            readonly={{@stage.isZeroStage}}
+            @screenReaderOnly={{true}}
+            {{on "focusout" this.checkThresholdValidity}}
+          >
+            <:label>Seuil du palier</:label>
+          </PixInput>
+          <span>%</span>
+        </div>
       {{/if}}
     {{/if}}
   </td>

--- a/admin/app/components/target-profiles/stages/stage.hbs
+++ b/admin/app/components/target-profiles/stages/stage.hbs
@@ -5,7 +5,7 @@
     {{else if @stage.isTypeLevel}}
       {{@stage.level}}
     {{else}}
-      {{@stage.threshold}}
+      {{@stage.threshold}}%
     {{/if}}
   </td>
   <td>{{@stage.title}}</td>

--- a/admin/app/styles/globals/tables.scss
+++ b/admin/app/styles/globals/tables.scss
@@ -12,7 +12,6 @@ thead {
 }
 
 tbody {
-
   tr.tr--clickable {
     cursor: pointer;
 
@@ -66,6 +65,18 @@ td.td--bold {
 
   &--break-word {
     word-break: break-all;
+  }
+}
+
+.table__cell--percentage {
+  display: flex;
+  align-items: center;
+
+  span {
+    margin-left: var(--pix-spacing-1x);
+    color: var(--pix-neutral-60);
+    font-weight: var(--pix-font-medium);
+    font-size: var(--font-size-small);
   }
 }
 

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
@@ -334,8 +334,8 @@ module('Acceptance | Target Profile Insights', function (hooks) {
           assert.true(firstStageThresholdInput.hasAttributes('value', '0'));
           assert.dom(screen.getAllByText('mon premier palier')[0]).exists();
           assert.dom(screen.getAllByText('mon deuxième palier')[0]).exists();
-          assert.dom(screen.getAllByText(0)[0]).exists();
-          assert.dom(screen.getAllByText(50)[0]).exists();
+          assert.dom(screen.getAllByText('0%')[0]).exists();
+          assert.dom(screen.getAllByText('50%')[0]).exists();
           assert.dom(screen.getByText('mon message 1')).exists();
           assert.dom(screen.getByText('mon message 2')).exists();
           assert.dom(screen.queryByText('Enregistrer')).doesNotExist();

--- a/admin/tests/integration/components/target-profiles/stages_test.js
+++ b/admin/tests/integration/components/target-profiles/stages_test.js
@@ -223,7 +223,7 @@ module('Integration | Component | TargetProfiles::Stages', function (hooks) {
       assert.dom(screen.getByText('Description prescripteur')).exists();
       assert.dom(screen.getByText('Actions')).exists();
       assert.dom('tbody tr').exists({ count: 1 });
-      assert.strictEqual(find('tbody tr td:nth-child(1)').textContent.trim(), '100');
+      assert.strictEqual(find('tbody tr td:nth-child(1)').textContent.trim(), '100%');
       assert.strictEqual(find('tbody tr td:nth-child(2)').textContent.trim(), 'My title');
       assert.strictEqual(find('tbody tr td:nth-child(3)').textContent.trim(), 'My message');
       assert.dom(screen.getByText('Voir détail')).exists();


### PR DESCRIPTION
## :unicorn: Problème

Dans le tableau d'affichage des paliers par seuil, on ne connait pas l'unité de façon explicite.

## :robot: Proposition

Afficher l'unité en suffixe de l'input de création et en suffixe des valeurs dans la liste des paliers par seuil.

## :100: Pour tester

- Voir [ce profil cible](https://admin-pr9121.review.pix.fr/target-profiles/56/insights) en RA
- Ajouter un palier par seuil et constater l'affichage des "%"