### PR TITLE
[FEATURE] Accepter un id de campagne dans l'url du simulateur (PIX-12760)

### DIFF
--- a/admin/app/components/smart-random-simulator/smart-random-params.hbs
+++ b/admin/app/components/smart-random-simulator/smart-random-params.hbs
@@ -1,4 +1,8 @@
-<Card class="admin-form__card" @title="Évaluation (campagne ou positionnement)">
+<Card
+  class="admin-form__card"
+  @title="Évaluation (campagne ou positionnement)"
+  {{did-insert this.loadParamsFromCampaignIdSearchQuery}}
+>
 
   <div class="load-campaign-params">
 

--- a/admin/app/components/smart-random-simulator/smart-random-params.js
+++ b/admin/app/components/smart-random-simulator/smart-random-params.js
@@ -79,6 +79,16 @@ export default class SmartRandomParams extends Component {
   }
 
   @action
+  loadParamsFromCampaignIdSearchQuery() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const campaignIdSearchQuery = urlParams.get('campaignId');
+    if (campaignIdSearchQuery) {
+      this.campaignId = campaignIdSearchQuery;
+      this.loadCampaignParams();
+    }
+  }
+
+  @action
   updateJsonFieldValue(key, event) {
     const value = event.target.value;
     delete this.errors[key];

--- a/admin/tests/integration/components/smart-random-simulator/smart-random-params_test.js
+++ b/admin/tests/integration/components/smart-random-simulator/smart-random-params_test.js
@@ -1,0 +1,61 @@
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Integration | Component | SmartRandomSimulator::TubesViewer', function (hooks) {
+  setupRenderingTest(hooks);
+  let loadCampaignParams;
+  let component;
+
+  hooks.beforeEach(async function () {
+    loadCampaignParams = sinon.stub();
+    this.set('knowledgeElements', []);
+    this.set('answers', []);
+    this.set('skills', []);
+    this.set('challenges', []);
+    this.set('locale', 'fr-fr');
+    this.set('assessmentId', 1);
+    this.set('loadCampaignParams', loadCampaignParams);
+    this.set('updateParametersValue', () => {});
+
+    component = hbs`
+      <SmartRandomSimulator::SmartRandomParams
+        @knowledgeElements={{this.knowledgeElements}}
+        @answers={{this.answers}}
+        @skills={{this.skills}}
+        @challenges={{this.challenges}}
+        @locale={{this.locale}}
+        @assessmentId={{this.assessmentId}}
+        @loadCampaignParams={{this.loadCampaignParams}}
+        @updateParametersValue={{this.updateParametersValue}}
+      />
+    `;
+  });
+
+  module('when url does not contain campaign id search query', function () {
+    test('should not call loadCampaignParams argument', async function (assert) {
+      // when
+      await render(component);
+
+      // then
+      sinon.assert.notCalled(loadCampaignParams);
+      assert.ok(true);
+    });
+  });
+
+  module('when url contains campaign id search query', function () {
+    test('should call loadCampaignParams argument', async function (assert) {
+      // given
+      URLSearchParams.prototype.get = () => '12';
+
+      // when
+      await render(component);
+
+      // then
+      sinon.assert.calledOnce(loadCampaignParams);
+      assert.ok(true);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Dans un futur proche nous aimerions mettre en place des liens qui conduisent au simulateur. Or en fonction du lien nous aimerions indiquer au simulateur quelle campagne tester.

## :robot: Proposition
Dans cette PR nous ajoutons la possibilité de passer un paramètre dans l'url ( campaignId ) qui sera interprété par le simulateur et permettra de charger les données d'une campagne au chargement de la page.

## :100: Pour tester
- [Se rendre sur la RA](https://admin-pr9122.review.pix.fr/smart-random-simulator/get-next-challenge)
- Renseigner un id de campagne dans l'url ( ?campaignId=1000000 )
- Vérifier que les données de la campagne sont chargées au lancement de la page ( ça peut prendre un peu de temps sur la RA ) et que le champ est pré rempli avec l'id passé en paramètre

