### PR TITLE
[TECH] Utiliser notre action de lint des titres de PR 

### DIFF
--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -9,6 +9,4 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: Slashgear/action-check-pr-title@v4.3.0
-        with:
-          regexp: '^\[[A-Z]+\] '
+      - uses: 1024pix/pix-actions/check-pr-title@main


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, nous utilisons pas notre action disponible dans le repo `1024pix/pix-actions` de lint des titres des PRs qui centralise la config pour cette action.

## :robot: Proposition
Utiliser la bonne action

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
