### PR TITLE
[BUGFIX] Echec du job sendSharedParticipationResults... (Pix-12762)

### DIFF
--- a/api/src/prescription/campaign-participation/domain/usecases/index.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/index.js
@@ -56,7 +56,7 @@ const dependencies = {
   organizationRepository,
   participationsForCampaignManagementRepository,
   poleEmploiSendingRepository,
-  poleEmploiNotifier: requirePoleEmploiNotifier,
+  poleEmploiNotifier: requirePoleEmploiNotifier(),
   stageCollectionRepository,
   targetProfileRepository,
   tutorialRepository,

--- a/api/src/prescription/campaign-participation/infrastructure/externals/pole-emploi-notifier.js
+++ b/api/src/prescription/campaign-participation/infrastructure/externals/pole-emploi-notifier.js
@@ -13,7 +13,7 @@ import { config } from '../../../../shared/config.js';
 
 const notify = async (userId, payload, dependencies) => {
   const { authenticationMethodRepository, httpAgent, httpErrorsHelper, monitoringTools } = dependencies;
-  if (config.featureToggles.depracatePoleEmploiPushNotification) {
+  if (config.featureToggles.deprecatePoleEmploiPushNotification) {
     payload = { ...payload, deprecated: true };
   }
   monitoringTools.logInfoWithCorrelationIds({

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -190,7 +190,7 @@ const configuration = (function () {
       isPix1dEnabled: toBoolean(process.env.FT_PIX_1D_ENABLED),
       isPixPlusLowerLeverEnabled: toBoolean(process.env.FT_ENABLE_PIX_PLUS_LOWER_LEVEL),
       isCertificationTokenScopeEnabled: toBoolean(process.env.FT_ENABLE_CERTIF_TOKEN_SCOPE),
-      depracatePoleEmploiPushNotification: toBoolean(process.env.DEPRECATE_PE_PUSH_NOTIFICATION),
+      deprecatePoleEmploiPushNotification: toBoolean(process.env.DEPRECATE_PE_PUSH_NOTIFICATION),
       isTextToSpeechButtonEnabled: toBoolean(process.env.FT_ENABLE_TEXT_TO_SPEECH_BUTTON),
     },
     hapi: {

--- a/api/tests/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -21,7 +21,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
           type: 'feature-toggles',
           attributes: {
             'are-v3-info-screens-enabled': false,
-            'depracate-pole-emploi-push-notification': false,
+            'deprecate-pole-emploi-push-notification': false,
             'is-always-ok-validate-next-challenge-endpoint-enabled': false,
             'is-pix1d-enabled': true,
             'is-pix-plus-lower-lever-enabled': false,

--- a/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
+++ b/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
@@ -88,7 +88,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
     context('when access token is valid', function () {
       context('when pole emploi deprecate push env variable is set', function () {
         beforeEach(function () {
-          sinon.stub(settings.featureToggles, 'depracatePoleEmploiPushNotification').value('true');
+          sinon.stub(settings.featureToggles, 'deprecatePoleEmploiPushNotification').value('true');
         });
         it('should send the notification to Pole Emploi with deprectation message', async function () {
           // given


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'ajout du flag de dépréciation du push FT. l'injection de dépendance n'executé pas la fonction. qui a pour effet d'injecter la function, et non le retour de la fonction. ( l'un ou l'autre du répository)

## :robot: Proposition
Injecter la fonction executé qui permet de retourner le bon repository en fonction du contexte activé

## :rainbow: Remarques
Il n'y a pas de test d'intégration sur ça. d'où aucun test KO lors de l'EPIX.
Suite à un défaut de recette des env FT, un test de bout en bout n'a pas pu être fait. 