### PR TITLE
[FEATURE] Afficher le nombre max de caractères du champ nom interne d'un parcours autonome (PIX-12778).

### DIFF
--- a/admin/app/components/autonomous-courses/create-autonomous-course-form.hbs
+++ b/admin/app/components/autonomous-courses/create-autonomous-course-form.hbs
@@ -13,7 +13,7 @@
         @requiredLabel="Champ obligatoire"
         {{on "change" (fn this.updateAutonomousCourseValue "internalTitle")}}
       >
-        <:label>Nom interne : </:label>
+        <:label>Nom interne :</:label>
       </PixInput>
       <PixFilterableAndSearchableSelect
         @placeholder="Choisir un profil cible"
@@ -40,10 +40,11 @@
         placeholder="Exemple : Le super nom de mon parcours autonome"
         required={{true}}
         @requiredLabel="Champ obligatoire"
+        maxlength="50"
         @subLabel="Le nom du parcours autonome sera affiché sur la page de démarrage du candidat."
         {{on "change" (fn this.updateAutonomousCourseValue "publicTitle")}}
       >
-        <:label>Nom public : </:label>
+        <:label>Nom public <small>(50 caractères maximum)</small> :</:label>
       </PixInput>
       <PixTextarea
         @id="text-page-accueil"

--- a/admin/app/components/autonomous-courses/update-autonomous-course-form.hbs
+++ b/admin/app/components/autonomous-courses/update-autonomous-course-form.hbs
@@ -1,15 +1,15 @@
 <form class="form update-autonomous-course" {{on "submit" this.onSubmit}}>
-  <p>
+  <span class="form__instructions">
     Les champs marqués de
-    <span class="mandatory-mark">*</span>
+    <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
     sont obligatoires.
-  </p>
+  </span>
   <PixInput
     class="form-field"
     @id="autonomousCourseName"
     required={{true}}
-    @value={{@autonomousCourse.internalTitle}}
     @requiredLabel="Champ obligatoire"
+    @value={{@autonomousCourse.internalTitle}}
     {{on "change" (fn this.updateAutonomousCourseValue "internalTitle")}}
   >
     <:label>Nom interne :</:label>
@@ -19,12 +19,13 @@
     class="form-field"
     placeholder="Exemple&nbsp;:&nbsp;Le super nom de mon parcours autonome"
     required={{true}}
+    maxlength="50"
     @value={{@autonomousCourse.publicTitle}}
     @requiredLabel="Champ obligatoire"
     @subLabel="Le nom du parcours autonome sera affiché sur la page de démarrage du candidat."
     {{on "change" (fn this.updateAutonomousCourseValue "publicTitle")}}
   >
-    <:label>Nom public </:label>
+    <:label>Nom public <small>(50 caractères maximum)</small> :</:label>
   </PixInput>
   <PixTextarea
     @id="text-page-accueil"

--- a/admin/app/controllers/authenticated/autonomous-courses/autonomous-course/details.js
+++ b/admin/app/controllers/authenticated/autonomous-courses/autonomous-course/details.js
@@ -9,10 +9,14 @@ export default class AutonomousCourseDetailsController extends Controller {
     try {
       await this.model.save();
       this.notifications.success('Parcours autonome modifié avec succès.');
-    } catch (error) {
-      this.notifications.error('Problème lors de la modification du parcours autonome.');
-      console.log(error);
+    } catch ({ errors }) {
       this.model.rollbackAttributes();
+
+      if (errors[0]?.detail) {
+        return this.notifications.error(errors[0].detail);
+      } else {
+        return this.notifications.error('Problème lors de la modification du parcours autonome.');
+      }
     }
   }
   @action


### PR DESCRIPTION
## :unicorn: Problème

Il n'était pas précisé sur admin que la taille max de ce nom public de parcours autonome est de 50 caractères.

## :robot: Proposition

Ajouter : 
- un sous-label précisant ce pré-requis
- l'attribut `maxlength` pour bloquer la taille de valeur des inputs concernés
- afficher le détail de l'erreur API si elle est fournie

## :100: Pour tester

- Essayer de créer ou modifier un parcours autonome avec un nom public très long
- Constater que l'input est limité à 50 caractères.
