### PR TITLE
[BUGFIX] Afficher la bonne langue dans le Language Switcher (PIX-10753)

### DIFF
--- a/mon-pix/app/controllers/authentication/login.js
+++ b/mon-pix/app/controllers/authentication/login.js
@@ -1,7 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import { tracked } from '@glimmer/tracking';
 
 export default class LoginController extends Controller {
   @service currentDomain;
@@ -9,16 +8,17 @@ export default class LoginController extends Controller {
   @service locale;
   @service router;
 
-  @tracked selectedLanguage = this.intl.primaryLocale;
-
   get isInternationalDomain() {
     return !this.currentDomain.isFranceDomain;
   }
 
+  get selectedLanguage() {
+    return this.intl.primaryLocale;
+  }
+
   @action
   onLanguageChange(language) {
-    this.selectedLanguage = language;
-    this.locale.setLocale(this.selectedLanguage);
+    this.locale.setLocale(language);
     this.router.replaceWith('authentication.login', { queryParams: { lang: null } });
   }
 }

--- a/mon-pix/app/controllers/inscription.js
+++ b/mon-pix/app/controllers/inscription.js
@@ -1,7 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import { tracked } from '@glimmer/tracking';
 
 export default class InscriptionController extends Controller {
   @service currentDomain;
@@ -9,16 +8,17 @@ export default class InscriptionController extends Controller {
   @service locale;
   @service router;
 
-  @tracked selectedLanguage = this.intl.primaryLocale;
-
   get isInternationalDomain() {
     return !this.currentDomain.isFranceDomain;
   }
 
+  get selectedLanguage() {
+    return this.intl.primaryLocale;
+  }
+
   @action
   onLanguageChange(language) {
-    this.selectedLanguage = language;
-    this.locale.setLocale(this.selectedLanguage);
+    this.locale.setLocale(language);
     this.router.replaceWith('inscription', { queryParams: { lang: null } });
   }
 }


### PR DESCRIPTION
## :unicorn: Problème

Lorsque l'on change de langue sur la page d'inscription ou de connexion, puis on change de page inscription vers connexion ou connexion vers inscription, la valeur par défaut du Language Switcher est utilisé au lieu de la sélection que l'utilisateur a fait précédemment.

## :robot: Proposition

Afficher la langue que l'utilisateur a sélectionné précédemment lors du changement de page connexion <-> inscription.

## :rainbow: Remarques

RAS

## :100: Pour tester

1. Ouvrir un nouvel onglet sur Pix App
2. Cliquer sur le lien _Créer un compte_ pour arriver sur la page d’inscription
3. Sélectionner la langue _English_ dans le _Language Switcher_
4. Cliquer sur le lien _log into your account_
5. Vérifier que la page s’affiche bien en anglais et également le _Language Switcher_
