### PR TITLE
[FEATURE] Ajouter un sélecteur de langue sur la double mire OIDC (PIX-12151)

### DIFF
--- a/mon-pix/app/components/authentication/login-or-register-oidc.js
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.js
@@ -22,6 +22,7 @@ export default class LoginOrRegisterOidcComponent extends Component {
   @service currentDomain;
   @service oidcIdentityProviders;
   @service store;
+  @service url;
 
   @tracked isTermsOfServiceValidated = false;
   @tracked loginErrorMessage = null;
@@ -50,17 +51,11 @@ export default class LoginOrRegisterOidcComponent extends Component {
   }
 
   get cguUrl() {
-    if (this.currentLanguage === 'en') {
-      return 'https://pix.org/en-gb/terms-and-conditions';
-    }
-    return `https://pix.${this.currentDomain.getExtension()}/conditions-generales-d-utilisation`;
+    return this.url.cguUrl;
   }
 
   get dataProtectionPolicyUrl() {
-    if (this.currentLanguage === 'en') {
-      return 'https://pix.org/en-gb/personal-data-protection-policy';
-    }
-    return `https://pix.${this.currentDomain.getExtension()}/politique-protection-donnees-personnelles-app`;
+    return this.url.dataProtectionPolicyUrl;
   }
 
   @action

--- a/mon-pix/app/controllers/authentication/login-or-register-oidc.js
+++ b/mon-pix/app/controllers/authentication/login-or-register-oidc.js
@@ -9,6 +9,10 @@ export default class LoginOrRegisterOidcController extends Controller {
   @service url;
   @service oidcIdentityProviders;
   @service store;
+  @service intl;
+  @service locale;
+  @service router;
+  @service currentDomain;
 
   @tracked showOidcReconciliation = false;
   @tracked authenticationKey = null;
@@ -21,6 +25,20 @@ export default class LoginOrRegisterOidcController extends Controller {
 
   get showcase() {
     return this.url.showcase;
+  }
+
+  get isInternationalDomain() {
+    return !this.currentDomain.isFranceDomain;
+  }
+
+  get selectedLanguage() {
+    return this.intl.primaryLocale;
+  }
+
+  @action
+  onLanguageChange(language) {
+    this.locale.setLocale(language);
+    this.router.replaceWith('authentication.login-or-register-oidc', { queryParams: { lang: null } });
   }
 
   @action toggleOidcReconciliation() {

--- a/mon-pix/app/templates/authentication/login-or-register-oidc.hbs
+++ b/mon-pix/app/templates/authentication/login-or-register-oidc.hbs
@@ -28,4 +28,8 @@
     {{/if}}
 
   </PixBlock>
+
+  {{#if this.isInternationalDomain}}
+    <LanguageSwitcher @selectedLanguage={{this.selectedLanguage}} @onLanguageChange={{this.onLanguageChange}} />
+  {{/if}}
 </PixBackgroundHeader>

--- a/mon-pix/mirage/routes/authentication/oidc/index.js
+++ b/mon-pix/mirage/routes/authentication/oidc/index.js
@@ -3,7 +3,15 @@ import { Response } from 'miragejs';
 export default function (config) {
   config.post('/oidc/token', (schema, request) => {
     if (!request.requestHeaders.Authorization) {
-      return new Response(401, {}, { errors: [{ code: 'SHOULD_VALIDATE_CGU', meta: { authenticationKey: 'key' } }] });
+      return new Response(
+        401,
+        {},
+        {
+          errors: [
+            { code: 'SHOULD_VALIDATE_CGU', meta: { authenticationKey: 'key', familyName: 'PIX', givenName: 'test' } },
+          ],
+        },
+      );
     }
 
     const createdUser = schema.users.create({

--- a/mon-pix/tests/acceptance/authentication/login-or-register-oidc_test.js
+++ b/mon-pix/tests/acceptance/authentication/login-or-register-oidc_test.js
@@ -1,0 +1,52 @@
+import { visit } from '@1024pix/ember-testing-library';
+import { click, currentURL } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import setupIntl from '../../helpers/setup-intl';
+
+module('Acceptance | Login or register oidc', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks);
+
+  module('when on international domain (.org)', function () {
+    module('when accessing "login-or-register-oidc" page', function () {
+      test('displays the page with "Français" as selected language', async function (assert) {
+        // when
+        const screen = await visit('/connexion/oidc-partner?code=oidc_example_code&state=auth_session_state');
+
+        // then
+        assert.strictEqual(
+          currentURL(),
+          '/connexion/oidc?authenticationKey=key&familyName=PIX&givenName=test&identityProviderSlug=oidc-partner',
+        );
+        assert.dom(screen.getByRole('button', { name: 'Sélectionnez une langue' })).exists();
+      });
+    });
+
+    module('when user select "English" as his language', function () {
+      test('displays the page with "English" as selected language', async function (assert) {
+        // given
+        const screen = await visit('/connexion/oidc-partner?code=oidc_example_code&state=auth_session_state');
+
+        // when
+        await click(screen.getByRole('button', { name: 'Sélectionnez une langue' }));
+        await screen.findByRole('listbox');
+        await click(screen.getByRole('option', { name: 'English' }));
+
+        // then
+        assert
+          .dom(
+            screen.getByRole('heading', {
+              name: this.intl.t('pages.login-or-register-oidc.register-form.title'),
+              level: 2,
+            }),
+          )
+          .exists();
+        assert.dom(screen.getByRole('button', { name: 'Select a language' })).exists();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Actuellement il n'est pas possible de modifier la langue d'affichage de la page lorsqu'une personne s'est connectée pour la première fois à Pix via un SSO.

## :robot: Proposition

Ajouter le sélecteur de langue sur la double mire OIDC.

## :rainbow: Remarques

- Le sélecteur se retrouvera également sur la page de rattachement du compte SSO au compte Pix existant.
- Il y a un problème de traduction sur la page de rattachement d'un compte SSO à un compte PIX. Des clés n'ont pas été traduites en anglais.

## :100: Pour tester

⚠️ A faire en local

1. Se connecter via le SSO disponible sur le domaine .org
2. Vérifier sur la double mire OIDC, l'affichage du sélecteur de langue en bas à gauche.
3. Modifier la langue
4. Vérifier la modification du contenu de la page dans la langue sélectionnée
5. Vérifier que les liens _conditions d'utilisation_ et _politique de confidentialité_ pointent bien vers les bonnes ressources
6. Se connecter avec un compte Pix existant
7. Vérifier l'affichage du sélecteur de language en bas à gauche
8. Modifier la langue
9. Vérifier la modification du contenu de la page dans la langue sélectionnée
