### PR TITLE
[FEATURE] Ajout d'une section étape dans un module (PIX-12790)

### DIFF
--- a/mon-pix/app/components/module/step.gjs
+++ b/mon-pix/app/components/module/step.gjs
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import { t } from 'ember-intl';
 import Element from 'mon-pix/components/module/element';
 
 export default class ModulixStep extends Component {
@@ -7,15 +8,20 @@ export default class ModulixStep extends Component {
   }
 
   <template>
-    {{#each this.elements as |element|}}
-      <div class="grain-card-content__element">
-        <Element
-          @element={{element}}
-          @submitAnswer={{@submitAnswer}}
-          @retryElement={{@retryElement}}
-          @getLastCorrectionForElement={{@getLastCorrectionForElement}}
-        />
-      </div>
-    {{/each}}
+    <section>
+      <h3
+        aria-label="{{t 'pages.modulix.stepper.step.position' currentStep=@currentStep totalSteps=@totalSteps}}"
+      >{{@currentStep}}/{{@totalSteps}}</h3>
+      {{#each this.elements as |element|}}
+        <div class="grain-card-content__element">
+          <Element
+            @element={{element}}
+            @submitAnswer={{@submitAnswer}}
+            @retryElement={{@retryElement}}
+            @getLastCorrectionForElement={{@getLastCorrectionForElement}}
+          />
+        </div>
+      {{/each}}
+    </section>
   </template>
 }

--- a/mon-pix/app/components/module/stepper.gjs
+++ b/mon-pix/app/components/module/stepper.gjs
@@ -1,0 +1,7 @@
+import Step from 'mon-pix/components/module/step';
+
+<template>
+  {{#each @steps as |step|}}
+    <Step @step={{step}} @currentStep={{1}} @totalSteps={{4}} />
+  {{/each}}
+</template>

--- a/mon-pix/app/components/module/stepper.gjs
+++ b/mon-pix/app/components/module/stepper.gjs
@@ -1,7 +1,8 @@
 import Step from 'mon-pix/components/module/step';
+import { inc } from 'mon-pix/helpers/inc';
 
 <template>
-  {{#each @steps as |step|}}
-    <Step @step={{step}} @currentStep={{1}} @totalSteps={{4}} />
+  {{#each @steps as |step index|}}
+    <Step @step={{step}} @currentStep={{inc index}} @totalSteps={{@steps.length}} />
   {{/each}}
 </template>

--- a/mon-pix/app/helpers/inc.js
+++ b/mon-pix/app/helpers/inc.js
@@ -1,7 +1,7 @@
 import { helper } from '@ember/component/helper';
 
-export function inc(params) {
-  return params[0] + 1;
+export function inc(number) {
+  return Number.parseInt(number) + 1;
 }
 
 export default helper(inc);

--- a/mon-pix/tests/integration/components/module/step_test.gjs
+++ b/mon-pix/tests/integration/components/module/step_test.gjs
@@ -20,10 +20,13 @@ module('Integration | Component | Module | Step', function (hooks) {
       };
 
       // when
-      const screen = await render(<template><ModulixStep @step={{step}} /></template>);
+      const screen = await render(
+        <template><ModulixStep @step={{step}} @currentStep={{1}} @totalSteps={{4}} /></template>,
+      );
 
       // then
       assert.dom(screen.getByText(element.content)).exists();
+      assert.dom(screen.getByRole('heading', { name: 'Étape 1 sur 4', level: 3 })).exists();
     });
 
     test('should display a step with a qcu element', async function (assert) {

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -36,6 +36,8 @@ module('Integration | Component | Module | Stepper', function (hooks) {
 
       // then
       assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 2);
+      assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 1 sur 2' })).exists();
+      assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 2 sur 2' })).exists();
     });
   });
 });

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -1,0 +1,41 @@
+import { render } from '@1024pix/ember-testing-library';
+import ModulixStepper from 'mon-pix/components/module/stepper';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Module | Stepper', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('A Stepper with 2 steps', function () {
+    test('should display 2 steps', async function (assert) {
+      // given
+      const steps = [
+        {
+          elements: [
+            {
+              id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+              type: 'text',
+              content: '<p>Text 1</p>',
+            },
+          ],
+        },
+        {
+          elements: [
+            {
+              id: '768441a5-a7d6-4987-ada9-7253adafd842',
+              type: 'text',
+              content: '<p>Text 2</p>',
+            },
+          ],
+        },
+      ];
+
+      // when
+      const screen = await render(<template><ModulixStepper @steps={{steps}} /></template>);
+
+      // then
+      assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 2);
+    });
+  });
+});

--- a/mon-pix/tests/unit/helpers/inc_test.js
+++ b/mon-pix/tests/unit/helpers/inc_test.js
@@ -1,0 +1,17 @@
+import { setupTest } from 'ember-qunit';
+import { inc } from 'mon-pix/helpers/inc';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | inc', function (hooks) {
+  setupTest(hooks);
+
+  module('inc', () => {
+    test('it should add one to a number', function (assert) {
+      assert.strictEqual(inc(10), 11);
+    });
+
+    test('it should add one to a string', function (assert) {
+      assert.strictEqual(inc('10'), 11);
+    });
+  });
+});

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1264,6 +1264,11 @@
         "goToForm": "Answer the questionnaire",
         "subtitle": "You have achieved the following objectives:"
       },
+      "stepper": {
+        "step": {
+          "position": "Step {currentStep} of {totalSteps}"
+        }
+      },
       "verification-precondition-failed-alert": {
         "qcm": "To validate, select at least two answers.",
         "qcu": "To validate, select an answer.",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1238,6 +1238,11 @@
           "lesson": "lección"
         }
       },
+      "stepper": {
+        "step": {
+          "position": "Paso {currentStep} de {totalSteps}"
+        }
+      },
       "modals": {
         "alternativeText": {
           "title": "Texto alternativo"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1264,6 +1264,11 @@
         "goToForm": "Répondre au questionnaire",
         "subtitle": "Vous avez atteint les objectifs suivants :"
       },
+      "stepper": {
+        "step": {
+          "position": "Étape {currentStep} sur {totalSteps}"
+        }
+      },
       "verification-precondition-failed-alert": {
         "qcm": "Pour valider, sélectionnez au moins deux réponses.",
         "qcu": "Pour valider, sélectionnez une réponse.",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1238,6 +1238,11 @@
           "lesson": "les"
         }
       },
+      "stepper": {
+        "step": {
+          "position": "Stap {currentStep} van {totalSteps}"
+        }
+      },
       "modals": {
         "alternativeText": {
           "title": "Tekst alternatief"


### PR DESCRIPTION
## :unicorn: Problème
Nous pouvons afficher des éléments dans une étape. A présent, nous voulons afficher l'étape sur laquelle se trouve un utilisateur et le nombre d'étapes qu'il y a dans un étapier.

## :robot: Proposition

- Englober un `Step` dans une balise `<section>`.
- Ajouter un titre de niveau `h3` dans lequel on affiche l'étape actuelle sur le nombre d'étapes totales.
- Ajout d'un composant parent `Stepper` qui envoie au `Step`, via des props, les informations concernants le nombre d'étapes

## :rainbow: Remarques
Nous avons mis à jour le helper `inc` pour qu'il prenne en compte les nombre.
On l'utilise pour itérer dans un tableau.

## :100: Pour tester
CI OK, on a rien touché à l'existant fonctionnellement :) 
