### PR TITLE
[BUGFIX] Gérer le cas où le paramètre tubes est vide à la création de déclencheurs de contenus formatifs (PIX-12738)

### DIFF
--- a/api/src/devcomp/application/trainings/index.js
+++ b/api/src/devcomp/application/trainings/index.js
@@ -221,12 +221,15 @@ const register = async function (server) {
               attributes: Joi.object({
                 type: Joi.string().valid('prerequisite', 'goal').required(),
                 threshold: Joi.number().min(0).max(100).required(),
-                tubes: Joi.array().items(
-                  Joi.object({
-                    tubeId: identifiersType.tubeId.required(),
-                    level: Joi.number().min(0).max(8).required(),
-                  }),
-                ),
+                tubes: Joi.array()
+                  .items(
+                    Joi.object({
+                      tubeId: identifiersType.tubeId.required(),
+                      level: Joi.number().min(0).max(8).required(),
+                    }),
+                  )
+                  .min(1)
+                  .required(),
               }),
               type: Joi.string().valid('training-triggers'),
             }).required(),

--- a/api/tests/devcomp/unit/application/trainings/index_test.js
+++ b/api/tests/devcomp/unit/application/trainings/index_test.js
@@ -1183,6 +1183,53 @@ describe('Unit | Devcomp | Application | Trainings | Router | training-router', 
         // then
         expect(result.statusCode).to.equal(400);
       });
+
+      it('should return bad request when tubes array is empty', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+        const invalidPayload = {
+          data: {
+            attributes: {
+              type: 'prerequisite',
+              threshold: 50,
+              tubes: [],
+            },
+            type: 'training-triggers',
+          },
+        };
+
+        // when
+        const result = await httpTestServer.request('PUT', '/api/admin/trainings/12344/triggers', invalidPayload);
+
+        // then
+        expect(result.statusCode).to.equal(400);
+      });
+
+      it('should return 200 OK when payload is valid', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').resolves(true);
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').resolves(true);
+        sinon.stub(trainingController, 'createOrUpdateTrigger').callsFake((request, h) => h.response().created());
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+        const validPayload = {
+          data: {
+            attributes: {
+              type: 'prerequisite',
+              threshold: 50,
+              tubes: [{ tubeId: 'recTube123', level: 2 }],
+            },
+            type: 'training-triggers',
+          },
+        };
+
+        // when
+        const result = await httpTestServer.request('PUT', '/api/admin/trainings/12344/triggers', validPayload);
+
+        // then
+        expect(result.statusCode).to.equal(201);
+      });
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème

Il est possible de créer des déclencheurs de contenu formatifs sans spécifier de sujets, ce qui déclenche une erreur 500.

## :robot: Proposition

Lorsque le paramètre `tubes` est vide, renvoyer une erreur 400.

## :rainbow: Remarques

- Petit refacto des tests pour retirer un test paramétré

## :100: Pour tester

- Essayer créer déclencheur de contenu formatif en mettant un pourcentage, mais sans sélectionner de sujet
- Constater que la réponse du serveur a un statut 400 plutôt que 500
