### PR TITLE
[FEATURE] Rendre dynamique le carousel des écrans d'instruction pour la certification V3 sur Pix App (PIX-12757).

### DIFF
--- a/mon-pix/app/components/certification-information.hbs
+++ b/mon-pix/app/components/certification-information.hbs
@@ -1,7 +1,4 @@
-<section class="certification-starter">
-  <h2 class="certification-start-page__title">{{t "pages.certification-information.screens.first.title"}}</h2>
-  <p>{{t "pages.certification-information.screens.first.how"}}</p>
-  <div>
-    {{t "pages.certification-information.screens.first.text" htmlSafe=true}}
-  </div>
-</section>
+<h2 class="certification-information__title">{{t "pages.certification-information.screens.first.title"}}</h2>
+<div>
+  {{t "pages.certification-information.screens.first.text" htmlSafe=true}}
+</div>

--- a/mon-pix/app/components/certification-information.hbs
+++ b/mon-pix/app/components/certification-information.hbs
@@ -1,4 +1,25 @@
-<h2 class="certification-information__title">{{t "pages.certification-information.screens.first.title"}}</h2>
-<div>
-  {{t "pages.certification-information.screens.first.text" htmlSafe=true}}
-</div>
+<h2 class="certification-information__title">{{this.information.title}}</h2>
+
+<p>{{this.information.text}}</p>
+
+<footer class="certification-information__footer">
+  <div class="certification-information-footer__dots">
+    {{#each this.paging as |page-class|}}
+      <img
+        class="certification-information-footer-dots__dot {{page-class}}"
+        src="/images/illustrations/certification-information-screens/ellipse.svg"
+        alt=""
+      />
+    {{/each}}
+  </div>
+  <div class="certification-information-footer__buttons">
+    {{#if this.showPreviousButton}}
+      <PixButton @size="large" @variant="secondary" @triggerAction={{this.previousStep}}>{{t
+          "pages.certification-information.buttons.previous"
+        }}</PixButton>
+    {{/if}}
+    <PixButton @size="large" @triggerAction={{this.nextStep}} @isDisabled={{this.isNextButtonDisabled}}>{{t
+        "pages.certification-information.buttons.continuous"
+      }}</PixButton>
+  </div>
+</footer>

--- a/mon-pix/app/components/certification-information.hbs
+++ b/mon-pix/app/components/certification-information.hbs
@@ -14,12 +14,22 @@
   </div>
   <div class="certification-information-footer__buttons">
     {{#if this.showPreviousButton}}
-      <PixButton @size="large" @variant="secondary" @triggerAction={{this.previousStep}}>{{t
-          "pages.certification-information.buttons.previous"
-        }}</PixButton>
+      <PixButton
+        @size="large"
+        @variant="secondary"
+        @triggerAction={{this.previousStep}}
+        aria-label={{t "pages.certification-information.buttons.previous.aria-label"}}
+      >
+        {{t "pages.certification-information.buttons.previous.label"}}
+      </PixButton>
     {{/if}}
-    <PixButton @size="large" @triggerAction={{this.nextStep}} @isDisabled={{this.isNextButtonDisabled}}>{{t
-        "pages.certification-information.buttons.continuous"
-      }}</PixButton>
+    <PixButton
+      @size="large"
+      @triggerAction={{this.nextStep}}
+      @isDisabled={{this.isNextButtonDisabled}}
+      aria-label={{this.nextButtonAriaLabel}}
+    >
+      {{t "pages.certification-information.buttons.continuous.label"}}
+    </PixButton>
   </div>
 </footer>

--- a/mon-pix/app/components/certification-information.js
+++ b/mon-pix/app/components/certification-information.js
@@ -1,0 +1,49 @@
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class CertificationInformation extends Component {
+  @service intl;
+  @tracked pageId = 1;
+  @tracked pageCount = 5;
+
+  _setupPaging(numberOfPages, currentPageId) {
+    const classOfPages = new Array(numberOfPages);
+    classOfPages[currentPageId - 1] = 'active';
+    return classOfPages;
+  }
+
+  get information() {
+    return {
+      title: this.intl.t(`pages.certification-information.screens.page${this.pageId}.title`),
+      text: this.intl.t(`pages.certification-information.screens.page${this.pageId}.text`, {
+        htmlSafe: true,
+      }),
+    };
+  }
+
+  get paging() {
+    return this._setupPaging(this.pageCount, this.pageId);
+  }
+
+  get showPreviousButton() {
+    return this.pageId > 1;
+  }
+
+  get isNextButtonDisabled() {
+    return this.pageId === this.pageCount;
+  }
+
+  @action
+  previousStep() {
+    this.pageId = this.pageId - 1;
+  }
+
+  @action
+  nextStep() {
+    if (this.pageId < this.pageCount) {
+      this.pageId = this.pageId + 1;
+    }
+  }
+}

--- a/mon-pix/app/components/certification-information.js
+++ b/mon-pix/app/components/certification-information.js
@@ -35,6 +35,11 @@ export default class CertificationInformation extends Component {
     return this.pageId === this.pageCount;
   }
 
+  get nextButtonAriaLabel() {
+    const translationKey = this.pageId === this.pageCount ? 'last-page.aria-label' : 'aria-label';
+    return this.intl.t(`pages.certification-information.buttons.continuous.${translationKey}`);
+  }
+
   @action
   previousStep() {
     this.pageId = this.pageId - 1;

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -42,7 +42,7 @@ Router.map(function () {
 
     this.route('certifications', function () {
       this.route('join', { path: '/' });
-      this.route('information', { path: '/informations' });
+      this.route('information', { path: '/candidat/:certification_candidate_id/informations' });
       this.route('start', { path: '/candidat/:certification_candidate_id' });
       this.route('resume', { path: '/:certification_course_id' });
       this.route('results', { path: '/:certification_id/results' });

--- a/mon-pix/app/routes/authenticated/certifications/information.js
+++ b/mon-pix/app/routes/authenticated/certifications/information.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class InformationRoute extends Route {
+  @service store;
+
+  async model(params) {
+    return await this.store.findRecord('certification-candidate-subscription', params.certification_candidate_id);
+  }
+}

--- a/mon-pix/app/routes/authenticated/certifications/start.js
+++ b/mon-pix/app/routes/authenticated/certifications/start.js
@@ -16,7 +16,7 @@ export default class StartRoute extends Route {
       certificationCandidateSubscription.isSessionVersion3 &&
       this.featureToggles.featureToggles.areV3InfoScreensEnabled
     ) {
-      this.router.replaceWith('authenticated.certifications.information');
+      this.router.replaceWith('authenticated.certifications.information', params.certification_candidate_id);
     }
 
     return certificationCandidateSubscription;

--- a/mon-pix/app/styles/pages/_certification-information.scss
+++ b/mon-pix/app/styles/pages/_certification-information.scss
@@ -1,10 +1,11 @@
 .certification-information {
   min-height: 100vh;
-  background: $pix-primary-certif-gradient;
   padding: 32px 80px;
+  background: $pix-primary-certif-gradient;
 
   &__title {
     @extend %pix-title-m;
+
     margin-bottom: var(--pix-spacing-8x);
   }
 
@@ -16,27 +17,27 @@
 
   &__header {
     display: flex;
+    gap: 16px;
     align-items: center;
     justify-content: start;
-    font-size: 1.125rem;
     margin-bottom: 110px;
-    gap: 16px;
+    font-size: 1.125rem;
   }
 
   &__card {
     max-width: 846px;
-    padding: 24px;
     margin: auto;
+    padding: 24px;
     border-radius: 24px;
   }
 
   &__footer {
-    margin-top: var(--pix-spacing-10x);
     display: flex;
     flex-flow: column wrap;
+    gap: 24px;
     align-items: center;
     justify-content: start;
-    gap: 24px;
+    margin-top: var(--pix-spacing-10x);
   }
 }
 
@@ -47,8 +48,8 @@
 
   &__separator {
     width: 1px;
-    background-color: var(--pix-neutral-0);
     height: 32px;
+    background-color: var(--pix-neutral-0);
   }
 
   &__title {

--- a/mon-pix/app/styles/pages/_certification-information.scss
+++ b/mon-pix/app/styles/pages/_certification-information.scss
@@ -1,9 +1,56 @@
 .certification-information {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
   min-height: 100vh;
   background: $pix-primary-certif-gradient;
+  padding: 32px 80px;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: start;
+    font-size: 1.125rem;
+    margin-bottom: 110px;
+    gap: 16px;
+  }
+
+  &__card {
+    max-width: 846px;
+    padding: 24px;
+    margin: auto;
+    border-radius: 24px;
+  }
+
+  &__footer {
+    display: flex;
+    flex-flow: column wrap;
+    align-items: center;
+    justify-content: start;
+    gap: 24px;
+  }
+}
+
+.certification-information-header {
+  &__logo {
+    max-width: 60px;
+  }
+
+  &__separator {
+    width: 1px;
+    background-color: var(--pix-neutral-0);
+    height: 32px;
+  }
+
+  &__title {
+    color: var(--pix-neutral-0);
+  }
+}
+
+.certification-information-footer {
+  &__buttons {
+    display: flex;
+    gap: 32px;
+  }
+}
+
+.certification-information-footer-dots__dot.active {
+    filter: brightness(0) saturate(100%) invert(17%) sepia(28%) saturate(7283%) hue-rotate(246deg) brightness(90%) contrast(94%);
 }

--- a/mon-pix/app/styles/pages/_certification-information.scss
+++ b/mon-pix/app/styles/pages/_certification-information.scss
@@ -3,6 +3,17 @@
   background: $pix-primary-certif-gradient;
   padding: 32px 80px;
 
+  &__title {
+    @extend %pix-title-m;
+    margin-bottom: var(--pix-spacing-8x);
+  }
+
+  &__text {
+    &--bold {
+      font-weight: 700;
+    }
+  }
+
   &__header {
     display: flex;
     align-items: center;
@@ -20,6 +31,7 @@
   }
 
   &__footer {
+    margin-top: var(--pix-spacing-10x);
     display: flex;
     flex-flow: column wrap;
     align-items: center;

--- a/mon-pix/app/templates/authenticated/certifications/information.hbs
+++ b/mon-pix/app/templates/authenticated/certifications/information.hbs
@@ -1,9 +1,24 @@
 {{page-title (t "pages.certification-information.title")}}
-
 <main class="certification-information">
-  <PixBackgroundHeader id="main">
-    <PixBlock @shadow="heavy" class="certification-start-page__block">
-      <CertificationInformation />
-    </PixBlock>
-  </PixBackgroundHeader>
+  <header class="certification-information__header">
+    <img class="certification-information-header__logo" src="/images/pix-logo-blanc.svg" alt="">
+    <span class="certification-information-header__separator"></span>
+    <h1 class="certification-information-header__title">{{t "pages.certification-information.title"}}</h1>
+  </header>
+  <PixBlock @shadow="heavy" class="certification-information__card">
+    <CertificationInformation />
+    <footer class="certification-information__footer">
+      <div class="certification-information-footer__dots">
+        <img class="certification-information-footer-dots__dot {{if true 'active'}}" src="/images/illustrations/certification-information-screens/ellipse.svg" alt="">
+        <img class="certification-information-footer-dots__dot" src="/images/illustrations/certification-information-screens/ellipse.svg" alt="">
+        <img class="certification-information-footer-dots__dot" src="/images/illustrations/certification-information-screens/ellipse.svg" alt="">
+        <img class="certification-information-footer-dots__dot" src="/images/illustrations/certification-information-screens/ellipse.svg" alt="">
+        <img class="certification-information-footer-dots__dot" src="/images/illustrations/certification-information-screens/ellipse.svg" alt="">
+      </div>
+      <div class="certification-information-footer__buttons">
+        <PixButton @size="large" @variant="secondary" @triggerAction={{this.cancelEdit}}>{{t "pages.certification-information.buttons.previous"}}</PixButton>
+        <PixButton @size="large">{{t "pages.certification-information.buttons.continuous"}}</PixButton>
+      </div>
+    </footer>
+  </PixBlock>
 </main>

--- a/mon-pix/app/templates/authenticated/certifications/information.hbs
+++ b/mon-pix/app/templates/authenticated/certifications/information.hbs
@@ -1,24 +1,11 @@
 {{page-title (t "pages.certification-information.title")}}
 <main class="certification-information">
   <header class="certification-information__header">
-    <img class="certification-information-header__logo" src="/images/pix-logo-blanc.svg" alt="">
+    <img class="certification-information-header__logo" src="/images/pix-logo-blanc.svg" alt="" />
     <span class="certification-information-header__separator"></span>
     <h1 class="certification-information-header__title">{{t "pages.certification-information.title"}}</h1>
   </header>
   <PixBlock @shadow="heavy" class="certification-information__card">
     <CertificationInformation />
-    <footer class="certification-information__footer">
-      <div class="certification-information-footer__dots">
-        <img class="certification-information-footer-dots__dot {{if true 'active'}}" src="/images/illustrations/certification-information-screens/ellipse.svg" alt="">
-        <img class="certification-information-footer-dots__dot" src="/images/illustrations/certification-information-screens/ellipse.svg" alt="">
-        <img class="certification-information-footer-dots__dot" src="/images/illustrations/certification-information-screens/ellipse.svg" alt="">
-        <img class="certification-information-footer-dots__dot" src="/images/illustrations/certification-information-screens/ellipse.svg" alt="">
-        <img class="certification-information-footer-dots__dot" src="/images/illustrations/certification-information-screens/ellipse.svg" alt="">
-      </div>
-      <div class="certification-information-footer__buttons">
-        <PixButton @size="large" @variant="secondary" @triggerAction={{this.cancelEdit}}>{{t "pages.certification-information.buttons.previous"}}</PixButton>
-        <PixButton @size="large">{{t "pages.certification-information.buttons.continuous"}}</PixButton>
-      </div>
-    </footer>
   </PixBlock>
 </main>

--- a/mon-pix/public/images/illustrations/certification-information-screens/ellipse.svg
+++ b/mon-pix/public/images/illustrations/certification-information-screens/ellipse.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle id="Ellipse 3" cx="6" cy="6" r="5.71429" fill="#F4F5F7" stroke="#5E6C84" stroke-width="0.571429"/>
+</svg>

--- a/mon-pix/tests/acceptance/authenticated/certifications/information_test.js
+++ b/mon-pix/tests/acceptance/authenticated/certifications/information_test.js
@@ -54,7 +54,7 @@ module('Acceptance | Certifications | Information', function (hooks) {
         assert.strictEqual(currentURL(), '/certifications/candidat/2/informations');
         assert.dom(screen.getByRole('heading', { name: 'Explication de la certification', level: 1 })).exists();
         assert.dom(screen.getByRole('heading', { name: 'Bienvenue à la certification Pix', level: 2 })).exists();
-        assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists();
+        assert.dom(screen.getByRole('button', { name: "Continuer vers l'écran suivant" })).exists();
       });
     });
 

--- a/mon-pix/tests/acceptance/authenticated/certifications/information_test.js
+++ b/mon-pix/tests/acceptance/authenticated/certifications/information_test.js
@@ -1,0 +1,97 @@
+import { visit } from '@1024pix/ember-testing-library';
+import { currentURL } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import { authenticateByEmail } from '../../../helpers/authentication';
+import { fillCertificationJoiner } from '../../../helpers/certification';
+import setupIntl from '../../../helpers/setup-intl';
+
+module('Acceptance | Certifications | Information', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks);
+
+  let user;
+
+  hooks.beforeEach(async function () {
+    user = server.create('user', 'withEmail', 'certifiable');
+  });
+
+  module('when certification candidate participates in a V3 session', function () {
+    module('when toggle areV3InfoScreensEnabled is enabled', function () {
+      test('should display the certification information page', async function (assert) {
+        // given
+        server.create('feature-toggle', {
+          id: 0,
+          areV3InfoScreensEnabled: true,
+        });
+        server.create('certification-candidate-subscription', {
+          id: 2,
+          sessionId: 123,
+          eligibleSubscription: null,
+          nonEligibleSubscription: null,
+          sessionVersion: 3,
+        });
+
+        await authenticateByEmail(user);
+
+        const screen = await visit('/certifications');
+
+        // when
+        await fillCertificationJoiner({
+          sessionId: '123',
+          firstName: 'toto',
+          lastName: 'titi',
+          dayOfBirth: '01',
+          monthOfBirth: '01',
+          yearOfBirth: '2000',
+          intl: this.intl,
+        });
+
+        // then
+        assert.strictEqual(currentURL(), '/certifications/candidat/2/informations');
+        assert.dom(screen.getByRole('heading', { name: 'Explication de la certification', level: 1 })).exists();
+        assert.dom(screen.getByRole('heading', { name: 'Bienvenue à la certification Pix', level: 2 })).exists();
+        assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists();
+      });
+    });
+
+    module('when toggle areV3InfoScreensEnabled is not enabled', function () {
+      test('should not display the v3 certification information page', async function (assert) {
+        // given
+        server.create('feature-toggle', {
+          id: 0,
+          areV3InfoScreensEnabled: false,
+        });
+        server.create('certification-candidate-subscription', {
+          id: 2,
+          sessionId: 123,
+          eligibleSubscription: null,
+          nonEligibleSubscription: null,
+          sessionVersion: 3,
+        });
+
+        await authenticateByEmail(user);
+        const screen = await visit('/certifications');
+
+        // when
+        await fillCertificationJoiner({
+          sessionId: '123',
+          firstName: 'toto',
+          lastName: 'titi',
+          dayOfBirth: '01',
+          monthOfBirth: '01',
+          yearOfBirth: '2000',
+          intl: this.intl,
+        });
+
+        // then
+        assert.strictEqual(currentURL(), '/certifications/candidat/2');
+        assert.dom(screen.getByRole('heading', { name: 'Vous allez commencer votre test de certification' })).exists();
+        assert.dom(screen.queryByRole('heading', { name: 'Explication de la certification' })).doesNotExist();
+      });
+    });
+  });
+});

--- a/mon-pix/tests/integration/components/assessment-banner_test.js
+++ b/mon-pix/tests/integration/components/assessment-banner_test.js
@@ -129,6 +129,7 @@ module('Integration | Component | assessment-banner', function (hooks) {
           const store = this.owner.lookup('service:store');
           store.createRecord('assessment', {});
           this.set('toggleTextToSpeech', sinon.stub());
+          const speechSynthesis = window.speechSynthesis;
           delete window.speechSynthesis;
 
           // when
@@ -138,6 +139,8 @@ module('Integration | Component | assessment-banner', function (hooks) {
 
           // then
           assert.dom(screen.queryByRole('button', { name: 'Désactiver la vocalisation' })).doesNotExist();
+
+          window.speechSynthesis = speechSynthesis;
         });
       });
     });

--- a/mon-pix/tests/integration/components/certification-information_test.js
+++ b/mon-pix/tests/integration/components/certification-information_test.js
@@ -1,0 +1,61 @@
+import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+
+module('Integration | Component | certification-information', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('when user accesses to v3 certification information page', function () {
+    test('should display the first page information', async function (assert) {
+      // given
+      // when
+      const screen = await render(hbs`<CertificationInformation/>`);
+
+      // then
+      assert.dom(screen.getByRole('heading', { name: 'Bienvenue à la certification Pix', level: 2 })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists();
+    });
+
+    module('on first page', function () {
+      test('should not display the previous button', async function (assert) {
+        // given
+        // when
+        const screen = await render(hbs`<CertificationInformation/>`);
+
+        // then
+        assert.dom(screen.queryByRole('button', { name: 'Précédent' })).doesNotExist();
+      });
+    });
+
+    module('on all pages except the first', function () {
+      test('should display the previous button', async function (assert) {
+        // given
+        const screen = await render(hbs`<CertificationInformation/>`);
+
+        // when
+        await click(screen.getByRole('button', { name: 'Continuer' }));
+
+        // then
+        assert.dom(screen.getByRole('button', { name: 'Précédent' })).exists();
+      });
+    });
+
+    module('on the last page', function () {
+      test('should disable the continue button', async function (assert) {
+        // given
+        const screen = await render(hbs`<CertificationInformation/>`);
+
+        // when
+        for (let i = 0; i < 4; i++) {
+          await click(screen.getByRole('button', { name: 'Continuer' }));
+        }
+
+        // then
+        assert.dom(screen.getByRole('button', { name: 'Continuer' })).isDisabled();
+      });
+    });
+  });
+});

--- a/mon-pix/tests/integration/components/certification-information_test.js
+++ b/mon-pix/tests/integration/components/certification-information_test.js
@@ -16,7 +16,7 @@ module('Integration | Component | certification-information', function (hooks) {
 
       // then
       assert.dom(screen.getByRole('heading', { name: 'Bienvenue à la certification Pix', level: 2 })).exists();
-      assert.dom(screen.getByRole('button', { name: 'Continuer' })).exists();
+      assert.dom(screen.getByRole('button', { name: "Continuer vers l'écran suivant" })).exists();
     });
 
     module('on first page', function () {
@@ -26,7 +26,7 @@ module('Integration | Component | certification-information', function (hooks) {
         const screen = await render(hbs`<CertificationInformation/>`);
 
         // then
-        assert.dom(screen.queryByRole('button', { name: 'Précédent' })).doesNotExist();
+        assert.dom(screen.queryByRole('button', { name: "Revenir vers l'écran précédent" })).doesNotExist();
       });
     });
 
@@ -36,25 +36,40 @@ module('Integration | Component | certification-information', function (hooks) {
         const screen = await render(hbs`<CertificationInformation/>`);
 
         // when
-        await click(screen.getByRole('button', { name: 'Continuer' }));
+        await click(screen.getByRole('button', { name: "Continuer vers l'écran suivant" }));
 
         // then
-        assert.dom(screen.getByRole('button', { name: 'Précédent' })).exists();
+        assert.dom(screen.getByRole('button', { name: "Revenir vers l'écran précédent" })).exists();
       });
     });
 
     module('on the last page', function () {
+      test('should change the continue aria label button', async function (assert) {
+        // given
+        const screen = await render(hbs`<CertificationInformation/>`);
+
+        // when
+        for (let i = 0; i < 4; i++) {
+          await click(screen.getByRole('button', { name: "Continuer vers l'écran suivant" }));
+        }
+
+        // then
+        assert.dom(screen.getByRole('button', { name: "Continuer vers la page d'entrée en certification" })).exists();
+      });
+
       test('should disable the continue button', async function (assert) {
         // given
         const screen = await render(hbs`<CertificationInformation/>`);
 
         // when
         for (let i = 0; i < 4; i++) {
-          await click(screen.getByRole('button', { name: 'Continuer' }));
+          await click(screen.getByRole('button', { name: "Continuer vers l'écran suivant" }));
         }
 
         // then
-        assert.dom(screen.getByRole('button', { name: 'Continuer' })).isDisabled();
+        assert
+          .dom(screen.getByRole('button', { name: "Continuer vers la page d'entrée en certification" }))
+          .isDisabled();
       });
     });
   });

--- a/mon-pix/tests/integration/components/challenge-statement_test.js
+++ b/mon-pix/tests/integration/components/challenge-statement_test.js
@@ -437,6 +437,7 @@ module('Integration | Component | ChallengeStatement', function (hooks) {
             instruction: 'La consigne du test avec un bouton de lecture à haute voix',
             id: 'rec_challenge1',
           });
+          const speechSynthesis = window.speechSynthesis;
           delete window.speechSynthesis;
 
           // when
@@ -454,6 +455,8 @@ module('Integration | Component | ChallengeStatement', function (hooks) {
               }),
             )
             .doesNotExist();
+
+          window.speechSynthesis = speechSynthesis;
         });
       });
     });

--- a/mon-pix/tests/unit/routes/authenticated/certifications/start_test.js
+++ b/mon-pix/tests/unit/routes/authenticated/certifications/start_test.js
@@ -37,7 +37,11 @@ module('Unit | Route | Certification | Start', function (hooks) {
         await route.model(params);
 
         // then
-        sinon.assert.calledWith(route.router.replaceWith, 'authenticated.certifications.information');
+        sinon.assert.calledWithExactly(
+          route.router.replaceWith,
+          'authenticated.certifications.information',
+          certificationCandidateId,
+        );
         assert.ok(true);
       });
     });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -436,8 +436,11 @@
       "screens": {
         "first": {
           "title": "Bienvenue à la certification Pix",
-          "how": "Comment fonctionne le test de certification ?",
-          "text": "Il s'agit d'un test adaptatif. C’est-à-dire, que votre capacité à répondre correctement (ou non) aux questions détermine en temps réel la difficulté des questions suivantes. <br/> <br/>Si vous ne savez pas répondre à une question, vous avez la possibilité de “passer” cette question. Les questions passées seront considérées comme échouées et ne vous seront pas proposées à nouveau.<br/><br/>Il est important d'aller jusqu'au bout du test, et donc de bien gérer votre temps. Une pénalité tenant compte du nombre de questions restantes sera appliquée."
+          "text": "'<span class=\"certification-information__text--bold\">'Comment fonctionne le test de certification ?'</span>' '<br><br>' '<span class=\"certification-information__text--bold\">'Il s'agit d'un test adaptatif.'</span>' C’est-à-dire, que votre capacité à répondre correctement (ou non) aux questions détermine en temps réel la difficulté des questions suivantes. '<br><br>'Si vous ne savez pas répondre à une question, '<span class=\"certification-information__text--bold\">'vous avez la possibilité de \"passer\" cette question.'</span>' Les questions passées seront considérées comme échouées et ne vous seront pas proposées à nouveau. '<br><br>' '<span class=\"certification-information__text--bold\">'Il est important d'aller jusqu'au bout du test'</span>', et donc de bien gérer votre temps. Une pénalité tenant compte du nombre de questions restantes sera appliquée."
+        },
+        "page2": {
+          "title": "Titre page 2",
+          "text": "Texte page 2"
         }
       }
     },

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -430,11 +430,11 @@
     "certification-information": {
       "title": "Explanation of certification",
       "buttons": {
-        "previous": "Previous",
-        "continuous": "Continue"
+        "continuous": "Continue",
+        "previous": "Previous"
       },
       "screens": {
-        "first": {
+        "page1": {
           "title": "Bienvenue à la certification Pix",
           "text": "'<span class=\"certification-information__text--bold\">'Comment fonctionne le test de certification ?'</span>' '<br><br>' '<span class=\"certification-information__text--bold\">'Il s'agit d'un test adaptatif.'</span>' C’est-à-dire, que votre capacité à répondre correctement (ou non) aux questions détermine en temps réel la difficulté des questions suivantes. '<br><br>'Si vous ne savez pas répondre à une question, '<span class=\"certification-information__text--bold\">'vous avez la possibilité de \"passer\" cette question.'</span>' Les questions passées seront considérées comme échouées et ne vous seront pas proposées à nouveau. '<br><br>' '<span class=\"certification-information__text--bold\">'Il est important d'aller jusqu'au bout du test'</span>', et donc de bien gérer votre temps. Une pénalité tenant compte du nombre de questions restantes sera appliquée."
         },

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -430,8 +430,17 @@
     "certification-information": {
       "title": "Explanation of certification",
       "buttons": {
-        "continuous": "Continue",
-        "previous": "Previous"
+        "continuous": {
+          "aria-label": "Continuer vers l'écran suivant",
+          "label": "Continuer",
+          "last-page": {
+            "aria-label": "Continuer vers la page d'entrée en certification"
+          }
+        },
+        "previous": {
+          "aria-label": "Revenir vers l'écran précédent",
+          "label": "Précédent"
+        }
       },
       "screens": {
         "page1": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -428,7 +428,11 @@
       }
     },
     "certification-information": {
-      "title": "information",
+      "title": "Explanation of certification",
+      "buttons": {
+        "previous": "Previous",
+        "continuous": "Continue"
+      },
       "screens": {
         "first": {
           "title": "Bienvenue à la certification Pix",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -505,8 +505,11 @@
       "screens": {
         "first": {
           "title": "Bienvenue à la certification Pix",
-          "how": "Comment fonctionne le test de certification ?",
-          "text": "Il s'agit d'un test adaptatif. C’est-à-dire, que votre capacité à répondre correctement (ou non) aux questions détermine en temps réel la difficulté des questions suivantes. <br/> <br/>Si vous ne savez pas répondre à une question, vous avez la possibilité de “passer” cette question. Les questions passées seront considérées comme échouées et ne vous seront pas proposées à nouveau.<br/><br/>Il est important d'aller jusqu'au bout du test, et donc de bien gérer votre temps. Une pénalité tenant compte du nombre de questions restantes sera appliquée."
+          "text": "'<span class=\"certification-information__text--bold\">'Comment fonctionne le test de certification ?'</span>' '<br><br>' '<span class=\"certification-information__text--bold\">'Il s'agit d'un test adaptatif.'</span>' C’est-à-dire, que votre capacité à répondre correctement (ou non) aux questions détermine en temps réel la difficulté des questions suivantes. '<br><br>'Si vous ne savez pas répondre à une question, '<span class=\"certification-information__text--bold\">'vous avez la possibilité de \"passer\" cette question.'</span>' Les questions passées seront considérées comme échouées et ne vous seront pas proposées à nouveau. '<br><br>' '<span class=\"certification-information__text--bold\">'Il est important d'aller jusqu'au bout du test'</span>', et donc de bien gérer votre temps. Une pénalité tenant compte du nombre de questions restantes sera appliquée."
+        },
+        "page2": {
+          "title": "Titre page 2",
+          "text": "Texte page 2"
         }
       }
     },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -498,6 +498,10 @@
     },
     "certification-information": {
       "title": "information",
+      "buttons": {
+        "previous": "Précédent",
+        "continuous": "Continuer"
+      },
       "screens": {
         "first": {
           "title": "Bienvenue à la certification Pix",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -503,7 +503,7 @@
         "continuous": "Continuer"
       },
       "screens": {
-        "first": {
+        "page1": {
           "title": "Bienvenue à la certification Pix",
           "text": "'<span class=\"certification-information__text--bold\">'Comment fonctionne le test de certification ?'</span>' '<br><br>' '<span class=\"certification-information__text--bold\">'Il s'agit d'un test adaptatif.'</span>' C’est-à-dire, que votre capacité à répondre correctement (ou non) aux questions détermine en temps réel la difficulté des questions suivantes. '<br><br>'Si vous ne savez pas répondre à une question, '<span class=\"certification-information__text--bold\">'vous avez la possibilité de \"passer\" cette question.'</span>' Les questions passées seront considérées comme échouées et ne vous seront pas proposées à nouveau. '<br><br>' '<span class=\"certification-information__text--bold\">'Il est important d'aller jusqu'au bout du test'</span>', et donc de bien gérer votre temps. Une pénalité tenant compte du nombre de questions restantes sera appliquée."
         },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -499,8 +499,17 @@
     "certification-information": {
       "title": "information",
       "buttons": {
-        "previous": "Précédent",
-        "continuous": "Continuer"
+        "continuous": {
+          "label": "Continuer",
+          "aria-label": "Continuer vers l'écran suivant",
+          "last-page": {
+            "aria-label": "Continuer vers la page d'entrée en certification"
+          }
+        },
+        "previous":{
+          "label": "Précédent",
+          "aria-label": "Revenir vers l'écran précédent"
+        }
       },
       "screens": {
         "page1": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -428,7 +428,11 @@
       }
     },
     "certification-information": {
-      "title": "information",
+      "title": "Explication de la certification",
+      "buttons": {
+        "previous": "Précédent",
+        "continuous": "Continuer"
+      },
       "screens": {
         "first": {
           "title": "Bienvenue à la certification Pix",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -436,8 +436,11 @@
       "screens": {
         "first": {
           "title": "Bienvenue à la certification Pix",
-          "how": "Comment fonctionne le test de certification ?",
-          "text": "Il s'agit d'un test adaptatif. C’est-à-dire, que votre capacité à répondre correctement (ou non) aux questions détermine en temps réel la difficulté des questions suivantes. <br/> <br/>Si vous ne savez pas répondre à une question, vous avez la possibilité de “passer” cette question. Les questions passées seront considérées comme échouées et ne vous seront pas proposées à nouveau.<br/><br/>Il est important d'aller jusqu'au bout du test, et donc de bien gérer votre temps. Une pénalité tenant compte du nombre de questions restantes sera appliquée."
+          "text": "'<span class=\"certification-information__text--bold\">'Comment fonctionne le test de certification ?'</span>' '<br><br>' '<span class=\"certification-information__text--bold\">'Il s'agit d'un test adaptatif.'</span>' C’est-à-dire, que votre capacité à répondre correctement (ou non) aux questions détermine en temps réel la difficulté des questions suivantes. '<br><br>'Si vous ne savez pas répondre à une question, '<span class=\"certification-information__text--bold\">'vous avez la possibilité de \"passer\" cette question.'</span>' Les questions passées seront considérées comme échouées et ne vous seront pas proposées à nouveau. '<br><br>' '<span class=\"certification-information__text--bold\">'Il est important d'aller jusqu'au bout du test'</span>', et donc de bien gérer votre temps. Une pénalité tenant compte du nombre de questions restantes sera appliquée."
+        },
+        "page2": {
+          "title": "Titre page 2",
+          "text": "Texte page 2"
         }
       }
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -430,11 +430,11 @@
     "certification-information": {
       "title": "Explication de la certification",
       "buttons": {
-        "previous": "Précédent",
-        "continuous": "Continuer"
+        "continuous": "Continuer",
+        "previous": "Précédent"
       },
       "screens": {
-        "first": {
+        "page1": {
           "title": "Bienvenue à la certification Pix",
           "text": "'<span class=\"certification-information__text--bold\">'Comment fonctionne le test de certification ?'</span>' '<br><br>' '<span class=\"certification-information__text--bold\">'Il s'agit d'un test adaptatif.'</span>' C’est-à-dire, que votre capacité à répondre correctement (ou non) aux questions détermine en temps réel la difficulté des questions suivantes. '<br><br>'Si vous ne savez pas répondre à une question, '<span class=\"certification-information__text--bold\">'vous avez la possibilité de \"passer\" cette question.'</span>' Les questions passées seront considérées comme échouées et ne vous seront pas proposées à nouveau. '<br><br>' '<span class=\"certification-information__text--bold\">'Il est important d'aller jusqu'au bout du test'</span>', et donc de bien gérer votre temps. Une pénalité tenant compte du nombre de questions restantes sera appliquée."
         },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -430,8 +430,17 @@
     "certification-information": {
       "title": "Explication de la certification",
       "buttons": {
-        "continuous": "Continuer",
-        "previous": "Précédent"
+        "continuous": {
+          "aria-label": "Continuer vers l'écran suivant",
+          "label": "Continuer",
+          "last-page": {
+            "aria-label": "Continuer vers la page d'entrée en certification"
+          }
+        },
+        "previous": {
+          "aria-label": "Revenir vers l'écran précédent",
+          "label": "Précédent"
+        }
       },
       "screens": {
         "page1": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -505,8 +505,7 @@
       "screens": {
         "first": {
           "title": "Bienvenue à la certification Pix",
-          "how": "Comment fonctionne le test de certification ?",
-          "text": "Il s'agit d'un test adaptatif. C’est-à-dire, que votre capacité à répondre correctement (ou non) aux questions détermine en temps réel la difficulté des questions suivantes. <br/> <br/>Si vous ne savez pas répondre à une question, vous avez la possibilité de “passer” cette question. Les questions passées seront considérées comme échouées et ne vous seront pas proposées à nouveau.<br/><br/>Il est important d'aller jusqu'au bout du test, et donc de bien gérer votre temps. Une pénalité tenant compte du nombre de questions restantes sera appliquée."
+          "text": "Comment fonctionne le test de certification ? \n Il s'agit d'un test adaptatif. C’est-à-dire, que votre capacité à répondre correctement (ou non) aux questions détermine en temps réel la difficulté des questions suivantes. <br/> <br/>Si vous ne savez pas répondre à une question, vous avez la possibilité de “passer” cette question. Les questions passées seront considérées comme échouées et ne vous seront pas proposées à nouveau.<br/><br/>Il est important d'aller jusqu'au bout du test, et donc de bien gérer votre temps. Une pénalité tenant compte du nombre de questions restantes sera appliquée."
         }
       }
     },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -498,6 +498,10 @@
     },
     "certification-information": {
       "title": "information",
+      "buttons": {
+        "previous": "Précédent",
+        "continuous": "Continuer"
+      },
       "screens": {
         "first": {
           "title": "Bienvenue à la certification Pix",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -499,8 +499,17 @@
     "certification-information": {
       "title": "information",
       "buttons": {
-        "previous": "Précédent",
-        "continuous": "Continuer"
+        "continuous": {
+          "label": "Continuer",
+          "aria-label": "Continuer vers l'écran suivant",
+          "last-page": {
+            "aria-label": "Continuer vers la page d'entrée en certification"
+          }
+        },
+        "previous":{
+          "label": "Précédent",
+          "aria-label": "Revenir vers l'écran précédent"
+        }
       },
       "screens": {
         "page1": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -503,9 +503,13 @@
         "continuous": "Continuer"
       },
       "screens": {
-        "first": {
+        "page1": {
           "title": "Bienvenue à la certification Pix",
-          "text": "Comment fonctionne le test de certification ? \n Il s'agit d'un test adaptatif. C’est-à-dire, que votre capacité à répondre correctement (ou non) aux questions détermine en temps réel la difficulté des questions suivantes. <br/> <br/>Si vous ne savez pas répondre à une question, vous avez la possibilité de “passer” cette question. Les questions passées seront considérées comme échouées et ne vous seront pas proposées à nouveau.<br/><br/>Il est important d'aller jusqu'au bout du test, et donc de bien gérer votre temps. Une pénalité tenant compte du nombre de questions restantes sera appliquée."
+          "text": "<span class=\"certification-information__text--bold\"> Comment fonctionne le test de certification ? </span> '<br> <br>' <span class=\"certification-information__text--bold\"> Il s'agit d'un test adaptatif.</span> C’est-à-dire, que votre capacité à répondre correctement (ou non) aux questions détermine en temps réel la difficulté des questions suivantes. '<br> <br>'Si vous ne savez pas répondre à une question, <span class=\"certification-information__text--bold\">vous avez la possibilité de “passer” cette question.</span> Les questions passées seront considérées comme échouées et ne vous seront pas proposées à nouveau. '<br> <br>' <span class=\"certification-information__text--bold\">Il est important d'aller jusqu'au bout du test</span>, et donc de bien gérer votre temps. Une pénalité tenant compte du nombre de questions restantes sera appliquée."
+        },
+        "page2": {
+          "title": "Titre page 2",
+          "text": "Texte page 2"
         }
       }
     },


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la nouvelle certif V3, nous allons mettre à disposition des candidats des écrans d’instruction afin de leur donner des infos sur le test qu’ils vont passer.

Cette page comprend pour le moment la première page, non stylisé ainsi que des boutons sans actions.

## :robot: Proposition

- Styliser le contenu de la première page.
- Conditionner l'affichage du bouton "Précédent"
- Donner des actions aux boutons "Précédent" et "Continuer" pour passer au contenu suivant ou précédent.

<img width="800" alt="Capture d’écran 2024-06-04 à 11 57 40" src="https://github.com/1024pix/pix/assets/58915422/6e9d9438-f5b4-4b7f-9ec6-e75e099bef6b">
<img width="1000" alt="Capture d’écran 2024-06-04 à 11 57 48" src="https://github.com/1024pix/pix/assets/58915422/308986ed-d67a-4784-94e7-62ea5b2de7b8">


## :rainbow: Remarques
Les autres pages sont volontairement vides, elles seront remplis dans une prochaine PR.

Les écrans étant protégés par un feature toggle, on peut se permettre de laisser les écrans visibles avec du contenu vide

## :100: Pour tester

- Créer une session V3 avec certifv3@example.net et ajouter un candidat
- Se réconcilier avec certifiable-contenu-user@example.net et vérifier que l'on obtient bien le premier écran d'instruction
- Constater que le bouton Précédent ne s'affiche pas
- Continuer
- Constater que l'on accède a une autre page de contenu, avec le bouton Précédent qui apparaît
- Revenir en arrière puis Continuer jusqu'au bout et constater que le bouton Continuer devient disable
