### PR TITLE
[FEATURE] Rendre inscription CORE optionnel (PIX-12213).

### DIFF
--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -58,7 +58,7 @@ class CertificationCandidate {
 
   /**
    * @param {Object} param
-   * @param {Array<Subscription>} param.subscriptions - cannot be empty. {@link Subscription>}
+   * @param {Array<Subscription>} param.subscriptions {@link Subscription>}
    */
   constructor({
     id,

--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -2,8 +2,10 @@ import JoiDate from '@joi/date';
 import BaseJoi from 'joi';
 import lodash from 'lodash';
 
+import { Subscription } from '../../../src/certification/enrolment/domain/models/Subscription.js';
 import { SubscriptionTypes } from '../../../src/certification/shared/domain/models/SubscriptionTypes.js';
-import { CERTIFICATION_CANDIDATES_ERRORS } from '../constants/certification-candidates-errors.js';
+import { validate } from '../../../src/certification/shared/domain/validators/certification-candidate-validator.js';
+import { subscriptionSchema } from '../../../src/certification/shared/domain/validators/subscription-validator.js';
 import {
   CertificationCandidatePersonalInfoFieldMissingError,
   CertificationCandidatePersonalInfoWrongFormat,
@@ -18,76 +20,6 @@ const BILLING_MODES = {
   PAID: 'PAID',
   PREPAID: 'PREPAID',
 };
-
-const certificationCandidateValidationJoiSchema = Joi.object({
-  firstName: Joi.string().trim().required().empty(['', null]).messages({
-    'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FIRST_NAME_REQUIRED.code,
-    'string.base': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FIRST_NAME_MUST_BE_A_STRING.code,
-  }),
-  lastName: Joi.string().trim().required().empty(['', null]).messages({
-    'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_LAST_NAME_REQUIRED.code,
-    'string.base': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_LAST_NAME_MUST_BE_A_STRING.code,
-  }),
-  sex: Joi.string().valid('M', 'F').required().empty(['', null]).messages({
-    'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_SEX_REQUIRED.code,
-    'any.only': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_SEX_NOT_VALID.code,
-  }),
-  email: Joi.string().email().allow(null).empty('').optional().messages({
-    'string.email': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EMAIL_NOT_VALID.code,
-  }),
-  resultRecipientEmail: Joi.string().email().empty(['', null]).optional().messages({
-    'string.email': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_RESULT_RECIPIENT_EMAIL_NOT_VALID.code,
-  }),
-  externalId: Joi.string().allow(null).empty(['', null]).optional().messages({
-    'string.base': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EXTERNAL_ID_MUST_BE_A_STRING.code,
-  }),
-  birthdate: Joi.date().format('YYYY-MM-DD').greater('1900-01-01').required().empty(['', null]).messages({
-    'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTHDATE_REQUIRED.code,
-    'date.format': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTHDATE_FORMAT_NOT_VALID.code,
-    'date.greater': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTHDATE_MUST_BE_GREATER.code,
-  }),
-  extraTimePercentage: Joi.number().allow(null).optional().min(0).less(10).messages({
-    'number.base': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EXTRA_TIME_INTEGER.code,
-    'number.min': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EXTRA_TIME_OUT_OF_RANGE.code,
-    'number.less': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EXTRA_TIME_OUT_OF_RANGE.code,
-  }),
-  sessionId: Joi.when('$isSessionsMassImport', {
-    is: false,
-    then: Joi.number().required().empty(['', null]).messages({
-      'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_SESSION_ID_REQUIRED.code,
-      'number.base': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_SESSION_ID_NOT_A_NUMBER.code,
-    }),
-  }),
-  complementaryCertification: Joi.object({
-    id: Joi.number().required(),
-    label: Joi.string().required().empty(null),
-    key: Joi.string().required().empty(null),
-  }).allow(null),
-  billingMode: Joi.when('$isSco', {
-    is: false,
-    then: Joi.string()
-      .valid(...Object.values(BILLING_MODES))
-      .required()
-      .empty(['', null])
-      .messages({
-        'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BILLING_MODE_REQUIRED.code,
-        'string.base': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BILLING_MODE_MUST_BE_A_STRING.code,
-        'any.only': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BILLING_MODE_NOT_VALID.code,
-      }),
-    otherwise: Joi.valid(null).messages({
-      'any.only': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BILLING_MODE_MUST_BE_EMPTY.code,
-    }),
-  }),
-  prepaymentCode: Joi.when('billingMode', {
-    is: 'PREPAID',
-    then: Joi.string().trim().required().empty(['', null]).messages({
-      'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_PREPAYMENT_CODE_REQUIRED.code,
-    }),
-    otherwise: Joi.valid(null).messages({
-      'any.only': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_PREPAYMENT_CODE_MUST_BE_EMPTY.code,
-    }),
-  }),
-});
 
 const certificationCandidateParticipationJoiSchema = Joi.object({
   id: Joi.any().allow(null).optional(),
@@ -118,12 +50,16 @@ const certificationCandidateParticipationJoiSchema = Joi.object({
     .valid(...Object.values(BILLING_MODES))
     .empty(null),
   prepaymentCode: Joi.string().allow(null).optional(),
+  subscriptions: Joi.array().items(subscriptionSchema).unique('type').required(),
 });
 
 class CertificationCandidate {
-  #subscriptions = new Set([SubscriptionTypes.CORE]);
   #complementaryCertification = null;
 
+  /**
+   * @param {Object} param
+   * @param {Array<Subscription>} param.subscriptions - cannot be empty. {@link Subscription>}
+   */
   constructor({
     id,
     firstName,
@@ -147,6 +83,7 @@ class CertificationCandidate {
     complementaryCertification = null,
     billingMode = null,
     prepaymentCode = null,
+    subscriptions = [],
   } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -167,6 +104,7 @@ class CertificationCandidate {
     this.sessionId = sessionId;
     this.userId = userId;
     this.organizationLearnerId = organizationLearnerId;
+    this.subscriptions = subscriptions;
     this.billingMode = billingMode;
     this.prepaymentCode = prepaymentCode;
 
@@ -178,17 +116,19 @@ class CertificationCandidate {
 
       set: function (complementaryCertification) {
         this.#complementaryCertification = complementaryCertification;
+        this.subscriptions = this.subscriptions.filter((subscription) => subscription.type === SubscriptionTypes.CORE);
         if (complementaryCertification?.id) {
-          this.#subscriptions?.add(SubscriptionTypes.COMPLEMENTARY);
+          this.subscriptions.push(
+            Subscription.buildComplementary({
+              certificationCandidateId: this.id,
+              complementaryCertificationId: complementaryCertification.id,
+            }),
+          );
         }
       },
     });
 
     this.complementaryCertification = complementaryCertification;
-  }
-
-  get subscriptions() {
-    return Array.from(this.#subscriptions);
   }
 
   static parseBillingMode({ billingMode, translate }) {
@@ -220,7 +160,7 @@ class CertificationCandidate {
   }
 
   validate(isSco = false) {
-    const { error } = certificationCandidateValidationJoiSchema.validate(
+    const { error } = validate(
       { ...this, complementaryCertification: this.complementaryCertification },
       {
         allowUnknown: true,
@@ -230,6 +170,7 @@ class CertificationCandidate {
         },
       },
     );
+
     if (error) {
       throw new CertificationCandidatesError({
         code: error.details?.[0]?.message,
@@ -239,7 +180,7 @@ class CertificationCandidate {
   }
 
   validateForMassSessionImport(isSco = false) {
-    const { error } = certificationCandidateValidationJoiSchema.validate(
+    const { error } = validate(
       { ...this, complementaryCertification: this.complementaryCertification },
       {
         abortEarly: false,
@@ -301,6 +242,14 @@ class CertificationCandidate {
 
   convertExtraTimePercentageToDecimal() {
     this.extraTimePercentage = this.extraTimePercentage / 100;
+  }
+
+  /**
+   * @param {Subscription} subscription
+   */
+  addSubscription(subscription) {
+    this.subscriptions = this.subscriptions.filter(({ type }) => subscription.type !== type);
+    this.subscriptions.push(subscription);
   }
 }
 

--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -76,7 +76,7 @@ class CertificationCandidate {
     birthdate,
     extraTimePercentage,
     createdAt,
-    authorizedToStart,
+    authorizedToStart = false,
     sessionId,
     userId,
     organizationLearnerId = null,

--- a/api/lib/domain/services/certification-candidates-ods-service.js
+++ b/api/lib/domain/services/certification-candidates-ods-service.js
@@ -147,7 +147,9 @@ async function extractCertificationCandidatesFromCandidatesImportSheet({
         sessionId,
         complementaryCertification,
         billingMode,
-        subscriptions: [Subscription.buildCore({ id: certificationCandidateData.certificationCandidateId })],
+        subscriptions: [
+          Subscription.buildCore({ certificationCandidateId: certificationCandidateData.certificationCandidateId }),
+        ],
       });
 
       try {

--- a/api/lib/domain/services/certification-candidates-ods-service.js
+++ b/api/lib/domain/services/certification-candidates-ods-service.js
@@ -1,6 +1,7 @@
 import bluebird from 'bluebird';
 import _ from 'lodash';
 
+import { Subscription } from '../../../src/certification/enrolment/domain/models/Subscription.js';
 import { ComplementaryCertificationKeys } from '../../../src/certification/shared/domain/models/ComplementaryCertificationKeys.js';
 import * as readOdsUtils from '../../../src/shared/infrastructure/utils/ods/read-ods-utils.js';
 import * as mailCheckImplementation from '../../../src/shared/mail/infrastructure/services/mail-check.js';
@@ -146,6 +147,7 @@ async function extractCertificationCandidatesFromCandidatesImportSheet({
         sessionId,
         complementaryCertification,
         billingMode,
+        subscriptions: [Subscription.buildCore({ id: certificationCandidateData.certificationCandidateId })],
       });
 
       try {

--- a/api/lib/infrastructure/repositories/sco-certification-candidate-repository.js
+++ b/api/lib/infrastructure/repositories/sco-certification-candidate-repository.js
@@ -18,11 +18,11 @@ const addNonEnrolledCandidatesToSession = async function ({ sessionId, scoCertif
     .filter((candidate) => !alreadyEnrolledCandidateOrganizationLearnerIds.includes(candidate.organizationLearnerId))
     .map(scoCandidateToDTO);
 
-  const addedCandidateIds = await knex
+  const coreSubscriptions = await knex
     .batchInsert('certification-candidates', candidatesToBeEnrolledDTOs)
     .returning(knex.raw('id as "certificationCandidateId", \'CORE\' as type'));
 
-  await knex.batchInsert('certification-subscriptions', addedCandidateIds);
+  await knex.batchInsert('certification-subscriptions', coreSubscriptions);
 };
 
 export { addNonEnrolledCandidatesToSession };

--- a/api/src/certification/enrolment/domain/models/Subscription.js
+++ b/api/src/certification/enrolment/domain/models/Subscription.js
@@ -1,0 +1,42 @@
+/**
+ * @typedef {import ('../../../shared/domain/models/SubscriptionTypes.js').SubscriptionTypes} SubscriptionTypes
+ */
+
+import { SubscriptionTypes } from '../../../shared/domain/models/SubscriptionTypes.js';
+
+class Subscription {
+  /**
+   * @param {Object} params
+   * @param {number} params.certificationCandidateId - identifier of the certification candidate
+   * @param {SubscriptionTypes} params.type
+   * @param {number} params.complementaryCertificationId
+   */
+  constructor({ certificationCandidateId, type, complementaryCertificationId }) {
+    this.certificationCandidateId = certificationCandidateId;
+    this.type = type;
+    this.complementaryCertificationId = complementaryCertificationId;
+  }
+
+  /**
+   * @param {Object} params
+   * @param {number} params.certificationCandidateId  - identifier of the certification candidate
+   */
+  static buildCore({ certificationCandidateId }) {
+    return new Subscription({ certificationCandidateId, type: SubscriptionTypes.CORE });
+  }
+
+  /**
+   * @param {Object} params
+   * @param {number} params.certificationCandidateId - identifier of the certification candidate
+   * @param {number} params.complementaryCertificationId
+   */
+  static buildComplementary({ certificationCandidateId, complementaryCertificationId }) {
+    return new Subscription({
+      certificationCandidateId,
+      type: SubscriptionTypes.COMPLEMENTARY,
+      complementaryCertificationId,
+    });
+  }
+}
+
+export { Subscription };

--- a/api/src/certification/enrolment/domain/models/Subscription.js
+++ b/api/src/certification/enrolment/domain/models/Subscription.js
@@ -3,6 +3,7 @@
  */
 
 import { SubscriptionTypes } from '../../../shared/domain/models/SubscriptionTypes.js';
+import { validate } from '../../../shared/domain/validators/subscription-validator.js';
 
 class Subscription {
   /**
@@ -15,6 +16,7 @@ class Subscription {
     this.certificationCandidateId = certificationCandidateId;
     this.type = type;
     this.complementaryCertificationId = complementaryCertificationId;
+    validate(this);
   }
 
   /**

--- a/api/src/certification/enrolment/domain/usecases/add-certification-candidate-to-session.js
+++ b/api/src/certification/enrolment/domain/usecases/add-certification-candidate-to-session.js
@@ -13,6 +13,7 @@ import {
   CertificationCandidatesError,
 } from '../../../../../lib/domain/errors.js';
 import * as mailCheckImplementation from '../../../../shared/mail/infrastructure/services/mail-check.js';
+import { Subscription } from '../models/Subscription.js';
 
 /**
  * @param {Object} params
@@ -79,6 +80,9 @@ const addCertificationCandidateToSession = async function ({
 
   certificationCandidate.updateBirthInformation(cpfBirthInformation);
 
+  certificationCandidate.addSubscription(
+    Subscription.buildCore({ certificationCandidateId: certificationCandidate.id }),
+  );
   certificationCandidate.complementaryCertification = complementaryCertification;
 
   if (certificationCandidate.resultRecipientEmail) {

--- a/api/src/certification/enrolment/domain/usecases/validate-sessions.js
+++ b/api/src/certification/enrolment/domain/usecases/validate-sessions.js
@@ -7,6 +7,7 @@ import bluebird from 'bluebird';
 import { CertificationCandidate } from '../../../../../lib/domain/models/CertificationCandidate.js';
 import { SessionEnrolment } from '../models/SessionEnrolment.js';
 import { SessionMassImportReport } from '../models/SessionMassImportReport.js';
+import { Subscription } from '../models/Subscription.js';
 
 /**
  * @param {Object} params
@@ -138,6 +139,7 @@ async function _createValidCertificationCandidates({
       sessionId,
       billingMode: billingMode || certificationCandidate.billingMode,
       complementaryCertification,
+      subscriptions: [Subscription.buildCore({ certificationCandidateId: certificationCandidate.id })],
     });
 
     const candidateBirthInformationValidation =

--- a/api/src/certification/shared/domain/validators/certification-candidate-validator.js
+++ b/api/src/certification/shared/domain/validators/certification-candidate-validator.js
@@ -1,0 +1,90 @@
+import JoiDate from '@joi/date';
+import BaseJoi from 'joi';
+const Joi = BaseJoi.extend(JoiDate);
+import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../../../lib/domain/constants/certification-candidates-errors.js';
+import { complementaryCertificationController } from '../../../complementary-certification/application/complementary-certification-controller.js';
+import { Subscription } from '../../../enrolment/domain/models/Subscription.js';
+import {subscriptionSchema} from './subscription-validator.js';
+
+const BILLING_MODES = {
+  FREE: 'FREE',
+  PAID: 'PAID',
+  PREPAID: 'PREPAID',
+};
+
+const schema = Joi.object({
+  firstName: Joi.string().trim().required().empty(['', null]).messages({
+    'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FIRST_NAME_REQUIRED.code,
+    'string.base': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FIRST_NAME_MUST_BE_A_STRING.code,
+  }),
+  lastName: Joi.string().trim().required().empty(['', null]).messages({
+    'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_LAST_NAME_REQUIRED.code,
+    'string.base': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_LAST_NAME_MUST_BE_A_STRING.code,
+  }),
+  sex: Joi.string().valid('M', 'F').required().empty(['', null]).messages({
+    'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_SEX_REQUIRED.code,
+    'any.only': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_SEX_NOT_VALID.code,
+  }),
+  email: Joi.string().email().allow(null).empty('').optional().messages({
+    'string.email': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EMAIL_NOT_VALID.code,
+  }),
+  resultRecipientEmail: Joi.string().email().empty(['', null]).optional().messages({
+    'string.email': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_RESULT_RECIPIENT_EMAIL_NOT_VALID.code,
+  }),
+  externalId: Joi.string().allow(null).empty(['', null]).optional().messages({
+    'string.base': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EXTERNAL_ID_MUST_BE_A_STRING.code,
+  }),
+  birthdate: Joi.date().format('YYYY-MM-DD').greater('1900-01-01').required().empty(['', null]).messages({
+    'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTHDATE_REQUIRED.code,
+    'date.format': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTHDATE_FORMAT_NOT_VALID.code,
+    'date.greater': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTHDATE_MUST_BE_GREATER.code,
+  }),
+  extraTimePercentage: Joi.number().allow(null).optional().min(0).less(10).messages({
+    'number.base': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EXTRA_TIME_INTEGER.code,
+    'number.min': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EXTRA_TIME_OUT_OF_RANGE.code,
+    'number.less': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EXTRA_TIME_OUT_OF_RANGE.code,
+  }),
+  sessionId: Joi.when('$isSessionsMassImport', {
+    is: false,
+    then: Joi.number().required().empty(['', null]).messages({
+      'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_SESSION_ID_REQUIRED.code,
+      'number.base': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_SESSION_ID_NOT_A_NUMBER.code,
+    }),
+  }),
+  complementaryCertification: Joi.object({
+    id: Joi.number().required(),
+    label: Joi.string().required().empty(null),
+    key: Joi.string().required().empty(null),
+  }).allow(null),
+  subscriptions: Joi.array().items(subscriptionSchema).unique('type').required(),
+  billingMode: Joi.when('$isSco', {
+    is: false,
+    then: Joi.string()
+      .valid(...Object.values(BILLING_MODES))
+      .required()
+      .empty(['', null])
+      .messages({
+        'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BILLING_MODE_REQUIRED.code,
+        'string.base': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BILLING_MODE_MUST_BE_A_STRING.code,
+        'any.only': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BILLING_MODE_NOT_VALID.code,
+      }),
+    otherwise: Joi.valid(null).messages({
+      'any.only': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BILLING_MODE_MUST_BE_EMPTY.code,
+    }),
+  }),
+  prepaymentCode: Joi.when('billingMode', {
+    is: 'PREPAID',
+    then: Joi.string().trim().required().empty(['', null]).messages({
+      'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_PREPAYMENT_CODE_REQUIRED.code,
+    }),
+    otherwise: Joi.valid(null).messages({
+      'any.only': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_PREPAYMENT_CODE_MUST_BE_EMPTY.code,
+    }),
+  }),
+});
+
+function validate(certificationCandidate, options = { allowUnknown: true }) {
+  return schema.validate(certificationCandidate, options);
+}
+
+export { validate };

--- a/api/src/certification/shared/domain/validators/certification-candidate-validator.js
+++ b/api/src/certification/shared/domain/validators/certification-candidate-validator.js
@@ -2,9 +2,7 @@ import JoiDate from '@joi/date';
 import BaseJoi from 'joi';
 const Joi = BaseJoi.extend(JoiDate);
 import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../../../lib/domain/constants/certification-candidates-errors.js';
-import { complementaryCertificationController } from '../../../complementary-certification/application/complementary-certification-controller.js';
-import { Subscription } from '../../../enrolment/domain/models/Subscription.js';
-import {subscriptionSchema} from './subscription-validator.js';
+import { subscriptionSchema } from './subscription-validator.js';
 
 const BILLING_MODES = {
   FREE: 'FREE',

--- a/api/src/certification/shared/domain/validators/subscription-validator.js
+++ b/api/src/certification/shared/domain/validators/subscription-validator.js
@@ -1,0 +1,22 @@
+import Joi from 'joi';
+
+import { SubscriptionTypes } from '../models/SubscriptionTypes.js';
+
+const subscriptionSchema = Joi.object({
+  certificationCandidateId: Joi.number().optional(),
+  type: Joi.string().required().valid(SubscriptionTypes.CORE, SubscriptionTypes.COMPLEMENTARY),
+  complementaryCertificationId: Joi.when('type', {
+    is: SubscriptionTypes.COMPLEMENTARY,
+    then: Joi.number().required(),
+    otherwise: Joi.any().valid(null).allow(null),
+  }),
+});
+
+function validate(subscription) {
+  const { error } = subscriptionSchema.validate(subscription);
+  if (error) {
+    throw new TypeError(error);
+  }
+}
+
+export { subscriptionSchema, validate };

--- a/api/tests/certification/course/unit/domain/usecases/end-assessment-by-supervisor_test.js
+++ b/api/tests/certification/course/unit/domain/usecases/end-assessment-by-supervisor_test.js
@@ -15,7 +15,9 @@ describe('Unit | UseCase | end-assessment-by-supervisor', function () {
   context('when assessment is already completed', function () {
     it('should not end the assessment', async function () {
       // when
-      const certificationCandidateId = domainBuilder.buildCertificationCandidate().id;
+      const certificationCandidateId = domainBuilder.buildCertificationCandidate({
+        subscriptions: [domainBuilder.buildCoreSubscription()],
+      }).id;
       const completedCertificationAssessment = domainBuilder.buildCertificationAssessment({
         state: CertificationAssessment.states.COMPLETED,
       });
@@ -37,7 +39,9 @@ describe('Unit | UseCase | end-assessment-by-supervisor', function () {
   context('when assessment is not completed', function () {
     it('should end the assessment', async function () {
       // when
-      const certificationCandidateId = domainBuilder.buildCertificationCandidate().id;
+      const certificationCandidateId = domainBuilder.buildCertificationCandidate({
+        subscriptions: [domainBuilder.buildCoreSubscription()],
+      }).id;
       const startedCertificationAssessment = domainBuilder.buildCertificationAssessment({
         state: CertificationAssessment.states.STARTED,
       });

--- a/api/tests/certification/enrolment/acceptance/application/certification-candidate-controller-post-certification-candidate_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/certification-candidate-controller-post-certification-candidate_test.js
@@ -10,7 +10,7 @@ import {
   sinon,
 } from '../../../../test-helper.js';
 
-describe('Acceptance | Controller | session-controller-post-certification-candidate', function () {
+describe('Acceptance | Controller | Certification | Enrolment | session-controller-post-certification-candidate', function () {
   let server;
   let resolveMx;
 
@@ -40,6 +40,7 @@ describe('Acceptance | Controller | session-controller-post-certification-candid
         birthINSEECode: '75115',
         birthPostalCode: null,
         birthCity: null,
+        subscriptions: [domainBuilder.buildCoreSubscription()],
       });
       userId = databaseBuilder.factory.buildUser().id;
 

--- a/api/tests/certification/enrolment/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
+++ b/api/tests/certification/enrolment/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
@@ -364,16 +364,9 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
     mailCheck.checkDomainIsValid.resolves();
     const isSco = false;
 
-    const userId = databaseBuilder.factory.buildUser().id;
-    const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-    databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
-    const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
-
-    await databaseBuilder.commit();
-
     const odsFilePath = `${__dirname}/attendance_sheet_extract_with_billing_ok_test.ods`;
     const odsBuffer = await readFile(odsFilePath);
-    candidateList = _buildCertificationCandidateList({ hasBillingMode: true, sessionId: 100505 });
+    candidateList = _buildCertificationCandidateList({ hasBillingMode: true, sessionId });
     const expectedCertificationCandidates = candidateList.map((candidate) => new CertificationCandidate(candidate));
 
     // when

--- a/api/tests/certification/enrolment/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
+++ b/api/tests/certification/enrolment/integration/domain/services/certification-candidates-ods-service/certification-candidates-ods-service_test.js
@@ -1,8 +1,6 @@
 import fs from 'node:fs';
 import * as url from 'node:url';
 
-import _ from 'lodash';
-
 import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../../../../../lib/domain/constants/certification-candidates-errors.js';
 import { CertificationCandidatesError } from '../../../../../../../lib/domain/errors.js';
 import { CertificationCandidate } from '../../../../../../../lib/domain/models/index.js';
@@ -28,6 +26,7 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
   let userId;
   let sessionId;
   let mailCheck;
+  let candidateList;
 
   beforeEach(async function () {
     const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({}).id;
@@ -64,6 +63,8 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
     await databaseBuilder.commit();
 
     mailCheck = { checkDomainIsValid: sinon.stub() };
+
+    candidateList = _buildCertificationCandidateList({ sessionId });
   });
 
   it('should throw a CertificationCandidatesError if there is an error in the file', async function () {
@@ -206,117 +207,8 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
       });
 
     // then
-    const expectedCertificationCandidates = _.map(
-      [
-        {
-          lastName: 'Gallagher',
-          firstName: 'Jack',
-          birthdate: '1980-08-10',
-          sex: 'M',
-          birthCity: 'Londres',
-          birthCountry: 'ANGLETERRE',
-          birthINSEECode: '99132',
-          birthPostalCode: null,
-          resultRecipientEmail: 'destinataire@gmail.com',
-          email: 'jack@d.it',
-          externalId: null,
-          extraTimePercentage: 0.15,
-          sessionId,
-        },
-        {
-          lastName: 'Jackson',
-          firstName: 'Janet',
-          birthdate: '2005-12-05',
-          sex: 'F',
-          birthCity: 'AJACCIO',
-          birthCountry: 'FRANCE',
-          birthINSEECode: '2A004',
-          birthPostalCode: null,
-          resultRecipientEmail: 'destinataire@gmail.com',
-          email: 'jaja@hotmail.fr',
-          externalId: 'DEF456',
-          extraTimePercentage: null,
-          sessionId,
-        },
-        {
-          lastName: 'Jackson',
-          firstName: 'Michael',
-          birthdate: '2004-04-04',
-          sex: 'M',
-          birthCity: 'PARIS 18',
-          birthCountry: 'FRANCE',
-          birthINSEECode: null,
-          birthPostalCode: '75018',
-          resultRecipientEmail: 'destinataire@gmail.com',
-          email: 'jackson@gmail.com',
-          externalId: 'ABC123',
-          extraTimePercentage: 0.6,
-          sessionId,
-        },
-        {
-          lastName: 'Mercury',
-          firstName: 'Freddy',
-          birthdate: '1925-06-28',
-          sex: 'M',
-          birthCity: 'SAINT-ANNE',
-          birthCountry: 'FRANCE',
-          birthINSEECode: null,
-          birthPostalCode: '97180',
-          resultRecipientEmail: null,
-          email: null,
-          externalId: 'GHI789',
-          extraTimePercentage: 1.5,
-          sessionId,
-        },
-        {
-          firstName: 'Annie',
-          lastName: 'Cordy',
-          birthCity: 'BUELLAS',
-          birthProvinceCode: undefined,
-          birthCountry: 'FRANCE',
-          birthPostalCode: '01310',
-          birthINSEECode: null,
-          sex: 'M',
-          email: null,
-          resultRecipientEmail: null,
-          externalId: 'GHI769',
-          birthdate: '1928-06-16',
-          extraTimePercentage: 1.5,
-          createdAt: undefined,
-          authorizedToStart: undefined,
-          userId: undefined,
-          organizationLearnerId: null,
-          complementaryCertification: null,
-          billingMode: null,
-          prepaymentCode: null,
-          sessionId,
-        },
-        {
-          firstName: 'Demis',
-          lastName: 'Roussos',
-          birthCity: 'BUELLAS',
-          birthProvinceCode: undefined,
-          birthCountry: 'FRANCE',
-          birthPostalCode: null,
-          birthINSEECode: '01065',
-          sex: 'M',
-          email: null,
-          resultRecipientEmail: null,
-          externalId: 'GHI799',
-          birthdate: '1946-06-15',
-          extraTimePercentage: 1.5,
-          createdAt: undefined,
-          authorizedToStart: undefined,
-          userId: undefined,
-          organizationLearnerId: null,
-          complementaryCertification: null,
-          billingMode: null,
-          prepaymentCode: null,
-          sessionId,
-        },
-      ],
-      (candidate) => new CertificationCandidate(candidate),
-    );
+    candidateList = _buildCertificationCandidateList({ sessionId });
+    const expectedCertificationCandidates = candidateList.map((candidate) => new CertificationCandidate(candidate));
     expect(actualCertificationCandidates).to.deep.equal(expectedCertificationCandidates);
   });
 
@@ -435,104 +327,17 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
 
       const odsFilePath = `${__dirname}/attendance_sheet_extract_with_complementary_certifications_ok_test.ods`;
       const odsBuffer = await readFile(odsFilePath);
-      const expectedCertificationCandidates = _.map(
-        [
-          {
-            lastName: 'Gallagher',
-            firstName: 'Jack',
-            birthdate: '1980-08-10',
-            sex: 'M',
-            birthCity: 'Londres',
-            birthCountry: 'ANGLETERRE',
-            birthINSEECode: '99132',
-            birthPostalCode: null,
-            resultRecipientEmail: 'destinataire@gmail.com',
-            email: 'jack@d.it',
-            externalId: null,
-            extraTimePercentage: 0.15,
-            sessionId,
-            billingMode: 'FREE',
-            complementaryCertification: domainBuilder.buildComplementaryCertification(
-              pixPlusEdu1erDegreComplementaryCertification,
-            ),
-          },
-          {
-            lastName: 'Jackson',
-            firstName: 'Janet',
-            birthdate: '2005-12-05',
-            sex: 'F',
-            birthCity: 'AJACCIO',
-            birthCountry: 'FRANCE',
-            birthINSEECode: '2A004',
-            birthPostalCode: null,
-            resultRecipientEmail: 'destinataire@gmail.com',
-            email: 'jaja@hotmail.fr',
-            externalId: 'DEF456',
-            extraTimePercentage: null,
-            sessionId,
-            billingMode: 'FREE',
-            complementaryCertification: domainBuilder.buildComplementaryCertification(
-              pixPlusDroitComplementaryCertification,
-            ),
-          },
-          {
-            lastName: 'Jackson',
-            firstName: 'Michael',
-            birthdate: '2004-04-04',
-            sex: 'M',
-            birthCity: 'PARIS 18',
-            birthCountry: 'FRANCE',
-            birthINSEECode: null,
-            birthPostalCode: '75018',
-            resultRecipientEmail: 'destinataire@gmail.com',
-            email: 'jackson@gmail.com',
-            externalId: 'ABC123',
-            extraTimePercentage: 0.6,
-            sessionId,
-            billingMode: 'FREE',
-            complementaryCertification: domainBuilder.buildComplementaryCertification(cleaComplementaryCertification),
-          },
-          {
-            lastName: 'Mercury',
-            firstName: 'Freddy',
-            birthdate: '1925-06-28',
-            sex: 'M',
-            birthCity: 'SAINT-ANNE',
-            birthCountry: 'FRANCE',
-            birthINSEECode: null,
-            birthPostalCode: '97180',
-            resultRecipientEmail: null,
-            email: null,
-            externalId: 'GHI789',
-            extraTimePercentage: 1.5,
-            sessionId,
-            billingMode: 'FREE',
-            complementaryCertification: domainBuilder.buildComplementaryCertification(
-              pixPlusEdu2ndDegreComplementaryCertification,
-            ),
-          },
-          {
-            lastName: 'Cendy',
-            firstName: 'Alain',
-            birthdate: '1988-06-28',
-            sex: 'M',
-            birthCity: 'SAINT-ANNE',
-            birthCountry: 'FRANCE',
-            birthINSEECode: null,
-            birthPostalCode: '97180',
-            resultRecipientEmail: null,
-            email: null,
-            externalId: 'SDQ987',
-            extraTimePercentage: null,
-            sessionId,
-            billingMode: 'FREE',
-            complementaryCertification: domainBuilder.buildComplementaryCertification(
-              PixPlusProSanteComplementaryCertification,
-            ),
-          },
-        ],
-        (candidate) => new CertificationCandidate(candidate),
-      );
+      candidateList = _buildCertificationCandidateList({
+        sessionId,
+        complementaryCertification: {
+          cleaComplementaryCertification,
+          pixPlusDroitComplementaryCertification,
+          pixPlusEdu1erDegreComplementaryCertification,
+          pixPlusEdu2ndDegreComplementaryCertification,
+          PixPlusProSanteComplementaryCertification,
+        },
+      });
+      const expectedCertificationCandidates = candidateList.map((candidate) => new CertificationCandidate(candidate));
 
       // when
       const actualCertificationCandidates =
@@ -568,76 +373,8 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
 
     const odsFilePath = `${__dirname}/attendance_sheet_extract_with_billing_ok_test.ods`;
     const odsBuffer = await readFile(odsFilePath);
-    const expectedCertificationCandidates = _.map(
-      [
-        {
-          lastName: 'Gallagher',
-          firstName: 'Jack',
-          birthdate: '1980-08-10',
-          sex: 'M',
-          birthCity: 'Londres',
-          birthCountry: 'ANGLETERRE',
-          birthINSEECode: '99132',
-          birthPostalCode: null,
-          resultRecipientEmail: 'destinataire@gmail.com',
-          email: 'jack@d.it',
-          externalId: null,
-          extraTimePercentage: 0.15,
-          sessionId,
-          billingMode: 'PAID',
-        },
-        {
-          lastName: 'Jackson',
-          firstName: 'Janet',
-          birthdate: '2005-12-05',
-          sex: 'F',
-          birthCity: 'AJACCIO',
-          birthCountry: 'FRANCE',
-          birthINSEECode: '2A004',
-          birthPostalCode: null,
-          resultRecipientEmail: 'destinataire@gmail.com',
-          email: 'jaja@hotmail.fr',
-          externalId: 'DEF456',
-          extraTimePercentage: null,
-          sessionId,
-          billingMode: 'FREE',
-        },
-        {
-          lastName: 'Jackson',
-          firstName: 'Michael',
-          birthdate: '2004-04-04',
-          sex: 'M',
-          birthCity: 'PARIS 18',
-          birthCountry: 'FRANCE',
-          birthINSEECode: null,
-          birthPostalCode: '75018',
-          resultRecipientEmail: 'destinataire@gmail.com',
-          email: 'jackson@gmail.com',
-          externalId: 'ABC123',
-          extraTimePercentage: 0.6,
-          sessionId,
-          billingMode: 'FREE',
-        },
-        {
-          lastName: 'Mercury',
-          firstName: 'Freddy',
-          birthdate: '1925-06-28',
-          sex: 'M',
-          birthCity: 'SAINT-ANNE',
-          birthCountry: 'FRANCE',
-          birthINSEECode: null,
-          birthPostalCode: '97180',
-          resultRecipientEmail: null,
-          email: null,
-          externalId: 'GHI789',
-          extraTimePercentage: 1.5,
-          sessionId,
-          billingMode: 'PREPAID',
-          prepaymentCode: 'CODE1',
-        },
-      ],
-      (candidate) => new CertificationCandidate(candidate),
-    );
+    candidateList = _buildCertificationCandidateList({ hasBillingMode: true, sessionId: 100505 });
+    const expectedCertificationCandidates = candidateList.map((candidate) => new CertificationCandidate(candidate));
 
     // when
     const actualCertificationCandidates =
@@ -681,117 +418,181 @@ describe('Integration | Services | extractCertificationCandidatesFromCandidatesI
       });
 
     // then
-    const expectedCertificationCandidates = _.map(
-      [
-        {
-          lastName: 'Gallagher',
-          firstName: 'Jack',
-          birthdate: '1980-08-10',
-          sex: 'M',
-          birthCity: 'Londres',
-          birthCountry: 'ANGLETERRE',
-          birthINSEECode: '99132',
-          birthPostalCode: null,
-          resultRecipientEmail: 'destinataire@gmail.com',
-          email: 'jack@d.it',
-          externalId: null,
-          extraTimePercentage: 0.15,
-          sessionId,
-        },
-        {
-          lastName: 'Jackson',
-          firstName: 'Janet',
-          birthdate: '2005-12-05',
-          sex: 'F',
-          birthCity: 'AJACCIO',
-          birthCountry: 'FRANCE',
-          birthINSEECode: '2A004',
-          birthPostalCode: null,
-          resultRecipientEmail: 'destinataire@gmail.com',
-          email: 'jaja@hotmail.fr',
-          externalId: 'DEF456',
-          extraTimePercentage: null,
-          sessionId,
-        },
-        {
-          lastName: 'Jackson',
-          firstName: 'Michael',
-          birthdate: '2004-04-04',
-          sex: 'M',
-          birthCity: 'PARIS 18',
-          birthCountry: 'FRANCE',
-          birthINSEECode: null,
-          birthPostalCode: '75018',
-          resultRecipientEmail: 'destinataire@gmail.com',
-          email: 'jackson@gmail.com',
-          externalId: 'ABC123',
-          extraTimePercentage: 0.6,
-          sessionId,
-        },
-        {
-          lastName: 'Mercury',
-          firstName: 'Freddy',
-          birthdate: '1925-06-28',
-          sex: 'M',
-          birthCity: 'SAINT-ANNE',
-          birthCountry: 'FRANCE',
-          birthINSEECode: null,
-          birthPostalCode: '97180',
-          resultRecipientEmail: null,
-          email: null,
-          externalId: 'GHI789',
-          extraTimePercentage: 1.5,
-          sessionId,
-        },
-        {
-          firstName: 'Annie',
-          lastName: 'Cordy',
-          birthCity: 'BUELLAS',
-          birthProvinceCode: undefined,
-          birthCountry: 'FRANCE',
-          birthPostalCode: '01310',
-          birthINSEECode: null,
-          sex: 'M',
-          email: null,
-          resultRecipientEmail: null,
-          externalId: 'GHI769',
-          birthdate: '1928-06-16',
-          extraTimePercentage: 1.5,
-          createdAt: undefined,
-          authorizedToStart: undefined,
-          userId: undefined,
-          organizationLearnerId: null,
-          complementaryCertification: null,
-          billingMode: null,
-          prepaymentCode: null,
-          sessionId,
-        },
-        {
-          firstName: 'Demis',
-          lastName: 'Roussos',
-          birthCity: 'BUELLAS',
-          birthProvinceCode: undefined,
-          birthCountry: 'FRANCE',
-          birthPostalCode: null,
-          birthINSEECode: '01065',
-          sex: 'M',
-          email: null,
-          resultRecipientEmail: null,
-          externalId: 'GHI799',
-          birthdate: '1946-06-15',
-          extraTimePercentage: 1.5,
-          createdAt: undefined,
-          authorizedToStart: undefined,
-          userId: undefined,
-          organizationLearnerId: null,
-          complementaryCertification: null,
-          billingMode: null,
-          prepaymentCode: null,
-          sessionId,
-        },
-      ],
-      (candidate) => new CertificationCandidate(candidate),
-    );
+    const expectedCertificationCandidates = candidateList.map((candidate) => new CertificationCandidate(candidate));
     expect(actualCertificationCandidates).to.deep.equal(expectedCertificationCandidates);
   });
 });
+
+function _buildCertificationCandidateList({ hasBillingMode = false, sessionId, complementaryCertification = null }) {
+  let candidateList;
+  const firstCandidate = {
+    lastName: 'Gallagher',
+    firstName: 'Jack',
+    birthdate: '1980-08-10',
+    sex: 'M',
+    birthCity: 'Londres',
+    birthCountry: 'ANGLETERRE',
+    birthINSEECode: '99132',
+    birthPostalCode: null,
+    resultRecipientEmail: 'destinataire@gmail.com',
+    email: 'jack@d.it',
+    externalId: null,
+    extraTimePercentage: 0.15,
+  };
+  const secondCandidate = {
+    lastName: 'Jackson',
+    firstName: 'Janet',
+    birthdate: '2005-12-05',
+    sex: 'F',
+    birthCity: 'AJACCIO',
+    birthCountry: 'FRANCE',
+    birthINSEECode: '2A004',
+    birthPostalCode: null,
+    resultRecipientEmail: 'destinataire@gmail.com',
+    email: 'jaja@hotmail.fr',
+    externalId: 'DEF456',
+    extraTimePercentage: null,
+  };
+  const thirdCandidate = {
+    lastName: 'Jackson',
+    firstName: 'Michael',
+    birthdate: '2004-04-04',
+    sex: 'M',
+    birthCity: 'PARIS 18',
+    birthCountry: 'FRANCE',
+    birthINSEECode: null,
+    birthPostalCode: '75018',
+    resultRecipientEmail: 'destinataire@gmail.com',
+    email: 'jackson@gmail.com',
+    externalId: 'ABC123',
+    extraTimePercentage: 0.6,
+  };
+  const fourthCandidate = {
+    lastName: 'Mercury',
+    firstName: 'Freddy',
+    birthdate: '1925-06-28',
+    sex: 'M',
+    birthCity: 'SAINT-ANNE',
+    birthCountry: 'FRANCE',
+    birthINSEECode: null,
+    birthPostalCode: '97180',
+    resultRecipientEmail: null,
+    email: null,
+    externalId: 'GHI789',
+    extraTimePercentage: 1.5,
+  };
+  const fifthCandidate = {
+    firstName: 'Annie',
+    lastName: 'Cordy',
+    birthCity: 'BUELLAS',
+    birthProvinceCode: undefined,
+    birthCountry: 'FRANCE',
+    birthPostalCode: '01310',
+    birthINSEECode: null,
+    sex: 'M',
+    email: null,
+    resultRecipientEmail: null,
+    externalId: 'GHI769',
+    birthdate: '1928-06-16',
+    extraTimePercentage: 1.5,
+    createdAt: undefined,
+    authorizedToStart: undefined,
+    userId: undefined,
+    organizationLearnerId: null,
+    complementaryCertification: null,
+    billingMode: null,
+    prepaymentCode: null,
+  };
+  const sixthCandidate = {
+    firstName: 'Demis',
+    lastName: 'Roussos',
+    birthCity: 'BUELLAS',
+    birthProvinceCode: undefined,
+    birthCountry: 'FRANCE',
+    birthPostalCode: null,
+    birthINSEECode: '01065',
+    sex: 'M',
+    email: null,
+    resultRecipientEmail: null,
+    externalId: 'GHI799',
+    birthdate: '1946-06-15',
+    extraTimePercentage: 1.5,
+    createdAt: undefined,
+    authorizedToStart: undefined,
+    userId: undefined,
+    organizationLearnerId: null,
+    complementaryCertification: null,
+    billingMode: null,
+    prepaymentCode: null,
+  };
+  const seventhCandidate = {
+    lastName: 'Cendy',
+    firstName: 'Alain',
+    birthdate: '1988-06-28',
+    sex: 'M',
+    birthCity: 'SAINT-ANNE',
+    birthCountry: 'FRANCE',
+    birthINSEECode: null,
+    birthPostalCode: '97180',
+    resultRecipientEmail: null,
+    email: null,
+    externalId: 'SDQ987',
+    extraTimePercentage: null,
+    sessionId,
+  };
+
+  if (hasBillingMode) {
+    candidateList = [
+      { ...firstCandidate, billingMode: 'PAID' },
+      { ...secondCandidate, billingMode: 'FREE' },
+      { ...thirdCandidate, billingMode: 'FREE' },
+      { ...fourthCandidate, billingMode: 'PREPAID', prepaymentCode: 'CODE1' },
+    ];
+  } else if (complementaryCertification) {
+    candidateList = [
+      {
+        ...firstCandidate,
+        billingMode: 'FREE',
+        complementaryCertification: domainBuilder.buildComplementaryCertification(
+          complementaryCertification.pixPlusEdu1erDegreComplementaryCertification,
+        ),
+      },
+      {
+        ...secondCandidate,
+        billingMode: 'FREE',
+        complementaryCertification: domainBuilder.buildComplementaryCertification(
+          complementaryCertification.pixPlusDroitComplementaryCertification,
+        ),
+      },
+      {
+        ...thirdCandidate,
+        billingMode: 'FREE',
+        complementaryCertification: domainBuilder.buildComplementaryCertification(
+          complementaryCertification.cleaComplementaryCertification,
+        ),
+      },
+      {
+        ...fourthCandidate,
+        billingMode: 'FREE',
+        complementaryCertification: domainBuilder.buildComplementaryCertification(
+          complementaryCertification.pixPlusEdu2ndDegreComplementaryCertification,
+        ),
+      },
+      {
+        ...seventhCandidate,
+        billingMode: 'FREE',
+        complementaryCertification: domainBuilder.buildComplementaryCertification(
+          complementaryCertification.PixPlusProSanteComplementaryCertification,
+        ),
+      },
+    ];
+  } else {
+    candidateList = [firstCandidate, secondCandidate, thirdCandidate, fourthCandidate, fifthCandidate, sixthCandidate];
+  }
+
+  return candidateList.map((candidate) => ({
+    ...candidate,
+    sessionId,
+    subscriptions: [domainBuilder.buildCoreSubscription()],
+  }));
+}

--- a/api/tests/certification/enrolment/unit/domain/models/CenterTypes_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/CenterTypes_test.js
@@ -1,7 +1,7 @@
 import { CenterTypes } from '../../../../../../src/certification/enrolment/domain/models/CenterTypes.js';
 import { expect } from '../../../../../test-helper.js';
 
-describe('Unit | Certification | Center | Domain | Models | CenterTypes', function () {
+describe('Unit | Certification | Enrolment | Domain | Models | CenterTypes', function () {
   it('should return the center types', function () {
     // given / when / then
     expect(CenterTypes).to.contains({

--- a/api/tests/certification/enrolment/unit/domain/models/Center_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/Center_test.js
@@ -3,7 +3,7 @@ import { CenterTypes } from '../../../../../../src/certification/enrolment/domai
 import { CERTIFICATION_FEATURES } from '../../../../../../src/certification/shared/domain/constants.js';
 import { catchErrSync, domainBuilder, expect } from '../../../../../test-helper.js';
 
-describe('Unit | Certification | Session | Domain | Models | Center', function () {
+describe('Unit | Certification | Enrolment | Domain | Models | Center', function () {
   describe('#hasBillingMode', function () {
     it('should return false when center is of type SCO', function () {
       // given

--- a/api/tests/certification/enrolment/unit/domain/models/SessionMassImportReport_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/SessionMassImportReport_test.js
@@ -1,7 +1,7 @@
 import { SessionMassImportReport } from '../../../../../../src/certification/enrolment/domain/models/SessionMassImportReport.js';
 import { expect } from '../../../../../test-helper.js';
 
-describe('Unit | Domain | Models | SessionMassImportReport', function () {
+describe('Unit | Certification | Enrolment | Domain | Models | SessionMassImportReport', function () {
   context('#addErrorsReports', function () {
     context('when there are reports', function () {
       it('should add blocking errors reports', function () {

--- a/api/tests/certification/enrolment/unit/domain/models/Subscription_test.js
+++ b/api/tests/certification/enrolment/unit/domain/models/Subscription_test.js
@@ -1,0 +1,73 @@
+import { Subscription } from '../../../../../../src/certification/enrolment/domain/models/Subscription.js';
+import { SubscriptionTypes } from '../../../../../../src/certification/shared/domain/models/SubscriptionTypes.js';
+import { catchErrSync, domainBuilder, expect } from '../../../../../test-helper.js';
+
+describe('Unit | Certification | Enrolment | Domain | Models | Subscription', function () {
+  let certificationCandidate;
+  let complementaryCertification;
+
+  beforeEach(function () {
+    certificationCandidate = domainBuilder.buildCertificationCandidate();
+    complementaryCertification = domainBuilder.buildComplementaryCertification();
+  });
+
+  describe('When the subscription is core', function () {
+    it('should return a core Subscription instance', function () {
+      // given
+      const expectedSubscription = new Subscription({
+        certificationCandidateId: certificationCandidate.id,
+        complementaryCertificationId: undefined,
+        type: SubscriptionTypes.CORE,
+      });
+
+      // when
+      const subscription = Subscription.buildCore({
+        certificationCandidateId: certificationCandidate.id,
+      });
+
+      // then
+      expect(subscription).to.deepEqualInstance(expectedSubscription);
+    });
+
+    it('should not allow to have a complementaryCertificationId', function () {
+      // given, when
+      const error = catchErrSync((data) => new Subscription(data))({
+        complementaryCertificationId: complementaryCertification.id,
+        type: SubscriptionTypes.CORE,
+      });
+
+      // then
+      expect(error).to.be.an.instanceOf(TypeError);
+    });
+  });
+
+  describe('When the subscription is complementary', function () {
+    it('should return a complementary Subscription instance', function () {
+      // given / when
+      const subscription = Subscription.buildComplementary({
+        certificationCandidateId: certificationCandidate.id,
+        complementaryCertificationId: complementaryCertification.id,
+      });
+
+      const expectedSubscription = new Subscription({
+        certificationCandidateId: certificationCandidate.id,
+        complementaryCertificationId: complementaryCertification.id,
+        type: SubscriptionTypes.COMPLEMENTARY,
+      });
+
+      // then
+      expect(subscription).to.deepEqualInstance(expectedSubscription);
+    });
+
+    it('should enforce the need of the complementaryCertificationId', function () {
+      // given /  when
+      const error = catchErrSync((data) => new Subscription(data))({
+        complementaryCertificationId: null,
+        type: SubscriptionTypes.COMPLEMENTARY,
+      });
+
+      // then
+      expect(error).to.be.an.instanceOf(TypeError);
+    });
+  });
+});

--- a/api/tests/certification/enrolment/unit/domain/services/sessions-import-validation-service_test.js
+++ b/api/tests/certification/enrolment/unit/domain/services/sessions-import-validation-service_test.js
@@ -885,5 +885,6 @@ function _buildValidCandidateData({ lineNumber = 0, candidateNumber = 2 } = { ca
     extraTimePercentage: 20,
     billingMode: 'PAID',
     line: lineNumber,
+    subscriptions: [domainBuilder.buildCoreSubscription()],
   });
 }

--- a/api/tests/certification/enrolment/unit/domain/usecases/add-certification-candidate-to-session_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/add-certification-candidate-to-session_test.js
@@ -7,6 +7,10 @@ import {
 import { CpfBirthInformationValidation } from '../../../../../../src/certification/enrolment/domain/services/certification-cpf-service.js';
 import { addCertificationCandidateToSession } from '../../../../../../src/certification/enrolment/domain/usecases/add-certification-candidate-to-session.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+import {
+  buildComplementarySubscription,
+  buildCoreSubscription,
+} from '../../../../../tooling/domain-builder/factory/index.js';
 
 describe('Unit | UseCase | add-certification-candidate-to-session', function () {
   let certificationCandidateRepository;
@@ -175,9 +179,20 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
           mailCheck,
         });
 
+        const expectedCertificationCandidate = domainBuilder.buildCertificationCandidate.pro({
+          ...certificationCandidate,
+          subscriptions: [
+            buildCoreSubscription({ certificationCandidateId: certificationCandidate.id }),
+            buildComplementarySubscription({
+              certificationCandidateId: certificationCandidate.id,
+              complementaryCertificationId: complementaryCertification.id,
+            }),
+          ],
+        });
+
         // then
-        expect(certificationCandidateRepository.saveInSession).to.has.been.calledWithExactly({
-          certificationCandidate,
+        expect(certificationCandidateRepository.saveInSession).to.have.been.calledWithExactly({
+          certificationCandidate: expectedCertificationCandidate,
           sessionId,
         });
       });

--- a/api/tests/certification/enrolment/unit/domain/usecases/add-certification-candidate-to-session_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/add-certification-candidate-to-session_test.js
@@ -15,6 +15,7 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
   let certificationCpfCityRepository;
   let sessionRepository;
   let mailCheck;
+  let certificationCandidateData;
 
   const sessionId = 1;
 
@@ -33,6 +34,10 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
     certificationCpfCountryRepository = Symbol('certificationCpfCountryRepository');
     certificationCpfCityRepository = Symbol('certificationCpfCityRepository');
     mailCheck = { checkDomainIsValid: sinon.stub() };
+    certificationCandidateData = {
+      sessionId: null,
+      subscriptions: [domainBuilder.buildCoreSubscription({ id: 123 })],
+    };
   });
 
   context('when the session is finalized', function () {
@@ -40,10 +45,7 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
       // given
       const session = domainBuilder.certification.enrolment.buildSession.finalized();
       sessionRepository.get.resolves(session);
-
-      const certificationCandidate = domainBuilder.buildCertificationCandidate.pro({
-        sessionId: null,
-      });
+      const certificationCandidate = domainBuilder.buildCertificationCandidate.pro(certificationCandidateData);
 
       // when
       const error = await catchErr(addCertificationCandidateToSession)({
@@ -71,8 +73,8 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
       sessionRepository.get.resolves(session);
       sessionRepository.isSco.resolves(false);
       const certificationCandidate = domainBuilder.buildCertificationCandidate.pro({
+        ...certificationCandidateData,
         email: 'toto@toto.fr;tutu@tutu.fr',
-        sessionId: null,
       });
 
       // when
@@ -108,9 +110,7 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
         const session = domainBuilder.certification.enrolment.buildSession.created();
         sessionRepository.get.resolves(session);
         sessionRepository.isSco.resolves(true);
-        const certificationCandidate = domainBuilder.buildCertificationCandidate({
-          sessionId: null,
-        });
+        const certificationCandidate = domainBuilder.buildCertificationCandidate(certificationCandidateData);
         certificationCandidateRepository.findBySessionIdAndPersonalInfo.resolves(['one match']);
         mailCheck.checkDomainIsValid.resolves();
 
@@ -147,7 +147,7 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
         const complementaryCertification =
           domainBuilder.certification.sessionManagement.buildCertificationSessionComplementaryCertification();
         const certificationCandidate = domainBuilder.buildCertificationCandidate.pro({
-          sessionId: null,
+          ...certificationCandidateData,
           complementaryCertification,
         });
         const cpfBirthInformationValidation = new CpfBirthInformationValidation();
@@ -187,9 +187,7 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
         const session = domainBuilder.certification.enrolment.buildSession.created();
         sessionRepository.get.resolves(session);
         sessionRepository.isSco.resolves(false);
-        const certificationCandidate = domainBuilder.buildCertificationCandidate.pro({
-          sessionId: null,
-        });
+        const certificationCandidate = domainBuilder.buildCertificationCandidate.pro(certificationCandidateData);
         const cpfBirthInformationValidation = new CpfBirthInformationValidation();
         cpfBirthInformationValidation.success({
           birthCountry: 'COUNTRY',
@@ -224,9 +222,7 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
         const session = domainBuilder.certification.enrolment.buildSession.created();
         sessionRepository.get.resolves(session);
         sessionRepository.isSco.resolves(false);
-        const certificationCandidate = domainBuilder.buildCertificationCandidate.pro({
-          sessionId: null,
-        });
+        const certificationCandidate = domainBuilder.buildCertificationCandidate.pro(certificationCandidateData);
         certificationCandidate.validate = sinon.stub();
         const cpfBirthInformationValidation = new CpfBirthInformationValidation();
         cpfBirthInformationValidation.success({
@@ -263,10 +259,7 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
           const session = domainBuilder.certification.enrolment.buildSession.created();
           sessionRepository.get.resolves(session);
           sessionRepository.isSco.resolves(false);
-          const certificationCandidate = domainBuilder.buildCertificationCandidate.pro({
-            sessionId: null,
-            complementaryCertification: null,
-          });
+          const certificationCandidate = domainBuilder.buildCertificationCandidate.pro(certificationCandidateData);
           const certificationCandidateError = {
             code: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_CITY_REQUIRED.code,
             getMessage: () => 'Failure message',
@@ -305,6 +298,7 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
             sessionRepository.get.resolves(session);
             sessionRepository.isSco.resolves(false);
             const certificationCandidate = domainBuilder.buildCertificationCandidate.pro({
+              ...certificationCandidateData,
               email: 'jesuisunemail@incorrect.fr',
               resultRecipientEmail: 'jesuisunemail@correct.fr',
             });
@@ -351,6 +345,7 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
             sessionRepository.get.resolves(session);
             sessionRepository.isSco.resolves(false);
             const certificationCandidate = domainBuilder.buildCertificationCandidate.pro({
+              ...certificationCandidateData,
               resultRecipientEmail: 'jesuisunemail@incorrect.fr',
               email: 'jesuisunemail@correct.fr',
             });

--- a/api/tests/certification/enrolment/unit/domain/usecases/create-sessions_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/create-sessions_test.js
@@ -12,6 +12,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
   let sessionRepository;
   let dependencies;
   let temporarySessionsStorageForMassImportService;
+  let certificationCandidateData;
 
   beforeEach(function () {
     certificationCenterRepository = { get: sinon.stub() };
@@ -27,6 +28,11 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
       certificationCandidateRepository,
       sessionRepository,
       temporarySessionsStorageForMassImportService,
+    };
+
+    certificationCandidateData = {
+      sessionId: undefined,
+      subscriptions: [domainBuilder.buildCoreSubscription()],
     };
   });
 
@@ -99,7 +105,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
           // given
           const certificationCenter = new CertificationCenter({ id: 567 });
           certificationCenterRepository.get.withArgs({ id: certificationCenter.id }).resolves(certificationCenter);
-          const certificationCandidate = domainBuilder.buildCertificationCandidate({ sessionId: undefined });
+          const certificationCandidate = domainBuilder.buildCertificationCandidate(certificationCandidateData);
           const sessionCreatorId = 1234;
           const temporaryCachedSessions = [
             {
@@ -244,7 +250,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
         // given
         const certificationCenter = new CertificationCenter();
         certificationCenterRepository.get.withArgs({ id: certificationCenter.id }).resolves(certificationCenter);
-        const certificationCandidate = domainBuilder.buildCertificationCandidate({ sessionId: undefined });
+        const certificationCandidate = domainBuilder.buildCertificationCandidate(certificationCandidateData);
         const temporaryCachedSessions = [
           {
             id: 1234,
@@ -282,7 +288,7 @@ describe('Unit | UseCase | sessions-mass-import | create-sessions', function () 
       // given
       const certificationCenter = new CertificationCenter();
       certificationCenterRepository.get.withArgs({ id: certificationCenter.id }).resolves(certificationCenter);
-      const certificationCandidate = domainBuilder.buildCertificationCandidate({ sessionId: undefined });
+      const certificationCandidate = domainBuilder.buildCertificationCandidate(certificationCandidateData);
       const temporaryCachedSessions = [
         {
           id: 1234,

--- a/api/tests/certification/enrolment/unit/domain/usecases/validate-sessions_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/validate-sessions_test.js
@@ -71,7 +71,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
       externalId: 'popi',
       birthdate: '1981-03-12',
       extraTimePercentage: '20',
-      subscriptions: [domainBuilder.buildCoreSubscription()],
+      subscriptions: [domainBuilder.buildCoreSubscription({ certificationCandidateId: 123 })],
       billingMode: 'Gratuite',
       sessionId: 1,
     };
@@ -89,7 +89,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
       externalId: 'souris',
       birthdate: '2003-07-04',
       extraTimePercentage: '20',
-      subscriptions: [domainBuilder.buildCoreSubscription()],
+      subscriptions: [domainBuilder.buildCoreSubscription({ certificationCandidateId: 456 })],
       billingMode: 'Gratuite',
       sessionId: 2,
     };

--- a/api/tests/certification/enrolment/unit/domain/usecases/validate-sessions_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/validate-sessions_test.js
@@ -1,6 +1,5 @@
 import { CERTIFICATION_CANDIDATES_ERRORS } from '../../../../../../lib/domain/constants/certification-candidates-errors.js';
 import { CERTIFICATION_SESSIONS_ERRORS } from '../../../../../../lib/domain/constants/sessions-errors.js';
-import { CertificationCandidate } from '../../../../../../lib/domain/models/index.js';
 import { SessionEnrolment } from '../../../../../../src/certification/enrolment/domain/models/SessionEnrolment.js';
 import { SessionMassImportReport } from '../../../../../../src/certification/enrolment/domain/models/SessionMassImportReport.js';
 import { CpfBirthInformationValidation } from '../../../../../../src/certification/enrolment/domain/services/certification-cpf-service.js';
@@ -8,33 +7,44 @@ import { validateSessions } from '../../../../../../src/certification/enrolment/
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 import { getI18n } from '../../../../../tooling/i18n/i18n.js';
 
+const userId = 1234;
+const cachedValidatedSessionsKey = 'uuid';
+const accessCode = 'accessCode';
+const certificationCenterId = '123';
+const certificationCenterName = 'certificationCenterName';
+const complementaryCertification = { id: 3, key: 'EDU_2ND_DEGRE', label: 'Pix+ Édu 2nd degré' };
+const cpfBirthInformation = {
+  birthCountry: 'France',
+  birthCity: '',
+  birthPostalCode: null,
+  birthINSEECode: '134',
+};
+
 describe('Unit | UseCase | sessions-mass-import | validate-sessions', function () {
-  let accessCode;
-  let certificationCenterId;
-  let certificationCenterName;
+  let i18n;
   let certificationCenter;
   let certificationCenterRepository;
   let certificationCourseRepository;
   let complementaryCertificationRepository;
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const i18n = getI18n();
   let sessionCodeService;
   let sessionsImportValidationService;
   let temporarySessionsStorageForMassImportService;
+  let firstSession;
+  let secondSession;
+  let candidate1;
+  let candidate2;
 
   beforeEach(function () {
-    accessCode = 'accessCode';
-    certificationCenterId = '123';
-    certificationCenterName = 'certificationCenterName';
+    i18n = getI18n();
     certificationCenter = domainBuilder.buildCertificationCenter({
       id: certificationCenterId,
       name: certificationCenterName,
     });
     certificationCenterRepository = { get: sinon.stub() };
-    complementaryCertificationRepository = { getByLabel: sinon.stub() };
-    certificationCourseRepository = sinon.stub();
-    sessionCodeService = { getNewSessionCode: sinon.stub().returns(accessCode) };
     certificationCenterRepository.get.withArgs({ id: certificationCenterId }).resolves(certificationCenter);
+    certificationCourseRepository = sinon.stub();
+    complementaryCertificationRepository = { getByLabel: sinon.stub() };
+    sessionCodeService = { getNewSessionCode: sinon.stub().returns(accessCode) };
 
     sessionsImportValidationService = {
       getValidatedComplementaryCertificationForMassImport: sinon.stub(),
@@ -46,53 +56,120 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
     temporarySessionsStorageForMassImportService = {
       save: sinon.stub(),
     };
+
+    candidate1 = {
+      id: 123,
+      firstName: 'Popi',
+      lastName: 'Doudou',
+      birthCity: '',
+      birthCountry: 'France',
+      birthPostalCode: null,
+      birthINSEECode: '134',
+      sex: 'M',
+      email: 'popidoudou@email.fr',
+      resultRecipientEmail: 'popidoudou@email.fr',
+      externalId: 'popi',
+      birthdate: '1981-03-12',
+      extraTimePercentage: '20',
+      subscriptions: [domainBuilder.buildCoreSubscription()],
+      billingMode: 'Gratuite',
+      sessionId: 1,
+    };
+    candidate2 = {
+      id: 456,
+      firstName: 'Lili',
+      lastName: 'Souris',
+      birthCity: '',
+      birthCountry: 'France',
+      birthPostalCode: null,
+      birthINSEECode: '134',
+      sex: 'F',
+      email: 'lilisouris@email.fr',
+      resultRecipientEmail: 'lilisouris@email.fr',
+      externalId: 'souris',
+      birthdate: '2003-07-04',
+      extraTimePercentage: '20',
+      subscriptions: [domainBuilder.buildCoreSubscription()],
+      billingMode: 'Gratuite',
+      sessionId: 2,
+    };
+    firstSession = {
+      address: 'Site 1',
+      date: '2023-03-12',
+      time: '01:00',
+      examiner: 'Oscar',
+      description: 'desc1',
+      room: 'Salle 1',
+      id: 1,
+      sessionId: 1,
+    };
+    secondSession = {
+      address: 'Site 2',
+      date: '2023-03-23',
+      time: '03:00',
+      examiner: 'Lalou',
+      description: 'desc2',
+      room: 'Salle 2',
+      id: 2,
+      sessionId: 2,
+    };
   });
 
   context('when sessions and candidates are valid', function () {
     it('return a sessions report', async function () {
       // given
-      const userId = 1234;
-      const cachedValidatedSessionsKey = 'uuid';
-      const validSessionData = _createValidSessionData();
-      const complementaryCertification = { id: 3, key: 'EDU_2ND_DEGRE', label: 'Pix+ Édu 2nd degré' };
+      const certificationCandidate1 = domainBuilder.buildCertificationCandidate({
+        ...candidate1,
+        complementaryCertification,
+      });
+      const session1 = { ...firstSession, certificationCandidates: [certificationCandidate1] };
+      const certificationCandidate2 = domainBuilder.buildCertificationCandidate({
+        ...candidate2,
+        complementaryCertification,
+      });
+      const session2 = { ...secondSession, certificationCandidates: [certificationCandidate2] };
+
       sessionsImportValidationService.getValidatedComplementaryCertificationForMassImport.resolves({
         certificationCandidateComplementaryErrors: [],
         complementaryCertification,
       });
+
       sessionsImportValidationService.getValidatedCandidateBirthInformation.resolves({
         certificationCandidateErrors: [],
-        cpfBirthInformation: {
-          birthCountry: 'France',
-          birthCity: '',
-          birthPostalCode: null,
-          birthINSEECode: '134',
-        },
-      });
-      sessionsImportValidationService.validateCandidateEmails.resolves([]);
-
-      const sessions = [
-        {
-          ...validSessionData,
-          line: 2,
-          room: 'Salle 1',
-        },
-        {
-          ...validSessionData,
-          line: 3,
-          room: 'Salle 2',
-        },
-      ];
-
-      sessionsImportValidationService.getUniqueCandidates.returns({
-        uniqueCandidates: validSessionData.certificationCandidates,
-        duplicateCandidateErrors: [],
+        cpfBirthInformation,
       });
 
       temporarySessionsStorageForMassImportService.save.resolves(cachedValidatedSessionsKey);
 
+      sessionsImportValidationService.getUniqueCandidates.withArgs([certificationCandidate1]).returns({
+        uniqueCandidates: [certificationCandidate1],
+        duplicateCandidateErrors: [],
+      });
+      sessionsImportValidationService.getUniqueCandidates.withArgs([certificationCandidate2]).returns({
+        uniqueCandidates: [certificationCandidate2],
+        duplicateCandidateErrors: [],
+      });
+
+      const [expectedSession1, expectedSession2] = [
+        domainBuilder.certification.enrolment.buildSession({
+          ...firstSession,
+          certificationCenterId,
+          certificationCenter: certificationCenterName,
+          accessCode,
+          certificationCandidates: [certificationCandidate1],
+        }),
+        domainBuilder.certification.enrolment.buildSession({
+          ...secondSession,
+          certificationCenterId,
+          certificationCenter: certificationCenterName,
+          accessCode,
+          certificationCandidates: [certificationCandidate2],
+        }),
+      ];
+
       // when
       const sessionsMassImportReport = await validateSessions({
-        sessions,
+        sessions: [session1, session2],
         userId,
         certificationCenterId,
         certificationCenterRepository,
@@ -103,63 +180,31 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
       });
 
       // then
-      const expectedSessions = [
-        new SessionEnrolment({
-          ...sessions[0],
-          certificationCenterId,
-          certificationCenter: certificationCenterName,
-          accessCode,
-          certificationCandidates: [
-            new CertificationCandidate({
-              sessionId: sessions[0].id,
-              lastName: 'Candidat 2',
-              firstName: 'Candidat 2',
-              birthdate: '1981-03-12',
-              sex: 'M',
-              birthINSEECode: '134',
-              birthPostalCode: null,
-              birthCity: '',
-              birthCountry: 'France',
-              resultRecipientEmail: 'robindahood@email.fr',
-              email: 'robindahood2@email.fr',
-              externalId: 'htehte',
-              extraTimePercentage: '20',
-              billingMode: 'FREE',
-              complementaryCertification,
-            }),
-          ],
-          supervisorPassword: sinon.match(/^[2346789BCDFGHJKMPQRTVWXY]{5}$/),
-        }),
-        new SessionEnrolment({
-          ...sessions[1],
-          certificationCenterId,
-          certificationCenter: certificationCenterName,
-          accessCode,
-          certificationCandidates: [
-            new CertificationCandidate({
-              sessionId: sessions[1].id,
-              lastName: 'Candidat 2',
-              firstName: 'Candidat 2',
-              birthdate: '1981-03-12',
-              sex: 'M',
-              birthINSEECode: '134',
-              birthPostalCode: null,
-              birthCity: '',
-              birthCountry: 'France',
-              resultRecipientEmail: 'robindahood@email.fr',
-              email: 'robindahood2@email.fr',
-              externalId: 'htehte',
-              extraTimePercentage: '20',
-              billingMode: 'FREE',
-              complementaryCertification,
-            }),
-          ],
-          supervisorPassword: sinon.match(/^[2346789BCDFGHJKMPQRTVWXY]{5}$/),
-        }),
-      ];
-
-      expect(temporarySessionsStorageForMassImportService.save).to.have.been.calledOnceWith({
-        sessions: expectedSessions,
+      expect(temporarySessionsStorageForMassImportService.save).to.have.been.calledWith({
+        sessions: [
+          sinon.match({
+            ...expectedSession1,
+            certificationCandidates: [
+              sinon.match({
+                ...certificationCandidate1,
+                billingMode: 'FREE',
+              }),
+            ],
+            createdBy: undefined,
+            supervisorPassword: sinon.match(/^[2346789BCDFGHJKMPQRTVWXY]{5}$/),
+          }),
+          sinon.match({
+            ...expectedSession2,
+            certificationCandidates: [
+              sinon.match({
+                ...certificationCandidate2,
+                billingMode: 'FREE',
+              }),
+            ],
+            createdBy: undefined,
+            supervisorPassword: sinon.match(/^[2346789BCDFGHJKMPQRTVWXY]{5}$/),
+          }),
+        ],
         userId,
       });
 
@@ -175,40 +220,33 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
     context('when there is only sessionId and candidate information', function () {
       it('should validate the candidates in the session', async function () {
         // given
-        const cachedValidatedSessionsKey = 'uuid';
-        const candidate1 = _createValidCandidateData({ candidateNumber: 1 });
-        const candidate2 = _createValidCandidateData({ candidateNumber: 2 });
-        const candidate3 = _createValidCandidateData({ candidateNumber: 3 });
-        const userId = 1234;
-        const sessions = [
-          {
-            sessionId: 1234,
-            certificationCandidates: [candidate1],
-          },
-          {
-            sessionId: 1235,
-            certificationCandidates: [candidate2, candidate3],
-          },
-        ];
+        const certificationCandidate1 = domainBuilder.buildCertificationCandidate(candidate1);
+        const session1 = { sessionId: 1, certificationCandidates: [certificationCandidate1] };
+        const certificationCandidate2 = domainBuilder.buildCertificationCandidate(candidate2);
+        const certificationCandidate3 = domainBuilder.buildCertificationCandidate({
+          ...candidate2,
+          lastName: 'Brun',
+          firstName: 'Petit Ours',
+        });
+        const session2 = { sessionId: 2, certificationCandidates: [certificationCandidate2, certificationCandidate3] };
 
+        sessionsImportValidationService.getUniqueCandidates.withArgs([certificationCandidate1]).returns({
+          uniqueCandidates: [certificationCandidate1],
+          duplicateCandidateErrors: [],
+        });
         sessionsImportValidationService.getUniqueCandidates
-          .onFirstCall()
+          .withArgs([certificationCandidate2, certificationCandidate3])
           .returns({
-            uniqueCandidates: [candidate1],
-            duplicateCandidateErrors: [],
-          })
-          .onSecondCall()
-          .returns({
-            uniqueCandidates: [candidate2, candidate3],
+            uniqueCandidates: [certificationCandidate2, certificationCandidate3],
             duplicateCandidateErrors: [],
           });
 
         const cpfBirthInformationValidation1 = new CpfBirthInformationValidation();
-        cpfBirthInformationValidation1.success({ ...candidate1 });
+        cpfBirthInformationValidation1.success({ ...certificationCandidate1 });
         const cpfBirthInformationValidation2 = new CpfBirthInformationValidation();
-        cpfBirthInformationValidation2.success({ ...candidate2 });
+        cpfBirthInformationValidation2.success({ ...certificationCandidate2 });
         const cpfBirthInformationValidation3 = new CpfBirthInformationValidation();
-        cpfBirthInformationValidation3.success({ ...candidate3 });
+        cpfBirthInformationValidation3.success({ ...certificationCandidate3 });
         sessionsImportValidationService.getValidatedCandidateBirthInformation
           .onFirstCall()
           .resolves({ certificationCandidateErrors: [], cpfBirthInformation: cpfBirthInformationValidation1 })
@@ -222,12 +260,11 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           complementaryCertification: null,
         });
 
-        sessionsImportValidationService.validateCandidateEmails.resolves([]);
         temporarySessionsStorageForMassImportService.save.resolves(cachedValidatedSessionsKey);
 
         // when
         const sessionsMassImportReport = await validateSessions({
-          sessions,
+          sessions: [session1, session2],
           userId,
           certificationCenterId,
           certificationCenterRepository,
@@ -239,36 +276,57 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
         });
 
         // then
-        const expectedSessions = [
+        const [expectedSession1, expectedSession2] = [
           new SessionEnrolment({
-            ...sessions[0],
-            id: 1234,
+            ...session1,
+            id: 1,
             certificationCenterId,
             certificationCenter: certificationCenterName,
             accessCode,
-            supervisorPassword: sinon.match(/^[2346789BCDFGHJKMPQRTVWXY]{5}$/),
-            certificationCandidates: [
-              new CertificationCandidate({ ...candidate1, sessionId: 1234, billingMode: 'FREE' }),
-            ],
+            certificationCandidates: [certificationCandidate1],
           }),
           new SessionEnrolment({
-            ...sessions[1],
-            id: 1235,
+            ...session2,
+            id: 2,
             certificationCenterId,
             certificationCenter: certificationCenterName,
             accessCode,
-            supervisorPassword: sinon.match(/^[2346789BCDFGHJKMPQRTVWXY]{5}$/),
-            certificationCandidates: [
-              new CertificationCandidate({ ...candidate2, sessionId: 1235, billingMode: 'FREE' }),
-              new CertificationCandidate({ ...candidate3, sessionId: 1235, billingMode: 'FREE' }),
-            ],
+            certificationCandidates: [certificationCandidate2, certificationCandidate3],
           }),
         ];
 
-        expect(temporarySessionsStorageForMassImportService.save).to.have.been.calledOnceWithExactly({
-          sessions: expectedSessions,
+        expect(temporarySessionsStorageForMassImportService.save).to.have.been.calledWith({
+          sessions: [
+            sinon.match({
+              ...expectedSession1,
+              certificationCandidates: [
+                sinon.match({
+                  ...certificationCandidate1,
+                  billingMode: 'FREE',
+                }),
+              ],
+              createdBy: undefined,
+              supervisorPassword: sinon.match(/^[2346789BCDFGHJKMPQRTVWXY]{5}$/),
+            }),
+            sinon.match({
+              ...expectedSession2,
+              certificationCandidates: [
+                sinon.match({
+                  ...certificationCandidate2,
+                  billingMode: 'FREE',
+                }),
+                sinon.match({
+                  ...certificationCandidate3,
+                  billingMode: 'FREE',
+                }),
+              ],
+              createdBy: undefined,
+              supervisorPassword: sinon.match(/^[2346789BCDFGHJKMPQRTVWXY]{5}$/),
+            }),
+          ],
           userId,
         });
+
         expect(sessionsMassImportReport).to.deep.equal({
           cachedValidatedSessionsKey,
           sessionsCount: 2,
@@ -294,17 +352,12 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
         certificationCandidateErrors: [],
         cpfBirthInformation: {},
       });
-      const validSessionData = _createValidSessionData();
 
-      const sessions = [
-        {
-          ...validSessionData,
-          address: null,
-        },
-      ];
+      const certificationCandidate = domainBuilder.buildCertificationCandidate(candidate1);
+      const sessions = [{ ...firstSession, certificationCandidates: [certificationCandidate], address: null }];
 
       sessionsImportValidationService.getUniqueCandidates.returns({
-        uniqueCandidates: validSessionData.certificationCandidates,
+        uniqueCandidates: [certificationCandidate],
         duplicateCandidateErrors: [],
       });
 
@@ -325,15 +378,9 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
     context('when at least one of the sessions is not valid', function () {
       it('should return sessionsMassImportReport', async function () {
         // given
-        const validSessionData = _createValidSessionData();
-        const candidate = _createValidCandidateData();
-
+        const certificationCandidate = domainBuilder.buildCertificationCandidate(candidate1);
         const sessions = [
-          {
-            ...validSessionData,
-            address: null,
-            certificationCandidates: [{ ...candidate, name: null }],
-          },
+          { ...firstSession, certificationCandidates: [{ ...certificationCandidate, name: null }], address: null },
         ];
 
         sessionsImportValidationService.getValidatedComplementaryCertificationForMassImport.resolves({
@@ -346,7 +393,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
         });
 
         sessionsImportValidationService.getUniqueCandidates.returns({
-          uniqueCandidates: validSessionData.certificationCandidates,
+          uniqueCandidates: [certificationCandidate],
           duplicateCandidateErrors: [],
         });
 
@@ -377,15 +424,29 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
     context('when there is at least one duplicate candidate in a session', function () {
       it('should remove duplicate certification candidates from the session', async function () {
         // given
-        const validSessionData = _createValidSessionData();
-        const firstCandidate = _createValidCandidateData({ line: 1, candidateNumber: 1 });
-        const firstCandidateDuplicate = _createValidCandidateData({ line: 3, candidateNumber: 1 });
-        const secondCandidate = _createValidCandidateData({ line: 2, candidateNumber: 2 });
-
+        const certificationCandidate1 = domainBuilder.buildCertificationCandidate({
+          ...candidate1,
+          line: 1,
+          candidateNumber: 1,
+        });
+        const certificationCandidate1Duplicate = domainBuilder.buildCertificationCandidate({
+          ...candidate1,
+          line: 3,
+          candidateNumber: 1,
+        });
+        const certificationCandidate2 = domainBuilder.buildCertificationCandidate({
+          ...candidate2,
+          line: 2,
+          candidateNumber: 2,
+        });
         const sessions = [
           {
-            ...validSessionData,
-            certificationCandidates: [firstCandidate, firstCandidateDuplicate, secondCandidate],
+            ...firstSession,
+            certificationCandidates: [
+              certificationCandidate1,
+              certificationCandidate1Duplicate,
+              certificationCandidate2,
+            ],
           },
         ];
 
@@ -400,7 +461,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
         });
 
         sessionsImportValidationService.getUniqueCandidates.returns({
-          uniqueCandidates: [firstCandidate, secondCandidate],
+          uniqueCandidates: [certificationCandidate1, certificationCandidate2],
           duplicateCandidateErrors: [
             {
               line: 3,
@@ -445,29 +506,15 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
     context('when candidate recipient (or convocation) email is not valid', function () {
       it('should return sessionsMassImportReport', async function () {
         // given
-        const validSessionData = _createValidSessionData();
-        const firstCandidate = _createValidCandidateData({ line: 1, candidateNumber: 1 });
-        const secondCandidatewithInvalidEmail = {
-          lastName: `Anne`,
-          firstName: `Toine`,
-          birthdate: '1981-03-12',
-          sex: 'M',
-          birthINSEECode: '134',
-          birthPostalCode: null,
-          birthCity: '',
-          birthCountry: 'France',
+        const certificationCandidate = domainBuilder.buildCertificationCandidate(candidate1);
+        const certificationCandidateWithInvalidEmail = domainBuilder.buildCertificationCandidate({
+          ...candidate2,
           resultRecipientEmail: 'invalidemail',
-          email: 'robindahood2@email.fr',
-          externalId: 'htehte',
-          extraTimePercentage: '20',
-          billingMode: 'Gratuite',
-          line: 2,
-        };
-
+        });
         const sessions = [
           {
-            ...validSessionData,
-            certificationCandidates: [firstCandidate, secondCandidatewithInvalidEmail],
+            ...firstSession,
+            certificationCandidates: [{ certificationCandidate, certificationCandidateWithInvalidEmail }],
           },
         ];
 
@@ -492,7 +539,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
             },
           ]);
         sessionsImportValidationService.getUniqueCandidates.returns({
-          uniqueCandidates: [firstCandidate, secondCandidatewithInvalidEmail],
+          uniqueCandidates: [certificationCandidate, certificationCandidateWithInvalidEmail],
           duplicateCandidateErrors: [],
         });
 
@@ -529,35 +576,3 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
     });
   });
 });
-
-function _createValidSessionData() {
-  return {
-    sessionId: undefined,
-    address: 'Site 1',
-    room: 'Salle 1',
-    date: '2023-03-12',
-    time: '01:00',
-    examiner: 'Pierre',
-    description: 'desc',
-    certificationCandidates: [_createValidCandidateData()],
-  };
-}
-
-function _createValidCandidateData({ line = 0, candidateNumber = 2 } = { line: 1, candidateNumber: 2 }) {
-  return {
-    lastName: `Candidat ${candidateNumber}`,
-    firstName: `Candidat ${candidateNumber}`,
-    birthdate: '1981-03-12',
-    sex: 'M',
-    birthINSEECode: '134',
-    birthPostalCode: null, //'3456',
-    birthCity: '',
-    birthCountry: 'France',
-    resultRecipientEmail: 'robindahood@email.fr',
-    email: 'robindahood2@email.fr',
-    externalId: 'htehte',
-    extraTimePercentage: '20',
-    billingMode: 'Gratuite',
-    line,
-  };
-}

--- a/api/tests/certification/enrolment/unit/infrastructure/serializers/certification-candidate-serializer_test.js
+++ b/api/tests/certification/enrolment/unit/infrastructure/serializers/certification-candidate-serializer_test.js
@@ -17,6 +17,7 @@ describe('Unit | Serializer | JSONAPI | certification-candidate-serializer', fun
       organizationLearnerId: 1,
       billingMode: 'PAID',
       complementaryCertification,
+      subscriptions: [domainBuilder.buildCoreSubscription()],
     });
   });
 

--- a/api/tests/tooling/domain-builder/factory/build-certification-candidate.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-candidate.js
@@ -24,7 +24,7 @@ const buildCertificationCandidate = function ({
   complementaryCertification = null,
   billingMode = null,
   prepaymentCode = null,
-  subscriptions = [domainBuilder.buildCoreSubscription()],
+  subscriptions = [domainBuilder.buildCoreSubscription({ certificationCandidateId: 123 })],
 } = {}) {
   return new CertificationCandidate({
     id,
@@ -54,6 +54,7 @@ const buildCertificationCandidate = function ({
 };
 
 buildCertificationCandidate.pro = function ({
+  id = 123,
   firstName = 'Poison',
   lastName = 'Ivy',
   sex = 'F',
@@ -71,9 +72,10 @@ buildCertificationCandidate.pro = function ({
   sessionId = 456,
   complementaryCertification = null,
   billingMode = 'FREE',
-  subscriptions = null,
+  subscriptions = [],
 }) {
   return new CertificationCandidate({
+    id,
     firstName,
     lastName,
     sex,

--- a/api/tests/tooling/domain-builder/factory/build-certification-candidate.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-candidate.js
@@ -1,6 +1,5 @@
 import { CertificationCandidate } from '../../../../lib/domain/models/CertificationCandidate.js';
 import { buildComplementaryCertification } from './build-complementary-certification.js';
-import { buildCoreSubscription } from './certification/enrolment/build-subscription.js';
 
 const buildCertificationCandidate = function ({
   id = 123,
@@ -25,7 +24,7 @@ const buildCertificationCandidate = function ({
   complementaryCertification = null,
   billingMode = null,
   prepaymentCode = null,
-  subscriptions = [buildCoreSubscription()],
+  subscriptions,
 } = {}) {
   if (complementaryCertification === undefined) {
     complementaryCertification = buildComplementaryCertification();
@@ -76,7 +75,7 @@ buildCertificationCandidate.pro = function ({
   sessionId = 456,
   complementaryCertification = null,
   billingMode = 'FREE',
-  subscriptions = [buildCoreSubscription()],
+  subscriptions = null,
 }) {
   return new CertificationCandidate({
     firstName,
@@ -117,7 +116,7 @@ buildCertificationCandidate.notPersisted = function ({
   authorizedToStart = false,
   sessionId = 456,
   complementaryCertification = null,
-  subscriptions = [buildCoreSubscription()],
+  subscriptions = null,
 }) {
   return new CertificationCandidate({
     firstName,

--- a/api/tests/tooling/domain-builder/factory/build-certification-candidate.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-candidate.js
@@ -1,5 +1,6 @@
 import { CertificationCandidate } from '../../../../lib/domain/models/CertificationCandidate.js';
 import { buildComplementaryCertification } from './build-complementary-certification.js';
+import { buildCoreSubscription } from './certification/enrolment/build-subscription.js';
 
 const buildCertificationCandidate = function ({
   id = 123,
@@ -21,10 +22,15 @@ const buildCertificationCandidate = function ({
   sessionId = 456,
   userId = 789,
   organizationLearnerId,
-  complementaryCertification = buildComplementaryCertification(),
+  complementaryCertification = null,
   billingMode = null,
   prepaymentCode = null,
+  subscriptions = [buildCoreSubscription()],
 } = {}) {
+  if (complementaryCertification === undefined) {
+    complementaryCertification = buildComplementaryCertification();
+  }
+
   return new CertificationCandidate({
     id,
     firstName,
@@ -48,6 +54,7 @@ const buildCertificationCandidate = function ({
     complementaryCertification,
     billingMode,
     prepaymentCode,
+    subscriptions,
   });
 };
 
@@ -69,6 +76,7 @@ buildCertificationCandidate.pro = function ({
   sessionId = 456,
   complementaryCertification = null,
   billingMode = 'FREE',
+  subscriptions = [buildCoreSubscription()],
 }) {
   return new CertificationCandidate({
     firstName,
@@ -88,6 +96,7 @@ buildCertificationCandidate.pro = function ({
     authorizedToStart,
     complementaryCertification,
     billingMode,
+    subscriptions,
   });
 };
 
@@ -108,6 +117,7 @@ buildCertificationCandidate.notPersisted = function ({
   authorizedToStart = false,
   sessionId = 456,
   complementaryCertification = null,
+  subscriptions = [buildCoreSubscription()],
 }) {
   return new CertificationCandidate({
     firstName,
@@ -126,6 +136,7 @@ buildCertificationCandidate.notPersisted = function ({
     extraTimePercentage,
     authorizedToStart,
     complementaryCertification,
+    subscriptions,
   });
 };
 

--- a/api/tests/tooling/domain-builder/factory/build-certification-candidate.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-candidate.js
@@ -1,5 +1,5 @@
 import { CertificationCandidate } from '../../../../lib/domain/models/CertificationCandidate.js';
-import { buildComplementaryCertification } from './build-complementary-certification.js';
+import { domainBuilder } from '../domain-builder.js';
 
 const buildCertificationCandidate = function ({
   id = 123,
@@ -17,19 +17,15 @@ const buildCertificationCandidate = function ({
   extraTimePercentage = 0.3,
   externalId = 'externalId',
   createdAt = new Date('2020-01-01'),
-  authorizedToStart = false,
+  authorizedToStart,
   sessionId = 456,
   userId = 789,
   organizationLearnerId,
   complementaryCertification = null,
   billingMode = null,
   prepaymentCode = null,
-  subscriptions,
+  subscriptions = [domainBuilder.buildCoreSubscription()],
 } = {}) {
-  if (complementaryCertification === undefined) {
-    complementaryCertification = buildComplementaryCertification();
-  }
-
   return new CertificationCandidate({
     id,
     firstName,
@@ -71,7 +67,7 @@ buildCertificationCandidate.pro = function ({
   birthdate = '1990-05-06',
   extraTimePercentage = 0.3,
   externalId = 'externalId',
-  authorizedToStart = false,
+  authorizedToStart,
   sessionId = 456,
   complementaryCertification = null,
   billingMode = 'FREE',
@@ -113,7 +109,7 @@ buildCertificationCandidate.notPersisted = function ({
   birthdate = '1990-05-06',
   extraTimePercentage = 0.3,
   externalId = 'externalId',
-  authorizedToStart = false,
+  authorizedToStart,
   sessionId = 456,
   complementaryCertification = null,
   subscriptions = null,

--- a/api/tests/tooling/domain-builder/factory/certification/enrolment/build-subscription.js
+++ b/api/tests/tooling/domain-builder/factory/certification/enrolment/build-subscription.js
@@ -1,0 +1,16 @@
+import { Subscription } from '../../../../../../src/certification/enrolment/domain/models/Subscription.js';
+import { SubscriptionTypes } from '../../../../../../src/certification/shared/domain/models/SubscriptionTypes.js';
+
+const buildSubscription = function ({
+  id = 123,
+  type = SubscriptionTypes.CORE,
+  complementaryCertificationId = null,
+} = {}) {
+  return new Subscription({
+    id,
+    type,
+    complementaryCertificationId,
+  });
+};
+
+export { buildSubscription };

--- a/api/tests/tooling/domain-builder/factory/certification/enrolment/build-subscription.js
+++ b/api/tests/tooling/domain-builder/factory/certification/enrolment/build-subscription.js
@@ -1,16 +1,11 @@
 import { Subscription } from '../../../../../../src/certification/enrolment/domain/models/Subscription.js';
-import { SubscriptionTypes } from '../../../../../../src/certification/shared/domain/models/SubscriptionTypes.js';
 
-const buildSubscription = function ({
-  id = 123,
-  type = SubscriptionTypes.CORE,
-  complementaryCertificationId = null,
-} = {}) {
-  return new Subscription({
-    id,
-    type,
-    complementaryCertificationId,
-  });
+const buildCoreSubscription = function ({ certificationCandidateId } = {}) {
+  return Subscription.buildCore({ certificationCandidateId });
 };
 
-export { buildSubscription };
+const buildComplementarySubscription = function ({ certificationCandidateId, complementaryCertificationId = 1 } = {}) {
+  return Subscription.buildComplementary({ certificationCandidateId, complementaryCertificationId });
+};
+
+export { buildComplementarySubscription, buildCoreSubscription };

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -172,6 +172,7 @@ import { buildV3CertificationCourseDetailsForAdministration } from './build-v3-c
 import { buildValidation } from './build-validation.js';
 import { buildValidator } from './build-validator.js';
 import { buildSessionEnrolment } from './certification/enrolment/build-session.js';
+import { buildSubscription } from './certification/enrolment/build-subscription.js';
 import { buildFlashAssessmentAlgorithm } from './certification/flash-certification/build-flash-assessment-algorithm.js';
 import { buildAssessmentResult as buildCertificationScoringAssessmentResult } from './certification/scoring/build-assessment-result.js';
 import { buildCertificationAssessmentHistory } from './certification/scoring/build-certification-assessment-history.js';
@@ -365,6 +366,7 @@ export {
   buildStageAcquisition,
   buildStageCollectionForTargetProfileManagement,
   buildStageCollectionForUserCampaignResults,
+  buildSubscription,
   buildSupOrganizationLearner,
   buildTag,
   buildTargetProfile,

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -172,7 +172,7 @@ import { buildV3CertificationCourseDetailsForAdministration } from './build-v3-c
 import { buildValidation } from './build-validation.js';
 import { buildValidator } from './build-validator.js';
 import { buildSessionEnrolment } from './certification/enrolment/build-session.js';
-import { buildSubscription } from './certification/enrolment/build-subscription.js';
+import { buildComplementarySubscription, buildCoreSubscription } from './certification/enrolment/build-subscription.js';
 import { buildFlashAssessmentAlgorithm } from './certification/flash-certification/build-flash-assessment-algorithm.js';
 import { buildAssessmentResult as buildCertificationScoringAssessmentResult } from './certification/scoring/build-assessment-result.js';
 import { buildCertificationAssessmentHistory } from './certification/scoring/build-certification-assessment-history.js';
@@ -311,6 +311,8 @@ export {
   buildComplementaryCertificationScoringWithComplementaryReferential,
   buildComplementaryCertificationScoringWithoutComplementaryReferential,
   buildComplementaryCertificationTargetProfileHistory,
+  buildComplementarySubscription,
+  buildCoreSubscription,
   buildCountry,
   buildCourse,
   buildCpfCertificationResult,
@@ -366,7 +368,6 @@ export {
   buildStageAcquisition,
   buildStageCollectionForTargetProfileManagement,
   buildStageCollectionForUserCampaignResults,
-  buildSubscription,
   buildSupOrganizationLearner,
   buildTag,
   buildTargetProfile,

--- a/api/tests/unit/domain/models/CertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidate_test.js
@@ -45,7 +45,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
     expectedData = {
       ...rawData,
       id: undefined,
-      authorizedToStart: undefined,
+      authorizedToStart: false,
       billingMode: 'FREE',
       birthINSEECode: undefined,
       birthPostalCode: undefined,

--- a/api/tests/unit/domain/models/CertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidate_test.js
@@ -804,7 +804,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
 
     it('should return an error if firstName is not defined', function () {
       // given
-      const certificationCandidate = domainBuilder.buildCertificationCandidate();
+      const certificationCandidate = domainBuilder.buildCertificationCandidate({ ...rawData, firstName: null });
       certificationCandidate.firstName = undefined;
 
       // when
@@ -819,8 +819,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
 
     it('should return an error if firstName is not a string', function () {
       // given
-      const certificationCandidate = domainBuilder.buildCertificationCandidate({ firstName: 123 });
-
+      const certificationCandidate = domainBuilder.buildCertificationCandidate({ ...rawData, firstName: 123 });
       // when
       try {
         certificationCandidate.validateParticipation();
@@ -833,7 +832,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
 
     it('should return an error if lastName is not defined', function () {
       // given
-      const certificationCandidate = domainBuilder.buildCertificationCandidate();
+      const certificationCandidate = domainBuilder.buildCertificationCandidate({ ...rawData, lastName: null });
       certificationCandidate.lastName = undefined;
 
       // when
@@ -848,7 +847,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
 
     it('should return an error if lastName is not a string', function () {
       // given
-      const certificationCandidate = domainBuilder.buildCertificationCandidate({ lastName: 123 });
+      const certificationCandidate = domainBuilder.buildCertificationCandidate({ ...rawData, lastName: 123 });
 
       // when
       try {
@@ -862,7 +861,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
 
     it('should return an error if birthdate is not defined', function () {
       // given
-      const certificationCandidate = domainBuilder.buildCertificationCandidate();
+      const certificationCandidate = domainBuilder.buildCertificationCandidate({ ...rawData, birthdate: null });
       certificationCandidate.birthdate = undefined;
 
       // when
@@ -877,7 +876,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
 
     it('should return an error if birthdate is not a date in iso format', function () {
       // given
-      const certificationCandidate = domainBuilder.buildCertificationCandidate({ birthdate: '04/01/1990' });
+      const certificationCandidate = domainBuilder.buildCertificationCandidate({ ...rawData, birthdate: '04/01/1990' });
 
       // when
       try {
@@ -891,7 +890,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
 
     it('should return an error if birthdate not greater than 1900-01-01', function () {
       // given
-      const certificationCandidate = domainBuilder.buildCertificationCandidate({ birthdate: '1899-06-06' });
+      const certificationCandidate = domainBuilder.buildCertificationCandidate({ ...rawData, birthdate: '1899-06-06' });
 
       // when
       try {
@@ -905,7 +904,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
 
     it('should return an error if birthdate does not exist (such as 31th November)', function () {
       // given
-      const certificationCandidate = domainBuilder.buildCertificationCandidate({ birthdate: '1999-11-31' });
+      const certificationCandidate = domainBuilder.buildCertificationCandidate({ ...rawData, birthdate: '1999-11-31' });
 
       // when
       try {
@@ -919,7 +918,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
 
     it('should return an error if sessionId is not defined', function () {
       // given
-      const certificationCandidate = domainBuilder.buildCertificationCandidate();
+      const certificationCandidate = domainBuilder.buildCertificationCandidate({ ...rawData, sessionId: null });
       certificationCandidate.sessionId = undefined;
 
       // when
@@ -934,7 +933,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
 
     it('should return an error if sessionId is not a number', function () {
       // given
-      const certificationCandidate = domainBuilder.buildCertificationCandidate({ sessionId: 'a' });
+      const certificationCandidate = domainBuilder.buildCertificationCandidate({ ...rawData, sessionId: 'a' });
 
       // when
       try {
@@ -952,6 +951,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       it(`should not throw if billing mode is expected value ${billingMode}`, async function () {
         // given
         const certificationCandidate = domainBuilder.buildCertificationCandidate({
+          ...rawData,
           billingMode,
           prepaymentCode: billingMode === CertificationCandidate.BILLING_MODES.PREPAID ? '12345' : undefined,
         });
@@ -968,7 +968,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
 
     it('should throw an error when billing mode is none of the expected values', async function () {
       // given
-      const certificationCandidate = domainBuilder.buildCertificationCandidate({ billingMode: 'Cadeau !' });
+      const certificationCandidate = domainBuilder.buildCertificationCandidate({ ...rawData, billingMode: 'Cadeau !' });
 
       // when
       try {
@@ -982,7 +982,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
 
     it('should throw an error if billing mode is "Prépayée" but prepaymentCode is empty', async function () {
       // given
-      const certificationCandidate = domainBuilder.buildCertificationCandidate({ billingMode: 'PREPAID' });
+      const certificationCandidate = domainBuilder.buildCertificationCandidate({ ...rawData, billingMode: 'PREPAID' });
 
       // when
       try {
@@ -1003,7 +1003,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       const birthPostalCode = 'birthPostalCode';
       const birthCity = 'birthCity';
 
-      const certificationCandidate = domainBuilder.buildCertificationCandidate();
+      const certificationCandidate = domainBuilder.buildCertificationCandidate(rawData);
 
       // when
       certificationCandidate.updateBirthInformation({ birthCountry, birthINSEECode, birthPostalCode, birthCity });
@@ -1019,7 +1019,10 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
   describe('isAuthorizedToStart', function () {
     it('should return false when authorizedToStart is false', function () {
       // given
-      const certificationCandidate = domainBuilder.buildCertificationCandidate({ authorizedToStart: false });
+      const certificationCandidate = domainBuilder.buildCertificationCandidate({
+        ...rawData,
+        authorizedToStart: false,
+      });
 
       // then
       expect(certificationCandidate.isAuthorizedToStart()).to.be.false;
@@ -1027,7 +1030,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
 
     it('should return true when authorizedToStart is true', function () {
       // given
-      const certificationCandidate = domainBuilder.buildCertificationCandidate({ authorizedToStart: true });
+      const certificationCandidate = domainBuilder.buildCertificationCandidate({ ...rawData, authorizedToStart: true });
 
       // then
       expect(certificationCandidate.isAuthorizedToStart()).to.be.true;
@@ -1038,6 +1041,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
     it('should return false when billingMode is not prepaid', function () {
       // given
       const certificationCandidate = domainBuilder.buildCertificationCandidate({
+        ...rawData,
         billingMode: CertificationCandidate.BILLING_MODES.FREE,
       });
 
@@ -1048,6 +1052,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
     it('should return true when billingMode is prepaid', function () {
       // given
       const certificationCandidate = domainBuilder.buildCertificationCandidate({
+        ...rawData,
         billingMode: CertificationCandidate.BILLING_MODES.PREPAID,
       });
 
@@ -1092,6 +1097,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
     it('should return true when certification candidate has acquired complementary certification', function () {
       // given
       const certificationCandidate = domainBuilder.buildCertificationCandidate({
+        ...rawData,
         complementaryCertification: domainBuilder.buildComplementaryCertification({ key: 'PIX+' }),
       });
 
@@ -1102,6 +1108,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
     it('should return false when certification candidate has not acquired complementary certification', function () {
       // given
       const certificationCandidate = domainBuilder.buildCertificationCandidate({
+        ...rawData,
         complementaryCertification: domainBuilder.buildComplementaryCertification({ key: 'toto' }),
       });
 
@@ -1114,6 +1121,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
     it('should convert extraTimePercentageToDecimal integer to decimal', function () {
       // given
       const certificationCandidate = domainBuilder.buildCertificationCandidate({
+        ...rawData,
         extraTimePercentage: 20,
       });
 

--- a/api/tests/unit/domain/models/CertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidate_test.js
@@ -1170,7 +1170,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       });
     });
 
-    describe('when there is a already subscription', function () {
+    describe('when there already is a subscription', function () {
       describe('when the subscription is CORE', function () {
         describe('when adding a CORE subscription', function () {
           it('should replace the CORE', function () {
@@ -1221,7 +1221,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
             // when
             certificationCandidate.addSubscription(coreSubscription);
 
-            // when / then
+            // then
             expect(certificationCandidate.subscriptions).to.deep.equal([
               Subscription.buildComplementary({
                 certificationCandidateId: certificationCandidate.id,

--- a/api/tests/unit/domain/services/session-publication-service_test.js
+++ b/api/tests/unit/domain/services/session-publication-service_test.js
@@ -33,15 +33,19 @@ describe('Unit | UseCase | session-publication-service', function () {
   beforeEach(function () {
     candidateWithRecipient1 = domainBuilder.buildCertificationCandidate({
       resultRecipientEmail: recipient1,
+      subscriptions: [domainBuilder.buildCoreSubscription()],
     });
     candidateWithRecipient2 = domainBuilder.buildCertificationCandidate({
       resultRecipientEmail: recipient2,
+      subscriptions: [domainBuilder.buildCoreSubscription()],
     });
     candidate2WithRecipient2 = domainBuilder.buildCertificationCandidate({
       resultRecipientEmail: recipient2,
+      subscriptions: [domainBuilder.buildCoreSubscription()],
     });
     candidateWithNoRecipient = domainBuilder.buildCertificationCandidate({
       resultRecipientEmail: null,
+      subscriptions: [domainBuilder.buildCoreSubscription()],
     });
     originalSession = domainBuilder.certification.sessionManagement.buildSession({
       id: sessionId,
@@ -385,6 +389,7 @@ describe('Unit | UseCase | session-publication-service', function () {
       it('should leave resultSentToPrescriberAt untouched', async function () {
         // given
         const candidateWithNoRecipient = domainBuilder.buildCertificationCandidate({
+          subscriptions: [domainBuilder.buildCoreSubscription()],
           resultRecipientEmail: null,
         });
         const sessionWithoutResultsRecipient = domainBuilder.certification.sessionManagement.buildSession({

--- a/api/tests/unit/domain/usecases/find-students-for-enrolment_test.js
+++ b/api/tests/unit/domain/usecases/find-students-for-enrolment_test.js
@@ -62,7 +62,11 @@ describe('Unit | UseCase | find-students-for-enrolment', function () {
         domainBuilder.buildOrganizationLearner({ id: iteration, organization }),
       );
       const certificationCandidates = [
-        domainBuilder.buildCertificationCandidate({ sessionId, organizationLearnerId: enrolledStudent.id }),
+        domainBuilder.buildCertificationCandidate({
+          sessionId,
+          organizationLearnerId: enrolledStudent.id,
+          subscriptions: [domainBuilder.buildCoreSubscription()],
+        }),
       ];
       organizationLearnerRepository.findByOrganizationIdAndUpdatedAtOrderByDivision
         .withArgs({ page: { number: 1, size: 10 }, filter: { divisions: ['3A'] }, organizationId: organization.id })

--- a/api/tests/unit/domain/usecases/get-candidate-import-sheet-data_test.js
+++ b/api/tests/unit/domain/usecases/get-candidate-import-sheet-data_test.js
@@ -24,8 +24,8 @@ describe('Unit | UseCase | get-candidate-import-sheet-data', function () {
       .resolves(true);
     const session = domainBuilder.certification.enrolment.buildSession({
       certificationCandidates: [
-        domainBuilder.buildCertificationCandidate(),
-        domainBuilder.buildCertificationCandidate(),
+        domainBuilder.buildCertificationCandidate({ subscriptions: [domainBuilder.buildCoreSubscription()] }),
+        domainBuilder.buildCertificationCandidate({ subscriptions: [domainBuilder.buildCoreSubscription()] }),
       ],
     });
     sessionRepository.getWithCertificationCandidates.withArgs({ id: sessionId }).resolves(session);

--- a/api/tests/unit/domain/usecases/get-certification-candidate-subscription_test.js
+++ b/api/tests/unit/domain/usecases/get-certification-candidate-subscription_test.js
@@ -5,6 +5,10 @@ describe('Unit | UseCase | get-certification-candidate-subscription', function (
   let certificationBadgesService;
   let certificationCandidateRepository;
   let certificationCenterRepository;
+  let certificationCandidateData;
+  const certificationCandidateId = 123;
+  const userId = 456;
+  const sessionId = 789;
   let sessionRepository;
 
   beforeEach(function () {
@@ -19,6 +23,13 @@ describe('Unit | UseCase | get-certification-candidate-subscription', function (
       getBySessionId: sinon.stub(),
     };
 
+    certificationCandidateData = {
+      id: certificationCandidateId,
+      userId,
+      sessionId,
+      subscriptions: [domainBuilder.buildCoreSubscription()],
+    };
+
     sessionRepository = {
       getVersion: sinon.stub(),
     };
@@ -28,9 +39,6 @@ describe('Unit | UseCase | get-certification-candidate-subscription', function (
     context('when the candidate is registered and eligible to one complementary certification', function () {
       it('should return the candidate without eligible complementary certification', async function () {
         // given
-        const certificationCandidateId = 123;
-        const userId = 456;
-        const sessionId = 789;
 
         const complementaryCertification = domainBuilder.buildComplementaryCertification({ key: 'PIX+' });
 
@@ -43,9 +51,7 @@ describe('Unit | UseCase | get-certification-candidate-subscription', function (
         });
 
         const candidateWithComplementaryCertification = domainBuilder.buildCertificationCandidate({
-          id: certificationCandidateId,
-          userId,
-          sessionId,
+          ...certificationCandidateData,
           complementaryCertification,
         });
 
@@ -111,9 +117,7 @@ describe('Unit | UseCase | get-certification-candidate-subscription', function (
         });
 
         const candidateWithoutComplementaryCertification = domainBuilder.buildCertificationCandidate({
-          id: certificationCandidateId,
-          userId,
-          sessionId,
+          ...certificationCandidateData,
           complementaryCertification: null,
         });
         certificationCandidateRepository.getWithComplementaryCertification

--- a/api/tests/unit/domain/usecases/get-session-results-by-result-recipient-email_test.js
+++ b/api/tests/unit/domain/usecases/get-session-results-by-result-recipient-email_test.js
@@ -37,10 +37,12 @@ describe('Unit | Domain | Use Cases | get-session-results-by-result-recipient-em
     const certificationCandidate1 = domainBuilder.buildCertificationCandidate({
       id: 456,
       resultRecipientEmail: 'notMatching@example.net',
+      subscriptions: [domainBuilder.buildCoreSubscription()],
     });
     const certificationCandidate2 = domainBuilder.buildCertificationCandidate({
       id: 789,
       resultRecipientEmail: 'matching@example.net',
+      subscriptions: [domainBuilder.buildCoreSubscription()],
     });
     const expectedSession = domainBuilder.certification.sessionManagement.buildSession({
       certificationCandidates: [certificationCandidate1, certificationCandidate2],

--- a/api/tests/unit/domain/usecases/import-certification-candidates-from-candidates-import-sheet_test.js
+++ b/api/tests/unit/domain/usecases/import-certification-candidates-from-candidates-import-sheet_test.js
@@ -79,6 +79,7 @@ describe('Unit | UseCase | import-certification-candidates-from-attendance-sheet
           const odsBuffer = 'buffer';
           const complementaryCertification = domainBuilder.buildComplementaryCertification();
           const certificationCandidate = domainBuilder.buildCertificationCandidate({
+            subscriptions: [domainBuilder.buildCoreSubscription()],
             complementaryCertification,
           });
           const certificationCandidates = [certificationCandidate];

--- a/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
+++ b/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
@@ -12,6 +12,7 @@ import { LanguageNotSupportedError } from '../../../../src/shared/domain/errors.
 import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';
 
 describe('Unit | Domain | Use Cases | link-user-to-session-certification-candidate', function () {
+  let certificationCandidateData;
   const sessionId = 42;
   const userId = 'userId';
   const firstName = 'Charlie';
@@ -26,6 +27,14 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
       sessionEnrolmentRepository.get
         .withArgs({ id: 42 })
         .resolves(domainBuilder.certification.enrolment.buildSession.created());
+
+      certificationCandidateData = {
+        userId,
+        firstName,
+        lastName,
+        birthdate,
+        subscriptions: [domainBuilder.buildCoreSubscription()],
+      };
     });
 
     context('when there is a problem with the personal info', function () {
@@ -100,7 +109,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
           context('when the linked user is the same as the user being linked', function () {
             it('should not create a link and return the matching certification candidate', async function () {
               // given
-              const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId });
+              const certificationCandidate = domainBuilder.buildCertificationCandidate(certificationCandidateData);
               const certificationCandidateRepository =
                 _buildFakeCertificationCandidateRepository().withFindBySessionIdAndPersonalInfo({
                   args: {
@@ -138,7 +147,10 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
           context('when the linked user is not the same as the user being linked', function () {
             it('should throw a CertificationCandidateAlreadyLinkedToUserError', async function () {
               // given
-              const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId: 'otherUserId' });
+              const certificationCandidate = domainBuilder.buildCertificationCandidate({
+                ...certificationCandidateData,
+                userId: 'otherUserId',
+              });
               const certificationCandidateRepository =
                 _buildFakeCertificationCandidateRepository().withFindBySessionIdAndPersonalInfo({
                   args: {
@@ -178,7 +190,10 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
           context('when the user is already linked to another candidate in the session', function () {
             it('should throw a UserAlreadyLinkedToCandidateInSessionError', async function () {
               // given
-              const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId: null });
+              const certificationCandidate = domainBuilder.buildCertificationCandidate({
+                ...certificationCandidateData,
+                userId: null,
+              });
               const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
                 .withFindBySessionIdAndPersonalInfo({
                   args: {
@@ -221,6 +236,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
             it('should create a link between the candidate and the user and return the linked certification candidate', async function () {
               // given
               const certificationCandidate = domainBuilder.buildCertificationCandidate({
+                ...certificationCandidateData,
                 userId: null,
                 id: 'candidateId',
               });
@@ -273,10 +289,8 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
           it('throws MatchingReconciledStudentNotFoundError', async function () {
             // given
             const certificationCandidate = domainBuilder.buildCertificationCandidate({
+              ...certificationCandidateData,
               userId: null,
-              firstName,
-              lastName,
-              birthdate,
             });
             const certificationCandidateRepository =
               _buildFakeCertificationCandidateRepository().withFindBySessionIdAndPersonalInfo({
@@ -339,10 +353,8 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
               // given
               const organizationLearner = domainBuilder.buildOrganizationLearner();
               const certificationCandidate = domainBuilder.buildCertificationCandidate({
+                ...certificationCandidateData,
                 userId: null,
-                firstName,
-                lastName,
-                birthdate,
                 organizationLearnerId: organizationLearner.id,
               });
               const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
@@ -419,10 +431,8 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
               // given
               const organizationLearner = domainBuilder.buildOrganizationLearner();
               const certificationCandidate = domainBuilder.buildCertificationCandidate({
+                ...certificationCandidateData,
                 userId: null,
-                firstName,
-                lastName,
-                birthdate,
                 organizationLearnerId: organizationLearner.id,
               });
               const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
@@ -440,7 +450,10 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
                     sessionId,
                     userId,
                   },
-                  resolves: domainBuilder.buildCertificationCandidate({ id: 'another candidate' }),
+                  resolves: domainBuilder.buildCertificationCandidate({
+                    id: 'another candidate',
+                    ...certificationCandidateData,
+                  }),
                 });
 
               const certificationCenter = domainBuilder.buildCertificationCenter({
@@ -496,6 +509,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
         it('should return the linked certification candidate', async function () {
           // given
           const certificationCandidate = domainBuilder.buildCertificationCandidate({
+            ...certificationCandidateData,
             userId: null,
             id: 'candidateId',
           });

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -147,6 +147,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
               userId: 2,
               sessionId: 1,
               authorizedToStart: false,
+              subscriptions: [domainBuilder.buildCoreSubscription()],
             });
             certificationCandidateRepository.getBySessionIdAndUserId
               .withArgs({ sessionId: 1, userId: 2 })
@@ -181,6 +182,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
               userId: 2,
               sessionId: 1,
               authorizedToStart: false,
+              subscriptions: [domainBuilder.buildCoreSubscription()],
             });
             certificationCandidateRepository.getBySessionIdAndUserId
               .withArgs({ sessionId: 1, userId: 2 })
@@ -225,6 +227,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
               userId: foundCertificationCandidateId,
               sessionId: 1,
               authorizedToStart: true,
+              subscriptions: [domainBuilder.buildCoreSubscription()],
             });
 
             certificationCandidateRepository.getBySessionIdAndUserId
@@ -260,6 +263,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
               userId: 2,
               sessionId: 1,
               authorizedToStart: true,
+              subscriptions: [domainBuilder.buildCoreSubscription()],
             });
             certificationCandidateRepository.getBySessionIdAndUserId
               .withArgs({ sessionId: 1, userId: 2 })
@@ -311,6 +315,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                   userId: 2,
                   sessionId: 1,
                   authorizedToStart: true,
+                  subscriptions: [domainBuilder.buildCoreSubscription()],
                 }),
               );
 
@@ -361,6 +366,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                     userId: 2,
                     sessionId: 1,
                     authorizedToStart: true,
+                    subscriptions: [domainBuilder.buildCoreSubscription()],
                   }),
                 );
 
@@ -423,6 +429,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                   userId: 2,
                   sessionId: 1,
                   authorizedToStart: true,
+                  subscriptions: [domainBuilder.buildCoreSubscription()],
                 });
                 certificationCandidateRepository.getBySessionIdAndUserId
                   .withArgs({ sessionId: 1, userId: 2 })
@@ -516,6 +523,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       userId,
                       sessionId: 1,
                       authorizedToStart: true,
+                      subscriptions: [domainBuilder.buildCoreSubscription()],
                     });
                     certificationCandidateRepository.getBySessionIdAndUserId
                       .withArgs({ sessionId: 1, userId })
@@ -569,6 +577,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       userId,
                       sessionId: 1,
                       authorizedToStart: true,
+                      subscriptions: [domainBuilder.buildCoreSubscription()],
                     });
                     certificationCandidateRepository.getBySessionIdAndUserId
                       .withArgs({ sessionId: 1, userId })
@@ -686,6 +695,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         userId: 2,
                         sessionId: 1,
                         authorizedToStart: true,
+                        subscriptions: [domainBuilder.buildCoreSubscription()],
                         complementaryCertification,
                       });
 
@@ -811,6 +821,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         userId: 2,
                         sessionId: 1,
                         authorizedToStart: true,
+                        subscriptions: [domainBuilder.buildCoreSubscription()],
                         complementaryCertification,
                       });
 
@@ -928,6 +939,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                           userId: 2,
                           sessionId: 1,
                           authorizedToStart: true,
+                          subscriptions: [domainBuilder.buildCoreSubscription()],
                           complementaryCertification,
                         });
 
@@ -1033,6 +1045,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                           userId: 2,
                           sessionId: 1,
                           authorizedToStart: true,
+                          subscriptions: [domainBuilder.buildCoreSubscription()],
                           complementaryCertification,
                         });
 
@@ -1154,6 +1167,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                         userId: 2,
                         authorizedToStart: true,
                         sessionId: 1,
+                        subscriptions: [domainBuilder.buildCoreSubscription()],
                         complementaryCertification: null,
                       });
 
@@ -1254,6 +1268,7 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', functi
                       userId: 2,
                       sessionId: 1,
                       authorizedToStart: true,
+                      subscriptions: [domainBuilder.buildCoreSubscription()],
                       complementaryCertification,
                     });
 


### PR DESCRIPTION
## :unicorn: Problème
Les utilisateurs Pix Certif des centres de certification (CDC) pilotes vont avoir a gérer des candidats qui seront à inscrire à Pix coeur et Pix+ mais aussi à d’autres candidats (déjà détenteurs d’une certification Pix coeur suffisante) qui ne seront à inscrire qu'à la certification complémentaire Pix+ seule.

L’inscription “pilote” d’un candidat doit pouvoir permettre d’inscrire ou pas un candidat à une Pix Coeur

La notion de “core optionnelle” n’a jamais existé (avant c'était implicite et en + obligatoire d'avoir une coeur), car la notion même de Pix coeur était implicite jusqu’ici dans le code. Il faut donc : rendre explicite une règle implicite, pour introduire la possibilité qu’elle devienne optionnelle.

## :robot: Proposition
Alimenter certification-subscriptions avec des lignes CORE de manière “paramétrable” à l'inscription d'un candidat pilote

⚠️  ne pas faire confiance au front, il conviendra au système de vérifier que le centre a l’autorisation d’inscrire un candidat à une complémentaire seule si et seulement si le CDC est pilote

## :rainbow: Remarques


## :100: Pour tester

### Pix Certif

**Il faut bien tester tous les cas d'inscriptions de candidats, et bien vérifier ce qui a été mis en base de donnée**

- Non reg : vérifier l’inscription d’un candidat pour tous les cas (V2 sco/non-sco, V3)
  - via modale avec et sans complémentaire
  - via import CSV avec et sans complémentaire
  - via import ODS avec et sans complémentaire

### Consommateur externe
- Non reg : vérifier que si on appelle l'API **directement sans passer par le front** que l'API fonctionne même si on ne peut pas de `subscriptions` en entrée
  
