### PR TITLE
[BUGFIX] Mettre à jour la colonne `updatedAt` de la table `assessments` lors de la mise à jour d'un assessment (PIX-11293).

### DIFF
--- a/api/src/shared/infrastructure/repositories/assessment-repository.js
+++ b/api/src/shared/infrastructure/repositories/assessment-repository.js
@@ -108,19 +108,25 @@ const ownedByUser = async function ({ id, userId = null }) {
 
 const _updateStateById = async function ({ id, state }, knexTransaction) {
   const knexConn = knexTransaction || knex;
-  const [assessment] = await knexConn('assessments').where({ id }).update({ state }).returning('*');
+  const [assessment] = await knexConn('assessments')
+    .where({ id })
+    .update({ state, updatedAt: new Date() })
+    .returning('*');
   return new Assessment(assessment);
 };
 
 const updateLastQuestionDate = async function ({ id, lastQuestionDate }) {
-  const [assessmentUpdated] = await knex('assessments').where({ id }).update({ lastQuestionDate }).returning('*');
+  const [assessmentUpdated] = await knex('assessments')
+    .where({ id })
+    .update({ lastQuestionDate, updatedAt: new Date() })
+    .returning('*');
   if (!assessmentUpdated) return null;
 };
 
 const updateWhenNewChallengeIsAsked = async function ({ id, lastChallengeId }) {
   const [assessmentUpdated] = await knex('assessments')
     .where({ id })
-    .update({ lastChallengeId, lastQuestionState: Assessment.statesOfLastQuestion.ASKED })
+    .update({ lastChallengeId, lastQuestionState: Assessment.statesOfLastQuestion.ASKED, updatedAt: new Date() })
     .returning('*');
   if (!assessmentUpdated) return null;
   return new Assessment(assessmentUpdated);
@@ -128,7 +134,10 @@ const updateWhenNewChallengeIsAsked = async function ({ id, lastChallengeId }) {
 
 const updateLastQuestionState = async function ({ id, lastQuestionState, domainTransaction }) {
   const knexConn = domainTransaction.knexTransaction || knex;
-  const [assessmentUpdated] = await knexConn('assessments').where({ id }).update({ lastQuestionState }).returning('*');
+  const [assessmentUpdated] = await knexConn('assessments')
+    .where({ id })
+    .update({ lastQuestionState, updatedAt: new Date() })
+    .returning('*');
   if (!assessmentUpdated) return null;
 };
 
@@ -137,7 +146,9 @@ const setAssessmentsAsStarted = async function ({
   domainTransaction = DomainTransaction.emptyTransaction(),
 }) {
   const knexConn = domainTransaction.knexTransaction || knex;
-  await knexConn('assessments').whereIn('id', assessmentIds).update({ state: Assessment.states.STARTED });
+  await knexConn('assessments')
+    .whereIn('id', assessmentIds)
+    .update({ state: Assessment.states.STARTED, updatedAt: new Date() });
 };
 
 export {


### PR DESCRIPTION
## :unicorn: Problème
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Lors de la migration de code de `assessment-repository` pour ne plus utiliser Bookshelf, nous avons oublié que Bookshelf gérait automatiquement la mise à jour de la colonne `updatedAt` lors de toute opération de mise à jour.
Depuis nous n'avons donc plus de mise à jour de cette colonne et toutes les lignes de la table `assessments` ont une date de mise à jour égale à leur date de création.
Cela pose soucis lors de l'analyse de cette table (pour établir des temps entre deux états par exemple).

## :robot: Proposition
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
On ajoute des tests d'intégration permettant de mettre en lumière ces colonnes non mises à jour.
On ajoute ensuite la mise à jour de la colonne `updatedAt` dans toutes les opérations de mise à jour de l'assessment, dans le fichier `assessment-repository`.

## :rainbow: Remarques
RAS

## :100: Pour tester

Passer une évaluation de compétence (en parcours autonome ou prescrit).
Constater en base de données que les derniers assessments ont une date de mise à jour (colonne `updatedAt`) différente de leur date de création (colonne `createdAt`).
