### PR TITLE
[FEATURE] Ne pas afficher le bouton pour copier le code de campagne pour les organisations rattachées au GAR (PIX-5974)

### DIFF
--- a/orga/app/components/campaign/empty-state.hbs
+++ b/orga/app/components/campaign/empty-state.hbs
@@ -2,12 +2,16 @@
   <img src="{{this.rootURL}}/images/empty-state.svg" alt="" role="none" />
 
   <div class="empty-state__text">
-    <p>{{t "pages.campaign.empty-state-with-copy-link"}}</p>
+    {{#if this.campaignCode}}
+      <p>{{t "pages.campaign.empty-state-with-copy-link"}}</p>
 
-    <CopyPasteButton
-      @clipBoardtext={{this.campaignUrl}}
-      @successMessage={{t "pages.campaign.copy.link.success"}}
-      @defaultMessage={{t "pages.campaign.copy.link.default"}}
-    />
+      <CopyPasteButton
+        @clipBoardtext={{this.campaignUrl}}
+        @successMessage={{t "pages.campaign.copy.link.success"}}
+        @defaultMessage={{t "pages.campaign.copy.link.default"}}
+      />
+    {{else}}
+      <p>{{t "pages.campaign.empty-state"}}</p>
+    {{/if}}
   </div>
 </section>

--- a/orga/app/components/campaign/empty-state.hbs
+++ b/orga/app/components/campaign/empty-state.hbs
@@ -2,7 +2,7 @@
   <img src="{{this.rootURL}}/images/empty-state.svg" alt="" role="none" />
 
   <div class="empty-state__text">
-    <p>{{t "pages.campaign.empty-state"}}</p>
+    <p>{{t "pages.campaign.empty-state-with-copy-link"}}</p>
 
     <CopyPasteButton
       @clipBoardtext={{this.campaignUrl}}

--- a/orga/app/components/campaign/empty-state.js
+++ b/orga/app/components/campaign/empty-state.js
@@ -4,7 +4,11 @@ import Component from '@glimmer/component';
 export default class EmptyState extends Component {
   @service url;
 
+  get campaignCode() {
+    return this.args.campaignCode;
+  }
+
   get campaignUrl() {
-    return `${this.url.campaignsRootUrl}${this.args.campaignCode}`;
+    return `${this.url.campaignsRootUrl}${this.campaignCode}`;
   }
 }

--- a/orga/app/controllers/authenticated/campaigns/campaign/activity.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/activity.js
@@ -4,9 +4,10 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class ActivityController extends Controller {
-  @service router;
-  @service notifications;
+  @service currentUser;
   @service intl;
+  @service notifications;
+  @service router;
 
   @tracked pageNumber = 1;
   @tracked pageSize = 50;
@@ -16,6 +17,10 @@ export default class ActivityController extends Controller {
   @tracked campaign;
   @tracked participations;
   @tracked search = null;
+
+  get isGARAuthenticationMethod() {
+    return this.currentUser.isGARAuthenticationMethod;
+  }
 
   @action
   goToParticipantPage(campaignId, participationId) {

--- a/orga/app/controllers/authenticated/campaigns/campaign/assessment-results.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/assessment-results.js
@@ -4,6 +4,7 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class AssessmentResultsController extends Controller {
+  @service currentUser;
   @service router;
 
   @tracked pageNumber = 1;
@@ -13,6 +14,10 @@ export default class AssessmentResultsController extends Controller {
   @tracked badges = [];
   @tracked stages = [];
   @tracked search = null;
+
+  get isGARAuthenticationMethod() {
+    return this.currentUser.isGARAuthenticationMethod;
+  }
 
   @action
   goToAssessmentPage(campaignId, participantId, event) {

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -4,6 +4,7 @@ import { tracked } from '@glimmer/tracking';
 export default class CurrentUserService extends Service {
   @service session;
   @service store;
+
   @tracked prescriber;
   @tracked memberships;
   @tracked organization;
@@ -11,6 +12,7 @@ export default class CurrentUserService extends Service {
   @tracked isSCOManagingStudents;
   @tracked isSUPManagingStudents;
   @tracked isAgriculture;
+  @tracked isGARAuthenticationMethod;
 
   async load() {
     if (this.session.isAuthenticated) {
@@ -44,18 +46,15 @@ export default class CurrentUserService extends Service {
 
   async _setOrganizationProperties(membership) {
     const organization = await membership.organization;
-
     const isAdminInOrganization = membership.isAdmin;
-
     const isSCOManagingStudents = organization.isSco && organization.isManagingStudents;
     const isSUPManagingStudents = organization.isSup && organization.isManagingStudents;
 
     this.isAdminInOrganization = isAdminInOrganization;
     this.isSCOManagingStudents = isSCOManagingStudents;
     this.isSUPManagingStudents = isSUPManagingStudents;
-
+    this.isGARAuthenticationMethod = organization.identityProviderForCampaigns === 'GAR';
     this.isAgriculture = organization.isAgriculture;
-
     this.organization = organization;
   }
 
@@ -76,15 +75,19 @@ export default class CurrentUserService extends Service {
   get canAccessPlacesPage() {
     return this.isAdminInOrganization && this.prescriber.placesManagement;
   }
+
   get canAccessMissionsPage() {
     return this.prescriber.missionsManagement;
   }
+
   get canAccessCampaignsPage() {
     return !this.prescriber.missionsManagement;
   }
+
   get canAccessParticipantsPage() {
     return !this.prescriber.missionsManagement;
   }
+
   get hasLearnerImportFeature() {
     return this.prescriber.hasOrganizationLearnerImport;
   }

--- a/orga/app/templates/authenticated/campaigns/campaign/activity.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/activity.hbs
@@ -26,5 +26,9 @@
     class="activity__participants-list"
   />
 {{else}}
-  <Campaign::EmptyState @campaignCode={{@model.campaign.code}} />
+  {{#if this.isGARAuthenticationMethod}}
+    <Campaign::EmptyState />
+  {{else}}
+    <Campaign::EmptyState @campaignCode={{@model.campaign.code}} />
+  {{/if}}
 {{/if}}

--- a/orga/app/templates/authenticated/campaigns/campaign/assessment-results.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/assessment-results.hbs
@@ -27,5 +27,9 @@
     class="assessment-results__list"
   />
 {{else}}
-  <Campaign::EmptyState @campaignCode={{@model.campaign.code}} />
+  {{#if this.isGARAuthenticationMethod}}
+    <Campaign::EmptyState />
+  {{else}}
+    <Campaign::EmptyState @campaignCode={{@model.campaign.code}} />
+  {{/if}}
 {{/if}}

--- a/orga/tests/acceptance/campaign-activity_test.js
+++ b/orga/tests/acceptance/campaign-activity_test.js
@@ -6,7 +6,11 @@ import { module, test } from 'qunit';
 
 import authenticateSession from '../helpers/authenticate-session';
 import setupIntl from '../helpers/setup-intl';
-import { createPrescriberByUser, createUserWithMembershipAndTermsOfServiceAccepted } from '../helpers/test-init';
+import {
+  createPrescriberByUser,
+  createPrescriberForOrganization,
+  createUserWithMembershipAndTermsOfServiceAccepted,
+} from '../helpers/test-init';
 
 module('Acceptance | Campaign Activity', function (hooks) {
   setupApplicationTest(hooks);
@@ -152,6 +156,42 @@ module('Acceptance | Campaign Activity', function (hooks) {
 
       // then
       assert.strictEqual(currentURL(), '/campagnes/1?search=Choupette');
+    });
+  });
+
+  module('when organization uses "GAR" as identity provider for campaigns', function () {
+    module('when there is no activity', function () {
+      test('displays an empty state message without copy button', async function (assert) {
+        // given
+        const userAttributes = {
+          id: 777,
+          firstName: 'Luc',
+          lastName: 'Harne',
+          email: 'luc@har.ne',
+          lang: 'fr',
+        };
+        const organizationAttributes = {
+          id: 777,
+          name: 'Cali Ber',
+          externalId: 'EXT_CALIBER',
+          identityProviderForCampaigns: 'GAR',
+        };
+        const organizationRole = 'ADMIN';
+        const user = createPrescriberForOrganization(userAttributes, organizationAttributes, organizationRole);
+
+        server.create('campaign', 'ofTypeAssessment', { id: 7654, participationsCount: 0, ownerId: user.id });
+
+        await authenticateSession(user.id);
+
+        // when
+        const screen = await visit('/campagnes/7654');
+
+        // then
+        assert.dom(screen.getByText(this.intl.t('pages.campaign.empty-state'))).exists();
+        assert
+          .dom(screen.queryByRole('button', { name: this.intl.t('pages.campaign.copy.link.default') }))
+          .doesNotExist();
+      });
     });
   });
 });

--- a/orga/tests/integration/components/campaign/empty-state_test.js
+++ b/orga/tests/integration/components/campaign/empty-state_test.js
@@ -10,6 +10,6 @@ module('Integration | Component | Campaign::EmptyState', function (hooks) {
   test('it displays the empty message', async function (assert) {
     const screen = await render(hbs`<Campaign::EmptyState @campaignCode='ABDC123' />`);
 
-    assert.dom(screen.getByText(this.intl.t('pages.campaign.empty-state'))).exists();
+    assert.dom(screen.getByText(this.intl.t('pages.campaign.empty-state-with-copy-link'))).exists();
   });
 });

--- a/orga/tests/integration/components/campaign/empty-state_test.js
+++ b/orga/tests/integration/components/campaign/empty-state_test.js
@@ -7,9 +7,12 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | Campaign::EmptyState', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it displays the empty message', async function (assert) {
-    const screen = await render(hbs`<Campaign::EmptyState @campaignCode='ABDC123' />`);
+  module('when a campaign code is provided', function () {
+    test('it displays the empty message with copy button', async function (assert) {
+      const screen = await render(hbs`<Campaign::EmptyState @campaignCode='ABDC123' />`);
 
-    assert.dom(screen.getByText(this.intl.t('pages.campaign.empty-state-with-copy-link'))).exists();
+      assert.dom(screen.getByText(this.intl.t('pages.campaign.empty-state-with-copy-link'))).exists();
+      assert.dom(screen.getByRole('button', { name: this.intl.t('pages.campaign.copy.link.default') })).exists();
+    });
   });
 });

--- a/orga/tests/integration/components/campaign/empty-state_test.js
+++ b/orga/tests/integration/components/campaign/empty-state_test.js
@@ -15,4 +15,17 @@ module('Integration | Component | Campaign::EmptyState', function (hooks) {
       assert.dom(screen.getByRole('button', { name: this.intl.t('pages.campaign.copy.link.default') })).exists();
     });
   });
+
+  module('when no campaign code is given', function () {
+    test('displays the empty message without copy button', async function (assert) {
+      // when
+      const screen = await render(hbs`<Campaign::EmptyState />`);
+
+      // then
+      assert.dom(screen.getByText(this.intl.t('pages.campaign.empty-state'))).exists();
+      assert
+        .dom(screen.queryByRole('button', { name: this.intl.t('pages.campaign.copy.link.default') }))
+        .doesNotExist();
+    });
+  });
 });

--- a/orga/tests/unit/services/current-user_test.js
+++ b/orga/tests/unit/services/current-user_test.js
@@ -251,6 +251,28 @@ module('Unit | Service | current-user', function (hooks) {
       });
     });
 
+    module('when organization has "GAR" as identity provider for campaigns', function () {
+      test('sets isGARAuthenticationMethod to true', async function (assert) {
+        // given
+        const organization = Object.create({
+          id: 9,
+          type: 'SUP',
+          isManagingStudents: false,
+          isSup: true,
+          identityProviderForCampaigns: 'GAR',
+        });
+        const membership = Object.create({ organization });
+        connectedUser.memberships = [membership];
+        connectedUser.userOrgaSettings = Object.create({ organization });
+
+        // when
+        await currentUserService.load();
+
+        // then
+        assert.true(currentUserService.isGARAuthenticationMethod);
+      });
+    });
+
     module('#canAccessPlacesPage', function () {
       test('should return true if user is admin and organization has feature activated', function (assert) {
         currentUserService.isAdminInOrganization = true;
@@ -413,6 +435,7 @@ module('Unit | Service | current-user', function (hooks) {
         });
       });
     });
+
     module('#hasLearnerImportFeature', function () {
       test('should return true if user has learnerImport feature activated', function (assert) {
         currentUserService.prescriber = {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -363,6 +363,7 @@
       },
       "created-by": "Owner",
       "created-on": "Created on",
+      "empty-state": "No participants yet!",
       "empty-state-with-copy-link": "No participants yet! Share with them the following link to join this campaign.",
       "multiple-sendings": {
         "title": "Multiple Sendings",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -363,7 +363,7 @@
       },
       "created-by": "Owner",
       "created-on": "Created on",
-      "empty-state": "No participants yet! Share with them the following link to join this campaign.",
+      "empty-state-with-copy-link": "No participants yet! Share with them the following link to join this campaign.",
       "multiple-sendings": {
         "title": "Multiple Sendings",
         "status": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -363,6 +363,7 @@
       },
       "created-by": "Propriétaire",
       "created-on": "Créée le",
+      "empty-state": "Aucun participant pour l’instant !",
       "empty-state-with-copy-link": "Aucun participant pour l’instant ! Envoyez-leur le lien suivant pour rejoindre votre campagne.",
       "multiple-sendings": {
         "title": "Envoi multiple",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -363,7 +363,7 @@
       },
       "created-by": "Propriétaire",
       "created-on": "Créée le",
-      "empty-state": "Aucun participant pour l’instant ! Envoyez-leur le lien suivant pour rejoindre votre campagne.",
+      "empty-state-with-copy-link": "Aucun participant pour l’instant ! Envoyez-leur le lien suivant pour rejoindre votre campagne.",
       "multiple-sendings": {
         "title": "Envoi multiple",
         "status": {


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, lorsque la liste est vide sur les pages Activité et Résultats d'une campagne, il y a la possibilité de copier le code de la campagne. il faudrait retirer cette possibilité et n'afficher qu'un message.

## :robot: Proposition

Pour les organisations qui sont rattachés au GAR, dans les détails d’une campagne sur Pix Orga, dans les onglets _Activité_ et _Résultats_, si la liste est vide, alors:

- retirer le bouton permettant de copier le lien de la campagne
- modifier la phrase _Aucun participant pour l’instant ! Envoyez-leur le lien suivant pour rejoindre votre campagne._ en **Aucun participant pour l’instant !**

## :rainbow: Remarques

Le composant _EmptyState_ a été modifié pour ne pas afficher l'option de copie si aucun code campagne n'est fourni.

## :100: Pour tester

1. Se connecter à Pix Orga https://orga-pr9150.review.pix.fr/ avec le compte allorga@example.net
2. Vérifier que vous êtes connecté sur l'organisation _Collège House of The Dragon (ACCESS_SCO)_
3. Créer une nouvelle campagne
4. Après création de la campagne vous serez redirigé sur la page des paramètres de la campagne
5. Cliquer sur l'onglet _Activité_
6. Vérifier l'affichage du texte **Aucun participant pour l’instant !** sans le bouton _copier_
7. Cliquer sur l'onglet _Résultats (0)_
8. Vérifier l'affichage du texte **Aucun participant pour l’instant !** sans le bouton _copier_