### PR TITLE
[BUGFIX] Corriger l'absence de langue à utiliser pour les épreuves de preview (PIX-12813)

### DIFF
--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -82,7 +82,7 @@ export default class ChallengeStatement extends Component {
     } else {
       const element = document.getElementsByClassName('challenge-statement-instruction__text')[0];
       const textToSpeech = new SpeechSynthesisUtterance(element.innerText);
-      textToSpeech.lang = this.currentUser.user.lang;
+      textToSpeech.lang = this.currentUser.user?.lang ? this.currentUser.user?.lang : 'fr';
       textToSpeech.onend = () => {
         this.isSpeaking = false;
         this.textToSpeechButtonTooltipText = this.intl.t('pages.challenge.statement.text-to-speech.play');


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on utilise une épreuve en aperçu, celle-ci est jouée sans avoir d'utilisateur courant lié à l'assessment. Or, la vocalisation utilise la langue de l'utilisateur courant pour lire la consigne. 

## :robot: Proposition
Dans un premier temps, utiliser le français comme langue par défaut pour la lecture d'une épreuve en aperçu. 

## :100: Pour tester
- Visiter le lien suivant https://app-pr9153.review.pix.fr/challenges/recLt9uwa2dR3IYpi/preview
- Vérifier que la vocalisation française fonctionne