### PR TITLE
[TECH] Ajouter un serveur SMTP pour le développement local

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -250,9 +250,27 @@ Si vous souhaitez le désactiver
 npm run local:remove-optional-checks
 ```
 
-#### Tracer de manière détaillée l'envoi d'email
+#### Tester les envois d'e-mails
 
-On peut tracer de manière détaillée (debug) l'appel de l'API d'email avec la
+##### Avec une interface web
+
+Il est possible de tester les envois d'e-mails avec [Mailpit](https://mailpit.axllent.org/), un outil qui simule un
+serveur SMTP et offre une interface web permettant de voir les e-mails envoyés.
+
+Il faut pour cela ajouter deux variables d'environnement au `.env`:
+
+```shell
+MAILING_ENABLED=true
+MAILING_PROVIDER=mailpit
+```
+
+Mailpit est inclus dans les images du fichier docker-compose.yml et sera donc lancé automatiquement.  
+
+On peut accéder à l'interface web Mailpit à l'adresse http://localhost:8025.
+
+##### Dans un terminal
+
+On peut également tracer de manière détaillée (debug) l'appel de l'API d'email avec la
 configuration d'une variable d'environnement :
 
 ```shell

--- a/api/lib/infrastructure/validate-environment-variables.js
+++ b/api/lib/infrastructure/validate-environment-variables.js
@@ -8,7 +8,7 @@ const schema = Joi.object({
   DATABASE_CONNECTION_POOL_MAX_SIZE: Joi.number().integer().min(0).optional(),
   DATABASE_CONNECTION_POOL_MIN_SIZE: Joi.number().integer().min(0).optional(),
   MAILING_ENABLED: Joi.string().optional().valid('true', 'false'),
-  MAILING_PROVIDER: Joi.string().optional().valid('brevo'),
+  MAILING_PROVIDER: Joi.string().optional().valid('brevo', 'mailpit'),
   BREVO_API_KEY: Joi.string().optional(),
   BREVO_ACCOUNT_CREATION_TEMPLATE_ID: Joi.number().optional(),
   BREVO_ORGANIZATION_INVITATION_TEMPLATE_ID: Joi.number().optional(),

--- a/api/sample.env
+++ b/api/sample.env
@@ -146,15 +146,16 @@ PGBOSS_CONNECTION_POOL_MAX_SIZE=
 # presence: optional
 # type: Boolean
 # default: `false`
-# MAILING_ENABLED=true
+MAILING_ENABLED=true
 
 # Select the emailing service provider. Available providers supported  are
-# Brevo (value="brevo").
+# - Brevo, used in production to send real emails (value="brevo").
+# - Mailpit, to test email sendings in a local environnement (value="mailpit").
 #
 # presence: required only if emailing is enabled
 # type: String
-# default: "brevo"
-# MAILING_PROVIDER=brevo
+# default: "mailpit"
+MAILING_PROVIDER=mailpit
 
 # SMTP URL
 # Allows to send emails via SMTP

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -238,7 +238,7 @@ const configuration = (function () {
     logOpsMetrics: toBoolean(process.env.LOG_OPS_METRICS),
     mailing: {
       enabled: toBoolean(process.env.MAILING_ENABLED),
-      provider: process.env.MAILING_PROVIDER || 'brevo',
+      provider: process.env.MAILING_PROVIDER || 'mailpit',
       smtpUrl: process.env.MAILING_SMTP_URL || 'smtp://username:password@localhost:1025/',
       mailpit: {
         templates: {},

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -240,6 +240,9 @@ const configuration = (function () {
       enabled: toBoolean(process.env.MAILING_ENABLED),
       provider: process.env.MAILING_PROVIDER || 'brevo',
       smtpUrl: process.env.MAILING_SMTP_URL || 'smtp://username:password@localhost:1025/',
+      mailpit: {
+        templates: {},
+      },
       brevo: {
         apiKey: process.env.BREVO_API_KEY,
         templates: {

--- a/api/src/shared/mail/infrastructure/providers/MailingProvider.js
+++ b/api/src/shared/mail/infrastructure/providers/MailingProvider.js
@@ -1,4 +1,13 @@
 class MailingProvider {
+  /**
+   * @param {Object} options
+   * @param {string} options.from sender email
+   * @param {string} options.fromName sender fullname
+   * @param {string} options.to recipient email
+   * @param {string} options.subject email subject
+   * @param {string} options.template template id
+   * @param {Object} options.variables record containing template variables (key-value)
+   */
   async sendEmail(/* options */) {
     throw new Error('Method #sendEmail(options) must be overridden');
   }

--- a/api/src/shared/mail/infrastructure/providers/MailpitProvider.js
+++ b/api/src/shared/mail/infrastructure/providers/MailpitProvider.js
@@ -1,0 +1,22 @@
+import { SmtpMailer } from '../services/smtp-mailer.js';
+import { MailingProvider } from './MailingProvider.js';
+
+class MailpitProvider extends MailingProvider {
+  constructor() {
+    super();
+    this._client = MailpitProvider.createSmtpMailerClient();
+  }
+
+  static createSmtpMailerClient() {
+    return new SmtpMailer();
+  }
+
+  async sendEmail({ from, fromName, to, subject, template, variables } = {}) {
+    const text = JSON.stringify({ templateId: template, ...variables }, null, 2);
+    const payload = { from, fromName, to, subject, text };
+
+    await this._client.sendEmail(payload);
+  }
+}
+
+export { MailpitProvider };

--- a/api/src/shared/mail/infrastructure/services/mailer.js
+++ b/api/src/shared/mail/infrastructure/services/mailer.js
@@ -5,6 +5,7 @@ import { logger } from '../../../infrastructure/utils/logger.js';
 import { EmailingAttempt } from '../../domain/models/EmailingAttempt.js';
 import { MailingProviderInvalidEmailError } from '../../domain/models/MailingProviderInvalidEmailError.js';
 import { BrevoProvider } from '../providers/BrevoProvider.js';
+import { MailpitProvider } from '../providers/MailpitProvider.js';
 import * as mailCheck from '../services/mail-check.js';
 
 const { mailing } = config;
@@ -17,6 +18,9 @@ class Mailer {
     switch (this._providerName) {
       case 'brevo':
         this._provider = new BrevoProvider();
+        break;
+      case 'mailpit':
+        this._provider = new MailpitProvider();
         break;
       default:
         logger.warn('Undefined mailing provider');

--- a/api/tests/shared/unit/mail/infrastructure/providers/MailpitProvider_test.js
+++ b/api/tests/shared/unit/mail/infrastructure/providers/MailpitProvider_test.js
@@ -1,0 +1,50 @@
+import { MailpitProvider } from '../../../../../../src/shared/mail/infrastructure/providers/MailpitProvider.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | Class | MailpitProvider', function () {
+  describe('#sendEmail', function () {
+    const senderEmailAddress = 'no-reply@example.net';
+    const userEmailAddress = 'user@example.net';
+    const templateId = 129291;
+
+    let stubbedSmtpMailerClient;
+    let mailingProvider;
+
+    context('when email check succeeds', function () {
+      beforeEach(function () {
+        sinon.stub(MailpitProvider, 'createSmtpMailerClient');
+
+        stubbedSmtpMailerClient = { sendEmail: sinon.stub() };
+        MailpitProvider.createSmtpMailerClient.returns(stubbedSmtpMailerClient);
+
+        mailingProvider = new MailpitProvider();
+      });
+
+      it('calls the given smtp mailer client with the correct payload', async function () {
+        // given
+        const options = {
+          from: senderEmailAddress,
+          to: userEmailAddress,
+          fromName: 'Ne pas repondre',
+          subject: 'Creation de compte',
+          template: templateId,
+          variables: { foo: 'bar' },
+        };
+
+        const expectedPayload = {
+          from: senderEmailAddress,
+          to: userEmailAddress,
+          fromName: 'Ne pas repondre',
+          subject: 'Creation de compte',
+          text: '{\n  "templateId": 129291,\n  "foo": "bar"\n}',
+        };
+
+        // when
+        await mailingProvider.sendEmail(options);
+
+        // then
+        expect(stubbedSmtpMailerClient.sendEmail).to.have.been.calledWithExactly(expectedPayload);
+      });
+    });
+  });
+});

--- a/api/tests/shared/unit/mail/infrastructure/services/mailer_test.js
+++ b/api/tests/shared/unit/mail/infrastructure/services/mailer_test.js
@@ -2,6 +2,8 @@ import { config } from '../../../../../../src/shared/config.js';
 import { logger } from '../../../../../../src/shared/infrastructure/utils/logger.js';
 import { EmailingAttempt } from '../../../../../../src/shared/mail/domain/models/EmailingAttempt.js';
 import { MailingProviderInvalidEmailError } from '../../../../../../src/shared/mail/domain/models/MailingProviderInvalidEmailError.js';
+import { BrevoProvider } from '../../../../../../src/shared/mail/infrastructure/providers/BrevoProvider.js';
+import { MailpitProvider } from '../../../../../../src/shared/mail/infrastructure/providers/MailpitProvider.js';
 import { Mailer } from '../../../../../../src/shared/mail/infrastructure/services/mailer.js';
 import { expect, sinon } from '../../../../../test-helper.js';
 
@@ -15,6 +17,34 @@ describe('Unit | Infrastructure | Mailers | mailer', function () {
       checkDomainIsValid: sinon.stub(),
     };
     sinon.stub(mailing, 'provider').value('brevo');
+  });
+
+  describe('constructor', function () {
+    context('when the provider is brevo', function () {
+      it('selects the brevo provider', function () {
+        // given
+        sinon.stub(mailing, 'provider').value('brevo');
+
+        // when
+        const mailer = new Mailer();
+
+        // then
+        expect(mailer._provider).to.be.instanceof(BrevoProvider);
+      });
+    });
+
+    context('when the provider is mailpit', function () {
+      it('selects the mailpit provider', function () {
+        // given
+        sinon.stub(mailing, 'provider').value('mailpit');
+
+        // when
+        const mailer = new Mailer();
+
+        // then
+        expect(mailer._provider).to.be.instanceof(MailpitProvider);
+      });
+    });
   });
 
   describe('#sendEmail', function () {

--- a/compose.yaml
+++ b/compose.yaml
@@ -25,5 +25,5 @@ services:
     image: axllent/mailpit:latest
     container_name: pix-api-smtp-server
     ports:
-      - 1025:1025
-      - 8025:8025
+      - '${PIX_MAILPIT_WEB_PORT:-1025}:1025'
+      - '${PIX_MAILPIT_SMTP_PORT:-8025}:8025'

--- a/compose.yaml
+++ b/compose.yaml
@@ -19,7 +19,7 @@ services:
     environment:
       - initialBuckets=pix-import-dev, pix-import-test
     ports:
-      - '${PIX_CACHE_PORT:-9090}:9090'
+      - '${PIX_S3_PORT:-9090}:9090'
 
   mailpit:
     image: axllent/mailpit:latest

--- a/compose.yaml
+++ b/compose.yaml
@@ -20,3 +20,10 @@ services:
       - initialBuckets=pix-import-dev, pix-import-test
     ports:
       - '${PIX_CACHE_PORT:-9090}:9090'
+
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: pix-api-smtp-server
+    ports:
+      - 1025:1025
+      - 8025:8025

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
     environment:
       - initialBuckets=pix-import-dev,pix-import-test
     ports:
-      - '${PIX_CACHE_PORT:-9090}:9090'
+      - '${PIX_S3_PORT:-9090}:9090'
 
   api:
     image: pix/api


### PR DESCRIPTION
## Problème

Sur les environnements de dev local, il est difficile le bon envoi des emails, car il n'est pas possible de configurer un serveur SMTP qui permettrait de tester les emails avec un outil comme Mailpit.

## Proposition de solution

- Ajouter Mailpit comme serveur smtp local (dans le docker-compose)
- Créer le MailpitProvider afin d'envoyer les emails vers ce serveur
- Modifier la configuration local pour que Mailpit soit utilisé par défaut

## Notes

Pour le moment, nous n'avons pas les templates complets des emails car ils sont configurés dans Brevo aujourd'hui. Seuls l'id du template et les variables sont visibles dans le corps de l'email. Nous allons étudier la possibilité de rapatrier les templates directement dans le code source afin de ne pas être dépendant du service d'envoi d'email.

## Pour tester

En local

1. Modifier le fichier .env de l'api pour avoir :

```
MAILING_ENABLED=true
MAILING_PROVIDER=mailpit
```

2. Lancer docker-compose pour avoir Mailpit: `docker-compose up -d`
3. Accéder à Pix App
4. Créer un compte (ou tout autre opération envoyant un e-mail)
5. Accéder à Mailpit: http://localhost:8025
6. Constater la bonne réception du mail avec le numéro de template et variables dans le corps
