### PR TITLE
[TECH] Remplacer les usages de Logger par les méthodes avec correlations IDs (PIX-12823)

### DIFF
--- a/api/db/batch-processing.js
+++ b/api/db/batch-processing.js
@@ -1,3 +1,5 @@
+import { logErrorWithCorrelationIds } from '../lib/infrastructure/monitoring-tools.js';
+
 const BATCH_SIZE = 10;
 import { logger } from '../src/shared/infrastructure/utils/logger.js';
 
@@ -10,7 +12,7 @@ function batch(knex, elementsToUpdate, treatment) {
     const assessments = remainingElementsToUpdate.splice(0, BATCH_SIZE);
     const promises = assessments.map((assessment) => {
       return treatment(assessment).catch((err) => {
-        logger.error('Treatment failed for :', assessment);
+        logErrorWithCorrelationIds('Treatment failed for :', assessment);
 
         throw err;
       });

--- a/api/db/batch-processing.js
+++ b/api/db/batch-processing.js
@@ -1,7 +1,6 @@
-import { logErrorWithCorrelationIds } from '../lib/infrastructure/monitoring-tools.js';
+import { logErrorWithCorrelationIds, logInfoWithCorrelationIds } from '../lib/infrastructure/monitoring-tools.js';
 
 const BATCH_SIZE = 10;
-import { logger } from '../src/shared/infrastructure/utils/logger.js';
 
 function batch(knex, elementsToUpdate, treatment) {
   function _innerTreatment(knex, remainingElementsToUpdate, countOfBatches, batchesDone) {
@@ -20,7 +19,7 @@ function batch(knex, elementsToUpdate, treatment) {
 
     return Promise.all(promises)
       .then((results) => {
-        logger.info(
+        logInfoWithCorrelationIds(
           `---- Lot ${batchesDone} : ${results.length} processed - (total: ${countOfBatches} lots, ${
             (batchesDone / countOfBatches) * 100
           }%)`,

--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -7,8 +7,7 @@ const { get } = _;
 import perf_hooks from 'node:perf_hooks';
 
 import { config } from '../lib/config.js';
-import { monitoringTools } from '../lib/infrastructure/monitoring-tools.js';
-import { logger } from '../src/shared/infrastructure/utils/logger.js';
+import { logErrorWithCorrelationIds, monitoringTools } from '../lib/infrastructure/monitoring-tools.js';
 
 const { performance } = perf_hooks;
 
@@ -46,7 +45,7 @@ try {
   });
 } catch (e) {
   if (e.message !== "Can't extend QueryBuilder with existing method ('whereInArray').") {
-    logger.error(e);
+    logErrorWithCorrelationIds(e);
   }
 }
 /* -------------------- */

--- a/api/index.js
+++ b/api/index.js
@@ -6,6 +6,7 @@ validateEnvironmentVariables();
 
 import { disconnect } from './db/knex-database-connection.js';
 import { learningContentCache } from './lib/infrastructure/caches/learning-content-cache.js';
+import { logErrorWithCorrelationIds } from './lib/infrastructure/monitoring-tools.js';
 import { temporaryStorage } from './lib/infrastructure/temporary-storage/index.js';
 import { redisMonitor } from './lib/infrastructure/utils/redis-monitor.js';
 import { createServer } from './server.js';
@@ -51,7 +52,7 @@ process.on('SIGINT', () => {
       import('./worker.js');
     }
   } catch (error) {
-    logger.error(error);
+    logErrorWithCorrelationIds(error);
     throw error;
   }
 })();

--- a/api/index.js
+++ b/api/index.js
@@ -6,11 +6,10 @@ validateEnvironmentVariables();
 
 import { disconnect } from './db/knex-database-connection.js';
 import { learningContentCache } from './lib/infrastructure/caches/learning-content-cache.js';
-import { logErrorWithCorrelationIds } from './lib/infrastructure/monitoring-tools.js';
+import { logErrorWithCorrelationIds, logInfoWithCorrelationIds } from './lib/infrastructure/monitoring-tools.js';
 import { temporaryStorage } from './lib/infrastructure/temporary-storage/index.js';
 import { redisMonitor } from './lib/infrastructure/utils/redis-monitor.js';
 import { createServer } from './server.js';
-import { logger } from './src/shared/infrastructure/utils/logger.js';
 
 let server;
 
@@ -20,22 +19,22 @@ const start = async function () {
 };
 
 async function _exitOnSignal(signal) {
-  logger.info(`Received signal: ${signal}.`);
-  logger.info('Stopping HAPI server...');
+  logInfoWithCorrelationIds(`Received signal: ${signal}.`);
+  logInfoWithCorrelationIds('Stopping HAPI server...');
   await server.stop({ timeout: 30000 });
   if (server.oppsy) {
-    logger.info('Stopping HAPI Oppsy server...');
+    logInfoWithCorrelationIds('Stopping HAPI Oppsy server...');
     await server.oppsy.stop();
   }
-  logger.info('Closing connexions to database...');
+  logInfoWithCorrelationIds('Closing connexions to database...');
   await disconnect();
-  logger.info('Closing connexions to cache...');
+  logInfoWithCorrelationIds('Closing connexions to cache...');
   await learningContentCache.quit();
-  logger.info('Closing connexions to temporary storage...');
+  logInfoWithCorrelationIds('Closing connexions to temporary storage...');
   await temporaryStorage.quit();
-  logger.info('Closing connexions to redis monitor...');
+  logInfoWithCorrelationIds('Closing connexions to redis monitor...');
   await redisMonitor.quit();
-  logger.info('Exiting process...');
+  logInfoWithCorrelationIds('Exiting process...');
 }
 
 process.on('SIGTERM', () => {

--- a/api/lib/application/cache/cache-controller.js
+++ b/api/lib/application/cache/cache-controller.js
@@ -2,12 +2,12 @@ import _ from 'lodash';
 
 import * as learningContentDatasource from '../../../src/shared/infrastructure/datasources/learning-content/datasource.js';
 import * as LearningContentDatasources from '../../../src/shared/infrastructure/datasources/learning-content/index.js';
-import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
+import { logErrorWithCorrelationIds } from '../../infrastructure/monitoring-tools.js';
 
 const refreshCacheEntries = function (_, h, dependencies = { learningContentDatasource }) {
   dependencies.learningContentDatasource
     .refreshLearningContentCacheRecords()
-    .catch((e) => logger.error('Error while reloading cache', e));
+    .catch((e) => logErrorWithCorrelationIds('Error while reloading cache', e));
   return h.response({}).code(202);
 };
 

--- a/api/lib/application/lcms/lcms-controller.js
+++ b/api/lib/application/lcms/lcms-controller.js
@@ -1,12 +1,11 @@
-import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import { usecases } from '../../domain/usecases/index.js';
-import { logErrorWithCorrelationIds } from '../../infrastructure/monitoring-tools.js';
+import { logErrorWithCorrelationIds, logInfoWithCorrelationIds } from '../../infrastructure/monitoring-tools.js';
 
 const createRelease = async function (request, h) {
   usecases
     .createLcmsRelease()
     .then(() => {
-      logger.info('Release created and cache reloaded');
+      logInfoWithCorrelationIds('Release created and cache reloaded');
     })
     .catch((e) => {
       logErrorWithCorrelationIds('Error while creating the release and reloading cache', e);

--- a/api/lib/application/lcms/lcms-controller.js
+++ b/api/lib/application/lcms/lcms-controller.js
@@ -1,5 +1,6 @@
 import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import { usecases } from '../../domain/usecases/index.js';
+import { logErrorWithCorrelationIds } from '../../infrastructure/monitoring-tools.js';
 
 const createRelease = async function (request, h) {
   usecases
@@ -8,7 +9,7 @@ const createRelease = async function (request, h) {
       logger.info('Release created and cache reloaded');
     })
     .catch((e) => {
-      logger.error('Error while creating the release and reloading cache', e);
+      logErrorWithCorrelationIds('Error while creating the release and reloading cache', e);
     });
   return h.response({}).code(204);
 };

--- a/api/lib/domain/events/handle-auto-jury.js
+++ b/api/lib/domain/events/handle-auto-jury.js
@@ -1,5 +1,6 @@
 import bluebird from 'bluebird';
 
+import { logErrorWithCorrelationIds } from '../../infrastructure/monitoring-tools.js';
 import { CertificationIssueReportResolutionAttempt } from '../models/CertificationIssueReportResolutionAttempt.js';
 import { CertificationIssueReportResolutionStrategies } from '../models/CertificationIssueReportResolutionStrategies.js';
 import { CertificationAssessment } from '../models/index.js';
@@ -174,7 +175,6 @@ async function _autoResolveCertificationIssueReport({
   certificationIssueReportRepository,
   certificationAssessmentRepository,
   resolutionStrategies,
-  logger,
 }) {
   const certificationIssueReports = await certificationIssueReportRepository.findByCertificationCourseId({
     certificationCourseId: certificationCourse.getId(),
@@ -187,7 +187,7 @@ async function _autoResolveCertificationIssueReport({
     try {
       return await resolutionStrategies.resolve({ certificationIssueReport, certificationAssessment });
     } catch (e) {
-      logger.error(e);
+      logErrorWithCorrelationIds(e);
       return CertificationIssueReportResolutionAttempt.unresolved();
     }
   });

--- a/api/lib/infrastructure/caches/DistributedCache.js
+++ b/api/lib/infrastructure/caches/DistributedCache.js
@@ -1,4 +1,4 @@
-import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
+import { logInfoWithCorrelationIds } from '../monitoring-tools.js';
 import { RedisClient } from '../utils/RedisClient.js';
 import { Cache } from './Cache.js';
 
@@ -21,10 +21,10 @@ class DistributedCache extends Cache {
   clientSubscriberCallback(_channel, rawMessage) {
     const message = JSON.parse(rawMessage);
     if (message.type === 'flushAll') {
-      logger.info({ event: 'cache-event' }, 'Flushing the local cache');
+      logInfoWithCorrelationIds({ event: 'cache-event' }, 'Flushing the local cache');
       return this._underlyingCache.flushAll();
     } else if (message.type === 'patch') {
-      logger.info({ event: 'cache-event' }, 'Patching the local cache');
+      logInfoWithCorrelationIds({ event: 'cache-event' }, 'Patching the local cache');
       this._underlyingCache.patch(message.cacheKey, message.patch);
     }
   }

--- a/api/lib/infrastructure/caches/LayeredCache.js
+++ b/api/lib/infrastructure/caches/LayeredCache.js
@@ -1,4 +1,4 @@
-import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
+import { logInfoWithCorrelationIds } from '../monitoring-tools.js';
 import { Cache } from './Cache.js';
 
 class LayeredCache extends Cache {
@@ -10,7 +10,7 @@ class LayeredCache extends Cache {
 
   get(key, generator) {
     return this._firstLevelCache.get(key, () => {
-      logger.info(
+      logInfoWithCorrelationIds(
         { event: 'cache-event', key },
         'Cannot found the key from the firstLevelCache. Fetching on the second one.',
       );

--- a/api/lib/infrastructure/caches/RedisCache.js
+++ b/api/lib/infrastructure/caches/RedisCache.js
@@ -6,7 +6,7 @@ import Redlock from 'redlock';
 
 import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import { config } from '../../config.js';
-import { logErrorWithCorrelationIds } from '../monitoring-tools.js';
+import { logErrorWithCorrelationIds, logInfoWithCorrelationIds } from '../monitoring-tools.js';
 import { RedisClient } from '../utils/RedisClient.js';
 import { applyPatch } from './apply-patch.js';
 import { Cache } from './Cache.js';
@@ -40,7 +40,7 @@ class RedisCache extends Cache {
   async _manageValueNotFoundInCache(key, generator) {
     const keyToLock = REDIS_LOCK_PREFIX + key;
     const retrieveAndSetValue = async () => {
-      logger.info({ key }, 'Executing generator for Redis key');
+      logInfoWithCorrelationIds({ key }, 'Executing generator for Redis key');
       const value = await generator();
       return this.set(key, value);
     };
@@ -65,7 +65,7 @@ class RedisCache extends Cache {
   async set(key, object) {
     const objectAsString = JSON.stringify(object);
 
-    logger.info({ key, length: objectAsString.length }, 'Setting Redis key');
+    logInfoWithCorrelationIds({ key, length: objectAsString.length }, 'Setting Redis key');
 
     await this._client.set(key, objectAsString);
     await this._client.del(`${key}:${PATCHES_KEY}`);
@@ -80,7 +80,7 @@ class RedisCache extends Cache {
   }
 
   flushAll() {
-    logger.info('Flushing Redis database');
+    logInfoWithCorrelationIds('Flushing Redis database');
 
     return this._client.flushall();
   }

--- a/api/lib/infrastructure/jobs/cpf-export/handlers/create-and-upload.js
+++ b/api/lib/infrastructure/jobs/cpf-export/handlers/create-and-upload.js
@@ -5,6 +5,8 @@ import dayjs from 'dayjs';
 import timezone from 'dayjs/plugin/timezone.js';
 import utc from 'dayjs/plugin/utc.js';
 
+import { logErrorWithCorrelationIds } from '../../../monitoring-tools.js';
+
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
@@ -21,7 +23,7 @@ const createAndUpload = async function ({
   const cpfCertificationResults = await cpfCertificationResultRepository.findByBatchId(batchId);
 
   if (cpfCertificationResults.length == 0) {
-    logger.error(`Create CPF results, with no certification found (batchId ${batchId})`);
+    logErrorWithCorrelationIds(`Create CPF results, with no certification found (batchId ${batchId})`);
     return;
   }
 

--- a/api/lib/infrastructure/jobs/cpf-export/handlers/create-and-upload.js
+++ b/api/lib/infrastructure/jobs/cpf-export/handlers/create-and-upload.js
@@ -5,7 +5,7 @@ import dayjs from 'dayjs';
 import timezone from 'dayjs/plugin/timezone.js';
 import utc from 'dayjs/plugin/utc.js';
 
-import { logErrorWithCorrelationIds } from '../../../monitoring-tools.js';
+import { logErrorWithCorrelationIds, logInfoWithCorrelationIds } from '../../../monitoring-tools.js';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -28,7 +28,9 @@ const createAndUpload = async function ({
   }
 
   const certificationCourseIds = cpfCertificationResults.map(({ id }) => id);
-  logger.info(`Create CPF results for ${certificationCourseIds.length} certifications (batchId ${batchId})`);
+  logInfoWithCorrelationIds(
+    `Create CPF results for ${certificationCourseIds.length} certifications (batchId ${batchId})`,
+  );
 
   const gzipStream = createGzip();
   cpfCertificationXmlExportService.buildXmlExport({
@@ -50,7 +52,7 @@ const createAndUpload = async function ({
     filename,
   });
 
-  logger.info(`${filename} generated in ${_getTimeInSec(start)}s.`);
+  logInfoWithCorrelationIds(`${filename} generated in ${_getTimeInSec(start)}s.`);
 };
 
 export { createAndUpload };

--- a/api/lib/infrastructure/jobs/cpf-export/handlers/send-email.js
+++ b/api/lib/infrastructure/jobs/cpf-export/handlers/send-email.js
@@ -1,5 +1,5 @@
-import { logger } from '../../../../../src/shared/infrastructure/utils/logger.js';
 import { config } from '../../../../config.js';
+import { logInfoWithCorrelationIds } from '../../../monitoring-tools.js';
 
 const { cpf } = config;
 const sendEmail = async function ({ getPreSignedUrls, mailService }) {
@@ -8,7 +8,7 @@ const sendEmail = async function ({ getPreSignedUrls, mailService }) {
   if (generatedFiles.length) {
     await mailService.sendCpfEmail({ email: cpf.sendEmailJob.recipient, generatedFiles });
   } else {
-    logger.info(`No CPF exports files ready to send`);
+    logInfoWithCorrelationIds(`No CPF exports files ready to send`);
   }
 };
 

--- a/api/lib/infrastructure/jobs/cpf-export/schedule-cpf-jobs.js
+++ b/api/lib/infrastructure/jobs/cpf-export/schedule-cpf-jobs.js
@@ -1,5 +1,6 @@
 import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
 import { config } from '../../../config.js';
+import { logErrorWithCorrelationIds } from '../../monitoring-tools.js';
 import { cpfExport } from './index.js';
 const { plannerJob, sendEmailJob } = config.cpf;
 
@@ -28,7 +29,7 @@ async function _processJob(job, handler, params) {
   try {
     await handler({ ...params, job, logger: buildLogger(job) });
   } catch (error) {
-    logger.error(error);
+    logErrorWithCorrelationIds(error);
     throw error;
   }
 }
@@ -38,7 +39,8 @@ function buildLogger(job) {
   const jobId = job.id;
   return {
     info: (message, ...args) => logger.info({ ...args, handlerName, jobId, type: 'JOB_LOG', message }),
-    error: (message, ...args) => logger.error({ ...args, handlerName, jobId, type: 'JOB_ERROR', message }),
+    error: (message, ...args) =>
+      logErrorWithCorrelationIds({ ...args, handlerName, jobId, type: 'JOB_ERROR', message }),
     trace: (message, ...args) => logger.trace({ ...args, handlerName, jobId, type: 'JOB_TRACE', message }),
   };
 }

--- a/api/lib/infrastructure/jobs/cpf-export/schedule-cpf-jobs.js
+++ b/api/lib/infrastructure/jobs/cpf-export/schedule-cpf-jobs.js
@@ -1,6 +1,6 @@
 import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
 import { config } from '../../../config.js';
-import { logErrorWithCorrelationIds } from '../../monitoring-tools.js';
+import { logErrorWithCorrelationIds, logInfoWithCorrelationIds } from '../../monitoring-tools.js';
 import { cpfExport } from './index.js';
 const { plannerJob, sendEmailJob } = config.cpf;
 
@@ -38,7 +38,7 @@ function buildLogger(job) {
   const handlerName = job.name;
   const jobId = job.id;
   return {
-    info: (message, ...args) => logger.info({ ...args, handlerName, jobId, type: 'JOB_LOG', message }),
+    info: (message, ...args) => logInfoWithCorrelationIds({ ...args, handlerName, jobId, type: 'JOB_LOG', message }),
     error: (message, ...args) =>
       logErrorWithCorrelationIds({ ...args, handlerName, jobId, type: 'JOB_ERROR', message }),
     trace: (message, ...args) => logger.trace({ ...args, handlerName, jobId, type: 'JOB_TRACE', message }),

--- a/api/lib/infrastructure/jobs/monitoring/MonitoredJobHandler.js
+++ b/api/lib/infrastructure/jobs/monitoring/MonitoredJobHandler.js
@@ -1,4 +1,4 @@
-import { logErrorWithCorrelationIds } from '../../monitoring-tools.js';
+import { logErrorWithCorrelationIds, logInfoWithCorrelationIds } from '../../monitoring-tools.js';
 
 class MonitoredJobHandler {
   constructor(handler, logger) {
@@ -19,7 +19,7 @@ class MonitoredJobHandler {
   }
 
   logJobStarting(data) {
-    this.logger.info({
+    logInfoWithCorrelationIds({
       data,
       handlerName: this.handler.name,
       type: 'JOB_LOG',

--- a/api/lib/infrastructure/jobs/monitoring/MonitoredJobHandler.js
+++ b/api/lib/infrastructure/jobs/monitoring/MonitoredJobHandler.js
@@ -1,3 +1,5 @@
+import { logErrorWithCorrelationIds } from '../../monitoring-tools.js';
+
 class MonitoredJobHandler {
   constructor(handler, logger) {
     this.handler = handler;
@@ -26,7 +28,7 @@ class MonitoredJobHandler {
   }
 
   logJobFailed(data, error) {
-    this.logger.error({
+    logErrorWithCorrelationIds({
       data,
       handlerName: this.handler.name,
       error: error?.message ? error.message + ' (see dedicated log for more information)' : undefined,

--- a/api/lib/infrastructure/jobs/monitoring/MonitoringJobExecutionTimeHandler.js
+++ b/api/lib/infrastructure/jobs/monitoring/MonitoringJobExecutionTimeHandler.js
@@ -1,5 +1,7 @@
 import dayjs from 'dayjs';
 
+import { logInfoWithCorrelationIds } from '../../monitoring-tools.js';
+
 class MonitoringJobExecutionTimeHandler {
   constructor({ logger }) {
     this.logger = logger;
@@ -12,7 +14,7 @@ class MonitoringJobExecutionTimeHandler {
     const totalTime = completedOn.diff(createdOn, 'second', true);
     const executionTime = completedOn.diff(startedOn, 'second', true);
 
-    this.logger.info({
+    logInfoWithCorrelationIds({
       event: 'pg-boss-execution-time',
       type: 'JOB_LOG_EXEC_TIME',
       handlerName: job.data.request.name,

--- a/api/lib/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler.js
+++ b/api/lib/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler.js
@@ -2,6 +2,7 @@ import cronParser from 'cron-parser';
 import dayjs from 'dayjs';
 
 import { knex } from '../../../../db/knex-database-connection.js';
+import { logInfoWithCorrelationIds } from '../../monitoring-tools.js';
 import { ComputeCertificabilityJob } from './ComputeCertificabilityJob.js';
 import { ScheduleComputeOrganizationLearnersCertificabilityJob } from './ScheduleComputeOrganizationLearnersCertificabilityJob.js';
 
@@ -37,7 +38,7 @@ class ScheduleComputeOrganizationLearnersCertificabilityJobHandler {
         });
 
         const chunkCount = Math.ceil(count / chunkSize);
-        this.logger.info(
+        this.logInfoWithCorrelationIds(
           `ScheduleComputeOrganizationLearnersCertificabilityJobHandler - Total learners to compute : ${count}`,
         );
 
@@ -45,7 +46,9 @@ class ScheduleComputeOrganizationLearnersCertificabilityJobHandler {
 
         for (let index = 0; index < chunkCount; index++) {
           const offset = index * chunkSize;
-          this.logger.info(`ScheduleComputeOrganizationLearnersCertificabilityJobHandler - Offset : ${offset}`);
+          logInfoWithCorrelationIds(
+            `ScheduleComputeOrganizationLearnersCertificabilityJobHandler - Offset : ${offset}`,
+          );
 
           const organizationLearnerIds =
             await this.organizationLearnerRepository.findByOrganizationsWhichNeedToComputeCertificability({
@@ -58,7 +61,7 @@ class ScheduleComputeOrganizationLearnersCertificabilityJobHandler {
               domainTransaction: { knexTransaction: trx },
             });
 
-          this.logger.info(
+          this.logInfoWithCorrelationIds(
             `ScheduleComputeOrganizationLearnersCertificabilityJobHandler - Ids count  : ${organizationLearnerIds.length}`,
           );
 
@@ -73,12 +76,12 @@ class ScheduleComputeOrganizationLearnersCertificabilityJobHandler {
           const jobsInserted = await this.pgBossRepository.insert(jobsToInsert, { knexTransaction: trx });
           totalJobsInserted += jobsInserted.rowCount;
 
-          this.logger.info(
+          this.logInfoWithCorrelationIds(
             `ScheduleComputeOrganizationLearnersCertificabilityJobHandler - Jobs inserted count  : ${jobsInserted.rowCount}`,
           );
         }
 
-        this.logger.info(
+        this.logInfoWithCorrelationIds(
           `ScheduleComputeOrganizationLearnersCertificabilityJobHandler - Total jobs inserted count : ${totalJobsInserted}`,
         );
       },

--- a/api/lib/infrastructure/lcms.js
+++ b/api/lib/infrastructure/lcms.js
@@ -1,6 +1,6 @@
-import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 import { config } from '../config.js';
 import { httpAgent } from './http/http-agent.js';
+import { logInfoWithCorrelationIds } from './monitoring-tools.js';
 
 const { lcms: lcmsConfig } = config;
 const getLatestRelease = async function () {
@@ -26,7 +26,7 @@ const getLatestRelease = async function () {
   const createdAt = response.data.createdAt;
   const message = `Release ${version} created on ${createdAt} successfully received from LCMS`;
 
-  logger.info(message);
+  logInfoWithCorrelationIds(message);
   return response.data.content;
 };
 

--- a/api/lib/infrastructure/plugins/pino.js
+++ b/api/lib/infrastructure/plugins/pino.js
@@ -4,7 +4,7 @@ import { stdSerializers } from 'pino';
 
 import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import { config } from '../../config.js';
-import { monitoringTools } from '../monitoring-tools.js';
+import { logErrorWithCorrelationIds, monitoringTools } from '../monitoring-tools.js';
 
 const serializersSym = Symbol.for('pino.serializers');
 
@@ -59,7 +59,7 @@ const plugin = {
         return;
       }
       if (event.error) {
-        logger.error(
+        logErrorWithCorrelationIds(
           {
             tags: event.tags,
             err: event.error,

--- a/api/lib/infrastructure/plugins/pino.js
+++ b/api/lib/infrastructure/plugins/pino.js
@@ -4,7 +4,7 @@ import { stdSerializers } from 'pino';
 
 import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import { config } from '../../config.js';
-import { logErrorWithCorrelationIds, monitoringTools } from '../monitoring-tools.js';
+import { logErrorWithCorrelationIds, logInfoWithCorrelationIds, monitoringTools } from '../monitoring-tools.js';
 
 const serializersSym = Symbol.for('pino.serializers');
 
@@ -43,15 +43,15 @@ const plugin = {
     logger[serializersSym] = Object.assign({}, serializers, logger[serializersSym]);
 
     server.ext('onPostStart', async function () {
-      logger.info(server.info, 'server started');
+      logInfoWithCorrelationIds(server.info, 'server started');
     });
 
     server.ext('onPostStop', async function () {
-      logger.info(server.info, 'server stopped');
+      logInfoWithCorrelationIds(server.info, 'server stopped');
     });
 
     server.events.on('log', function (event) {
-      logger.info({ tags: event.tags, data: event.data });
+      logInfoWithCorrelationIds({ tags: event.tags, data: event.data });
     });
 
     server.events.on('request', function (request, event) {
@@ -71,7 +71,7 @@ const plugin = {
 
     server.events.on('response', (request) => {
       const info = request.info;
-      logger.info(
+      logInfoWithCorrelationIds(
         {
           queryParams: request.query,
           req: request,

--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -2,8 +2,8 @@ import lodash from 'lodash';
 
 import { FileValidationError } from '../../../../lib/domain/errors.js';
 import { convertDateValue } from '../../../../src/shared/infrastructure/utils/date-utils.js';
-import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
 import { csvHelper } from '../../helpers/csv.js';
+import { logErrorWithCorrelationIds } from '../../monitoring-tools.js';
 import { COMPLEMENTARY_CERTIFICATION_SUFFIX, emptySession, headers } from '../../utils/csv/sessions-import.js';
 
 const { isEmpty } = lodash;
@@ -25,7 +25,7 @@ function _csvSerializeValue(data) {
       return `"${_csvFormulaEscapingPrefix(data)}${data.replace(/"/g, '""')}"`;
     }
   } else {
-    logger.error(`Unknown value type in _csvSerializeValue: ${typeof data}: ${data}`);
+    logErrorWithCorrelationIds(`Unknown value type in _csvSerializeValue: ${typeof data}: ${data}`);
     return '""';
   }
 }

--- a/api/lib/infrastructure/utils/RedisClient.js
+++ b/api/lib/infrastructure/utils/RedisClient.js
@@ -2,6 +2,7 @@ import Redis from 'ioredis';
 import Redlock from 'redlock';
 
 import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
+import { logInfoWithCorrelationIds } from '../monitoring-tools.js';
 
 class RedisClient {
   constructor(redisUrl, { name, prefix } = {}) {
@@ -11,8 +12,12 @@ class RedisClient {
 
     this._client = new Redis(redisUrl);
 
-    this._client.on('connect', () => logger.info({ redisClient: this._clientName }, 'Connected to server'));
-    this._client.on('end', () => logger.info({ redisClient: this._clientName }, 'Disconnected from server'));
+    this._client.on('connect', () =>
+      logInfoWithCorrelationIds({ redisClient: this._clientName }, 'Connected to server'),
+    );
+    this._client.on('end', () =>
+      logInfoWithCorrelationIds({ redisClient: this._clientName }, 'Disconnected from server'),
+    );
     this._client.on('error', (err) => logger.warn({ redisClient: this._clientName, err }, 'Error encountered'));
 
     this._clientWithLock = new Redlock(
@@ -45,13 +50,13 @@ class RedisClient {
 
   subscribe(channel) {
     this._client.subscribe(channel, () =>
-      logger.info({ redisClient: this._clientName }, `Subscribed to channel '${channel}'`),
+      logInfoWithCorrelationIds({ redisClient: this._clientName }, `Subscribed to channel '${channel}'`),
     );
   }
 
   publish(channel, message) {
     this._client.publish(channel, message, () =>
-      logger.info({ redisClient: this._clientName }, `Published on channel '${channel}'`),
+      logInfoWithCorrelationIds({ redisClient: this._clientName }, `Published on channel '${channel}'`),
     );
   }
 

--- a/api/scripts/_template.js
+++ b/api/scripts/_template.js
@@ -7,8 +7,7 @@ const { performance } = perf_hooks;
 
 import { disconnect, knex } from '../db/knex-database-connection.js';
 import { learningContentCache as cache } from '../lib/infrastructure/caches/learning-content-cache.js';
-import { logErrorWithCorrelationIds } from '../lib/infrastructure/monitoring-tools.js';
-import { logger } from '../src/shared/infrastructure/utils/logger.js';
+import { logErrorWithCorrelationIds, logInfoWithCorrelationIds } from '../lib/infrastructure/monitoring-tools.js';
 
 const doSomething = async ({ throwError }) => {
   if (throwError) {
@@ -24,11 +23,11 @@ const __filename = modulePath;
 
 async function main() {
   const startTime = performance.now();
-  logger.info(`Script ${__filename} has started`);
+  logInfoWithCorrelationIds(`Script ${__filename} has started`);
   await doSomething({ throwError: false });
   const endTime = performance.now();
   const duration = Math.round(endTime - startTime);
-  logger.info(`Script has ended: took ${duration} milliseconds`);
+  logInfoWithCorrelationIds(`Script has ended: took ${duration} milliseconds`);
 }
 
 (async () => {

--- a/api/scripts/_template.js
+++ b/api/scripts/_template.js
@@ -7,6 +7,7 @@ const { performance } = perf_hooks;
 
 import { disconnect, knex } from '../db/knex-database-connection.js';
 import { learningContentCache as cache } from '../lib/infrastructure/caches/learning-content-cache.js';
+import { logErrorWithCorrelationIds } from '../lib/infrastructure/monitoring-tools.js';
 import { logger } from '../src/shared/infrastructure/utils/logger.js';
 
 const doSomething = async ({ throwError }) => {
@@ -35,7 +36,7 @@ async function main() {
     try {
       await main();
     } catch (error) {
-      logger.error(error);
+      logErrorWithCorrelationIds(error);
       process.exitCode = 1;
     } finally {
       await disconnect();

--- a/api/scripts/certification/fill-issue-report-category-id.js
+++ b/api/scripts/certification/fill-issue-report-category-id.js
@@ -3,7 +3,7 @@ import * as url from 'node:url';
 import bluebird from 'bluebird';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
-import { logger } from '../../src/shared/infrastructure/utils/logger.js';
+import { logInfoWithCorrelationIds } from '../../lib/infrastructure/monitoring-tools.js';
 
 const modulePath = url.fileURLToPath(import.meta.url);
 const isLaunchedFromCommandLine = process.argv[1] === modulePath;
@@ -14,11 +14,11 @@ async function _getIdCategorySubcategoryFromCertificationIssueReport() {
 }
 
 async function main() {
-  logger.info(`Script ${__filename} est lancé !`);
+  logInfoWithCorrelationIds(`Script ${__filename} est lancé !`);
 
   const certificationIssueReports = await _getIdCategorySubcategoryFromCertificationIssueReport();
 
-  logger.info(`Nb de certification issue reports à modifier : ${certificationIssueReports.length}`);
+  logInfoWithCorrelationIds(`Nb de certification issue reports à modifier : ${certificationIssueReports.length}`);
 
   const categories = await knex('issue-report-categories').select('name', 'id');
 
@@ -27,11 +27,11 @@ async function main() {
   const { count: reportsNotUpdated } = await knex('certification-issue-reports').count('*').whereNull('categoryId');
 
   if (reportsNotUpdated > 0) {
-    logger.info(
+    logInfoWithCorrelationIds(
       `Nb de certification issue reports non mis à jour : ${reportsNotUpdated.length} / ${certificationIssueReports.length}`,
     );
   } else {
-    logger.info(`${certificationIssueReports.length} certification issue reports mis à jour`);
+    logInfoWithCorrelationIds(`${certificationIssueReports.length} certification issue reports mis à jour`);
   }
 }
 
@@ -62,6 +62,6 @@ async function _updateIssueReportsWithCategoryId(certificationIssueReports, cate
       updatedAt: new Date(),
     });
     count++;
-    if (count % 1000 === 0) logger.info('Nombre de certification issue report mis à jour : ', count);
+    if (count % 1000 === 0) logInfoWithCorrelationIds('Nombre de certification issue report mis à jour : ', count);
   });
 }

--- a/api/scripts/certification/fill-last-assessment-result-certification-course-table.js
+++ b/api/scripts/certification/fill-last-assessment-result-certification-course-table.js
@@ -6,7 +6,7 @@ import bluebird from 'bluebird';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 import { learningContentCache as cache } from '../../lib/infrastructure/caches/learning-content-cache.js';
-import { logger } from '../../src/shared/infrastructure/utils/logger.js';
+import { logErrorWithCorrelationIds } from '../../lib/infrastructure/monitoring-tools.js';
 
 const ASSOC_TABLE_NAME = 'certification-courses-last-assessment-results';
 
@@ -19,7 +19,7 @@ const addLastAssessmentResultCertificationCourse = async () => {
         const lastAssessmentResultId = await _getLatestAssessmentResultId(certificationCourseId);
         if (lastAssessmentResultId) return { certificationCourseId, lastAssessmentResultId };
       } catch (err) {
-        logger.error(`Went wrong for certification ${certificationCourseId}`);
+        logErrorWithCorrelationIds(`Went wrong for certification ${certificationCourseId}`);
       }
     })
     .filter(Boolean);
@@ -27,7 +27,7 @@ const addLastAssessmentResultCertificationCourse = async () => {
   try {
     await knex(ASSOC_TABLE_NAME).insert(data);
   } catch (e) {
-    logger.error(e);
+    logErrorWithCorrelationIds(e);
   }
 };
 
@@ -43,7 +43,7 @@ function main() {
     try {
       await main();
     } catch (error) {
-      logger.error(error);
+      logErrorWithCorrelationIds(error);
       process.exitCode = 1;
     } finally {
       await disconnect();

--- a/api/scripts/certification/generate-certification-csv-results-by-session-ids.js
+++ b/api/scripts/certification/generate-certification-csv-results-by-session-ids.js
@@ -13,6 +13,7 @@ const { isEmpty } = lodash;
 import { disconnect } from '../../db/knex-database-connection.js';
 import { usecases } from '../../lib/domain/usecases/index.js';
 import { learningContentCache as cache } from '../../lib/infrastructure/caches/learning-content-cache.js';
+import { logErrorWithCorrelationIds } from '../../lib/infrastructure/monitoring-tools.js';
 import { temporaryStorage } from '../../lib/infrastructure/temporary-storage/index.js';
 import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 
@@ -36,7 +37,7 @@ async function main() {
     const { session, certificationResults } = await usecases.getSessionResults({ sessionId });
 
     if (isEmpty(certificationResults)) {
-      logger.error(`Pas de résultat trouvé pour la session ${sessionId}`);
+      logErrorWithCorrelationIds(`Pas de résultat trouvé pour la session ${sessionId}`);
       return;
     }
 
@@ -61,7 +62,7 @@ const isLaunchedFromCommandLine = process.argv[1] === modulePath;
     try {
       await main();
     } catch (error) {
-      logger.error(error);
+      logErrorWithCorrelationIds(error);
       process.exitCode = 1;
     } finally {
       await _disconnect();

--- a/api/scripts/certification/get-user-certification-eligibility.js
+++ b/api/scripts/certification/get-user-certification-eligibility.js
@@ -10,6 +10,7 @@ import * as certificationBadgesService from '../../lib/domain/services/certifica
 import * as placementProfileService from '../../lib/domain/services/placement-profile-service.js';
 import { usecases } from '../../lib/domain/usecases/index.js';
 import { learningContentCache as cache } from '../../lib/infrastructure/caches/learning-content-cache.js';
+import { logErrorWithCorrelationIds } from '../../lib/infrastructure/monitoring-tools.js';
 import { temporaryStorage } from '../../lib/infrastructure/temporary-storage/index.js';
 import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 
@@ -76,7 +77,7 @@ async function main() {
     try {
       await main();
     } catch (error) {
-      logger.error(error);
+      logErrorWithCorrelationIds(error);
       process.exitCode = 1;
     } finally {
       await disconnect();

--- a/api/scripts/certification/import-certification-cpf-cities.js
+++ b/api/scripts/certification/import-certification-cpf-cities.js
@@ -16,6 +16,8 @@ import { checkCsvHeader, parseCsv } from '../helpers/csvHelpers.js';
 const { uniqBy, values } = lodash;
 import * as url from 'node:url';
 
+import { logErrorWithCorrelationIds } from '../../lib/infrastructure/monitoring-tools.js';
+
 const wordsToReplace = [
   {
     regex: /(^|\s)STE($|\s)/,
@@ -432,7 +434,7 @@ async function main(filePath) {
       const filePath = process.argv[2];
       await main(filePath);
     } catch (error) {
-      logger.error(error);
+      logErrorWithCorrelationIds(error);
       process.exitCode = 1;
     } finally {
       await disconnect();

--- a/api/scripts/certification/import-pilot-certification-centers-from-csv.js
+++ b/api/scripts/certification/import-pilot-certification-centers-from-csv.js
@@ -13,6 +13,7 @@ import { checkCsvHeader, parseCsv } from '../helpers/csvHelpers.js';
 const { values } = lodash;
 import * as url from 'node:url';
 
+import { logErrorWithCorrelationIds } from '../../lib/infrastructure/monitoring-tools.js';
 import { CERTIFICATION_FEATURES } from '../../src/certification/shared/domain/constants.js';
 
 const headers = {
@@ -108,7 +109,7 @@ async function main(filePath) {
       const filePath = process.argv[2];
       await main(filePath);
     } catch (error) {
-      logger.error(error);
+      logErrorWithCorrelationIds(error);
       process.exitCode = 1;
     } finally {
       await disconnect();

--- a/api/scripts/certification/launch-auto-jury-for-session.js
+++ b/api/scripts/certification/launch-auto-jury-for-session.js
@@ -6,19 +6,18 @@ import { disconnect, knex } from '../../db/knex-database-connection.js';
 import { handleAutoJury } from '../../lib/domain/events/handle-auto-jury.js';
 import * as events from '../../lib/domain/events/index.js';
 import { SessionFinalized } from '../../lib/domain/events/SessionFinalized.js';
-import { logErrorWithCorrelationIds } from '../../lib/infrastructure/monitoring-tools.js';
+import { logErrorWithCorrelationIds, logInfoWithCorrelationIds } from '../../lib/infrastructure/monitoring-tools.js';
 import * as certificationAssessmentRepository from '../../src/certification/shared/infrastructure/repositories/certification-assessment-repository.js';
 import * as certificationCourseRepository from '../../src/certification/shared/infrastructure/repositories/certification-course-repository.js';
 import * as certificationIssueReportRepository from '../../src/certification/shared/infrastructure/repositories/certification-issue-report-repository.js';
 import * as challengeRepository from '../../src/shared/infrastructure/repositories/challenge-repository.js';
-import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 
 const modulePath = url.fileURLToPath(import.meta.url);
 const isLaunchedFromCommandLine = process.argv[1] === modulePath;
 
 async function main() {
   const id = process.argv[2];
-  logger.info(`Launch auto jury for session ${id}`);
+  logInfoWithCorrelationIds(`Launch auto jury for session ${id}`);
 
   const { sessionId, finalizedAt, certificationCenterName, sessionDate, sessionTime, examinerGlobalComment } =
     await knex('sessions')
@@ -47,11 +46,10 @@ async function main() {
     certificationAssessmentRepository,
     certificationCourseRepository,
     challengeRepository,
-    logger,
   });
   await events.eventDispatcher.dispatch(event);
 
-  logger.info('Done !');
+  logInfoWithCorrelationIds('Done !');
 }
 
 (async () => {

--- a/api/scripts/certification/launch-auto-jury-for-session.js
+++ b/api/scripts/certification/launch-auto-jury-for-session.js
@@ -6,6 +6,7 @@ import { disconnect, knex } from '../../db/knex-database-connection.js';
 import { handleAutoJury } from '../../lib/domain/events/handle-auto-jury.js';
 import * as events from '../../lib/domain/events/index.js';
 import { SessionFinalized } from '../../lib/domain/events/SessionFinalized.js';
+import { logErrorWithCorrelationIds } from '../../lib/infrastructure/monitoring-tools.js';
 import * as certificationAssessmentRepository from '../../src/certification/shared/infrastructure/repositories/certification-assessment-repository.js';
 import * as certificationCourseRepository from '../../src/certification/shared/infrastructure/repositories/certification-course-repository.js';
 import * as certificationIssueReportRepository from '../../src/certification/shared/infrastructure/repositories/certification-issue-report-repository.js';
@@ -58,7 +59,7 @@ async function main() {
     try {
       await main();
     } catch (error) {
-      logger.error(error);
+      logErrorWithCorrelationIds(error);
       process.exitCode = 1;
     } finally {
       await disconnect();

--- a/api/scripts/certification/send-certification-result-emails.js
+++ b/api/scripts/certification/send-certification-result-emails.js
@@ -9,6 +9,7 @@ import i18n from 'i18n';
 import { disconnect } from '../../db/knex-database-connection.js';
 import * as mailService from '../../lib/domain/services/mail-service.js';
 import { manageEmails } from '../../lib/domain/services/session-publication-service.js';
+import { logErrorWithCorrelationIds } from '../../lib/infrastructure/monitoring-tools.js';
 import * as sessionRepository from '../../src/certification/session-management/infrastructure/repositories/session-repository.js';
 import * as certificationCenterRepository from '../../src/certification/shared/infrastructure/repositories/certification-center-repository.js';
 import { logger } from '../../src/shared/infrastructure/utils/logger.js';
@@ -45,12 +46,12 @@ async function main() {
     try {
       session = await sessionRepository.getWithCertificationCandidates({ id: parseInt(sessionId) });
     } catch (e) {
-      logger.error({ e });
+      logErrorWithCorrelationIds({ e });
       return;
     }
 
     if (!session.isPublished()) {
-      logger.error(`La session ${sessionId} n'est pas publiée`);
+      logErrorWithCorrelationIds(`La session ${sessionId} n'est pas publiée`);
       return;
     }
 
@@ -68,7 +69,7 @@ async function main() {
 
       successes++;
     } catch (e) {
-      logger.error(e);
+      logErrorWithCorrelationIds(e);
     }
   });
 
@@ -83,7 +84,7 @@ const isLaunchedFromCommandLine = process.argv[1] === modulePath;
     try {
       await main();
     } catch (error) {
-      logger.error(error);
+      logErrorWithCorrelationIds(error);
       process.exitCode = 1;
     } finally {
       await disconnect();

--- a/api/scripts/certification/update-certification-infos.js
+++ b/api/scripts/certification/update-certification-infos.js
@@ -11,6 +11,7 @@ import bluebird from 'bluebird';
 import lodash from 'lodash';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
+import { logErrorWithCorrelationIds } from '../../lib/infrastructure/monitoring-tools.js';
 import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 // Usage: node scripts/certification/update-certifications-infos path/data.csv path/sessionsId.csv
 // data.csv
@@ -106,7 +107,7 @@ async function updateCertificationInfos(dataFilePath, sessionIdsFilePath) {
     if (trx) {
       await trx.rollback();
     }
-    logger.error(error);
+    logErrorWithCorrelationIds(error);
     throw error;
   }
 
@@ -127,7 +128,7 @@ async function main() {
     try {
       await main();
     } catch (error) {
-      logger.error(error);
+      logErrorWithCorrelationIds(error);
       process.exitCode = 1;
     } finally {
       await disconnect();

--- a/api/scripts/certification/validate-cpf-xml.js
+++ b/api/scripts/certification/validate-cpf-xml.js
@@ -3,6 +3,7 @@ import * as url from 'node:url';
 
 import { parseXml } from 'libxmljs2';
 
+import { logErrorWithCorrelationIds } from '../../lib/infrastructure/monitoring-tools.js';
 import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
@@ -24,7 +25,7 @@ async function main(xmlPath) {
       message.replace(/Element '\{urn:cdc:cpf:pc5:schema:1.0.0\}(.*)'/, '$1').replace('\n', '');
     parsedXmlToExport.validationErrors.forEach((error) => set.add(extractMessage(error)));
 
-    set.forEach((errorSet) => logger.error(errorSet));
+    set.forEach((errorSet) => logErrorWithCorrelationIds(errorSet));
 
     logger.warn(`${parsedXmlToExport.validationErrors.length} erreurs dans le fichier`);
   }
@@ -36,7 +37,7 @@ async function main(xmlPath) {
     const xmlPath = process.argv[2];
     await main(xmlPath);
   } catch (error) {
-    logger.error(error);
+    logErrorWithCorrelationIds(error);
     process.exitCode = 1;
   }
 })();

--- a/api/scripts/data-generation/generate-certif-cli.js
+++ b/api/scripts/data-generation/generate-certif-cli.js
@@ -15,6 +15,7 @@ import { databaseBuffer } from '../../db/database-builder/database-buffer.js';
 import { DatabaseBuilder } from '../../db/database-builder/database-builder.js';
 import { CampaignParticipationStatuses } from '../../lib/domain/models/index.js';
 import { learningContentCache } from '../../lib/infrastructure/caches/learning-content-cache.js';
+import { logErrorWithCorrelationIds } from '../../lib/infrastructure/monitoring-tools.js';
 import { temporaryStorage } from '../../lib/infrastructure/temporary-storage/index.js';
 import { getNewSessionCode } from '../../src/certification/enrolment/domain/services/session-code-service.js';
 import * as skillRepository from '../../src/shared/infrastructure/repositories/skill-repository.js';
@@ -384,7 +385,7 @@ if (!isInTest) {
     complementaryCertifications: JSON.parse(complementaryCertifications) || [],
   })
     .catch((error) => {
-      logger.error(error);
+      logErrorWithCorrelationIds(error);
       throw error;
     })
     .finally(_disconnect);

--- a/api/scripts/data-generation/seeds/dump-target-profile-data-as-seeds.js
+++ b/api/scripts/data-generation/seeds/dump-target-profile-data-as-seeds.js
@@ -11,7 +11,7 @@ import { hideBin } from 'yargs/helpers';
 
 import { disconnect, knex } from '../../../db/knex-database-connection.js';
 import { learningContentCache } from '../../../lib/infrastructure/caches/learning-content-cache.js';
-import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
+import { logErrorWithCorrelationIds } from '../../../lib/infrastructure/monitoring-tools.js';
 
 async function main() {
   try {
@@ -19,7 +19,7 @@ async function main() {
     console.log(`Récupération du profil cible ${targetProfileId} / ${withBadges ? 'avec' : 'sans'} les RTs`);
     await doJob(targetProfileId, withBadges);
   } catch (err) {
-    logger.error(err);
+    logErrorWithCorrelationIds(err);
     throw err;
   } finally {
     await disconnect();

--- a/api/scripts/database/create-database.js
+++ b/api/scripts/database/create-database.js
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 
 import { PGSQL_DUPLICATE_DATABASE_ERROR } from '../../db/pgsql-errors.js';
+import { logErrorWithCorrelationIds } from '../../lib/infrastructure/monitoring-tools.js';
 import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 import { PgClient } from '../PgClient.js';
 
@@ -21,7 +22,7 @@ PgClient.getClient(url.href).then(async (client) => {
     if (error.code === PGSQL_DUPLICATE_DATABASE_ERROR) {
       logger.info(`Database ${DB_TO_CREATE_NAME} already created`);
     } else {
-      logger.error(`Database creation failed: ${error.detail}`);
+      logErrorWithCorrelationIds(`Database creation failed: ${error.detail}`);
     }
   } finally {
     await client.end();

--- a/api/scripts/database/create-database.js
+++ b/api/scripts/database/create-database.js
@@ -1,8 +1,7 @@
 import 'dotenv/config';
 
 import { PGSQL_DUPLICATE_DATABASE_ERROR } from '../../db/pgsql-errors.js';
-import { logErrorWithCorrelationIds } from '../../lib/infrastructure/monitoring-tools.js';
-import { logger } from '../../src/shared/infrastructure/utils/logger.js';
+import { logErrorWithCorrelationIds, logInfoWithCorrelationIds } from '../../lib/infrastructure/monitoring-tools.js';
 import { PgClient } from '../PgClient.js';
 
 const dbUrl = process.env.NODE_ENV === 'test' ? process.env.TEST_DATABASE_URL : process.env.DATABASE_URL;
@@ -16,11 +15,11 @@ url.pathname = '/postgres';
 PgClient.getClient(url.href).then(async (client) => {
   try {
     await client.query_and_log(`CREATE DATABASE ${DB_TO_CREATE_NAME};`);
-    logger.info('Database created');
+    logInfoWithCorrelationIds('Database created');
     await client.end();
   } catch (error) {
     if (error.code === PGSQL_DUPLICATE_DATABASE_ERROR) {
-      logger.info(`Database ${DB_TO_CREATE_NAME} already created`);
+      logInfoWithCorrelationIds(`Database ${DB_TO_CREATE_NAME} already created`);
     } else {
       logErrorWithCorrelationIds(`Database creation failed: ${error.detail}`);
     }

--- a/api/scripts/database/drop-database.js
+++ b/api/scripts/database/drop-database.js
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 
 import { PGSQL_NON_EXISTENT_DATABASE_ERROR } from '../../db/pgsql-errors.js';
+import { logErrorWithCorrelationIds } from '../../lib/infrastructure/monitoring-tools.js';
 import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 import { PgClient } from '../PgClient.js';
 
@@ -10,7 +11,7 @@ function isPlatformScalingo() {
 
 function preventDatabaseDropAsItCannotBeCreatedAgain() {
   if (isPlatformScalingo()) {
-    logger.error('Database will not be dropped, as it would require to recreate the addon');
+    logErrorWithCorrelationIds('Database will not be dropped, as it would require to recreate the addon');
     process.exitCode = 1;
   }
 }
@@ -35,7 +36,7 @@ PgClient.getClient(url.href).then(async (client) => {
     if (error.code === PGSQL_NON_EXISTENT_DATABASE_ERROR) {
       logger.info(`Database ${DB_TO_DELETE_NAME} does not exist`);
     } else {
-      logger.error(`Database drop failed: ${error.detail}`);
+      logErrorWithCorrelationIds(`Database drop failed: ${error.detail}`);
     }
   } finally {
     await client.end();

--- a/api/scripts/database/drop-database.js
+++ b/api/scripts/database/drop-database.js
@@ -1,8 +1,7 @@
 import 'dotenv/config';
 
 import { PGSQL_NON_EXISTENT_DATABASE_ERROR } from '../../db/pgsql-errors.js';
-import { logErrorWithCorrelationIds } from '../../lib/infrastructure/monitoring-tools.js';
-import { logger } from '../../src/shared/infrastructure/utils/logger.js';
+import { logErrorWithCorrelationIds, logInfoWithCorrelationIds } from '../../lib/infrastructure/monitoring-tools.js';
 import { PgClient } from '../PgClient.js';
 
 function isPlatformScalingo() {
@@ -30,11 +29,11 @@ PgClient.getClient(url.href).then(async (client) => {
   try {
     const WITH_FORCE = _withForceOption();
     await client.query_and_log(`DROP DATABASE ${DB_TO_DELETE_NAME}${WITH_FORCE};`);
-    logger.info('Database dropped');
+    logInfoWithCorrelationIds('Database dropped');
     await client.end();
   } catch (error) {
     if (error.code === PGSQL_NON_EXISTENT_DATABASE_ERROR) {
-      logger.info(`Database ${DB_TO_DELETE_NAME} does not exist`);
+      logInfoWithCorrelationIds(`Database ${DB_TO_DELETE_NAME} does not exist`);
     } else {
       logErrorWithCorrelationIds(`Database drop failed: ${error.detail}`);
     }

--- a/api/scripts/database/empty-database.js
+++ b/api/scripts/database/empty-database.js
@@ -1,11 +1,10 @@
 import { disconnect, emptyAllTables } from '../../db/knex-database-connection.js';
-import { logErrorWithCorrelationIds } from '../../lib/infrastructure/monitoring-tools.js';
-import { logger } from '../../src/shared/infrastructure/utils/logger.js';
+import { logErrorWithCorrelationIds, logInfoWithCorrelationIds } from '../../lib/infrastructure/monitoring-tools.js';
 
 const main = async () => {
-  logger.info('Emptying all tables...');
+  logInfoWithCorrelationIds('Emptying all tables...');
   await emptyAllTables();
-  logger.info('Done!');
+  logInfoWithCorrelationIds('Done!');
 };
 
 (async () => {

--- a/api/scripts/database/empty-database.js
+++ b/api/scripts/database/empty-database.js
@@ -1,4 +1,5 @@
 import { disconnect, emptyAllTables } from '../../db/knex-database-connection.js';
+import { logErrorWithCorrelationIds } from '../../lib/infrastructure/monitoring-tools.js';
 import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 
 const main = async () => {
@@ -11,7 +12,7 @@ const main = async () => {
   try {
     await main();
   } catch (error) {
-    logger.error(error);
+    logErrorWithCorrelationIds(error);
     process.exitCode = 1;
   } finally {
     await disconnect();

--- a/api/scripts/database/pg-boss-migration.js
+++ b/api/scripts/database/pg-boss-migration.js
@@ -3,7 +3,7 @@ import 'dotenv/config';
 import PgBoss from 'pg-boss';
 
 import { disconnect } from '../../db/knex-database-connection.js';
-import { logger } from '../../src/shared/infrastructure/utils/logger.js';
+import { logErrorWithCorrelationIds } from '../../lib/infrastructure/monitoring-tools.js';
 
 async function main() {
   console.log('run pgboss migrations');
@@ -17,7 +17,7 @@ async function main() {
   try {
     await main();
   } catch (error) {
-    logger.error(error);
+    logErrorWithCorrelationIds(error);
     process.exitCode = 1;
   } finally {
     await disconnect();

--- a/api/scripts/database/restore-dump/download-backup.js
+++ b/api/scripts/database/restore-dump/download-backup.js
@@ -7,6 +7,7 @@ import fs from 'node:fs';
 import Joi from 'joi';
 
 import { disconnect } from '../../../db/knex-database-connection.js';
+import { logInfoWithCorrelationIds } from '../../../lib/infrastructure/monitoring-tools.js';
 import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import { ScalingoClient } from './helpers/scalingo/scalingo-client.js';
 
@@ -45,7 +46,7 @@ async function getScalingoBackup(configuration) {
   const client = await ScalingoClient.getInstance(configuration);
 
   const addon = await client.getAddon(postgresDatabaseAddonProviderId);
-  logger.info('Add-on ID: ' + addon.id);
+  logInfoWithCorrelationIds('Add-on ID: ' + addon.id);
 
   const dbClient = await client.getDatabaseClient(addon.id);
 
@@ -62,11 +63,11 @@ async function getScalingoBackup(configuration) {
   const lastBackupId = lastBackup.id;
   const expectedSize = lastBackup.size;
 
-  logger.info(`About to download backup id ${lastBackupId} created at ${lastBackupDate}`);
+  logInfoWithCorrelationIds(`About to download backup id ${lastBackupId} created at ${lastBackupDate}`);
 
-  logger.info('Backup download - Doing..');
+  logInfoWithCorrelationIds('Backup download - Doing..');
   await dbClient.downloadBackup(lastBackupId, process.env.DUMP_FILE_PATH);
-  logger.info('Backup download - Done');
+  logInfoWithCorrelationIds('Backup download - Done');
 
   checkDumpSize({ dumpFilePath, expectedSize });
 }

--- a/api/scripts/fill-in-assessment-method.js
+++ b/api/scripts/fill-in-assessment-method.js
@@ -1,7 +1,7 @@
 import 'dotenv/config';
 
 import { knex } from '../db/knex-database-connection.js';
-import { logger } from '../src/shared/infrastructure/utils/logger.js';
+import { logInfoWithCorrelationIds } from '../lib/infrastructure/monitoring-tools.js';
 
 async function fillInAssessmentMethod() {
   const chunkSize = 50000;
@@ -23,10 +23,10 @@ async function fillInAssessmentMethod() {
 	      END`),
       });
 
-    logger.info(`Updated rows : ${rowsUpdatedCount}`);
+    logInfoWithCorrelationIds(`Updated rows : ${rowsUpdatedCount}`);
   }
 
-  logger.info('End fillInAssessmentMethod');
+  logInfoWithCorrelationIds('End fillInAssessmentMethod');
 }
 
 (async () => {

--- a/api/scripts/fill-target-profiles-with-default-image-url.js
+++ b/api/scripts/fill-target-profiles-with-default-image-url.js
@@ -4,6 +4,7 @@ import perf_hooks from 'node:perf_hooks';
 import * as url from 'node:url';
 
 import { disconnect, knex } from '../db/knex-database-connection.js';
+import { logErrorWithCorrelationIds } from '../lib/infrastructure/monitoring-tools.js';
 import { logger } from '../src/shared/infrastructure/utils/logger.js';
 
 const { performance } = perf_hooks;
@@ -34,7 +35,7 @@ async function main() {
     try {
       await main();
     } catch (error) {
-      logger.error(error);
+      logErrorWithCorrelationIds(error);
       process.exitCode = 1;
     } finally {
       await disconnect();

--- a/api/scripts/fill-target-profiles-with-default-image-url.js
+++ b/api/scripts/fill-target-profiles-with-default-image-url.js
@@ -4,8 +4,7 @@ import perf_hooks from 'node:perf_hooks';
 import * as url from 'node:url';
 
 import { disconnect, knex } from '../db/knex-database-connection.js';
-import { logErrorWithCorrelationIds } from '../lib/infrastructure/monitoring-tools.js';
-import { logger } from '../src/shared/infrastructure/utils/logger.js';
+import { logErrorWithCorrelationIds, logInfoWithCorrelationIds } from '../lib/infrastructure/monitoring-tools.js';
 
 const { performance } = perf_hooks;
 
@@ -23,11 +22,11 @@ async function fillTargetProfilesWithDefaultImageUrl() {
 
 async function main() {
   const startTime = performance.now();
-  logger.info(`Script ${__filename} has started`);
+  logInfoWithCorrelationIds(`Script ${__filename} has started`);
   await fillTargetProfilesWithDefaultImageUrl();
   const endTime = performance.now();
   const duration = Math.round(endTime - startTime);
-  logger.info(`Script has ended: took ${duration} milliseconds`);
+  logInfoWithCorrelationIds(`Script has ended: took ${duration} milliseconds`);
 }
 
 (async () => {

--- a/api/scripts/generate-api-documentation.js
+++ b/api/scripts/generate-api-documentation.js
@@ -4,7 +4,7 @@ import * as url from 'node:url';
 
 import jsdocToMarkdown from 'jsdoc-to-markdown';
 
-import { logger } from '../src/shared/infrastructure/utils/logger.js';
+import { logErrorWithCorrelationIds } from '../lib/infrastructure/monitoring-tools.js';
 
 async function main(baseFolder) {
   const docs = await jsdocToMarkdown.render({ files: `${baseFolder}/**/application/api/*.js` });
@@ -20,7 +20,7 @@ const isLaunchedFromCommandLine = process.argv[1] === modulePath;
     try {
       await main(process.argv[2]);
     } catch (error) {
-      logger.error(error);
+      logErrorWithCorrelationIds(error);
       process.exitCode = 1;
     }
   }

--- a/api/scripts/prod/compute-badge-acquisitions.js
+++ b/api/scripts/prod/compute-badge-acquisitions.js
@@ -14,6 +14,7 @@ import yargs from 'yargs/yargs';
 
 import { disconnect, knex } from '../../db/knex-database-connection.js';
 import { learningContentCache as cache } from '../../lib/infrastructure/caches/learning-content-cache.js';
+import { logErrorWithCorrelationIds } from '../../lib/infrastructure/monitoring-tools.js';
 import * as badgeAcquisitionRepository from '../../lib/infrastructure/repositories/badge-acquisition-repository.js';
 import * as badgeForCalculationRepository from '../../lib/infrastructure/repositories/badge-for-calculation-repository.js';
 import * as knowledgeElementRepository from '../../lib/infrastructure/repositories/knowledge-element-repository.js';
@@ -147,7 +148,7 @@ const isLaunchedFromCommandLine = process.argv[1] === modulePath;
     try {
       await main();
     } catch (error) {
-      logger.error(error);
+      logErrorWithCorrelationIds(error);
       process.exitCode = 1;
     } finally {
       await disconnect();

--- a/api/scripts/prod/target-profile-migrations/convert-target-profiles-into-new-format.js
+++ b/api/scripts/prod/target-profile-migrations/convert-target-profiles-into-new-format.js
@@ -6,8 +6,7 @@ import _ from 'lodash';
 
 import { disconnect, knex } from '../../../db/knex-database-connection.js';
 import { learningContentCache } from '../../../lib/infrastructure/caches/learning-content-cache.js';
-import { logErrorWithCorrelationIds } from '../../../lib/infrastructure/monitoring-tools.js';
-import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
+import { logErrorWithCorrelationIds, logInfoWithCorrelationIds } from '../../../lib/infrastructure/monitoring-tools.js';
 import { autoMigrateTargetProfile } from './common.js';
 
 async function main() {
@@ -26,14 +25,14 @@ async function main() {
 async function doJob(dryRun) {
   const targetProfileIds = await _findTargetProfileIdsToConvert();
   if (targetProfileIds.length === 0) {
-    logger.info('Aucun profil cible à convertir.');
+    logInfoWithCorrelationIds('Aucun profil cible à convertir.');
     return;
   }
-  logger.info(`${targetProfileIds.length} à convertir...`);
+  logInfoWithCorrelationIds(`${targetProfileIds.length} à convertir...`);
   for (const targetProfileId of targetProfileIds) {
     const trx = await knex.transaction();
     try {
-      logger.info(`Conversion de ${targetProfileId}...`);
+      logInfoWithCorrelationIds(`Conversion de ${targetProfileId}...`);
       await _convertTargetProfile(targetProfileId, trx);
       if (dryRun) await trx.rollback();
       else await trx.commit();

--- a/api/scripts/prod/target-profile-migrations/convert-target-profiles-into-new-format.js
+++ b/api/scripts/prod/target-profile-migrations/convert-target-profiles-into-new-format.js
@@ -6,6 +6,7 @@ import _ from 'lodash';
 
 import { disconnect, knex } from '../../../db/knex-database-connection.js';
 import { learningContentCache } from '../../../lib/infrastructure/caches/learning-content-cache.js';
+import { logErrorWithCorrelationIds } from '../../../lib/infrastructure/monitoring-tools.js';
 import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import { autoMigrateTargetProfile } from './common.js';
 
@@ -14,7 +15,7 @@ async function main() {
     const dryRun = process.env.DRY_RUN === 'true';
     await doJob(dryRun);
   } catch (err) {
-    logger.error(err);
+    logErrorWithCorrelationIds(err);
     throw err;
   } finally {
     await disconnect();
@@ -37,7 +38,7 @@ async function doJob(dryRun) {
       if (dryRun) await trx.rollback();
       else await trx.commit();
     } catch (err) {
-      logger.error(`${targetProfileId} Echec. Raison : ${err}`);
+      logErrorWithCorrelationIds(`${targetProfileId} Echec. Raison : ${err}`);
       await trx.rollback();
     }
   }

--- a/api/scripts/prod/target-profile-migrations/extract-need-stages-migration.js
+++ b/api/scripts/prod/target-profile-migrations/extract-need-stages-migration.js
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 import * as dotenv from 'dotenv';
 import { read as readXlsx, utils as xlsxUtils } from 'xlsx';
 
-import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
+import { logErrorWithCorrelationIds, logInfoWithCorrelationIds } from '../../../lib/infrastructure/monitoring-tools.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
@@ -31,7 +31,7 @@ async function doJob(multiFormFiles) {
   const outputFile = resolve(__dirname, 'need-stages-migration.json');
   await writeFile(resolve(__dirname, 'need-stages-migration.json'), JSON.stringify(targetProfileIds, null, 2));
 
-  logger.info(`Wrote ${outputFile}`);
+  logInfoWithCorrelationIds(`Wrote ${outputFile}`);
 }
 
 async function parseMultiformFileStage(file) {
@@ -78,12 +78,12 @@ const isLaunchedFromCommandLine = process.argv[1] === modulePath;
 
 async function main() {
   const startTime = performance.now();
-  logger.info(`Script ${modulePath} has started`);
+  logInfoWithCorrelationIds(`Script ${modulePath} has started`);
   const [, , ...files] = process.argv;
   await doJob(files);
   const endTime = performance.now();
   const duration = Math.round(endTime - startTime);
-  logger.info(`Script has ended: took ${duration} milliseconds`);
+  logInfoWithCorrelationIds(`Script has ended: took ${duration} milliseconds`);
 }
 
 (async () => {
@@ -91,7 +91,7 @@ async function main() {
     try {
       await main();
     } catch (error) {
-      logger.error(error);
+      logErrorWithCorrelationIds(error);
       process.exitCode = 1;
     }
   }

--- a/api/scripts/prod/target-profile-migrations/migrate-stages-to-level.js
+++ b/api/scripts/prod/target-profile-migrations/migrate-stages-to-level.js
@@ -10,12 +10,11 @@ import { utils as xlsxUtils, writeXLSX } from 'xlsx';
 
 import { disconnect } from '../../../db/knex-database-connection.js';
 import { learningContentCache as cache } from '../../../lib/infrastructure/caches/learning-content-cache.js';
-import { logErrorWithCorrelationIds } from '../../../lib/infrastructure/monitoring-tools.js';
+import { logErrorWithCorrelationIds, logInfoWithCorrelationIds } from '../../../lib/infrastructure/monitoring-tools.js';
 import * as stageCollectionRepository from '../../../src/evaluation/infrastructure/repositories/stage-collection-repository.js';
 import * as organizationRepository from '../../../src/shared/infrastructure/repositories/organization-repository.js';
 import * as skillRepository from '../../../src/shared/infrastructure/repositories/skill-repository.js';
 import * as targetProfileForAdminRepository from '../../../src/shared/infrastructure/repositories/target-profile-for-admin-repository.js';
-import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 
 const modulePath = fileURLToPath(import.meta.url);
 const isLaunchedFromCommandLine = process.argv[1] === modulePath;
@@ -207,12 +206,12 @@ async function _writeReport(migrations) {
 async function main() {
   const startTime = performance.now();
   const dryRun = process.env.DRY_RUN !== 'false';
-  logger.info({ dryRun }, `Script ${modulePath} has started`);
+  logInfoWithCorrelationIds({ dryRun }, `Script ${modulePath} has started`);
   const inputFile = resolve(process.cwd(), process.argv[2]);
   await migrateStagesToLevel(inputFile, dryRun);
   const endTime = performance.now();
   const duration = Math.round(endTime - startTime);
-  logger.info(`Script has ended: took ${duration} milliseconds`);
+  logInfoWithCorrelationIds(`Script has ended: took ${duration} milliseconds`);
 }
 
 (async () => {

--- a/api/scripts/prod/target-profile-migrations/migrate-stages-to-level.js
+++ b/api/scripts/prod/target-profile-migrations/migrate-stages-to-level.js
@@ -10,6 +10,7 @@ import { utils as xlsxUtils, writeXLSX } from 'xlsx';
 
 import { disconnect } from '../../../db/knex-database-connection.js';
 import { learningContentCache as cache } from '../../../lib/infrastructure/caches/learning-content-cache.js';
+import { logErrorWithCorrelationIds } from '../../../lib/infrastructure/monitoring-tools.js';
 import * as stageCollectionRepository from '../../../src/evaluation/infrastructure/repositories/stage-collection-repository.js';
 import * as organizationRepository from '../../../src/shared/infrastructure/repositories/organization-repository.js';
 import * as skillRepository from '../../../src/shared/infrastructure/repositories/skill-repository.js';
@@ -219,7 +220,7 @@ async function main() {
     try {
       await main();
     } catch (error) {
-      logger.error(error);
+      logErrorWithCorrelationIds(error);
       process.exitCode = 1;
     } finally {
       await disconnect();

--- a/api/scripts/prod/target-profile-migrations/parse-xls-files-for-target-profiles-migration.js
+++ b/api/scripts/prod/target-profile-migrations/parse-xls-files-for-target-profiles-migration.js
@@ -17,6 +17,7 @@ import XLSX from 'xlsx';
 import { disconnect, knex } from '../../../db/knex-database-connection.js';
 import { normalizeAndRemoveAccents } from '../../../lib/domain/services/validation-treatments.js';
 import { learningContentCache as cache } from '../../../lib/infrastructure/caches/learning-content-cache.js';
+import { logErrorWithCorrelationIds } from '../../../lib/infrastructure/monitoring-tools.js';
 import * as tubeRepository from '../../../lib/infrastructure/repositories/tube-repository.js';
 import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import { autoMigrateTargetProfile } from './common.js';
@@ -60,7 +61,7 @@ const mapperFnc = (line) => {
       multiformCap: ouiNonToBoolean(line.multiformCap),
     };
   } catch (_e) {
-    logger.error(
+    logErrorWithCorrelationIds(
       { targetProfileId: line.id, targetProfileName: line.name },
       "Erreur lors de la migration d'un profil cible: Ligne EXCEL incorrecte, valeur de cellule invalide",
     );
@@ -217,7 +218,7 @@ async function migrateTargetProfiles(targetProfiles, multiFormData, dryRun) {
         }
       });
     } catch (e) {
-      logger.error(
+      logErrorWithCorrelationIds(
         { targetProfileId: targetProfile.id, targetProfileName: targetProfile.name },
         "Erreur lors de la migration d'un profil cible: %s",
         e,
@@ -316,7 +317,7 @@ async function main() {
     try {
       await main();
     } catch (error) {
-      logger.error(error);
+      logErrorWithCorrelationIds(error);
       process.exitCode = 1;
     } finally {
       await disconnect();

--- a/api/scripts/prod/target-profile-migrations/parse-xls-files-for-target-profiles-migration.js
+++ b/api/scripts/prod/target-profile-migrations/parse-xls-files-for-target-profiles-migration.js
@@ -17,7 +17,7 @@ import XLSX from 'xlsx';
 import { disconnect, knex } from '../../../db/knex-database-connection.js';
 import { normalizeAndRemoveAccents } from '../../../lib/domain/services/validation-treatments.js';
 import { learningContentCache as cache } from '../../../lib/infrastructure/caches/learning-content-cache.js';
-import { logErrorWithCorrelationIds } from '../../../lib/infrastructure/monitoring-tools.js';
+import { logErrorWithCorrelationIds, logInfoWithCorrelationIds } from '../../../lib/infrastructure/monitoring-tools.js';
 import * as tubeRepository from '../../../lib/infrastructure/repositories/tube-repository.js';
 import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 import { autoMigrateTargetProfile } from './common.js';
@@ -164,7 +164,7 @@ async function migrateTargetProfiles(targetProfiles, multiFormData, dryRun) {
           if (targetProfile.obsolete) {
             _checkIfTPHasUnexpectedMultiformInstructions(targetProfile.id, multiFormData);
             await _outdate(targetProfile.id, trx);
-            logger.info(
+            logInfoWithCorrelationIds(
               { targetProfileId: targetProfile.id, targetProfileName: targetProfile.name },
               `Profil cible marqué comme obsolète`,
             );
@@ -172,7 +172,7 @@ async function migrateTargetProfiles(targetProfiles, multiFormData, dryRun) {
           }
           if (targetProfile.auto) {
             _checkIfTPHasUnexpectedMultiformInstructions(targetProfile.id, multiFormData);
-            logger.info(
+            logInfoWithCorrelationIds(
               { targetProfileId: targetProfile.id, targetProfileName: targetProfile.name },
               `Profil cible migré automatiquement`,
             );
@@ -181,7 +181,7 @@ async function migrateTargetProfiles(targetProfiles, multiFormData, dryRun) {
           if (targetProfile.uncap) {
             _checkIfTPHasUnexpectedMultiformInstructions(targetProfile.id, multiFormData);
             await _uncap(targetProfile.id, trx);
-            logger.info(
+            logInfoWithCorrelationIds(
               { targetProfileId: targetProfile.id, targetProfileName: targetProfile.name },
               `Profil cible décappé`,
             );
@@ -190,7 +190,7 @@ async function migrateTargetProfiles(targetProfiles, multiFormData, dryRun) {
           if (typeof targetProfile.uniformCap === 'number') {
             _checkIfTPHasUnexpectedMultiformInstructions(targetProfile.id, multiFormData);
             await _uniformCap(targetProfile.id, targetProfile.uniformCap, trx);
-            logger.info(
+            logInfoWithCorrelationIds(
               { targetProfileId: targetProfile.id, targetProfileName: targetProfile.name },
               'Profil cible cappé uniformément à %s',
               targetProfile.uniformCap,
@@ -202,7 +202,7 @@ async function migrateTargetProfiles(targetProfiles, multiFormData, dryRun) {
             if (!targetProfileMultiFormData || targetProfileMultiFormData.length === 0)
               throw new Error('Profil cible cappé multiforme sans instructions');
             await _multiformCap(targetProfile, targetProfileMultiFormData, trx);
-            logger.info(
+            logInfoWithCorrelationIds(
               { targetProfileId: targetProfile.id, targetProfileName: targetProfile.name },
               `Profil cible cappé multiformément`,
             );
@@ -303,13 +303,13 @@ const __filename = modulePath;
 
 async function main() {
   const startTime = performance.now();
-  logger.info(`Script ${__filename} has started`);
+  logInfoWithCorrelationIds(`Script ${__filename} has started`);
   const [, , mainFile, ...multiFormFiles] = process.argv;
   const dryRun = process.env.DRY_RUN === 'true';
   await doJob(mainFile, multiFormFiles, dryRun);
   const endTime = performance.now();
   const duration = Math.round(endTime - startTime);
-  logger.info(`Script has ended: took ${duration} milliseconds`);
+  logInfoWithCorrelationIds(`Script has ended: took ${duration} milliseconds`);
 }
 
 (async () => {

--- a/api/scripts/prod/target-profile-migrations/revert-stages-to-threshold.js
+++ b/api/scripts/prod/target-profile-migrations/revert-stages-to-threshold.js
@@ -10,6 +10,7 @@ import { readFile, set_fs, utils as xlsxUtils } from 'xlsx';
 
 import { disconnect } from '../../../db/knex-database-connection.js';
 import { learningContentCache as cache } from '../../../lib/infrastructure/caches/learning-content-cache.js';
+import { logErrorWithCorrelationIds } from '../../../lib/infrastructure/monitoring-tools.js';
 import * as stageCollectionRepository from '../../../src/evaluation/infrastructure/repositories/stage-collection-repository.js';
 import * as targetProfileForAdminRepository from '../../../src/shared/infrastructure/repositories/target-profile-for-admin-repository.js';
 import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
@@ -75,7 +76,7 @@ async function _computeReverts(inputFile, sample) {
       );
 
       if (!precheckNoChanges || !precheckUnknownStage) {
-        logger.error(
+        logErrorWithCorrelationIds(
           { stageReverts, stagesWLevel },
           `Skipping target profile ${targetProfile.id} which had changes since migration`,
         );
@@ -131,7 +132,7 @@ async function main() {
     try {
       await main();
     } catch (error) {
-      logger.error(error);
+      logErrorWithCorrelationIds(error);
       process.exitCode = 1;
     } finally {
       await disconnect();

--- a/api/scripts/refresh-cache.js
+++ b/api/scripts/refresh-cache.js
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 
 import { learningContentCache } from '../lib/infrastructure/caches/learning-content-cache.js';
+import { logErrorWithCorrelationIds } from '../lib/infrastructure/monitoring-tools.js';
 import * as learningContentDatasource from '../src/shared/infrastructure/datasources/learning-content/datasource.js';
 import { logger } from '../src/shared/infrastructure/utils/logger.js';
 
@@ -10,5 +11,5 @@ learningContentDatasource
   .then(() => {
     logger.info('Learning Content refreshed');
   })
-  .catch((e) => logger.error('Error while reloading cache', e))
+  .catch((e) => logErrorWithCorrelationIds('Error while reloading cache', e))
   .finally(() => learningContentCache.quit());

--- a/api/scripts/refresh-cache.js
+++ b/api/scripts/refresh-cache.js
@@ -1,15 +1,14 @@
 import 'dotenv/config';
 
 import { learningContentCache } from '../lib/infrastructure/caches/learning-content-cache.js';
-import { logErrorWithCorrelationIds } from '../lib/infrastructure/monitoring-tools.js';
+import { logErrorWithCorrelationIds, logInfoWithCorrelationIds } from '../lib/infrastructure/monitoring-tools.js';
 import * as learningContentDatasource from '../src/shared/infrastructure/datasources/learning-content/datasource.js';
-import { logger } from '../src/shared/infrastructure/utils/logger.js';
 
-logger.info('Starting refreshing Learning Content');
+logInfoWithCorrelationIds('Starting refreshing Learning Content');
 learningContentDatasource
   .refreshLearningContentCacheRecords()
   .then(() => {
-    logger.info('Learning Content refreshed');
+    logInfoWithCorrelationIds('Learning Content refreshed');
   })
   .catch((e) => logErrorWithCorrelationIds('Error while reloading cache', e))
   .finally(() => learningContentCache.quit());

--- a/api/scripts/update-audit-api-csv-file.js
+++ b/api/scripts/update-audit-api-csv-file.js
@@ -1,7 +1,7 @@
 import url from 'node:url';
 
 import { parseCsvWithHeader } from '../lib/infrastructure/helpers/csv.js';
-import { logger } from '../src/shared/infrastructure/utils/logger.js';
+import { logErrorWithCorrelationIds } from '../lib/infrastructure/monitoring-tools.js';
 const swaggerUrl = `https://app.pix.fr/api/swagger.json`;
 
 /**
@@ -79,7 +79,7 @@ if (isLaunchedFromCommandLine) {
   try {
     await main();
   } catch (error) {
-    logger.error(error);
+    logErrorWithCorrelationIds(error);
     throw error;
   }
 }

--- a/api/src/certification/complementary-certification/domain/usecases/send-target-profile-notifications.js
+++ b/api/src/certification/complementary-certification/domain/usecases/send-target-profile-notifications.js
@@ -1,5 +1,6 @@
 import bluebird from 'bluebird';
 
+import { logErrorWithCorrelationIds } from '../../../../../lib/infrastructure/monitoring-tools.js';
 import { CONCURRENCY_HEAVY_OPERATIONS } from '../../../../shared/infrastructure/constants.js';
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 const EVENT_NAME = 'attach-target-profile-certif';
@@ -26,7 +27,7 @@ async function sendTargetProfileNotifications({
           email,
         });
         if (result.hasFailed()) {
-          logger.error({
+          logErrorWithCorrelationIds({
             event: EVENT_NAME,
             message: `Failed to send email to notify organisation user "${email}" of ${complementaryCertificationName}'s target profile change`,
           });

--- a/api/src/certification/complementary-certification/domain/usecases/send-target-profile-notifications.js
+++ b/api/src/certification/complementary-certification/domain/usecases/send-target-profile-notifications.js
@@ -1,8 +1,10 @@
 import bluebird from 'bluebird';
 
-import { logErrorWithCorrelationIds } from '../../../../../lib/infrastructure/monitoring-tools.js';
+import {
+  logErrorWithCorrelationIds,
+  logInfoWithCorrelationIds,
+} from '../../../../../lib/infrastructure/monitoring-tools.js';
 import { CONCURRENCY_HEAVY_OPERATIONS } from '../../../../shared/infrastructure/constants.js';
-import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 const EVENT_NAME = 'attach-target-profile-certif';
 
 export { sendTargetProfileNotifications };
@@ -39,7 +41,7 @@ async function sendTargetProfileNotifications({
       { concurrency: CONCURRENCY_HEAVY_OPERATIONS },
     );
 
-    logger.info({
+    logInfoWithCorrelationIds({
       event: EVENT_NAME,
       message: `${sucessCounter} email(s) sent to notify organisation users of ${complementaryCertificationName}'s target profile change`,
     });

--- a/api/src/certification/course/infrastructure/utils/pdf/certification-attestation-pdf.js
+++ b/api/src/certification/course/infrastructure/utils/pdf/certification-attestation-pdf.js
@@ -8,9 +8,9 @@ import dayjs from 'dayjs';
 import _ from 'lodash';
 import { PDFDocument, rgb } from 'pdf-lib';
 
+import { logErrorWithCorrelationIds } from '../../../../../../lib/infrastructure/monitoring-tools.js';
 import { CertificationAttestationGenerationError } from '../../../../../shared/domain/errors.js';
 import { LANGUAGES_CODE } from '../../../../../shared/domain/services/language-service.js';
-import { logger } from '../../../../../shared/infrastructure/utils/logger.js';
 import { AttestationViewModel } from './AttestationViewModel.js';
 
 const { ENGLISH } = LANGUAGES_CODE;
@@ -126,7 +126,7 @@ async function _embedCertificationImage(pdfDocument, certificationImagePath) {
       responseType: 'arraybuffer',
     });
   } catch (error) {
-    logger.error(error);
+    logErrorWithCorrelationIds(error);
     throw new CertificationAttestationGenerationError();
   }
   const [page] = await pdfDocument.embedPdf(response.data);

--- a/api/src/certification/course/scripts/generate-certification-attestations-by-session-ids.js
+++ b/api/src/certification/course/scripts/generate-certification-attestations-by-session-ids.js
@@ -13,6 +13,7 @@ import i18n from 'i18n';
 
 import { disconnect } from '../../../../db/knex-database-connection.js';
 import { learningContentCache as cache } from '../../../../lib/infrastructure/caches/learning-content-cache.js';
+import { logErrorWithCorrelationIds } from '../../../../lib/infrastructure/monitoring-tools.js';
 import { options } from '../../../../lib/infrastructure/plugins/i18n.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
@@ -47,7 +48,7 @@ async function main() {
     const certificationCourses = await certificationCourseRepository.findCertificationCoursesBySessionId({ sessionId });
 
     if (isEmpty(certificationCourses)) {
-      logger.error(`Pas de certifications trouvées pour la session ${sessionId}.`);
+      logErrorWithCorrelationIds(`Pas de certifications trouvées pour la session ${sessionId}.`);
       return;
     }
 
@@ -66,7 +67,7 @@ async function main() {
     );
 
     if (isEmpty(certificationAttestations)) {
-      logger.error(`Pas d'attestation trouvée pour la session ${sessionId}.`);
+      logErrorWithCorrelationIds(`Pas d'attestation trouvée pour la session ${sessionId}.`);
       return;
     }
 
@@ -93,7 +94,7 @@ const isLaunchedFromCommandLine = process.argv[1] === modulePath;
     try {
       await main();
     } catch (error) {
-      logger.error(error);
+      logErrorWithCorrelationIds(error);
       process.exitCode = 1;
     } finally {
       await disconnect();

--- a/api/src/certification/course/scripts/generate-certification-attestations-by-session-ids.js
+++ b/api/src/certification/course/scripts/generate-certification-attestations-by-session-ids.js
@@ -13,10 +13,12 @@ import i18n from 'i18n';
 
 import { disconnect } from '../../../../db/knex-database-connection.js';
 import { learningContentCache as cache } from '../../../../lib/infrastructure/caches/learning-content-cache.js';
-import { logErrorWithCorrelationIds } from '../../../../lib/infrastructure/monitoring-tools.js';
+import {
+  logErrorWithCorrelationIds,
+  logInfoWithCorrelationIds,
+} from '../../../../lib/infrastructure/monitoring-tools.js';
 import { options } from '../../../../lib/infrastructure/plugins/i18n.js';
 import { NotFoundError } from '../../../shared/domain/errors.js';
-import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import * as certificationCourseRepository from '../../shared/infrastructure/repositories/certification-course-repository.js';
 import * as certificateRepository from '../infrastructure/repositories/certificate-repository.js';
 import * as certificationAttestationPdf from '../infrastructure/utils/pdf/certification-attestation-pdf.js';
@@ -33,10 +35,10 @@ i18n.configure({
  * Usage: LOG_LEVEL=info NODE_TLS_REJECT_UNAUTHORIZED='0' PGSSLMODE=require node scripts/certification/generate-certification-attestations-by-session-ids.js 86781
  */
 async function main() {
-  logger.info("Début du script de génération d'attestations pour une session.");
+  logInfoWithCorrelationIds("Début du script de génération d'attestations pour une session.");
 
   if (process.argv.length <= 2) {
-    logger.info(
+    logInfoWithCorrelationIds(
       'Usage: NODE_TLS_REJECT_UNAUTHORIZED="0" PGSSLMODE=require node scripts/generate-certification-attestations-by-session-id.js 1234,5678,9012',
     );
     return;
@@ -71,7 +73,9 @@ async function main() {
       return;
     }
 
-    logger.info(`${certificationAttestations.length} attestations récupérées pour la session ${sessionId}.`);
+    logInfoWithCorrelationIds(
+      `${certificationAttestations.length} attestations récupérées pour la session ${sessionId}.`,
+    );
 
     const { buffer } = await certificationAttestationPdf.getCertificationAttestationsPdfBuffer({
       certificates: certificationAttestations,
@@ -79,12 +83,12 @@ async function main() {
     });
 
     const filename = `attestation-pix-session-${sessionId}.pdf`;
-    logger.info(`Génération du fichier pdf ${filename}.`);
+    logInfoWithCorrelationIds(`Génération du fichier pdf ${filename}.`);
 
     await fs.promises.writeFile(filename, buffer);
   });
 
-  logger.info('Fin du script.');
+  logInfoWithCorrelationIds('Fin du script.');
 }
 
 const modulePath = url.fileURLToPath(import.meta.url);

--- a/api/src/certification/session-management/domain/usecases/integrate-cpf-processing-receipts.js
+++ b/api/src/certification/session-management/domain/usecases/integrate-cpf-processing-receipts.js
@@ -6,6 +6,7 @@
 import bluebird from 'bluebird';
 
 import { CONCURRENCY_HEAVY_OPERATIONS } from '../../../../../lib/infrastructure/constants.js';
+import { logErrorWithCorrelationIds } from '../../../../../lib/infrastructure/monitoring-tools.js';
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 
 /**
@@ -26,7 +27,7 @@ const integrateCpfProccessingReceipts = async function ({ cpfReceiptsStorage, cp
       await cpfReceiptsStorage.deleteReceipt({ cpfReceipt });
     } catch (error) {
       // Do not block next CPF receipt integration
-      logger.error('An error occured while integrating a CPF receipt', error);
+      logErrorWithCorrelationIds('An error occured while integrating a CPF receipt', error);
     }
   }
 

--- a/api/src/certification/session-management/infrastructure/repositories/jury-session-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/jury-session-repository.js
@@ -2,8 +2,8 @@ import { knex } from '../../../../../db/knex-database-connection.js';
 import { PGSQL_FOREIGN_KEY_VIOLATION_ERROR } from '../../../../../db/pgsql-errors.js';
 import { NotFoundError } from '../../../../../lib/domain/errors.js';
 import { JurySession, statuses } from '../../../../../lib/domain/models/JurySession.js';
+import { logErrorWithCorrelationIds } from '../../../../../lib/infrastructure/monitoring-tools.js';
 import { fetchPage } from '../../../../shared/infrastructure/utils/knex-utils.js';
-import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 import { CertificationOfficer } from '../../domain/models/CertificationOfficer.js';
 
 const COLUMNS = Object.freeze([
@@ -69,7 +69,7 @@ const assignCertificationOfficer = async function ({ id, assignedCertificationOf
     if (error instanceof NotFoundError) {
       throw error;
     }
-    logger.error(error);
+    logErrorWithCorrelationIds(error);
   }
 };
 

--- a/api/src/certification/shared/infrastructure/repositories/certification-challenge-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-challenge-repository.js
@@ -2,6 +2,7 @@ import { knex } from '../../../../../db/knex-database-connection.js';
 import { AssessmentEndedError } from '../../../../../lib/domain/errors.js';
 import { CertificationChallenge } from '../../../../../lib/domain/models/CertificationChallenge.js';
 import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';
+import { logInfoWithCorrelationIds } from '../../../../../lib/infrastructure/monitoring-tools.js';
 import { logger } from '../../../../shared/infrastructure/utils/logger.js';
 
 const logContext = {
@@ -38,7 +39,7 @@ const getNextNonAnsweredChallengeByCourseId = async function (assessmentId, cour
     .first();
 
   if (!certificationChallenge) {
-    logger.info(logContext, `no found challenges for certificationCourseId : ${courseId}`);
+    logInfoWithCorrelationIds(logContext, `no found challenges for certificationCourseId : ${courseId}`);
     throw new AssessmentEndedError();
   }
 

--- a/api/src/identity-access-management/application/saml/saml.controller.js
+++ b/api/src/identity-access-management/application/saml/saml.controller.js
@@ -1,6 +1,6 @@
 import { config } from '../../../../lib/config.js';
+import { logErrorWithCorrelationIds } from '../../../../lib/infrastructure/monitoring-tools.js';
 import { tokenService } from '../../../shared/domain/services/token-service.js';
-import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import { usecases } from '../../domain/usecases/index.js';
 import * as saml from '../../infrastructure/saml.js';
 
@@ -17,7 +17,7 @@ const assert = async function (request, h) {
   try {
     userAttributes = await saml.parsePostResponse(request.payload);
   } catch (e) {
-    logger.error({ e }, 'SAML: Error while parsing post response');
+    logErrorWithCorrelationIds({ e }, 'SAML: Error while parsing post response');
     return h.response(e.toString()).code(400);
   }
 
@@ -30,7 +30,7 @@ const assert = async function (request, h) {
 
     return h.redirect(redirectionUrl);
   } catch (e) {
-    logger.error({ e }, 'SAML: Error while get external authentication redirection url');
+    logErrorWithCorrelationIds({ e }, 'SAML: Error while get external authentication redirection url');
     return h.response(e.toString()).code(500);
   }
 };

--- a/api/src/identity-access-management/domain/services/fwb-oidc-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/fwb-oidc-authentication-service.js
@@ -1,4 +1,4 @@
-import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
+import { logErrorWithCorrelationIds } from '../../../../lib/infrastructure/monitoring-tools.js';
 import { OidcAuthenticationService } from '../../domain/services/oidc-authentication-service.js';
 
 export class FwbOidcAuthenticationService extends OidcAuthenticationService {
@@ -7,7 +7,7 @@ export class FwbOidcAuthenticationService extends OidcAuthenticationService {
 
     if (!oidcProvider.additionalRequiredProperties) {
       this.isReady = false;
-      logger.error(
+      logErrorWithCorrelationIds(
         `OIDC Provider "${this.identityProvider}" has been DISABLED because of missing "additionalRequiredProperties" object.`,
       );
       return;

--- a/api/src/identity-access-management/domain/services/oidc-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/oidc-authentication-service.js
@@ -8,12 +8,11 @@ import { Issuer } from 'openid-client';
 import { OIDC_ERRORS } from '../../../../lib/domain/constants.js';
 import { OidcMissingFieldsError } from '../../../../lib/domain/errors.js';
 import { AuthenticationMethod, AuthenticationSessionContent } from '../../../../lib/domain/models/index.js';
-import { monitoringTools } from '../../../../lib/infrastructure/monitoring-tools.js';
+import { logErrorWithCorrelationIds, monitoringTools } from '../../../../lib/infrastructure/monitoring-tools.js';
 import { temporaryStorage } from '../../../../lib/infrastructure/temporary-storage/index.js';
 import { config } from '../../../shared/config.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { OidcError } from '../../../shared/domain/errors.js';
-import { logger } from '../../../shared/infrastructure/utils/logger.js';
 
 const DEFAULT_SCOPE = 'openid profile';
 const DEFAULT_REQUIRED_CLAIMS = ['sub', 'family_name', 'given_name'];
@@ -115,7 +114,7 @@ export class OidcAuthenticationService {
 
       this.client = new issuer.Client(metadata);
     } catch (error) {
-      logger.error(`OIDC Provider "${this.identityProvider}" is UNAVAILABLE: ${error}`);
+      logErrorWithCorrelationIds(`OIDC Provider "${this.identityProvider}" is UNAVAILABLE: ${error}`);
     }
   }
 

--- a/api/src/identity-access-management/domain/services/pole-emploi-oidc-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/pole-emploi-oidc-authentication-service.js
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 
 import { AuthenticationMethod } from '../../../../lib/domain/models/index.js';
-import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
+import { logErrorWithCorrelationIds } from '../../../../lib/infrastructure/monitoring-tools.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { OidcAuthenticationService } from '../../domain/services/oidc-authentication-service.js';
 
@@ -11,7 +11,7 @@ export class PoleEmploiOidcAuthenticationService extends OidcAuthenticationServi
 
     if (!oidcProvider.additionalRequiredProperties) {
       this.isReady = false;
-      logger.error(
+      logErrorWithCorrelationIds(
         `OIDC Provider "${this.identityProvider}" has been DISABLED because of missing "additionalRequiredProperties" object.`,
       );
       return;

--- a/api/src/school/domain/services/get-next-activity-info.js
+++ b/api/src/school/domain/services/get-next-activity-info.js
@@ -1,4 +1,4 @@
-import { logger } from '../../../shared/infrastructure/utils/logger.js';
+import { logErrorWithCorrelationIds } from '../../../../lib/infrastructure/monitoring-tools.js';
 import { Activity } from '../models/Activity.js';
 import { ActivityInfo } from '../models/ActivityInfo.js';
 
@@ -38,7 +38,9 @@ export function getNextActivityInfo({ activities, stepCount }) {
     return _getNextActivityInfoOnFailure(currentStepActivities, lastActivity);
   }
 
-  logger.error(`Pix1D - Unexpected status '${lastActivity.status}' on last activity with id: '${lastActivity.id}'`);
+  logErrorWithCorrelationIds(
+    `Pix1D - Unexpected status '${lastActivity.status}' on last activity with id: '${lastActivity.id}'`,
+  );
   return END_OF_MISSION;
 }
 

--- a/api/src/school/scripts/create-school-learners.js
+++ b/api/src/school/scripts/create-school-learners.js
@@ -5,6 +5,7 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
 import { disconnect, knex } from '../../../db/knex-database-connection.js';
+import { logErrorWithCorrelationIds } from '../../../lib/infrastructure/monitoring-tools.js';
 import * as schoolRepository from '../../../src/school/infrastructure/repositories/school-repository.js';
 import { Organization } from '../../organizational-entities/domain/models/Organization.js';
 import { ORGANIZATION_FEATURE } from '../../shared/domain/constants.js';
@@ -135,7 +136,7 @@ async function main() {
     try {
       await main();
     } catch (error) {
-      logger.error('\x1b[31mErreur : %s\x1b[0m', error.message);
+      logErrorWithCorrelationIds('\x1b[31mErreur : %s\x1b[0m', error.message);
       process.exitCode = 1;
     } finally {
       disconnect();

--- a/api/worker.js
+++ b/api/worker.js
@@ -19,17 +19,16 @@ import { ComputeCertificabilityJob } from './lib/infrastructure/jobs/organizatio
 import { ComputeCertificabilityJobHandler } from './lib/infrastructure/jobs/organization-learner/ComputeCertificabilityJobHandler.js';
 import { ScheduleComputeOrganizationLearnersCertificabilityJob } from './lib/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJob.js';
 import { ScheduleComputeOrganizationLearnersCertificabilityJobHandler } from './lib/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler.js';
-import { logErrorWithCorrelationIds } from './lib/infrastructure/monitoring-tools.js';
+import { logErrorWithCorrelationIds, logInfoWithCorrelationIds } from './lib/infrastructure/monitoring-tools.js';
 import * as organizationLearnerRepository from './lib/infrastructure/repositories/organization-learner-repository.js';
 import * as pgBossRepository from './lib/infrastructure/repositories/pgboss-repository.js';
 import { ImportOrganizationLearnersJob } from './src/prescription/learner-management/infrastructure/jobs/ImportOrganizationLearnersJob.js';
 import { ImportOrganizationLearnersJobHandler } from './src/prescription/learner-management/infrastructure/jobs/ImportOrganizationLearnersJobHandler.js';
 import { ValidateOrganizationImportFileJob } from './src/prescription/learner-management/infrastructure/jobs/ValidateOrganizationImportFileJob.js';
 import { ValidateOrganizationImportFileJobHandler } from './src/prescription/learner-management/infrastructure/jobs/ValidateOrganizationImportFileJobHandler.js';
-import { logger } from './src/shared/infrastructure/utils/logger.js';
 
 async function startPgBoss() {
-  logger.info('Starting pg-boss');
+  logInfoWithCorrelationIds('Starting pg-boss');
   const monitorStateIntervalSeconds = config.pgBoss.monitorStateIntervalSeconds;
   const pgBoss = new PgBoss({
     connectionString: process.env.DATABASE_URL,
@@ -38,16 +37,16 @@ async function startPgBoss() {
     archiveFailedAfterSeconds: config.pgBoss.archiveFailedAfterSeconds,
   });
   pgBoss.on('monitor-states', (state) => {
-    logger.info({ event: 'pg-boss-state', name: 'global' }, { ...state, queues: undefined });
+    logInfoWithCorrelationIds({ event: 'pg-boss-state', name: 'global' }, { ...state, queues: undefined });
     _.each(state.queues, (queueState, queueName) => {
-      logger.info({ event: 'pg-boss-state', name: queueName }, queueState);
+      logInfoWithCorrelationIds({ event: 'pg-boss-state', name: queueName }, queueState);
     });
   });
   pgBoss.on('error', (err) => {
     logErrorWithCorrelationIds({ event: 'pg-boss-error' }, err);
   });
   pgBoss.on('wip', (data) => {
-    logger.info({ event: 'pg-boss-wip' }, data);
+    logInfoWithCorrelationIds({ event: 'pg-boss-wip' }, data);
   });
   await pgBoss.start();
   return pgBoss;

--- a/api/worker.js
+++ b/api/worker.js
@@ -19,6 +19,7 @@ import { ComputeCertificabilityJob } from './lib/infrastructure/jobs/organizatio
 import { ComputeCertificabilityJobHandler } from './lib/infrastructure/jobs/organization-learner/ComputeCertificabilityJobHandler.js';
 import { ScheduleComputeOrganizationLearnersCertificabilityJob } from './lib/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJob.js';
 import { ScheduleComputeOrganizationLearnersCertificabilityJobHandler } from './lib/infrastructure/jobs/organization-learner/ScheduleComputeOrganizationLearnersCertificabilityJobHandler.js';
+import { logErrorWithCorrelationIds } from './lib/infrastructure/monitoring-tools.js';
 import * as organizationLearnerRepository from './lib/infrastructure/repositories/organization-learner-repository.js';
 import * as pgBossRepository from './lib/infrastructure/repositories/pgboss-repository.js';
 import { ImportOrganizationLearnersJob } from './src/prescription/learner-management/infrastructure/jobs/ImportOrganizationLearnersJob.js';
@@ -43,7 +44,7 @@ async function startPgBoss() {
     });
   });
   pgBoss.on('error', (err) => {
-    logger.error({ event: 'pg-boss-error' }, err);
+    logErrorWithCorrelationIds({ event: 'pg-boss-error' }, err);
   });
   pgBoss.on('wip', (data) => {
     logger.info({ event: 'pg-boss-wip' }, data);
@@ -115,7 +116,7 @@ if (!isTestEnv) {
   if (!startInWebProcess || (startInWebProcess && isEntryPointFromOtherFile)) {
     await runJobs();
   } else {
-    logger.error(
+    logErrorWithCorrelationIds(
       'Worker process is started in the web process. Please unset the START_JOB_IN_WEB_PROCESS environment variable to start a dedicated worker process.',
     );
     // eslint-disable-next-line n/no-process-exit


### PR DESCRIPTION
## :unicorn: Problème
Ajout d'infos dans les logs. Le correlationID n'est pas loggué partout pour l'instant.
Le but est de pouvoir prévenir automatiquement chaque équipe en cas d'erreur, en fonction d'un label @team qu'il faudra ajouter sur chaque route.

## :robot: Proposition
Remplacer les usages de Logger.info, error, warn, etc par loggerInfoWithCorrelationId, etc

## :rainbow: Remarques
Pour l'instant logger.warn & logger.traces & logger.fatal ne sont pas gérées

## :100: Pour tester
Un log drain sur la review app a été ajouté pour avoir les logs dans scalingo.
(scalingo --region osc-fr1 -app pix-api-review-pr9157 log-drains-add --type datadog --token --drain-region eu --with-addons)
[datadog logs](https://app.datadoghq.eu/logs?query=service%3A%28pix-api-review-pr9157%2A%29%20&agg_m=status&agg_m_source=base&agg_t=cardinality&cols=host%2Cservice%2Creq%2Creq.id&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1717503328466&to_ts=1717517728466&live=true)
https://app-pr9157.review.pix.fr/
