### PR TITLE
[TECH] Ajouter les montées de version Node.js des dockerfiles au groupement Renovate

### DIFF
--- a/docker/dockerfiles/Dockerfile.ember
+++ b/docker/dockerfiles/Dockerfile.ember
@@ -1,10 +1,11 @@
+# renovate datasource=node-version depName=node
 FROM node:20.14.0 as dev
 
 WORKDIR /code
 COPY . .
 
 RUN npm ci
-RUN npm install -g ember-cli 
+RUN npm install -g ember-cli
 
 CMD [ "npm", "run", "start:watch" ]
 

--- a/docker/dockerfiles/Dockerfile.hapi
+++ b/docker/dockerfiles/Dockerfile.hapi
@@ -1,10 +1,10 @@
+# renovate datasource=node-version depName=node
 FROM node:20.14.0 as dev
-
 
 EXPOSE 3000
 
 USER node
-COPY --chown=node:node . /code 
+COPY --chown=node:node . /code
 
 WORKDIR /code
 RUN npm ci

--- a/high-level-tests/e2e/Dockerfile
+++ b/high-level-tests/e2e/Dockerfile
@@ -1,3 +1,4 @@
+# renovate datasource=node-version depName=node
 FROM node:20.14.0
 
 # To run chrome headless with no-sandbox.

--- a/high-level-tests/e2e/docker-compose.yaml
+++ b/high-level-tests/e2e/docker-compose.yaml
@@ -26,6 +26,7 @@ services:
   orga:
     container_name: pix-e2e-orga
     user: node
+    # renovate datasource=node-version depName=node
     image: node:20.14.0
     command: npx ember serve --proxy http://api:3000
     volumes:


### PR DESCRIPTION
## :unicorn: Problème
Les PRs Renovate ne groupent pas les montées de version de Node.js de nos applis avec la version de Node précisée dans les configurations Docker. On se retrouve donc avec un déphasage.

Voir par exemple :
- https://github.com/1024pix/pix/pull/9163
- https://github.com/1024pix/pix/pull/9169

## :robot: Proposition
Ajouter la configuration qu'on a précisé côté config CircleCI au dessus des lignes des Dockerfile et docker-compose.

## :rainbow: Remarques
RAS

## :100: Pour tester
Essai jusqu'à la prochaine version de Node, et rollback si ça pose problème.