### PR TITLE
[BUGFIX] Ignorer la casse lors de la détermination des noms d'élèves à afficher (PIX-12800).

### DIFF
--- a/api/db/seeds/data/team-1d/data-builder.js
+++ b/api/db/seeds/data/team-1d/data-builder.js
@@ -98,6 +98,18 @@ async function _createSco1dOrganizations(databaseBuilder) {
     division: 'CM1-B',
     organizationId: TEAM_1D_ORGANIZATION_1_ID,
   });
+  await databaseBuilder.factory.prescription.organizationLearners.buildOndeOrganizationLearner({
+    firstName: 'BOB',
+    lastName: 'Le coyotte',
+    division: 'CM1-B',
+    organizationId: TEAM_1D_ORGANIZATION_1_ID,
+  });
+  await databaseBuilder.factory.prescription.organizationLearners.buildOndeOrganizationLearner({
+    firstName: 'Bob',
+    lastName: 'Le CObaye',
+    division: 'CM1-B',
+    organizationId: TEAM_1D_ORGANIZATION_1_ID,
+  });
 
   await databaseBuilder.factory.prescription.organizationLearners.buildOndeOrganizationLearner({
     firstName: 'Aya',

--- a/api/src/school/domain/models/School.js
+++ b/api/src/school/domain/models/School.js
@@ -33,8 +33,12 @@ class School {
   #shortestLastNamePostfix(lastName, otherLastNames) {
     let nbOfLettersToKeep = 1;
     const lastNameLength = lastName.length;
+    const normalizedLastName = lastName.toLowerCase();
+    const normalizedOtherLastNames = otherLastNames.map((s) => s.toLowerCase());
     while (
-      otherLastNames.some((otherLastName) => otherLastName.startsWith(lastName.substring(0, nbOfLettersToKeep))) &&
+      normalizedOtherLastNames.some((otherLastName) =>
+        otherLastName.startsWith(normalizedLastName.substring(0, nbOfLettersToKeep)),
+      ) &&
       nbOfLettersToKeep < lastNameLength
     ) {
       nbOfLettersToKeep++;
@@ -52,7 +56,7 @@ class School {
     const otherLearnersWithSameFirstNameAndDivision = this.#organizationLearners.filter(
       (otherLearner) =>
         otherLearner !== learner &&
-        otherLearner.firstName === learner.firstName &&
+        otherLearner.firstName.toLowerCase() === learner.firstName.toLowerCase() &&
         otherLearner.division === learner.division,
     );
     if (otherLearnersWithSameFirstNameAndDivision.length === 0) {

--- a/api/tests/school/unit/domain/models/School_test.js
+++ b/api/tests/school/unit/domain/models/School_test.js
@@ -35,6 +35,7 @@ describe('Unit | Domain | School', function () {
             lastNames: ['Abricot', 'Abricotier', 'Abricotierer'],
             expectedLastNameLetters: ['Abricot', 'Abricotier', 'Abricotiere.'],
           },
+          { lastNames: ['Abricotier', 'AbriCoteur'], expectedLastNameLetters: ['Abricoti.', 'AbriCote.'] },
         ];
 
         // eslint-disable-next-line mocha/no-setup-in-describe
@@ -60,6 +61,26 @@ describe('Unit | Domain | School', function () {
                   }),
               ),
             );
+          });
+        });
+
+        context('when firstnames do not have the same case', function () {
+          it('should return display name: firstname + first different lastname letter', function () {
+            // given
+            const organizationLearners = [
+              new OrganizationLearner({ firstName: 'Ernest', lastName: 'Abea', division: 'CM1' }),
+              new OrganizationLearner({ firstName: 'ERNEST', lastName: 'Beaba', division: 'CM1' }),
+            ];
+
+            // when
+            const school = new School({ organizationLearners });
+
+            // then
+
+            expect(school.organizationLearners).to.deep.equal([
+              new OrganizationLearnerDTO({ firstName: 'Ernest', displayName: 'Ernest A.', division: 'CM1' }),
+              new OrganizationLearnerDTO({ firstName: 'ERNEST', displayName: 'ERNEST B.', division: 'CM1' }),
+            ]);
           });
         });
       });


### PR DESCRIPTION
## :unicorn: Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Lors de l’affichage des prénoms et des noms en cas d’homonyme, la casse est prise en compte, ce qui peut donner des noms identiques.
Par exemple, si deux élèves ayant le même prénom ont celui-ci saisi avec une casse différente, on affichera deux prénoms strictement identiques.
`Ernest Nom1` et `ERNEST Nom2` seront affichés `Ernest` et `ERNEST`.

## :robot: Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

On compare les noms et prénoms en les mettant d'abord en minuscule afin d'ignorer la casse utilisée lors de la saisie.
Ainsi, `Ernest Nom1` et `ERNEST Nom2` seront affichés `Ernest Nom1` et `ERNEST Nom2`.

## :rainbow: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

RAS

## :100: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

Dans une école avec des homonymes aux casses différentes au sein de la même classe, vérifier que les noms affichés sont tous différents.
