### PR TITLE
[FEATURE] Ajouter le bouton `suivant` dans le stepper (PIX-12839)

### DIFF
--- a/mon-pix/app/components/module/stepper.gjs
+++ b/mon-pix/app/components/module/stepper.gjs
@@ -20,13 +20,19 @@ export default class ModulixStepper extends Component {
     return this.stepsToDisplay.length - 1;
   }
 
+  get hasNextStep() {
+    return this.stepsToDisplay.length < this.args.steps.length;
+  }
+
   <template>
     {{#each this.stepsToDisplay as |step index|}}
       <Step @step={{step}} @currentStep={{inc index}} @totalSteps={{@steps.length}} />
     {{/each}}
-    <PixButton @size="large" @variant="primary" @iconAfter="arrow-down" @triggerAction={{this.displayNextStep}}>{{t
-        "pages.modulix.buttons.stepper.next"
-      }}
-    </PixButton>
+    {{#if this.hasNextStep}}
+      <PixButton @size="large" @variant="primary" @iconAfter="arrow-down" @triggerAction={{this.displayNextStep}}>{{t
+          "pages.modulix.buttons.stepper.next"
+        }}
+      </PixButton>
+    {{/if}}
   </template>
 }

--- a/mon-pix/app/components/module/stepper.gjs
+++ b/mon-pix/app/components/module/stepper.gjs
@@ -1,5 +1,7 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 import Step from 'mon-pix/components/module/step';
 import { inc } from 'mon-pix/helpers/inc';
 
@@ -11,5 +13,9 @@ export default class ModulixStepper extends Component {
     {{#each this.stepsToDisplay as |step index|}}
       <Step @step={{step}} @currentStep={{inc index}} @totalSteps={{@steps.length}} />
     {{/each}}
+    <PixButton @size="large" @variant="primary" @iconAfter="arrow-down" @triggerAction={{null}}>{{t
+        "pages.modulix.buttons.stepper.next"
+      }}
+    </PixButton>
   </template>
 }

--- a/mon-pix/app/components/module/stepper.gjs
+++ b/mon-pix/app/components/module/stepper.gjs
@@ -1,4 +1,5 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
@@ -9,11 +10,21 @@ export default class ModulixStepper extends Component {
   @tracked
   stepsToDisplay = [this.args.steps[0]];
 
+  @action
+  displayNextStep() {
+    const nextStep = this.args.steps[this.lastIndex + 1];
+    this.stepsToDisplay = [...this.stepsToDisplay, nextStep];
+  }
+
+  get lastIndex() {
+    return this.stepsToDisplay.length - 1;
+  }
+
   <template>
     {{#each this.stepsToDisplay as |step index|}}
       <Step @step={{step}} @currentStep={{inc index}} @totalSteps={{@steps.length}} />
     {{/each}}
-    <PixButton @size="large" @variant="primary" @iconAfter="arrow-down" @triggerAction={{null}}>{{t
+    <PixButton @size="large" @variant="primary" @iconAfter="arrow-down" @triggerAction={{this.displayNextStep}}>{{t
         "pages.modulix.buttons.stepper.next"
       }}
     </PixButton>

--- a/mon-pix/app/components/module/stepper.gjs
+++ b/mon-pix/app/components/module/stepper.gjs
@@ -1,8 +1,15 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import Step from 'mon-pix/components/module/step';
 import { inc } from 'mon-pix/helpers/inc';
 
-<template>
-  {{#each @steps as |step index|}}
-    <Step @step={{step}} @currentStep={{inc index}} @totalSteps={{@steps.length}} />
-  {{/each}}
-</template>
+export default class ModulixStepper extends Component {
+  @tracked
+  stepsToDisplay = [this.args.steps[0]];
+
+  <template>
+    {{#each this.stepsToDisplay as |step index|}}
+      <Step @step={{step}} @currentStep={{inc index}} @totalSteps={{@steps.length}} />
+    {{/each}}
+  </template>
+}

--- a/mon-pix/config/icons.js
+++ b/mon-pix/config/icons.js
@@ -2,6 +2,7 @@ module.exports = function () {
   return {
     'free-brands-svg-icons': ['facebook-f', 'linkedin-in', 'twitter'],
     'free-solid-svg-icons': [
+      'arrow-down',
       'arrow-left',
       'arrow-right',
       'arrows-rotate',

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -1,4 +1,4 @@
-import { render } from '@1024pix/ember-testing-library';
+import { clickByName, render } from '@1024pix/ember-testing-library';
 import ModulixStepper from 'mon-pix/components/module/stepper';
 import { module, test } from 'qunit';
 
@@ -38,6 +38,37 @@ module('Integration | Component | Module | Stepper', function (hooks) {
       assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 1);
       assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 1 sur 2' })).exists();
       assert.dom(screen.getByRole('button', { name: this.intl.t('pages.modulix.buttons.stepper.next') })).exists();
+    });
+
+    test('should display the next step by clicking on the Next button', async function (assert) {
+      // given
+      const steps = [
+        {
+          elements: [
+            {
+              id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+              type: 'text',
+              content: '<p>Text 1</p>',
+            },
+          ],
+        },
+        {
+          elements: [
+            {
+              id: '768441a5-a7d6-4987-ada9-7253adafd842',
+              type: 'text',
+              content: '<p>Text 2</p>',
+            },
+          ],
+        },
+      ];
+      const screen = await render(<template><ModulixStepper @steps={{steps}} /></template>);
+
+      // when
+      await clickByName(this.intl.t('pages.modulix.buttons.stepper.next'));
+
+      // then
+      assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 2);
     });
   });
 });

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -8,7 +8,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   module('A Stepper with 2 steps', function () {
-    test('should display the first step', async function (assert) {
+    test('should display the first step with the button Next', async function (assert) {
       // given
       const steps = [
         {
@@ -37,6 +37,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
       // then
       assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 1);
       assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 1 sur 2' })).exists();
+      assert.dom(screen.getByRole('button', { name: this.intl.t('pages.modulix.buttons.stepper.next') })).exists();
     });
   });
 });

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -40,35 +40,68 @@ module('Integration | Component | Module | Stepper', function (hooks) {
       assert.dom(screen.getByRole('button', { name: this.intl.t('pages.modulix.buttons.stepper.next') })).exists();
     });
 
-    test('should display the next step by clicking on the Next button', async function (assert) {
-      // given
-      const steps = [
-        {
-          elements: [
-            {
-              id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
-              type: 'text',
-              content: '<p>Text 1</p>',
-            },
-          ],
-        },
-        {
-          elements: [
-            {
-              id: '768441a5-a7d6-4987-ada9-7253adafd842',
-              type: 'text',
-              content: '<p>Text 2</p>',
-            },
-          ],
-        },
-      ];
-      const screen = await render(<template><ModulixStepper @steps={{steps}} /></template>);
+    module('When user clicks on the Next button', function () {
+      test('should display the next step', async function (assert) {
+        // given
+        const steps = [
+          {
+            elements: [
+              {
+                id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                type: 'text',
+                content: '<p>Text 1</p>',
+              },
+            ],
+          },
+          {
+            elements: [
+              {
+                id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                type: 'text',
+                content: '<p>Text 2</p>',
+              },
+            ],
+          },
+        ];
+        const screen = await render(<template><ModulixStepper @steps={{steps}} /></template>);
 
-      // when
-      await clickByName(this.intl.t('pages.modulix.buttons.stepper.next'));
+        // when
+        await clickByName(this.intl.t('pages.modulix.buttons.stepper.next'));
 
-      // then
-      assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 2);
+        // then
+        assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 2);
+      });
+
+      test('should not display the Next button when there are no steps left', async function (assert) {
+        // given
+        const steps = [
+          {
+            elements: [
+              {
+                id: '342183f7-af51-4e4e-ab4c-ebed1e195063',
+                type: 'text',
+                content: '<p>Text 1</p>',
+              },
+            ],
+          },
+          {
+            elements: [
+              {
+                id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                type: 'text',
+                content: '<p>Text 2</p>',
+              },
+            ],
+          },
+        ];
+        const screen = await render(<template><ModulixStepper @steps={{steps}} /></template>);
+
+        // when
+        await clickByName(this.intl.t('pages.modulix.buttons.stepper.next'));
+        assert
+          .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.stepper.next') }))
+          .doesNotExist();
+      });
     });
   });
 });

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -8,7 +8,7 @@ module('Integration | Component | Module | Stepper', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   module('A Stepper with 2 steps', function () {
-    test('should display 2 steps', async function (assert) {
+    test('should display the first step', async function (assert) {
       // given
       const steps = [
         {
@@ -35,9 +35,8 @@ module('Integration | Component | Module | Stepper', function (hooks) {
       const screen = await render(<template><ModulixStepper @steps={{steps}} /></template>);
 
       // then
-      assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 2);
+      assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 1);
       assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 1 sur 2' })).exists();
-      assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 2 sur 2' })).exists();
     });
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1220,6 +1220,9 @@
           "continue": "Continue",
           "skip": "Skip",
           "terminate": "Terminate"
+        },
+        "stepper": {
+          "next": "Next"
         }
       },
       "details": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1220,6 +1220,9 @@
           "continue": "Continuar",
           "skip": "Ir a",
           "terminate": "Finalizar"
+        },
+        "stepper": {
+          "next": "Siguiente"
         }
       },
       "details": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1220,6 +1220,9 @@
           "continue": "Continuer",
           "skip": "Passer",
           "terminate": "Terminer"
+        },
+        "stepper": {
+          "next": "Suivant"
         }
       },
       "details": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1220,6 +1220,9 @@
           "continue": "Ga verder met",
           "skip": "Overslaan",
           "terminate": "Afwerking"
+        },
+        "stepper": {
+          "next": "Volgende"
         }
       },
       "details": {


### PR DESCRIPTION
## :unicorn: Problème
En ce moment, nous affichons tous les steps d'un Stepper à la fois car nous ne gérons pas encore le passage d'une step à l'autre.

## :robot: Proposition
Ajouter le bouton "Suivant" qui permet d'afficher la step suivante.
Nous avons opté pour un découpage de ce besoin en deux PR:

- Ici nous gérons l'affichage du bouton avec comme seule condition sa disparition lorsqu'on arrive à la dernière étape du Stepper.
- Dans une PR suivante, nous gérerons les cas à la marge (par exemple, lorsqu'une étape se fini par un élément répondable)

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
CI 🍏
