### PR TITLE
[BUGFIX] Ne pas afficher les boutons de vocalisation si la fonctionnalité a été désactivée sur le navigateur (PIX-12831).

### DIFF
--- a/mon-pix/app/components/assessment-banner.js
+++ b/mon-pix/app/components/assessment-banner.js
@@ -21,7 +21,9 @@ export default class AssessmentBanner extends Component {
 
   get showTextToSpeechActivationButton() {
     return (
-      this.featureToggles.featureToggles?.isTextToSpeechButtonEnabled && this.args.displayTextToSpeechActivationButton
+      this.featureToggles.featureToggles?.isTextToSpeechButtonEnabled &&
+      this.args.displayTextToSpeechActivationButton &&
+      window.speechSynthesis
     );
   }
 

--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -55,6 +55,7 @@ export default class ChallengeStatement extends Component {
 
   get showTextToSpeechButton() {
     return (
+      window.speechSynthesis &&
       !this.args.assessment.isCertification &&
       this.featureToggles.featureToggles?.isTextToSpeechButtonEnabled &&
       this.args.isTextToSpeechActivated
@@ -105,10 +106,12 @@ export default class ChallengeStatement extends Component {
   }
 
   stopTextToSpeechOnLeaveOrRefresh() {
-    speechSynthesis.cancel();
-    this.router.on('routeWillChange', () => {
+    if (window.speechSynthesis) {
       speechSynthesis.cancel();
-    });
+      this.router.on('routeWillChange', () => {
+        speechSynthesis.cancel();
+      });
+    }
   }
 
   get orderedAttachments() {

--- a/mon-pix/tests/integration/components/assessment-banner_test.js
+++ b/mon-pix/tests/integration/components/assessment-banner_test.js
@@ -122,6 +122,24 @@ module('Integration | Component | assessment-banner', function (hooks) {
         // then
         assert.dom(screen.getByRole('button', { name: 'Désactiver la vocalisation' })).exists();
       });
+
+      module('when the browers speech synthesis is disabled', function () {
+        test('it should not display text to speech button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          store.createRecord('assessment', {});
+          this.set('toggleTextToSpeech', sinon.stub());
+          delete window.speechSynthesis;
+
+          // when
+          const screen = await render(
+            hbs`<AssessmentBanner @displayHomeLink={{true}} @displayTextToSpeechActivationButton={{true}} @isTextToSpeechActivated={{true}} @toggleTextToSpeech={{this.toggleTextToSpeech}}/>`,
+          );
+
+          // then
+          assert.dom(screen.queryByRole('button', { name: 'Désactiver la vocalisation' })).doesNotExist();
+        });
+      });
     });
 
     module('when displayTextToSpeechActivationButton is false', function () {

--- a/mon-pix/tests/integration/components/challenge-statement_test.js
+++ b/mon-pix/tests/integration/components/challenge-statement_test.js
@@ -428,6 +428,34 @@ module('Integration | Component | ChallengeStatement', function (hooks) {
           });
         });
       });
+
+      module('when the browers speech synthesis is disabled', function () {
+        test('it should not display text to speech button', async function (assert) {
+          // given
+          addAssessmentToContext(this, { id: '267567' });
+          addChallengeToContext(this, {
+            instruction: 'La consigne du test avec un bouton de lecture à haute voix',
+            id: 'rec_challenge1',
+          });
+          delete window.speechSynthesis;
+
+          // when
+          const screen = await render(hbs`<ChallengeStatement
+                    @challenge={{this.challenge}}
+                    @assessment={{this.assessment}}
+                    @isTextToSpeechActivated={{true}}
+                    />`);
+
+          // then
+          assert
+            .dom(
+              screen.queryByRole('button', {
+                name: this.intl.t('pages.challenge.statement.text-to-speech.play'),
+              }),
+            )
+            .doesNotExist();
+        });
+      });
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème

Sur Firefox, dans `about:config`, si l'utilisateur a décidé volontairement de désactiver `media.webspeech.synth.enabled`, alors le SpeechSynthesis n'est plus disponible.

## :robot: Proposition

Prendre en compte la possibilité que la fonctionnalité puisse être désactivé et conditionner l'affichage.

## :100: Pour tester

- Sur Firefox, reproduire le cas indiqué dans la partie Problème
- Aller sur épreuve, constater que les boutons de vocalisation ne sont pas affichés mais que l'épreuve fonctionne comme souhaité.
