### PR TITLE
[BUGFIX] Créer un script afin de recréer des données manquantes sur les états des participations à une campagne définit (PIX-12837)

### DIFF
--- a/api/db/database-builder/factory/build-pole-emploi-sending.js
+++ b/api/db/database-builder/factory/build-pole-emploi-sending.js
@@ -1,0 +1,28 @@
+import { PoleEmploiSending } from '../../../lib/domain/models/PoleEmploiSending.js';
+import { databaseBuffer } from '../database-buffer.js';
+
+const buildPoleEmploiSending = ({
+  id = databaseBuffer.getNextId(),
+  type = PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_SHARING,
+  campaignParticipationId,
+  isSuccessful = true,
+  responseCode = '200',
+  payload = null,
+  createdAt = new Date('2020-01-01'),
+} = {}) => {
+  const values = {
+    id,
+    type,
+    campaignParticipationId,
+    isSuccessful,
+    responseCode,
+    payload,
+    createdAt,
+  };
+  return databaseBuffer.pushInsertable({
+    tableName: 'pole-emploi-sendings',
+    values,
+  });
+};
+
+export { buildPoleEmploiSending };

--- a/api/scripts/prod/insert-missing-pole-emploi-sending-from-date.js
+++ b/api/scripts/prod/insert-missing-pole-emploi-sending-from-date.js
@@ -1,0 +1,343 @@
+import * as url from 'node:url';
+
+import dayjs from 'dayjs';
+
+import { disconnect, knex } from '../../db/knex-database-connection.js';
+import { PoleEmploiSending } from '../../lib/domain/models/PoleEmploiSending.js';
+import { PoleEmploiPayload } from '../../lib/infrastructure/externals/pole-emploi/PoleEmploiPayload.js';
+import * as badgeAcquisitionRepository from '../../lib/infrastructure/repositories/badge-acquisition-repository.js';
+import { campaignParticipationResultRepository } from '../../lib/infrastructure/repositories/campaign-participation-result-repository.js';
+import * as campaignRepository from '../../lib/infrastructure/repositories/campaign-repository.js';
+import * as poleEmploiSendingRepository from '../../lib/infrastructure/repositories/pole-emploi-sending-repository.js';
+import * as targetProfileRepository from '../../lib/infrastructure/repositories/target-profile-repository.js';
+import * as badgeRepository from '../../src/evaluation/infrastructure/repositories/badge-repository.js';
+import * as campaignParticipationRepository from '../../src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js';
+import { CampaignParticipationStatuses } from '../../src/prescription/shared/domain/constants.js';
+import { Assessment } from '../../src/shared/domain/models/Assessment.js';
+import * as assessmentRepository from '../../src/shared/infrastructure/repositories/assessment-repository.js';
+import * as organizationRepository from '../../src/shared/infrastructure/repositories/organization-repository.js';
+import * as userRepository from '../../src/shared/infrastructure/repositories/user-repository.js';
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
+
+async function insertMissingPoleEmploiSendingFromDate(startDate, endDate = new Date(), campaignCode = 'YOURCODE') {
+  const start = dayjs(startDate, 'YYYY-MM-DD');
+  const end = dayjs(endDate, 'YYYY-MM-DD');
+
+  if (!start.isValid()) {
+    throw new Error("La date de début n'est pas valide");
+  }
+
+  if (!end.isValid()) {
+    throw new Error("La date de fin n'est pas valide");
+  }
+
+  if (!start.isBefore(end, 'day')) {
+    throw new Error('La date de fin est antérieur à la date de début');
+  }
+
+  const campaignByCode = await knex('id').from('campaigns').where({ code: campaignCode }).first();
+
+  if (!campaignByCode) {
+    throw new Error("Le code campagne fourni n'existe pas");
+  }
+
+  const campaign = await campaignRepository.get(campaignByCode.id);
+  const organization = await organizationRepository.get(campaign.organizationId);
+
+  if (!campaign.isAssessment() || !organization.isPoleEmploi) {
+    throw new Error('La campagne ne respecte pas les conditions pour générer les événements');
+  }
+
+  const startedParticipations = await _getStartedParticipationsInsideIntervall(campaign.id, start, end);
+  logger.info('Started Participation found :', startedParticipations.length);
+
+  const toShareParticipations = await _getToShareParticipationsInsideIntervall(campaign.id, start, end);
+  logger.info('To Share Participation found :', toShareParticipations.length);
+
+  const sharedParticipations = await _getSharedParticipationsInsideIntervall(campaign.id, start, end);
+  logger.info('Shared Participation found :', sharedParticipations.length);
+
+  const campaignParticipationIds = _aggregatePoleEmploiSendingsToCreateByCampaignParticipation(
+    startedParticipations,
+    toShareParticipations,
+    sharedParticipations,
+  );
+
+  // common data for all campaign
+  const targetProfile = await targetProfileRepository.get(campaign.targetProfileId);
+  const badges = await badgeRepository.findByCampaignId(campaign.id);
+  const badgeIds = badges.map((badge) => badge.id);
+  const responseCode = `SCRIPT_${startDate}_to_${endDate}`;
+
+  // Start to INSERT PoleEmploiSendingsJobs
+  for (const [campaignParticipationId, poleEmploiSendingTypes] of Object.entries(campaignParticipationIds)) {
+    const participation = await campaignParticipationRepository.get(campaignParticipationId);
+    const user = await userRepository.get(participation.userId);
+
+    //handle-pole-emploi-participation-started
+    if (poleEmploiSendingTypes.includes(PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_START))
+      await _buildStartSendingParticipation({ campaign, participation, user, targetProfile, responseCode });
+
+    //handle-pole-emploi-participation-finished
+    if (poleEmploiSendingTypes.includes(PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_COMPLETION))
+      await _buildCompletionSendingParticipation({ campaign, participation, user, targetProfile, responseCode });
+
+    //send-shared-participation-results-to-pole-emploi
+    if (poleEmploiSendingTypes.includes(PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_SHARING))
+      await _buildSharingSendingParticipation({
+        campaign,
+        participation,
+        user,
+        targetProfile,
+        badges,
+        badgeIds,
+        responseCode,
+      });
+  }
+}
+
+const modulePath = url.fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === modulePath;
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await insertMissingPoleEmploiSendingFromDate(process.argv[2], process.argv[3], process.argv[4]);
+      console.log('done');
+    } catch (error) {
+      console.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+    }
+  }
+})();
+
+async function _buildStartSendingParticipation({ campaign, participation, user, targetProfile, responseCode }) {
+  const payload = PoleEmploiPayload.buildForParticipationStarted({
+    user,
+    campaign,
+    targetProfile,
+    participation,
+  });
+
+  const poleEmploiSending = PoleEmploiSending.buildForParticipationStarted({
+    campaignParticipationId: participation.id,
+    payload: payload.toString(),
+    isSuccessful: false,
+    responseCode,
+  });
+
+  return poleEmploiSendingRepository.create({ poleEmploiSending });
+}
+
+async function _buildCompletionSendingParticipation({ campaign, participation, user, targetProfile, responseCode }) {
+  const assessment = await assessmentRepository.get(participation.lastAssessment.id);
+
+  const payload = PoleEmploiPayload.buildForParticipationFinished({
+    user,
+    campaign,
+    targetProfile,
+    participation,
+    assessment,
+  });
+
+  const poleEmploiSending = PoleEmploiSending.buildForParticipationFinished({
+    campaignParticipationId: participation.id,
+    payload: payload.toString(),
+    isSuccessful: false,
+    responseCode,
+  });
+
+  return poleEmploiSendingRepository.create({ poleEmploiSending });
+}
+
+async function _buildSharingSendingParticipation({
+  campaign,
+  participation,
+  user,
+  targetProfile,
+  badges,
+  badgeIds,
+  responseCode,
+}) {
+  const badgeAcquiredIds = await badgeAcquisitionRepository.getAcquiredBadgeIds({
+    badgeIds,
+    userId: participation.userId,
+  });
+  const participationResult = await campaignParticipationResultRepository.getByParticipationId(participation.id);
+
+  const payload = PoleEmploiPayload.buildForParticipationShared({
+    user,
+    campaign,
+    targetProfile,
+    participation,
+    participationResult,
+    badges,
+    badgeAcquiredIds,
+  });
+
+  const poleEmploiSending = PoleEmploiSending.buildForParticipationShared({
+    campaignParticipationId: participation.id,
+    payload: payload.toString(),
+    isSuccessful: false,
+    responseCode,
+  });
+
+  return poleEmploiSendingRepository.create({ poleEmploiSending });
+}
+
+function _aggregatePoleEmploiSendingsToCreateByCampaignParticipation(
+  startedParticipations,
+  toShareParticipations,
+  sharedParticipations,
+) {
+  const campaignParticipationIds = {};
+
+  startedParticipations.forEach((participation) => {
+    _insertPoleEmploiSending(
+      campaignParticipationIds,
+      participation,
+      PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_START,
+    );
+  });
+
+  toShareParticipations.forEach((participation) => {
+    _insertPoleEmploiSending(
+      campaignParticipationIds,
+      participation,
+      PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_START,
+    );
+    _insertPoleEmploiSending(
+      campaignParticipationIds,
+      participation,
+      PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_COMPLETION,
+    );
+  });
+
+  sharedParticipations.forEach((participation) => {
+    _insertPoleEmploiSending(
+      campaignParticipationIds,
+      participation,
+      PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_START,
+    );
+    _insertPoleEmploiSending(
+      campaignParticipationIds,
+      participation,
+      PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_COMPLETION,
+    );
+    _insertPoleEmploiSending(
+      campaignParticipationIds,
+      participation,
+      PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_SHARING,
+    );
+  });
+
+  return campaignParticipationIds;
+}
+
+function _insertPoleEmploiSending(campaignParticipationIds, participation, type) {
+  if (!participation.types || !participation.types.includes(type)) {
+    if (!campaignParticipationIds[participation.campaignParticipationId]) {
+      campaignParticipationIds[participation.campaignParticipationId] = [];
+    }
+
+    campaignParticipationIds[participation.campaignParticipationId].push(type);
+  }
+}
+
+function _getStartedParticipationsInsideIntervall(campaignId, startDate, endDate) {
+  return knex
+    .with('createdAtWithParticipationId', (queryBuilder) => {
+      queryBuilder
+        .select({
+          campaignParticipationId: 'campaign-participations.id',
+        })
+        .from('campaign-participations')
+        .where({ campaignId, status: CampaignParticipationStatuses.STARTED })
+        .whereBetween('createdAt', [startDate, endDate]);
+    })
+    .select({
+      campaignParticipationId: 'createdAtWithParticipationId.campaignParticipationId',
+      types: knex.raw('string_agg("pole-emploi-sendings"."type", \',\')'),
+    })
+    .from('createdAtWithParticipationId')
+    .leftJoin(
+      'pole-emploi-sendings',
+      'pole-emploi-sendings.campaignParticipationId',
+      'createdAtWithParticipationId.campaignParticipationId',
+    )
+    .groupBy('createdAtWithParticipationId.campaignParticipationId')
+    .havingRaw('count("pole-emploi-sendings"."id") = 0');
+}
+
+function _getSharedParticipationsInsideIntervall(campaignId, startDate, endDate) {
+  return knex
+    .with('createdAtWithParticipationId', (queryBuilder) => {
+      queryBuilder
+        .select({
+          campaignParticipationId: 'campaign-participations.id',
+        })
+        .from('campaign-participations')
+        .where({ campaignId, status: CampaignParticipationStatuses.SHARED })
+        .whereBetween('sharedAt', [startDate, endDate]);
+    })
+    .select({
+      campaignParticipationId: 'createdAtWithParticipationId.campaignParticipationId',
+      types: knex.raw('string_agg("pole-emploi-sendings"."type", \',\')'),
+    })
+    .from('createdAtWithParticipationId')
+    .leftJoin(
+      'pole-emploi-sendings',
+      'pole-emploi-sendings.campaignParticipationId',
+      'createdAtWithParticipationId.campaignParticipationId',
+    )
+    .groupBy('createdAtWithParticipationId.campaignParticipationId');
+}
+
+function _getToShareParticipationsInsideIntervall(campaignId, startDate, endDate) {
+  return knex
+    .with('createdAtWithParticipationId', (queryBuilder) => {
+      queryBuilder
+        .select({
+          campaignParticipationId: 'assessments.campaignParticipationId',
+          createdAt: 'answers.createdAt',
+        })
+        .from('answers')
+        .join('assessments', function () {
+          this.on('assessments.id', 'answers.assessmentId')
+            .andOnVal('assessments.state', Assessment.states.COMPLETED)
+            .andOnVal('assessments.isImproving', knex.raw('IS'), knex.raw('false'))
+            .andOnVal(
+              'assessments.campaignParticipationId',
+              knex.raw('IN'),
+              knex.select('id').from('campaign-participations').where({
+                campaignId,
+                status: CampaignParticipationStatuses.TO_SHARE,
+              }),
+            );
+        })
+        .whereBetween('answers.createdAt', [startDate, endDate]);
+    })
+    .with('oneDateByParticipation', (queryBuilder) => {
+      queryBuilder
+        .select('campaignParticipationId')
+        .max('createdAt')
+        .from('createdAtWithParticipationId')
+        .groupBy('campaignParticipationId');
+    })
+    .select({
+      campaignParticipationId: 'oneDateByParticipation.campaignParticipationId',
+      types: knex.raw('string_agg("pole-emploi-sendings"."type", \',\')'),
+    })
+    .from('oneDateByParticipation')
+    .leftJoin(
+      'pole-emploi-sendings',
+      'pole-emploi-sendings.campaignParticipationId',
+      'oneDateByParticipation.campaignParticipationId',
+    )
+    .groupBy('oneDateByParticipation.campaignParticipationId')
+    .havingRaw('count("pole-emploi-sendings"."id") <= 1');
+}
+
+export { insertMissingPoleEmploiSendingFromDate };

--- a/api/tests/integration/scripts/prod/insert-missing-pole-emploi-sending-from-date_test.js
+++ b/api/tests/integration/scripts/prod/insert-missing-pole-emploi-sending-from-date_test.js
@@ -1,0 +1,581 @@
+import dayjs from 'dayjs';
+
+import { PoleEmploiSending } from '../../../../lib/domain/models/PoleEmploiSending.js';
+import { insertMissingPoleEmploiSendingFromDate } from '../../../../scripts/prod/insert-missing-pole-emploi-sending-from-date.js';
+import { Tag } from '../../../../src/organizational-entities/domain/models/Tag.js';
+import { CampaignParticipationStatuses, CampaignTypes } from '../../../../src/prescription/shared/domain/constants.js';
+import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
+import {
+  catchErr,
+  databaseBuilder,
+  expect,
+  knex,
+  learningContentBuilder,
+  mockLearningContent,
+} from '../../../test-helper.js';
+
+describe('Script | Prod | Delete Organization Learners From Organization', function () {
+  describe('#insertMissingPoleEmploiSendingFromDate', function () {
+    beforeEach(async function () {
+      const learningContent = [
+        {
+          id: '1. Information et données',
+          competences: [
+            {
+              id: 'competence_id',
+              tubes: [
+                {
+                  id: 'recTube1',
+                  skills: [
+                    {
+                      id: 'recSkill1',
+                      challenges: [{ id: 'k_challenge_id' }],
+                      level: 1,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      const learningContentObjects = learningContentBuilder.fromAreas(learningContent);
+      mockLearningContent(learningContentObjects);
+    });
+
+    context('validation', function () {
+      context('startDate', function () {
+        it('throw an error when startDate not a date', async function () {
+          const error = await catchErr(insertMissingPoleEmploiSendingFromDate)('coucou');
+
+          expect(error).to.be.instanceOf(Error);
+        });
+
+        it('throw an error when startDate is not in a valid format', async function () {
+          const error = await catchErr(insertMissingPoleEmploiSendingFromDate)('20/01/2020');
+
+          expect(error).to.be.instanceOf(Error);
+        });
+      });
+
+      context('endDate', function () {
+        it('throw an error when is not a date', async function () {
+          const error = await catchErr(insertMissingPoleEmploiSendingFromDate)('2024-01-01', 'coucou');
+
+          expect(error).to.be.instanceOf(Error);
+        });
+
+        it('throw an error when is not in a valid format', async function () {
+          const error = await catchErr(insertMissingPoleEmploiSendingFromDate)('2024-01-01', '20/01/2020');
+
+          expect(error).to.be.instanceOf(Error);
+        });
+      });
+
+      context('date comparaison', function () {
+        it('throw an error when startDate after  endDate', async function () {
+          const error = await catchErr(insertMissingPoleEmploiSendingFromDate)('2024-01-01', '2020-01-01');
+
+          expect(error).to.be.instanceOf(Error);
+        });
+
+        it('throw an error when startDate equal to endDate', async function () {
+          const error = await catchErr(insertMissingPoleEmploiSendingFromDate)('2024-01-01', '2024-01-01');
+
+          expect(error).to.be.instanceOf(Error);
+        });
+      });
+
+      context('campaign', function () {
+        it('should throw an error when no campaign found for given id', async function () {
+          const error = await catchErr(insertMissingPoleEmploiSendingFromDate)(
+            '2020-01-01',
+            '2024-01-01',
+            'UNKNOWN_CAMPAIGN',
+          );
+
+          expect(error).to.be.instanceOf(Error);
+        });
+
+        it('should throw an error when campaign is not assessment type', async function () {
+          databaseBuilder.factory.buildCampaign({ code: 'PROFILE_CODE', type: CampaignTypes.PROFILES_COLLECTION });
+
+          await databaseBuilder.commit();
+
+          const error = await catchErr(insertMissingPoleEmploiSendingFromDate)(
+            '2020-01-01',
+            '2024-01-01',
+            'PROFILE_CODE',
+          );
+
+          expect(error).to.be.instanceOf(Error);
+        });
+
+        it('should throw an error when organization is not PE', async function () {
+          databaseBuilder.factory.buildCampaign({ code: 'ASSESSMENT_CODE', type: CampaignTypes.ASSESSMENT });
+
+          await databaseBuilder.commit();
+
+          const error = await catchErr(insertMissingPoleEmploiSendingFromDate)(
+            '2020-01-01',
+            '2024-01-01',
+            'ASSESSMENT_CODE',
+          );
+
+          expect(error).to.be.instanceOf(Error);
+        });
+
+        it('should not throw an error when organization is PE with assessment campaign', async function () {
+          const organizationId = databaseBuilder.factory.buildOrganization().id;
+          const tagId = databaseBuilder.factory.buildTag({ name: Tag.POLE_EMPLOI }).id;
+
+          databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+          databaseBuilder.factory.buildCampaign({
+            code: 'ASSESSMENT_CODE',
+            type: CampaignTypes.ASSESSMENT,
+            organizationId,
+          });
+
+          await databaseBuilder.commit();
+
+          const call = () => insertMissingPoleEmploiSendingFromDate('2020-01-01', '2024-01-01', 'ASSESSMENT_CODE');
+
+          expect(call).to.not.throw();
+        });
+      });
+    });
+
+    context('data', function () {
+      const campaignCode = 'MY_CODE';
+      let campaign;
+
+      beforeEach(async function () {
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const tagId = databaseBuilder.factory.buildTag({ name: Tag.POLE_EMPLOI }).id;
+
+        databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+
+        campaign = databaseBuilder.factory.buildCampaign({
+          code: campaignCode,
+          type: CampaignTypes.ASSESSMENT,
+          organizationId,
+        });
+
+        await databaseBuilder.commit();
+      });
+
+      context('Common cases', function () {
+        it('should return no event to create for participation from other campaign inside date interval', async function () {
+          const otherCampaign = databaseBuilder.factory.buildCampaign({ code: 'ANOTHER_CAMPAIGN' });
+
+          const createdAt = new Date('2024-02-03');
+
+          const firstParticipation = _buildLearnerWithStartedParticipation(otherCampaign, createdAt);
+          const secondParticipation = _buildLearnerWithToShareParticipation(otherCampaign, createdAt);
+          const thirdParticipation = _buildLearnerWithSharedParticipation(otherCampaign, createdAt, createdAt);
+
+          await databaseBuilder.commit();
+
+          await insertMissingPoleEmploiSendingFromDate('2024-02-02', '2024-02-04', campaignCode);
+
+          const result = await knex('pole-emploi-sendings')
+            .select('type')
+            .whereIn('campaignParticipationId', [firstParticipation.id, secondParticipation.id, thirdParticipation.id])
+            .where({ isSuccessful: false, responseCode: 'SCRIPT_2024-02-02_to_2024-02-04' });
+
+          expect(result).lengthOf(0);
+        });
+
+        it('should return no event to create for participation outside the interval', async function () {
+          const firstParticipation = _buildLearnerWithStartedParticipation(campaign, new Date('2024-02-01'));
+
+          const secondParticipation = _buildLearnerWithToShareParticipation(campaign, new Date('2024-02-05'));
+
+          const thirdParticipation = _buildLearnerWithSharedParticipation(
+            campaign,
+            new Date('2024-02-05'),
+            new Date('2024-02-06'),
+          );
+
+          await databaseBuilder.commit();
+
+          await insertMissingPoleEmploiSendingFromDate('2024-02-02', '2024-02-04', campaignCode);
+
+          const result = await knex('pole-emploi-sendings')
+            .select('type')
+            .whereIn('campaignParticipationId', [firstParticipation.id, secondParticipation.id, thirdParticipation.id])
+            .where({ isSuccessful: false, responseCode: 'SCRIPT_2024-02-02_to_2024-02-04' });
+
+          expect(result).lengthOf(0);
+        });
+      });
+
+      context('Status STARTED', function () {
+        it('should return started event participation to create inside date interval', async function () {
+          const createdAt = new Date('2024-02-03');
+
+          const participation = _buildLearnerWithStartedParticipation(campaign, createdAt);
+
+          await databaseBuilder.commit();
+
+          await insertMissingPoleEmploiSendingFromDate('2024-02-02', '2024-02-04', campaignCode);
+
+          const result = await knex('pole-emploi-sendings').select('type').where({
+            campaignParticipationId: participation.id,
+            isSuccessful: false,
+            responseCode: 'SCRIPT_2024-02-02_to_2024-02-04',
+            type: PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_START,
+          });
+
+          expect(result).lengthOf(1);
+        });
+
+        it('should return empty started event participation to create inside date interval when exists', async function () {
+          const createdAt = new Date('2024-02-03');
+
+          const participation = _buildLearnerWithStartedParticipation(campaign, createdAt);
+          _buildPoleEmploiSendingsForStartedParticipation(participation);
+
+          await databaseBuilder.commit();
+
+          await insertMissingPoleEmploiSendingFromDate('2024-02-02', '2024-02-04', campaignCode);
+
+          const result = await knex('pole-emploi-sendings')
+            .select('type')
+            .where({
+              campaignParticipationId: participation.id,
+              isSuccessful: false,
+              responseCode: 'SCRIPT_2024-02-02_to_2024-02-04',
+            })
+            .whereIn('type', [PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_START]);
+
+          expect(result).lengthOf(0);
+        });
+      });
+
+      context('Status TO_SHARE', function () {
+        it('should return started / completion event participation to create inside date interval', async function () {
+          const createdAt = new Date('2024-02-03');
+
+          const participation = _buildLearnerWithToShareParticipation(campaign, createdAt);
+
+          await databaseBuilder.commit();
+
+          await insertMissingPoleEmploiSendingFromDate('2024-02-02', '2024-02-04', campaignCode);
+
+          const result = await knex('pole-emploi-sendings')
+            .select('type')
+            .where({
+              campaignParticipationId: participation.id,
+              isSuccessful: false,
+              responseCode: 'SCRIPT_2024-02-02_to_2024-02-04',
+            })
+            .whereIn('type', [
+              PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_START,
+              PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_COMPLETION,
+            ]);
+
+          expect(result).lengthOf(2);
+        });
+
+        it('should return completion event participation to create inside date interval when started already exists', async function () {
+          const createdAt = new Date('2024-02-03');
+
+          const participation = _buildLearnerWithToShareParticipation(campaign, createdAt);
+          _buildPoleEmploiSendingsForStartedParticipation(participation);
+
+          await databaseBuilder.commit();
+
+          await insertMissingPoleEmploiSendingFromDate('2024-02-02', '2024-02-04', campaignCode);
+
+          const result = await knex('pole-emploi-sendings')
+            .select('type')
+            .where({
+              campaignParticipationId: participation.id,
+              isSuccessful: false,
+              responseCode: 'SCRIPT_2024-02-02_to_2024-02-04',
+            })
+            .whereIn('type', [PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_COMPLETION]);
+
+          expect(result).lengthOf(1);
+        });
+
+        it('should return no event participation to create inside date interval when started / completion already exists', async function () {
+          const createdAt = new Date('2024-02-03');
+
+          const participation = _buildLearnerWithToShareParticipation(campaign, createdAt);
+          _buildPoleEmploiSendingsForToShareParticipation(participation);
+
+          await databaseBuilder.commit();
+
+          await insertMissingPoleEmploiSendingFromDate('2024-02-02', '2024-02-04', campaignCode);
+
+          const result = await knex('pole-emploi-sendings').select('type').where({
+            campaignParticipationId: participation.id,
+            isSuccessful: false,
+            responseCode: 'SCRIPT_2024-02-02_to_2024-02-04',
+          });
+
+          expect(result).lengthOf(0);
+        });
+      });
+
+      context('Status SHARED', function () {
+        it('should return started / completion / shared event participation inside date interval', async function () {
+          const createdAt = new Date('2024-02-01');
+          const sharedAt = new Date('2024-02-03');
+
+          const participation = _buildLearnerWithSharedParticipation(campaign, createdAt, sharedAt);
+
+          await databaseBuilder.commit();
+
+          await insertMissingPoleEmploiSendingFromDate('2024-02-02', '2024-02-04', campaignCode);
+
+          const result = await knex('pole-emploi-sendings')
+            .select('type')
+            .where({
+              campaignParticipationId: participation.id,
+              isSuccessful: false,
+              responseCode: 'SCRIPT_2024-02-02_to_2024-02-04',
+            })
+            .whereIn('type', [
+              PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_START,
+              PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_COMPLETION,
+              PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_SHARING,
+            ]);
+
+          expect(result).lengthOf(3);
+        });
+
+        it('should return started / completion / shared event participation inside date interval even if is Improved', async function () {
+          const createdAt = new Date('2024-02-01');
+          const sharedAt = new Date('2024-02-03');
+          const isImproved = true;
+
+          const participation = _buildLearnerWithSharedParticipation(campaign, createdAt, sharedAt, isImproved);
+
+          await databaseBuilder.commit();
+
+          await insertMissingPoleEmploiSendingFromDate('2024-02-02', '2024-02-04', campaignCode);
+
+          const result = await knex('pole-emploi-sendings')
+            .select('type')
+            .where({
+              campaignParticipationId: participation.id,
+              isSuccessful: false,
+              responseCode: 'SCRIPT_2024-02-02_to_2024-02-04',
+            })
+            .whereIn('type', [
+              PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_START,
+              PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_COMPLETION,
+              PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_SHARING,
+            ]);
+
+          expect(result).lengthOf(3);
+        });
+
+        it('should return completion / shared event participation to create inside date interval when started already exists', async function () {
+          const createdAt = new Date('2024-02-01');
+          const sharedAt = new Date('2024-02-03');
+
+          const participation = _buildLearnerWithSharedParticipation(campaign, createdAt, sharedAt);
+          _buildPoleEmploiSendingsForStartedParticipation(participation);
+
+          await databaseBuilder.commit();
+
+          await insertMissingPoleEmploiSendingFromDate('2024-02-02', '2024-02-04', campaignCode);
+
+          const result = await knex('pole-emploi-sendings')
+            .select('type')
+            .where({
+              campaignParticipationId: participation.id,
+              isSuccessful: false,
+              responseCode: 'SCRIPT_2024-02-02_to_2024-02-04',
+            })
+            .whereIn('type', [
+              PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_COMPLETION,
+              PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_SHARING,
+            ]);
+
+          expect(result).lengthOf(2);
+        });
+
+        it('should return shared event participation to create inside date interval when started/completion already exists', async function () {
+          const createdAt = new Date('2024-02-01');
+          const sharedAt = new Date('2024-02-03');
+
+          const participation = _buildLearnerWithSharedParticipation(campaign, createdAt, sharedAt);
+          _buildPoleEmploiSendingsForToShareParticipation(participation);
+
+          await databaseBuilder.commit();
+
+          await insertMissingPoleEmploiSendingFromDate('2024-02-02', '2024-02-04', campaignCode);
+
+          const result = await knex('pole-emploi-sendings')
+            .select('type')
+            .where({
+              campaignParticipationId: participation.id,
+              isSuccessful: false,
+              responseCode: 'SCRIPT_2024-02-02_to_2024-02-04',
+            })
+            .whereIn('type', [PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_SHARING]);
+
+          expect(result).lengthOf(1);
+        });
+
+        it('should return no event participation to create inside date interval when started/completion/shared already exists', async function () {
+          const createdAt = new Date('2024-02-01');
+          const sharedAt = new Date('2024-02-03');
+
+          const participation = _buildLearnerWithSharedParticipation(campaign, createdAt, sharedAt);
+          _buildPoleEmploiSendingsForSharedParticipation(participation);
+
+          await databaseBuilder.commit();
+
+          await insertMissingPoleEmploiSendingFromDate('2024-02-02', '2024-02-04', campaignCode);
+
+          const result = await knex('pole-emploi-sendings').select('type').where({
+            campaignParticipationId: participation.id,
+            isSuccessful: false,
+            responseCode: 'SCRIPT_2024-02-02_to_2024-02-04',
+          });
+
+          expect(result).lengthOf(0);
+        });
+      });
+    });
+
+    function _buildLearnerWithStartedParticipation(campaign, createdAt) {
+      const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: campaign.organizationId,
+      });
+
+      const participation = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        organizationLearnerId,
+        userId,
+        createdAt,
+        status: CampaignParticipationStatuses.STARTED,
+      });
+
+      databaseBuilder.factory.buildAssessment({
+        userId,
+        campaignParticipationId: participation.id,
+        state: Assessment.states.STARTED,
+        createdAt,
+      });
+
+      return participation;
+    }
+
+    function _buildLearnerWithToShareParticipation(campaign, createdAt) {
+      const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: campaign.organizationId,
+      });
+
+      const participation = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        organizationLearnerId,
+        userId,
+        createdAt,
+        status: CampaignParticipationStatuses.TO_SHARE,
+      });
+
+      const assessment = databaseBuilder.factory.buildAssessment({
+        userId,
+        campaignParticipationId: participation.id,
+        state: Assessment.states.COMPLETED,
+        createdAt,
+      });
+
+      databaseBuilder.factory.buildAnswer({
+        assessmentId: assessment.id,
+        createdAt,
+      });
+
+      return participation;
+    }
+
+    function _buildLearnerWithSharedParticipation(campaign, createdAt, sharedAt, isImproved = false) {
+      const { id: organizationLearnerId, userId } = databaseBuilder.factory.buildOrganizationLearner({
+        organizationId: campaign.organizationId,
+      });
+
+      const participation = databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        organizationLearnerId,
+        userId,
+        createdAt,
+        status: CampaignParticipationStatuses.SHARED,
+        isImproved,
+        sharedAt,
+      });
+
+      const assessment = databaseBuilder.factory.buildAssessment({
+        userId,
+        campaignParticipationId: participation.id,
+        state: Assessment.states.COMPLETED,
+        createdAt,
+        updatedAt: sharedAt,
+      });
+
+      databaseBuilder.factory.buildAnswer({
+        assessmentId: assessment.id,
+        createdAt: dayjs(sharedAt).subtract(10, 'day'),
+      });
+
+      databaseBuilder.factory.buildAnswer({
+        assessmentId: assessment.id,
+        createdAt: sharedAt,
+      });
+
+      return participation;
+    }
+
+    function _buildPoleEmploiSendingsForStartedParticipation(participation) {
+      databaseBuilder.factory.buildPoleEmploiSending({
+        campaignParticipationId: participation.id,
+        createdAt: participation.createdAt,
+        type: PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_START,
+      });
+    }
+
+    function _buildPoleEmploiSendingsForToShareParticipation(participation) {
+      databaseBuilder.factory.buildPoleEmploiSending({
+        campaignParticipationId: participation.id,
+        createdAt: participation.createdAt,
+        type: PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_START,
+      });
+      databaseBuilder.factory.buildPoleEmploiSending({
+        campaignParticipationId: participation.id,
+        createdAt: participation.createdAt,
+        type: PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_COMPLETION,
+      });
+      databaseBuilder.factory.buildPoleEmploiSending({
+        campaignParticipationId: participation.id,
+        createdAt: participation.createdAt,
+        type: PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_COMPLETION,
+      });
+    }
+
+    function _buildPoleEmploiSendingsForSharedParticipation(participation) {
+      databaseBuilder.factory.buildPoleEmploiSending({
+        campaignParticipationId: participation.id,
+        createdAt: participation.createdAt,
+        type: PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_START,
+      });
+      databaseBuilder.factory.buildPoleEmploiSending({
+        campaignParticipationId: participation.id,
+        createdAt: participation.sharedAt,
+        type: PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_COMPLETION,
+      });
+      databaseBuilder.factory.buildPoleEmploiSending({
+        campaignParticipationId: participation.id,
+        createdAt: participation.sharedAt,
+        updateAt: participation.sharedAt,
+        type: PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_SHARING,
+      });
+    }
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Suite aux derniers soucis de prod sur la migration FT, certaines données n'ont pas été créer

## :robot: Proposition
Ajouter un script qui permet de recréer les données manquantes

## :rainbow: Remarques
les trois requêtes sur metabase s'executent dans un temps plus que raisonnable ( < 10sec pour les trois ).

le code était implémenté directement dans les usecases. j'ai extrait ce qui était nécessaire pour le bon fonctionnement de chaque entité.

le plus longs sera peut être la récupération et l'envoi. 

le code est permissif. si il part en timeout. On n'inserera seulement les données qui ne sont pas présentes dans pole-emploi-sendings

Prévoir du chunk ? 🤔 

## :100: Pour tester
<TODO>