### PR TITLE
[BUGFIX] Ignore la casse du code école dans l'URL d'accès direct (PIX-12852)

### DIFF
--- a/junior/app/adapters/school.js
+++ b/junior/app/adapters/school.js
@@ -1,0 +1,8 @@
+import ApplicationAdapter from './application';
+
+export default class SchoolAdapter extends ApplicationAdapter {
+  urlForQueryRecord(query) {
+    query.code = query.code?.toUpperCase();
+    return `${this.host}/${this.namespace}/schools`;
+  }
+}

--- a/junior/app/services/store.js
+++ b/junior/app/services/store.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data/store';

--- a/junior/tests/acceptance/access-school_test.js
+++ b/junior/tests/acceptance/access-school_test.js
@@ -68,6 +68,17 @@ module('Acceptance | School', function (hooks) {
       assert.dom(screen.getByRole('link', { name: 'CM2 A' })).exists();
       assert.dom(screen.getByRole('link', { name: 'CM2-B' })).exists();
     });
+
+    test('should ignore code case from direct link', async function (assert) {
+      // given
+      const school = this.server.create('school');
+      // when
+      const screen = await visit('/schools/minipixou');
+      // then
+      assert.dom(screen.getByText(school.name)).exists();
+      assert.dom(screen.getByRole('link', { name: 'CM2 A' })).exists();
+      assert.dom(screen.getByRole('link', { name: 'CM2-B' })).exists();
+    });
   });
 
   module('with invalid school code', function () {


### PR DESCRIPTION
## :unicorn: Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Si on essaie d'accéder à une école directement en saisissant son URL contenant le code, celui-ci doit obligatoirement être en majuscule sans quoi une erreur est affichée.

## :robot: Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

On ajoute un adapter `School` pour forcer la casse du code école en majuscule lorsqu'on appelle l'API pour retrouver les informations de l'école.

## :rainbow: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

On en profite pour créer un service `store.js` pour supprimer un message d'avertissement au sujet d'une obsolescence Ember.

## :100: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

Se rendre sur l'URL `/school/MAXIPIXOU`.
Constater l'affichage des classes de `CM1` et `CM2`.

Se rendre sur l'URL `/school/maxipixou`.
Constater l'affichage des classes de `CM1` et `CM2`.
