### PR TITLE
[BUGFIX] Ajoute le point d'exclamation dans le bouton de démarrage de mission sur Pix Junior.

### DIFF
--- a/junior/translations/fr.json
+++ b/junior/translations/fr.json
@@ -45,7 +45,7 @@
           "finished": "Terminé"
         },
         "purpose-title": "Objectif de la mission :",
-        "start-mission": "C'est parti",
+        "start-mission": "C'est parti !",
         "welcome": "Prépare-toi à résoudre des épreuves et relever des défis."
       },
       "end-page": {


### PR DESCRIPTION
## :unicorn: Problème
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
On est allé un peu vite et on a supprimé le `!` lors de https://github.com/1024pix/pix/pull/9173.

## :robot: Proposition
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
On remet ce point d'exclamation qui est _plus engageant_.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->
RAS

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
Se rendre sur la page de début de mission et constater que le bouton affiche le texte `C'est parti !`.
