### PR TITLE
[FEATURE] Ouvre Pix Junior depuis Pix Orga dans un nouvel onglet

### DIFF
--- a/orga/app/templates/authenticated/missions/list.hbs
+++ b/orga/app/templates/authenticated/missions/list.hbs
@@ -17,7 +17,7 @@
     {{t "pages.missions.list.banner.copypaste-container.abstract"}}
     &nbsp;
 
-    <a href={{@model.pixJuniorSchoolUrl}}>
+    <a href={{@model.pixJuniorSchoolUrl}} target="_blank" rel="noopener noreferrer">
       {{t "pages.missions.list.banner.copypaste-container.import-text"}}
     </a>
 


### PR DESCRIPTION
## :unicorn: Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Lorsqu'on clique sur le lien d'une école depuis Pix Orga, on est redirigé vers l'application Pix Junior au sein du même onglet.
Cela peut être perturbant pour les utilisateurs qui souhaitent conserver leur contexte Pix Orga.

## :robot: Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

On ajoute `target=_blank` au lien afin d'ouvrir celui-ci dans un nouvel onglet.

## :rainbow: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

RAS

## :100: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

Se connecter sur Pix Orga avec `1d-orga@example.net`.
Cliquer sur le lien de l'école (dans la bannière).
Constater que Pix Junior est ouvert dans un nouvel onglet.
