### PR TITLE
[BUGFIX] Empecher d'accéder à la page mission si l'utilisateur n'appartient pas à une orga SCO-1D (PIX-12853)

### DIFF
--- a/orga/app/components/layout/sidebar.js
+++ b/orga/app/components/layout/sidebar.js
@@ -22,16 +22,16 @@ export default class SidebarMenu extends Component {
   }
 
   get shouldDisplayPlacesEntry() {
-    return this.currentUser.shouldAccessPlacesPage;
+    return this.currentUser.canAccessPlacesPage;
   }
   get shouldDisplayMissionsEntry() {
-    return this.currentUser.shouldAccessMissionsPage;
+    return this.currentUser.canAccessMissionsPage;
   }
   get shouldDisplayCampaignsEntry() {
-    return this.currentUser.shouldAccessCampaignsPage;
+    return this.currentUser.canAccessCampaignsPage;
   }
   get shouldDisplayParticipantsEntry() {
-    return this.currentUser.shouldAccessParticipantsPage;
+    return this.currentUser.canAccessParticipantsPage;
   }
 
   get organizationLearnersList() {

--- a/orga/app/routes/authenticated/campaigns/list/all-campaigns.js
+++ b/orga/app/routes/authenticated/campaigns/list/all-campaigns.js
@@ -25,7 +25,7 @@ export default class AuthenticatedCampaignsListAllCampaignsRoute extends Route {
   @service router;
 
   beforeModel() {
-    if (!this.currentUser.shouldAccessCampaignsPage) {
+    if (!this.currentUser.canAccessCampaignsPage) {
       return this.router.replaceWith(this.currentUser.homePage);
     }
   }

--- a/orga/app/routes/authenticated/campaigns/list/all-campaigns.js
+++ b/orga/app/routes/authenticated/campaigns/list/all-campaigns.js
@@ -22,6 +22,13 @@ export default class AuthenticatedCampaignsListAllCampaignsRoute extends Route {
 
   @service store;
   @service currentUser;
+  @service router;
+
+  beforeModel() {
+    if (!this.currentUser.shouldAccessCampaignsPage) {
+      return this.router.replaceWith('authenticated.campaigns.list.index');
+    }
+  }
 
   model(params) {
     return this.store.query(

--- a/orga/app/routes/authenticated/campaigns/list/all-campaigns.js
+++ b/orga/app/routes/authenticated/campaigns/list/all-campaigns.js
@@ -26,7 +26,7 @@ export default class AuthenticatedCampaignsListAllCampaignsRoute extends Route {
 
   beforeModel() {
     if (!this.currentUser.shouldAccessCampaignsPage) {
-      return this.router.replaceWith('authenticated.campaigns.list.index');
+      return this.router.replaceWith(this.currentUser.homePage);
     }
   }
 

--- a/orga/app/routes/authenticated/campaigns/list/index.js
+++ b/orga/app/routes/authenticated/campaigns/list/index.js
@@ -6,8 +6,8 @@ export default class IndexRoute extends Route {
   @service currentUser;
 
   beforeModel() {
-    if (this.currentUser.shouldAccessMissionsPage) {
-      return this.router.replaceWith('authenticated.missions');
+    if (!this.currentUser.shouldAccessCampaignsPage) {
+      return this.router.replaceWith(this.currentUser.homePage);
     }
     return this.router.replaceWith('authenticated.campaigns.list.my-campaigns');
   }

--- a/orga/app/routes/authenticated/campaigns/list/index.js
+++ b/orga/app/routes/authenticated/campaigns/list/index.js
@@ -6,7 +6,7 @@ export default class IndexRoute extends Route {
   @service currentUser;
 
   beforeModel() {
-    if (!this.currentUser.shouldAccessCampaignsPage) {
+    if (!this.currentUser.canAccessCampaignsPage) {
       return this.router.replaceWith(this.currentUser.homePage);
     }
     return this.router.replaceWith('authenticated.campaigns.list.my-campaigns');

--- a/orga/app/routes/authenticated/campaigns/list/index.js
+++ b/orga/app/routes/authenticated/campaigns/list/index.js
@@ -3,8 +3,12 @@ import { inject as service } from '@ember/service';
 
 export default class IndexRoute extends Route {
   @service router;
+  @service currentUser;
 
   beforeModel() {
+    if (this.currentUser.shouldAccessMissionsPage) {
+      return this.router.replaceWith('authenticated.missions');
+    }
     return this.router.replaceWith('authenticated.campaigns.list.my-campaigns');
   }
 }

--- a/orga/app/routes/authenticated/campaigns/list/my-campaigns.js
+++ b/orga/app/routes/authenticated/campaigns/list/my-campaigns.js
@@ -25,7 +25,7 @@ export default class AuthenticatedCampaignsListAllCampaignsRoute extends Route {
   @service router;
 
   beforeModel() {
-    if (!this.currentUser.shouldAccessCampaignsPage) {
+    if (!this.currentUser.canAccessCampaignsPage) {
       return this.router.replaceWith(this.currentUser.homePage);
     }
   }

--- a/orga/app/routes/authenticated/campaigns/list/my-campaigns.js
+++ b/orga/app/routes/authenticated/campaigns/list/my-campaigns.js
@@ -22,6 +22,13 @@ export default class AuthenticatedCampaignsListAllCampaignsRoute extends Route {
 
   @service currentUser;
   @service store;
+  @service router;
+
+  beforeModel() {
+    if (!this.currentUser.shouldAccessCampaignsPage) {
+      return this.router.replaceWith('authenticated.campaigns.list.index');
+    }
+  }
 
   model(params) {
     return this.store.query(

--- a/orga/app/routes/authenticated/campaigns/list/my-campaigns.js
+++ b/orga/app/routes/authenticated/campaigns/list/my-campaigns.js
@@ -26,7 +26,7 @@ export default class AuthenticatedCampaignsListAllCampaignsRoute extends Route {
 
   beforeModel() {
     if (!this.currentUser.shouldAccessCampaignsPage) {
-      return this.router.replaceWith('authenticated.campaigns.list.index');
+      return this.router.replaceWith(this.currentUser.homePage);
     }
   }
 

--- a/orga/app/routes/authenticated/import-organization-participants.js
+++ b/orga/app/routes/authenticated/import-organization-participants.js
@@ -10,7 +10,7 @@ export default class ImportOrganizationParticipantsRoute extends Route {
   beforeModel() {
     super.beforeModel(...arguments);
 
-    if (!this.currentUser.shouldAccessImportPage) {
+    if (!this.currentUser.canAccessImportPage) {
       return this.router.replaceWith('application');
     }
   }

--- a/orga/app/routes/authenticated/index.js
+++ b/orga/app/routes/authenticated/index.js
@@ -5,10 +5,6 @@ export default class IndexRoute extends Route {
   @service router;
   @service currentUser;
   beforeModel() {
-    if (this.currentUser.shouldAccessMissionsPage) {
-      return this.router.replaceWith('authenticated.missions');
-    } else {
-      return this.router.replaceWith('authenticated.campaigns');
-    }
+    return this.router.replaceWith(this.currentUser.homePage);
   }
 }

--- a/orga/app/routes/authenticated/missions.js
+++ b/orga/app/routes/authenticated/missions.js
@@ -6,7 +6,7 @@ export default class MissionListRoute extends Route {
   @service router;
 
   beforeModel() {
-    if (!this.currentUser.shouldAccessMissionsPage) {
+    if (!this.currentUser.canAccessMissionsPage) {
       this.router.replaceWith('application');
     }
   }

--- a/orga/app/routes/authenticated/sco-organization-participants/list.js
+++ b/orga/app/routes/authenticated/sco-organization-participants/list.js
@@ -22,7 +22,7 @@ export default class ListRoute extends Route {
   async model(params) {
     const organizationId = this.currentUser.organization.id;
     return RSVP.hash({
-      importDetail: this.currentUser.shouldAccessImportPage
+      importDetail: this.currentUser.canAccessImportPage
         ? await this.store.queryRecord('organization-import-detail', {
             organizationId: this.currentUser.organization.id,
           })

--- a/orga/app/routes/authenticated/sup-organization-participants/list.js
+++ b/orga/app/routes/authenticated/sup-organization-participants/list.js
@@ -21,7 +21,7 @@ export default class ListRoute extends Route {
   async model(params) {
     const organizationId = this.currentUser.organization.id;
     return RSVP.hash({
-      importDetail: this.currentUser.shouldAccessImportPage
+      importDetail: this.currentUser.canAccessImportPage
         ? await this.store.queryRecord('organization-import-detail', {
             organizationId: this.currentUser.organization.id,
           })

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -59,6 +59,13 @@ export default class CurrentUserService extends Service {
     this.organization = organization;
   }
 
+  get homePage() {
+    if (this.shouldAccessMissionsPage) {
+      return 'authenticated.missions';
+    }
+    return 'authenticated.campaigns';
+  }
+
   get shouldAccessImportPage() {
     return Boolean(
       (this.isSCOManagingStudents || this.isSUPManagingStudents || this.hasLearnerImportFeature) &&

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -60,29 +60,29 @@ export default class CurrentUserService extends Service {
   }
 
   get homePage() {
-    if (this.shouldAccessMissionsPage) {
+    if (this.canAccessMissionsPage) {
       return 'authenticated.missions';
     }
     return 'authenticated.campaigns';
   }
 
-  get shouldAccessImportPage() {
+  get canAccessImportPage() {
     return Boolean(
       (this.isSCOManagingStudents || this.isSUPManagingStudents || this.hasLearnerImportFeature) &&
         this.isAdminInOrganization,
     );
   }
 
-  get shouldAccessPlacesPage() {
+  get canAccessPlacesPage() {
     return this.isAdminInOrganization && this.prescriber.placesManagement;
   }
-  get shouldAccessMissionsPage() {
+  get canAccessMissionsPage() {
     return this.prescriber.missionsManagement;
   }
-  get shouldAccessCampaignsPage() {
+  get canAccessCampaignsPage() {
     return !this.prescriber.missionsManagement;
   }
-  get shouldAccessParticipantsPage() {
+  get canAccessParticipantsPage() {
     return !this.prescriber.missionsManagement;
   }
   get hasLearnerImportFeature() {

--- a/orga/tests/acceptance/campaign-list-all-campaigns_test.js
+++ b/orga/tests/acceptance/campaign-list-all-campaigns_test.js
@@ -255,5 +255,20 @@ module('Acceptance | campaigns/all-campaigns', function (hooks) {
         assert.ok(screen.getByText(this.intl.t('pages.campaigns-list.no-campaign')));
       });
     });
+
+    module('When the user can access to campaigns pages', function () {
+      test('it should not access to mission page', async function (assert) {
+        // given
+        const user = createUserWithMembershipAndTermsOfServiceAccepted();
+        createPrescriberByUser({ user });
+        await authenticateSession(user.id);
+
+        // when
+        await visit('missions');
+
+        // then
+        assert.deepEqual(currentURL(), '/campagnes/les-miennes');
+      });
+    });
   });
 });

--- a/orga/tests/acceptance/campaign-list-my-campaigns_test.js
+++ b/orga/tests/acceptance/campaign-list-my-campaigns_test.js
@@ -183,5 +183,20 @@ module('Acceptance | /campaigns/list/my-campaigns ', function (hooks) {
         assert.ok(screen.getByText(this.intl.t('pages.campaigns-list.no-campaign')));
       });
     });
+
+    module('When the user can access to campaigns pages', function () {
+      test('it should not access to mission page', async function (assert) {
+        // given
+        const user = createUserWithMembershipAndTermsOfServiceAccepted();
+        createPrescriberByUser({ user });
+        await authenticateSession(user.id);
+
+        // when
+        await visitScreen('missions');
+
+        // then
+        assert.deepEqual(currentURL(), '/campagnes/les-miennes');
+      });
+    });
   });
 });

--- a/orga/tests/acceptance/missions-list_test.js
+++ b/orga/tests/acceptance/missions-list_test.js
@@ -166,5 +166,33 @@ module('Acceptance | Missions List', function (hooks) {
       // then
       assert.deepEqual(currentURL(), '/missions/1');
     });
+
+    test('should not access to my-campaigns page', async function (assert) {
+      const user = createUserWithMembershipAndTermsOfServiceAccepted();
+      const prescriber = createPrescriberByUser({ user });
+      prescriber.features = { ...prescriber.features, MISSIONS_MANAGEMENT: true };
+      await authenticateSession(user.id);
+
+      server.create('mission', { id: 1, name: 'Super Mission', competenceName: 'Super competence' });
+
+      await visit('/campagnes/les-miennes');
+
+      // then
+      assert.deepEqual(currentURL(), '/missions');
+    });
+
+    test('should not access to all-campaigns page', async function (assert) {
+      const user = createUserWithMembershipAndTermsOfServiceAccepted();
+      const prescriber = createPrescriberByUser({ user });
+      prescriber.features = { ...prescriber.features, MISSIONS_MANAGEMENT: true };
+      await authenticateSession(user.id);
+
+      server.create('mission', { id: 1, name: 'Super Mission', competenceName: 'Super competence' });
+
+      await visit('/campagnes/toutes');
+
+      // then
+      assert.deepEqual(currentURL(), '/missions');
+    });
   });
 });

--- a/orga/tests/integration/components/layout/sidebar_test.js
+++ b/orga/tests/integration/components/layout/sidebar_test.js
@@ -38,7 +38,7 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
     test('the logo should redirect to campaigns page', async function (assert) {
       class CurrentUserStub extends Service {
         organization = Object.create({ id: 5 });
-        shouldAccessCampaignsPage = true;
+        canAccessCampaignsPage = true;
       }
       this.owner.register('service:current-user', CurrentUserStub);
       const intl = this.owner.lookup('service:intl');
@@ -54,8 +54,8 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
     test('should display Campagne and Équipe menu for all organisation members', async function (assert) {
       class CurrentUserStub extends Service {
         organization = Object.create({ id: 1 });
-        shouldAccessCampaignsPage = true;
-        shouldAccessParticipantsPage = true;
+        canAccessCampaignsPage = true;
+        canAccessParticipantsPage = true;
       }
       this.owner.register('service:current-user', CurrentUserStub);
       const intl = this.owner.lookup('service:intl');
@@ -80,10 +80,10 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
       assert.dom(screen.getByText('Documentation')).exists();
     });
 
-    test('should display Places menu if shouldAccessPlacesPage is true', async function (assert) {
+    test('should display Places menu if canAccessPlacesPage is true', async function (assert) {
       class CurrentUserStub extends Service {
         organization = Object.create({ id: 1 });
-        shouldAccessPlacesPage = true;
+        canAccessPlacesPage = true;
       }
       this.owner.register('service:current-user', CurrentUserStub);
 
@@ -92,10 +92,10 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
       assert.ok(screen.getByText(this.intl.t('navigation.main.places')));
     });
 
-    test('should not display Places menu if shouldAccessPlacesPage is false', async function (assert) {
+    test('should not display Places menu if canAccessPlacesPage is false', async function (assert) {
       class CurrentUserStub extends Service {
         organization = Object.create({ id: 1 });
-        shouldAccessPlacesPage = false;
+        canAccessPlacesPage = false;
       }
       this.owner.register('service:current-user', CurrentUserStub);
 
@@ -110,7 +110,7 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
       // given
       class CurrentUserStub extends Service {
         organization = Object.create({ id: 1, type: 'PRO' });
-        shouldAccessParticipantsPage = true;
+        canAccessParticipantsPage = true;
       }
 
       this.owner.register('service:current-user', CurrentUserStub);
@@ -131,7 +131,7 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
       class CurrentUserStub extends Service {
         organization = Object.create({ id: 1, type: 'SUP' });
         isSUPManagingStudents = true;
-        shouldAccessParticipantsPage = true;
+        canAccessParticipantsPage = true;
       }
 
       this.owner.register('service:current-user', CurrentUserStub);
@@ -150,7 +150,7 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
       class CurrentUserStub extends Service {
         organization = Object.create({ id: 1, type: 'SUP' });
         isSUPManagingStudents = false;
-        shouldAccessParticipantsPage = true;
+        canAccessParticipantsPage = true;
       }
 
       this.owner.register('service:current-user', CurrentUserStub);
@@ -171,8 +171,8 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
       class CurrentUserStub extends Service {
         organization = Object.create({ id: 1, type: 'SCO' });
         isSCOManagingStudents = true;
-        shouldAccessMissionsPage = false;
-        shouldAccessParticipantsPage = true;
+        canAccessMissionsPage = false;
+        canAccessParticipantsPage = true;
       }
 
       this.owner.register('service:current-user', CurrentUserStub);
@@ -191,7 +191,7 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
       class CurrentUserStub extends Service {
         organization = Object.create({ id: 1, type: 'SCO' });
         isSCOManagingStudents = false;
-        shouldAccessParticipantsPage = true;
+        canAccessParticipantsPage = true;
       }
 
       this.owner.register('service:current-user', CurrentUserStub);
@@ -248,7 +248,7 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
     test('the logo should redirect to mission page', async function (assert) {
       class CurrentUserStub extends Service {
         organization = Object.create({ id: 5 });
-        shouldAccessMissionsPage = true;
+        canAccessMissionsPage = true;
       }
       this.owner.register('service:current-user', CurrentUserStub);
       const intl = this.owner.lookup('service:intl');
@@ -263,7 +263,7 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
     test('should display Mission menu', async function (assert) {
       class CurrentUserStub extends Service {
         organization = Object.create({ id: 5 });
-        shouldAccessMissionsPage = true;
+        canAccessMissionsPage = true;
       }
       this.owner.register('service:current-user', CurrentUserStub);
       const intl = this.owner.lookup('service:intl');
@@ -277,7 +277,7 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
     test('should not display Campagne and Participants menus', async function (assert) {
       class CurrentUserStub extends Service {
         organization = Object.create({ id: 5 });
-        shouldAccessMissionsPage = true;
+        canAccessMissionsPage = true;
       }
       this.owner.register('service:current-user', CurrentUserStub);
       const intl = this.owner.lookup('service:intl');

--- a/orga/tests/unit/routes/authenticated/import-organization-participants_test.js
+++ b/orga/tests/unit/routes/authenticated/import-organization-participants_test.js
@@ -13,7 +13,7 @@ module('Unit | Route | authenticated/import-organization-participants', function
     store = this.owner.lookup('service:store');
     replaceWithStub = sinon.stub(route.router, 'replaceWith');
     sinon.stub(store, 'queryRecord');
-    route.currentUser = { shouldAccessImportPage: true, organization: { id: Symbol('organization-id') } };
+    route.currentUser = { canAccessImportPage: true, organization: { id: Symbol('organization-id') } };
   });
 
   test('should return organization-import-detail', async function (assert) {
@@ -32,9 +32,9 @@ module('Unit | Route | authenticated/import-organization-participants', function
   });
 
   module('beforeModel', function () {
-    test('should redirect to application when shouldAccessImportPage is false', function (assert) {
+    test('should redirect to application when canAccessImportPage is false', function (assert) {
       // given
-      route.currentUser.shouldAccessImportPage = false;
+      route.currentUser.canAccessImportPage = false;
 
       // when
       route.beforeModel();
@@ -45,7 +45,7 @@ module('Unit | Route | authenticated/import-organization-participants', function
 
     test('should not redirect to application when currentUser.isAdminInOrganization and currentUser.isSCOManagingStudents are true', function (assert) {
       // given
-      route.currentUser.shouldAccessImportPage = true;
+      route.currentUser.canAccessImportPage = true;
 
       // when
       route.beforeModel();

--- a/orga/tests/unit/routes/authenticated/missions_test.js
+++ b/orga/tests/unit/routes/authenticated/missions_test.js
@@ -7,10 +7,10 @@ module('Unit | Route | authenticated/missions', function (hooks) {
   setupTest(hooks);
 
   module('beforeModel', function () {
-    test('should not redirect to application when currentUser.shouldAccessMissionsPage is true', function (assert) {
+    test('should not redirect to application when currentUser.canAccessMissionsPage is true', function (assert) {
       // given
       class CurrentUserStub extends Service {
-        shouldAccessMissionsPage = true;
+        canAccessMissionsPage = true;
       }
 
       this.owner.register('service:current-user', CurrentUserStub);
@@ -25,10 +25,10 @@ module('Unit | Route | authenticated/missions', function (hooks) {
       assert.notOk(route.router.replaceWith.calledWith(expectedRedirection));
     });
 
-    test('should redirect to application when currentUser.shouldAccessMissionsPage is false', function (assert) {
+    test('should redirect to application when currentUser.canAccessMissionsPage is false', function (assert) {
       // given
       class CurrentUserStub extends Service {
-        shouldAccessMissionsPage = false;
+        canAccessMissionsPage = false;
       }
 
       this.owner.register('service:current-user', CurrentUserStub);

--- a/orga/tests/unit/routes/authenticated/sco-organization-participants/list_test.js
+++ b/orga/tests/unit/routes/authenticated/sco-organization-participants/list_test.js
@@ -77,7 +77,7 @@ module('Unit | Route | authenticated/sco-organization-participants/list', functi
     module('when user is admin of organization', function () {
       test('should return import information model', async function (assert) {
         // given
-        route.currentUser.shouldAccessImportPage = true;
+        route.currentUser.canAccessImportPage = true;
         // when
         const { importDetail } = await route.model(params);
 
@@ -89,7 +89,7 @@ module('Unit | Route | authenticated/sco-organization-participants/list', functi
     module('when user is member of organization', function () {
       test('should not return import information model', async function (assert) {
         // given
-        route.currentUser.shouldAccessImportPage = false;
+        route.currentUser.canAccessImportPage = false;
         // when
         const { importDetail } = await route.model(params);
 

--- a/orga/tests/unit/routes/authenticated/sup-organization-participants/list_test.js
+++ b/orga/tests/unit/routes/authenticated/sup-organization-participants/list_test.js
@@ -72,7 +72,7 @@ module('Unit | Route | authenticated/sup-organization-participants/list', functi
     test('should return import information model', async function (assert) {
       //given
 
-      route.currentUser.shouldAccessImportPage = true;
+      route.currentUser.canAccessImportPage = true;
       //when
       const { importDetail } = await route.model(params);
 
@@ -84,7 +84,7 @@ module('Unit | Route | authenticated/sup-organization-participants/list', functi
   module('when user is member of organization', function () {
     test('should not return import information model', async function (assert) {
       //given
-      route.currentUser.shouldAccessImportPage = false;
+      route.currentUser.canAccessImportPage = false;
 
       //when
       const { importDetail } = await route.model(params);

--- a/orga/tests/unit/services/current-user_test.js
+++ b/orga/tests/unit/services/current-user_test.js
@@ -251,14 +251,14 @@ module('Unit | Service | current-user', function (hooks) {
       });
     });
 
-    module('#shouldAccessPlacesPage', function () {
+    module('#canAccessPlacesPage', function () {
       test('should return true if user is admin and organization has feature activated', function (assert) {
         currentUserService.isAdminInOrganization = true;
         currentUserService.prescriber = {
           placesManagement: true,
         };
 
-        assert.true(currentUserService.shouldAccessPlacesPage);
+        assert.true(currentUserService.canAccessPlacesPage);
       });
 
       test('should return false if user is admin and organization does not have feature activated', function (assert) {
@@ -267,7 +267,7 @@ module('Unit | Service | current-user', function (hooks) {
           placesManagement: false,
         };
 
-        assert.false(currentUserService.shouldAccessPlacesPage);
+        assert.false(currentUserService.canAccessPlacesPage);
       });
 
       test('should return false if user is not admin', function (assert) {
@@ -276,17 +276,17 @@ module('Unit | Service | current-user', function (hooks) {
           placesManagement: true,
         };
 
-        assert.false(currentUserService.shouldAccessPlacesPage);
+        assert.false(currentUserService.canAccessPlacesPage);
       });
     });
 
-    module('#shouldAccessMissionsPage', function () {
+    module('#canAccessMissionsPage', function () {
       test('should return true if user has feature activated', function (assert) {
         currentUserService.prescriber = {
           missionsManagement: true,
         };
 
-        assert.true(currentUserService.shouldAccessMissionsPage);
+        assert.true(currentUserService.canAccessMissionsPage);
       });
 
       test('should return false if user does not have feature activated', function (assert) {
@@ -294,17 +294,17 @@ module('Unit | Service | current-user', function (hooks) {
           missionsManagement: false,
         };
 
-        assert.false(currentUserService.shouldAccessMissionsPage);
+        assert.false(currentUserService.canAccessMissionsPage);
       });
     });
 
-    module('#shouldAccessCampaignsPage', function () {
+    module('#canAccessCampaignsPage', function () {
       test('should return false if user has mission feature activated', function (assert) {
         currentUserService.prescriber = {
           missionsManagement: true,
         };
 
-        assert.false(currentUserService.shouldAccessCampaignsPage);
+        assert.false(currentUserService.canAccessCampaignsPage);
       });
 
       test('should return true if user does not have missions feature activated', function (assert) {
@@ -312,17 +312,17 @@ module('Unit | Service | current-user', function (hooks) {
           missionsManagement: false,
         };
 
-        assert.true(currentUserService.shouldAccessCampaignsPage);
+        assert.true(currentUserService.canAccessCampaignsPage);
       });
     });
 
-    module('#shouldAccessParticipantsPage', function () {
+    module('#canAccessParticipantsPage', function () {
       test('should return false if user has mission feature activated', function (assert) {
         currentUserService.prescriber = {
           missionsManagement: true,
         };
 
-        assert.false(currentUserService.shouldAccessParticipantsPage);
+        assert.false(currentUserService.canAccessParticipantsPage);
       });
 
       test('should return true if user does not have missions feature activated', function (assert) {
@@ -330,11 +330,11 @@ module('Unit | Service | current-user', function (hooks) {
           missionsManagement: false,
         };
 
-        assert.true(currentUserService.shouldAccessParticipantsPage);
+        assert.true(currentUserService.canAccessParticipantsPage);
       });
     });
 
-    module('#shouldAccessImportPage', function (hooks) {
+    module('#canAccessImportPage', function (hooks) {
       hooks.beforeEach(function () {
         currentUserService.prescriber = { hasOrganizationLearnerImport: false };
       });
@@ -344,35 +344,35 @@ module('Unit | Service | current-user', function (hooks) {
           currentUserService.isAdminInOrganization = true;
           currentUserService.isSCOManagingStudents = false;
 
-          assert.false(currentUserService.shouldAccessImportPage);
+          assert.false(currentUserService.canAccessImportPage);
         });
 
         test('should return true if organization is sco managing student', function (assert) {
           currentUserService.isAdminInOrganization = true;
           currentUserService.isSCOManagingStudents = true;
 
-          assert.true(currentUserService.shouldAccessImportPage);
+          assert.true(currentUserService.canAccessImportPage);
         });
 
         test('should return false if organization not sup managing student', function (assert) {
           currentUserService.isAdminInOrganization = true;
           currentUserService.isSUPManagingStudents = false;
 
-          assert.false(currentUserService.shouldAccessImportPage);
+          assert.false(currentUserService.canAccessImportPage);
         });
 
         test('should return true if organization is sup managing student', function (assert) {
           currentUserService.isAdminInOrganization = true;
           currentUserService.isSUPManagingStudents = true;
 
-          assert.true(currentUserService.shouldAccessImportPage);
+          assert.true(currentUserService.canAccessImportPage);
         });
 
         test('should return true if user can use import learner feature', function (assert) {
           currentUserService.isAdminInOrganization = true;
           currentUserService.prescriber = { hasOrganizationLearnerImport: true };
 
-          assert.true(currentUserService.shouldAccessImportPage);
+          assert.true(currentUserService.canAccessImportPage);
         });
       });
 
@@ -381,35 +381,35 @@ module('Unit | Service | current-user', function (hooks) {
           currentUserService.isAdminInOrganization = false;
           currentUserService.isSCOManagingStudents = false;
 
-          assert.false(currentUserService.shouldAccessImportPage);
+          assert.false(currentUserService.canAccessImportPage);
         });
 
         test('should return false if organization is sco managing student', function (assert) {
           currentUserService.isAdminInOrganization = false;
           currentUserService.isSCOManagingStudents = true;
 
-          assert.false(currentUserService.shouldAccessImportPage);
+          assert.false(currentUserService.canAccessImportPage);
         });
 
         test('should return false if organization not sup managing student', function (assert) {
           currentUserService.isAdminInOrganization = false;
           currentUserService.isSUPManagingStudents = false;
 
-          assert.false(currentUserService.shouldAccessImportPage);
+          assert.false(currentUserService.canAccessImportPage);
         });
 
         test('should return false if organization is sup managing student', function (assert) {
           currentUserService.isAdminInOrganization = false;
           currentUserService.isSUPManagingStudents = true;
 
-          assert.false(currentUserService.shouldAccessImportPage);
+          assert.false(currentUserService.canAccessImportPage);
         });
 
         test('should return false if user can use import learner feature', function (assert) {
           currentUserService.isAdminInOrganization = false;
           currentUserService.prescriber = { hasOrganizationLearnerImport: true };
 
-          assert.false(currentUserService.shouldAccessImportPage);
+          assert.false(currentUserService.canAccessImportPage);
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Quand un user appartenait à plusieurs orga dont une de type `SCO-1D`, et que via le menu en haut à gauche, il changeait d'orga passant d'une orga autre que `SCO-1D` à une de type `SCO-1D`, l'utilisateur restait sur la page `campagnes/les-miennes`

## :robot: Proposition
Faire en sorte d'accéder à la page mission que si l'orga est de type `SCO-1D` et d'accéder aux pages des campagnes que si l'orga n'est pas de type `SCO-1D`

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- Aller sur pix orga avec `member-orga@example.net` et changer d'orga pour vérifier qu'on affiche la bonne page en fonction de l'orga.
- Taper directement dans l'url `missions` si on est avec une orga autre que l'orga `Pix1D`
- Taper directement dans l'url `campagnes/les-miennes` ou  `campagnes/toutes` si on est avec l'orga `Pix1D`