### PR TITLE
[FEATURE] Permettre la pérénité des `organization-learners` via l'import générique d'un import à l'autre (PIX-12788)

### DIFF
--- a/api/src/prescription/learner-management/domain/usecases/import-from-feature/save-organization-learners-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-from-feature/save-organization-learners-file.js
@@ -31,9 +31,22 @@ const saveOrganizationLearnersFile = async function ({
 
     learnerSet.addLearners(learnersData);
 
+    const existingLearners = await organizationLearnerRepository.findAllCommonLearnersFromOrganizationId({
+      organizationId,
+    });
+
+    learnerSet.setExistingLearners(existingLearners);
+
     const learners = learnerSet.learners;
 
-    await organizationLearnerRepository.disableCommonOrganizationLearnersFromOrganizationId({ organizationId });
+    await organizationLearnerRepository.disableCommonOrganizationLearnersFromOrganizationId({
+      organizationId,
+      excludeOrganizationLearnerIds: learners.existinglearnerIds,
+    });
+    await organizationLearnerRepository.updateCommonLearnersFromOrganizationId({
+      organizationId,
+      learners: learners.update,
+    });
     await organizationLearnerRepository.saveCommonOrganizationLearners(learners.create);
   } catch (error) {
     if (Array.isArray(error)) {

--- a/api/src/prescription/learner-management/domain/usecases/import-from-feature/save-organization-learners-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-from-feature/save-organization-learners-file.js
@@ -22,17 +22,19 @@ const saveOrganizationLearnersFile = async function ({
 
     const parser = CommonCsvLearnerParser.buildParser({ buffer, importFormat });
 
-    const learners = parser.parse(organizationImport.encoding);
+    const learnersData = parser.parse(organizationImport.encoding);
 
     const learnerSet = ImportOrganizationLearnerSet.buildSet({
       organizationId,
       importFormat,
     });
 
-    learnerSet.addLearners(learners);
+    learnerSet.addLearners(learnersData);
+
+    const learners = learnerSet.learners;
 
     await organizationLearnerRepository.disableCommonOrganizationLearnersFromOrganizationId({ organizationId });
-    await organizationLearnerRepository.saveCommonOrganizationLearners(learnerSet.learners);
+    await organizationLearnerRepository.saveCommonOrganizationLearners(learners.create);
   } catch (error) {
     if (Array.isArray(error)) {
       errors.push(...error);

--- a/api/src/prescription/learner-management/domain/usecases/import-from-feature/save-organization-learners-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-from-feature/save-organization-learners-file.js
@@ -31,7 +31,7 @@ const saveOrganizationLearnersFile = async function ({
 
     learnerSet.addLearners(learners);
 
-    await organizationLearnerRepository.disableCommonOrganizationLearnersFromOrganizationId(organizationId);
+    await organizationLearnerRepository.disableCommonOrganizationLearnersFromOrganizationId({ organizationId });
     await organizationLearnerRepository.saveCommonOrganizationLearners(learnerSet.learners);
   } catch (error) {
     if (Array.isArray(error)) {

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
@@ -68,9 +68,17 @@ const saveCommonOrganizationLearners = function (learners) {
   const knex = ApplicationTransaction.getConnection();
   return knex('organization-learners').insert(learners);
 };
-const disableCommonOrganizationLearnersFromOrganizationId = function (organizationId) {
+
+const disableCommonOrganizationLearnersFromOrganizationId = function ({
+  organizationId,
+  excludeOrganizationLearnerIds = [],
+}) {
   const knex = ApplicationTransaction.getConnection();
-  return knex('organization-learners').where({ organizationId }).update({ isDisabled: true, updatedAt: new Date() });
+  return knex('organization-learners')
+    .where({ organizationId, isDisabled: false })
+    .whereNull('deletedAt')
+    .update({ isDisabled: true, updatedAt: new Date() })
+    .whereNotIn('id', excludeOrganizationLearnerIds);
 };
 
 export {

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
@@ -4,6 +4,7 @@ import { OrganizationLearnersCouldNotBeSavedError } from '../../../../../lib/dom
 import { OrganizationLearner } from '../../../../../lib/domain/models/index.js';
 import * as organizationLearnerRepository from '../../../../../lib/infrastructure/repositories/organization-learner-repository.js';
 import { ApplicationTransaction } from '../../../shared/infrastructure/ApplicationTransaction.js';
+import { CommonOrganizationLearner } from '../../domain/models/ImportOrganizationLearnerSet.js';
 
 const removeByIds = function ({ organizationLearnerIds, userId, domainTransaction }) {
   return domainTransaction
@@ -81,10 +82,24 @@ const disableCommonOrganizationLearnersFromOrganizationId = function ({
     .whereNotIn('id', excludeOrganizationLearnerIds);
 };
 
+const findAllCommonLearnersFromOrganizationId = async function ({ organizationId }) {
+  const knex = ApplicationTransaction.getConnection();
+
+  const existingLearners = await knex('view-active-organization-learners')
+    .select(['firstName', 'id', 'lastName', 'userId', 'organizationId', 'attributes'])
+    .where({ organizationId });
+
+  return existingLearners.map(
+    ({ firstName, lastName, id, userId, organizationId, attributes }) =>
+      new CommonOrganizationLearner({ firstName, lastName, id, userId, organizationId, ...attributes }),
+  );
+};
+
 export {
   addOrUpdateOrganizationOfOrganizationLearners,
   disableAllOrganizationLearnersInOrganization,
   disableCommonOrganizationLearnersFromOrganizationId,
+  findAllCommonLearnersFromOrganizationId,
   removeByIds,
   saveCommonOrganizationLearners,
 };

--- a/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js
@@ -82,6 +82,19 @@ const disableCommonOrganizationLearnersFromOrganizationId = function ({
     .whereNotIn('id', excludeOrganizationLearnerIds);
 };
 
+const updateCommonLearnersFromOrganizationId = function ({ learners, organizationId }) {
+  const knex = ApplicationTransaction.getConnection();
+
+  return Promise.all(
+    learners.map((learner) => {
+      return knex('organization-learners')
+        .where({ id: learner.id, organizationId })
+        .whereNull('deletedAt')
+        .update({ ...learner, isDisabled: false, updatedAt: new Date() });
+    }),
+  );
+};
+
 const findAllCommonLearnersFromOrganizationId = async function ({ organizationId }) {
   const knex = ApplicationTransaction.getConnection();
 
@@ -102,4 +115,5 @@ export {
   findAllCommonLearnersFromOrganizationId,
   removeByIds,
   saveCommonOrganizationLearners,
+  updateCommonLearnersFromOrganizationId,
 };

--- a/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/learner-management/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -12,6 +12,7 @@ import {
   findAllCommonLearnersFromOrganizationId,
   removeByIds,
   saveCommonOrganizationLearners,
+  updateCommonLearnersFromOrganizationId,
 } from '../../../../../../src/prescription/learner-management/infrastructure/repositories/organization-learner-repository.js';
 import { ApplicationTransaction } from '../../../../../../src/prescription/shared/infrastructure/ApplicationTransaction.js';
 import { catchErr, databaseBuilder, domainBuilder, expect, knex, sinon } from '../../../../../test-helper.js';
@@ -1140,7 +1141,7 @@ describe('Integration | Repository | Organization Learner Management | Organizat
       });
 
       const { firstName, lastName, id, userId, attributes, isDisabled } =
-        await databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+        databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
           ...firstLearnerData,
           isDisabled: false,
           organizationId,
@@ -1176,7 +1177,7 @@ describe('Integration | Repository | Organization Learner Management | Organizat
         INE: '234567890',
       });
 
-      await databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+      databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
         ...learnerData,
         isDisabled: true,
         organizationId,
@@ -1203,7 +1204,7 @@ describe('Integration | Repository | Organization Learner Management | Organizat
 
       const userId = databaseBuilder.factory.buildUser().id;
 
-      await databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+      databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
         ...learnerData,
         isDisabled: false,
         deletedAt: new Date('2020-01-01'),
@@ -1231,7 +1232,7 @@ describe('Integration | Repository | Organization Learner Management | Organizat
         INE: '234567890',
       });
 
-      await databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+      databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
         ...learnerData,
         isDisabled: false,
       });
@@ -1245,6 +1246,187 @@ describe('Integration | Repository | Organization Learner Management | Organizat
 
       // then
       expect(organizationLearners).lengthOf(0);
+    });
+  });
+
+  describe('#updateCommonLearnersFromOrganizationId', function () {
+    let clock;
+    let organizationId;
+    let firstLearner, secondLearner;
+    const now = new Date('2023-02-02');
+
+    beforeEach(async function () {
+      clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+
+      organizationId = databaseBuilder.factory.buildOrganization().id;
+
+      await databaseBuilder.commit();
+    });
+
+    afterEach(function () {
+      clock.restore();
+    });
+
+    context('non deleted users', function () {
+      beforeEach(async function () {
+        const firstLearnerData = new CommonOrganizationLearner({
+          firstName: 'Sacha',
+          lastName: 'Du Bourg Palette',
+          organizationId,
+          INE: '234567890',
+          hooby: 'Pokemon Hunter',
+        });
+
+        const secondLearnerData = new CommonOrganizationLearner({
+          firstName: 'Kasumi',
+          lastName: 'Yawa',
+          organizationId,
+          INE: '0987654321',
+          hooby: 'Pokemon master',
+        });
+
+        firstLearner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+          ...firstLearnerData,
+          isDisabled: true,
+          organizationId,
+        });
+
+        secondLearner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+          ...secondLearnerData,
+          isDisabled: true,
+          updatedAt: new Date('2020-01-01'),
+          organizationId,
+        });
+
+        await databaseBuilder.commit();
+      });
+
+      it('update given learners', async function () {
+        const updatedLearner = {
+          ...firstLearner,
+          firstName: 'Sakura',
+          lastName: 'Kādokyaputā',
+          attributes: {
+            hooby: 'Card Captor',
+          },
+        };
+
+        await updateCommonLearnersFromOrganizationId({ organizationId, learners: [updatedLearner] });
+
+        const learnerFromDB = await knex('organization-learners').where({ id: firstLearner.id }).first();
+
+        expect(learnerFromDB.isDisabled).to.be.false;
+        expect(learnerFromDB.updatedAt).to.be.deep.equal(now);
+        expect(learnerFromDB.deletedAt).to.be.null;
+        expect(learnerFromDB.attributes.hooby).to.be.equal('Card Captor');
+        expect(learnerFromDB.firstName).to.be.equal('Sakura');
+        expect(learnerFromDB.lastName).to.be.equal('Kādokyaputā');
+      });
+
+      it('should not update other learners', async function () {
+        const updatedLearner = {
+          ...firstLearner,
+          firstName: 'Sakura',
+          lastName: 'Kādokyaputā',
+          attributes: {
+            hooby: 'Card Captor',
+          },
+        };
+
+        await updateCommonLearnersFromOrganizationId({ organizationId, learners: [updatedLearner] });
+
+        const learnerFromDB = await knex('organization-learners').where({ id: secondLearner.id }).first();
+
+        expect(learnerFromDB.isDisabled).to.be.true;
+        expect(learnerFromDB.updatedAt).to.deep.equal(new Date('2020-01-01'));
+        expect(learnerFromDB.deletedAt).to.be.null;
+        expect(learnerFromDB.attributes.hooby).to.be.equal('Pokemon master');
+        expect(learnerFromDB.attributes.INE).to.be.equal('0987654321');
+        expect(learnerFromDB.firstName).to.be.equal('Kasumi');
+        expect(learnerFromDB.lastName).to.be.equal('Yawa');
+      });
+    });
+
+    it('should not update deleted learners', async function () {
+      const learnerData = new CommonOrganizationLearner({
+        firstName: 'Sacha',
+        lastName: 'Du Bourg Palette',
+        organizationId,
+        INE: '234567890',
+        hooby: 'Pokemon Hunter',
+      });
+
+      const learner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+        ...learnerData,
+        deletedAt: new Date('2020-01-01'),
+        updatedAt: new Date('2020-01-01'),
+        isDisabled: true,
+        organizationId,
+      });
+
+      const updatedLearner = {
+        ...learner,
+        firstName: 'Sakura',
+        lastName: 'Kādokyaputā',
+        attributes: {
+          hooby: 'Card Captor',
+        },
+      };
+
+      await databaseBuilder.commit();
+
+      await updateCommonLearnersFromOrganizationId({ organizationId, learners: [updatedLearner] });
+
+      const learnerFromDB = await knex('organization-learners').where({ id: learner.id }).first();
+
+      expect(learnerFromDB.isDisabled).to.be.true;
+      expect(learnerFromDB.updatedAt).to.deep.equal(new Date('2020-01-01'));
+      expect(learnerFromDB.deletedAt).to.deep.equal(new Date('2020-01-01'));
+      expect(learnerFromDB.attributes.hooby).to.be.equal('Pokemon Hunter');
+      expect(learnerFromDB.attributes.INE).to.be.equal('234567890');
+      expect(learnerFromDB.firstName).to.be.equal('Sacha');
+      expect(learnerFromDB.lastName).to.be.equal('Du Bourg Palette');
+    });
+
+    it('should not update learners from other organizationId', async function () {
+      const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      const learnerData = new CommonOrganizationLearner({
+        firstName: 'Sacha',
+        lastName: 'Du Bourg Palette',
+        organizationId,
+        INE: '234567890',
+        hooby: 'Pokemon Hunter',
+      });
+
+      const learner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+        ...learnerData,
+        updatedAt: new Date('2020-01-01'),
+        isDisabled: true,
+        organizationId: otherOrganizationId,
+      });
+
+      const updatedLearner = {
+        ...learner,
+        firstName: 'Sakura',
+        lastName: 'Kādokyaputā',
+        attributes: {
+          hooby: 'Card Captor',
+        },
+      };
+
+      await databaseBuilder.commit();
+
+      await updateCommonLearnersFromOrganizationId({ organizationId, learners: [updatedLearner] });
+
+      const learnerFromDB = await knex('organization-learners').where({ id: learner.id }).first();
+
+      expect(learnerFromDB.isDisabled).to.be.true;
+      expect(learnerFromDB.organizationId).to.be.equal(otherOrganizationId);
+      expect(learnerFromDB.updatedAt).to.deep.equal(new Date('2020-01-01'));
+      expect(learnerFromDB.attributes.hooby).to.be.equal('Pokemon Hunter');
+      expect(learnerFromDB.attributes.INE).to.be.equal('234567890');
+      expect(learnerFromDB.firstName).to.be.equal('Sacha');
+      expect(learnerFromDB.lastName).to.be.equal('Du Bourg Palette');
     });
   });
 });

--- a/api/tests/prescription/learner-management/unit/domain/usecases/import-from-feature/save-organization-learners-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/import-from-feature/save-organization-learners-file_test.js
@@ -111,9 +111,9 @@ describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
 
       // then
       expect(
-        organizationLearnerRepositoryStub.disableCommonOrganizationLearnersFromOrganizationId.calledOnceWithExactly(
+        organizationLearnerRepositoryStub.disableCommonOrganizationLearnersFromOrganizationId.calledOnceWithExactly({
           organizationId,
-        ),
+        }),
         'organizationLearnerRepository.disableCommonOrganizationLearnersFromOrganizationId',
       ).to.be.true;
       expect(

--- a/api/tests/prescription/learner-management/unit/domain/usecases/import-from-feature/save-organization-learners-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/import-from-feature/save-organization-learners-file_test.js
@@ -28,7 +28,7 @@ describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
     fileEncoding = Symbol('file encoding');
     dataBuffer = Symbol('DataBuffer');
     dataStream = Symbol('DataStream');
-    buildLearners = Symbol('build learners');
+    buildLearners = Symbol('saved learners');
 
     importFormat = Symbol('importFormat');
 
@@ -63,7 +63,9 @@ describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
     sinon.stub(ImportOrganizationLearnerSet, 'buildSet');
     importOrganizationLearnerSetStub = {
       addLearners: sinon.stub(),
-      learners: buildLearners,
+      learners: {
+        create: buildLearners,
+      },
     };
 
     organizationLearnerImportFormatRepositoryStub = {

--- a/api/tests/prescription/learner-management/unit/domain/usecases/import-from-feature/save-organization-learners-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/import-from-feature/save-organization-learners-file_test.js
@@ -18,9 +18,12 @@ describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
     organizationId,
     dataStream,
     s3Filepath,
-    buildLearners,
+    learnerToSave,
+    learnerToUpdate,
+    learnerIds,
     importFormat,
-    parsedLearners;
+    parsedLearners,
+    existingLearners;
 
   beforeEach(function () {
     organizationId = 1234;
@@ -28,7 +31,10 @@ describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
     fileEncoding = Symbol('file encoding');
     dataBuffer = Symbol('DataBuffer');
     dataStream = Symbol('DataStream');
-    buildLearners = Symbol('saved learners');
+    existingLearners = Symbol('Existing learners');
+    learnerToSave = Symbol('learner to save');
+    learnerToUpdate = Symbol('learner to update');
+    learnerIds = Symbol('learner Ids');
 
     importFormat = Symbol('importFormat');
 
@@ -51,7 +57,9 @@ describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
 
     organizationLearnerRepositoryStub = {
       disableCommonOrganizationLearnersFromOrganizationId: sinon.stub(),
+      updateCommonLearnersFromOrganizationId: sinon.stub(),
       saveCommonOrganizationLearners: sinon.stub(),
+      findAllCommonLearnersFromOrganizationId: sinon.stub(),
     };
 
     sinon.stub(CommonCsvLearnerParser, 'buildParser');
@@ -63,8 +71,11 @@ describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
     sinon.stub(ImportOrganizationLearnerSet, 'buildSet');
     importOrganizationLearnerSetStub = {
       addLearners: sinon.stub(),
+      setExistingLearners: sinon.stub(),
       learners: {
-        create: buildLearners,
+        create: learnerToSave,
+        update: learnerToUpdate,
+        existinglearnerIds: learnerIds,
       },
     };
 
@@ -92,6 +103,10 @@ describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
       .returns(commonCsvLearnerParserStub);
     commonCsvLearnerParserStub.parse.withArgs(fileEncoding).returns(parsedLearners);
 
+    organizationLearnerRepositoryStub.findAllCommonLearnersFromOrganizationId
+      .withArgs({ organizationId })
+      .resolves(existingLearners);
+
     // instantiate learners to save
     ImportOrganizationLearnerSet.buildSet
       .withArgs({ organizationId, importFormat })
@@ -113,13 +128,28 @@ describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
 
       // then
       expect(
+        organizationLearnerRepositoryStub.findAllCommonLearnersFromOrganizationId.calledOnceWithExactly({
+          organizationId,
+        }),
+        'organizationLearnerRepository.findAllCommonLearnersFromOrganizationId',
+      ).to.be.true;
+      expect(importOrganizationLearnerSetStub.setExistingLearners.calledOnceWithExactly(existingLearners)).to.be.true;
+      expect(
         organizationLearnerRepositoryStub.disableCommonOrganizationLearnersFromOrganizationId.calledOnceWithExactly({
           organizationId,
+          excludeOrganizationLearnerIds: learnerIds,
         }),
         'organizationLearnerRepository.disableCommonOrganizationLearnersFromOrganizationId',
       ).to.be.true;
       expect(
-        organizationLearnerRepositoryStub.saveCommonOrganizationLearners.calledOnceWithExactly(buildLearners),
+        organizationLearnerRepositoryStub.updateCommonLearnersFromOrganizationId.calledOnceWithExactly({
+          organizationId,
+          learners: learnerToUpdate,
+        }),
+        'organizationLearnerRepository.updateCommonLearnersFromOrganizationId',
+      ).to.be.true;
+      expect(
+        organizationLearnerRepositoryStub.saveCommonOrganizationLearners.calledOnceWithExactly(learnerToSave),
         'organizationLearnerRepository.saveCommonOrganizationLearners',
       ).to.be.true;
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement nous désactivons les learners
Puis nous ajoutons de nouveaux

Or nous avons besoin de ne desactiver que ceux qui ne sont plus dans le prochain fichier, et réactiver ceux qui serait potentiellement déjà désactiver.

## :robot: Proposition
Ajouter cette fonctionnalité dans l'import générique afin de permettre aux organisations d'avoir une pérénité des comptes d'une année sur l'autre

## :100: Pour tester
Faire plusieurs import. 

Vérifier que les learners présent sont toujours les mêmes et pas un nouvelle création.
Vérifier que des learners précedemment désactiver sont maintenant réactivé.