### PR TITLE
[FEATURE] Ouverture de session d'école Pix Junior depuis Orga (PIX-12724)

### DIFF
--- a/api/db/migrations/20240607144451_add-session-expiration-date-to-school.js
+++ b/api/db/migrations/20240607144451_add-session-expiration-date-to-school.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'schools';
+const COLUMN_NAME = 'sessionExpirationDate';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dateTime(COLUMN_NAME).defaultTo(null);
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/db/migrations/20240610093658_add-unicity-constraint-on-school-code.js
+++ b/api/db/migrations/20240610093658_add-unicity-constraint-on-school-code.js
@@ -1,0 +1,25 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/DEV/pages/2153512965/Cr+er+une+migration
+
+// If your migrations target `answers` or `knowledge-elements`
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+const TABLE_NAME = 'schools';
+const COLUMN_NAME = 'code';
+
+const up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.unique(COLUMN_NAME);
+  });
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropUnique(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/src/school/application/school-controller.js
+++ b/api/src/school/application/school-controller.js
@@ -7,5 +7,11 @@ const getSchool = async function (request) {
   return schoolSerializer.serialize(school);
 };
 
-const schoolController = { getSchool };
+const activateSchoolSession = async function (request, h) {
+  const { organizationId } = request.params;
+  await usecases.activateSchoolSession({ organizationId });
+  return h.response().code(204);
+};
+
+const schoolController = { getSchool, activateSchoolSession };
 export { schoolController };

--- a/api/src/school/application/school-route.js
+++ b/api/src/school/application/school-route.js
@@ -25,6 +25,24 @@ const register = async function (server) {
         ],
       },
     },
+    {
+      method: 'POST',
+      path: '/api/pix1d/schools/{organizationId}/session/activate',
+      config: {
+        pre: [
+          { method: securityPreHandlers.checkPix1dActivated },
+          { method: securityPreHandlers.checkUserBelongsToOrganization },
+        ],
+        validate: {
+          params: Joi.object({
+            organizationId: identifiersType.organizationId,
+          }),
+        },
+        handler: schoolController.activateSchoolSession,
+        tags: ['api', 'pix1d', 'school'],
+        notes: ["- Elle permet de d'activer une session d'une orga"],
+      },
+    },
   ]);
 };
 

--- a/api/src/school/domain/usecases/activate-school-session.js
+++ b/api/src/school/domain/usecases/activate-school-session.js
@@ -1,0 +1,9 @@
+const SCHOOL_SESSION_DURATION_HOURS = 4;
+
+const activateSchoolSession = async function ({ organizationId, schoolRepository } = {}) {
+  const sessionExpirationDate = new Date();
+  sessionExpirationDate.setHours(sessionExpirationDate.getHours() + SCHOOL_SESSION_DURATION_HOURS);
+  await schoolRepository.updateSessionExpirationDate(organizationId, sessionExpirationDate);
+};
+
+export { activateSchoolSession };

--- a/api/src/school/infrastructure/repositories/school-repository.js
+++ b/api/src/school/infrastructure/repositories/school-repository.js
@@ -31,4 +31,7 @@ const getById = async function (organizationId) {
   return result.code;
 };
 
-export { getByCode, getById, isCodeAvailable, save };
+const updateSessionExpirationDate = async function (organizationId, sessionExpirationDate) {
+  await knex('schools').where({ organizationId }).update({ sessionExpirationDate });
+};
+export { getByCode, getById, isCodeAvailable, save, updateSessionExpirationDate };

--- a/api/tests/school/integration/infrastructure/repositories/school-repository_test.js
+++ b/api/tests/school/integration/infrastructure/repositories/school-repository_test.js
@@ -88,4 +88,22 @@ describe('Integration | Repository | School', function () {
       expect(code).to.equal('BADOIT710');
     });
   });
+
+  describe('#updateSessionExpirationDate', function () {
+    it('should update the sessionExpirationDate into given school', async function () {
+      //given
+      const { organizationId } = databaseBuilder.factory.buildSchool({ code: 'BADOIT710' });
+      await databaseBuilder.commit();
+
+      const sessionExpirationDate = new Date();
+
+      // when
+      await schoolRepository.updateSessionExpirationDate(organizationId, sessionExpirationDate);
+
+      // then
+      const school = await knex('schools').first();
+
+      expect(school.sessionExpirationDate).to.deep.equal(sessionExpirationDate);
+    });
+  });
 });

--- a/api/tests/school/unit/domain/usecases/activate-school-session_test.js
+++ b/api/tests/school/unit/domain/usecases/activate-school-session_test.js
@@ -1,0 +1,22 @@
+import { activateSchoolSession } from '../../../../../src/school/domain/usecases/activate-school-session.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Domain | Use Cases | activate-school-session', function () {
+  let clock;
+  const now = new Date('2022-11-28T12:00:00Z');
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
+  it('should update sessionExpirationDate to now + 4h', async function () {
+    const schoolRepository = { updateSessionExpirationDate: sinon.stub() };
+    const nowPlus4h = new Date('2022-11-28T16:00:00Z');
+    await activateSchoolSession({ organizationId: 123456, schoolRepository });
+    expect(schoolRepository.updateSessionExpirationDate).to.have.been.calledWithExactly(123456, nowPlus4h);
+  });
+});

--- a/orga/app/adapters/organization.js
+++ b/orga/app/adapters/organization.js
@@ -1,0 +1,13 @@
+import fetch from 'fetch';
+
+import ApplicationAdapter from './application';
+
+export default class OrganizationImportDetailAdapter extends ApplicationAdapter {
+  async activateSession({ organizationId, token }) {
+    const url = `${this.host}/${this.namespace}/pix1d/schools/${organizationId}/session/activate`;
+    return fetch(url, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    });
+  }
+}

--- a/orga/app/components/layout/school-session-management.gjs
+++ b/orga/app/components/layout/school-session-management.gjs
@@ -1,0 +1,31 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+
+export default class SchoolSessionManagement extends Component {
+  @service currentUser;
+  @service session;
+  @service store;
+
+  get canManageSession() {
+    return this.currentUser.canAccessMissionsPage;
+  }
+
+  @action
+  activateSession() {
+    const organization = this.currentUser.organization;
+    return this.store
+      .adapterFor('organization')
+      .activateSession({ organizationId: organization.id, token: this.session?.data?.authenticated?.access_token });
+  }
+
+  <template>
+    {{#if this.canManageSession}}
+      <PixButton class="button-activate-session" @variant="secondary" @triggerAction={{this.activateSession}}>{{t
+          "navigation.school-sessions.activate-button"
+        }}</PixButton>
+    {{/if}}
+  </template>
+}

--- a/orga/app/components/layout/topbar.hbs
+++ b/orga/app/components/layout/topbar.hbs
@@ -1,4 +1,5 @@
 <div class="topbar">
   <Layout::OrganizationPlacesOrCreditInfo @placesCount={{@placesCount}} />
+  <Layout::SchoolSessionManagement />
   <Layout::UserLoggedMenu class="topbar__user-logged-menu" @reloadPlaceStatistics={{@reloadPlaceStatistics}} />
 </div>

--- a/orga/app/styles/components/layout/topbar.scss
+++ b/orga/app/styles/components/layout/topbar.scss
@@ -7,4 +7,8 @@
   height: 60px;
   margin-bottom: var(--pix-spacing-6x);
   background-color: var(--pix-neutral-0);
+
+  .button-activate-session {
+    margin-right: var(--pix-spacing-3x);
+  }
 }

--- a/orga/tests/integration/components/layout/school-session-management_test.gjs
+++ b/orga/tests/integration/components/layout/school-session-management_test.gjs
@@ -1,0 +1,44 @@
+import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import SchoolSessionManagement from 'pix-orga/components/layout/school-session-management';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Components | Layout | SchoolSessionManagement', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('when user can manage missions', function () {
+    test('should display activate session button', async function (assert) {
+      // given
+      class CurrentUserStub extends Service {
+        isAdminInOrganization = false;
+        canAccessMissionsPage = true;
+      }
+
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      // when
+      const screen = await render(<template><SchoolSessionManagement /></template>);
+      // then
+      assert.ok(screen.getByRole('button', { name: this.intl.t('navigation.school-sessions.activate-button') }));
+    });
+  });
+
+  module('when user cannot manage missions', function () {
+    test('should not display activate session button', async function (assert) {
+      // given
+      class CurrentUserStub extends Service {
+        isAdminInOrganization = true;
+        canAccessMissionsPage = false;
+      }
+
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      // when
+      const screen = await render(<template><SchoolSessionManagement /></template>);
+      // then
+      assert.notOk(screen.queryByRole('button', { name: this.intl.t('navigation.school-sessions.activate-button') }));
+    });
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -308,6 +308,9 @@
       "link": "See details",
       "number": "{count, plural, =0 {0 seat available} =1 {1 seat available} other {{count, number} seats available}}"
     },
+    "school-sessions": {
+      "activate-button": "Activate session"
+    },
     "team-members": {
       "aria-label": "Team members navigation"
     },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -308,6 +308,9 @@
       "link": "voir le détail",
       "number": "{count, plural, =0 {0 place disponible} =1 {1 place disponible} other {{count} places disponibles}}"
     },
+    "school-sessions": {
+      "activate-button": "Activer la session"
+    },
     "team-members": {
       "aria-label": "Navigation de la section équipe"
     },


### PR DESCRIPTION
## :unicorn: Problème
Pix Junior est accessible sans authentification et donne accès à la liste des élèves, importés dans une école, à partir d'un simple code école.
Ce code école peut être attaqué en force brute dans l'application.

## :robot: Proposition
Pour limiter la surface d'attaque de ce code, celui-ci ne sera rendu utilisable qu'à condition qu'une session ait été ouverte par l'enseignant.  
Cette PR a pour objectif de permettre l'ouverture initiale d'une session par école pour une durée de 4h.

## :rainbow: Remarques
La session pourra être reconduite ce qui fera l'objet d'une prochaine PR.
L'absence de session ouverte empêchera l'accès à l'école via le code école. Cela fera aussi l'objet d'une prochaine PR.

## :100: Pour tester
Se connecter sur Pix Orga sur une orga de type SCO-1D.
Dans le bandeau en haut à droite, cliquer sur le bouton "Activer la session".
En base de données, pour l'enregistrement `schools` de l'école courante, la colonne `sessionExpirationDate` est valorisée à la date/heure de clic + 4h.