### PR TITLE
[FEATURE] Rendre séléctionnable toute la zone de réponse QCU/QCM Modulix (PIX-12851)

### DIFF
--- a/mon-pix/app/components/module/element/qcm.hbs
+++ b/mon-pix/app/components/module/element/qcm.hbs
@@ -14,15 +14,14 @@
 
     <div class="element-qcm__proposals">
       {{#each this.element.proposals as |proposal|}}
-        <div class="element-qcm-proposals__proposal">
-          <PixCheckbox
-            name={{this.element.id}}
-            @isDisabled={{this.disableInput}}
-            {{on "click" (fn this.checkboxSelected proposal.id)}}
-          >
-            <:label>{{proposal.content}}</:label>
-          </PixCheckbox>
-        </div>
+        <PixCheckbox
+          name={{this.element.id}}
+          @isDisabled={{this.disableInput}}
+          @variant="tile"
+          {{on "click" (fn this.checkboxSelected proposal.id)}}
+        >
+          <:label>{{proposal.content}}</:label>
+        </PixCheckbox>
       {{/each}}
     </div>
   </fieldset>

--- a/mon-pix/app/components/module/element/qcm.js
+++ b/mon-pix/app/components/module/element/qcm.js
@@ -13,7 +13,7 @@ export default class ModuleQcm extends ModuleElement {
   }
 
   get disableInput() {
-    return super.disableInput ? 'true' : null;
+    return super.disableInput ? true : null;
   }
 
   resetAnswers() {

--- a/mon-pix/app/components/module/element/qcu.hbs
+++ b/mon-pix/app/components/module/element/qcu.hbs
@@ -14,18 +14,17 @@
 
     <div class="element-qcu__proposals">
       {{#each this.element.proposals as |proposal|}}
-        <div class="element-qcu-proposals__proposal">
-          <PixRadioButton
-            name={{this.element.id}}
-            @value={{proposal.id}}
-            @isDisabled={{this.disableInput}}
-            {{on "click" (fn this.radioClicked proposal.id)}}
-          >
-            <:label>
-              {{proposal.content}}
-            </:label>
-          </PixRadioButton>
-        </div>
+        <PixRadioButton
+          name={{this.element.id}}
+          @value={{proposal.id}}
+          @isDisabled={{this.disableInput}}
+          @variant="tile"
+          {{on "click" (fn this.radioClicked proposal.id)}}
+        >
+          <:label>
+            {{proposal.content}}
+          </:label>
+        </PixRadioButton>
       {{/each}}
     </div>
   </fieldset>

--- a/mon-pix/app/components/module/element/qcu.js
+++ b/mon-pix/app/components/module/element/qcu.js
@@ -23,6 +23,6 @@ export default class ModuleQcu extends ModuleElement {
   }
 
   get disableInput() {
-    return super.disableInput ? 'true' : null;
+    return super.disableInput ? true : null;
   }
 }

--- a/mon-pix/app/styles/components/module/_qcm.scss
+++ b/mon-pix/app/styles/components/module/_qcm.scss
@@ -22,16 +22,3 @@
     margin-bottom: var(--pix-spacing-4x);
   }
 }
-
-.element-qcm-proposals {
-  &__proposal {
-    padding: var(--pix-spacing-2x);
-    background: var(--pix-neutral-0);
-    border: 1px solid var(--pix-neutral-100);
-    border-radius: var(--pix-spacing-2x);
-
-    &:not(:last-child) {
-      margin-bottom: var(--pix-spacing-2x);
-    }
-  }
-}

--- a/mon-pix/app/styles/components/module/_qcu.scss
+++ b/mon-pix/app/styles/components/module/_qcu.scss
@@ -22,16 +22,3 @@
     margin-bottom: var(--pix-spacing-4x);
   }
 }
-
-.element-qcu-proposals {
-  &__proposal {
-    padding: var(--pix-spacing-2x);
-    background: var(--pix-neutral-0);
-    border: 1px solid var(--pix-neutral-100);
-    border-radius: var(--pix-spacing-2x);
-
-    &:not(:last-child) {
-      margin-bottom: var(--pix-spacing-2x);
-    }
-  }
-}


### PR DESCRIPTION
## :unicorn: Problème
Il n'est pas possible de cliquer sur toute la zone de réponse des QCU/QCM de Modulix.

## :robot: Proposition
Utiliser la nouvelle variante `tile` des composants `PixCheckbox` et `PixRadioButton` pour le permettre.

Maquettes : https://www.figma.com/design/47MuKB1wXoLEgMal06idN3/R%26D-DevComp?node-id=2235-10384&t=UXZjpwa0VtxzaP5W-0

## :rainbow: Remarques
Micro nettoyage pour éviter des erreurs avec `@isDisabled`.

## :100: Pour tester
Sur les modules (ex : https://app-pr9206.review.pix.fr/modules/bien-ecrire-son-adresse-mail/) :

- Vérifier que l’entièreté de la zone de réponse est clickable sur les QCU & QCM.
- Vérifier aussi que les checkbox/radio sont focusables une fois vérifiés.
- Vérifier qu'au hover le background change de couleur.