### PR TITLE
[FEATURE] Afficher les étapes de sélection de l'algorithme après que l'évaluation soit terminée (PIX-12763) 

### DIFF
--- a/admin/app/components/smart-random-simulator/current-challenge.hbs
+++ b/admin/app/components/smart-random-simulator/current-challenge.hbs
@@ -1,4 +1,4 @@
-<div class="current-challenge__details">
+<Card class="admin-form__card current-challenge" @title="Épreuve en cours: {{this.currentChallenge.skill.name}}">
   <ul>
     <li>Nom de l'acquis testé : <span class="current-challenge__name">{{@challenge.skill.name}}</span></li>
 
@@ -41,4 +41,4 @@
     </PixButton>
 
   </div>
-</div>
+</Card>

--- a/admin/app/components/smart-random-simulator/reset.hbs
+++ b/admin/app/components/smart-random-simulator/reset.hbs
@@ -1,6 +1,6 @@
-<section class="reset">
-  <p>🎉 Évaluation terminée</p>
-  <PixButton @variant="primary" @size="large" @triggerAction={{@reset}}>
+<Card class="admin-form__card" @title="Évaluation terminée">
+  <p>🎉 Évaluation terminée 🎉</p>
+  <PixButton @variant="primary" @triggerAction={{@reset}}>
     Recommencer ?
   </PixButton>
-</section>
+</Card>

--- a/admin/app/components/smart-random-simulator/smart-random-params.hbs
+++ b/admin/app/components/smart-random-simulator/smart-random-params.hbs
@@ -1,91 +1,88 @@
-<form class="admin-form">
-  <section class="admin-form__content">
+<Card class="admin-form__card" @title="Évaluation (campagne ou positionnement)">
 
-    <Card class="admin-form__card" @title="Évaluation (campagne ou positionnement)">
+  <div class="load-campaign-params">
 
-      <div class="load-campaign-params">
+    <p>
+      Charger les paramètres depuis un identifiant de campagne :
+    </p>
 
-        <p>
-          Charger les paramètres depuis un identifiant de campagne :
-        </p>
+    <PixInput
+      @id="campaignId"
+      @placeholder="12345"
+      @value={{this.campaignId}}
+      {{on "change" this.updateCampaignIdValue}}
+      type="number"
+    />
 
-        <PixInput
-          @id="campaignId"
-          @placeholder="12345"
-          @value={{this.campaignId}}
-          {{on "change" this.updateCampaignIdValue}}
-          type="number"
-        />
+    <PixButton @triggerAction={{this.loadCampaignParams}} @size="small">
+      Charger
+    </PixButton>
 
-        <PixButton @triggerAction={{this.loadCampaignParams}} @size="small">
-          Charger
-        </PixButton>
-      </div>
+  </div>
 
-      <PixTextarea
-        @id="skills"
-        @value={{fn this.stringify @skills}}
-        spellcheck="false"
-        class="form-field"
-        placeholder={{this.stringify this.skillsExample}}
-        @subLabel={{fn this.stringify this.skillsExample}}
-        {{on "change" (fn this.updateJsonFieldValue "skills")}}
-        @errorMessage={{this.errors.skills}}
-      >
-        <:label>Acquis ({{@skills.length}}) :</:label>
-      </PixTextarea>
-      <PixTextarea
-        @id="challenges"
-        @value={{fn this.stringify @challenges}}
-        spellcheck="false"
-        class="form-field"
-        placeholder={{this.stringify this.challengesExample}}
-        @subLabel={{fn this.stringify this.challengesExample}}
-        {{on "change" (fn this.updateJsonFieldValue "challenges")}}
-        @errorMessage={{this.errors.challenges}}
-      >
-        <:label>Épreuves ({{@challenges.length}}) :</:label>
-      </PixTextarea>
-    </Card>
+  <PixTextarea
+    @id="skills"
+    @value={{fn this.stringify @skills}}
+    spellcheck="false"
+    class="form-field"
+    placeholder={{this.stringify this.skillsExample}}
+    @subLabel={{fn this.stringify this.skillsExample}}
+    {{on "change" (fn this.updateJsonFieldValue "skills")}}
+    @errorMessage={{this.errors.skills}}
+  >
+    <:label>Acquis ({{@skills.length}}) :</:label>
+  </PixTextarea>
 
-    <Card class="admin-form__card" @title="Infos de l'utilisateur">
-      <PixTextarea
-        @id="knowledge-elements"
-        class="form-field"
-        placeholder={{this.stringify this.knowledgeElementsExample}}
-        @subLabel={{fn this.stringify this.knowledgeElementsExample}}
-        spellcheck="false"
-        @value={{fn this.stringify @knowledgeElements}}
-        {{on "change" (fn this.updateJsonFieldValue "knowledgeElements")}}
-        @errorMessage={{this.errors.knowledgeElements}}
-      >
-        <:label>Knowledge elements de l'utilisateur ({{@knowledgeElements.length}}) :</:label>
-      </PixTextarea>
-      <PixTextarea
-        @id="answers"
-        @value={{fn this.stringify @answers}}
-        spellcheck="false"
-        class="form-field"
-        placeholder={{this.stringify this.answersExample}}
-        @subLabel={{fn this.stringify this.answersExample}}
-        {{on "change" (fn this.updateJsonFieldValue "answers")}}
-        @errorMessage={{this.errors.answers}}
-      >
-        <:label>Réponses de l'utilisateur ({{@answers.length}}) :</:label>
-      </PixTextarea>
-      <PixInput
-        @id="assessment-id"
-        @value={{@assessmentId}}
-        placeholder="12345"
-        type="text"
-        {{on "change" (fn this.updateFormFieldValue "assessmentId")}}
-      >
-        <:label>ID de l'assessment</:label>
-      </PixInput>
-      <PixSelect @options={{this.acceptedLocales}} @onChange={{this.updateLocaleValue}} @value={{@locale}}>
-        <:label>Langue de l'utilisateur</:label>
-      </PixSelect>
-    </Card>
+  <PixTextarea
+    @id="challenges"
+    @value={{fn this.stringify @challenges}}
+    spellcheck="false"
+    class="form-field"
+    placeholder={{this.stringify this.challengesExample}}
+    @subLabel={{fn this.stringify this.challengesExample}}
+    {{on "change" (fn this.updateJsonFieldValue "challenges")}}
+    @errorMessage={{this.errors.challenges}}
+  >
+    <:label>Épreuves ({{@challenges.length}}) :</:label>
+  </PixTextarea>
 
-  </section>
-</form>
+</Card>
+
+<Card class="admin-form__card" @title="Infos de l'utilisateur">
+  <PixTextarea
+    @id="knowledge-elements"
+    class="form-field"
+    placeholder={{this.stringify this.knowledgeElementsExample}}
+    @subLabel={{fn this.stringify this.knowledgeElementsExample}}
+    spellcheck="false"
+    @value={{fn this.stringify @knowledgeElements}}
+    {{on "change" (fn this.updateJsonFieldValue "knowledgeElements")}}
+    @errorMessage={{this.errors.knowledgeElements}}
+  >
+    <:label>Knowledge elements de l'utilisateur ({{@knowledgeElements.length}}) :</:label>
+  </PixTextarea>
+  <PixTextarea
+    @id="answers"
+    @value={{fn this.stringify @answers}}
+    spellcheck="false"
+    class="form-field"
+    placeholder={{this.stringify this.answersExample}}
+    @subLabel={{fn this.stringify this.answersExample}}
+    {{on "change" (fn this.updateJsonFieldValue "answers")}}
+    @errorMessage={{this.errors.answers}}
+  >
+    <:label>Réponses de l'utilisateur ({{@answers.length}}) :</:label>
+  </PixTextarea>
+  <PixInput
+    @id="assessment-id"
+    @value={{@assessmentId}}
+    placeholder="12345"
+    type="text"
+    {{on "change" (fn this.updateFormFieldValue "assessmentId")}}
+  >
+    <:label>ID de l'assessment</:label>
+  </PixInput>
+  <PixSelect @options={{this.acceptedLocales}} @onChange={{this.updateLocaleValue}} @value={{@locale}}>
+    <:label>Langue de l'utilisateur</:label>
+  </PixSelect>
+</Card>

--- a/admin/app/components/smart-random-simulator/tubes-viewer.hbs
+++ b/admin/app/components/smart-random-simulator/tubes-viewer.hbs
@@ -1,4 +1,4 @@
-<div class="tubes-viewer">
+<Card class="admin-form__card" @title="Étapes de sélection">
 
   <ul class="tubes-viewer__steps">
     <li>
@@ -85,4 +85,4 @@
 
   </table>
 
-</div>
+</Card>

--- a/admin/app/controllers/authenticated/smart-random-simulator/get-next-challenge.js
+++ b/admin/app/controllers/authenticated/smart-random-simulator/get-next-challenge.js
@@ -146,15 +146,15 @@ export default class SmartRandomSimulator extends Controller {
     });
 
     switch (apiResponse.status) {
-      case 204: {
-        this.assessmentComplete = true;
-        break;
-      }
       case 200: {
         const responseBody = await apiResponse.json();
-        this.returnedChallenges = [...this.returnedChallenges, responseBody.challenge];
         this.smartRandomDetails = responseBody.smartRandomDetails;
         this.displayedStepIndex = this.smartRandomDetails.steps.length - 1;
+        if (!responseBody.challenge) {
+          this.assessmentComplete = true;
+          break;
+        }
+        this.returnedChallenges = [...this.returnedChallenges, responseBody.challenge];
         break;
       }
       default: {

--- a/admin/app/styles/authenticated/smart-random-simulator/get-next-challenge.scss
+++ b/admin/app/styles/authenticated/smart-random-simulator/get-next-challenge.scss
@@ -31,14 +31,4 @@
     justify-content: center;
   }
 
-  .reset {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-top: 20px;
-
-    p {
-      margin-right: 10px;
-    }
-  }
 }

--- a/admin/app/templates/authenticated/smart-random-simulator/get-next-challenge.hbs
+++ b/admin/app/templates/authenticated/smart-random-simulator/get-next-challenge.hbs
@@ -8,7 +8,7 @@
   </header>
 
   <main class="page-body smart-random-simulator">
-    <section>
+    <section class="admin-form__content">
       <SmartRandomSimulator::SmartRandomParams
         @knowledgeElements={{this.knowledgeElements}}
         @answers={{this.answers}}
@@ -29,42 +29,46 @@
       <section class="admin-form__content">
 
         {{#if this.assessmentComplete}}
+
           <SmartRandomSimulator::Reset @reset={{this.reset}} />
+
+          <SmartRandomSimulator::TubesViewer
+            @tubes={{this.skillsByTube}}
+            @currentSkillId={{this.currentChallenge.skill.id}}
+            @knowledgeElements={{this.knowledgeElements}}
+            @smartRandomDetails={{this.smartRandomDetails}}
+            @totalNumberOfSkills={{this.skills.length}}
+            @numberOfSkillsStillAvailable={{this.numberOfSkillsStillAvailable}}
+            @displayedStepIndex={{this.displayedStepIndex}}
+            @selectDisplayedStepIndex={{this.selectDisplayedStepIndex}}
+          />
+
         {{else if this.currentChallenge}}
 
-          <Card
-            class="admin-form__card current-challenge"
-            @title="Épreuve en cours: {{this.currentChallenge.skill.name}}"
-          >
+          <SmartRandomSimulator::CurrentChallenge
+            @assessmentComplete={{this.assessmentComplete}}
+            @challenge={{this.currentChallenge}}
+            @reset={{this.reset}}
+            @succeedCurrentChallenge={{this.succeedCurrentChallenge}}
+            @failCurrentChallenge={{this.failCurrentChallenge}}
+            @getNextChallenge={{this.getNextChallenge}}
+          />
 
-            <h2 class="current-challenge__title">Détails</h2>
-
-            <SmartRandomSimulator::CurrentChallenge
-              @assessmentComplete={{this.assessmentComplete}}
-              @challenge={{this.currentChallenge}}
-              @reset={{this.reset}}
-              @succeedCurrentChallenge={{this.succeedCurrentChallenge}}
-              @failCurrentChallenge={{this.failCurrentChallenge}}
-              @getNextChallenge={{this.getNextChallenge}}
-            />
-
-            <h2 class="current-challenge__title">Étapes de sélection</h2>
-
-            <SmartRandomSimulator::TubesViewer
-              @tubes={{this.skillsByTube}}
-              @currentSkillId={{this.currentChallenge.skill.id}}
-              @knowledgeElements={{this.knowledgeElements}}
-              @smartRandomDetails={{this.smartRandomDetails}}
-              @totalNumberOfSkills={{this.skills.length}}
-              @numberOfSkillsStillAvailable={{this.numberOfSkillsStillAvailable}}
-              @displayedStepIndex={{this.displayedStepIndex}}
-              @selectDisplayedStepIndex={{this.selectDisplayedStepIndex}}
-            />
-
-          </Card>
+          <SmartRandomSimulator::TubesViewer
+            @tubes={{this.skillsByTube}}
+            @currentSkillId={{this.currentChallenge.skill.id}}
+            @knowledgeElements={{this.knowledgeElements}}
+            @smartRandomDetails={{this.smartRandomDetails}}
+            @totalNumberOfSkills={{this.skills.length}}
+            @numberOfSkillsStillAvailable={{this.numberOfSkillsStillAvailable}}
+            @displayedStepIndex={{this.displayedStepIndex}}
+            @selectDisplayedStepIndex={{this.selectDisplayedStepIndex}}
+          />
 
         {{else}}
+
           <SmartRandomSimulator::Start @startAssessment={{this.startAssessment}} />
+
         {{/if}}
       </section>
     </section>

--- a/admin/tests/unit/controllers/authenticated/smart-random-simulator/get-next-challenge-test.js
+++ b/admin/tests/unit/controllers/authenticated/smart-random-simulator/get-next-challenge-test.js
@@ -23,6 +23,11 @@ module('Unit | Controller | authenticated/smart-random-simulator/get-next-challe
     smartRandomDetails: { predictedLevel: 8, steps: [] },
   };
 
+  const getAssessmentCompleteApiResponseBody = {
+    challenge: null,
+    smartRandomDetails: { predictedLevel: 8, steps: [] },
+  };
+
   const getCampaignParamsApiResponseBody = {
     skills: [
       {
@@ -165,10 +170,10 @@ module('Unit | Controller | authenticated/smart-random-simulator/get-next-challe
       });
     });
 
-    module('when api answer is 204', function () {
+    module('when api answer is 200 and does not contain a challenge', function () {
       test('it should set assessmentComplete', async function (assert) {
         // given
-        const apiResponse = new Response(null, { status: 204 });
+        const apiResponse = new Response(JSON.stringify(getAssessmentCompleteApiResponseBody), { status: 200 });
         fetchStub.resolves(apiResponse);
         assert.false(controller.assessmentComplete);
 
@@ -181,7 +186,7 @@ module('Unit | Controller | authenticated/smart-random-simulator/get-next-challe
       });
     });
 
-    module('when api answer is not 200 or 204', function () {
+    module('when api answer is not 200', function () {
       test('it should call error notification service function', async function (assert) {
         // given
         const apiResponse = new Response(

--- a/api/src/evaluation/domain/usecases/get-next-challenge-for-simulator.js
+++ b/api/src/evaluation/domain/usecases/get-next-challenge-for-simulator.js
@@ -4,7 +4,7 @@ import { STEPS_NAMES } from '../models/SmartRandomStep.js';
  * @param {simulationParameters: SimulationParameters} simulationParameters
  * @param pickChallengeService
  * @param smartRandomService
- * @returns {Promise<{challenge: Challenge, smartRandomDetails: SmartRandomDetails} | null>}
+ * @returns {Promise<{challenge: Challenge | null, smartRandomDetails: SmartRandomDetails}}
  */
 const getNextChallengeForSimulator = function ({ simulationParameters, pickChallengeService, smartRandomService }) {
   const { possibleSkillsForNextChallenge, hasAssessmentEnded, smartRandomDetails } =
@@ -20,7 +20,10 @@ const getNextChallengeForSimulator = function ({ simulationParameters, pickChall
     });
 
   if (hasAssessmentEnded) {
-    return null;
+    return {
+      challenge: null,
+      smartRandomDetails,
+    };
   }
 
   const challenge = pickChallengeService.pickChallenge({

--- a/api/tests/evaluation/acceptance/application/smart-random-simulator/smart-random-simulator-controller_test.js
+++ b/api/tests/evaluation/acceptance/application/smart-random-simulator/smart-random-simulator-controller_test.js
@@ -101,11 +101,12 @@ describe('Acceptance | API | Smart Random Simulator', function () {
           response = await server.inject(options);
         });
 
-        it('should return a 204 status code', async function () {
-          expect(response.statusCode).to.equal(204);
+        it('should return a 200 status code', async function () {
+          expect(response.statusCode).to.equal(200);
         });
-        it('should return an empty payload', async function () {
-          expect(response.payload).to.be.empty;
+        it('should return smart random details and no challenge', async function () {
+          expect(JSON.parse(response.payload).challenge).to.be.null;
+          expect(JSON.parse(response.payload).smartRandomDetails).to.exist;
         });
       });
     });

--- a/api/tests/evaluation/integration/domain/usecases/get-next-challenge-for-simulator_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/get-next-challenge-for-simulator_test.js
@@ -51,7 +51,7 @@ describe('Integration | Usecases | Get next challenge for simulator', function (
   });
 
   context('when there is no more challenge', function () {
-    it('should return null', async function () {
+    it('should return only smartRandom details', async function () {
       // given
       const simulationParameters = new SimulationParameters({
         skills: [],
@@ -62,12 +62,13 @@ describe('Integration | Usecases | Get next challenge for simulator', function (
       });
 
       // when
-      const nextChallenge = await evaluationUsecases.getNextChallengeForSimulator({
+      const { challenge, smartRandomDetails } = await evaluationUsecases.getNextChallengeForSimulator({
         simulationParameters,
       });
 
       // then
-      expect(nextChallenge).to.be.null;
+      expect(challenge).to.be.null;
+      expect(smartRandomDetails).to.be.instanceOf(SmartRandomDetails);
     });
   });
 });

--- a/api/tests/evaluation/unit/domain/usecases/get-next-challenge-for-simulator_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/get-next-challenge-for-simulator_test.js
@@ -18,7 +18,7 @@ describe('Unit | UseCase | get-next-challenge-for-simulator', function () {
     });
 
     context('when smartRandomService hasAssessmentEnded property is true', function () {
-      it('should return null and call only smartRandomService', function () {
+      it('should only return smartRandom details and call only smartRandomService', function () {
         // given
         smartRandomService.getPossibleSkillsForNextChallenge.returns({
           hasAssessmentEnded: true,
@@ -26,7 +26,7 @@ describe('Unit | UseCase | get-next-challenge-for-simulator', function () {
         });
 
         // when
-        const result = getNextChallengeForSimulator({
+        const { challenge } = getNextChallengeForSimulator({
           simulationParameters: {
             answers: [],
           },
@@ -37,7 +37,7 @@ describe('Unit | UseCase | get-next-challenge-for-simulator', function () {
         // then
         expect(smartRandomService.getPossibleSkillsForNextChallenge).to.have.been.calledOnce;
         expect(pickChallengeService.pickChallenge).to.not.have.been.called;
-        expect(result).to.be.null;
+        expect(challenge).to.be.null;
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Le simulateur Smart Random n'affiche pas les étapes de sélection pour la dernière épreuve, on se contente d'indiquer que l'évaluation est terminée.

## :robot: Proposition
Cette PR a pour but de visualiser les ultimes étapes de sélection qui ont conduit à la fin de l'évaluation, c'est à dire à ne sélectionner aucune épreuve.

## :100: Pour tester
- [Se rendre sur la RA](https://admin-pr9209.review.pix.fr/smart-random-simulator/get-next-challenge)
- Rensigner un id de campagne disponible dans les seeds ( 1000000 )
- Réussir ou échouer toutes les épreuves
- Vérifier qu'a la fin de l'évaluation les étapes de sélection sont bien visibles

