### PR TITLE
[FEATURE] Ajouter une route pour anonymiser en masse les données du GAR

### DIFF
--- a/api/src/identity-access-management/application/anonymization/anonymization.admin.controller.js
+++ b/api/src/identity-access-management/application/anonymization/anonymization.admin.controller.js
@@ -1,0 +1,21 @@
+import { GarAnonymizationParser } from '../../domain/services/GarAnonymizationParser.js';
+import { usecases } from '../../domain/usecases/index.js';
+import { anonymizeGarResultSerializer } from '../../infrastructure/serializers/jsonapi/anonymize-gar-result.serializer.js';
+
+/**
+ * @param request
+ * @param h
+ * @return {Promise<*>}
+ */
+async function anonymizeGarData(request, h) {
+  const filePath = request.payload.path;
+
+  const userIds = await GarAnonymizationParser.getCsvData(filePath);
+  const result = await usecases.anonymizeGarAuthenticationMethods({ userIds });
+
+  return h.response(anonymizeGarResultSerializer.serialize(result)).code(200);
+}
+
+export const anonymizationAdminController = {
+  anonymizeGarData,
+};

--- a/api/src/identity-access-management/application/anonymization/anonymization.admin.route.js
+++ b/api/src/identity-access-management/application/anonymization/anonymization.admin.route.js
@@ -1,0 +1,41 @@
+import { PayloadTooLargeError, sendJsonApiError } from '../../../shared/application/http-errors.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
+import { anonymizationAdminController } from './anonymization.admin.controller.js';
+
+const ERRORS = {
+  PAYLOAD_TOO_LARGE: 'PAYLOAD_TOO_LARGE',
+};
+const TWENTY_MEGABYTES = 1048576 * 20;
+
+export const anonymizationAdminRoutes = [
+  {
+    method: 'POST',
+    path: '/api/admin/anonymize/gar',
+    config: {
+      pre: [
+        {
+          method: (request, h) => securityPreHandlers.checkAdminMemberHasRoleSuperAdmin(request, h),
+          assign: 'hasAuthorizationToAccessAdminScope',
+        },
+      ],
+      payload: {
+        maxBytes: TWENTY_MEGABYTES,
+        output: 'file',
+        failAction: (request, h) => {
+          return sendJsonApiError(
+            new PayloadTooLargeError('An error occurred, payload is too large', ERRORS.PAYLOAD_TOO_LARGE, {
+              maxSize: '20',
+            }),
+            h,
+          );
+        },
+      },
+      handler: (request, h) => anonymizationAdminController.anonymizeGarData(request, h),
+      tags: ['api', 'admin', 'identity-access-management', 'anonymization'],
+      notes: [
+        "- **Cette route est restreinte aux utilisateurs authentifiés ayant un rôle SUPER_ADMIN permettant un accès à l'application d'administration de Pix**\n" +
+          "- Elle permet d'anonymiser les utilisateurs du GAR",
+      ],
+    },
+  },
+];

--- a/api/src/identity-access-management/application/routes.js
+++ b/api/src/identity-access-management/application/routes.js
@@ -1,3 +1,4 @@
+import { anonymizationAdminRoutes } from './anonymization/anonymization.admin.route.js';
 import { oidcProviderAdminRoutes } from './oidc-provider/oidc-provider.admin.route.js';
 import { oidcProviderRoutes } from './oidc-provider/oidc-provider.route.js';
 import { passwordRoutes } from './password/password.route.js';
@@ -8,6 +9,7 @@ import { userRoutes } from './user/user.route.js';
 
 const register = async function (server) {
   server.route([
+    ...anonymizationAdminRoutes,
     ...oidcProviderAdminRoutes,
     ...oidcProviderRoutes,
     ...passwordRoutes,

--- a/api/src/identity-access-management/domain/services/GarAnonymizationParser.js
+++ b/api/src/identity-access-management/domain/services/GarAnonymizationParser.js
@@ -1,0 +1,33 @@
+import { createReadStream } from 'node:fs';
+
+import Joi from 'joi';
+
+import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { validateEntity } from '../../../shared/domain/validators/entity-validator.js';
+import { CsvColumn } from '../../../shared/infrastructure/serializers/csv/csv-column.js';
+import { CsvParser } from '../../../shared/infrastructure/serializers/csv/csv-parser.js';
+import { getDataBuffer } from '../../../shared/infrastructure/utils/buffer.js';
+
+const CSV_HEADER = {
+  columns: [
+    new CsvColumn({
+      isRequired: true,
+      name: 'User ID',
+      property: 'id',
+    }),
+  ],
+};
+
+const SCHEMA = Joi.array().items(Joi.object({ id: identifiersType.userId }));
+
+async function getCsvData(filePath) {
+  const stream = createReadStream(filePath);
+  const buffer = await getDataBuffer(stream);
+  const csvParser = new CsvParser(buffer, CSV_HEADER);
+  const csvData = csvParser.parse();
+
+  validateEntity(SCHEMA, csvData);
+  return csvData.map(({ id }) => id);
+}
+
+export const GarAnonymizationParser = { CSV_HEADER, getCsvData };

--- a/api/src/identity-access-management/domain/usecases/anonymize-gar-authentication-methods.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/anonymize-gar-authentication-methods.usecase.js
@@ -1,0 +1,14 @@
+/**
+ * @typedef {function} anonymizeGarAuthenticationMethods
+ * @param {Object} params
+ * @param {string} params.userIds
+ * @param {AuthenticationMethodRepository} params.authenticationMethodRepository
+ * @return {Promise<{anonymized: string[], total: number}>}
+ */
+export const anonymizeGarAuthenticationMethods = async function ({ userIds, authenticationMethodRepository }) {
+  const total = userIds.length;
+  const { anonymizedUserCount } = await authenticationMethodRepository.batchAnonymizeByUserIds({
+    userIds,
+  });
+  return { anonymized: anonymizedUserCount, total };
+};

--- a/api/src/identity-access-management/infrastructure/serializers/jsonapi/anonymize-gar-result.serializer.js
+++ b/api/src/identity-access-management/infrastructure/serializers/jsonapi/anonymize-gar-result.serializer.js
@@ -1,0 +1,11 @@
+import jsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = jsonapiSerializer;
+
+const serialize = function (anonymizedResults) {
+  return new Serializer('anonymize-gar-results', {
+    attributes: ['anonymized', 'total'],
+  }).serialize(anonymizedResults);
+};
+
+export const anonymizeGarResultSerializer = { serialize };

--- a/api/tests/identity-access-management/acceptance/application/anonymization.admin.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/anonymization.admin.route.test.js
@@ -1,0 +1,68 @@
+import {
+  createServer,
+  databaseBuilder,
+  expect,
+  generateValidRequestAuthorizationHeader,
+  insertUserWithRoleSuperAdmin,
+} from '../../../test-helper.js';
+
+describe('Acceptance | Identity Access Management | Application | Route | Admin | Anonymization', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('POST /api/admin/anonymize/gar', function () {
+    context('when a CSV file is loaded', function () {
+      it('responds with a 200 and serialized payload', async function () {
+        // given
+        const user = await insertUserWithRoleSuperAdmin();
+
+        const userId1 = databaseBuilder.factory.buildUser().id;
+        const userId2 = databaseBuilder.factory.buildUser().id;
+        const userId3 = databaseBuilder.factory.buildUser().id;
+
+        databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
+          userId: userId1,
+          externalIdentifier: 'externalId1',
+        });
+        databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
+          userId: userId2,
+          externalIdentifier: 'externalId2',
+        });
+        databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
+          userId: userId3,
+          externalIdentifier: 'externalId3',
+        });
+        await databaseBuilder.commit();
+
+        const input = `User ID
+      ${userId1}
+      ${userId2}
+      ${userId3}
+      `;
+
+        const options = {
+          method: 'POST',
+          headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+          url: '/api/admin/anonymize/gar',
+          payload: input,
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data).to.deep.equal({
+          type: 'anonymize-gar-results',
+          attributes: {
+            anonymized: 3,
+            total: 3,
+          },
+        });
+      });
+    });
+  });
+});

--- a/api/tests/identity-access-management/integration/application/anonymization.admin.route.test.js
+++ b/api/tests/identity-access-management/integration/application/anonymization.admin.route.test.js
@@ -1,0 +1,93 @@
+import iconv from 'iconv-lite';
+
+import { PIX_ADMIN } from '../../../../src/authorization/domain/constants.js';
+import { identityAccessManagementRoutes } from '../../../../src/identity-access-management/application/routes.js';
+import {
+  databaseBuilder,
+  expect,
+  generateValidRequestAuthorizationHeader,
+  HttpTestServer,
+} from '../../../test-helper.js';
+
+const routesUnderTest = identityAccessManagementRoutes[0];
+
+describe('Integration | Identity Access Management | Application | Route | Anonymization', function () {
+  let httpTestServer;
+
+  beforeEach(async function () {
+    httpTestServer = new HttpTestServer();
+    httpTestServer.setupAuthentication();
+    await httpTestServer.register(routesUnderTest);
+  });
+
+  describe('POST /api/admin/anonymize/gar', function () {
+    context('when user is not superadmin', function () {
+      it('returns 403 HTTP status code', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser.withRole({ role: PIX_ADMIN.ROLES.CERTIF });
+        //  when
+        const response = await httpTestServer.request(
+          'POST',
+          '/api/admin/anonymize/gar',
+          {
+            data: {},
+          },
+          null,
+          { authorization: generateValidRequestAuthorizationHeader(user.id) },
+        );
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+    context('when csv file does not have required header', function () {
+      it('returns 412 HTTP status code', async function () {
+        //given
+        const user = databaseBuilder.factory.buildUser.withRole({ role: PIX_ADMIN.ROLES.SUPER_ADMIN });
+        await databaseBuilder.commit();
+        const input = `
+      123
+      456
+      789
+      `;
+
+        const options = {
+          method: 'POST',
+          headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+          url: '/api/admin/anonymize/gar',
+          payload: iconv.encode(input, 'UTF-8'),
+        };
+        // when
+        const response = await httpTestServer.requestObject(options);
+        // then
+        expect(response.statusCode).to.equal(412);
+        expect(response.statusMessage).to.equal('Precondition Failed');
+      });
+    });
+
+    context('when csv file does not have valid user ids', function () {
+      it('returns 422 HTTP status code', async function () {
+        //given
+        const user = databaseBuilder.factory.buildUser.withRole({ role: PIX_ADMIN.ROLES.SUPER_ADMIN });
+        await databaseBuilder.commit();
+        const input = `User ID;
+      toto
+      tata
+      titi
+      `;
+
+        const options = {
+          method: 'POST',
+          headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+          url: '/api/admin/anonymize/gar',
+          payload: iconv.encode(input, 'UTF-8'),
+        };
+        // when
+        const response = await httpTestServer.requestObject(options);
+        // then
+        expect(response.statusCode).to.equal(412);
+        expect(response.statusMessage).to.equal('Precondition Failed');
+      });
+    });
+  });
+});

--- a/api/tests/identity-access-management/unit/application/anonymization.admin.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/anonymization.admin.controller.test.js
@@ -1,0 +1,77 @@
+import { anonymizationAdminController } from '../../../../src/identity-access-management/application/anonymization/anonymization.admin.controller.js';
+import { GarAnonymizationParser } from '../../../../src/identity-access-management/domain/services/GarAnonymizationParser.js';
+import { usecases } from '../../../../src/identity-access-management/domain/usecases/index.js';
+import { anonymizeGarResultSerializer } from '../../../../src/identity-access-management/infrastructure/serializers/jsonapi/anonymize-gar-result.serializer.js';
+import { createTempFile, expect, hFake, sinon } from '../../../test-helper.js';
+
+describe('Unit | Identity Access Management | Application | Controller | Admin | anonymization', function () {
+  describe('anonymizeGarData', function () {
+    let csvHeaders;
+    let fileData;
+    let filePath;
+    let request;
+    let total;
+    let anonymized;
+    let expectedJSON;
+
+    beforeEach(async function () {
+      csvHeaders = 'User ID';
+      fileData = `${csvHeaders}
+      1;4;6;15;78`;
+      filePath = await createTempFile('test.csv', fileData);
+      request = { payload: { path: filePath } };
+      anonymized = 4;
+      total = 5;
+      expectedJSON = {
+        data: {
+          type: 'anonymize-gar-results',
+          attributes: {
+            anonymized,
+            total,
+          },
+        },
+      };
+
+      sinon.stub(GarAnonymizationParser, 'getCsvData').resolves([1, 4, 6, 15, 78]);
+      sinon.stub(usecases, 'anonymizeGarAuthenticationMethods').resolves({ total, anonymized });
+      sinon.stub(anonymizeGarResultSerializer, 'serialize').returns(expectedJSON);
+    });
+
+    it('calls anonymizeGarAuthenticationMethods usecase', async function () {
+      // given
+      // when
+      await anonymizationAdminController.anonymizeGarData(request, hFake);
+
+      // then
+      expect(usecases.anonymizeGarAuthenticationMethods).to.have.been.called;
+    });
+
+    it('returns a 200 with anonymizeGarAuthenticationMethods usecase result', async function () {
+      // given
+      // when
+      const result = await anonymizationAdminController.anonymizeGarData(request, hFake);
+
+      // then
+      expect(result.statusCode).to.equal(200);
+      expect(usecases.anonymizeGarAuthenticationMethods).to.have.been.called;
+      expect(result.source).to.deep.equal(expectedJSON);
+    });
+
+    it('calls anonymizeGarResultSerializer.serialize', async function () {
+      // when
+      await anonymizationAdminController.anonymizeGarData(request, hFake);
+
+      // then
+      expect(anonymizeGarResultSerializer.serialize).to.have.been.called;
+    });
+
+    it('calls parsing function', async function () {
+      // when
+      await anonymizationAdminController.anonymizeGarData(request, hFake);
+
+      // then
+      expect(await GarAnonymizationParser.getCsvData).to.have.been.calledOnce;
+      expect(await GarAnonymizationParser.getCsvData.calledWith(filePath)).to.be.true;
+    });
+  });
+});

--- a/api/tests/identity-access-management/unit/domain/usecases/anonymize-gar-authentication-methods.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/anonymize-gar-authentication-methods.usecase.test.js
@@ -1,0 +1,19 @@
+import { anonymizeGarAuthenticationMethods } from '../../../../../src/identity-access-management/domain/usecases/anonymize-gar-authentication-methods.usecase.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Identity Access Management | Domain | UseCase | anonymize-gar-authentication-methods', function () {
+  it('returns anonymized userId number and total of userIds', async function () {
+    // given
+    const authenticationMethodRepository = {
+      batchAnonymizeByUserIds: sinon.stub().resolves({ anonymizedUserCount: 3 }),
+    };
+    const userIds = [1, 2, 3];
+
+    // when
+    const result = await anonymizeGarAuthenticationMethods({ userIds, authenticationMethodRepository });
+
+    // then
+    expect(result.anonymized).to.be.equal(3);
+    expect(result.total).to.be.equal(3);
+  });
+});

--- a/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/anonymize-gar-result.serializer.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/serializers/jsonapi/anonymize-gar-result.serializer.test.js
@@ -1,0 +1,28 @@
+import { anonymizeGarResultSerializer } from '../../../../../../src/identity-access-management/infrastructure/serializers/jsonapi/anonymize-gar-result.serializer.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | Identity Access Management | Infrastructure | Serializer | JSONAPI | anonymize-gar-result', function () {
+  describe('#serialize', function () {
+    it('converts GAR anonymized results into JSON API data', function () {
+      //given
+      const anonymized = 7307;
+      const total = 7351;
+      const anonymizedResults = { anonymized, total };
+
+      //when
+      const json = anonymizeGarResultSerializer.serialize(anonymizedResults);
+
+      //then
+      const expectedJSON = {
+        data: {
+          type: 'anonymize-gar-results',
+          attributes: {
+            anonymized,
+            total,
+          },
+        },
+      };
+      expect(json).to.deep.equal(expectedJSON);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Il faut mettre en place une route réservée aux super-admin pour anonymiser les données du GAR.

## :robot: Proposition
Nous avons décidé de ne pas supprimer la ligne de la table authentication-method, mais de mettre à jour (en batch, par lot de 1000) certains champs de cette table;  le nom et le prénom seront remplacés par 'anonymized', et le champ `ExternalId `par 'anonymized-{id de la ligne}'

## :rainbow: Remarques
- Gestion des erreurs : en cas d'id inexistant, le processus continue.
- Certains cas d'erreurs (validation du fichier) rendent cependant impossible toute anonymisation (voir tests).
- Le test du scénario de réconciliation après anonymisation n'est peut-être pas complet avec les seeds dont nous disposons pour l'instant.

## :100: Pour tester

Pour l'ensemble des tests il faut : 

1. dans la table authentication-complement, récupérer les id des 4 users dont le GAR est l'identity provider. 
2. faire un fichier csv avec en en-tête `User ID` et en données les 4 id. Noter le path du fichier 
3. se connecter sur pix admin , d'abord en tant que CertifUser (pour le premier test) puis en tant que superAdmin (pour tous les autres) et récupérer pour chacune des deux connexions un 'Bearer token'
4. en renseignant le chemin du fichier en payload et bearer token en entête de la requête, on peut dans Postman par exemple (ou une autre application permettant de tester les api), faire la requête suivante de format `POST http://localhost:3000/api/admin/anonymize/gar` :  

- **pour tester les autorisations** : lancer la requête avec en payload le fichier csv correct, mais avec le Bearer Token du profil Certif. Constater l'erreur `403, Forbidden Access`. Vérifier en base de données qu'aucune ligne de la table authentication-complement n'est modifiée.

Pour la suite des tests il faut le Bearer Token du profil SuperAdmin :

- **pour tester la validation du format de données** : remplacer le dernier id par _toto_ et garder les trois autres . Constater l'erreur `422 / Unprocessable entity`, avec le détail `ValidationError: \"[3].id\" must be a number`.Vérifier en base de données qu'aucune ligne de la table authentication-complement n'est modifiée.

- **pour tester la correction du header** : remplacer par exemple `User ID` par `Organization ID`. Constater l'erreur `412 "ENCODING NOT SUPPORTED"`. Vérifier en base de données qu'aucune ligne de la table authentication-method n'est modifiée.

- **pour tester un scénario passant** :  remplacer un des id (le troisième par exemple) par un id inexistant en base, les autres sont valides: 
1. constater la réponse 200
```
{
   "data": {
       "type": "anonymize-gar-results",
       "attributes": {
           "anonymized": 3,
           "total": 4
       }
   }
}
```
2.constater que les trois champs (Nom, Prénom, ExternalId) existants ont été modifiés comme attendu (voir description de la pr) en base.

**Scénario de test de la réconciliation après anonymisation :** 

- se connecter au "Faux Gar" avec le profil d'un utilisateur "GAR" (par exemple Bob Léponge - date de naissance nécessaire).
- Accéder à la campagne SCOBADGE1
- Se déconneter
- Anonymiser l'utilisateur comme montré précédemment
- Vérifier que les données sont anonymisées en base de donnée
- Se connecter à nouveau comme précédemment, via le "Faux GAR", avec le profil Bob Léponge, à la même campagne. 
- Vérifier que les données sont re-remplies dans la table authentication-methods

--- 

Si c'est curl qui est utilisé pour effectuer l'envoi du fichier, voici ci-dessous la commande curl.

Remplacer `XXX` par le bon token.

Et il faut créer un fichier CSV ayant pour nom `accounts_to_nonymize.csv`.

```shell
bearer='XXX'

curl \
-X POST \
-H "Authorization: Bearer $bearer" \
--data-binary @accounts_to_nonymize.csv \
http://localhost:3000/api/admin/anonymize/gar
```