### PR TITLE
[FEATURE] Audit logger peut log des events en masse (PIX-12808)

### DIFF
--- a/api/lib/infrastructure/jobs/audit-log/UserAnonymizedBatchEventsLoggingJob.js
+++ b/api/lib/infrastructure/jobs/audit-log/UserAnonymizedBatchEventsLoggingJob.js
@@ -1,0 +1,15 @@
+import { JobPgBoss } from '../JobPgBoss.js';
+
+export class UserAnonymizedBatchEventsLoggingJob extends JobPgBoss {
+  constructor(queryBuilder) {
+    super(
+      {
+        name: 'UserAnonymizedBatchEventsLoggingJob',
+        retryLimit: 10,
+        retryDelay: 30,
+        retryBackoff: true,
+      },
+      queryBuilder,
+    );
+  }
+}

--- a/api/lib/infrastructure/jobs/audit-log/UserAnonymizedBatchEventsLoggingJobHandler.js
+++ b/api/lib/infrastructure/jobs/audit-log/UserAnonymizedBatchEventsLoggingJobHandler.js
@@ -1,0 +1,24 @@
+import { auditLoggerRepository } from '../../repositories/audit-logger-repository.js';
+import { UserAnonymizedBatchEventsLoggingJob } from './UserAnonymizedBatchEventsLoggingJob.js';
+
+export class UserAnonymizedBatchEventsLoggingJobHandler {
+  get name() {
+    return UserAnonymizedBatchEventsLoggingJob.name;
+  }
+
+  async handle(events = []) {
+    return auditLoggerRepository.logEvents(
+      events.map((event) => {
+        const { userId: targetUserId, updatedByUserId: userId, role, client, occurredAt } = event;
+        return {
+          targetUserId: targetUserId.toString(),
+          userId: userId.toString(),
+          role,
+          client,
+          occurredAt,
+          action: 'ANONYMIZATION',
+        };
+      }),
+    );
+  }
+}

--- a/api/lib/infrastructure/repositories/audit-logger-repository.js
+++ b/api/lib/infrastructure/repositories/audit-logger-repository.js
@@ -5,6 +5,17 @@ import { httpAgent } from '../http/http-agent.js';
 const { auditLogger } = config;
 const basicAuthorizationToken = btoa(`pix-api:${auditLogger.clientSecret}`);
 
+/**
+ * Log an event
+ *
+ * @param {Object} event Event to log
+ * @param {string} event.targetUserId User id which is concerned by the event
+ * @param {string} event.userId User id which is logging the event
+ * @param {Date} event.occurredAt Date of the event
+ * @param {AuditLogAction} event.action Action type of the event
+ * @param {AuditLogRole} event.role Role of the event
+ * @param {AuditLogClient} event.client Client system of the event
+ */
 const logEvent = async function (event) {
   const url = `${auditLogger.baseUrl}/api/audit-logs`;
   const headers = {
@@ -18,6 +29,21 @@ const logEvent = async function (event) {
   }
 };
 
-const auditLoggerRepository = { logEvent };
+/**
+ * Log multiple events
+ *
+ * @param {Object[]} events Event to log
+ * @param {string} event[].targetUserId User id which is concerned by the event
+ * @param {string} event[].userId User id which is logging the event
+ * @param {Date} events[].occurredAt Date of the event
+ * @param {AuditLogAction} events[].action Action type of the event
+ * @param {AuditLogRole} events[].role Role of the event
+ * @param {AuditLogClient} events[].client Client system of the event
+ */
+const logEvents = async function (events) {
+  await logEvent(events);
+};
+
+const auditLoggerRepository = { logEvent, logEvents };
 
 export { auditLoggerRepository };

--- a/api/tests/unit/infrastructure/jobs/audit-log/UserAnonymizedBatchEventsLoggingJobHandler_test.js
+++ b/api/tests/unit/infrastructure/jobs/audit-log/UserAnonymizedBatchEventsLoggingJobHandler_test.js
@@ -1,0 +1,62 @@
+import { UserAnonymized } from '../../../../../lib/domain/events/UserAnonymized.js';
+import { UserAnonymizedBatchEventsLoggingJobHandler } from '../../../../../lib/infrastructure/jobs/audit-log/UserAnonymizedBatchEventsLoggingJobHandler.js';
+import { auditLoggerRepository } from '../../../../../lib/infrastructure/repositories/audit-logger-repository.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Infrastructure | Jobs | audit-log | User anonymized batch events logging', function () {
+  let clock;
+
+  beforeEach(function () {
+    const now = new Date('2023-08-18');
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
+  context('#handle', function () {
+    it('calls the user anonymized events', async function () {
+      // given
+      sinon.stub(auditLoggerRepository, 'logEvents').resolves();
+
+      const event1 = new UserAnonymized({
+        userId: 1,
+        updatedByUserId: 2,
+        role: 'SUPER_ADMIN',
+      });
+
+      const event2 = new UserAnonymized({
+        userId: 2,
+        updatedByUserId: 3,
+        role: 'SUPER_ADMIN',
+      });
+
+      const userAnonymizedEventLoggingJobHandler = new UserAnonymizedBatchEventsLoggingJobHandler();
+
+      // when
+      await userAnonymizedEventLoggingJobHandler.handle([event1, event2]);
+
+      // then
+      const expectedEvent = [
+        {
+          userId: event1.updatedByUserId.toString(),
+          targetUserId: event1.userId.toString(),
+          role: 'SUPER_ADMIN',
+          occurredAt: new Date(),
+          action: 'ANONYMIZATION',
+          client: 'PIX_ADMIN',
+        },
+        {
+          userId: event2.updatedByUserId.toString(),
+          targetUserId: event2.userId.toString(),
+          role: 'SUPER_ADMIN',
+          occurredAt: new Date(),
+          action: 'ANONYMIZATION',
+          client: 'PIX_ADMIN',
+        },
+      ];
+      expect(auditLoggerRepository.logEvents).to.have.been.calledWithExactly(expectedEvent);
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/jobs/audit-log/UserAnonymizedEventLoggingJobHandler_test.js
+++ b/api/tests/unit/infrastructure/jobs/audit-log/UserAnonymizedEventLoggingJobHandler_test.js
@@ -3,7 +3,7 @@ import { UserAnonymizedEventLoggingJobHandler } from '../../../../../lib/infrast
 import { auditLoggerRepository } from '../../../../../lib/infrastructure/repositories/audit-logger-repository.js';
 import { expect, sinon } from '../../../../test-helper.js';
 
-describe('Unit | Infrastructure | Jobs | audit-log | ', function () {
+describe('Unit | Infrastructure | Jobs | audit-log | User anonymized event logging', function () {
   let clock;
 
   beforeEach(function () {

--- a/api/tests/unit/infrastructure/repositories/audit-logger-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/audit-logger-repository_test.js
@@ -68,4 +68,75 @@ describe('Unit | Infrastructure | Repositories | audit-logger-repository', funct
       });
     });
   });
+
+  describe('#logEvents', function () {
+    context('success', function () {
+      it('logs multiple events', async function () {
+        // given
+        const payload = [
+          {
+            userId: 1,
+            targetUserId: 2,
+            action: 'ANONYMIZATION',
+            occurredAt: new Date(),
+            role: 'SUPPORT',
+            client: 'PIX_ADMIN',
+          },
+          {
+            userId: 1,
+            targetUserId: 2,
+            action: 'ANONYMIZATION',
+            occurredAt: new Date(),
+            role: 'SUPPORT',
+            client: 'PIX_ADMIN',
+          },
+        ];
+        const url = `${auditLogger.baseUrl}/api/audit-logs`;
+        const headers = {
+          Authorization: `Basic ${btoa(`pix-api:${auditLogger.clientSecret}`)}`,
+        };
+        sinon.stub(httpAgent, 'post').resolves({ isSuccessful: true, code: 204 });
+
+        // when
+        await auditLoggerRepository.logEvents(payload);
+
+        // then
+        expect(httpAgent.post).to.have.been.calledWithExactly({ url, payload, headers });
+      });
+    });
+
+    context('failure', function () {
+      context('when response is not successful', function () {
+        it('throws an error', async function () {
+          // given
+          const payload = [
+            {
+              userId: 1,
+              targetUserId: 2,
+              action: 'ANONYMIZATION',
+              occurredAt: new Date(),
+              role: 'SUPPORT',
+              client: 'PIX_ADMIN',
+            },
+            {
+              userId: 1,
+              targetUserId: 2,
+              action: 'ANONYMIZATION',
+              occurredAt: new Date(),
+              role: 'SUPPORT',
+              client: 'PIX_ADMIN',
+            },
+          ];
+          sinon.stub(httpAgent, 'post').resolves({ code: 400, isSuccessful: false });
+
+          // when
+          const error = await catchErr(auditLoggerRepository.logEvent)(payload);
+
+          // then
+          expect(error).to.be.instanceOf(AuditLoggerApiError);
+          expect(error.message).to.equal('Pix Audit Logger Api answered with status 400');
+        });
+      });
+    });
+  });
 });

--- a/api/worker.js
+++ b/api/worker.js
@@ -6,6 +6,8 @@ import _ from 'lodash';
 import PgBoss from 'pg-boss';
 
 import { config } from './lib/config.js';
+import { UserAnonymizedBatchEventsLoggingJob } from './lib/infrastructure/jobs/audit-log/UserAnonymizedBatchEventsLoggingJob.js';
+import { UserAnonymizedBatchEventsLoggingJobHandler } from './lib/infrastructure/jobs/audit-log/UserAnonymizedBatchEventsLoggingJobHandler.js';
 import { UserAnonymizedEventLoggingJob } from './lib/infrastructure/jobs/audit-log/UserAnonymizedEventLoggingJob.js';
 import { UserAnonymizedEventLoggingJobHandler } from './lib/infrastructure/jobs/audit-log/UserAnonymizedEventLoggingJobHandler.js';
 import { ParticipationResultCalculationJob } from './lib/infrastructure/jobs/campaign-result/ParticipationResultCalculationJob.js';
@@ -88,6 +90,7 @@ export async function runJobs(dependencies = { startPgBoss, createMonitoredJobQu
   );
 
   monitoredJobQueue.performJob(UserAnonymizedEventLoggingJob.name, UserAnonymizedEventLoggingJobHandler);
+  monitoredJobQueue.performJob(UserAnonymizedBatchEventsLoggingJob.name, UserAnonymizedBatchEventsLoggingJobHandler);
 
   if (config.pgBoss.validationFileJobEnabled) {
     monitoredJobQueue.performJob(ValidateOrganizationImportFileJob.name, ValidateOrganizationImportFileJobHandler);

--- a/audit-logger/tests/acceptance/controllers/create-audit-log.controller.test.ts
+++ b/audit-logger/tests/acceptance/controllers/create-audit-log.controller.test.ts
@@ -37,7 +37,7 @@ describe('Acceptance | Controllers | CreateAuditLogController', () => {
   });
 
   describe('when user credentials are invalid', () => {
-    test('returns a unauthorized http status', async() => {
+    test('returns a unauthorized http status', async () => {
       // when
       options = {
         ...options,
@@ -51,12 +51,43 @@ describe('Acceptance | Controllers | CreateAuditLogController', () => {
   });
 
   describe('when request is valid', () => {
-    test('returns a no content http status', async () => {
-      // when
-      const response = await server.inject(options);
+    describe('with a single event log', () => {
+      test('returns a no content http status', async () => {
+        // when
+        const response = await server.inject(options);
 
-      // then
-      expect(response.statusCode).toEqual(204);
+        // then
+        expect(response.statusCode).toEqual(204);
+      });
+    });
+
+    describe('with multiple event logs', () => {
+      test('returns a no content http status', async () => {
+        // when
+        const response = await server.inject(options);
+
+        options.payload = [
+          {
+            targetUserId: '2',
+            userId: 3,
+            action: 'READ',
+            occurredAt: new Date('2023-07-05'),
+            role: 'METIER',
+            client: 'PIX_APP',
+          },
+          {
+            targetUserId: '2',
+            userId: 3,
+            action: 'READ',
+            occurredAt: new Date('2023-07-06'),
+            role: 'METIER',
+            client: 'PIX_APP',
+          },
+        ];
+
+        // then
+        expect(response.statusCode).toEqual(204);
+      });
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, le endpoint `/api/audit-logs` ne permet que d'envoyer un évèvement unitaire. Dans le cas de traitements en masse ou plus volumineux, il serait bien d'avoir la possibilité d'envoyer plusieurs évènements en un seul appel au endpoint (pour limiter la charge réseau).

## :robot: Proposition

- Ajouter la possibilité d'avoir plusieurs évènements dans le payload du endpoint `/api/audit-logs`
- Ajouter un Job côté API permettant d'envoyer plusieurs évènements

## :100: Pour tester

Pour tester en local:

- Faire un build de `api/audit-logger` avec `npm run build`

- Executer `api/audit-logger` avec `npm start`

- Add a single event with this curl command:
```bash
curl -X POST http://localhost:3001/api/audit-logs \
-H "Content-Type: application/json" \
-u pix-api:pixApiClientSecretTest \
-d '{
  "targetUserId": "2",
  "userId": "3",
  "action": "ANONYMIZATION",
  "occurredAt": "2023-07-05",
  "role": "SUPPORT",
  "client": "PIX_ADMIN"
}'
```

- Add multiple events with this curl command:
```bash
curl -X POST http://localhost:3001/api/audit-logs \
-H "Content-Type: application/json" \
-u pix-api:pixApiClientSecretTest \
-d '[
  {
    "targetUserId": "2",
    "userId": "3",
    "action": "ANONYMIZATION",
    "occurredAt": "2023-07-05",
    "role": "SUPPORT",
    "client": "PIX_ADMIN"
  },
  {
    "targetUserId": "4",
    "userId": "5",
    "action": "ANONYMIZATION",
    "occurredAt": "2023-07-06",
    "role": "SUPPORT",
    "client": "PIX_ADMIN"
  }
]'
```

- Check events in DB `postgresql://postgres@localhost/pix_audit_logging`:
![image](https://github.com/1024pix/pix/assets/516360/efb85029-4250-4178-bdfb-84d15284c934)


