### PR TITLE
[TECH] Renommage de la table complementary-certification-subscriptions (PIX-12210).

### DIFF
--- a/api/db/database-builder/database-builder.js
+++ b/api/db/database-builder/database-builder.js
@@ -234,14 +234,6 @@ class DatabaseBuilder {
 
         if (!_.isEmpty(tableName)) {
           if (tableName === 'pgboss.version') return;
-          if (tableName === 'certification-subscriptions') {
-            // View are not part of pg_class, or due to a table migration
-            // we temporarily need to mark as dirty any operation on the view
-            // for retrocompatibility purpose
-            this._setTableAsDirty('complementary-certification-subscriptions');
-            return;
-          }
-
           this._setTableAsDirty(tableName);
         }
       }

--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -109,7 +109,6 @@ async function emptyAllTables() {
     'knex_migrations',
     'knex_migrations_lock',
     'view-active-organization-learners',
-    'certification-subscriptions',
   );
 
   const tables = _.map(tablesToDelete, (tableToDelete) => `"${tableToDelete}"`).join();

--- a/api/db/migrations/20240610140200_remove-view-for-certification-subscriptions-table.js
+++ b/api/db/migrations/20240610140200_remove-view-for-certification-subscriptions-table.js
@@ -1,0 +1,13 @@
+const up = async function (knex) {
+  await knex.schema.dropView('certification-subscriptions');
+  return knex.schema.renameTable('complementary-certification-subscriptions', 'certification-subscriptions');
+};
+
+const down = async function (knex) {
+  await knex.schema.renameTable('certification-subscriptions', 'complementary-certification-subscriptions');
+  return knex.schema.createView('certification-subscriptions', function (view) {
+    view.as(knex('complementary-certification-subscriptions'));
+  });
+};
+
+export { down, up };


### PR DESCRIPTION
## :unicorn: Problème
Nous voulons faire porter la notion d’inscription d’un candidat à une certif Pix coeur de manière détachée d’une certif complémentaire. Mais aujourd’jui nous assumons que un candidat passe toujours un pix coeur.

## :robot: Proposition

* Renommer la table
* Supprimer la vue

## :rainbow: Remarques
* On a le GO de l'équipe DATA
* Le code utilise déjà le nouveau nom de table (c'était d'ailleurs le but de l'usage d'une vue en transition)

## :100: Pour tester
C'est de la non reg uniquement, le but est de vérifier que tout est OK niveau complémentaires.

### Pix V2
* Sur Pix certif, centre non sco de préférence, certification V2
*  Inscrire via l'import deux candidats : avec et sans complémentaire
* Inscrire deux candidats via la modale d'inscription : avec et sans complémentaire
  * * Bien vérifier l'affichage des **détails session** notamment sur la partie complémentaire 
  * Bien vérifier l'affichage des **détails candidats** notamment sur la partie complémentaire 
* Passer au moins deux certifications : avec et sans complémentaire
  * Vérifier que le candidat avec complémentaire voit les infos d'affichage complémentaire
  * Bien vérifier l'affichage de la **supervision** notamment sur la partie complémentaire 
* Après le passage de la certification, faire le process vers la publication en vérifiant au passage
  * Pix Admin : détails autour de la certif, sur la partie complémentaire
  * Pix App : candidat voit son macaron & co après publication

# Pix V3
* Passer une certification V3 jusqu'à publication, rien à vérifier de particulier

### Scripts
* Générer des données de test avec generate-certif-cli, en mettant des complémentaires

