### PR TITLE
[BUGFIX] Corriger l'affichage des methodes de connexion dans Mon Compte

### DIFF
--- a/mon-pix/app/styles/components/_user-account.scss
+++ b/mon-pix/app/styles/components/_user-account.scss
@@ -25,11 +25,16 @@
 
   &__menu-and-content {
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     justify-content: center;
+
+    @include device-is('mobile') {
+      flex-wrap: wrap;
+    }
 
     .pix-block {
       width: auto;
+      min-width: 336px;
     }
   }
 
@@ -61,7 +66,7 @@
 
       &__link {
         display: block;
-        padding: 16px 60px 16px 20px;
+        padding: var(--pix-spacing-4x);
         color: $pix-neutral-60;
 
         svg {

--- a/mon-pix/app/styles/pages/_connection-methods.scss
+++ b/mon-pix/app/styles/pages/_connection-methods.scss
@@ -1,10 +1,11 @@
 .user-account-panel__item {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: $pix-spacing-m;
   justify-content: space-between;
   padding-top: 16px;
   padding-bottom: 16px;
+  word-break: break-word;
   border-top: $pix-neutral-15 1px solid;
 
   &--with-success-message {

--- a/mon-pix/app/templates/authenticated/user-account/connection-methods.hbs
+++ b/mon-pix/app/templates/authenticated/user-account/connection-methods.hbs
@@ -14,13 +14,15 @@
             </p>
             <p class="user-account-panel-item__value" data-test-email>{{@model.user.email}}</p>
           </div>
-          <PixButton
-            class="user-account-panel-item__button"
-            @triggerAction={{this.enableEmailEditionMode}}
-            @size="small"
-          >
-            {{t "pages.user-account.connexion-methods.edit-button"}}
-          </PixButton>
+          <div>
+            <PixButton
+              class="user-account-panel-item__button"
+              @triggerAction={{this.enableEmailEditionMode}}
+              @size="small"
+            >
+              {{t "pages.user-account.connexion-methods.edit-button"}}
+            </PixButton>
+          </div>
         </div>
 
         {{#if this.showEmailUpdatedMessage}}


### PR DESCRIPTION
## :unicorn: Problème

Dans "Mon compte", l'affichage de "Mes méthodes de connexion" n'est pas bon quand l'email est trop long. Affichage vertical au lieu d'horizontal.

Exemple:
![SCR-20240611-nitw](https://github.com/1024pix/pix/assets/516360/e3259e36-7ffa-4299-9f91-f6bfdb544b55)


## :robot: Proposition

Corriger le layout pour toujours avoir un affichage sur 2 colonnes (sauf en mobile) et s'assurer que l'email va à la ligne quand il atteint la taille du maximale du bloc.


Autre souci identifié, quand l'email est vraiment long, il dépasse du bloc:
![SCR-20240611-niel](https://github.com/1024pix/pix/assets/516360/85a1bc86-ddde-44f3-997b-db098e366055)

**Après correction:**
<img width="644" alt="SCR-20240611-nilu" src="https://github.com/1024pix/pix/assets/516360/8b354df5-5391-4d9c-a1f5-b49536062261">


## :100: Pour tester

1. Créer un compte sur Pix app avec un email très long
2. Aller sur "Mon Compte" > "Mes méthodes de connexion"

> L'affichage est correct, vérifier également sur mobile.