### PR TITLE
[FEATURE] Gérer l'affichage du bouton "Suivant" avec des éléments répondables (PIX-12856)

### DIFF
--- a/mon-pix/app/components/module/stepper.gjs
+++ b/mon-pix/app/components/module/stepper.gjs
@@ -24,13 +24,19 @@ export default class ModulixStepper extends Component {
     return this.stepsToDisplay.length < this.args.steps.length;
   }
 
-  get hasAnswerableElementInCurrentStep() {
+  get answerableElementsInCurrentStep() {
     const currentStep = this.stepsToDisplay[this.stepsToDisplay.length - 1];
-    return currentStep.elements.some((element) => element.isAnswerable);
+    return currentStep.elements.filter((element) => element.isAnswerable);
+  }
+
+  get allAnswerableElementsAreAnsweredInCurrentStep() {
+    return this.answerableElementsInCurrentStep.every((element) => {
+      return this.args.passage.getLastCorrectionForElement(element) !== undefined;
+    });
   }
 
   get shouldDisplayNextButton() {
-    return this.hasNextStep && !this.hasAnswerableElementInCurrentStep;
+    return this.hasNextStep && this.allAnswerableElementsAreAnsweredInCurrentStep;
   }
 
   <template>

--- a/mon-pix/app/components/module/stepper.gjs
+++ b/mon-pix/app/components/module/stepper.gjs
@@ -24,11 +24,25 @@ export default class ModulixStepper extends Component {
     return this.stepsToDisplay.length < this.args.steps.length;
   }
 
+  get hasAnswerableElementInCurrentStep() {
+    const currentStep = this.stepsToDisplay[this.stepsToDisplay.length - 1];
+    return currentStep.elements.some((element) => element.isAnswerable);
+  }
+
+  get shouldDisplayNextButton() {
+    return this.hasNextStep && !this.hasAnswerableElementInCurrentStep;
+  }
+
   <template>
     {{#each this.stepsToDisplay as |step index|}}
-      <Step @step={{step}} @currentStep={{inc index}} @totalSteps={{@steps.length}} />
+      <Step
+        @step={{step}}
+        @currentStep={{inc index}}
+        @totalSteps={{@steps.length}}
+        @getLastCorrectionForElement={{@getLastCorrectionForElement}}
+      />
     {{/each}}
-    {{#if this.hasNextStep}}
+    {{#if this.shouldDisplayNextButton}}
       <PixButton @size="large" @variant="primary" @iconAfter="arrow-down" @triggerAction={{this.displayNextStep}}>{{t
           "pages.modulix.buttons.stepper.next"
         }}

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -40,6 +40,51 @@ module('Integration | Component | Module | Stepper', function (hooks) {
       assert.dom(screen.getByRole('button', { name: this.intl.t('pages.modulix.buttons.stepper.next') })).exists();
     });
 
+    module('When step contains at least one answerable element', function () {
+      test('should not display the Next button', async function (assert) {
+        // given
+        const steps = [
+          {
+            elements: [
+              {
+                id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                instruction: 'Instruction',
+                proposals: [
+                  { id: '1', content: 'radio1' },
+                  { id: '2', content: 'radio2' },
+                ],
+                isAnswerable: true,
+                type: 'qcu',
+              },
+            ],
+          },
+          {
+            elements: [
+              {
+                id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                type: 'text',
+                content: '<p>Text 2</p>',
+                isAnswerable: false,
+              },
+            ],
+          },
+        ];
+        function getLastCorrectionForElementStub() {}
+
+        // when
+        const screen = await render(
+          <template>
+            <ModulixStepper @steps={{steps}} @getLastCorrectionForElement={{getLastCorrectionForElementStub}} />
+          </template>,
+        );
+
+        // then
+        assert
+          .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.stepper.next') }))
+          .doesNotExist();
+      });
+    });
+
     module('When user clicks on the Next button', function () {
       test('should display the next step', async function (assert) {
         // given

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -40,48 +40,185 @@ module('Integration | Component | Module | Stepper', function (hooks) {
       assert.dom(screen.getByRole('button', { name: this.intl.t('pages.modulix.buttons.stepper.next') })).exists();
     });
 
-    module('When step contains at least one answerable element', function () {
-      test('should not display the Next button', async function (assert) {
-        // given
-        const steps = [
-          {
-            elements: [
-              {
-                id: 'd0690f26-978c-41c3-9a21-da931857739c',
-                instruction: 'Instruction',
-                proposals: [
-                  { id: '1', content: 'radio1' },
-                  { id: '2', content: 'radio2' },
-                ],
-                isAnswerable: true,
-                type: 'qcu',
-              },
-            ],
-          },
-          {
-            elements: [
-              {
-                id: '768441a5-a7d6-4987-ada9-7253adafd842',
-                type: 'text',
-                content: '<p>Text 2</p>',
-                isAnswerable: false,
-              },
-            ],
-          },
-        ];
-        function getLastCorrectionForElementStub() {}
+    module('When step contains answerable elements', function () {
+      module('When the only answerable element is unanswered', function () {
+        test('should not display the Next button', async function (assert) {
+          // given
+          const steps = [
+            {
+              elements: [
+                {
+                  id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                  instruction: 'Instruction',
+                  proposals: [
+                    { id: '1', content: 'radio1' },
+                    { id: '2', content: 'radio2' },
+                  ],
+                  isAnswerable: true,
+                  type: 'qcu',
+                },
+              ],
+            },
+            {
+              elements: [
+                {
+                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                  type: 'text',
+                  content: '<p>Text 2</p>',
+                  isAnswerable: false,
+                },
+              ],
+            },
+          ];
+          function getLastCorrectionForElementStub() {}
 
-        // when
-        const screen = await render(
-          <template>
-            <ModulixStepper @steps={{steps}} @getLastCorrectionForElement={{getLastCorrectionForElementStub}} />
-          </template>,
-        );
+          const store = this.owner.lookup('service:store');
+          const passage = store.createRecord('passage');
+          passage.getLastCorrectionForElement = getLastCorrectionForElementStub;
 
-        // then
-        assert
-          .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.stepper.next') }))
-          .doesNotExist();
+          // when
+          const screen = await render(
+            <template>
+              <ModulixStepper
+                @passage={{passage}}
+                @steps={{steps}}
+                @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
+              />
+            </template>,
+          );
+
+          // then
+          assert
+            .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.stepper.next') }))
+            .doesNotExist();
+        });
+      });
+
+      module('When at least one of the answerable elements is unanswered', function () {
+        test('should not display the Next button', async function (assert) {
+          // given
+          const steps = [
+            {
+              elements: [
+                {
+                  id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                  instruction: 'Instruction',
+                  proposals: [
+                    { id: '1', content: 'radio1' },
+                    { id: '2', content: 'radio2' },
+                  ],
+                  isAnswerable: true,
+                  type: 'qcu',
+                },
+                {
+                  id: '69f08624-6e63-4be1-b662-6e6bc820d99f',
+                  instruction: 'Instruction',
+                  proposals: [
+                    { id: '1', content: 'radio3' },
+                    { id: '2', content: 'radio4' },
+                  ],
+                  isAnswerable: true,
+                  type: 'qcu',
+                },
+              ],
+            },
+            {
+              elements: [
+                {
+                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                  type: 'text',
+                  content: '<p>Text 2</p>',
+                  isAnswerable: false,
+                },
+              ],
+            },
+          ];
+          function getLastCorrectionForElementStub(element) {
+            if (element.id === 'd0690f26-978c-41c3-9a21-da931857739c') {
+              return Symbol('Correction');
+            } else {
+              return undefined;
+            }
+          }
+
+          const store = this.owner.lookup('service:store');
+          const passage = store.createRecord('passage');
+          passage.getLastCorrectionForElement = getLastCorrectionForElementStub;
+
+          // when
+          const screen = await render(
+            <template>
+              <ModulixStepper
+                @passage={{passage}}
+                @steps={{steps}}
+                @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
+              />
+            </template>,
+          );
+
+          // then
+          assert
+            .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.stepper.next') }))
+            .doesNotExist();
+        });
+      });
+
+      module('When all answerable elements are answered', function () {
+        test('should display the next button', async function (assert) {
+          // given
+          const steps = [
+            {
+              elements: [
+                {
+                  id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                  instruction: 'Instruction',
+                  proposals: [
+                    { id: '1', content: 'radio1' },
+                    { id: '2', content: 'radio2' },
+                  ],
+                  isAnswerable: true,
+                  type: 'qcu',
+                },
+              ],
+            },
+            {
+              elements: [
+                {
+                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                  type: 'text',
+                  content: '<p>Text 2</p>',
+                  isAnswerable: false,
+                },
+              ],
+            },
+          ];
+          function getLastCorrectionForElementStub() {}
+
+          const store = this.owner.lookup('service:store');
+          const passage = store.createRecord('passage');
+          const correction = store.createRecord('correction-response');
+          store.createRecord('element-answer', {
+            elementId: 'd0690f26-978c-41c3-9a21-da931857739c',
+            correction,
+            passage,
+          });
+
+          // when
+          const screen = await render(
+            <template>
+              <ModulixStepper
+                @passage={{passage}}
+                @steps={{steps}}
+                @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
+              />
+            </template>,
+          );
+
+          // then
+          assert
+            .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.stepper.next') }))
+            .exists();
+        });
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Dans les Stepper de Modulix, nous n'avons implémenté le bouton "Suivant" qu'avec des Step contenant des élément non-répondables. Il manque la gestion du cas où des éléments répondables sont présents.

## :robot: Proposition
Implémenter les deux cas suivants :

1. Lorsque la Step contient des éléments répondables non vérifiés
2. Lorsque tous les éléments répondables de la Step sont vérifiés

## :rainbow: Remarques
Pour l'instant nous avons fait le choix de passer en props le Passage dans le composant Stepper, ainsi qu'une fonction `getLastCorrectionForElement` comme Grain le fait pour chacun de ses éléments.
Ça marche très bien pour l'instant mais il faudra sûrement revoir cette façon de faire lorsque nous afficherons des Stepper dans les Grains.

## :100: Pour tester
CI 🍏
