### PR TITLE
[FEATURE] Afficher la dernière page des écrans d'instructions sur Pix App (PIX-12900).

### DIFF
--- a/mon-pix/app/components/certification-instructions/step-five.hbs
+++ b/mon-pix/app/components/certification-instructions/step-five.hbs
@@ -1,0 +1,44 @@
+<div class="certification-instructions__content">
+  <span class="certification-instructions__question--bold">{{t "pages.certification-instructions.steps.5.text"}}</span>
+  <ul class="certification-instructions-content__list">
+    <li>
+      <span class="certification-instructions__text--bold">
+        {{t "pages.certification-instructions.steps.5.list.no-communication.strong-text"}}
+      </span>
+      {{t "pages.certification-instructions.steps.5.list.no-communication.text"}}
+    </li>
+    <li>
+      <span class="certification-instructions__text--bold">
+        {{t "pages.certification-instructions.steps.5.list.no-connected-device.strong-text"}}
+      </span>
+      {{t "pages.certification-instructions.steps.5.list.no-connected-device.text"}}
+    </li>
+    <li>
+      <span class="certification-instructions__text--bold">
+        {{t "pages.certification-instructions.steps.5.list.no-cheat-sheet.strong-text"}}
+      </span>
+      {{t "pages.certification-instructions.steps.5.list.no-cheat-sheet.text"}}
+    </li>
+    <li>
+      <span class="certification-instructions__text--bold">
+        {{t "pages.certification-instructions.steps.5.list.no-artificial-intelligence.strong-text"}}
+      </span>
+      {{t "pages.certification-instructions.steps.5.list.no-artificial-intelligence.text"}}
+    </li>
+    <li>
+      <span class="certification-instructions__text--bold">
+        {{t "pages.certification-instructions.steps.5.list.no-forum.strong-text"}}
+      </span>
+      {{t "pages.certification-instructions.steps.5.list.no-forum.text"}}
+    </li>
+    <li>
+      <span class="certification-instructions__text--bold">
+        {{t "pages.certification-instructions.steps.5.list.other.strong-text"}}
+      </span>
+      {{t "pages.certification-instructions.steps.5.list.other.text"}}
+    </li>
+  </ul>
+  <PixCheckbox {{on "change" this.onChange}}>
+    <:label>{{t "pages.certification-instructions.steps.5.checkbox-label"}}</:label>
+  </PixCheckbox>
+</div>

--- a/mon-pix/app/components/certification-instructions/step-five.js
+++ b/mon-pix/app/components/certification-instructions/step-five.js
@@ -1,0 +1,13 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class StepFive extends Component {
+  @tracked checked = false;
+
+  @action
+  onChange(event) {
+    this.checked = !!event.target.checked;
+    this.args.enableNextButton(this.checked);
+  }
+}

--- a/mon-pix/app/components/certification-instructions/steps.hbs
+++ b/mon-pix/app/components/certification-instructions/steps.hbs
@@ -13,6 +13,9 @@
   {{#if (eq this.pageId 4)}}
     <CertificationInstructions::StepFour />
   {{/if}}
+  {{#if (eq this.pageId 5)}}
+    <CertificationInstructions::StepFive @enableNextButton={{this.enableNextButton}} />
+  {{/if}}
 </div>
 
 <footer class="certification-instructions__footer">

--- a/mon-pix/app/components/certification-instructions/steps.js
+++ b/mon-pix/app/components/certification-instructions/steps.js
@@ -7,6 +7,7 @@ export default class Steps extends Component {
   @service intl;
   @tracked pageId = 1;
   @tracked pageCount = 5;
+  @tracked isConfirmationCheckboxChecked = false;
 
   _setupPaging(numberOfPages, currentPageId) {
     const classOfPages = new Array(numberOfPages);
@@ -27,7 +28,7 @@ export default class Steps extends Component {
   }
 
   get isNextButtonDisabled() {
-    return this.pageId === this.pageCount;
+    return !this.isConfirmationCheckboxChecked && this.pageId === this.pageCount;
   }
 
   get nextButtonAriaLabel() {
@@ -45,5 +46,10 @@ export default class Steps extends Component {
     if (this.pageId < this.pageCount) {
       this.pageId = this.pageId + 1;
     }
+  }
+
+  @action
+  enableNextButton(checked) {
+    this.isConfirmationCheckboxChecked = checked;
   }
 }

--- a/mon-pix/app/components/certification-instructions/steps.js
+++ b/mon-pix/app/components/certification-instructions/steps.js
@@ -8,6 +8,7 @@ export default class Steps extends Component {
   @tracked pageId = 1;
   @tracked pageCount = 5;
   @tracked isConfirmationCheckboxChecked = false;
+  @service router;
 
   _setupPaging(numberOfPages, currentPageId) {
     const classOfPages = new Array(numberOfPages);
@@ -45,6 +46,14 @@ export default class Steps extends Component {
   nextStep() {
     if (this.pageId < this.pageCount) {
       this.pageId = this.pageId + 1;
+    }
+
+    if (this.isConfirmationCheckboxChecked) {
+      this.router.transitionTo('authenticated.certifications.start', this.args.candidateId, {
+        queryParams: {
+          isConfirmationCheckboxChecked: this.isConfirmationCheckboxChecked,
+        },
+      });
     }
   }
 

--- a/mon-pix/app/routes/authenticated/certifications/start.js
+++ b/mon-pix/app/routes/authenticated/certifications/start.js
@@ -5,6 +5,11 @@ export default class StartRoute extends Route {
   @service store;
   @service router;
   @service featureToggles;
+  hasSeenCertificationInstructions = false;
+
+  beforeModel(transition) {
+    this.hasSeenCertificationInstructions = transition.to.queryParams.isConfirmationCheckboxChecked;
+  }
 
   async model(params) {
     const certificationCandidateSubscription = await this.store.findRecord(
@@ -13,6 +18,7 @@ export default class StartRoute extends Route {
     );
 
     if (
+      !this.hasSeenCertificationInstructions &&
       certificationCandidateSubscription.isSessionVersion3 &&
       this.featureToggles.featureToggles.areV3InfoScreensEnabled
     ) {

--- a/mon-pix/app/styles/pages/_certification-instructions.scss
+++ b/mon-pix/app/styles/pages/_certification-instructions.scss
@@ -90,6 +90,13 @@
     min-width: 120px;
     min-height: 120px;
   }
+
+  &__list {
+    li {
+      margin-left: var(--pix-spacing-4x);
+      list-style: disc;
+    }
+  }
 }
 
 .certification-instructions-content-images {

--- a/mon-pix/app/templates/authenticated/certifications/information.hbs
+++ b/mon-pix/app/templates/authenticated/certifications/information.hbs
@@ -6,6 +6,6 @@
     <h1 class="certification-instructions-header__title">{{t "pages.certification-instructions.title"}}</h1>
   </header>
   <PixBlock @shadow="heavy" class="certification-instructions__card">
-    <CertificationInstructions::Steps />
+    <CertificationInstructions::Steps @candidateId={{this.model.id}} />
   </PixBlock>
 </main>

--- a/mon-pix/tests/integration/components/steps_test.js
+++ b/mon-pix/tests/integration/components/steps_test.js
@@ -95,9 +95,7 @@ module('Integration | Component | steps', function (hooks) {
         // given
         // when
         const screen = await render(hbs`<CertificationInstructions::Steps/>`);
-        for (let i = 0; i < 4; i++) {
-          await click(screen.getByRole('button', { name: "Continuer vers l'écran suivant" }));
-        }
+        await _goToLastPage(screen);
 
         // then
         assert.dom(screen.getByRole('heading', { name: 'Règles à respecter', level: 2 })).exists();
@@ -116,9 +114,7 @@ module('Integration | Component | steps', function (hooks) {
         const screen = await render(hbs`<CertificationInstructions::Steps/>`);
 
         // when
-        for (let i = 0; i < 4; i++) {
-          await click(screen.getByRole('button', { name: "Continuer vers l'écran suivant" }));
-        }
+        await _goToLastPage(screen);
 
         // then
         assert.dom(screen.getByRole('button', { name: "Continuer vers la page d'entrée en certification" })).exists();
@@ -129,9 +125,7 @@ module('Integration | Component | steps', function (hooks) {
         const screen = await render(hbs`<CertificationInstructions::Steps/>`);
 
         // when
-        for (let i = 0; i < 4; i++) {
-          await click(screen.getByRole('button', { name: "Continuer vers l'écran suivant" }));
-        }
+        await _goToLastPage(screen);
 
         // then
         assert
@@ -143,9 +137,7 @@ module('Integration | Component | steps', function (hooks) {
         test('should enable the continue button', async function (assert) {
           // given
           const screen = await render(hbs`<CertificationInstructions::Steps/>`);
-          for (let i = 0; i < 4; i++) {
-            await click(screen.getByRole('button', { name: "Continuer vers l'écran suivant" }));
-          }
+          await _goToLastPage(screen);
 
           // when
           await click(
@@ -176,3 +168,10 @@ module('Integration | Component | steps', function (hooks) {
     });
   });
 });
+
+async function _goToLastPage(screen) {
+  const pageCount = 4;
+  for (let i = 0; i < pageCount; i++) {
+    await click(screen.getByRole('button', { name: "Continuer vers l'écran suivant" }));
+  }
+}

--- a/mon-pix/tests/integration/components/steps_test.js
+++ b/mon-pix/tests/integration/components/steps_test.js
@@ -91,6 +91,26 @@ module('Integration | Component | steps', function (hooks) {
     });
 
     module('on the last page', function () {
+      test('should display information', async function (assert) {
+        // given
+        // when
+        const screen = await render(hbs`<CertificationInstructions::Steps/>`);
+        for (let i = 0; i < 4; i++) {
+          await click(screen.getByRole('button', { name: "Continuer vers l'écran suivant" }));
+        }
+
+        // then
+        assert.dom(screen.getByRole('heading', { name: 'Règles à respecter', level: 2 })).exists();
+        assert.dom(screen.getByText('En certification, il est interdit de :')).exists();
+        assert
+          .dom(
+            screen.getByRole('checkbox', {
+              name: 'En cochant cette case, je reconnais avoir pris connaissances de ces règles et je m’engage à les respecter.',
+            }),
+          )
+          .exists();
+      });
+
       test('should change the continue aria label button', async function (assert) {
         // given
         const screen = await render(hbs`<CertificationInstructions::Steps/>`);
@@ -117,6 +137,28 @@ module('Integration | Component | steps', function (hooks) {
         assert
           .dom(screen.getByRole('button', { name: "Continuer vers la page d'entrée en certification" }))
           .isDisabled();
+      });
+
+      module('when the checkbox is checked', function () {
+        test('should enable the continue button', async function (assert) {
+          // given
+          const screen = await render(hbs`<CertificationInstructions::Steps/>`);
+          for (let i = 0; i < 4; i++) {
+            await click(screen.getByRole('button', { name: "Continuer vers l'écran suivant" }));
+          }
+
+          // when
+          await click(
+            screen.getByRole('checkbox', {
+              name: 'En cochant cette case, je reconnais avoir pris connaissances de ces règles et je m’engage à les respecter.',
+            }),
+          );
+
+          // then
+          assert
+            .dom(screen.getByRole('button', { name: "Continuer vers la page d'entrée en certification" }))
+            .isEnabled();
+        });
       });
     });
 

--- a/mon-pix/tests/unit/components/certification-instructions/steps_test.js
+++ b/mon-pix/tests/unit/components/certification-instructions/steps_test.js
@@ -1,0 +1,60 @@
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Unit | Component | certification-instruction | steps', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('#nextStep', function () {
+    module('when pageId is lower than pageCount', function () {
+      test('should change the pageId', async function (assert) {
+        // given
+        const component = createGlimmerComponent('certification-instructions/steps');
+
+        component.pageId = 1;
+        component.pageCount = 2;
+        component.isConfirmationCheckboxChecked = false;
+
+        // when
+        await component.nextStep();
+
+        // then
+        assert.strictEqual(component.pageId, 2);
+      });
+    });
+
+    module('when pageId equal pageCount', function () {
+      module('when confirmation checkbox is checked', function () {
+        test('should redirect to certificartion starter', async function (assert) {
+          // given
+          const component = createGlimmerComponent('certification-instructions/steps');
+
+          component.pageId = 2;
+          component.pageCount = 2;
+          component.args = {
+            candidateId: 123,
+          };
+          component.isConfirmationCheckboxChecked = true;
+          const transitionToStub = sinon.stub();
+          component.router = {
+            transitionTo: transitionToStub,
+          };
+
+          // when
+          await component.nextStep();
+
+          // then
+          assert.ok(
+            transitionToStub.calledWith('authenticated.certifications.start', 123, {
+              queryParams: {
+                isConfirmationCheckboxChecked: true,
+              },
+            }),
+          );
+        });
+      });
+    });
+  });
+});

--- a/mon-pix/tests/unit/routes/authenticated/certifications/start_test.js
+++ b/mon-pix/tests/unit/routes/authenticated/certifications/start_test.js
@@ -8,41 +8,80 @@ module('Unit | Route | Certification | Start', function (hooks) {
 
   module('#model', function () {
     module('when session is V3 and toggle is enabled', function () {
-      test('should redirect to certification information page', async function (assert) {
-        // given
-        const certificationCandidateId = 'certification-candidate-id';
-        const params = { certification_candidate_id: certificationCandidateId };
-        const store = this.owner.lookup('service:store');
+      module('when hasSeenCertificationInstructions is false', function () {
+        test('should redirect to certification information page', async function (assert) {
+          // given
+          const certificationCandidateId = 'certification-candidate-id';
+          const params = { certification_candidate_id: certificationCandidateId };
+          const store = this.owner.lookup('service:store');
 
-        const certificationCandidateSubscription = store.createRecord('certification-candidate-subscription', {
-          id: certificationCandidateId,
-          sessionId: 1234,
-          sessionVersion: 3,
+          const certificationCandidateSubscription = store.createRecord('certification-candidate-subscription', {
+            id: certificationCandidateId,
+            sessionId: 1234,
+            sessionVersion: 3,
+          });
+          const featureToggles = Object.create({
+            featureToggles: {
+              areV3InfoScreensEnabled: true,
+            },
+          });
+
+          const findRecordStub = sinon.stub().returns(certificationCandidateSubscription);
+          const storeStub = Service.create({ findRecord: findRecordStub });
+
+          const route = this.owner.lookup('route:authenticated/certifications.start');
+          route.set('store', storeStub);
+          route.set('featureToggles', featureToggles);
+          route.router = { replaceWith: sinon.stub() };
+          route.hasSeenCertificationInstructions = false;
+
+          // when
+          await route.model(params);
+
+          // then
+          sinon.assert.calledWithExactly(
+            route.router.replaceWith,
+            'authenticated.certifications.information',
+            certificationCandidateId,
+          );
+          assert.ok(true);
         });
-        const featureToggles = Object.create({
-          featureToggles: {
-            areV3InfoScreensEnabled: true,
-          },
+      });
+
+      module('when hasSeenCertificationInstructions is true', function () {
+        test('should not redirect to certification information page', async function (assert) {
+          // given
+          const certificationCandidateId = 'certification-candidate-id';
+          const params = { certification_candidate_id: certificationCandidateId };
+          const store = this.owner.lookup('service:store');
+
+          const certificationCandidateSubscription = store.createRecord('certification-candidate-subscription', {
+            id: certificationCandidateId,
+            sessionId: 1234,
+            sessionVersion: 3,
+          });
+          const featureToggles = Object.create({
+            featureToggles: {
+              areV3InfoScreensEnabled: true,
+            },
+          });
+
+          const findRecordStub = sinon.stub().returns(certificationCandidateSubscription);
+          const storeStub = Service.create({ findRecord: findRecordStub });
+
+          const route = this.owner.lookup('route:authenticated/certifications.start');
+          route.set('store', storeStub);
+          route.set('featureToggles', featureToggles);
+          route.router = { replaceWith: sinon.stub() };
+          route.hasSeenCertificationInstructions = true;
+
+          // when
+          await route.model(params);
+
+          // then
+          sinon.assert.notCalled(route.router.replaceWith);
+          assert.ok(true);
         });
-
-        const findRecordStub = sinon.stub().returns(certificationCandidateSubscription);
-        const storeStub = Service.create({ findRecord: findRecordStub });
-
-        const route = this.owner.lookup('route:authenticated/certifications.start');
-        route.set('store', storeStub);
-        route.set('featureToggles', featureToggles);
-        route.router = { replaceWith: sinon.stub() };
-
-        // when
-        await route.model(params);
-
-        // then
-        sinon.assert.calledWithExactly(
-          route.router.replaceWith,
-          'authenticated.certifications.information',
-          certificationCandidateId,
-        );
-        assert.ok(true);
       });
     });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -461,6 +461,37 @@
         "4": {
           "title": "Que faire en cas de problème ?",
           "text": "'<span class=\"certification-instructions__text--bold\">'En cas de problème technique'</span>' (par exemple, l'image refuse de s'afficher), suivez ces étapes : '<br>' cliquez sur \"'<span class=\"certification-instructions__text--bold\">'Signaler un problème avec la question'</span>'\", puis sur \"Oui, je suis sûr(e)\" et informez votre surveillant."
+        },
+        "5": {
+          "title": "Règles à respecter",
+          "checkbox-label": "En cochant cette case, je reconnais avoir pris connaissances de ces règles et je m’engage à les respecter.",
+          "list": {
+            "no-artificial-intelligence": {
+              "strong-text": "Avoir recours à un système d’intelligence artificielle",
+              "text": " ou un chatbot"
+            },
+            "no-cheat-sheet": {
+              "strong-text": "Utiliser des antisèches",
+              "text": "(physiques ou électroniques), des ressources de spoil ou des notes personnelles"
+            },
+            "no-communication": {
+              "strong-text": "Communiquer avec quelqu’un d’autre",
+              "text": ", dans la salle ou à l’extérieur, par voie physique ou électronique"
+            },
+            "no-connected-device": {
+              "strong-text": "Utiliser un téléphone mobile ou tout appareil connecté",
+              "text": "(autre que l’ordinateur mobilisé dans le cadre de la certification)"
+            },
+            "no-forum": {
+              "strong-text": "Consulter un forum d’entraide",
+              "text": " apportant directement la réponse à une épreuve"
+            },
+            "other": {
+              "strong-text": "Mobiliser tout autre moyen délivrant directement la réponse",
+              "text": ", sans avoir effectué le travail requis par la consigne."
+            }
+          },
+          "text": "En certification, il est interdit de :"
         }
       }
     },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -530,6 +530,37 @@
         "4": {
           "title": "Que faire en cas de problème ?",
           "text": "'<span class=\"certification-instructions__text--bold\">'En cas de problème technique'</span>' (par exemple, l'image refuse de s'afficher), suivez ces étapes : '<br>' cliquez sur \"'<span class=\"certification-instructions__text--bold\">'Signaler un problème avec la question'</span>'\", puis sur \"Oui, je suis sûr(e)\" et informez votre surveillant."
+        },
+        "5": {
+          "title": "Règles à respecter",
+          "text": "En certification, il est interdit de :",
+          "list": {
+            "no-communication": {
+              "strong-text": "Communiquer avec quelqu’un d’autre",
+              "text": ", dans la salle ou à l’extérieur, par voie physique ou électronique"
+            },
+            "no-connected-device": {
+              "strong-text": "Utiliser un téléphone mobile ou tout appareil connecté",
+              "text": "(autre que l’ordinateur mobilisé dans le cadre de la certification)"
+            },
+            "no-cheat-sheet": {
+              "strong-text": "Utiliser des antisèches",
+              "text": "(physiques ou électroniques), des ressources de spoil ou des notes personnelles"
+            },
+            "no-artificial-intelligence": {
+              "strong-text": "Avoir recours à un système d’intelligence artificielle",
+              "text": " ou un chatbot"
+            },
+            "no-forum": {
+              "strong-text": "Consulter un forum d’entraide",
+              "text": " apportant directement la réponse à une épreuve"
+            },
+            "other": {
+              "strong-text": "Mobiliser tout autre moyen délivrant directement la réponse",
+              "text": ", sans avoir effectué le travail requis par la consigne."
+            }
+          },
+          "checkbox-label": "En cochant cette case, je reconnais avoir pris connaissances de ces règles et je m’engage à les respecter."
         }
       }
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -461,6 +461,37 @@
         "4": {
           "title": "Que faire en cas de problème ?",
           "text": "'<span class=\"certification-instructions__text--bold\">'En cas de problème technique'</span>' (par exemple, l'image refuse de s'afficher), suivez ces étapes : '<br><br>' cliquez sur \"'<span class=\"certification-instructions__text--bold\">'Signaler un problème avec la question'</span>'\", puis sur \"Oui, je suis sûr(e)\" et informez votre surveillant."
+        },
+        "5": {
+          "title": "Règles à respecter",
+          "checkbox-label": "En cochant cette case, je reconnais avoir pris connaissances de ces règles et je m’engage à les respecter.",
+          "list": {
+            "no-artificial-intelligence": {
+              "strong-text": "Avoir recours à un système d’intelligence artificielle",
+              "text": " ou un chatbot"
+            },
+            "no-cheat-sheet": {
+              "strong-text": "Utiliser des antisèches",
+              "text": "(physiques ou électroniques), des ressources de spoil ou des notes personnelles"
+            },
+            "no-communication": {
+              "strong-text": "Communiquer avec quelqu’un d’autre",
+              "text": ", dans la salle ou à l’extérieur, par voie physique ou électronique"
+            },
+            "no-connected-device": {
+              "strong-text": "Utiliser un téléphone mobile ou tout appareil connecté",
+              "text": "(autre que l’ordinateur mobilisé dans le cadre de la certification)"
+            },
+            "no-forum": {
+              "strong-text": "Consulter un forum d’entraide",
+              "text": " apportant directement la réponse à une épreuve"
+            },
+            "other": {
+              "strong-text": "Mobiliser tout autre moyen délivrant directement la réponse",
+              "text": ", sans avoir effectué le travail requis par la consigne."
+            }
+          },
+          "text": "En certification, il est interdit de :"
         }
       }
     },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -530,6 +530,37 @@
         "4": {
           "title": "Que faire en cas de problème ?",
           "text": "'<span class=\"certification-instructions__text--bold\">'En cas de problème technique'</span>' (par exemple, l'image refuse de s'afficher), suivez ces étapes : '<br><br>' cliquez sur \"'<span class=\"certification-instructions__text--bold\">'Signaler un problème avec la question'</span>'\", puis sur \"Oui, je suis sûr(e)\" et informez votre surveillant."
+        },
+        "5": {
+          "title": "Règles à respecter",
+          "text": "En certification, il est interdit de :",
+          "list": {
+            "no-communication": {
+              "strong-text": "Communiquer avec quelqu’un d’autre",
+              "text": ", dans la salle ou à l’extérieur, par voie physique ou électronique"
+            },
+            "no-connected-device": {
+              "strong-text": "Utiliser un téléphone mobile ou tout appareil connecté",
+              "text": "(autre que l’ordinateur mobilisé dans le cadre de la certification)"
+            },
+            "no-cheat-sheet": {
+              "strong-text": "Utiliser des antisèches",
+              "text": "(physiques ou électroniques), des ressources de spoil ou des notes personnelles"
+            },
+            "no-artificial-intelligence": {
+              "strong-text": "Avoir recours à un système d’intelligence artificielle",
+              "text": " ou un chatbot"
+            },
+            "no-forum": {
+              "strong-text": "Consulter un forum d’entraide",
+              "text": " apportant directement la réponse à une épreuve"
+            },
+            "other": {
+              "strong-text": "Mobiliser tout autre moyen délivrant directement la réponse",
+              "text": ", sans avoir effectué le travail requis par la consigne."
+            }
+          },
+          "checkbox-label": "En cochant cette case, je reconnais avoir pris connaissances de ces règles et je m’engage à les respecter."
         }
       }
     },


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la nouvelle certif V3, nous allons mettre à disposition des candidats des écrans d’instruction afin de leur donner des infos sur le test qu’ils vont passer.

Cette page comprend toutes les pages sauf la dernière.

## :robot: Proposition

https://github.com/1024pix/pix/assets/58915422/85e2bc4e-15f0-447b-a4de-abf32af4e783

## :100: Pour tester
- Créer une session V3 avec certifv3@example.net et ajouter un candidat
- Se réconcilier avec certifiable-contenu-user@example.net et vérifier que l'on obtient bien le premier écran d'instruction
- Constater que la dernière page est rempli
- Cocher la checkbox pour valider les infos
- Cliquer sur continuer
- Constater que l'on est redirigé vers la page code candidat (on passe pour l'instant un booléen, sans enregistrer quoi que ce soit)
- Quitter cette page pour revenir dans le formulaire
- Remplir le formulaire candidat et valider
- constater que l'on ne passe plus dans les écrans mais dans la page code candidat directement
