### PR TITLE
[TECH] Creer une souscription "Coeur" pour chaque candidat existant (PIX-12526)

### DIFF
--- a/api/db/migrations/20240610164300_catching-up-on-CORE-subscriptions.js
+++ b/api/db/migrations/20240610164300_catching-up-on-CORE-subscriptions.js
@@ -1,0 +1,50 @@
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
+
+const TABLE_NAME = 'certification-subscriptions';
+
+const up = async function (knex) {
+  let numberOfBatchProcessed = 0;
+  const CHUNK_SIZE = 250000;
+  const BATCH_LIMIT = 40; // around 7 millions lines in prod, 40*250000 = 1 billion so it covers the actual volume
+
+  let hasNext = false;
+  do {
+    const insertions = await knex
+      .into(knex.raw('?? (??, ??)', [TABLE_NAME, 'certificationCandidateId', 'type']))
+      .insert(nextCandidatesWithoutCoreSubscription(knex, CHUNK_SIZE));
+
+    hasNext = insertions.rowCount === CHUNK_SIZE;
+    logger.info(
+      `${TABLE_NAME}: Batch number ${++numberOfBatchProcessed} of ${insertions.rowCount} items inserted. hasNext = ${hasNext}`,
+    );
+  } while (hasNext && numberOfBatchProcessed <= BATCH_LIMIT);
+};
+
+const down = async function (knex) {
+  return knex(TABLE_NAME)
+    .where({
+      type: 'CORE',
+    })
+    .del();
+};
+
+// We INSERT in batch of CHUNK_SIZE, hence not needing a transaction for this migration
+// @see: https://knexjs.org/guide/migrations.html#migration-api
+const config = { transaction: false };
+
+export { config, down, up };
+
+const nextCandidatesWithoutCoreSubscription = (knex, chunkSize) => {
+  return (builder) => {
+    builder
+      .from('certification-candidates')
+      .select(knex.raw(`id as "certificationCandidateId", 'CORE' as type`))
+      .leftJoin(TABLE_NAME, function () {
+        this.on('certification-candidates.id', `${TABLE_NAME}.certificationCandidateId`).andOnVal({
+          type: 'CORE',
+        });
+      })
+      .whereNull(`${TABLE_NAME}.certificationCandidateId`)
+      .limit(chunkSize);
+  };
+};


### PR DESCRIPTION
## :unicorn: Problème
Chaque candidat qui passe la certification "coeur" doit avoir une ligne associé dans la table "certification-subscbriptions". 
Les données existantes n'ont pas cette ligne

## :robot: Proposition
Ajouter une migration qui ajoute ces lignes

## :rainbow: Remarques
- Cette PR doit passer avant la PR qui permet d'inscrire des complementaire dans la coeur https://github.com/1024pix/pix/pull/9145

## :100: Pour tester
Verifier qu'on a bien du 1 ligne "CORE" pour chaque candidat et 2 lignes les inscriptions complementaires
```
select count(*) from "certification-candidates"
select count(*) from "certification-subscriptions" where type = 'CORE'; -- 52
select count(*) from "certification-subscriptions" where type = 'COMPLEMENTARY'; -- 11
```
