### PR TITLE
[BUGFIX] Permettre de focus sur les propositions de QCU/QCM/QROCM une fois répondu (PIX-12906)

### DIFF
--- a/mon-pix/app/components/module/element/qcm.hbs
+++ b/mon-pix/app/components/module/element/qcm.hbs
@@ -1,5 +1,5 @@
 <form class="element-qcm" aria-describedby="instruction-{{this.element.id}}">
-  <fieldset disabled={{this.disableInput}}>
+  <fieldset>
     <legend class="screen-reader-only">
       {{t "pages.modulix.qcm.direction"}}
     </legend>

--- a/mon-pix/app/components/module/element/qcu.hbs
+++ b/mon-pix/app/components/module/element/qcu.hbs
@@ -1,5 +1,5 @@
 <form class="element-qcu" aria-describedby="instruction-{{this.element.id}}">
-  <fieldset disabled={{this.disableInput}}>
+  <fieldset>
     <legend class="screen-reader-only">
       {{t "pages.modulix.qcu.direction"}}
     </legend>

--- a/mon-pix/app/components/module/element/qrocm.hbs
+++ b/mon-pix/app/components/module/element/qrocm.hbs
@@ -6,7 +6,7 @@
   autocorrect="off"
   spellcheck="false"
 >
-  <fieldset disabled={{this.disableInput}}>
+  <fieldset>
     <legend class="screen-reader-only">
       {{t "pages.modulix.qrocm.direction" count=this.nbOfProposals}}
     </legend>
@@ -35,6 +35,7 @@
                 @screenReaderOnly={{true}}
                 {{on "change" (fn this.onInputChanged block)}}
                 size={{block.size}}
+                readonly={{this.disableInput}}
               >
                 <:label>{{block.ariaLabel}}</:label>
               </PixInput>
@@ -49,6 +50,7 @@
               @hideDefaultOption={{true}}
               @onChange={{fn this.onSelectChanged block}}
               @screenReaderOnly={{true}}
+              @isDisabled={{this.disableInput}}
             >
               <:label>{{block.ariaLabel}}</:label>
             </PixSelect>

--- a/mon-pix/tests/integration/components/module/qcm_test.js
+++ b/mon-pix/tests/integration/components/module/qcm_test.js
@@ -203,6 +203,29 @@ module('Integration | Component | Module | QCM', function (hooks) {
     assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).exists();
   });
 
+  test('should be able to focus back to proposals when feedback appears', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const correctionResponse = store.createRecord('correction-response', {
+      feedback: 'Too Bad!',
+      status: 'ko',
+      solution: 'solution',
+    });
+
+    prepareContextRecords.call(this, store, correctionResponse);
+    this.set('submitAnswer', () => {});
+
+    // when
+    const screen = await render(
+      hbs`<Module::Element::Qcm @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+    );
+
+    // then
+    const checkbox1 = screen.getByRole('checkbox', { name: 'checkbox1', disabled: true });
+    checkbox1.focus();
+    assert.deepEqual(document.activeElement, checkbox1);
+  });
+
   test('should not display retry button when an ok feedback appears', async function (assert) {
     // given
     const store = this.owner.lookup('service:store');

--- a/mon-pix/tests/integration/components/module/qcu_test.js
+++ b/mon-pix/tests/integration/components/module/qcu_test.js
@@ -190,6 +190,29 @@ module('Integration | Component | Module | QCU', function (hooks) {
     assert.dom(screen.queryByRole('button', { name: 'Réessayer' })).exists();
   });
 
+  test('should be able to focus back to proposals when feedback appears', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const correctionResponse = store.createRecord('correction-response', {
+      feedback: 'Too Bad!',
+      status: 'ko',
+      solution: 'solution',
+    });
+
+    prepareContextRecords.call(this, store, correctionResponse);
+    this.set('submitAnswer', () => {});
+
+    // when
+    const screen = await render(
+      hbs`<Module::Element::Qcu @element={{this.el}} @submitAnswer={{this.submitAnswer}}  @correction={{this.correctionResponse}} />`,
+    );
+
+    // then
+    const radio1 = screen.getByRole('radio', { name: 'radio1', disabled: true });
+    radio1.focus();
+    assert.deepEqual(document.activeElement, radio1);
+  });
+
   test('should not display retry button when an ok feedback appears', async function (assert) {
     // given
     const store = this.owner.lookup('service:store');


### PR DESCRIPTION
## :unicorn: Problème
Il n'est pas possible de prendre le focus sur les propositions QCU/QCM/QROCM une fois répondu.

## :robot: Proposition
Pour des raisons d'accessibilité, on doit pouvoir retabuler dessus pour lire leur état au lecteur d'écran.

## :rainbow: Remarques
RAS

## :100: Pour tester
CI 🍏 tabuler sur les propositions de QCU+QCM+QROCM une fois répondus.
