### PR TITLE
[FEATURE] Affichage du statut de session d'école dans Pix Orga (PIX-12725)

### DIFF
--- a/api/db/database-builder/factory/build-school.js
+++ b/api/db/database-builder/factory/build-school.js
@@ -3,7 +3,12 @@ import _ from 'lodash';
 import { databaseBuffer } from '../database-buffer.js';
 import { buildOrganization } from './build-organization.js';
 
-const buildSchool = function ({ id = databaseBuffer.getNextId(), code, organizationId } = {}) {
+const buildSchool = function ({
+  id = databaseBuffer.getNextId(),
+  code,
+  organizationId,
+  sessionExpirationDate = null,
+} = {}) {
   organizationId = _.isNil(organizationId) ? buildOrganization({ type: 'SCO-1D' }).id : organizationId;
   // Because of unicity constraint if no code is given we set the unique id as campaign code.
   code = _.isUndefined(code) ? id.toString() : code;
@@ -12,6 +17,7 @@ const buildSchool = function ({ id = databaseBuffer.getNextId(), code, organizat
     id,
     code,
     organizationId,
+    sessionExpirationDate,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'schools',

--- a/api/src/organizational-entities/domain/models/Organization.js
+++ b/api/src/organizational-entities/domain/models/Organization.js
@@ -32,6 +32,7 @@ class Organization {
     formNPSUrl,
     showSkills,
     schoolCode,
+    sessionExpirationDate,
     archivedAt,
   } = {}) {
     this.id = id;
@@ -53,6 +54,7 @@ class Organization {
     this.formNPSUrl = formNPSUrl;
     this.showSkills = showSkills;
     this.schoolCode = schoolCode;
+    this.sessionExpirationDate = sessionExpirationDate;
     this.archivedAt = archivedAt;
   }
 

--- a/api/src/team/infrastructure/repositories/prescriber-repository.js
+++ b/api/src/team/infrastructure/repositories/prescriber-repository.js
@@ -51,6 +51,8 @@ const getPrescriber = async function (userId) {
 export const prescriberRepository = { getPrescriber };
 
 function _toPrescriberDomain(user, userOrgaSettings, tags, memberships, organizations, schools) {
+  const currentSchool = schools.find((school) => school.organizationId === userOrgaSettings.currentOrganizationId);
+
   return new Prescriber({
     ...user,
     memberships: memberships.map(
@@ -67,7 +69,8 @@ function _toPrescriberDomain(user, userOrgaSettings, tags, memberships, organiza
       id: userOrgaSettings.id,
       currentOrganization: new Organization({
         ...organizations.find((organization) => organization.id === userOrgaSettings.currentOrganizationId),
-        schoolCode: schools.find((school) => school.organizationId === userOrgaSettings.currentOrganizationId)?.code,
+        schoolCode: currentSchool?.code,
+        sessionExpirationDate: currentSchool?.sessionExpirationDate,
         tags: tags.map((tag) => new Tag(tag)),
       }),
     }),

--- a/api/src/team/infrastructure/serializers/jsonapi/prescriber-serializer.js
+++ b/api/src/team/infrastructure/serializers/jsonapi/prescriber-serializer.js
@@ -63,6 +63,7 @@ const serialize = function (prescriber) {
           'documentationUrl',
           'groups',
           'schoolCode',
+          'sessionExpirationDate',
         ],
         memberships: {
           ref: 'id',

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -120,6 +120,7 @@ describe('Integration | Repository | Organization', function () {
         createdBy: userId,
         targetProfileShares: [],
         schoolCode: undefined,
+        sessionExpirationDate: undefined,
       });
       expect(organizationSaved.tags[0].id).to.be.equal(tagId);
     });
@@ -193,6 +194,7 @@ describe('Integration | Repository | Organization', function () {
           showSkills: false,
           archivedAt: null,
           schoolCode: undefined,
+          sessionExpirationDate: undefined,
         });
       });
 

--- a/api/tests/team/integration/infrastructure/repositories/prescriber-repository_test.js
+++ b/api/tests/team/integration/infrastructure/repositories/prescriber-repository_test.js
@@ -181,7 +181,7 @@ describe('Integration | Team | Infrastructure | Repository | Prescriber', functi
           expect(foundPrescriber.userOrgaSettings.currentOrganization.tags[0]).to.be.instanceOf(Tag);
         });
       });
-      context('when organizations have school codes', function () {
+      context('when organization is a school', function () {
         it('should set code into organizations associated to the prescriber', async function () {
           // given
           const school = databaseBuilder.factory.buildSchool();
@@ -199,6 +199,23 @@ describe('Integration | Team | Infrastructure | Repository | Prescriber', functi
             (membership) => membership.organization.id === school.organizationId,
           );
           expect(schoolMembership.organization.schoolCode).to.equal(school.code);
+        });
+
+        it('should set sessionExpirationDate into current organization associated to the prescriber', async function () {
+          // given
+          const school = databaseBuilder.factory.buildSchool({
+            organizationId: userOrgaSettings.currentOrganizationId,
+            sessionExpirationDate: new Date('2013-03-04'),
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const foundPrescriber = await prescriberRepository.getPrescriber(user.id);
+
+          // then
+          expect(foundPrescriber.userOrgaSettings.currentOrganization.sessionExpirationDate).to.deep.equal(
+            school.sessionExpirationDate,
+          );
         });
       });
 

--- a/api/tests/team/integration/infrastructure/repositories/user-orga-settings-repository_test.js
+++ b/api/tests/team/integration/infrastructure/repositories/user-orga-settings-repository_test.js
@@ -32,6 +32,7 @@ describe('Integration | Team | Infrastructure | Repository | UserOrgaSettings', 
     'identityProviderForCampaigns',
     'parentOrganizationId',
     'schoolCode',
+    'sessionExpirationDate',
   ];
 
   let user;

--- a/orga/app/components/layout/school-session-management.gjs
+++ b/orga/app/components/layout/school-session-management.gjs
@@ -1,31 +1,85 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import Component from '@glimmer/component';
+import dayjs from 'dayjs';
+import LocalizedFormat from 'dayjs/plugin/localizedFormat';
 import { t } from 'ember-intl';
+dayjs.extend(LocalizedFormat);
 
 export default class SchoolSessionManagement extends Component {
   @service currentUser;
   @service session;
   @service store;
+  @service intl;
 
   get canManageSession() {
     return this.currentUser.canAccessMissionsPage;
   }
 
+  get sessionIsActive() {
+    return this.currentUser.organization.sessionExpirationDate > new Date();
+  }
+
+  get sessionStatus() {
+    return this.sessionIsActive
+      ? this.intl.t('navigation.school-sessions.status.activated')
+      : this.intl.t('navigation.school-sessions.status.deactivated');
+  }
+
+  get expirationDateParameter() {
+    return {
+      sessionExpirationDate: dayjs(this.currentUser.organization.sessionExpirationDate).format('LT'),
+    };
+  }
+
+  get buttonLabel() {
+    return this.sessionIsActive
+      ? this.intl.t('navigation.school-sessions.extend-button')
+      : this.intl.t('navigation.school-sessions.activate-button');
+  }
+
   @action
-  activateSession() {
+  async activateSession() {
     const organization = this.currentUser.organization;
-    return this.store
+    await this.store
       .adapterFor('organization')
       .activateSession({ organizationId: organization.id, token: this.session?.data?.authenticated?.access_token });
+
+    await this.args.refreshAuthenticatedModel();
   }
 
   <template>
     {{#if this.canManageSession}}
-      <PixButton class="button-activate-session" @variant="secondary" @triggerAction={{this.activateSession}}>{{t
-          "navigation.school-sessions.activate-button"
-        }}</PixButton>
+      <p class="school-session__status">
+        {{#if this.sessionIsActive}}
+          {{t "navigation.school-sessions.status.active-label" this.expirationDateParameter}}
+        {{else}}
+          {{t "navigation.school-sessions.status.inactive-label"}}
+        {{/if}}
+      </p>
+      <PixTooltip @id="school-session-info-tooltip" @position="bottom" @isWide="true">
+        <:triggerElement>
+          <FaIcon
+            @icon="circle-info"
+            tabindex="0"
+            aria-label={{t "navigation.school-sessions.status.aria-label"}}
+            aria-describedby="school-session-info-tooltip"
+          />
+        </:triggerElement>
+
+        <:tooltip>
+          {{t "navigation.school-sessions.status.info-text" htmlSafe=true}}
+        </:tooltip>
+      </PixTooltip>
+
+      <PixButton
+        class="school-session__button"
+        @variant="secondary"
+        @triggerAction={{this.activateSession}}
+      >{{this.buttonLabel}}</PixButton>
     {{/if}}
   </template>
 }

--- a/orga/app/components/layout/topbar.hbs
+++ b/orga/app/components/layout/topbar.hbs
@@ -1,5 +1,5 @@
 <div class="topbar">
   <Layout::OrganizationPlacesOrCreditInfo @placesCount={{@placesCount}} />
-  <Layout::SchoolSessionManagement />
-  <Layout::UserLoggedMenu class="topbar__user-logged-menu" @reloadPlaceStatistics={{@reloadPlaceStatistics}} />
+  <Layout::SchoolSessionManagement @refreshAuthenticatedModel={{@refreshAuthenticatedModel}} />
+  <Layout::UserLoggedMenu class="topbar__user-logged-menu" @refreshAuthenticatedModel={{@refreshAuthenticatedModel}} />
 </div>

--- a/orga/app/components/layout/user-logged-menu.js
+++ b/orga/app/components/layout/user-logged-menu.js
@@ -56,7 +56,7 @@ export default class UserLoggedMenu extends Component {
     this.router.replaceWith('authenticated', { queryParams });
 
     await this.currentUser.load();
-    this.args.reloadPlaceStatistics();
+    this.args.refreshAuthenticatedModel();
 
     this.closeMenu();
   }

--- a/orga/app/controllers/authenticated.js
+++ b/orga/app/controllers/authenticated.js
@@ -7,7 +7,7 @@ export default class AuthenticatedController extends Controller {
   @service store;
 
   @action
-  reloadPlaceStatistics() {
+  refreshAuthenticatedModel() {
     this.send('refreshModel');
   }
 }

--- a/orga/app/models/organization.js
+++ b/orga/app/models/organization.js
@@ -10,6 +10,7 @@ export default class Organization extends Model {
   @attr('string') documentationUrl;
   @attr('string') identityProviderForCampaigns;
   @attr('string') schoolCode;
+  @attr('date') sessionExpirationDate;
 
   @hasMany('campaign', { async: true, inverse: 'organization' }) campaigns;
   @hasMany('target-profile', { async: true, inverse: null }) targetProfiles;

--- a/orga/app/routes/authenticated.js
+++ b/orga/app/routes/authenticated.js
@@ -2,6 +2,7 @@ import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import get from 'lodash/get';
+import RSVP from 'rsvp';
 
 export default class AuthenticatedRoute extends Route {
   @service currentUser;
@@ -24,10 +25,15 @@ export default class AuthenticatedRoute extends Route {
 
   async model() {
     if (this.currentUser.prescriber.placesManagement) {
-      return await this.store.queryRecord('organization-place-statistic', {
-        organizationId: this.currentUser.organization.id,
+      return RSVP.hash({
+        available: this.store.queryRecord('organization-place-statistic', {
+          organizationId: this.currentUser.organization.id,
+        }),
       });
-    } else return null;
+    }
+    if (this.currentUser.canAccessMissionsPage) {
+      await this.currentUser.load();
+    }
   }
 
   @action

--- a/orga/app/styles/components/layout/topbar.scss
+++ b/orga/app/styles/components/layout/topbar.scss
@@ -8,7 +8,21 @@
   margin-bottom: var(--pix-spacing-6x);
   background-color: var(--pix-neutral-0);
 
-  .button-activate-session {
-    margin-right: var(--pix-spacing-3x);
+  .school-session {
+
+    &__button {
+      margin: 0 var(--pix-spacing-3x);
+    }
+
+    &__status {
+      @extend %pix-body-s;
+
+      margin: 0 var(--pix-spacing-1x);
+      font-weight: var(--pix-font-bold);
+
+      &__icon-info {
+        width: var(--pix-spacing-6x);
+      }
+    }
   }
 }

--- a/orga/app/templates/authenticated.hbs
+++ b/orga/app/templates/authenticated.hbs
@@ -3,7 +3,7 @@
 
   <div class="main-content">
     <header>
-      <Layout::Topbar @placesCount={{@model.available}} @reloadPlaceStatistics={{this.reloadPlaceStatistics}} />
+      <Layout::Topbar @placesCount={{@model.available}} @refreshAuthenticatedModel={{this.refreshAuthenticatedModel}} />
     </header>
 
     <main class="main-content__body page">

--- a/orga/tests/integration/components/layout/school-session-management_test.gjs
+++ b/orga/tests/integration/components/layout/school-session-management_test.gjs
@@ -1,7 +1,9 @@
 import { render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
+import { click } from '@ember/test-helpers';
 import SchoolSessionManagement from 'pix-orga/components/layout/school-session-management';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -9,19 +11,112 @@ module('Integration | Components | Layout | SchoolSessionManagement', function (
   setupIntlRenderingTest(hooks);
 
   module('when user can manage missions', function () {
-    test('should display activate session button', async function (assert) {
-      // given
+    test('should display the info-text icon', async function (assert) {
+      const sessionExpirationDate = null;
+
       class CurrentUserStub extends Service {
         isAdminInOrganization = false;
         canAccessMissionsPage = true;
+        organization = {
+          sessionExpirationDate,
+        };
       }
 
       this.owner.register('service:current-user', CurrentUserStub);
 
       // when
       const screen = await render(<template><SchoolSessionManagement /></template>);
+
+      await click(screen.getByLabelText(this.intl.t('navigation.school-sessions.status.aria-label')));
+
+      const tooltipText = this.intl.t('navigation.school-sessions.status.info-text', { htmlSafe: true });
+      const tooltip = screen.getByRole('tooltip');
+
       // then
-      assert.ok(screen.getByRole('button', { name: this.intl.t('navigation.school-sessions.activate-button') }));
+      assert.strictEqual(tooltip.innerHTML.trim(), tooltipText.toString());
+    });
+
+    module('session expiration date management', function (hooks) {
+      let clock;
+      hooks.afterEach(function () {
+        clock.restore();
+      });
+
+      module('when there is no session expiration date', function () {
+        test('should display inactive status', async function (assert) {
+          // given
+          const now = new Date(2024, 1, 1, 16, 1);
+          clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+
+          class CurrentUserStub extends Service {
+            isAdminInOrganization = false;
+            canAccessMissionsPage = true;
+            organization = {
+              sessionExpirationDate: null,
+            };
+          }
+
+          this.owner.register('service:current-user', CurrentUserStub);
+
+          // when
+          const screen = await render(<template><SchoolSessionManagement /></template>);
+          // then
+          assert.ok(screen.getByText(this.intl.t('navigation.school-sessions.status.inactive-label')));
+          assert.ok(screen.getByRole('button', { name: this.intl.t('navigation.school-sessions.activate-button') }));
+        });
+      });
+      module('when session expiration date is in the future', function () {
+        test('should display active status and extend session button', async function (assert) {
+          // given
+          const sessionExpirationDate = new Date(2024, 1, 1, 16, 1);
+          const now = new Date(2024, 1, 1, 16);
+          clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+
+          class CurrentUserStub extends Service {
+            isAdminInOrganization = false;
+            canAccessMissionsPage = true;
+            organization = {
+              sessionExpirationDate,
+            };
+          }
+
+          this.owner.register('service:current-user', CurrentUserStub);
+
+          // when
+          const screen = await render(<template><SchoolSessionManagement /></template>);
+          // then
+          assert.ok(
+            screen.getByText(
+              this.intl.t('navigation.school-sessions.status.active-label', { sessionExpirationDate: '16:01' }),
+            ),
+          );
+          assert.ok(screen.getByRole('button', { name: this.intl.t('navigation.school-sessions.extend-button') }));
+        });
+      });
+      module('when session expiration date is in the past', function () {
+        test('should display inactive status and activate session button', async function (assert) {
+          // given
+          const sessionExpirationDate = new Date(2024, 1, 1, 16);
+          const now = new Date(2024, 1, 1, 16, 1);
+          clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+
+          class CurrentUserStub extends Service {
+            isAdminInOrganization = false;
+            canAccessMissionsPage = true;
+            organization = {
+              sessionExpirationDate,
+            };
+          }
+
+          this.owner.register('service:current-user', CurrentUserStub);
+
+          // when
+          const screen = await render(<template><SchoolSessionManagement /></template>);
+          // then
+          assert.ok(screen.getByText(this.intl.t('navigation.school-sessions.status.inactive-label')));
+          assert.ok(screen.getByRole('button', { name: this.intl.t('navigation.school-sessions.activate-button') }));
+        });
+      });
     });
   });
 

--- a/orga/tests/integration/components/layout/user-logged-menu_test.js
+++ b/orga/tests/integration/components/layout/user-logged-menu_test.js
@@ -95,7 +95,7 @@ module('Integration | Component | Layout::UserLoggedMenu', function (hooks) {
 
   test('should redirect to authenticated route before reload the current user', async function (assert) {
     const replaceWithStub = sinon.stub();
-    const reloadPlaceStatistics = sinon.stub();
+    const refreshAuthenticatedModel = sinon.stub();
 
     class RouterStub extends Service {
       replaceWith = replaceWithStub;
@@ -107,15 +107,17 @@ module('Integration | Component | Layout::UserLoggedMenu', function (hooks) {
         return { save() {} };
       }
     }
-    this.set('reloadPlaceStatistics', reloadPlaceStatistics);
+    this.set('refreshAuthenticatedModel', refreshAuthenticatedModel);
     this.owner.register('service:router', RouterStub);
     this.owner.register('service:store', StoreStub);
 
-    const screen = await render(hbs`<Layout::UserLoggedMenu @reloadPlaceStatistics={{this.reloadPlaceStatistics}} />`);
+    const screen = await render(
+      hbs`<Layout::UserLoggedMenu @refreshAuthenticatedModel={{this.refreshAuthenticatedModel}} />`,
+    );
     await clickByName('Ouvrir le menu utilisateur');
     await click(screen.getByRole('button', { name: `${organization2.name} (${organization2.externalId})` }));
 
     sinon.assert.callOrder(replaceWithStub, loadStub);
-    assert.ok(reloadPlaceStatistics.calledOnce);
+    assert.ok(refreshAuthenticatedModel.calledOnce);
   });
 });

--- a/orga/tests/unit/controllers/authenticated_test.js
+++ b/orga/tests/unit/controllers/authenticated_test.js
@@ -11,7 +11,7 @@ module('Unit | Controller | authenticated', function (hooks) {
     controller.send = sinon.stub();
 
     // when
-    controller.reloadPlaceStatistics();
+    controller.refreshAuthenticatedModel();
     // then
     assert.true(controller.send.calledWithExactly('refreshModel'));
   });

--- a/orga/tests/unit/routes/authenticated_test.js
+++ b/orga/tests/unit/routes/authenticated_test.js
@@ -25,6 +25,7 @@ module('Unit | Route | authenticated', function (hooks) {
     test('should redirect towards cgu if not accepted yet', async function (assert) {
       // given
       const organizationId = Symbol('organizationId');
+
       class CurrentUserStub extends Service {
         prescriber = { placesManagement: true, pixOrgaTermsOfServiceAccepted: false };
         organization = {
@@ -51,6 +52,7 @@ module('Unit | Route | authenticated', function (hooks) {
     test('should not redirect towards cgu if already accepted yet', async function (assert) {
       // given
       const organizationId = Symbol('organizationId');
+
       class CurrentUserStub extends Service {
         prescriber = { placesManagement: true, pixOrgaTermsOfServiceAccepted: true };
         organization = {
@@ -79,6 +81,7 @@ module('Unit | Route | authenticated', function (hooks) {
     test('should query record organization-place-statistic', async function (assert) {
       // given
       const organizationId = Symbol('organizationId');
+
       class CurrentUserStub extends Service {
         prescriber = { placesManagement: true };
         organization = {
@@ -103,6 +106,7 @@ module('Unit | Route | authenticated', function (hooks) {
     test('should not query record organization-place-statistic if user organization does not have placeManagement feature', async function (assert) {
       // given
       const organizationId = Symbol('organizationId');
+
       class CurrentUserStub extends Service {
         prescriber = { placesManagement: false };
         organization = {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -312,7 +312,15 @@
       "number": "{count, plural, =0 {0 seat available} =1 {1 seat available} other {{count, number} seats available}}"
     },
     "school-sessions": {
-      "activate-button": "Activate session"
+      "activate-button": "Activate session",
+      "extend-button": "Extend session",
+      "status": {
+        "title": "Session status",
+        "active-label": "Active session until {sessionExpirationDate}",
+        "aria-label": "How does the session work ?",
+        "inactive-label": "Inactive session",
+        "info-text": "Students can only access missions when the session is active.'<br>'At the end of the session, students who are in the middle of a mission will not be disconnected."
+      }
     },
     "team-members": {
       "aria-label": "Team members navigation"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -18,7 +18,6 @@
     },
     "global": "Une erreur est survenue. Veuillez réessayer ultérieurement.",
     "or-separator": " ou ",
-
     "student-csv-import": {
       "bad-csv-format": "Le fichier doit être au format csv avec séparateur virgule ou point-virgule.",
       "encoding-not-supported": "Encodage du fichier non supporté.",
@@ -313,7 +312,15 @@
       "number": "{count, plural, =0 {0 place disponible} =1 {1 place disponible} other {{count} places disponibles}}"
     },
     "school-sessions": {
-      "activate-button": "Activer la session"
+      "activate-button": "Activer la session",
+      "extend-button": "Prolonger la session",
+      "status": {
+        "title": "Statut de la session",
+        "active-label": "Session active jusqu'à {sessionExpirationDate}",
+        "aria-label": "Explication sur la session",
+        "inactive-label": "Session inactive",
+        "info-text": "Les missions sont accessibles par les élèves uniquement lorsque la session est active.'<br>' À la fin de la session, les élèves en cours de mission ne seront pas déconnectés."
+      }
     },
     "team-members": {
       "aria-label": "Navigation de la section équipe"


### PR DESCRIPTION
## :unicorn: Problème
Le professeur dispose d'un bouton dans la page Missions pour activer une session d'école pour Pix Junior. Mais il n'a aucun feedback et ne sait pas si la session a été activée.

## :robot: Proposition
Afficher le statut de la session et son heure de fin si elle est active.

## :100: Pour tester
Depuis Pix Orga, aller sur une école sans session active.
↪️ Dans l'onglet Missions, le statut de la session est indiqué comme "Inactive".
Cliquer sur "Activer la session" : 
↪️ Le statut de la session passe à "Active jusqu'à <heure courante + 4h>"
Modifier en base l'heure de fin de session pour avoir une heure passée.
 ↪️ Le statut de la session passe à "Inactive"

