### PR TITLE
[TECH] MAJ du thème QUnit pour les tests certifs.

### DIFF
--- a/certif/ember-cli-build.js
+++ b/certif/ember-cli-build.js
@@ -27,6 +27,9 @@ module.exports = function (defaults) {
         '@ember-data/store': {
           polyfillUUID: true,
         },
+        'ember-qunit': {
+          theme: 'ember',
+        },
       },
     },
   });

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -62,7 +62,7 @@
         "ember-load-initializers": "^2.1.2",
         "ember-modifier": "^4.1.0",
         "ember-page-title": "^8.0.0",
-        "ember-qunit": "^8.0.0",
+        "ember-qunit": "^8.1.0",
         "ember-resolver": "^11.0.0",
         "ember-simple-auth": "^6.0.0",
         "ember-source": "^5.8.0",
@@ -31288,14 +31288,15 @@
       }
     },
     "node_modules/ember-qunit": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/ember-qunit/-/ember-qunit-8.0.2.tgz",
-      "integrity": "sha512-Rf60jeUTWNsF3Imf/FLujW/B/DFmKVXKmXO1lirTXjpertKfwRhp/3MnN8a/U/WyodTIsERkInGT1IqTtphCdQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/ember-qunit/-/ember-qunit-8.1.0.tgz",
+      "integrity": "sha512-55/xqvVQwhiNcnh/tCzWyvlYzrYqwDY0/cIPyDQbAxGKtkUt9jCfRUGllfyOofC6LX0fL/0fIi+5e9sg1m6vXw==",
       "dev": true,
       "dependencies": {
         "@embroider/addon-shim": "^1.8.6",
         "@embroider/macros": "^1.13.1",
-        "ember-cli-test-loader": "^3.1.0"
+        "ember-cli-test-loader": "^3.1.0",
+        "qunit-theme-ember": "^1.0.0"
       },
       "peerDependencies": {
         "@ember/test-helpers": ">=3.0.3",
@@ -41299,6 +41300,12 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/qunit-dom/-/qunit-dom-3.1.2.tgz",
       "integrity": "sha512-urHvzhDxihYrMBpsT/Fk7So79CPfvS0ZwZw2VPA+0JV1Q1XP2IhDg/PLHTt+r2j7787iQAOpILx2GjwAa6CpnA==",
+      "dev": true
+    },
+    "node_modules/qunit-theme-ember": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/qunit-theme-ember/-/qunit-theme-ember-1.0.0.tgz",
+      "integrity": "sha512-vdMVVo6ecdCkWttMTKeyq1ZTLGHcA6zdze2zhguNuc3ritlJMhOXY5RDseqazOwqZVfCg3rtlmL3fMUyIzUyFQ==",
       "dev": true
     },
     "node_modules/qunit/node_modules/commander": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -98,7 +98,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-modifier": "^4.1.0",
     "ember-page-title": "^8.0.0",
-    "ember-qunit": "^8.0.0",
+    "ember-qunit": "^8.1.0",
     "ember-resolver": "^11.0.0",
     "ember-simple-auth": "^6.0.0",
     "ember-source": "^5.8.0",


### PR DESCRIPTION
## :unicorn: Problème

L'interface de tests de QUnit se fait vieillotte.

## :robot: Proposition

MAJ de l'interface avec la dernière version de `ember-qunit` en suivant les infos prodiguées par [ce lien](https://blog.ignacemaes.com/how-to-use-the-new-ember-theme-for-qunit/)

![Capture d’écran 2024-06-12 à 09 33 02](https://github.com/1024pix/pix/assets/36371437/69608d78-aae4-4e86-8984-fe468aa8eb98)

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

En local, aller faire un tour sur `/tests`
Tests verts.
