### PR TITLE
[TECH] Mettre à jour le fichier CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,26 @@
 # @1024pix/devcomp owns any file in the `/api/src/devcomp/` directory in the root of your repository and any of its subdirectories.
 /api/src/devcomp/ @1024pix/team-devcomp
+/api/tests/devcomp/ @1024pix/team-devcomp
+
+
+# Directories maintained by team Certification
+/api/src/certification/ @1024pix/team-certification
+/api/tests/certification/ @1024pix/team-certification
+
+
+# Directories maintained by team Evaluation
+/api/src/evaluation/ @1024pix/team-evaluation
+/api/tests/evaluation/ @1024pix/team-evaluation
+
+
+# Directories maintained by team Prescription
+/api/src/prescription/ @1024pix/team-prescription
+/api/tests/prescription/ @1024pix/team-prescription
+
+
+# Directories maintained by team Junior
+/api/src/school/ @1024pix/team-junior
+/api/tests/school/ @1024pix/team-junior
 
 
 # Directories maintained by team Accès


### PR DESCRIPTION
## :unicorn: Problème

Actuellement seul les équipes `team-devcomp` et `team-acces` sont associés à leurs domaines.

## :robot: Proposition

Rendre les _maintainers_ de chaque domaines visible lors de la création des pull requests.

## :rainbow: Remarques

RAS

## :100: Pour tester

CI ✅ 
