### PR TITLE
[BUGFIX] Afficher une connexion externe par ligne sur l'écran de rattachement d'un compte externe à un compte Pix (PIX-12858)

### DIFF
--- a/mon-pix/app/components/authentication/oidc-reconciliation.hbs
+++ b/mon-pix/app/components/authentication/oidc-reconciliation.hbs
@@ -14,20 +14,28 @@
         title={{t "pages.oidc-reconciliation.current-authentication-methods"}}
       >
         {{#if this.shouldShowEmail}}
-          <dt>{{t "pages.oidc-reconciliation.email"}}</dt>
-          <dd>{{@email}}</dd>
+          <div>
+            <dt>{{t "pages.oidc-reconciliation.email"}}</dt>
+            <dd>{{@email}}</dd>
+          </div>
         {{/if}}
         {{#if this.shouldShowUsername}}
-          <dt>{{t "pages.oidc-reconciliation.username"}}</dt>
-          <dd>{{@username}}</dd>
+          <div>
+            <dt>{{t "pages.oidc-reconciliation.username"}}</dt>
+            <dd>{{@username}}</dd>
+          </div>
         {{/if}}
         {{#if this.shouldShowGarAuthenticationMethod}}
-          <dt>{{t "pages.oidc-reconciliation.external-connection"}}</dt>
-          <dd>{{t "pages.user-account.connexion-methods.authentication-methods.gar"}}</dd>
+          <div>
+            <dt>{{t "pages.oidc-reconciliation.external-connection"}}</dt>
+            <dd>{{t "pages.user-account.connexion-methods.authentication-methods.gar"}}</dd>
+          </div>
         {{/if}}
         {{#each this.oidcAuthenticationMethodOrganizationNames as |organizationName|}}
-          <dt>{{t "pages.oidc-reconciliation.external-connection"}}</dt>
-          <dd>{{organizationName}}</dd>
+          <div>
+            <dt>{{t "pages.oidc-reconciliation.external-connection"}}</dt>
+            <dd>{{organizationName}}</dd>
+          </div>
         {{/each}}
       </dl>
     </div>


### PR DESCRIPTION
## :unicorn: Problème

Lorsque l'on rattache un compte externe à un compte Pix ayant déjà plusieurs méthodes de connexion, on obtiens l'aperçu suivant :

<img width="467" alt="Capture d’écran 2024-06-10 à 10 37 40" src="https://github.com/1024pix/pix/assets/6919604/271e376f-2604-4046-a970-a7ea4b823fa4">


## :robot: Proposition

Afficher une méthode de connexion par ligne.

## :rainbow: Remarques

Je me suis basé sur un article de MDN pour l'utilisation d'une balise _div_ (https://developer.mozilla.org/fr/docs/Web/HTML/Element/dl#int%C3%A9gration_de_groupes_nom-valeur_dans_les_%C3%A9l%C3%A9ments_div).

## :100: Pour tester

1. Rattacher 2 méthodes de connexions externes à un compte Pix
2. Tenter de rattacher une 3e méthode de connexion au même compte Pix
3. Constater l'affichage d'une méthode de connexion par ligne
