### PR TITLE
[FEATURE] Utiliser la langue de l'épreuve en cas d'absence de langue utilisateur (PIX-12862).

### DIFF
--- a/api/src/shared/infrastructure/serializers/jsonapi/challenge-serializer.js
+++ b/api/src/shared/infrastructure/serializers/jsonapi/challenge-serializer.js
@@ -24,6 +24,7 @@ const serialize = function (challenges) {
       'alternativeInstruction',
       'focused',
       'shuffled',
+      'locales',
     ],
     transform: (record) => {
       const challenge = _.pickBy(record, (value) => !_.isUndefined(value));

--- a/api/tests/shared/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
@@ -25,6 +25,7 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', function () {
         embedHeight: 500,
         format: 'mots',
         shuffled: false,
+        locales: ['fr', 'en'],
       });
 
       // when
@@ -48,6 +49,7 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', function () {
             'embed-height': 500,
             format: 'mots',
             shuffled: false,
+            locales: ['fr', 'en'],
           },
         },
       });

--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -82,7 +82,7 @@ export default class ChallengeStatement extends Component {
     } else {
       const element = document.getElementsByClassName('challenge-statement-instruction__text')[0];
       const textToSpeech = new SpeechSynthesisUtterance(element.innerText);
-      textToSpeech.lang = this.getChallengeLanguage();
+      textToSpeech.lang = this.getTextToSpeechLanguage();
       textToSpeech.pitch = 0.8;
       textToSpeech.rate = 0.8;
       textToSpeech.onend = () => {
@@ -98,7 +98,7 @@ export default class ChallengeStatement extends Component {
     this.addMetrics();
   }
 
-  getChallengeLanguage() {
+  getTextToSpeechLanguage() {
     if (this.args.challenge.locales.length) {
       return this.args.challenge.locales[0];
     }

--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -83,6 +83,8 @@ export default class ChallengeStatement extends Component {
       const element = document.getElementsByClassName('challenge-statement-instruction__text')[0];
       const textToSpeech = new SpeechSynthesisUtterance(element.innerText);
       textToSpeech.lang = this.getChallengeLanguage();
+      textToSpeech.pitch = 0.8;
+      textToSpeech.rate = 0.8;
       textToSpeech.onend = () => {
         this.isSpeaking = false;
         this.textToSpeechButtonTooltipText = this.intl.t('pages.challenge.statement.text-to-speech.play');

--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -82,7 +82,7 @@ export default class ChallengeStatement extends Component {
     } else {
       const element = document.getElementsByClassName('challenge-statement-instruction__text')[0];
       const textToSpeech = new SpeechSynthesisUtterance(element.innerText);
-      textToSpeech.lang = this.currentUser.user?.lang ? this.currentUser.user?.lang : 'fr';
+      textToSpeech.lang = this.getChallengeLanguage();
       textToSpeech.onend = () => {
         this.isSpeaking = false;
         this.textToSpeechButtonTooltipText = this.intl.t('pages.challenge.statement.text-to-speech.play');
@@ -94,6 +94,16 @@ export default class ChallengeStatement extends Component {
       speechSynthesis.speak(textToSpeech);
     }
     this.addMetrics();
+  }
+
+  getChallengeLanguage() {
+    if (this.args.challenge.locales.length) {
+      return this.args.challenge.locales[0];
+    }
+    if (this.currentUser.user?.lang) {
+      return this.currentUser.user.lang;
+    }
+    return 'fr';
   }
 
   addMetrics() {

--- a/mon-pix/app/models/challenge.js
+++ b/mon-pix/app/models/challenge.js
@@ -7,6 +7,7 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 export default class Challenge extends Model {
   // attributes
   @attr('array') attachments;
+  @attr('array') locales;
   @attr('string') embedUrl;
   @attr('string') embedTitle;
   @attr('string') embedHeight;

--- a/mon-pix/tests/integration/components/challenge-statement_test.js
+++ b/mon-pix/tests/integration/components/challenge-statement_test.js
@@ -200,6 +200,11 @@ module('Integration | Component | ChallengeStatement', function (hooks) {
       );
     });
 
+    /*
+     * Vocalisation
+     * ------------------------------------------------
+     */
+
     module('Text to speech button:', function () {
       module('when FT_ENABLE_TEXT_TO_SPEECH_BUTTON is enabled', function (hooks) {
         hooks.beforeEach(async function () {
@@ -218,6 +223,7 @@ module('Integration | Component | ChallengeStatement', function (hooks) {
               addChallengeToContext(this, {
                 instruction: 'La consigne du test avec un bouton de lecture à haute voix',
                 id: 'rec_challenge1',
+                locales: ['fr'],
               });
 
               // when
@@ -244,6 +250,7 @@ module('Integration | Component | ChallengeStatement', function (hooks) {
                 addChallengeToContext(this, {
                   instruction: "Test d'intégration vocalisation",
                   id: 'rec_challenge1',
+                  locales: ['fr'],
                 });
                 const screen = await render(hbs`<ChallengeStatement
                           @challenge={{this.challenge}}
@@ -276,6 +283,7 @@ module('Integration | Component | ChallengeStatement', function (hooks) {
                 addChallengeToContext(this, {
                   instruction: "Test d'intégration vocalisation",
                   id: 'rec_challenge4',
+                  locales: ['fr'],
                 });
                 const add = sinon.stub();
 
@@ -314,6 +322,7 @@ module('Integration | Component | ChallengeStatement', function (hooks) {
               addChallengeToContext(this, {
                 instruction: 'La consigne du test avec un bouton de lecture à haute voix',
                 id: 'rec_challenge1',
+                locales: ['fr'],
               });
 
               // when
@@ -342,6 +351,7 @@ module('Integration | Component | ChallengeStatement', function (hooks) {
             addChallengeToContext(this, {
               instruction: 'La consigne du test avec un bouton de lecture à haute voix',
               id: 'rec_challenge1',
+              locales: ['fr'],
             });
 
             // when
@@ -380,6 +390,7 @@ module('Integration | Component | ChallengeStatement', function (hooks) {
               addChallengeToContext(this, {
                 instruction: 'La consigne du test avec un bouton de lecture à haute voix',
                 id: 'rec_challenge1',
+                locales: ['fr'],
               });
 
               // when
@@ -407,6 +418,7 @@ module('Integration | Component | ChallengeStatement', function (hooks) {
               addChallengeToContext(this, {
                 instruction: 'La consigne du test avec un bouton de lecture à haute voix',
                 id: 'rec_challenge1',
+                locales: ['fr'],
               });
 
               // when
@@ -436,6 +448,7 @@ module('Integration | Component | ChallengeStatement', function (hooks) {
           addChallengeToContext(this, {
             instruction: 'La consigne du test avec un bouton de lecture à haute voix',
             id: 'rec_challenge1',
+            locales: ['fr'],
           });
           const speechSynthesis = window.speechSynthesis;
           delete window.speechSynthesis;

--- a/mon-pix/tests/unit/components/challenge-statement_test.js
+++ b/mon-pix/tests/unit/components/challenge-statement_test.js
@@ -96,4 +96,47 @@ module('Unit | Component | challenge statement', function (hooks) {
       assert.ok(orderedAttachments[3].includes('ods'));
     });
   });
+
+  module('#getTextToSpeechLanguage', function () {
+    test('should return the challenge language if given', function (assert) {
+      // given
+      const challenge = EmberObject.create({ locales: ['en'] });
+      const component = createGlimmerComponent('challenge-statement', { challenge });
+
+      // when
+      const textToSpeechLanguage = component.getTextToSpeechLanguage();
+
+      // then
+      assert.strictEqual(textToSpeechLanguage, 'en');
+    });
+
+    test('should return the user language if challenge has no defined', function (assert) {
+      // given
+      const challenge = EmberObject.create({ locales: [] });
+      const component = createGlimmerComponent('challenge-statement', { challenge });
+      component.currentUser = EmberObject.create({
+        user: {
+          lang: 'nl',
+        },
+      });
+
+      // when
+      const textToSpeechLanguage = component.getTextToSpeechLanguage();
+
+      // then
+      assert.strictEqual(textToSpeechLanguage, 'nl');
+    });
+
+    test('should return FR as default language', function (assert) {
+      // given
+      const challenge = EmberObject.create({ locales: [] });
+      const component = createGlimmerComponent('challenge-statement', { challenge });
+
+      // when
+      const textToSpeechLanguage = component.getTextToSpeechLanguage();
+
+      // then
+      assert.strictEqual(textToSpeechLanguage, 'fr');
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Suite à la publication du bouton de vocalisation, certains aspects restent à régler : 
- Utiliser la langue de l'épreuve si la langue de l'utilisateur n'est pas connue
- Régler la vitesse de lecture et le niveau de hauteur de la voix de lecture

## :robot: Proposition
Résoudre les problèmes listés

## :100: Pour tester
- Lancer Pix App
- Accéder à une épreuve d'aperçu et vérifier que la lecture d'épreuve fonctionne