### PR TITLE
[BUGFIX] Corriger le tag 'POLE EMPLOI' dans les seeds (PIX-12919)

### DIFF
--- a/api/db/seeds/data/common/constants.js
+++ b/api/db/seeds/data/common/constants.js
@@ -1,3 +1,5 @@
+import { Tag } from '../../../../src/organizational-entities/domain/models/Tag.js';
+
 const DEFAULT_PASSWORD = 'pix123';
 const COMMON_OFFSET_ID = 1000;
 
@@ -35,39 +37,39 @@ const IMPORT_FORMAT_GENERIC_ID = COMMON_OFFSET_ID + 2;
 //TAGS
 const AGRICULTURE_TAG = {
   id: 1,
-  name: 'AGRICULTURE',
+  name: Tag.AGRICULTURE,
 };
 const PUBLIC_TAG = {
   id: 2,
-  name: 'PUBLIC',
+  name: Tag.PUBLIC,
 };
 const PRIVE_TAG = {
   id: 3,
-  name: 'PRIVE',
+  name: Tag.PRIVE,
 };
 const POLE_EMPLOI_TAG = {
   id: 4,
-  name: 'POLE_EMPLOI',
+  name: Tag.POLE_EMPLOI,
 };
 const CFA_TAG = {
   id: 5,
-  name: 'CFA',
+  name: Tag.CFA,
 };
 const AEFE_TAG = {
   id: 6,
-  name: 'AEFE',
+  name: Tag.AEFE,
 };
 const MEDNUM_TAG = {
   id: 7,
-  name: 'MEDNUM',
+  name: Tag.MEDIATION_NUMERIQUE,
 };
 const COLLEGE_TAG = {
   id: 8,
-  name: 'COLLEGE',
+  name: Tag.COLLEGE,
 };
 const LYCEE_TAG = {
   id: 9,
-  name: 'LYCEE',
+  name: Tag.LYCEE,
 };
 
 export {

--- a/api/src/organizational-entities/domain/models/Tag.js
+++ b/api/src/organizational-entities/domain/models/Tag.js
@@ -10,4 +10,8 @@ Tag.MEDIATION_NUMERIQUE = 'MEDNUM';
 Tag.CFA = 'CFA';
 Tag.AEFE = 'AEFE';
 Tag.MLF = 'MLF';
+Tag.PUBLIC = 'PUBLIC';
+Tag.PRIVE = 'PRIVE';
+Tag.COLLEGE = 'COLLEGE';
+Tag.LYCEE = 'LYCEE';
 export { Tag };


### PR DESCRIPTION
## :unicorn: Problème
Lors d’un precedent refacto, une coquille s’est glissée et le tag pole emploi. Dans les seed il a un name = ‘POLE_EMPLOI’ au lieu d'être ‘POLE EMPLOI’

## :robot: Proposition
Utiliser le model Tag qui utilise les bons noms des tags pour build les seeds.
On en profite pour rajouter les noms des tags manquant dans le model

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

- Verifier en BDD sur la table "tags" que les tags sont bien nommés, et particulièrement le 'POLE EMPLOI'
- Il est possible également de vérifier directement sur PixAdmin : 
- Sur la page d'une Organisation, dans l'onglet Tags.
- Avant (avec la coquille sur le POLE_EMPLOI) : 

![image](https://github.com/1024pix/pix/assets/101280231/90379bf4-9ed9-4efe-97fc-28ff3de62508)

- 🐈‍⬛ 
