### PR TITLE
[FEATURE] Signaler si la campagne n'existe pas dans le simulateur (PIX-12892)

### DIFF
--- a/admin/app/components/smart-random-simulator/smart-random-params.js
+++ b/admin/app/components/smart-random-simulator/smart-random-params.js
@@ -124,6 +124,6 @@ export default class SmartRandomParams extends Component {
   }
 
   @action loadCampaignParams() {
-    this.args.loadCampaignParams(this.campaignId);
+    return this.args.loadCampaignParams(this.campaignId);
   }
 }

--- a/api/src/evaluation/domain/usecases/get-campaign-parameters-for-simulator.js
+++ b/api/src/evaluation/domain/usecases/get-campaign-parameters-for-simulator.js
@@ -4,7 +4,8 @@ const getCampaignParametersForSimulator = async function ({
   campaignRepository,
   challengeRepository,
 }) {
-  const skills = await campaignRepository.findSkills({ campaignId });
+  const campaign = await campaignRepository.get(campaignId);
+  const skills = await campaignRepository.findSkills({ campaignId: campaign.id });
   const challenges = await challengeRepository.findOperativeBySkills(skills, locale);
   const sanitizedChallenges = challenges.map((challenge) => ({
     id: challenge.id,

--- a/api/tests/evaluation/integration/domain/usecases/get-campaign-parameters-for-simulator_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/get-campaign-parameters-for-simulator_test.js
@@ -1,3 +1,4 @@
+import { NotFoundError } from '../../../../../lib/domain/errors.js';
 import { evaluationUsecases } from '../../../../../src/evaluation/domain/usecases/index.js';
 import {
   databaseBuilder,
@@ -14,38 +15,51 @@ function buildLearningContent() {
 }
 
 describe('Integration | Domain | UseCases | get-campaign-parameters-for-simulator', function () {
-  it('should return skills and challenges', async function () {
-    // given
-    const campaignId = 100000;
-
-    databaseBuilder.factory.buildCampaign({ id: campaignId });
-    databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'skillId' });
-
-    await databaseBuilder.commit();
-    buildLearningContent();
-
-    // when
-    const result = await evaluationUsecases.getCampaignParametersForSimulator({
-      campaignId,
-      locale: 'fr',
+  describe('when the campaign does not exist', function () {
+    it('should return show a not found error', async function () {
+      expect(
+        evaluationUsecases.getCampaignParametersForSimulator({
+          campaignId: 666,
+          locale: 'fr',
+        }),
+      ).to.eventually.throw(NotFoundError);
     });
+  });
 
-    // then
-    expect(result).to.deep.equal({
-      skills: [
-        {
-          id: 'skillId',
-          name: '@sau6',
-          pixValue: 3,
-          competenceId: 'competenceId',
-          tutorialIds: [],
-          learningMoreTutorialIds: [],
-          tubeId: 'tubeId',
-          version: 1,
-          difficulty: undefined,
-        },
-      ],
-      challenges: [],
+  describe('when the campaign do exists', function () {
+    it('should return skills and challenges', async function () {
+      // given
+      const campaignId = 100000;
+
+      databaseBuilder.factory.buildCampaign({ id: campaignId });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'skillId' });
+
+      await databaseBuilder.commit();
+      buildLearningContent();
+
+      // when
+      const result = await evaluationUsecases.getCampaignParametersForSimulator({
+        campaignId,
+        locale: 'fr',
+      });
+
+      // then
+      expect(result).to.deep.equal({
+        skills: [
+          {
+            id: 'skillId',
+            name: '@sau6',
+            pixValue: 3,
+            competenceId: 'competenceId',
+            tutorialIds: [],
+            learningMoreTutorialIds: [],
+            tubeId: 'tubeId',
+            version: 1,
+            difficulty: undefined,
+          },
+        ],
+        challenges: [],
+      });
     });
   });
 });

--- a/api/tests/evaluation/unit/domain/usecases/get-campaign-parameters-for-simulator_test.js
+++ b/api/tests/evaluation/unit/domain/usecases/get-campaign-parameters-for-simulator_test.js
@@ -10,6 +10,7 @@ describe('Unit | UseCase | get-campaign-parameters-for-simulator', function () {
     beforeEach(function () {
       campaignRepository = {
         findSkills: sinon.stub(),
+        get: sinon.stub(),
       };
 
       challengeRepository = {
@@ -29,6 +30,8 @@ describe('Unit | UseCase | get-campaign-parameters-for-simulator', function () {
       ];
 
       // given
+      campaignRepository.get.withArgs(12).resolves({ id: 12 });
+
       campaignRepository.findSkills
         .withArgs({
           campaignId: 12,


### PR DESCRIPTION
## :unicorn: Problème
Si on tape un numéro de campagne éroné, le simulateur charge tout de même des données vides. Ça rend Quentin triste

## :robot: Proposition
Dans cette PR, nous appelons au préalable la campagne depuis la base de données. Si celle ci n'existe pas on envoie alors une 404 qui informera l'utilisateur de son erreur.

## :100: Pour tester
aller vers le [simulateur](https://admin-pr9243.review.pix.fr/smart-random-simulator/get-next-challenge)
rentrer un numéro de campagne farfelu ( 40000000000000 )
vérifier la présence du message d'erreur
vérifier que ça fonctionne toujours pour les campagnes existantes ( 1000000 )