### PR TITLE
[TECH] ajoute la configuration pour activer les synchros de traduction dans orga (pix-12923)

### DIFF
--- a/.phrase.yml
+++ b/.phrase.yml
@@ -2,84 +2,89 @@ phrase:
   file_format: nested_json
   push:
     sources:
-    - file: ./mon-pix/translations/fr.json
-      project_id: "9ca9a54c81b5a85168c8df3d6953a49e"
-      params:
-        locale_id: 'fr'
+      - file: ./mon-pix/translations/fr.json
+        project_id: "9ca9a54c81b5a85168c8df3d6953a49e"
+        params:
+          locale_id: "fr"
 
-    - file: ./mon-pix/translations/en.json
-      project_id: "9ca9a54c81b5a85168c8df3d6953a49e"
-      params:
-        locale_id: 'en'
+      - file: ./mon-pix/translations/en.json
+        project_id: "9ca9a54c81b5a85168c8df3d6953a49e"
+        params:
+          locale_id: "en"
 
-    - file: ./orga/translations/fr.json
-      project_id: "93a23f4b74a86dbb53244134fb21ef43"
-      params:
-        locale_id: 'fr'
+      - file: ./orga/translations/fr.json
+        project_id: "93a23f4b74a86dbb53244134fb21ef43"
+        params:
+          locale_id: "fr"
 
-    - file: ./orga/translations/en.json
-      project_id: "93a23f4b74a86dbb53244134fb21ef43"
-      params:
-        locale_id: 'en'
+      - file: ./orga/translations/en.json
+        project_id: "93a23f4b74a86dbb53244134fb21ef43"
+        params:
+          locale_id: "en"
 
-    - file: ./certif/translations/fr.json
-      project_id: "3371843f0a06e47d0fba1374b19b439c"
-      params:
-        locale_id: 'fr'
+      - file: ./certif/translations/fr.json
+        project_id: "3371843f0a06e47d0fba1374b19b439c"
+        params:
+          locale_id: "fr"
 
-    - file: ./certif/translations/en.json
-      project_id: "3371843f0a06e47d0fba1374b19b439c"
-      params:
-        locale_id: 'en'
+      - file: ./certif/translations/en.json
+        project_id: "3371843f0a06e47d0fba1374b19b439c"
+        params:
+          locale_id: "en"
 
-    - file: ./admin/translations/fr.json
-      project_id: "0e242bea62d0ac0d989d082b8d1d96d7"
-      params:
-        locale_id: 'fr'
+      - file: ./admin/translations/fr.json
+        project_id: "0e242bea62d0ac0d989d082b8d1d96d7"
+        params:
+          locale_id: "fr"
 
-    - file: ./admin/translations/en.json
-      project_id: "0e242bea62d0ac0d989d082b8d1d96d7"
-      params:
-        locale_id: 'en'
+      - file: ./admin/translations/en.json
+        project_id: "0e242bea62d0ac0d989d082b8d1d96d7"
+        params:
+          locale_id: "en"
 
-    - file: ./junior/translations/fr.json
-      project_id: "dd99bbfc9e880398e292a808e7013896"
-      params:
-        locale_id: 'fr'
+      - file: ./junior/translations/fr.json
+        project_id: "dd99bbfc9e880398e292a808e7013896"
+        params:
+          locale_id: "fr"
 
-    - file: ./junior/translations/en.json
-      project_id: "dd99bbfc9e880398e292a808e7013896"
-      params:
-        locale_id: 'en'
+      - file: ./junior/translations/en.json
+        project_id: "dd99bbfc9e880398e292a808e7013896"
+        params:
+          locale_id: "en"
 
-    - file: ./api/translations/fr.json
-      project_id: "88f30f82bdab4e25ac5e57b6663a941a"
-      params:
-        locale_id: 'fr'
+      - file: ./api/translations/fr.json
+        project_id: "88f30f82bdab4e25ac5e57b6663a941a"
+        params:
+          locale_id: "fr"
 
-    - file: ./api/translations/en.json
-      project_id: "88f30f82bdab4e25ac5e57b6663a941a"
-      params:
-        locale_id: 'en'
+      - file: ./api/translations/en.json
+        project_id: "88f30f82bdab4e25ac5e57b6663a941a"
+        params:
+          locale_id: "en"
 
   pull:
     targets:
-     - file: ./mon-pix/translations/nl.json
-       project_id: "9ca9a54c81b5a85168c8df3d6953a49e"
-       params:
-         locale_id: 'nl'
+      - file: ./mon-pix/translations/nl.json
+        project_id: "9ca9a54c81b5a85168c8df3d6953a49e"
+        params:
+          locale_id: "nl"
 
-     - file: ./mon-pix/translations/es.json
-       project_id: "9ca9a54c81b5a85168c8df3d6953a49e"
-       params:
-         locale_id: 'es'
+      - file: ./mon-pix/translations/es.json
+        project_id: "9ca9a54c81b5a85168c8df3d6953a49e"
+        params:
+          locale_id: "es"
 
-     - file: ./api/translations/nl.json
-       project_id: "88f30f82bdab4e25ac5e57b6663a941a"
-       params:
-         locale_id: 'nl'
+      - file: ./api/translations/nl.json
+        project_id: "88f30f82bdab4e25ac5e57b6663a941a"
+        params:
+          locale_id: "nl"
 
-     - file: ./api/translations/es.json
-       project_id: "88f30f82bdab4e25ac5e57b6663a941a"
-       params:
-         locale_id: 'es'
+      - file: ./api/translations/es.json
+        project_id: "88f30f82bdab4e25ac5e57b6663a941a"
+        params:
+          locale_id: "es"
+
+      - file: ./orga/translations/nl.json
+        project_id: "93a23f4b74a86dbb53244134fb21ef43"
+        params:
+          locale_id: "nl"


### PR DESCRIPTION
## :unicorn: Problème
Le support du neerlandais n'est pas activé, cela empeche la synchro descendante des fichiers de trad

## :robot: Proposition
Ajouter un cible pour la synchro dans la config phrase

## :rainbow: Remarques
RAS

## :100: Pour tester
c'est pas possible 
