### PR TITLE
[FEATURE] Afficher un Stepper dans un Grain (PIX-12840)

### DIFF
--- a/high-level-tests/e2e/cypress/integration/pix-app/modulix-a11y.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/modulix-a11y.feature
@@ -18,6 +18,7 @@ Fonctionnalité: Accessibilité de Modulix
     Quand je vais au grain suivant
     Quand je vais au grain suivant
     Quand je vais au grain suivant
+    Quand je vais au grain suivant
     Alors la page devrait être accessible
     Quand je clique sur "Terminer"
     Et que j'attends 500 ms

--- a/mon-pix/app/components/module/grain.hbs
+++ b/mon-pix/app/components/module/grain.hbs
@@ -12,15 +12,23 @@
   </div>
   <div class="grain__card grain-card--{{this.grainType}}">
     <div class="grain-card__content">
-      {{#each this.displayableElements as |element|}}
-        <div class="grain-card-content__element">
-          <Module::Element
-            @element={{element}}
-            @submitAnswer={{@submitAnswer}}
-            @retryElement={{@retryElement}}
+      {{#each this.displayableComponents as |component|}}
+        {{#if (eq component.type "element")}}
+          <div class="grain-card-content__element">
+            <Module::Element
+              @element={{component.element}}
+              @submitAnswer={{@submitAnswer}}
+              @retryElement={{@retryElement}}
+              @getLastCorrectionForElement={{this.getLastCorrectionForElement}}
+            />
+          </div>
+        {{else if (eq component.type "stepper")}}
+          <Module::Stepper
+            @steps={{component.steps}}
+            @passage={{@passage}}
             @getLastCorrectionForElement={{this.getLastCorrectionForElement}}
           />
-        </div>
+        {{/if}}
       {{/each}}
     </div>
 

--- a/mon-pix/app/components/module/grain.js
+++ b/mon-pix/app/components/module/grain.js
@@ -57,7 +57,15 @@ export default class ModuleGrain extends Component {
   }
 
   static getSupportedComponentStepper(component) {
-    return component;
+    const steps = [];
+    for (const step of component.steps) {
+      const elements = step.elements.filter((element) => ModuleGrain.AVAILABLE_ELEMENT_TYPES.includes(element.type));
+      if (elements.length > 0) {
+        steps.push({ ...step, elements });
+      }
+    }
+
+    return steps.length > 0 ? { ...component, steps } : undefined;
   }
 
   static getSupportedComponents(grain) {

--- a/mon-pix/app/components/module/grain.js
+++ b/mon-pix/app/components/module/grain.js
@@ -48,6 +48,30 @@ export default class ModuleGrain extends Component {
     return ModuleGrain.getSupportedElements(this.args.grain);
   }
 
+  static getSupportedComponents(grain) {
+    return grain.components
+      .map((component) => {
+        if (component.type === 'element') {
+          if (ModuleGrain.AVAILABLE_ELEMENT_TYPES.includes(component.element.type)) {
+            return component;
+          } else {
+            return undefined;
+          }
+        } else if (component.type === 'stepper') {
+          return component;
+        } else {
+          return undefined;
+        }
+      })
+      .filter((component) => {
+        return component !== undefined;
+      });
+  }
+
+  get displayableComponents() {
+    return ModuleGrain.getSupportedComponents(this.args.grain);
+  }
+
   get hasAnswerableElements() {
     return this.displayableElements.some((element) => element.isAnswerable);
   }

--- a/mon-pix/app/components/module/grain.js
+++ b/mon-pix/app/components/module/grain.js
@@ -48,19 +48,28 @@ export default class ModuleGrain extends Component {
     return ModuleGrain.getSupportedElements(this.args.grain);
   }
 
+  static getSupportedComponentElement(component) {
+    if (ModuleGrain.AVAILABLE_ELEMENT_TYPES.includes(component.element.type)) {
+      return component;
+    } else {
+      return undefined;
+    }
+  }
+
+  static getSupportedComponentStepper(component) {
+    return component;
+  }
+
   static getSupportedComponents(grain) {
     return grain.components
       .map((component) => {
-        if (component.type === 'element') {
-          if (ModuleGrain.AVAILABLE_ELEMENT_TYPES.includes(component.element.type)) {
-            return component;
-          } else {
+        switch (component.type) {
+          case 'element':
+            return ModuleGrain.getSupportedComponentElement(component);
+          case 'stepper':
+            return ModuleGrain.getSupportedComponentStepper(component);
+          default:
             return undefined;
-          }
-        } else if (component.type === 'stepper') {
-          return component;
-        } else {
-          return undefined;
         }
       })
       .filter((component) => {

--- a/mon-pix/app/components/module/passage.js
+++ b/mon-pix/app/components/module/passage.js
@@ -10,7 +10,7 @@ export default class ModulePassage extends Component {
   @service metrics;
   @service store;
 
-  displayableGrains = this.args.module.grains.filter((grain) => ModuleGrain.getSupportedElements(grain).length > 0);
+  displayableGrains = this.args.module.grains.filter((grain) => ModuleGrain.getSupportedComponents(grain).length > 0);
   @tracked grainsToDisplay = this.displayableGrains.length > 0 ? [this.displayableGrains[0]] : [];
 
   static SCROLL_OFFSET_PX = 70;

--- a/mon-pix/app/components/module/step.gjs
+++ b/mon-pix/app/components/module/step.gjs
@@ -1,27 +1,34 @@
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 import Element from 'mon-pix/components/module/element';
+import ModuleGrain from 'mon-pix/components/module/grain';
 
 export default class ModulixStep extends Component {
-  get elements() {
-    return this.args.step.elements;
+  get displayableElements() {
+    return this.args.step.elements.filter((element) => ModuleGrain.AVAILABLE_ELEMENT_TYPES.includes(element.type));
+  }
+
+  get hasDisplayableElements() {
+    return this.displayableElements.length > 0;
   }
 
   <template>
-    <section>
-      <h3
-        aria-label="{{t 'pages.modulix.stepper.step.position' currentStep=@currentStep totalSteps=@totalSteps}}"
-      >{{@currentStep}}/{{@totalSteps}}</h3>
-      {{#each this.elements as |element|}}
-        <div class="grain-card-content__element">
-          <Element
-            @element={{element}}
-            @submitAnswer={{@submitAnswer}}
-            @retryElement={{@retryElement}}
-            @getLastCorrectionForElement={{@getLastCorrectionForElement}}
-          />
-        </div>
-      {{/each}}
-    </section>
+    {{#if this.hasDisplayableElements}}
+      <section>
+        <h3
+          aria-label="{{t 'pages.modulix.stepper.step.position' currentStep=@currentStep totalSteps=@totalSteps}}"
+        >{{@currentStep}}/{{@totalSteps}}</h3>
+        {{#each this.displayableElements as |element|}}
+          <div class="grain-card-content__element">
+            <Element
+              @element={{element}}
+              @submitAnswer={{@submitAnswer}}
+              @retryElement={{@retryElement}}
+              @getLastCorrectionForElement={{@getLastCorrectionForElement}}
+            />
+          </div>
+        {{/each}}
+      </section>
+    {{/if}}
   </template>
 }

--- a/mon-pix/app/components/module/stepper.gjs
+++ b/mon-pix/app/components/module/stepper.gjs
@@ -3,16 +3,25 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
+import ModuleGrain from 'mon-pix/components/module/grain';
 import Step from 'mon-pix/components/module/step';
 import { inc } from 'mon-pix/helpers/inc';
 
 export default class ModulixStepper extends Component {
+  displayableSteps = this.args.steps.filter((step) =>
+    step.elements.some((element) => ModuleGrain.AVAILABLE_ELEMENT_TYPES.includes(element.type)),
+  );
+
   @tracked
-  stepsToDisplay = [this.args.steps[0]];
+  stepsToDisplay = [this.displayableSteps[0]];
+
+  get hasDisplayableSteps() {
+    return this.displayableSteps.length > 0;
+  }
 
   @action
   displayNextStep() {
-    const nextStep = this.args.steps[this.lastIndex + 1];
+    const nextStep = this.displayableSteps[this.lastIndex + 1];
     this.stepsToDisplay = [...this.stepsToDisplay, nextStep];
   }
 
@@ -21,7 +30,7 @@ export default class ModulixStepper extends Component {
   }
 
   get hasNextStep() {
-    return this.stepsToDisplay.length < this.args.steps.length;
+    return this.stepsToDisplay.length < this.displayableSteps.length;
   }
 
   get answerableElementsInCurrentStep() {
@@ -40,19 +49,21 @@ export default class ModulixStepper extends Component {
   }
 
   <template>
-    {{#each this.stepsToDisplay as |step index|}}
-      <Step
-        @step={{step}}
-        @currentStep={{inc index}}
-        @totalSteps={{@steps.length}}
-        @getLastCorrectionForElement={{@getLastCorrectionForElement}}
-      />
-    {{/each}}
-    {{#if this.shouldDisplayNextButton}}
-      <PixButton @size="large" @variant="primary" @iconAfter="arrow-down" @triggerAction={{this.displayNextStep}}>{{t
-          "pages.modulix.buttons.stepper.next"
-        }}
-      </PixButton>
+    {{#if this.hasDisplayableSteps}}
+      {{#each this.stepsToDisplay as |step index|}}
+        <Step
+          @step={{step}}
+          @currentStep={{inc index}}
+          @totalSteps={{this.displayableSteps.length}}
+          @getLastCorrectionForElement={{@getLastCorrectionForElement}}
+        />
+      {{/each}}
+      {{#if this.shouldDisplayNextButton}}
+        <PixButton @size="large" @variant="primary" @iconAfter="arrow-down" @triggerAction={{this.displayNextStep}}>{{t
+            "pages.modulix.buttons.stepper.next"
+          }}
+        </PixButton>
+      {{/if}}
     {{/if}}
   </template>
 }

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -2,6 +2,7 @@ import { clickByName, render } from '@1024pix/ember-testing-library';
 // eslint-disable-next-line no-restricted-imports
 import { find } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import ModuleGrain from 'mon-pix/components/module/grain';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -120,181 +121,155 @@ module('Integration | Component | Module | Grain', function (hooks) {
     });
   });
 
-  module('when element is a text', function () {
-    test('should display text element', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const textElement = {
-        content: 'element content',
-        type: 'text',
-        isAnswerable: false,
-      };
-      const grain = store.createRecord('grain', {
-        title: 'Grain title',
-        components: [{ type: 'element', element: textElement }],
+  module('when component is an element', function () {
+    module('when element is a text', function () {
+      test('should display text element', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const textElement = {
+          content: 'element content',
+          type: 'text',
+          isAnswerable: false,
+        };
+        const grain = store.createRecord('grain', {
+          title: 'Grain title',
+          components: [{ type: 'element', element: textElement }],
+        });
+        this.set('grain', grain);
+
+        // when
+        const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} />`);
+
+        // then
+        assert.ok(screen.getByText('element content'));
       });
-      this.set('grain', grain);
-
-      // when
-      const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} />`);
-
-      // then
-      assert.ok(screen.getByText('element content'));
-    });
-  });
-
-  module('when element is a qcu', function () {
-    test('should display qcu element', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const qcuElement = {
-        instruction: 'instruction',
-        proposals: ['radio1', 'radio2'],
-        type: 'qcu',
-        isAnswerable: true,
-      };
-      const grain = store.createRecord('grain', {
-        title: 'Grain title',
-        components: [{ type: 'element', element: qcuElement }],
-      });
-      this.set('grain', grain);
-      const passage = store.createRecord('passage');
-      this.set('passage', passage);
-
-      // when
-      const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @passage={{this.passage}} />`);
-
-      // then
-      assert.strictEqual(screen.getAllByRole('radio').length, qcuElement.proposals.length);
-    });
-  });
-
-  module('when element is a qrocm', function () {
-    test('should display qrocm element', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const qrocmElement = {
-        instruction: 'Mon instruction',
-        proposals: [
-          {
-            type: 'text',
-            content: '<p>Le symbole</>',
-          },
-          {
-            input: 'symbole',
-            type: 'input',
-            inputType: 'text',
-            size: 1,
-            display: 'inline',
-            placeholder: '',
-            ariaLabel: 'Réponse 1',
-            defaultValue: '',
-          },
-          {
-            input: 'premiere-partie',
-            type: 'select',
-            display: 'inline',
-            placeholder: '',
-            ariaLabel: 'Réponse 2',
-            defaultValue: '',
-            options: [
-              {
-                id: '1',
-                content: "l'identifiant",
-              },
-              {
-                id: '2',
-                content: "le fournisseur d'adresse mail",
-              },
-            ],
-          },
-        ],
-        type: 'qrocm',
-        isAnswerable: true,
-      };
-      const grain = store.createRecord('grain', {
-        title: 'Grain title',
-        components: [{ type: 'element', element: qrocmElement }],
-      });
-      this.set('grain', grain);
-      const passage = store.createRecord('passage');
-      this.set('passage', passage);
-
-      // when
-      const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @passage={{this.passage}} />`);
-
-      // then
-      assert.ok(screen);
-      assert.dom(screen.getByText('Mon instruction')).exists({ count: 1 });
-    });
-  });
-
-  module('when element is an image', function () {
-    test('should display image element', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const url =
-        'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg';
-      const imageElement = {
-        url,
-        alt: 'alt text',
-        alternativeText: 'alternative instruction',
-        type: 'image',
-      };
-      const grain = store.createRecord('grain', {
-        title: 'Grain title',
-        components: [{ type: 'element', element: imageElement }],
-      });
-      this.set('grain', grain);
-
-      // when
-      const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} />`);
-
-      // then
-      assert.ok(screen.getByRole('img', { name: 'alt text' }).hasAttribute('src', url));
-    });
-  });
-
-  module('when all elements are answered', function () {
-    test('should not display skip button', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const element = { id: 'qcu-id', type: 'qcu', isAnswerable: true };
-      const grain = store.createRecord('grain', {
-        title: 'Grain title',
-        components: [{ type: 'element', element }],
-      });
-      this.set('grain', grain);
-      const passage = store.createRecord('passage');
-      this.set('passage', passage);
-
-      const correction = store.createRecord('correction-response');
-      store.createRecord('element-answer', { elementId: element.id, correction, passage });
-
-      // when
-      const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
-
-      // then
-      assert
-        .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') }))
-        .doesNotExist();
     });
 
-    module('when canMoveToNextGrain is true', function () {
-      test('should display continue button', async function (assert) {
+    module('when element is a qcu', function () {
+      test('should display qcu element', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const qcuElement = {
+          instruction: 'instruction',
+          proposals: ['radio1', 'radio2'],
+          type: 'qcu',
+          isAnswerable: true,
+        };
+        const grain = store.createRecord('grain', {
+          title: 'Grain title',
+          components: [{ type: 'element', element: qcuElement }],
+        });
+        this.set('grain', grain);
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
+
+        // when
+        const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} @passage={{this.passage}} />`);
+
+        // then
+        assert.strictEqual(screen.getAllByRole('radio').length, qcuElement.proposals.length);
+      });
+    });
+
+    module('when element is a qrocm', function () {
+      test('should display qrocm element', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const qrocmElement = {
+          instruction: 'Mon instruction',
+          proposals: [
+            {
+              type: 'text',
+              content: '<p>Le symbole</>',
+            },
+            {
+              input: 'symbole',
+              type: 'input',
+              inputType: 'text',
+              size: 1,
+              display: 'inline',
+              placeholder: '',
+              ariaLabel: 'Réponse 1',
+              defaultValue: '',
+            },
+            {
+              input: 'premiere-partie',
+              type: 'select',
+              display: 'inline',
+              placeholder: '',
+              ariaLabel: 'Réponse 2',
+              defaultValue: '',
+              options: [
+                {
+                  id: '1',
+                  content: "l'identifiant",
+                },
+                {
+                  id: '2',
+                  content: "le fournisseur d'adresse mail",
+                },
+              ],
+            },
+          ],
+          type: 'qrocm',
+          isAnswerable: true,
+        };
+        const grain = store.createRecord('grain', {
+          title: 'Grain title',
+          components: [{ type: 'element', element: qrocmElement }],
+        });
+        this.set('grain', grain);
+        const passage = store.createRecord('passage');
+        this.set('passage', passage);
+
+        // when
+        const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} @passage={{this.passage}} />`);
+
+        // then
+        assert.ok(screen);
+        assert.dom(screen.getByText('Mon instruction')).exists({ count: 1 });
+      });
+    });
+
+    module('when element is an image', function () {
+      test('should display image element', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const url =
+          'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg';
+        const imageElement = {
+          url,
+          alt: 'alt text',
+          alternativeText: 'alternative instruction',
+          type: 'image',
+        };
+        const grain = store.createRecord('grain', {
+          title: 'Grain title',
+          components: [{ type: 'element', element: imageElement }],
+        });
+        this.set('grain', grain);
+
+        // when
+        const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} />`);
+
+        // then
+        assert.ok(screen.getByRole('img', { name: 'alt text' }).hasAttribute('src', url));
+      });
+    });
+
+    module('when all elements are answered', function () {
+      test('should not display skip button', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
         const element = { id: 'qcu-id', type: 'qcu', isAnswerable: true };
         const grain = store.createRecord('grain', {
-          title: '1st Grain title',
+          title: 'Grain title',
           components: [{ type: 'element', element }],
         });
-        store.createRecord('module', { grains: [grain] });
         this.set('grain', grain);
         const passage = store.createRecord('passage');
         this.set('passage', passage);
@@ -304,122 +279,150 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
         // when
         const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
-
-        // then
-        assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists();
-      });
-    });
-    module('when canMoveToNextGrain is false', function () {
-      test('should not display continue button', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const element = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', {
-          title: '1st Grain title',
-          components: [{ type: 'element', element }],
-        });
-        store.createRecord('module', { grains: [grain] });
-        this.set('grain', grain);
-        const passage = store.createRecord('passage');
-        this.set('passage', passage);
-
-        // when
-        const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
-
-        // then
-        assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
-      });
-    });
-  });
-
-  module('when at least one element has not been answered', function () {
-    module('when canMoveToNextGrain is true', function () {
-      test('should not display continue button', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const element = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', {
-          title: 'Grain title',
-          components: [{ type: 'element', element }],
-        });
-        this.set('grain', grain);
-        const passage = store.createRecord('passage');
-        this.set('passage', passage);
-
-        // when
-        const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
-
-        // then
-        assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
-      });
-
-      test('should display skip button', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const element = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', {
-          title: '1st Grain title',
-          components: [{ type: 'element', element }],
-        });
-        store.createRecord('module', { grains: [grain] });
-        this.set('grain', grain);
-        const passage = store.createRecord('passage');
-        this.set('passage', passage);
-
-        // when
-        const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
-
-        // then
-        assert.dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') })).exists();
-      });
-    });
-
-    module('when canMoveToNextGrain is false', function () {
-      test('should not display continue button', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const element = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', {
-          title: 'Grain title',
-          components: [{ type: 'element', element }],
-        });
-        this.set('grain', grain);
-        const passage = store.createRecord('passage');
-        this.set('passage', passage);
-
-        // when
-        const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
-
-        // then
-        assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
-      });
-
-      test('should not display skip button', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const element = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', {
-          title: 'Grain title',
-          components: [{ type: 'element', element }],
-        });
-        store.createRecord('module', { grains: [grain] });
-        this.set('grain', grain);
-        const passage = store.createRecord('passage');
-        this.set('passage', passage);
-
-        // when
-        const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
+            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
 
         // then
         assert
           .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') }))
           .doesNotExist();
+      });
+
+      module('when canMoveToNextGrain is true', function () {
+        test('should display continue button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const element = { id: 'qcu-id', type: 'qcu', isAnswerable: true };
+          const grain = store.createRecord('grain', {
+            title: '1st Grain title',
+            components: [{ type: 'element', element }],
+          });
+          store.createRecord('module', { grains: [grain] });
+          this.set('grain', grain);
+          const passage = store.createRecord('passage');
+          this.set('passage', passage);
+
+          const correction = store.createRecord('correction-response');
+          store.createRecord('element-answer', { elementId: element.id, correction, passage });
+
+          // when
+          const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
+
+          // then
+          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists();
+        });
+      });
+      module('when canMoveToNextGrain is false', function () {
+        test('should not display continue button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const element = { type: 'qcu', isAnswerable: true };
+          const grain = store.createRecord('grain', {
+            title: '1st Grain title',
+            components: [{ type: 'element', element }],
+          });
+          store.createRecord('module', { grains: [grain] });
+          this.set('grain', grain);
+          const passage = store.createRecord('passage');
+          this.set('passage', passage);
+
+          // when
+          const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
+
+          // then
+          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+        });
+      });
+    });
+
+    module('when at least one element has not been answered', function () {
+      module('when canMoveToNextGrain is true', function () {
+        test('should not display continue button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const element = { type: 'qcu', isAnswerable: true };
+          const grain = store.createRecord('grain', {
+            title: 'Grain title',
+            components: [{ type: 'element', element }],
+          });
+          this.set('grain', grain);
+          const passage = store.createRecord('passage');
+          this.set('passage', passage);
+
+          // when
+          const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
+
+          // then
+          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+        });
+
+        test('should display skip button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const element = { type: 'qcu', isAnswerable: true };
+          const grain = store.createRecord('grain', {
+            title: '1st Grain title',
+            components: [{ type: 'element', element }],
+          });
+          store.createRecord('module', { grains: [grain] });
+          this.set('grain', grain);
+          const passage = store.createRecord('passage');
+          this.set('passage', passage);
+
+          // when
+          const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
+
+          // then
+          assert.dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') })).exists();
+        });
+      });
+
+      module('when canMoveToNextGrain is false', function () {
+        test('should not display continue button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const element = { type: 'qcu', isAnswerable: true };
+          const grain = store.createRecord('grain', {
+            title: 'Grain title',
+            components: [{ type: 'element', element }],
+          });
+          this.set('grain', grain);
+          const passage = store.createRecord('passage');
+          this.set('passage', passage);
+
+          // when
+          const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
+
+          // then
+          assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
+        });
+
+        test('should not display skip button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const element = { type: 'qcu', isAnswerable: true };
+          const grain = store.createRecord('grain', {
+            title: 'Grain title',
+            components: [{ type: 'element', element }],
+          });
+          store.createRecord('module', { grains: [grain] });
+          this.set('grain', grain);
+          const passage = store.createRecord('passage');
+          this.set('passage', passage);
+
+          // when
+          const screen = await render(hbs`
+              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
+
+          // then
+          assert
+            .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') }))
+            .doesNotExist();
+        });
       });
     });
   });

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -427,6 +427,28 @@ module('Integration | Component | Module | Grain', function (hooks) {
     });
   });
 
+  module('when component is a stepper', function () {
+    test('should display the stepper', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const textElement = {
+        content: 'element content',
+        type: 'text',
+        isAnswerable: false,
+      };
+      const grain = store.createRecord('grain', {
+        title: 'Grain title',
+        components: [{ type: 'stepper', steps: [{ elements: [textElement] }] }],
+      });
+
+      // when
+      const screen = await render(<template><ModuleGrain @grain={{grain}} /></template>);
+
+      // then
+      assert.ok(screen.getByText('element content'));
+    });
+  });
+
   module('when continueAction is called', function () {
     test('should call continueAction pass in argument', async function (assert) {
       // given

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -60,8 +60,8 @@ module('Integration | Component | Module | Passage', function (hooks) {
           element: nonExistingElement1,
         },
         {
-          type: 'element',
-          element: nonExistingElement2,
+          type: 'stepper',
+          steps: [{ elements: [nonExistingElement2] }],
         },
       ];
       const grain = store.createRecord('grain', { id: 'grainId1', components });

--- a/mon-pix/tests/integration/components/module/step_test.gjs
+++ b/mon-pix/tests/integration/components/module/step_test.gjs
@@ -56,4 +56,58 @@ module('Integration | Component | Module | Step', function (hooks) {
       assert.dom(screen.queryByRole('button', { name: 'Vérifier' })).exists();
     });
   });
+
+  module('unsupported element', function () {
+    module('when there is no supported elements', function () {
+      test('should not display a step', async function (assert) {
+        // given
+        const element = {
+          id: '768441a5-a7d6-4987-ada9-7253adafd842',
+          type: 'unknown',
+          content: 'content',
+        };
+        const step = {
+          elements: [element],
+        };
+
+        // when
+        const screen = await render(
+          <template><ModulixStep @step={{step}} @currentStep={{1}} @totalSteps={{4}} /></template>,
+        );
+
+        // then
+        assert.dom(screen.queryByText(element.content)).doesNotExist();
+        assert.dom(screen.queryByRole('heading', { name: 'Étape 1 sur 4', level: 3 })).doesNotExist();
+      });
+    });
+
+    module('when one of the elements is not supported', function () {
+      test('should not display this element', async function (assert) {
+        // given
+        const unknownElement = {
+          id: '768441a5-a7d6-4987-ada9-7253adafd842',
+          type: 'unknown',
+          content: 'content',
+        };
+        const textElement = {
+          id: 'd0690f26-978c-41c3-9a21-da931857739c',
+          content: 'Instruction',
+          type: 'text',
+        };
+        const step = {
+          elements: [unknownElement, textElement],
+        };
+
+        // when
+        const screen = await render(
+          <template><ModulixStep @step={{step}} @currentStep={{1}} @totalSteps={{4}} /></template>,
+        );
+
+        // then
+        assert.dom(screen.getByText(textElement.content)).exists();
+        assert.dom(screen.queryByText(unknownElement.content)).doesNotExist();
+        assert.dom(screen.getByRole('heading', { name: 'Étape 1 sur 4', level: 3 })).exists();
+      });
+    });
+  });
 });

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -222,6 +222,102 @@ module('Integration | Component | Module | Stepper', function (hooks) {
       });
     });
 
+    module('When stepper contains unsupported elements', function () {
+      module('When there is no supported elements in one step', function () {
+        test('should not display the Step', async function (assert) {
+          // given
+          const steps = [
+            {
+              elements: [
+                {
+                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                  type: 'unknown',
+                  content: 'content',
+                },
+              ],
+            },
+            {
+              elements: [
+                {
+                  id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                  type: 'text',
+                  content: '<p>Text 2</p>',
+                  isAnswerable: false,
+                },
+              ],
+            },
+          ];
+          function getLastCorrectionForElementStub() {}
+
+          const store = this.owner.lookup('service:store');
+          const passage = store.createRecord('passage');
+
+          // when
+          const screen = await render(
+            <template>
+              <ModulixStepper
+                @passage={{passage}}
+                @steps={{steps}}
+                @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
+              />
+            </template>,
+          );
+
+          // then
+          assert.strictEqual(screen.getAllByRole('heading', { level: 3 }).length, 1);
+          assert.dom(screen.getByRole('heading', { level: 3, name: 'Étape 1 sur 1' })).exists();
+          assert
+            .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.stepper.next') }))
+            .doesNotExist();
+        });
+      });
+
+      module('When there are no supported elements at all', function () {
+        test('should not display the Stepper', async function (assert) {
+          // given
+          const steps = [
+            {
+              elements: [
+                {
+                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                  type: 'unknown',
+                  content: 'content',
+                },
+              ],
+            },
+            {
+              elements: [
+                {
+                  id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                  type: 'unknown',
+                  content: '<p>Text 2</p>',
+                },
+              ],
+            },
+          ];
+          function getLastCorrectionForElementStub() {}
+
+          const store = this.owner.lookup('service:store');
+          const passage = store.createRecord('passage');
+
+          // when
+          const screen = await render(
+            <template>
+              <ModulixStepper
+                @passage={{passage}}
+                @steps={{steps}}
+                @getLastCorrectionForElement={{getLastCorrectionForElementStub}}
+              />
+            </template>,
+          );
+
+          // then
+          assert.strictEqual(screen.queryAllByRole('heading', { level: 3 }).length, 0);
+          assert.dom(screen.queryByRole('heading', { level: 3, name: 'Étape 1 sur 1' })).doesNotExist();
+        });
+      });
+    });
+
     module('When user clicks on the Next button', function () {
       test('should display the next step', async function (assert) {
         // given


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le `Stepper` est implémenté mais il ne s'affiche pas encore dans le _didacticiel_.

## :robot: Proposition
Implémenter la logique du `Grain` qui permette d'afficher un `Stepper`.

## :rainbow: Remarques
Il y a de la duplication dans le code (ex. le `ModuleGrain.AVAILABLE_ELEMENT_TYPES` utilisé dans 5 fichiers), mais on peut rester sur du _WET_ pour l'instant.

Côté `ComponentElement` on avait fait en sorte de ne pas avoir besoin de passer le `passage` en paramètre. Par simplicité, on l'a fourni dans `ComponentStepper` alors qu'on passe également `this.getLastCorrectionForElement` qui pourrait venir du passage. Il faudra par la suite simplifier ce contrat d'interface et essayer de l'aligner entre ces 2 composants.

## :100: Pour tester
Non-régression des modules hors _didacticiel_.

Dans le _didacticiel_, le premier grain contient un `Stepper` avec deux `Steps`.

- Vérifier que le bouton "_Suivant_" fonctionne (affichage du second `Step` et modification du titre "1/2" -> "2/2")
- Vérifier que le bouton "_Suivant_" disparaît quand on arrive au second `Step`.
- Vérifier que l'on arrive encore à naviguer dans le reste du _didacticiel_.
