### PR TITLE
[TECH] check autonomous course id presence (PIX-12938)

### DIFF
--- a/api/lib/infrastructure/validate-environment-variables.js
+++ b/api/lib/infrastructure/validate-environment-variables.js
@@ -28,6 +28,7 @@ const schema = Joi.object({
   AUTH_SECRET: Joi.string().required(),
   SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES: Joi.number().integer().min(1).optional(),
   NODE_ENV: Joi.string().optional().valid('development', 'test', 'production'),
+  AUTONOMOUS_COURSES_ORGANIZATION_ID: Joi.number().required(),
   FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE: Joi.string().optional().valid('true', 'false'),
   FT_ENABLE_PIX_PLUS_LOWER_LEVEL: Joi.string().optional().valid('true', 'false'),
   FT_ENABLE_TEXT_TO_SPEECH_BUTTON: Joi.string().optional().valid('true', 'false'),


### PR DESCRIPTION
## :unicorn: Problème
Rien ne signale l'absence de la variable d'environnement "AUTONOMOUS_COURSES_ORGANIZATION_ID" qui est pourtant nécessaire à la bonne marche de l'application. En découle frustrations, pleurs, cris et tsunamis.

## :robot: Proposition
Ajouter cette variable dans le schéma de validation. Le développeur sera averti si il lui manque la variable concernée.

## :100: Pour tester
Tenter de démarrer l'apli sans la variable d'env  "AUTONOMOUS_COURSES_ORGANIZATION_ID", vérifier la présence du message d'erreur concernant l'absence de ladite variable.
Vérifier que l'apli se lance correctement si cette variable est renseignée.