### PR TITLE
[BUGFIX] Afficher un message d'erreur lorsqu'une donnée n'est pas unique (Pix-12936)

### DIFF
--- a/orga/app/services/error-messages.js
+++ b/orga/app/services/error-messages.js
@@ -25,6 +25,7 @@ const CSV_IMPORT_ERRORS = {
   IDENTIFIER_UNIQUE: 'api-error-messages.student-csv-import.identifier-unique',
   INSEE_CODE_INVALID: 'api-error-messages.student-csv-import.insee-code-invalid',
   PAYLOAD_TOO_LARGE: 'api-error-messages.student-csv-import.payload-too-large',
+  PROPERTY_NOT_UNIQ: 'api-error-messages.csv-import.property-not-uniq',
   STUDENT_NUMBER_UNIQUE: 'api-error-messages.student-csv-import.student-number-unique',
   STUDENT_NUMBER_FORMAT: 'api-error-messages.student-csv-import.student-number-format',
 };

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -9,6 +9,9 @@
       "target-profile-required": "Please select a customised test for your campaign.",
       "title_too_long": "Please choose a shorter title."
     },
+    "csv-import": {
+      "property-not-uniq": "Row {line} : The field “{field}” must be unique within the file."
+    },
     "default": "The service is temporarily unavailable. Please try again later.",
     "edit-student-number": {
       "student-number-exists": "The student number entered is already used by {firstName} {lastName}"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -9,12 +9,16 @@
       "target-profile-required": "Veuillez sélectionner un parcours pour votre campagne.",
       "title_too_long": "Le titre de la campagne est trop long."
     },
+    "csv-import": {
+      "property-not-uniq": "Ligne {line} : Le champ “{field}” doit être unique au sein du fichier."
+    },
     "default": "Le service est momentanément indisponible. Veuillez réessayer ultérieurement.",
     "edit-student-number": {
       "student-number-exists": "Le numéro étudiant saisi est déjà utilisé par l’étudiant {firstName} {lastName}"
     },
     "global": "Une erreur est survenue. Veuillez réessayer ultérieurement.",
     "or-separator": " ou ",
+
     "student-csv-import": {
       "bad-csv-format": "Le fichier doit être au format csv avec séparateur virgule ou point-virgule.",
       "encoding-not-supported": "Encodage du fichier non supporté.",


### PR DESCRIPTION
## :unicorn: Problème
Lors d'un import ONDE avec des doublons d'INE, une erreur était effectivement remontée mais il n'y avait pas de texte explicatif.
<img width="1728" alt="Capture d’écran 2024-06-13 à 10 58 23" src="https://github.com/1024pix/pix/assets/35958509/3be3a7d0-a070-4a74-91bc-136f00173724">
Il manquait une traduction qui gérait ce cas.

## :robot: Proposition
Ajouter cette traduction

## :rainbow: Remarques


## :100: Pour tester
- aller sur pix orga avec le compte `1d-orga@example.net`
- Importer le fichier 'onde_ko_ine' dans le drive Pix junior et voir qu'on a bien l'erreur qui s'affiche