### PR TITLE
[TECH] Corriger un test flaky sur PixAdmin (PIX-12942)

### DIFF
--- a/admin/app/components/administration/add-organization-features-in-batch.js
+++ b/admin/app/components/administration/add-organization-features-in-batch.js
@@ -15,7 +15,7 @@ export default class AddOrganizationFeaturesInBatch extends Component {
 
     let response;
     try {
-      const fileContent = await readFileAsText(files[0]);
+      const fileContent = files[0];
 
       const token = this.session.data.authenticated.access_token;
       response = await window.fetch(`${ENV.APP.API_HOST}/api/admin/organizations/add-organization-features`, {
@@ -42,11 +42,3 @@ export default class AddOrganizationFeaturesInBatch extends Component {
     }
   }
 }
-
-const readFileAsText = (file) =>
-  new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = (event) => resolve(event.target.result);
-    reader.onerror = reject;
-    reader.readAsText(file);
-  });

--- a/admin/tests/integration/components/administration/update-organizations-in-batch_test.js
+++ b/admin/tests/integration/components/administration/update-organizations-in-batch_test.js
@@ -30,41 +30,24 @@ module('Integration | Component |  administration/update-organizations-in-batch'
     test('it displays a success notification', async function (assert) {
       // given
       window.fetch.resolves(fetchResponse({ status: 204 }));
-      const notificationSuccessStub = sinon.stub();
-      class NotificationsStub extends Service {
-        success = notificationSuccessStub;
-        clearAll = sinon.stub();
-      }
-      this.owner.register('service:notifications', NotificationsStub);
 
       // when
-      const screen = await render(hbs`<Administration::UpdateOrganizationsInBatch />`);
+      const screen = await render(hbs`<Administration::UpdateOrganizationsInBatch /><NotificationContainer />`);
       const input = await screen.getByLabelText(
         this.intl.t('components.administration.update-organizations-in-batch.upload-button'),
       );
       await triggerEvent(input, 'change', { files: [file] });
 
       // then
-      assert.ok(true);
-      sinon.assert.calledWith(
-        notificationSuccessStub,
-        this.intl.t('components.administration.update-organizations-in-batch.notifications.success'),
+      assert.ok(
+        await screen.findByText(
+          this.intl.t('components.administration.update-organizations-in-batch.notifications.success'),
+        ),
       );
     });
   });
 
-  module('when import fails', function (hooks) {
-    let notificationErrorStub;
-
-    hooks.beforeEach(function () {
-      notificationErrorStub = sinon.stub().returns();
-      class NotificationsStub extends Service {
-        error = notificationErrorStub;
-        clearAll = sinon.stub();
-      }
-      this.owner.register('service:notifications', NotificationsStub);
-    });
-
+  module('when import fails', function () {
     test('it displays an error when organization not found', async function (assert) {
       // given
       window.fetch.resolves(
@@ -77,15 +60,21 @@ module('Integration | Component |  administration/update-organizations-in-batch'
       );
 
       // when
-      const screen = await render(hbs`<Administration::UpdateOrganizationsInBatch />`);
+      const screen = await render(hbs`<Administration::UpdateOrganizationsInBatch /><NotificationContainer />`);
       const input = await screen.findByLabelText(
         this.intl.t('components.administration.update-organizations-in-batch.upload-button'),
       );
       await triggerEvent(input, 'change', { files: [file] });
 
       // then
-      assert.ok(true);
-      sinon.assert.calledWith(notificationErrorStub, 'Identifiant non trouvé pour l\'organisation "123".');
+      assert.ok(
+        await screen.findByText(
+          this.intl.t(
+            'components.administration.update-organizations-in-batch.notifications.errors.organization-not-found',
+            { organizationId: '123' },
+          ),
+        ),
+      );
     });
 
     test('it displays an error when parent organization not found', async function (assert) {
@@ -105,17 +94,20 @@ module('Integration | Component |  administration/update-organizations-in-batch'
       );
 
       // when
-      const screen = await render(hbs`<Administration::UpdateOrganizationsInBatch />`);
+      const screen = await render(hbs`<Administration::UpdateOrganizationsInBatch /><NotificationContainer />`);
       const input = await screen.findByLabelText(
         this.intl.t('components.administration.update-organizations-in-batch.upload-button'),
       );
       await triggerEvent(input, 'change', { files: [file] });
 
       // then
-      assert.ok(true);
-      sinon.assert.calledWith(
-        notificationErrorStub,
-        'L\'organisation parente de l\'organisation "123" non trouvée en base de données.',
+      assert.ok(
+        await screen.findByText(
+          this.intl.t(
+            'components.administration.update-organizations-in-batch.notifications.errors.parent-organization-not-found',
+            { organizationId: '123' },
+          ),
+        ),
       );
     });
 
@@ -136,17 +128,20 @@ module('Integration | Component |  administration/update-organizations-in-batch'
       );
 
       // when
-      const screen = await render(hbs`<Administration::UpdateOrganizationsInBatch />`);
+      const screen = await render(hbs`<Administration::UpdateOrganizationsInBatch /><NotificationContainer />`);
       const input = await screen.findByLabelText(
         this.intl.t('components.administration.update-organizations-in-batch.upload-button'),
       );
       await triggerEvent(input, 'change', { files: [file] });
 
       // then
-      assert.ok(true);
-      sinon.assert.calledWith(
-        notificationErrorStub,
-        'Le format de l\'email du DPO est incorrect "foo" pour l\'organisation "123".',
+      assert.ok(
+        await screen.findByText(
+          this.intl.t(
+            'components.administration.update-organizations-in-batch.notifications.errors.data-protection-email-invalid',
+            { organizationId: '123', value: 'foo' },
+          ),
+        ),
       );
     });
 
@@ -162,15 +157,21 @@ module('Integration | Component |  administration/update-organizations-in-batch'
       );
 
       // when
-      const screen = await render(hbs`<Administration::UpdateOrganizationsInBatch />`);
+      const screen = await render(hbs`<Administration::UpdateOrganizationsInBatch /><NotificationContainer />`);
       const input = await screen.findByLabelText(
         this.intl.t('components.administration.update-organizations-in-batch.upload-button'),
       );
       await triggerEvent(input, 'change', { files: [file] });
 
       // then
-      assert.ok(true);
-      sinon.assert.calledWith(notificationErrorStub, 'Une erreur s\'est produite sur l\'organisation "123".');
+      assert.ok(
+        await screen.findByText(
+          this.intl.t(
+            'components.administration.update-organizations-in-batch.notifications.errors.organization-batch-update-error',
+            { organizationId: '123' },
+          ),
+        ),
+      );
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Nous avons un test d'intégration qui est flaky : 
`Integration | Component |  administration/add-organization-features-in-batch > when import fails: it displays an error notification`

## :robot: Proposition
Corriger le flaky. 

**Explication :** 

Notre manière d'écrire les tests de notifications ne permettent pas d'attendre que le traitement a bien été effectué. Le résultat est que la plupart du temps quand l'assertion est jouée le traitement est terminé, mais par moment ça n'est pas le cas rendant le test flaky. Le seul moyen d'attendre que le traitement soit vraiment fini est d'utiliser testing library avec un **find** qui va vérifier que la notification est bien apparue à l'écran.

La nouvelle implémentation de ces tests en plus de ne plus être flaky est aussi moins verbeuse (moins de lignes de code et pas de stubs) et permet de vérifier vraiment ce que voit l'utilisateur.

## :rainbow: Remarques

Pour essayer de voir si on corrigeait le flaky avec notre fix on a lancer une commande dans un terminal pour faire une boucle de 100 itérations qui jouait le test à chaque fois : 
La boucle : `for i in {1..100}; do COMMANDE_ICI; done`
Lancer un test spécifique : `npm run test --module 'NOM_DU_MODULE_A_TESTER'`

Ce qui nous donne dans notre exemple : 
`for i in {1..100}; do npm run test --module 'Integration | Component |  administration/add-organization-features-in-batch'; done`

## :100: Pour tester
Les tests passent 👍 
🐈‍⬛ 
