### PR TITLE
[BUGFIX] Tourner sur les déclinaisons entre 2 passages d'une épreuve

### DIFF
--- a/api/src/school/domain/models/Activity.js
+++ b/api/src/school/domain/models/Activity.js
@@ -71,7 +71,7 @@ class Activity {
     return levels.TRAINING;
   }
 
-  isLevel(level) {
+  hasLevel(level) {
     return this.level === level;
   }
 }

--- a/api/src/school/domain/models/Activity.js
+++ b/api/src/school/domain/models/Activity.js
@@ -74,6 +74,10 @@ class Activity {
   hasLevel(level) {
     return this.level === level;
   }
+
+  hasStepIndex(stepIndex) {
+    return this.stepIndex === stepIndex;
+  }
 }
 
 Activity.levels = levels;

--- a/api/src/school/domain/services/challenge.js
+++ b/api/src/school/domain/services/challenge.js
@@ -2,6 +2,7 @@ export const challengeService = { getAlternativeVersion };
 
 function getAlternativeVersion({ mission, activities, activityInfo }) {
   const alreadyPlayedAlternativeVersions = activities
+    .filter((activity) => activity.hasStepIndex(activityInfo.stepIndex))
     .filter((activity) => activity.hasLevel(activityInfo.level))
     .map((activity) => activity.alternativeVersion);
 

--- a/api/src/school/domain/services/challenge.js
+++ b/api/src/school/domain/services/challenge.js
@@ -2,7 +2,7 @@ export const challengeService = { getAlternativeVersion };
 
 function getAlternativeVersion({ mission, activities, activityInfo }) {
   const alreadyPlayedAlternativeVersions = activities
-    .filter((activity) => activity.isLevel(activityInfo.level))
+    .filter((activity) => activity.hasLevel(activityInfo.level))
     .map((activity) => activity.alternativeVersion);
 
   const activityChallengeIds = mission.getChallengeIds(activityInfo);

--- a/api/src/school/domain/services/get-next-activity-info.js
+++ b/api/src/school/domain/services/get-next-activity-info.js
@@ -96,7 +96,7 @@ function _getNextActivityInfoOnFailure(activities, lastActivity) {
 }
 
 function _nbOfActivitiesOfLevel(activities, level) {
-  return activities.filter((activity) => activity.isLevel(level)).length;
+  return activities.filter((activity) => activity.hasLevel(level)).length;
 }
 
 function _hasAlreadyDoneActivity(activities, level) {

--- a/api/tests/school/unit/domain/models/Activity_test.js
+++ b/api/tests/school/unit/domain/models/Activity_test.js
@@ -59,11 +59,11 @@ describe('Unit | domain | Activity', function () {
     context('when level is TUTORIAL', function () {
       it('return true', function () {
         const activity = new Activity({ level: 'TUTORIAL' });
-        expect(activity.isLevel(Activity.levels.TUTORIAL)).to.be.true;
+        expect(activity.hasLevel(Activity.levels.TUTORIAL)).to.be.true;
       });
       it('return false', function () {
         const activity = new Activity({ level: 'VALIDATION' });
-        expect(activity.isLevel(Activity.levels.TUTORIAL)).to.be.false;
+        expect(activity.hasLevel(Activity.levels.TUTORIAL)).to.be.false;
       });
     });
   });

--- a/api/tests/school/unit/domain/services/challenge_test.js
+++ b/api/tests/school/unit/domain/services/challenge_test.js
@@ -8,7 +8,7 @@ describe('Unit | Service | Challenge', function () {
     describe('when the first challenge has multiple alternative versions', function () {
       context('when there is not any already played alternative versions', function () {
         it('returns a version randomly between all alternative versions', async function () {
-          const activities = [new Activity({ level: Activity.levels.VALIDATION, alternativeVersion: 1 })];
+          const activities = [new Activity({ level: Activity.levels.VALIDATION, stepIndex: 0, alternativeVersion: 1 })];
           const mission = domainBuilder.buildMission({
             content: {
               steps: [{ trainingChallenges: [['challenge-id-alt1', 'challenge-id-alt2', 'challenge-id-alt3']] }],
@@ -27,7 +27,7 @@ describe('Unit | Service | Challenge', function () {
       });
       context('when there is an already played alternative version', function () {
         it('returns a version randomly between remaining alternative versions', async function () {
-          const activities = [new Activity({ level: Activity.levels.TRAINING, alternativeVersion: 0 })];
+          const activities = [new Activity({ level: Activity.levels.TRAINING, stepIndex: 0, alternativeVersion: 0 })];
           const mission = domainBuilder.buildMission({
             content: {
               steps: [{ trainingChallenges: [['challenge-id-alt1', 'challenge-id-alt2', 'challenge-id-alt3']] }],
@@ -39,17 +39,35 @@ describe('Unit | Service | Challenge', function () {
             mission,
             activityInfo: new ActivityInfo({ stepIndex: 0, level: Activity.levels.TRAINING }),
             activities,
-            stepIndex: 0,
           });
 
           expect(result).to.equal(2);
         });
       });
+      context('when there is an already played alternative version in another step', function () {
+        it('ignores other steps already played versions and returns a version randomly between all alternative versions', async function () {
+          const activities = [new Activity({ level: Activity.levels.TRAINING, stepIndex: 0, alternativeVersion: 0 })];
+          const mission = domainBuilder.buildMission({
+            content: {
+              steps: [{}, { trainingChallenges: [['challenge-id-alt1', 'challenge-id-alt2', 'challenge-id-alt3']] }],
+            },
+          });
+
+          sinon.stub(Math, 'random').returns(0.6);
+          const result = challengeService.getAlternativeVersion({
+            mission,
+            activityInfo: new ActivityInfo({ stepIndex: 1, level: Activity.levels.TRAINING }),
+            activities,
+          });
+
+          expect(result).to.equal(1);
+        });
+      });
       context('when there are already played alternative versions', function () {
         it('returns a version randomly between remaining alternative versions', async function () {
           const activities = [
-            new Activity({ level: Activity.levels.TRAINING, alternativeVersion: 1 }),
-            new Activity({ level: Activity.levels.TRAINING, alternativeVersion: 2 }),
+            new Activity({ level: Activity.levels.TRAINING, stepIndex: 0, alternativeVersion: 1 }),
+            new Activity({ level: Activity.levels.TRAINING, stepIndex: 0, alternativeVersion: 2 }),
           ];
           const mission = domainBuilder.buildMission({
             content: {
@@ -85,7 +103,6 @@ describe('Unit | Service | Challenge', function () {
             mission,
             activityInfo: new ActivityInfo({ stepIndex: 0, level: Activity.levels.TRAINING }),
             activities,
-            stepIndex: 0,
           });
 
           expect(result).to.equal(1);
@@ -96,7 +113,7 @@ describe('Unit | Service | Challenge', function () {
     describe('when the first challenge has has one version and the second has multiple', function () {
       context('when there is not any already played alternative versions', function () {
         it('returns a version randomly between all alternative versions of the 2nd challenge', async function () {
-          const activities = [new Activity({ level: Activity.levels.VALIDATION, alternativeVersion: 1 })];
+          const activities = [new Activity({ level: Activity.levels.VALIDATION, stepIndex: 0, alternativeVersion: 1 })];
           const mission = domainBuilder.buildMission({
             content: {
               steps: [
@@ -121,7 +138,7 @@ describe('Unit | Service | Challenge', function () {
       });
       context('when there is an already played alternative version', function () {
         it('returns a version randomly between remaining alternative versions of the 2nd challenge', async function () {
-          const activities = [new Activity({ level: Activity.levels.TRAINING, alternativeVersion: 0 })];
+          const activities = [new Activity({ level: Activity.levels.TRAINING, stepIndex: 0, alternativeVersion: 0 })];
           const mission = domainBuilder.buildMission({
             content: {
               steps: [
@@ -147,8 +164,8 @@ describe('Unit | Service | Challenge', function () {
       context('when there are already played alternative versions', function () {
         it('returns a version randomly between remaining alternative versions', async function () {
           const activities = [
-            new Activity({ level: Activity.levels.TRAINING, alternativeVersion: 1 }),
-            new Activity({ level: Activity.levels.TRAINING, alternativeVersion: 2 }),
+            new Activity({ level: Activity.levels.TRAINING, stepIndex: 0, alternativeVersion: 1 }),
+            new Activity({ level: Activity.levels.TRAINING, stepIndex: 0, alternativeVersion: 2 }),
           ];
           const mission = domainBuilder.buildMission({
             content: {
@@ -176,9 +193,9 @@ describe('Unit | Service | Challenge', function () {
       context('when all alternative versions have already been played', function () {
         it('returns a version randomly between all alternative versions', async function () {
           const activities = [
-            new Activity({ level: Activity.levels.TRAINING, alternativeVersion: 0 }),
-            new Activity({ level: Activity.levels.TRAINING, alternativeVersion: 1 }),
-            new Activity({ level: Activity.levels.TRAINING, alternativeVersion: 2 }),
+            new Activity({ level: Activity.levels.TRAINING, stepIndex: 0, alternativeVersion: 0 }),
+            new Activity({ level: Activity.levels.TRAINING, stepIndex: 0, alternativeVersion: 1 }),
+            new Activity({ level: Activity.levels.TRAINING, stepIndex: 0, alternativeVersion: 2 }),
           ];
           const mission = domainBuilder.buildMission({
             content: {


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'on joue pour la 2ème fois une épreuve Pix Junior (même étape, même activité et même numéro d'épreuve), une autre déclinaison (ou le proto si on a joué une déclinaison) devrait nous être proposée. Ce n'est pas le cas actuellement.

## :robot: Proposition
Prendre en compte l'étape dans la recherche des alternatives déjà jouées.

## :100: Pour tester
Jouer plusieurs fois la mission Données personnelles en descendant à l'entraînement pour chacune : 
- Sur les épreuves de validations de la 2ème étape : on a les déclinaisons correspondantes sur va1 / va2 (Benjamin ou Leïla)
- On a systématiquement une décli différentes entre 2 jeu de la même activité de validation (et même étape) sur le même passage
- On n'a pas systématiquement la même décli proposée en 1er lors de 2 passages différents.