### PR TITLE
[BUGFIX] Fix transaction et updateAt dans le repo organization-for-admin

### DIFF
--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -67,7 +67,7 @@ const findChildrenByParentOrganizationId = async function (parentOrganizationId)
  * @return {Promise<OrganizationForAdmin|NotFoundError>}
  */
 const get = async function (id, domainTransaction = DomainTransaction.emptyTransaction()) {
-  const knexConn = domainTransaction.transaction ?? knex;
+  const knexConn = domainTransaction.knexTransaction ?? knex;
   const organization = await knexConn(ORGANIZATIONS_TABLE_NAME)
     .select({
       id: 'organizations.id',
@@ -161,7 +161,7 @@ const save = async function (organization) {
  * @return {Promise<void>}
  */
 const update = async function (organization, domainTransaction = DomainTransaction.emptyTransaction()) {
-  const knexConn = domainTransaction.transaction ?? knex;
+  const knexConn = domainTransaction.knexTransaction ?? knex;
   const organizationRawData = _.pick(organization, [
     'credit',
     'documentationUrl',

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -185,7 +185,9 @@ const update = async function (organization, domainTransaction = DomainTransacti
   await _addTags(knexConn, organization.tagsToAdd);
   await _removeTags(knexConn, organization.tagsToRemove);
 
-  await knexConn(ORGANIZATIONS_TABLE_NAME).update(organizationRawData).where({ id: organization.id });
+  await knexConn(ORGANIZATIONS_TABLE_NAME)
+    .update({ ...organizationRawData, updatedAt: new Date() })
+    .where({ id: organization.id });
 };
 
 /**

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -527,6 +527,7 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       // then
       const updatedOrganization = await knex('organizations').where({ id: childOrganization.id }).first();
       expect(updatedOrganization.parentOrganizationId).to.equal(parentOrganizationId);
+      expect(updatedOrganization.updatedAt).to.deep.equal(new Date('2022-02-02'));
     });
 
     it('should enable feature', async function () {


### PR DESCRIPTION
## :unicorn: Problème

La mise à jour d'organisation en masse n'est pas transactionnelle. Si une ligne du CSV comporte une erreur, les lignes précédentes ont été appliquées. On souhaite que l'opération soit transactionnelle.

La mise à jour en masse des organisations est bien transactionnelle, **le problème est uniquement sur la mise à jour** en masse d'organisations.

De plus, le champ `updatedAt` n'est pas mis à jour quand l'update de l'organisation en masse est réalisé.

## :robot: Proposition

Le repository `organization-for-admin.update` n'utilisait pas la transaction du domaine.

## :rainbow: Remarques

N/A

## :100: Pour tester

⚠️ **Modifiez les noms des organisations dans les fichiers (car il est possible que quelqu'un ait déjà appliqué la modif sur la RA)**

1. Se connecter sur Pix Admin en tant que superadmin
2. Aller sur "Administration" > "Mise à jour des organisations en masse"
3. Charger le fichier:
```
Organization ID,Organization Name,Organization External ID,Organization Parent ID,Organization Identity Provider Code,Organization Documentation URL,Organization Province Code,DPO Last Name,DPO First Name,DPO E-mail
1000,Organisation 1,,,,,,,,
1001,Organisation 2,,,,,,,,blablabla
```
> Aucune des organisations n'est mise à jour, car il y a une erreur sur la seconde orga

4. Charger le fichier:
```
Organization ID,Organization Name,Organization External ID,Organization Parent ID,Organization Identity Provider Code,Organization Documentation URL,Organization Province Code,DPO Last Name,DPO First Name,DPO E-mail
1000,Organisation 1,,,,,,,,
1001,Organisation 2,,,,,,,,
```
> Les 2 organisations sont bien modifiées et la date de mise à jour est modifiée.