### PR TITLE
[FEATURE] Changement de traduction pour informer de l'activation de session (Pix-12728)

### DIFF
--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -838,7 +838,7 @@
             "info": "from Onde (exportable file in the menu Lists & documents > Extractions > School pupils or their supervisor)."
           },
           "copypaste-container": {
-            "abstract": "Start your missions with your students by using this ",
+            "abstract": "Start your missions with your students by activating a session with the above button and using this ",
             "button": {
               "success": "copied !",
               "tooltip": "copy link"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -838,7 +838,7 @@
             "info": " depuis Onde (fichier exportable dans le menu Listes & documents > Extractions > Élèves de l’école ou leur responsable)."
           },
           "copypaste-container": {
-            "abstract": "Démarrez vos premières missions avec vos élèves en utilisant le",
+            "abstract": "Démarrez vos premières missions avec vos élèves en activant la session via le bouton ci-dessus et en utilisant le",
             "button": {
               "success": "copié !",
               "tooltip": "copier le lien"


### PR DESCRIPTION
## :unicorn: Problème
Le text dans la bannière n'était plus adapté. L'activation de session n'était point documentée.

## :robot: Proposition
Changer les traductions.

## :rainbow: Remarques
Le sens de lecture reste bizarre.

## :100: Pour tester
Se connecter a la RA puis vérifier que que le text informe de l'existence de l'activation de session.