### PR TITLE
[BUGFIX] Corrige un flaky sur l'import d'OIDC provider

### DIFF
--- a/admin/app/components/administration/oidc-providers-import.js
+++ b/admin/app/components/administration/oidc-providers-import.js
@@ -15,7 +15,7 @@ export default class OidcProvidersImport extends Component {
 
     let response;
     try {
-      const fileContent = await readFileAsText(files[0]);
+      const fileContent = files[0];
 
       const token = this.session.data.authenticated.access_token;
       response = await fetch(`${ENV.APP.API_HOST}/api/admin/oidc-providers/import`, {
@@ -49,11 +49,3 @@ export default class OidcProvidersImport extends Component {
     }
   }
 }
-
-const readFileAsText = (file) =>
-  new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = (event) => resolve(event.target.result);
-    reader.onerror = reject;
-    reader.readAsText(file);
-  });

--- a/admin/tests/integration/components/administration/oidc-providers-import_test.js
+++ b/admin/tests/integration/components/administration/oidc-providers-import_test.js
@@ -1,14 +1,12 @@
 import { render } from '@1024pix/ember-testing-library';
-import Service from '@ember/service';
 import { triggerEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { module, test } from 'qunit';
-import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
-module('Integration | Component |  administration/oidc-providers-import', function (hooks) {
+module('Integration | Component | administration/oidc-providers-import', function (hooks) {
   setupIntlRenderingTest(hooks);
   setupMirage(hooks);
 
@@ -17,26 +15,18 @@ module('Integration | Component |  administration/oidc-providers-import', functi
       // given
       this.server.post('/admin/oidc-providers/import', () => new Response(204));
       const file = new Blob(['foo'], { type: `valid-file` });
-      const notificationSuccessStub = sinon.stub();
-      class NotificationsStub extends Service {
-        clearAll = sinon.stub();
-        success = notificationSuccessStub;
-      }
-      this.owner.register('service:notifications', NotificationsStub);
 
       // when
-      const screen = await render(hbs`<Administration::OidcProvidersImport />`);
+      const screen = await render(hbs`<Administration::OidcProvidersImport /><NotificationContainer />`);
       const input = await screen.findByLabelText(
         this.intl.t('components.administration.oidc-providers-import.upload-button'),
       );
       await triggerEvent(input, 'change', { files: [file] });
 
       // then
-      sinon.assert.calledWith(
-        notificationSuccessStub,
-        this.intl.t('components.administration.oidc-providers-import.notifications.success'),
+      assert.ok(
+        await screen.findByText(this.intl.t('components.administration.oidc-providers-import.notifications.success')),
       );
-      assert.ok(true);
     });
   });
 
@@ -54,22 +44,16 @@ module('Integration | Component |  administration/oidc-providers-import', functi
         400,
       );
       const file = new Blob(['foo'], { type: `invalid-file` });
-      const notificationErrorStub = sinon.stub().returns();
-      class NotificationsStub extends Service {
-        error = notificationErrorStub;
-        clearAll = sinon.stub();
-      }
-      this.owner.register('service:notifications', NotificationsStub);
 
       // when
-      const screen = await render(hbs`<Administration::OidcProvidersImport />`);
+      const screen = await render(hbs`<Administration::OidcProvidersImport /><NotificationContainer />`);
       const input = await screen.findByLabelText(
         this.intl.t('components.administration.oidc-providers-import.upload-button'),
       );
       await triggerEvent(input, 'change', { files: [file] });
 
       // then
-      assert.ok(notificationErrorStub.called);
+      assert.ok(await screen.findByText(this.intl.t('common.notifications.generic-error')));
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Les tests d'import de l'OIDC providers sont flaky:
```
<testcase classname="Chrome 126.0" name="Exam Partition 2 - Integration | Component |  administration/oidc-providers-import &gt; when import succeeds: it displays a success notification" time="0.193"><error message="Promise rejected during &quot;it displays a success notification&quot;: expected stub to be called with arguments "><![CDATA[Source:
AssertError: expected stub to be called with arguments 
    at Object.fail (http://localhost:4203/assets/chunk.522be314b7d716dc423a.js:78843:378)
    at failAssertion (http://localhost:4203/assets/chunk.522be314b7d716dc423a.js:78844:2105)
    at assert.<computed> [as calledWith] (http://localhost:4203/assets/chunk.522be314b7d716dc423a.js:78844:2529)
    at Object.<anonymous> (http://localhost:4203/assets/chunk.522be314b7d716dc423a.js:12866:60)]]></error></testcase>
```

## :robot: Proposition

Corriger le flaky sur le même principe que [cette PR](https://github.com/1024pix/pix/pull/9253) (car même cause de flakyness)

## :rainbow: Remarques

N/A

## :100: Pour tester

1. Se connecter en tant que superadmin sur Pix Admin
2. Aller sur "Administration" > "Import d'OIDC providers"
3. Importer un fichier JSON du type: 

```
[
    {
        "identityProvider": "GAGACONNECT",
        "organizationName": "Gaga Connect",
        "scope": "openid profile email",
        "slug": "gaga-connect",
        "source": "gagaconnect",
        "clientId": "CLIENT_ID",
        "clientSecret": "CLIENT_SECRET",
        "accessTokenLifespan": "4h",
        "claimsToStore": "email",
        "enabled": true,
        "enabledForPixAdmin": false,
        "openidConfigurationUrl": "https://gaga.example.net/.well-known/openid-configuration",
        "redirectUri": "https://app.dev.pix.org/connexion/gaga-connect"
    }
]
```
