### PR TITLE
[FEATURE] Ajouter un cadre autour des média des épreuves (Pix-12894) 

### DIFF
--- a/junior/app/pods/components/challenge/challenge-actions/challenge-actions.scss
+++ b/junior/app/pods/components/challenge/challenge-actions/challenge-actions.scss
@@ -1,7 +1,7 @@
 .challenge-actions {
   display: flex;
   justify-content: space-between;
-  margin: 16px auto;
+  margin: var(--pix-spacing-8x) auto;
 
   button:only-child {
     margin-left: auto;

--- a/junior/app/pods/components/challenge/item/challenge-item.scss
+++ b/junior/app/pods/components/challenge/item/challenge-item.scss
@@ -16,6 +16,10 @@
   &__media {
     width: 60%;
     margin-right: var(--pix-spacing-6x);
+    padding: var(--pix-spacing-4x);
+    background-color: var(--pix-neutral-0);
+    border-radius: 24px;
+    box-shadow: 0 0 1px 0 var(--pix-primary-500), 8px 8px 32px -8px rgb(63 125 216 / 35%);
 
     &--single-display {
       width: unset;

--- a/junior/app/pods/components/challenge/item/challenge-item.scss
+++ b/junior/app/pods/components/challenge/item/challenge-item.scss
@@ -37,7 +37,6 @@
 
   &__qrocm {
     align-items: center;
-    padding: 20px 20px;
   }
 
   &__qcm, &__qcu {

--- a/junior/app/pods/components/challenge/item/component.js
+++ b/junior/app/pods/components/challenge/item/component.js
@@ -2,10 +2,10 @@ import Component from '@glimmer/component';
 
 export default class Item extends Component {
   get isMediaWithForm() {
-    return this.args.challenge.hasForm && this.#hasMedia;
+    return this.args.challenge.hasForm && this.hasMedia;
   }
 
-  get #hasMedia() {
+  get hasMedia() {
     return this.args.challenge.illustrationUrl || this.args.challenge.hasValidEmbedDocument;
   }
 }

--- a/junior/app/pods/components/challenge/item/template.hbs
+++ b/junior/app/pods/components/challenge/item/template.hbs
@@ -1,21 +1,23 @@
 <div class="challenge-item {{unless this.isMediaWithForm 'challenge-item--single-display'}}">
-  <div class="challenge-item__media {{unless this.isMediaWithForm 'challenge-item__media--single-display'}}">
-    {{#if @challenge.illustrationUrl}}
-      <div class="challenge-item__image">
-        <Challenge::ChallengeIllustration @src={{@challenge.illustrationUrl}} @alt={{@challenge.illustrationAlt}} />
-      </div>
-    {{/if}}
-    {{#if @challenge.hasValidEmbedDocument}}
-      <div class="challenge-item__embed">
-        <Challenge::ChallengeEmbedSimulator
-          @url={{@challenge.embedUrl}}
-          @title={{@challenge.embedTitle}}
-          @height={{@challenge.embedHeight}}
-          @hideSimulator={{@isDisabled}}
-        />
-      </div>
-    {{/if}}
-  </div>
+  {{#if this.hasMedia}}
+    <div class="challenge-item__media {{unless this.isMediaWithForm 'challenge-item__media--single-display'}}">
+      {{#if @challenge.illustrationUrl}}
+        <div class="challenge-item__image">
+          <Challenge::ChallengeIllustration @src={{@challenge.illustrationUrl}} @alt={{@challenge.illustrationAlt}} />
+        </div>
+      {{/if}}
+      {{#if @challenge.hasValidEmbedDocument}}
+        <div class="challenge-item__embed">
+          <Challenge::ChallengeEmbedSimulator
+            @url={{@challenge.embedUrl}}
+            @title={{@challenge.embedTitle}}
+            @height={{@challenge.embedHeight}}
+            @hideSimulator={{@isDisabled}}
+          />
+        </div>
+      {{/if}}
+    </div>
+  {{/if}}
   <div class="challenge-item__proposals {{unless this.isMediaWithForm 'challenge-item__proposals--single-display'}}">
     {{#if @challenge.autoReply}}
       <div class="challenge-item__autoreply">

--- a/junior/app/styles/app.scss
+++ b/junior/app/styles/app.scss
@@ -16,7 +16,7 @@ body {
   font-weight: 600;
   font-family: $font-nunito;
   text-align: center;
-  background: rgb(var(--pix-primary-50) 0.2);
+  background: rgba(236 242 251 / 20%);
 }
 
 b {


### PR DESCRIPTION
## :unicorn: Problème
On a des épreuves avec des embed et/ou des illustrations. Sauf qu'elles ne ressortent pas trop à coté des inputs de réponses.
Avant
![Capture d’écran 2024-06-14 à 14 30 43](https://github.com/1024pix/pix/assets/35958509/7fdaf874-589d-4599-bc6d-526e9e0d163f)

## :robot: Proposition
Mettre en valeur les médias.
![Capture d’écran 2024-06-14 à 14 31 34](https://github.com/1024pix/pix/assets/35958509/4dfd3cbf-0765-40c1-a8a1-bd691801190e)


## :rainbow: Remarques
BSR: 
- Correction de la couleur de background de la page.
- Correction de l'espace entre un QROC et un média.

## :100: Pour tester
- Aller sur Pix junior et commencer une mission et admirer le beau cadre