### PR TITLE
[FEATURE] Afficher une étiquette "Version Bêta" sur la page d'accueil de Pix Junior (PIX-12954)

### DIFF
--- a/junior/app/pods/organization-code/home.scss
+++ b/junior/app/pods/organization-code/home.scss
@@ -1,11 +1,18 @@
 @import '../../styles/globals/fonts';
 
+
 .school-code {
   display: flex;
   flex-direction: column;
-  margin-top: 120px;
+  margin-top: 100px;
 
   p, label {
+    width: fit-content;
+  }
+
+  &__welcome-with-bubble {
+    display: flex;
+    flex-direction: column;
     width: fit-content;
   }
 
@@ -28,6 +35,32 @@
   &__input {
     font-family: $font-nunito;
     text-transform: uppercase;
+  }
+
+  &__rotated-bubble {
+    align-self: flex-end;
+    width: fit-content;
+    height: fit-content;
+    margin-bottom: 30px;
+    padding: 12px 24px;
+    color: var(--pix-neutral-0);
+    font-size: 1.5rem;
+    text-align: left;
+    background-color: var(--pix-primary-500);
+    border-radius: 16px;
+    transform: rotate(-8deg);
+
+    &::after {
+      position: absolute;
+      bottom: -14px;
+      left: 20px;
+      display: block;
+      width: 0;
+      border-color: transparent var(--pix-primary-500);
+      border-style: solid;
+      border-width: 0px 0px 15px 25px;
+      content: "";
+    }
   }
 
   .pix1d-button {

--- a/junior/app/pods/organization-code/template.hbs
+++ b/junior/app/pods/organization-code/template.hbs
@@ -1,7 +1,10 @@
 {{page-title (t "pages.home.page-title")}}
 
 <form onSubmit={{this.goToSchool}} class="school-code">
-  <p class="school-code__welcome">{{t "pages.home.welcome"}}</p>
+  <div class="school-code__welcome-with-bubble">
+    <div class="school-code__rotated-bubble">{{t "pages.home.beta"}}</div>
+    <p class="school-code__welcome">{{t "pages.home.welcome"}}</p>
+  </div>
   <p class="school-code__instructions">{{t "pages.home.code-instruction"}}</p>
   <label for="organization-code" class="school-code__label">{{t "pages.home.code-label"}}</label>
   <PixInputCode

--- a/junior/translations/fr.json
+++ b/junior/translations/fr.json
@@ -20,6 +20,7 @@
     },
     "home": {
       "page-title": "Page d'accueil",
+      "beta": "Version Bêta",
       "welcome": "Bienvenue sur Pix Junior !",
       "code-instruction": "Saisis le code de ton école pour accéder à ta classe",
       "code-label": "Code de l'école",


### PR DESCRIPTION
## :unicorn: Problème
Pour le séminaire et le lancement en septembre de Pix Junior, rien n'indique que la version mise à disposition est une bêta.

## :robot: Proposition
Ajouter une étiquette sur la page d'accueil pour indiquer que Pix Junior est une bêta pour le moment.

## :100: Pour tester
Aller sur la page d'accueil de Pix Junior. Un message indique qu'il s'agit d'une version Bêta.
![maquette](https://github.com/1024pix/pix/assets/118176432/6c99e435-f83f-44ad-bc01-5aeffa5b149a)
