### PR TITLE
[TECH] Mettre a jour ember-source en 5.8.0 sur PixAdmin (PIX-12963)

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -61,7 +61,7 @@
         "ember-qunit": "^8.0.0",
         "ember-resolver": "^11.0.0",
         "ember-simple-auth": "^6.0.0",
-        "ember-source": "~4.12.0",
+        "ember-source": "^5.0.0",
         "ember-template-imports": "^4.1.1",
         "ember-template-lint": "^6.0.0",
         "ember-template-lint-plugin-prettier": "^5.0.0",
@@ -33205,15 +33205,15 @@
       }
     },
     "node_modules/ember-source": {
-      "version": "4.12.4",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-5.0.0.tgz",
+      "integrity": "sha512-zy0iU3Mf9HZXVQacqWLAfHCbQge8Ysi2EpU6XTgrdf2PX5ILdWTbSPklxuTlkGV7NrG5PkIfGW8hfimwY6I/tw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
         "@babel/plugin-transform-block-scoping": "^7.20.5",
         "@ember/edition-utils": "^1.2.0",
         "@glimmer/vm-babel-plugins": "0.84.2",
-        "@simple-dom/interface": "^1.4.0",
         "babel-plugin-debug-macros": "^0.3.4",
         "babel-plugin-filter-imports": "^4.0.0",
         "broccoli-concat": "^4.2.5",
@@ -33238,7 +33238,7 @@
         "silent-error": "^1.1.1"
       },
       "engines": {
-        "node": ">= 14.*"
+        "node": ">= 16.*"
       },
       "peerDependencies": {
         "@glimmer/component": "^1.1.2"

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -61,7 +61,7 @@
         "ember-qunit": "^8.0.0",
         "ember-resolver": "^11.0.0",
         "ember-simple-auth": "^6.0.0",
-        "ember-source": "^5.0.0",
+        "ember-source": "^5.8.0",
         "ember-template-imports": "^4.1.1",
         "ember-template-lint": "^6.0.0",
         "ember-template-lint-plugin-prettier": "^5.0.0",
@@ -10196,6 +10196,64 @@
         "node": ">=6"
       }
     },
+    "node_modules/@glimmer/compiler": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/compiler/-/compiler-0.87.1.tgz",
+      "integrity": "sha512-7qXrOv55cH/YW+Vs4dFkNJsNXAW/jP+7kZLhKcH8wCduPfBCQxb9HNh1lBESuFej2rCks6h9I1qXeZHkc/oWxQ==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/interfaces": "^0.87.1",
+        "@glimmer/syntax": "^0.87.1",
+        "@glimmer/util": "^0.87.1",
+        "@glimmer/vm": "^0.87.1",
+        "@glimmer/wire-format": "^0.87.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/@glimmer/compiler/node_modules/@glimmer/interfaces": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.87.1.tgz",
+      "integrity": "sha512-2lbwLY4Bt9i2SvwT4hhY0TgEYKhOMQBgYvRiraq2BYHwO8iLKh3lC8iO3d+rQ3VgDtQ9i/sP6HG848VNRyVHxA==",
+      "dev": true,
+      "dependencies": {
+        "@simple-dom/interface": "^1.4.0"
+      }
+    },
+    "node_modules/@glimmer/compiler/node_modules/@glimmer/syntax": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.87.1.tgz",
+      "integrity": "sha512-zYzZT6LgpSF0iv5iuxmMV5Pf52aE8dukNC2KfrHC6gXJfM4eLZMZcyk76NW5m+SEetZSOXX6AWv/KwLnoxiMfQ==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/interfaces": "^0.87.1",
+        "@glimmer/util": "^0.87.1",
+        "@glimmer/wire-format": "^0.87.1",
+        "@handlebars/parser": "~2.0.0",
+        "simple-html-tokenizer": "^0.5.11"
+      }
+    },
+    "node_modules/@glimmer/compiler/node_modules/@glimmer/util": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.87.1.tgz",
+      "integrity": "sha512-Duxi2JutaIewfIWp8PJl7U5n12yasKWtZFHNLSrg+C8TKeMXdRyJtI7uqtqg0Z/6F9JwdJe/IPhTvdsTTfzAuA==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/env": "0.1.7",
+        "@glimmer/interfaces": "^0.87.1"
+      }
+    },
+    "node_modules/@glimmer/compiler/node_modules/@glimmer/wire-format": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/wire-format/-/wire-format-0.87.1.tgz",
+      "integrity": "sha512-O3W1HDfRGX7wHZqvP8UzI/nWyZ2GIMFolU7l6WcLGU9HIdzqfxsc7ae2Icob/fq2kV9meHti4yDEdTMlBVK9AQ==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/interfaces": "^0.87.1",
+        "@glimmer/util": "^0.87.1"
+      }
+    },
     "node_modules/@glimmer/component": {
       "version": "1.1.2",
       "dev": true,
@@ -10818,10 +10876,96 @@
         "rsvp": "^4.8.4"
       }
     },
+    "node_modules/@glimmer/debug": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/debug/-/debug-0.87.1.tgz",
+      "integrity": "sha512-rja9/Hofv1NEjIqp8P2eQuHY3+orlS3BL4fbFyvrE+Pw4lRwQPLm6UdgCMHZGGe9yweZAGvNVH6CimDBq7biwA==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/interfaces": "^0.87.1",
+        "@glimmer/util": "^0.87.1",
+        "@glimmer/vm": "^0.87.1"
+      }
+    },
+    "node_modules/@glimmer/debug/node_modules/@glimmer/interfaces": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.87.1.tgz",
+      "integrity": "sha512-2lbwLY4Bt9i2SvwT4hhY0TgEYKhOMQBgYvRiraq2BYHwO8iLKh3lC8iO3d+rQ3VgDtQ9i/sP6HG848VNRyVHxA==",
+      "dev": true,
+      "dependencies": {
+        "@simple-dom/interface": "^1.4.0"
+      }
+    },
+    "node_modules/@glimmer/debug/node_modules/@glimmer/util": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.87.1.tgz",
+      "integrity": "sha512-Duxi2JutaIewfIWp8PJl7U5n12yasKWtZFHNLSrg+C8TKeMXdRyJtI7uqtqg0Z/6F9JwdJe/IPhTvdsTTfzAuA==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/env": "0.1.7",
+        "@glimmer/interfaces": "^0.87.1"
+      }
+    },
+    "node_modules/@glimmer/destroyable": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/destroyable/-/destroyable-0.87.1.tgz",
+      "integrity": "sha512-v9kdMq/FCSMcXK4gIKxPCSEcYXjDAnapKVY2o9fCgqky+mbpd0XuGoxaXa35nFwDk69L/9/8B3vXQOpa6ThikA==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/env": "0.1.7",
+        "@glimmer/global-context": "^0.87.1",
+        "@glimmer/interfaces": "^0.87.1",
+        "@glimmer/util": "^0.87.1"
+      }
+    },
+    "node_modules/@glimmer/destroyable/node_modules/@glimmer/global-context": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/global-context/-/global-context-0.87.1.tgz",
+      "integrity": "sha512-Mitr7pBeVDTplFWlohyzxWLpFll7ffMZN+fnkBmUj8HiDLbD790Lb8lR9B2nL3t4RGnh6W9kDkCnZB+hvDm/eQ==",
+      "dev": true
+    },
+    "node_modules/@glimmer/destroyable/node_modules/@glimmer/interfaces": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.87.1.tgz",
+      "integrity": "sha512-2lbwLY4Bt9i2SvwT4hhY0TgEYKhOMQBgYvRiraq2BYHwO8iLKh3lC8iO3d+rQ3VgDtQ9i/sP6HG848VNRyVHxA==",
+      "dev": true,
+      "dependencies": {
+        "@simple-dom/interface": "^1.4.0"
+      }
+    },
+    "node_modules/@glimmer/destroyable/node_modules/@glimmer/util": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.87.1.tgz",
+      "integrity": "sha512-Duxi2JutaIewfIWp8PJl7U5n12yasKWtZFHNLSrg+C8TKeMXdRyJtI7uqtqg0Z/6F9JwdJe/IPhTvdsTTfzAuA==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/env": "0.1.7",
+        "@glimmer/interfaces": "^0.87.1"
+      }
+    },
     "node_modules/@glimmer/di": {
       "version": "0.1.11",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@glimmer/encoder": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/encoder/-/encoder-0.87.1.tgz",
+      "integrity": "sha512-5oZEkdtYcAbkiWuXFQ8ofSEGH5uzqi86WK9/IXb7Qn4t6o7ixadWk8nhtORRpVS1u4FpAjhsAysnzRFoNqJwbQ==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/interfaces": "^0.87.1",
+        "@glimmer/vm": "^0.87.1"
+      }
+    },
+    "node_modules/@glimmer/encoder/node_modules/@glimmer/interfaces": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.87.1.tgz",
+      "integrity": "sha512-2lbwLY4Bt9i2SvwT4hhY0TgEYKhOMQBgYvRiraq2BYHwO8iLKh3lC8iO3d+rQ3VgDtQ9i/sP6HG848VNRyVHxA==",
+      "dev": true,
+      "dependencies": {
+        "@simple-dom/interface": "^1.4.0"
+      }
     },
     "node_modules/@glimmer/env": {
       "version": "0.1.7",
@@ -10842,6 +10986,255 @@
       "license": "MIT",
       "dependencies": {
         "@simple-dom/interface": "^1.4.0"
+      }
+    },
+    "node_modules/@glimmer/manager": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/manager/-/manager-0.87.1.tgz",
+      "integrity": "sha512-jEUZZQWcuxKg+Ri/A1HGURm9pBrx13JDHx1djYCnPo96yjtQFYxEG0VcwLq2EtAEpFrekwfO1b6m3JZiFqmtGg==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/debug": "^0.87.1",
+        "@glimmer/destroyable": "^0.87.1",
+        "@glimmer/env": "0.1.7",
+        "@glimmer/global-context": "^0.87.1",
+        "@glimmer/interfaces": "^0.87.1",
+        "@glimmer/reference": "^0.87.1",
+        "@glimmer/util": "^0.87.1",
+        "@glimmer/validator": "^0.87.1",
+        "@glimmer/vm": "^0.87.1"
+      }
+    },
+    "node_modules/@glimmer/manager/node_modules/@glimmer/global-context": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/global-context/-/global-context-0.87.1.tgz",
+      "integrity": "sha512-Mitr7pBeVDTplFWlohyzxWLpFll7ffMZN+fnkBmUj8HiDLbD790Lb8lR9B2nL3t4RGnh6W9kDkCnZB+hvDm/eQ==",
+      "dev": true
+    },
+    "node_modules/@glimmer/manager/node_modules/@glimmer/interfaces": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.87.1.tgz",
+      "integrity": "sha512-2lbwLY4Bt9i2SvwT4hhY0TgEYKhOMQBgYvRiraq2BYHwO8iLKh3lC8iO3d+rQ3VgDtQ9i/sP6HG848VNRyVHxA==",
+      "dev": true,
+      "dependencies": {
+        "@simple-dom/interface": "^1.4.0"
+      }
+    },
+    "node_modules/@glimmer/manager/node_modules/@glimmer/reference": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/reference/-/reference-0.87.1.tgz",
+      "integrity": "sha512-KJwKYDnds6amsmVB1YxmFhJGI/TNCNmsFBWKUH8K0odmiggUCjt3AwUoOKztkwh3xxy/jpq+5AahIuV+uBgW7A==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/env": "^0.1.7",
+        "@glimmer/global-context": "^0.87.1",
+        "@glimmer/interfaces": "^0.87.1",
+        "@glimmer/util": "^0.87.1",
+        "@glimmer/validator": "^0.87.1"
+      }
+    },
+    "node_modules/@glimmer/manager/node_modules/@glimmer/util": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.87.1.tgz",
+      "integrity": "sha512-Duxi2JutaIewfIWp8PJl7U5n12yasKWtZFHNLSrg+C8TKeMXdRyJtI7uqtqg0Z/6F9JwdJe/IPhTvdsTTfzAuA==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/env": "0.1.7",
+        "@glimmer/interfaces": "^0.87.1"
+      }
+    },
+    "node_modules/@glimmer/manager/node_modules/@glimmer/validator": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/validator/-/validator-0.87.1.tgz",
+      "integrity": "sha512-GqzULgK9m2QPfPswhyV30tZmsUegowv9Tyfz2l15cLDFX9L5GcEORpzKXjR0TzCplffuqOC1g8rnMaPsP55apw==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/env": "^0.1.7",
+        "@glimmer/global-context": "^0.87.1",
+        "@glimmer/interfaces": "^0.87.1",
+        "@glimmer/util": "^0.87.1"
+      }
+    },
+    "node_modules/@glimmer/node": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/node/-/node-0.87.1.tgz",
+      "integrity": "sha512-peESyArA08Va9f3gpBnhO+RNkK4Oe0Q8sMPQILCloAukNe2+DQOhTvDgVjRUKmVXMJCWoSgmJtxkiB3ZE193vw==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/interfaces": "^0.87.1",
+        "@glimmer/runtime": "^0.87.1",
+        "@glimmer/util": "^0.87.1",
+        "@simple-dom/document": "^1.4.0"
+      }
+    },
+    "node_modules/@glimmer/node/node_modules/@glimmer/interfaces": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.87.1.tgz",
+      "integrity": "sha512-2lbwLY4Bt9i2SvwT4hhY0TgEYKhOMQBgYvRiraq2BYHwO8iLKh3lC8iO3d+rQ3VgDtQ9i/sP6HG848VNRyVHxA==",
+      "dev": true,
+      "dependencies": {
+        "@simple-dom/interface": "^1.4.0"
+      }
+    },
+    "node_modules/@glimmer/node/node_modules/@glimmer/util": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.87.1.tgz",
+      "integrity": "sha512-Duxi2JutaIewfIWp8PJl7U5n12yasKWtZFHNLSrg+C8TKeMXdRyJtI7uqtqg0Z/6F9JwdJe/IPhTvdsTTfzAuA==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/env": "0.1.7",
+        "@glimmer/interfaces": "^0.87.1"
+      }
+    },
+    "node_modules/@glimmer/opcode-compiler": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/opcode-compiler/-/opcode-compiler-0.87.1.tgz",
+      "integrity": "sha512-D9OFrH3CrGNXfGtgcVWvu3xofpQZPoYFkqj3RrcDwnsSIYPSqUYTIOO6dwpxTbPlzkASidq0B2htXK7WkCERVw==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/debug": "^0.87.1",
+        "@glimmer/encoder": "^0.87.1",
+        "@glimmer/env": "0.1.7",
+        "@glimmer/global-context": "^0.87.1",
+        "@glimmer/interfaces": "^0.87.1",
+        "@glimmer/manager": "^0.87.1",
+        "@glimmer/reference": "^0.87.1",
+        "@glimmer/util": "^0.87.1",
+        "@glimmer/vm": "^0.87.1",
+        "@glimmer/wire-format": "^0.87.1"
+      }
+    },
+    "node_modules/@glimmer/opcode-compiler/node_modules/@glimmer/global-context": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/global-context/-/global-context-0.87.1.tgz",
+      "integrity": "sha512-Mitr7pBeVDTplFWlohyzxWLpFll7ffMZN+fnkBmUj8HiDLbD790Lb8lR9B2nL3t4RGnh6W9kDkCnZB+hvDm/eQ==",
+      "dev": true
+    },
+    "node_modules/@glimmer/opcode-compiler/node_modules/@glimmer/interfaces": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.87.1.tgz",
+      "integrity": "sha512-2lbwLY4Bt9i2SvwT4hhY0TgEYKhOMQBgYvRiraq2BYHwO8iLKh3lC8iO3d+rQ3VgDtQ9i/sP6HG848VNRyVHxA==",
+      "dev": true,
+      "dependencies": {
+        "@simple-dom/interface": "^1.4.0"
+      }
+    },
+    "node_modules/@glimmer/opcode-compiler/node_modules/@glimmer/reference": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/reference/-/reference-0.87.1.tgz",
+      "integrity": "sha512-KJwKYDnds6amsmVB1YxmFhJGI/TNCNmsFBWKUH8K0odmiggUCjt3AwUoOKztkwh3xxy/jpq+5AahIuV+uBgW7A==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/env": "^0.1.7",
+        "@glimmer/global-context": "^0.87.1",
+        "@glimmer/interfaces": "^0.87.1",
+        "@glimmer/util": "^0.87.1",
+        "@glimmer/validator": "^0.87.1"
+      }
+    },
+    "node_modules/@glimmer/opcode-compiler/node_modules/@glimmer/util": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.87.1.tgz",
+      "integrity": "sha512-Duxi2JutaIewfIWp8PJl7U5n12yasKWtZFHNLSrg+C8TKeMXdRyJtI7uqtqg0Z/6F9JwdJe/IPhTvdsTTfzAuA==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/env": "0.1.7",
+        "@glimmer/interfaces": "^0.87.1"
+      }
+    },
+    "node_modules/@glimmer/opcode-compiler/node_modules/@glimmer/validator": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/validator/-/validator-0.87.1.tgz",
+      "integrity": "sha512-GqzULgK9m2QPfPswhyV30tZmsUegowv9Tyfz2l15cLDFX9L5GcEORpzKXjR0TzCplffuqOC1g8rnMaPsP55apw==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/env": "^0.1.7",
+        "@glimmer/global-context": "^0.87.1",
+        "@glimmer/interfaces": "^0.87.1",
+        "@glimmer/util": "^0.87.1"
+      }
+    },
+    "node_modules/@glimmer/opcode-compiler/node_modules/@glimmer/wire-format": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/wire-format/-/wire-format-0.87.1.tgz",
+      "integrity": "sha512-O3W1HDfRGX7wHZqvP8UzI/nWyZ2GIMFolU7l6WcLGU9HIdzqfxsc7ae2Icob/fq2kV9meHti4yDEdTMlBVK9AQ==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/interfaces": "^0.87.1",
+        "@glimmer/util": "^0.87.1"
+      }
+    },
+    "node_modules/@glimmer/owner": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/owner/-/owner-0.87.1.tgz",
+      "integrity": "sha512-ayYjznPMSGpgygNT7XlTXeel6Cl/fafm4WJeRRgdPxG1EZMjKPlfpfAyNzf9peEIlW3WMbPu3RAIYrf54aThWQ==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/util": "^0.87.1"
+      }
+    },
+    "node_modules/@glimmer/owner/node_modules/@glimmer/interfaces": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.87.1.tgz",
+      "integrity": "sha512-2lbwLY4Bt9i2SvwT4hhY0TgEYKhOMQBgYvRiraq2BYHwO8iLKh3lC8iO3d+rQ3VgDtQ9i/sP6HG848VNRyVHxA==",
+      "dev": true,
+      "dependencies": {
+        "@simple-dom/interface": "^1.4.0"
+      }
+    },
+    "node_modules/@glimmer/owner/node_modules/@glimmer/util": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.87.1.tgz",
+      "integrity": "sha512-Duxi2JutaIewfIWp8PJl7U5n12yasKWtZFHNLSrg+C8TKeMXdRyJtI7uqtqg0Z/6F9JwdJe/IPhTvdsTTfzAuA==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/env": "0.1.7",
+        "@glimmer/interfaces": "^0.87.1"
+      }
+    },
+    "node_modules/@glimmer/program": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/program/-/program-0.87.1.tgz",
+      "integrity": "sha512-+r1Dz5Da0zyYwBhPmqoXiw3qmDamqqhVmSCtJLLcZ6exXXC2ZjGoNdynfos80A91dx+PFqYgHg+5lfa5STT9iQ==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/encoder": "^0.87.1",
+        "@glimmer/env": "0.1.7",
+        "@glimmer/interfaces": "^0.87.1",
+        "@glimmer/manager": "^0.87.1",
+        "@glimmer/opcode-compiler": "^0.87.1",
+        "@glimmer/util": "^0.87.1",
+        "@glimmer/vm": "^0.87.1",
+        "@glimmer/wire-format": "^0.87.1"
+      }
+    },
+    "node_modules/@glimmer/program/node_modules/@glimmer/interfaces": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.87.1.tgz",
+      "integrity": "sha512-2lbwLY4Bt9i2SvwT4hhY0TgEYKhOMQBgYvRiraq2BYHwO8iLKh3lC8iO3d+rQ3VgDtQ9i/sP6HG848VNRyVHxA==",
+      "dev": true,
+      "dependencies": {
+        "@simple-dom/interface": "^1.4.0"
+      }
+    },
+    "node_modules/@glimmer/program/node_modules/@glimmer/util": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.87.1.tgz",
+      "integrity": "sha512-Duxi2JutaIewfIWp8PJl7U5n12yasKWtZFHNLSrg+C8TKeMXdRyJtI7uqtqg0Z/6F9JwdJe/IPhTvdsTTfzAuA==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/env": "0.1.7",
+        "@glimmer/interfaces": "^0.87.1"
+      }
+    },
+    "node_modules/@glimmer/program/node_modules/@glimmer/wire-format": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/wire-format/-/wire-format-0.87.1.tgz",
+      "integrity": "sha512-O3W1HDfRGX7wHZqvP8UzI/nWyZ2GIMFolU7l6WcLGU9HIdzqfxsc7ae2Icob/fq2kV9meHti4yDEdTMlBVK9AQ==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/interfaces": "^0.87.1",
+        "@glimmer/util": "^0.87.1"
       }
     },
     "node_modules/@glimmer/reference": {
@@ -10873,6 +11266,86 @@
       "dependencies": {
         "@glimmer/env": "^0.1.7",
         "@glimmer/global-context": "0.84.3"
+      }
+    },
+    "node_modules/@glimmer/runtime": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/runtime/-/runtime-0.87.1.tgz",
+      "integrity": "sha512-7QBONxRFesnHzelCiUahZjRj3nhbUxPg0F+iD+3rALrXaWfB1pkhngMTK2DYEmsJ7kq04qVzwBnTSrqsmLzOTg==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/destroyable": "^0.87.1",
+        "@glimmer/env": "0.1.7",
+        "@glimmer/global-context": "^0.87.1",
+        "@glimmer/interfaces": "^0.87.1",
+        "@glimmer/manager": "^0.87.1",
+        "@glimmer/owner": "^0.87.1",
+        "@glimmer/program": "^0.87.1",
+        "@glimmer/reference": "^0.87.1",
+        "@glimmer/util": "^0.87.1",
+        "@glimmer/validator": "^0.87.1",
+        "@glimmer/vm": "^0.87.1",
+        "@glimmer/wire-format": "^0.87.1"
+      }
+    },
+    "node_modules/@glimmer/runtime/node_modules/@glimmer/global-context": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/global-context/-/global-context-0.87.1.tgz",
+      "integrity": "sha512-Mitr7pBeVDTplFWlohyzxWLpFll7ffMZN+fnkBmUj8HiDLbD790Lb8lR9B2nL3t4RGnh6W9kDkCnZB+hvDm/eQ==",
+      "dev": true
+    },
+    "node_modules/@glimmer/runtime/node_modules/@glimmer/interfaces": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.87.1.tgz",
+      "integrity": "sha512-2lbwLY4Bt9i2SvwT4hhY0TgEYKhOMQBgYvRiraq2BYHwO8iLKh3lC8iO3d+rQ3VgDtQ9i/sP6HG848VNRyVHxA==",
+      "dev": true,
+      "dependencies": {
+        "@simple-dom/interface": "^1.4.0"
+      }
+    },
+    "node_modules/@glimmer/runtime/node_modules/@glimmer/reference": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/reference/-/reference-0.87.1.tgz",
+      "integrity": "sha512-KJwKYDnds6amsmVB1YxmFhJGI/TNCNmsFBWKUH8K0odmiggUCjt3AwUoOKztkwh3xxy/jpq+5AahIuV+uBgW7A==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/env": "^0.1.7",
+        "@glimmer/global-context": "^0.87.1",
+        "@glimmer/interfaces": "^0.87.1",
+        "@glimmer/util": "^0.87.1",
+        "@glimmer/validator": "^0.87.1"
+      }
+    },
+    "node_modules/@glimmer/runtime/node_modules/@glimmer/util": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.87.1.tgz",
+      "integrity": "sha512-Duxi2JutaIewfIWp8PJl7U5n12yasKWtZFHNLSrg+C8TKeMXdRyJtI7uqtqg0Z/6F9JwdJe/IPhTvdsTTfzAuA==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/env": "0.1.7",
+        "@glimmer/interfaces": "^0.87.1"
+      }
+    },
+    "node_modules/@glimmer/runtime/node_modules/@glimmer/validator": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/validator/-/validator-0.87.1.tgz",
+      "integrity": "sha512-GqzULgK9m2QPfPswhyV30tZmsUegowv9Tyfz2l15cLDFX9L5GcEORpzKXjR0TzCplffuqOC1g8rnMaPsP55apw==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/env": "^0.1.7",
+        "@glimmer/global-context": "^0.87.1",
+        "@glimmer/interfaces": "^0.87.1",
+        "@glimmer/util": "^0.87.1"
+      }
+    },
+    "node_modules/@glimmer/runtime/node_modules/@glimmer/wire-format": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/wire-format/-/wire-format-0.87.1.tgz",
+      "integrity": "sha512-O3W1HDfRGX7wHZqvP8UzI/nWyZ2GIMFolU7l6WcLGU9HIdzqfxsc7ae2Icob/fq2kV9meHti4yDEdTMlBVK9AQ==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/interfaces": "^0.87.1",
+        "@glimmer/util": "^0.87.1"
       }
     },
     "node_modules/@glimmer/syntax": {
@@ -10915,12 +11388,45 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@glimmer/vm-babel-plugins": {
-      "version": "0.84.2",
+    "node_modules/@glimmer/vm": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/vm/-/vm-0.87.1.tgz",
+      "integrity": "sha512-JSFr85ASZmuN4H72px7GHtnW79PPRHpqHw6O/6UUZd+ocwWHy+nG9JGbo8kntvqN5xP0SdCipjv/c0u7nkc8tg==",
       "dev": true,
-      "license": "MIT",
+      "dependencies": {
+        "@glimmer/interfaces": "^0.87.1",
+        "@glimmer/util": "^0.87.1"
+      }
+    },
+    "node_modules/@glimmer/vm-babel-plugins": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.87.1.tgz",
+      "integrity": "sha512-VbhYHa+HfGFiTIOOkvFuYPwBTaDvWTAR1Q55RI25JI6Nno0duBLB3UVRTDgHM+iOfbgRN7OSR5XCe/C5X5C5LA==",
+      "dev": true,
       "dependencies": {
         "babel-plugin-debug-macros": "^0.3.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@glimmer/vm/node_modules/@glimmer/interfaces": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.87.1.tgz",
+      "integrity": "sha512-2lbwLY4Bt9i2SvwT4hhY0TgEYKhOMQBgYvRiraq2BYHwO8iLKh3lC8iO3d+rQ3VgDtQ9i/sP6HG848VNRyVHxA==",
+      "dev": true,
+      "dependencies": {
+        "@simple-dom/interface": "^1.4.0"
+      }
+    },
+    "node_modules/@glimmer/vm/node_modules/@glimmer/util": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.87.1.tgz",
+      "integrity": "sha512-Duxi2JutaIewfIWp8PJl7U5n12yasKWtZFHNLSrg+C8TKeMXdRyJtI7uqtqg0Z/6F9JwdJe/IPhTvdsTTfzAuA==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/env": "0.1.7",
+        "@glimmer/interfaces": "^0.87.1"
       }
     },
     "node_modules/@glimmer/wire-format": {
@@ -15036,6 +15542,12 @@
       "dependencies": {
         "underscore": ">=1.8.3"
       }
+    },
+    "node_modules/backburner.js": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/backburner.js/-/backburner.js-2.8.0.tgz",
+      "integrity": "sha512-zYXY0KvpD7/CWeOLF576mV8S+bQsaIoj/GNLXXB+Eb8SJcQy5lqSjkRrZ0MZhdKUs9QoqmGNIEIe3NQfGiiscQ==",
+      "dev": true
     },
     "node_modules/bail": {
       "version": "1.0.5",
@@ -33205,24 +33717,43 @@
       }
     },
     "node_modules/ember-source": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-5.0.0.tgz",
-      "integrity": "sha512-zy0iU3Mf9HZXVQacqWLAfHCbQge8Ysi2EpU6XTgrdf2PX5ILdWTbSPklxuTlkGV7NrG5PkIfGW8hfimwY6I/tw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-5.8.0.tgz",
+      "integrity": "sha512-jRmT5egy7XG2G9pKNdNNwNBZqFxrl7xJwdYrJ3ugreR7zK1FR28lHSR5CMSKtYLmJZxu340cf2EbRohWEtO2Zw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
-        "@babel/plugin-transform-block-scoping": "^7.20.5",
         "@ember/edition-utils": "^1.2.0",
-        "@glimmer/vm-babel-plugins": "0.84.2",
+        "@glimmer/compiler": "0.87.1",
+        "@glimmer/component": "^1.1.2",
+        "@glimmer/destroyable": "0.87.1",
+        "@glimmer/env": "^0.1.7",
+        "@glimmer/global-context": "0.87.1",
+        "@glimmer/interfaces": "0.87.1",
+        "@glimmer/manager": "0.87.1",
+        "@glimmer/node": "0.87.1",
+        "@glimmer/opcode-compiler": "0.87.1",
+        "@glimmer/owner": "0.87.1",
+        "@glimmer/program": "0.87.1",
+        "@glimmer/reference": "0.87.1",
+        "@glimmer/runtime": "0.87.1",
+        "@glimmer/syntax": "0.87.1",
+        "@glimmer/util": "0.87.1",
+        "@glimmer/validator": "0.87.1",
+        "@glimmer/vm": "0.87.1",
+        "@glimmer/vm-babel-plugins": "0.87.1",
+        "@simple-dom/interface": "^1.4.0",
         "babel-plugin-debug-macros": "^0.3.4",
+        "babel-plugin-ember-template-compilation": "^2.1.1",
         "babel-plugin-filter-imports": "^4.0.0",
+        "backburner.js": "^2.8.0",
         "broccoli-concat": "^4.2.5",
         "broccoli-debug": "^0.6.4",
         "broccoli-file-creator": "^2.1.1",
         "broccoli-funnel": "^3.0.8",
         "broccoli-merge-trees": "^4.2.0",
         "chalk": "^4.0.0",
-        "ember-auto-import": "^2.5.0",
+        "ember-auto-import": "^2.6.3",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-get-component-path-option": "^1.0.0",
         "ember-cli-is-package-missing": "^1.0.0",
@@ -33232,10 +33763,12 @@
         "ember-cli-typescript-blueprint-polyfill": "^0.1.0",
         "ember-cli-version-checker": "^5.1.2",
         "ember-router-generator": "^2.0.0",
-        "inflection": "^1.13.2",
-        "resolve": "^1.22.0",
-        "semver": "^7.3.8",
-        "silent-error": "^1.1.1"
+        "inflection": "^2.0.1",
+        "route-recognizer": "^0.3.4",
+        "router_js": "^8.0.3",
+        "semver": "^7.5.2",
+        "silent-error": "^1.1.1",
+        "simple-html-tokenizer": "^0.5.11"
       },
       "engines": {
         "node": ">= 16.*"
@@ -33267,6 +33800,79 @@
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/ember-source/node_modules/@glimmer/global-context": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/global-context/-/global-context-0.87.1.tgz",
+      "integrity": "sha512-Mitr7pBeVDTplFWlohyzxWLpFll7ffMZN+fnkBmUj8HiDLbD790Lb8lR9B2nL3t4RGnh6W9kDkCnZB+hvDm/eQ==",
+      "dev": true
+    },
+    "node_modules/ember-source/node_modules/@glimmer/interfaces": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.87.1.tgz",
+      "integrity": "sha512-2lbwLY4Bt9i2SvwT4hhY0TgEYKhOMQBgYvRiraq2BYHwO8iLKh3lC8iO3d+rQ3VgDtQ9i/sP6HG848VNRyVHxA==",
+      "dev": true,
+      "dependencies": {
+        "@simple-dom/interface": "^1.4.0"
+      }
+    },
+    "node_modules/ember-source/node_modules/@glimmer/reference": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/reference/-/reference-0.87.1.tgz",
+      "integrity": "sha512-KJwKYDnds6amsmVB1YxmFhJGI/TNCNmsFBWKUH8K0odmiggUCjt3AwUoOKztkwh3xxy/jpq+5AahIuV+uBgW7A==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/env": "^0.1.7",
+        "@glimmer/global-context": "^0.87.1",
+        "@glimmer/interfaces": "^0.87.1",
+        "@glimmer/util": "^0.87.1",
+        "@glimmer/validator": "^0.87.1"
+      }
+    },
+    "node_modules/ember-source/node_modules/@glimmer/syntax": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.87.1.tgz",
+      "integrity": "sha512-zYzZT6LgpSF0iv5iuxmMV5Pf52aE8dukNC2KfrHC6gXJfM4eLZMZcyk76NW5m+SEetZSOXX6AWv/KwLnoxiMfQ==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/interfaces": "^0.87.1",
+        "@glimmer/util": "^0.87.1",
+        "@glimmer/wire-format": "^0.87.1",
+        "@handlebars/parser": "~2.0.0",
+        "simple-html-tokenizer": "^0.5.11"
+      }
+    },
+    "node_modules/ember-source/node_modules/@glimmer/util": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.87.1.tgz",
+      "integrity": "sha512-Duxi2JutaIewfIWp8PJl7U5n12yasKWtZFHNLSrg+C8TKeMXdRyJtI7uqtqg0Z/6F9JwdJe/IPhTvdsTTfzAuA==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/env": "0.1.7",
+        "@glimmer/interfaces": "^0.87.1"
+      }
+    },
+    "node_modules/ember-source/node_modules/@glimmer/validator": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/validator/-/validator-0.87.1.tgz",
+      "integrity": "sha512-GqzULgK9m2QPfPswhyV30tZmsUegowv9Tyfz2l15cLDFX9L5GcEORpzKXjR0TzCplffuqOC1g8rnMaPsP55apw==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/env": "^0.1.7",
+        "@glimmer/global-context": "^0.87.1",
+        "@glimmer/interfaces": "^0.87.1",
+        "@glimmer/util": "^0.87.1"
+      }
+    },
+    "node_modules/ember-source/node_modules/@glimmer/wire-format": {
+      "version": "0.87.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/wire-format/-/wire-format-0.87.1.tgz",
+      "integrity": "sha512-O3W1HDfRGX7wHZqvP8UzI/nWyZ2GIMFolU7l6WcLGU9HIdzqfxsc7ae2Icob/fq2kV9meHti4yDEdTMlBVK9AQ==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/interfaces": "^0.87.1",
+        "@glimmer/util": "^0.87.1"
       }
     },
     "node_modules/ember-source/node_modules/@types/fs-extra": {
@@ -33749,14 +34355,6 @@
       "engines": {
         "node": ">=6 <7 || >=8"
       }
-    },
-    "node_modules/ember-source/node_modules/inflection": {
-      "version": "1.13.4",
-      "dev": true,
-      "engines": [
-        "node >= 0.4.0"
-      ],
-      "license": "MIT"
     },
     "node_modules/ember-source/node_modules/istextorbinary": {
       "version": "2.1.0",
@@ -45429,8 +46027,23 @@
     "node_modules/route-recognizer": {
       "version": "0.3.4",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
+    },
+    "node_modules/router_js": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/router_js/-/router_js-8.0.5.tgz",
+      "integrity": "sha512-0TpJIJoOpPVlX3JIGAQd/vivCXWkoi6wTAM7CkYo2cuASCQsK4qtJ9pvzYki7iZw44hO6nRN3z6paVTMiAPLdw==",
+      "dev": true,
+      "dependencies": {
+        "@glimmer/env": "^0.1.7"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "route-recognizer": "^0.3.4",
+        "rsvp": "^4.8.5"
+      }
     },
     "node_modules/rsvp": {
       "version": "4.8.5",

--- a/admin/package.json
+++ b/admin/package.json
@@ -92,7 +92,7 @@
     "ember-qunit": "^8.0.0",
     "ember-resolver": "^11.0.0",
     "ember-simple-auth": "^6.0.0",
-    "ember-source": "^5.0.0",
+    "ember-source": "^5.8.0",
     "ember-template-imports": "^4.1.1",
     "ember-template-lint": "^6.0.0",
     "ember-template-lint-plugin-prettier": "^5.0.0",
@@ -127,7 +127,7 @@
   },
   "overrides": {
     "ember-dayjs": {
-      "ember-source": "^5.0.0"
+      "ember-source": "^5.8.0"
     }
   }
 }

--- a/admin/package.json
+++ b/admin/package.json
@@ -92,7 +92,7 @@
     "ember-qunit": "^8.0.0",
     "ember-resolver": "^11.0.0",
     "ember-simple-auth": "^6.0.0",
-    "ember-source": "~4.12.0",
+    "ember-source": "^5.0.0",
     "ember-template-imports": "^4.1.1",
     "ember-template-lint": "^6.0.0",
     "ember-template-lint-plugin-prettier": "^5.0.0",
@@ -124,5 +124,10 @@
     "tracked-built-ins": "^3.1.1",
     "webpack": "^5.88.2",
     "xss": "^1.0.15"
+  },
+  "overrides": {
+    "ember-dayjs": {
+      "ember-source": "^5.0.0"
+    }
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Nous avons encore un peu de retard sur la version LTS de ember-source

## :robot: Proposition
Monter ember-source en 5.8.0

## :rainbow: Remarques
https://emberjs.com/releases/lts/

## :100: Pour tester
Tests au vert ✅ 
🐈‍⬛ 