### PR TITLE
[BUGFIX] Adapter la hauteur de l'embed en fonction de la hauteur de l'écran (Pix-12973)

### DIFF
--- a/junior/app/pods/components/challenge/challenge-embed-simulator/component.js
+++ b/junior/app/pods/components/challenge/challenge-embed-simulator/component.js
@@ -4,7 +4,8 @@ import Component from '@glimmer/component';
 export default class ChallengeEmbedSimulator extends Component {
   get embedDocumentHeightStyle() {
     const baseHeight = this.args.height ?? '600';
-    const height = this.args.isMediaWithForm ? (baseHeight * window.innerHeight) / 950 : baseHeight;
-    return htmlSafe(`height: ${height}px`);
+    const itemMedia = document.getElementsByClassName('challenge-item__media ')[0];
+    const height = this.args.isMediaWithForm ? (baseHeight * itemMedia.offsetWidth) / 710 : baseHeight;
+    return htmlSafe(`height: ${height}px; max-height: ${baseHeight}px`);
   }
 }

--- a/junior/app/pods/components/challenge/challenge-embed-simulator/component.js
+++ b/junior/app/pods/components/challenge/challenge-embed-simulator/component.js
@@ -1,8 +1,10 @@
 import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
+
 export default class ChallengeEmbedSimulator extends Component {
   get embedDocumentHeightStyle() {
-    const height = this.args.height ?? '600';
+    const baseHeight = this.args.height ?? '600';
+    const height = this.args.isMediaWithForm ? (baseHeight * window.innerHeight) / 950 : baseHeight;
     return htmlSafe(`height: ${height}px`);
   }
 }

--- a/junior/app/pods/components/challenge/item/challenge-item.scss
+++ b/junior/app/pods/components/challenge/item/challenge-item.scss
@@ -15,6 +15,7 @@
 
   &__media {
     width: 60%;
+    height: fit-content;
     margin-right: var(--pix-spacing-6x);
     padding: var(--pix-spacing-4x);
     background-color: var(--pix-neutral-0);

--- a/junior/app/pods/components/challenge/item/component.js
+++ b/junior/app/pods/components/challenge/item/component.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 
 export default class Item extends Component {
   get isMediaWithForm() {
-    return this.args.challenge.hasForm && this.hasMedia;
+    return this.args.challenge.hasForm && this.hasMedia && this.args.challenge.type !== undefined;
   }
 
   get hasMedia() {

--- a/junior/app/pods/components/challenge/item/template.hbs
+++ b/junior/app/pods/components/challenge/item/template.hbs
@@ -13,6 +13,7 @@
             @title={{@challenge.embedTitle}}
             @height={{@challenge.embedHeight}}
             @hideSimulator={{@isDisabled}}
+            @isMediaWithForm={{this.isMediaWithForm}}
           />
         </div>
       {{/if}}


### PR DESCRIPTION
## :unicorn: Problème
Avec l'ajout d'un cadre autour de l'embed, il est ressorti que la hauteur de l'embed n'était pas toujours adaptée en fonction de  la hauteur de l'écran

<img width="972" alt="Capture d’écran 2024-06-17 à 11 24 18" src="https://github.com/1024pix/pix/assets/35958509/19439d88-2863-4301-9cc3-3f4e192dcafa">
<img width="945" alt="Capture d’écran 2024-06-17 à 11 24 26" src="https://github.com/1024pix/pix/assets/35958509/836afc72-0881-4b5a-bba6-67e5bfd85880">




## :robot: Proposition
Faire en sorte que la hauteur de l'embed soit plus adaptée à l'écran
<img width="950" alt="Capture d’écran 2024-06-17 à 11 19 22" src="https://github.com/1024pix/pix/assets/35958509/cfd7e77f-21a6-42de-9105-51bafc48314e">


## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- tester les épreuves sur différentes machines (ordi, tablette) avec différentes résolutions
