### PR TITLE
[FEATURE][ORGA] Ne pas afficher le bouton pour copier le code de campagne pour les organisations rattachées au GAR (PIX-12916)

### DIFF
--- a/orga/app/controllers/authenticated/campaigns/campaign/activity.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/activity.js
@@ -18,8 +18,8 @@ export default class ActivityController extends Controller {
   @tracked participations;
   @tracked search = null;
 
-  get isGARAuthenticationMethod() {
-    return this.currentUser.isGARAuthenticationMethod;
+  get isGarAuthenticationMethod() {
+    return this.currentUser.isGarAuthenticationMethod;
   }
 
   @action

--- a/orga/app/controllers/authenticated/campaigns/campaign/analysis.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/analysis.js
@@ -4,7 +4,7 @@ import { service } from '@ember/service';
 export default class AnalysisController extends Controller {
   @service currentUser;
 
-  get isGARAuthenticationMethod() {
-    return this.currentUser.isGARAuthenticationMethod;
+  get isGarAuthenticationMethod() {
+    return this.currentUser.isGarAuthenticationMethod;
   }
 }

--- a/orga/app/controllers/authenticated/campaigns/campaign/analysis.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/analysis.js
@@ -1,0 +1,10 @@
+import Controller from '@ember/controller';
+import { service } from '@ember/service';
+
+export default class AnalysisController extends Controller {
+  @service currentUser;
+
+  get isGARAuthenticationMethod() {
+    return this.currentUser.isGARAuthenticationMethod;
+  }
+}

--- a/orga/app/controllers/authenticated/campaigns/campaign/assessment-results.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/assessment-results.js
@@ -15,8 +15,8 @@ export default class AssessmentResultsController extends Controller {
   @tracked stages = [];
   @tracked search = null;
 
-  get isGARAuthenticationMethod() {
-    return this.currentUser.isGARAuthenticationMethod;
+  get isGarAuthenticationMethod() {
+    return this.currentUser.isGarAuthenticationMethod;
   }
 
   @action

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -12,7 +12,7 @@ export default class CurrentUserService extends Service {
   @tracked isSCOManagingStudents;
   @tracked isSUPManagingStudents;
   @tracked isAgriculture;
-  @tracked isGARAuthenticationMethod;
+  @tracked isGarAuthenticationMethod;
 
   async load() {
     if (this.session.isAuthenticated) {
@@ -53,7 +53,7 @@ export default class CurrentUserService extends Service {
     this.isAdminInOrganization = isAdminInOrganization;
     this.isSCOManagingStudents = isSCOManagingStudents;
     this.isSUPManagingStudents = isSUPManagingStudents;
-    this.isGARAuthenticationMethod = organization.identityProviderForCampaigns === 'GAR';
+    this.isGarAuthenticationMethod = organization.identityProviderForCampaigns === 'GAR';
     this.isAgriculture = organization.isAgriculture;
     this.organization = organization;
   }

--- a/orga/app/templates/authenticated/campaigns/campaign/activity.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/activity.hbs
@@ -26,7 +26,7 @@
     class="activity__participants-list"
   />
 {{else}}
-  {{#if this.isGARAuthenticationMethod}}
+  {{#if this.isGarAuthenticationMethod}}
     <Campaign::EmptyState />
   {{else}}
     <Campaign::EmptyState @campaignCode={{@model.campaign.code}} />

--- a/orga/app/templates/authenticated/campaigns/campaign/analysis.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/analysis.hbs
@@ -12,7 +12,7 @@
     @campaignCollectiveResult={{@model.campaignCollectiveResult}}
   />
 {{else}}
-  {{#if this.isGARAuthenticationMethod}}
+  {{#if this.isGarAuthenticationMethod}}
     <Campaign::EmptyState />
   {{else}}
     <Campaign::EmptyState @campaignCode={{@model.code}} />

--- a/orga/app/templates/authenticated/campaigns/campaign/analysis.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/analysis.hbs
@@ -12,5 +12,9 @@
     @campaignCollectiveResult={{@model.campaignCollectiveResult}}
   />
 {{else}}
-  <Campaign::EmptyState @campaignCode={{@model.code}} />
+  {{#if this.isGARAuthenticationMethod}}
+    <Campaign::EmptyState />
+  {{else}}
+    <Campaign::EmptyState @campaignCode={{@model.code}} />
+  {{/if}}
 {{/if}}

--- a/orga/app/templates/authenticated/campaigns/campaign/assessment-results.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/assessment-results.hbs
@@ -27,7 +27,7 @@
     class="assessment-results__list"
   />
 {{else}}
-  {{#if this.isGARAuthenticationMethod}}
+  {{#if this.isGarAuthenticationMethod}}
     <Campaign::EmptyState />
   {{else}}
     <Campaign::EmptyState @campaignCode={{@model.campaign.code}} />

--- a/orga/tests/acceptance/campaign-analysis_test.js
+++ b/orga/tests/acceptance/campaign-analysis_test.js
@@ -5,7 +5,11 @@ import { module, test } from 'qunit';
 
 import authenticateSession from '../helpers/authenticate-session';
 import setupIntl from '../helpers/setup-intl';
-import { createPrescriberByUser, createUserWithMembershipAndTermsOfServiceAccepted } from '../helpers/test-init';
+import {
+  createPrescriberByUser,
+  createPrescriberForOrganization,
+  createUserWithMembershipAndTermsOfServiceAccepted,
+} from '../helpers/test-init';
 
 module('Acceptance | Campaign Analysis', function (hooks) {
   setupApplicationTest(hooks);
@@ -35,5 +39,49 @@ module('Acceptance | Campaign Analysis', function (hooks) {
     // then
     assert.ok(screen.getByLabelText(this.intl.t('pages.campaign-review.table.analysis.title')));
     assert.ok(screen.getByText(this.intl.t('pages.campaign-review.table.analysis.column.subjects', { count: 2 })));
+  });
+
+  module('when organization uses "GAR" as identity provider for campaigns', function () {
+    module('when there is no activity', function () {
+      test('displays an empty state message without copy button', async function (assert) {
+        // given
+        const userAttributes = {
+          id: 777,
+          firstName: 'Luc',
+          lastName: 'Harne',
+          email: 'luc@har.ne',
+          lang: 'fr',
+        };
+        const organizationAttributes = {
+          id: 777,
+          name: 'Cali Ber',
+          externalId: 'EXT_CALIBER',
+          identityProviderForCampaigns: 'GAR',
+        };
+        const organizationRole = 'ADMIN';
+        const user = createPrescriberForOrganization(userAttributes, organizationAttributes, organizationRole);
+
+        const campaignAnalysis = server.create('campaign-analysis', 'withTubeRecommendations');
+        const campaignCollectiveResult = server.create('campaign-collective-result');
+        server.create('campaign', 'ofTypeAssessment', {
+          id: 7654,
+          participationsCount: 0,
+          ownerId: user.id,
+          campaignAnalysis,
+          campaignCollectiveResult,
+        });
+
+        await authenticateSession(user.id);
+
+        // when
+        const screen = await visit('/campagnes/7654/analyse');
+
+        // then
+        assert.dom(screen.getByText(this.intl.t('pages.campaign.empty-state'))).exists();
+        assert
+          .dom(screen.queryByRole('button', { name: this.intl.t('pages.campaign.copy.link.default') }))
+          .doesNotExist();
+      });
+    });
   });
 });

--- a/orga/tests/unit/services/current-user_test.js
+++ b/orga/tests/unit/services/current-user_test.js
@@ -252,7 +252,7 @@ module('Unit | Service | current-user', function (hooks) {
     });
 
     module('when organization has "GAR" as identity provider for campaigns', function () {
-      test('sets isGARAuthenticationMethod to true', async function (assert) {
+      test('sets isGarAuthenticationMethod to true', async function (assert) {
         // given
         const organization = Object.create({
           id: 9,
@@ -269,7 +269,7 @@ module('Unit | Service | current-user', function (hooks) {
         await currentUserService.load();
 
         // then
-        assert.true(currentUserService.isGARAuthenticationMethod);
+        assert.true(currentUserService.isGarAuthenticationMethod);
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème

La page `Analyse` dans les détails d'une campagne affiche toujours un bouton pour copier le code de campagne pour les organisations rattachées au GAR.

Il faudrait avoir le même comportement que cette PR #9150. Ce bouton ne doit pas s'afficher.

## :robot: Proposition

Ne pas afficher le bouton copier le code campagne pour les organisations rattachées au GAR sur la page `Analyse`.

## :rainbow: Remarques

La méthode `isGARAuthenticationMethod` a été renommé en `isGarAuthenticationMethod`.

## :100: Pour tester

1. Se connecter sur Pix Admin avec le compte superadmin@example.net
2. Aller sur la page de détails de l'organisation **SCO SIECLE**
3. Modifier l'organisation en ajoutant le **GAR** comme SSO
4. Se connecter sur Pix orga avec le compte admin-orga@example.net
5. Créer une nouvelle campagne avec les informations suivantes :
    - Nom de la campagne > à vous de choisir
    - Quel est l'objectif de votre campagne ? > Évaluer les participants
    - Que souhaitez-vous tester ? > Pix (Niv3 ~ 5) - NO Badges - NO Stages
    - Souhaitez-vous permettre aux participants d’envoyer plusieurs fois leurs résultats ? > Non
6. Constater l'affichage de la page `Paramètres` de la campagne nouvellement créée
7. Cliquer sur l'onglet `Analyse`
8. Constater l'affichage du composant _EmptyState_ sans le bouton copier