### PR TITLE
[BUGFIX] Erreur lors du reset de mot de passe (PIX-12935)

### DIFF
--- a/api/src/identity-access-management/application/user/user.controller.js
+++ b/api/src/identity-access-management/application/user/user.controller.js
@@ -36,21 +36,19 @@ const save = async function (request, h, dependencies = { userSerializer, reques
 /**
  * @param request
  * @param h
- * @param {Object} dependencies
- * @param {UserSerializer} dependencies.userSerializer
  * @return {Promise<*>}
  */
-const updatePassword = async function (request, h, dependencies = { userSerializer }) {
+const updatePassword = async function (request, h) {
   const userId = request.params.id;
   const password = request.payload.data.attributes.password;
 
-  const updatedUser = await usecases.updateUserPassword({
+  await usecases.updateUserPassword({
     userId,
     password,
     temporaryKey: request.query['temporary-key'] || '',
   });
 
-  return dependencies.userSerializer.serialize(updatedUser);
+  return h.response().code(204);
 };
 
 const userController = { save, updatePassword };

--- a/api/src/identity-access-management/domain/usecases/update-user-password.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/update-user-password.usecase.js
@@ -10,7 +10,7 @@ import { UserNotAuthorizedToUpdatePasswordError } from '../../../shared/domain/e
  *   authenticationMethodRepository: AuthenticationMethodRepository,
  *   userRepository: UserRepository,
  * }} params
- * @return {Promise<*>}
+ * @return {Promise<void>}
  * @throws {UserNotAuthorizedToUpdatePasswordError}
  */
 export const updateUserPassword = async function ({
@@ -31,13 +31,12 @@ export const updateUserPassword = async function ({
 
   await resetPasswordService.hasUserAPasswordResetDemandInProgress(user.email, temporaryKey);
 
-  const updatedUser = await authenticationMethodRepository.updateChangedPassword({
+  await authenticationMethodRepository.updateChangedPassword({
     userId: user.id,
     hashedPassword,
   });
   await resetPasswordService.invalidateOldResetPasswordDemand(user.email);
+
   user.markEmailAsValid();
   await userRepository.update(user.mapToDatabaseDto());
-
-  return updatedUser;
 };

--- a/api/tests/identity-access-management/acceptance/application/user.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/user.route.test.js
@@ -228,7 +228,7 @@ describe('Acceptance | Identity Access Management | Application | Route | User',
           const response = await server.inject(options);
 
           // then
-          expect(response.statusCode).to.equal(200);
+          expect(response.statusCode).to.equal(204);
         });
       });
     });

--- a/api/tests/identity-access-management/unit/application/user.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/user.controller.test.js
@@ -163,10 +163,6 @@ describe('Unit | Identity Access Management | Application | Controller | User', 
 
     it('updates password', async function () {
       // given
-      userSerializer.deserialize.withArgs(payload).returns({
-        password: userPassword,
-        temporaryKey: userTemporaryKey,
-      });
       usecases.updateUserPassword
         .withArgs({
           userId,
@@ -174,13 +170,12 @@ describe('Unit | Identity Access Management | Application | Controller | User', 
           temporaryKey: userTemporaryKey,
         })
         .resolves({});
-      userSerializer.serialize.withArgs({}).returns('ok');
 
       // when
-      const response = await userController.updatePassword(request, hFake, { userSerializer });
+      const response = await userController.updatePassword(request, hFake);
 
       // then
-      expect(response).to.be.equal('ok');
+      expect(response.statusCode).to.equal(204);
     });
   });
 });

--- a/docs/security/reset_with_email.puml
+++ b/docs/security/reset_with_email.puml
@@ -20,7 +20,7 @@ API -> MonPix : 201 Created \n { data: {\ntype: "password-reset-demands", \nid: 
 User -> MonPix : /changer-mot-de-passe/<TOKEN>
 note left: Saisie nouveau mot de passe \nclic sur Envoyer
 MonPix -> API : PATCH /api/users/{id}/password-update\n&temporaryKey=<TOKEN>\n\n { data: { \ntype: "users", \nattributes: {  \nid: <ID>,  \nemail: <EMAIL>, \npassword:<PASSWORD>}\n}}
-API -> MonPix : 200 OK Created \n{ data: { \ntype: "users", \nattributes: (..)} \n}
+API -> MonPix : 204 No Content
 MonPix -> User : "Votre mot de passe a été modifié avec succès."
 note left: Clic sur connectez-vous
 @enduml


### PR DESCRIPTION
## :unicorn: Problème

Lors du reset de mot de passe sur Pix App, une erreur est affichée (_"Une erreur est survenue, nos équipes sont en train de résoudre..."_).

Malgré ce message d'erreur, le mot de passe est correctement mis à jour.

## :robot: Proposition

**Analyse**

Le problème vient du endpoint de mise à jour de mot de passe:
```
PATCH /api/users/101455/password-update?temporary-key=xxx
```

La réponse de ce endpoint est incorrecte, il retournait une réponse JSON-API avec un user id qui n'était pas celui de l'utilisateur:
```json
{ "type": "users", "id": "101456", "attributes": {} }
```

Quand le front reçoit cette réponse il met à jour la resource "User" et notamment sont `id`, par conséquent tous les appels suivants sont incorrects (404), car il sont basés sur le mauvais id.

À noté que ember met en évidence le changement d'id avec un warning dans la console du navigateur:
![SCR-20240617-jqms](https://github.com/1024pix/pix/assets/516360/a02c2874-f290-415a-b413-661049627876)

Le problème vient du use-case qui retourne le modèle `AuthenticationMethod` (avec l'id 101456) et ce modèle est ensuite sérialisé par le controller avec le sérialiser de "User".

**Changement**

La réponse du endpoint `PATCH /api/users/101455/password-update?temporary-key=xxx` n'a pas besoin de retourner de données dans sa réponse (aujourd'hui seul l'id est retourné). Donc au lieu de retourner une réponse `200 OK`, nous changeons la réponse en `204 No Content`.

## :rainbow: Remarques

N/A

## :100: Pour tester

1. Aller sur Pix app et cliquer sur "Mot de passe oublié"
2. Saisir l'adresse email "james-paledroits@example.net"
3. Dans l'email de reset, cliquer sur le lien de reset de mot de passe (attention, en local il sera peut-être nécessaire de modifier le hostname du lien)
4. Changer son mot de passe
> Aucun message d'erreur, confirmation que le mot de passe a bien été modifié. Vous pouvez vous connecter avec votre nouveau mot de passe.
