### PR TITLE
[FEATURE] Duplication de la route d'ajout de candidat de certification (PIX-12977).

### DIFF
--- a/api/src/certification/enrolment/application/certification-candidate-controller.js
+++ b/api/src/certification/enrolment/application/certification-candidate-controller.js
@@ -7,7 +7,7 @@ import * as sessionCertificationCandidateSerializer from '../infrastructure/seri
 const addCandidate = async function (request, h, dependencies = { certificationCandidateSerializer }) {
   const sessionId = request.params.id;
   const certificationCandidate = await dependencies.certificationCandidateSerializer.deserialize(request.payload);
-  const complementaryCertification = request.payload.data.attributes['complementary-certification'] ?? null;
+  const complementaryCertification = _getSubscriptionParameter(request) ?? null;
   const certificationCandidateId = await usecases.addCertificationCandidateToSession({
     sessionId,
     certificationCandidate,
@@ -32,6 +32,11 @@ const deleteCandidate = async function (request) {
   await usecases.deleteUnlinkedCertificationCandidate({ certificationCandidateId });
 
   return null;
+};
+
+const _getSubscriptionParameter = (request) => {
+  const { attributes } = request.payload.data;
+  return attributes['subscription'] ?? attributes['complementary-certification'];
 };
 
 const certificationCandidateController = {

--- a/api/src/certification/enrolment/application/certification-candidate-controller.js
+++ b/api/src/certification/enrolment/application/certification-candidate-controller.js
@@ -7,11 +7,11 @@ import * as sessionCertificationCandidateSerializer from '../infrastructure/seri
 const addCandidate = async function (request, h, dependencies = { certificationCandidateSerializer }) {
   const sessionId = request.params.id;
   const certificationCandidate = await dependencies.certificationCandidateSerializer.deserialize(request.payload);
-  const complementaryCertification = _getSubscriptionParameter(request) ?? null;
+  const subscription = _getSubscriptionParameter(request) ?? null;
   const certificationCandidateId = await usecases.addCertificationCandidateToSession({
     sessionId,
     certificationCandidate,
-    complementaryCertification,
+    subscription,
   });
 
   return h

--- a/api/src/certification/enrolment/application/certification-candidate-route.js
+++ b/api/src/certification/enrolment/application/certification-candidate-route.js
@@ -56,10 +56,11 @@ const register = async function (server) {
           },
         ],
         handler: certificationCandidateController.addCandidate,
-        tags: ['api', 'sessions', 'certification-candidates'],
+        tags: ['api', 'sessions', 'certification-candidates', 'deprecated'],
         notes: [
           'Cette route est restreinte aux utilisateurs authentifiés',
           'Elle ajoute un candidat de certification à la session.',
+          'Cette route est dépréciée',
         ],
       },
     },

--- a/api/src/certification/enrolment/application/certification-candidate-route.js
+++ b/api/src/certification/enrolment/application/certification-candidate-route.js
@@ -64,6 +64,62 @@ const register = async function (server) {
       },
     },
     {
+      method: 'POST',
+      path: '/api/sessions/{id}/certification-candidate',
+      config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.sessionId,
+          }),
+          payload: Joi.object({
+            data: {
+              type: Joi.string().valid('certification-candidates').required(),
+              attributes: {
+                subscription: Joi.object()
+                  .keys({
+                    id: Joi.number().required(),
+                    key: Joi.string(),
+                    label: Joi.string(),
+                  })
+                  .optional(),
+                'first-name': Joi.string().empty(['', null]).required(),
+                'last-name': Joi.string().empty(['', null]).required(),
+                'birth-city': Joi.string().empty(['', null]),
+                'birth-province-code': Joi.string().empty(['', null]),
+                'birth-country': Joi.string().empty(['', null]),
+                'birth-postal-code': Joi.string().empty(['', null]),
+                'birth-insee-code': Joi.string().empty(['', null]),
+                'result-recipient-email': Joi.string().empty(['', null]),
+                'external-id': Joi.string().empty(['', null]),
+                'extra-time-percentage': Joi.number().empty([null]),
+                'billing-mode': Joi.string().empty(['', null]),
+                'prepayment-code': Joi.string().empty(['', null]),
+                'is-linked': Joi.boolean().valid(false).optional(),
+                sex: Joi.string().empty(['', null]).required(),
+                email: Joi.string().empty(['', null]),
+                birthdate: Joi.date().format('YYYY-MM-DD').raw().required().messages({
+                  'date.format': 'CANDIDATE_BIRTHDATE_FORMAT_NOT_VALID',
+                }),
+                'organization-learner-id': Joi.number().empty(null).forbidden(),
+              },
+            },
+          }),
+        },
+        pre: [
+          {
+            method: authorization.verifySessionAuthorization,
+            assign: 'authorizationCheck',
+          },
+        ],
+        handler: certificationCandidateController.addCandidate,
+        tags: ['api', 'sessions', 'certification-candidates'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs authentifiés',
+          'Elle ajoute un candidat de certification à la session.',
+        ],
+      },
+    },
+    {
       method: 'GET',
       path: '/api/sessions/{id}/certification-candidates',
       config: {

--- a/api/src/certification/enrolment/domain/usecases/add-certification-candidate-to-session.js
+++ b/api/src/certification/enrolment/domain/usecases/add-certification-candidate-to-session.js
@@ -26,7 +26,7 @@ import { Subscription } from '../models/Subscription.js';
 const addCertificationCandidateToSession = async function ({
   sessionId,
   certificationCandidate,
-  complementaryCertification,
+  subscription,
   sessionRepository,
   certificationCandidateRepository,
   certificationCpfService,
@@ -83,7 +83,7 @@ const addCertificationCandidateToSession = async function ({
   certificationCandidate.addSubscription(
     Subscription.buildCore({ certificationCandidateId: certificationCandidate.id }),
   );
-  certificationCandidate.complementaryCertification = complementaryCertification;
+  certificationCandidate.complementaryCertification = subscription;
 
   if (certificationCandidate.resultRecipientEmail) {
     try {

--- a/api/tests/certification/enrolment/acceptance/application/certification-candidate-controller-post-certification-candidate_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/certification-candidate-controller-post-certification-candidate_test.js
@@ -150,4 +150,129 @@ describe('Acceptance | Controller | Certification | Enrolment | session-controll
       ]);
     });
   });
+
+  describe('#add', function () {
+    let options;
+    let payload;
+    let sessionId;
+    let userId;
+    let certificationCandidate;
+    let complementaryCertificationId;
+
+    beforeEach(function () {
+      certificationCandidate = domainBuilder.buildCertificationCandidate.pro({
+        birthCountry: 'FRANCE',
+        birthINSEECode: '75115',
+        birthPostalCode: null,
+        birthCity: null,
+        subscriptions: [domainBuilder.buildCoreSubscription()],
+      });
+      userId = databaseBuilder.factory.buildUser().id;
+
+      databaseBuilder.factory.buildOrganization({
+        type: 'PRO',
+        name: 'PRO_ORGANIZATION',
+        externalId: 'EXTERNAL_ID',
+      });
+
+      const { id: certificationCenterId, name: certificationCenter } = databaseBuilder.factory.buildCertificationCenter(
+        {
+          name: 'PRO_CERTIFICATION_CENTER',
+          type: 'PRO',
+          externalId: 'EXTERNAL_ID',
+        },
+      );
+
+      sessionId = databaseBuilder.factory.buildSession({ certificationCenterId, certificationCenter }).id;
+      databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
+      databaseBuilder.factory.buildCertificationCpfCountry({
+        name: 'FRANCE',
+        code: '99100',
+        matcher: 'ACEFNR',
+      });
+      databaseBuilder.factory.buildCertificationCpfCity({
+        name: 'PARIS 15',
+        INSEECode: '75115',
+      });
+      complementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({
+        label: 'Certif complémentaire 1',
+      }).id;
+
+      payload = {
+        data: {
+          type: 'certification-candidates',
+          attributes: {
+            'first-name': certificationCandidate.firstName,
+            'last-name': certificationCandidate.lastName,
+            'birth-city': null,
+            'birth-country': certificationCandidate.birthCountry,
+            email: certificationCandidate.email,
+            'result-recipient-email': certificationCandidate.resultRecipientEmail,
+            'external-id': certificationCandidate.externalId,
+            birthdate: certificationCandidate.birthdate,
+            'extra-time-percentage': certificationCandidate.extraTimePercentage,
+            'has-seen-end-test-screen': certificationCandidate.hasSeenEndTestScreen,
+            'birth-insee-code': certificationCandidate.birthINSEECode,
+            'birth-postal-code': null,
+            'billing-mode': 'FREE',
+            sex: certificationCandidate.sex,
+            subscription: {
+              id: complementaryCertificationId,
+              label: 'Certif complémentaire 1',
+              key: 'CERTIF',
+            },
+          },
+        },
+      };
+      options = {
+        method: 'POST',
+        url: `/api/sessions/${sessionId}/certification-candidate`,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(userId),
+        },
+        payload,
+      };
+
+      return databaseBuilder.commit();
+    });
+
+    it('should respond with a 201 created', async function () {
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(201);
+    });
+
+    it('should return the saved certification candidate', async function () {
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.result.data.id).to.exist;
+      expect(response.result.data.type).to.equal('certification-candidates');
+    });
+
+    it('should save the complementary certification subscription', async function () {
+      // when
+      await server.inject(options);
+
+      // then
+      const complementaryCertificationRegistrationsInDB = await knex('certification-subscriptions').select(
+        'complementaryCertificationId',
+        'type',
+      );
+
+      expect(complementaryCertificationRegistrationsInDB).to.have.deep.members([
+        {
+          complementaryCertificationId: null,
+          type: SubscriptionTypes.CORE,
+        },
+        {
+          complementaryCertificationId,
+          type: SubscriptionTypes.COMPLEMENTARY,
+        },
+      ]);
+    });
+  });
 });

--- a/api/tests/certification/enrolment/unit/application/certification-candidate-controller_test.js
+++ b/api/tests/certification/enrolment/unit/application/certification-candidate-controller_test.js
@@ -24,7 +24,7 @@ describe('Unit | Controller | certification-candidate-controller', function () {
         .withArgs({
           sessionId,
           certificationCandidate,
-          complementaryCertification: null,
+          subscription: null,
         })
         .resolves(addedCertificationCandidateId);
       const certificationCandidateSerializer = {

--- a/api/tests/certification/enrolment/unit/application/certification-candidate-route_test.js
+++ b/api/tests/certification/enrolment/unit/application/certification-candidate-route_test.js
@@ -110,6 +110,111 @@ describe('Unit | Application | Sessions | Routes', function () {
     });
   });
 
+  describe('POST /api/sessions/{id}/certification-candidate', function () {
+    const correctAttributes = {
+      'first-name': 'prenom',
+      'last-name': 'nom',
+      birthdate: '2000-01-01',
+      'birth-city': null,
+      'birth-province-code': null,
+      'birth-country': 'FRANCE',
+      'birth-postal-code': null,
+      'birth-insee-code': '75115',
+      email: 'guybrush.threepwood@example.net',
+      'result-recipient-email': 'theotherone@example.net',
+      'external-id': '44AA3355',
+      'extra-time-percentage': 0.15,
+      'organization-learner-id': null,
+      sex: 'F',
+      'billing-mode': 'FREE',
+      'prepayment-code': null,
+      subscription: { id: 5 },
+    };
+
+    describe('when the payload is correct', function () {
+      it('should return 404 if the user is not authorized on the session', async function () {
+        // given
+        sinon.stub(authorization, 'verifySessionAuthorization').throws(new NotFoundError());
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const response = await httpTestServer.request('POST', '/api/sessions/3/certification-candidate', {
+          data: { attributes: correctAttributes, type: 'certification-candidates' },
+        });
+
+        // then
+        expect(response.statusCode).to.equal(404);
+      });
+
+      it('should return 200', async function () {
+        // given
+        sinon.stub(authorization, 'verifySessionAuthorization').returns(true);
+        sinon.stub(certificationCandidateController, 'addCandidate').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/sessions/1/certification-candidate', {
+          data: {
+            attributes: correctAttributes,
+            type: 'certification-candidates',
+          },
+        });
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+
+    describe('when the payload is incorrect', function () {
+      describe('when an attribute has wrong type', function () {
+        it('should return 400', async function () {
+          // given
+          sinon.stub(authorization, 'verifySessionAuthorization').returns(true);
+          sinon.stub(certificationCandidateController, 'addCandidate').returns('ok');
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          // when
+          const response = await httpTestServer.request('POST', '/api/sessions/1/certification-candidate', {
+            data: {
+              attributes: { ...correctAttributes, subscription: [] },
+              type: 'certification-candidates',
+            },
+          });
+
+          // then
+          expect(response.statusCode).to.equal(400);
+          const { errors } = JSON.parse(response.payload);
+          expect(errors[0].detail).to.equals('"data.attributes.subscription" must be of type object');
+        });
+      });
+
+      describe('when there is an unexpected attribute', function () {
+        it('should return 400', async function () {
+          // given
+          sinon.stub(authorization, 'verifySessionAuthorization').returns(true);
+          sinon.stub(certificationCandidateController, 'addCandidate').returns('ok');
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          // when
+          const response = await httpTestServer.request('POST', '/api/sessions/1/certification-candidate', {
+            data: {
+              attributes: { ...correctAttributes, toto: 3 },
+              type: 'certification-candidates',
+            },
+          });
+
+          // then
+          expect(response.statusCode).to.equal(400);
+          const { errors } = JSON.parse(response.payload);
+          expect(errors[0].detail).to.equals('"data.attributes.toto" is not allowed');
+        });
+      });
+    });
+  });
+
   describe('GET /api/sessions/{id}/certification-candidates', function () {
     it('should exist', async function () {
       // given

--- a/api/tests/certification/enrolment/unit/domain/usecases/add-certification-candidate-to-session_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/add-certification-candidate-to-session_test.js
@@ -170,7 +170,7 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
         await addCertificationCandidateToSession({
           sessionId,
           certificationCandidate,
-          complementaryCertification,
+          subscription: complementaryCertification,
           certificationCandidateRepository,
           certificationCpfService,
           certificationCpfCountryRepository,
@@ -219,7 +219,7 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
         await addCertificationCandidateToSession({
           sessionId,
           certificationCandidate,
-          complementaryCertification: null,
+          subscription: null,
           certificationCandidateRepository,
           certificationCpfService,
           certificationCpfCountryRepository,
@@ -255,7 +255,7 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
         await addCertificationCandidateToSession({
           sessionId,
           certificationCandidate,
-          complementaryCertification: null,
+          subscription: null,
           certificationCandidateRepository,
           certificationCpfService,
           certificationCpfCountryRepository,
@@ -290,7 +290,7 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
           const error = await catchErr(addCertificationCandidateToSession)({
             sessionId,
             certificationCandidate,
-            complementaryCertification: null,
+            subscription: null,
             certificationCandidateRepository,
             certificationCpfService,
             certificationCpfCountryRepository,
@@ -333,7 +333,7 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
             const error = await catchErr(addCertificationCandidateToSession)({
               sessionId,
               certificationCandidate,
-              complementaryCertification: null,
+              subscription: null,
               certificationCandidateRepository,
               certificationCpfService,
               certificationCpfCountryRepository,
@@ -380,7 +380,7 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
             const error = await catchErr(addCertificationCandidateToSession)({
               sessionId,
               certificationCandidate,
-              complementaryCertification: null,
+              subscription: null,
               certificationCandidateRepository,
               certificationCpfService,
               certificationCpfCountryRepository,


### PR DESCRIPTION
## :unicorn: Problème

Dans le cadre de la séparation Pix/Pix+, nous souhaitons remplacer le paramètre `complementary-certification` du payload d'ajout de candidat par `subscription` (Celui-ci pourra contenir désormais à la fois du `CORE` ou du `COMPLEMENTARY`)

Cependant, et afin de ne pas casser l’existant pour les partenaires de Pix en ce qui concerne l’ajout de candidat (et notamment du payload), nous avons fait le choix de dupliquer la route concernant l’ajout de candidaten remplaçant le paramètre `complementary-certification` par `subscription`.

## :robot: Proposition

Duplication de la route d'ajout de candidat en session

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

Tests verts

Ajout d'un candidat via la requête cURL suivante (en attendant le ticket front): 

```
TOKEN=$(curl 'https://api-pr9287.review.pix.fr/api/token' --data-raw 'grant_type=password&username=certif-pro@example.net&password=pix123&scope=pix-certif' | jq -r .access_token)
curl https://api-pr9287.review.pix.fr/api/sessions/7409/certification-candidate \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-language: fr-fr" \
    -X POST \
    -d @./candidate.json | jq '.'
```

Où `candidate.json` est un fichier situé dans le dossier où votre requête est exécutée et contenant des informations de ce type : 

```
{
  "data": {
    "type": "certification-candidates",
    "attributes": {
      "first-name": "titi",
      "last-name": "titi",
      "birth-city": null,
      "birth-country": "FRANCE",
      "email": "titi@titi.fr",
      "result-recipient-email": null,
      "external-id": null,
      "birthdate": "2000-01-01",
      "extra-time-percentage": null,
      "birth-insee-code": "75115",
      "birth-postal-code": null,
      "billing-mode": "FREE",
      "sex": "M",
      "subscription": {
        "id": 52,
        "label": "Certif complémentaire 1",
        "key": "CERTIF"
      }
    }
  }
}
```

Non régression : Ajout d'un candidat via la modale d'inscription dans pix-certif