### PR TITLE
[TECH] Corrige le code pour suivre la règle de lint no-builtin-form-components.

### DIFF
--- a/admin/app/components/badges/badge.hbs
+++ b/admin/app/components/badges/badge.hbs
@@ -68,7 +68,7 @@
                 class="badge-form-check-field__control"
                 @checked={{this.form.isCertifiable}}
                 {{on "change" (toggle "form.isCertifiable" this)}}
-              ><:label>Certifiable : </:label></PixCheckbox>
+              ><:label>Certifiable</:label></PixCheckbox>
             </div>
             <div class="badge-edit-form__field">
               <PixCheckbox
@@ -76,7 +76,7 @@
                 @type="checkbox"
                 @checked={{this.form.isAlwaysVisible}}
                 {{on "change" (toggle "form.isAlwaysVisible" this)}}
-              ><:label>Lacunes : </:label></PixCheckbox>
+              ><:label>Lacunes</:label></PixCheckbox>
             </div>
             <div class="badge-edit-form__actions">
               <PixButton @size="small" @variant="secondary" @triggerAction={{this.cancel}}>Annuler</PixButton>

--- a/admin/app/components/badges/badge.hbs
+++ b/admin/app/components/badges/badge.hbs
@@ -1,5 +1,3 @@
-{{! template-lint-disable no-builtin-form-components}}
-{{! TODO: Use PixUI components instead }}
 <header class="page-header">
   <div class="page-title">
     <p>
@@ -26,62 +24,59 @@
         <div class="badge-edit-form">
           <form class="form" {{on "submit" this.updateBadge}}>
             <div class="badge-edit-form__field">
-              <label for="title" class="badge-edit-form-field__label">
-                <abbr title="obligatoire" class="mandatory-mark">*</abbr>
-                Titre :
-              </label>
-              <Input id="title" @type="text" class="form-control" @value={{this.form.title}} required={{true}} />
+              <PixInput
+                class="form-control"
+                @value={{this.form.title}}
+                @requiredLabel={{true}}
+                {{on "input" (pick "target.value" (set this "form.title"))}}
+              ><:label>Titre : </:label></PixInput>
             </div>
             <div class="badge-edit-form__field">
-              <label for="key" class="badge-edit-form-field__label">
-                <abbr title="obligatoire" class="mandatory-mark">*</abbr>
-                Clé :
-              </label>
-              <Input id="key" @type="text" class="form-control" @value={{this.form.key}} required={{true}} />
+              <PixInput
+                class="form-control"
+                @value={{this.form.key}}
+                @requiredLabel={{true}}
+                {{on "input" (pick "target.value" (set this "form.key"))}}
+              ><:label>Clé : </:label></PixInput>
             </div>
             <div class="badge-edit-form__field">
-              <label for="message" class="badge-edit-form-field__label">
-                Message :
-              </label>
-              <Textarea id="message" class="form-control" @value={{this.form.message}} rows="4" />
+              <PixTextarea
+                class="form-control"
+                @value={{this.form.message}}
+                rows="4"
+                {{on "input" (pick "target.value" (set this "form.message"))}}
+              ><:label>Message : </:label></PixTextarea>
             </div>
             <div class="badge-edit-form__field">
-              <label for="imageUrl" class="badge-edit-form-field__label">
-                <abbr title="obligatoire" class="mandatory-mark">*</abbr>
-                Nom de l'image (svg) :
-              </label>
-              <Input id="imageUrl" @type="text" class="form-control" @value={{this.form.imageName}} required={{true}} />
+              <PixInput
+                class="form-control"
+                @value={{this.form.imageName}}
+                @requiredLabel={{true}}
+                {{on "input" (pick "target.value" (set this "form.imageName"))}}
+              ><:label>Nom de l'image (svg) : </:label></PixInput>
             </div>
             <div class="badge-edit-form__field">
-              <label for="altMessage" class="badge-edit-form-field__label">
-                <abbr title="obligatoire" class="mandatory-mark">*</abbr>
-                Message Alternatif :
-              </label>
-              <Input
-                id="altMessage"
-                @type="text"
+              <PixInput
                 class="form-control"
                 @value={{this.form.altMessage}}
-                required={{true}}
-              />
+                @requiredLabel={{true}}
+                {{on "input" (pick "target.value" (set this "form.altMessage"))}}
+              ><:label>Message Alternatif : </:label></PixInput>
             </div>
             <div class="badge-edit-form__field">
-              <label for="isCertifiable">Certifiable : </label>
-              <Input
+              <PixCheckbox
                 class="badge-form-check-field__control"
-                @type="checkbox"
                 @checked={{this.form.isCertifiable}}
-                id="isCertifiable"
-              />
+                {{on "change" (toggle "form.isCertifiable" this)}}
+              ><:label>Certifiable : </:label></PixCheckbox>
             </div>
             <div class="badge-edit-form__field">
-              <label for="isAlwaysVisible">Lacunes : </label>
-              <Input
+              <PixCheckbox
                 class="badge-form-check-field__control"
                 @type="checkbox"
                 @checked={{this.form.isAlwaysVisible}}
-                id="isAlwaysVisible"
-              />
+                {{on "change" (toggle "form.isAlwaysVisible" this)}}
+              ><:label>Lacunes : </:label></PixCheckbox>
             </div>
             <div class="badge-edit-form__actions">
               <PixButton @size="small" @variant="secondary" @triggerAction={{this.cancel}}>Annuler</PixButton>

--- a/admin/app/components/certification-centers/creation-form.hbs
+++ b/admin/app/components/certification-centers/creation-form.hbs
@@ -1,86 +1,87 @@
 <form class="form certification-center-form" {{on "submit" @onSubmit}}>
 
-  <section class="form-section">
+  <PixInput
+    @id="certificationCenterName"
+    onchange={{this.handleCenterNameChange}}
+    class="form-field"
+    required={{true}}
+    aria-required={{true}}
+  >
+    <:label>Nom du centre</:label>
+  </PixInput>
 
-    <PixInput
-      @id="certificationCenterName"
-      onchange={{this.handleCenterNameChange}}
-      class="form-field"
+  <div class="form-field">
+    <PixSelect
+      @options={{this.certificationCenterTypes}}
+      @placeholder="-- Choisissez --"
+      @hideDefaultOption={{true}}
+      @onChange={{this.selectCertificationCenterType}}
+      @value={{@certificationCenter.type}}
       required={{true}}
       aria-required={{true}}
     >
-      <:label>Nom du centre</:label>
-    </PixInput>
+      <:label>Type d'établissement</:label>
+      <:default as |certificationCenterType|>{{certificationCenterType.label}}</:default>
+    </PixSelect>
+  </div>
 
-    <div class="form-field">
-      <PixSelect
-        @options={{this.certificationCenterTypes}}
-        @placeholder="-- Choisissez --"
-        @hideDefaultOption={{true}}
-        @onChange={{this.selectCertificationCenterType}}
-        @value={{@certificationCenter.type}}
-        required={{true}}
-        aria-required={{true}}
-      >
-        <:label>Type d'établissement</:label>
-        <:default as |certificationCenterType|>{{certificationCenterType.label}}</:default>
-      </PixSelect>
-    </div>
+  <PixInput @id="certificationCenterExternalId" onchange={{this.handleExternalIdChange}} class="form-field">
+    <:label>Identifiant externe</:label>
+  </PixInput>
 
-    <PixInput @id="certificationCenterExternalId" onchange={{this.handleExternalIdChange}} class="form-field">
-      <:label>Identifiant externe</:label>
-    </PixInput>
+  <PixInput
+    @id="dataProtectionOfficerFirstName"
+    {{on "change" this.handleDataProtectionOfficerFirstNameChange}}
+    class="form-field"
+  >
+    <:label>Prénom du DPO</:label>
+  </PixInput>
 
-    <PixInput
-      @id="dataProtectionOfficerFirstName"
-      {{on "change" this.handleDataProtectionOfficerFirstNameChange}}
-      class="form-field"
-    >
-      <:label>Prénom du DPO</:label>
-    </PixInput>
+  <PixInput
+    @id="dataProtectionOfficerLastName"
+    {{on "change" this.handleDataProtectionOfficerLastNameChange}}
+    class="form-field"
+  >
+    <:label>Nom du DPO</:label>
+  </PixInput>
 
-    <PixInput
-      @id="dataProtectionOfficerLastName"
-      {{on "change" this.handleDataProtectionOfficerLastNameChange}}
-      class="form-field"
-    >
-      <:label>Nom du DPO</:label>
-    </PixInput>
+  <PixInput
+    @id="dataProtectionOfficerEmail"
+    {{on "change" this.handleDataProtectionOfficerEmailChange}}
+    class="form-field"
+  >
+    <:label>Adresse e-mail du DPO</:label>
+  </PixInput>
 
-    <PixInput
-      @id="dataProtectionOfficerEmail"
-      {{on "change" this.handleDataProtectionOfficerEmailChange}}
-      class="form-field"
-    >
-      <:label>Adresse e-mail du DPO</:label>
-    </PixInput>
+  <div class="form-field">
+    <PixCheckbox @id="isV3Pilot" @size="small" onChange={{this.handleIsV3PilotChange}}>
+      <:label>{{t "components.certification-centers.is-v3-pilot-label"}}</:label>
+    </PixCheckbox>
+  </div>
 
-    <div class="form-field">
-      <PixCheckbox @id="isV3Pilot" @size="small" onChange={{this.handleIsV3PilotChange}}>
-        <:label>{{t "components.certification-centers.is-v3-pilot-label"}}</:label>
-      </PixCheckbox>
-    </div>
-
-    <section>
-      <h2 class="habilitations-title">Habilitations aux certifications complémentaires</h2>
-      <ul class="form-field habilitations-checkbox-list">
-        {{#each @habilitations as |habilitation index|}}
-          <li class="habilitation-entry">
-            <PixCheckbox
-              @id={{concat "habilitation_" index}}
-              @size="small"
-              onChange={{fn this.updateGrantedHabilitation habilitation}}
-            >
-              <:label>{{habilitation.label}}</:label>
-            </PixCheckbox>
-          </li>
-        {{/each}}
-      </ul>
-    </section>
+  <section>
+    <h2 class="habilitations-title">Habilitations aux certifications complémentaires</h2>
+    <ul class="form-field habilitations-checkbox-list">
+      {{#each @habilitations as |habilitation index|}}
+        <li class="habilitation-entry">
+          <PixCheckbox
+            @id={{concat "habilitation_" index}}
+            @size="small"
+            onChange={{fn this.updateGrantedHabilitation habilitation}}
+          >
+            <:label>{{habilitation.label}}</:label>
+          </PixCheckbox>
+        </li>
+      {{/each}}
+    </ul>
   </section>
 
-  <section class="form-section form-actions">
-    <PixButton @size="small" @variant="secondary" @triggerAction={{@onCancel}}>Annuler</PixButton>
-    <PixButton @type="submit" @size="small">Ajouter</PixButton>
-  </section>
+  <ul class="form-actions">
+    <li>
+      <PixButton @size="small" @variant="secondary" @triggerAction={{@onCancel}}>Annuler</PixButton>
+    </li>
+    <li>
+      <PixButton @type="submit" @size="small">Ajouter</PixButton>
+    </li>
+  </ul>
 </form>

--- a/admin/app/components/certification-centers/information-edit.hbs
+++ b/admin/app/components/certification-centers/information-edit.hbs
@@ -1,20 +1,15 @@
-{{! template-lint-disable no-builtin-form-components}}
-{{! TODO: Use PixUI components instead }}
 <h2 class="certification-center-information__edit-title">Modifier un centre de certification</h2>
 
 <form class="form certification-center-information__edit-form" onsubmit={{this.updateCertificationCenter}}>
 
-  <label class="field-label">
-    <abbr title="obligatoire" class="mandatory-mark">*</abbr>
-    Nom du centre
-    <Input
-      id="name"
-      @type="text"
-      class={{if (v-get this.form "name" "isInvalid") "form-control is-invalid" "form-control"}}
-      @value={{this.form.name}}
-      required={{true}}
-    />
-  </label>
+  <PixInput
+    class={{if (v-get this.form "name" "isInvalid") "form-control is-invalid" "form-control"}}
+    @value={{this.form.name}}
+    @requiredLabel={{true}}
+    {{on "input" (pick "target.value" (set this "form.name"))}}
+  >
+    <:label>Nom du centre</:label>
+  </PixInput>
 
   {{#if (v-get this.form "name" "isInvalid")}}
     <span class="error" aria-label="Message d'erreur du champ nom">
@@ -33,15 +28,13 @@
     <:default as |certificationCenterType|>{{certificationCenterType.label}}</:default>
   </PixSelect>
 
-  <label class="field-label">
-    Identifiant externe
-    <Input
-      id="external-id"
-      @type="text"
-      class={{if (v-get this.form "externalId" "isInvalid") "form-control is-invalid" "form-control"}}
-      @value={{this.form.externalId}}
-    />
-  </label>
+  <PixInput
+    class={{if (v-get this.form "externalId" "isInvalid") "form-control is-invalid" "form-control"}}
+    @value={{this.form.externalId}}
+    {{on "input" (pick "target.value" (set this "form.externalId"))}}
+  >
+    <:label>Identifiant externe</:label>
+  </PixInput>
 
   {{#if (v-get this.form "externalId" "isInvalid")}}
     <span class="error" aria-label="Message d'erreur du champ ID externe">
@@ -49,19 +42,13 @@
     </span>
   {{/if}}
 
-  <label class="field-label">
-    Prénom du
-    <abbr title="Délégué à la protection des données">DPO</abbr>
-    <Input
-      @type="text"
-      class={{if
-        (v-get this.form "dataProtectionOfficerFirstName" "isInvalid")
-        "form-control is-invalid"
-        "form-control"
-      }}
-      @value={{this.form.dataProtectionOfficerFirstName}}
-    />
-  </label>
+  <PixInput
+    class={{if (v-get this.form "dataProtectionOfficerFirstName" "isInvalid") "form-control is-invalid" "form-control"}}
+    @value={{this.form.dataProtectionOfficerFirstName}}
+    {{on "input" (pick "target.value" (set this "form.dataProtectionOfficerFirstName"))}}
+  >
+    <:label>Prénom du <abbr title="Délégué à la protection des données">DPO</abbr></:label>
+  </PixInput>
 
   {{#if (v-get this.form "dataProtectionOfficerFirstName" "isInvalid")}}
     <span class="error" aria-label="Message d'erreur du champ Prénom du DPO">
@@ -69,20 +56,11 @@
     </span>
   {{/if}}
 
-  <label class="field-label">
-    Nom du
-    <abbr title="Délégué à la protection des données">DPO</abbr>
-    <Input
-      id="data-protection-officer-last-name"
-      @type="text"
-      class={{if
-        (v-get this.form "dataProtectionOfficerLastName" "isInvalid")
-        "form-control is-invalid"
-        "form-control"
-      }}
-      @value={{this.form.dataProtectionOfficerLastName}}
-    />
-  </label>
+  <PixInput
+    class={{if (v-get this.form "dataProtectionOfficerLastName" "isInvalid") "form-control is-invalid" "form-control"}}
+    @value={{this.form.dataProtectionOfficerLastName}}
+    {{on "input" (pick "target.value" (set this "form.dataProtectionOfficerLastName"))}}
+  ><:label>Nom du <abbr title="Délégué à la protection des données">DPO</abbr></:label></PixInput>
 
   {{#if (v-get this.form "dataProtectionOfficerLastName" "isInvalid")}}
     <span class="error" aria-label="Message d'erreur du champ Nom du DPO">
@@ -90,15 +68,11 @@
     </span>
   {{/if}}
 
-  <label class="field-label">
-    Adresse e-mail du
-    <abbr title="Délégué à la protection des données">DPO</abbr>
-    <Input
-      @type="text"
-      class={{if (v-get this.form "dataProtectionOfficerEmail" "isInvalid") "form-control is-invalid" "form-control"}}
-      @value={{this.form.dataProtectionOfficerEmail}}
-    />
-  </label>
+  <PixInput
+    class={{if (v-get this.form "dataProtectionOfficerEmail" "isInvalid") "form-control is-invalid" "form-control"}}
+    @value={{this.form.dataProtectionOfficerEmail}}
+    {{on "input" (pick "target.value" (set this "form.dataProtectionOfficerEmail"))}}
+  ><:label>Adresse e-mail du <abbr title="Délégué à la protection des données">DPO</abbr></:label></PixInput>
 
   {{#if (v-get this.form "dataProtectionOfficerEmail" "isInvalid")}}
     <span class="error" aria-label="Message d'erreur du champ Adresse e-mail du DPO">
@@ -114,15 +88,14 @@
   <ul class="form-field certification-center-information__edit-form__habilitations-checkbox-list">
     {{#each this.availableHabilitations as |habilitation|}}
       <li class="habilitation-entry">
-        <Input
-          id="habilitation-checkbox__{{habilitation.id}}"
-          @type="checkbox"
+        <PixCheckbox
           @checked={{contains habilitation this.habilitations}}
-          {{on "input" (fn this.updateGrantedHabilitation habilitation)}}
-        />
-        <label class="field-label" for="habilitation-checkbox__{{habilitation.id}}">
-          {{habilitation.label}}
-        </label>
+          {{on "change" (fn this.updateGrantedHabilitation habilitation)}}
+        >
+          <:label>
+            {{habilitation.label}}
+          </:label>
+        </PixCheckbox>
       </li>
     {{/each}}
   </ul>

--- a/admin/app/components/certifications/candidate-edit-modal.hbs
+++ b/admin/app/components/certifications/candidate-edit-modal.hbs
@@ -1,5 +1,4 @@
-{{! template-lint-disable no-at-ember-render-modifiers no-builtin-form-components }}
-{{! TODO: Use PixUI components instead }}
+{{! template-lint-disable no-at-ember-render-modifiers }}
 {{! TODO: Use this documentation to remove usage of did-insert and did-update
 https://guides.emberjs.com/release/components/template-lifecycle-dom-and-modifiers/#toc_communicating-between-elements-in-a-component}}
 <PixModal
@@ -14,17 +13,22 @@ https://guides.emberjs.com/release/components/template-lifecycle-dom-and-modifie
       </p>
 
       <div class="candidate-edit-modal--content__field">
-        <label for="last-name">
-          Nom de famille
-        </label>
-        <Input id="last-name" @type="text" class="input" @value={{this.lastName}} {{did-insert this.focus}} required />
+        <PixInput
+          class="input"
+          @value={{this.lastName}}
+          {{did-insert this.focus}}
+          {{on "input" (pick "target.value" (set this "lastName"))}}
+          required
+        ><:label>Nom de famille</:label></PixInput>
       </div>
 
       <div class="candidate-edit-modal--content__field">
-        <label for="first-name">
-          Prénom
-        </label>
-        <Input id="first-name" @type="text" class="input" @value={{this.firstName}} required />
+        <PixInput
+          class="input"
+          @value={{this.firstName}}
+          required
+          {{on "input" (pick "target.value" (set this "firstName"))}}
+        ><:label>Prénom</:label></PixInput>
       </div>
 
       <div class="candidate-edit-modal--content__field-radio-button">
@@ -102,28 +106,40 @@ https://guides.emberjs.com/release/components/template-lifecycle-dom-and-modifie
 
       {{#if this.isBirthInseeCodeRequired}}
         <div class="candidate-edit-modal--content__field">
-          <label for="birth-insee-code">
-            Code Insee de naissance
-          </label>
-          <Input id="birth-insee-code" @type="text" class="input" @value={{this.birthInseeCode}} required />
+          <PixInput
+            class="input"
+            @value={{this.birthInseeCode}}
+            required
+            {{on "input" (pick "target.value" (set this "birthInseeCode"))}}
+          ><:label>
+              Code Insee de naissance
+            </:label></PixInput>
         </div>
       {{/if}}
 
       {{#if this.isBirthPostalCodeRequired}}
         <div class="candidate-edit-modal--content__field">
-          <label for="birth-postal-code">
-            Code postal de naissance
-          </label>
-          <Input id="birth-postal-code" @type="text" class="input" @value={{this.birthPostalCode}} required />
+          <PixInput
+            class="input"
+            @value={{this.birthPostalCode}}
+            required
+            {{on "input" (pick "target.value" (set this "birthPostalCode"))}}
+          ><:label>
+              Code postal de naissance
+            </:label></PixInput>
         </div>
       {{/if}}
 
       {{#if this.isBirthCityRequired}}
         <div class="candidate-edit-modal--content__field">
-          <label for="birth-city">
-            Commune de naissance
-          </label>
-          <Input id="birth-city" @type="text" class="input" @value={{this.birthCity}} required />
+          <PixInput
+            class="input"
+            @value={{this.birthCity}}
+            required
+            {{on "input" (pick "target.value" (set this "birthCity"))}}
+          ><:label>
+              Commune de naissance
+            </:label></PixInput>
         </div>
       {{/if}}
     </form>

--- a/admin/app/components/certifications/certification/comments.hbs
+++ b/admin/app/components/certifications/certification/comments.hbs
@@ -13,13 +13,24 @@
       @label="Pour l'organisation :"
       @fieldId="certification-commentForOrganization"
     />
-    <Certifications::InfoField
-      @value={{@certification.commentByJury}}
-      @edition={{this.isEditingJuryComment}}
-      @label="Notes internes Jury Pix :"
-      @fieldId="certification-commentByJury"
-      @isTextarea={{true}}
-    />
+    <div class="certification-info-field">
+      {{#if this.isEditingJuryComment}}
+        <label for="certification-commentByJury" class="certification-info-field__label">
+          Notes internes Jury Pix :
+        </label>
+        <PixTextarea
+          id="certification-commentByJury"
+          @value={{@certification.commentByJury}}
+          class="form-control"
+          {{on "input" (pick "target.value" (set this "commentByJury"))}}
+        />
+      {{else}}
+        <p>Notes internes Jury Pix :</p>
+        <p>
+          {{if @certification.commentByJury @certification.commentByJury " - "}}
+        </p>
+      {{/if}}
+    </div>
     <Certifications::InfoField @value={{@certification.juryId}} @edition={{false}} @label="Identifiant jury :" />
 
     {{#if this.isEditingJuryComment}}

--- a/admin/app/components/certifications/certification/comments.js
+++ b/admin/app/components/certifications/certification/comments.js
@@ -4,6 +4,7 @@ import { tracked } from '@glimmer/tracking';
 
 export default class Comments extends Component {
   @tracked isEditingJuryComment = false;
+  @tracked commentByJury;
 
   @action
   editJuryComment() {
@@ -12,7 +13,7 @@ export default class Comments extends Component {
 
   @action
   async saveJuryComment() {
-    const hasBeenSaved = await this.args.onJuryCommentSave();
+    const hasBeenSaved = await this.args.onJuryCommentSave(this.commentByJury);
     if (hasBeenSaved) {
       this.cancelJuryCommentEdition();
     }

--- a/admin/app/components/certifications/info-field.hbs
+++ b/admin/app/components/certifications/info-field.hbs
@@ -1,14 +1,12 @@
-{{! template-lint-disable no-builtin-form-components}}
-{{! TODO: Use PixUI components instead }}
 <div class="certification-info-field">
   {{#if @edition}}
     <label for={{@fieldId}} class="certification-info-field__label">
       {{@label}}
     </label>
     {{#if @isTextarea}}
-      <Textarea id={{@fieldId}} @value={{@value}} class="form-control" ...attributes />
+      <PixTextarea id={{@fieldId}} @value={{@value}} class="form-control" ...attributes />
     {{else}}
-      <Input id={{@fieldId}} @type="text" @value={{@value}} class="form-control" ...attributes />
+      <PixInput id={{@fieldId}} @type="text" @value={{@value}} class="form-control" ...attributes />
     {{/if}}
     {{#if @suffix}}
       <span class="certification-info-field__suffix">{{@suffix}}</span>

--- a/admin/app/components/complementary-certifications/attach-badges/index.hbs
+++ b/admin/app/components/complementary-certifications/attach-badges/index.hbs
@@ -1,5 +1,3 @@
-{{! template-lint-disable no-builtin-form-components}}
-{{! TODO: Use PixUI components instead }}
 <div class="page-section attach-target-profile">
   <h1 class="attach-target-profile__header">
     Rattacher un nouveau profil cible à la certification
@@ -32,15 +30,14 @@
       {{#if @currentTargetProfile}}
 
         <div class="badge-edit-form__field attach-target-profile__notification">
-          <Input
+          <PixCheckbox
             class="badge-edit-form__control attach-target-profile__notification__checkbox"
-            @type="checkbox"
             @checked="false"
             {{on "change" this.onNotificationUpdated}}
-            id="notification-checkbox"
-          />
+          >
+            <:label>Notifier les organisations avec une campagne basée sur l’ancien PC</:label>
+          </PixCheckbox>
 
-          <label for="notification-checkbox">Notifier les organisations avec une campagne basée sur l’ancien PC</label>
           <PixTooltip @position="top-left" @isLight={{true}} @isWide={{true}}>
             <:triggerElement>
               <FaIcon @icon="circle-question" tabindex="0" />

--- a/admin/app/components/login-form.hbs
+++ b/admin/app/components/login-form.hbs
@@ -31,25 +31,23 @@
       {{/if}}
     {{else}}
       <PixInput
-        class="login-form__fields login-form__email-field"
-        placeholder={{t "pages.login.fields.email.label"}}
-        aria-label={{t "pages.login.fields.email.label"}}
         required="true"
         @value={{this.email}}
         autocomplete="true"
         {{on "input" (pick "target.value" (set this "email"))}}
-      />
+      >
+        <:label>{{t "pages.login.fields.email.label"}} </:label>
+      </PixInput>
 
       <PixInput
-        class="login-form__fields"
-        placeholder={{t "pages.login.fields.password.label"}}
-        aria-label={{t "pages.login.fields.password.label"}}
         required="true"
         type="password"
         @value={{this.password}}
         autocomplete="true"
         {{on "input" (pick "target.value" (set this "password"))}}
-      />
+      >
+        <:label>{{t "pages.login.fields.password.label"}} </:label>
+      </PixInput>
 
       {{#if this.errorMessage}}
         <p class="login-form__error">{{this.errorMessage}}</p>

--- a/admin/app/components/login-form.hbs
+++ b/admin/app/components/login-form.hbs
@@ -31,6 +31,7 @@
       {{/if}}
     {{else}}
       <PixInput
+        placeholder={{t "pages.login.fields.email.label"}}
         required="true"
         @value={{this.email}}
         autocomplete="true"
@@ -40,6 +41,7 @@
       </PixInput>
 
       <PixInput
+        placeholder={{t "pages.login.fields.password.label"}}
         required="true"
         type="password"
         @value={{this.password}}

--- a/admin/app/components/login-form.hbs
+++ b/admin/app/components/login-form.hbs
@@ -1,5 +1,3 @@
-{{! template-lint-disable no-builtin-form-components}}
-{{! TODO: Use PixUI components instead }}
 <header class="login-page__header">
   <h1 class="login-page__header__title">Pix Admin</h1>
   <p class="login-form__information">{{t "pages.login.title"}}</p>
@@ -32,23 +30,25 @@
         </PixMessage>
       {{/if}}
     {{else}}
-      <Input
+      <PixInput
         class="login-form__fields login-form__email-field"
         placeholder={{t "pages.login.fields.email.label"}}
         aria-label={{t "pages.login.fields.email.label"}}
         required="true"
         @value={{this.email}}
         autocomplete="true"
+        {{on "input" (pick "target.value" (set this "email"))}}
       />
 
-      <Input
+      <PixInput
         class="login-form__fields"
         placeholder={{t "pages.login.fields.password.label"}}
         aria-label={{t "pages.login.fields.password.label"}}
         required="true"
-        @type="password"
+        type="password"
         @value={{this.password}}
         autocomplete="true"
+        {{on "input" (pick "target.value" (set this "password"))}}
       />
 
       {{#if this.errorMessage}}

--- a/admin/app/components/organizations/information-section-edit.hbs
+++ b/admin/app/components/organizations/information-section-edit.hbs
@@ -8,16 +8,12 @@
     </span>
 
     <div class="form-field">
-      {{#if (v-get this.form "name" "isInvalid")}}
-        <div class="form-field__error">
-          {{v-get this.form "name" "message"}}
-        </div>
-      {{/if}}
       <PixInput
-        class={{if (v-get this.form "name" "isInvalid") "form-control is-invalid" "form-control"}}
-        @value={{this.form.name}}
         required={{true}}
-        {{on "input" (pick "target.value" (set this "form.name"))}}
+        @errorMessage={{this.form.nameError.message}}
+        @validationStatus={{this.form.nameError.status}}
+        @value={{this.form.name}}
+        {{on "input" (fn this.updateFormValue "name")}}
       ><:label>
           <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
           Nom
@@ -25,116 +21,74 @@
     </div>
 
     <div class="form-field">
-      {{#if (v-get this.form "externalId" "isInvalid")}}
-        <div class="form-field__error">
-          {{v-get this.form "externalId" "message"}}
-        </div>
-      {{/if}}
       <PixInput
-        class={{if (v-get this.form "externalId" "isInvalid") "form-control is-invalid" "form-control"}}
+        @errorMessage={{this.form.externalIdError.message}}
+        @validationStatus={{this.form.externalIdError.status}}
         @value={{this.form.externalId}}
-        {{on "input" (pick "target.value" (set this "form.externalId"))}}
+        {{on "input" (fn this.updateFormValue "externalId")}}
       ><:label>Identifiant externe</:label></PixInput>
     </div>
 
     <div class="form-field">
-      {{#if (v-get this.form "provinceCode" "isInvalid")}}
-        <div class="form-field__error">
-          {{v-get this.form "provinceCode" "message"}}
-        </div>
-      {{/if}}
       <PixInput
-        class={{if (v-get this.form "provinceCode" "isInvalid") "form-control is-invalid" "form-control"}}
+        @errorMessage={{this.form.provinceCodeError.message}}
+        @validationStatus={{this.form.provinceCodeError.status}}
         @value={{this.form.provinceCode}}
-        {{on "input" (pick "target.value" (set this "form.provinceCode"))}}
+        {{on "input" (fn this.updateFormValue "provinceCode")}}
       ><:label>Département (en 3 chiffres)</:label></PixInput>
     </div>
 
     <div class="form-field">
-      {{#if (v-get this.form "dataProtectionOfficerFirstName" "isInvalid")}}
-        <div class="form-field__error">
-          {{v-get this.form "dataProtectionOfficerFirstName" "message"}}
-        </div>
-      {{/if}}
       <PixInput
-        class={{if
-          (v-get this.form "dataProtectionOfficerFirstName" "isInvalid")
-          "form-control is-invalid"
-          "form-control"
-        }}
+        @errorMessage={{this.form.dataProtectionOfficerFirstNameError.message}}
+        @validationStatus={{this.form.dataProtectionOfficerFirstNameError.status}}
         @value={{this.form.dataProtectionOfficerFirstName}}
-        {{on "input" (pick "target.value" (set this "form.dataProtectionOfficerFirstName"))}}
+        {{on "input" (fn this.updateFormValue "dataProtectionOfficerFirstName")}}
       ><:label>Prénom du DPO</:label></PixInput>
     </div>
 
     <div class="form-field">
-      {{#if (v-get this.form "dataProtectionOfficerLastName" "isInvalid")}}
-        <div class="form-field__error">
-          {{v-get this.form "dataProtectionOfficerLastName" "message"}}
-        </div>
-      {{/if}}
       <PixInput
-        class={{if
-          (v-get this.form "dataProtectionOfficerLastName" "isInvalid")
-          "form-control is-invalid"
-          "form-control"
-        }}
+        @errorMessage={{this.form.dataProtectionOfficerLastNameError.message}}
+        @validationStatus={{this.form.dataProtectionOfficerLastNameError.status}}
         @value={{this.form.dataProtectionOfficerLastName}}
-        {{on "input" (pick "target.value" (set this "form.dataProtectionOfficerLastName"))}}
+        {{on "input" (fn this.updateFormValue "dataProtectionOfficerLastName")}}
       ><:label>Nom du DPO</:label></PixInput>
     </div>
 
     <div class="form-field">
-      {{#if (v-get this.form "dataProtectionOfficerEmail" "isInvalid")}}
-        <div class="form-field__error">
-          {{v-get this.form "dataProtectionOfficerEmail" "message"}}
-        </div>
-      {{/if}}
       <PixInput
-        class={{if (v-get this.form "dataProtectionOfficerEmail" "isInvalid") "form-control is-invalid" "form-control"}}
+        @errorMessage={{this.form.dataProtectionOfficerEmailError.message}}
+        @validationStatus={{this.form.dataProtectionOfficerEmailError.status}}
         @value={{this.form.dataProtectionOfficerEmail}}
-        {{on "input" (pick "target.value" (set this "form.dataProtectionOfficerEmail"))}}
+        {{on "input" (fn this.updateFormValue "dataProtectionOfficerEmail")}}
       ><:label>Adresse e-mail du DPO</:label></PixInput>
     </div>
 
     <div class="form-field">
-      {{#if (v-get this.form "credit" "isInvalid")}}
-        <div class="form-field__error">
-          {{v-get this.form "credit" "message"}}
-        </div>
-      {{/if}}
       <PixInput
         type="number"
-        class={{if (v-get this.form "credit" "isInvalid") "form-control is-invalid" "form-control"}}
+        @errorMessage={{this.form.creditError.message}}
+        @validationStatus={{this.form.creditError.status}}
         @value={{this.form.credit}}
-        {{on "input" (pick "target.value" (set this "form.credit"))}}
+        {{on "input" (fn this.updateFormValue "credit")}}
       ><:label>Crédits</:label></PixInput>
     </div>
 
     <div class="form-field">
-      {{#if (v-get this.form "documentationUrl" "isInvalid")}}
-        <div class="form-field__error">
-          {{v-get this.form "documentationUrl" "message"}}
-        </div>
-      {{/if}}
       <PixInput
-        class={{if (v-get this.form "documentationUrl" "isInvalid") "form-control is-invalid" "form-control"}}
+        @errorMessage={{this.form.documentationUrlError.message}}
+        @validationStatus={{this.form.documentationUrlError.status}}
         @value={{this.form.documentationUrl}}
-        {{on "input" (pick "target.value" (set this "form.documentationUrl"))}}
+        {{on "input" (fn this.updateFormValue "documentationUrl")}}
       ><:label>Lien vers la documentation</:label></PixInput>
     </div>
 
-    <div class="form-field organization-edit-form__checkbox">
+    <div class="form-field">
       <PixCheckbox
-        class={{if (v-get this.form "showSkills" "isInvalid") "form-control is-invalid" "form-control"}}
         @checked={{this.form.showSkills}}
-        {{on "change" (toggle "form.showSkills" this)}}
+        {{on "change" (fn this.updateFormCheckBoxValue "showSkills")}}
       ><:label>Affichage des acquis dans l'export de résultats</:label></PixCheckbox>
-      {{#if (v-get this.form "showSkills" "isInvalid")}}
-        <div class="form-field__error">
-          {{v-get this.form "showSkills" "message"}}
-        </div>
-      {{/if}}
     </div>
 
     <div class="form-field">
@@ -149,49 +103,37 @@
     </div>
 
     <div class="form-field">
-      {{#if (v-get this.form "email" "isInvalid")}}
-        <div class="form-field__error">
-          {{v-get this.form "email" "message"}}
-        </div>
-      {{/if}}
       <PixInput
-        class={{if (v-get this.form "email" "isInvalid") "form-control is-invalid" "form-control"}}
+        @errorMessage={{this.form.emailError.message}}
+        @validationStatus={{this.form.emailError.status}}
         @value={{this.form.email}}
-        {{on "input" (pick "target.value" (set this "form.email"))}}
+        {{on "input" (fn this.updateFormValue "email")}}
       ><:label>Adresse e-mail d'activation SCO</:label></PixInput>
     </div>
 
     {{#if (or @organization.isOrganizationSCO @organization.isOrganizationSUP)}}
-      <div class="form-field organization-edit-form__checkbox">
+      <div class="form-field">
         <PixCheckbox
-          class={{if (v-get this.form "isManagingStudents" "isInvalid") "form-control is-invalid" "form-control"}}
           @checked={{this.form.isManagingStudents}}
-          {{on "change" (toggle "form.isManagingStudents" this)}}
+          {{on "change" (fn this.updateFormCheckBoxValue "isManagingStudents")}}
         ><:label>Gestion d’élèves/étudiants</:label></PixCheckbox>
-        {{#if (v-get this.form "isManagingStudents" "isInvalid")}}
-          <div class="form-field__error">
-            {{v-get this.form "isManagingStudents" "message"}}
-          </div>
-        {{/if}}
       </div>
     {{/if}}
 
-    <div class="form-field organization-edit-form__checkbox">
+    <div class="form-field">
       <PixCheckbox
         @id="isMultipleSendingAssessmentEnabled"
-        {{on "change" this.onChangeMultipleSendingAssessment}}
         @checked={{this.form.isMultipleSendingAssessmentEnabled}}
-        @class="form-field__label"
+        {{on "change" (fn this.updateFormCheckBoxValue "isMultipleSendingAssessmentEnabled")}}
       >
         <:label>Activer l'envoi multiple pour les campagnes de type évaluation</:label>
       </PixCheckbox>
     </div>
-    <div class="form-field organization-edit-form__checkbox">
+    <div class="form-field">
       <PixCheckbox
         @id="isPlacesManagementEnabled"
-        {{on "change" this.onChangePlacesManagement}}
         @checked={{this.form.isPlacesManagementEnabled}}
-        @class="form-field__label"
+        {{on "change" (fn this.updateFormCheckBoxValue "isPlacesManagementEnabled")}}
       >
         <:label>Activer la page Places sur PixOrga</:label>
       </PixCheckbox>

--- a/admin/app/components/organizations/information-section-edit.hbs
+++ b/admin/app/components/organizations/information-section-edit.hbs
@@ -1,5 +1,3 @@
-{{! template-lint-disable no-builtin-form-components}}
-{{! TODO: Use PixUI components instead }}
 <div class="organization__edit-form">
   <form class="form" {{on "submit" this.updateOrganization}}>
 
@@ -10,145 +8,128 @@
     </span>
 
     <div class="form-field">
-      <label for="name" class="form-field__label">
-        <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-        Nom
-      </label>
       {{#if (v-get this.form "name" "isInvalid")}}
         <div class="form-field__error">
           {{v-get this.form "name" "message"}}
         </div>
       {{/if}}
-      <Input
-        id="name"
-        @type="text"
+      <PixInput
         class={{if (v-get this.form "name" "isInvalid") "form-control is-invalid" "form-control"}}
         @value={{this.form.name}}
         required={{true}}
-      />
+        {{on "input" (pick "target.value" (set this "form.name"))}}
+      ><:label>
+          <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+          Nom
+        </:label></PixInput>
     </div>
 
     <div class="form-field">
-      <label for="externalId" class="form-field__label">Identifiant externe</label>
       {{#if (v-get this.form "externalId" "isInvalid")}}
         <div class="form-field__error">
           {{v-get this.form "externalId" "message"}}
         </div>
       {{/if}}
-      <Input
-        id="externalId"
-        @type="text"
+      <PixInput
         class={{if (v-get this.form "externalId" "isInvalid") "form-control is-invalid" "form-control"}}
         @value={{this.form.externalId}}
-      />
+        {{on "input" (pick "target.value" (set this "form.externalId"))}}
+      ><:label>Identifiant externe</:label></PixInput>
     </div>
 
     <div class="form-field">
-      <label for="provinceCode" class="form-field__label">Département (en 3 chiffres)</label>
       {{#if (v-get this.form "provinceCode" "isInvalid")}}
         <div class="form-field__error">
           {{v-get this.form "provinceCode" "message"}}
         </div>
       {{/if}}
-      <Input
-        id="provinceCode"
-        @type="text"
+      <PixInput
         class={{if (v-get this.form "provinceCode" "isInvalid") "form-control is-invalid" "form-control"}}
         @value={{this.form.provinceCode}}
-      />
+        {{on "input" (pick "target.value" (set this "form.provinceCode"))}}
+      ><:label>Département (en 3 chiffres)</:label></PixInput>
     </div>
 
     <div class="form-field">
-      <label for="dataProtectionOfficerFirstName" class="form-field__label">Prénom du DPO</label>
       {{#if (v-get this.form "dataProtectionOfficerFirstName" "isInvalid")}}
         <div class="form-field__error">
           {{v-get this.form "dataProtectionOfficerFirstName" "message"}}
         </div>
       {{/if}}
-      <Input
-        id="dataProtectionOfficerFirstName"
-        @type="text"
+      <PixInput
         class={{if
           (v-get this.form "dataProtectionOfficerFirstName" "isInvalid")
           "form-control is-invalid"
           "form-control"
         }}
         @value={{this.form.dataProtectionOfficerFirstName}}
-      />
+        {{on "input" (pick "target.value" (set this "form.dataProtectionOfficerFirstName"))}}
+      ><:label>Prénom du DPO</:label></PixInput>
     </div>
 
     <div class="form-field">
-      <label for="dataProtectionOfficerLastName" class="form-field__label">Nom du DPO</label>
       {{#if (v-get this.form "dataProtectionOfficerLastName" "isInvalid")}}
         <div class="form-field__error">
           {{v-get this.form "dataProtectionOfficerLastName" "message"}}
         </div>
       {{/if}}
-      <Input
-        id="dataProtectionOfficerLastName"
-        @type="text"
+      <PixInput
         class={{if
           (v-get this.form "dataProtectionOfficerLastName" "isInvalid")
           "form-control is-invalid"
           "form-control"
         }}
         @value={{this.form.dataProtectionOfficerLastName}}
-      />
+        {{on "input" (pick "target.value" (set this "form.dataProtectionOfficerLastName"))}}
+      ><:label>Nom du DPO</:label></PixInput>
     </div>
 
     <div class="form-field">
-      <label for="dataProtectionOfficerEmail" class="form-field__label">Adresse e-mail du DPO</label>
       {{#if (v-get this.form "dataProtectionOfficerEmail" "isInvalid")}}
         <div class="form-field__error">
           {{v-get this.form "dataProtectionOfficerEmail" "message"}}
         </div>
       {{/if}}
-      <Input
-        id="dataProtectionOfficerEmail"
-        @type="text"
+      <PixInput
         class={{if (v-get this.form "dataProtectionOfficerEmail" "isInvalid") "form-control is-invalid" "form-control"}}
         @value={{this.form.dataProtectionOfficerEmail}}
-      />
+        {{on "input" (pick "target.value" (set this "form.dataProtectionOfficerEmail"))}}
+      ><:label>Adresse e-mail du DPO</:label></PixInput>
     </div>
 
     <div class="form-field">
-      <label for="credits" class="form-field__label">Crédits</label>
       {{#if (v-get this.form "credit" "isInvalid")}}
         <div class="form-field__error">
           {{v-get this.form "credit" "message"}}
         </div>
       {{/if}}
-      <Input
-        id="credits"
-        @type="number"
+      <PixInput
+        type="number"
         class={{if (v-get this.form "credit" "isInvalid") "form-control is-invalid" "form-control"}}
         @value={{this.form.credit}}
-      />
+        {{on "input" (pick "target.value" (set this "form.credit"))}}
+      ><:label>Crédits</:label></PixInput>
     </div>
 
     <div class="form-field">
-      <label for="documentationUrl" class="form-field__label">Lien vers la documentation</label>
       {{#if (v-get this.form "documentationUrl" "isInvalid")}}
         <div class="form-field__error">
           {{v-get this.form "documentationUrl" "message"}}
         </div>
       {{/if}}
-      <Input
-        id="documentationUrl"
-        @type="text"
+      <PixInput
         class={{if (v-get this.form "documentationUrl" "isInvalid") "form-control is-invalid" "form-control"}}
         @value={{this.form.documentationUrl}}
-      />
+        {{on "input" (pick "target.value" (set this "form.documentationUrl"))}}
+      ><:label>Lien vers la documentation</:label></PixInput>
     </div>
 
     <div class="form-field organization-edit-form__checkbox">
-      <Input
-        id="showSkills"
-        @type="checkbox"
+      <PixCheckbox
         class={{if (v-get this.form "showSkills" "isInvalid") "form-control is-invalid" "form-control"}}
         @checked={{this.form.showSkills}}
-      />
-      <label for="showSkills" class="form-field__label">Affichage des acquis dans l'export de résultats</label>
+        {{on "change" (toggle "form.showSkills" this)}}
+      ><:label>Affichage des acquis dans l'export de résultats</:label></PixCheckbox>
       {{#if (v-get this.form "showSkills" "isInvalid")}}
         <div class="form-field__error">
           {{v-get this.form "showSkills" "message"}}
@@ -168,29 +149,25 @@
     </div>
 
     <div class="form-field">
-      <label for="email" class="form-field__label">Adresse e-mail d'activation SCO</label>
       {{#if (v-get this.form "email" "isInvalid")}}
         <div class="form-field__error">
           {{v-get this.form "email" "message"}}
         </div>
       {{/if}}
-      <Input
-        id="email"
-        @type="text"
+      <PixInput
         class={{if (v-get this.form "email" "isInvalid") "form-control is-invalid" "form-control"}}
         @value={{this.form.email}}
-      />
+        {{on "input" (pick "target.value" (set this "form.email"))}}
+      ><:label>Adresse e-mail d'activation SCO</:label></PixInput>
     </div>
 
     {{#if (or @organization.isOrganizationSCO @organization.isOrganizationSUP)}}
       <div class="form-field organization-edit-form__checkbox">
-        <Input
-          id="isManagingStudents"
-          @type="checkbox"
+        <PixCheckbox
           class={{if (v-get this.form "isManagingStudents" "isInvalid") "form-control is-invalid" "form-control"}}
           @checked={{this.form.isManagingStudents}}
-        />
-        <label for="isManagingStudents" class="form-field__label">Gestion d’élèves/étudiants</label>
+          {{on "change" (toggle "form.isManagingStudents" this)}}
+        ><:label>Gestion d’élèves/étudiants</:label></PixCheckbox>
         {{#if (v-get this.form "isManagingStudents" "isInvalid")}}
           <div class="form-field__error">
             {{v-get this.form "isManagingStudents" "message"}}

--- a/admin/app/components/organizations/information-section-edit.js
+++ b/admin/app/components/organizations/information-section-edit.js
@@ -39,13 +39,13 @@ export default class OrganizationInformationSectionEditionMode extends Component
   }
 
   @action
-  onChangeMultipleSendingAssessment() {
-    this.form.isMultipleSendingAssessmentEnabled = !this.form.isMultipleSendingAssessmentEnabled;
+  updateFormCheckBoxValue(key) {
+    this.form[key] = !this.form[key];
   }
 
   @action
-  onChangePlacesManagement() {
-    this.form.isPlacesManagementEnabled = !this.form.isPlacesManagementEnabled;
+  updateFormValue(key, event) {
+    this.form[key] = event.target.value;
   }
 
   @action

--- a/admin/app/components/organizations/places-lot-creation-form.hbs
+++ b/admin/app/components/organizations/places-lot-creation-form.hbs
@@ -1,5 +1,3 @@
-{{! template-lint-disable no-builtin-form-components}}
-{{! TODO: Use PixUI components instead }}
 <section class="page-section">
   <div class="places__add-form">
     <form class="form" {{on "submit" this.onSubmit}}>
@@ -9,15 +7,11 @@
         sont obligatoires.
       </span>
       <div class="form-field">
-        <label for="count" class="form-field__label">
-          Nombre :
-        </label>
-        <Input
-          id="count"
-          @type="string"
+        <PixInput
           class={{if @errors.count "form-control is-invalid" "form-control"}}
           @value={{this.count}}
-        />
+          {{on "input" (pick "target.value" (set this "count"))}}
+        ><:label>Nombre :</:label></PixInput>
 
         {{#if @errors.count}}
           <div class="form-field__error">
@@ -26,16 +20,13 @@
         {{/if}}
       </div>
       <div class="form-field">
-        <label for="activationDate" class="form-field__label">
-          <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-          Date d'activation :
-        </label>
-        <Input
-          id="activationDate"
-          @type="date"
+        <PixInput
+          type="date"
           class={{if @errors.activationDate "form-control is-invalid" "form-control"}}
           @value={{this.activationDate}}
-        />
+          @requiredLabel={{true}}
+          {{on "input" (pick "target.value" (set this "activationDate"))}}
+        ><:label>Date d'activation : </:label></PixInput>
 
         {{#if @errors.activationDate}}
           <div class="form-field__error">
@@ -44,13 +35,12 @@
         {{/if}}
       </div>
       <div class="form-field">
-        <label for="expirationDate" class="form-field__label">Date d'expiration :</label>
-        <Input
-          id="expirationDate"
+        <PixInput
           class={{if @errors.expirationDate "form-control is-invalid" "form-control"}}
-          @type="date"
+          type="date"
           @value={{this.expirationDate}}
-        />
+          {{on "input" (pick "target.value" (set this "expirationDate"))}}
+        ><:label>Date d'expiration : </:label></PixInput>
 
         {{#if @errors.expirationDate}}
           <div class="form-field__error">
@@ -71,16 +61,13 @@
         </PixSelect>
       </div>
       <div class="form-field">
-        <label for="reference" class="form-field__label">
-          <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-          Référence :</label>
-        <Input
-          id="reference"
-          @type="text"
+        <PixInput
           @value={{this.reference}}
           class={{if @errors.reference "form-control is-invalid" "form-control"}}
           maxlength="255"
-        />
+          @requiredLabel={{true}}
+          {{on "input" (pick "target.value" (set this "reference"))}}
+        ><:label>Référence :</:label></PixInput>
 
         {{#if @errors.reference}}
           <div class="form-field__error">

--- a/admin/app/components/organizations/target-profiles-section.hbs
+++ b/admin/app/components/organizations/target-profiles-section.hbs
@@ -1,5 +1,3 @@
-{{! template-lint-disable no-builtin-form-components}}
-{{! TODO: Use PixUI components instead }}
 {{#if this.accessControl.hasAccessToOrganizationActionsScope}}
   <section class="page-section">
     <header class="page-section__header">
@@ -7,11 +5,12 @@
     </header>
     <div class="organization__forms-section">
       <form class="organization__sub-form form" {{on "submit" this.attachTargetProfiles}}>
-        <Input
+        <PixInput
           aria-label="ID du ou des profil(s) cible(s)"
           @value={{this.targetProfilesToAttach}}
           class="organization-sub-form__input form-field__text form-control"
           placeholder="1, 2"
+          {{on "input" (pick "target.value" (set this "targetProfilesToAttach"))}}
         />
         <PixButton @type="submit" @size="small" @isDisabled={{this.isDisabled}}>Valider</PixButton>
       </form>

--- a/admin/app/components/stages/update-stage.hbs
+++ b/admin/app/components/stages/update-stage.hbs
@@ -4,7 +4,6 @@
     <div class="form-field">
       {{#if @stage.isFirstSkill}}
         <label class="form-field__label">1er acquis</label>
-        <br />
       {{else if @isTypeLevel}}
         <Stages::StageLevelSelect
           @id="threshold-or-level"
@@ -30,7 +29,6 @@
           <:label>{{@stageTypeName}}</:label>
         </PixInput>
       {{/if}}
-      <br />
 
       <PixInput
         @id="title"
@@ -43,7 +41,6 @@
       >
         <:label>Titre du palier</:label>
       </PixInput>
-      <br />
 
       <PixTextarea
         @id="message"
@@ -53,7 +50,6 @@
       >
         <:label>Message</:label>
       </PixTextarea>
-      <br />
 
       <PixInput
         @type="text"

--- a/admin/app/components/stages/update-stage.hbs
+++ b/admin/app/components/stages/update-stage.hbs
@@ -1,5 +1,3 @@
-{{! template-lint-disable no-builtin-form-components}}
-{{! TODO: Use PixUI components instead }}
 <section class="page-section">
 
   <form class="form stage-form" {{on "submit" this.updateStage}}>
@@ -57,15 +55,24 @@
       </PixTextarea>
       <br />
 
-      <label for="prescriberTitle" class="form-field__label">
-        Titre pour le prescripteur
-      </label>
-      <Input id="prescriberTitle" @type="text" class="form-control" @value={{this.prescriberTitle}} maxlength="255" />
+      <PixInput
+        @type="text"
+        class="form-control"
+        @value={{this.prescriberTitle}}
+        maxlength="255"
+        {{on "input" (pick "target.value" (set this "prescriberTitle"))}}
+      ><:label>
+          Titre pour le prescripteur
+        </:label></PixInput>
 
-      <label for="prescriberDescription" class="form-field__label">
-        Description pour le prescripteur
-      </label>
-      <Textarea id="prescriberDescription" class="form-control" @value={{this.prescriberDescription}} rows="4" />
+      <PixTextarea
+        class="form-control"
+        @value={{this.prescriberDescription}}
+        rows="4"
+        {{on "input" (pick "target.value" (set this "prescriberDescription"))}}
+      ><:label>
+          Description pour le prescripteur
+        </:label></PixTextarea>
     </div>
     <div class="form-actions">
       <PixButton @variant="secondary" @size="small" @triggerAction={{@toggleEditMode}}>Annuler

--- a/admin/app/components/target-profiles/organizations.hbs
+++ b/admin/app/components/target-profiles/organizations.hbs
@@ -1,16 +1,15 @@
-{{! template-lint-disable no-builtin-form-components}}
-{{! TODO: Use PixUI components instead }}
 <section class="page-section target-profile-organizations">
   <div class="organization__forms-section">
     <form class="organization__form" {{on "submit" this.attachOrganizations}}>
       <label for="attach-organizations">Rattacher une ou plusieurs organisation(s)</label>
       <div class="organization__sub-form">
-        <Input
+        <PixInput
           id="attach-organizations"
           @value={{this.organizationsToAttach}}
           class="form-field__text form-control"
           placeholder="1, 2"
           aria-describedby="attach-organizations-info"
+          {{on "input" (pick "target.value" (set this "organizationsToAttach"))}}
         />
         <p id="attach-organizations-info" hidden>Ids des organisations, séparés par une virgule</p>
         <PixButton
@@ -28,12 +27,13 @@
       <label for="attach-organizations-from-existing-target-profile">Rattacher les organisations d'un profil cible
         existant</label>
       <div class="organization__sub-form">
-        <Input
+        <PixInput
           id="attach-organizations-from-existing-target-profile"
           @value={{this.existingTargetProfile}}
           class="form-field__text form-control"
           placeholder="1135"
           aria-describedby="attach-organizations-from-existing-target-profile-info"
+          {{on "input" (pick "target.value" (set this "existingTargetProfile"))}}
         />
         <p id="attach-organizations-from-existing-target-profile-info" hidden>Id du profil cible existant</p>
         <PixButton

--- a/admin/app/components/trainings/create-or-update-training-form.hbs
+++ b/admin/app/components/trainings/create-or-update-training-form.hbs
@@ -79,6 +79,17 @@
         <:label>Langue localisée</:label>
       </PixSelect>
       <div class="admin-form--training__logo-url-input">
+        <PixInput
+          @id="trainingEditorLogoUrl"
+          @subLabel="Exemple : logo-ministere-education-nationale-et-jeunesse.svg"
+          required={{true}}
+          aria-required={{true}}
+          placeholder="logo-ministere-education-nationale-et-jeunesse.svg"
+          @value={{this.form.editorLogoUrl}}
+          {{on "change" (fn this.updateForm "editorLogoUrl")}}
+        >
+          <:label>Nom du fichier du logo éditeur (.svg)</:label>
+        </PixInput>
         <small>
           <a
             href="https://1024pix.github.io/pix-images-list/editeurs-cf.html"
@@ -87,19 +98,7 @@
           >
             Voir la liste des logos éditeur
           </a>
-          <br />Exemple : logo-ministere-education-nationale-et-jeunesse.svg
         </small>
-        <PixInput
-          @id="trainingEditorLogoUrl"
-          required={{true}}
-          aria-required={{true}}
-          @screenReaderOnly={{true}}
-          placeholder="logo-ministere-education-nationale-et-jeunesse.svg"
-          @value={{this.form.editorLogoUrl}}
-          {{on "change" (fn this.updateForm "editorLogoUrl")}}
-        >
-          <:label>Nom du fichier du logo éditeur (.svg)</:label>
-        </PixInput>
       </div>
       <PixInput
         @id="trainingEditorName"

--- a/admin/app/components/users/user-overview.hbs
+++ b/admin/app/components/users/user-overview.hbs
@@ -1,5 +1,3 @@
-{{! template-lint-disable no-builtin-form-components}}
-{{! TODO: Use PixUI components instead }}
 <section class="page-section">
   <div class="user-detail-personal-information-section">
     {{#if this.isEditionMode}}
@@ -10,56 +8,53 @@
           sont obligatoires.
         </span>
         <div class="form-field">
-          <label for="firstName" class="form-field__label">
-            <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-            Prénom :
-          </label>
           {{#if (v-get this.form "firstName" "isInvalid")}}
             <div class="form-field__error" aria-label="Message d'erreur du champ prénom">
               {{v-get this.form "firstName" "message"}}
             </div>
           {{/if}}
-          <Input
-            id="firstName"
-            @type="text"
+          <PixInput
             class="form-control {{if (v-get this.form 'firstName' 'isInvalid') 'is-invalid'}}"
             @value={{this.form.firstName}}
-          />
+            {{on "input" (pick "target.value" (set this "form.firstName"))}}
+          ><:label>
+              <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+              Prénom :
+            </:label></PixInput>
         </div>
         <div class="form-field">
-          <label for="lastName" class="form-field__label">
-            <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-            Nom :
-          </label>
           {{#if (v-get this.form "lastName" "isInvalid")}}
             <div class="form-field__error" aria-label="Message d'erreur du champ nom">
               {{v-get this.form "lastName" "message"}}
             </div>
           {{/if}}
-          <Input
-            id="lastName"
-            @type="text"
+          <PixInput
             class="form-control {{if (v-get this.form 'lastName' 'isInvalid') 'is-invalid'}}"
             @value={{this.form.lastName}}
-          />
+            {{on "input" (pick "target.value" (set this "form.lastName"))}}
+          >
+            <:label>
+              <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+              Nom :
+            </:label></PixInput>
         </div>
         {{#if this.canModifyEmail}}
           <div class="form-field">
-            <label for="email" class="form-field__label">
-              <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-              Adresse e-mail :
-            </label>
             {{#if (v-get this.form "email" "isInvalid")}}
               <div class="form-field__error" aria-label="Message d'erreur du champ email">
                 {{v-get this.form "email" "message"}}
               </div>
             {{/if}}
-            <Input
-              id="email"
-              @type="email"
+            <PixInput
+              type="email"
               class="form-control {{if (v-get this.form 'email' 'isInvalid') 'is-invalid'}}"
               @value={{this.form.email}}
-            />
+              {{on "input" (pick "target.value" (set this "form.email"))}}
+            >
+              <:label>
+                <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+                Adresse e-mail :
+              </:label></PixInput>
           </div>
         {{/if}}
         {{#if @user.username}}
@@ -73,12 +68,15 @@
                 {{v-get this.form "username" "message"}}
               </div>
             {{/if}}
-            <Input
-              id="username"
+            <PixInput
               @type="text"
               class="form-control {{if (v-get this.form 'username' 'isInvalid') 'is-invalid'}}"
               @value={{this.form.username}}
-            />
+              {{on "input" (pick "target.value" (set this "form.username"))}}
+            ><:label>
+                <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+                Identifiant :
+              </:label></PixInput>
           </div>
         {{/if}}
         <div class="form-field">

--- a/admin/app/components/users/user-overview.hbs
+++ b/admin/app/components/users/user-overview.hbs
@@ -8,30 +8,22 @@
           sont obligatoires.
         </span>
         <div class="form-field">
-          {{#if (v-get this.form "firstName" "isInvalid")}}
-            <div class="form-field__error" aria-label="Message d'erreur du champ prénom">
-              {{v-get this.form "firstName" "message"}}
-            </div>
-          {{/if}}
           <PixInput
-            class="form-control {{if (v-get this.form 'firstName' 'isInvalid') 'is-invalid'}}"
+            @errorMessage={{this.form.firstNameError.message}}
+            @validationStatus={{this.form.firstNameError.status}}
             @value={{this.form.firstName}}
-            {{on "input" (pick "target.value" (set this "form.firstName"))}}
+            {{on "input" (fn this.updateFormValue "firstName")}}
           ><:label>
               <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
               Prénom :
             </:label></PixInput>
         </div>
         <div class="form-field">
-          {{#if (v-get this.form "lastName" "isInvalid")}}
-            <div class="form-field__error" aria-label="Message d'erreur du champ nom">
-              {{v-get this.form "lastName" "message"}}
-            </div>
-          {{/if}}
           <PixInput
-            class="form-control {{if (v-get this.form 'lastName' 'isInvalid') 'is-invalid'}}"
+            @errorMessage={{this.form.lastNameError.message}}
+            @validationStatus={{this.form.lastNameError.status}}
             @value={{this.form.lastName}}
-            {{on "input" (pick "target.value" (set this "form.lastName"))}}
+            {{on "input" (fn this.updateFormValue "lastName")}}
           >
             <:label>
               <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
@@ -40,16 +32,11 @@
         </div>
         {{#if this.canModifyEmail}}
           <div class="form-field">
-            {{#if (v-get this.form "email" "isInvalid")}}
-              <div class="form-field__error" aria-label="Message d'erreur du champ email">
-                {{v-get this.form "email" "message"}}
-              </div>
-            {{/if}}
             <PixInput
-              type="email"
-              class="form-control {{if (v-get this.form 'email' 'isInvalid') 'is-invalid'}}"
+              @errorMessage={{this.form.emailError.message}}
+              @validationStatus={{this.form.emailError.status}}
               @value={{this.form.email}}
-              {{on "input" (pick "target.value" (set this "form.email"))}}
+              {{on "input" (fn this.updateFormValue "email")}}
             >
               <:label>
                 <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
@@ -59,20 +46,11 @@
         {{/if}}
         {{#if @user.username}}
           <div class="form-field">
-            <label for="username" class="form-field__label">
-              <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-              Identifiant :
-            </label>
-            {{#if (v-get this.form "username" "isInvalid")}}
-              <div class="form-field__error" aria-label="Message d'erreur du champ identifiant">
-                {{v-get this.form "username" "message"}}
-              </div>
-            {{/if}}
             <PixInput
-              @type="text"
-              class="form-control {{if (v-get this.form 'username' 'isInvalid') 'is-invalid'}}"
+              @errorMessage={{this.form.usernameError.message}}
+              @validationStatus={{this.form.usernameError.status}}
               @value={{this.form.username}}
-              {{on "input" (pick "target.value" (set this "form.username"))}}
+              {{on "input" (fn this.updateFormValue "username")}}
             ><:label>
                 <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
                 Identifiant :

--- a/admin/app/components/users/user-overview.js
+++ b/admin/app/components/users/user-overview.js
@@ -158,4 +158,9 @@ export default class UserOverview extends Component {
   onLocaleChange(locale) {
     this.form.locale = locale;
   }
+
+  @action
+  updateFormValue(key, event) {
+    this.form[key] = event.target.value;
+  }
 }

--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -92,7 +92,8 @@ export default class CertificationInformationsController extends Controller {
     this.displayConfirm = false;
   }
 
-  saveAssessmentResult() {
+  saveAssessmentResult(commentByJury) {
+    this.certification.commentByJury = commentByJury;
     return this.certification.save({ adapterOptions: { updateJuryComment: true } });
   }
 
@@ -224,9 +225,9 @@ export default class CertificationInformationsController extends Controller {
   }
 
   @action
-  async onJuryCommentSave() {
+  async onJuryCommentSave(commentByJury) {
     try {
-      await this.saveAssessmentResult();
+      await this.saveAssessmentResult(commentByJury);
       this.notifications.success('Le commentaire du jury a bien été enregistré.');
       return true;
     } catch (e) {

--- a/admin/app/models/organization-form.js
+++ b/admin/app/models/organization-form.js
@@ -123,4 +123,48 @@ export default class OrganizationForm extends Model.extend(Validations) {
   @attr('string') documentationUrl;
   @attr('boolean') showSkills;
   @attr() identityProviderForCampaigns;
+
+  #getErrorAttribute(name) {
+    const nameAttribute = this.validations.attrs.get(name);
+    if (nameAttribute.isInvalid) {
+      return { message: nameAttribute.message, status: 'error' };
+    }
+    return { message: null, status: null };
+  }
+
+  get creditError() {
+    return this.#getErrorAttribute('credit');
+  }
+
+  get dataProtectionOfficerEmailError() {
+    return this.#getErrorAttribute('dataProtectionOfficerEmail');
+  }
+
+  get dataProtectionOfficerFirstNameError() {
+    return this.#getErrorAttribute('dataProtectionOfficerFirstName');
+  }
+
+  get dataProtectionOfficerLastNameError() {
+    return this.#getErrorAttribute('dataProtectionOfficerLastName');
+  }
+
+  get documentationUrlError() {
+    return this.#getErrorAttribute('documentationUrl');
+  }
+
+  get emailError() {
+    return this.#getErrorAttribute('email');
+  }
+
+  get externalIdError() {
+    return this.#getErrorAttribute('externalId');
+  }
+
+  get nameError() {
+    return this.#getErrorAttribute('name');
+  }
+
+  get provinceCodeError() {
+    return this.#getErrorAttribute('provinceCode');
+  }
 }

--- a/admin/app/models/user-form.js
+++ b/admin/app/models/user-form.js
@@ -75,4 +75,28 @@ export default class UserForm extends Model.extend(Validations) {
   @attr() username;
   @attr() lang;
   @attr() locale;
+
+  #getErrorAttribute(name) {
+    const nameAttribute = this.validations.attrs.get(name);
+    if (nameAttribute.isInvalid) {
+      return { message: nameAttribute.message, status: 'error' };
+    }
+    return { message: null, status: null };
+  }
+
+  get emailError() {
+    return this.#getErrorAttribute('email');
+  }
+
+  get firstNameError() {
+    return this.#getErrorAttribute('firstName');
+  }
+
+  get lastNameError() {
+    return this.#getErrorAttribute('lastName');
+  }
+
+  get usernameError() {
+    return this.#getErrorAttribute('username');
+  }
 }

--- a/admin/app/models/user-form.js
+++ b/admin/app/models/user-form.js
@@ -74,4 +74,5 @@ export default class UserForm extends Model.extend(Validations) {
   @attr() email;
   @attr() username;
   @attr() lang;
+  @attr() locale;
 }

--- a/admin/app/styles/authenticated/organizations/get.scss
+++ b/admin/app/styles/authenticated/organizations/get.scss
@@ -71,15 +71,8 @@
     .organization__edit-form {
       width: 500px;
 
-      .organization-edit-form__checkbox {
-        display: flex;
-        align-items: center;
-
-        & > input[type='checkbox'] {
-          width: 16px;
-          height: 16px;
-          margin-right: var(--pix-spacing-3x);
-        }
+      & .pix-input {
+        width: 100%;
       }
     }
   }

--- a/admin/app/styles/components/badges/badge.scss
+++ b/admin/app/styles/components/badges/badge.scss
@@ -28,6 +28,10 @@
 
   &__field {
     margin-bottom: 12px;
+
+    .pix-input {
+      width: 100%;
+    }
   }
 
   &__actions {

--- a/admin/app/styles/components/certification-center-form.scss
+++ b/admin/app/styles/components/certification-center-form.scss
@@ -1,5 +1,7 @@
 /* stylelint-disable selector-class-pattern */
 .certification-center-form {
+  display: flex;
+  flex-direction: column;
   max-width: 400px;
 
   .habilitations-title {

--- a/admin/app/styles/components/target-profiles/stage-form.scss
+++ b/admin/app/styles/components/target-profiles/stage-form.scss
@@ -1,3 +1,9 @@
 .stage-form {
   max-width: 60%;
+
+  .form-field {
+    .pix-input {
+      width: 100%;
+    }
+  }
 }

--- a/admin/app/styles/components/trainings/create-or-update-training-form.scss
+++ b/admin/app/styles/components/trainings/create-or-update-training-form.scss
@@ -7,7 +7,7 @@
 
   small {
     display: block;
-    margin-bottom: var(--pix-spacing-2x);
+    margin-top: var(--pix-spacing-2x);
     color: var(--pix-neutral-500);
     font-size: 0.813rem;
   }

--- a/admin/app/styles/components/users/user-overview.scss
+++ b/admin/app/styles/components/users/user-overview.scss
@@ -19,6 +19,10 @@
     margin-bottom: 16px;
   }
 
+  & .pix-input {
+    width: 100%;
+  }
+
   .pix-select {
     &__label {
       margin: 0;

--- a/admin/app/styles/login.scss
+++ b/admin/app/styles/login.scss
@@ -32,7 +32,6 @@
   display: flex;
   flex-direction: column;
   gap: var(--pix-spacing-8x);
-  align-items: center;
   padding: var(--pix-spacing-12x);
   background: var(--pix-neutral-0);
   border-radius: 10px;
@@ -49,6 +48,7 @@
     display: flex;
     align-items: center;
     width: fit-content;
+    margin: auto;
     font-weight: $font-medium;
     background-color: var(--pix-neutral-0);
     border: 1px solid var(--pix-neutral-800);
@@ -77,19 +77,6 @@
 .login-form__error {
   color: var(--pix-error-500);
   font-size: 0.875rem;
-}
-
-.login-form__email-field {
-  margin-top: 0;
-}
-
-.login-form__fields {
-  width: 100%;
-  padding: 8px;
-  font-size: 14px;
-  line-height: 22px;
-  border: 1px solid var(--pix-neutral-100);
-  border-radius: 3px;
 }
 
 .login-form__button {

--- a/admin/app/templates/authenticated/certification-centers/get/team.hbs
+++ b/admin/app/templates/authenticated/certification-centers/get/team.hbs
@@ -1,19 +1,17 @@
-{{! template-lint-disable no-builtin-form-components}}
-{{! TODO: Use PixUI components instead }}
 <section class="page-section">
   <header class="page-section__header">
     <h2 class="page-section__title">Ajouter un membre</h2>
   </header>
 
   <div class="certification-center__section">
-    {{! template-lint-disable require-input-label }}
-    <Input
+    <PixInput
       id="userEmailToAdd"
-      @type="email"
+      type="email"
       @value={{this.userEmailToAdd}}
       aria-label="Adresse e-mail du nouveau membre"
       class="form-field__text form-control"
       placeholder="membre@inviter.net"
+      {{on "input" (pick "target.value" (set this "userEmailToAdd"))}}
       {{on "focusout" this.updateEmailErrorMessage}}
     />
 

--- a/admin/app/templates/authenticated/certifications.hbs
+++ b/admin/app/templates/authenticated/certifications.hbs
@@ -1,16 +1,16 @@
-{{! template-lint-disable require-input-label no-builtin-form-components }}
-{{! TODO: Use PixUI components instead }}
+{{! template-lint-disable require-input-label }}
 {{page-title (t "pages.certifications.title")}}
 <div class="page">
   <header class="page-header">
     <h1 class="page-title">{{t "pages.certifications.title"}}</h1>
     <div class="page-actions">
       <form class="form-inline" {{on "submit" this.loadCertification}}>
-        <Input
+        <PixInput
           placeholder="Identifiant"
           aria-label="Rechercher une session avec un identifiant"
           @type="text"
           @value={{this.inputId}}
+          {{on "input" (pick "target.value" (set this "inputId"))}}
         />
         <PixButton @size="small" @type="submit">{{t "pages.certifications.actions.load.label"}}</PixButton>
       </form>

--- a/admin/app/templates/authenticated/sessions/session.hbs
+++ b/admin/app/templates/authenticated/sessions/session.hbs
@@ -1,5 +1,4 @@
-{{! template-lint-disable require-input-label no-builtin-form-components }}
-{{! TODO: Use PixUI components instead }}
+{{! template-lint-disable require-input-label }}
 {{page-title "Session " @model.id}}
 <header class="page-header">
   <div class="page-title">
@@ -9,11 +8,12 @@
   </div>
   <div class="page-actions">
     <form class="form-inline" {{on "submit" this.loadSession}}>
-      <Input
+      <PixInput
         placeholder="Identifiant"
         aria-label="Rechercher une session avec un identifiant"
         @type="text"
         @value={{this.inputId}}
+        {{on "input" (pick "target.value" (set this "inputId"))}}
       />
       <PixButton @size="small" @type="submit">Charger</PixButton>
     </form>

--- a/admin/app/templates/authenticated/trainings/training/target-profiles.hbs
+++ b/admin/app/templates/authenticated/trainings/training/target-profiles.hbs
@@ -8,12 +8,14 @@
       <div class="training__forms-section">
         <form class="training__sub-form form" {{on "submit" this.attachTargetProfiles}}>
           <PixInput
-            aria-label="ID du ou des profil(s) cible(s)"
             @value={{this.targetProfilesToAttach}}
+            @screenReaderOnly={{true}}
             class="training-sub-form__input form-field__text form-control"
             placeholder="1, 2"
             {{on "input" (pick "target.value" (set this "targetProfilesToAttach"))}}
-          />
+          >
+            <:label>ID du ou des profil(s) cible(s)</:label>
+          </PixInput>
           <PixButton @type="submit" @size="small" @isDisabled={{this.noTargetProfilesToAttach}}>Valider</PixButton>
         </form>
       </div>

--- a/admin/app/templates/authenticated/trainings/training/target-profiles.hbs
+++ b/admin/app/templates/authenticated/trainings/training/target-profiles.hbs
@@ -1,5 +1,3 @@
-{{! template-lint-disable no-builtin-form-components}}
-{{! TODO: Use PixUI components instead }}
 <div class="training-target-profiles">
 
   {{#if this.canAttachTargetProfiles}}
@@ -9,11 +7,12 @@
       </header>
       <div class="training__forms-section">
         <form class="training__sub-form form" {{on "submit" this.attachTargetProfiles}}>
-          <Input
+          <PixInput
             aria-label="ID du ou des profil(s) cible(s)"
             @value={{this.targetProfilesToAttach}}
             class="training-sub-form__input form-field__text form-control"
             placeholder="1, 2"
+            {{on "input" (pick "target.value" (set this "targetProfilesToAttach"))}}
           />
           <PixButton @type="submit" @size="small" @isDisabled={{this.noTargetProfilesToAttach}}>Valider</PixButton>
         </form>

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -60,6 +60,7 @@
         "ember-page-title": "^8.0.0",
         "ember-qunit": "^8.0.0",
         "ember-resolver": "^11.0.0",
+        "ember-set-helper": "^3.0.1",
         "ember-simple-auth": "^6.0.0",
         "ember-source": "^5.8.0",
         "ember-template-imports": "^4.1.1",
@@ -33802,6 +33803,16 @@
       },
       "engines": {
         "node": "8.* || 10.* || >= 12"
+      }
+    },
+    "node_modules/ember-set-helper": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ember-set-helper/-/ember-set-helper-3.0.1.tgz",
+      "integrity": "sha512-Ord3CuttDiF88wiNpHNDjf4aFKPnHSkpeK7zFfH9nV7YdDFSJissDCZEg42A0ReWY1WuqWbc2hMl5XkgupdyZQ==",
+      "dev": true,
+      "dependencies": {
+        "@embroider/addon-shim": "^1.8.7",
+        "decorator-transforms": "^1.0.1"
       }
     },
     "node_modules/ember-simple-auth": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -91,6 +91,7 @@
     "ember-page-title": "^8.0.0",
     "ember-qunit": "^8.0.0",
     "ember-resolver": "^11.0.0",
+    "ember-set-helper": "^3.0.1",
     "ember-simple-auth": "^6.0.0",
     "ember-source": "^5.8.0",
     "ember-template-imports": "^4.1.1",

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
@@ -501,8 +501,8 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         await fillByLabel('Message :', 'nouveau message');
         await fillByLabel("* Nom de l'image (svg) :", 'new_image.svg');
         await fillByLabel('* Message Alternatif :', 'nouveau alt');
-        await clickByName('Certifiable :');
-        await clickByName('Lacunes :');
+        await clickByName('Certifiable');
+        await clickByName('Lacunes');
         await clickByName('Enregistrer');
 
         // then

--- a/admin/tests/integration/components/trainings/create-or-update-training-form_test.js
+++ b/admin/tests/integration/components/trainings/create-or-update-training-form_test.js
@@ -49,7 +49,7 @@ module('Integration | Component | Trainings::CreateOrUpdateTrainingForm', functi
     assert.dom(screen.getByLabelText('Heures (HH)')).exists();
     assert.dom(screen.getByLabelText('Minutes (MM)')).exists();
     assert.dom(screen.getByLabelText('Langue localisée')).exists();
-    assert.dom(screen.getByLabelText('Nom du fichier du logo éditeur (.svg)')).exists();
+    assert.dom(screen.getByLabelText('Nom du fichier du logo éditeur', { exact: false })).exists();
     assert.dom(screen.queryByLabelText('Mettre en pause')).doesNotExist();
     assert
       .dom(
@@ -126,7 +126,7 @@ module('Integration | Component | Trainings::CreateOrUpdateTrainingForm', functi
       assert.dom(screen.getByLabelText('Heures (HH)')).hasValue(model.duration.hours.toString());
       assert.dom(screen.getByLabelText('Minutes (MM)')).hasValue(model.duration.minutes.toString());
       assert.strictEqual(screen.getByLabelText('Langue localisée').innerText, localeCategories[model.locale]);
-      assert.dom(screen.getByLabelText('Nom du fichier du logo éditeur (.svg)')).hasValue(editorLogo);
+      assert.dom(screen.getByLabelText('Nom du fichier du logo éditeur', { exact: false })).hasValue(editorLogo);
       assert.strictEqual(screen.getByLabelText('Mettre en pause').checked, model.isDisabled);
       assert
         .dom(


### PR DESCRIPTION
## :unicorn: Problème

Suite à la PR https://github.com/1024pix/pix/pull/9270 qui met en place la configuration pour les fichiers gjs sur PixAdmin, il y a deux nouvelles règles de lint que notre code ne respectent pas.

## :robot: Proposition

Dans cette PR, on traite la règle no-builtin-form-components en remplaçant les composants builtin par des composants PixUI.

## :rainbow: Remarques

Il y a de nombreuses régressions visuelles suite à ces changements. Nous aurions besoin que toutes les teams concernées participent à l'effort pour les corriger.

J'ai appliqué le code décrit ici pour migrer : https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-builtin-form-components.md#migration

## :100: Pour tester

Vérifier les écrans impactés par les changements. Nous ne pouvons pas faire confiance seulement à la couverture de test puisqu'il y a des changements graphiques.

### Test Accès (RA de Pix Admin)
#### Formulaire mise à jour détail utilisateur
- Cliquer sur l'onglet Utlisateurs
- Faire une recherche avec un prénom (ex: Ayame) puis aller sur la page de détail correspondante
- Cliquer sur le bouton modifier 
- Vérifier que les validations se font bien et que l'erreur est bien affichée en cas de problème de saisie : 
    - pour les champs _prénom / nom / identifiant / adresse email_, champs non vide
    - pour le _prénom / nom / identifiant_ (limite de 255 caractères)
    - pour l'adresse email, le format de l'adresse
- Vérifier que, lorsqu'on sélectionne une locale (ex: nl-BE), l'option sélectionnée est bien affichée.
- Enfin, tester la mise à jour de chaque champ. _Rafraîchir_ la page ensuite et constater qu'il n'y a pas de régressions dessus.

#### Formulaire mise à jour d'une organisation
-  Cliquer sur l'onglet Organisations
- Aller sur la page de détail de l'organisation _Lycée Joséphine Baker_
- Cliquer sur le bouton modifier
- Vérifier que les validations se font bien et que l'erreur est bien affichée en cas de problème de saisie : 
    - Pour tous les champs input texte, la limite de 255 caractères
    - Pour le champ _nom_, non vide
    - Pour le champ _crédits_, un nombre positif
    - Pour le champ _lien de la documentation_ format de l'url
    - Pour les champs _Adresse e-mail du DPO +  Adresse e-mail d'activation SCO_ , le format de l'adresse email
- Enfin, tester la mise à jour de chaque champ. Rafraîchir la page ensuite et constater qu'il n'y a pas de régressions dessus.