### PR TITLE
[BUGFIX] Modification de la valeur CORE en BDD (PIX-12981).

### DIFF
--- a/api/db/migrations/20240617134714_update-core-type.js
+++ b/api/db/migrations/20240617134714_update-core-type.js
@@ -1,0 +1,20 @@
+const TABLE_NAME = 'certification-subscriptions';
+
+const up = async function (knex) {
+  await knex(TABLE_NAME)
+    .delete()
+    .where({ type: 'CORE' })
+    .whereExists(
+      knex(`${TABLE_NAME} as cs`)
+        .where({ type: '"CORE"' })
+        .whereRaw(`cs."certificationCandidateId" = ??."certificationCandidateId"`, TABLE_NAME),
+    );
+
+  await knex(TABLE_NAME).update({ type: 'CORE' }).where({ type: '"CORE"' });
+};
+
+const down = function () {
+  return true;
+};
+
+export { down, up };

--- a/api/lib/infrastructure/repositories/sco-certification-candidate-repository.js
+++ b/api/lib/infrastructure/repositories/sco-certification-candidate-repository.js
@@ -1,5 +1,4 @@
 import { knex } from '../../../db/knex-database-connection.js';
-import { SubscriptionTypes } from '../../../src/certification/shared/domain/models/SubscriptionTypes.js';
 
 const addNonEnrolledCandidatesToSession = async function ({ sessionId, scoCertificationCandidates }) {
   const organizationLearnerIds = scoCertificationCandidates.map((candidate) => candidate.organizationLearnerId);
@@ -21,11 +20,7 @@ const addNonEnrolledCandidatesToSession = async function ({ sessionId, scoCertif
 
   const addedCandidateIds = await knex
     .batchInsert('certification-candidates', candidatesToBeEnrolledDTOs)
-    .returning(knex.raw('id as "certificationCandidateId", \'??\' as type', [SubscriptionTypes.CORE]));
-
-  // addedCandidateIds.forEach((candidate) => {
-  //   candidate.type = SubscriptionTypes.CORE;
-  // });
+    .returning(knex.raw('id as "certificationCandidateId", \'CORE\' as type'));
 
   await knex.batchInsert('certification-subscriptions', addedCandidateIds);
 };


### PR DESCRIPTION
## :unicorn: Problème

La valeur `CORE` n'est pas enregistrée au bon format en BDD (`"CORE"`)

## :robot: Proposition

- Correctif de l'enregistrement de la valeur `CORE` dans le code
- Migration pour remettre les types dont la valeur serait à `"CORE"` au bon format (`CORE`)

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
1)
Rollback la migration

Récupérer deux `certificationCandidateId` (id1, id2) de certification-subscriptions en BDD

`UPDATE "certification-subscriptions" SET type='"CORE"' WHERE "certificationCandidateId"= {id1};`
`UPDATE "certification-subscriptions" SET type='"CORE"' WHERE "certificationCandidateId"= {id2};`
`insert into "certification-subscriptions" ("certificationCandidateId", "type") values ({id1}, 'CORE');`
Lancer la migration
`SELECT * FROM "certification-subscriptions" WHERE "certificationCandidateId" IN ({id1}, {id2});`

Vérifier qu'il n'y ait pas de doublon d'id de certificationCandidateId et que le type soit set à `CORE`

2) Inscrire un.e candidat.e sur une session. S'assurer qu'il/elle a bien une subscription CORE
