### PR TITLE
[TECH] Suppression d'avertissements liés à des dépréciations à venir d'Ember data.

### DIFF
--- a/junior/app/transforms/boolean.js
+++ b/junior/app/transforms/boolean.js
@@ -1,0 +1,1 @@
+export { BooleanTransform as default } from '@ember-data/serializer/transform';

--- a/junior/app/transforms/string.js
+++ b/junior/app/transforms/string.js
@@ -1,0 +1,1 @@
+export { StringTransform as default } from '@ember-data/serializer/transform';


### PR DESCRIPTION
## :unicorn: Problème
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Lors de la navigation sur l'application Pix Junior, en regardant la console du navigateur, on constate des messages avertissants de dépréciations à venir d'Ember Data.
Les messages sont les suivants : 
```
DEPRECATION: You are relying on ember-data auto-magically installing the StringTransform. Use `export { StringTransform as default } from '@ember-data/serializer/transform';` in app/transforms/string.js instead [deprecation id: ember-data:deprecate-legacy-imports] This will be removed in ember-data 6.0.
```

```
DEPRECATION: You are relying on ember-data auto-magically installing the BooleanTransform. Use `export { BooleanTransform as default } from '@ember-data/serializer/transform';` in app/transforms/boolean.js instead [deprecation id: ember-data:deprecate-legacy-imports] This will be removed in ember-data 6.0.
```

## :robot: Proposition
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

Appliquer les recommandations données dans les messages d'avertissements en créant les transformeurs `boolean` et `string`.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->
RAS

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
En développement (donc en local), naviguer dans l'application avec la console ouverte et constater qu'il n'y a plus de messages d'avertissements.
