### PR TITLE
[BUGFIX] Corriger l'affichage des places dans le Header Et sur la pages des Places sur PixOrga (PIX-13017)

### DIFF
--- a/orga/app/routes/authenticated.js
+++ b/orga/app/routes/authenticated.js
@@ -31,11 +31,6 @@ export default class AuthenticatedRoute extends Route {
         }),
       });
     }
-    if (this.currentUser.canAccessMissionsPage) {
-      // when user can access mission page, we force load currentUser
-      // so the page is re rendered and session status can be live updated
-      await this.currentUser.load();
-    }
   }
 
   @action

--- a/orga/app/routes/authenticated.js
+++ b/orga/app/routes/authenticated.js
@@ -2,7 +2,6 @@ import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import get from 'lodash/get';
-import RSVP from 'rsvp';
 
 export default class AuthenticatedRoute extends Route {
   @service currentUser;
@@ -25,12 +24,10 @@ export default class AuthenticatedRoute extends Route {
 
   async model() {
     if (this.currentUser.prescriber.placesManagement) {
-      return RSVP.hash({
-        available: this.store.queryRecord('organization-place-statistic', {
-          organizationId: this.currentUser.organization.id,
-        }),
+      return this.store.queryRecord('organization-place-statistic', {
+        organizationId: this.currentUser.organization.id,
       });
-    }
+    } else return null;
   }
 
   @action

--- a/orga/app/routes/authenticated.js
+++ b/orga/app/routes/authenticated.js
@@ -32,6 +32,8 @@ export default class AuthenticatedRoute extends Route {
       });
     }
     if (this.currentUser.canAccessMissionsPage) {
+      // when user can access mission page, we force load currentUser
+      // so the page is re rendered and session status can be live updated
       await this.currentUser.load();
     }
   }

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -546,4 +546,14 @@ function routes() {
 
     return new Response(204);
   });
+
+  this.post('/pix1d/schools/:school_id/session/activate', (schema, request) => {
+    const schoolId = request.params.school_id;
+    const organization = schema.organizations.find(schoolId);
+    organization.sessionExpirationDate = new Date();
+    organization.sessionExpirationDate.setHours(organization.sessionExpirationDate.getHours() + 4);
+    organization.save();
+
+    return new Response(204);
+  });
 }

--- a/orga/tests/acceptance/authentication_test.js
+++ b/orga/tests/acceptance/authentication_test.js
@@ -297,6 +297,31 @@ module('Acceptance | authentication', function (hooks) {
           ),
         );
       });
+
+      test('should handle starting session', async function (assert) {
+        const now = new Date(2024, 5, 12, 14);
+        clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+        const user = createPrescriberForOrganization(
+          { lang: 'fr', pixOrgaTermsOfServiceAccepted: true },
+          {
+            schoolCode: 'AZERTY',
+            sessionExpirationDate: null,
+          },
+          'MEMBER',
+          {
+            MISSIONS_MANAGEMENT: true,
+          },
+        );
+        await authenticateSession(user.id);
+        const screen = await visit('/');
+        await clickByName(this.intl.t('navigation.school-sessions.activate-button'));
+
+        assert.ok(
+          screen.getByText(
+            this.intl.t('navigation.school-sessions.status.active-label', { sessionExpirationDate: '18:00' }),
+          ),
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Depuis l'ajout des infos de session d'une école pour Pix Junior, l'information de places disponibles a été "cassée" comme en témoigne la capture d'écran ci-dessous.
![image](https://github.com/1024pix/pix/assets/2989532/0b51b57a-293a-47e8-90ca-c3dc061946f9)

Après analyse, cela est du à l'utilisation inutile de `RSVP.hash` qui retourne les statistiques de l'organisation dans un objet alors que le composant qui le lit attend un objet directement.


## :robot: Proposition

Supprimer l'usage inutile de `RSVP.hash`.


## :rainbow: Remarques
On en profite pour remettre en cause l'appel de `this.currentUser.load` dans le model de la route `authenticated`.
Après ajout d'un test d'acceptance sur le démarrage d'une session, on se rend compte que cet appel n'est pas utile.
On supprime donc cet appel.

Les tests manquants au sujet de l'affichage des places disponibles seront ajoutés dans une future PR.

## :100: Pour tester
Se connecter sur PixOrga.

Voir les places s'afficher (sur l'Orga Pro Classic)
Vérifier que le lancement d'une session (sur une organisation de type SCO-1D) est fonctionnel.