### PR TITLE
[BUGFIX] Réparer les caractères de balises HTML incorrects (PIX-13036)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/adresse-ip-publique-et-vous.json
@@ -15,23 +15,23 @@
   },
   "transitionTexts": [
     {
-      "content": "<p>En naviguant sur internet, il arrive qu'un site sache où vous vous trouvez alors que vous ne lui avez pas partagé votre localisation.<span aria-hidden=\"true\">📍</span>️<br>Mystère&#8239;? Pas vraiment. On vous explique tout dans ce module.</p>",
+      "content": "<p>En naviguant sur internet, il arrive qu'un site sache où vous vous trouvez alors que vous ne lui avez pas partagé votre localisation.<span aria-hidden=\"true\">📍</span><br>Mystère&#8239;? Pas vraiment. On vous explique tout dans ce module.</p>",
       "grainId": "1d516eb9-e7b7-48a3-a3b5-7971ad171d6f"
     },
     {
-      "content": "<p>Dans la vidéo suivante, vous allez découvrir ce qu'est une adresse IP publique et à quoi elle sert.&nbsp;<span aria-hidden=\"true\">📺</span>️</p>",
+      "content": "<p>Dans la vidéo suivante, vous allez découvrir ce qu'est une adresse IP publique et à quoi elle sert.&nbsp;<span aria-hidden=\"true\">📺</span></p>",
       "grainId": "4f4ada91-e239-4991-9fc8-ab491aabc424"
     },
     {
-      "content": "<p>Vous en savez désormais plus sur les adresses IP publiques.&nbsp;<span aria-hidden=\"true\">👩‍💻</span>️<span aria-hidden=\"true\">👨🏿‍💻</span>️ Vérifions ensemble. </p>",
+      "content": "<p>Vous en savez désormais plus sur les adresses IP publiques.&nbsp;<span aria-hidden=\"true\">👩‍💻</span><span aria-hidden=\"true\">👨🏿‍💻</span> Vérifions ensemble. </p>",
       "grainId": "eba0b676-c0c4-4b32-b5e4-dd94d13766a5"
     },
     {
-      "content": "<p>Lorsque vous êtes en ligne, votre adresse IP publique est partagée et utilisée. Mais savez-vous quelles informations cette adresse donne sur vous&#8239;?&nbsp;<span aria-hidden=\"true\">👁️‍🗨️</span>️</p>",
+      "content": "<p>Lorsque vous êtes en ligne, votre adresse IP publique est partagée et utilisée. Mais savez-vous quelles informations cette adresse donne sur vous&#8239;?&nbsp;<span aria-hidden=\"true\">👁️‍🗨️</span></p>",
       "grainId": "96cdedc1-2d31-40c2-ac02-d3fd83f26e30"
     },
     {
-      "content": "<p>On l'a vu, on peut déterminer une zone géographique à partir d'une adresse IP publique. Place à la pratique.&nbsp;<span aria-hidden=\"true\">🌍</span>️</p>",
+      "content": "<p>On l'a vu, on peut déterminer une zone géographique à partir d'une adresse IP publique. Place à la pratique.&nbsp;<span aria-hidden=\"true\">🌍</span></p>",
       "grainId": "09304128-193f-4ea8-bda7-edffd72b1bf2"
     },
     {
@@ -54,7 +54,7 @@
           "element": {
             "id": "67b68f2a-349d-4df7-90a5-c9f5dc930a1a",
             "type": "text",
-            "content": "<p> Voici la page de résultats d'une recherche en ligne sur des recettes végétariennes.<span aria-hidden=\"true\">🥗</span>️<br>Le moteur de recherche indique que l'utilisateur se trouve actuellement vers Toulouse.</p>"
+            "content": "<p> Voici la page de résultats d'une recherche en ligne sur des recettes végétariennes.<span aria-hidden=\"true\">🥗</span><br>Le moteur de recherche indique que l'utilisateur se trouve actuellement vers Toulouse.</p>"
           }
         },
         {
@@ -149,7 +149,7 @@
             ],
             "feedbacks": {
               "valid": "<span class=\"feedback__state\">Correct</span>.<p>L'adresse IP publique est l’équivalent d’une adresse postale pour identifier où est une personne.</p>",
-              "invalid": "<span class=\"feedback__state\">Incorrect</span>.<p>Vous pensez peut-être plutôt à l'adresse <strong>web</strong> ou l'adresse <strong>mail</strong>.<br>Vous pouvez remonter voir la vidéo.<span aria-hidden=\"true\">👆</span>️</p>"
+              "invalid": "<span class=\"feedback__state\">Incorrect</span>.<p>Vous pensez peut-être plutôt à l'adresse <strong>web</strong> ou l'adresse <strong>mail</strong>.<br>Vous pouvez remonter voir la vidéo.<span aria-hidden=\"true\">👆</span></p>"
             },
             "solution": "1"
           }
@@ -305,7 +305,7 @@
           "element": {
             "id": "27fc867a-7258-4f85-b8cc-bdd1ab2d26a5",
             "type": "text",
-            "content": "<h3>Ce qu'il faut retenir&nbsp;<span aria-hidden=\"true\">🎓</span>️</h3><ul><li>L’adresse IP publique donne une information sur la zone géographique de la connexion.</li><li>Votre adresse IP publique est celle de votre box internet.</li><li>Les personnes connectées à la même box internet ont la même adresse IP publique.</li><li>À partir d'une adresse IP publique, on peut seulement identifier un pays, voire une ville de connexion.</li></ul>"
+            "content": "<h3>Ce qu'il faut retenir&nbsp;<span aria-hidden=\"true\">🎓</span></h3><ul><li>L’adresse IP publique donne une information sur la zone géographique de la connexion.</li><li>Votre adresse IP publique est celle de votre box internet.</li><li>Les personnes connectées à la même box internet ont la même adresse IP publique.</li><li>À partir d'une adresse IP publique, on peut seulement identifier un pays, voire une ville de connexion.</li></ul>"
           }
         }
       ]
@@ -335,12 +335,8 @@
                 "placeholder": "",
                 "ariaLabel": "Nom du pays :",
                 "defaultValue": "",
-                "tolerances": [
-                  "t1"
-                ],
-                "solutions": [
-                  "France"
-                ]
+                "tolerances": ["t1"],
+                "solutions": ["France"]
               }
             ],
             "feedbacks": {
@@ -510,7 +506,7 @@
           "element": {
             "id": "eed9177c-4bc9-401c-928f-13585df010f7",
             "type": "qcu",
-            "instruction": "<p>Pour finir ce module, cherchez votre adresse IP publique actuelle.<span aria-hidden=\"true\">🕵️‍♂️</span>️<span aria-hidden=\"true\">🕵🏽‍♀️</span>️</p><p>Pensez-vous avoir réussi à la trouver&#8239;?</p>",
+            "instruction": "<p>Pour finir ce module, cherchez votre adresse IP publique actuelle.<span aria-hidden=\"true\">🕵️‍♂️</span><span aria-hidden=\"true\">🕵🏽‍♀️</span></p><p>Pensez-vous avoir réussi à la trouver&#8239;?</p>",
             "proposals": [
               {
                 "id": "1",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/bien-ecrire-son-adresse-mail.json
@@ -15,7 +15,7 @@
   },
   "transitionTexts": [
     {
-      "content": "<p>Naomi a oublié l’adresse mail de son ami Mickaël.&nbsp;<span aria-hidden=\"true\">🤷‍♀</span>️<br> Elle en a besoin pour envoyer un document à son ami. Naomi lui demande donc par SMS de lui redonner son adresse mail. <br> Lancez la vidéo pour voir leur discussion.&nbsp;<span aria-hidden=\"true\">📺</span></p>",
+      "content": "<p>Naomi a oublié l’adresse mail de son ami Mickaël.&nbsp;<span aria-hidden=\"true\">🤷‍♀</span><br> Elle en a besoin pour envoyer un document à son ami. Naomi lui demande donc par SMS de lui redonner son adresse mail. <br> Lancez la vidéo pour voir leur discussion.&nbsp;<span aria-hidden=\"true\">📺</span></p>",
       "grainId": "34d225e8-5d52-4ebd-9acd-8bde8438cfc9"
     },
     {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -7,10 +7,7 @@
     "description": "Découvrez avec ce didacticiel comment fonctionne Modulix !",
     "duration": 5,
     "level": "Débutant",
-    "objectives": [
-      "Naviguer dans Modulix",
-      "Découvrir les leçons et les activités"
-    ]
+    "objectives": ["Naviguer dans Modulix", "Découvrir les leçons et les activités"]
   },
   "transitionTexts": [
     {
@@ -30,11 +27,11 @@
       "grainId": "0be0f5eb-4cb6-47c2-b9d3-cb2ceb4cd21c"
     },
     {
-      "content": "<p>Vous l'avez peut-être remarqué&nbsp;: dans un module, vous pouvez voir tous les contenus en remontant la page&nbsp;<span aria-hidden=\"true\">👆</span>️</p>",
+      "content": "<p>Vous l'avez peut-être remarqué&nbsp;: dans un module, vous pouvez voir tous les contenus en remontant la page&nbsp;<span aria-hidden=\"true\">👆</span></p>",
       "grainId": "2a77a10f-19a3-4544-80f9-8012dad6506a"
     },
     {
-      "content": "<p>Vous arrivez à la fin de ce didacticiel. Une dernière activité et vous serez prêt à explorer tous les modules que vous souhaitez&#8239;!<span aria-hidden=\"true\">🌟</span>️ </p>",
+      "content": "<p>Vous arrivez à la fin de ce didacticiel. Une dernière activité et vous serez prêt à explorer tous les modules que vous souhaitez&#8239;!<span aria-hidden=\"true\">🌟</span> </p>",
       "grainId": "7cf75e70-8749-4392-8081-f2c02badb0fb"
     }
   ],
@@ -48,18 +45,22 @@
           "type": "stepper",
           "steps": [
             {
-              "elements": [{
-                "id": "342183f7-af51-4e4e-ab4c-ebed1e195063",
-                "type": "text",
-                "content": "<p>À la fin de cette vidéo, une question sera posée sur les compétences Pix.</p>"
-              }]
+              "elements": [
+                {
+                  "id": "342183f7-af51-4e4e-ab4c-ebed1e195063",
+                  "type": "text",
+                  "content": "<p>À la fin de cette vidéo, une question sera posée sur les compétences Pix.</p>"
+                }
+              ]
             },
             {
-              "elements": [{
-                "id": "342183f7-af51-4e4e-ab4c-ebed1e195063",
-                "type": "text",
-                "content": "<p>À la fin de cette vidéo, une question sera posée sur les compétences Pix.</p>"
-              }]
+              "elements": [
+                {
+                  "id": "342183f7-af51-4e4e-ab4c-ebed1e195063",
+                  "type": "text",
+                  "content": "<p>À la fin de cette vidéo, une question sera posée sur les compétences Pix.</p>"
+                }
+              ]
             }
           ]
         }
@@ -83,7 +84,7 @@
           "element": {
             "id": "a2372bf4-86a4-4ecc-a188-b51f4f98bca2",
             "type": "text",
-            "content": "<p>Voici un texte de leçon. Parfois, il y a des émojis pour aider à la lecture&nbsp;<span aria-hidden=\"true\">📚</span>️.<br>Et là, voici une image&#8239;!</p>"
+            "content": "<p>Voici un texte de leçon. Parfois, il y a des émojis pour aider à la lecture&nbsp;<span aria-hidden=\"true\">📚</span>.<br>Et là, voici une image&#8239;!</p>"
           }
         },
         {
@@ -147,7 +148,7 @@
             ],
             "feedbacks": {
               "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>",
-              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden=\"true\">👆</span>️!</p>"
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden=\"true\">👆</span>!</p>"
             },
             "solution": "1"
           }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/distinguer-vrai-faux-sur-internet.json
@@ -15,15 +15,15 @@
   },
   "transitionTexts": [
     {
-      "content": "<p>Commençons par un jeu.&nbsp;<span aria-hidden=\"true\">🎮</span>️<br>Sans chercher sur internet, essayez de deviner si chaque information proposée dans ces articles de journaux est plutôt vraie ou plutôt fausse. Bonne chance&#8239;!</p>",
+      "content": "<p>Commençons par un jeu.&nbsp;<span aria-hidden=\"true\">🎮</span><br>Sans chercher sur internet, essayez de deviner si chaque information proposée dans ces articles de journaux est plutôt vraie ou plutôt fausse. Bonne chance&#8239;!</p>",
       "grainId": "f242e81e-b182-44a1-a668-557f26b5ff8b"
     },
     {
-      "content": "<p>Vous l'avez remarqué, en lisant seulement le titre d’un article, c’est presque impossible de savoir si une information est vraie ou fausse.&nbsp;<span aria-hidden=\"true\">🤔</span>️<br>Parfois, ce ne sont même pas des informations mais par exemple des opinions.&nbsp;<span aria-hidden=\"true\">📚</span>️ Vous allez découvrir la différence dans la vidéo suivante.</p>",
+      "content": "<p>Vous l'avez remarqué, en lisant seulement le titre d’un article, c’est presque impossible de savoir si une information est vraie ou fausse.&nbsp;<span aria-hidden=\"true\">🤔</span><br>Parfois, ce ne sont même pas des informations mais par exemple des opinions.&nbsp;<span aria-hidden=\"true\">📚</span> Vous allez découvrir la différence dans la vidéo suivante.</p>",
       "grainId": "eb83569f-2e37-49ed-aa6f-31c420b673b9"
     },
     {
-      "content": "<p>Vous savez maintenant mieux repérer une information. Mais une information peut être fausse ...<br>Voyons ensemble des questions à se poser pour vérifier une information.&nbsp;<span aria-hidden=\"true\">🗒️</span>️</p>",
+      "content": "<p>Vous savez maintenant mieux repérer une information. Mais une information peut être fausse ...<br>Voyons ensemble des questions à se poser pour vérifier une information.&nbsp;<span aria-hidden=\"true\">🗒️</span></p>",
       "grainId": "ed22ab38-ec6d-47df-88ea-4894f1cd6c8a"
     },
     {
@@ -39,7 +39,7 @@
       "grainId": "428ea826-6e21-4c56-a5a2-f97373f1e833"
     },
     {
-      "content": "<p>Maintenant, à vous d’étudier une nouvelle situation.&nbsp;<span aria-hidden=\"true\">🕵️</span>️<span aria-hidden=\"true\">🕵🏿‍♀️</span>️</p>",
+      "content": "<p>Maintenant, à vous d’étudier une nouvelle situation.&nbsp;<span aria-hidden=\"true\">🕵️</span><span aria-hidden=\"true\">🕵🏿‍♀️</span></p>",
       "grainId": "9f56f75e-3e2d-4a6e-8623-9b74747b236d"
     }
   ],
@@ -314,7 +314,7 @@
           "element": {
             "id": "332d9e96-d12e-4809-9d25-173a57ed93be",
             "type": "text",
-            "content": "<h3>Question n°1&nbsp;: qui est l’auteur de cette information&#8239;?&nbsp;<span aria-hidden=\"true\">🖋️</span>️</h3><p>En vous posant cette question, vous pourrez mieux évaluer l’information.<br>Par exemple, si vous connaissez ou non l’auteur, si l’auteur est reconnu ou encore si l’auteur a un intérêt particulier à ce que cette information circule.</p>"
+            "content": "<h3>Question n°1&nbsp;: qui est l’auteur de cette information&#8239;?&nbsp;<span aria-hidden=\"true\">🖋️</span></h3><p>En vous posant cette question, vous pourrez mieux évaluer l’information.<br>Par exemple, si vous connaissez ou non l’auteur, si l’auteur est reconnu ou encore si l’auteur a un intérêt particulier à ce que cette information circule.</p>"
           }
         },
         {
@@ -330,7 +330,7 @@
           "element": {
             "id": "8aa4a733-4a92-4007-897d-ab884a7add85",
             "type": "text",
-            "content": "<h3>Question n°2&nbsp;: quelle est la date de l’information&#8239;?&nbsp;<span aria-hidden=\"true\">📅</span>️</h3><p>C’est simple à vérifier et très important&#8239;! Des informations vraies un jour peuvent être fausses le lendemain. <br>Par exemple, une alerte inondation ou une promotion dans un magasin.</p>"
+            "content": "<h3>Question n°2&nbsp;: quelle est la date de l’information&#8239;?&nbsp;<span aria-hidden=\"true\">📅</span></h3><p>C’est simple à vérifier et très important&#8239;! Des informations vraies un jour peuvent être fausses le lendemain. <br>Par exemple, une alerte inondation ou une promotion dans un magasin.</p>"
           }
         },
         {
@@ -346,7 +346,7 @@
           "element": {
             "id": "36577421-d9d0-4f49-ac43-b4e804ba5635",
             "type": "text",
-            "content": "<h3>Question n°3&nbsp;: d’où provient cette information&#8239;?&nbsp;<span aria-hidden=\"true\">ℹ️</span>️</h3><p>C'est-à-dire, son origine, sa source. Cherchez à savoir si c’est une observation, un témoignage, un résultat d’expérience, etc.<br>Regardez également si vous pouvez vérifier cette information par vous-même et si l’auteur a partagé ses sources.</p>"
+            "content": "<h3>Question n°3&nbsp;: d’où provient cette information&#8239;?&nbsp;<span aria-hidden=\"true\">ℹ️</span></h3><p>C'est-à-dire, son origine, sa source. Cherchez à savoir si c’est une observation, un témoignage, un résultat d’expérience, etc.<br>Regardez également si vous pouvez vérifier cette information par vous-même et si l’auteur a partagé ses sources.</p>"
           }
         }
       ]
@@ -386,13 +386,9 @@
             ],
             "feedbacks": {
               "valid": "<span class=\"feedback__state\">Correct.</span><p> Tous ces éléments permettent de vérifier une information. </p>",
-              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Retournez voir la leçon ci-dessus si besoin&nbsp;<span aria-hidden=\"true\">⬆</span>️!</p>"
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Retournez voir la leçon ci-dessus si besoin&nbsp;<span aria-hidden=\"true\">⬆</span>!</p>"
             },
-            "solutions": [
-              "2",
-              "3",
-              "5"
-            ]
+            "solutions": ["2", "3", "5"]
           }
         }
       ]
@@ -582,7 +578,7 @@
           "element": {
             "id": "eb90d3ea-797f-4e4a-9675-e679b9f5bf3c",
             "type": "text",
-            "content": "<p>Stéphane n'arrive pas à faire pousser sa nouvelle plante verte d’intérieur&nbsp;<span aria-hidden=\"true\">🪴</span>️. Il cherche des astuces sur les réseaux sociaux.<br>Il trouve les informations suivantes, publiées le 28 août 2023, par SuperJardinier&nbsp;:</p>"
+            "content": "<p>Stéphane n'arrive pas à faire pousser sa nouvelle plante verte d’intérieur&nbsp;<span aria-hidden=\"true\">🪴</span>. Il cherche des astuces sur les réseaux sociaux.<br>Il trouve les informations suivantes, publiées le 28 août 2023, par SuperJardinier&nbsp;:</p>"
           }
         },
         {
@@ -623,10 +619,7 @@
               "valid": "<span class=\"feedback__state\">Correct.</span><p> Plusieurs indices, comme l'absence de source ou le code promotionnel, poussent à vouloir en savoir plus avant de tester ou de partager ces astuces.</p>",
               "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Plusieurs indices, comme l'absence de source ou le code promotionnel, poussent à vouloir en savoir plus avant de tester ou de partager ces astuces.</p>"
             },
-            "solutions": [
-              "2",
-              "3"
-            ]
+            "solutions": ["2", "3"]
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/principes-fondateurs-wikipedia.json
@@ -15,7 +15,7 @@
   },
   "transitionTexts": [
     {
-      "content": "<p>Vous avez probablement déjà utilisé Wikipédia. Mais connaissez-vous la signification de son logo&#8239;?&nbsp;<span aria-hidden=\"true\">🌎</span>️&nbsp;<span aria-hidden=\"true\">🧩</span>️</p>",
+      "content": "<p>Vous avez probablement déjà utilisé Wikipédia. Mais connaissez-vous la signification de son logo&#8239;?&nbsp;<span aria-hidden=\"true\">🌎</span>&nbsp;<span aria-hidden=\"true\">🧩</span></p>",
       "grainId": "da95d2bc-e597-4366-a095-21f7ab0f4845"
     },
     {
@@ -31,7 +31,7 @@
       "grainId": "5f048ad8-d008-4956-840b-37e84138b433"
     },
     {
-      "content": "<p>Comme tout site internet, Wikipédia a besoin d’argent pour fonctionner.&nbsp;<span aria-hidden=\"true\">💰</span>️</p>",
+      "content": "<p>Comme tout site internet, Wikipédia a besoin d’argent pour fonctionner.&nbsp;<span aria-hidden=\"true\">💰</span></p>",
       "grainId": "09b21f5f-b7e7-4c7a-9059-bdb2a2be246d"
     },
     {
@@ -110,7 +110,7 @@
           "element": {
             "id": "afc8b60f-c2c1-405b-a6a4-a0e08e23ccc3",
             "type": "text",
-            "content": "<h3>1 - Wikipédia est une encyclopédie en ligne.&nbsp;<span aria-hidden=\"true\">📖</span>️</h3><p>Des connaissances du monde entier y sont rassemblées, classées et exposées méthodiquement. Wikipédia n'est donc ni un journal ni un réseau social.</p>"
+            "content": "<h3>1 - Wikipédia est une encyclopédie en ligne.&nbsp;<span aria-hidden=\"true\">📖</span></h3><p>Des connaissances du monde entier y sont rassemblées, classées et exposées méthodiquement. Wikipédia n'est donc ni un journal ni un réseau social.</p>"
           }
         },
         {
@@ -126,7 +126,7 @@
           "element": {
             "id": "81710de7-1311-4980-81f5-87944e56de28",
             "type": "text",
-            "content": "<h3>2 - Wikipédia propose des contenus les plus neutres possible.&nbsp;<span aria-hidden=\"true\">⚖️</span>️</h3><p>Une opinion ou un point de vue unique n’ont pas leur place. Si besoin, les divers points de vue sont présentés, sans jugement de valeur.</p>"
+            "content": "<h3>2 - Wikipédia propose des contenus les plus neutres possible.&nbsp;<span aria-hidden=\"true\">⚖️</span></h3><p>Une opinion ou un point de vue unique n’ont pas leur place. Si besoin, les divers points de vue sont présentés, sans jugement de valeur.</p>"
           }
         },
         {
@@ -142,7 +142,7 @@
           "element": {
             "id": "78385472-07b0-4229-bfb8-a10636690300",
             "type": "text",
-            "content": "<h3>3 - Wikipédia est publié sous licence libre.&nbsp;<span aria-hidden=\"true\">🪁</span>️</h3><p>En résumé, chacun peut créer, copier, modifier et partager le contenu qui se trouve sur Wikipédia. Certaines conditions doivent tout de même être respectées.</p>"
+            "content": "<h3>3 - Wikipédia est publié sous licence libre.&nbsp;<span aria-hidden=\"true\">🪁</span></h3><p>En résumé, chacun peut créer, copier, modifier et partager le contenu qui se trouve sur Wikipédia. Certaines conditions doivent tout de même être respectées.</p>"
           }
         },
         {
@@ -158,7 +158,7 @@
           "element": {
             "id": "df11aa2c-1ebf-4a60-99a3-533dfc06756d",
             "type": "text",
-            "content": "<h3>4 - Wikipédia est un projet collaboratif.&nbsp;<span aria-hidden=\"true\">🙋🏽‍♂️</span>️<span aria-hidden=\"true\">🙋🏻‍♀️</span>️<span aria-hidden=\"true\">🙋🏿‍♀️</span>️<span aria-hidden=\"true\">🙋‍♂️</span>️</h3><p>C’est probablement sa caractéristique la plus remarquable. Tout le monde peut améliorer les contenus de Wikipédia&#8239;! Des règles claires de savoir-vivre sont à respecter.</p>"
+            "content": "<h3>4 - Wikipédia est un projet collaboratif.&nbsp;<span aria-hidden=\"true\">🙋🏽‍♂️</span><span aria-hidden=\"true\">🙋🏻‍♀️</span><span aria-hidden=\"true\">🙋🏿‍♀️</span><span aria-hidden=\"true\">🙋‍♂️</span></h3><p>C’est probablement sa caractéristique la plus remarquable. Tout le monde peut améliorer les contenus de Wikipédia&#8239;! Des règles claires de savoir-vivre sont à respecter.</p>"
           }
         },
         {
@@ -174,7 +174,7 @@
           "element": {
             "id": "ca62ac2d-950d-4c00-b14d-2ac9e7d509f2",
             "type": "text",
-            "content": "<h3>5 - Wikipédia n’a pas d’autres principes fixes que ceux présentés ci-dessus.&nbsp;<span aria-hidden=\"true\">📜</span>️</h3><p>Il est toutefois possible de proposer et de créer des règles pour améliorer continuellement Wikipédia, en accord avec ses principes.</p>"
+            "content": "<h3>5 - Wikipédia n’a pas d’autres principes fixes que ceux présentés ci-dessus.&nbsp;<span aria-hidden=\"true\">📜</span></h3><p>Il est toutefois possible de proposer et de créer des règles pour améliorer continuellement Wikipédia, en accord avec ses principes.</p>"
           }
         }
       ]
@@ -214,7 +214,7 @@
             ],
             "feedbacks": {
               "valid": "<span class=\"feedback__state\">Correct.</span><p> Vous avez bien identifié les principes de Wikipédia. </p>",
-              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Remonter la page pour relire la leçon.&nbsp;<span aria-hidden=\"true\">⬆</span>️</p>"
+              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Remonter la page pour relire la leçon.&nbsp;<span aria-hidden=\"true\">⬆</span></p>"
             },
             "solutions": ["1", "3", "4"]
           }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/sources-informations.json
@@ -15,15 +15,15 @@
   },
   "transitionTexts": [
     {
-      "content": "<p>Léna et Elias discutent par SMS des Jeux asiatiques de 2029.<span aria-hidden=\"true\">🏅</span>️ Léna cherche à savoir si l’information donnée par Elias est vraie ou fausse.</p>",
+      "content": "<p>Léna et Elias discutent par SMS des Jeux asiatiques de 2029.<span aria-hidden=\"true\">🏅</span> Léna cherche à savoir si l’information donnée par Elias est vraie ou fausse.</p>",
       "grainId": "652a469a-36b8-41ae-8cc5-1853b35d08ef"
     },
     {
-      "content": "<p>Léna a posé plusieurs questions à Elias pour trouver l’origine de l’information. C’est ce qu’on appelle la <strong>source d’une information. </strong>&nbsp;<span aria-hidden=\"true\">ℹ️</span>️<br>On vous explique tout dans la leçon suivante.</p>",
+      "content": "<p>Léna a posé plusieurs questions à Elias pour trouver l’origine de l’information. C’est ce qu’on appelle la <strong>source d’une information. </strong>&nbsp;<span aria-hidden=\"true\">ℹ️</span><br>On vous explique tout dans la leçon suivante.</p>",
       "grainId": "54cc6a3f-9603-4863-9ba4-052210425be2"
     },
     {
-      "content": "<p>Vous en savez maintenant plus sur ce qu'est une source d'information. Vérifions que vous avez compris l'essentiel.&nbsp;<span aria-hidden=\"true\">🎯</span>️</p>",
+      "content": "<p>Vous en savez maintenant plus sur ce qu'est une source d'information. Vérifions que vous avez compris l'essentiel.&nbsp;<span aria-hidden=\"true\">🎯</span></p>",
       "grainId": "42e4007c-9123-4aff-806a-6d7a8de3fd0a"
     },
     {
@@ -69,7 +69,7 @@
           "element": {
             "id": "a2f57d43-a8a1-4659-8730-f5cd39c350e0",
             "type": "text",
-            "content": "<p><span aria-hidden=\"true\">👉</span>️ C'est assez dur de savoir. On ne sait pas comment Sandy a obtenu cette information.</p>"
+            "content": "<p><span aria-hidden=\"true\">👉</span> C'est assez dur de savoir. On ne sait pas comment Sandy a obtenu cette information.</p>"
           }
         },
         {
@@ -150,7 +150,7 @@
           "element": {
             "id": "81f2c1af-aeef-4d68-93a9-f4dd3cf1f8bc",
             "type": "text",
-            "content": "<h3>C'est quoi une source d'information&#8239;?</h3><p><span aria-hidden=\"true\">👉</span>️ La source est l’origine de l’information. C’est quelqu’un qui donne des détails sur une information.</p><p><span aria-hidden=\"true\">✅</span>️ Exemple&nbsp;: si ma voisine Madame Sarah me dit qu'il y a une soucoupe volante dans le ciel, c'est elle la source de cette information.</p>"
+            "content": "<h3>C'est quoi une source d'information&#8239;?</h3><p><span aria-hidden=\"true\">👉</span> La source est l’origine de l’information. C’est quelqu’un qui donne des détails sur une information.</p><p><span aria-hidden=\"true\">✅</span> Exemple&nbsp;: si ma voisine Madame Sarah me dit qu'il y a une soucoupe volante dans le ciel, c'est elle la source de cette information.</p>"
           }
         },
         {
@@ -166,7 +166,7 @@
           "element": {
             "id": "e3ebd36a-c8b9-4990-af63-061329824708",
             "type": "text",
-            "content": "<h3>Comment savoir si on peut croire une source&#8239;?</h3><span aria-hidden=\"true\">👉</span>️ Il faut se poser quelques questions sur cette source&nbsp;: <ul><li>la source est-elle experte du sujet&#8239;?</li><li>la source est-elle influencée par ses émotions ou ses intérêts&#8239;?</li></ul><p><span aria-hidden=\"true\">✅</span>️ Exemple&nbsp;: Madame Sarah a l'impression d'avoir vu une soucoupe dans le ciel. Elle a interprété ce qu'elle a vu. Ce n'est peut-être pas une source fiable.</p>"
+            "content": "<h3>Comment savoir si on peut croire une source&#8239;?</h3><span aria-hidden=\"true\">👉</span> Il faut se poser quelques questions sur cette source&nbsp;: <ul><li>la source est-elle experte du sujet&#8239;?</li><li>la source est-elle influencée par ses émotions ou ses intérêts&#8239;?</li></ul><p><span aria-hidden=\"true\">✅</span> Exemple&nbsp;: Madame Sarah a l'impression d'avoir vu une soucoupe dans le ciel. Elle a interprété ce qu'elle a vu. Ce n'est peut-être pas une source fiable.</p>"
           }
         }
       ]
@@ -215,7 +215,7 @@
           "element": {
             "id": "96cf39cd-88df-4104-a155-0fff0b40ac31",
             "type": "text",
-            "content": "<p>Une radio a publié une interview pour expliquer l’origine de la soucoupe volante vue par Madame Sarah.&nbsp;<span aria-hidden=\"true\">👽</span>️&nbsp;<span aria-hidden=\"true\">🛸</span>️<br>Vous devrez par la suite choisir qui est la source d'information dans cette interview.</p>"
+            "content": "<p>Une radio a publié une interview pour expliquer l’origine de la soucoupe volante vue par Madame Sarah.&nbsp;<span aria-hidden=\"true\">👽</span>&nbsp;<span aria-hidden=\"true\">🛸</span><br>Vous devrez par la suite choisir qui est la source d'information dans cette interview.</p>"
           }
         },
         {
@@ -292,7 +292,7 @@
           "element": {
             "id": "9723333b-6378-4dbd-84a2-92a8fc1cc41a",
             "type": "text",
-            "content": "<h3>Certaines sources d'information sont <strong>fiables</strong>.&nbsp;<span aria-hidden=\"true\">👍</span>️</h3><p>Le but de ces sources est d'informer et de partager des informations vérifiées, qui ont donc beaucoup de chances d'être vraies.</p>"
+            "content": "<h3>Certaines sources d'information sont <strong>fiables</strong>.&nbsp;<span aria-hidden=\"true\">👍</span></h3><p>Le but de ces sources est d'informer et de partager des informations vérifiées, qui ont donc beaucoup de chances d'être vraies.</p>"
           }
         },
         {
@@ -308,7 +308,7 @@
           "element": {
             "id": "0c5bf4bb-989c-4c60-a54c-ae1f842bc8fe",
             "type": "text",
-            "content": "<h3>Certaines sources d'information sont <strong>humoristiques</strong>.&nbsp;<span aria-hidden=\"true\">🤹</span>️</h3><p>Le but de ces sources est de faire rire et de partager des informations qui ont beaucoup de chances d'être fausses.</p>"
+            "content": "<h3>Certaines sources d'information sont <strong>humoristiques</strong>.&nbsp;<span aria-hidden=\"true\">🤹</span></h3><p>Le but de ces sources est de faire rire et de partager des informations qui ont beaucoup de chances d'être fausses.</p>"
           }
         },
         {
@@ -324,7 +324,7 @@
           "element": {
             "id": "e22b6b68-a154-4b5a-a896-5b36eb6127a3",
             "type": "text",
-            "content": "<h3>Certaines sources d'information sont <strong>contestables</strong>.&nbsp;<span aria-hidden=\"true\">🤨</span>️</h3><p>Le but de ces sources est d'influencer ou de manipuler les gens. Mais le partage de ces informations a pour principal objectif de gagner de l'argent ou du pouvoir. Ces informations peuvent donc être remises en question.</p>"
+            "content": "<h3>Certaines sources d'information sont <strong>contestables</strong>.&nbsp;<span aria-hidden=\"true\">🤨</span></h3><p>Le but de ces sources est d'influencer ou de manipuler les gens. Mais le partage de ces informations a pour principal objectif de gagner de l'argent ou du pouvoir. Ces informations peuvent donc être remises en question.</p>"
           }
         }
       ]

--- a/api/tests/devcomp/acceptance/scripts/get-elements_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-elements_test.js
@@ -37,12 +37,12 @@ describe('Acceptance | Script | Get Elements as CSV', function () {
         },
         {
           content:
-            '<p>Vous l\'avez peut-être remarqué&nbsp;: dans un module, vous pouvez voir tous les contenus en remontant la page&nbsp;<span aria-hidden="true">👆</span>️</p>',
+            '<p>Vous l\'avez peut-être remarqué&nbsp;: dans un module, vous pouvez voir tous les contenus en remontant la page&nbsp;<span aria-hidden="true">👆</span></p>',
           grainId: '2a77a10f-19a3-4544-80f9-8012dad6506a',
         },
         {
           content:
-            '<p>Vous arrivez à la fin de ce didacticiel. Une dernière activité et vous serez prêt à explorer tous les modules que vous souhaitez&#8239;!<span aria-hidden="true">🌟</span>️ </p>',
+            '<p>Vous arrivez à la fin de ce didacticiel. Une dernière activité et vous serez prêt à explorer tous les modules que vous souhaitez&#8239;!<span aria-hidden="true">🌟</span> </p>',
           grainId: '7cf75e70-8749-4392-8081-f2c02badb0fb',
         },
       ],
@@ -97,7 +97,7 @@ describe('Acceptance | Script | Get Elements as CSV', function () {
                 id: 'a2372bf4-86a4-4ecc-a188-b51f4f98bca2',
                 type: 'text',
                 content:
-                  '<p>Voici un texte de leçon. Parfois, il y a des émojis pour aider à la lecture&nbsp;<span aria-hidden="true">📚</span>️.<br>Et là, voici une image&#8239;!</p>',
+                  '<p>Voici un texte de leçon. Parfois, il y a des émojis pour aider à la lecture&nbsp;<span aria-hidden="true">📚</span>.<br>Et là, voici une image&#8239;!</p>',
               },
             },
             {
@@ -163,7 +163,7 @@ describe('Acceptance | Script | Get Elements as CSV', function () {
                 feedbacks: {
                   valid: '<p>Correct&#8239;! Ces 16 compétences sont rangées dans 5 domaines.</p>',
                   invalid:
-                    '<p>Incorrect. Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>️!</p>',
+                    '<p>Incorrect. Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>!</p>',
                 },
                 solution: '1',
               },

--- a/api/tests/devcomp/acceptance/scripts/get-modules_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-modules_test.js
@@ -39,12 +39,12 @@ describe('Acceptance | Script | Get Modules as CSV', function () {
           },
           {
             content:
-              '<p>Vous l\'avez peut-être remarqué&nbsp;: dans un module, vous pouvez voir tous les contenus en remontant la page&nbsp;<span aria-hidden="true">👆</span>️</p>',
+              '<p>Vous l\'avez peut-être remarqué&nbsp;: dans un module, vous pouvez voir tous les contenus en remontant la page&nbsp;<span aria-hidden="true">👆</span></p>',
             grainId: '2a77a10f-19a3-4544-80f9-8012dad6506a',
           },
           {
             content:
-              '<p>Vous arrivez à la fin de ce didacticiel. Une dernière activité et vous serez prêt à explorer tous les modules que vous souhaitez&#8239;!<span aria-hidden="true">🌟</span>️ </p>',
+              '<p>Vous arrivez à la fin de ce didacticiel. Une dernière activité et vous serez prêt à explorer tous les modules que vous souhaitez&#8239;!<span aria-hidden="true">🌟</span> </p>',
             grainId: '7cf75e70-8749-4392-8081-f2c02badb0fb',
           },
         ],
@@ -99,7 +99,7 @@ describe('Acceptance | Script | Get Modules as CSV', function () {
                   id: 'a2372bf4-86a4-4ecc-a188-b51f4f98bca2',
                   type: 'text',
                   content:
-                    '<p>Voici un texte de leçon. Parfois, il y a des émojis pour aider à la lecture&nbsp;<span aria-hidden="true">📚</span>️.<br>Et là, voici une image&#8239;!</p>',
+                    '<p>Voici un texte de leçon. Parfois, il y a des émojis pour aider à la lecture&nbsp;<span aria-hidden="true">📚</span>.<br>Et là, voici une image&#8239;!</p>',
                 },
               },
               {
@@ -165,7 +165,7 @@ describe('Acceptance | Script | Get Modules as CSV', function () {
                   feedbacks: {
                     valid: '<p>Correct&#8239;! Ces 16 compétences sont rangées dans 5 domaines.</p>',
                     invalid:
-                      '<p>Incorrect. Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>️!</p>',
+                      '<p>Incorrect. Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>!</p>',
                   },
                   solution: '1',
                 },

--- a/api/tests/devcomp/acceptance/scripts/get-proposals_test.js
+++ b/api/tests/devcomp/acceptance/scripts/get-proposals_test.js
@@ -38,12 +38,12 @@ describe('Acceptance | Script | Get Proposals as CSV', function () {
         },
         {
           content:
-            '<p>Vous l\'avez peut-être remarqué&nbsp;: dans un module, vous pouvez voir tous les contenus en remontant la page&nbsp;<span aria-hidden="true">👆</span>️</p>',
+            '<p>Vous l\'avez peut-être remarqué&nbsp;: dans un module, vous pouvez voir tous les contenus en remontant la page&nbsp;<span aria-hidden="true">👆</span></p>',
           grainId: '2a77a10f-19a3-4544-80f9-8012dad6506a',
         },
         {
           content:
-            '<p>Vous arrivez à la fin de ce didacticiel. Une dernière activité et vous serez prêt à explorer tous les modules que vous souhaitez&#8239;!<span aria-hidden="true">🌟</span>️ </p>',
+            '<p>Vous arrivez à la fin de ce didacticiel. Une dernière activité et vous serez prêt à explorer tous les modules que vous souhaitez&#8239;!<span aria-hidden="true">🌟</span> </p>',
           grainId: '7cf75e70-8749-4392-8081-f2c02badb0fb',
         },
       ],
@@ -98,7 +98,7 @@ describe('Acceptance | Script | Get Proposals as CSV', function () {
                 id: 'a2372bf4-86a4-4ecc-a188-b51f4f98bca2',
                 type: 'text',
                 content:
-                  '<p>Voici un texte de leçon. Parfois, il y a des émojis pour aider à la lecture&nbsp;<span aria-hidden="true">📚</span>️.<br>Et là, voici une image&#8239;!</p>',
+                  '<p>Voici un texte de leçon. Parfois, il y a des émojis pour aider à la lecture&nbsp;<span aria-hidden="true">📚</span>.<br>Et là, voici une image&#8239;!</p>',
               },
             },
             {
@@ -164,7 +164,7 @@ describe('Acceptance | Script | Get Proposals as CSV', function () {
                 feedbacks: {
                   valid: '<p>Correct&#8239;! Ces 16 compétences sont rangées dans 5 domaines.</p>',
                   invalid:
-                    '<p>Incorrect. Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>️!</p>',
+                    '<p>Incorrect. Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>!</p>',
                 },
                 solution: '1',
               },

--- a/api/tests/devcomp/integration/repositories/element-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/element-repository_test.js
@@ -28,7 +28,7 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
           valid:
             '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
           invalid:
-            '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>️!</p>',
+            '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>!</p>',
         },
         solution: '1',
       });
@@ -72,7 +72,7 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
                     valid:
                       '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
                     invalid:
-                      '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>️!</p>',
+                      '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>!</p>',
                   },
                   solution: '1',
                 },

--- a/api/tests/devcomp/unit/domain/models/module/Module_test.js
+++ b/api/tests/devcomp/unit/domain/models/module/Module_test.js
@@ -757,7 +757,7 @@ describe('Unit | Devcomp | Domain | Models | Module | Module', function () {
                           feedbacks: {
                             valid: '<p>Correct&#8239;! Ces 16 compétences sont rangées dans 5 domaines.</p>',
                             invalid:
-                              '<p>Incorrect. Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>️!</p>',
+                              '<p>Incorrect. Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>!</p>',
                           },
                           solution: '1',
                         },

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/joi-error-parser_test.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/joi-error-parser_test.js
@@ -198,7 +198,7 @@ Valeur concernée à rechercher : "b7ea7630-824"
                   ],
                   errorCount: 1,
                   warningCount: 0,
-                  source: "<p>Incorrect. Remonter la page pour relire la leçon <span aria-hidden='true'>⬆</span>️</p>",
+                  source: "<p>Incorrect. Remonter la page pour relire la leçon <span aria-hidden='true'>⬆</span></p>",
                 },
               ],
               errorCount: 1,
@@ -265,7 +265,7 @@ Error(attr-quotes): Attribute "aria-hidden" used ' instead of expected "
 https://html-validate.org/rules/attr-quotes.html
 
 Valeur concernée à rechercher :
-<p>Incorrect. Remonter la page pour relire la leçon <span aria-hidden='true'>⬆</span>️</p>
+<p>Incorrect. Remonter la page pour relire la leçon <span aria-hidden='true'>⬆</span></p>
 
 ============================================================
 `;

--- a/mon-pix/app/controllers/module-preview.js
+++ b/mon-pix/app/controllers/module-preview.js
@@ -45,7 +45,7 @@ export default class ModulePreviewController extends Controller {
           "element": {
             "id": "3333333a-3333-3bcd-e333-3f3333gh3333",
             "type": "text",
-            "content": "<p>Voici un texte de leçon. Parfois, il y a des émojis pour aider à la lecture&nbsp;<span aria-hidden='true'>📚</span>️.<br>Et là, voici une image&#8239;!</p>"
+            "content": "<p>Voici un texte de leçon. Parfois, il y a des émojis pour aider à la lecture&nbsp;<span aria-hidden='true'>📚</span>.<br>Et là, voici une image&#8239;!</p>"
           }
         },
         {


### PR DESCRIPTION
## :unicorn: Problème
Le caractère HTML `>️` n'est pas le caractère de chevron fermant `>`. Le lecteur d'écran annonce "variation 16" alors qu'il ne devrait rien dire.

Sur VS Code, ces caractères sont entourés :
<img width="445" alt="image" src="https://github.com/1024pix/pix/assets/5855339/64408cd0-3349-4f57-bd5b-7f5ac4186a7c">

## :robot: Proposition
Corriger les caractères utilisés : dans le contenu, dans le code et dans les tests.

## :rainbow: Remarques
RAS

## :100: Pour tester
Dans les modules de Modulix, vérifier avec VoiceOver que "variation 16" n'est plus énoncé lorsque vous lisez du contenu avec la présence d'un emoji (ex: https://app-pr9306.review.pix.fr/modules/bien-ecrire-son-adresse-mail).
