### PR TITLE
[TECH] Ajout d'un index sur la table `certification-subscriptions` (PIX-13028).

### DIFF
--- a/api/db/migrations/20240610164300_catching-up-on-CORE-subscriptions.js
+++ b/api/db/migrations/20240610164300_catching-up-on-CORE-subscriptions.js
@@ -1,50 +1,14 @@
-import { logger } from '../../src/shared/infrastructure/utils/logger.js';
-
-const TABLE_NAME = 'certification-subscriptions';
-
-const up = async function (knex) {
-  let numberOfBatchProcessed = 0;
-  const CHUNK_SIZE = 250000;
-  const BATCH_LIMIT = 40; // around 7 millions lines in prod, 40*250000 = 1 billion so it covers the actual volume
-
-  let hasNext = false;
-  do {
-    const insertions = await knex
-      .into(knex.raw('?? (??, ??)', [TABLE_NAME, 'certificationCandidateId', 'type']))
-      .insert(nextCandidatesWithoutCoreSubscription(knex, CHUNK_SIZE));
-
-    hasNext = insertions.rowCount === CHUNK_SIZE;
-    logger.info(
-      `${TABLE_NAME}: Batch number ${++numberOfBatchProcessed} of ${insertions.rowCount} items inserted. hasNext = ${hasNext}`,
-    );
-  } while (hasNext && numberOfBatchProcessed <= BATCH_LIMIT);
+/**
+ * Migration's content replaced by two migrations:
+ *  *  api/db/migrations/20240618134300_catching-up-on-CORE-subscriptions.js
+ *  *  api/db/migrations/20240618143134_add-index-on-certification-candidate-id-in-subscriptions-table.js
+ */
+const up = async function () {
+  return;
 };
 
-const down = async function (knex) {
-  return knex(TABLE_NAME)
-    .where({
-      type: 'CORE',
-    })
-    .del();
+const down = async function () {
+  return;
 };
 
-// We INSERT in batch of CHUNK_SIZE, hence not needing a transaction for this migration
-// @see: https://knexjs.org/guide/migrations.html#migration-api
-const config = { transaction: false };
-
-export { config, down, up };
-
-const nextCandidatesWithoutCoreSubscription = (knex, chunkSize) => {
-  return (builder) => {
-    builder
-      .from('certification-candidates')
-      .select(knex.raw(`id as "certificationCandidateId", 'CORE' as type`))
-      .leftJoin(TABLE_NAME, function () {
-        this.on('certification-candidates.id', `${TABLE_NAME}.certificationCandidateId`).andOnVal({
-          type: 'CORE',
-        });
-      })
-      .whereNull(`${TABLE_NAME}.certificationCandidateId`)
-      .limit(chunkSize);
-  };
-};
+export { down, up };

--- a/api/db/migrations/20240618134300_catching-up-on-CORE-subscriptions.js
+++ b/api/db/migrations/20240618134300_catching-up-on-CORE-subscriptions.js
@@ -1,0 +1,50 @@
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
+
+const TABLE_NAME = 'certification-subscriptions';
+
+const up = async function (knex) {
+  let numberOfBatchProcessed = 0;
+  const CHUNK_SIZE = 250000;
+  const BATCH_LIMIT = 40; // around 7 millions lines in prod, 40*250000 = 1 billion so it covers the actual volume
+
+  let hasNext = false;
+  do {
+    const insertions = await knex
+      .into(knex.raw('?? (??, ??)', [TABLE_NAME, 'certificationCandidateId', 'type']))
+      .insert(nextCandidatesWithoutCoreSubscription(knex, CHUNK_SIZE));
+
+    hasNext = insertions.rowCount === CHUNK_SIZE;
+    logger.info(
+      `${TABLE_NAME}: Batch number ${++numberOfBatchProcessed} of ${insertions.rowCount} items inserted. hasNext = ${hasNext}`,
+    );
+  } while (hasNext && numberOfBatchProcessed <= BATCH_LIMIT);
+};
+
+const down = async function (knex) {
+  return knex(TABLE_NAME)
+    .where({
+      type: 'CORE',
+    })
+    .del();
+};
+
+// We INSERT in batch of CHUNK_SIZE, hence not needing a transaction for this migration
+// @see: https://knexjs.org/guide/migrations.html#migration-api
+const config = { transaction: false };
+
+export { config, down, up };
+
+const nextCandidatesWithoutCoreSubscription = (knex, chunkSize) => {
+  return (builder) => {
+    builder
+      .from('certification-candidates')
+      .select(knex.raw(`id as "certificationCandidateId", 'CORE' as type`))
+      .leftJoin(TABLE_NAME, function () {
+        this.on('certification-candidates.id', `${TABLE_NAME}.certificationCandidateId`).andOnVal({
+          type: 'CORE',
+        });
+      })
+      .whereNull(`${TABLE_NAME}.certificationCandidateId`)
+      .limit(chunkSize);
+  };
+};

--- a/api/db/migrations/20240618143134_add-index-on-certification-candidate-id-in-subscriptions-table.js
+++ b/api/db/migrations/20240618143134_add-index-on-certification-candidate-id-in-subscriptions-table.js
@@ -1,0 +1,12 @@
+const TABLE_NAME = 'certification-subscriptions';
+const COLUMN_NAME = 'certificationCandidateId';
+
+const up = async function (knex) {
+  return knex.schema.table(TABLE_NAME, (table) => table.index(COLUMN_NAME));
+};
+
+const down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, (table) => table.dropIndex(COLUMN_NAME));
+};
+
+export { down, up };


### PR DESCRIPTION
## :unicorn: Problème

Suite à une précèdente migration dans une PR précèdente https://github.com/1024pix/pix/pull/9228 
Les appels de l'espace surveillant (toutes les 5 secondes) ont déclenchés une sur-sollicitation de la base de données en production, crééant un ralentissement de la plateforme.

Un rollback de la migration a été déclenché pour correction.

## :robot: Proposition

* EXPLAIN ANALYZE de la requête problématique
  * ⚠️ sur une base de données locale chargée avec un gros volume de candidats (9 Million), sans quoi le QUERY PLAN serait faussé
* Mise en place d'un index
* Nouvel EXPLAIN ANALYZE pour vérifier l'impact

## :rainbow: Remarques

Le EXPLAIN ANALYZE a révélé la chose suivante sur la requête de supervision 

```text
->  Parallel Seq Scan on "complementary-certification-subscriptions"  (cost=0.00..101779.62 rows=1 width=8) (actual time=189.316..298.650 rows=4 loops=3)                  |
                                                  Filter: ("complementaryCertificationId" IS NOT NULL)                                                                                                                 |
                                                  Rows Removed by Filter: 3220017
```

Basé sur les critères résumé ci-dessous 

> 
> Find the nodes where most of the execution time was spent.
> 
> Find the lowest node where the estimated row count is significantly different from the actual row count. Very often, this is the cause of bad performance, and the long execution time somewhere else is only a consequence of a bad plan choice based on a bad estimate. “Significantly different” typically means a factor of 10 or so.
> 
> Find long running sequential scans with a filter condition that removes many rows. These are good candidates for an index.

source : How to interpret PostgreSQL EXPLAIN ANALYZE output  

 
Si on confronte au EXPLAIN ANALYZE et particulièrement au snippet précèdent

* C’est un seq scan
* Pire : un parallel seq scan : il décide tente de séparer le volume de données en deux pour trouver + vite
* C’est le second “plus long” en execution: 298.650
* Le filter enlève un nombre très élevé de lignes : Rows Removed by Filter: 3220017

## :100: Pour tester

A voir si + de tests sur un environnemen t dédié, en tout cas en local

### Avant / Après index

⚠️ Test non réalisé sur un environnement de benchmark dédié

![perf_test](https://github.com/1024pix/pix/assets/170271/7142b84c-7fde-4aa6-802d-56f749050c8b)

