### PR TITLE
[FEATURE] Afficher le statut de la dernière mission pour chaque élève dans Pix Orga (PIX-11200).

### DIFF
--- a/api/db/database-builder/factory/build-mission-assessment.js
+++ b/api/db/database-builder/factory/build-mission-assessment.js
@@ -13,7 +13,9 @@ const buildMissionAssessment = function ({
   state = Assessment.states.STARTED,
   lastChallengeId,
 } = {}) {
-  assessmentId = _.isUndefined(assessmentId) ? buildPix1dAssessment({ state, lastChallengeId }).id : assessmentId;
+  assessmentId = _.isUndefined(assessmentId)
+    ? buildPix1dAssessment({ state, lastChallengeId, createdAt }).id
+    : assessmentId;
   organizationLearnerId = _.isUndefined(organizationLearnerId) ? buildOrganizationLearner().id : organizationLearnerId;
 
   const values = {

--- a/api/src/school/application/mission-learner-controller.js
+++ b/api/src/school/application/mission-learner-controller.js
@@ -3,9 +3,9 @@ import { usecases } from '../domain/usecases/index.js';
 import * as missionLearnerSerializer from '../infrastructure/serializers/mission-learner-serializer.js';
 
 const findPaginatedMissionLearners = async function (request) {
-  const organizationId = request.params.id;
+  const { organizationId, missionId } = request.params;
   const { page } = extractParameters(request.query);
-  const result = await usecases.findPaginatedMissionLearners({ organizationId, page });
+  const result = await usecases.findPaginatedMissionLearners({ organizationId, missionId, page });
   return missionLearnerSerializer.serialize(result);
 };
 

--- a/api/src/school/application/mission-learner-route.js
+++ b/api/src/school/application/mission-learner-route.js
@@ -8,7 +8,7 @@ const register = async function (server) {
   server.route([
     {
       method: 'GET',
-      path: '/api/organizations/{id}/mission-learners',
+      path: '/api/organizations/{organizationId}/missions/{missionId}/learners',
       config: {
         pre: [
           { method: securityPreHandlers.checkUserBelongsToOrganization },
@@ -16,7 +16,8 @@ const register = async function (server) {
         ],
         validate: {
           params: Joi.object({
-            id: identifiersType.organizationId,
+            organizationId: identifiersType.organizationId,
+            missionId: identifiersType.missionId,
           }),
           query: Joi.object({
             'page[number]': Joi.number().integer().empty(''),
@@ -27,7 +28,7 @@ const register = async function (server) {
         tags: ['api', 'pix1d', 'mission-learners'],
         notes: [
           '- **Cette route est restreinte aux personnes authentifiées' +
-            "- Elle permet de récupérer tous les participants (organization-leaner) d'une orga",
+            "- Elle permet de récupérer tous les participants (mission-learner) à une mission au sein d'une organisation donnée",
         ],
       },
     },

--- a/api/src/school/domain/models/MissionLearnerWithStatus.js
+++ b/api/src/school/domain/models/MissionLearnerWithStatus.js
@@ -1,0 +1,10 @@
+import { MissionLearner } from './MissionLearner.js';
+
+class MissionLearnerWithStatus extends MissionLearner {
+  constructor({ status } = {}) {
+    super(...arguments);
+    this.status = status;
+  }
+}
+
+export { MissionLearnerWithStatus };

--- a/api/src/school/domain/usecases/find-paginated-mission-learners.js
+++ b/api/src/school/domain/usecases/find-paginated-mission-learners.js
@@ -1,0 +1,28 @@
+import { MissionLearnerWithStatus } from '../models/MissionLearnerWithStatus.js';
+
+const findPaginatedMissionLearners = async function ({
+  missionLearnerRepository,
+  missionAssessmentRepository,
+  organizationId,
+  missionId,
+  page,
+} = {}) {
+  const { pagination, missionLearners } = await missionLearnerRepository.findPaginatedMissionLearners({
+    organizationId,
+    page,
+  });
+
+  const missionLearnersWithStatus = await missionAssessmentRepository.getStatusesForLearners(
+    missionId,
+    missionLearners,
+    (learner, status) =>
+      new MissionLearnerWithStatus({
+        ...learner,
+        status: status ?? 'not-started',
+      }),
+  );
+
+  return { pagination, missionLearners: missionLearnersWithStatus };
+};
+
+export { findPaginatedMissionLearners };

--- a/api/src/school/domain/usecases/get-all-mission-learners.js
+++ b/api/src/school/domain/usecases/get-all-mission-learners.js
@@ -1,5 +1,0 @@
-const findPaginatedMissionLearners = async function ({ missionLearnerRepository, organizationId, page } = {}) {
-  return await missionLearnerRepository.findPaginatedMissionLearners({ organizationId, page });
-};
-
-export { findPaginatedMissionLearners };

--- a/api/src/school/infrastructure/serializers/mission-learner-serializer.js
+++ b/api/src/school/infrastructure/serializers/mission-learner-serializer.js
@@ -2,7 +2,7 @@ import { Serializer } from 'jsonapi-serializer';
 
 const serialize = function ({ missionLearners, pagination }) {
   return new Serializer('mission-learner', {
-    attributes: ['firstName', 'lastName', 'division', 'organizationId'],
+    attributes: ['firstName', 'lastName', 'division', 'organizationId', 'status'],
     meta: pagination,
   }).serialize(missionLearners);
 };

--- a/api/tests/school/integration/application/mission-learner-controller_test.js
+++ b/api/tests/school/integration/application/mission-learner-controller_test.js
@@ -1,5 +1,5 @@
 import { missionLearnerController } from '../../../../src/school/application/mission-learner-controller.js';
-import { MissionLearner } from '../../../../src/school/domain/models/MissionLearner.js';
+import { MissionLearnerWithStatus } from '../../../../src/school/domain/models/MissionLearnerWithStatus.js';
 import { usecases } from '../../../../src/school/domain/usecases/index.js';
 import { expect, hFake, sinon } from '../../../test-helper.js';
 
@@ -7,12 +7,13 @@ describe('Integration | Controller | mission-learner-controller', function () {
   describe('#findPaginatedMissionLearners', function () {
     it('should return missionLearners', async function () {
       const organizationId = 1;
-      const missionLearner = new MissionLearner({
+      const missionLearner = new MissionLearnerWithStatus({
         id: 1,
         firstName: 'TechnoMechanicus',
         lastName: 'Musk',
         organizationId,
         division: 'CP',
+        status: 'not-started',
       });
       const pagination = {
         page: 1,
@@ -40,6 +41,7 @@ describe('Integration | Controller | mission-learner-controller', function () {
             'last-name': missionLearner.lastName,
             division: missionLearner.division,
             'organization-id': missionLearner.organizationId,
+            status: missionLearner.status,
           },
           id: missionLearner.id.toString(),
           type: 'mission-learners',

--- a/api/tests/school/integration/domain/usecases/find-paginated-mission-learners_test.js
+++ b/api/tests/school/integration/domain/usecases/find-paginated-mission-learners_test.js
@@ -1,0 +1,83 @@
+import { Assessment } from '../../../../../lib/domain/models/index.js';
+import { MissionLearnerWithStatus } from '../../../../../src/school/domain/models/MissionLearnerWithStatus.js';
+import { usecases } from '../../../../../src/school/domain/usecases/index.js';
+import { databaseBuilder, expect } from '../../../../test-helper.js';
+
+describe('Integration | Usecase | find-paginated-mission-learners', function () {
+  describe('#findPaginatedMissionLearners', function () {
+    it('should return mission learners with mission progress status', async function () {
+      const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO-1D' });
+
+      const organizationLearnerWithoutAssessment =
+        databaseBuilder.factory.prescription.organizationLearners.buildOndeOrganizationLearner({
+          organizationId: organization.id,
+        });
+      const organizationLearnerWithStartedAssessment =
+        databaseBuilder.factory.prescription.organizationLearners.buildOndeOrganizationLearner({
+          organizationId: organization.id,
+        });
+      const organizationLearnerWithCompletedAssessment =
+        databaseBuilder.factory.prescription.organizationLearners.buildOndeOrganizationLearner({
+          organizationId: organization.id,
+        });
+
+      const startedAssessment = databaseBuilder.factory.buildPix1dAssessment({
+        state: Assessment.states.STARTED,
+      });
+      const completedAssessment = databaseBuilder.factory.buildPix1dAssessment({
+        state: Assessment.states.COMPLETED,
+      });
+
+      const missionId = 1;
+      databaseBuilder.factory.buildMissionAssessment({
+        missionId,
+        organizationLearnerId: organizationLearnerWithStartedAssessment.id,
+        assessmentId: startedAssessment.id,
+      });
+      databaseBuilder.factory.buildMissionAssessment({
+        missionId,
+        organizationLearnerId: organizationLearnerWithCompletedAssessment.id,
+        assessmentId: completedAssessment.id,
+      });
+      await databaseBuilder.commit();
+
+      const page = {
+        page: 1,
+        pageCount: 1,
+        pageSize: 50,
+        rowCount: 1,
+      };
+      const result = await usecases.findPaginatedMissionLearners({
+        organizationId: organization.id,
+        missionId,
+        page,
+      });
+
+      expect(result).to.deep.equal({
+        missionLearners: [
+          new MissionLearnerWithStatus({
+            ...organizationLearnerWithoutAssessment,
+            division: 'CM2A',
+            status: 'not-started',
+          }),
+          new MissionLearnerWithStatus({
+            ...organizationLearnerWithStartedAssessment,
+            division: 'CM2A',
+            status: 'started',
+          }),
+          new MissionLearnerWithStatus({
+            ...organizationLearnerWithCompletedAssessment,
+            division: 'CM2A',
+            status: 'completed',
+          }),
+        ],
+        pagination: {
+          page: 1,
+          pageCount: 1,
+          pageSize: 10,
+          rowCount: 3,
+        },
+      });
+    });
+  });
+});

--- a/api/tests/school/unit/application/mission-learner-route_test.js
+++ b/api/tests/school/unit/application/mission-learner-route_test.js
@@ -4,7 +4,7 @@ import { securityPreHandlers } from '../../../../src/shared/application/security
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
 
 describe('Unit | Route | mission-learner-route', function () {
-  describe('GET /api/organizations/{id}/mission-learners', function () {
+  describe('GET /api/organizations/{id}/missions/{missionId}/learners', function () {
     it('should check user belongs to organization and pix1d is activated', async function () {
       // given
       const mock = sinon.mock(securityPreHandlers);
@@ -14,7 +14,7 @@ describe('Unit | Route | mission-learner-route', function () {
       await httpTestServer.register(moduleUnderTest);
 
       // when
-      await httpTestServer.request('GET', '/api/organizations/4/mission-learners');
+      await httpTestServer.request('GET', '/api/organizations/4/missions/1/learners');
 
       // then
       mock.verify();
@@ -30,7 +30,7 @@ describe('Unit | Route | mission-learner-route', function () {
       await httpTestServer.register(moduleUnderTest);
 
       // when
-      const response = await httpTestServer.request('GET', '/api/organizations/4/mission-learners');
+      const response = await httpTestServer.request('GET', '/api/organizations/4/missions/1/learners');
 
       // then
       expect(response.statusCode).to.equal(200);
@@ -45,7 +45,22 @@ describe('Unit | Route | mission-learner-route', function () {
       await httpTestServer.register(moduleUnderTest);
 
       // when
-      const response = await httpTestServer.request('GET', '/api/organizations/AZRTY/mission-learners');
+      const response = await httpTestServer.request('GET', '/api/organizations/AZRTY/missions/1/learners');
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('should return 400 when the missionId is not a number', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserBelongsToOrganization').callsFake((request, h) => h.response(true));
+      sinon.stub(securityPreHandlers, 'checkPix1dActivated').callsFake((request, h) => h.response(true));
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('GET', '/api/organizations/4/missions/UIOP/learners');
 
       // then
       expect(response.statusCode).to.equal(400);

--- a/api/tests/school/unit/infrastructure/repositories/mission-learner-repository_test.js
+++ b/api/tests/school/unit/infrastructure/repositories/mission-learner-repository_test.js
@@ -1,3 +1,4 @@
+import { OrganizationLearner } from '../../../../../lib/domain/models/OrganizationLearner.js';
 import { MissionLearner } from '../../../../../src/school/domain/models/MissionLearner.js';
 import * as missionLearnersRepository from '../../../../../src/school/infrastructure/repositories/mission-learner-repository.js';
 import { expect, sinon } from '../../../../test-helper.js';
@@ -25,7 +26,7 @@ describe('Unit | Repository | organizationLearner', function () {
 
       organizationLearnerApiStub.find
         .withArgs({ organizationId, page: customPagination })
-        .resolves({ organizationLearners: [rawStudent], pagination: expectedPagination });
+        .resolves({ organizationLearners: [new OrganizationLearner(rawStudent)], pagination: expectedPagination });
 
       const { missionLearners, pagination } = await missionLearnersRepository.findPaginatedMissionLearners({
         organizationId,

--- a/orga/app/adapters/mission-learner.js
+++ b/orga/app/adapters/mission-learner.js
@@ -1,11 +1,12 @@
 import ApplicationAdapter from './application';
 
-export default class MissionAdapter extends ApplicationAdapter {
+export default class MissionLearnerAdapter extends ApplicationAdapter {
   urlForQuery(query) {
-    if (query.organizationId) {
-      const { organizationId } = query;
+    if (query.organizationId && query.missionId) {
+      const { organizationId, missionId } = query;
       delete query.organizationId;
-      return `${this.host}/${this.namespace}/organizations/${organizationId}/mission-learners`;
+      delete query.missionId;
+      return `${this.host}/${this.namespace}/organizations/${organizationId}/missions/${missionId}/learners`;
     }
     return super.urlForQuery(...arguments);
   }

--- a/orga/app/controllers/authenticated/missions/details/learners.js
+++ b/orga/app/controllers/authenticated/missions/details/learners.js
@@ -14,4 +14,12 @@ export default class MissionLearnersController extends Controller {
   clearFilters() {
     this.pageNumber = null;
   }
+
+  statusColor(status) {
+    return {
+      'not-started': 'tertiary',
+      completed: 'success',
+      started: 'secondary',
+    }[status];
+  }
 }

--- a/orga/app/models/mission-learner.js
+++ b/orga/app/models/mission-learner.js
@@ -5,4 +5,9 @@ export default class MissionLearner extends Model {
   @attr('string') firstName;
   @attr('string') lastName;
   @attr('string') organizationId;
+  @attr('string') status;
+
+  get displayableStatus() {
+    return `pages.missions.details.learners.list.mission-status.${this.status}`;
+  }
 }

--- a/orga/app/routes/authenticated/missions/details/learners.js
+++ b/orga/app/routes/authenticated/missions/details/learners.js
@@ -24,11 +24,12 @@ export default class MissionLearnersRoute extends Route {
   }
   model(params) {
     const organizationId = this.currentUser.organization.id;
-    const mission = this.modelFor('authenticated.missions.details');
+    const missionModel = this.modelFor('authenticated.missions.details');
     const missionLearners = this.store.query(
       'mission-learner',
       {
         organizationId,
+        missionId: missionModel.mission.id,
         page: {
           number: params.pageNumber,
           size: params.pageSize,
@@ -36,6 +37,6 @@ export default class MissionLearnersRoute extends Route {
       },
       { reload: true },
     );
-    return RSVP.hash({ missionLearners, mission });
+    return RSVP.hash({ missionLearners, mission: missionModel });
   }
 }

--- a/orga/app/templates/authenticated/missions/details/learners.hbs
+++ b/orga/app/templates/authenticated/missions/details/learners.hbs
@@ -11,12 +11,13 @@
           <Table::Header scope="col">{{t "pages.missions.details.learners.list.headers.first-name"}}</Table::Header>
           <Table::Header scope="col">{{t "pages.missions.details.learners.list.headers.last-name"}}</Table::Header>
           <Table::Header scope="col">{{t "pages.missions.details.learners.list.headers.division"}}</Table::Header>
+          <Table::Header scope="col">{{t "pages.missions.details.learners.list.headers.status"}}</Table::Header>
         </tr>
       </thead>
       <tbody>
 
         {{#each this.model.missionLearners as |missionLearner|}}
-          <tr>
+          <tr aria-label={{t "pages.missions.details.learners.list.aria-label"}}>
             <td>
               {{missionLearner.firstName}}
             </td>
@@ -25,6 +26,9 @@
             </td>
             <td>
               {{missionLearner.division}}
+            </td>
+            <td>
+              <PixTag @color={{this.statusColor missionLearner.status}}>{{t missionLearner.displayableStatus}}</PixTag>
             </td>
           </tr>
         {{/each}}

--- a/orga/app/templates/authenticated/missions/list.hbs
+++ b/orga/app/templates/authenticated/missions/list.hbs
@@ -45,7 +45,11 @@
       </thead>
       <tbody>
         {{#each @model.missions as |mission|}}
-          <tr class="tr--clickable" {{on "click" (fn this.goToMissionDetails mission.id)}}>
+          <tr
+            aria-label={{t "pages.missions.list.aria-label"}}
+            class="tr--clickable"
+            {{on "click" (fn this.goToMissionDetails mission.id)}}
+          >
             <td>
               {{mission.name}}
             </td>

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -68,8 +68,7 @@ function routes() {
   this.post('/revoke', () => {});
 
   this.get('/prescription/prescribers/:id', (schema, request) => {
-    const prescriber = schema.prescribers.find(request.params.id);
-    return prescriber;
+    return schema.prescribers.find(request.params.id);
   });
 
   this.post('/users', (schema, request) => {
@@ -532,7 +531,7 @@ function routes() {
     return schema.missions.find(missionId);
   });
 
-  this.get('/organizations/:organization_id/mission-learners', findPaginatedMissionLearners);
+  this.get('/organizations/:organization_id/missions/:mission_id/learners', findPaginatedMissionLearners);
 
   this.get('/frameworks/for-target-profile-submission', (schema) => {
     return schema.frameworks.all();

--- a/orga/tests/helpers/test-init.js
+++ b/orga/tests/helpers/test-init.js
@@ -1,5 +1,5 @@
 export function createPrescriberByUser({ user, participantCount = 0, features }) {
-  const prescriber = server.create('prescriber', {
+  return server.create('prescriber', {
     id: user.id,
     firstName: user.firstName,
     lastName: user.lastName,
@@ -13,8 +13,6 @@ export function createPrescriberByUser({ user, participantCount = 0, features })
       COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY: false,
     },
   });
-
-  return prescriber;
 }
 
 export function createPrescriberWithPixOrgaTermsOfService({ pixOrgaTermsOfServiceAccepted }) {
@@ -48,10 +46,11 @@ export function createPrescriberWithPixOrgaTermsOfService({ pixOrgaTermsOfServic
   });
 }
 
-function _addUserToOrganization(user, { externalId } = {}) {
+function _addUserToOrganization(user, { externalId, organizationType } = {}) {
   const organization = server.create('organization', {
     name: 'BRO & Evil Associates',
     externalId,
+    type: organizationType,
   });
 
   const memberships = server.create('membership', {
@@ -61,6 +60,7 @@ function _addUserToOrganization(user, { externalId } = {}) {
 
   user.userOrgaSettings = server.create('user-orga-setting', { user, organization });
   user.memberships = [memberships];
+
   return user;
 }
 
@@ -76,7 +76,7 @@ export function createUserWithMembership() {
   return _addUserToOrganization(user);
 }
 
-export function createUserWithMembershipAndTermsOfServiceAccepted() {
+export function createUserWithMembershipAndTermsOfServiceAccepted({ organizationType } = {}) {
   const user = server.create('user', {
     id: 7,
     firstName: 'Harry',
@@ -86,7 +86,7 @@ export function createUserWithMembershipAndTermsOfServiceAccepted() {
     pixOrgaTermsOfServiceAccepted: true,
   });
   server.create('member-identity', { id: user.id, firstName: 'Harry', lastName: 'Cover' });
-  return _addUserToOrganization(user, { externalId: 'EXTBRO' });
+  return _addUserToOrganization(user, { externalId: 'EXTBRO', organizationType });
 }
 
 export function createUserMembershipWithRole(organizationRole) {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -817,11 +817,18 @@
         "learners": {
           "title": "List of participants",
           "list": {
+            "aria-label": "Student",
             "caption": "List of students with their result for the mission {missionName}",
             "headers": {
               "division": "Division",
               "first-name": "First name",
-              "last-name": "Last name"
+              "last-name": "Last name",
+              "status": "Mission status"
+            },
+            "mission-status": {
+              "completed": "Completed",
+              "not-started": "Not started",
+              "started": "In progress"
             }
           },
           "no-data": "There is not any participants"
@@ -831,6 +838,7 @@
         }
       },
       "list": {
+        "aria-label": "Mission",
         "banner": {
           "admin": {
             "abstract": "To get started, please ",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -817,11 +817,18 @@
         "learners": {
           "title": "Liste des participations",
           "list": {
+            "aria-label": "Élève",
             "caption": "Tableau des élèves avec le résultat de leur participation à la mission {missionName}",
             "headers": {
               "division": "Classe",
               "first-name": "Prénom",
-              "last-name": "Nom"
+              "last-name": "Nom",
+              "status": "Statut de la mission"
+            },
+            "mission-status": {
+              "completed": "Terminée",
+              "not-started": "Non débutée",
+              "started": "En cours"
             }
           },
           "no-data": "Il n'y a aucun participant"
@@ -831,6 +838,7 @@
         }
       },
       "list": {
+        "aria-label": "Mission",
         "banner": {
           "admin": {
             "abstract": "Pour commencer, veuillez ",


### PR DESCRIPTION
## :unicorn: Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Pix Orga permet au professeur de voir les élèves d'une mission donnée mais n'affiche pas le statut d'avancement au sein de ladite mission.
Cela peut manquer au professeur qui souhaite suivre l'avancement de ses élèves.

## :robot: Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

Sur la page de détail d’une mission, afficher dans la liste une colonne Statut :

- Pour un élève qui n’a pas commencé cette mission afficher “Non débutée” (en bleu)
- Pour un élève qui a commencé mais pas terminé, afficher “En cours” (en orange)
- Pour un élève qui a terminé la mission, afficher “Terminée” (en vert)

On modifie la route qui liste les `MissionLearner` afin d'inclure la mission, car on affiche les participants à une mission donnée.

## :rainbow: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

Le modèle `MissionLearner` (côté Pix Orga) devrait sûrement avoir un lien vers la mission. A garder en tête pour le futur.

## :100: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

Se connecter sur Pix Orga avec `1d-orga@example.net`.
Se rendre sur les détails d'une mission.
Constater que le statut de la participation à la mission de chaque élève est affichée dans le tableau.

Se rendre sur Pix Junior et faire une mission jusqu'au bout.
Vérifier que le statut de la participation de l'élève choisi à la mission est désormais `Terminée`.
