### PR TITLE
[FEATURE] Cache les campagnes supprimées sur PixOrga (PIX-13019).

### DIFF
--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-report-repository.js
@@ -114,11 +114,16 @@ const findPaginatedFilteredByOrganizationId = async function ({ organizationId, 
     .join('users', 'users.id', 'campaigns.ownerId')
     .leftJoin('campaign-participations', 'campaign-participations.campaignId', 'campaigns.id')
     .where('campaigns.organizationId', organizationId)
+    .whereNull('campaigns.deletedAt')
     .modify(_setSearchFiltersForQueryBuilder, filter, userId)
     .orderBy('campaigns.createdAt', 'DESC');
 
   const { results, pagination } = await fetchPage(query, page);
-  const atLeastOneCampaign = await knex('campaigns').select('id').where({ organizationId }).first(1);
+  const atLeastOneCampaign = await knex('campaigns')
+    .select('id')
+    .where({ organizationId })
+    .whereNull('deletedAt')
+    .first(1);
   const hasCampaigns = Boolean(atLeastOneCampaign);
 
   const campaignReports = results.map((result) => new CampaignReport(result));

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-report-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-report-repository_test.js
@@ -371,6 +371,45 @@ describe('Integration | Repository | Campaign-Report', function () {
       page = { number: 1, size: 4 };
     });
 
+    context('when the given organization has deleted campaigns', function () {
+      it('should return an empty array', async function () {
+        // given
+        databaseBuilder.factory.buildCampaign({ organizationId, deletedAt: new Date() });
+        await databaseBuilder.commit();
+
+        // when
+        const { models: campaignsWithReports, meta } =
+          await campaignReportRepository.findPaginatedFilteredByOrganizationId({
+            organizationId,
+            filter,
+            page,
+          });
+
+        // then
+        expect(campaignsWithReports.length).to.deep.equal(0);
+        expect(meta.hasCampaigns).to.equal(false);
+      });
+
+      it('should return one campaign', async function () {
+        // given
+        databaseBuilder.factory.buildCampaign({ organizationId, deletedAt: new Date() });
+        databaseBuilder.factory.buildCampaign({ organizationId });
+        await databaseBuilder.commit();
+
+        // when
+        const { models: campaignsWithReports, meta } =
+          await campaignReportRepository.findPaginatedFilteredByOrganizationId({
+            organizationId,
+            filter,
+            page,
+          });
+
+        // then
+        expect(campaignsWithReports.length).to.deep.equal(1);
+        expect(meta.hasCampaigns).to.equal(true);
+      });
+    });
+
     context('when the given organization has no campaign', function () {
       it('should return an empty array', async function () {
         // given


### PR DESCRIPTION
## :unicorn: Problème
Il n'est pas possible sur PixOrga de se débarrasser de campagnes dont on ne veut plus. Seul l'archivage permet de les déplacer dans un affichage différent. Nous allons donc ajouter la possibilité de supprimer les campagnes. Pour pouvoir développer la fonctionnalités itérativement, nous traitons en premier les conséquences d'une campagne supprimée avant que ce soit possible.

## :robot: Proposition
On ajoute un filtre sur les pages mes campagnes et toutes les campagnes pour ne plus afficher les campagnes supprimées

## :rainbow: Remarques
Dans cette PR, on change juste l'affichage des pages de liste. Il est toujours possible si on connaît l'id d'une campagne et les urls de l'application PixOrga de continuer à accéder à ses informations.

## :100: Pour tester
- Se connecter à PixOrga
- En base de données, ajouter une date dans la colonne deletedAt d'une campagne
- Sur les pages mes campagnes et toutes les campagnes, constater que la campagne n'est plus visible
