### PR TITLE
[TECH] Flaky sur database-builder test

### DIFF
--- a/api/tests/integration/tooling/database-builder/database-builder_test.js
+++ b/api/tests/integration/tooling/database-builder/database-builder_test.js
@@ -6,6 +6,9 @@ describe('Integration | Tooling | DatabaseBuilder | database-builder', function 
   describe('#create', function () {
     it('returns an initialised instance of DatabaseBuilder', async function () {
       // given
+      // Internally DatabaseBuilder.create calls for a database TRUNCATE thats takes more than the default mocha timeout
+      this.timeout(5000);
+
       // when
       const databaseBuilder = await DatabaseBuilder.create({ knex });
 


### PR DESCRIPTION
## :unicorn: Problème
Un flaky récurrent sur le test `API Integration Integration | Tooling | DatabaseBuilder | database-builder #create returns an initialised instance of DatabaseBuilder`

En local, c'est quasi systématique

## :robot: Proposition

* En théorie le Database.create est passé avec `increaseCurrentTestTimeout` dans `api/tests/test-helper.js` qui fait +2000ms sur le timeout de mocha (par défaut à 2000 aussi, mais pilotable autrement)
* Le test lui ne passe pas de valeur
* On peut néanmoins piloter à l'échelle restreinte du test le timeout (source: https://mochajs.org/#timeouts)

## :rainbow: Remarques


## :100: Pour tester

* Tests au vert
* En local plus de flaky sur le test cible (si vous en aviez avant)
