### PR TITLE
[FEATURE] Gestion des actions du Grain (PIX-12927)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -37,36 +37,6 @@
   ],
   "grains": [
     {
-      "id": "47cd065b-dbf2-4adc-b5c3-02fb69cb9ec2",
-      "type": "activity",
-      "title": "Test Stepper",
-      "components": [
-        {
-          "type": "stepper",
-          "steps": [
-            {
-              "elements": [
-                {
-                  "id": "342183f7-af51-4e4e-ab4c-ebed1e195063",
-                  "type": "text",
-                  "content": "<p>À la fin de cette vidéo, une question sera posée sur les compétences Pix.</p>"
-                }
-              ]
-            },
-            {
-              "elements": [
-                {
-                  "id": "342183f7-af51-4e4e-ab4c-ebed1e195063",
-                  "type": "text",
-                  "content": "<p>À la fin de cette vidéo, une question sera posée sur les compétences Pix.</p>"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "f312c33d-e7c9-4a69-9ba0-913957b8f7dd",
       "type": "lesson",
       "title": "Voici une leçon",
@@ -80,22 +50,34 @@
           }
         },
         {
-          "type": "element",
-          "element": {
-            "id": "a2372bf4-86a4-4ecc-a188-b51f4f98bca2",
-            "type": "text",
-            "content": "<p>Voici un texte de leçon. Parfois, il y a des émojis pour aider à la lecture&nbsp;<span aria-hidden=\"true\">📚</span>.<br>Et là, voici une image&#8239;!</p>"
-          }
-        },
-        {
-          "type": "element",
-          "element": {
-            "id": "8d7687c8-4a02-4d7e-bf6c-693a6d481c78",
-            "type": "image",
-            "url": "https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg",
-            "alt": "Dessin détaillé dans l'alternative textuelle",
-            "alternativeText": "Dessin d'un ordinateur dans un univers spatial."
-          }
+          "type": "stepper",
+          "steps": [
+            {
+              "elements": [
+                {
+                  "id": "a2372bf4-86a4-4ecc-a188-b51f4f98bca2",
+                  "type": "text",
+                  "content": "<p>Voici un texte de leçon. Parfois, il y a des émojis pour aider à la lecture&nbsp;<span aria-hidden=\"true\">📚</span>.</p>"
+                }
+              ]
+            },
+            {
+              "elements": [
+                {
+                  "id": "4cfd27d5-0947-47af-bfb6-52467143c38b",
+                  "type": "text",
+                  "content": "<p>Et là, voici une image&#8239;!</p>"
+                },
+                {
+                  "id": "8d7687c8-4a02-4d7e-bf6c-693a6d481c78",
+                  "type": "image",
+                  "url": "https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg",
+                  "alt": "Dessin détaillé dans l'alternative textuelle",
+                  "alternativeText": "Dessin d'un ordinateur dans un univers spatial."
+                }
+              ]
+            }
+          ]
         }
       ]
     },
@@ -131,27 +113,81 @@
       "title": "Voici un vrai-faux",
       "components": [
         {
-          "type": "element",
-          "element": {
-            "id": "71de6394-ff88-4de3-8834-a40057a50ff4",
-            "type": "qcu",
-            "instruction": "<p>Pix évalue 16 compétences numériques différentes.</p>",
-            "proposals": [
-              {
-                "id": "1",
-                "content": "Vrai"
-              },
-              {
-                "id": "2",
-                "content": "Faux"
-              }
-            ],
-            "feedbacks": {
-              "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>",
-              "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden=\"true\">👆</span>!</p>"
+          "type": "stepper",
+          "steps": [
+            {
+              "elements": [
+                {
+                  "id": "71de6394-ff88-4de3-8834-a40057a50ff4",
+                  "type": "qcu",
+                  "instruction": "<p>Pix évalue 16 compétences numériques différentes.</p>",
+                  "proposals": [
+                    {
+                      "id": "1",
+                      "content": "Vrai"
+                    },
+                    {
+                      "id": "2",
+                      "content": "Faux"
+                    }
+                  ],
+                  "feedbacks": {
+                    "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>",
+                    "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden=\"true\">👆</span>!</p>"
+                  },
+                  "solution": "1"
+                }
+              ]
             },
-            "solution": "1"
-          }
+            {
+              "elements": [
+                {
+                  "id": "79dc17f9-142b-4e19-bcbe-bfde4e170d3f",
+                  "type": "qcu",
+                  "instruction": "<p>Pix est découpé en 6 domaines.</p>",
+                  "proposals": [
+                    {
+                      "id": "1",
+                      "content": "Vrai"
+                    },
+                    {
+                      "id": "2",
+                      "content": "Faux"
+                    }
+                  ],
+                  "feedbacks": {
+                    "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p> Bien vu !</p>",
+                    "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Et non ! Il y a seulement 5 domaines sur Pix.</p>"
+                  },
+                  "solution": "2"
+                }
+              ]
+            },
+            {
+              "elements": [
+                {
+                  "id": "9c73500d-abd9-4cc4-ab2d-a3876285b13c",
+                  "type": "qcu",
+                  "instruction": "<p>Les compétences de Pix sont sur 8 niveaux.</p>",
+                  "proposals": [
+                    {
+                      "id": "1",
+                      "content": "Vrai"
+                    },
+                    {
+                      "id": "2",
+                      "content": "Faux"
+                    }
+                  ],
+                  "feedbacks": {
+                    "valid": "<span class=\"feedback__state\">Correct&#8239;!</span><p> Et oui ! A noter, seulement 7 sont actifs aujourd’hui.</p>",
+                    "invalid": "<span class=\"feedback__state\">Incorrect.</span><p> Incorrect ! Il existe 8 niveaux par compétence.</p>"
+                  },
+                  "solution": "1"
+                }
+              ]
+            }
+          ]
         }
       ]
     },

--- a/api/src/devcomp/infrastructure/repositories/element-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/element-repository.js
@@ -15,7 +15,16 @@ async function getByIdForAnswerVerification({ moduleId, elementId, moduleDatasou
 
   const foundElement = moduleData.grains
     .flatMap(({ components }) => components)
-    .find((component) => component.type === 'element' && component.element.id === elementId);
+    .flatMap((component) => {
+      if (component.type === 'element') {
+        return component.element;
+      } else if (component.type === 'stepper') {
+        return component.steps.flatMap(({ elements }) => elements);
+      }
+    })
+    .find((element) => {
+      return element.id === elementId;
+    });
 
   if (foundElement === undefined) {
     throw new NotFoundError();

--- a/api/tests/devcomp/integration/repositories/element-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/element-repository_test.js
@@ -6,7 +6,7 @@ import { catchErr, expect, sinon } from '../../../test-helper.js';
 
 describe('Integration | DevComp | Repositories | ElementRepository', function () {
   describe('#getByIdForAnswerVerification', function () {
-    it('should return the element', async function () {
+    it('should return an element from a component element', async function () {
       // given
       const moduleId = 'didacticiel-modulix';
       const elementId = '71de6394-ff88-4de3-8834-a40057a50ff4';
@@ -73,6 +73,125 @@ describe('Integration | DevComp | Repositories | ElementRepository', function ()
                       '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
                     invalid:
                       '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>!</p>',
+                  },
+                  solution: '1',
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      // when
+      const foundElement = await elementRepository.getByIdForAnswerVerification({
+        moduleId,
+        elementId,
+        moduleDatasource: moduleDatasourceStub,
+      });
+
+      // then
+      expect(foundElement).to.be.instanceof(QCUForAnswerVerification);
+      expect(foundElement).to.deep.equal(element);
+    });
+
+    it('should return an element from a component stepper', async function () {
+      // given
+      const moduleId = 'didacticiel-modulix';
+      const elementId = '71de6394-ff88-4de3-8834-a40057a50ff4';
+      const element = new QCUForAnswerVerification({
+        id: elementId,
+        type: 'qcu',
+        instruction: '<p>Pix évalue 16 compétences numériques différentes.</p>',
+        proposals: [
+          {
+            id: '1',
+            content: 'Vrai',
+          },
+          {
+            id: '2',
+            content: 'Faux',
+          },
+        ],
+        feedbacks: {
+          valid:
+            '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
+          invalid:
+            '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>️!</p>',
+        },
+        solution: '1',
+      });
+      const moduleDatasourceStub = {
+        getBySlug: sinon.stub(),
+      };
+      moduleDatasourceStub.getBySlug.withArgs(moduleId).resolves({
+        id: '6282925d-4775-4bca-b513-4c3009ec5886',
+        slug: 'didacticiel-modulix',
+        title: 'Didacticiel Modulix',
+        details: {
+          image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+          description: 'Découvrez avec ce didacticiel comment fonctionne Modulix !',
+          duration: 5,
+          level: 'Débutant',
+          objectives: ['Naviguer dans Modulix', 'Découvrir les leçons et les activités'],
+        },
+        grains: [
+          {
+            id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+            type: 'lesson',
+            title: 'Voici une leçon',
+            components: [
+              {
+                type: 'stepper',
+                steps: [
+                  {
+                    elements: [
+                      {
+                        id: '71de6394-ff88-4de3-8834-a40057a50ff4',
+                        type: 'qcu',
+                        instruction: '<p>Pix évalue 16 compétences numériques différentes.</p>',
+                        proposals: [
+                          {
+                            id: '1',
+                            content: 'Vrai',
+                          },
+                          {
+                            id: '2',
+                            content: 'Faux',
+                          },
+                        ],
+                        feedbacks: {
+                          valid:
+                            '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
+                          invalid:
+                            '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>️!</p>',
+                        },
+                        solution: '1',
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: 'element',
+                element: {
+                  id: '126939bd-a2ed-4a4b-ad44-f37e9d09440a',
+                  type: 'qcu',
+                  instruction: '<p>Pix évalue 16 compétences numériques différentes.</p>',
+                  proposals: [
+                    {
+                      id: '1',
+                      content: 'Vrai',
+                    },
+                    {
+                      id: '2',
+                      content: 'Faux',
+                    },
+                  ],
+                  feedbacks: {
+                    valid:
+                      '<span class="feedback__state">Correct&#8239;!</span><p> Ces 16 compétences sont rangées dans 5 domaines.</p>',
+                    invalid:
+                      '<span class="feedback__state">Incorrect.</span><p> Retourner voir la vidéo si besoin&nbsp;<span aria-hidden="true">👆</span>️!</p>',
                   },
                   solution: '1',
                 },

--- a/high-level-tests/e2e/cypress/integration/pix-app/modulix-a11y.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/modulix-a11y.feature
@@ -18,7 +18,6 @@ Fonctionnalité: Accessibilité de Modulix
     Quand je vais au grain suivant
     Quand je vais au grain suivant
     Quand je vais au grain suivant
-    Quand je vais au grain suivant
     Alors la page devrait être accessible
     Quand je clique sur "Terminer"
     Et que j'attends 500 ms

--- a/mon-pix/app/components/module/grain.hbs
+++ b/mon-pix/app/components/module/grain.hbs
@@ -25,6 +25,8 @@
         {{else if (eq component.type "stepper")}}
           <Module::Stepper
             @steps={{component.steps}}
+            @submitAnswer={{@submitAnswer}}
+            @retryElement={{@retryElement}}
             @passage={{@passage}}
             @getLastCorrectionForElement={{this.getLastCorrectionForElement}}
           />

--- a/mon-pix/app/components/module/grain.hbs
+++ b/mon-pix/app/components/module/grain.hbs
@@ -29,6 +29,7 @@
             @retryElement={{@retryElement}}
             @passage={{@passage}}
             @getLastCorrectionForElement={{this.getLastCorrectionForElement}}
+            @stepperIsFinished={{this.stepperIsFinished}}
           />
         {{/if}}
       {{/each}}

--- a/mon-pix/app/components/module/grain.js
+++ b/mon-pix/app/components/module/grain.js
@@ -1,5 +1,6 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 
 import ModulePassage from './passage';
 
@@ -8,6 +9,12 @@ export default class ModuleGrain extends Component {
 
   static AVAILABLE_ELEMENT_TYPES = ['text', 'image', 'video', 'qcu', 'qcm', 'qrocm'];
   static AVAILABLE_GRAIN_TYPES = ['lesson', 'activity'];
+
+  @tracked isStepperFinished = this.hasStepper === false;
+
+  get hasStepper() {
+    return this.args.grain.components.some((component) => component.type === 'stepper');
+  }
 
   get grainType() {
     if (ModuleGrain.AVAILABLE_GRAIN_TYPES.includes(this.args.grain.type)) {
@@ -22,12 +29,25 @@ export default class ModuleGrain extends Component {
     return this.args.passage.getLastCorrectionForElement(element);
   }
 
+  @action
+  stepperIsFinished() {
+    this.isStepperFinished = true;
+  }
+
   get shouldDisplayContinueButton() {
-    return this.args.canMoveToNextGrain && this.allElementsAreAnswered;
+    if (!this.hasStepper) {
+      return this.args.canMoveToNextGrain && this.allElementsAreAnswered;
+    } else {
+      return this.args.canMoveToNextGrain && this.isStepperFinished;
+    }
   }
 
   get shouldDisplaySkipButton() {
-    return this.args.canMoveToNextGrain && this.hasAnswerableElements && !this.allElementsAreAnswered;
+    if (this.hasStepper && !this.isStepperFinished) {
+      return this.args.canMoveToNextGrain;
+    } else {
+      return this.args.canMoveToNextGrain && !this.isStepperFinished;
+    }
   }
 
   static getSupportedElements(grain) {

--- a/mon-pix/app/components/module/grain.js
+++ b/mon-pix/app/components/module/grain.js
@@ -35,10 +35,10 @@ export default class ModuleGrain extends Component {
   }
 
   get shouldDisplayContinueButton() {
-    if (!this.hasStepper) {
-      return this.args.canMoveToNextGrain && this.allElementsAreAnswered;
+    if (this.hasStepper) {
+      return this.args.canMoveToNextGrain && this.isStepperFinished && this.allElementsAreAnswered;
     } else {
-      return this.args.canMoveToNextGrain && this.isStepperFinished;
+      return this.args.canMoveToNextGrain && this.allElementsAreAnswered;
     }
   }
 
@@ -46,17 +46,20 @@ export default class ModuleGrain extends Component {
     if (this.hasStepper && !this.isStepperFinished) {
       return this.args.canMoveToNextGrain;
     } else {
-      return this.args.canMoveToNextGrain && !this.isStepperFinished;
+      return this.args.canMoveToNextGrain && this.hasAnswerableElements && !this.allElementsAreAnswered;
     }
   }
 
   static getSupportedElements(grain) {
     return grain.components
-      .map((component) => {
-        if (component.type === 'element') {
-          return component.element;
-        } else {
-          return undefined;
+      .flatMap((component) => {
+        switch (component.type) {
+          case 'element':
+            return component.element;
+          case 'stepper':
+            return component.steps.flatMap(({ elements }) => elements);
+          default:
+            return undefined;
         }
       })
       .filter((element) => {

--- a/mon-pix/app/components/module/stepper.gjs
+++ b/mon-pix/app/components/module/stepper.gjs
@@ -55,6 +55,8 @@ export default class ModulixStepper extends Component {
           @step={{step}}
           @currentStep={{inc index}}
           @totalSteps={{this.displayableSteps.length}}
+          @submitAnswer={{@submitAnswer}}
+          @retryElement={{@retryElement}}
           @getLastCorrectionForElement={{@getLastCorrectionForElement}}
         />
       {{/each}}

--- a/mon-pix/app/components/module/stepper.gjs
+++ b/mon-pix/app/components/module/stepper.gjs
@@ -23,6 +23,10 @@ export default class ModulixStepper extends Component {
   displayNextStep() {
     const nextStep = this.displayableSteps[this.lastIndex + 1];
     this.stepsToDisplay = [...this.stepsToDisplay, nextStep];
+
+    if (!this.hasNextStep) {
+      this.args.stepperIsFinished();
+    }
   }
 
   get lastIndex() {

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -718,13 +718,230 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
         // when
         await render(hbs`
-          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @retryElement={{this.retryElement}} />`);
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}}  @retryElement={{this.retryElement}} />`);
 
         // then
         await clickByName('radio1');
         await clickByName(this.intl.t('pages.modulix.buttons.activity.retry'));
         sinon.assert.calledOnce(retryElementStub);
         assert.ok(true);
+      });
+    });
+
+    module.only('when there are only unanswerable elements in stepper', function () {
+      module('when there are still steps to display', function () {
+        test('should display skip button', async function (assert) {
+          // given
+          const steps = [
+            {
+              elements: [
+                {
+                  id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                  type: 'text',
+                  content: '<p>Text 1</p>',
+                  isAnswerable: false,
+                },
+              ],
+            },
+            {
+              elements: [
+                {
+                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                  type: 'text',
+                  content: '<p>Text 2</p>',
+                  isAnswerable: false,
+                },
+              ],
+            },
+          ];
+
+          const store = this.owner.lookup('service:store');
+          const grain = store.createRecord('grain', {
+            title: 'Grain title',
+            components: [
+              {
+                type: 'stepper',
+                steps,
+              },
+            ],
+          });
+
+          const passage = store.createRecord('passage');
+          const retryElementStub = sinon.stub();
+
+          this.set('grain', grain);
+          this.set('passage', passage);
+          this.set('retryElement', retryElementStub);
+
+          // when
+          const screen = await render(hbs`
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}}  />`);
+
+          // then
+          assert.dom(screen.getByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') })).exists();
+        });
+        test('should not display continue button', async function (assert) {
+          // given
+          const steps = [
+            {
+              elements: [
+                {
+                  id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                  type: 'text',
+                  content: '<p>Text 1</p>',
+                  isAnswerable: false,
+                },
+              ],
+            },
+            {
+              elements: [
+                {
+                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                  type: 'text',
+                  content: '<p>Text 2</p>',
+                  isAnswerable: false,
+                },
+              ],
+            },
+          ];
+
+          const store = this.owner.lookup('service:store');
+          const grain = store.createRecord('grain', {
+            title: 'Grain title',
+            components: [
+              {
+                type: 'stepper',
+                steps,
+              },
+            ],
+          });
+
+          const passage = store.createRecord('passage');
+          const retryElementStub = sinon.stub();
+
+          this.set('grain', grain);
+          this.set('passage', passage);
+          this.set('retryElement', retryElementStub);
+
+          // when
+          const screen = await render(hbs`
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}}  />`);
+
+          // then
+          assert
+            .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.continue') }))
+            .doesNotExist();
+        });
+      });
+
+      module('when there is no more steps to display', function () {
+        test('should display continue button', async function (assert) {
+          // given
+          const steps = [
+            {
+              elements: [
+                {
+                  id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                  type: 'text',
+                  content: '<p>Text 1</p>',
+                  isAnswerable: false,
+                },
+              ],
+            },
+            {
+              elements: [
+                {
+                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                  type: 'text',
+                  content: '<p>Text 2</p>',
+                  isAnswerable: false,
+                },
+              ],
+            },
+          ];
+
+          const store = this.owner.lookup('service:store');
+          const grain = store.createRecord('grain', {
+            title: 'Grain title',
+            components: [
+              {
+                type: 'stepper',
+                steps,
+              },
+            ],
+          });
+
+          const passage = store.createRecord('passage');
+          const retryElementStub = sinon.stub();
+
+          this.set('grain', grain);
+          this.set('passage', passage);
+          this.set('retryElement', retryElementStub);
+
+          // when
+          const screen = await render(hbs`
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}}  />`);
+          await clickByName(this.intl.t('pages.modulix.buttons.stepper.next'));
+
+          // then
+          assert
+            .dom(screen.getByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.continue') }))
+            .exists();
+        });
+
+        test('should not display skip button', async function (assert) {
+          // given
+          const steps = [
+            {
+              elements: [
+                {
+                  id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                  type: 'text',
+                  content: '<p>Text 1</p>',
+                  isAnswerable: false,
+                },
+              ],
+            },
+            {
+              elements: [
+                {
+                  id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                  type: 'text',
+                  content: '<p>Text 2</p>',
+                  isAnswerable: false,
+                },
+              ],
+            },
+          ];
+
+          const store = this.owner.lookup('service:store');
+          const grain = store.createRecord('grain', {
+            title: 'Grain title',
+            components: [
+              {
+                type: 'stepper',
+                steps,
+              },
+            ],
+          });
+
+          const passage = store.createRecord('passage');
+          const retryElementStub = sinon.stub();
+
+          this.set('grain', grain);
+          this.set('passage', passage);
+          this.set('retryElement', retryElementStub);
+
+          // when
+          const screen = await render(hbs`
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}}  />`);
+          await clickByName(this.intl.t('pages.modulix.buttons.stepper.next'));
+
+          // then
+          assert
+            .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') }))
+            .doesNotExist();
+        });
       });
     });
   });

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -487,72 +487,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
     });
   });
 
-  module('when shouldDisplayTerminateButton is true', function () {
-    test('should display the terminate button', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const element = { type: 'text', isAnswerable: false };
-      const grain = store.createRecord('grain', { title: 'Grain title', components: [{ type: 'element', element }] });
-      this.set('grain', grain);
-
-      // when
-      const screen = await render(hbs`
-        <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{true}} />`);
-
-      // then
-      assert.dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.terminate') })).exists();
-    });
-
-    module('when terminateAction is called', function () {
-      test('should call terminateAction passed in argument', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const element = { type: 'qcu', isAnswerable: true };
-        const grain = store.createRecord('grain', {
-          title: 'Grain title',
-          components: [{ type: 'element', element }],
-        });
-        this.set('grain', grain);
-        const passage = store.createRecord('passage');
-        this.set('passage', passage);
-
-        const terminateActionStub = sinon.stub();
-        this.set('terminateAction', terminateActionStub);
-
-        // when
-        await render(
-          hbs`
-            <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{true}}
-                           @terminateAction={{this.terminateAction}} @passage={{this.passage}} />`,
-        );
-        await clickByName(this.intl.t('pages.modulix.buttons.grain.terminate'));
-
-        // then
-        sinon.assert.calledOnce(terminateActionStub);
-        assert.ok(true);
-      });
-    });
-  });
-
-  module('when shouldDisplayTerminateButton is false', function () {
-    test('should not display the terminate button', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const element = { type: 'text', isAnswerable: false };
-      const grain = store.createRecord('grain', { title: 'Grain title', components: [{ type: 'element', element }] });
-      this.set('grain', grain);
-
-      // when
-      const screen = await render(hbs`
-        <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{false}} />`);
-
-      // then
-      assert
-        .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.terminate') }))
-        .doesNotExist();
-    });
-  });
-
   module('when retryElement is called', function () {
     test('should call retryElement pass in argument', async function (assert) {
       // given
@@ -728,7 +662,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
       });
     });
 
-    module.only('when there are only unanswerable elements in stepper', function () {
+    module('when there are only unanswerable elements in stepper', function () {
       module('when there are still steps to display', function () {
         test('should display skip button', async function (assert) {
           // given

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -427,28 +427,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
     });
   });
 
-  module('when component is a stepper', function () {
-    test('should display the stepper', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const textElement = {
-        content: 'element content',
-        type: 'text',
-        isAnswerable: false,
-      };
-      const grain = store.createRecord('grain', {
-        title: 'Grain title',
-        components: [{ type: 'stepper', steps: [{ elements: [textElement] }] }],
-      });
-
-      // when
-      const screen = await render(<template><ModuleGrain @grain={{grain}} /></template>);
-
-      // then
-      assert.ok(screen.getByText('element content'));
-    });
-  });
-
   module('when continueAction is called', function () {
     test('should call continueAction pass in argument', async function (assert) {
       // given
@@ -604,6 +582,26 @@ module('Integration | Component | Module | Grain', function (hooks) {
   });
 
   module('when grain contains a stepper', function () {
+    test('should display the stepper', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const textElement = {
+        content: 'element content',
+        type: 'text',
+        isAnswerable: false,
+      };
+      const grain = store.createRecord('grain', {
+        title: 'Grain title',
+        components: [{ type: 'stepper', steps: [{ elements: [textElement] }] }],
+      });
+
+      // when
+      const screen = await render(<template><ModuleGrain @grain={{grain}} /></template>);
+
+      // then
+      assert.ok(screen.getByText('element content'));
+    });
+
     module('When we verify an answerable element', function () {
       test('should call the submitAnswer action', async function (assert) {
         // given

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -19,7 +19,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
     // when
     const screen = await render(hbs`
-        <Module::Grain @grain={{this.grain}} />`);
+      <Module::Grain @grain={{this.grain}} />`);
 
     // then
     assert.ok(screen.getByRole('heading', { name: grain.title, level: 2 }));
@@ -36,7 +36,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // when
       const screen = await render(hbs`
-          <Module::Grain @grain={{this.grain}} @transition={{this.transition}} />`);
+        <Module::Grain @grain={{this.grain}} @transition={{this.transition}} />`);
 
       // then
       assert.ok(screen.getByText('transition text'));
@@ -52,7 +52,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // when
       await render(hbs`
-          <Module::Grain @grain={{this.grain}} />`);
+        <Module::Grain @grain={{this.grain}} />`);
 
       // then
       assert.dom('.grain__header').doesNotExist();
@@ -68,7 +68,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // when
       const screen = await render(hbs`
-          <Module::Grain @grain={{this.grain}} />`);
+        <Module::Grain @grain={{this.grain}} />`);
 
       // then
       assert.dom(find('.grain-card--activity')).exists();
@@ -83,7 +83,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // when
       const screen = await render(hbs`
-          <Module::Grain @grain={{this.grain}} />`);
+        <Module::Grain @grain={{this.grain}} />`);
 
       // then
       assert.dom(find('.grain-card--lesson')).exists();
@@ -98,7 +98,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // when
       const screen = await render(hbs`
-          <Module::Grain @grain={{this.grain}} />`);
+        <Module::Grain @grain={{this.grain}} />`);
 
       // then
       assert.dom(find('.grain-card--lesson')).exists();
@@ -113,7 +113,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // when
       const screen = await render(hbs`
-          <Module::Grain @grain={{this.grain}} />`);
+        <Module::Grain @grain={{this.grain}} />`);
 
       // then
       assert.dom(find('.grain-card--lesson')).exists();
@@ -139,7 +139,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
         // when
         const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} />`);
+          <Module::Grain @grain={{this.grain}} />`);
 
         // then
         assert.ok(screen.getByText('element content'));
@@ -166,7 +166,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
         // when
         const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @passage={{this.passage}} />`);
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} />`);
 
         // then
         assert.strictEqual(screen.getAllByRole('radio').length, qcuElement.proposals.length);
@@ -226,7 +226,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
         // when
         const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @passage={{this.passage}} />`);
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} />`);
 
         // then
         assert.ok(screen);
@@ -254,7 +254,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
         // when
         const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} />`);
+          <Module::Grain @grain={{this.grain}} />`);
 
         // then
         assert.ok(screen.getByRole('img', { name: 'alt text' }).hasAttribute('src', url));
@@ -279,7 +279,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
         // when
         const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
+          <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
 
         // then
         assert
@@ -306,7 +306,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
           // when
           const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
+            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
 
           // then
           assert.dom(screen.queryByRole('button', { name: 'Continuer' })).exists();
@@ -328,7 +328,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
           // when
           const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
+            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
 
           // then
           assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
@@ -352,7 +352,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
           // when
           const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
+            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
 
           // then
           assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
@@ -373,7 +373,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
           // when
           const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
+            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
 
           // then
           assert.dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') })).exists();
@@ -395,7 +395,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
           // when
           const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
+            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
 
           // then
           assert.dom(screen.queryByRole('button', { name: 'Continuer' })).doesNotExist();
@@ -416,7 +416,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
           // when
           const screen = await render(hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
+            <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{false}} @passage={{this.passage}} />`);
 
           // then
           assert
@@ -467,8 +467,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
       // when
       await render(
         hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}}
-                             @continueAction={{this.continueAction}} />`,
+          <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}}
+                         @continueAction={{this.continueAction}} />`,
       );
       await clickByName('Continuer');
 
@@ -497,8 +497,9 @@ module('Integration | Component | Module | Grain', function (hooks) {
       // when
       await render(
         hbs`
-              <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}}
-                             @continueAction={{this.continueAction}} @skipAction={{this.skipAction}} @passage={{this.passage}} />`,
+          <Module::Grain @grain={{this.grain}} @canMoveToNextGrain={{true}}
+                         @continueAction={{this.continueAction}} @skipAction={{this.skipAction}}
+                         @passage={{this.passage}} />`,
       );
       await clickByName(this.intl.t('pages.modulix.buttons.grain.skip'));
 
@@ -518,7 +519,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // when
       const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{true}} />`);
+        <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{true}} />`);
 
       // then
       assert.dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.terminate') })).exists();
@@ -543,8 +544,8 @@ module('Integration | Component | Module | Grain', function (hooks) {
         // when
         await render(
           hbs`
-              <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{true}}
-                             @terminateAction={{this.terminateAction}} @passage={{this.passage}} />`,
+            <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{true}}
+                           @terminateAction={{this.terminateAction}} @passage={{this.passage}} />`,
         );
         await clickByName(this.intl.t('pages.modulix.buttons.grain.terminate'));
 
@@ -565,7 +566,7 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // when
       const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{false}} />`);
+        <Module::Grain @grain={{this.grain}} @shouldDisplayTerminateButton={{false}} />`);
 
       // then
       assert
@@ -592,12 +593,141 @@ module('Integration | Component | Module | Grain', function (hooks) {
 
       // when
       await render(hbs`
-            <Module::Grain @grain={{this.grain}} @retryElement={{this.retryElement}} @canMoveToNextGrain={{true}} @passage={{this.passage}} />`);
+        <Module::Grain @grain={{this.grain}} @retryElement={{this.retryElement}} @canMoveToNextGrain={{true}}
+                       @passage={{this.passage}} />`);
       await clickByName(this.intl.t('pages.modulix.buttons.activity.retry'));
 
       // then
       sinon.assert.calledOnce(retryElementStub);
       assert.ok(true);
+    });
+  });
+
+  module('when grain contains a stepper', function () {
+    module('When we verify an answerable element', function () {
+      test('should call the submitAnswer action', async function (assert) {
+        // given
+        const steps = [
+          {
+            elements: [
+              {
+                id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                instruction: 'Instruction',
+                proposals: [
+                  { id: '1', content: 'radio1' },
+                  { id: '2', content: 'radio2' },
+                ],
+                isAnswerable: true,
+                type: 'qcu',
+              },
+            ],
+          },
+          {
+            elements: [
+              {
+                id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                type: 'text',
+                content: '<p>Text 2</p>',
+                isAnswerable: false,
+              },
+            ],
+          },
+        ];
+        function getLastCorrectionForElementStub() {}
+        const submitAnswerStub = sinon.stub();
+        const store = this.owner.lookup('service:store');
+        const grain = store.createRecord('grain', {
+          title: 'Grain title',
+          components: [
+            {
+              type: 'stepper',
+              steps,
+            },
+          ],
+        });
+        const passage = store.createRecord('passage');
+        passage.getLastCorrectionForElement = getLastCorrectionForElementStub;
+        this.set('grain', grain);
+        this.set('passage', passage);
+        this.set('submitAnswer', submitAnswerStub);
+
+        // when
+        await render(hbs`
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @submitAnswer={{this.submitAnswer}} />`);
+
+        // then
+        await clickByName('radio1');
+        await clickByName(this.intl.t('pages.modulix.buttons.activity.verify'));
+        sinon.assert.calledOnce(submitAnswerStub);
+        assert.ok(true);
+      });
+    });
+
+    module('When we retry an answerable element', function () {
+      test('should call the retryElement action', async function (assert) {
+        // given
+        const steps = [
+          {
+            elements: [
+              {
+                id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                instruction: 'Instruction',
+                proposals: [
+                  { id: '1', content: 'radio1' },
+                  { id: '2', content: 'radio2' },
+                ],
+                isAnswerable: true,
+                type: 'qcu',
+              },
+            ],
+          },
+          {
+            elements: [
+              {
+                id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                type: 'text',
+                content: '<p>Text 2</p>',
+                isAnswerable: false,
+              },
+            ],
+          },
+        ];
+        const retryElementStub = sinon.stub();
+        const store = this.owner.lookup('service:store');
+        const grain = store.createRecord('grain', {
+          title: 'Grain title',
+          components: [
+            {
+              type: 'stepper',
+              steps,
+            },
+          ],
+        });
+        const passage = store.createRecord('passage');
+        const correctionResponse = store.createRecord('correction-response', {
+          feedback: 'Too bad!',
+          status: 'ko',
+          solution: '1',
+        });
+        store.createRecord('element-answer', {
+          correction: correctionResponse,
+          elementId: 'd0690f26-978c-41c3-9a21-da931857739c',
+          passage,
+        });
+        this.set('grain', grain);
+        this.set('passage', passage);
+        this.set('retryElement', retryElementStub);
+
+        // when
+        await render(hbs`
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @retryElement={{this.retryElement}} />`);
+
+        // then
+        await clickByName('radio1');
+        await clickByName(this.intl.t('pages.modulix.buttons.activity.retry'));
+        sinon.assert.calledOnce(retryElementStub);
+        assert.ok(true);
+      });
     });
   });
 });

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -878,5 +878,490 @@ module('Integration | Component | Module | Grain', function (hooks) {
         });
       });
     });
+
+    module('when there are answerable elements in stepper', function () {
+      module('when user response is not verified', function () {
+        module('when there are still steps to display', function () {
+          test('should display skip button', async function (assert) {
+            // given
+            const steps = [
+              {
+                elements: [
+                  {
+                    id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                    instruction: 'instruction',
+                    proposals: ['radio1', 'radio2'],
+                    type: 'qcu',
+                    isAnswerable: true,
+                  },
+                ],
+              },
+              {
+                elements: [
+                  {
+                    id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                    type: 'text',
+                    content: '<p>Text 2</p>',
+                    isAnswerable: false,
+                  },
+                ],
+              },
+            ];
+
+            const store = this.owner.lookup('service:store');
+            const grain = store.createRecord('grain', {
+              title: 'Grain title',
+              components: [
+                {
+                  type: 'stepper',
+                  steps,
+                },
+              ],
+            });
+
+            const passage = store.createRecord('passage');
+            const retryElementStub = sinon.stub();
+
+            this.set('grain', grain);
+            this.set('passage', passage);
+            this.set('retryElement', retryElementStub);
+
+            // when
+            const screen = await render(hbs`
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}}  />`);
+
+            // then
+            assert.dom(screen.getByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') })).exists();
+          });
+          test('should not display continue button', async function (assert) {
+            // given
+            const steps = [
+              {
+                elements: [
+                  {
+                    id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                    instruction: 'instruction',
+                    proposals: ['radio1', 'radio2'],
+                    type: 'qcu',
+                    isAnswerable: true,
+                  },
+                ],
+              },
+              {
+                elements: [
+                  {
+                    id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                    type: 'text',
+                    content: '<p>Text 2</p>',
+                    isAnswerable: false,
+                  },
+                ],
+              },
+            ];
+
+            const store = this.owner.lookup('service:store');
+            const grain = store.createRecord('grain', {
+              title: 'Grain title',
+              components: [
+                {
+                  type: 'stepper',
+                  steps,
+                },
+              ],
+            });
+
+            const passage = store.createRecord('passage');
+            const retryElementStub = sinon.stub();
+
+            this.set('grain', grain);
+            this.set('passage', passage);
+            this.set('retryElement', retryElementStub);
+
+            // when
+            const screen = await render(hbs`
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}}  />`);
+
+            // then
+            assert
+              .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.continue') }))
+              .doesNotExist();
+          });
+        });
+
+        module('when there is no more steps to display', function () {
+          module('when the last step contains an answerable element', function () {
+            test('should display skip button', async function (assert) {
+              // given
+              const steps = [
+                {
+                  elements: [
+                    {
+                      id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                      type: 'text',
+                      content: '<p>Text 2</p>',
+                      isAnswerable: false,
+                    },
+                  ],
+                },
+                {
+                  elements: [
+                    {
+                      id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                      instruction: 'instruction',
+                      proposals: ['radio1', 'radio2'],
+                      type: 'qcu',
+                      isAnswerable: true,
+                    },
+                  ],
+                },
+              ];
+
+              const store = this.owner.lookup('service:store');
+              const grain = store.createRecord('grain', {
+                title: 'Grain title',
+                components: [
+                  {
+                    type: 'stepper',
+                    steps,
+                  },
+                ],
+              });
+
+              const passage = store.createRecord('passage');
+              const retryElementStub = sinon.stub();
+
+              this.set('grain', grain);
+              this.set('passage', passage);
+              this.set('retryElement', retryElementStub);
+
+              // when
+              const screen = await render(hbs`
+            <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}}  />`);
+              await clickByName(this.intl.t('pages.modulix.buttons.stepper.next'));
+
+              // then
+              assert
+                .dom(screen.getByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') }))
+                .exists();
+            });
+
+            test('should not display continue button', async function (assert) {
+              // given
+              const steps = [
+                {
+                  elements: [
+                    {
+                      id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                      type: 'text',
+                      content: '<p>Text 2</p>',
+                      isAnswerable: false,
+                    },
+                  ],
+                },
+                {
+                  elements: [
+                    {
+                      id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                      instruction: 'instruction',
+                      proposals: ['radio1', 'radio2'],
+                      type: 'qcu',
+                      isAnswerable: true,
+                    },
+                  ],
+                },
+              ];
+
+              const store = this.owner.lookup('service:store');
+              const grain = store.createRecord('grain', {
+                title: 'Grain title',
+                components: [
+                  {
+                    type: 'stepper',
+                    steps,
+                  },
+                ],
+              });
+
+              const passage = store.createRecord('passage');
+              const retryElementStub = sinon.stub();
+
+              this.set('grain', grain);
+              this.set('passage', passage);
+              this.set('retryElement', retryElementStub);
+
+              // when
+              const screen = await render(hbs`
+            <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}}  />`);
+              await clickByName(this.intl.t('pages.modulix.buttons.stepper.next'));
+
+              // then
+              assert
+                .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.continue') }))
+                .doesNotExist();
+            });
+          });
+        });
+      });
+
+      module('when user response has been verified', function () {
+        module('when there are still steps to display', function () {
+          test('should display skip button', async function (assert) {
+            // given
+            const steps = [
+              {
+                elements: [
+                  {
+                    id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                    instruction: 'instruction',
+                    proposals: [
+                      { id: '1', content: 'radio1' },
+                      { id: '2', content: 'radio2' },
+                    ],
+                    type: 'qcu',
+                    isAnswerable: true,
+                  },
+                ],
+              },
+              {
+                elements: [
+                  {
+                    id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                    type: 'text',
+                    content: '<p>Text 2</p>',
+                    isAnswerable: false,
+                  },
+                ],
+              },
+            ];
+
+            const store = this.owner.lookup('service:store');
+            const grain = store.createRecord('grain', {
+              title: 'Grain title',
+              components: [
+                {
+                  type: 'stepper',
+                  steps,
+                },
+              ],
+            });
+
+            const passage = store.createRecord('passage');
+            const correction = store.createRecord('correction-response', { status: 'ok', feedback: 'super' });
+            store.createRecord('element-answer', {
+              elementId: 'd0690f26-978c-41c3-9a21-da931857739c',
+              correction,
+              passage,
+            });
+            const retryElementStub = sinon.stub();
+
+            this.set('grain', grain);
+            this.set('passage', passage);
+            this.set('retryElement', retryElementStub);
+
+            // when
+            const screen = await render(hbs`
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}}  />`);
+
+            // then
+            assert.dom(screen.getByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') })).exists();
+          });
+          test('should not display continue button', async function (assert) {
+            // given
+            const steps = [
+              {
+                elements: [
+                  {
+                    id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                    instruction: 'instruction',
+                    proposals: [
+                      { id: '1', content: 'radio1' },
+                      { id: '2', content: 'radio2' },
+                    ],
+                    type: 'qcu',
+                    isAnswerable: true,
+                  },
+                ],
+              },
+              {
+                elements: [
+                  {
+                    id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                    type: 'text',
+                    content: '<p>Text 2</p>',
+                    isAnswerable: false,
+                  },
+                ],
+              },
+            ];
+
+            const store = this.owner.lookup('service:store');
+            const grain = store.createRecord('grain', {
+              title: 'Grain title',
+              components: [
+                {
+                  type: 'stepper',
+                  steps,
+                },
+              ],
+            });
+
+            const passage = store.createRecord('passage');
+            const correction = store.createRecord('correction-response', { status: 'ok', feedback: 'super' });
+            store.createRecord('element-answer', {
+              elementId: 'd0690f26-978c-41c3-9a21-da931857739c',
+              correction,
+              passage,
+            });
+            const retryElementStub = sinon.stub();
+
+            this.set('grain', grain);
+            this.set('passage', passage);
+            this.set('retryElement', retryElementStub);
+
+            // when
+            const screen = await render(hbs`
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}}  />`);
+
+            // then
+            assert
+              .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.continue') }))
+              .doesNotExist();
+          });
+        });
+        module('when there is no more steps to display', function () {
+          module('when the last step contains an answerable element', function () {
+            test('should not display skip button', async function (assert) {
+              // given
+              const steps = [
+                {
+                  elements: [
+                    {
+                      id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                      type: 'text',
+                      content: '<p>Text 2</p>',
+                      isAnswerable: false,
+                    },
+                  ],
+                },
+                {
+                  elements: [
+                    {
+                      id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                      instruction: 'instruction',
+                      proposals: [
+                        { id: '1', content: 'radio1' },
+                        { id: '2', content: 'radio2' },
+                      ],
+                      type: 'qcu',
+                      isAnswerable: true,
+                    },
+                  ],
+                },
+              ];
+
+              const store = this.owner.lookup('service:store');
+              const grain = store.createRecord('grain', {
+                title: 'Grain title',
+                components: [
+                  {
+                    type: 'stepper',
+                    steps,
+                  },
+                ],
+              });
+
+              const passage = store.createRecord('passage');
+              const correction = store.createRecord('correction-response', { status: 'ok', feedback: 'super' });
+              store.createRecord('element-answer', {
+                elementId: 'd0690f26-978c-41c3-9a21-da931857739c',
+                correction,
+                passage,
+              });
+              const retryElementStub = sinon.stub();
+
+              this.set('grain', grain);
+              this.set('passage', passage);
+              this.set('retryElement', retryElementStub);
+
+              // when
+              const screen = await render(hbs`
+                <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}}  />`);
+
+              await clickByName(this.intl.t('pages.modulix.buttons.stepper.next'));
+
+              // then
+              assert
+                .dom(screen.getByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.continue') }))
+                .exists();
+            });
+
+            test('should display continue button', async function (assert) {
+              // given
+              const steps = [
+                {
+                  elements: [
+                    {
+                      id: '768441a5-a7d6-4987-ada9-7253adafd842',
+                      type: 'text',
+                      content: '<p>Text 2</p>',
+                      isAnswerable: false,
+                    },
+                  ],
+                },
+                {
+                  elements: [
+                    {
+                      id: 'd0690f26-978c-41c3-9a21-da931857739c',
+                      instruction: 'instruction',
+                      proposals: [
+                        { id: '1', content: 'radio1' },
+                        { id: '2', content: 'radio2' },
+                      ],
+                      type: 'qcu',
+                      isAnswerable: true,
+                    },
+                  ],
+                },
+              ];
+
+              const store = this.owner.lookup('service:store');
+              const grain = store.createRecord('grain', {
+                title: 'Grain title',
+                components: [
+                  {
+                    type: 'stepper',
+                    steps,
+                  },
+                ],
+              });
+
+              const passage = store.createRecord('passage');
+              const correction = store.createRecord('correction-response', { status: 'ok', feedback: 'super' });
+              store.createRecord('element-answer', {
+                elementId: 'd0690f26-978c-41c3-9a21-da931857739c',
+                correction,
+                passage,
+              });
+              const retryElementStub = sinon.stub();
+
+              this.set('grain', grain);
+              this.set('passage', passage);
+              this.set('retryElement', retryElementStub);
+
+              // when
+              const screen = await render(hbs`
+                <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}}  />`);
+
+              await clickByName(this.intl.t('pages.modulix.buttons.stepper.next'));
+
+              // then
+              assert
+                .dom(screen.getByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.continue') }))
+                .exists();
+            });
+          });
+        });
+      });
+    });
   });
 });

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -428,4 +428,78 @@ module('Integration | Component | Module | Passage', function (hooks) {
       assert.ok(true);
     });
   });
+
+  module('when there is no more grain to display', function () {
+    test('should display the terminate button', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const element = { type: 'text', isAnswerable: false };
+      const grain = store.createRecord('grain', { title: 'Grain title', components: [{ type: 'element', element }] });
+
+      const module = store.createRecord('module', { title: 'Module title', grains: [grain], transitionTexts: [] });
+      const passage = store.createRecord('passage');
+
+      // when
+      const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
+
+      // then
+      assert.dom(screen.getByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.terminate') })).exists();
+    });
+
+    module('when there is an answerable element', function () {
+      module('and it is not answered', function () {
+        test('should display the terminate button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const qcuElement = {
+            instruction: 'instruction',
+            proposals: ['radio1', 'radio2'],
+            type: 'qcu',
+          };
+          const grain = store.createRecord('grain', {
+            title: 'Grain title',
+            components: [{ type: 'element', element: qcuElement }],
+          });
+
+          const module = store.createRecord('module', { title: 'Module title', grains: [grain], transitionTexts: [] });
+          const passage = store.createRecord('passage');
+
+          // when
+          const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
+
+          // then
+          assert
+            .dom(screen.getByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.terminate') }))
+            .exists();
+        });
+      });
+
+      module('and it answered', function () {
+        test('should display the terminate button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const qcuElement = {
+            instruction: 'instruction',
+            proposals: ['radio1', 'radio2'],
+            type: 'qcu',
+          };
+          const grain = store.createRecord('grain', {
+            title: 'Grain title',
+            components: [{ type: 'element', element: qcuElement }],
+          });
+
+          const module = store.createRecord('module', { title: 'Module title', grains: [grain], transitionTexts: [] });
+          const passage = store.createRecord('passage');
+
+          // when
+          const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
+
+          // then
+          assert
+            .dom(screen.getByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.terminate') }))
+            .exists();
+        });
+      });
+    });
+  });
 });

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -501,5 +501,60 @@ module('Integration | Component | Module | Passage', function (hooks) {
         });
       });
     });
+
+    module('when there is a stepper', function () {
+      module('when it is not finished', function () {
+        test('should display the terminate button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const textElement = { type: 'text', isAnswerable: false };
+          const qcuElement = {
+            instruction: 'instruction',
+            proposals: ['radio1', 'radio2'],
+            type: 'qcu',
+          };
+          const grain = store.createRecord('grain', {
+            title: 'Grain title',
+            components: [{ type: 'stepper', steps: [{ elements: [textElement] }, { elements: [qcuElement] }] }],
+          });
+
+          const module = store.createRecord('module', { title: 'Module title', grains: [grain], transitionTexts: [] });
+          const passage = store.createRecord('passage');
+
+          // when
+          const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
+
+          // then
+          assert
+            .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.terminate') }))
+            .exists();
+        });
+      });
+
+      module('when it is finished', function () {
+        test('should display the terminate button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const text1Element = { type: 'text', isAnswerable: false };
+          const text2Element = { type: 'text', isAnswerable: false };
+          const grain = store.createRecord('grain', {
+            title: 'Grain title',
+            components: [{ type: 'stepper', steps: [{ elements: [text1Element] }, { elements: [text2Element] }] }],
+          });
+
+          const module = store.createRecord('module', { title: 'Module title', grains: [grain], transitionTexts: [] });
+          const passage = store.createRecord('passage');
+
+          // when
+          const screen = await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
+          await clickByName(this.intl.t('pages.modulix.buttons.stepper.next'));
+
+          // then
+          assert
+            .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.terminate') }))
+            .exists();
+        });
+      });
+    });
   });
 });

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -466,7 +466,12 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             ],
           },
         ];
-        const screen = await render(<template><ModulixStepper @steps={{steps}} /></template>);
+
+        function stepperIsFinished() {}
+
+        const screen = await render(
+          <template><ModulixStepper @steps={{steps}} @stepperIsFinished={{stepperIsFinished}} /></template>,
+        );
 
         // when
         await clickByName(this.intl.t('pages.modulix.buttons.stepper.next'));
@@ -497,7 +502,12 @@ module('Integration | Component | Module | Stepper', function (hooks) {
             ],
           },
         ];
-        const screen = await render(<template><ModulixStepper @steps={{steps}} /></template>);
+
+        function stepperIsFinished() {}
+
+        const screen = await render(
+          <template><ModulixStepper @steps={{steps}} @stepperIsFinished={{stepperIsFinished}} /></template>,
+        );
 
         // when
         await clickByName(this.intl.t('pages.modulix.buttons.stepper.next'));


### PR DESCRIPTION
## :unicorn: Problème
Avec l'arrivée du Stepper, de nouvelles règles métiers se mettent en place concernant l'affichage des boutons `Suivant`, `Continuer` et `Terminer` orchestrés par le Grain. 

## :robot: Proposition

1. Ajouter différents exemples de stepper dans le module `didacticiel-modulix`.
2. Mettre à jour le `element-repository` pour retourner des éléments au sein d'un stepper
3. Passer en props les actions permettant d'afficher les boutons `Vérifier` et `Réessayer` du Stepper au Steps
4. Puis les passer du Grain au Stepper
5. Ajouter la gestion de l'affichage des boutons `Continuer` et `Suivant` lorsqu'il n'y a que des éléments non répondables _(Texte, Image, Video)_ dans les steps d'un stepper
6. Ensuite, ajouter cette gestion dans le cas où il y des éléments répondables _(QCU, QCM, QROCM)_ dans les steps d'un stepper

C'est le Stepper qui prévient le Grain quand il est finis, lorsque la dernière step a été affiché.

## :rainbow: Remarques
La gestion des boutons `Continuer` et `Passer` se fait actuellement dans le grain, mais elle doit prendre en compte le cas des composants de type `element` et celui des composants de type `stepper` ce qui alourdit énormément la logique du grain. Ça le rend moins stable. On se questionne sur le fait d'avoir une étape intermédiaire où mettre cette logique liée aux composants.

## :100: Pour tester
Se rendre sur [module `didacticiel-modulix`](https://app-pr9325.review.pix.fr/modules/didacticiel-modulix/details) et vérifier l'affichage cohérent des boutons `Passer`, `Continuer` et `Terminer` de chaque grain et de chaque étapes des Steppers.
