### PR TITLE
[FEATURE] Afficher les erreurs front lors d'un probleme d'acces à une certification (PIX-13218).

### DIFF
--- a/mon-pix/app/components/certification-starter.hbs
+++ b/mon-pix/app/components/certification-starter.hbs
@@ -51,7 +51,15 @@
         spellcheck={{false}}
       />
       {{#if this.errorMessage}}
-        <div class="certification-start-page__errors">{{this.errorMessage}}</div>
+        <div class="certification-start-page__information">
+          <p class="certification-start-page__information--error">{{this.errorMessage}}</p>
+          {{#if this.technicalErrorInfo}}
+            <details>
+              <summary>{{t "pages.certification-start.error-messages.unknown.summary-label"}}</summary>
+              <p>{{this.technicalErrorInfo}}</p>
+            </details>
+          {{/if}}
+        </div>
       {{/if}}
     </div>
 

--- a/mon-pix/app/components/certification-starter.js
+++ b/mon-pix/app/components/certification-starter.js
@@ -13,6 +13,7 @@ export default class CertificationJoiner extends Component {
 
   @tracked inputAccessCode = '';
   @tracked errorMessage = null;
+  @tracked technicalErrorInfo = '';
   @tracked classNames = [];
   @tracked certificationCourse = null;
 
@@ -38,15 +39,15 @@ export default class CertificationJoiner extends Component {
       this.focusedCertificationChallengeWarningManager.reset();
       this.router.replaceWith('authenticated.certifications.resume', newCertificationCourse.id);
       this.windowPostMessage.startCertification();
-    } catch (err) {
+    } catch (error) {
       newCertificationCourse.deleteRecord();
-      const statusCode = err.errors?.[0]?.status;
+      const statusCode = error.errors?.[0]?.status;
       if (statusCode === '404') {
         this.errorMessage = this.intl.t('pages.certification-start.error-messages.access-code-error');
       } else if (statusCode === '412') {
         this.errorMessage = this.intl.t('pages.certification-start.error-messages.session-not-accessible');
       } else if (statusCode === '403') {
-        const errorCode = err.errors?.[0]?.code;
+        const errorCode = error.errors?.[0]?.code;
         if (errorCode === 'CANDIDATE_NOT_AUTHORIZED_TO_JOIN_SESSION') {
           this.errorMessage = this.intl.t('pages.certification-start.error-messages.candidate-not-authorized-to-start');
         } else if (errorCode === 'CANDIDATE_NOT_AUTHORIZED_TO_RESUME_SESSION') {
@@ -55,6 +56,8 @@ export default class CertificationJoiner extends Component {
           );
         }
       } else {
+        // This should not happen, but in case it does, let give as much info as possible
+        this.technicalErrorInfo = `${error.message} ${error.stack}`;
         this.errorMessage = this.intl.t('pages.certification-start.error-messages.generic');
       }
     }

--- a/mon-pix/app/styles/components/_certification-starter.scss
+++ b/mon-pix/app/styles/components/_certification-starter.scss
@@ -19,24 +19,21 @@
     }
   }
 
-  &__errors {
-    margin: 5px;
-    color: $pix-warning-60;
-    font-size: 0.875rem;
-    text-align: start;
+  &__information {
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-3x);
+    align-items: center;
+    margin-top: var(--pix-spacing-3x);
 
-    &__list {
-      li {
-        margin: 8px 0 0 16px;
-        text-align: start;
-        list-style: disc;
-      }
+    @extend %pix-body-s;
+
+    &--error {
+      color: var(--pix-error-500);
     }
 
-    a,
-    a:visited {
-      color: $pix-warning-60;
-      text-decoration: underline;
+    details {
+      text-align: center;
     }
   }
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -601,7 +601,10 @@
         "candidate-not-authorized-to-resume": "Please contact your invigilator to resume your certification test.",
         "candidate-not-authorized-to-start": "Your invigilator has not confirmed your presence in the test room. Therefore, you cannot start your certification test yet. Please inform your invigilator.",
         "generic": "An unexpected server error has occurred.",
-        "session-not-accessible": "The certification session is no longer available."
+        "session-not-accessible": "The certification session is no longer available.",
+        "unknown": {
+          "summary-label": "Show more details:"
+        }
       },
       "first-title": "You are about to begin your certification test.",
       "link-to-user-certification": "See my certificates",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -600,7 +600,10 @@
         "candidate-not-authorized-to-resume": "Ponte en contacto con el supervisor para que autorice la reanudación de tu examen.",
         "candidate-not-authorized-to-start": "El supervisor no ha confirmado tu presencia en la sala de prueba. Por lo tanto, aún no puedes empezar la prueba de certificación. Por favor, informa al supervisor.",
         "generic": "Acaba de producirse un error inesperado en el servidor.",
-        "session-not-accessible": "La sesión de certificación ya no está disponible."
+        "session-not-accessible": "La sesión de certificación ya no está disponible.",
+        "unknown": {
+          "summary-label": "Afficher plus de détails :"
+        }
       },
       "first-title": "Estás a punto de empezar tu prueba de certificación",
       "link-to-user-certification": "Ver mis certificaciones",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -601,7 +601,10 @@
         "candidate-not-authorized-to-resume": "Merci de contacter votre surveillant afin qu'il autorise la reprise de votre test.",
         "candidate-not-authorized-to-start": "Votre surveillant n’a pas confirmé votre présence dans la salle de test. Vous ne pouvez donc pas encore commencer votre test de certification. Merci de prévenir votre surveillant.",
         "generic": "Une erreur serveur inattendue vient de se produire.",
-        "session-not-accessible": "La session de certification n'est plus accessible."
+        "session-not-accessible": "La session de certification n'est plus accessible.",
+        "unknown": {
+          "summary-label": "Afficher plus de détails :"
+        }
       },
       "first-title": "Vous allez commencer votre test de certification",
       "link-to-user-certification": "Voir mes certifications",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -600,7 +600,10 @@
         "candidate-not-authorized-to-resume": "Neem contact op met je surveillant om toestemming te vragen om je toets te hervatten.",
         "candidate-not-authorized-to-start": "Je surveillant heeft je aanwezigheid in de testruimte nog niet bevestigd. Je kunt daarom nog niet beginnen met je certificeringstoets. Stel je surveillant hiervan op de hoogte.",
         "generic": "Er is zojuist een onverwachte serverfout opgetreden.",
-        "session-not-accessible": "De certificeringssessie is niet langer toegankelijk."
+        "session-not-accessible": "De certificeringssessie is niet langer toegankelijk.",
+        "unknown": {
+          "summary-label": "Afficher plus de détails :"
+        }
       },
       "first-title": "Je staat op het punt om aan je certificeringstest te beginnen",
       "link-to-user-certification": "Bekijk mijn certificaten",


### PR DESCRIPTION
## :unicorn: Problème
On nous a plusieurs fois signalé une erreur front lors de l'accès a une certification que nous n'arrivons pas à reproduire

## :robot: Proposition
Permettre à l'utilisateur d'acceder au message d'erreur pour pouvoir nous le transferer facilement s'il/elle le souhaite)

## :100: Pour tester
- Se connecter sur Pix App avec certif-success@example.net
- Entrer en certification
- Sur la page du code candidat, ouvrir la console et mettre le network en offline (simulation 500)
- Entrer un code bidon et constater le message suivant : 

<img width="868" alt="Capture d’écran 2024-07-01 à 17 23 11" src="https://github.com/1024pix/pix/assets/58915422/44f7042f-b493-4473-9686-d3ff47e44d44">
