### PR TITLE
[FEATURE] Utiliser les tokens de texte sur la page d'erreur surveillant sur Pix Certif (PIX-11587).

### DIFF
--- a/certif/app/styles/pages/session-supervising-error.scss
+++ b/certif/app/styles/pages/session-supervising-error.scss
@@ -26,18 +26,14 @@
   }
 
   &__title {
-    color: var(--pix-neutral-800);
-
     @extend %pix-title-s;
-
-    font-weight: normal;
   }
 
   &__subtitle {
-    margin: 8px 0;
-    color: var(--pix-neutral-500);
-    font-weight: normal;
-    font-size: 0.8rem;
+    margin: var(--pix-spacing-2x) 0;
+
+    @extend %pix-body-s;
+
     text-align: center;
   }
 

--- a/certif/app/styles/pages/session-supervising-error.scss
+++ b/certif/app/styles/pages/session-supervising-error.scss
@@ -6,7 +6,7 @@
   height: 100px;
   min-height: 100vh;
   background: $pix-primary-certif-gradient;
-  box-shadow: 0 2px 8px 0 rgb(0 0 0 / 10%);
+  box-shadow: 0 2px var(--pix-spacing-2x) 0 rgb(0 0 0 / 10%);
 }
 
 .session-supervising-error-page__panel {
@@ -15,8 +15,8 @@
   align-items: center;
   box-sizing: border-box;
   max-width: 463px;
-  margin: auto 8px;
-  padding: 32px 8px 16px;
+  margin: auto var(--pix-spacing-2x);
+  padding: var(--pix-spacing-8x) var(--pix-spacing-2x) var(--pix-spacing-4x);
   background-color: var(--pix-neutral-0);
   border-radius: 10px;
 
@@ -38,6 +38,6 @@
   }
 
   &__button {
-    margin-top: 16px;
+    margin-top: var(--pix-spacing-4x);
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Actuellement la page d'erreur surveillant sur Pix Certif n'utilise pas les tokens de texte de Pix UI

## :robot: Proposition
Les utiliser.
Pour le texte : pix-body-s
Le titre utilisait déjà le token mais on surchargeait une couleur et une font-weight.

## :100: Pour tester

- Se connecter sur certif avec certif-pro@example.net
- Aller sur l'espace surveillant et remplir les infos de n'importe quelle session
- Se connecter
- Dans l'url, changer l'id par un bidon
- Constater le avant après

<img width="992" alt="Capture d’écran 2024-06-20 à 14 52 35" src="https://github.com/1024pix/pix/assets/58915422/8a6d2e74-54d2-429a-a412-4521d3df28f8">
<img width="992" alt="Capture d’écran 2024-06-20 à 15 02 37" src="https://github.com/1024pix/pix/assets/58915422/c53ad53f-3982-41d2-ae32-f99646289d9d">
