### PR TITLE
[FEATURE] Anonymize GAR import (PIX-12809)

### DIFF
--- a/admin/app/components/administration/anonymize-gar-import.hbs
+++ b/admin/app/components/administration/anonymize-gar-import.hbs
@@ -1,0 +1,10 @@
+<section class="page-section">
+  <header class="page-section__header">
+    <h2 class="page-section__title">{{t "components.administration.anonymize-gar-import.title"}}</h2>
+  </header>
+  <p>{{t "components.administration.anonymize-gar-import.description"}}</p>
+  <br />
+  <PixButtonUpload @id="anonymize-gar-upload" @onChange={{this.anonymizeGar}} @variant="secondary" accept=".csv">
+    {{t "components.administration.anonymize-gar-import.upload-button"}}
+  </PixButtonUpload>
+</section>

--- a/admin/app/components/administration/anonymize-gar-import.hbs
+++ b/admin/app/components/administration/anonymize-gar-import.hbs
@@ -2,9 +2,21 @@
   <header class="page-section__header">
     <h2 class="page-section__title">{{t "components.administration.anonymize-gar-import.title"}}</h2>
   </header>
+
   <p>{{t "components.administration.anonymize-gar-import.description"}}</p>
   <br />
-  <PixButtonUpload @id="anonymize-gar-upload" @onChange={{this.anonymizeGar}} @variant="secondary" accept=".csv">
-    {{t "components.administration.anonymize-gar-import.upload-button"}}
+
+  <PixButtonUpload
+    @id="anonymize-gar-upload"
+    @onChange={{this.anonymizeGar}}
+    @variant="secondary"
+    disabled={{this.isLoading}}
+    accept=".csv"
+  >
+    {{#if this.isLoading}}
+      {{t "common.forms.loading"}}
+    {{else}}
+      {{t "components.administration.anonymize-gar-import.upload-button"}}
+    {{/if}}
   </PixButtonUpload>
 </section>

--- a/admin/app/components/administration/anonymize-gar-import.js
+++ b/admin/app/components/administration/anonymize-gar-import.js
@@ -1,0 +1,61 @@
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import ENV from 'pix-admin/config/environment';
+
+export default class AnonymizeGarImport extends Component {
+  @service intl;
+  @service notifications;
+  @service session;
+
+  @action
+  async anonymizeGar(files) {
+    this.notifications.clearAll();
+
+    try {
+      const token = this.session.data.authenticated.access_token;
+
+      const response = await window.fetch(`${ENV.APP.API_HOST}/api/admin/anonymize/gar`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'text/csv',
+          Accept: 'application/json',
+        },
+        method: 'POST',
+        body: files[0],
+      });
+
+      const json = await response.json();
+
+      if (response.ok) {
+        const { anonymized, total } = json.data.attributes;
+
+        if (anonymized === total) {
+          return this.notifications.success(
+            this.intl.t('components.administration.anonymize-gar-import.notifications.success.full', { anonymized }),
+          );
+        }
+
+        return this.notifications.warning(
+          this.intl.t('components.administration.anonymize-gar-import.notifications.success.partial', {
+            anonymized,
+            total,
+          }),
+        );
+      }
+
+      const error = json.errors[0];
+      if (error.code === 'PAYLOAD_TOO_LARGE') {
+        return this.notifications.error(
+          this.intl.t('components.administration.anonymize-gar-import.notifications.error.payload-too-large', {
+            maxSize: error.meta.maxSize,
+          }),
+        );
+      }
+
+      this.errorResponseHandler.notify(await response.json());
+    } catch (error) {
+      this.notifications.error(this.intl.t('common.notifications.generic-error'));
+    }
+  }
+}

--- a/admin/app/components/administration/anonymize-gar-import.js
+++ b/admin/app/components/administration/anonymize-gar-import.js
@@ -1,6 +1,7 @@
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import ENV from 'pix-admin/config/environment';
 
 export default class AnonymizeGarImport extends Component {
@@ -8,8 +9,11 @@ export default class AnonymizeGarImport extends Component {
   @service notifications;
   @service session;
 
+  @tracked isLoading = false;
+
   @action
   async anonymizeGar(files) {
+    this.isLoading = true;
     this.notifications.clearAll();
 
     try {
@@ -56,6 +60,8 @@ export default class AnonymizeGarImport extends Component {
       this.errorResponseHandler.notify(await response.json());
     } catch (error) {
       this.notifications.error(this.intl.t('common.notifications.generic-error'));
+    } finally {
+      this.isLoading = false;
     }
   }
 }

--- a/admin/app/templates/authenticated/administration.hbs
+++ b/admin/app/templates/authenticated/administration.hbs
@@ -24,6 +24,8 @@
     <Administration::UpdateCampaignCode />
 
     <Administration::OidcProvidersImport />
+
+    <Administration::AnonymizeGarImport />
   </main>
 
 </div>

--- a/admin/tests/integration/components/administration/anonymize-gar-import_test.js
+++ b/admin/tests/integration/components/administration/anonymize-gar-import_test.js
@@ -1,0 +1,157 @@
+import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import { triggerEvent } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+const accessToken = 'An access token';
+const fileContent = 'foo';
+const file = new Blob([fileContent], { type: `valid-file` });
+
+module('Integration | Component |  administration/anonymize-gar-import', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    class SessionService extends Service {
+      data = { authenticated: { access_token: accessToken } };
+    }
+    this.owner.register('service:session', SessionService);
+    sinon.stub(window, 'fetch');
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
+  module('when import fully succeeds', function () {
+    test('it displays a success notification', async function (assert) {
+      // given
+      window.fetch.resolves(
+        fetchMock({
+          status: 200,
+          body: {
+            data: {
+              type: 'anonymize-gar-results',
+              attributes: {
+                anonymized: 10,
+                total: 10,
+              },
+            },
+          },
+        }),
+      );
+
+      // when
+      const screen = await render(hbs`<Administration::AnonymizeGarImport /><NotificationContainer />`);
+      const input = await screen.getByLabelText(
+        this.intl.t('components.administration.anonymize-gar-import.upload-button'),
+      );
+      await triggerEvent(input, 'change', { files: [file] });
+
+      // then
+      assert.ok(
+        await screen.findByText(
+          this.intl.t('components.administration.anonymize-gar-import.notifications.success.full', { anonymized: 10 }),
+        ),
+      );
+    });
+  });
+
+  module('when import partially succeeds', function () {
+    test('it displays a warning notification', async function (assert) {
+      // given
+      window.fetch.resolves(
+        fetchMock({
+          status: 200,
+          body: {
+            data: {
+              type: 'anonymize-gar-results',
+              attributes: {
+                anonymized: 5,
+                total: 10,
+              },
+            },
+          },
+        }),
+      );
+
+      // when
+      const screen = await render(hbs`<Administration::AnonymizeGarImport /><NotificationContainer />`);
+      const input = await screen.getByLabelText(
+        this.intl.t('components.administration.anonymize-gar-import.upload-button'),
+      );
+      await triggerEvent(input, 'change', { files: [file] });
+
+      // then
+      assert.ok(
+        await screen.findByText(
+          this.intl.t('components.administration.anonymize-gar-import.notifications.success.partial', {
+            anonymized: 5,
+            total: 10,
+          }),
+        ),
+      );
+    });
+  });
+
+  module('when import fails', function () {
+    module('when file is too large', function () {
+      test('it displays an error notification', async function (assert) {
+        // given
+        window.fetch.resolves(
+          fetchMock({
+            body: {
+              errors: [{ code: 'PAYLOAD_TOO_LARGE', meta: { maxSize: '20' } }],
+            },
+            status: 413,
+          }),
+        );
+
+        // when
+        const screen = await render(hbs`<Administration::AnonymizeGarImport /><NotificationContainer />`);
+        const input = await screen.findByLabelText(
+          this.intl.t('components.administration.anonymize-gar-import.upload-button'),
+        );
+        await triggerEvent(input, 'change', { files: [file] });
+
+        // then
+        assert.ok(
+          await screen.findByText(
+            this.intl.t('components.administration.anonymize-gar-import.notifications.error.payload-too-large', {
+              maxSize: 20,
+            }),
+          ),
+        );
+      });
+    });
+
+    module('when file an unexpected error happens', function () {
+      test('it displays an error notification', async function (assert) {
+        // given
+        window.fetch.resolves(fetchMock({ status: 500 }));
+
+        // when
+        const screen = await render(hbs`<Administration::AnonymizeGarImport /><NotificationContainer />`);
+        const input = await screen.findByLabelText(
+          this.intl.t('components.administration.anonymize-gar-import.upload-button'),
+        );
+        await triggerEvent(input, 'change', { files: [file] });
+
+        // then
+        assert.ok(await screen.findByText(this.intl.t('common.notifications.generic-error')));
+      });
+    });
+  });
+});
+
+function fetchMock({ body, status }) {
+  return new window.Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-type': 'application/json',
+    },
+  });
+}

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -16,7 +16,8 @@
       "login-user-temporary-blocked-error": "You have reached too many failed login attempts. Please try again later or '<'a href=\"{url}\"'>'reset your password here'</a>'."
     },
     "forms": {
-      "mandatory-fields": "The fields marked '<abbr title=\"required\" class=\"mandatory-mark\">'*'</abbr>' are required"
+      "mandatory-fields": "The fields marked '<abbr title=\"required\" class=\"mandatory-mark\">'*'</abbr>' are required",
+      "loading": "Loading..."
     },
     "notifications": {
       "generic-error": "An error occurred."
@@ -40,6 +41,20 @@
           "success": "Features have been enabled."
         },
         "upload-button": "Import CSV file"
+      },
+      "anonymize-gar-import": {
+        "title": "Anonymize GAR Data",
+        "description": "Note: Anonymization should be done once a year. Provide the list of user IDs to be anonymized.",
+        "notifications": {
+          "error": {
+            "payload-too-large": "The CSV file must be a maximum size of {maxSize}Mb."
+          },
+          "success": {
+            "full": "All GAR data has been successfully anonymized for the {anonymized} users provided.",
+            "partial": "GAR data has been anonymized for {anonymized} users for a total of {total}."
+          }
+        },
+        "upload-button": "Anonymize from a CSV file"
       },
       "oidc-providers-import": {
         "title": "OIDC Providers import",

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -16,8 +16,8 @@
       "login-user-temporary-blocked-error": "You have reached too many failed login attempts. Please try again later or '<'a href=\"{url}\"'>'reset your password here'</a>'."
     },
     "forms": {
-      "mandatory-fields": "The fields marked '<abbr title=\"required\" class=\"mandatory-mark\">'*'</abbr>' are required",
-      "loading": "Loading..."
+      "loading": "Loading...",
+      "mandatory-fields": "The fields marked '<abbr title=\"required\" class=\"mandatory-mark\">'*'</abbr>' are required"
     },
     "notifications": {
       "generic-error": "An error occurred."

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -16,7 +16,8 @@
       "login-user-temporary-blocked-error": "Vous avez effectué trop de tentatives de connexion. Réessayez plus tard ou cliquez sur '<'a href=\"{url}\"'>'mot de passe oublié'</a>' pour le réinitialiser."
     },
     "forms": {
-      "mandatory-fields": "Les champs marqués de '<abbr title=\"obligatoire\" class=\"mandatory-mark\">'*'</abbr>' sont obligatoires"
+      "mandatory-fields": "Les champs marqués de '<abbr title=\"obligatoire\" class=\"mandatory-mark\">'*'</abbr>' sont obligatoires",
+      "loading": "Chargement..."
     },
     "notifications": {
       "generic-error": "Une erreur est survenue."
@@ -40,6 +41,20 @@
           "success": "Les fonctionnalités ont bien été activés."
         },
         "upload-button": "Importer un fichier CSV"
+      },
+      "anonymize-gar-import": {
+        "title": "Anonymiser les données du GAR",
+        "description": "Note: Anonymisation à effectuer 1 fois par an. Fournir la liste des identifiants utilisateurs à anonymiser.",
+        "notifications": {
+          "error": {
+            "payload-too-large": "Le fichier CSV doit avoir une taille maximum de {maxSize}Mb."
+          },
+          "success": {
+            "full": "Toutes les données du GAR ont bien été anonymisés pour les {anonymized} utilisateurs fournis.",
+            "partial": "Les données du GAR ont été anonymisés pour {anonymized} utilisateurs sur un total de {total}."
+          }
+        },
+        "upload-button": "Anonymiser à partir d'un fichier CSV"
       },
       "campaigns-import": {
         "title": "Création de campagnes en masse",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -16,8 +16,8 @@
       "login-user-temporary-blocked-error": "Vous avez effectué trop de tentatives de connexion. Réessayez plus tard ou cliquez sur '<'a href=\"{url}\"'>'mot de passe oublié'</a>' pour le réinitialiser."
     },
     "forms": {
-      "mandatory-fields": "Les champs marqués de '<abbr title=\"obligatoire\" class=\"mandatory-mark\">'*'</abbr>' sont obligatoires",
-      "loading": "Chargement..."
+      "loading": "Chargement...",
+      "mandatory-fields": "Les champs marqués de '<abbr title=\"obligatoire\" class=\"mandatory-mark\">'*'</abbr>' sont obligatoires"
     },
     "notifications": {
       "generic-error": "Une erreur est survenue."


### PR DESCRIPTION
## :unicorn: Problème

La route d'anonymisation des données du GAR par fichier CSV a été créée. Il faut maintenant un formulaire dans l'interface d'admin pour importer le fichier et avoir les retours de l'import.

## :robot: Proposition

Créer un formulaire dans "Admin" > "Administration"

<img width="950" alt="image" src="https://github.com/1024pix/pix/assets/516360/07d6a53f-a602-4f0a-8b2c-51c47ef061e2">


## :rainbow: Remarques

N/A

## :100: Pour tester

1. Se connecter en super admin sur Pix Admin
2. Aller sur "Administration" > "Anonymiser les données du GAR"
3. Importer un fichier CSV avec des IDs:
```
User ID
101576
101579
991919
```

ℹ️ Vous pouvez retrouver des identifiants utilisateurs à anonymiser avec cette requête:
```sql
select * from "authentication-methods" where "identityProvider" = 'GAR';
```


