### PR TITLE
[FEATURE] Mettre à jour le lien d'aide des épreuves avec téléchargement (PIX-13078).

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -820,7 +820,7 @@
           },
           "description": "Pix lets you choose which format of file to download. If you do not know which option to use, select the default option. This is the file format that is the most commonly used.",
           "file-type": "file .{fileExtension}",
-          "help": "Need help to '<a href=\"https://support.pix.org/en/support/solutions/articles/15000036390\" class=\"challenge-statement__action-help--link\" target=\"_blank\" aria-label=\"open, edit or find this file (opens in new window)\">'open, edit or find this file'</a>'?"
+          "help": "Need help to '<a href=\"https://pix.org/en/help-how-to-open-modify-find-a-downloaded-file-in-a-pix-question\" class=\"challenge-statement__action-help--link\" target=\"_blank\" aria-label=\"open, edit or find this file (opens in new window)\">'open, edit or find this file'</a>'?"
         },
         "sr-only": {
           "alternative-instruction": "This question contains an illustration with a text alternative.",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -814,7 +814,7 @@
           },
           "description": "Pix te permite elegir el formato del archivo que deseas descargar. Si no sabes qué opción elegir, quédate con la opción por defecto. Este es el formato de archivo admitido por el mayor número de aplicaciones de software.",
           "file-type": "archivo .{fileExtension}",
-          "help": "¿Necesitas ayuda con '<a href=\"https://support.pix.org/fr/support/solutions/articles/15000036390\" class=\"challenge-statement__action-help--link\" target=\"_blank\" aria-label=\"abrir, modificar o encontrar este archivo (abrir en una nueva ventana)\">'abrir, modificar o encontrar este archivo'</a>'?"
+          "help": "¿Necesitas ayuda con '<a href=\"https://pix.org/en/help-how-to-open-modify-find-a-downloaded-file-in-a-pix-question\" class=\"challenge-statement__action-help--link\" target=\"_blank\" aria-label=\"abrir, modificar o encontrar este archivo (abrir en una nueva ventana)\">'abrir, modificar o encontrar este archivo'</a>'?"
         },
         "sr-only": {
           "alternative-instruction": "Esta prueba contiene una ilustración con un texto alternativo.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -820,7 +820,7 @@
           },
           "description": "Pix vous laisse le choix du format de fichier à télécharger. Si vous ne savez pas quelle option retenir, conservez le choix par défaut. Il correspond au format de fichier pris en charge par le plus grand nombre de logiciels.",
           "file-type": "fichier .{fileExtension}",
-          "help": "Besoin d'aide pour '<a href=\"https://support.pix.org/fr/support/solutions/articles/15000036390\" class=\"challenge-statement__action-help--link\" target=\"_blank\" aria-label=\"ouvrir, modifier ou retrouver ce fichier (ouverture dans une nouvelle fenêtre)\">'ouvrir, modifier ou retrouver ce fichier'</a>' ?"
+          "help": "Besoin d'aide pour '<a href=\"https://pix.org/fr/aide-ouvrir-modifier-retrouver-un-fichier-telecharge-depuis-une-question-pix\" class=\"challenge-statement__action-help--link\" target=\"_blank\" aria-label=\"ouvrir, modifier ou retrouver ce fichier (ouverture dans une nouvelle fenêtre)\">'ouvrir, modifier ou retrouver ce fichier'</a>' ?"
         },
         "sr-only": {
           "alternative-instruction": "Cette épreuve contient une illustration avec une alternative textuelle.",


### PR DESCRIPTION
## :unicorn: Problème

Le lien d'aide actuel sur les écrans d'épreuve avec téléchargement pointe vers l'ancien site du support.

## :robot: Proposition

Mettre à jour ces liens vers les nouvelles pages d'aide, en fonction de la locale :
- Pour les versions francophones : le lien est `https://pix.org/fr/aide-ouvrir-modifier-retrouver-un-fichier-telecharge-depuis-une-question-pix`
- Pour `en` et `es` : le lien est `https://pix.org/en/help-how-to-open-modify-find-a-downloaded-file-in-a-pix-question`
- Pour `nl`, le lien était déjà ok

## :100: Pour tester

- Test possible sur une épreuve FR : https://app-pr9330.review.pix.fr/challenges/recXMLEokPmm3RT6O/preview
- Version EN : https://app-pr9330.review.pix.org/challenges/recXMLEokPmm3RT6O/preview?lang=en
- Version ES (renvoie vers une page anglaise) : https://app-pr9330.review.pix.org/challenges/recXMLEokPmm3RT6O/preview?lang=es
- Version NL : https://app-pr9330.review.pix.org/challenges/recXMLEokPmm3RT6O/preview?lang=nl
- Vérifier les fichiers de traduction.
