### PR TITLE
[BUGFIX] Corriger la création de campagne en masse via PixAdmin (PIX-13073)

### DIFF
--- a/api/db/migrations/20240620134506_replace-empty-string-by-null-in-idPixLabel-on-campaigns.js
+++ b/api/db/migrations/20240620134506_replace-empty-string-by-null-in-idPixLabel-on-campaigns.js
@@ -1,0 +1,23 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/DEV/pages/2153512965/Cr+er+une+migration
+
+// If your migrations target `answers` or `knowledge-elements`
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+const TABLE_NAME = 'campaigns';
+const COLUMN_NAME = 'idPixLabel';
+
+const up = async function (knex) {
+  await knex(TABLE_NAME)
+    .update({ [COLUMN_NAME]: null })
+    .where(COLUMN_NAME, '');
+};
+
+const down = async function () {
+  // no down, because we cant rollback
+};
+
+export { down, up };

--- a/api/src/prescription/campaign/domain/models/CampaignForCreation.js
+++ b/api/src/prescription/campaign/domain/models/CampaignForCreation.js
@@ -19,7 +19,7 @@ class CampaignForCreation {
   } = {}) {
     this.name = name;
     this.title = title;
-    this.idPixLabel = idPixLabel;
+    this.idPixLabel = idPixLabel === '' ? null : idPixLabel;
     this.customLandingPageText = customLandingPageText;
     this.type = type;
     this.targetProfileId = targetProfileId;

--- a/api/tests/integration/migration/20240620134506_replace-empty-string-by-null-in-idPixLabel-on-campaigns_test.js
+++ b/api/tests/integration/migration/20240620134506_replace-empty-string-by-null-in-idPixLabel-on-campaigns_test.js
@@ -1,0 +1,34 @@
+import { up as migrationToTest } from '../../../db/migrations/20240620134506_replace-empty-string-by-null-in-idPixLabel-on-campaigns.js';
+import { databaseBuilder, expect, knex } from '../../test-helper.js';
+
+describe('Integration | Migration | replace-empty-string-by-null-in-idPixLabel-on-campaigns', function () {
+  it('should replace empty string by null in idPixLabel', async function () {
+    // given
+    const campaignId = databaseBuilder.factory.buildCampaign({ idPixLabel: '' }).id;
+
+    await databaseBuilder.commit();
+
+    // when
+    await migrationToTest(knex);
+
+    // then
+    const patchedCampaign = await knex('campaigns').where('id', campaignId).first();
+
+    expect(patchedCampaign.idPixLabel).to.be.null;
+  });
+
+  it('should not replace by null exisiting idPixLabel', async function () {
+    // given
+    const campaignId = databaseBuilder.factory.buildCampaign({ idPixLabel: 'Pat Pas Trouille' }).id;
+
+    await databaseBuilder.commit();
+
+    // when
+    await migrationToTest(knex);
+
+    // then
+    const patchedCampaign = await knex('campaigns').where('id', campaignId).first();
+
+    expect(patchedCampaign.idPixLabel).to.equal('Pat Pas Trouille');
+  });
+});

--- a/api/tests/prescription/campaign/unit/domain/models/CampaignForCreation_test.js
+++ b/api/tests/prescription/campaign/unit/domain/models/CampaignForCreation_test.js
@@ -280,5 +280,51 @@ describe('Unit | Domain | Models | CampaignForCreation', function () {
         expect(error.invalidAttributes).to.deep.equal([{ attribute: 'type', message: 'CAMPAIGN_PURPOSE_IS_REQUIRED' }]);
       });
     });
+
+    context('idPixLabel', function () {
+      context('when it is empty string', function () {
+        it('should save null instead of empty string', function () {
+          const attributes = {
+            name: 'CampaignName',
+            type: CampaignTypes.ASSESSMENT,
+            targetProfileId: 1,
+            creatorId: 2,
+            ownerId: 2,
+            organizationId: 3,
+            title: '',
+            idPixLabel: '',
+            customLandingPageText: '',
+            customResultPageButtonText: null,
+            customResultPageButtonUrl: null,
+          };
+
+          const campaignForCreation = new CampaignForCreation(attributes);
+
+          expect(campaignForCreation.idPixLabel).to.be.null;
+        });
+      });
+
+      context('when it is fullfilled', function () {
+        it('should save given value', function () {
+          const attributes = {
+            name: 'CampaignName',
+            type: CampaignTypes.ASSESSMENT,
+            targetProfileId: 1,
+            creatorId: 2,
+            ownerId: 2,
+            organizationId: 3,
+            title: '',
+            idPixLabel: 'Mon idPixLabel',
+            customLandingPageText: '',
+            customResultPageButtonText: null,
+            customResultPageButtonUrl: null,
+          };
+
+          const campaignForCreation = new CampaignForCreation(attributes);
+
+          expect(campaignForCreation.idPixLabel).to.equal('Mon idPixLabel');
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Lors de la création en masse de campagne via PixAdmin, si on ne remplit pas dans le .csv le champ IdPixLabel, il prends la valeur `''`.
Ce qui pose problème lors de l'édition d'une campagne via PixOrga ou via PixAdmin, l'API nous renvoyant une 422 : 
![image](https://github.com/1024pix/pix/assets/101280231/fd2f6757-adc4-4fb4-92de-c93e425599cf)


## :robot: Proposition

- Dans le model CampaignForCreation ( qui est utilisé lors de la création en masse ainsi que lors de la création d'une campagne via PixOrga ) on va fixer la valeur de `idPixLabel` soit par `null` si c'est une chaine vide, soit par sa valeur
- Une migration à également été crée pour rattraper toutes les campagnes crées en masse impactées par ce bug

## :rainbow: Remarques
Exemple de csv pour créa en masse : 
```csv 
Identifiant de l'organisation*,Nom de la campagne*,Identifiant du profil cible*,Libellé de l'identifiant externe,Titre du parcours,Descriptif du parcours,Identifiant du propriétaire,Envoi multiple,Identifiant du créateur*,Texte de la page de fin de parcours,Texte du bouton de la page de fin de parcours,URL du bouton de la page de fin de parcours
1006,Test crea en masse fixed,76,,pouet,pouet,1000,FALSE,1000,,,
```

## :100: Pour tester
- Se connecter à PixAdmin
- Faire une création en masse de campagne ( exemple de csv au dessus ) 
- Aller sur la page de l'organisation 1006
- Aller dans l'onglet campagne et aller sur la page de la campagne précedemment crée
- Faire une modification du nom par exemple
- Enregistrer
- Constater que la modif à été prise en compte et qu'il n'y a pas d'erreur
- 🐈‍⬛ 
