### PR TITLE
[BUGFIX] Corriger les infos renvoyées pour les analyses de campagne (PIX-13021)

### DIFF
--- a/api/src/prescription/campaign/infrastructure/repositories/helpers/get-latest-participation-shared-for-one-learner.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/helpers/get-latest-participation-shared-for-one-learner.js
@@ -1,8 +1,21 @@
+/**
+ * @function
+ * @name getLatestParticipationSharedForOneLearner
+ * @param {Knex.QueryBuilder} queryBuilder
+ * @param {string} columnName
+ * @param {number} campaignId
+ * @description
+ * This function is meant to be use as a subquery on the table campaign-participations aliased as "cp"
+ * to get latest campaign participation of an organization learner for given campaignId
+ *
+ * @returns {Knex.QueryBuilder}
+ */
 export const getLatestParticipationSharedForOneLearner = (queryBuilder, columnName, campaignId) =>
   queryBuilder('campaign-participations')
     .select(columnName)
     .orderBy('sharedAt', 'desc')
     .where('organizationLearnerId', queryBuilder.ref('cp.organizationLearnerId'))
     .where({ campaignId })
+    .whereNotNull('sharedAt')
     .limit(1)
     .as(columnName);

--- a/api/src/prescription/campaign/infrastructure/repositories/helpers/get-latest-participation-shared-for-one-learner.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/helpers/get-latest-participation-shared-for-one-learner.js
@@ -1,0 +1,8 @@
+export const getLatestParticipationSharedForOneLearner = (queryBuilder, columnName, campaignId) =>
+  queryBuilder('campaign-participations')
+    .select(columnName)
+    .orderBy('sharedAt', 'desc')
+    .where('organizationLearnerId', queryBuilder.ref('cp.organizationLearnerId'))
+    .where({ campaignId })
+    .limit(1)
+    .as(columnName);

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-collective-result-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-collective-result-repository_test.js
@@ -923,15 +923,18 @@ describe('Integration | Repository | Campaign collective result repository', fun
       context('when there is one participant who shared his participation and try to improve it', function () {
         beforeEach(async function () {
           const { id: userId } = databaseBuilder.factory.buildUser();
+          const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ userId }).id;
           databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
             userId,
+            organizationLearnerId,
             sharedAt: new Date('2020-01-01'),
             isImproved: true,
           });
           databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
             userId,
+            organizationLearnerId,
             sharedAt: new Date('2020-01-04'),
             isImproved: false,
           });

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participations-stats-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-participations-stats-repository_test.js
@@ -203,8 +203,23 @@ describe('Integration | Repository | Campaign Participations Stats', function ()
       it('counts the last participation for each participant', async function () {
         const { id: campaignId } = databaseBuilder.factory.buildCampaign();
         const { id: userId } = databaseBuilder.factory.buildUser();
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId, userId, masteryRate: 0.5, isImproved: true });
-        databaseBuilder.factory.buildCampaignParticipation({ campaignId, userId, masteryRate: 1, isImproved: false });
+        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({ userId }).id;
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          userId,
+          organizationLearnerId,
+          masteryRate: 0.5,
+          isImproved: true,
+          sharedAt: new Date('2021-01-01'),
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          userId,
+          organizationLearnerId,
+          masteryRate: 1,
+          isImproved: false,
+          sharedAt: new Date('2024-03-03'),
+        });
 
         await databaseBuilder.commit();
         const resultDistribution = await campaignParticipationsStatsRepository.countParticipationsByMasteryRate({

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/helpers/get-latest-participation-shared-for-one-learner_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/helpers/get-latest-participation-shared-for-one-learner_test.js
@@ -1,0 +1,42 @@
+import { getLatestParticipationSharedForOneLearner } from '../../../../../../../src/prescription/campaign/infrastructure/repositories/helpers/get-latest-participation-shared-for-one-learner.js';
+import { CampaignParticipationStatuses } from '../../../../../../../src/prescription/shared/domain/constants.js';
+import { databaseBuilder, expect, knex } from '../../../../../../test-helper.js';
+
+describe('Integration | Infrastructure | Repository | Helpers | get-latest-participation-shared-for-one-learner', function () {
+  describe('#getLatestParticipationSharedForOneLearner', function () {
+    it('should retrieve the last participation shared by learner', async function () {
+      const userId = databaseBuilder.factory.buildUser().id;
+      const campaignId = databaseBuilder.factory.buildCampaign({ multipleSendings: true, type: 'ASSESSMENT' }).id;
+      const firstLearnerId = databaseBuilder.factory.buildOrganizationLearner({ userId }).id;
+      databaseBuilder.factory.buildCampaignParticipation({
+        organizationLearnerId: firstLearnerId,
+        campaignId,
+        userId,
+        status: CampaignParticipationStatuses.SHARED,
+        sharedAt: new Date('2023-01-01'),
+        masteryRate: 0.7,
+        isImproved: true,
+      });
+      databaseBuilder.factory.buildCampaignParticipation({
+        organizationLearnerId: firstLearnerId,
+        campaignId,
+        userId,
+        status: CampaignParticipationStatuses.STARTED,
+        sharedAt: new Date('2024-01-01'),
+        masteryRate: 0.1,
+      });
+
+      await databaseBuilder.commit();
+
+      const result = await knex
+        .select(['organizationLearnerId', getLatestParticipationSharedForOneLearner(knex, 'masteryRate', campaignId)])
+        .from('campaign-participations as cp')
+        .where({ campaignId })
+        .groupBy('organizationLearnerId');
+
+      expect(result.length).to.equal(1);
+      expect(result[0].organizationLearnerId).to.equal(firstLearnerId);
+      expect(result[0].masteryRate).to.equal('0.70');
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Depuis qu'on affiche dans PixOrga toutes les participations à une campagne à envoi multiple, on se retrouve avec des petits soucis à plusieurs endroits. 
Si un participant faire une nouvelle participation, alors on se retrouve avec les infos de sa participation en cours, alors que pour les résultats et l'analyse, on veut la dernière partagée
On en a au moins detecter 3 qui sont corriger dans cette PR qui sont : 
L'affichage du résultat moyen dans l'onglet Résultat d'une campagne : 
![image](https://github.com/1024pix/pix/assets/101280231/f84ebd8b-2ac9-43b3-acba-9d351ad8d9de)
L'affichage en dessous de la répartition par résultat : 
![image](https://github.com/1024pix/pix/assets/101280231/2ce73d40-0ccd-4c98-81cb-c3d1b8de8a4e)
Et enfin dans l'onglet Analyse, les %  dans les résultats par compétence
![image](https://github.com/1024pix/pix/assets/101280231/fc6ca809-e40a-4960-b703-6dda061cbd92)

## :robot: Proposition
Dans les différents repositories, supprimer la clause `where isImproved: false` et corriger le comportement pour recuperer quand même la dernière participation partagée, non supprimée par participant.

## :rainbow: Remarques
On a creer une méthode "générique" pour récuperer les informations de la dernière participation partagée pour un learner. Et on utilise cette méthode dans les différents repositories


## :100: Pour tester
- Se connecter à PixOrga
- Creer une campagne d'évaluation à envoi multiple
- Participer à cette campagne avec un learner en répondant au moins bon à une ou deux questions.
- Partager les résultats
- Constater l'affichage correct dans les résultats ainsi que dans l'analyse de la campagne
- Recommencer une participation avec ce même learner sans rien répondre, juste commencer
- Retourner sur PixOrga
- Constater que l'affichage est toujours le même que précedemment, car il prends en compte la derniere participation partagée et non celle en cours
- 🐈‍⬛ 