### PR TITLE
[BUGFIX] Correction wording participation supprimée dans PixAdmin (PIX-13081)

### DIFF
--- a/admin/app/components/campaigns/participations-section.hbs
+++ b/admin/app/components/campaigns/participations-section.hbs
@@ -18,7 +18,7 @@
             <th>Date de début</th>
             <th>Statut</th>
             <th>Date d'envoi</th>
-            <th>Supprimé le</th>
+            <th>Supprimée le</th>
             {{#if this.accessControl.hasAccessToOrganizationActionsScope}}
               {{#if @idPixLabel}}
                 <th>Actions</th>


### PR DESCRIPTION
## :unicorn: Problème
Il manque un "e" à "Supprimé le" au niveau de la liste des participations dans une campagne, dans PixAdmin. 

## :robot: Proposition
Ajouter un "e" 🙃  

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

- Se connecter à PixAdmin
- Vérifier qu'on a bien "Supprimée le" au niveau de la liste des participations d'une campagne
- 🫰 