### PR TITLE
[FEATURE] Mettre à jour les URLs de la page d'accueil du support utilisateur

### DIFF
--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -22,7 +22,7 @@ const PIX_APP_URL_FRENCH_FRANCE = `${config.domain.pixApp + config.domain.tldFr}
 const PIX_APP_CONNECTION_URL_FRENCH_FRANCE = `${PIX_APP_URL_FRENCH_FRANCE}/connexion`;
 const PIX_ORGA_HOME_URL_FRENCH_FRANCE = `${config.domain.pixOrga + config.domain.tldFr}`;
 const PIX_CERTIF_HOME_URL_FRENCH_FRANCE = `${config.domain.pixCertif + config.domain.tldFr}`;
-const HELPDESK_FRENCH_FRANCE = 'https://support.pix.fr';
+const HELPDESK_FRENCH_FRANCE = 'https://pix.fr/support';
 
 // INTERNATIONAL
 const PIX_HOME_NAME_INTERNATIONAL = `pix${config.domain.tldOrg}`;
@@ -41,8 +41,8 @@ const PIX_APP_CONNECTION_URL_INTERNATIONAL = {
   nl: `${PIX_APP_URL_INTERNATIONAL}/connexion/?lang=nl`,
 };
 const PIX_HELPDESK_URL_INTERNATIONAL = {
-  en: 'https://support.pix.org/en/support/home',
-  fr: 'https://support.pix.org',
+  en: 'https://pix.org/en/support',
+  fr: 'https://pix.org/fr/support',
   nl: 'https://pix.org/nl-be/support',
 };
 const translations = {

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -81,7 +81,7 @@ describe('Unit | Service | MailService', function () {
           expect(options.variables).to.include({
             homeName: 'pix.org',
             homeUrl: 'https://pix.org/fr/',
-            helpdeskUrl: 'https://support.pix.org',
+            helpdeskUrl: 'https://pix.org/fr/support',
             displayNationalLogo: false,
             redirectionUrl: 'https://app.pix.org/connexion/?lang=fr',
             ...mainTranslationsMapping.fr['pix-account-creation-email'].params,
@@ -101,7 +101,7 @@ describe('Unit | Service | MailService', function () {
           expect(options.variables).to.include({
             homeName: 'pix.fr',
             homeUrl: 'https://pix.fr',
-            helpdeskUrl: 'https://support.pix.fr',
+            helpdeskUrl: 'https://pix.fr/support',
             displayNationalLogo: true,
             redirectionUrl: 'https://app.pix.fr/connexion',
             ...mainTranslationsMapping.fr['pix-account-creation-email'].params,
@@ -121,7 +121,7 @@ describe('Unit | Service | MailService', function () {
           expect(options.variables).to.include({
             homeName: 'pix.org',
             homeUrl: 'https://pix.org/en-gb/',
-            helpdeskUrl: 'https://support.pix.org/en/support/home',
+            helpdeskUrl: 'https://pix.org/en/support',
             displayNationalLogo: false,
             redirectionUrl: 'https://app.pix.org/connexion/?lang=en',
             ...mainTranslationsMapping.en['pix-account-creation-email'].params,
@@ -161,7 +161,7 @@ describe('Unit | Service | MailService', function () {
           expect(options.variables).to.include({
             homeName: 'pix.org',
             homeUrl: 'https://pix.org/en-gb/',
-            helpdeskUrl: 'https://support.pix.org/en/support/home',
+            helpdeskUrl: 'https://pix.org/en/support',
             displayNationalLogo: false,
             redirectionUrl: 'https://app.pix.org/connexion/?lang=es',
             ...mainTranslationsMapping.es['pix-account-creation-email'].params,
@@ -250,7 +250,7 @@ describe('Unit | Service | MailService', function () {
             homeName: 'pix.org',
             homeUrl: 'https://pix.org/en-gb/',
             resetUrl: `https://app.pix.org/changer-mot-de-passe/${temporaryKey}/?lang=en`,
-            helpdeskURL: 'https://support.pix.org/en/support/home',
+            helpdeskURL: 'https://pix.org/en/support',
           },
         };
 
@@ -308,7 +308,7 @@ describe('Unit | Service | MailService', function () {
             homeName: 'pix.org',
             homeUrl: 'https://pix.org/en-gb/',
             resetUrl: `https://app.pix.org/changer-mot-de-passe/${temporaryKey}/?lang=es`,
-            helpdeskURL: 'https://support.pix.org/en/support/home',
+            helpdeskURL: 'https://pix.org/en/support',
           },
         };
 
@@ -337,7 +337,7 @@ describe('Unit | Service | MailService', function () {
             homeName: 'pix.org',
             homeUrl: 'https://pix.org/fr/',
             resetUrl: `https://app.pix.org/changer-mot-de-passe/${temporaryKey}/?lang=fr`,
-            helpdeskURL: 'https://support.pix.org',
+            helpdeskURL: 'https://pix.org/fr/support',
           },
         };
 
@@ -366,7 +366,7 @@ describe('Unit | Service | MailService', function () {
             homeName: 'pix.fr',
             homeUrl: 'https://pix.fr',
             resetUrl: `https://app.pix.fr/changer-mot-de-passe/${temporaryKey}`,
-            helpdeskURL: 'https://support.pix.fr',
+            helpdeskURL: 'https://pix.fr/support',
           },
         };
 
@@ -395,7 +395,7 @@ describe('Unit | Service | MailService', function () {
             homeName: 'pix.fr',
             homeUrl: 'https://pix.fr',
             resetUrl: `https://app.pix.fr/changer-mot-de-passe/${temporaryKey}`,
-            helpdeskURL: 'https://support.pix.fr',
+            helpdeskURL: 'https://pix.fr/support',
           },
         };
 
@@ -506,7 +506,7 @@ describe('Unit | Service | MailService', function () {
             pixHomeUrl: 'https://pix.org/fr/',
             pixOrgaHomeUrl: 'https://orga.pix.org/?lang=fr',
             redirectionUrl: `https://orga.pix.org/rejoindre?invitationId=${organizationInvitationId}&code=${code}&lang=fr`,
-            supportUrl: 'https://support.pix.org',
+            supportUrl: 'https://pix.org/fr/support',
             ...mainTranslationsMapping.fr['organization-invitation-email'].params,
           });
         });
@@ -529,7 +529,7 @@ describe('Unit | Service | MailService', function () {
             pixHomeUrl: 'https://pix.fr',
             pixOrgaHomeUrl: 'https://orga.pix.fr/',
             redirectionUrl: `https://orga.pix.fr/rejoindre?invitationId=${organizationInvitationId}&code=${code}`,
-            supportUrl: 'https://support.pix.fr',
+            supportUrl: 'https://pix.fr/support',
             ...mainTranslationsMapping.fr['organization-invitation-email'].params,
           });
         });
@@ -552,7 +552,7 @@ describe('Unit | Service | MailService', function () {
             pixHomeUrl: 'https://pix.fr',
             pixOrgaHomeUrl: 'https://orga.pix.fr/',
             redirectionUrl: `https://orga.pix.fr/rejoindre?invitationId=${organizationInvitationId}&code=${code}`,
-            supportUrl: 'https://support.pix.fr',
+            supportUrl: 'https://pix.fr/support',
             ...mainTranslationsMapping.fr['organization-invitation-email'].params,
           });
         });
@@ -575,7 +575,7 @@ describe('Unit | Service | MailService', function () {
             pixHomeUrl: 'https://pix.org/en-gb/',
             pixOrgaHomeUrl: 'https://orga.pix.org/?lang=en',
             redirectionUrl: `https://orga.pix.org/rejoindre?invitationId=${organizationInvitationId}&code=${code}&lang=en`,
-            supportUrl: 'https://support.pix.org/en/support/home',
+            supportUrl: 'https://pix.org/en/support',
             ...mainTranslationsMapping.en['organization-invitation-email'].params,
           });
         });
@@ -653,7 +653,7 @@ describe('Unit | Service | MailService', function () {
         pixHomeUrl: 'https://pix.fr',
         pixCertifHomeUrl: 'https://certif.pix.fr/',
         redirectionUrl: `https://certif.pix.fr/rejoindre?invitationId=7&code=ABCDEFGH01`,
-        supportUrl: 'https://support.pix.fr',
+        supportUrl: 'https://pix.fr/support',
         ...mainTranslationsMapping.fr['certification-center-invitation-email'].params,
       });
     });
@@ -684,7 +684,7 @@ describe('Unit | Service | MailService', function () {
           pixHomeUrl: 'https://pix.org/fr/',
           pixCertifHomeUrl: 'https://certif.pix.org/?lang=fr',
           redirectionUrl: `https://certif.pix.org/rejoindre?invitationId=7&code=AAABBBCCC7&lang=fr`,
-          supportUrl: 'https://support.pix.org',
+          supportUrl: 'https://pix.org/fr/support',
           ...mainTranslationsMapping.fr['certification-center-invitation-email'].params,
         });
       });
@@ -716,7 +716,7 @@ describe('Unit | Service | MailService', function () {
           pixHomeUrl: 'https://pix.org/en-gb/',
           pixCertifHomeUrl: 'https://certif.pix.org/?lang=en',
           redirectionUrl: `https://certif.pix.org/rejoindre?invitationId=777&code=LLLJJJVVV1&lang=en`,
-          supportUrl: 'https://support.pix.org/en/support/home',
+          supportUrl: 'https://pix.org/en/support',
           ...mainTranslationsMapping.en['certification-center-invitation-email'].params,
         });
       });

--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -45,9 +45,9 @@ export default class Url extends Service {
   }
 
   get supportUrl() {
-    if (this.currentDomain.isFranceDomain) return 'https://support.pix.fr';
+    if (this.currentDomain.isFranceDomain) return 'https://pix.fr/support';
 
-    return this.#isFrenchSpoken() ? 'https://support.pix.org' : 'https://support.pix.org/en/support/home';
+    return this.#isFrenchSpoken() ? 'https://pix.org/fr/support' : 'https://pix.org/en/support';
   }
 
   get joiningIssueSheetUrl() {

--- a/certif/tests/acceptance/session-add-students_test.js
+++ b/certif/tests/acceptance/session-add-students_test.js
@@ -87,7 +87,7 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
       await click(screen.getByRole('link', { name: 'Inscrire des candidats' }));
 
       // then
-      assert.dom(screen.getByRole('link', { name: 'support.pix.fr Ouverture dans une nouvelle fenêtre' })).exists();
+      assert.dom(screen.getByRole('link', { name: 'pix.fr/support Ouverture dans une nouvelle fenêtre' })).exists();
     });
 
     test('it should be possible to return to candidates page from add student page', async function (assert) {

--- a/certif/tests/unit/services/url_test.js
+++ b/certif/tests/unit/services/url_test.js
@@ -247,7 +247,7 @@ module('Unit | Service | url', function (hooks) {
         const supportUrl = service.supportUrl;
 
         // then
-        assert.strictEqual(supportUrl, 'https://support.pix.fr');
+        assert.strictEqual(supportUrl, 'https://pix.fr/support');
       });
     });
 
@@ -263,7 +263,7 @@ module('Unit | Service | url', function (hooks) {
           const supportUrl = service.supportUrl;
 
           // then
-          assert.strictEqual(supportUrl, 'https://support.pix.org/en/support/home');
+          assert.strictEqual(supportUrl, 'https://pix.org/en/support');
         });
       });
 
@@ -278,7 +278,7 @@ module('Unit | Service | url', function (hooks) {
           const supportUrl = service.supportUrl;
 
           // then
-          assert.strictEqual(supportUrl, 'https://support.pix.org');
+          assert.strictEqual(supportUrl, 'https://pix.org/fr/support');
         });
       });
     });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -272,7 +272,7 @@
           "information": "Inscrivez des élèves et c'est partix !"
         },
         "information": "Si certain(e)s élèves n’apparaissent pas dans cette liste, merci de ré-importer le fichier élèves dans Pix Orga.'<br>' Si malgré tout des élèves ne sont pas visibles, merci de contacter",
-        "link-label": "support.pix.org",
+        "link-label": "pix.org/en/support",
         "list": {
           "action-bar": {
             "candidate-already-enrolled": "candidat(s) déjà inscrit(s) à la session",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -272,7 +272,7 @@
           "information": "Inscrivez des élèves et c'est partix !"
         },
         "information": "Si certain(e)s élèves n’apparaissent pas dans cette liste, merci de ré-importer le fichier élèves dans Pix Orga.'<br>' Si malgré tout des élèves ne sont pas visibles, merci de contacter",
-        "link-label": "support.pix.fr",
+        "link-label": "pix.fr/support",
         "list": {
           "action-bar": {
             "candidate-already-enrolled": "candidat(s) déjà inscrit(s) à la session",

--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -82,16 +82,16 @@ export default class Url extends Service {
     const currentLanguage = this.intl.primaryLocale;
 
     if (this.currentDomain.isFranceDomain) {
-      return 'https://support.pix.org/fr/support/home';
+      return 'https://pix.fr/support';
     }
 
     switch (currentLanguage) {
       case ENGLISH_INTERNATIONAL_LOCALE:
-        return 'https://support.pix.org/en/support/home';
+        return 'https://pix.org/en/support';
       case DUTCH_INTERNATIONAL_LOCALE:
         return 'https://pix.org/nl-be/support';
       default:
-        return 'https://support.pix.org/fr/support/home';
+        return 'https://pix.org/fr/support';
     }
   }
 

--- a/mon-pix/tests/acceptance/footer_test.js
+++ b/mon-pix/tests/acceptance/footer_test.js
@@ -35,7 +35,7 @@ module('Acceptance | Footer', function (hooks) {
       assert.dom('.footer').doesNotExist();
     });
 
-    test('should contain link to support.pix.org', async function (assert) {
+    test('should contain link to pix.org/fr/support', async function (assert) {
       // when
       await visit('/');
 
@@ -43,7 +43,7 @@ module('Acceptance | Footer', function (hooks) {
       assert.ok(
         find('.footer-container-content__navigation ul li:nth-child(1) a')
           .getAttribute('href')
-          .includes('support.pix.org'),
+          .includes('pix.org/fr/support'),
       );
     });
 

--- a/mon-pix/tests/acceptance/user-logged-menu_test.js
+++ b/mon-pix/tests/acceptance/user-logged-menu_test.js
@@ -38,7 +38,7 @@ module('Acceptance | User account', function (hooks) {
       assert.strictEqual(currentURL(), '/mes-certifications');
     });
 
-    test('should contain link to support.pix.org/fr/support/home', async function (assert) {
+    test('should contain link to pix.fr/support', async function (assert) {
       // given
       server.create('campaign-participation-overview', { assessmentState: 'completed' });
       const user = server.create('user', 'withEmail', 'withAssessmentParticipations', { firstName: 'Henri' });
@@ -49,7 +49,7 @@ module('Acceptance | User account', function (hooks) {
 
       // then
       const helplink = screen.getByRole('link', { name: 'Aide' }).getAttribute('href');
-      assert.strictEqual(helplink, 'https://support.pix.org/fr/support/home');
+      assert.strictEqual(helplink, 'https://pix.fr/support');
     });
 
     test('should open My account page when click on menu', async function (assert) {

--- a/mon-pix/tests/integration/components/Sitemap/content_test.js
+++ b/mon-pix/tests/integration/components/Sitemap/content_test.js
@@ -111,7 +111,7 @@ module('Integration | Component | Sitemap::Content', function (hooks) {
           name: `${this.intl.t('navigation.main.help')} ${this.intl.t('navigation.external-link-title')}`,
         }),
       )
-      .hasAttribute('href', 'https://support.pix.org/fr/support/home');
+      .hasAttribute('href', 'https://pix.org/fr/support');
   });
 
   test('should contain an external link to accessibility page', async function (assert) {

--- a/mon-pix/tests/unit/services/url_test.js
+++ b/mon-pix/tests/unit/services/url_test.js
@@ -424,7 +424,7 @@ module('Unit | Service | url', function (hooks) {
         const service = this.owner.lookup('service:url');
         service.currentDomain = { isFranceDomain: true };
         service.intl = { primaryLocale: FRENCH_INTERNATIONAL_LOCALE };
-        const expectedSupportHomeUrl = 'https://support.pix.org/fr/support/home';
+        const expectedSupportHomeUrl = 'https://pix.fr/support';
 
         // when
         const supportHomeUrl = service.supportHomeUrl;
@@ -439,7 +439,7 @@ module('Unit | Service | url', function (hooks) {
           const service = this.owner.lookup('service:url');
           service.currentDomain = { isFranceDomain: true };
           service.intl = { primaryLocale: ENGLISH_INTERNATIONAL_LOCALE };
-          const expectedSupportHomeUrl = 'https://support.pix.org/fr/support/home';
+          const expectedSupportHomeUrl = 'https://pix.fr/support';
 
           // when
           const supportHomeUrl = service.supportHomeUrl;
@@ -455,7 +455,7 @@ module('Unit | Service | url', function (hooks) {
           const service = this.owner.lookup('service:url');
           service.currentDomain = { isFranceDomain: true };
           service.intl = { primaryLocale: DUTCH_INTERNATIONAL_LOCALE };
-          const expectedSupportHomeUrl = 'https://support.pix.org/fr/support/home';
+          const expectedSupportHomeUrl = 'https://pix.fr/support';
 
           // when
           const supportHomeUrl = service.supportHomeUrl;
@@ -473,7 +473,7 @@ module('Unit | Service | url', function (hooks) {
           const service = this.owner.lookup('service:url');
           service.currentDomain = { isFranceDomain: false };
           service.intl = { primaryLocale: FRENCH_INTERNATIONAL_LOCALE };
-          const expectedSupportHomeUrl = 'https://support.pix.org/fr/support/home';
+          const expectedSupportHomeUrl = 'https://pix.org/fr/support';
 
           // when
           const supportHomeUrl = service.supportHomeUrl;
@@ -489,7 +489,7 @@ module('Unit | Service | url', function (hooks) {
           const service = this.owner.lookup('service:url');
           service.currentDomain = { isFranceDomain: false };
           service.intl = { primaryLocale: ENGLISH_INTERNATIONAL_LOCALE };
-          const expectedSupportHomeUrl = 'https://support.pix.org/en/support/home';
+          const expectedSupportHomeUrl = 'https://pix.org/en/support';
 
           // when
           const supportHomeUrl = service.supportHomeUrl;

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -131,7 +131,7 @@
       "dashboard": "Home",
       "help": "Help",
       "label": "Main navigation",
-      "link-help": "https://support.pix.org/en/support/home",
+      "link-help": "https://pix.org/en/support",
       "skills": "Competences",
       "start-certification": "Certification",
       "trainings": "My trainings",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -131,7 +131,7 @@
       "dashboard": "Inicio",
       "help": "Ayuda",
       "label": "Menú principal",
-      "link-help": "https://support.pix.org/fr/support/home",
+      "link-help": "https://pix.org/fr/support",
       "skills": "Competencias",
       "start-certification": "Certificación",
       "trainings": "Mis formaciones",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -131,7 +131,7 @@
       "dashboard": "Accueil",
       "help": "Aide",
       "label": "Menu principal",
-      "link-help": "https://support.pix.org/fr/support/home",
+      "link-help": "https://pix.fr/support",
       "skills": "Compétences",
       "start-certification": "Certification",
       "trainings": "Mes formations",


### PR DESCRIPTION
## :unicorn: Problème
Le site du support est déplacé à l'intérieur du site vitrine.

## :robot: Proposition
Mettre à jour les URLs de la page d'accueil du site du support, selon les locales.

Il s'agit concrètement de modifier : 
- `support.pix.org/<locale>/home` en `pix.org/<locale>/support`,
- `support.pix.fr` (équivalent à `support.pix.org/fr`) en `pix.fr/support`,

## :rainbow: Remarques
Il restera des liens à mettre à jour, notamment : 
- Ouverture de ticket au support,
- Page d'article ([assistance code parcours](https://github.com/1024pix/pix/blob/4ed3c7be61acddd9b1c4bf91501318f4867df8c1/mon-pix/translations/fr.json#L773), [lien d'aide au téléchargement](https://github.com/1024pix/pix/pull/9330))

## :100: Pour tester
Vérifier que les redirections sont valides.
