### PR TITLE
[TECH] Créer la route pour enregistrer la confirmation de lecture des écrans d'instructions (PIX-12901)

### DIFF
--- a/api/db/database-builder/factory/build-certification-candidate.js
+++ b/api/db/database-builder/factory/build-certification-candidate.js
@@ -22,7 +22,7 @@ const buildCertificationCandidate = function ({
   createdAt = new Date('2020-01-01'),
   extraTimePercentage = 0.3,
   userId,
-  organizationLearnerId,
+  organizationLearnerId = null,
   authorizedToStart = false,
   billingMode = null,
   prepaymentCode = null,

--- a/api/db/database-builder/factory/build-certification-candidate.js
+++ b/api/db/database-builder/factory/build-certification-candidate.js
@@ -26,6 +26,7 @@ const buildCertificationCandidate = function ({
   authorizedToStart = false,
   billingMode = null,
   prepaymentCode = null,
+  hasSeenCertificationInstructions = false,
 } = {}) {
   sessionId = _.isUndefined(sessionId) ? buildSession().id : sessionId;
   userId = _.isUndefined(userId) ? buildUser().id : userId;
@@ -52,6 +53,7 @@ const buildCertificationCandidate = function ({
     authorizedToStart,
     billingMode,
     prepaymentCode,
+    hasSeenCertificationInstructions,
   };
 
   databaseBuffer.pushInsertable({
@@ -81,6 +83,7 @@ const buildCertificationCandidate = function ({
     authorizedToStart,
     billingMode,
     prepaymentCode,
+    hasSeenCertificationInstructions,
   };
 };
 

--- a/api/db/migrations/20240620085415_add-has-seen-certification-instructions-column-on-certification-candidates-table.js
+++ b/api/db/migrations/20240620085415_add-has-seen-certification-instructions-column-on-certification-candidates-table.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'certification-candidates';
+const COLUMN_NAME = 'hasSeenCertificationInstructions';
+
+const up = function (knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.boolean(COLUMN_NAME).defaultTo(false);
+  });
+};
+
+const down = function (knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+export { down, up };

--- a/api/src/certification/enrolment/application/certification-candidate-controller.js
+++ b/api/src/certification/enrolment/application/certification-candidate-controller.js
@@ -34,6 +34,20 @@ const deleteCandidate = async function (request) {
   return null;
 };
 
+const validateCertificationInstructions = async function (
+  request,
+  h,
+  dependencies = { certificationCandidateSerializer },
+) {
+  const certificationCandidateId = request.params.certificationCandidateId;
+
+  const updatedCandidate = await usecases.candidateHasSeenCertificationInstructions({
+    certificationCandidateId,
+  });
+
+  return dependencies.certificationCandidateSerializer.serializeForApp(updatedCandidate);
+};
+
 const _getSubscriptionParameter = (request) => {
   const { attributes } = request.payload.data;
   return attributes['subscription'] ?? attributes['complementary-certification'];
@@ -43,5 +57,6 @@ const certificationCandidateController = {
   addCandidate,
   getCandidate,
   deleteCandidate,
+  validateCertificationInstructions,
 };
 export { certificationCandidateController };

--- a/api/src/certification/enrolment/application/certification-candidate-route.js
+++ b/api/src/certification/enrolment/application/certification-candidate-route.js
@@ -2,6 +2,7 @@ import JoiDate from '@joi/date';
 import BaseJoi from 'joi';
 const Joi = BaseJoi.extend(JoiDate);
 import { authorization } from '../../../../lib/application/preHandlers/authorization.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { certificationCandidateController } from './certification-candidate-controller.js';
 
@@ -164,6 +165,29 @@ const register = async function (server) {
         notes: [
           'Cette route est restreinte aux utilisateurs authentifiés',
           'Elle supprime un candidat de certification à la session.',
+        ],
+      },
+    },
+    {
+      method: 'PATCH',
+      path: '/api/certification-candidates/{certificationCandidateId}/validate-certification-instructions',
+      config: {
+        validate: {
+          params: Joi.object({
+            certificationCandidateId: identifiersType.certificationCandidateId,
+          }),
+        },
+        pre: [
+          {
+            method: securityPreHandlers.checkUserIsCandidate,
+            assign: 'authorizationCheck',
+          },
+        ],
+        handler: certificationCandidateController.validateCertificationInstructions,
+        tags: ['api', 'certification-candidates'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs authentifiés',
+          'Elle permet à un candidat de valider les instructions de certification',
         ],
       },
     },

--- a/api/src/certification/enrolment/application/http-error-mapper-configuration.js
+++ b/api/src/certification/enrolment/application/http-error-mapper-configuration.js
@@ -1,11 +1,19 @@
 import { HttpErrors } from '../../../shared/application/http-errors.js';
 import { DomainErrorMappingConfiguration } from '../../../shared/application/models/domain-error-mapping-configuration.js';
-import { CertificationCandidateForbiddenDeletionError, SessionStartedDeletionError } from '../domain/errors.js';
+import {
+  CertificationCandidateForbiddenDeletionError,
+  CertificationCandidateNotFoundError,
+  SessionStartedDeletionError,
+} from '../domain/errors.js';
 
 const enrolmentDomainErrorMappingConfiguration = [
   {
     name: CertificationCandidateForbiddenDeletionError.name,
     httpErrorFn: (error) => new HttpErrors.ForbiddenError(error.message, error.code),
+  },
+  {
+    name: CertificationCandidateNotFoundError.name,
+    httpErrorFn: (error) => new HttpErrors.NotFoundError(error.message),
   },
   { name: SessionStartedDeletionError.name, httpErrorFn: (error) => new HttpErrors.ConflictError(error.message) },
 ].map((domainErrorMappingConfiguration) => new DomainErrorMappingConfiguration(domainErrorMappingConfiguration));

--- a/api/src/certification/enrolment/application/usecases/checkUserIsCandidate.js
+++ b/api/src/certification/enrolment/application/usecases/checkUserIsCandidate.js
@@ -1,0 +1,10 @@
+import * as candidateRepository from '../../infrastructure/repositories/candidate-repository.js';
+
+const execute = async ({ userId, certificationCandidateId, dependencies = { candidateRepository } }) => {
+  return dependencies.candidateRepository.isUserCertificationCandidate({
+    certificationCandidateId,
+    userId,
+  });
+};
+
+export { execute };

--- a/api/src/certification/enrolment/domain/errors.js
+++ b/api/src/certification/enrolment/domain/errors.js
@@ -12,4 +12,14 @@ class SessionStartedDeletionError extends DomainError {
   }
 }
 
-export { CertificationCandidateForbiddenDeletionError, SessionStartedDeletionError };
+class CertificationCandidateNotFoundError extends DomainError {
+  constructor(message = 'Certification candidate not found') {
+    super(message);
+  }
+}
+
+export {
+  CertificationCandidateForbiddenDeletionError,
+  CertificationCandidateNotFoundError,
+  SessionStartedDeletionError,
+};

--- a/api/src/certification/enrolment/domain/models/Candidate.js
+++ b/api/src/certification/enrolment/domain/models/Candidate.js
@@ -54,4 +54,8 @@ export class Candidate {
   isLinkedToAUser() {
     return !_.isNil(this.userId);
   }
+
+  validateCertificationInstructions() {
+    this.hasSeenCertificationInstructions = true;
+  }
 }

--- a/api/src/certification/enrolment/domain/models/Candidate.js
+++ b/api/src/certification/enrolment/domain/models/Candidate.js
@@ -24,6 +24,7 @@ export class Candidate {
     complementaryCertificationId,
     billingMode,
     prepaymentCode,
+    hasSeenCertificationInstructions = false,
   } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -47,6 +48,7 @@ export class Candidate {
     this.complementaryCertificationId = complementaryCertificationId;
     this.billingMode = billingMode;
     this.prepaymentCode = prepaymentCode;
+    this.hasSeenCertificationInstructions = hasSeenCertificationInstructions;
   }
 
   isLinkedToAUser() {

--- a/api/src/certification/enrolment/domain/usecases/candidate-has-seen-certification-instructions.js
+++ b/api/src/certification/enrolment/domain/usecases/candidate-has-seen-certification-instructions.js
@@ -1,0 +1,22 @@
+/**
+ * @typedef {import ('./index.js').CandidateRepository} CandidateRepository
+ */
+import { CertificationCandidateNotFoundError } from '../errors.js';
+
+/**
+ * @param {Object} params
+ * @param {CandidateRepository} params.candidateRepository
+ */
+const candidateHasSeenCertificationInstructions = async function ({ certificationCandidateId, candidateRepository }) {
+  const certificationCandidate = await candidateRepository.get({ certificationCandidateId });
+
+  if (!certificationCandidate) {
+    throw new CertificationCandidateNotFoundError();
+  }
+
+  certificationCandidate.validateCertificationInstructions();
+
+  return candidateRepository.update(certificationCandidate);
+};
+
+export { candidateHasSeenCertificationInstructions };

--- a/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
@@ -84,7 +84,28 @@ const update = async function (certificationCandidate) {
   return _toDomain(updatedCertificationCandidate);
 };
 
-export { findBySessionId, get, update };
+/**
+ * @function
+ * @param {Object} params
+ * @param {number} params.certificationCandidateId
+ * @param {number} params.userId
+ *
+ * @return {Boolean} Returns true if candidate is found or false otherwise
+ */
+const isUserCertificationCandidate = async function ({ certificationCandidateId, userId }) {
+  const certificationCandidate = await knex
+    .select(1)
+    .from('certification-candidates')
+    .where({
+      id: certificationCandidateId,
+      userId,
+    })
+    .first();
+
+  return Boolean(certificationCandidate);
+};
+
+export { findBySessionId, get, isUserCertificationCandidate, update };
 
 function _toDomain(result) {
   return result ? new Candidate(result) : null;

--- a/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
@@ -1,6 +1,6 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
-import { Candidate } from '../../../enrolment/domain/models/Candidate.js';
 import { CertificationCandidateNotFoundError } from '../../domain/errors.js';
+import { Candidate } from '../../domain/models/Candidate.js';
 
 const findBySessionId = async function ({ sessionId }) {
   const results = await knex
@@ -19,6 +19,23 @@ const findBySessionId = async function ({ sessionId }) {
     .orderByRaw('LOWER("certification-candidates"."lastName") asc')
     .orderByRaw('LOWER("certification-candidates"."firstName") asc');
   return results.map(_toDomain);
+};
+
+/**
+ * @function
+ * @param {Candidate} params
+ * @param {number} params.certificationCandidateId
+ *
+ * @return {Candidate}
+ */
+const get = async function ({ certificationCandidateId }) {
+  const certificationCandidate = await knex('certification-candidates')
+    .where({
+      id: certificationCandidateId,
+    })
+    .first();
+
+  return _toDomain(certificationCandidate);
 };
 
 /**
@@ -67,7 +84,7 @@ const update = async function (certificationCandidate) {
   return _toDomain(updatedCertificationCandidate);
 };
 
-export { findBySessionId, update };
+export { findBySessionId, get, update };
 
 function _toDomain(result) {
   return result ? new Candidate(result) : null;

--- a/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
+++ b/api/src/certification/enrolment/infrastructure/repositories/candidate-repository.js
@@ -1,5 +1,6 @@
 import { knex } from '../../../../../db/knex-database-connection.js';
 import { Candidate } from '../../../enrolment/domain/models/Candidate.js';
+import { CertificationCandidateNotFoundError } from '../../domain/errors.js';
 
 const findBySessionId = async function ({ sessionId }) {
   const results = await knex
@@ -20,7 +21,53 @@ const findBySessionId = async function ({ sessionId }) {
   return results.map(_toDomain);
 };
 
-export { findBySessionId };
+/**
+ * @function
+ * @param {Object} certificationCandidate
+ *
+ * @return {Candidate}
+ * @throws {CertificationCandidateNotFoundError} Certification candidate not found
+ */
+const update = async function (certificationCandidate) {
+  const [updatedCertificationCandidate] = await knex('certification-candidates')
+    .where({
+      id: certificationCandidate.id,
+    })
+    .update({
+      id: certificationCandidate.id,
+      firstName: certificationCandidate.firstName,
+      lastName: certificationCandidate.lastName,
+      sex: certificationCandidate.sex,
+      birthPostalCode: certificationCandidate.birthPostalCode,
+      birthINSEECode: certificationCandidate.birthINSEECode,
+      birthCity: certificationCandidate.birthCity,
+      birthProvinceCode: certificationCandidate.birthProvinceCode,
+      birthCountry: certificationCandidate.birthCountry,
+      email: certificationCandidate.email,
+      resultRecipientEmail: certificationCandidate.resultRecipientEmail,
+      externalId: certificationCandidate.externalId,
+      birthdate: certificationCandidate.birthdate,
+      extraTimePercentage: certificationCandidate.extraTimePercentage,
+      createdAt: certificationCandidate.createdAt,
+      authorizedToStart: certificationCandidate.authorizedToStart,
+      sessionId: certificationCandidate.sessionId,
+      userId: certificationCandidate.userId,
+      organizationLearnerId: certificationCandidate.organizationLearnerId,
+      complementaryCertificationId: certificationCandidate.complementaryCertificationId,
+      billingMode: certificationCandidate.billingMode,
+      prepaymentCode: certificationCandidate.prepaymentCode,
+      hasSeenCertificationInstructions: certificationCandidate.hasSeenCertificationInstructions,
+    })
+    .returning('*');
+
+  if (!updatedCertificationCandidate) {
+    throw new CertificationCandidateNotFoundError();
+  }
+
+  return _toDomain(updatedCertificationCandidate);
+};
+
+export { findBySessionId, update };
 
 function _toDomain(result) {
   return result ? new Candidate(result) : null;

--- a/api/src/certification/shared/infrastructure/serializers/jsonapi/certification-candidate-serializer.js
+++ b/api/src/certification/shared/infrastructure/serializers/jsonapi/certification-candidate-serializer.js
@@ -2,7 +2,13 @@ import jsonapiSerializer from 'jsonapi-serializer';
 
 import { CertificationCandidate } from '../../../../../../lib/domain/models/index.js';
 
-const { Deserializer } = jsonapiSerializer;
+const { Deserializer, Serializer } = jsonapiSerializer;
+
+const serializeForApp = function (certificationCandidate) {
+  return new Serializer('certification-candidate', {
+    attributes: ['firstName', 'lastName', 'birthdate', 'sessionId', 'hasSeenCertificationInstructions'],
+  }).serialize(certificationCandidate);
+};
 
 const deserialize = async function (json) {
   delete json.data.attributes['is-linked'];
@@ -19,4 +25,4 @@ const deserialize = async function (json) {
   });
 };
 
-export { deserialize };
+export { deserialize, serializeForApp };

--- a/api/src/shared/application/security-pre-handlers.js
+++ b/api/src/shared/application/security-pre-handlers.js
@@ -27,6 +27,7 @@ import * as checkUserIsMemberOfCertificationCenterSessionUsecase from '../../../
 import * as checkUserOwnsCertificationCourseUseCase from '../../../lib/application/usecases/checkUserOwnsCertificationCourse.js';
 import { Organization } from '../../../lib/domain/models/index.js';
 import { PIX_ADMIN } from '../../authorization/domain/constants.js';
+import * as checkUserIsCandidateUseCase from '../../certification/enrolment/application/usecases/checkUserIsCandidate.js';
 import * as certificationIssueReportRepository from '../../certification/shared/infrastructure/repositories/certification-issue-report-repository.js';
 import { ForbiddenAccess, NotFoundError } from '../domain/errors.js';
 import * as organizationRepository from '../infrastructure/repositories/organization-repository.js';
@@ -59,6 +60,25 @@ async function checkIfUserIsBlocked(
 
   if (grantType === 'password') {
     await dependencies.checkIfUserIsBlockedUseCase.execute(username);
+  }
+
+  return h.response(true);
+}
+
+async function checkUserIsCandidate(
+  request,
+  h,
+  dependencies = {
+    checkUserIsCandidateUseCase,
+  },
+) {
+  const userId = request.auth.credentials.userId;
+  const certificationCandidateId = request.params.certificationCandidateId;
+
+  const isUserCandidate = await dependencies.checkUserIsCandidateUseCase.execute({ userId, certificationCandidateId });
+
+  if (!isUserCandidate) {
+    return _replyForbiddenError(h);
   }
 
   return h.response(true);
@@ -736,6 +756,7 @@ const securityPreHandlers = {
   checkUserIsAdminOfCertificationCenter,
   checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationId,
   checkUserIsAdminOfCertificationCenterWithCertificationCenterMembershipId,
+  checkUserIsCandidate,
   checkUserIsMemberOfCertificationCenter,
   checkUserIsMemberOfCertificationCenterSessionFromCertificationCourseId,
   checkUserIsMemberOfCertificationCenterSessionFromCertificationIssueReportId,

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -372,6 +372,7 @@ const configuration = (function () {
     config.features.pixCertifScoBlockedAccessDateLycee = null;
     config.features.pixCertifScoBlockedAccessDateCollege = null;
 
+    config.featureToggles.areV3InfoScreensEnabled = false;
     config.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled = false;
     config.featureToggles.isPix1dEnabled = true;
     config.featureToggles.isCertificationTokenScopeEnabled = false;

--- a/api/tests/certification/enrolment/acceptance/application/certification-candidate-route_test.js
+++ b/api/tests/certification/enrolment/acceptance/application/certification-candidate-route_test.js
@@ -74,4 +74,48 @@ describe('Acceptance | Controller | Session | certification-candidate-route', fu
       );
     });
   });
+
+  describe('PATCH /api/certification-candidates/{certificationCandidateId}/validate-certification-instructions', function () {
+    it('should respond with a 200', async function () {
+      // given
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
+      const candidateUserId = databaseBuilder.factory.buildUser().id;
+      const candidateId = databaseBuilder.factory.buildCertificationCandidate({
+        id: 1001,
+        sessionId,
+        userId: candidateUserId,
+        hasSeenCertificationInstructions: false,
+      }).id;
+
+      await databaseBuilder.commit();
+
+      // when
+      const options = {
+        method: 'PATCH',
+        url: `/api/certification-candidates/${candidateId}/validate-certification-instructions`,
+        payload: {},
+        headers: { authorization: generateValidRequestAuthorizationHeader(candidateUserId, 'pix') },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result).to.deep.equal({
+        data: {
+          attributes: {
+            birthdate: '2000-01-04',
+            'first-name': 'first-name',
+            'has-seen-certification-instructions': true,
+            'last-name': 'last-name',
+            'session-id': sessionId,
+          },
+          id: '1001',
+          type: 'certification-candidates',
+        },
+      });
+    });
+  });
 });

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
@@ -190,4 +190,46 @@ describe('Integration | Certification | Session | Repository | Candidate', funct
       });
     });
   });
+
+  describe('#isUserCertificationCandidate', function () {
+    describe('when the candidate exists and is reconciled to a given user', function () {
+      it('should return true', async function () {
+        // when
+        const userId = databaseBuilder.factory.buildUser().id;
+        const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
+          userId,
+        });
+
+        await databaseBuilder.commit();
+
+        const isUserCertificationCandidate = await candidateRepository.isUserCertificationCandidate({
+          userId,
+          certificationCandidateId: certificationCandidate.id,
+        });
+
+        // then
+        expect(isUserCertificationCandidate).to.be.true;
+      });
+    });
+
+    describe('when the candidate is not reconciled to the given user', function () {
+      it('should return false', async function () {
+        // when
+        const userId = databaseBuilder.factory.buildUser().id;
+        const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({
+          userId: null,
+        });
+
+        await databaseBuilder.commit();
+
+        const isUserCertificationCandidate = await candidateRepository.isUserCertificationCandidate({
+          userId,
+          certificationCandidateId: certificationCandidate.id,
+        });
+
+        // then
+        expect(isUserCertificationCandidate).to.be.false;
+      });
+    });
+  });
 });

--- a/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
+++ b/api/tests/certification/enrolment/integration/infrastructure/repositories/candidate-repository_test.js
@@ -115,6 +115,39 @@ describe('Integration | Certification | Session | Repository | Candidate', funct
     });
   });
 
+  describe('#get', function () {
+    describe('when the candidate exists', function () {
+      it('should return the candidate', async function () {
+        // when
+        const certificationCandidate = databaseBuilder.factory.buildCertificationCandidate();
+
+        await databaseBuilder.commit();
+
+        const result = await candidateRepository.get({ certificationCandidateId: certificationCandidate.id });
+
+        // then
+        expect(result).to.deepEqualInstance(
+          new Candidate({
+            ...certificationCandidate,
+          }),
+        );
+      });
+    });
+
+    describe('when the candidate does not exist', function () {
+      it('return null', async function () {
+        // given
+        const wrongCertificationCandidateId = 4568;
+
+        //when
+        const result = await candidateRepository.get({ certificationCandidateId: wrongCertificationCandidateId });
+
+        // then
+        expect(result).to.be.null;
+      });
+    });
+  });
+
   describe('#update', function () {
     describe('when the candidate exists', function () {
       it('should update the candidate', async function () {

--- a/api/tests/certification/enrolment/unit/application/certification-candidate-controller_test.js
+++ b/api/tests/certification/enrolment/unit/application/certification-candidate-controller_test.js
@@ -1,6 +1,6 @@
 import { certificationCandidateController } from '../../../../../src/certification/enrolment/application/certification-candidate-controller.js';
 import { usecases } from '../../../../../src/certification/enrolment/domain/usecases/index.js';
-import { expect, hFake, sinon } from '../../../../test-helper.js';
+import { domainBuilder, expect, hFake, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Controller | certification-candidate-controller', function () {
   describe('#addCandidate', function () {
@@ -45,6 +45,37 @@ describe('Unit | Controller | certification-candidate-controller', function () {
         },
       });
       expect(response.statusCode).to.equal(201);
+    });
+  });
+
+  describe('#validateCertificationInstructions', function () {
+    it('should return the updated certification candidate', async function () {
+      // given
+      const certificationCandidatesJsonApi = 'candidatesJSONAPI';
+      const certificationCandidate = 'candidate';
+      const certificationCandidateId = 2;
+      const request = {
+        params: { certificationCandidateId },
+      };
+      sinon.stub(usecases, 'candidateHasSeenCertificationInstructions');
+      const certificationCandidateSerializer = {
+        serializeForApp: sinon.stub(),
+      };
+      certificationCandidateSerializer.serializeForApp.returns(certificationCandidatesJsonApi);
+      const updatedCertificationCandidate = domainBuilder.certification.enrolment.buildCertificationSessionCandidate();
+      usecases.candidateHasSeenCertificationInstructions
+        .withArgs({
+          certificationCandidate,
+        })
+        .resolves(updatedCertificationCandidate);
+
+      // when
+      const response = await certificationCandidateController.validateCertificationInstructions(request, hFake, {
+        certificationCandidateSerializer,
+      });
+
+      // then
+      expect(response).to.deep.equal(certificationCandidatesJsonApi);
     });
   });
 

--- a/api/tests/certification/enrolment/unit/application/validator/checkUserIsCandidate_test.js
+++ b/api/tests/certification/enrolment/unit/application/validator/checkUserIsCandidate_test.js
@@ -1,0 +1,54 @@
+import * as checkUserIsCandidateUseCase from '../../../../../../src/certification/enrolment/application/usecases/checkUserIsCandidate.js';
+import { expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | Application | Validator | checkUserIsCandidateUseCase', function () {
+  context('When user is the candidate', function () {
+    it('should return true', async function () {
+      // given
+      const userId = 'userId';
+      const certificationCandidateId = 'certificationCandidateId';
+      const candidateRepositoryStub = {
+        isUserCertificationCandidate: sinon.stub(),
+      };
+
+      candidateRepositoryStub.isUserCertificationCandidate
+        .withArgs({ userId, certificationCandidateId })
+        .resolves(true);
+
+      // when
+      const response = await checkUserIsCandidateUseCase.execute({
+        userId,
+        certificationCandidateId,
+        dependencies: { candidateRepository: candidateRepositoryStub },
+      });
+
+      // then
+      expect(response).to.be.true;
+    });
+  });
+
+  context('When user is not the candidate', function () {
+    it('should return false', async function () {
+      // given
+      const userId = 'userId';
+      const certificationCandidateId = 'certificationCandidateId';
+      const candidateRepositoryStub = {
+        isUserCertificationCandidate: sinon.stub(),
+      };
+
+      candidateRepositoryStub.isUserCertificationCandidate
+        .withArgs({ userId, certificationCandidateId })
+        .returns(false);
+
+      // when
+      const response = await checkUserIsCandidateUseCase.execute({
+        userId,
+        certificationCandidateId,
+        dependencies: { candidateRepository: candidateRepositoryStub },
+      });
+
+      // then
+      expect(response).to.be.false;
+    });
+  });
+});

--- a/api/tests/certification/enrolment/unit/domain/usecases/candidate-has-seen-certification-instructions_test.js
+++ b/api/tests/certification/enrolment/unit/domain/usecases/candidate-has-seen-certification-instructions_test.js
@@ -1,0 +1,51 @@
+import { CertificationCandidateNotFoundError } from '../../../../../../src/certification/enrolment/domain/errors.js';
+import { Candidate } from '../../../../../../src/certification/enrolment/domain/models/Candidate.js';
+import { candidateHasSeenCertificationInstructions } from '../../../../../../src/certification/enrolment/domain/usecases/candidate-has-seen-certification-instructions.js';
+import { catchErr, domainBuilder, expect, sinon } from '../../../../../test-helper.js';
+
+describe('Unit | UseCase | candidate-has-seen-certification-instructions', function () {
+  let candidateRepository;
+
+  beforeEach(function () {
+    candidateRepository = {
+      get: sinon.stub(),
+      update: sinon.stub(),
+    };
+  });
+
+  context('when the candidate is found', function () {
+    it('should return updated candidate', async function () {
+      // given
+      const candidate = domainBuilder.certification.enrolment.buildCertificationSessionCandidate({
+        id: 187,
+        hasSeenCertificationInstructions: false,
+      });
+      const expectedUpdatedCandidate = new Candidate({ id: 187, hasSeenCertificationInstructions: true });
+      candidateRepository.get.withArgs({ certificationCandidateId: 187 }).resolves(candidate);
+      candidateRepository.update.withArgs(candidate).resolves(expectedUpdatedCandidate);
+
+      // when
+      const updatedCandidate = await candidateHasSeenCertificationInstructions({
+        certificationCandidateId: 187,
+        candidateRepository,
+      });
+
+      // then
+      expect(updatedCandidate).to.deep.equal(expectedUpdatedCandidate);
+    });
+
+    context('when no candidate is found', function () {
+      it('should throw an CertificationCandidateNotFoundError', async function () {
+        // given
+        // when
+        const error = await catchErr(candidateHasSeenCertificationInstructions)({
+          certificationCandidateId: 1,
+          candidateRepository,
+        });
+
+        // then
+        expect(error).to.be.an.instanceOf(CertificationCandidateNotFoundError);
+      });
+    });
+  });
+});

--- a/api/tests/certification/shared/unit/infrastructure/serializers/jsonapi/certification-candidate-serializer_test.js
+++ b/api/tests/certification/shared/unit/infrastructure/serializers/jsonapi/certification-candidate-serializer_test.js
@@ -67,4 +67,35 @@ describe('Unit | Serializer | JSONAPI | certification-candidate-serializer', fun
       );
     });
   });
+
+  describe('#serializeForApp()', function () {
+    it('should convert a CertificationCandidate model object into JSON API data for app', async function () {
+      // given
+      const certificationCandidate = domainBuilder.certification.enrolment.buildCertificationSessionCandidate({
+        firstName: 'toto',
+        lastName: 'tutu',
+        sessionId: 1234,
+        hasSeenCertificationInstructions: true,
+        birthdate: '1984-28-05',
+      });
+
+      // when
+      const serializedCertificationCandidateForApp = await serializer.serializeForApp(certificationCandidate);
+
+      // then
+      expect(serializedCertificationCandidateForApp).to.deep.equal({
+        data: {
+          type: 'certification-candidates',
+          id: certificationCandidate.id.toString(),
+          attributes: {
+            'first-name': 'toto',
+            'last-name': 'tutu',
+            birthdate: '1984-28-05',
+            'session-id': 1234,
+            'has-seen-certification-instructions': true,
+          },
+        },
+      });
+    });
+  });
 });

--- a/api/tests/identity-access-management/integration/application/password/password.controller.test.js
+++ b/api/tests/identity-access-management/integration/application/password/password.controller.test.js
@@ -1,6 +1,6 @@
 import { UserNotFoundError } from '../../../../../lib/domain/errors.js';
 import { passwordController } from '../../../../../src/identity-access-management/application/password/password.controller.js';
-import { catchErr, databaseBuilder, expect, hFake } from '../../../../test-helper.js';
+import { catchErr, databaseBuilder, expect, hFake, sinon } from '../../../../test-helper.js';
 
 describe('Integration | Identity Access Management | Application | Controller | password', function () {
   describe('#createResetPasswordDemand', function () {
@@ -28,12 +28,12 @@ describe('Integration | Identity Access Management | Application | Controller | 
 
       // then
       expect(response.statusCode).to.equal(201);
-      expect(response.source).to.deep.equal({
+      sinon.assert.match(response.source, {
         data: {
           attributes: {
             email: 'user@example.net',
           },
-          id: '1',
+          id: sinon.match.string,
           type: 'password-reset-demands',
         },
       });

--- a/api/tests/shared/unit/application/security-pre-handlers_test.js
+++ b/api/tests/shared/unit/application/security-pre-handlers_test.js
@@ -79,6 +79,52 @@ describe('Unit | Application | SecurityPreHandlers', function () {
     });
   });
 
+  describe('#checkUserIsCandidate', function () {
+    let request;
+
+    beforeEach(function () {
+      sinon.stub(tokenService, 'extractTokenFromAuthChain');
+      request = {
+        auth: { credentials: { userId: 1234 } },
+        params: {
+          certificationCandidateId: 456,
+        },
+      };
+    });
+
+    context('Successful case', function () {
+      it('should authorize access to resource when the user is the certificartion candidate', async function () {
+        // given
+        const checkUserIsCandidateUseCaseStub = {
+          execute: sinon.stub().resolves(true),
+        };
+        // when
+        const response = await securityPreHandlers.checkUserIsCandidate(request, hFake, {
+          checkUserIsCandidateUseCase: checkUserIsCandidateUseCaseStub,
+        });
+
+        // then
+        expect(response.source).to.be.true;
+      });
+    });
+
+    context('Error cases', function () {
+      it('should forbid resource access when the user is not the certificartion candidate', async function () {
+        // given
+        const checkUserIsCandidateUseCaseStub = {
+          execute: sinon.stub().resolves(false),
+        };
+        // when
+        const response = await securityPreHandlers.checkUserIsCandidate(request, hFake, {
+          checkUserIsCandidateUseCase: checkUserIsCandidateUseCaseStub,
+        });
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+  });
+
   describe('#checkAdminMemberHasRoleCertif', function () {
     let request;
 

--- a/api/tests/tooling/domain-builder/factory/build-certification-session-candidate.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-session-candidate.js
@@ -23,6 +23,7 @@ const buildCertificationSessionCandidate = function ({
   complementaryCertificationId,
   billingMode = null,
   prepaymentCode = null,
+  hasSeenCertificationInstructions = false,
 } = {}) {
   return new Candidate({
     id,
@@ -47,6 +48,7 @@ const buildCertificationSessionCandidate = function ({
     complementaryCertificationId,
     billingMode,
     prepaymentCode,
+    hasSeenCertificationInstructions,
   });
 };
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur Pix App, lorsque le candidat valide avoir lu les règles des écrans d'instructions, nous n'enregistrons pas ce choix. Or il est nécessaire de l'enregistrer pour un besoin RGPD.

## :robot: Proposition
Créer la route API sur la confirmation du candidat

## :rainbow: Remarques
Un preHandler à été créé pour confirmer l'identité du candidat (id coté url) couplé au userId de l'utilisateur authentifié.

## :100: Pour tester
Les tests passent :)
