### PR TITLE
[TECH] Revoir la méthode pour créer/mettre à jour des organization-learners lors de l'import (PIX-13242)

### DIFF
--- a/api/src/prescription/learner-management/domain/models/ImportOrganizationLearnerSet.js
+++ b/api/src/prescription/learner-management/domain/models/ImportOrganizationLearnerSet.js
@@ -233,8 +233,7 @@ class ImportOrganizationLearnerSet {
 
   get learners() {
     const learners = {
-      create: [],
-      update: [],
+      list: [],
       existinglearnerIds: [],
     };
 
@@ -244,12 +243,9 @@ class ImportOrganizationLearnerSet {
         unicityKey: Object.values(this.#unicityColumnMapping),
       });
 
-      if (learner.id) {
-        learners.update.push(learner);
-        learners.existinglearnerIds.push(learner.id);
-      } else {
-        learners.create.push(learner);
-      }
+      learners.list.push(learner);
+
+      if (learner.id) learners.existinglearnerIds.push(learner.id);
     });
 
     return learners;

--- a/api/src/prescription/learner-management/domain/usecases/import-from-feature/save-organization-learners-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-from-feature/save-organization-learners-file.js
@@ -43,11 +43,7 @@ const saveOrganizationLearnersFile = async function ({
       organizationId,
       excludeOrganizationLearnerIds: learners.existinglearnerIds,
     });
-    await organizationLearnerRepository.updateCommonLearnersFromOrganizationId({
-      organizationId,
-      learners: learners.update,
-    });
-    await organizationLearnerRepository.saveCommonOrganizationLearners(learners.create);
+    await organizationLearnerRepository.saveCommonOrganizationLearners(learners.list);
   } catch (error) {
     if (Array.isArray(error)) {
       errors.push(...error);

--- a/api/tests/prescription/learner-management/unit/domain/models/ImportOrganizationLearnerSet_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/models/ImportOrganizationLearnerSet_test.js
@@ -60,10 +60,9 @@ describe('Unit | Models | ImportOrganizationLearnerSet', function () {
 
         const learners = learnerSet.learners;
 
-        expect(learners.create).to.lengthOf(1);
-        expect(learners.update).to.lengthOf(0);
-        expect(learners.create[0]).to.be.an.instanceOf(CommonOrganizationLearner);
-        expect(learners.create).to.deep.equal([
+        expect(learners.list).to.lengthOf(1);
+        expect(learners.list[0]).to.be.an.instanceOf(CommonOrganizationLearner);
+        expect(learners.list).to.deep.equal([
           new CommonOrganizationLearner({
             firstName: 'Tomie',
             lastName: 'Katana',
@@ -89,33 +88,15 @@ describe('Unit | Models | ImportOrganizationLearnerSet', function () {
 
         const learners = learnerSet.learners;
 
-        expect(learners.create).to.lengthOf(2);
+        expect(learners.list).to.lengthOf(2);
       });
     });
 
     describe('update learner context', function () {
-      it('return several learner to update', function () {
+      it('return learner to update', function () {
         const learnerSet = ImportOrganizationLearnerSet.buildSet({ organizationId, importFormat });
 
-        const learnerAttributes2 = {
-          prénom: 'Edgar',
-          nom: 'Paslatugène',
-          "nom d'usage": 'Edou',
-          anniversaire: '34',
-          group: 'Han',
-        };
-        learnerSet.addLearners([learnerAttributes, learnerAttributes2]);
-
-        const learnerFromDB2 = new CommonOrganizationLearner({
-          id: 777,
-          userId: 42,
-          firstName: 'Edgar',
-          lastName: 'làsaymieux',
-          "nom d'usage": 'Ed',
-          anniversaire: '30',
-          group: 'Solo',
-          organizationId,
-        });
+        learnerSet.addLearners([learnerAttributes]);
 
         const learnerFromDB1 = new CommonOrganizationLearner({
           id: 666,
@@ -128,12 +109,11 @@ describe('Unit | Models | ImportOrganizationLearnerSet', function () {
           organizationId,
         });
 
-        learnerSet.setExistingLearners([learnerFromDB1, learnerFromDB2]);
+        learnerSet.setExistingLearners([learnerFromDB1]);
 
         const learners = learnerSet.learners;
 
-        expect(learners.update).lengthOf(2);
-        expect(learners.create).lengthOf(0);
+        expect(learners.list).lengthOf(1);
       });
 
       it('return distinct list of learner to create or update', function () {
@@ -164,7 +144,7 @@ describe('Unit | Models | ImportOrganizationLearnerSet', function () {
 
         const learners = learnerSet.learners;
 
-        expect(learners.create).to.deep.equals([
+        expect(learners.list).to.deep.equals([
           {
             firstName: 'Tomie',
             lastName: 'Katana',
@@ -175,8 +155,6 @@ describe('Unit | Models | ImportOrganizationLearnerSet', function () {
               group: 'Solo',
             },
           },
-        ]);
-        expect(learners.update).to.deep.equals([
           {
             id: 777,
             userId: 42,
@@ -472,7 +450,7 @@ describe('Unit | Models | ImportOrganizationLearnerSet', function () {
 
         const learners = learnerSet.learners;
 
-        expect(learners.create[0].attributes.anniversaire).to.equal('2026-03-06');
+        expect(learners.list[0].attributes.anniversaire).to.equal('2026-03-06');
       });
 
       it('when there is several date configs, should transform all the dates', async function () {
@@ -494,8 +472,8 @@ describe('Unit | Models | ImportOrganizationLearnerSet', function () {
 
         const learners = learnerSet.learners;
 
-        expect(learners.create[0].attributes.anniversaire).to.equal('2010-03-06');
-        expect(learners.create[0].attributes.marriage).to.equal('2027-06-09');
+        expect(learners.list[0].attributes.anniversaire).to.equal('2010-03-06');
+        expect(learners.list[0].attributes.marriage).to.equal('2027-06-09');
       });
     });
   });

--- a/api/tests/prescription/learner-management/unit/domain/usecases/import-from-feature/save-organization-learners-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/import-from-feature/save-organization-learners-file_test.js
@@ -19,7 +19,6 @@ describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
     dataStream,
     s3Filepath,
     learnerToSave,
-    learnerToUpdate,
     learnerIds,
     importFormat,
     parsedLearners,
@@ -33,7 +32,6 @@ describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
     dataStream = Symbol('DataStream');
     existingLearners = Symbol('Existing learners');
     learnerToSave = Symbol('learner to save');
-    learnerToUpdate = Symbol('learner to update');
     learnerIds = Symbol('learner Ids');
 
     importFormat = Symbol('importFormat');
@@ -57,7 +55,6 @@ describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
 
     organizationLearnerRepositoryStub = {
       disableCommonOrganizationLearnersFromOrganizationId: sinon.stub(),
-      updateCommonLearnersFromOrganizationId: sinon.stub(),
       saveCommonOrganizationLearners: sinon.stub(),
       findAllCommonLearnersFromOrganizationId: sinon.stub(),
     };
@@ -73,8 +70,7 @@ describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
       addLearners: sinon.stub(),
       setExistingLearners: sinon.stub(),
       learners: {
-        create: learnerToSave,
-        update: learnerToUpdate,
+        list: learnerToSave,
         existinglearnerIds: learnerIds,
       },
     };
@@ -140,13 +136,6 @@ describe('Unit | UseCase | saveOrganizationLearnersFile', function () {
           excludeOrganizationLearnerIds: learnerIds,
         }),
         'organizationLearnerRepository.disableCommonOrganizationLearnersFromOrganizationId',
-      ).to.be.true;
-      expect(
-        organizationLearnerRepositoryStub.updateCommonLearnersFromOrganizationId.calledOnceWithExactly({
-          organizationId,
-          learners: learnerToUpdate,
-        }),
-        'organizationLearnerRepository.updateCommonLearnersFromOrganizationId',
       ).to.be.true;
       expect(
         organizationLearnerRepositoryStub.saveCommonOrganizationLearners.calledOnceWithExactly(learnerToSave),


### PR DESCRIPTION
## :unicorn: Problème
Des retours sur la 1ere PR que l'on a décidé de prendre dans un second temps. 

## :robot: Proposition
Permettre de n'avoir qu'une fonction qui sauvegarde les organization-learners, en faisant un update dans le cas ou l' id est renseigné / existant )

## :rainbow: Remarques
RAS

## :100: Pour tester
faire un import générique et vérifier que l'on met bien à jour l'apprenant que l'on souhaite mettre à jour