### PR TITLE
[BUGFIX] Correction du variant pix button des boutons Modifier et Dupliquer une campagne (PIX-13102)

### DIFF
--- a/orga/app/components/campaign/settings/view.hbs
+++ b/orga/app/components/campaign/settings/view.hbs
@@ -112,10 +112,10 @@
 
   {{#if this.displayCampaignActionsButtons}}
     <div class="campaign-settings-buttons">
-      <PixButtonLink @route="authenticated.campaigns.update" @model={{@campaign.id}} @variant="tertiary">
+      <PixButtonLink @route="authenticated.campaigns.update" @model={{@campaign.id}} @variant="secondary">
         {{t "pages.campaign-settings.actions.edit"}}
       </PixButtonLink>
-      <PixButtonLink @route="authenticated.campaigns.new" @query={{this.queryForDuplicate}} @variant="tertiary">
+      <PixButtonLink @route="authenticated.campaigns.new" @query={{this.queryForDuplicate}} @variant="secondary">
         {{t "pages.campaign-settings.actions.duplicate"}}
       </PixButtonLink>
       <PixButton @triggerAction={{fn this.archiveCampaign @campaign.id}} @variant="error">


### PR DESCRIPTION
## :unicorn: Problème
Suite à la dernière Les boutons Dupliquer et Modifier une campagne sont en tertiary au lieu d'être en secondary 

## :robot: Proposition
Passer les 2 boutons en secondary 

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- Se connecter sur PixOrga 
- Ouvrir une campagne 
- Aller sur l'onglet Paramètres 
- Vérifier que les boutons sont bien en secondary 
- 🫰  