### PR TITLE
[FEATURE] [FRONT] Permettre de se réconcilier à une organization ayant l'import générique (PIX-12559)

### DIFF
--- a/mon-pix/app/adapters/organization-learner.js
+++ b/mon-pix/app/adapters/organization-learner.js
@@ -1,0 +1,17 @@
+import ApplicationAdapter from './application';
+
+export default class OrganizationLearner extends ApplicationAdapter {
+  urlForCreateRecord() {
+    return `${this.host}/${this.namespace}/organization-learners/reconcile`;
+  }
+
+  async createRecord(_, type, snapshot) {
+    const url = this.buildURL(type.modelName, null, snapshot, 'createRecord');
+
+    const data = this.serialize(snapshot);
+
+    await this.ajax(url, 'POST', { data });
+
+    return { data: { id: 'success', type: 'organization-learner' } };
+  }
+}

--- a/mon-pix/app/components/campaigns/invited/learner-reconciliation.gjs
+++ b/mon-pix/app/components/campaigns/invited/learner-reconciliation.gjs
@@ -1,0 +1,107 @@
+import PixBackgroundHeader from '@1024pix/pix-ui/components/pix-background-header';
+import PixBlock from '@1024pix/pix-ui/components/pix-block';
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
+
+export default class LearnerReconciliation extends Component {
+  @service intl;
+  @tracked reconciliationFieldData;
+
+  constructor() {
+    super(...arguments);
+
+    this.reconciliationFieldData = [];
+
+    this.args.reconciliationFields.forEach(({ key, columnName }) => {
+      this.reconciliationFieldData.push({
+        id: key,
+        value: null,
+        status: 'default',
+        errorMessage: null,
+        label: columnName,
+      });
+    });
+  }
+
+  @action
+  async submitHandler(event) {
+    event.preventDefault();
+
+    this._validateForm();
+
+    if (this.isFormInvalid) return;
+
+    this.args.onSubmit(
+      this.reconciliationFieldData.reduce((object, reconciliationField) => {
+        object[reconciliationField.id] = reconciliationField.value;
+
+        return object;
+      }, {}),
+    );
+  }
+
+  get isFormInvalid() {
+    return Object.values(this.reconciliationFieldData).some((field) => field.status === 'error');
+  }
+
+  _validateForm() {
+    const fields = this.reconciliationFieldData.map((field) => {
+      if (!field.value) {
+        return {
+          ...field,
+          status: 'error',
+          errorMessage: this.intl.t('components.invited.reconciliation.error-message.mandatory-field'),
+        };
+      } else {
+        return { ...field, status: '', errorMessage: null };
+      }
+    });
+    // force tracked properties to update as they don't detect deep changes
+    this.reconciliationFieldData = fields;
+  }
+
+  @action
+  updateFields(index, event) {
+    this.reconciliationFieldData[index].value = event.target.value.trim();
+  }
+
+  <template>
+    <PixBackgroundHeader>
+      <PixBlock class="learner-reconciliation">
+        <header class="learner-reconciliation__title-container" role="banner">
+          <h1 class="learner-reconciliation__title">{{t
+              "components.invited.reconciliation.title"
+              organizationName=@organizationName
+            }}</h1>
+
+          <p class="learner-reconciliation__sub-title">{{t "common.form.mandatory-all-fields"}}</p>
+        </header>
+
+        <form onSubmit={{this.submitHandler}} role="form" class="learner-reconciliation__form">
+          {{#each this.reconciliationFieldData as |reconciliationField index|}}
+            <PixInput
+              @id={{reconciliationField.id}}
+              @errorMessage={{reconciliationField.errorMessage}}
+              @validationStatus={{reconciliationField.status}}
+              @value={{reconciliationField.value}}
+              {{on "change" (fn this.updateFields index)}}
+            >
+              <:label>{{reconciliationField.label}}</:label>
+            </PixInput>
+          {{/each}}
+          {{#if @reconciliationError}}
+            <div class="join-restricted-campaign__error" aria-live="polite">{{@reconciliationError}}</div>
+          {{/if}}
+          <PixButton @type="submit" @isLoading={{@isLoading}}>{{t "common.actions.lets-go"}}</PixButton>
+        </form>
+      </PixBlock>
+    </PixBackgroundHeader>
+  </template>
+}

--- a/mon-pix/app/components/pages/campaigns/invited/reconciliation.gjs
+++ b/mon-pix/app/components/pages/campaigns/invited/reconciliation.gjs
@@ -1,0 +1,67 @@
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import LearnerReconciliation from '../../../campaigns/invited/learner-reconciliation';
+
+export default class InvitedWrapper extends Component {
+  @service store;
+  @service campaignStorage;
+  @service router;
+  @service intl;
+
+  @tracked isLoading = false;
+  @tracked errorMessage = null;
+
+  @action
+  async registerLearner(reconciliationInfos) {
+    this.isLoading = true;
+    this.errorMessage = null;
+    const organizationLearner = this.store.createRecord('organization-learner', {
+      campaignCode: this.args.model.code,
+      reconciliationInfos,
+    });
+
+    try {
+      await organizationLearner.save();
+
+      this.campaignStorage.set(this.args.model.code, 'associationDone', true);
+      return this.router.transitionTo('campaigns.invited.fill-in-participant-external-id', this.args.model.code);
+    } catch (errorResponse) {
+      this.handleError(errorResponse);
+    } finally {
+      this.isLoading = false;
+      organizationLearner.unloadRecord();
+    }
+  }
+
+  handleError(errorResponse) {
+    if (!errorResponse.errors) throw errorResponse;
+    errorResponse.errors.forEach((error) => {
+      if (error.status === '400') {
+        this.errorMessage = this.intl.t(
+          'components.invited.reconciliation.error-message.invalid-reconciliation-error',
+          { fields: this.reconciliationFieldNames.join(', ') },
+        );
+      } else {
+        this.errorMessage = error.detail;
+      }
+    });
+  }
+  get reconciliationFieldNames() {
+    return this.args.model.reconciliationFields.map(({ columnName }) => columnName);
+  }
+
+  <template>
+    <main role="main">
+      <LearnerReconciliation
+        @organizationName={{@model.organizationName}}
+        @reconciliationFields={{@model.reconciliationFields}}
+        @reconciliationError={{this.errorMessage}}
+        @onSubmit={{this.registerLearner}}
+        @isLoading={{this.isLoading}}
+      />
+    </main>
+  </template>
+}

--- a/mon-pix/app/models/campaign.js
+++ b/mon-pix/app/models/campaign.js
@@ -27,6 +27,9 @@ export default class Campaign extends Model {
   @attr('boolean') multipleSendings;
   @attr('boolean') isFlash;
 
+  @attr('boolean') isReconciliationRequired;
+  @attr() reconciliationFields;
+
   get isAssessment() {
     return this.type === 'ASSESSMENT';
   }

--- a/mon-pix/app/models/organization-learner.js
+++ b/mon-pix/app/models/organization-learner.js
@@ -1,0 +1,6 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class OrganizationLearner extends Model {
+  @attr('string') campaignCode;
+  @attr() reconciliationInfos;
+}

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -98,6 +98,7 @@ Router.map(function () {
     });
     this.route('campaign-landing-page', { path: '/presentation' });
     this.route('invited', { path: '/prescrit' }, function () {
+      this.route('reconciliation', { path: '/enregistrement' });
       this.route('student-sco', { path: '/eleve' });
       this.route('student-sup', { path: '/etudiant' });
       this.route('fill-in-participant-external-id', { path: '/identifiant' });

--- a/mon-pix/app/routes/campaigns/invited.js
+++ b/mon-pix/app/routes/campaigns/invited.js
@@ -19,22 +19,28 @@ export default class InvitedRoute extends Route {
   }
 
   afterModel(campaign) {
-    if (this.shouldAssociateWithScoInformation(campaign)) {
+    const associationDone = this.campaignStorage.get(campaign.code, 'associationDone');
+
+    if (this.shouldAssociateInformation(campaign, associationDone)) {
+      this.router.replaceWith('campaigns.invited.reconciliation', campaign.code);
+    } else if (this.shouldAssociateWithScoInformation(campaign, associationDone)) {
       this.router.replaceWith('campaigns.invited.student-sco', campaign.code);
-    } else if (this.shouldAssociateWithSupInformation(campaign)) {
+    } else if (this.shouldAssociateWithSupInformation(campaign, associationDone)) {
       this.router.replaceWith('campaigns.invited.student-sup', campaign.code);
     } else {
       this.router.replaceWith('campaigns.invited.fill-in-participant-external-id', campaign.code);
     }
   }
 
-  shouldAssociateWithScoInformation(campaign) {
-    const associationDone = this.campaignStorage.get(campaign.code, 'associationDone');
+  shouldAssociateInformation(campaign, associationDone) {
+    return !associationDone && campaign.isReconciliationRequired;
+  }
+
+  shouldAssociateWithScoInformation(campaign, associationDone) {
     return campaign.isOrganizationSCO && campaign.isRestricted && !associationDone;
   }
 
-  shouldAssociateWithSupInformation(campaign) {
-    const associationDone = this.campaignStorage.get(campaign.code, 'associationDone');
+  shouldAssociateWithSupInformation(campaign, associationDone) {
     return campaign.isOrganizationSUP && campaign.isRestricted && !associationDone;
   }
 }

--- a/mon-pix/app/routes/campaigns/invited/reconciliation.js
+++ b/mon-pix/app/routes/campaigns/invited/reconciliation.js
@@ -1,0 +1,30 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class ReconciliationRoute extends Route {
+  @service currentUser;
+  @service campaignStorage;
+  @service store;
+  @service session;
+  @service router;
+
+  beforeModel(transition) {
+    this.session.requireAuthenticationAndApprovedTermsOfService(transition);
+  }
+
+  model() {
+    return this.modelFor('campaigns');
+  }
+
+  async afterModel(campaign) {
+    const organizationLearner = await this.store.queryRecord('organization-learner-identity', {
+      userId: this.currentUser.user.id,
+      campaignCode: campaign.code,
+    });
+
+    if (organizationLearner) {
+      this.campaignStorage.set(campaign.code, 'associationDone', true);
+      this.router.replaceWith('campaigns.invited.fill-in-participant-external-id', campaign.code);
+    }
+  }
+}

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -121,7 +121,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @import 'components/user-tutorials/sidebar';
 @import 'components/pix-toggle';
 @import 'components/skip-link';
-@import 'components/campaigns/assessment/skill-review/share-badge-icons';
+@import 'components/campaigns';
 @import 'components/modulix/feedback';
 
 /* pages */

--- a/mon-pix/app/styles/components/campaigns/index.scss
+++ b/mon-pix/app/styles/components/campaigns/index.scss
@@ -1,0 +1,2 @@
+@import 'assessment/skill-review/share-badge-icons';
+@import 'invited/learner-reconcilation';

--- a/mon-pix/app/styles/components/campaigns/invited/learner-reconcilation.scss
+++ b/mon-pix/app/styles/components/campaigns/invited/learner-reconcilation.scss
@@ -1,0 +1,30 @@
+.learner-reconciliation {
+  padding: var(--pix-spacing-10x);
+
+  &__main-title {
+    margin-bottom: var(--pix-spacing-8x);
+  }
+
+  &__title {
+    @extend %pix-title-l;
+
+    margin-bottom: var(--pix-spacing-4x);
+    color: $pix-neutral-100;
+    text-align: center;
+  }
+
+  &__sub-title {
+    @extend %pix-body-s;
+
+    padding-bottom: 10px;
+    color: $pix-neutral-70;
+    text-align: center;
+  }
+
+  &__form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-4x);
+    align-items: center;
+  }
+}

--- a/mon-pix/app/templates/campaigns/invited/reconciliation.hbs
+++ b/mon-pix/app/templates/campaigns/invited/reconciliation.hbs
@@ -1,0 +1,3 @@
+{{page-title (t "pages.join.title")}}
+
+<Pages::Campaigns::Invited::Reconciliation @model={{@model}} />

--- a/mon-pix/config/ember-intl.js
+++ b/mon-pix/config/ember-intl.js
@@ -12,7 +12,7 @@ module.exports = function (/* environment */) {
      * @type {String?}
      * @default "null"
      */
-    fallbackLocale: null,
+    fallbackLocale: 'fr',
 
     /**
      * Path where translations are kept.  This is relative to the project root.
@@ -56,7 +56,7 @@ module.exports = function (/* environment */) {
      * @type {Boolean}
      * @default "false"
      */
-    errorOnMissingTranslations: true,
+    errorOnMissingTranslations: false,
 
     /**
      * Filter missing translations to ignore expected missing translations.

--- a/mon-pix/tests/integration/components/campaign/invited/learner-reconciliation_test.js
+++ b/mon-pix/tests/integration/components/campaign/invited/learner-reconciliation_test.js
@@ -1,0 +1,142 @@
+import { render, within } from '@1024pix/ember-testing-library';
+import { click, fillIn } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Campaign | Invited | learner-reconciliation', function (hooks) {
+  setupIntlRenderingTest(hooks);
+  let reconciliationFields, organizationName, onSubmit;
+
+  hooks.beforeEach(function () {
+    onSubmit = sinon.stub();
+    organizationName = 'My Organization';
+    reconciliationFields = [
+      {
+        key: 'field2',
+        columnName: 'Prénom',
+      },
+      {
+        key: 'field1',
+        columnName: 'Date de naissance',
+      },
+    ];
+
+    this.set('reconciliationFields', reconciliationFields);
+    this.set('organizationName', organizationName);
+    this.set('onSubmit', onSubmit);
+  });
+
+  test('it should display reconciliation form', async function (assert) {
+    // given / when
+    const screen = await render(
+      hbs`<Campaigns::Invited::LearnerReconciliation
+        @reconciliationFields={{this.reconciliationFields}}
+        @organizationName={{this.organizationName}}
+      />`,
+    );
+    // then
+    assert.ok(
+      screen.getByRole('heading', {
+        name: this.intl.t('components.invited.reconciliation.title', { organizationName }),
+        level: 1,
+      }),
+    );
+    assert.ok(screen.getByText(this.intl.t('common.form.mandatory-all-fields')));
+
+    assert.ok(screen.getByRole('textbox', { name: 'Prénom' }));
+    assert.ok(screen.getByRole('textbox', { name: 'Date de naissance' }));
+    assert.ok(screen.getByRole('button', { name: this.intl.t('common.actions.lets-go') }));
+  });
+
+  module('validation cases', function () {
+    test('should display error message when field not defined', async function (assert) {
+      // given
+      const screen = await render(
+        hbs`<Campaigns::Invited::LearnerReconciliation
+          @reconciliationFields={{this.reconciliationFields}}
+          @organizationName={{this.organizationName}}
+        />`,
+      );
+      // when
+      const button = screen.getByRole('button', { name: this.intl.t('common.actions.lets-go') });
+
+      await click(button);
+      // then
+      assert.strictEqual(
+        screen.getAllByText(this.intl.t('components.invited.reconciliation.error-message.mandatory-field')).length,
+        2,
+      );
+    });
+    module('isLoading', function () {
+      test('should not disable button', async function (assert) {
+        // given
+        const screen = await render(
+          hbs`<Campaigns::Invited::LearnerReconciliation
+            @reconciliationFields={{this.reconciliationFields}}
+            @organizationName={{this.organizationName}}
+            @onSubmit={{this.onSubmit}}
+            @isLoading={{false}}
+          />`,
+        );
+        // when
+        const button = screen.getByRole('button', { name: this.intl.t('common.actions.lets-go') });
+        assert.false(button.hasAttribute('disabled'));
+      });
+
+      test('should disable button', async function (assert) {
+        // given
+        const screen = await render(
+          hbs`<Campaigns::Invited::LearnerReconciliation
+            @reconciliationFields={{this.reconciliationFields}}
+            @organizationName={{this.organizationName}}
+            @onSubmit={{this.onSubmit}}
+            @isLoading={{true}}
+          />`,
+        );
+        // when
+        const form = screen.getByRole('form');
+        const button = within(form).getByRole('button');
+        assert.true(button.hasAttribute('disabled'));
+      });
+    });
+
+    test('should call submit to register learner', async function (assert) {
+      // given
+      const screen = await render(
+        hbs`<Campaigns::Invited::LearnerReconciliation
+          @reconciliationFields={{this.reconciliationFields}}
+          @organizationName={{this.organizationName}}
+          @onSubmit={{this.onSubmit}}
+        />`,
+      );
+      // when
+      await fillIn(screen.getByRole('textbox', { name: 'Prénom' }), 'jaune');
+      await fillIn(screen.getByRole('textbox', { name: 'Date de naissance' }), '06/01/2020');
+
+      const button = screen.getByRole('button', { name: this.intl.t('common.actions.lets-go') });
+
+      await click(button);
+
+      // then
+      assert.true(onSubmit.calledWithExactly({ field2: 'jaune', field1: '06/01/2020' }));
+    });
+  });
+
+  module('error case', function () {
+    test('should display errorMessage', async function (assert) {
+      // given
+      const screen = await render(
+        hbs`<Campaigns::Invited::LearnerReconciliation
+          @reconciliationFields={{this.reconciliationFields}}
+          @organizationName={{this.organizationName}}
+          @reconciliationError={{'Une erreur!!!'}}
+          @onSubmit={{this.onSubmit}}
+        />`,
+      );
+      assert.ok(screen.getByText('Une erreur!!!'));
+    });
+  });
+});

--- a/mon-pix/tests/unit/adapters/organization-learner-identity_test.js
+++ b/mon-pix/tests/unit/adapters/organization-learner-identity_test.js
@@ -1,5 +1,6 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
+// import sinon from 'sinon';
 
 module('Unit | Adapters | organization-learner-identity', function (hooks) {
   setupTest(hooks);
@@ -8,6 +9,7 @@ module('Unit | Adapters | organization-learner-identity', function (hooks) {
 
   hooks.beforeEach(function () {
     adapter = this.owner.lookup('adapter:organization-learner-identity');
+    // adapter.ajax = sinon.stub().resolves();
   });
 
   module('#urlForQueryRecord', function () {

--- a/mon-pix/tests/unit/adapters/organization-learner_test.js
+++ b/mon-pix/tests/unit/adapters/organization-learner_test.js
@@ -1,0 +1,23 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Adapters | organization-learner', function (hooks) {
+  setupTest(hooks);
+
+  let adapter;
+
+  hooks.beforeEach(function () {
+    adapter = this.owner.lookup('adapter:organization-learner');
+    adapter.ajax = sinon.stub().resolves();
+  });
+
+  module('#urlForCreateRecord', function () {
+    test('should redirect to /api/organization-learners/reconcile', async function (assert) {
+      // when
+      const url = await adapter.urlForCreateRecord();
+      // then
+      assert.true(url.endsWith('/api/organization-learners/reconcile'));
+    });
+  });
+});

--- a/mon-pix/tests/unit/components/pages/campaigns/invited/reconciliation_test.js
+++ b/mon-pix/tests/unit/components/pages/campaigns/invited/reconciliation_test.js
@@ -1,0 +1,98 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import createGlimmerComponent from '../../../../../helpers/create-glimmer-component';
+
+module('Unit | Component | Pages | Campaigns | Invited | Reconciliation', function (hooks) {
+  setupTest(hooks);
+  let createRecordStub, component, model, campaignCode;
+  hooks.beforeEach(function () {
+    campaignCode = Symbol('code');
+    createRecordStub = {
+      unloadRecord: sinon.stub(),
+      save: sinon.stub(),
+    };
+    model = {
+      code: campaignCode,
+    };
+
+    component = createGlimmerComponent('pages/campaigns/invited/reconciliation', { model });
+    component.router = { transitionTo: sinon.stub().returns() };
+    component.store = {
+      createRecord: sinon.stub(),
+    };
+    component.campaignStorage = {
+      set: sinon.stub(),
+    };
+  });
+
+  test('loading state must be false by default', async function (assert) {
+    // then
+    assert.false(component.isLoading);
+  });
+
+  test('should transition to next route if everything ok', async function (assert) {
+    // given
+    const reconciliationInfos = Symbol('reconciliationInfos');
+    component.store.createRecord
+      .withArgs('organization-learner', {
+        campaignCode,
+        reconciliationInfos,
+      })
+      .returns(createRecordStub);
+    // when
+    await component.registerLearner(reconciliationInfos);
+
+    assert.true(createRecordStub.save.called, 'called save');
+    assert.true(createRecordStub.unloadRecord.called, 'called unloadRecord');
+    assert.true(
+      component.campaignStorage.set.calledWithExactly(campaignCode, 'associationDone', true),
+      'called campaignStorage',
+    );
+    assert.true(
+      component.router.transitionTo.calledWithExactly(
+        'campaigns.invited.fill-in-participant-external-id',
+        campaignCode,
+      ),
+      'called transitionTo',
+    );
+  });
+
+  test('should not called transition when error occured', async function (assert) {
+    // given
+    const reconciliationInfos = Symbol('reconciliationInfos');
+    component.store.createRecord
+      .withArgs('organization-learner', {
+        campaignCode,
+        reconciliationInfos,
+      })
+      .returns(createRecordStub);
+    createRecordStub.save.rejects({ errors: [{ status: 400, detail: 'oh no !' }] });
+    // when
+    await component.registerLearner(reconciliationInfos);
+
+    // then
+    assert.true(createRecordStub.save.called, 'call save method');
+    assert.true(createRecordStub.unloadRecord.called, 'call unloadRecord record');
+    assert.true(component.campaignStorage.set.notCalled, 'not called campaignStorage');
+    assert.true(component.router.transitionTo.notCalled, 'not called transitionTo');
+  });
+
+  test('should set errorMessage when error occured', async function (assert) {
+    // given
+    const reconciliationInfos = Symbol('reconciliationInfos');
+    component.store.createRecord
+      .withArgs('organization-learner', {
+        campaignCode,
+        reconciliationInfos,
+      })
+      .returns(createRecordStub);
+    createRecordStub.save.rejects({ errors: [{ status: 400, title: ' title error ', detail: 'Une erreur !' }] });
+    // when
+    await component.registerLearner(reconciliationInfos);
+
+    // then
+    assert.strictEqual(component.errorMessage, 'Une erreur !');
+  });
+});

--- a/mon-pix/tests/unit/routes/campaigns/invited_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/invited_test.js
@@ -48,44 +48,132 @@ module('Unit | Route | Invited', function (hooks) {
   });
 
   module('#afterModel', function () {
-    test('should redirect to student sco invited page when association is needed', async function (assert) {
-      //given
-      campaign = EmberObject.create({
-        isRestricted: true,
-        isOrganizationSCO: true,
+    module('reconciliation', function () {
+      test('should redirect to reconciliation invited page when association is needed', async function (assert) {
+        //given
+        campaign = EmberObject.create({
+          isReconciliationRequired: true,
+        });
+
+        route.campaignStorage.get.withArgs(campaign.code, 'associationDone').returns(false);
+
+        //when
+        await route.afterModel(campaign);
+
+        //then
+        const expectedResult = route.router.replaceWith.calledWithExactly(
+          'campaigns.invited.reconciliation',
+          campaign.code,
+        );
+        assert.true(expectedResult);
       });
-      route.campaignStorage.get.withArgs(campaign.code, 'associationDone').returns(false);
 
-      //when
-      await route.afterModel(campaign);
+      test('should redirect to fill in participant external page when association is already done', async function (assert) {
+        //given
+        campaign = EmberObject.create({
+          isReconciliationRequired: true,
+        });
 
-      //then
-      sinon.assert.calledWith(route.router.replaceWith, 'campaigns.invited.student-sco', campaign.code);
-      assert.ok(true);
+        route.campaignStorage.get.withArgs(campaign.code, 'associationDone').returns(true);
+
+        //when
+        await route.afterModel(campaign);
+
+        //then
+        const expectedResult = route.router.replaceWith.calledWithExactly(
+          'campaigns.invited.fill-in-participant-external-id',
+          campaign.code,
+        );
+        assert.true(expectedResult);
+      });
     });
 
-    test('should redirect to student sup invited page when association is needed', async function (assert) {
-      //given
-      campaign = EmberObject.create({
-        isRestricted: true,
-        isOrganizationSUP: true,
+    module('student sco', function () {
+      test('should redirect student sco invited page when association is needed', async function (assert) {
+        //given
+        campaign = EmberObject.create({
+          isRestricted: true,
+          isOrganizationSCO: true,
+        });
+        route.campaignStorage.get.withArgs(campaign.code, 'associationDone').returns(false);
+
+        //when
+        await route.afterModel(campaign);
+
+        //then
+        const expectedResult = route.router.replaceWith.calledWithExactly(
+          'campaigns.invited.student-sco',
+          campaign.code,
+        );
+        assert.true(expectedResult);
       });
-      route.campaignStorage.get.withArgs(campaign.code, 'associationDone').returns(false);
 
-      //when
-      await route.afterModel(campaign);
+      test('should redirect to fill in participant external page when association is already done', async function (assert) {
+        //given
+        campaign = EmberObject.create({
+          isRestricted: true,
+          isOrganizationSCO: true,
+        });
+        route.campaignStorage.get.withArgs(campaign.code, 'associationDone').returns(true);
 
-      //then
-      sinon.assert.calledWith(route.router.replaceWith, 'campaigns.invited.student-sup', campaign.code);
-      assert.ok(true);
+        //when
+        await route.afterModel(campaign);
+
+        //then
+        const expectedResult = route.router.replaceWith.calledWithExactly(
+          'campaigns.invited.fill-in-participant-external-id',
+          campaign.code,
+        );
+        assert.true(expectedResult);
+      });
+    });
+
+    module('student sup', function () {
+      test('should redirect student sup invited page when association is needed', async function (assert) {
+        //given
+        campaign = EmberObject.create({
+          isRestricted: true,
+          isOrganizationSUP: true,
+        });
+        route.campaignStorage.get.withArgs(campaign.code, 'associationDone').returns(false);
+
+        //when
+        await route.afterModel(campaign);
+
+        //then
+        const expectedResult = route.router.replaceWith.calledWithExactly(
+          'campaigns.invited.student-sup',
+          campaign.code,
+        );
+        assert.true(expectedResult);
+      });
+
+      test('should redirect to fill in participant external page when association is already done', async function (assert) {
+        //given
+        campaign = EmberObject.create({
+          isRestricted: true,
+          isOrganizationSUP: true,
+        });
+        route.campaignStorage.get.withArgs(campaign.code, 'associationDone').returns(true);
+
+        //when
+        await route.afterModel(campaign);
+
+        //then
+        const expectedResult = route.router.replaceWith.calledWithExactly(
+          'campaigns.invited.fill-in-participant-external-id',
+          campaign.code,
+        );
+        assert.true(expectedResult);
+      });
     });
 
     test('should redirect to fill in participant external otherwise', async function (assert) {
       //given
+      route.campaignStorage.get.withArgs(campaign.code, 'associationDone').returns(false);
       campaign = EmberObject.create({
         isRestricted: false,
       });
-      route.campaignStorage.get.withArgs(campaign.code, 'associationDone').returns(false);
 
       //when
       await route.afterModel(campaign);

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -40,6 +40,7 @@
       "cancel": "Cancel",
       "close": "Close",
       "confirm": "Confirm",
+      "lets-go": "Let's go!",
       "quit": "Exit",
       "sign-out": "Sign out",
       "stay": "Stay",
@@ -107,6 +108,17 @@
     "skip-links": {
       "skip-to-content": "Skip to main content",
       "skip-to-footer": "Skip to footer"
+    }
+  },
+  "components": {
+    "invited": {
+      "reconciliation": {
+        "title": "Join organization { organizationName }",
+        "error-message": {
+          "invalid-reconciliation-error": "Check your information ({fields}) or contact a teacher.",
+          "mandatory-field": "This field is mandatory"
+        }
+      }
     }
   },
   "navigation": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -40,6 +40,7 @@
       "cancel": "Annuler",
       "close": "Fermer",
       "confirm": "Confirmer",
+      "lets-go": "C'est parti !",
       "quit": "Quitter",
       "sign-out": "Se déconnecter",
       "stay": "Rester",
@@ -107,6 +108,17 @@
     "skip-links": {
       "skip-to-content": "Aller au contenu",
       "skip-to-footer": "Aller au bas de page"
+    }
+  },
+  "components": {
+    "invited": {
+      "reconciliation": {
+        "title": "Rejoignez l'organisation { organizationName }",
+        "error-message": {
+          "invalid-reconciliation-error": "Vérifiez vos informations ({fields}) ou contactez un enseignant.",
+          "mandatory-field": "Ce champ est obligatoire"
+        }
+      }
     }
   },
   "navigation": {


### PR DESCRIPTION
## :unicorn: Problème
Maintenant que l'import générique est en place, nous avons besoin que nos apprenant puisse se rattacher son compte à l'apprenant que son organisation aura créée pour lui lors de l'import

## :robot: Proposition
Permettre d'accéder à la page de réconciliation, et afficher les champs requis pour se réconcilier

## :rainbow: Remarques
Limitations connues
- les champs de saisie de date doivent être pour l'instant saisie dans le format Bdd (YYYY-MM-DD)
- la comparaison des champs est sensible à la casse, espaces et aux diacritiques
- 
## :100: Pour tester

- Faire un import sur l'orga PRO_MANAGING 
- Se connecter sur App (mon-pix) avec un compte existant ( member-orga@example.net)
- Renseigner le code campagne PROGENCOL et valider
- Cliquer sur "C'est parti"

### Afficher les erreurs de saisie
- Cliquer sur "C'est parti"
- Voir les erreur de champ obligatoire
### Afficher l'erreur de réconciliation
- Saisir "test" dans chaque champ
- cliquer sur "C'est parti"
- Voir l'erreur de réconciliation
### Cas passant
- Saisir Bal / TERRE / 2000-05-01
- Voir l'écran de saisie de l'identifiant idPixLabel