### PR TITLE
[FEATURE] Ajouter un filtre sur les classes (Pix-11916)

### DIFF
--- a/api/lib/domain/usecases/organizations-administration/get-organization-details.js
+++ b/api/lib/domain/usecases/organizations-administration/get-organization-details.js
@@ -3,7 +3,7 @@ import { Organization } from '../../models/index.js';
 const getOrganizationDetails = async function ({ organizationId, organizationForAdminRepository, schoolRepository }) {
   const organization = await organizationForAdminRepository.get(organizationId);
   if (organization.type === Organization.types.SCO1D) {
-    organization.code = await schoolRepository.getById(organization.id);
+    organization.code = await schoolRepository.getById({ organizationId });
   }
   return organization;
 };

--- a/api/src/prescription/campaign/domain/usecases/update-campaign-code.js
+++ b/api/src/prescription/campaign/domain/usecases/update-campaign-code.js
@@ -8,7 +8,7 @@ const updateCampaignCode = async function ({ campaignId, campaignCode, campaignA
 
   campaign.updateFields({ code: campaignCode });
 
-  const isCodeAvailable = await campaignAdministrationRepository.isCodeAvailable(campaignCode);
+  const isCodeAvailable = await campaignAdministrationRepository.isCodeAvailable({ code: campaignCode });
   if (!isCodeAvailable) {
     throw new CampaignUniqueCodeError();
   }

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js
@@ -94,7 +94,7 @@ const save = async function (campaigns, dependencies = { skillRepository }) {
   }
 };
 
-const isCodeAvailable = async function (code) {
+const isCodeAvailable = async function ({ code }) {
   return !(await knex('campaigns').first('id').where({ code }));
 };
 

--- a/api/src/school/application/mission-learner-controller.js
+++ b/api/src/school/application/mission-learner-controller.js
@@ -4,8 +4,11 @@ import * as missionLearnerSerializer from '../infrastructure/serializers/mission
 
 const findPaginatedMissionLearners = async function (request) {
   const { organizationId, missionId } = request.params;
-  const { page } = extractParameters(request.query);
-  const result = await usecases.findPaginatedMissionLearners({ organizationId, missionId, page });
+  const { page, filter } = extractParameters(request.query);
+  if (filter.divisions && !Array.isArray(filter.divisions)) {
+    filter.divisions = [filter.divisions];
+  }
+  const result = await usecases.findPaginatedMissionLearners({ organizationId, missionId, page, filter });
   return missionLearnerSerializer.serialize(result);
 };
 

--- a/api/src/school/application/mission-learner-route.js
+++ b/api/src/school/application/mission-learner-route.js
@@ -22,6 +22,7 @@ const register = async function (server) {
           query: Joi.object({
             'page[number]': Joi.number().integer().empty(''),
             'page[size]': Joi.number().integer().empty(''),
+            'filter[divisions][]': [Joi.string(), Joi.array().items(Joi.string())],
           }),
         },
         handler: missionLearnerController.findPaginatedMissionLearners,

--- a/api/src/school/application/school-controller.js
+++ b/api/src/school/application/school-controller.js
@@ -1,3 +1,4 @@
+import * as divisionSerializer from '../../prescription/campaign/infrastructure/serializers/jsonapi/division-serializer.js';
 import { usecases } from '../domain/usecases/index.js';
 import * as schoolSerializer from '../infrastructure/serializers/school-serializer.js';
 
@@ -13,5 +14,11 @@ const activateSchoolSession = async function (request, h) {
   return h.response().code(204);
 };
 
-const schoolController = { getSchool, activateSchoolSession };
+const getDivisions = async function (request) {
+  const { organizationId } = request.params;
+  const divisions = await usecases.getDivisions({ organizationId });
+  return divisionSerializer.serialize(divisions);
+};
+
+const schoolController = { getSchool, activateSchoolSession, getDivisions };
 export { schoolController };

--- a/api/src/school/application/school-route.js
+++ b/api/src/school/application/school-route.js
@@ -43,6 +43,24 @@ const register = async function (server) {
         notes: ["- Elle permet de d'activer une session d'une orga"],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/pix1d/schools/{organizationId}/divisions',
+      config: {
+        pre: [
+          { method: securityPreHandlers.checkPix1dActivated },
+          { method: securityPreHandlers.checkUserBelongsToOrganization },
+        ],
+        validate: {
+          params: Joi.object({
+            organizationId: identifiersType.organizationId,
+          }),
+        },
+        handler: schoolController.getDivisions,
+        tags: ['api', 'pix1d', 'school'],
+        notes: ["- Elle permet de récupérer la liste des classes d'une école liée à une organisation."],
+      },
+    },
   ]);
 };
 

--- a/api/src/school/domain/models/Division.js
+++ b/api/src/school/domain/models/Division.js
@@ -1,0 +1,7 @@
+class Division {
+  constructor({ name } = {}) {
+    this.name = name;
+  }
+}
+
+export { Division };

--- a/api/src/school/domain/usecases/activate-school-session.js
+++ b/api/src/school/domain/usecases/activate-school-session.js
@@ -3,7 +3,7 @@ const SCHOOL_SESSION_DURATION_HOURS = 4;
 const activateSchoolSession = async function ({ organizationId, schoolRepository } = {}) {
   const sessionExpirationDate = new Date();
   sessionExpirationDate.setHours(sessionExpirationDate.getHours() + SCHOOL_SESSION_DURATION_HOURS);
-  await schoolRepository.updateSessionExpirationDate(organizationId, sessionExpirationDate);
+  await schoolRepository.updateSessionExpirationDate({ organizationId, sessionExpirationDate });
 };
 
 export { activateSchoolSession };

--- a/api/src/school/domain/usecases/find-paginated-mission-learners.js
+++ b/api/src/school/domain/usecases/find-paginated-mission-learners.js
@@ -8,10 +8,12 @@ const findPaginatedMissionLearners = async function ({
   organizationId,
   missionId,
   page,
+  filter,
 } = {}) {
   const { pagination, missionLearners } = await missionLearnerRepository.findPaginatedMissionLearners({
     organizationId,
     page,
+    filter,
   });
 
   const missionLearnersWithStatus = await missionAssessmentRepository.getStatusesForLearners(

--- a/api/src/school/domain/usecases/get-divisions.js
+++ b/api/src/school/domain/usecases/get-divisions.js
@@ -1,0 +1,5 @@
+const getDivisions = async function ({ organizationId, schoolRepository } = {}) {
+  return schoolRepository.getDivisions({ organizationId });
+};
+
+export { getDivisions };

--- a/api/src/school/domain/usecases/get-school-by-code.js
+++ b/api/src/school/domain/usecases/get-school-by-code.js
@@ -1,7 +1,7 @@
 import { School } from '../models/School.js';
 
 const getSchoolByCode = async function ({ code, schoolRepository, organizationLearnerRepository } = {}) {
-  const school = await schoolRepository.getByCode(code);
+  const school = await schoolRepository.getByCode({ code });
   const organizationLearners = await organizationLearnerRepository.getStudentsByOrganizationId({
     organizationId: school.id,
   });

--- a/api/src/school/domain/usecases/index.js
+++ b/api/src/school/domain/usecases/index.js
@@ -12,7 +12,6 @@ import * as activityRepository from '../../infrastructure/repositories/activity-
 import { repositories } from '../../infrastructure/repositories/index.js';
 import * as missionAssessmentRepository from '../../infrastructure/repositories/mission-assessment-repository.js';
 import * as missionRepository from '../../infrastructure/repositories/mission-repository.js';
-import * as schoolRepository from '../../infrastructure/repositories/school-repository.js';
 
 const dependencies = {
   activityAnswerRepository,
@@ -24,7 +23,7 @@ const dependencies = {
   missionRepository,
   missionLearnerRepository: repositories.missionLearnerRepository,
   organizationLearnerRepository: repositories.organizationLearnerRepository,
-  schoolRepository,
+  schoolRepository: repositories.schoolRepository,
   challengeRepository,
 };
 

--- a/api/src/school/infrastructure/repositories/index.js
+++ b/api/src/school/infrastructure/repositories/index.js
@@ -2,10 +2,12 @@ import * as organizationLearnerApi from '../../../prescription/organization-lear
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import * as missionLearnerRepository from '../../infrastructure/repositories/mission-learner-repository.js';
 import * as organizationLearnerRepository from '../../infrastructure/repositories/organization-learner-repository.js';
+import * as schoolRepository from '../../infrastructure/repositories/school-repository.js';
 
 const repositoriesWithoutInjectedDependencies = {
   organizationLearnerRepository,
   missionLearnerRepository,
+  schoolRepository,
 };
 
 const dependencies = {

--- a/api/src/school/infrastructure/repositories/mission-learner-repository.js
+++ b/api/src/school/infrastructure/repositories/mission-learner-repository.js
@@ -1,7 +1,7 @@
 import { SchoolLearner } from '../../domain/models/SchoolLearner.js';
 
-const findPaginatedMissionLearners = async function ({ organizationId, page, organizationLearnerApi }) {
-  const { organizationLearners, pagination } = await organizationLearnerApi.find({ organizationId, page });
+const findPaginatedMissionLearners = async function ({ organizationId, page, filter, organizationLearnerApi }) {
+  const { organizationLearners, pagination } = await organizationLearnerApi.find({ organizationId, page, filter });
 
   const missionLearners = organizationLearners.map((missionLearner) => new SchoolLearner({ ...missionLearner }));
   return { missionLearners, pagination };

--- a/api/src/school/infrastructure/repositories/school-repository.js
+++ b/api/src/school/infrastructure/repositories/school-repository.js
@@ -8,11 +8,11 @@ const save = async function ({ organizationId, code, domainTransaction = DomainT
   await knexConn('schools').insert({ organizationId, code }).returning('*');
 };
 
-const isCodeAvailable = async function (code) {
+const isCodeAvailable = async function ({ code }) {
   return !(await knex('schools').first('id').where({ code }));
 };
 
-const getByCode = async function (code) {
+const getByCode = async function ({ code }) {
   const data = await knex('schools')
     .select('organizations.id', 'name', 'code')
     .join('organizations', 'organizations.id', 'organizationId')
@@ -26,12 +26,12 @@ const getByCode = async function (code) {
   return new School(data);
 };
 
-const getById = async function (organizationId) {
+const getById = async function ({ organizationId }) {
   const result = await knex('schools').first('code').where({ organizationId });
   return result.code;
 };
 
-const updateSessionExpirationDate = async function (organizationId, sessionExpirationDate) {
+const updateSessionExpirationDate = async function ({ organizationId, sessionExpirationDate }) {
   await knex('schools').where({ organizationId }).update({ sessionExpirationDate });
 };
 export { getByCode, getById, isCodeAvailable, save, updateSessionExpirationDate };

--- a/api/src/school/infrastructure/repositories/school-repository.js
+++ b/api/src/school/infrastructure/repositories/school-repository.js
@@ -1,5 +1,6 @@
 import { knex } from '../../../../db/knex-database-connection.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+import { Division } from '../../domain/models/Division.js';
 import { School } from '../../domain/models/School.js';
 import { SchoolNotFoundError } from '../../domain/school-errors.js';
 
@@ -34,4 +35,13 @@ const getById = async function ({ organizationId }) {
 const updateSessionExpirationDate = async function ({ organizationId, sessionExpirationDate }) {
   await knex('schools').where({ organizationId }).update({ sessionExpirationDate });
 };
-export { getByCode, getById, isCodeAvailable, save, updateSessionExpirationDate };
+
+const getDivisions = async function ({ organizationId, organizationLearnerApi }) {
+  const { organizationLearners } = await organizationLearnerApi.find({
+    organizationId,
+  });
+  const divisionLearners = organizationLearners.map((organizationLearner) => organizationLearner.division);
+  return [...new Set(divisionLearners)].sort().map((divisionName) => new Division({ name: divisionName }));
+};
+
+export { getByCode, getById, getDivisions, isCodeAvailable, save, updateSessionExpirationDate };

--- a/api/src/shared/domain/services/code-generator.js
+++ b/api/src/shared/domain/services/code-generator.js
@@ -15,7 +15,7 @@ function generate(repository, pendingList = []) {
     return generate(repository, pendingList);
   }
 
-  return repository.isCodeAvailable(generatedCode).then((isCodeAvailable) => {
+  return repository.isCodeAvailable({ code: generatedCode }).then((isCodeAvailable) => {
     if (isCodeAvailable) {
       return Promise.resolve(generatedCode);
     }

--- a/api/src/team/application/prescriber-informations.controller.js
+++ b/api/src/team/application/prescriber-informations.controller.js
@@ -10,10 +10,8 @@ import { prescriberSerializer } from '../infrastructure/serializers/jsonapi/pres
 const get = async function (request, h, dependencies = { prescriberSerializer }) {
   const authenticatedUserId = request.auth.credentials.userId;
 
-  const prescriber = await usecases
-    .getPrescriber({ userId: authenticatedUserId })
-    .then((prescriber) => dependencies.prescriberSerializer.serialize(prescriber));
-  return prescriber;
+  const prescriber = await usecases.getPrescriber({ userId: authenticatedUserId });
+  return dependencies.prescriberSerializer.serialize(prescriber);
 };
 
 export const prescriberInformationsController = { get };

--- a/api/src/team/infrastructure/serializers/jsonapi/prescriber-serializer.js
+++ b/api/src/team/infrastructure/serializers/jsonapi/prescriber-serializer.js
@@ -1,5 +1,7 @@
 import jsonapiSerializer from 'jsonapi-serializer';
 
+import { Organization } from '../../../../organizational-entities/domain/models/Organization.js';
+
 const { Serializer } = jsonapiSerializer;
 
 /**
@@ -111,6 +113,9 @@ const serialize = function (prescriber) {
           nullIfMissing: true,
           relationshipLinks: {
             related(record, current, parent) {
+              if (parent.attributes.type === Organization.types.SCO1D) {
+                return `/api/pix1d/schools/${parent.id}/divisions`;
+              }
               return `/api/organizations/${parent.id}/divisions`;
             },
           },

--- a/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-administration-repository_test.js
+++ b/api/tests/prescription/campaign/integration/infrastructure/repositories/campaign-administration-repository_test.js
@@ -15,7 +15,7 @@ describe('Integration | Repository | Campaign Administration', function () {
 
     it('should resolve true if the code is available', async function () {
       // when
-      const isCodeAvailable = await campaignAdministrationRepository.isCodeAvailable('FRANCE998');
+      const isCodeAvailable = await campaignAdministrationRepository.isCodeAvailable({ code: 'FRANCE998' });
 
       // then
       expect(isCodeAvailable).to.be.true;
@@ -23,7 +23,7 @@ describe('Integration | Repository | Campaign Administration', function () {
 
     it('should resolve false if the code is not available', async function () {
       // when
-      const isCodeAvailable = await campaignAdministrationRepository.isCodeAvailable('BADOIT710');
+      const isCodeAvailable = await campaignAdministrationRepository.isCodeAvailable({ code: 'BADOIT710' });
 
       // then
       expect(isCodeAvailable).to.be.false;

--- a/api/tests/prescription/campaign/unit/domain/usecases/update-campaign-code_test.js
+++ b/api/tests/prescription/campaign/unit/domain/usecases/update-campaign-code_test.js
@@ -21,7 +21,7 @@ describe('Unit | UseCase | update-campaign-code', function () {
 
     codeGenerator.validate.withArgs(campaignCode).returns(true);
     campaignAdministrationRepository.get.withArgs(campaignId).resolves(campaignStub);
-    campaignAdministrationRepository.isCodeAvailable.withArgs(campaignCode).resolves(true);
+    campaignAdministrationRepository.isCodeAvailable.withArgs({ code: campaignCode }).resolves(true);
 
     // when
     await updateCampaignCode({ campaignId, campaignCode, campaignAdministrationRepository, codeGenerator });
@@ -51,7 +51,7 @@ describe('Unit | UseCase | update-campaign-code', function () {
       const campaignCode = Symbol('campaign-code');
       campaignAdministrationRepository.get.withArgs(campaignId).resolves(campaignStub);
       codeGenerator.validate.withArgs(campaignCode).returns(true);
-      campaignAdministrationRepository.isCodeAvailable.withArgs(campaignCode).resolves(false);
+      campaignAdministrationRepository.isCodeAvailable.withArgs({ code: campaignCode }).resolves(false);
       // when
       const error = await catchErr(updateCampaignCode)({
         campaignId,

--- a/api/tests/school/integration/application/mission-learner-controller_test.js
+++ b/api/tests/school/integration/application/mission-learner-controller_test.js
@@ -7,6 +7,7 @@ describe('Integration | Controller | mission-learner-controller', function () {
   describe('#findPaginatedMissionLearners', function () {
     it('should return missionLearners', async function () {
       const organizationId = 1;
+      const missionId = 1;
       const missionLearner = new MissionLearner({
         id: 1,
         firstName: 'TechnoMechanicus',
@@ -23,14 +24,16 @@ describe('Integration | Controller | mission-learner-controller', function () {
         rowCount: 1,
       };
 
-      sinon.stub(usecases, 'findPaginatedMissionLearners').resolves({ missionLearners: [missionLearner], pagination });
+      const findPaginatedMissionLearnersStub = sinon.stub(usecases, 'findPaginatedMissionLearners');
+      findPaginatedMissionLearnersStub.resolves({ missionLearners: [missionLearner], pagination });
 
       const result = await missionLearnerController.findPaginatedMissionLearners(
         {
           params: {
-            id: organizationId,
+            organizationId,
+            missionId,
           },
-          query: { 'page[size]': 50, 'page[number]': 1, 'filters[division]': 'CP' },
+          query: { 'page[size]': 50, 'page[number]': 1, 'filter[divisions]': 'CP' },
         },
         hFake,
       );
@@ -50,6 +53,12 @@ describe('Integration | Controller | mission-learner-controller', function () {
         },
       ]);
       expect(result.meta).to.deep.equal(pagination);
+      expect(findPaginatedMissionLearnersStub).to.have.been.calledWith({
+        organizationId,
+        missionId,
+        page: { size: 50, number: 1 },
+        filter: { divisions: ['CP'] },
+      });
     });
 
     it('should return empty result when there is no mission learners', async function () {

--- a/api/tests/school/integration/application/mission-learner-controller_test.js
+++ b/api/tests/school/integration/application/mission-learner-controller_test.js
@@ -30,7 +30,7 @@ describe('Integration | Controller | mission-learner-controller', function () {
           params: {
             id: organizationId,
           },
-          query: { 'page[size]': 50, 'page[number]': 1 },
+          query: { 'page[size]': 50, 'page[number]': 1, 'filters[division]': 'CP' },
         },
         hFake,
       );

--- a/api/tests/school/integration/domain/usecases/find-paginated-mission-learners_test.js
+++ b/api/tests/school/integration/domain/usecases/find-paginated-mission-learners_test.js
@@ -63,6 +63,7 @@ describe('Integration | Usecase | find-paginated-mission-learners', function () 
         organizationId: organization.id,
         missionId,
         page,
+        filter: { divisions: ['CM2A'] },
       });
 
       expect(result).to.deep.equal({

--- a/api/tests/school/integration/infrastructure/repositories/mission-assessment-repository_test.js
+++ b/api/tests/school/integration/infrastructure/repositories/mission-assessment-repository_test.js
@@ -162,5 +162,18 @@ describe('Integration | Repository | mission-assessment-repository', function ()
         [organizationLearnerWithStartedAssessment.id, 'started', startedMissionAssessment.assessmentId],
       ]);
     });
+
+    it('should return empty array when there is no learners', async function () {
+      const missionId = 1;
+      const results = await missionAssessmentRepository.getStatusesForLearners(
+        missionId,
+        [],
+        (learner, status, assessmentId) => {
+          return [learner.id, status, assessmentId];
+        },
+      );
+
+      expect(results).to.deep.equal([]);
+    });
   });
 });

--- a/api/tests/school/integration/infrastructure/repositories/school-repository_test.js
+++ b/api/tests/school/integration/infrastructure/repositories/school-repository_test.js
@@ -1,7 +1,7 @@
 import { Organization } from '../../../../../lib/domain/models/index.js';
 import { School } from '../../../../../src/school/domain/models/School.js';
 import { SchoolNotFoundError } from '../../../../../src/school/domain/school-errors.js';
-import * as schoolRepository from '../../../../../src/school/infrastructure/repositories/school-repository.js';
+import { repositories } from '../../../../../src/school/infrastructure/repositories/index.js';
 import { catchErr, databaseBuilder, expect, knex } from '../../../../test-helper.js';
 
 describe('Integration | Repository | School', function () {
@@ -12,7 +12,7 @@ describe('Integration | Repository | School', function () {
       await databaseBuilder.commit();
 
       // when
-      await schoolRepository.save({ organizationId: organization.id, code: 'HAPPYY123' });
+      await repositories.schoolRepository.save({ organizationId: organization.id, code: 'HAPPYY123' });
 
       // then
       const savedSchool = await knex('schools').first();
@@ -30,7 +30,7 @@ describe('Integration | Repository | School', function () {
 
       const expectedSchool = new School({ name: 'École des fans', id: organization.id, code: 'HAPPYY123' });
       // when
-      const result = await schoolRepository.getByCode('HAPPYY123');
+      const result = await repositories.schoolRepository.getByCode({ code: 'HAPPYY123' });
 
       // then
       expect(result).to.deep.equal(expectedSchool);
@@ -43,7 +43,7 @@ describe('Integration | Repository | School', function () {
       await databaseBuilder.commit();
 
       // when
-      const error = await catchErr(schoolRepository.getByCode)('NOTHAPPY');
+      const error = await catchErr(repositories.schoolRepository.getByCode)({ code: 'NOTHAPPY' });
 
       // then
       expect(error).to.be.an.instanceof(SchoolNotFoundError);
@@ -59,7 +59,7 @@ describe('Integration | Repository | School', function () {
 
     it('should resolve true if the code is available', async function () {
       // when
-      const isCodeAvailable = await schoolRepository.isCodeAvailable('FRANCE998');
+      const isCodeAvailable = await repositories.schoolRepository.isCodeAvailable({ code: 'FRANCE998' });
 
       // then
       expect(isCodeAvailable).to.be.true;
@@ -67,7 +67,7 @@ describe('Integration | Repository | School', function () {
 
     it('should resolve false if the code is not available', async function () {
       // when
-      const isCodeAvailable = await schoolRepository.isCodeAvailable('BADOIT710');
+      const isCodeAvailable = await repositories.schoolRepository.isCodeAvailable({ code: 'BADOIT710' });
 
       // then
       expect(isCodeAvailable).to.be.false;
@@ -82,7 +82,7 @@ describe('Integration | Repository | School', function () {
       await databaseBuilder.commit();
 
       // when
-      const code = await schoolRepository.getById(organizationId);
+      const code = await repositories.schoolRepository.getById({ organizationId });
 
       // then
       expect(code).to.equal('BADOIT710');
@@ -98,7 +98,7 @@ describe('Integration | Repository | School', function () {
       const sessionExpirationDate = new Date();
 
       // when
-      await schoolRepository.updateSessionExpirationDate(organizationId, sessionExpirationDate);
+      await repositories.schoolRepository.updateSessionExpirationDate({ organizationId, sessionExpirationDate });
 
       // then
       const school = await knex('schools').first();

--- a/api/tests/school/unit/application/mission-learner-route_test.js
+++ b/api/tests/school/unit/application/mission-learner-route_test.js
@@ -24,16 +24,28 @@ describe('Unit | Route | mission-learner-route', function () {
       // given
       sinon.stub(securityPreHandlers, 'checkUserBelongsToOrganization').callsFake((request, h) => h.response(true));
       sinon.stub(securityPreHandlers, 'checkPix1dActivated').callsFake((request, h) => h.response(true));
-      sinon.stub(missionLearnerController, 'findPaginatedMissionLearners').callsFake((request, h) => h.response('ok'));
+      const findPaginatedMissionLearnersStub = sinon.stub(missionLearnerController, 'findPaginatedMissionLearners');
+      findPaginatedMissionLearnersStub.callsFake((request, h) => h.response('ok'));
 
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 
       // when
-      const response = await httpTestServer.request('GET', '/api/organizations/4/missions/1/learners');
+      const response = await httpTestServer.request(
+        'GET',
+        `/api/organizations/4/missions/1/learners?filter[divisions][]=CM2-C&filter[divisions][]=CM2-B&page[number]=1&page[size]=25`,
+      );
 
       // then
       expect(response.statusCode).to.equal(200);
+      expect(findPaginatedMissionLearnersStub).to.have.been.calledWith(
+        sinon.match.has(
+          'query',
+          sinon.match.has('filter[divisions][]', ['CM2-C', 'CM2-B']),
+          sinon.match.has('page[number]', '1'),
+          sinon.match.has('page[size]', '25'),
+        ),
+      );
     });
 
     it('should return 400 when the organizationId is not a number', async function () {

--- a/api/tests/school/unit/application/school-controller_test.js
+++ b/api/tests/school/unit/application/school-controller_test.js
@@ -1,4 +1,5 @@
 import { schoolController } from '../../../../src/school/application/school-controller.js';
+import { Division } from '../../../../src/school/domain/models/Division.js';
 import { OrganizationLearner } from '../../../../src/school/domain/models/OrganizationLearner.js';
 import { School } from '../../../../src/school/domain/models/School.js';
 import { usecases } from '../../../../src/school/domain/usecases/index.js';
@@ -59,6 +60,73 @@ describe('Unit | Controller | school-controller', function () {
 
         expect(usecases.getSchoolByCode).to.have.been.calledWith({ code });
         expect(response).to.deep.equal(serializedSchool);
+      });
+    });
+  });
+
+  describe('#getDivision', function () {
+    context('if organization has divisions', function () {
+      it('should return the serialized divisions', async function () {
+        // given
+        const organizationId = 1;
+
+        sinon.stub(usecases, 'getDivisions');
+        usecases.getDivisions.resolves([
+          new Division({
+            name: 'CM1-A',
+          }),
+          new Division({
+            name: 'CM1-B',
+          }),
+          new Division({
+            name: 'CM1-C',
+          }),
+          new Division({
+            name: 'CM1-Z',
+          }),
+        ]);
+        // when
+
+        const request = {
+          params: { organizationId },
+        };
+        const response = await schoolController.getDivisions(request, hFake);
+        // Then
+        const serializedDivisions = {
+          data: [
+            {
+              id: 'CM1-A',
+              attributes: {
+                name: 'CM1-A',
+              },
+              type: 'divisions',
+            },
+            {
+              id: 'CM1-B',
+              attributes: {
+                name: 'CM1-B',
+              },
+              type: 'divisions',
+            },
+            {
+              id: 'CM1-C',
+              attributes: {
+                name: 'CM1-C',
+              },
+              type: 'divisions',
+            },
+            {
+              id: 'CM1-Z',
+              attributes: {
+                name: 'CM1-Z',
+              },
+              type: 'divisions',
+            },
+          ],
+        };
+
+        expect(usecases.getDivisions).to.have.been.calledWith({ organizationId });
+        expect(response).to.deep.equal(serializedDivisions);
       });
     });
   });

--- a/api/tests/school/unit/application/school-route_test.js
+++ b/api/tests/school/unit/application/school-route_test.js
@@ -1,5 +1,6 @@
 import { schoolController } from '../../../../src/school/application/school-controller.js';
 import * as moduleUnderTest from '../../../../src/school/application/school-route.js';
+import { Division } from '../../../../src/school/domain/models/Division.js';
 import { usecases } from '../../../../src/school/domain/usecases/index.js';
 import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
@@ -29,6 +30,8 @@ describe('Unit | Router | school-router', function () {
         sinon
           .stub(securityPreHandlers, 'checkUserBelongsToOrganization')
           .callsFake((request, h) => h.response().code(403).takeover());
+        sinon.stub(schoolController, 'activateSchoolSession');
+
         const httpTestServer = new HttpTestServer();
         await httpTestServer.register(moduleUnderTest);
 
@@ -37,6 +40,7 @@ describe('Unit | Router | school-router', function () {
 
         // then
         expect(response.statusCode).to.equal(403);
+        expect(schoolController.activateSchoolSession).to.not.have.been.called;
       });
     });
 
@@ -56,6 +60,46 @@ describe('Unit | Router | school-router', function () {
         expect(schoolController.activateSchoolSession).to.have.been.called;
         expect(usecases.activateSchoolSession).to.have.been.calledWith({ organizationId: 123456 });
         expect(response.statusCode).to.equal(204);
+      });
+    });
+  });
+
+  describe('GET /api/pix1d/schools/{organizationId}/divisions', function () {
+    context('when user does not belong to organization', function () {
+      it('should return 403', async function () {
+        // given
+        sinon
+          .stub(securityPreHandlers, 'checkUserBelongsToOrganization')
+          .callsFake((_, h) => h.response().code(403).takeover());
+        sinon.stub(schoolController, 'getDivisions');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('GET', '/api/pix1d/schools/123456/divisions');
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        expect(schoolController.getDivisions).to.not.have.been.called;
+      });
+    });
+
+    context('when user belongs to organization', function () {
+      it('should return 200', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'checkUserBelongsToOrganization').callsFake((_, h) => h.response(true));
+        sinon.spy(schoolController, 'getDivisions');
+        sinon.stub(usecases, 'getDivisions').returns([new Division({ name: 'CM2' })]);
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('GET', '/api/pix1d/schools/123456/divisions');
+
+        // then
+        expect(schoolController.getDivisions).to.have.been.called;
+        expect(usecases.getDivisions).to.have.been.calledWith({ organizationId: 123456 });
+        expect(response.statusCode).to.equal(200);
       });
     });
   });

--- a/api/tests/school/unit/domain/usecases/activate-school-session_test.js
+++ b/api/tests/school/unit/domain/usecases/activate-school-session_test.js
@@ -17,6 +17,9 @@ describe('Unit | Domain | Use Cases | activate-school-session', function () {
     const schoolRepository = { updateSessionExpirationDate: sinon.stub() };
     const nowPlus4h = new Date('2022-11-28T16:00:00Z');
     await activateSchoolSession({ organizationId: 123456, schoolRepository });
-    expect(schoolRepository.updateSessionExpirationDate).to.have.been.calledWithExactly(123456, nowPlus4h);
+    expect(schoolRepository.updateSessionExpirationDate).to.have.been.calledWithExactly({
+      organizationId: 123456,
+      sessionExpirationDate: nowPlus4h,
+    });
   });
 });

--- a/api/tests/school/unit/domain/usecases/find-paginated-mission-learners_test.js
+++ b/api/tests/school/unit/domain/usecases/find-paginated-mission-learners_test.js
@@ -1,0 +1,53 @@
+import { findPaginatedMissionLearners } from '../../../../../src/school/domain/usecases/find-paginated-mission-learners.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Domain | Use Cases | find-paginated-mission-learners', function () {
+  let missionLearnerRepository,
+    missionAssessmentRepository,
+    activityRepository,
+    organizationId,
+    missionId,
+    page,
+    learner,
+    pagination,
+    filter;
+
+  beforeEach(function () {
+    missionLearnerRepository = { findPaginatedMissionLearners: sinon.stub() };
+    missionAssessmentRepository = { getStatusesForLearners: sinon.stub() };
+    activityRepository = { getAllByAssessmentId: sinon.stub() };
+    organizationId = 1234567;
+    missionId = 3;
+    page = { size: 4, number: 2 };
+    learner = {
+      id: 34,
+    };
+    pagination = { page: 2, pageCount: 1, pageSize: 4, rowCount: 8 };
+    filter = { divisions: ['CP'] };
+  });
+
+  it('should call missionLearnerRepository with good args', async function () {
+    missionLearnerRepository.findPaginatedMissionLearners.resolves({ pagination, missionLearners: [learner] });
+    missionAssessmentRepository.getStatusesForLearners
+      .withArgs(missionId, [learner], function () {
+        return;
+      })
+      .resolves([learner]);
+
+    await findPaginatedMissionLearners({
+      organizationId,
+      page,
+      missionId,
+      missionLearnerRepository,
+      missionAssessmentRepository,
+      activityRepository,
+      filter,
+    });
+
+    expect(missionLearnerRepository.findPaginatedMissionLearners).to.have.been.calledWithExactly({
+      organizationId,
+      page,
+      filter,
+    });
+  });
+});

--- a/api/tests/school/unit/domain/usecases/get-divisions_test.js
+++ b/api/tests/school/unit/domain/usecases/get-divisions_test.js
@@ -1,0 +1,17 @@
+import { Division } from '../../../../../src/school/domain/models/Division.js';
+import { getDivisions } from '../../../../../src/school/domain/usecases/get-divisions.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Domain | Use Cases | get-divisions', function () {
+  it('should call the school repository ', async function () {
+    const organizationId = 'someOrgaId';
+    const schoolRepository = { getDivisions: sinon.stub() };
+    const schoolDivision = new Division('CM2');
+    schoolRepository.getDivisions.resolves([schoolDivision]);
+
+    const divisions = await getDivisions({ organizationId, schoolRepository });
+
+    expect(schoolRepository.getDivisions).to.have.been.calledWithExactly({ organizationId });
+    expect(divisions).to.contain(schoolDivision);
+  });
+});

--- a/api/tests/school/unit/infrastructure/repositories/mission-learner-repository_test.js
+++ b/api/tests/school/unit/infrastructure/repositories/mission-learner-repository_test.js
@@ -23,14 +23,16 @@ describe('Unit | Repository | organizationLearner', function () {
         pageSize: 100,
         rowCount: 1,
       };
+      const divisionFilter = { divisions: ['4ème'] };
 
       organizationLearnerApiStub.find
-        .withArgs({ organizationId, page: customPagination })
+        .withArgs({ organizationId, page: customPagination, filter: divisionFilter })
         .resolves({ organizationLearners: [new OrganizationLearner(rawStudent)], pagination: expectedPagination });
 
       const { missionLearners, pagination } = await missionLearnersRepository.findPaginatedMissionLearners({
         organizationId,
         page: customPagination,
+        filter: divisionFilter,
         organizationLearnerApi: organizationLearnerApiStub,
       });
 

--- a/api/tests/team/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
+++ b/api/tests/team/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
@@ -1,4 +1,4 @@
-import { Membership } from '../../../../../../lib/domain/models/index.js';
+import { Membership, Organization } from '../../../../../../lib/domain/models/index.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../../../../../../src/identity-access-management/domain/constants/identity-providers.js';
 import { ORGANIZATION_FEATURE } from '../../../../../../src/shared/domain/constants.js';
 import { prescriberSerializer } from '../../../../../../src/team/infrastructure/serializers/jsonapi/prescriber-serializer.js';
@@ -196,6 +196,34 @@ describe('Unit | Team | Infrastructure | Serializer | JSONAPI | prescriber', fun
 
         // then
         expect(result).to.be.deep.equal(expectedPrescriberSerialized);
+      });
+    });
+
+    context('when organization is a school (type: SCO-1D)', function () {
+      it('should serialize prescriber organization with school division link', function () {
+        // given
+        const organization = domainBuilder.buildOrganization({ type: Organization.types.SCO1D });
+
+        const membership = domainBuilder.buildMembership({
+          organization,
+          organizationRole: Membership.roles.MEMBER,
+          user,
+        });
+
+        const userOrgaSettings = domainBuilder.buildUserOrgaSettings({ currentOrganization: organization });
+
+        const prescriber = domainBuilder.buildPrescriber({
+          memberships: [membership],
+          userOrgaSettings,
+        });
+
+        // when
+        const result = prescriberSerializer.serialize(prescriber);
+
+        // then
+        expect(result.included[0].relationships.divisions.links.related).to.equal(
+          `/api/pix1d/schools/${organization.id}/divisions`,
+        );
       });
     });
   });

--- a/api/tests/unit/domain/usecases/get-organization-details_test.js
+++ b/api/tests/unit/domain/usecases/get-organization-details_test.js
@@ -46,7 +46,7 @@ describe('Unit | UseCase | get-organization-details', function () {
       });
 
       // then
-      expect(schoolRepository.getById).to.have.been.calledWithExactly(organizationId);
+      expect(schoolRepository.getById).to.have.been.calledWithExactly({ organizationId });
       expect(organization.code).to.deep.equal(code);
     });
   });

--- a/orga/app/components/campaign/filter/campaign-filters.hbs
+++ b/orga/app/components/campaign/filter/campaign-filters.hbs
@@ -1,9 +1,9 @@
 <PixFilterBanner
-  @title={{t "pages.campaigns-list.filter.title"}}
+  @title={{t "common.filters.title"}}
   class="participant-filter-banner hide-on-mobile"
   aria-label={{t "pages.campaigns-list.filter.legend"}}
   @details={{t "pages.campaigns-list.filter.results" total=@numResults}}
-  @clearFiltersLabel={{t "pages.campaigns-list.filter.clear"}}
+  @clearFiltersLabel={{t "common.filters.actions.clear"}}
   @isClearFilterButtonDisabled={{this.isClearFiltersButtonDisabled}}
   @onClearFilters={{@onClearFilters}}
 >

--- a/orga/app/components/campaign/filter/participation-filters.hbs
+++ b/orga/app/components/campaign/filter/participation-filters.hbs
@@ -1,10 +1,10 @@
 {{#if this.displayFilters}}
   <PixFilterBanner
-    @title={{t "pages.campaign-results.filters.title"}}
+    @title={{t "common.filters.title"}}
     class="participant-filter-banner hide-on-mobile"
     aria-label={{t "pages.campaign-results.filters.aria-label"}}
     @details={{t "pages.campaign-results.filters.participations-count" count=@rowCount}}
-    @clearFiltersLabel={{t "pages.campaign-results.filters.actions.clear"}}
+    @clearFiltersLabel={{t "common.filters.actions.clear"}}
     @onClearFilters={{@onResetFilter}}
     @isClearFilterButtonDisabled={{this.isClearFiltersButtonDisabled}}
   >

--- a/orga/app/components/organization-participant/learner-filters.hbs
+++ b/orga/app/components/organization-participant/learner-filters.hbs
@@ -1,9 +1,9 @@
 <PixFilterBanner
-  @title={{t "pages.organization-participants.filters.title"}}
+  @title={{t "common.filters.title"}}
   class="participant-filter-banner hide-on-mobile"
   aria-label={{t "pages.organization-participants.filters.aria-label"}}
   @details={{t "pages.organization-participants.filters.participations-count" count=@learnersCount}}
-  @clearFiltersLabel={{t "pages.organization-participants.filters.actions.clear"}}
+  @clearFiltersLabel={{t "common.filters.actions.clear"}}
   @onClearFilters={{@onResetFilter}}
   @isClearFilterButtonDisabled={{this.isClearFiltersButtonDisabled}}
 >

--- a/orga/app/components/sco-organization-participant/sco-learner-filters.hbs
+++ b/orga/app/components/sco-organization-participant/sco-learner-filters.hbs
@@ -1,9 +1,9 @@
 <PixFilterBanner
-  @title={{t "pages.sco-organization-participants.filter.title"}}
+  @title={{t "common.filters.title"}}
   class="participant-filter-banner hide-on-mobile"
   aria-label={{t "pages.sco-organization-participants.filter.aria-label"}}
   @details={{t "pages.sco-organization-participants.filter.students-count" count=@studentsCount}}
-  @clearFiltersLabel={{t "pages.sco-organization-participants.filter.actions.clear"}}
+  @clearFiltersLabel={{t "common.filters.actions.clear"}}
   @onClearFilters={{@onResetFilter}}
   @isClearFilterButtonDisabled={{this.isClearFiltersButtonDisabled}}
 >

--- a/orga/app/components/sup-organization-participant/sup-learner-filters.hbs
+++ b/orga/app/components/sup-organization-participant/sup-learner-filters.hbs
@@ -1,9 +1,9 @@
 <PixFilterBanner
-  @title={{t "pages.sup-organization-participants.filter.title"}}
+  @title={{t "common.filters.title"}}
   class="participant-filter-banner hide-on-mobile"
   aria-label={{t "pages.sup-organization-participants.filter.aria-label"}}
   @details={{t "pages.sup-organization-participants.filter.students-count" count=@studentsCount}}
-  @clearFiltersLabel={{t "pages.sup-organization-participants.filter.actions.clear"}}
+  @clearFiltersLabel={{t "common.filters.actions.clear"}}
   @onClearFilters={{@onResetFilter}}
   @isClearFilterButtonDisabled={{this.isClearFiltersButtonDisabled}}
 >

--- a/orga/app/controllers/authenticated/missions/details/learners.js
+++ b/orga/app/controllers/authenticated/missions/details/learners.js
@@ -9,7 +9,11 @@ export default class MissionLearnersController extends Controller {
   @service router;
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
   @tracked pageSize = 25;
+  @tracked divisions = [];
 
+  get learnersCount() {
+    return this.model.missionLearners.meta.rowCount;
+  }
   @action
   clearFilters() {
     this.pageNumber = null;
@@ -21,5 +25,21 @@ export default class MissionLearnersController extends Controller {
       completed: 'success',
       started: 'secondary',
     }[status];
+  }
+
+  @action
+  onSelectDivisions(divisions) {
+    this.divisions = divisions;
+    this.pageNumber = null;
+  }
+
+  @action
+  onResetFilter() {
+    this.divisions = [];
+  }
+
+  @action
+  refresh() {
+    this.send('refreshModel');
   }
 }

--- a/orga/app/models/organization.js
+++ b/orga/app/models/organization.js
@@ -18,6 +18,10 @@ export default class Organization extends Model {
   @hasMany('group', { async: true, inverse: null }) groups;
   @hasMany('division', { async: true, inverse: null }) divisions;
 
+  get isSco1d() {
+    return this.type === 'SCO-1D';
+  }
+
   get isSco() {
     return this.type === 'SCO';
   }

--- a/orga/app/routes/authenticated/missions/details/learners.js
+++ b/orga/app/routes/authenticated/missions/details/learners.js
@@ -8,6 +8,7 @@ export default class MissionLearnersRoute extends Route {
   @service store;
 
   queryParams = {
+    divisions: { refreshModel: true },
     pageNumber: {
       refreshModel: true,
     },
@@ -20,16 +21,21 @@ export default class MissionLearnersRoute extends Route {
     if (isExiting) {
       controller.pageNumber = 1;
       controller.pageSize = 25;
+      controller.divisions = undefined;
     }
   }
+
   model(params) {
-    const organizationId = this.currentUser.organization.id;
+    const organization = this.currentUser.organization;
     const missionModel = this.modelFor('authenticated.missions.details');
     const missionLearners = this.store.query(
       'mission-learner',
       {
-        organizationId,
+        organizationId: organization.id,
         missionId: missionModel.mission.id,
+        filter: {
+          divisions: params.divisions,
+        },
         page: {
           number: params.pageNumber,
           size: params.pageSize,
@@ -37,6 +43,6 @@ export default class MissionLearnersRoute extends Route {
       },
       { reload: true },
     );
-    return RSVP.hash({ missionLearners, mission: missionModel });
+    return RSVP.hash({ missionLearners, mission: missionModel, organization });
   }
 }

--- a/orga/app/templates/authenticated/missions/details/learners.hbs
+++ b/orga/app/templates/authenticated/missions/details/learners.hbs
@@ -1,5 +1,20 @@
 <h2 class="learners-title">{{t "pages.missions.details.learners.title"}}</h2>
 {{#if @model.missionLearners}}
+  <PixFilterBanner
+    @title={{t "common.filters.title"}}
+    class="participant-filter-banner hide-on-mobile"
+    aria-label={{t "pages.missions.details.learners.list.filters.aria-label"}}
+    @details={{t "pages.missions.details.learners.list.filters.learners-count" count=this.learnersCount}}
+    @clearFiltersLabel={{t "common.filters.actions.clear"}}
+    @onClearFilters={{this.onResetFilter}}
+    @isClearFilterButtonDisabled={{this.isClearFiltersButtonDisabled}}
+  >
+    <Ui::DivisionsFilter
+      @model={{@model.organization}}
+      @selected={{this.divisions}}
+      @onSelect={{this.onSelectDivisions}}
+    />
+  </PixFilterBanner>
   <div class="panel">
     <table class="table content-text content-text--small participation-list__table">
       <caption class="screen-reader-only">{{t

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -503,6 +503,10 @@ function routes() {
     return schema.divisions.all();
   });
 
+  this.get('/pix1d/schools/:id/divisions', (schema, _) => {
+    return schema.divisions.all();
+  });
+
   this.post('/memberships/:id/disable', (schema, request) => {
     const membershipId = request.params.id;
 

--- a/orga/mirage/handlers/find-paginated-mission-learners.js
+++ b/orga/mirage/handlers/find-paginated-mission-learners.js
@@ -3,10 +3,17 @@ import { applyPagination, getPaginationFromQueryParams } from './pagination-util
 export function findPaginatedMissionLearners(schema, request) {
   const organizationId = request.params.organization_id;
   const queryParams = request.queryParams;
-  const missionLearners = schema.missionLearners.where({ organizationId }).models;
+  const divisionsFilter = queryParams['filter[divisions]'];
+
+  let missionLearners = schema.missionLearners.where({ organizationId });
+  if (divisionsFilter) {
+    missionLearners = schema.missionLearners.where((learner) => {
+      return divisionsFilter.includes(learner.division) && learner.organizationId === Number(organizationId);
+    });
+  }
   const rowCount = missionLearners.length;
   const pagination = getPaginationFromQueryParams(queryParams);
-  const paginatedMissionLearners = applyPagination(missionLearners, pagination);
+  const paginatedMissionLearners = applyPagination(missionLearners.models, pagination);
 
   const json = this.serialize({ modelName: 'missionLearners', models: paginatedMissionLearners }, 'membership');
   json.meta = {

--- a/orga/mirage/serializers/organization.js
+++ b/orga/mirage/serializers/organization.js
@@ -2,6 +2,11 @@ import ApplicationSerializer from './application';
 
 export default ApplicationSerializer.extend({
   links(organization) {
+    let divisionUrl = `/api/organizations/${organization.id}/divisions`;
+    if (organization.type === 'SCO-1D') {
+      divisionUrl = `/api/pix1d/schools/${organization.id}/divisions`;
+    }
+
     return {
       campaigns: {
         related: `/api/organizations/${organization.id}/campaigns`,
@@ -19,7 +24,7 @@ export default ApplicationSerializer.extend({
         related: `/api/organizations/${organization.id}/groups`,
       },
       divisions: {
-        related: `/api/organizations/${organization.id}/divisions`,
+        related: divisionUrl,
       },
     };
   },

--- a/orga/tests/acceptance/campaign-list-all-campaigns_test.js
+++ b/orga/tests/acceptance/campaign-list-all-campaigns_test.js
@@ -231,7 +231,7 @@ module('Acceptance | campaigns/all-campaigns', function (hooks) {
           await fillByLabel('Rechercher une campagne', campaignName1);
           await fillByLabel('Rechercher un propriétaire', owner.firstName);
           await clickByName(this.intl.t('pages.campaigns-list.action.campaign.label'));
-          await clickByName(this.intl.t('pages.campaigns-list.filter.clear'));
+          await clickByName(this.intl.t('common.filters.actions.clear'));
 
           //then
           assert.ok(screen.getByLabelText(this.intl.t('pages.campaigns-list.filter.by-owner')));

--- a/orga/tests/acceptance/campaign-list-my-campaigns_test.js
+++ b/orga/tests/acceptance/campaign-list-my-campaigns_test.js
@@ -159,7 +159,7 @@ module('Acceptance | /campaigns/list/my-campaigns ', function (hooks) {
             // when
             await fillByLabel('Rechercher une campagne', 'ma super campagne');
             await clickByName(this.intl.t('pages.campaigns-list.action.campaign.label'));
-            await clickByName(this.intl.t('pages.campaigns-list.filter.clear'));
+            await clickByName(this.intl.t('common.filters.actions.clear'));
 
             //then
             assert.ok(screen.getByPlaceholderText(this.intl.t('pages.campaigns-list.filter.by-name')));

--- a/orga/tests/integration/components/campaign/filter/campaign-filters_test.js
+++ b/orga/tests/integration/components/campaign/filter/campaign-filters_test.js
@@ -24,7 +24,7 @@ module('Integration | Component | Campaign::Filter::CampaignFilters', function (
     );
 
     // then
-    assert.dom(screen.getByText(this.intl.t('pages.campaigns-list.filter.title'))).exists();
+    assert.dom(screen.getByText(this.intl.t('common.filters.title'))).exists();
     assert.dom(screen.getByLabelText(this.intl.t('pages.campaigns-list.filter.by-name'))).exists();
     assert.dom(screen.getByLabelText(this.intl.t('pages.campaigns-list.filter.by-owner'))).exists();
     assert.dom(screen.getByLabelText(this.intl.t('pages.campaigns-list.action.campaign.label'))).exists();
@@ -46,7 +46,7 @@ module('Integration | Component | Campaign::Filter::CampaignFilters', function (
       );
 
       // When
-      await clickByName(this.intl.t('pages.campaigns-list.filter.clear'));
+      await clickByName(this.intl.t('common.filters.actions.clear'));
 
       // then
       sinon.assert.called(this.onClickClearFiltersSpy);

--- a/orga/tests/integration/components/organization-participant/list_test.js
+++ b/orga/tests/integration/components/organization-participant/list_test.js
@@ -1001,7 +1001,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
 
       // when
       const resetButton = await screen.findByRole('button', {
-        name: this.intl.t('pages.organization-participants.filters.actions.clear'),
+        name: this.intl.t('common.filters.actions.clear'),
       });
       await click(resetButton);
 

--- a/orga/tests/integration/components/sup-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/list_test.js
@@ -977,7 +977,7 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
 
       // when
       const resetButton = await screen.findByRole('button', {
-        name: this.intl.t('pages.organization-participants.filters.actions.clear'),
+        name: this.intl.t('common.filters.actions.clear'),
       });
       await click(resetButton);
 

--- a/orga/tests/integration/components/sup-organization-participant/modal/edit-student-number-modal_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/modal/edit-student-number-modal_test.js
@@ -166,7 +166,10 @@ module('Integration | Component | SupOrganizationParticipant::Modal::EditStudent
         sinon.assert.calledOnce(closeStub);
         assert.ok(
           notificationsStub.sendSuccess.calledWith(
-            `La modification du numéro étudiant de ${this.student.firstName} ${this.student.lastName} a bien été effectué.`,
+            this.intl.t('pages.sup-organization-participants.edit-student-number-modal.form.success', {
+              firstName: this.student.firstName,
+              lastName: this.student.lastName,
+            }),
           ),
         );
       });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -185,6 +185,10 @@
     },
     "breadcrumb": "Breadcrumb",
     "filters": {
+      "title": "Filters",
+      "actions": {
+        "clear": "Clear filters"
+      },
       "divisions": {
         "empty": "No class",
         "label": "Search by classes",
@@ -815,10 +819,14 @@
           "title": "Competence :"
         },
         "learners": {
-          "title": "List of participants",
+          "title": "List of students",
           "list": {
             "aria-label": "Student",
             "caption": "List of students with their result for the mission {missionName}",
+            "filters": {
+              "aria-label": "Filter on students",
+              "learners-count": "{count, plural, =0 {No student} =1 {1 student} other {{count} students}}"
+            },
             "headers": {
               "division": "Division",
               "first-name": "First name",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -534,10 +534,6 @@
       "title": "Results",
       "average": "Average results",
       "filters": {
-        "title": "Filters",
-        "actions": {
-          "clear": "Clear filters"
-        },
         "aria-label": "Filters on participations",
         "participations-count": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count} participants}}",
         "type": {
@@ -687,10 +683,8 @@
         "create": "Create a campaign"
       },
       "filter": {
-        "title": "Filters",
         "by-name": "Search for a campaign",
         "by-owner": "Search for an owner",
-        "clear": "Clear filters",
         "legend": "Filters for the campaigns table, input fields allow to filter the table by campaign name and/or by owner name. Buttons allow to switch between ongoing and archived campaigns.",
         "results": "{total, plural, =0 {0 campaigns} =1 {1 campaign} other {{total, number} campaigns}}"
       },
@@ -948,10 +942,6 @@
         "message": "No participants yet!"
       },
       "filters": {
-        "title": "Filters",
-        "actions": {
-          "clear": "Clear filters"
-        },
         "aria-label": "Filters on participants",
         "participations-count": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count} participants}}",
         "type": {
@@ -1150,10 +1140,6 @@
         "without-mediacentre": "Without Mediacentre"
       },
       "filter": {
-        "title": "Filters",
-        "actions": {
-          "clear": "Clear filters"
-        },
         "aria-label": "Filters on students",
         "certificability": {
           "label": "Search by certificability",
@@ -1313,10 +1299,6 @@
         "no-participants-action": "The administrator must import the students database by clicking on the import button."
       },
       "filter": {
-        "title": "Filters",
-        "actions": {
-          "clear": "Clear filters"
-        },
         "aria-label": "Filters on students",
         "certificability": {
           "label": "Search by certificability",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -185,6 +185,10 @@
     },
     "breadcrumb": "Fil d'ariane",
     "filters": {
+      "title": "Filtres",
+      "actions": {
+        "clear": "Effacer les filtres"
+      },
       "divisions": {
         "empty": "Aucune classe",
         "label": "Rechercher par classes",
@@ -815,10 +819,14 @@
           "title": "Compétence :"
         },
         "learners": {
-          "title": "Liste des participations",
+          "title": "Liste des élèves",
           "list": {
             "aria-label": "Élève",
             "caption": "Tableau des élèves avec le résultat de leur participation à la mission {missionName}",
+            "filters": {
+              "aria-label": "Filtre sur les élèves",
+              "learners-count": "{count, plural, =0 {Aucun élève} =1 {1 élève} other {{count} élèves}}"
+            },
             "headers": {
               "division": "Classe",
               "first-name": "Prénom",
@@ -1297,7 +1305,7 @@
           "error": "Le numéro étudiant ne doit pas être vide.",
           "new-student-number-label": "Nouveau numéro étudiant",
           "student-number": "Numéro étudiant actuel de {firstName} {lastName} est : ",
-          "success": "La modification du numéro étudiant de {firstName} {lastName} a bien été effectué."
+          "success": "La modification du numéro étudiant de {firstName} {lastName} a bien ��té effectué."
         }
       },
       "empty-state": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1291,7 +1291,7 @@
           "error": "Le numéro étudiant ne doit pas être vide.",
           "new-student-number-label": "Nouveau numéro étudiant",
           "student-number": "Numéro étudiant actuel de {firstName} {lastName} est : ",
-          "success": "La modification du numéro étudiant de {firstName} {lastName} a bien ��té effectué."
+          "success": "La modification du numéro étudiant de {firstName} {lastName} a bien été effectuée."
         }
       },
       "empty-state": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -534,10 +534,6 @@
       "title": "Résultats",
       "average": "Moyenne des résultats",
       "filters": {
-        "title": "Filtres",
-        "actions": {
-          "clear": "Effacer les filtres"
-        },
         "aria-label": "Filtres sur les participations",
         "participations-count": "{count, plural, =0 {0 participant} =1 {1 participant} other {{count} participants}}",
         "type": {
@@ -687,10 +683,8 @@
         "create": "Créer une campagne"
       },
       "filter": {
-        "title": "Filtres",
         "by-name": "Rechercher une campagne",
         "by-owner": "Rechercher un propriétaire",
-        "clear": "Effacer les filtres",
         "legend": "Filtres pour le tableau des campagnes, des champs de saisie permettent de filtrer le tableau par le nom de la campagne et par nom du propriétaire. Des boutons permettent de filtrer les campagnes actives et archivées.",
         "results": "{total, plural, =0 {0 campagne} =1 {1 campagne} other {{total, number} campagnes}}"
       },
@@ -948,10 +942,6 @@
         "message": "Aucun participant pour l’instant !"
       },
       "filters": {
-        "title": "Filtres",
-        "actions": {
-          "clear": "Effacer les filtres"
-        },
         "aria-label": "Filtres sur les participants",
         "participations-count": "{count, plural, =0 {0 participant} =1 {1 participant} other {{count} participants}}",
         "type": {
@@ -1150,10 +1140,6 @@
         "without-mediacentre": "Sans Mediacentre"
       },
       "filter": {
-        "title": "Filtres",
-        "actions": {
-          "clear": "Effacer les filtres"
-        },
         "aria-label": "Filtres sur les élèves",
         "certificability": {
           "label": "Rechercher par certificabilité",
@@ -1313,10 +1299,6 @@
         "no-participants-action": "L’administrateur doit importer les étudiants en cliquant sur le bouton importer."
       },
       "filter": {
-        "title": "Filtres",
-        "actions": {
-          "clear": "Effacer les filtres"
-        },
         "aria-label": "Filtrer les étudiants",
         "certificability": {
           "label": "Rechercher par certificabilité",


### PR DESCRIPTION
## :unicorn: Problème
Dans le tableau de détails d'une mission, il ya tous les élèves de l'école. Par très pratique pour s'y retrouver.


## :robot: Proposition
Faire en sorte de pouvoir filtrer par classe

## :rainbow: Remarques
Pour la team Prescription:
Pour pouvoir filtrer par classe, il faut pouvoir récupérer la liste des classes de l'école.
On passe donc par l'api interne pour récupérer tous les learners et ensuite leur classe. Sauf que si on veut utiliser l'api interne pour doit modifier la signature pour pouvoir faire de l'injection de dépendance.
On a donc du modifier le paramètre de la méthode `iscodeAvailable` des repo `school-repository` et `campaign-administration-repository`

Pour la team Accès:
Nous avons eu besoin de modifier l'url pour récupérer les divisions de l'orga pour le prescriber car nous ne pouvons pas utiliser le même point d'entrée que pour les orgas SCO (tant que tous les points d'entrée n'ont pas été adaptés côté prescription pour être compatibles avec les learners créés avec l'import générique).

## :100: Pour tester
- Non régression: 
   - Aller sur pix Orga et créer une campagne et aller sur pix, renseigner le code de la campagne et la commencer.
   - Aller sur pix admin, créer une orga de type `SCO-1D` et aller sur pix junior et renseigner le code de l'orga et voir si on affiche bien sur la page de la liste des écoles.
   - Activer une session sur une école : la session est indiquée comme active pour 4h

- Tester le filtre
  - Aller sur pix orga, voir le détails d'une mission et filtrer pour n'afficher que les élèves de la classe sélectionnée.