### PR TITLE
[FEATURE] Suppression de l'utilisation du composant "Tag compact" (PIX-11127).

### DIFF
--- a/admin/app/components/certifications/info-tag.hbs
+++ b/admin/app/components/certifications/info-tag.hbs
@@ -1,8 +1,8 @@
 <div class="certification-informations__tag--float">
   {{#if @record.isPublished}}
-    <PixTag @compact="{{true}}" @color="success">Publiée</PixTag>
+    <PixTag @color="success">Publiée</PixTag>
   {{/if}}
   {{#if @record.isCancelled}}
-    <PixTag @compact="{{true}}" @color="error">Annulée</PixTag>
+    <PixTag @color="error">Annulée</PixTag>
   {{/if}}
 </div>

--- a/admin/app/components/organizations/all-tags.hbs
+++ b/admin/app/components/organizations/all-tags.hbs
@@ -15,7 +15,7 @@
               onClick={{fn this.removeTagToOrganization tag}}
               aria-label="Tag {{tag.name}} assigné à l'organisation"
             >
-              <PixTag @compact="true" @color="purple-light">
+              <PixTag @color="purple-light">
                 {{tag.name}}
               </PixTag>
             </button>
@@ -25,7 +25,7 @@
               onClick={{fn this.addRecentlyUsedTagToOrganization tag}}
               aria-label="Tag {{tag.name}} non assigné à l'organisation"
             >
-              <PixTag @compact="true" @color="grey-light">
+              <PixTag @color="grey-light">
                 {{tag.name}}
               </PixTag>
             </button>
@@ -58,7 +58,7 @@
               onClick={{fn this.removeTagToOrganization tag}}
               aria-label="Tag {{tag.name}} assigné à l'organisation"
             >
-              <PixTag @compact="true" @color="purple-light">
+              <PixTag @color="purple-light">
                 {{tag.name}}
               </PixTag>
             </button>
@@ -68,7 +68,7 @@
               onClick={{fn this.addTagToOrganization tag}}
               aria-label="Tag {{tag.name}} non assigné à l'organisation"
             >
-              <PixTag @compact="true" @color="grey-light">
+              <PixTag @color="grey-light">
                 {{tag.name}}
               </PixTag>
             </button>
@@ -80,5 +80,4 @@
   {{else}}
     <p>Aucun résultat.</p>
   {{/if}}
-
 </section>

--- a/admin/app/components/organizations/information-section-view.hbs
+++ b/admin/app/components/organizations/information-section-view.hbs
@@ -5,7 +5,7 @@
     <ul class="organization-tags-list">
       {{#each @organization.tags as |tag|}}
         <li class="organization-tags-list__tag">
-          <PixTag @compact="true" @color="purple-light">{{tag.name}}</PixTag>
+          <PixTag @color="purple-light">{{tag.name}}</PixTag>
         </li>
       {{/each}}
     </ul>
@@ -61,9 +61,7 @@
 
         <li>Nom du DPO : {{@organization.dataProtectionOfficerFullName}}</li>
         <li>Adresse e-mail du DPO : {{@organization.dataProtectionOfficerEmail}}</li>
-
         <br />
-
         <li>Crédits : {{@organization.credit}}</li>
         <li>Lien vers la documentation :
           {{#if @organization.documentationUrl}}

--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -3,24 +3,23 @@
     <div class="session-supervising-candidate-in-list__status-container">
       {{#if @candidate.hasStarted}}
         {{#if @candidate.isAuthorizedToResume}}
-          <PixTag
-            @compact={{true}}
-            class="session-supervising-candidate-in-list__status-container--authorized-to-resume"
-          >{{t "common.forms.certification-labels.candidate-status.authorized-to-resume"}}</PixTag>
+          <PixTag class="session-supervising-candidate-in-list__status-container--authorized-to-resume">{{t
+              "common.forms.certification-labels.candidate-status.authorized-to-resume"
+            }}</PixTag>
         {{else}}
           {{#if (eq @candidate.liveAlert.status "ongoing")}}
-            <PixTag @compact={{true}} class="session-supervising-candidate-in-list__status-container--ongoing-alert">{{t
+            <PixTag class="session-supervising-candidate-in-list__status-container--ongoing-alert">{{t
                 "common.forms.certification-labels.candidate-status.ongoing-live-alert"
               }}</PixTag>
           {{else}}
-            <PixTag @compact={{true}} class="session-supervising-candidate-in-list__status-container--started">{{t
+            <PixTag class="session-supervising-candidate-in-list__status-container--started">{{t
                 "common.forms.certification-labels.candidate-status.ongoing"
               }}</PixTag>
           {{/if}}
         {{/if}}
       {{/if}}
       {{#if @candidate.hasCompleted}}
-        <PixTag @compact={{true}} class="session-supervising-candidate-in-list__status-container--completed">{{t
+        <PixTag class="session-supervising-candidate-in-list__status-container--completed">{{t
             "common.forms.certification-labels.candidate-status.finished"
           }}</PixTag>
       {{/if}}

--- a/mon-pix/app/components/campaign-participation-overview/card/disabled.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card/disabled.hbs
@@ -1,6 +1,6 @@
 <article class="campaign-participation-overview-card" role="article">
   <div class="campaign-participation-overview-card__header">
-    <PixTag class="campaign-participation-overview-card-header__tag" @compact={{true}} @color="grey-light">
+    <PixTag class="campaign-participation-overview-card-header__tag" @color="grey-light">
       {{t "pages.campaign-participation-overview.card.tag.disabled"}}
     </PixTag>
     <h2 class="campaign-participation-overview-card-header__title">{{@model.organizationName}}</h2>

--- a/mon-pix/app/components/campaign-participation-overview/card/ended.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card/ended.hbs
@@ -1,6 +1,6 @@
 <article class="campaign-participation-overview-card" role="article">
   <div class="campaign-participation-overview-card__header">
-    <PixTag class="campaign-participation-overview-card-header__tag" @compact={{true}} @color="grey-light">
+    <PixTag class="campaign-participation-overview-card-header__tag" @color="grey-light">
       {{t "pages.campaign-participation-overview.card.tag.finished"}}
     </PixTag>
     <h2 class="campaign-participation-overview-card-header__title">{{@model.organizationName}}</h2>

--- a/mon-pix/app/components/campaign-participation-overview/card/ongoing.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card/ongoing.hbs
@@ -1,6 +1,6 @@
 <article class="campaign-participation-overview-card" role="article">
   <div class="campaign-participation-overview-card__header">
-    <PixTag class="campaign-participation-overview-card-header__tag" @compact={{true}} @color="green-light">
+    <PixTag class="campaign-participation-overview-card-header__tag" @color="green-light">
       {{t "pages.campaign-participation-overview.card.tag.started"}}
     </PixTag>
     <h2 class="campaign-participation-overview-card-header__title">{{@model.organizationName}}</h2>

--- a/mon-pix/app/components/campaign-participation-overview/card/to-share.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card/to-share.hbs
@@ -1,6 +1,6 @@
 <article class="campaign-participation-overview-card" role="article">
   <div class="campaign-participation-overview-card__header">
-    <PixTag class="campaign-participation-overview-card-header__tag" @compact={{true}} @color="yellow-light">
+    <PixTag class="campaign-participation-overview-card-header__tag" @color="yellow-light">
       {{t "pages.campaign-participation-overview.card.tag.completed"}}
     </PixTag>
     <h2 class="campaign-participation-overview-card-header__title">{{@model.organizationName}}</h2>

--- a/mon-pix/app/components/training/card.hbs
+++ b/mon-pix/app/components/training/card.hbs
@@ -2,12 +2,14 @@
   <a class="training-card__content" href={{@training.link}} target="_blank" {{on "click" this.trackAccess}}>
     <h3 class="training-card-content__title">{{@training.title}}</h3>
     <div class="training-card-content__infos" title="{{this.tagTitle}}">
-      <PixTag @compact={{true}} @color={{this.tagColor}} class="training-card-content-infos__tag">
+      <PixTag @color={{this.tagColor}} class="training-card-content-infos__tag">
         <ul class="training-card-content-infos-tag__list">
           <li class="training-card-content-infos-tag-list__type">
             {{this.type}}
           </li>
-          <li class="training-card-content-infos-tag-list__duration"><time>{{this.durationFormatted}}</time></li>
+          <li class="training-card-content-infos-tag-list__duration">
+            <time>{{this.durationFormatted}}</time>
+          </li>
         </ul>
       </PixTag>
     </div>


### PR DESCRIPTION
## :unicorn: Problème
Des petits tags compacts ont été utilisés par le passé. Maintenant il faut généraliser l’utilisation des tags basic et remplacer tous les tags compact qui pourraient encore exister. 
De plus, le composant Pix UI “[Tag Compact](https://ui.pix.fr/?path=/story/basics-tag--compact-tag)” qui n’existe pas côté design. 

## :robot: Proposition
L’usage est d’utiliser uniquement le composant “[Tag basic](https://ui.pix.fr/?path=/story/basics-tag--tag)”. 
Retirer la propriété `@compact=true` des éléments `PixTag`

## :100: Pour tester
Sur Pix Certif :
- Se connecter avec le compte `certif-pro@example.net`
- Aller sur l'espace surveillant de la session **7405** avec le code **PIX12**
- Observer que la beauté des tags n'est pas altérée pour "**En cours**", "**+ temps majoré 30 %**", "**Terminer**"
![Capture d’écran 2024-06-28 à 11 14 15](https://github.com/1024pix/pix/assets/103997660/079f41f9-5137-45a8-af79-62e807c70580)![Capture d’écran 2024-06-28 à 11 08 17](https://github.com/1024pix/pix/assets/103997660/49d931df-d0cc-4fd3-9576-31ea2050f1d7)![Capture d’écran 2024-06-28 à 11 08 10](https://github.com/1024pix/pix/assets/103997660/da5ee6fe-acb1-4093-be3f-e47eb724858a)![Capture d’écran 2024-06-28 à 11 08 04](https://github.com/1024pix/pix/assets/103997660/192ff38d-7107-4f4d-8b6f-dbd931d02200)


Sur Pix Admin : 
- Se connecter avec le compte `superadmin`
- Aller sur la session de certification : [https://admin-pr9359.review.pix.fr/sessions/7407/certifications](https://admin-pr9359.review.pix.fr/sessions/7407/certifications)
- Observer le changement des tags **Publiée** et **Annulée** (avant / après):
<img width="111" alt="Capture d’écran 2024-06-27 à 17 34 13" src="https://github.com/1024pix/pix/assets/103997660/93273566-6839-44b3-8b9e-d6f76e8c5592">
<img width="111" alt="Capture d’écran 2024-06-27 à 17 34 05" src="https://github.com/1024pix/pix/assets/103997660/fedf74c3-3306-45b3-b054-41d98fa33977">

<img width="111" alt="Capture d’écran 2024-06-27 à 17 33 15" src="https://github.com/1024pix/pix/assets/103997660/2f342306-cb42-49ed-ba67-ccd39f433bce">
<img width="111" alt="Capture d’écran 2024-06-27 à 17 33 23" src="https://github.com/1024pix/pix/assets/103997660/a46ecfd7-2db0-4edc-b649-54001620428a">

- puis aller sur l'organisation. : https://admin-pr9359.review.pix.fr/organizations/107320/all-tags
- Observer que la beauté des tags n'est pas altérée dans la description de l'orga et dans la section **Tags** en bas de page **Liste de tags récemment utilisés**

Sur Mon Pix :
- Se connecter avec le compte `learneremail1001_10@example.net`
- Aller sur la page "Mes parcours" dans le menu de droite
- Observer que la beauté des tags n'est pas altérée dans les cards comme "Terminé", "En cours"
(avant / après)
![Capture d’écran 2024-06-28 à 10 16 23](https://github.com/1024pix/pix/assets/103997660/42375921-a92b-4ca8-99cd-1093d752cf19)![Capture d’écran 2024-06-28 à 10 13 36](https://github.com/1024pix/pix/assets/103997660/f0dce63f-2f12-42bc-95d6-2b2ddcc5b21f)![Capture d’écran 2024-06-28 à 10 27 40](https://github.com/1024pix/pix/assets/103997660/642cd060-50c2-4986-8919-07e0af36fd18)![Capture d’écran 2024-06-28 à 10 27 45](https://github.com/1024pix/pix/assets/103997660/d7ac7fb2-c83d-477e-8149-a580d484e590)

