### PR TITLE
[BUGFIX] Force l'encodage UTF-8 pour la maj d'organisations en masse (PIX-13053)

### DIFF
--- a/api/src/organizational-entities/domain/usecases/update-organizations-in-batch.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/update-organizations-in-batch.usecase.js
@@ -138,6 +138,6 @@ async function _getCsvData(filePath) {
   const stream = createReadStream(filePath);
   const buffer = await getDataBuffer(stream);
   const csvParser = new CsvParser(buffer, CSV_HEADER);
-  const csvData = csvParser.parse();
+  const csvData = csvParser.parse('utf8');
   return csvData.map((row) => new OrganizationBatchUpdateDTO(row));
 }

--- a/api/src/shared/infrastructure/serializers/csv/csv-parser.js
+++ b/api/src/shared/infrastructure/serializers/csv/csv-parser.js
@@ -46,8 +46,8 @@ class CsvParser {
     }
   }
 
-  parse() {
-    const encoding = this._getFileEncoding();
+  parse(forceEncoding) {
+    const encoding = forceEncoding || this._getFileEncoding();
 
     if (!encoding) {
       throw new CsvImportError(ERRORS.ENCODING_NOT_SUPPORTED);

--- a/api/tests/shared/unit/infrastructure/serializers/csv/csv-parser_test.js
+++ b/api/tests/shared/unit/infrastructure/serializers/csv/csv-parser_test.js
@@ -129,6 +129,13 @@ describe('Unit | Shared | Infrastructure | Serializer | CsvParser', function () 
       expect(result.firstName).to.equal('Éçéà niño véga');
     });
 
+    it('Force encoding', function () {
+      const encodedInput = iconv.encode(input, 'utf16');
+      const parser = new CsvParser(encodedInput, header);
+      const [result] = parser.parse('utf16');
+      expect(result.firstName).to.equal('Éçéà niño véga');
+    });
+
     it('Throw an error if encoding not supported', async function () {
       const encodedInput = iconv.encode(input, 'utf16');
       const parser = new CsvParser(encodedInput, header);


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, les caractères spéciaux ne sont pas pris en compte lors de la modification en masse des organisations.

Cela est dû à la manière de traiter le fichier CSV au niveau de l’API. Le code actuel va tenter de déduire l’encodage du fichier entrainant l’utilisation d’un mauvais encodage et donc le retrait des caractères spéciaux.

## :robot: Proposition

Il faudrait forcer l’utilisation de l’encodage UTF8 lors du traitement du fichier CSV, comme pour la création en masse d’organisations.

## :rainbow: Remarques

N/A

## :100: Pour tester

1. Se connecter sur Pix Admin en tant que super admin
2. Aller sur "Administration" > "Mise à jour en masse d'organisations"
3. Mettre à jour le nom de l'organisation `9000000` avec le CSV suivant:

```
Organization ID,Organization Name,Organization External ID,Organization Parent ID,Organization Identity Provider Code,Organization Documentation URL,Organization Province Code,DPO Last Name,DPO First Name,DPO E-mail
9000000,Organisation 🎉🎉🎉 2,,,,,,,,
```

4. Aller sur la liste des organisation et vérifier que le nom de l'organisation est correctement mise à jour.

![image](https://github.com/1024pix/pix/assets/516360/fec392b6-bf4c-46b8-9781-a1b20860c6f4)

_Si vous voyez des caractères bizarres, comme ci-dessous, c'est que ça n'a pas fonctionné 😬_
![SCR-20240624-opym](https://github.com/1024pix/pix/assets/516360/14f7361d-4327-4f26-8119-43ee4aaf6802)

