### PR TITLE
[TECH] Mettre à jour des textes de l'écran d'épreuve focus (PIX-12746).

### DIFF
--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -798,7 +798,7 @@
       },
       "is-focused-challenge": {
         "info-alert": {
-          "title": "Répondez à cette question sans chercher sur internet ni utiliser de logiciels.",
+          "title": "Essayez de répondre à cette question sans vous aider d’internet ou d’applications.",
           "subtitle": "En certification, si vous changez de page, votre réponse ne sera pas validée."
         }
       },
@@ -856,7 +856,7 @@
           "close": "J'ai compris",
           "focused": {
             "title": "Mode Focus",
-            "content": "'<p class=\"tooltip-tag-information__title--focused\">'Restez sur cette page pour répondre !'</p>' N'utilisez pas internet ou une application pour répondre. Toute activité en dehors de la zone est détectée."
+            "content": "'<p class=\"tooltip-tag-information__title--focused\">'Essayez de rester sur cette page pour répondre !'</p>' Cette question ne nécessite ni internet, ni application."
           },
           "other": {
             "title": "Mode Libre",


### PR DESCRIPTION
## :unicorn: Problème

Dans le cadre de la lutte contre la fraude, on a prévu d'augmenter le nombre de nos épreuves focus. Dans cette optique, on pense qu'il est judicieux de revoir les messages associés, en positionnement.

## :robot: Proposition

Modifier les textes comme attendus.

## :100: Pour tester

Tester sur [une épreuve focus](https://app-pr9365.review.pix.fr/challenges/rec2dRKsI4aBIsayz/preview).
