### PR TITLE
[TECH] Migrer la route DELETE /api/certification-center-invitations/{certificationCenterInvitationId} vers team (PIX-13160)(PIX-13085)

### DIFF
--- a/api/lib/application/certification-center-invitations/index.js
+++ b/api/lib/application/certification-center-invitations/index.js
@@ -2,7 +2,6 @@ import Joi from 'joi';
 
 import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../src/shared/domain/types/identifiers-type.js';
-import { certificationCenterInvitationAdminController } from '../../../src/team/application/certification-center-invitation/certification-center-invitation.admin.controller.js';
 import { certificationCenterInvitationController } from './certification-center-invitation-controller.js';
 
 const register = async function (server) {
@@ -49,29 +48,6 @@ const register = async function (server) {
           "- Cette route permet de récupérer les détails d'une invitation selon un **id d'invitation** et un **code**\n",
         ],
         tags: ['api', 'invitations'],
-      },
-    },
-    {
-      method: 'DELETE',
-      path: '/api/certification-center-invitations/{certificationCenterInvitationId}',
-      config: {
-        handler: certificationCenterInvitationAdminController.cancelCertificationCenterInvitation,
-        pre: [
-          {
-            method: securityPreHandlers.checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationId,
-            assign: 'isAdminOfCertificationCenter',
-          },
-        ],
-        validate: {
-          params: Joi.object({
-            certificationCenterInvitationId: identifiersType.certificationCenterInvitationId.required(),
-          }),
-        },
-        notes: [
-          '- **Cette route est restreinte aux utilisateurs appartenant à un centre de certification**\n',
-          "- Cette route permet d'annuler une invitation actuellement en attente selon un **id d'invitation**",
-        ],
-        tags: ['api', 'certification-center-invitation'],
       },
     },
     {

--- a/api/src/team/application/certification-center-invitation/certification-center-invitation.controller.js
+++ b/api/src/team/application/certification-center-invitation/certification-center-invitation.controller.js
@@ -17,4 +17,10 @@ const sendInvitations = async function (request, h) {
   return h.response().code(204);
 };
 
-export const certificationCenterInvitationController = { sendInvitations };
+const cancelCertificationCenterInvitation = async function (request, h) {
+  const certificationCenterInvitationId = request.params.certificationCenterInvitationId;
+  await usecases.cancelCertificationCenterInvitation({ certificationCenterInvitationId });
+  return h.response().code(204);
+};
+
+export const certificationCenterInvitationController = { cancelCertificationCenterInvitation, sendInvitations };

--- a/api/src/team/application/certification-center-invitation/certification-center-invitation.route.js
+++ b/api/src/team/application/certification-center-invitation/certification-center-invitation.route.js
@@ -35,4 +35,28 @@ export const certificationCenterInvitationRoutes = [
       tags: ['api', 'certification-center', 'invitations'],
     },
   },
+  {
+    method: 'DELETE',
+    path: '/api/certification-center-invitations/{certificationCenterInvitationId}',
+    config: {
+      handler: (request, h) => certificationCenterInvitationController.cancelCertificationCenterInvitation(request, h),
+      pre: [
+        {
+          method: (request, h) =>
+            securityPreHandlers.checkUserIsAdminOfCertificationCenterWithCertificationCenterInvitationId(request, h),
+          assign: 'isAdminOfCertificationCenter',
+        },
+      ],
+      validate: {
+        params: Joi.object({
+          certificationCenterInvitationId: identifiersType.certificationCenterInvitationId.required(),
+        }),
+      },
+      notes: [
+        '- **Cette route est restreinte aux utilisateurs appartenant à un centre de certification**\n',
+        "- Cette route permet d'annuler une invitation actuellement en attente selon un **id d'invitation**",
+      ],
+      tags: ['team', 'api', 'certification-center-invitation'],
+    },
+  },
 ];

--- a/api/tests/acceptance/application/certification-center-invitations/index_test.js
+++ b/api/tests/acceptance/application/certification-center-invitations/index_test.js
@@ -103,50 +103,6 @@ describe('Acceptance | API | Certification center invitations', function () {
       });
     });
 
-    describe('DELETE /api/certification-center-invitations/{id}', function () {
-      context('when user is an admin', function () {
-        let adminUser, certificationCenter;
-
-        beforeEach(async function () {
-          adminUser = databaseBuilder.factory.buildUser();
-          certificationCenter = databaseBuilder.factory.buildCertificationCenter();
-          databaseBuilder.factory.buildCertificationCenterMembership({
-            userId: adminUser.id,
-            certificationCenterId: certificationCenter.id,
-            role: 'ADMIN',
-          });
-
-          await databaseBuilder.commit();
-        });
-
-        it('cancels the certification center invitation and returns a 204 HTTP status code', async function () {
-          // given
-          const certificationCenterInvitation = databaseBuilder.factory.buildCertificationCenterInvitation({
-            certificationCenterId: certificationCenter.id,
-          });
-          const request = {
-            headers: {
-              authorization: generateValidRequestAuthorizationHeader(adminUser.id),
-            },
-            method: 'DELETE',
-            url: `/api/certification-center-invitations/${certificationCenterInvitation.id}`,
-          };
-
-          await databaseBuilder.commit();
-
-          // when
-          const { statusCode } = await server.inject(request);
-
-          // then
-          const cancelledCertificationCenterInvitation = await knex(CERTIFICATION_CENTER_INVITATIONS_TABLE_NAME)
-            .where({ id: certificationCenterInvitation.id })
-            .first();
-          expect(cancelledCertificationCenterInvitation.status).to.equal('cancelled');
-          expect(statusCode).to.equal(204);
-        });
-      });
-    });
-
     describe(`PATCH /api/certification-center-invitations/{id}`, function () {
       context('when user is admin of the certification center', function () {
         let adminUser;


### PR DESCRIPTION
## :unicorn: Problème
L'API avec l'url DELETE /api/certification-center-invitations/{certificationCenterInvitationId} est toujours dans lib.

## :robot: Proposition
Le migrer dans src/team

## :rainbow: Remarques
RAS

## :100: Pour tester
- Se connecter à la RA de Pix certif avec le compte james-paledroits@example.net
- Aller dans l'onglet Equipe -> Invitations
- Ouvrir la console navigateur -> Network
- Supprimer une invitation dans la liste (ex: camille-onette@example.net)
- Vérifier que l'appel DELETE /api/certification-center-invitations/{certificationCenterInvitationId} renvoie bien une 204