### PR TITLE
[TECH] Migrer la route POST /api/revoke vers src/identity-access-management (PIX-13121)

### DIFF
--- a/api/lib/application/authentication/authentication-controller.js
+++ b/api/lib/application/authentication/authentication-controller.js
@@ -46,17 +46,9 @@ const authenticateApplication = async function (request, h) {
     .header('Pragma', 'no-cache');
 };
 
-const revokeToken = async function (request, h) {
-  if (request.payload.token_type_hint === 'access_token') return null;
-
-  await usecases.revokeRefreshToken({ refreshToken: request.payload.token });
-  return h.response().code(204);
-};
-
 const authenticationController = {
   authenticateExternalUser,
   authenticateApplication,
-  revokeToken,
 };
 
 export { authenticationController };

--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -2,7 +2,6 @@ import Joi from 'joi';
 
 import { responseAuthenticationDoc } from '../../infrastructure/open-api-doc/authentication/response-authentication-doc.js';
 import { responseObjectErrorDoc } from '../../infrastructure/open-api-doc/livret-scolaire/response-object-error-doc.js';
-import { BadRequestError, sendJsonApiError } from '../http-errors.js';
 import { authenticationController as AuthenticationController } from './authentication-controller.js';
 
 const register = async function (server) {
@@ -47,33 +46,6 @@ const register = async function (server) {
         },
         handler: AuthenticationController.authenticateApplication,
         tags: ['api', 'authorization-server'],
-      },
-    },
-    {
-      method: 'POST',
-      path: '/api/revoke',
-      config: {
-        auth: false,
-        payload: {
-          allow: 'application/x-www-form-urlencoded',
-        },
-        validate: {
-          payload: Joi.object()
-            .required()
-            .keys({
-              token: Joi.string().required(),
-              token_type_hint: ['access_token', 'refresh_token'],
-            }),
-          failAction: (request, h) => {
-            return sendJsonApiError(
-              new BadRequestError('The server could not understand the request due to invalid token.'),
-              h,
-            );
-          },
-        },
-        handler: AuthenticationController.revokeToken,
-        notes: ['- Cette route permet de supprimer le refresh token du temporary storage'],
-        tags: ['api'],
       },
     },
     {

--- a/api/lib/domain/usecases/revoke-refresh-token.js
+++ b/api/lib/domain/usecases/revoke-refresh-token.js
@@ -1,5 +1,0 @@
-const revokeRefreshToken = async function ({ refreshToken, refreshTokenService }) {
-  await refreshTokenService.revokeRefreshToken({ refreshToken });
-};
-
-export { revokeRefreshToken };

--- a/api/src/identity-access-management/application/token/token.controller.js
+++ b/api/src/identity-access-management/application/token/token.controller.js
@@ -56,4 +56,11 @@ const createToken = async function (request, h, dependencies = { tokenService })
     .header('Pragma', 'no-cache');
 };
 
-export const tokenController = { authenticateAnonymousUser, createToken };
+const revokeToken = async function (request, h) {
+  if (request.payload.token_type_hint === 'access_token') return null;
+
+  await usecases.revokeRefreshToken({ refreshToken: request.payload.token });
+  return h.response().code(204);
+};
+
+export const tokenController = { authenticateAnonymousUser, createToken, revokeToken };

--- a/api/src/identity-access-management/application/token/token.controller.js
+++ b/api/src/identity-access-management/application/token/token.controller.js
@@ -14,6 +14,14 @@ const authenticateAnonymousUser = async function (request, h) {
   return h.response(response).code(200);
 };
 
+/**
+ * @param request
+ * @param h
+ * @param {{
+ *   tokenService: TokenService
+ * }} dependencies
+ * @return {Promise<*>}
+ */
 const createToken = async function (request, h, dependencies = { tokenService }) {
   let accessToken, refreshToken;
   let expirationDelaySeconds;

--- a/api/src/identity-access-management/application/token/token.route.js
+++ b/api/src/identity-access-management/application/token/token.route.js
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 
+import { BadRequestError, sendJsonApiError } from '../../../../lib/application/http-errors.js';
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { tokenController } from './token.controller.js';
 
@@ -55,6 +56,33 @@ export const tokenRoutes = [
         "- Cette route permet de créer un utilisateur à partir d'un code parcours Accès Simplifié\n" +
           "- Elle retournera un access token Pix correspondant à l'utilisateur.",
       ],
+      tags: ['identity-access-management', 'api', 'token'],
+    },
+  },
+  {
+    method: 'POST',
+    path: '/api/revoke',
+    config: {
+      auth: false,
+      payload: {
+        allow: 'application/x-www-form-urlencoded',
+      },
+      validate: {
+        payload: Joi.object()
+          .required()
+          .keys({
+            token: Joi.string().required(),
+            token_type_hint: ['access_token', 'refresh_token'],
+          }),
+        failAction: (request, h) => {
+          return sendJsonApiError(
+            new BadRequestError('The server could not understand the request due to invalid token.'),
+            h,
+          );
+        },
+      },
+      handler: (request, h) => tokenController.revokeToken(request, h),
+      notes: ['- Cette route permet de supprimer le refresh token du temporary storage'],
       tags: ['identity-access-management', 'api', 'token'],
     },
   },

--- a/api/src/identity-access-management/domain/usecases/revoke-refresh-token.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/revoke-refresh-token.usecase.js
@@ -1,0 +1,10 @@
+/**
+ * @param {{
+ *   refreshToken: string,
+ *   refreshTokenService: RefreshTokenService
+ * }} params
+ * @return {Promise<void>}
+ */
+export const revokeRefreshToken = async function ({ refreshToken, refreshTokenService }) {
+  await refreshTokenService.revokeRefreshToken({ refreshToken });
+};

--- a/api/src/shared/domain/services/token-service.js
+++ b/api/src/shared/domain/services/token-service.js
@@ -237,6 +237,10 @@ const tokenService = {
   extractCampaignResultsTokenContent,
 };
 
+/**
+ * @typedef TokenService
+ */
+
 export {
   createAccessTokenForSaml,
   createAccessTokenFromAnonymousUser,

--- a/api/tests/identity-access-management/acceptance/application/token.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/token.route.test.js
@@ -432,6 +432,82 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
       });
     });
   });
+
+  describe('POST /api/revoke', function () {
+    const method = 'POST';
+    const url = '/api/revoke';
+    const headers = {
+      'content-type': 'application/x-www-form-urlencoded',
+    };
+
+    let payload;
+
+    beforeEach(function () {
+      payload = querystring.stringify({
+        token: 'jwt.access.token',
+        token_type_hint: 'access_token',
+      });
+    });
+
+    it('returns a response with HTTP status code 204 when route handler (a.k.a. controller) is successful', async function () {
+      // when
+      const response = await server.inject({ method, url, payload, auth: null, headers });
+
+      // then
+      expect(response.statusCode).to.equal(204);
+    });
+
+    it('returns a 400 when grant type is not "access_token" nor "refresh_token"', async function () {
+      // given
+      payload = querystring.stringify({
+        token: 'jwt.access.token',
+        token_type_hint: 'not_standard_token_type',
+      });
+
+      // when
+      const response = await server.inject({ method, url, payload, auth: null, headers });
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('returns a 400 when token is missing', async function () {
+      // given
+      payload = querystring.stringify({
+        token_type_hint: 'access_token',
+      });
+
+      // when
+      const response = await server.inject({ method, url, payload, auth: null, headers });
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('returns a response with HTTP status code 204 even when token type hint is missing', async function () {
+      // given
+      payload = querystring.stringify({
+        token: 'jwt.access.token',
+      });
+
+      // when
+      const response = await server.inject({ method, url, payload, auth: null, headers });
+
+      // then
+      expect(response.statusCode).to.equal(204);
+    });
+
+    it('returns a JSON API error (415) when request "Content-Type" header is not "application/x-www-form-urlencoded"', async function () {
+      // given
+      headers['content-type'] = 'text/html';
+
+      // when
+      const response = await server.inject({ method, url, payload, auth: null, headers });
+
+      // then
+      expect(response.statusCode).to.equal(415);
+    });
+  });
 });
 
 function _getOptions({ scope, password, username }) {

--- a/api/tests/identity-access-management/acceptance/application/token.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/token.route.test.js
@@ -432,20 +432,20 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
       });
     });
   });
-
-  function _getOptions({ scope, password, username }) {
-    return {
-      method: 'POST',
-      url: '/api/token',
-      headers: {
-        'content-type': 'application/x-www-form-urlencoded',
-      },
-      payload: querystring.stringify({
-        grant_type: 'password',
-        username,
-        password,
-        scope,
-      }),
-    };
-  }
 });
+
+function _getOptions({ scope, password, username }) {
+  return {
+    method: 'POST',
+    url: '/api/token',
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded',
+    },
+    payload: querystring.stringify({
+      grant_type: 'password',
+      username,
+      password,
+      scope,
+    }),
+  };
+}

--- a/api/tests/identity-access-management/unit/application/token.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/token.controller.test.js
@@ -120,4 +120,48 @@ describe('Unit | Identity Access Management | Application | Controller | Token',
       });
     });
   });
+
+  describe('#revokeToken', function () {
+    it('returns 204', async function () {
+      // given
+      const token = 'jwt.refresh.token';
+      const request = {
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+        },
+        payload: {
+          token,
+        },
+      };
+      sinon.stub(usecases, 'revokeRefreshToken').resolves();
+
+      // when
+      const response = await tokenController.revokeToken(request, hFake);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+      sinon.assert.calledWith(usecases.revokeRefreshToken, { refreshToken: token });
+    });
+
+    it('returns null when token hint is of type access token', async function () {
+      // given
+      const token = 'jwt.refresh.token';
+      const request = {
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+        },
+        payload: {
+          token,
+          token_type_hint: 'access_token',
+        },
+      };
+      sinon.stub(usecases, 'revokeRefreshToken').resolves();
+
+      // when
+      const response = await tokenController.revokeToken(request, hFake);
+
+      // then
+      expect(response).to.be.null;
+    });
+  });
 });

--- a/api/tests/identity-access-management/unit/domain/usecases/revoke-refresh-token.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/revoke-refresh-token.usecase.test.js
@@ -1,8 +1,8 @@
-import { revokeRefreshToken } from '../../../../lib/domain/usecases/revoke-refresh-token.js';
-import { expect, sinon } from '../../../test-helper.js';
+import { revokeRefreshToken } from '../../../../../src/identity-access-management/domain/usecases/revoke-refresh-token.usecase.js';
+import { expect, sinon } from '../../../../test-helper.js';
 
-describe('Unit | UseCase | revoke-refresh-token', function () {
-  it('should revoke refresh token', async function () {
+describe('Unit | Identity Access Management | Domain | UseCase | revoke-refresh-token', function () {
+  it('revokes refresh token', async function () {
     // given
     const refreshToken = 'valid refresh token';
     const refreshTokenService = { revokeRefreshToken: sinon.stub() };

--- a/api/tests/integration/application/authentication/index_test.js
+++ b/api/tests/integration/application/authentication/index_test.js
@@ -1,5 +1,3 @@
-import querystring from 'node:querystring';
-
 import { createServer, expect } from '../../../test-helper.js';
 
 describe('Integration | Application | Route | AuthenticationRouter', function () {
@@ -7,82 +5,6 @@ describe('Integration | Application | Route | AuthenticationRouter', function ()
 
   beforeEach(async function () {
     server = await createServer();
-  });
-
-  describe('POST /revoke', function () {
-    const method = 'POST';
-    const url = '/api/revoke';
-    const headers = {
-      'content-type': 'application/x-www-form-urlencoded',
-    };
-
-    let payload;
-
-    beforeEach(function () {
-      payload = querystring.stringify({
-        token: 'jwt.access.token',
-        token_type_hint: 'access_token',
-      });
-    });
-
-    it('should return a response with HTTP status code 204 when route handler (a.k.a. controller) is successful', async function () {
-      // when
-      const response = await server.inject({ method, url, payload, auth: null, headers });
-
-      // then
-      expect(response.statusCode).to.equal(204);
-    });
-
-    it('should return a 400 when grant type is not "access_token" nor "refresh_token"', async function () {
-      // given
-      payload = querystring.stringify({
-        token: 'jwt.access.token',
-        token_type_hint: 'not_standard_token_type',
-      });
-
-      // when
-      const response = await server.inject({ method, url, payload, auth: null, headers });
-
-      // then
-      expect(response.statusCode).to.equal(400);
-    });
-
-    it('should return a 400 when token is missing', async function () {
-      // given
-      payload = querystring.stringify({
-        token_type_hint: 'access_token',
-      });
-
-      // when
-      const response = await server.inject({ method, url, payload, auth: null, headers });
-
-      // then
-      expect(response.statusCode).to.equal(400);
-    });
-
-    it('should return a response with HTTP status code 204 even when token type hint is missing', async function () {
-      // given
-      payload = querystring.stringify({
-        token: 'jwt.access.token',
-      });
-
-      // when
-      const response = await server.inject({ method, url, payload, auth: null, headers });
-
-      // then
-      expect(response.statusCode).to.equal(204);
-    });
-
-    it('should return a JSON API error (415) when request "Content-Type" header is not "application/x-www-form-urlencoded"', async function () {
-      // given
-      headers['content-type'] = 'text/html';
-
-      // when
-      const response = await server.inject({ method, url, payload, auth: null, headers });
-
-      // then
-      expect(response.statusCode).to.equal(415);
-    });
   });
 
   describe('POST /api/token-from-external-user', function () {

--- a/api/tests/unit/application/authentication/authentication-controller_test.js
+++ b/api/tests/unit/application/authentication/authentication-controller_test.js
@@ -94,48 +94,4 @@ describe('Unit | Application | Controller | Authentication', function () {
       });
     });
   });
-
-  describe('#revokeToken', function () {
-    it('should return 204', async function () {
-      // given
-      const token = 'jwt.refresh.token';
-      const request = {
-        headers: {
-          'content-type': 'application/x-www-form-urlencoded',
-        },
-        payload: {
-          token,
-        },
-      };
-      sinon.stub(usecases, 'revokeRefreshToken').resolves();
-
-      // when
-      const response = await authenticationController.revokeToken(request, hFake);
-
-      // then
-      expect(response.statusCode).to.equal(204);
-      sinon.assert.calledWith(usecases.revokeRefreshToken, { refreshToken: token });
-    });
-
-    it('should return null when token hint is of type access token', async function () {
-      // given
-      const token = 'jwt.refresh.token';
-      const request = {
-        headers: {
-          'content-type': 'application/x-www-form-urlencoded',
-        },
-        payload: {
-          token,
-          token_type_hint: 'access_token',
-        },
-      };
-      sinon.stub(usecases, 'revokeRefreshToken').resolves();
-
-      // when
-      const response = await authenticationController.revokeToken(request, hFake);
-
-      // then
-      expect(response).to.be.null;
-    });
-  });
 });


### PR DESCRIPTION
## :unicorn: Problème

La route `POST /api/revoke` est encore dans le dossier `lib`.

## :robot: Proposition

Faire la migration vers son bounded context `identity-access-management`.

## :rainbow: Remarques

À valider avant cette PR :

- [x] #9368 

Il y a un appel pour révoquer l'access_token mais le code n'en fait rien.
https://github.com/1024pix/pix/blob/c61a32f9983067ccb44091e97af30470dfc772ef/api/src/identity-access-management/application/token/token.controller.js#L68
Je pense que c'est dû au fonctionnement de Ember Simple Auth (ESA), car c'est l'addon qui gère la déconnexion.

## :100: Pour tester

1. Se connecter sur Pix App
2. Ouvrir la console développeur sur l'onglet Réseau
3. Se déconnecter
4. Vérifier que les requêtes _POST /api/revoke_ sont en 204 (une requête par token - access_token et refresh_token)
5. Constater que vous êtes bien déconnecter de Pix App