### PR TITLE
[FEATURE] Enregistrer le click sur le bouton suivant dans un Stepper sur Matomo (PIX-12857)

### DIFF
--- a/mon-pix/app/components/module/grain.hbs
+++ b/mon-pix/app/components/module/grain.hbs
@@ -31,6 +31,7 @@
               @passage={{@passage}}
               @getLastCorrectionForElement={{this.getLastCorrectionForElement}}
               @stepperIsFinished={{this.stepperIsFinished}}
+              @continueToNextStep={{@continueToNextStep}}
             />
           </div>
         {{/if}}

--- a/mon-pix/app/components/module/passage.hbs
+++ b/mon-pix/app/components/module/passage.hbs
@@ -14,6 +14,7 @@
         @passage={{@passage}}
         @transition={{this.grainTransition grain.id}}
         @submitAnswer={{this.submitAnswer}}
+        @continueToNextStep={{this.continueToNextStep}}
         @canMoveToNextGrain={{this.grainCanMoveToNextGrain index}}
         @continueAction={{this.continueToNextGrain}}
         @skipAction={{this.skipToNextGrain}}

--- a/mon-pix/app/components/module/passage.js
+++ b/mon-pix/app/components/module/passage.js
@@ -24,13 +24,13 @@ export default class ModulePassage extends Component {
     return this.grainsToDisplay.length < this.displayableGrains.length;
   }
 
-  get lastIndex() {
+  get currentGrainIndex() {
     return this.grainsToDisplay.length - 1;
   }
 
   @action
   skipToNextGrain() {
-    const lastGrain = this.displayableGrains[this.lastIndex];
+    const currentGrain = this.displayableGrains[this.currentGrainIndex];
 
     this.addNextGrainToDisplay();
 
@@ -38,13 +38,13 @@ export default class ModulePassage extends Component {
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.id}`,
-      'pix-event-name': `Click sur le bouton passer du grain : ${lastGrain.id}`,
+      'pix-event-name': `Click sur le bouton passer du grain : ${currentGrain.id}`,
     });
   }
 
   @action
   continueToNextGrain() {
-    const lastGrain = this.displayableGrains[this.lastIndex];
+    const currentGrain = this.displayableGrains[this.currentGrainIndex];
 
     this.addNextGrainToDisplay();
 
@@ -52,13 +52,13 @@ export default class ModulePassage extends Component {
       event: 'custom-event',
       'pix-event-category': 'Modulix',
       'pix-event-action': `Passage du module : ${this.args.module.id}`,
-      'pix-event-name': `Click sur le bouton continuer du grain : ${lastGrain.id}`,
+      'pix-event-name': `Click sur le bouton continuer du grain : ${currentGrain.id}`,
     });
   }
 
   @action
   continueToNextStep(currentStepPosition) {
-    const currentGrain = this.displayableGrains[this.lastIndex];
+    const currentGrain = this.displayableGrains[this.currentGrainIndex];
 
     this.metrics.add({
       event: 'custom-event',
@@ -73,18 +73,18 @@ export default class ModulePassage extends Component {
       return;
     }
 
-    const nextGrain = this.displayableGrains[this.lastIndex + 1];
+    const nextGrain = this.displayableGrains[this.currentGrainIndex + 1];
     this.grainsToDisplay = [...this.grainsToDisplay, nextGrain];
   }
 
   @action
   grainCanMoveToNextGrain(index) {
-    return this.lastIndex === index && this.hasNextGrain;
+    return this.currentGrainIndex === index && this.hasNextGrain;
   }
 
   @action
   grainShouldDisplayTerminateButton(index) {
-    return this.lastIndex === index && !this.hasNextGrain;
+    return this.currentGrainIndex === index && !this.hasNextGrain;
   }
 
   @action

--- a/mon-pix/app/components/module/passage.js
+++ b/mon-pix/app/components/module/passage.js
@@ -56,6 +56,18 @@ export default class ModulePassage extends Component {
     });
   }
 
+  @action
+  continueToNextStep(currentStepPosition) {
+    const currentGrain = this.displayableGrains[this.lastIndex];
+
+    this.metrics.add({
+      event: 'custom-event',
+      'pix-event-category': 'Modulix',
+      'pix-event-action': `Passage du module : ${this.args.module.id}`,
+      'pix-event-name': `Click sur le bouton suivant de l'étape ${currentStepPosition} du stepper dans le grain : ${currentGrain.id}`,
+    });
+  }
+
   addNextGrainToDisplay() {
     if (!this.hasNextGrain) {
       return;

--- a/mon-pix/app/components/module/stepper.gjs
+++ b/mon-pix/app/components/module/stepper.gjs
@@ -21,12 +21,15 @@ export default class ModulixStepper extends Component {
 
   @action
   displayNextStep() {
-    const nextStep = this.displayableSteps[this.lastIndex + 1];
+    const currentStepPosition = this.lastIndex + 1;
+    const nextStep = this.displayableSteps[currentStepPosition];
     this.stepsToDisplay = [...this.stepsToDisplay, nextStep];
 
     if (!this.hasNextStep) {
       this.args.stepperIsFinished();
     }
+
+    this.args.continueToNextStep(currentStepPosition);
   }
 
   get lastIndex() {

--- a/mon-pix/app/components/module/stepper.gjs
+++ b/mon-pix/app/components/module/stepper.gjs
@@ -21,7 +21,7 @@ export default class ModulixStepper extends Component {
 
   @action
   displayNextStep() {
-    const currentStepPosition = this.lastIndex + 1;
+    const currentStepPosition = this.currentStepIndex + 1;
     const nextStep = this.displayableSteps[currentStepPosition];
     this.stepsToDisplay = [...this.stepsToDisplay, nextStep];
 
@@ -32,7 +32,7 @@ export default class ModulixStepper extends Component {
     this.args.continueToNextStep(currentStepPosition);
   }
 
-  get lastIndex() {
+  get currentStepIndex() {
     return this.stepsToDisplay.length - 1;
   }
 

--- a/mon-pix/tests/integration/components/module/grain_test.gjs
+++ b/mon-pix/tests/integration/components/module/grain_test.gjs
@@ -768,7 +768,19 @@ module('Integration | Component | Module | Grain', function (hooks) {
         });
       });
 
-      module('when there is no more steps to display', function () {
+      module('when there is no more steps to display', function (hooks) {
+        let passage;
+        let retryElementStub;
+        let continueToNextStepStub;
+        let store;
+
+        hooks.beforeEach(function () {
+          store = this.owner.lookup('service:store');
+          passage = store.createRecord('passage');
+          retryElementStub = sinon.stub();
+          continueToNextStepStub = sinon.stub();
+        });
+
         test('should display continue button', async function (assert) {
           // given
           const steps = [
@@ -794,7 +806,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
             },
           ];
 
-          const store = this.owner.lookup('service:store');
           const grain = store.createRecord('grain', {
             title: 'Grain title',
             components: [
@@ -805,16 +816,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
             ],
           });
 
-          const passage = store.createRecord('passage');
-          const retryElementStub = sinon.stub();
-
           this.set('grain', grain);
           this.set('passage', passage);
           this.set('retryElement', retryElementStub);
+          this.set('continueToNextStep', continueToNextStepStub);
 
           // when
           const screen = await render(hbs`
-          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}}  />`);
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}} @continueToNextStep={{this.continueToNextStep}} />`);
           await clickByName(this.intl.t('pages.modulix.buttons.stepper.next'));
 
           // then
@@ -848,7 +857,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
             },
           ];
 
-          const store = this.owner.lookup('service:store');
           const grain = store.createRecord('grain', {
             title: 'Grain title',
             components: [
@@ -859,16 +867,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
             ],
           });
 
-          const passage = store.createRecord('passage');
-          const retryElementStub = sinon.stub();
-
           this.set('grain', grain);
           this.set('passage', passage);
           this.set('retryElement', retryElementStub);
+          this.set('continueToNextStep', continueToNextStepStub);
 
           // when
           const screen = await render(hbs`
-          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}}  />`);
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}} @continueToNextStep={{this.continueToNextStep}} />`);
           await clickByName(this.intl.t('pages.modulix.buttons.stepper.next'));
 
           // then
@@ -880,7 +886,19 @@ module('Integration | Component | Module | Grain', function (hooks) {
     });
 
     module('when there are answerable elements in stepper', function () {
-      module('when user response is not verified', function () {
+      module('when user response is not verified', function (hooks) {
+        let passage;
+        let retryElementStub;
+        let continueToNextStepStub;
+        let store;
+
+        hooks.beforeEach(function () {
+          store = this.owner.lookup('service:store');
+          passage = store.createRecord('passage');
+          retryElementStub = sinon.stub();
+          continueToNextStepStub = sinon.stub();
+        });
+
         module('when there are still steps to display', function () {
           test('should display skip button', async function (assert) {
             // given
@@ -908,7 +926,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
               },
             ];
 
-            const store = this.owner.lookup('service:store');
             const grain = store.createRecord('grain', {
               title: 'Grain title',
               components: [
@@ -919,20 +936,19 @@ module('Integration | Component | Module | Grain', function (hooks) {
               ],
             });
 
-            const passage = store.createRecord('passage');
-            const retryElementStub = sinon.stub();
-
             this.set('grain', grain);
             this.set('passage', passage);
             this.set('retryElement', retryElementStub);
+            this.set('continueToNextStep', continueToNextStepStub);
 
             // when
             const screen = await render(hbs`
-          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}}  />`);
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}} @continueToNextStep={{this.continueToNextStep}} />`);
 
             // then
             assert.dom(screen.getByRole('button', { name: this.intl.t('pages.modulix.buttons.grain.skip') })).exists();
           });
+
           test('should not display continue button', async function (assert) {
             // given
             const steps = [
@@ -959,7 +975,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
               },
             ];
 
-            const store = this.owner.lookup('service:store');
             const grain = store.createRecord('grain', {
               title: 'Grain title',
               components: [
@@ -970,16 +985,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
               ],
             });
 
-            const passage = store.createRecord('passage');
-            const retryElementStub = sinon.stub();
-
             this.set('grain', grain);
             this.set('passage', passage);
             this.set('retryElement', retryElementStub);
+            this.set('continueToNextStep', continueToNextStepStub);
 
             // when
             const screen = await render(hbs`
-          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}}  />`);
+          <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}} @continueToNextStep={{this.continueToNextStep}} />`);
 
             // then
             assert
@@ -1016,7 +1029,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
                 },
               ];
 
-              const store = this.owner.lookup('service:store');
               const grain = store.createRecord('grain', {
                 title: 'Grain title',
                 components: [
@@ -1027,16 +1039,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
                 ],
               });
 
-              const passage = store.createRecord('passage');
-              const retryElementStub = sinon.stub();
-
               this.set('grain', grain);
               this.set('passage', passage);
               this.set('retryElement', retryElementStub);
+              this.set('continueToNextStep', continueToNextStepStub);
 
               // when
               const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}}  />`);
+            <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}} @continueToNextStep={{this.continueToNextStep}} />`);
               await clickByName(this.intl.t('pages.modulix.buttons.stepper.next'));
 
               // then
@@ -1071,7 +1081,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
                 },
               ];
 
-              const store = this.owner.lookup('service:store');
               const grain = store.createRecord('grain', {
                 title: 'Grain title',
                 components: [
@@ -1082,16 +1091,14 @@ module('Integration | Component | Module | Grain', function (hooks) {
                 ],
               });
 
-              const passage = store.createRecord('passage');
-              const retryElementStub = sinon.stub();
-
               this.set('grain', grain);
               this.set('passage', passage);
               this.set('retryElement', retryElementStub);
+              this.set('continueToNextStep', continueToNextStepStub);
 
               // when
               const screen = await render(hbs`
-            <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}}  />`);
+            <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}} @continueToNextStep={{this.continueToNextStep}} />`);
               await clickByName(this.intl.t('pages.modulix.buttons.stepper.next'));
 
               // then
@@ -1228,7 +1235,19 @@ module('Integration | Component | Module | Grain', function (hooks) {
               .doesNotExist();
           });
         });
-        module('when there is no more steps to display', function () {
+
+        module('when there is no more steps to display', function (hooks) {
+          let passage;
+          let retryElementStub;
+          let continueToNextStepStub;
+          let store;
+
+          hooks.beforeEach(function () {
+            store = this.owner.lookup('service:store');
+            passage = store.createRecord('passage');
+            retryElementStub = sinon.stub();
+            continueToNextStepStub = sinon.stub();
+          });
           module('when the last step contains an answerable element', function () {
             test('should not display skip button', async function (assert) {
               // given
@@ -1270,22 +1289,21 @@ module('Integration | Component | Module | Grain', function (hooks) {
                 ],
               });
 
-              const passage = store.createRecord('passage');
               const correction = store.createRecord('correction-response', { status: 'ok', feedback: 'super' });
               store.createRecord('element-answer', {
                 elementId: 'd0690f26-978c-41c3-9a21-da931857739c',
                 correction,
                 passage,
               });
-              const retryElementStub = sinon.stub();
 
               this.set('grain', grain);
               this.set('passage', passage);
               this.set('retryElement', retryElementStub);
+              this.set('continueToNextStep', continueToNextStepStub);
 
               // when
               const screen = await render(hbs`
-                <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}}  />`);
+                <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}} @continueToNextStep={{this.continueToNextStep}} />`);
 
               await clickByName(this.intl.t('pages.modulix.buttons.stepper.next'));
 
@@ -1335,7 +1353,6 @@ module('Integration | Component | Module | Grain', function (hooks) {
                 ],
               });
 
-              const passage = store.createRecord('passage');
               const correction = store.createRecord('correction-response', { status: 'ok', feedback: 'super' });
               store.createRecord('element-answer', {
                 elementId: 'd0690f26-978c-41c3-9a21-da931857739c',
@@ -1347,10 +1364,11 @@ module('Integration | Component | Module | Grain', function (hooks) {
               this.set('grain', grain);
               this.set('passage', passage);
               this.set('retryElement', retryElementStub);
+              this.set('continueToNextStep', continueToNextStepStub);
 
               // when
               const screen = await render(hbs`
-                <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}}  />`);
+                <Module::Grain @grain={{this.grain}} @passage={{this.passage}} @canMoveToNextGrain={{true}} @retryElement={{this.retryElement}} @continueToNextStep={{this.continueToNextStep}} />`);
 
               await clickByName(this.intl.t('pages.modulix.buttons.stepper.next'));
 

--- a/mon-pix/tests/integration/components/module/passage_test.gjs
+++ b/mon-pix/tests/integration/components/module/passage_test.gjs
@@ -429,6 +429,42 @@ module('Integration | Component | Module | Passage', function (hooks) {
     });
   });
 
+  module('when user click on next step button', function () {
+    test('should push event', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const text1Element = { content: 'content', type: 'text' };
+      const text2Element = { content: 'content 2', type: 'text' };
+      const step1 = { elements: [text1Element] };
+      const step2 = { elements: [text2Element] };
+      const grain = store.createRecord('grain', {
+        id: '123',
+        components: [{ type: 'stepper', steps: [step1, step2] }],
+      });
+
+      const module = store.createRecord('module', { id: '1', title: 'Module title', grains: [grain] });
+      const passage = store.createRecord('passage');
+      const continueToNextStepButtonName = this.intl.t('pages.modulix.buttons.stepper.next');
+
+      await render(<template><ModulePassage @module={{module}} @passage={{passage}} /></template>);
+
+      const metrics = this.owner.lookup('service:metrics');
+      metrics.add = sinon.stub();
+
+      // when
+      await clickByName(continueToNextStepButtonName);
+
+      // then
+      sinon.assert.calledWithExactly(metrics.add, {
+        event: 'custom-event',
+        'pix-event-category': 'Modulix',
+        'pix-event-action': `Passage du module : ${module.id}`,
+        'pix-event-name': `Click sur le bouton suivant de l'étape 1 du stepper dans le grain : ${grain.id}`,
+      });
+      assert.ok(true);
+    });
+  });
+
   module('when there is no more grain to display', function () {
     test('should display the terminate button', async function (assert) {
       // given

--- a/mon-pix/tests/integration/components/module/stepper_test.gjs
+++ b/mon-pix/tests/integration/components/module/stepper_test.gjs
@@ -468,9 +468,16 @@ module('Integration | Component | Module | Stepper', function (hooks) {
         ];
 
         function stepperIsFinished() {}
+        function continueToNextStepStub() {}
 
         const screen = await render(
-          <template><ModulixStepper @steps={{steps}} @stepperIsFinished={{stepperIsFinished}} /></template>,
+          <template>
+            <ModulixStepper
+              @steps={{steps}}
+              @stepperIsFinished={{stepperIsFinished}}
+              @continueToNextStep={{continueToNextStepStub}}
+            />
+          </template>,
         );
 
         // when
@@ -504,9 +511,16 @@ module('Integration | Component | Module | Stepper', function (hooks) {
         ];
 
         function stepperIsFinished() {}
+        function continueToNextStepStub() {}
 
         const screen = await render(
-          <template><ModulixStepper @steps={{steps}} @stepperIsFinished={{stepperIsFinished}} /></template>,
+          <template>
+            <ModulixStepper
+              @steps={{steps}}
+              @stepperIsFinished={{stepperIsFinished}}
+              @continueToNextStep={{continueToNextStepStub}}
+            />
+          </template>,
         );
 
         // when


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, les utilisateurs peuvent passer d'une `Step` à une autre au sein d'un `Stepper` mais cette information n'est remontée nul-part malgré la pertinence qu'elle pourrait avoir dans le cadre de l'étude des comportements des utilisateurs.

## :robot: Proposition
Faire remonter un événement vers _Matomo_ à chaque fois que l'on clique sur le bouton "_Suivant_" d'un `Stepper`.
Comme nous ne savions pas précisemment quelle information remontée, nous avons proposé ce format:

```json
{
      "event": "custom-event",
      "pix-event-category": "Modulix",
      "pix-event-action": "Passage du module : <module-id>",
      "pix-event-name": "Click sur le bouton suivant de l'étape <step-position> du stepper dans le grain : <grain-id>",
}
```

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

CI 🍏

1. Se rendre sur [le didacticiel](https://app-pr9379.review.pix.fr/modules/didacticiel-modulix/passage)
2. Vérifier qu'il n'y a pas de régressions sur le module