### PR TITLE
[FEATURE] Ajout de filtre dans organization-learner-api (Pix-13162)

### DIFF
--- a/api/src/prescription/organization-learner/domain/usecases/find-paginated-organization-learners.js
+++ b/api/src/prescription/organization-learner/domain/usecases/find-paginated-organization-learners.js
@@ -1,5 +1,10 @@
-const findPaginatedOrganizationLearners = async function ({ organizationId, page, organizationLearnerRepository }) {
-  return organizationLearnerRepository.findPaginatedLearners({ organizationId, page });
+const findPaginatedOrganizationLearners = async function ({
+  organizationId,
+  page,
+  filter,
+  organizationLearnerRepository,
+}) {
+  return organizationLearnerRepository.findPaginatedLearners({ organizationId, page, filter });
 };
 
 export { findPaginatedOrganizationLearners };

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
@@ -74,13 +74,22 @@ async function get(organizationLearnerId) {
   throw new NotFoundError(`Student not found for ID ${organizationLearnerId}`);
 }
 
-async function findPaginatedLearners({ organizationId, page }) {
+async function findPaginatedLearners({ organizationId, page, filter }) {
   const query = knex
     .select('id', 'firstName', 'lastName', 'organizationId', 'attributes')
     .from('view-active-organization-learners')
     .where({ isDisabled: false, organizationId })
     .orderBy('firstName', 'ASC')
     .orderBy('lastName', 'ASC');
+
+  if (filter) {
+    Object.entries(filter).forEach(([name, values]) => {
+      query.andWhere(function () {
+        // eslint-disable-next-line knex/avoid-injections
+        this.whereRaw(`attributes->>'${name}' in ( ${values.map((_) => '?').join(' , ')} )`, values);
+      });
+    });
+  }
 
   const { results, pagination } = await fetchPage(query, page);
 

--- a/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/organization-learner-repository.js
@@ -79,8 +79,8 @@ async function findPaginatedLearners({ organizationId, page, filter }) {
     .select('id', 'firstName', 'lastName', 'organizationId', 'attributes')
     .from('view-active-organization-learners')
     .where({ isDisabled: false, organizationId })
-    .orderBy('firstName', 'ASC')
-    .orderBy('lastName', 'ASC');
+    .orderByRaw('LOWER("firstName") ASC')
+    .orderByRaw('LOWER("lastName") ASC');
 
   if (filter) {
     Object.entries(filter).forEach(([name, values]) => {

--- a/api/tests/prescription/organization-learner/integration/application/api/organization-learners-api_test.js
+++ b/api/tests/prescription/organization-learner/integration/application/api/organization-learners-api_test.js
@@ -26,7 +26,7 @@ describe('Integration | API | Organization Learner', function () {
       });
     });
 
-    context('when there is a pagination', function () {
+    context('when there is only a pagination', function () {
       it('should return all learners from the selected page', async function () {
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         databaseBuilder.factory.buildOrganizationLearner({

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -538,6 +538,7 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
         expect(result.learners[0].id).to.equal(secondLearner.id);
         expect(result.learners[1].id).to.equal(firstLearner.id);
       });
+
       it('orders by lastName when firstName are identical', async function () {
         const secondLearner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
           organizationId,
@@ -581,6 +582,46 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
           pageSize: 1,
           rowCount: 2,
           pageCount: 2,
+        });
+      });
+
+      context('Filtering', function () {
+        it('retrieve filtered and paginated learners', async function () {
+          databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+            organizationId,
+            attributes: { 'Libellé classe': 'Druid' },
+          });
+          databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+            organizationId,
+            firstName: 'Alban',
+            attributes: { 'Libellé classe': 'Witch' },
+          });
+
+          const rogueLearner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+            organizationId,
+            firstName: 'Zoé',
+            attributes: { 'Libellé classe': 'Rogue' },
+          });
+
+          await databaseBuilder.commit();
+
+          const result = await organizationLearnerRepository.findPaginatedLearners({
+            organizationId,
+            page: {
+              size: 1,
+              number: 2,
+            },
+            filter: { 'Libellé classe': ['Witch', 'Rogue'] },
+          });
+
+          expect(result.pagination).to.deep.equal({
+            page: 2,
+            pageSize: 1,
+            rowCount: 2,
+            pageCount: 2,
+          });
+          expect(result.learners.length).to.equal(1);
+          expect(result.learners[0].id).to.equal(rogueLearner.id);
         });
       });
     });

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -510,14 +510,14 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
       expect(result.learners).lengthOf(2);
     });
 
-    context('ordered learners', function () {
+    context('ordered learners without case sensitive', function () {
       let firstLearner;
 
       beforeEach(async function () {
         firstLearner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
           organizationId,
+          firstName: 'toto',
           lastName: 'Gilgamesh',
-          firstName: 'Toto',
           attributes: { classe: 'Warlock' },
         });
         await databaseBuilder.commit();
@@ -529,30 +529,43 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
           firstName: 'Tata',
           lastName: 'Gilgamesh',
         });
-
-        await databaseBuilder.commit();
-
-        const result = await organizationLearnerRepository.findPaginatedLearners({ organizationId });
-
-        expect(result.learners).lengthOf(2);
-        expect(result.learners[0].id).to.equal(secondLearner.id);
-        expect(result.learners[1].id).to.equal(firstLearner.id);
-      });
-
-      it('orders by lastName when firstName are identical', async function () {
-        const secondLearner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+        const thirdLearner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
           organizationId,
           firstName: 'Toto',
-          lastName: 'Aubert',
+          lastName: 'Gulgamesh',
         });
 
         await databaseBuilder.commit();
 
         const result = await organizationLearnerRepository.findPaginatedLearners({ organizationId });
 
-        expect(result.learners).lengthOf(2);
+        expect(result.learners).lengthOf(3);
         expect(result.learners[0].id).to.equal(secondLearner.id);
         expect(result.learners[1].id).to.equal(firstLearner.id);
+        expect(result.learners[2].id).to.equal(thirdLearner.id);
+      });
+
+      it('orders by lastName when firstName are identical', async function () {
+        const secondLearner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+          organizationId,
+          firstName: 'Toto',
+          lastName: 'Auberto',
+        });
+
+        const thirdLearner = databaseBuilder.factory.prescription.organizationLearners.buildOrganizationLearner({
+          organizationId,
+          firstName: 'Toto',
+          lastName: 'auberto',
+        });
+
+        await databaseBuilder.commit();
+
+        const result = await organizationLearnerRepository.findPaginatedLearners({ organizationId });
+
+        expect(result.learners).lengthOf(3);
+        expect(result.learners[0].id).to.equal(secondLearner.id);
+        expect(result.learners[1].id).to.equal(thirdLearner.id);
+        expect(result.learners[2].id).to.equal(firstLearner.id);
       });
     });
 

--- a/api/tests/prescription/organization-learner/unit/domain/usecases/find-paginated-organization-learners_test.js
+++ b/api/tests/prescription/organization-learner/unit/domain/usecases/find-paginated-organization-learners_test.js
@@ -1,7 +1,7 @@
 import { findPaginatedOrganizationLearners } from '../../../../../../src/prescription/organization-learner/domain/usecases/find-paginated-organization-learners.js';
 import { expect, sinon } from '../../../../../test-helper.js';
 
-describe('Unit | UseCase | find-organisation-learner', function () {
+describe('Unit | UseCase | find-paginated-organisation-learners', function () {
   it('should call organization learner repository', async function () {
     // given
     const organizationId = 1234;
@@ -14,6 +14,7 @@ describe('Unit | UseCase | find-organisation-learner', function () {
     await findPaginatedOrganizationLearners({
       organizationId,
       page: { size: 1, number: 1 },
+      filter: { 'Libellé classe': ['div'] },
       organizationLearnerRepository,
     });
 
@@ -21,6 +22,7 @@ describe('Unit | UseCase | find-organisation-learner', function () {
     expect(organizationLearnerRepository.findPaginatedLearners).to.have.been.calledWithExactly({
       organizationId,
       page: { size: 1, number: 1 },
+      filter: { 'Libellé classe': ['div'] },
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Pour Pix Junior on a besoin de mettre en place des filtres mais l'API interne ne permet pas à l'heure actuelle de le faire.

## :robot: Proposition
Passer l'information jusqu'au repository de la présence de filtre et de les appliquer sur les requêtes SQL. 

## :rainbow: Remarques
On à ajouter une correspondance entre noms des filtre et l'info stocké dans la colonne 'attributes' en DB.
De plus on a modifié la requête qui ordonne les learners pour qu'elle soit insensible à la casse

## :100: Pour tester
Run les test ?