### PR TITLE
[BUGFIX] Retirer la taille minimum pour le champ idPixLabel (PIX-13178)

### DIFF
--- a/api/src/prescription/campaign/domain/validators/campaign-update-validator.js
+++ b/api/src/prescription/campaign/domain/validators/campaign-update-validator.js
@@ -34,9 +34,8 @@ const campaignValidationJoiSchema = Joi.object({
     'number.base': 'MISSING_ORGANIZATION',
   }),
 
-  idPixLabel: Joi.string().allow(null).default(null).min(3).messages({
+  idPixLabel: Joi.string().allow(null).default(null).messages({
     'string.empty': 'EXTERNAL_USER_ID_IS_REQUIRED',
-    'string.min': 'EXTERNAL_USER_ID_IS_REQUIRED',
   }),
 
   title: Joi.string()

--- a/api/tests/prescription/campaign/unit/domain/validators/campaign-update-validator_test.js
+++ b/api/tests/prescription/campaign/unit/domain/validators/campaign-update-validator_test.js
@@ -261,26 +261,6 @@ describe('Unit | Domain | Validators | campaign-validator', function () {
                 _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
               }
             });
-
-            it('should reject with error when idPixLabel length is under 3 characters', function () {
-              // given
-              const expectedError = {
-                attribute: 'idPixLabel',
-                message: 'EXTERNAL_USER_ID_IS_REQUIRED',
-              };
-
-              try {
-                // when
-                campaignUpdateValidator.validate({
-                  ...campaign,
-                  idPixLabel: 'AZ',
-                });
-                expect.fail('should have thrown an error');
-              } catch (entityValidationErrors) {
-                // then
-                _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
-              }
-            });
           });
 
           context('#type', function () {


### PR DESCRIPTION
## :unicorn: Problème
Lors de la modification d'une campagne, on passe par un "campaign-update-validator", qui vérifie la taille min du idPixLabel au passage. Cependant, ce champ n'est pas controlé lors de la création, donc on peut créer une campagne avec seulement 1 ou 2 caractères dans le idPixLabel. De plus, lors de la modification d'une campagne, on ne peut de toute façon pas modifier ce label. La vérification de sa taille ne sert donc pas.

## :robot: Proposition
Retirer la validation de la taille minimum de ce champ et son test associé.

## :rainbow: Remarques


## :100: Pour tester

- Aller sur PixOrga
- Créer une campagne en cochant "Oui" à "Souhaitez-vous demander un identifiant externe ?"
- Mettre seulement 1 ou 2 caractère dans le libellé de l'identifiant
- Valider la création de campagne
- Essayer de modifier le titre de la campagne
- Vérifier qu'il n'y a plus d'erreur et que le titre se met bien à jour
- 🐈‍⬛ 
