### PR TITLE
[FEATURE] Ajouter les règles de validation du Stepper (PIX-13143)

### DIFF
--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module.js
@@ -55,14 +55,22 @@ const grainSchema = Joi.object({
   id: uuidSchema,
   type: Joi.string().valid('lesson', 'activity').required(),
   title: htmlNotAllowedSchema.required(),
-  components: Joi.array().items(
-    Joi.alternatives().conditional('.type', {
-      switch: [
-        { is: 'element', then: componentElementSchema },
-        { is: 'stepper', then: componentStepperSchema },
-      ],
+  components: Joi.array()
+    .items(
+      Joi.alternatives().conditional('.type', {
+        switch: [
+          { is: 'element', then: componentElementSchema },
+          { is: 'stepper', then: componentStepperSchema },
+        ],
+      }),
+    )
+    .custom((value, helpers) => {
+      const steppersInArray = value.filter(({ type }) => type === 'stepper');
+      if (steppersInArray.length > 1) {
+        return helpers.message("Il ne peut y avoir qu'un stepper par grain");
+      }
+      return value;
     }),
-  ),
 }).required();
 
 const moduleSchema = Joi.object({

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module.js
@@ -70,6 +70,19 @@ const grainSchema = Joi.object({
         return helpers.message("Il ne peut y avoir qu'un stepper par grain");
       }
       return value;
+    })
+    .custom((value, helpers) => {
+      const steppersInArray = value.filter(({ type }) => type === 'stepper');
+      const elementsInArray = value.filter(({ type }) => type === 'element');
+      const containsAnswerableElement = elementsInArray.some(({ element }) =>
+        ['qcu', 'qcm', 'qrocm'].includes(element.type),
+      );
+      if (steppersInArray.length === 1 && containsAnswerableElement) {
+        return helpers.message(
+          "Un grain ne peut pas être composé d'un composant 'stepper' et d'un composant 'element' répondable (QCU, QCM ou QROCM)",
+        );
+      }
+      return value;
     }),
 }).required();
 


### PR DESCRIPTION
## :unicorn: Problème
Afin d'aider à la contribution dans le référentiel Modulix, il manque deux règles de validation autour des `Stepper`.

## :robot: Proposition

1. Retourner une erreur de validation si un `Grain` comporte plus d'un `Stepper`.
2. Retourner une erreur de validation si un `Grain` comporte un ou plusieurs éléments _répondables_ en plus d'un `Stepper`. 

## :rainbow: Remarques
Il serait intéressant de reprendre chaque règle de validation que l'on fait avec _Joi_ afin de vérifier si certaines ne seraient pas des règles d'invariants qui auraient + leur place dans le domaine.

## :100: Pour tester

### Règle 1

1. Aller dans le fichier du module _didacticiel-modulix_ (`api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json`)
2. Ajouter le stepper suivant dans le premier grain:

```json
{
  "type": "stepper",
  "steps": [
    {
      "elements": [
        {
          "id": "a2372bf4-86a4-4ecc-a188-b51f4f98bca2",
          "type": "text",
          "content": "<p>Voici un texte de leçon</p>"
        }
      ]
    },
    {
      "elements": [
        {
          "id": "4cfd27d5-0947-47af-bfb6-52467143c38b",
          "type": "text",
          "content": "<p>Et là, voici une image&#8239;!</p>"
        }
      ]
    }
  ]
}
```
(ainsi vous aurez 2 stepper dans le même grain)
3. Lancer le script `npm run modulix:test`
4. Constater l'erreur "_Il ne peut y avoir qu'un stepper par grain_"

### Règle 2

1. Aller dans le fichier du module _didacticiel-modulix_ (`api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json`)
2. Remplacer l'élément `text` ligne 57 par ce `qcu`:

```json
{
  "id": "71de6394-ff88-4de3-8834-a40057a50ff4",
  "type": "qcu",
  "instruction": "<p>Pix évalue 16 compétences numériques différentes.</p>",
  "proposals": [
    {
      "id": "1",
      "content": "Vrai"
    },
    {
      "id": "2",
      "content": "Faux"
    }
  ],
  "feedbacks": {
    "valid": "ok",
    "invalid": "ko"
  },
  "solution": "1"
}
```
(ainsi, vous aurez un élément répondable en plus d'un stepper)
3. Lancer le script `npm run modulix:test`
4. Constater l'erreur "_Un grain ne peut pas être composé d'un composant 'stepper' et d'un composant 'element' répondable (QCU, QCM ou QROCM)_"
