### PR TITLE
[BUGFIX] Retourner une erreur lorsqu'on tente de modifier une clé de badge par une clé existante (PIX-13191).

### DIFF
--- a/admin/app/components/badges/badge.js
+++ b/admin/app/components/badges/badge.js
@@ -66,8 +66,9 @@ export default class Badge extends Component {
       this.notifications.success('Le résultat thématique a été mis à jour.');
       this.editMode = false;
     } catch (error) {
-      console.error(error);
-      this.notifications.error('Erreur lors de la mise à jour du résultat thématique.');
+      error.errors.forEach((error) => {
+        this.notifications.error(error.detail);
+      });
     }
   }
 

--- a/admin/app/components/badges/badge.js
+++ b/admin/app/components/badges/badge.js
@@ -6,6 +6,7 @@ import { tracked } from '@glimmer/tracking';
 export default class Badge extends Component {
   @service notifications;
   @service store;
+  @service intl;
 
   @tracked editMode = false;
   @tracked form = {};
@@ -65,9 +66,17 @@ export default class Badge extends Component {
       await this.args.onUpdateBadge(badgeDTO);
       this.notifications.success('Le résultat thématique a été mis à jour.');
       this.editMode = false;
-    } catch (error) {
-      error.errors.forEach((error) => {
-        this.notifications.error(error.detail);
+    } catch (err) {
+      let errorMessage;
+      err.errors.forEach((error) => {
+        if (error?.code === 'BADGE_KEY_UNIQUE_CONSTRAINT_VIOLATED') {
+          errorMessage = this.intl.t('components.badges.api-error-messages.key-already-exists', {
+            badgeKey: error.meta,
+          });
+        } else {
+          errorMessage = error.detail;
+        }
+        this.notifications.error(errorMessage);
       });
     }
   }

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -120,6 +120,11 @@
         "upload-button": "Import CSV file"
       }
     },
+    "badges": {
+      "api-error-messages": {
+        "key-already-exists": "The badge key {badgeKey} already exists"
+      }
+    },
     "certification-centers": {
       "is-v3-pilot-label": "V3 Certification Pilot (This center will only be able to organize v3 sessions)",
       "membership-item": {
@@ -158,6 +163,30 @@
       "roles": {
         "admin": "Administrator",
         "member": "Member"
+      }
+    },
+    "organizations": {
+      "all-tags": {
+        "recently-used-tags": "List of tags recently used with {tagName}"
+      },
+      "children": {
+        "attach-child-form": {
+          "input-information": "ID of organisation to add",
+          "input-label": "Add a child organisation",
+          "name": "Add a child organisation form"
+        }
+      },
+      "children-list": {
+        "table-headers": {
+          "external-id": "External Identifier",
+          "id": "ID",
+          "name": "Name"
+        },
+        "table-name": "List of children organisations"
+      },
+      "information-section-view": {
+        "child-organization": "Child organization",
+        "parent-organization": "Parent organization"
       }
     },
     "organizations": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -128,6 +128,11 @@
         "upload-button": "Importer un fichier CSV"
       }
     },
+    "badges": {
+      "api-error-messages": {
+        "key-already-exists": "La clé de badge {badgeKey} est déjà utilisée"
+      }
+    },
     "certification-centers": {
       "is-v3-pilot-label": "Pilote Certification V3 (ce centre de certification ne pourra organiser que des sessions V3)",
       "membership-item": {

--- a/api/src/evaluation/application/badges/index.js
+++ b/api/src/evaluation/application/badges/index.js
@@ -31,7 +31,7 @@ const register = async function (server) {
                 key: Joi.string().required(),
                 'alt-message': Joi.string().required(),
                 'image-url': Joi.string().required(),
-                message: Joi.string().required().allow(null),
+                message: Joi.string().required().allow(null, ''),
                 title: Joi.string().required().allow(null),
                 'is-certifiable': Joi.boolean().required(),
                 'is-always-visible': Joi.boolean().required(),

--- a/api/src/evaluation/domain/models/Badge.js
+++ b/api/src/evaluation/domain/models/Badge.js
@@ -1,3 +1,5 @@
+const UPDATABLE_PROPERTIES = ['message', 'altMessage', 'key', 'title', 'imageUrl', 'isCertifiable', 'isAlwaysVisible'];
+
 class Badge {
   constructor({
     id,
@@ -21,6 +23,12 @@ class Badge {
     this.targetProfileId = targetProfileId;
     this.isAlwaysVisible = isAlwaysVisible;
     this.complementaryCertificationBadge = complementaryCertificationBadge;
+  }
+
+  updateBadgeProperties(badgeToUpdate) {
+    UPDATABLE_PROPERTIES.forEach((property) => {
+      if (badgeToUpdate[property]) this[property] = badgeToUpdate[property];
+    });
   }
 }
 

--- a/api/src/evaluation/domain/usecases/create-badge.js
+++ b/api/src/evaluation/domain/usecases/create-badge.js
@@ -11,7 +11,6 @@ const createBadge = async function ({
   const { campaignThreshold, cappedTubesCriteria, ...badge } = badgeCreation;
   return DomainTransaction.execute(async (domainTransaction) => {
     await targetProfileRepository.get(targetProfileId, domainTransaction);
-    await badgeRepository.isKeyAvailable(badge.key, domainTransaction);
 
     const isCampaignThresholdValid = campaignThreshold || campaignThreshold === 0;
     const hasCappedTubesCriteria = cappedTubesCriteria?.length > 0;

--- a/api/src/evaluation/domain/usecases/update-badge.js
+++ b/api/src/evaluation/domain/usecases/update-badge.js
@@ -1,15 +1,7 @@
-const updateBadge = async function ({ badgeId, badge, badgeRepository }) {
-  const existingBadge = await badgeRepository.get(badgeId);
-
-  if (badge.message) existingBadge.message = badge.message;
-  if (badge.altMessage) existingBadge.altMessage = badge.altMessage;
-  if (badge.key) existingBadge.key = badge.key;
-  if (badge.title) existingBadge.title = badge.title;
-  if (typeof badge.isCertifiable === 'boolean') existingBadge.isCertifiable = badge.isCertifiable;
-  if (typeof badge.isAlwaysVisible === 'boolean') existingBadge.isAlwaysVisible = badge.isAlwaysVisible;
-  if (badge.imageUrl) existingBadge.imageUrl = badge.imageUrl;
-
-  return badgeRepository.update(existingBadge);
+const updateBadge = async function ({ badgeId, badge: badgeDataToUpdate, badgeRepository }) {
+  const badgeToUpdate = await badgeRepository.get(badgeId);
+  badgeToUpdate.updateBadgeProperties(badgeDataToUpdate);
+  return badgeRepository.update(badgeToUpdate);
 };
 
 export { updateBadge };

--- a/api/src/evaluation/infrastructure/repositories/badge-repository.js
+++ b/api/src/evaluation/infrastructure/repositories/badge-repository.js
@@ -47,7 +47,11 @@ const update = async function (badge) {
     return new Badge({ ...badge, ...updatedBadge });
   } catch (error) {
     if (knexUtils.isUniqConstraintViolated(error) && error.constraint === BADGE_KEY_UNIQUE_CONSTRAINT) {
-      throw new AlreadyExistingEntityError(`The badge key ${badge.key} already exists`);
+      throw new AlreadyExistingEntityError(
+        `The badge key ${badge.key} already exists`,
+        'BADGE_KEY_UNIQUE_CONSTRAINT_VIOLATED',
+        badge.key,
+      );
     }
     throw error;
   }

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -166,6 +166,10 @@ function _mapToHttpError(error) {
     return new HttpErrors.ForbiddenError(error.message, error.code);
   }
 
+  if (error instanceof DomainErrors.AlreadyExistingEntityError) {
+    return new HttpErrors.PreconditionFailedError(error.message, error.code, error.meta);
+  }
+
   return new HttpErrors.BaseHttpError(error.message);
 }
 

--- a/api/src/shared/domain/errors.js
+++ b/api/src/shared/domain/errors.js
@@ -9,8 +9,9 @@ class DomainError extends Error {
 }
 
 class AlreadyExistingEntityError extends DomainError {
-  constructor(message = 'L’entité existe déjà.') {
-    super(message);
+  constructor(message = 'L’entité existe déjà.', code, meta) {
+    super(message, code);
+    if (meta) this.meta = meta;
   }
 }
 

--- a/api/tests/evaluation/integration/domain/usecases/create-badge_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/create-badge_test.js
@@ -185,6 +185,7 @@ describe('Integration | UseCases | create-badge', function () {
     it('should throw a AlreadyExistingEntityError', async function () {
       // given
       badgeCreation.key = existingBadgeKey;
+      badgeCreation.campaignThreshold = 99;
 
       // when
       const error = await catchErr(createBadge)({

--- a/api/tests/evaluation/integration/domain/usecases/update-badge_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/update-badge_test.js
@@ -69,6 +69,9 @@ describe('Integration | UseCases | create-badge', function () {
       });
 
       expect(error.name).to.equal('AlreadyExistingEntityError');
+      expect(error.code).to.equal('BADGE_KEY_UNIQUE_CONSTRAINT_VIOLATED');
+      expect(error.meta).to.equal('firstBadgeKey');
+      expect(error.message).to.equal('The badge key firstBadgeKey already exists');
     });
   });
 });

--- a/api/tests/evaluation/integration/domain/usecases/update-badge_test.js
+++ b/api/tests/evaluation/integration/domain/usecases/update-badge_test.js
@@ -1,0 +1,74 @@
+import { Badge } from '../../../../../src/evaluation/domain/models/Badge.js';
+import { updateBadge } from '../../../../../src/evaluation/domain/usecases/update-badge.js';
+import * as badgeRepository from '../../../../../src/evaluation/infrastructure/repositories/badge-repository.js';
+import { catchErr, databaseBuilder, expect, mockLearningContent } from '../../../../test-helper.js';
+
+describe('Integration | UseCases | create-badge', function () {
+  let targetProfileId;
+  let alreadyExistingFirstBadge;
+  let alreadyExistingSecondBadge;
+
+  beforeEach(async function () {
+    const learningContent = {
+      skills: [{ id: 'recSkill1' }],
+    };
+
+    mockLearningContent(learningContent);
+
+    targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+    databaseBuilder.factory.buildTargetProfileTube({ tubeId: 'monTubeA', level: 2, targetProfileId });
+    databaseBuilder.factory.buildTargetProfileTube({ tubeId: 'monTubeB', level: 8, targetProfileId });
+    alreadyExistingFirstBadge = databaseBuilder.factory.buildBadge({ id: 1, key: 'firstBadgeKey' });
+    alreadyExistingSecondBadge = databaseBuilder.factory.buildBadge({ id: 2, key: 'secondBadgeKey' });
+
+    await databaseBuilder.commit();
+  });
+
+  it('should update the badge', async function () {
+    const dataToUpdate = {
+      message: 'newMessage',
+      altMessage: 'newAltMessage',
+      key: 'newKey',
+      title: 'newTitle',
+      imageUrl: 'newImageUrl',
+      isCertifiable: false,
+      isAlwaysVisible: true,
+    };
+
+    const updatedFirstBadge = await updateBadge({
+      badgeId: alreadyExistingFirstBadge.id,
+      badge: dataToUpdate,
+      badgeRepository,
+    });
+
+    expect(updatedFirstBadge).to.be.instanceOf(Badge);
+
+    for (const property in dataToUpdate) {
+      expect(updatedFirstBadge[property]).to.equal(dataToUpdate[property]);
+    }
+  });
+
+  describe('when the badge id does not exists', function () {
+    it('should throw a not found error', async function () {
+      const error = await catchErr(updateBadge)({
+        badgeId: 0,
+        badge: {},
+        badgeRepository,
+      });
+
+      expect(error.name).to.equal('NotFoundError');
+    });
+  });
+
+  describe('when the badge key has changed and is already taken by another badge', function () {
+    it('should throw an AlreadyExistingEntityError', async function () {
+      const error = await catchErr(updateBadge)({
+        badgeId: alreadyExistingSecondBadge.id,
+        badge: { key: alreadyExistingFirstBadge.key },
+        badgeRepository,
+      });
+
+      expect(error.name).to.equal('AlreadyExistingEntityError');
+    });
+  });
+});

--- a/api/tests/evaluation/integration/infrastructure/repositories/badge-repository_test.js
+++ b/api/tests/evaluation/integration/infrastructure/repositories/badge-repository_test.js
@@ -212,34 +212,6 @@ describe('Integration | Repository | Badge', function () {
     });
   });
 
-  describe('#isKeyAvailable', function () {
-    it('should return true', async function () {
-      // given
-      const key = 'NOT_EXISTING_KEY';
-
-      // when
-      const result = await badgeRepository.isKeyAvailable(key);
-
-      // then
-      expect(result).to.be.true;
-    });
-
-    describe('when key is already exists', function () {
-      it('should return AlreadyExistEntityError', async function () {
-        // given
-        const key = 'AN_EXISTING_KEY';
-        databaseBuilder.factory.buildBadge({ key });
-        await databaseBuilder.commit();
-
-        // when
-        const error = await catchErr(badgeRepository.isKeyAvailable)(key);
-
-        // then
-        expect(error).to.instanceOf(AlreadyExistingEntityError);
-      });
-    });
-  });
-
   describe('#isAssociated', function () {
     describe('when the badge is not associated to a badge acquisition', function () {
       it('should return false', async function () {

--- a/api/tests/evaluation/integration/infrastructure/repositories/badge-repository_test.js
+++ b/api/tests/evaluation/integration/infrastructure/repositories/badge-repository_test.js
@@ -210,6 +210,37 @@ describe('Integration | Repository | Badge', function () {
       // then
       expect(updatedBadge).to.deep.equal(expectedBadge);
     });
+
+    describe('when the badge key already exists', function () {
+      it('should throw an AlreadyExistingEntityError with all error info', async function () {
+        // given
+        const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+        databaseBuilder.factory.buildBadge({
+          id: 1,
+          key: 'TOTO1',
+          targetProfileId,
+        });
+        databaseBuilder.factory.buildBadge({
+          id: 2,
+          key: 'TOTO2',
+          targetProfileId,
+        });
+        await databaseBuilder.commit();
+        const updateData = {
+          id: 2,
+          key: 'TOTO1',
+        };
+
+        // when
+        const error = await catchErr(badgeRepository.update)(updateData);
+
+        // then
+        expect(error).to.be.instanceOf(AlreadyExistingEntityError);
+        expect(error.code).to.equal('BADGE_KEY_UNIQUE_CONSTRAINT_VIOLATED');
+        expect(error.meta).to.equal('TOTO1');
+        expect(error.message).to.equal('The badge key TOTO1 already exists');
+      });
+    });
   });
 
   describe('#isAssociated', function () {

--- a/api/tests/evaluation/unit/domain/models/Badge_test.js
+++ b/api/tests/evaluation/unit/domain/models/Badge_test.js
@@ -1,0 +1,60 @@
+import { domainBuilder, expect } from '../../../../test-helper.js';
+
+describe('Unit | Domain | Models | Badge', function () {
+  describe('#updateBadgeProperties', function () {
+    it('should update instantiated badge with given properties', function () {
+      // given
+      const badge = domainBuilder.buildBadge({
+        id: 1,
+        altMessage: 'altMessage',
+        imageUrl: '/img/badge.svg',
+        message: 'original message',
+        title: 'original title',
+        key: 'original key',
+        isCertifiable: false,
+        targetProfileId: 456,
+        isAlwaysVisible: false,
+        complementaryCertificationBadge: null,
+      });
+
+      const updateData = {
+        altMessage: 'new message',
+        imageUrl: '/img/new-badge.svg',
+        message: 'new message',
+        title: 'new title',
+        key: 'new key',
+        isCertifiable: true,
+        isAlwaysVisible: true,
+      };
+
+      // when
+      badge.updateBadgeProperties(updateData);
+
+      // then
+      expect(badge.altMessage).to.equal('new message');
+      expect(badge.imageUrl).to.equal('/img/new-badge.svg');
+      expect(badge.message).to.equal('new message');
+      expect(badge.title).to.equal('new title');
+      expect(badge.key).to.equal('new key');
+      expect(badge.isCertifiable).to.equal(true);
+      expect(badge.isAlwaysVisible).to.equal(true);
+    });
+
+    it('should not update instantiated badge target profile id', function () {
+      // given
+      const badge = domainBuilder.buildBadge({
+        targetProfileId: 456,
+      });
+
+      const updateData = {
+        targetProfileId: 555,
+      };
+
+      // when
+      badge.updateBadgeProperties(updateData);
+
+      // then
+      expect(badge.targetProfileId).to.equal(456);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Dans Pix Admin, lorsqu'on cherche à créer un badge, on ne peut pas utiliser une clé (key) déjà existante car une contrainte d'unicité est en place. Malheureusement, cette condition n'est pas vérifiée lors de la modification d'un badge. 

## :robot: Proposition

Retourner une erreur lorsqu'on tente de violer la contrainte d'unicité d'une key lors de la modification d'un badge.

## :100: Pour tester

- Se connecter sur Pix Admin
- Aller sur l'onglet des badges (ou résultats thématiques)
- Tenter de modifier la clé avec une clé déjà existante (à compléter avec les infos nécessaires)
