### PR TITLE
[FEATURE] Autoriser les centres V3 comme pilote de séparation Pix/Pix+ (PIX-13170).

### DIFF
--- a/api/tests/integration/scripts/certification/next-gen/import-pilot-certification-centers-from-csv_test.js
+++ b/api/tests/integration/scripts/certification/next-gen/import-pilot-certification-centers-from-csv_test.js
@@ -1,6 +1,6 @@
-import { main } from '../../../../scripts/certification/import-pilot-certification-centers-from-csv.js';
-import { CERTIFICATION_FEATURES } from '../../../../src/certification/shared/domain/constants.js';
-import { catchErr, createTempFile, databaseBuilder, expect, knex, removeTempFile } from '../../../test-helper.js';
+import { main } from '../../../../../scripts/certification/next-gen/import-pilot-certification-centers-from-csv.js';
+import { CERTIFICATION_FEATURES } from '../../../../../src/certification/shared/domain/constants.js';
+import { catchErr, createTempFile, databaseBuilder, expect, knex, removeTempFile } from '../../../../test-helper.js';
 
 describe('Integration | Scripts | Certification | import-pilot-certification-centers-from-csv', function () {
   let file;
@@ -24,9 +24,9 @@ describe('Integration | Scripts | Certification | import-pilot-certification-cen
         key: CERTIFICATION_FEATURES.CAN_REGISTER_FOR_A_COMPLEMENTARY_CERTIFICATION_ALONE.key,
       }).id;
 
-      databaseBuilder.factory.buildCertificationCenter({ id: certificationCenterId1 });
-      databaseBuilder.factory.buildCertificationCenter({ id: certificationCenterId2 });
-      databaseBuilder.factory.buildCertificationCenter({ id: certificationCenterId3 });
+      databaseBuilder.factory.buildCertificationCenter({ id: certificationCenterId1, isV3Pilot: true });
+      databaseBuilder.factory.buildCertificationCenter({ id: certificationCenterId2, isV3Pilot: true });
+      databaseBuilder.factory.buildCertificationCenter({ id: certificationCenterId3, isV3Pilot: true });
 
       databaseBuilder.factory.buildCertificationCenterFeature({ certificationCenterId1, featureId });
 
@@ -61,9 +61,9 @@ describe('Integration | Scripts | Certification | import-pilot-certification-cen
           key: CERTIFICATION_FEATURES.CAN_REGISTER_FOR_A_COMPLEMENTARY_CERTIFICATION_ALONE.key,
         }).id;
 
-        databaseBuilder.factory.buildCertificationCenter({ id: v2CertificationCenterId });
-        databaseBuilder.factory.buildCertificationCenter({ id: v3CertificationCenterId, isV3Pilot: true });
-        databaseBuilder.factory.buildCertificationCenter({ id: v2CertificationCenterId2 });
+        databaseBuilder.factory.buildCertificationCenter({ id: v2CertificationCenterId, isV3Pilot: true });
+        databaseBuilder.factory.buildCertificationCenter({ id: v3CertificationCenterId, isV3Pilot: false });
+        databaseBuilder.factory.buildCertificationCenter({ id: v2CertificationCenterId2, isV3Pilot: true });
         databaseBuilder.factory.buildCertificationCenterFeature({ v2CertificationCenterId, featureId });
         await databaseBuilder.commit();
 
@@ -71,7 +71,7 @@ describe('Integration | Scripts | Certification | import-pilot-certification-cen
         const error = await catchErr(main)(csvFilePath);
 
         // then
-        expect(error.message).to.equal('V3 certification centers : 2002 are not allowed as pilots');
+        expect(error.message).to.equal('V2 certification centers : 2002 are not allowed as pilots');
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème

Pour la feature d’affichage des complémentaire sur des sessions V3 il faut modifier le script qui empêche aujourd’hui la V3 d’etre “complementaryAlone”  dans api/scripts/certification/import-pilot-certification-centers-from-csv.js

Les centre V2 ne seront pas pilote séparation

Les centres V3 pourront etre pilote séparation, mais on ne veut pas tout de suite affiché la nouvelle feature à tous les centres V3

de fait la réciproque n’est pas vrai :donc un pilote V3 n’est pas nécessairement pilote pix+

## :robot: Proposition

* Dans api/scripts/certification/import-pilot-certification-centers-from-csv.js
* Inverser la condition : andWhere({ isV3Pilot: true }) => andWhereNot({ isV3Pilot: true })
* Cela valide :
  * que l’on traitera aucune session V2 en pilote (puisque bloqué)
  * que il faut que le centre soit bien activé V3 pour être aussi pilote pix/pix+

## :rainbow: Remarques

### Pourquoi ne pas simplement enlever la condition ?

* L'équipe sait qu'elle ne va pas coder la séparation pour la V2
* La séparation va être cependant dévelopée avant la généralisation V3
* Ne pas l'inscrire dans le code en ferait une règle métier implicite, c'est généralement une mauvaise idée
* En tant normal, la contrainte devrait être plutôt côté Domain, mais ici on est dans un script qui n'utilise pas le Domain
* Par conséquent, n'aimant pas les règles métiers "dans les têtes", je conserve ici de bien expliciter la règle métier

## :100: Pour tester

* Créer un centre pilote V3 sur Pix Admin avec `superadmin@example.net`
* Créer un centre **non pilote V3** sur Pix Admin
* Mettre ces deux centres dans un CSV (voir example ci-dessous)
* Lancer le script, vérifier que le script refuse le centre V2
* Enlever le centre V2 du CSV
* Relancer le script, vérifier que pas d'erreurs
* Vérifier sur Pix Admin (rafraichir la page) que le centre V3 a désormais bien l'habilitation pilote de séparation
* Vérifier sur Pix Admin que le centre V2 lui n'a **pas** l'habilitation

Exemple de CSV :

```csv
certification_center_id;
xxxx;
yyyyyy;
```
