### PR TITLE
[BUGFIX] Corriger le clignotement sur le bouton `Continuer` des grains (PIX-13097)(PIX-12362)

### DIFF
--- a/mon-pix/app/components/module/grain.js
+++ b/mon-pix/app/components/module/grain.js
@@ -124,7 +124,7 @@ export default class ModuleGrain extends Component {
 
   get allElementsAreAnswered() {
     return this.answerableElements.every((element) => {
-      return !!this.args.passage.getLastCorrectionForElement(element);
+      return this.args.passage.hasAnswerAlreadyBeenVerified(element);
     });
   }
 

--- a/mon-pix/app/models/passage.js
+++ b/mon-pix/app/models/passage.js
@@ -11,6 +11,10 @@ export default class Passage extends Model {
     return elementAnswers.at(-1)?.correction;
   }
 
+  hasAnswerAlreadyBeenVerified(element) {
+    return this.elementAnswers.some((answer) => answer.elementId === element.id);
+  }
+
   terminate = memberAction({
     path: 'terminate',
     type: 'post',

--- a/mon-pix/tests/unit/models/modules/passage_test.js
+++ b/mon-pix/tests/unit/models/modules/passage_test.js
@@ -60,4 +60,70 @@ module('Unit | Model | Module | Passage', function (hooks) {
       });
     });
   });
+
+  module('#hasAnswerAlreadyBeenVerified', function () {
+    module('when the element has already been answered', function () {
+      test('should return true', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const qcuElement = {
+          id: 'a6838f8e-05ee-42e0-9820-13a9977cf5dc',
+          instruction: 'Instruction',
+          proposals: [
+            { id: '1', content: 'radio1' },
+            { id: '2', content: 'radio2' },
+          ],
+          type: 'qcus',
+        };
+
+        const elementAnswer = store.createRecord('element-answer', {
+          elementId: qcuElement.id,
+        });
+        const passage = store.createRecord('passage', { moduleId: '234', elementAnswers: [elementAnswer] });
+
+        // when
+        const qcuHasBeenVerified = passage.hasAnswerAlreadyBeenVerified(qcuElement);
+
+        // then
+        assert.true(qcuHasBeenVerified);
+      });
+    });
+
+    module('when the element has never been answered', function () {
+      test('should return false', function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const firstQcuElement = {
+          id: 'a6838f8e-05ee-42e0-9820-13a9977cf5dc',
+          instruction: 'Instruction',
+          proposals: [
+            { id: '1', content: 'radio1' },
+            { id: '2', content: 'radio2' },
+          ],
+          type: 'qcu',
+        };
+
+        const secondQcuElement = {
+          id: 'edb948e1-6264-44a4-93db-611611011ab7',
+          instruction: 'Instruction',
+          proposals: [
+            { id: '3', content: 'radio1' },
+            { id: '4', content: 'radio2' },
+          ],
+          type: 'qcu',
+        };
+
+        const elementAnswerForFirstQcu = store.createRecord('element-answer', {
+          elementId: firstQcuElement.id,
+        });
+        const passage = store.createRecord('passage', { moduleId: '234', elementAnswers: [elementAnswerForFirstQcu] });
+
+        // when
+        const qcuHasBeenVerified = passage.hasAnswerAlreadyBeenVerified(secondQcuElement);
+
+        // then
+        assert.false(qcuHasBeenVerified);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème

### Présentation du bug

A la fin d'un grain, lorsqu'un utilisateur répond à une question pour une deuxième fois (après avoir cliqué sur le bouton Réessayer) et qu'il vérifie à nouveau sa proposition, on remarque que le bouton `Continuer` permettant de passer au grain suivant, est remplacé par le bouton `Passer`. Puis lorsqu'on reçoit la feedback, le bouton `Continuer` revient.

### Explication algorithmique du bug

L'affichage du bouton `Passer` dépend de plusieurs conditions.
Une d'elles est de savoir si les éléments répondables ont tous été répondus ou pas.
Pour vérifier cela, le `Grain` prend tous les éléments répondables, et pour chacun d'eux, il passe par le modèle `Passage` pour récupérer leur dernière `element-answer`. Si celle-ci existe et si elle a une `correction`, on considère que l'élément a été répondu.

Sachant cela, lorsque le bouton `Vérifier` est cliqué, il se passe les événements suivants:

1. On crée un nouvel `element-answer` et on l'ajoute dans le _store_ de _Ember_
2. On lance la requête vers l'api pour récupérer la `correction`
3. Sans attendre la réponse de l'api, le `Grain` vérifie si tous les éléments répondables ont été répondus
4. Il interroge le model `Passage` qui trouve ce nouvel `element-answer` qui vient d'être crée, mais celui-ci n'a donc pas encore reçu sa `correction`
5. Le bouton `Passer` apparaît donc
6. Une fois que l'api a renvoyé la `correction`, le _store_ est mis à jour, ainsi notre `element-answer` a enfin une `correction` et le bouton `Continuer` apparaît.


## :robot: Proposition
Ajouter une méthode dans le passage qui renvoie un boolean si une réponse a déjà été enregistrée. Dans cette méthode, ne pas prendre en compte la présence ou non d'une correction.
Passer cette méthode dans le grain, lorsque l'on vérifie si tous les éléments ont été répondus.

## :rainbow: Remarques
Le bug a été initialement relevé au sein d'un stepper, mais en investiguant on s'est rendu compte que cela arrivait aussi dans les grains sans stepper.

## :100: Pour tester

1. Se rendre dans le [didacticiel](https://app-pr9394.review.pix.fr/modules/didacticiel-modulix)
2. Passer votre navigateur en réseau faible (Slow 3G)

![image](https://github.com/1024pix/pix/assets/128788023/df8e47a4-838e-4027-863e-a9ebbe814c16)
3. Répondre Vrai-Vrai-faux au stepper 2 du didacticiel
4. Le bouton “Continuer” s’affiche
5. Je clique sur “Réessayer” du 2ème QCU
6. Je revérifie
7. Le temps que le feedback arrive, constater que le bouton “Continuer” est toujours présent

