### PR TITLE
[FEATURE] Modification du lien de contact support sur la page de récupération du compte (PIX-13145)

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -215,7 +215,7 @@
         },
         "contact-support": {
           "link-text": "contactez le support.",
-          "link-url": "https://support.pix.org/fr/support/tickets/new"
+          "link-url": "https://pix.fr/support/form/aide-recuperer-mon-compte"
         },
         "send-email-confirmation": {
           "title": "Récupération de votre compte Pix",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -215,7 +215,7 @@
         },
         "contact-support": {
           "link-text": "contactez le support.",
-          "link-url": "https://support.pix.org/fr/support/tickets/new"
+          "link-url": "https://pix.fr/support/form/aide-recuperer-mon-compte"
         },
         "send-email-confirmation": {
           "title": "Récupération de votre compte Pix",


### PR DESCRIPTION
## :robot: Contexte
Un message d'erreur indique de contacter le support si les infos ne sont pas reconnues sur la page /recuperer-mon-compte.
Il faut modifier le lien contenu dans le message d’erreur pour utiliser la nouvelle url du site support https://pix.fr/support/form/aide-recuperer-mon-compte

## :rainbow: Remarques
RAS

## :100: Pour tester
- Ouvrir la RA de Pix App sur la page https://app-pr9397.review.pix.fr/recuperer-mon-compte 
- Sur cette page, saisir les identifiants d'un élève qui n'existe pas (ex: INE 123456789XX, nom Test, prénom Test, Date de naissance 01/01/1900)
- Vérifier qu'un message d'erreur s'affiche _Pix ne reconnait pas vos données. Vérifiez qu'elles sont exactes, sinon contactez le support_
- Vérifier que le lien pointe maintenant vers https://pix.fr/support/form/aide-recuperer-mon-compte

### Langue _en_
- Faire le même test que plus haut mais avec https://app-pr9397.review.pix.org/recuperer-mon-compte?lang=en

### Langue _es /nl_
Modification fait sur cette PR de Phrase : https://github.com/1024pix/pix/pull/9393