### PR TITLE
[FEATURE] Augmentation de la taille maximale de la payload pour la route /api/audit-log (PIX-13204)

### DIFF
--- a/audit-logger/src/lib/controllers/create-audit-log.controller.ts
+++ b/audit-logger/src/lib/controllers/create-audit-log.controller.ts
@@ -6,8 +6,10 @@ import { AuditLogActionTypes, AuditLogClientTypes, AuditLogRoleTypes } from '../
 import { type CreateAuditLogUseCase } from '../domain/usecases/create-audit-log.usecase.js';
 import { createAuditLogUseCase } from '../domain/usecases/usecases.js';
 
+const TWENTY_MEGABYTES = 1048576 * 20;
+
 export class CreateAuditLogController {
-  constructor(private readonly createAuditLogUseCase: CreateAuditLogUseCase) {}
+  constructor(private readonly createAuditLogUseCase: CreateAuditLogUseCase) { }
 
   async handle(request: Request, h: ResponseToolkit): Promise<ResponseObject> {
     const auditLogs = request.payload as AuditLog[];
@@ -25,6 +27,9 @@ export const CREATE_AUDIT_LOG_ROUTE: ServerRoute = {
   path: '/api/audit-logs',
   options: {
     auth: 'simple',
+    payload: {
+      maxBytes: TWENTY_MEGABYTES,
+    },
     handler: createAuditLogController.handle.bind(createAuditLogController),
     validate: {
       payload: Joi.array()


### PR DESCRIPTION
## :unicorn: Problème

La route `/api/audit-log` ne permet pas de recevoir des payloads de plus de 1Mb ce qui est gênant pour des gros traitements comme les traitements d'anonymisation qui peuvent être sur des millions d'enregistrements et ainsi générer des événements correspondants.

## :robot: Proposition

Augmenter la taille max de la payload, mais uniquement sur la route `/api/audit-log`.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

1. Créer un fichier de 20 Mb : 

   Sur Linux : 

   ```shell
   head -c20m /dev/urandom > test-20Mb.dat
   ```

   Sur MacOS : 
   ```shell
   mkfile -n 20m test-20Mb.dat
   ```

2. Créer un fichier de 30 Mb : 

   Sur Linux : 
   ```shell
   head -c30m /dev/urandom > test-30Mb.dat
   ```

   Sur MacOS : 
   ```shell
   mkfile -n 30m test-30Mb.dat
   ```

3. Envoyer le fichier de 20 Mb et vérifier que vérifier que l'Audit Logger **ne renvoie pas** l'erreur suivante : 

   ```shell
   curl \
   -X POST \
   -u pix-api:pixApiClientSecretTest \
   --data-binary @test-20Mb.dat \
   http://localhost:3001/api/audit-logs
   ```

   ```
   {"statusCode":413,"error":"Request Entity Too Large","message":"Payload content length greater than maximum allowed: 20971520"}
   ```

4. Envoyer le fichier 30 Mb et vérifier que vérifier que l'Audit Logger **renvoie** l'erreur suivante : 

   ```shell
   curl \
   -X POST \
   -u pix-api:pixApiClientSecretTest \
   --data-binary @test-30Mb.dat \
   http://localhost:3001/api/audit-logs
   ```

   ```
   {"statusCode":413,"error":"Request Entity Too Large","message":"Payload content length greater than maximum allowed: 20971520"}
   ```