### PR TITLE
[TECH] Utiliser la table certification-courses-last-assessment-results (PIX-13205)

### DIFF
--- a/api/tests/integration/infrastructure/repositories/competence-mark-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-mark-repository_test.js
@@ -70,7 +70,10 @@ describe('Integration | Repository | CompetenceMark', function () {
       // given
       const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
       const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
-      const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({ assessmentId }).id;
+      const assessmentResultId = databaseBuilder.factory.buildAssessmentResult.last({
+        assessmentId,
+        certificationCourseId,
+      }).id;
       const anotherAssessmentResultId = databaseBuilder.factory.buildAssessmentResult().id;
       _.map(
         [
@@ -144,7 +147,8 @@ describe('Integration | Repository | CompetenceMark', function () {
         assessmentId,
         createdAt: new Date('2020-01-01'),
       }).id;
-      const latestAssessmentResult = databaseBuilder.factory.buildAssessmentResult({
+      const latestAssessmentResult = databaseBuilder.factory.buildAssessmentResult.last({
+        certificationCourseId,
         assessmentId,
         createdAt: new Date('2021-01-01'),
       }).id;


### PR DESCRIPTION
## :unicorn: Problème
Il peut y avoir plusieurs assessment-results par assessment. Par ailleurs on utilise pas/peu l'assessment coté certif. 
Recuperer le dernier asessements-results via le certificationCourse est complexe

## :robot: Proposition
Utiliser la table `certification-courses-last-assessment-results` cree pour cela

## :rainbow: Remarques
Il ne restait qu'une route dans ce cas: `/api/admin/certifications/{id}/details`
PLus d'infos: https://github.com/1024pix/pix/pull/5350

## :100: Pour tester
Verifier qu'on recupere bien les competences marks dans l'onglet detail d'une certification depuis admin
