### PR TITLE
[TECH] Retirer les placeholders des champs de connexion sur Pix Admin (PIX-13209).

### DIFF
--- a/admin/app/components/login-form.hbs
+++ b/admin/app/components/login-form.hbs
@@ -31,7 +31,6 @@
       {{/if}}
     {{else}}
       <PixInput
-        placeholder={{t "pages.login.fields.email.label"}}
         required="true"
         @value={{this.email}}
         autocomplete="true"
@@ -41,7 +40,6 @@
       </PixInput>
 
       <PixInput
-        placeholder={{t "pages.login.fields.password.label"}}
         required="true"
         type="password"
         @value={{this.password}}


### PR DESCRIPTION
## :unicorn: Problème
Ça c'est non :(
<img width="338" alt="Capture d’écran 2024-06-28 à 15 15 47" src="https://github.com/1024pix/pix/assets/58915422/b71e639b-3c64-4d3e-ae7a-76515072b4c9">


## :robot: Proposition
Retirer les placeholders qui n'apportent plus rien depuis que les labels ont été mis en place sur les champs.

## :rainbow: Remarques
"Passe une bonne journée 🌻"

## :100: Pour tester
- Se rendre sur Admin
- Plus de placeholder, c'est beau
