### PR TITLE
[FEATURE] Lancement et hauteur automatiques d'embed (PIX-13211)

### DIFF
--- a/mon-pix/app/components/challenge-embed-simulator.hbs
+++ b/mon-pix/app/components/challenge-embed-simulator.hbs
@@ -32,16 +32,18 @@
       ></iframe>
     </div>
 
-    <div class="embed__reboot">
-      <button
-        type="button"
-        class="link link--grey embed-reboot__content"
-        aria-label={{t "pages.challenge.embed-simulator.actions.reset-label"}}
-        {{on "click" this.rebootSimulator}}
-      >
-        <FaIcon @icon="rotate-right" class="embed-reboot-content__icon" />
-        {{t "pages.challenge.embed-simulator.actions.reset"}}
-      </button>
-    </div>
+    {{#if this.isSimulatorRebootable}}
+      <div class="embed__reboot">
+        <button
+          type="button"
+          class="link link--grey embed-reboot__content"
+          aria-label={{t "pages.challenge.embed-simulator.actions.reset-label"}}
+          {{on "click" this.rebootSimulator}}
+        >
+          <FaIcon @icon="rotate-right" class="embed-reboot-content__icon" />
+          {{t "pages.challenge.embed-simulator.actions.reset"}}
+        </button>
+      </div>
+    {{/if}}
   </div>
 </div>

--- a/mon-pix/app/components/challenge-embed-simulator.js
+++ b/mon-pix/app/components/challenge-embed-simulator.js
@@ -44,14 +44,18 @@ export default class ChallengeEmbedSimulator extends Component {
 
     window.addEventListener('message', ({ origin, data }) => {
       if (!isEmbedAllowedOrigin(origin)) return;
-      if (!isHeightMessage(data)) return;
-      thisComponent.embedHeight = data.height + 20;
+      if (isHeightMessage(data)) {
+        thisComponent.embedHeight = data.height + 20;
+      }
+      if (isAutoLaunchMessage(data)) {
+        thisComponent.launchSimulator();
+      }
     });
   }
 
   @action
-  launchSimulator(event) {
-    const iframe = this._getIframe(event);
+  launchSimulator() {
+    const iframe = this.iframe;
     iframe.contentWindow.postMessage('launch', '*');
     iframe.focus();
     this.isSimulatorLaunched = true;
@@ -64,8 +68,8 @@ export default class ChallengeEmbedSimulator extends Component {
   }
 
   @action
-  rebootSimulator(event) {
-    const iframe = this._getIframe(event);
+  rebootSimulator() {
+    const iframe = this.iframe;
     const tmpSrc = iframe.src;
 
     const loadListener = () => {
@@ -85,8 +89,8 @@ export default class ChallengeEmbedSimulator extends Component {
     iframe.src = 'about:blank';
   }
 
-  _getIframe(event) {
-    return event.currentTarget.parentElement.parentElement.querySelector('.embed__iframe');
+  get iframe() {
+    return document.querySelector('.embed__iframe');
   }
 }
 
@@ -106,6 +110,15 @@ function isReadyMessage(data) {
  */
 function isHeightMessage(data) {
   return isMessageType(data, 'height');
+}
+
+/**
+ * Checks if event is a "auto-launch" message.
+ * @param {unknown} data
+ * @returns {boolean}
+ */
+function isAutoLaunchMessage(data) {
+  return isMessageType(data, 'auto-launch');
 }
 
 function isMessageType(data, type) {

--- a/mon-pix/app/components/challenge-embed-simulator.js
+++ b/mon-pix/app/components/challenge-embed-simulator.js
@@ -44,6 +44,10 @@ export default class ChallengeEmbedSimulator extends Component {
 
     window.addEventListener('message', ({ origin, data }) => {
       if (!isEmbedAllowedOrigin(origin)) return;
+      if (isReadyMessage(data) && thisComponent.isSimulatorLaunched) {
+        iframe.contentWindow.postMessage('launch', '*');
+        iframe.focus();
+      }
       if (isHeightMessage(data)) {
         thisComponent.embedHeight = data.height + 20;
       }
@@ -59,12 +63,6 @@ export default class ChallengeEmbedSimulator extends Component {
     iframe.contentWindow.postMessage('launch', '*');
     iframe.focus();
     this.isSimulatorLaunched = true;
-    window.addEventListener('message', ({ origin, data }) => {
-      if (!isEmbedAllowedOrigin(origin)) return;
-      if (!isReadyMessage(data)) return;
-      iframe.contentWindow.postMessage('launch', '*');
-      iframe.focus();
-    });
   }
 
   @action

--- a/mon-pix/app/components/challenge-embed-simulator.js
+++ b/mon-pix/app/components/challenge-embed-simulator.js
@@ -12,6 +12,9 @@ export default class ChallengeEmbedSimulator extends Component {
   isSimulatorLaunched = false;
 
   @tracked
+  isSimulatorRebootable = true;
+
+  @tracked
   embedHeight;
 
   _embedMessageListener;
@@ -55,6 +58,7 @@ export default class ChallengeEmbedSimulator extends Component {
       }
       if (isAutoLaunchMessage(data)) {
         thisComponent.launchSimulator();
+        thisComponent.isSimulatorRebootable = false;
       }
     };
 

--- a/mon-pix/app/components/challenge-embed-simulator.js
+++ b/mon-pix/app/components/challenge-embed-simulator.js
@@ -14,6 +14,8 @@ export default class ChallengeEmbedSimulator extends Component {
   @tracked
   embedHeight;
 
+  _embedMessageListener;
+
   constructor(owner, args) {
     super(owner, args);
     this.embedHeight = args.embedDocument?.height;
@@ -42,7 +44,7 @@ export default class ChallengeEmbedSimulator extends Component {
 
     iframe.addEventListener('load', loadListener);
 
-    window.addEventListener('message', ({ origin, data }) => {
+    thisComponent._embedMessageListener = ({ origin, data }) => {
       if (!isEmbedAllowedOrigin(origin)) return;
       if (isReadyMessage(data) && thisComponent.isSimulatorLaunched) {
         iframe.contentWindow.postMessage('launch', '*');
@@ -54,7 +56,9 @@ export default class ChallengeEmbedSimulator extends Component {
       if (isAutoLaunchMessage(data)) {
         thisComponent.launchSimulator();
       }
-    });
+    };
+
+    window.addEventListener('message', thisComponent._embedMessageListener);
   }
 
   @action
@@ -85,6 +89,11 @@ export default class ChallengeEmbedSimulator extends Component {
     iframe.addEventListener('load', loadListener);
 
     iframe.src = 'about:blank';
+  }
+
+  willDestroy() {
+    super.willDestroy();
+    window.removeEventListener('message', this._embedMessageListener);
   }
 
   get iframe() {

--- a/mon-pix/tests/integration/components/challenge-embed-simulator_test.js
+++ b/mon-pix/tests/integration/components/challenge-embed-simulator_test.js
@@ -98,5 +98,19 @@ module('Integration | Component | Challenge Embed Simulator', function (hooks) {
     test('should define a src attribute on the iframe element that is the one defined in the referential for field "Embed URL"', function (assert) {
       assert.strictEqual(find('.embed__iframe').src, 'http://embed-simulator.url/');
     });
+
+    module('when embed sends its height', function () {
+      test('should listen for embed height and resize iframe container', async function (assert) {
+        const event = new MessageEvent('message', {
+          data: { from: 'pix', type: 'height', height: 480 },
+          origin: 'https://epreuves.pix.fr',
+        });
+        window.dispatchEvent(event);
+
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        assert.strictEqual(find('.embed__iframe').style.cssText, 'height: 500px;');
+      });
+    });
   });
 });

--- a/mon-pix/tests/integration/components/challenge-embed-simulator_test.js
+++ b/mon-pix/tests/integration/components/challenge-embed-simulator_test.js
@@ -114,7 +114,7 @@ module('Integration | Component | Challenge Embed Simulator', function (hooks) {
     });
 
     module('when embed auto launches', function () {
-      test('should not display launch button', async function (assert) {
+      test('should not display launch button and reboot button', async function (assert) {
         const event = new MessageEvent('message', {
           data: { from: 'pix', type: 'auto-launch' },
           origin: 'https://epreuves.pix.fr',
@@ -124,6 +124,7 @@ module('Integration | Component | Challenge Embed Simulator', function (hooks) {
         await new Promise((resolve) => setTimeout(resolve, 0));
 
         assert.dom(screen.queryByText(this.intl.t('pages.challenge.embed-simulator.actions.launch'))).doesNotExist();
+        assert.dom(screen.queryByText(this.intl.t('pages.challenge.embed-simulator.actions.reset'))).doesNotExist();
       });
     });
   });

--- a/mon-pix/tests/integration/components/challenge-embed-simulator_test.js
+++ b/mon-pix/tests/integration/components/challenge-embed-simulator_test.js
@@ -73,6 +73,8 @@ module('Integration | Component | Challenge Embed Simulator', function (hooks) {
   });
 
   module('Embed simulator', function (hooks) {
+    let screen;
+
     hooks.beforeEach(async function () {
       // given
       this.set('embedDocument', {
@@ -82,9 +84,7 @@ module('Integration | Component | Challenge Embed Simulator', function (hooks) {
       });
 
       // when
-      await render(hbs`<ChallengeEmbedSimulator @embedDocument={{this.embedDocument}} />`);
-
-      // then
+      screen = await render(hbs`<ChallengeEmbedSimulator @embedDocument={{this.embedDocument}} />`);
     });
 
     test('should have an height that is the one defined in the referential', function (assert) {
@@ -110,6 +110,20 @@ module('Integration | Component | Challenge Embed Simulator', function (hooks) {
         await new Promise((resolve) => setTimeout(resolve, 0));
 
         assert.strictEqual(find('.embed__iframe').style.cssText, 'height: 500px;');
+      });
+    });
+
+    module('when embed auto launches', function () {
+      test('should not display launch button', async function (assert) {
+        const event = new MessageEvent('message', {
+          data: { from: 'pix', type: 'auto-launch' },
+          origin: 'https://epreuves.pix.fr',
+        });
+        window.dispatchEvent(event);
+
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        assert.dom(screen.queryByText(this.intl.t('pages.challenge.embed-simulator.actions.launch'))).doesNotExist();
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème

 - Pour certains embeds (QCU/QCM images, carousel), on ne veut pas de l'overlay de lancement.
 - On a du double scroll sur les épreuves avec embed quand la largeur de la fenêtre est trop petite.

## :robot: Proposition

Écouter de nouveaux messages envoyés par les embeds :
 - un message `height` permettant de changer la hauteur de l'iframe
 - un message `auto-launch` permettant de lancer automatiquement l'embed

## :rainbow: Remarques

N/A

## :100: Pour tester

Faire une preview de challenge1anilZTmbS1zAU sur la RA.