### PR TITLE
[FEATURE] Update le texte informatif sur le repasser/RAZ en fin de parcours 

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1637,7 +1637,7 @@
           "text": "You are about to reset and restart your customised test <strong>{targetProfileName}</strong>, in order to try to improve your results. At the end of this customised test, you can submit your results.",
           "warning-text": "Your pix score, levels and eligibility for certification obtained during this customised test will be deleted."
         },
-        "notifications": "If you choose to retry the failed questions or reset and restart from the beginning, your organisation will no longer be able to see your previously sent results. At the end of this customised test you will need to submit your results, so that it can be taken into account by the organiser."
+        "notifications": "If you choose to retry the failed questions or reset and restart from the beginning, you will need to submit your new results for them to be taken into account by the organizer. Previously submitted results remain accessible to the organizer."
       },
       "retry": {
         "button": "Retake my customised test",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1637,7 +1637,7 @@
           "text": "Vous êtes sur le point de remettre à zéro votre parcours <strong>{targetProfileName}</strong>, afin de tenter d’améliorer votre niveau. A la fin du parcours, vous pourrez à nouveau envoyer vos résultats.",
           "warning-text": "Vos Pix, vos niveaux et votre certificabilité obtenus lors de ce parcours vont être supprimés."
         },
-        "notifications": "Si vous retentez les questions échouées ou remettez à zéro pour tout retenter, votre organisation ne pourra plus voir votre dernier résultat. Pour que votre résultat soit comptabilisé par l'organisateur du test, vous devrez l'envoyer à nouveau."
+        "notifications": "Si vous repassez les questions échouées ou remettez à zéro pour tout retenter, vous devrez à nouveau envoyer vos résultats afin qu’ils soient comptabilisés par l’organisateur. Il continuera d’avoir accès à vos résultats précédemment envoyés."
       },
       "retry": {
         "button": "Repasser mon parcours",


### PR DESCRIPTION
## :unicorn: Problème
Suite aux travaux effectués sur l’historique des participations, le message d’information sur le repasser et le retenter avec RAZ est inexact : 

> Si vous retentez les questions échouées ou remettez à zéro pour tout retenter, votre organisation ne pourra plus voir votre dernier résultat. Pour que votre résultat soit comptabilisé par l'organisateur du test, vous devrez l'envoyer à nouveau.

## :robot: Proposition
Mettre à jour la notif pour expliquer au prescrit qu’il devra envoyer ses résultats mais que les précédents sont bien conservés par le prescripteur. 

> Si vous repassez les questions échouées ou remettez à zéro pour tout retenter, vous devrez à nouveau envoyer vos résultats afin qu’ils soient comptabilisés par l’organisateur. Il continuera d’avoir accès à vos résultats précédemment envoyés.

> If you choose to retry the failed questions or reset and restart from the beginning, you will need to submit your new results for them to be taken into account by the organizer. Previously submitted results remain accessible to the organizer.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- se connecter à PixApp 
- faire une campagne avec RAZ
- envoyer ses résultats
- rafraîchir
- s'assurer qu'on a bien le message maj et qu'il n'y a pas de coquille 
- 🫰 
