### PR TITLE
[FEATURE] Traduction en EN de la page de réconcilation SSO

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1364,9 +1364,9 @@
     },
     "oidc-reconciliation": {
       "title": "Warning",
-      "authentication-method-to-add": "Login method added :",
+      "authentication-method-to-add": "Login method added:",
       "confirm": "Continue",
-      "current-authentication-methods": "My current login methods :",
+      "current-authentication-methods": "My current login methods:",
       "email": "Email address",
       "external-connection": "External login",
       "external-connection-via": "Login via",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1363,18 +1363,18 @@
       "message": "You've been logged out.'<br>'Thanks! See you soon"
     },
     "oidc-reconciliation": {
-      "title": "Attention",
-      "authentication-method-to-add": "Méthode de connexion ajoutée :",
-      "confirm": "Continuer",
-      "current-authentication-methods": "Mes méthodes de connexion actuelles :",
-      "email": "Adresse e-mail",
-      "external-connection": "Connexion externe",
-      "external-connection-via": "Connexion via",
-      "information": "L'évaluation des compétences étant personnalisée, votre compte doit rester strictement personnel",
-      "return": "Retour",
-      "sub-title": "Un nouveau moyen de connexion est sur le point d'être ajouté à votre compte Pix",
-      "switch-account": "Changer de compte",
-      "username": "Identifiant"
+      "title": "Warning",
+      "authentication-method-to-add": "Login method added :",
+      "confirm": "Continue",
+      "current-authentication-methods": "My current login methods :",
+      "email": "Email address",
+      "external-connection": "External login",
+      "external-connection-via": "Login via",
+      "information": "As the assessment of your digital skills is personalized, your account must remain strictly personal",
+      "return": "Back",
+      "sub-title": "A new login method is about to be added to your Pix account",
+      "switch-account": "Change account",
+      "username": "Username"
     },
     "password-reset-demand": {
       "title": "Forgot your password?",


### PR DESCRIPTION
## :unicorn: Problème
Les traductions en anglais sont manquantes sur la page de réconcilation des SSO. Plus précisement, c'est la page affichée lorsqu'on décide d'utiliser un compte personnel et d'y ajouter une méthode de connexion.

![image](https://github.com/1024pix/pix/assets/146068290/481000ac-0826-4262-9c4c-b81697ca9619)

## :robot: Proposition
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

- Prendre un compte de test d'un de nos partenaires
- Vérifier que celui-ci est vierge de SSO dans Pix Admin 
- Se connecter en SSO via pix.org et choisir l'anglais
- Choisir de se connecter avec un compte PIX utilisant une méthode de connexion e-mail
- La page s'affiche en anglais
