### PR TITLE
[FEATURE] Afficher les résultats dernier passage terminé, et s'il n'y en a pas, alors afficher le statut du passage en cours (Pix-13144)

### DIFF
--- a/api/tests/school/integration/infrastructure/repositories/mission-assessment-repository_test.js
+++ b/api/tests/school/integration/infrastructure/repositories/mission-assessment-repository_test.js
@@ -118,18 +118,14 @@ describe('Integration | Repository | mission-assessment-repository', function ()
       const organizationLearnerWithCompletedAssessment = databaseBuilder.factory.buildOrganizationLearner();
       const organizationLearnerWithStartedAssessment = databaseBuilder.factory.buildOrganizationLearner();
       const organizationLearnerWithoutAssessment = databaseBuilder.factory.buildOrganizationLearner();
+      const organizationLearnerWhoRetriedMission = databaseBuilder.factory.buildOrganizationLearner();
+      const organizationLearnerWhoRetriedAndCompletedMissions = databaseBuilder.factory.buildOrganizationLearner();
+
       const missionId = 1;
 
       const startedMissionAssessment = databaseBuilder.factory.buildMissionAssessment({
         missionId,
         organizationLearnerId: organizationLearnerWithStartedAssessment.id,
-        state: Assessment.states.STARTED,
-        createdAt: new Date('2023-10-10'),
-      });
-
-      databaseBuilder.factory.buildMissionAssessment({
-        missionId,
-        organizationLearnerId: organizationLearnerWithCompletedAssessment.id,
         state: Assessment.states.STARTED,
         createdAt: new Date('2023-10-10'),
       });
@@ -141,12 +137,42 @@ describe('Integration | Repository | mission-assessment-repository', function ()
         createdAt: new Date('2024-10-10'),
       });
 
+      const firstMissionAssessmentCompleted = databaseBuilder.factory.buildMissionAssessment({
+        missionId,
+        organizationLearnerId: organizationLearnerWhoRetriedMission.id,
+        state: Assessment.states.COMPLETED,
+        createdAt: new Date('2023-10-10'),
+      });
+
+      databaseBuilder.factory.buildMissionAssessment({
+        missionId,
+        organizationLearnerId: organizationLearnerWhoRetriedMission.id,
+        state: Assessment.states.STARTED,
+        createdAt: new Date('2024-10-11'),
+      });
+
+      databaseBuilder.factory.buildMissionAssessment({
+        missionId,
+        organizationLearnerId: organizationLearnerWhoRetriedAndCompletedMissions.id,
+        state: Assessment.states.COMPLETED,
+        createdAt: new Date('2023-10-10'),
+      });
+
+      const secondMissionAssessmentCompleted = databaseBuilder.factory.buildMissionAssessment({
+        missionId,
+        organizationLearnerId: organizationLearnerWhoRetriedAndCompletedMissions.id,
+        state: Assessment.states.COMPLETED,
+        createdAt: new Date('2024-10-11'),
+      });
+
       await databaseBuilder.commit();
 
       const organizationLearners = [
         organizationLearnerWithCompletedAssessment,
         organizationLearnerWithoutAssessment,
         organizationLearnerWithStartedAssessment,
+        organizationLearnerWhoRetriedMission,
+        organizationLearnerWhoRetriedAndCompletedMissions,
       ];
       const results = await missionAssessmentRepository.getStatusesForLearners(
         missionId,
@@ -160,6 +186,12 @@ describe('Integration | Repository | mission-assessment-repository', function ()
         [organizationLearnerWithCompletedAssessment.id, 'completed', completedMissionAssessment.assessmentId],
         [organizationLearnerWithoutAssessment.id, undefined, undefined],
         [organizationLearnerWithStartedAssessment.id, 'started', startedMissionAssessment.assessmentId],
+        [organizationLearnerWhoRetriedMission.id, 'completed', firstMissionAssessmentCompleted.assessmentId],
+        [
+          organizationLearnerWhoRetriedAndCompletedMissions.id,
+          'completed',
+          secondMissionAssessmentCompleted.assessmentId,
+        ],
       ]);
     });
 


### PR DESCRIPTION
## :unicorn: Problème
On affichait le statut et le positionnement du dernier passage. Or ce que souhaite c'est afficher le résultat du dernier passage terminé, et s'il n'y en a pas, alors afficher le statut du passage en cours

## :robot: Proposition
Faire en sorte d'afficher le résultat du dernier passage terminé, et s'il n'y en a pas, alors afficher le statut du passage en cours

## :rainbow: Remarques

## :100: Pour tester
- Aller sur pix orga avec `member-orga@example.net` et sélectionner la mission
- Sur pix junior, commencer le parcours pour un élève, le finir retourner sur pix orga et voir que les résultats ont été mis à jours
- Retourner sur pis junior et recommencer la mission, aller voir sur pix orga qu'on affiche tjr le résultat du passage précédent.