### PR TITLE
[FEATURE] Mettre à jour le contenu de l'email "Création de compte" (PIX-12924)

### DIFF
--- a/api/lib/application/sco-organization-learners/sco-organization-learner-controller.js
+++ b/api/lib/application/sco-organization-learners/sco-organization-learner-controller.js
@@ -102,6 +102,7 @@ const createAndReconcileUserToOrganizationLearner = async function (
     password: payload.password,
     campaignCode: payload['campaign-code'],
     locale,
+    i18n: request.i18n,
   });
 
   return h.response().code(204);

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -4,10 +4,7 @@ import { LOCALE } from '../../../src/shared/domain/constants.js';
 import { tokenService } from '../../../src/shared/domain/services/token-service.js';
 import { urlBuilder } from '../../../src/shared/infrastructure/utils/url-builder.js';
 import { mailer } from '../../../src/shared/mail/infrastructure/services/mailer.js';
-import enTranslations from '../../../translations/en.json' with { type: 'json' };
-import frTranslations from '../../../translations/fr.json' with { type: 'json' };
-import { es as esTranslations } from '../../../translations/index.js';
-import nlTranslations from '../../../translations/nl.json' with { type: 'json' };
+import * as translations from '../../../translations/index.js';
 import { config } from '../../config.js';
 
 const { ENGLISH_SPOKEN, FRENCH_FRANCE, FRENCH_SPOKEN, DUTCH_SPOKEN, SPANISH_SPOKEN } = LOCALE;
@@ -45,12 +42,6 @@ const PIX_HELPDESK_URL_INTERNATIONAL = {
   en: 'https://pix.org/en/support',
   fr: 'https://pix.org/fr/support',
   nl: 'https://pix.org/nl-be/support',
-};
-const translations = {
-  en: enTranslations,
-  es: esTranslations,
-  fr: frTranslations,
-  nl: nlTranslations,
 };
 
 /**
@@ -107,7 +98,7 @@ function sendCertificationResultEmail({
     sessionId,
     sessionDate: formattedSessionDate,
     fr: {
-      ...frTranslations['certification-result-email'].params,
+      ...translations.fr['certification-result-email'].params,
       homeName: PIX_HOME_NAME_FRENCH_FRANCE,
       homeUrl: PIX_HOME_URL_FRENCH_FRANCE,
       homeNameInternational: PIX_HOME_NAME_INTERNATIONAL,
@@ -116,7 +107,7 @@ function sendCertificationResultEmail({
       link: `${link}?lang=fr`,
     },
     en: {
-      ...enTranslations['certification-result-email'].params,
+      ...translations.en['certification-result-email'].params,
       homeName: PIX_HOME_NAME_INTERNATIONAL,
       homeUrl: PIX_HOME_URL_INTERNATIONAL.en,
       title: translate({ phrase: 'certification-result-email.title', locale: 'en' }, { sessionId }),
@@ -126,7 +117,7 @@ function sendCertificationResultEmail({
 
   return mailer.sendEmail({
     from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: `${frTranslations['email-sender-name']['pix-app']} / ${enTranslations['email-sender-name']['pix-app']}`,
+    fromName: `${translations.fr['email-sender-name']['pix-app']} / ${translations.en['email-sender-name']['pix-app']}`,
     to: email,
     template: mailer.certificationResultTemplateId,
     variables: templateVariables,
@@ -365,7 +356,7 @@ function sendVerificationCodeEmail({ code, email, locale = FRENCH_FRANCE, transl
 function sendCpfEmail({ email, generatedFiles }) {
   const options = {
     from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: frTranslations['email-sender-name']['pix-app'],
+    fromName: translations.fr['email-sender-name']['pix-app'],
     to: email,
     template: mailer.cpfEmailTemplateId,
     variables: { generatedFiles },
@@ -379,7 +370,7 @@ function sendNotificationToCertificationCenterRefererForCleaResults({ email, ses
 
   const options = {
     from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: frTranslations['email-sender-name']['pix-app'],
+    fromName: translations.fr['email-sender-name']['pix-app'],
     to: email,
     template: mailer.acquiredCleaResultTemplateId,
     variables: { sessionId, sessionDate: formattedSessionDate },
@@ -391,7 +382,7 @@ function sendNotificationToCertificationCenterRefererForCleaResults({ email, ses
 function sendNotificationToOrganizationMembersForTargetProfileDetached({ email, complementaryCertificationName }) {
   const options = {
     from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: frTranslations['email-sender-name']['pix-app'],
+    fromName: translations.fr['email-sender-name']['pix-app'],
     to: email,
     template: mailer.targetProfileNotCertifiableTemplateId,
     variables: { complementaryCertificationName },

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -50,7 +50,7 @@ const PIX_HELPDESK_URL_INTERNATIONAL = {
  * @param redirectionUrl
  * @returns {Promise<EmailingAttempt>}
  */
-function sendAccountCreationEmail({ email, firstName, locale = FRENCH_FRANCE, token, redirectionUrl }) {
+function sendAccountCreationEmail({ email, firstName, locale = FRENCH_FRANCE, token, redirectionUrl, i18n }) {
   const mailerConfig = _getMailerConfig(locale);
   const redirectUrl = redirectionUrl || mailerConfig.pixAppConnectionUrl;
 
@@ -61,6 +61,7 @@ function sendAccountCreationEmail({ email, firstName, locale = FRENCH_FRANCE, to
     helpdeskUrl: mailerConfig.helpdeskUrl,
     displayNationalLogo: mailerConfig.displayNationalLogo,
     ...mailerConfig.translation['pix-account-creation-email'].params,
+    title: i18n.__({ phrase: 'pix-account-creation-email.params.title', locale }, { firstName }),
   };
   const pixName = mailerConfig.translation['email-sender-name']['pix-app'];
   const accountCreationEmailSubject = mailerConfig.translation['pix-account-creation-email'].subject;

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -50,7 +50,7 @@ const PIX_HELPDESK_URL_INTERNATIONAL = {
  * @param redirectionUrl
  * @returns {Promise<EmailingAttempt>}
  */
-function sendAccountCreationEmail({ email, locale = FRENCH_FRANCE, token, redirectionUrl }) {
+function sendAccountCreationEmail({ email, firstName, locale = FRENCH_FRANCE, token, redirectionUrl }) {
   const mailerConfig = _getMailerConfig(locale);
   const redirectUrl = redirectionUrl || mailerConfig.pixAppConnectionUrl;
 

--- a/api/lib/domain/usecases/create-and-reconcile-user-to-organization-learner.js
+++ b/api/lib/domain/usecases/create-and-reconcile-user-to-organization-learner.js
@@ -30,6 +30,7 @@ const createAndReconcileUserToOrganizationLearner = async function ({
   userService,
   passwordValidator,
   userValidator,
+  i18n,
 }) {
   const campaign = await campaignRepository.getByCode(campaignCode);
   if (!campaign) {
@@ -89,6 +90,7 @@ const createAndReconcileUserToOrganizationLearner = async function ({
       locale,
       token,
       redirectionUrl,
+      i18n,
     });
   }
   return createdUser;

--- a/api/lib/domain/usecases/create-and-reconcile-user-to-organization-learner.js
+++ b/api/lib/domain/usecases/create-and-reconcile-user-to-organization-learner.js
@@ -83,7 +83,13 @@ const createAndReconcileUserToOrganizationLearner = async function ({
   if (!isUsernameMode) {
     const redirectionUrl = urlBuilder.getCampaignUrl(locale, campaignCode);
     const token = await emailValidationDemandRepository.save(createdUser.id);
-    await mailService.sendAccountCreationEmail({ email: createdUser.email, locale, token, redirectionUrl });
+    await mailService.sendAccountCreationEmail({
+      email: createdUser.email,
+      firstName: createdUser.firstName,
+      locale,
+      token,
+      redirectionUrl,
+    });
   }
   return createdUser;
 };

--- a/api/src/identity-access-management/application/user/user.controller.js
+++ b/api/src/identity-access-management/application/user/user.controller.js
@@ -127,6 +127,7 @@ const save = async function (request, h, dependencies = { userSerializer, reques
     password,
     campaignCode,
     localeFromHeader,
+    i18n: request.i18n,
   });
 
   return h.response(dependencies.userSerializer.serialize(savedUser)).created();

--- a/api/src/identity-access-management/domain/usecases/create-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/create-user.usecase.js
@@ -70,6 +70,7 @@ const createUser = async function ({
     const token = await emailValidationDemandRepository.save(savedUser.id);
     await mailService.sendAccountCreationEmail({
       email: savedUser.email,
+      firstName: savedUser.firstName,
       locale: localeFromHeader,
       token,
       redirectionUrl,

--- a/api/src/identity-access-management/domain/usecases/create-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/create-user.usecase.js
@@ -34,6 +34,7 @@ const createUser = async function ({
   userService,
   userValidator,
   passwordValidator,
+  i18n,
 }) {
   const isValid = await _validateData({
     password,
@@ -74,6 +75,7 @@ const createUser = async function ({
       locale: localeFromHeader,
       token,
       redirectionUrl,
+      i18n,
     });
 
     return savedUser;

--- a/api/tests/identity-access-management/integration/application/user.route.test.js
+++ b/api/tests/identity-access-management/integration/application/user.route.test.js
@@ -1,4 +1,5 @@
 import { identityAccessManagementRoutes } from '../../../../src/identity-access-management/application/routes.js';
+import * as i18nPlugin from '../../../../src/shared/infrastructure/plugins/i18n.js';
 import { expect, HttpTestServer } from '../../../test-helper.js';
 
 const routesUnderTest = identityAccessManagementRoutes[0];
@@ -8,6 +9,7 @@ describe('Integration | Identity Access Management | Application | Route | User'
 
   beforeEach(async function () {
     httpTestServer = new HttpTestServer();
+    await httpTestServer.register(i18nPlugin);
     await httpTestServer.register(routesUnderTest);
   });
 

--- a/api/tests/identity-access-management/integration/domain/usecases/create-user.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/create-user.usecase.test.js
@@ -1,6 +1,7 @@
 import { User } from '../../../../../src/identity-access-management/domain/models/User.js';
 import { usecases } from '../../../../../src/identity-access-management/domain/usecases/index.js';
 import { expect } from '../../../../test-helper.js';
+import { getI18n } from '../../../../tooling/i18n/i18n.js';
 
 describe('Integration | Identity Access Management | Domain | UseCase | create-user', function () {
   it('returns the saved user', async function () {
@@ -10,7 +11,7 @@ describe('Integration | Identity Access Management | Domain | UseCase | create-u
     const password = 'P@ssW0rd';
 
     // when
-    const savedUser = await usecases.createUser({ password, user });
+    const savedUser = await usecases.createUser({ password, user, i18n: getI18n() });
 
     // then
     expect(savedUser).to.be.instanceOf(User);

--- a/api/tests/identity-access-management/unit/application/user.controller.test.js
+++ b/api/tests/identity-access-management/unit/application/user.controller.test.js
@@ -278,6 +278,7 @@ describe('Unit | Identity Access Management | Application | Controller | User', 
             password,
             localeFromHeader,
             campaignCode: null,
+            i18n: undefined,
           };
 
           dependencies.localeService.getCanonicalLocale.returns(localeFromCookie);

--- a/api/tests/identity-access-management/unit/domain/usecases/create-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/create-user.usecase.test.js
@@ -469,6 +469,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
         // then
         expect(mailService.sendAccountCreationEmail).to.have.been.calledWithExactly({
           email: userEmail,
+          firstName: user.firstName,
           locale: localeFromHeader,
           token,
           redirectionUrl: expectedRedirectionUrl,
@@ -503,6 +504,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           // then
           expect(mailService.sendAccountCreationEmail).to.have.been.calledWithExactly({
             email: userEmail,
+            firstName: user.firstName,
             locale: localeFromHeader,
             token,
             redirectionUrl: expectedRedirectionUrl,
@@ -539,6 +541,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           // then
           expect(mailService.sendAccountCreationEmail).to.have.been.calledWithExactly({
             email: userEmail,
+            firstName: user.firstName,
             locale: localeFromHeader,
             token,
             redirectionUrl: expectedRedirectionUrl,
@@ -575,7 +578,8 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
       // then
       expect(emailValidationDemandRepository.save).to.have.been.calledWith(userId);
       expect(mailService.sendAccountCreationEmail).to.have.been.calledWith({
-        email: savedUser.email,
+        email: user.email,
+        firstName: user.firstName,
         locale: localeFromHeader,
         token,
         redirectionUrl,

--- a/api/tests/identity-access-management/unit/domain/usecases/create-user.usecase.test.js
+++ b/api/tests/identity-access-management/unit/domain/usecases/create-user.usecase.test.js
@@ -473,6 +473,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
           locale: localeFromHeader,
           token,
           redirectionUrl: expectedRedirectionUrl,
+          i18n: undefined,
         });
       });
 
@@ -508,6 +509,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
             locale: localeFromHeader,
             token,
             redirectionUrl: expectedRedirectionUrl,
+            i18n: undefined,
           });
         });
       });
@@ -545,6 +547,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
             locale: localeFromHeader,
             token,
             redirectionUrl: expectedRedirectionUrl,
+            i18n: undefined,
           });
         });
       });
@@ -583,6 +586,7 @@ describe('Unit | Identity Access Management | Domain | UseCase | create-user', f
         locale: localeFromHeader,
         token,
         redirectionUrl,
+        i18n: undefined,
       });
       expect(createdUser).to.deep.equal(savedUser);
     });

--- a/api/tests/integration/domain/usecases/create-and-reconcile-user-to-organization-learner_test.js
+++ b/api/tests/integration/domain/usecases/create-and-reconcile-user-to-organization-learner_test.js
@@ -22,6 +22,9 @@ import * as userService from '../../../../src/shared/domain/services/user-servic
 import * as passwordValidator from '../../../../src/shared/domain/validators/password-validator.js';
 import * as userValidator from '../../../../src/shared/domain/validators/user-validator.js';
 import { catchErr, databaseBuilder, expect } from '../../../test-helper.js';
+import { getI18n } from '../../../tooling/i18n/i18n.js';
+
+const i18n = getI18n();
 
 describe('Integration | UseCases | create-and-reconcile-user-to-organization-learner', function () {
   const pickUserAttributes = ['firstName', 'lastName', 'email', 'username', 'cgu'];
@@ -50,6 +53,7 @@ describe('Integration | UseCases | create-and-reconcile-user-to-organization-lea
         obfuscationService,
         userReconciliationService,
         userService,
+        i18n,
       });
 
       // then
@@ -86,6 +90,7 @@ describe('Integration | UseCases | create-and-reconcile-user-to-organization-lea
         obfuscationService,
         userReconciliationService,
         userService,
+        i18n,
       });
 
       // then
@@ -135,6 +140,7 @@ describe('Integration | UseCases | create-and-reconcile-user-to-organization-lea
           obfuscationService,
           userReconciliationService,
           userService,
+          i18n,
         });
 
         // then
@@ -195,6 +201,7 @@ describe('Integration | UseCases | create-and-reconcile-user-to-organization-lea
             userService,
             passwordValidator,
             userValidator,
+            i18n,
           });
 
           // then
@@ -238,6 +245,7 @@ describe('Integration | UseCases | create-and-reconcile-user-to-organization-lea
             obfuscationService,
             userReconciliationService,
             userService,
+            i18n,
           });
 
           // then
@@ -258,6 +266,7 @@ describe('Integration | UseCases | create-and-reconcile-user-to-organization-lea
             locale,
             password,
             userAttributes,
+            i18n,
           });
 
           // then
@@ -325,6 +334,7 @@ describe('Integration | UseCases | create-and-reconcile-user-to-organization-lea
             obfuscationService,
             userReconciliationService,
             userService,
+            i18n,
           });
 
           // then
@@ -366,6 +376,7 @@ describe('Integration | UseCases | create-and-reconcile-user-to-organization-lea
             userService,
             passwordValidator,
             userValidator,
+            i18n,
           });
 
           // then

--- a/api/tests/integration/infrastructure/plugins/i18n_test.js
+++ b/api/tests/integration/infrastructure/plugins/i18n_test.js
@@ -1,0 +1,99 @@
+import * as i18nPlugin from '../../../../src/shared/infrastructure/plugins/i18n.js';
+import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
+import { getI18n } from '../../../tooling/i18n/i18n.js';
+
+describe('Integration | Infrastructure | plugins | i18n', function () {
+  let httpTestServer;
+  let handlerStub;
+
+  describe('validate the i18n configuration', function () {
+    let i18n;
+
+    before(function () {
+      i18n = getI18n();
+    });
+
+    it('supports all Pix locales', async function () {
+      // when
+      const allLocales = i18n.getLocales();
+
+      // then
+      expect(allLocales).to.deep.equal(['en', 'fr', 'es', 'nl']);
+    });
+
+    it('returns fr as default locale', async function () {
+      // when
+      const result = i18n.__('email-sender-name.pix-app');
+
+      // then
+      expect(result).to.equal('PIX - Ne pas répondre');
+    });
+
+    it('fallbacks to fr locale when the locale is not supported', async function () {
+      // when
+      const result = i18n.__({ phrase: 'email-sender-name.pix-app', locale: 'foo' });
+
+      // then
+      expect(result).to.equal('PIX - Ne pas répondre');
+    });
+
+    it('interpolates parameters with single mustache', async function () {
+      // when
+      const result = i18n.__('Hello {name}', { name: 'Bob' });
+
+      // then
+      expect(result).to.equal('Hello Bob');
+    });
+  });
+
+  describe('integrates the i18n plugin in HTTP server requests', function () {
+    beforeEach(async function () {
+      httpTestServer = new HttpTestServer();
+      handlerStub = sinon.stub().returns({});
+
+      await httpTestServer.register([i18nPlugin]);
+      await httpTestServer.register({
+        name: 'test-api',
+        register: (server) => {
+          server.route([{ method: 'GET', path: '/', config: { handler: handlerStub } }]);
+        },
+      });
+    });
+
+    it('uses the fr locale by default', async function () {
+      // when
+      await httpTestServer.request('GET', '/', null, null);
+
+      // then
+      const { i18n } = handlerStub.getCall(0).args[0];
+      expect(i18n.__('email-sender-name.pix-app')).to.equal('PIX - Ne pas répondre');
+    });
+
+    it('returns the language defined by the header Accept-Language', async function () {
+      // when
+      await httpTestServer.request('GET', '/', null, null, { 'Accept-Language': 'en' });
+
+      // then
+      const { i18n } = handlerStub.getCall(0).args[0];
+      expect(i18n.__('email-sender-name.pix-app')).to.equal('PIX - Noreply');
+    });
+
+    it('fallbacks to fr locale when the header Accept-Language locale is not supported', async function () {
+      // when
+      await httpTestServer.request('GET', '/', null, null, { 'Accept-Language': 'foo' });
+
+      // then
+      const { i18n } = handlerStub.getCall(0).args[0];
+      expect(i18n.__('email-sender-name.pix-app')).to.equal('PIX - Ne pas répondre');
+    });
+
+    it('returns the language defined by the lang parameter', async function () {
+      // when
+      await httpTestServer.request('GET', '/?lang=en');
+
+      // then
+      const { i18n } = handlerStub.getCall(0).args[0];
+      expect(i18n.__('email-sender-name.pix-app')).to.equal('PIX - Noreply');
+    });
+  });
+});

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -20,9 +20,12 @@ const mainTranslationsMapping = {
 
 const { ENGLISH_SPOKEN, FRENCH_FRANCE, FRENCH_SPOKEN, DUTCH_SPOKEN, SPANISH_SPOKEN } = LOCALE;
 
+const i18n = getI18n();
+
 describe('Unit | Service | MailService', function () {
   const senderEmailAddress = 'ne-pas-repondre@pix.fr';
   const userEmailAddress = 'user@example.net';
+  const userFirstName = 'Bob';
 
   beforeEach(function () {
     sinon.stub(mailer, 'sendEmail').resolves();
@@ -46,7 +49,7 @@ describe('Unit | Service | MailService', function () {
       };
 
       // when
-      await mailService.sendAccountCreationEmail({ email: userEmailAddress, locale, token, redirectionUrl });
+      await mailService.sendAccountCreationEmail({ email: userEmailAddress, locale, token, redirectionUrl, i18n });
 
       // then
       const options = mailer.sendEmail.firstCall.args[0];
@@ -68,7 +71,7 @@ describe('Unit | Service | MailService', function () {
           const expectedParams = new URLSearchParams({ token, redirect_url: redirectionUrl });
 
           // when
-          await mailService.sendAccountCreationEmail({ email: userEmailAddress, locale, token, redirectionUrl });
+          await mailService.sendAccountCreationEmail({ email: userEmailAddress, locale, token, redirectionUrl, i18n });
 
           // then
           const actualRedirectionUrl = mailer.sendEmail.firstCall.args[0].variables.redirectionUrl;
@@ -87,7 +90,12 @@ describe('Unit | Service | MailService', function () {
           const expectedParams = new URLSearchParams({ redirect_url: 'https://app.pix.org/connexion/?lang=fr' });
 
           // when
-          await mailService.sendAccountCreationEmail({ email: userEmailAddress, locale });
+          await mailService.sendAccountCreationEmail({
+            email: userEmailAddress,
+            firstName: userFirstName,
+            locale,
+            i18n,
+          });
 
           // then
           const options = mailer.sendEmail.firstCall.args[0];
@@ -99,6 +107,7 @@ describe('Unit | Service | MailService', function () {
             displayNationalLogo: false,
             redirectionUrl: `https://app.pix.org/api/users/validate-email?${expectedParams.toString()}`,
             ...mainTranslationsMapping.fr['pix-account-creation-email'].params,
+            title: 'Bonjour Bob,',
           });
         });
 
@@ -108,7 +117,12 @@ describe('Unit | Service | MailService', function () {
           const expectedParams = new URLSearchParams({ redirect_url: 'https://app.pix.fr/connexion' });
 
           // when
-          await mailService.sendAccountCreationEmail({ email: userEmailAddress, locale });
+          await mailService.sendAccountCreationEmail({
+            email: userEmailAddress,
+            firstName: userFirstName,
+            locale,
+            i18n,
+          });
 
           // then
           const options = mailer.sendEmail.firstCall.args[0];
@@ -120,6 +134,7 @@ describe('Unit | Service | MailService', function () {
             displayNationalLogo: true,
             redirectionUrl: `https://app.pix.fr/api/users/validate-email?${expectedParams.toString()}`,
             ...mainTranslationsMapping.fr['pix-account-creation-email'].params,
+            title: 'Bonjour Bob,',
           });
         });
 
@@ -129,7 +144,12 @@ describe('Unit | Service | MailService', function () {
           const expectedParams = new URLSearchParams({ redirect_url: 'https://app.pix.org/connexion/?lang=en' });
 
           // when
-          await mailService.sendAccountCreationEmail({ email: userEmailAddress, locale });
+          await mailService.sendAccountCreationEmail({
+            email: userEmailAddress,
+            firstName: userFirstName,
+            locale,
+            i18n,
+          });
 
           // then
           const options = mailer.sendEmail.firstCall.args[0];
@@ -141,6 +161,7 @@ describe('Unit | Service | MailService', function () {
             displayNationalLogo: false,
             redirectionUrl: `https://app.pix.org/api/users/validate-email?${expectedParams.toString()}`,
             ...mainTranslationsMapping.en['pix-account-creation-email'].params,
+            title: 'Hello Bob,',
           });
         });
 
@@ -150,7 +171,12 @@ describe('Unit | Service | MailService', function () {
           const expectedParams = new URLSearchParams({ redirect_url: 'https://app.pix.org/connexion/?lang=nl' });
 
           // when
-          await mailService.sendAccountCreationEmail({ email: userEmailAddress, locale });
+          await mailService.sendAccountCreationEmail({
+            email: userEmailAddress,
+            firstName: userFirstName,
+            locale,
+            i18n,
+          });
 
           // then
           const options = mailer.sendEmail.firstCall.args[0];
@@ -162,6 +188,7 @@ describe('Unit | Service | MailService', function () {
             displayNationalLogo: false,
             redirectionUrl: `https://app.pix.org/api/users/validate-email?${expectedParams.toString()}`,
             ...mainTranslationsMapping.nl['pix-account-creation-email'].params,
+            title: 'Hallo Bob,',
           });
         });
 
@@ -171,7 +198,12 @@ describe('Unit | Service | MailService', function () {
           const expectedParams = new URLSearchParams({ redirect_url: 'https://app.pix.org/connexion/?lang=es' });
 
           // when
-          await mailService.sendAccountCreationEmail({ email: userEmailAddress, locale });
+          await mailService.sendAccountCreationEmail({
+            email: userEmailAddress,
+            firstName: userFirstName,
+            locale,
+            i18n,
+          });
 
           // then
           const options = mailer.sendEmail.firstCall.args[0];
@@ -183,6 +215,7 @@ describe('Unit | Service | MailService', function () {
             displayNationalLogo: false,
             redirectionUrl: `https://app.pix.org/api/users/validate-email?${expectedParams.toString()}`,
             ...mainTranslationsMapping.es['pix-account-creation-email'].params,
+            title: 'Hola Bob,',
           });
         });
       });
@@ -193,7 +226,7 @@ describe('Unit | Service | MailService', function () {
     it(`should call sendEmail with from, to, template, tags, ${FRENCH_FRANCE} and ${ENGLISH_SPOKEN} translations`, async function () {
       // given
       sinon.stub(settings.domain, 'pixApp').value('https://pix.app');
-      const translate = getI18n().__;
+      const translate = i18n.__;
       const sessionDate = '2020-10-03';
       const sessionId = '3';
       const certificationCenterName = 'Vincennes';
@@ -780,7 +813,7 @@ describe('Unit | Service | MailService', function () {
   describe('#sendVerificationCodeEmail', function () {
     it(`calls sendEmail with from, to, template, tags and locale ${FRENCH_SPOKEN}`, async function () {
       // given
-      const translate = getI18n().__;
+      const translate = i18n.__;
       const userEmail = 'user@example.net';
       const code = '999999';
 
@@ -808,7 +841,7 @@ describe('Unit | Service | MailService', function () {
 
     it(`calls sendEmail with from, to, template, tags and locale ${FRENCH_FRANCE}`, async function () {
       // given
-      const translate = getI18n().__;
+      const translate = i18n.__;
       const userEmail = 'user@example.net';
       const code = '999999';
 
@@ -836,7 +869,7 @@ describe('Unit | Service | MailService', function () {
 
     it(`calls sendEmail with from, to, template, tags and locale ${ENGLISH_SPOKEN}`, async function () {
       // given
-      const translate = getI18n().__;
+      const translate = i18n.__;
       const userEmail = 'user@example.net';
       const code = '999999';
 
@@ -866,7 +899,7 @@ describe('Unit | Service | MailService', function () {
 
     it(`calls sendEmail with from, to, template, tags and locale ${DUTCH_SPOKEN}`, async function () {
       // given
-      const translate = getI18n().__;
+      const translate = i18n.__;
       const userEmail = 'user@example.net';
       const code = '999999';
 
@@ -896,7 +929,7 @@ describe('Unit | Service | MailService', function () {
 
     it(`calls sendEmail with from, to, template, tags and locale ${SPANISH_SPOKEN}`, async function () {
       // given
-      const translate = getI18n().__;
+      const translate = i18n.__;
       const userEmail = 'user@example.net';
       const code = '999999';
 

--- a/api/tests/unit/domain/usecases/create-and-reconcile-user-to-organization-learner_test.js
+++ b/api/tests/unit/domain/usecases/create-and-reconcile-user-to-organization-learner_test.js
@@ -318,6 +318,7 @@ describe('Unit | UseCase | create-and-reconcile-user-to-organization-learner', f
             locale,
             token,
             redirectionUrl: expectedRedirectionUrl,
+            i18n: undefined,
           });
         });
 

--- a/api/tests/unit/domain/usecases/create-and-reconcile-user-to-organization-learner_test.js
+++ b/api/tests/unit/domain/usecases/create-and-reconcile-user-to-organization-learner_test.js
@@ -171,6 +171,7 @@ describe('Unit | UseCase | create-and-reconcile-user-to-organization-learner', f
     context('When creation is with email', function () {
       beforeEach(function () {
         userAttributes.email = createdUser.email;
+        userAttributes.firstName = createdUser.firstName;
         userAttributes.withUsername = false;
       });
 
@@ -313,6 +314,7 @@ describe('Unit | UseCase | create-and-reconcile-user-to-organization-learner', f
           expect(emailValidationDemandRepository.save).to.have.been.calledWith(createdUser.id);
           expect(mailService.sendAccountCreationEmail).to.have.been.calledWithExactly({
             email: userAttributes.email,
+            firstName: userAttributes.firstName,
             locale,
             token,
             redirectionUrl: expectedRedirectionUrl,

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -352,11 +352,12 @@
       "askForHelp": "Any questions? We’re here to help, contact us",
       "disclaimer": "If you did not create this account, you can ask its deletion",
       "doNotAnswer": "This is an automated email message, please do not reply.",
-      "goToPix": "Get started",
+      "goToPix": "Validate my email address",
       "helpdeskLinkLabel": "here",
       "moreOn": "More on",
       "pixPresentation": "Pix is the online public service to assess, develop and certify your digital skills.",
-      "subtitle": "You can now start testing your skills."
+      "subtitle": "Thank you for creating your account. There is one last step to secure your account: validating your email address.",
+      "subtitleDescription": "It is very simple, please click on the button below and login to your Pix account."
     },
     "subject": "Your Pix account has been created"
   },

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -348,7 +348,6 @@
   },
   "pix-account-creation-email": {
     "params": {
-      "title": "Your Pix account has been created!",
       "askForHelp": "Any questions? We’re here to help, contact us",
       "disclaimer": "If you did not create this account, you can ask its deletion",
       "doNotAnswer": "This is an automated email message, please do not reply.",
@@ -357,7 +356,8 @@
       "moreOn": "More on",
       "pixPresentation": "Pix is the online public service to assess, develop and certify your digital skills.",
       "subtitle": "Thank you for creating your account. There is one last step to secure your account: validating your email address.",
-      "subtitleDescription": "It is very simple, please click on the button below and login to your Pix account."
+      "subtitleDescription": "It is very simple, please click on the button below and login to your Pix account.",
+      "title": "Hello {firstName},"
     },
     "subject": "Your Pix account has been created"
   },

--- a/api/translations/es.json
+++ b/api/translations/es.json
@@ -369,7 +369,7 @@
       "pixPresentation": "Pix es el servicio público en línea para evaluar, desarrollar y certificar las competencias digitales.",
       "subtitle": "Gracias por crear su cuenta. Queda un paso para asegurar tu cuenta validando tu dirección de correo electrónico.",
       "subtitleDescription": "Es muy sencillo, sólo tiene que hacer clic en el botón de abajo e iniciar sesión en su cuenta Pix.",
-      "title": "¡Tu cuenta Pix ha sido creada correctamente!"
+      "title": "Hola {firstName},"
     },
     "subject": "tu cuenta Pix ha sido creada correctamente"
   },

--- a/api/translations/es.json
+++ b/api/translations/es.json
@@ -363,11 +363,12 @@
       "askForHelp": "¿Necesitas ayuda? Ponte en contacto con nosotros",
       "disclaimer": "Si no has creado tú la cuenta, puedes pedir que se elimine",
       "doNotAnswer": "Este es un correo electrónico automático, por favor, no respondas directamente.",
-      "goToPix": "Empezar las pruebas",
+      "goToPix": "Confirmo mi dirección de correo electrónico",
       "helpdeskLinkLabel": "aquí",
       "moreOn": "Más información sobre",
       "pixPresentation": "Pix es el servicio público en línea para evaluar, desarrollar y certificar las competencias digitales.",
-      "subtitle": "Ya puedes empezar las pruebas.",
+      "subtitle": "Gracias por crear su cuenta. Queda un paso para asegurar tu cuenta validando tu dirección de correo electrónico.",
+      "subtitleDescription": "Es muy sencillo, sólo tiene que hacer clic en el botón de abajo e iniciar sesión en su cuenta Pix.",
       "title": "¡Tu cuenta Pix ha sido creada correctamente!"
     },
     "subject": "tu cuenta Pix ha sido creada correctamente"

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -362,7 +362,6 @@
   },
   "pix-account-creation-email": {
     "params": {
-      "title": "Votre compte Pix a bien été créé !",
       "askForHelp": "Besoin d’aide, contactez-nous",
       "disclaimer": "Si vous n'êtes pas à l’origine de cette création de compte, vous pouvez en demander la suppression",
       "doNotAnswer": "Ceci est un e-mail automatique, merci de ne pas y répondre.",
@@ -371,7 +370,8 @@
       "moreOn": "En savoir plus sur",
       "pixPresentation": "Pix est le service public en ligne pour évaluer, développer et certifier ses compétences numériques.",
       "subtitle": "Merci d'avoir créé votre compte. Il reste une étape pour sécuriser votre compte en validant votre adresse e-mail.",
-      "subtitleDescription": "C'est très simple, il vous suffit de cliquer sur le bouton ci-dessous et de vous connecter à votre compte Pix."
+      "subtitleDescription": "C'est très simple, il vous suffit de cliquer sur le bouton ci-dessous et de vous connecter à votre compte Pix.",
+      "title": "Bonjour {firstName},"
     },
     "subject": "Votre compte Pix a bien été créé"
   },

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -366,11 +366,12 @@
       "askForHelp": "Besoin d’aide, contactez-nous",
       "disclaimer": "Si vous n'êtes pas à l’origine de cette création de compte, vous pouvez en demander la suppression",
       "doNotAnswer": "Ceci est un e-mail automatique, merci de ne pas y répondre.",
-      "goToPix": "Commencer les tests",
+      "goToPix": "Je valide mon adresse e-mail",
       "helpdeskLinkLabel": "ici",
       "moreOn": "En savoir plus sur",
       "pixPresentation": "Pix est le service public en ligne pour évaluer, développer et certifier ses compétences numériques.",
-      "subtitle": "Vous pouvez désormais commencer les tests."
+      "subtitle": "Merci d'avoir créé votre compte. Il reste une étape pour sécuriser votre compte en validant votre adresse e-mail.",
+      "subtitleDescription": "C'est très simple, il vous suffit de cliquer sur le bouton ci-dessous et de vous connecter à votre compte Pix."
     },
     "subject": "Votre compte Pix a bien été créé"
   },

--- a/api/translations/nl.json
+++ b/api/translations/nl.json
@@ -361,7 +361,7 @@
       "pixPresentation": "Pix is de online overheidsdienst voor het beoordelen, ontwikkelen en certificeren van je digitale vaardigheden.",
       "subtitle": "Bedankt voor het aanmaken van je account. Er is nog één stap over om je account te beveiligen door je e-mailadres te valideren.",
       "subtitleDescription": "Het is heel eenvoudig, klik op de knop hieronder en log in op je Pix-account.",
-      "title": "Je Pix-account is aangemaakt!"
+      "title": "Hallo {firstName},"
     },
     "subject": "Je Pix-account is aangemaakt"
   },

--- a/api/translations/nl.json
+++ b/api/translations/nl.json
@@ -355,11 +355,12 @@
       "askForHelp": "Hulp nodig? Neem contact met ons op",
       "disclaimer": "Als je de account niet hebt aangemaakt, kun je vragen om deze te verwijderen.",
       "doNotAnswer": "Dit is een automatische e-mail, antwoord niet.",
-      "goToPix": "Beginnen met de tests",
+      "goToPix": "Ik bevestig mijn e-mailadres",
       "helpdeskLinkLabel": "hier",
       "moreOn": "Ontdek meer over",
       "pixPresentation": "Pix is de online overheidsdienst voor het beoordelen, ontwikkelen en certificeren van je digitale vaardigheden.",
-      "subtitle": "Je kunt nu beginnen met de tests.",
+      "subtitle": "Bedankt voor het aanmaken van je account. Er is nog één stap over om je account te beveiligen door je e-mailadres te valideren.",
+      "subtitleDescription": "Het is heel eenvoudig, klik op de knop hieronder en log in op je Pix-account.",
       "title": "Je Pix-account is aangemaakt!"
     },
     "subject": "Je Pix-account is aangemaakt"


### PR DESCRIPTION
## :robot: Contexte
Inciter l’utilisateur ayant reçu cet email à cliquer sur le bouton pour valider son adresse email lorsqu'il reçoit le mail de création de son compte.

- [ ] Après le merge de cette PR, synchroniser les nouvelles clés dans Phrase (ici `pix-account-creation-email.params.subtitleDescription`) et faire la traduction en nl et es.
- [ ] Modification et validation du template Brevo en production ?

## :robot: Proposition

1. Modification des textes `fr`, `en`, `nl` et `es` pour les paramètres du template d'email de création de compte.
2. Modification de la clé `pix-account-creation-email.params.title` pour avoir un clé dynamique avec le prénom de l'utilisateur.
  - nécessite le passage du prénom de l'utilisateur
  - nécessite l'utilisation de i18n 

## :rainbow: Remarques

- Le template Brevo pour la création de compte a été modifié pour ajouter un champ `subtitleDescription` correspondant à la clé de traduction `pix-account-creation-email.params.subtitleDescription`

## 🫡 Scout rules

En voulant comprendre la configuration et l'intégration i18n dans HAPI, je me suis rendu compte qu'il n'y avait aucun tests dessus, j'ai donc ajouté des tests d'intégration de la config `i18n` et du plugin `hapi-i18n`.

## :100: Pour tester
- Aller sur la RA de Pix App .org
- S'inscrire en saisissant une adresse email auquelle vous avez accès
- Vérifier dans le mail de création de compte que le contenu est bien à jour.
- Répéter ces étapes en changeant la locale, avec le language switcher, afin de tester le contenu en anglais, espagnol et néerlandais.

![image](https://github.com/1024pix/pix/assets/516360/8b9b8700-19ee-4e5c-b1a6-43b81c64103f)
