### PR TITLE
[TECH] Monter à la version 46.10.8 de pix-ui (PIX-13247).

### DIFF
--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -14,7 +14,7 @@
         "@1024pix/ember-matomo-tag-manager": "^2.4.3",
         "@1024pix/ember-testing-library": "^1.1.0",
         "@1024pix/eslint-config": "^1.3.4",
-        "@1024pix/pix-ui": "^46.10.2",
+        "@1024pix/pix-ui": "^46.10.8",
         "@1024pix/stylelint-config": "^5.1.15",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.2",
@@ -857,12 +857,11 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "46.10.2",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-46.10.2.tgz",
-      "integrity": "sha512-2GMv3Ui4to08cfS4L4hPnr41mcJEGgCVhgBhiTDYHEhk6dKxWigWLaaJAGMckVuQURdUdr0ROHPCBlJqLhrs9w==",
+      "version": "46.10.8",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-46.10.8.tgz",
+      "integrity": "sha512-gyw20ZHjCv+w79MncdWXCaRvlGgPC7G6udDCyrYgJvhFhgkUo3waKxxKigo1ozENW4dAwZgbisY864JEtkYWYg==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "@formatjs/intl": "^2.5.1",
         "ember-auto-import": "^2.5.0",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -46,7 +46,7 @@
     "@1024pix/ember-matomo-tag-manager": "^2.4.3",
     "@1024pix/ember-testing-library": "^1.1.0",
     "@1024pix/eslint-config": "^1.3.4",
-    "@1024pix/pix-ui": "^46.10.2",
+    "@1024pix/pix-ui": "^46.10.8",
     "@1024pix/stylelint-config": "^5.1.15",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.2",


### PR DESCRIPTION
## :unicorn: Problème
La largeur des select n'est plus bonne sur pix app.

## :robot: Proposition
Effectuer la montée de version de pix-ui afin de bénéficier du [correctif des selects](https://github.com/1024pix/pix-ui/pull/678)

## :rainbow: Remarques


## :100: Pour tester
- Les tests sont verts
- Faire un tour sur pix-app et constater que les options des selects s'affichent correctement
