### PR TITLE
[BUGFIX] Rafraichir le cache LCMS en asynchrone (pgboss)

### DIFF
--- a/api/lib/application/cache/cache-controller.js
+++ b/api/lib/application/cache/cache-controller.js
@@ -1,13 +1,12 @@
 import _ from 'lodash';
 
-import * as learningContentDatasource from '../../../src/shared/infrastructure/datasources/learning-content/datasource.js';
+import { knex } from '../../../db/knex-database-connection.js';
 import * as LearningContentDatasources from '../../../src/shared/infrastructure/datasources/learning-content/index.js';
-import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
+import { LcmsRefreshCacheJob } from '../../infrastructure/jobs/lcms/LcmsRefreshCacheJob.js';
 
-const refreshCacheEntries = function (_, h, dependencies = { learningContentDatasource }) {
-  dependencies.learningContentDatasource
-    .refreshLearningContentCacheRecords()
-    .catch((e) => logger.error('Error while reloading cache', e));
+const refreshCacheEntries = async function (_, h) {
+  const refreshJob = new LcmsRefreshCacheJob(knex);
+  await refreshJob.schedule();
   return h.response({}).code(202);
 };
 

--- a/api/lib/application/cache/cache-controller.js
+++ b/api/lib/application/cache/cache-controller.js
@@ -1,12 +1,10 @@
 import _ from 'lodash';
 
-import { knex } from '../../../db/knex-database-connection.js';
+import { sharedUsecases as usecases } from '../../../src/shared/domain/usecases/index.js';
 import * as LearningContentDatasources from '../../../src/shared/infrastructure/datasources/learning-content/index.js';
-import { LcmsRefreshCacheJob } from '../../infrastructure/jobs/lcms/LcmsRefreshCacheJob.js';
 
 const refreshCacheEntries = async function (_, h) {
-  const refreshJob = new LcmsRefreshCacheJob(knex);
-  await refreshJob.schedule();
+  await usecases.refreshLearningContentCache();
   return h.response({}).code(202);
 };
 

--- a/api/lib/infrastructure/jobs/lcms/LcmsRefreshCacheJob.js
+++ b/api/lib/infrastructure/jobs/lcms/LcmsRefreshCacheJob.js
@@ -1,0 +1,9 @@
+import { JobPgBoss } from '../JobPgBoss.js';
+
+class LcmsRefreshCacheJob extends JobPgBoss {
+  constructor(queryBuilder) {
+    super({ name: 'LcmsRefreshCacheJob', retryLimit: 0 }, queryBuilder);
+  }
+}
+
+export { LcmsRefreshCacheJob };

--- a/api/lib/infrastructure/jobs/lcms/LcmsRefreshCacheJobHandler.js
+++ b/api/lib/infrastructure/jobs/lcms/LcmsRefreshCacheJobHandler.js
@@ -1,0 +1,18 @@
+import { LcmsRefreshCacheJob } from './LcmsRefreshCacheJob.js';
+
+class LcmsRefreshCacheJobHandler {
+  constructor({ learningContentDatasource, logger }) {
+    this.logger = logger;
+    this.learningContentDatasource = learningContentDatasource;
+  }
+
+  async handle() {
+    await this.learningContentDatasource.refreshLearningContentCacheRecords();
+  }
+
+  get name() {
+    return LcmsRefreshCacheJob.name;
+  }
+}
+
+export { LcmsRefreshCacheJobHandler };

--- a/api/src/shared/domain/usecases/index.js
+++ b/api/src/shared/domain/usecases/index.js
@@ -1,6 +1,8 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { knex } from '../../../../db/knex-database-connection.js';
+import { LcmsRefreshCacheJob } from '../../../../lib/infrastructure/jobs/lcms/LcmsRefreshCacheJob.js';
 import * as complementaryCertificationBadgeRepository from '../../../certification/complementary-certification/infrastructure/repositories/complementary-certification-badge-repository.js';
 import * as badgeRepository from '../../../evaluation/infrastructure/repositories/badge-repository.js';
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
@@ -15,6 +17,7 @@ const usecasesWithoutInjectedDependencies = {
 const dependencies = {
   complementaryCertificationBadgeRepository,
   badgeRepository,
+  lcmsRefreshCacheJob: new LcmsRefreshCacheJob(knex),
 };
 
 const sharedUsecases = injectDependencies(usecasesWithoutInjectedDependencies, dependencies);

--- a/api/src/shared/domain/usecases/refresh-learning-content-cache.js
+++ b/api/src/shared/domain/usecases/refresh-learning-content-cache.js
@@ -1,0 +1,4 @@
+const refreshLearningContentCache = async function ({ lcmsRefreshCacheJob }) {
+  await lcmsRefreshCacheJob.schedule();
+};
+export { refreshLearningContentCache };

--- a/api/tests/shared/unit/domain/usecases/refresh-learning-content-cache_test.js
+++ b/api/tests/shared/unit/domain/usecases/refresh-learning-content-cache_test.js
@@ -1,0 +1,15 @@
+import { refreshLearningContentCache } from '../../../../../src/shared/domain/usecases/refresh-learning-content-cache.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Domain | Usecases | Refresh Learning Content Cache', function () {
+  it('should use repository to schedule reefresh job', async function () {
+    // given
+    const lcmsRefreshCacheJob = { schedule: sinon.stub() };
+
+    // when
+    await refreshLearningContentCache({ lcmsRefreshCacheJob });
+
+    // then
+    expect(lcmsRefreshCacheJob.schedule).to.have.been.calledOnce;
+  });
+});

--- a/api/tests/unit/application/cache/cache-controller_test.js
+++ b/api/tests/unit/application/cache/cache-controller_test.js
@@ -1,6 +1,6 @@
 import { cacheController } from '../../../../lib/application/cache/cache-controller.js';
+import { sharedUsecases as usecases } from '../../../../src/shared/domain/usecases/index.js';
 import * as learningContentDatasources from '../../../../src/shared/infrastructure/datasources/learning-content/index.js';
-import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
 import { expect, hFake, sinon } from '../../../test-helper.js';
 
 describe('Unit | Controller | cache-controller', function () {
@@ -79,52 +79,17 @@ describe('Unit | Controller | cache-controller', function () {
   });
 
   describe('#refreshCacheEntries', function () {
-    const request = {};
-    let learningContentDatasourceStub;
-
-    beforeEach(function () {
-      learningContentDatasourceStub = { refreshLearningContentCacheRecords: sinon.stub() };
-    });
-
     context('nominal case', function () {
       it('should reply with http status 202', async function () {
         // given
-        const numberOfDeletedKeys = 0;
-        learningContentDatasourceStub.refreshLearningContentCacheRecords.resolves(numberOfDeletedKeys);
+        sinon.stub(usecases, 'refreshLearningContentCache').resolves();
 
         // when
-        const response = await cacheController.refreshCacheEntries(request, hFake, {
-          learningContentDatasource: learningContentDatasourceStub,
-        });
+        const response = await cacheController.refreshCacheEntries({}, hFake);
 
         // then
-        expect(learningContentDatasourceStub.refreshLearningContentCacheRecords).to.have.been.calledOnce;
+        expect(usecases.refreshLearningContentCache).to.have.been.calledOnce;
         expect(response.statusCode).to.equal(202);
-      });
-    });
-
-    context('error case', function () {
-      let response;
-
-      beforeEach(async function () {
-        // given
-        sinon.stub(logger, 'error');
-        learningContentDatasourceStub.refreshLearningContentCacheRecords.rejects();
-
-        // when
-        response = await cacheController.refreshCacheEntries(request, hFake, {
-          learningContentDatasource: learningContentDatasourceStub,
-        });
-      });
-
-      it('should reply with http status 202', async function () {
-        // then
-        expect(response.statusCode).to.equal(202);
-      });
-
-      it('should call log errors', async function () {
-        // then
-        expect(logger.error).to.have.been.calledOnce;
       });
     });
   });

--- a/api/worker.js
+++ b/api/worker.js
@@ -16,6 +16,8 @@ import { SendSharedParticipationResultsToPoleEmploiHandler } from './lib/infrast
 import { SendSharedParticipationResultsToPoleEmploiJob } from './lib/infrastructure/jobs/campaign-result/SendSharedParticipationResultsToPoleEmploiJob.js';
 import { scheduleCpfJobs } from './lib/infrastructure/jobs/cpf-export/schedule-cpf-jobs.js';
 import { JobQueue } from './lib/infrastructure/jobs/JobQueue.js';
+import { LcmsRefreshCacheJob } from './lib/infrastructure/jobs/lcms/LcmsRefreshCacheJob.js';
+import { LcmsRefreshCacheJobHandler } from './lib/infrastructure/jobs/lcms/LcmsRefreshCacheJobHandler.js';
 import { MonitoredJobQueue } from './lib/infrastructure/jobs/monitoring/MonitoredJobQueue.js';
 import { ComputeCertificabilityJob } from './lib/infrastructure/jobs/organization-learner/ComputeCertificabilityJob.js';
 import { ComputeCertificabilityJobHandler } from './lib/infrastructure/jobs/organization-learner/ComputeCertificabilityJobHandler.js';
@@ -27,6 +29,7 @@ import { ImportOrganizationLearnersJob } from './src/prescription/learner-manage
 import { ImportOrganizationLearnersJobHandler } from './src/prescription/learner-management/infrastructure/jobs/ImportOrganizationLearnersJobHandler.js';
 import { ValidateOrganizationImportFileJob } from './src/prescription/learner-management/infrastructure/jobs/ValidateOrganizationImportFileJob.js';
 import { ValidateOrganizationImportFileJobHandler } from './src/prescription/learner-management/infrastructure/jobs/ValidateOrganizationImportFileJobHandler.js';
+import * as learningContentDatasource from './src/shared/infrastructure/datasources/learning-content/datasource.js';
 import { logger } from './src/shared/infrastructure/utils/logger.js';
 
 async function startPgBoss() {
@@ -73,6 +76,10 @@ export async function runJobs(dependencies = { startPgBoss, createMonitoredJobQu
   const pgBoss = await dependencies.startPgBoss();
   const monitoredJobQueue = dependencies.createMonitoredJobQueue(pgBoss);
 
+  monitoredJobQueue.performJob(LcmsRefreshCacheJob.name, LcmsRefreshCacheJobHandler, {
+    learningContentDatasource,
+    logger,
+  });
   monitoredJobQueue.performJob(
     ScheduleComputeOrganizationLearnersCertificabilityJob.name,
     ScheduleComputeOrganizationLearnersCertificabilityJobHandler,


### PR DESCRIPTION
## :unicorn: Problème

Lors d'un rafraîchissement du cache du référentiel de contenu (LCMS) - via Pix Admin par exemple - le conteneur traitant la requête consomme l'intégralité de sa RAM et finit par crasher.
Cela est du au fait que la taille de la release de référentiel est devenue trop importante pour en mettre 2 dans la RAM du même conteneur.

## :robot: Proposition

La mise à jour du cache n'est pas une opération qui nécessite d'être synchrone.
On met donc en place un job asynchrone (en utilisant pgboss) pour la mise à jour du cache.
Le `cache-controller` appelle désormais un usecase dont la responsabilité est d'ajouter un job de mise à jour du cache à la file de job asynchrone.

## :rainbow: Remarques

## :100: Pour tester

Se connecter à Pix Admin.
Lancer une mise à jour du cache.
Voir que cette mise à jour s'effectue sans soucis.