### PR TITLE
[TECH] Ajoute la domainTransaction dans le AsyncLocalStorage (PIX-13257).

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-repository.js
@@ -73,7 +73,8 @@ const getCampaignCodeByCampaignParticipationId = async function (campaignPartici
 };
 
 const getCampaignIdByCampaignParticipationId = async function (campaignParticipationId) {
-  const campaign = await knex('campaigns')
+  const knexConn = DomainTransaction.getConnection();
+  const campaign = await knexConn('campaigns')
     .select('campaigns.id')
     .join('campaign-participations', 'campaign-participations.campaignId', 'campaigns.id')
     .where({ 'campaign-participations.id': campaignParticipationId })

--- a/api/src/prescription/campaign-participation/application/campaign-participation-controller.js
+++ b/api/src/prescription/campaign-participation/application/campaign-participation-controller.js
@@ -97,12 +97,9 @@ const updateParticipantExternalId = async function (request, h) {
 const deleteCampaignParticipationForAdmin = async function (request, h) {
   const { userId } = request.auth.credentials;
   const { id: campaignParticipationId } = request.params;
-  await DomainTransaction.execute(async (domainTransaction) => {
-    await usecases.deleteCampaignParticipationForAdmin({
-      userId,
-      campaignParticipationId,
-      domainTransaction,
-    });
+  await usecases.deleteCampaignParticipationForAdmin({
+    userId,
+    campaignParticipationId,
   });
   return h.response({}).code(204);
 };

--- a/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation-for-admin.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation-for-admin.js
@@ -1,28 +1,26 @@
 import bluebird from 'bluebird';
 
-import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+import { withTransaction } from '../../../../shared/domain/DomainTransaction.js';
 
-const deleteCampaignParticipationForAdmin = async function ({
+const deleteCampaignParticipationForAdmin = withTransaction(async function ({
   userId,
   campaignParticipationId,
   campaignRepository,
   campaignParticipationRepository,
 }) {
-  await DomainTransaction.execute(async () => {
-    const campaignId = await campaignRepository.getCampaignIdByCampaignParticipationId(campaignParticipationId);
+  const campaignId = await campaignRepository.getCampaignIdByCampaignParticipationId(campaignParticipationId);
 
-    const campaignParticipations =
-      await campaignParticipationRepository.getAllCampaignParticipationsInCampaignForASameLearner({
-        campaignId,
-        campaignParticipationId,
-      });
-
-    await bluebird.mapSeries(campaignParticipations, async (campaignParticipation) => {
-      campaignParticipation.delete(userId);
-      const { id, deletedAt, deletedBy } = campaignParticipation;
-      await campaignParticipationRepository.remove({ id, deletedAt, deletedBy });
+  const campaignParticipations =
+    await campaignParticipationRepository.getAllCampaignParticipationsInCampaignForASameLearner({
+      campaignId,
+      campaignParticipationId,
     });
+
+  await bluebird.mapSeries(campaignParticipations, async (campaignParticipation) => {
+    campaignParticipation.delete(userId);
+    const { id, deletedAt, deletedBy } = campaignParticipation;
+    await campaignParticipationRepository.remove({ id, deletedAt, deletedBy });
   });
-};
+});
 
 export { deleteCampaignParticipationForAdmin };

--- a/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation-for-admin.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation-for-admin.js
@@ -3,7 +3,6 @@ import bluebird from 'bluebird';
 const deleteCampaignParticipationForAdmin = async function ({
   userId,
   campaignParticipationId,
-  domainTransaction,
   campaignRepository,
   campaignParticipationRepository,
 }) {
@@ -13,13 +12,12 @@ const deleteCampaignParticipationForAdmin = async function ({
     await campaignParticipationRepository.getAllCampaignParticipationsInCampaignForASameLearner({
       campaignId,
       campaignParticipationId,
-      domainTransaction,
     });
 
   await bluebird.mapSeries(campaignParticipations, async (campaignParticipation) => {
     campaignParticipation.delete(userId);
     const { id, deletedAt, deletedBy } = campaignParticipation;
-    await campaignParticipationRepository.remove({ id, deletedAt, deletedBy, domainTransaction });
+    await campaignParticipationRepository.remove({ id, deletedAt, deletedBy });
   });
 };
 

--- a/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation-for-admin.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/delete-campaign-participation-for-admin.js
@@ -1,23 +1,27 @@
 import bluebird from 'bluebird';
 
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+
 const deleteCampaignParticipationForAdmin = async function ({
   userId,
   campaignParticipationId,
   campaignRepository,
   campaignParticipationRepository,
 }) {
-  const campaignId = await campaignRepository.getCampaignIdByCampaignParticipationId(campaignParticipationId);
+  await DomainTransaction.execute(async () => {
+    const campaignId = await campaignRepository.getCampaignIdByCampaignParticipationId(campaignParticipationId);
 
-  const campaignParticipations =
-    await campaignParticipationRepository.getAllCampaignParticipationsInCampaignForASameLearner({
-      campaignId,
-      campaignParticipationId,
+    const campaignParticipations =
+      await campaignParticipationRepository.getAllCampaignParticipationsInCampaignForASameLearner({
+        campaignId,
+        campaignParticipationId,
+      });
+
+    await bluebird.mapSeries(campaignParticipations, async (campaignParticipation) => {
+      campaignParticipation.delete(userId);
+      const { id, deletedAt, deletedBy } = campaignParticipation;
+      await campaignParticipationRepository.remove({ id, deletedAt, deletedBy });
     });
-
-  await bluebird.mapSeries(campaignParticipations, async (campaignParticipation) => {
-    campaignParticipation.delete(userId);
-    const { id, deletedAt, deletedBy } = campaignParticipation;
-    await campaignParticipationRepository.remove({ id, deletedAt, deletedBy });
   });
 };
 

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
@@ -3,6 +3,7 @@ import { NotFoundError } from '../../../../../lib/domain/errors.js';
 import { Campaign } from '../../../../../lib/domain/models/Campaign.js';
 import * as knowledgeElementRepository from '../../../../../lib/infrastructure/repositories/knowledge-element-repository.js';
 import * as knowledgeElementSnapshotRepository from '../../../../../lib/infrastructure/repositories/knowledge-element-snapshot-repository.js';
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { Assessment } from '../../../../shared/domain/models/Assessment.js';
 import { ApplicationTransaction } from '../../../shared/infrastructure/ApplicationTransaction.js';
 import { CampaignParticipation } from '../../domain/models/CampaignParticipation.js';
@@ -54,12 +55,8 @@ const get = async function (id, domainTransaction) {
   });
 };
 
-const getAllCampaignParticipationsInCampaignForASameLearner = async function ({
-  campaignId,
-  campaignParticipationId,
-  domainTransaction,
-}) {
-  const knexConn = domainTransaction.knexTransaction;
+const getAllCampaignParticipationsInCampaignForASameLearner = async function ({ campaignId, campaignParticipationId }) {
+  const knexConn = DomainTransaction.getConnection();
   const result = await knexConn('campaign-participations')
     .select('organizationLearnerId')
     .where({ id: campaignParticipationId, campaignId })
@@ -97,8 +94,8 @@ const getCampaignParticipationsForOrganizationLearner = async function ({ organi
   );
 };
 
-const remove = async function ({ id, deletedAt, deletedBy, domainTransaction }) {
-  const knexConn = domainTransaction.knexTransaction;
+const remove = async function ({ id, deletedAt, deletedBy }) {
+  const knexConn = DomainTransaction.getConnection();
   return await knexConn('campaign-participations').where({ id }).update({ deletedAt, deletedBy });
 };
 

--- a/api/src/shared/domain/DomainTransaction.js
+++ b/api/src/shared/domain/DomainTransaction.js
@@ -1,4 +1,8 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
 import { knex } from '../../../db/knex-database-connection.js';
+
+const asyncLocalStorage = new AsyncLocalStorage();
 
 class DomainTransaction {
   constructor(knexTransaction) {
@@ -7,12 +11,24 @@ class DomainTransaction {
 
   static execute(lambda) {
     return knex.transaction((trx) => {
-      return lambda(new DomainTransaction(trx));
+      const domainTransaction = new DomainTransaction(trx);
+      return asyncLocalStorage.run({ transaction: domainTransaction }, lambda, domainTransaction);
     });
+  }
+
+  static getConnection() {
+    const store = asyncLocalStorage.getStore();
+
+    if (store?.transaction) {
+      const domainTransaction = store.transaction;
+      return domainTransaction.knexTransaction;
+    }
+    return knex;
   }
 
   static emptyTransaction() {
     return new DomainTransaction(null);
   }
 }
-export { DomainTransaction };
+
+export { asyncLocalStorage, DomainTransaction };

--- a/api/src/shared/domain/DomainTransaction.js
+++ b/api/src/shared/domain/DomainTransaction.js
@@ -31,4 +31,13 @@ class DomainTransaction {
   }
 }
 
-export { asyncLocalStorage, DomainTransaction };
+/**
+ * @template F
+ * @param {F} func
+ * @returns {F}
+ */
+function withTransaction(func) {
+  return (...args) => DomainTransaction.execute(() => func(...args));
+}
+
+export { asyncLocalStorage, DomainTransaction, withTransaction };

--- a/api/src/shared/domain/DomainTransaction.js
+++ b/api/src/shared/domain/DomainTransaction.js
@@ -9,11 +9,11 @@ class DomainTransaction {
     this.knexTransaction = knexTransaction;
   }
 
-  static execute(lambda) {
+  static execute(lambda, transactionConfig) {
     return knex.transaction((trx) => {
       const domainTransaction = new DomainTransaction(trx);
       return asyncLocalStorage.run({ transaction: domainTransaction }, lambda, domainTransaction);
-    });
+    }, transactionConfig);
   }
 
   static getConnection() {
@@ -34,10 +34,11 @@ class DomainTransaction {
 /**
  * @template F
  * @param {F} func
+ * @param {import('knex').Knex.TransactionConfig | undefined} transactionConfig
  * @returns {F}
  */
-function withTransaction(func) {
-  return (...args) => DomainTransaction.execute(() => func(...args));
+function withTransaction(func, transactionConfig) {
+  return (...args) => DomainTransaction.execute(() => func(...args), transactionConfig);
 }
 
 export { asyncLocalStorage, DomainTransaction, withTransaction };

--- a/api/tests/certification/session-management/unit/domain/usecases/unfinalize-session_test.js
+++ b/api/tests/certification/session-management/unit/domain/usecases/unfinalize-session_test.js
@@ -1,4 +1,4 @@
-import { knex } from '../../../../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../../../../../lib/infrastructure/DomainTransaction.js';
 import { SessionAlreadyPublishedError } from '../../../../../../src/certification/session-management/domain/errors.js';
 import { unfinalizeSession } from '../../../../../../src/certification/session-management/domain/usecases/unfinalize-session.js';
 import { catchErr, expect, sinon } from '../../../../../test-helper.js';
@@ -10,7 +10,7 @@ describe('Unit | UseCase | unfinalize-session', function () {
   describe('when session is not published', function () {
     it('should call repositories with transaction', async function () {
       // given
-      sinon.stub(knex, 'transaction').callsFake((fn) => fn());
+      sinon.stub(DomainTransaction, 'execute').callsFake((fn) => fn({}));
 
       sessionRepository = {
         unfinalize: sinon.stub(),

--- a/api/tests/prescription/campaign-participation/unit/domain/usecases/delete-campaign-participation-for-admin_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/usecases/delete-campaign-participation-for-admin_test.js
@@ -13,7 +13,9 @@ describe('Unit | UseCase | delete-campaign-participation-for-admin', function ()
   beforeEach(function () {
     clock = sinon.useFakeTimers({ now: now.getTime(), toFake: ['Date'] });
     sinon.stub(DomainTransaction, 'execute');
-    DomainTransaction.execute.callsFake((fn) => fn({}));
+    DomainTransaction.execute.callsFake((fn) => {
+      return fn({});
+    });
   });
 
   afterEach(function () {

--- a/api/tests/prescription/campaign-participation/unit/domain/usecases/delete-campaign-participation-for-admin_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/usecases/delete-campaign-participation-for-admin_test.js
@@ -26,7 +26,6 @@ describe('Unit | UseCase | delete-campaign-participation-for-admin', function ()
       remove: sinon.stub(),
     };
     const campaignParticipationId = 1234;
-    const domainTransaction = Symbol('domainTransaction');
     const campaignId = domainBuilder.buildCampaign().id;
     const ownerId = domainBuilder.buildUser().id;
     const organizationLearnerId = domainBuilder.buildOrganizationLearner().id;
@@ -52,7 +51,6 @@ describe('Unit | UseCase | delete-campaign-participation-for-admin', function ()
       .withArgs({
         campaignId,
         campaignParticipationId,
-        domainTransaction,
       })
       .resolves(campaignParticipations);
 
@@ -60,7 +58,6 @@ describe('Unit | UseCase | delete-campaign-participation-for-admin', function ()
     await deleteCampaignParticipationForAdmin({
       userId: ownerId,
       campaignParticipationId,
-      domainTransaction,
       campaignRepository,
       campaignParticipationRepository,
     });
@@ -77,7 +74,6 @@ describe('Unit | UseCase | delete-campaign-participation-for-admin', function ()
         id: deletedCampaignParticipation.id,
         deletedAt: deletedCampaignParticipation.deletedAt,
         deletedBy: deletedCampaignParticipation.deletedBy,
-        domainTransaction,
       });
     });
   });

--- a/api/tests/prescription/campaign-participation/unit/domain/usecases/delete-campaign-participation-for-admin_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/usecases/delete-campaign-participation-for-admin_test.js
@@ -1,5 +1,6 @@
 import { CampaignParticipation } from '../../../../../../src/prescription/campaign-participation/domain/models/CampaignParticipation.js';
 import { usecases } from '../../../../../../src/prescription/campaign-participation/domain/usecases/index.js';
+import { DomainTransaction } from '../../../../../../src/shared/domain/DomainTransaction.js';
 import { domainBuilder, expect, sinon } from '../../../../../test-helper.js';
 
 const { deleteCampaignParticipationForAdmin } = usecases;
@@ -11,6 +12,8 @@ describe('Unit | UseCase | delete-campaign-participation-for-admin', function ()
 
   beforeEach(function () {
     clock = sinon.useFakeTimers({ now: now.getTime(), toFake: ['Date'] });
+    sinon.stub(DomainTransaction, 'execute');
+    DomainTransaction.execute.callsFake((fn) => fn({}));
   });
 
   afterEach(function () {

--- a/api/tests/shared/unit/domain/DomainTransaction_test.js
+++ b/api/tests/shared/unit/domain/DomainTransaction_test.js
@@ -1,0 +1,52 @@
+import { asyncLocalStorage, DomainTransaction } from '../../../../src/shared/domain/DomainTransaction.js';
+import { expect, knex, sinon } from '../../../../tests/test-helper.js';
+
+describe('Unit | Infrastructure | DomainTransaction', function () {
+  describe('#getConnection', function () {
+    it('should return connection from store', function () {
+      const transaction = Symbol('transaction');
+      const domainTransaction = new DomainTransaction(transaction);
+      const storeStub = { transaction: domainTransaction };
+      sinon.stub(asyncLocalStorage, 'getStore');
+      asyncLocalStorage.getStore.returns(storeStub);
+
+      const connection = DomainTransaction.getConnection();
+
+      expect(connection).to.equal(transaction);
+    });
+
+    it('should return knex connection by default', function () {
+      sinon.stub(asyncLocalStorage, 'getStore');
+
+      const connection = DomainTransaction.getConnection();
+
+      expect(connection).to.equal(knex);
+    });
+  });
+
+  describe('#execute', function () {
+    it('should store transaction', async function () {
+      const transactionStub = {};
+      const domainTransaction = new DomainTransaction(transactionStub);
+      sinon.stub(asyncLocalStorage, 'run');
+      sinon.stub(knex, 'transaction');
+      knex.transaction.callsFake((fn) => fn(transactionStub));
+
+      await DomainTransaction.execute(function () {
+        // Something
+      });
+
+      expect(asyncLocalStorage.run).to.have.been.calledWith({ transaction: domainTransaction });
+    });
+
+    it('should return function result', async function () {
+      const expectedResult = Symbol('return');
+      sinon.stub(knex, 'transaction');
+      knex.transaction.callsFake((fn) => fn({}));
+
+      const result = await DomainTransaction.execute(() => expectedResult);
+
+      expect(result).to.equal(expectedResult);
+    });
+  });
+});

--- a/api/tests/shared/unit/domain/DomainTransaction_test.js
+++ b/api/tests/shared/unit/domain/DomainTransaction_test.js
@@ -1,4 +1,8 @@
-import { asyncLocalStorage, DomainTransaction } from '../../../../src/shared/domain/DomainTransaction.js';
+import {
+  asyncLocalStorage,
+  DomainTransaction,
+  withTransaction,
+} from '../../../../src/shared/domain/DomainTransaction.js';
 import { expect, knex, sinon } from '../../../../tests/test-helper.js';
 
 describe('Unit | Infrastructure | DomainTransaction', function () {
@@ -47,6 +51,20 @@ describe('Unit | Infrastructure | DomainTransaction', function () {
       const result = await DomainTransaction.execute(() => expectedResult);
 
       expect(result).to.equal(expectedResult);
+    });
+  });
+
+  describe('#withTransaction', function () {
+    it('should get transaction from store', async function () {
+      const transactionStub = { commit: sinon.stub() };
+      sinon.stub(knex, 'transaction');
+      knex.transaction.callsFake(() => transactionStub);
+      const myUseCase = withTransaction(() => {
+        return DomainTransaction.getConnection();
+      });
+      const connection = await myUseCase();
+
+      expect(connection).to.equal(transactionStub);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Le fonctionnement de la méthode execute de DomainTransaction oblige à passer à chaque méthode de repositories appelés dans les usecases à prendre en paramètre une instance de DomainTransaction. 

Le problème de cette implémentation est qu'il arrive d'oublier de passer une domainTransaction et la valeur par défaut mise au niveau des méthodes repositories avec la méthode static emptyTransaction pour simplifier les tests cache ces oublis. La conséquence est que nous avons des usecases semi-transactionnels. 

## :robot: Proposition

On change le fonctionnement de la méthode execute pour qu'il stocke l'instance de la DomainTransaction dans le AsyncLocalStorage. 

On ajoute un méthode static getConnection qui permet de récupérer une transaction si elle existe ou l'instance knex.

On conserve la possibilité d'utiliser les DomainTransaction tel qu'on le fait aujourd'hui pour permettre de migrer progressivement.

## :rainbow: Remarques

Voici le différence d'utilisation avant et après.

### Avant : 

Usecase : 

```js
const updateCampaignCode = async function ({ campaignId, campaignCode, campaignAdministrationRepository }) {
  await DomainTransaction.execute(async (domainTransaction) => {
    const campaign = await campaignAdministrationRepository.get(campaignId, domainTransaction);
    if (!campaign) {
      throw new UnknownCampaignId();
    }

    campaign.updateFields({ code: campaignCode });

    const isCodeAvailable = await campaignAdministrationRepository.isCodeAvailable({
      code: campaignCode,
      domainTransaction,
    });
    if (!isCodeAvailable) {
      throw new CampaignUniqueCodeError();
    }

    await campaignAdministrationRepository.update(campaign, domainTransaction);
  });
};
```

Repository : 

```js
const get = async function (id, domainTransaction = DomainTransaction.emptyTransaction()) {
  const knexConn = domainTransaction.knexTransaction || knex;
  const campaign = await knexConn('campaigns').where({ id }).first();

  if (!campaign) return null;

  const { count: participationCount } = await knexConn('campaign-participations')
    .count('id')
    .where({ campaignId: id })
    .first();

  return new Campaign({
    ...campaign,
    participationCount,
  });
};
```

### Apres

Usecase : 

```diff
const updateCampaignCode = async function ({ campaignId, campaignCode, campaignAdministrationRepository }) {
-  await DomainTransaction.execute(async (domainTransaction) => {
+  await DomainTransaction.execute(async () => {
-    const campaign = await campaignAdministrationRepository.get(campaignId, domainTransaction);
+    const campaign = await campaignAdministrationRepository.get(campaignId);
    if (!campaign) {
      throw new UnknownCampaignId();
    }

    campaign.updateFields({ code: campaignCode });

-    const isCodeAvailable = await campaignAdministrationRepository.isCodeAvailable({
-      code: campaignCode,
-      domainTransaction,
-    });
+    const isCodeAvailable = await campaignAdministrationRepository.isCodeAvailable({ code: campaignCode });
    if (!isCodeAvailable) {
      throw new CampaignUniqueCodeError();
    }

-    await campaignAdministrationRepository.update(campaign, domainTransaction);
+    await campaignAdministrationRepository.update(campaign);
  });
};
```

Repository : 

```diff
- const get = async function (id, domainTransaction = DomainTransaction.emptyTransaction()) {
+ const get = async function (id) {
-  const knexConn = domainTransaction.knexTransaction || knex;
+  const knexConn = DomainTransaction.getConnection();
  const campaign = await knexConn('campaigns').where({ id }).first();

  if (!campaign) return null;

  const { count: participationCount } = await knexConn('campaign-participations')
    .count('id')
    .where({ campaignId: id })
    .first();

  return new Campaign({
    ...campaign,
    participationCount,
  });
};
```

TODO : @1024pix/team-prescription va devoir supprimer leur expérimentation avec l'ApplicationTransaction en faveur de la DomainTransaction.

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

La CI est verte 💚 
