### PR TITLE
[TECH] Récupérer les correlations IDs dans le logger.js (PIX-12823)

### DIFF
--- a/api/lib/infrastructure/monitoring-tools.js
+++ b/api/lib/infrastructure/monitoring-tools.js
@@ -1,69 +1,21 @@
+import async_hooks from 'node:async_hooks';
+
 import Request from '@hapi/hapi/lib/request.js';
 import lodash from 'lodash';
 
+import {
+  getCorrelationContext,
+  logErrorWithCorrelationIds,
+  logInfoWithCorrelationIds,
+} from '../../src/shared/infrastructure/utils/logger.js';
+import * as requestResponseUtils from '../../src/shared/infrastructure/utils/request-response-utils.js';
 import { config } from '../config.js';
 
-const { get, set, update, omit } = lodash;
-import async_hooks from 'node:async_hooks';
-
-import { logger } from '../../src/shared/infrastructure/utils/logger.js';
-import * as requestResponseUtils from '../../src/shared/infrastructure/utils/request-response-utils.js';
+const { get, set, update } = lodash;
 
 const { AsyncLocalStorage } = async_hooks;
 
 const asyncLocalStorage = new AsyncLocalStorage();
-
-function getCorrelationContext() {
-  if (!config.hapi.enableRequestMonitoring) {
-    return {};
-  }
-  const context = asyncLocalStorage.getStore();
-  const request = get(context, 'request');
-  return {
-    user_id: extractUserIdFromRequest(request),
-    request_id: get(request, 'info.id', '-'),
-  };
-}
-
-function logInfoWithCorrelationIds(data) {
-  const context = getCorrelationContext();
-  logger.info(
-    {
-      ...context,
-      ...omit(data, 'message'),
-    },
-    get(data, 'message', '-'),
-  );
-}
-
-/**
- * In order to be displayed properly in Datadog,
- * the parameter "data" should contain
- * - a required property message as string
- * - all other properties you need to pass to Datadog
- *
- * @example
- * const data = {
- *   message: 'Error message',
- *   context: 'My Context',
- *   data: { more: 'data', if: 'needed' },
- *   event: 'Event which trigger this error',
- *   team: 'My Team',
- * };
- * monitoringTools.logErrorWithCorrelationIds(data);
- *
- * @param {object} data
- */
-function logErrorWithCorrelationIds(data) {
-  const context = getCorrelationContext();
-  logger.error(
-    {
-      ...context,
-      ...omit(data, 'message'),
-    },
-    get(data, 'message', '-'),
-  );
-}
 
 function extractUserIdFromRequest(request) {
   let userId = get(request, 'auth.credentials.userId');
@@ -138,6 +90,7 @@ export {
   asyncLocalStorage,
   extractUserIdFromRequest,
   getContext,
+  getCorrelationContext,
   getInContext,
   incrementInContext,
   installHapiHook,

--- a/api/src/shared/infrastructure/utils/logger.js
+++ b/api/src/shared/infrastructure/utils/logger.js
@@ -48,33 +48,15 @@ function extractUserIdFromRequest(request) {
   return userId || '-';
 }
 
-function parseDataForLogger(data) {
-  return typeof data === 'string' || data instanceof String
-    ? {
-        message: data,
-      }
-    : data;
+function _parseDataForLogger(data) {
+  return typeof data === 'string' || data instanceof String ? { message: data } : data;
 }
 
-function _logErrorWithCorrelationIds(logger) {
+function _logWithCorrelationIds(loggingFunction) {
   return function (data) {
-    const parsedData = parseDataForLogger(data);
+    const parsedData = _parseDataForLogger(data);
     const context = getCorrelationContext();
-    logger.error(
-      {
-        ...context,
-        ...omit(parsedData, 'message'),
-      },
-      get(parsedData, 'message', '-'),
-    );
-  };
-}
-
-function _logInfoWithCorrelationIds(logger) {
-  return function (data) {
-    const parsedData = parseDataForLogger(data);
-    const context = getCorrelationContext();
-    logger.info(
+    loggingFunction(
       {
         ...context,
         ...omit(parsedData, 'message'),
@@ -85,32 +67,67 @@ function _logInfoWithCorrelationIds(logger) {
 }
 
 /**
- * In order to be displayed properly in Datadog,
- * the parameter "data" should contain
- * - a required property message as string
- * - all other properties you need to pass to Datadog
- *
- * @example
- * const data = {
- *   message: 'Error message',
- *   context: 'My Context',
- *   data: { more: 'data', if: 'needed' },
- *   event: 'Event which trigger this error',
- *   team: 'My Team',
- * };
- * logErrorWithCorrelationIds(data);
- *
- * @param {object} data
+ * @param {object|string} data
+ * @see : logger#error for details
+ * @deprecated use logger#error instead
  */
-const logErrorWithCorrelationIds = _logErrorWithCorrelationIds(internalLogger);
-const logInfoWithCorrelationIds = _logInfoWithCorrelationIds(internalLogger);
+const logErrorWithCorrelationIds = _logWithCorrelationIds(internalLogger.error.bind(internalLogger));
+
+/**
+ * @param {object|string} data
+ * @see : logger#info for details
+ * @deprecated use logger#info instead
+ */
+const logInfoWithCorrelationIds = _logWithCorrelationIds(internalLogger.info.bind(internalLogger));
 
 const logger = {
-  error: logErrorWithCorrelationIds,
-  info: logInfoWithCorrelationIds,
+  /**
+   * In order to be displayed properly in Datadog,
+   * the parameter "data" should contain
+   * - a required property message as string
+   * - all other properties you need to pass to Datadog
+   *
+   * It is also possible to provide raw message as string.
+   *
+   * @example
+   * const data = {
+   *   message: 'Error message',
+   *   context: 'My Context',
+   *   data: { more: 'data', if: 'needed' },
+   *   event: 'Event which trigger this error',
+   *   team: 'My Team',
+   * };
+   * logger.error(data);
+   * or
+   * logger.error('Error message');
+   *
+   * @param {object|string} data
+   */
+  error: _logWithCorrelationIds(internalLogger.error.bind(internalLogger)),
+  /**
+   * @param {object|string} data
+   * @see : logger#error for details
+   */
+  info: _logWithCorrelationIds(internalLogger.info.bind(internalLogger)),
+  /**
+   * @param {object|string} data
+   * @see : logger#error for details
+   */
   warn: internalLogger.warn.bind(internalLogger),
+  /**
+   * @param {object|string} data
+   * @see : logger#error for details
+   */
   trace: internalLogger.trace.bind(internalLogger),
+  /**
+   * @param {object|string} data
+   * @see : logger#error for details
+   */
   fatal: internalLogger.fatal.bind(internalLogger),
+  /**
+   * @param {object|string} data
+   * @see : logger#error for details
+   */
   debug: internalLogger.debug.bind(internalLogger),
 };
 

--- a/api/src/shared/infrastructure/utils/logger.js
+++ b/api/src/shared/infrastructure/utils/logger.js
@@ -1,7 +1,12 @@
+import lodash from 'lodash';
 import pino from 'pino';
 import pretty from 'pino-pretty';
 
+import { asyncLocalStorage } from '../../../prescription/shared/infrastructure/utils/async-local-storage.js';
 import { config } from '../../config.js';
+import { requestResponseUtils } from './request-response-utils.js';
+
+const { get, omit } = lodash;
 
 const { logging } = config;
 
@@ -16,7 +21,7 @@ if (logging.logForHumans) {
   });
 }
 
-const logger = pino(
+const internalLogger = pino(
   {
     level: logging.logLevel,
     redact: ['req.headers.authorization'],
@@ -25,4 +30,88 @@ const logger = pino(
   prettyPrint,
 );
 
-export { logger };
+function getCorrelationContext() {
+  if (!config.hapi.enableRequestMonitoring) {
+    return {};
+  }
+  const context = asyncLocalStorage.getStore();
+  const request = get(context, 'request');
+  return {
+    user_id: extractUserIdFromRequest(request),
+    request_id: get(request, 'info.id', '-'),
+  };
+}
+
+function extractUserIdFromRequest(request) {
+  let userId = get(request, 'auth.credentials.userId');
+  if (!userId && get(request, 'headers.authorization')) userId = requestResponseUtils.extractUserIdFromRequest(request);
+  return userId || '-';
+}
+
+function parseDataForLogger(data) {
+  return typeof data === 'string' || data instanceof String
+    ? {
+        message: data,
+      }
+    : data;
+}
+
+function _logErrorWithCorrelationIds(logger) {
+  return function (data) {
+    const parsedData = parseDataForLogger(data);
+    const context = getCorrelationContext();
+    logger.error(
+      {
+        ...context,
+        ...omit(parsedData, 'message'),
+      },
+      get(parsedData, 'message', '-'),
+    );
+  };
+}
+
+function _logInfoWithCorrelationIds(logger) {
+  return function (data) {
+    const parsedData = parseDataForLogger(data);
+    const context = getCorrelationContext();
+    logger.info(
+      {
+        ...context,
+        ...omit(parsedData, 'message'),
+      },
+      get(parsedData, 'message', '-'),
+    );
+  };
+}
+
+/**
+ * In order to be displayed properly in Datadog,
+ * the parameter "data" should contain
+ * - a required property message as string
+ * - all other properties you need to pass to Datadog
+ *
+ * @example
+ * const data = {
+ *   message: 'Error message',
+ *   context: 'My Context',
+ *   data: { more: 'data', if: 'needed' },
+ *   event: 'Event which trigger this error',
+ *   team: 'My Team',
+ * };
+ * logErrorWithCorrelationIds(data);
+ *
+ * @param {object} data
+ */
+const logErrorWithCorrelationIds = _logErrorWithCorrelationIds(internalLogger);
+const logInfoWithCorrelationIds = _logInfoWithCorrelationIds(internalLogger);
+
+const logger = {
+  error: logErrorWithCorrelationIds,
+  info: logInfoWithCorrelationIds,
+  warn: internalLogger.warn.bind(internalLogger),
+  trace: internalLogger.trace.bind(internalLogger),
+  fatal: internalLogger.fatal.bind(internalLogger),
+  debug: internalLogger.debug.bind(internalLogger),
+};
+
+export { getCorrelationContext, logErrorWithCorrelationIds, logger, logInfoWithCorrelationIds };


### PR DESCRIPTION
> 👷‍♀️👷‍♂️ Ceci est une reprise de la PR [Remplacer les usages de Logger par les méthodes avec correlations IDs](https://github.com/1024pix/pix/pull/9157)

## :unicorn: Problème
Ajout d'infos dans les logs. Les _correlationIDs_ (`request-id` & `user-id`) ne sont pas loggués partout pour l'instant.
Le but est de pouvoir prévenir automatiquement chaque équipe en cas d'erreur, en fonction d'un label `@team` qu'il faudra ajouter sur chaque route.

## :robot: Proposition
Dans le fichier `logger.js`, utiliser `loggerInfoWithCorrelationId` lors de l'appel de `logger.info`, et `loggerErrorWithCorrelationId` lors de l'appel de `logger.error`.

Le `logger.js` expose alors ses `loggerInfoWithCorrelationId` et `loggerErrorWithCorrelationId` afin de permettre à `monitoring-tools` de les utiliser sans nécessiter de grosses refacto

## :rainbow: Remarques
Pour l'instant `logger.warn` & `logger.trace` & `logger.fatal` & `logger.debug` ne sont pas gérées.

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
