### PR TITLE
[FEATURE] Enregistrer la confirmation de lecture des écrans d'instructions sur Pix App (PIX-12907).

### DIFF
--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -51,6 +51,7 @@ const certificationCandidateParticipationJoiSchema = Joi.object({
     .empty(null),
   prepaymentCode: Joi.string().allow(null).optional(),
   subscriptions: Joi.array().items(subscriptionSchema).unique('type').required(),
+  hasSeenCertificationInstructions: Joi.boolean().optional(),
 });
 
 class CertificationCandidate {
@@ -84,6 +85,7 @@ class CertificationCandidate {
     billingMode = null,
     prepaymentCode = null,
     subscriptions = [],
+    hasSeenCertificationInstructions = false,
   } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -107,6 +109,7 @@ class CertificationCandidate {
     this.subscriptions = subscriptions;
     this.billingMode = billingMode;
     this.prepaymentCode = prepaymentCode;
+    this.hasSeenCertificationInstructions = hasSeenCertificationInstructions;
 
     Object.defineProperty(this, 'complementaryCertification', {
       enumerable: true,

--- a/api/src/certification/enrolment/infrastructure/serializers/certification-candidate-serializer.js
+++ b/api/src/certification/enrolment/infrastructure/serializers/certification-candidate-serializer.js
@@ -35,6 +35,7 @@ const serialize = function (certificationCandidates) {
       'complementaryCertification',
       'billingMode',
       'prepaymentCode',
+      'hasSeenCertificationInstructions',
     ],
   }).serialize(certificationCandidates);
 };

--- a/api/tests/unit/domain/models/CertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidate_test.js
@@ -55,6 +55,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       resultRecipientEmail: undefined,
       complementaryCertification: null,
       subscriptions: [coreSubscription],
+      hasSeenCertificationInstructions: false,
     };
   });
 

--- a/mon-pix/app/adapters/certification-candidate-subscription.js
+++ b/mon-pix/app/adapters/certification-candidate-subscription.js
@@ -1,6 +1,6 @@
 import ApplicationAdapter from './application';
 
-export default class AccountRecoveryDemandAdapter extends ApplicationAdapter {
+export default class CertificationCandidateSubscription extends ApplicationAdapter {
   urlForFindRecord(id) {
     return `${this.host}/${this.namespace}/certification-candidates/${id}/subscriptions`;
   }

--- a/mon-pix/app/adapters/certification-candidate.js
+++ b/mon-pix/app/adapters/certification-candidate.js
@@ -13,4 +13,15 @@ export default class CertificationCandidate extends ApplicationAdapter {
 
     return url;
   }
+
+  urlForUpdateRecord(id, modelName, { adapterOptions }) {
+    const url = super.urlForUpdateRecord(...arguments);
+
+    if (adapterOptions && adapterOptions.hasSeenCertificationInstructions) {
+      delete adapterOptions.hasSeenCertificationInstructions;
+      return `${url}/validate-certification-instructions`;
+    }
+
+    return url;
+  }
 }

--- a/mon-pix/app/components/certification-instructions/steps.js
+++ b/mon-pix/app/components/certification-instructions/steps.js
@@ -43,18 +43,25 @@ export default class Steps extends Component {
   }
 
   @action
-  nextStep() {
+  async nextStep() {
     if (this.pageId < this.pageCount) {
       this.pageId = this.pageId + 1;
     }
 
     if (this.isConfirmationCheckboxChecked) {
-      this.router.transitionTo('authenticated.certifications.start', this.args.candidateId, {
-        queryParams: {
-          isConfirmationCheckboxChecked: this.isConfirmationCheckboxChecked,
-        },
-      });
+      await this.submit();
+
+      this.router.transitionTo('authenticated.certifications.start', this.args.candidate.id);
     }
+  }
+
+  @action
+  async submit() {
+    await this.args.candidate.save({
+      adapterOptions: {
+        hasSeenCertificationInstructions: true,
+      },
+    });
   }
 
   @action

--- a/mon-pix/app/models/certification-candidate.js
+++ b/mon-pix/app/models/certification-candidate.js
@@ -5,6 +5,7 @@ export default class CertificationCandidate extends Model {
   @attr('string') firstName;
   @attr('string') lastName;
   @attr('date-only') birthdate;
+  @attr('boolean') hasSeenCertificationInstructions;
 
   // references
   @attr('number') sessionId;

--- a/mon-pix/app/routes/authenticated/certifications/information.js
+++ b/mon-pix/app/routes/authenticated/certifications/information.js
@@ -5,6 +5,6 @@ export default class InformationRoute extends Route {
   @service store;
 
   async model(params) {
-    return await this.store.findRecord('certification-candidate-subscription', params.certification_candidate_id);
+    return this.store.peekRecord('certification-candidate', params.certification_candidate_id);
   }
 }

--- a/mon-pix/app/routes/authenticated/certifications/information.js
+++ b/mon-pix/app/routes/authenticated/certifications/information.js
@@ -3,8 +3,18 @@ import { service } from '@ember/service';
 
 export default class InformationRoute extends Route {
   @service store;
+  @service router;
 
   async model(params) {
-    return this.store.peekRecord('certification-candidate', params.certification_candidate_id);
+    const certificationCandidate = await this.store.peekRecord(
+      'certification-candidate',
+      params.certification_candidate_id,
+    );
+
+    if (!certificationCandidate) {
+      this.router.replaceWith('authenticated.certifications.join');
+    }
+
+    return certificationCandidate;
   }
 }

--- a/mon-pix/app/routes/authenticated/certifications/start.js
+++ b/mon-pix/app/routes/authenticated/certifications/start.js
@@ -5,11 +5,6 @@ export default class StartRoute extends Route {
   @service store;
   @service router;
   @service featureToggles;
-  hasSeenCertificationInstructions = false;
-
-  beforeModel(transition) {
-    this.hasSeenCertificationInstructions = transition.to.queryParams.isConfirmationCheckboxChecked;
-  }
 
   async model(params) {
     const certificationCandidateSubscription = await this.store.findRecord(
@@ -17,8 +12,15 @@ export default class StartRoute extends Route {
       params.certification_candidate_id,
     );
 
+    const certificationCandidate = await this.store.peekRecord(
+      'certification-candidate',
+      params.certification_candidate_id,
+    );
+
+    const hasSeenCertificationInstructions = certificationCandidate?.hasSeenCertificationInstructions;
+
     if (
-      !this.hasSeenCertificationInstructions &&
+      !hasSeenCertificationInstructions &&
       certificationCandidateSubscription.isSessionVersion3 &&
       this.featureToggles.featureToggles.areV3InfoScreensEnabled
     ) {

--- a/mon-pix/app/templates/authenticated/certifications/information.hbs
+++ b/mon-pix/app/templates/authenticated/certifications/information.hbs
@@ -6,6 +6,6 @@
     <h1 class="instructions-header__title">{{t "pages.certification-instructions.title"}}</h1>
   </header>
   <PixBlock @shadow="heavy" class="instructions-step">
-    <CertificationInstructions::Steps @candidateId={{this.model.id}} />
+    <CertificationInstructions::Steps @candidate={{this.model}} />
   </PixBlock>
 </main>

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -35,6 +35,7 @@ import putTutorialEvaluation from './routes/put-tutorial-evaluation';
 import putUserSavedTutorial from './routes/put-user-saved-tutorial';
 import loadScoOrganizationLearnersRoutes from './routes/sco-organization-learners/index';
 import loadSupOrganizationLearnersRoutes from './routes/sup-organization-learners/index';
+import updateCertificationCandidates from './routes/update-certification-candidates';
 import loadUserRoutes from './routes/users/index';
 
 export default function makeServer(config) {
@@ -108,4 +109,9 @@ function routes() {
   this.get('/certification-courses/:id');
 
   this.post('/feedbacks');
+
+  this.patch(
+    '/certification-candidates/:certificationCandidateId/validate-certification-instructions',
+    updateCertificationCandidates,
+  );
 }

--- a/mon-pix/mirage/routes/post-session-participation.js
+++ b/mon-pix/mirage/routes/post-session-participation.js
@@ -7,8 +7,12 @@ export default function (schema, request) {
   const firstName = params.data.attributes['first-name'];
   const lastName = params.data.attributes['last-name'];
   const birthdate = params.data.attributes['birthdate'];
+  let hasSeenCertificationInstructions = false;
   if (!every([firstName, lastName, birthdate, sessionId])) {
     return new Response(400);
+  }
+  if (lastName === 'hasSeenCertificationInstructions') {
+    hasSeenCertificationInstructions = true;
   }
   if (lastName === 'PasInscrite') {
     return new Response(404);
@@ -32,5 +36,6 @@ export default function (schema, request) {
     lastName: 'Bravo',
     sessionId: 1,
     birthdate: '1990-01-04',
+    hasSeenCertificationInstructions,
   });
 }

--- a/mon-pix/mirage/routes/update-certification-candidates.js
+++ b/mon-pix/mirage/routes/update-certification-candidates.js
@@ -1,0 +1,7 @@
+export default function (schema, request) {
+  const certificationCandidateId = request.params.certificationCandidateId;
+  const certificationCandidate = schema.certificationCandidates.find(certificationCandidateId);
+  certificationCandidate.update({ hasSeenCertificationInstructions: true });
+
+  return certificationCandidate;
+}

--- a/mon-pix/tests/acceptance/authenticated/certifications/information_test.js
+++ b/mon-pix/tests/acceptance/authenticated/certifications/information_test.js
@@ -1,5 +1,5 @@
 import { visit } from '@1024pix/ember-testing-library';
-import { currentURL } from '@ember/test-helpers';
+import { click, currentURL } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -21,7 +21,7 @@ module('Acceptance | Certifications | Information', function (hooks) {
 
   module('when certification candidate participates in a V3 session', function () {
     module('when toggle areV3InfoScreensEnabled is enabled', function () {
-      test('should display the certification information page', async function (assert) {
+      test('should display the certification instructions page', async function (assert) {
         // given
         server.create('feature-toggle', {
           id: 0,
@@ -55,6 +55,88 @@ module('Acceptance | Certifications | Information', function (hooks) {
         assert.dom(screen.getByRole('heading', { name: 'Explication de la certification', level: 1 })).exists();
         assert.dom(screen.getByRole('heading', { name: 'Bienvenue à la certification Pix', level: 2 })).exists();
         assert.dom(screen.getByRole('button', { name: "Continuer vers l'écran suivant" })).exists();
+      });
+
+      module('when user validates instructions', function () {
+        test('should validate checkbox and redirect to the certification start page', async function (assert) {
+          // given
+          server.create('feature-toggle', {
+            id: 0,
+            areV3InfoScreensEnabled: true,
+          });
+          server.create('certification-candidate-subscription', {
+            id: 2,
+            sessionId: 123,
+            eligibleSubscription: null,
+            nonEligibleSubscription: null,
+            sessionVersion: 3,
+          });
+
+          await authenticateByEmail(user);
+
+          const screen = await visit('/certifications');
+
+          // when
+          await fillCertificationJoiner({
+            sessionId: '123',
+            firstName: 'toto',
+            lastName: 'titi',
+            dayOfBirth: '01',
+            monthOfBirth: '01',
+            yearOfBirth: '2000',
+            intl: this.intl,
+          });
+          for (let i = 0; i < 4; i++) {
+            await click(screen.getByRole('button', { name: "Continuer vers l'écran suivant" }));
+          }
+
+          await click(
+            screen.getByRole('checkbox', {
+              name: 'En cochant cette case, je reconnais avoir pris connaissance de ces règles et je m’engage à les respecter.',
+            }),
+          );
+          await click(screen.getByRole('button', { name: "Continuer vers la page d'entrée en certification" }));
+
+          // then
+          assert.strictEqual(currentURL(), '/certifications/candidat/2');
+        });
+      });
+
+      module('when user has already validated instructions', function () {
+        test('should redirect to the certification start page', async function (assert) {
+          // given
+          server.create('feature-toggle', {
+            id: 0,
+            areV3InfoScreensEnabled: true,
+          });
+          server.create('certification-candidate-subscription', {
+            id: 2,
+            sessionId: 123,
+            eligibleSubscription: null,
+            nonEligibleSubscription: null,
+            sessionVersion: 3,
+          });
+
+          const candidateLastName = 'hasSeenCertificationInstructions';
+
+          await authenticateByEmail(user);
+
+          await visit('/certifications');
+
+          // when
+          await fillCertificationJoiner({
+            sessionId: '123',
+            firstName: 'toto',
+            lastName: candidateLastName,
+            dayOfBirth: '01',
+            monthOfBirth: '01',
+            yearOfBirth: '2000',
+            intl: this.intl,
+          });
+
+          // then
+          assert.strictEqual(currentURL(), '/certifications/candidat/2');
+        });
       });
     });
 

--- a/mon-pix/tests/unit/adapters/certification-candidate_test.js
+++ b/mon-pix/tests/unit/adapters/certification-candidate_test.js
@@ -31,4 +31,28 @@ module('Unit | Adapters | certification-candidate', function (hooks) {
       assert.true(url.endsWith('/sessions/456/candidate-participation'));
     });
   });
+
+  module('#urlForUpdateRecord', function () {
+    module('when hasSeenCertificationInstructions option is true', function () {
+      test('should redirect to session/id/certification-candidate/participation', async function (assert) {
+        // when
+        const options = { adapterOptions: { hasSeenCertificationInstructions: true } };
+        const url = await adapter.urlForUpdateRecord(456, 'certification-candidate', options);
+
+        // then
+        assert.true(url.endsWith('/certification-candidates/456/validate-certification-instructions'));
+      });
+    });
+
+    module('when hasSeenCertificationInstructions option is false', function () {
+      test('should build create url from certification-candidate id', async function (assert) {
+        // when
+        const options = { adapterOptions: {} };
+        const url = await adapter.urlForUpdateRecord(456, 'certification-candidate', options);
+
+        // then
+        assert.true(url.endsWith('/certification-candidates/456'));
+      });
+    });
+  });
 });

--- a/mon-pix/tests/unit/components/certification-instructions/steps_test.js
+++ b/mon-pix/tests/unit/components/certification-instructions/steps_test.js
@@ -27,32 +27,29 @@ module('Unit | Component | certification-instruction | steps', function (hooks) 
 
     module('when pageId equal pageCount', function () {
       module('when confirmation checkbox is checked', function () {
-        test('should redirect to certificartion starter', async function (assert) {
+        test('should redirect to certification starter', async function (assert) {
           // given
           const component = createGlimmerComponent('certification-instructions/steps');
 
           component.pageId = 2;
           component.pageCount = 2;
-          component.args = {
-            candidateId: 123,
-          };
           component.isConfirmationCheckboxChecked = true;
           const transitionToStub = sinon.stub();
+          const saveStub = sinon.stub();
+          saveStub.resolves();
           component.router = {
             transitionTo: transitionToStub,
+          };
+          component.args.candidate = {
+            save: saveStub,
+            id: 123,
           };
 
           // when
           await component.nextStep();
 
           // then
-          assert.ok(
-            transitionToStub.calledWith('authenticated.certifications.start', 123, {
-              queryParams: {
-                isConfirmationCheckboxChecked: true,
-              },
-            }),
-          );
+          assert.ok(transitionToStub.calledWith('authenticated.certifications.start', 123));
         });
       });
     });

--- a/mon-pix/tests/unit/routes/authenticated/certifications/information_test.js
+++ b/mon-pix/tests/unit/routes/authenticated/certifications/information_test.js
@@ -25,5 +25,23 @@ module('Unit | Route | Certifications | Information', function (hooks) {
       // then
       assert.deepEqual(model, certificationCandidate);
     });
+
+    module('when no candidate exist', function () {
+      test('should return to certification form', async function (assert) {
+        // given
+        const peekRecordStub = sinon.stub().resolves();
+        const storeStub = Service.create({ peekRecord: peekRecordStub });
+        const route = this.owner.lookup('route:authenticated/certifications.information');
+        route.set('store', storeStub);
+        route.router = { replaceWith: sinon.stub() };
+
+        // when
+        await route.model(1234);
+
+        // then
+        sinon.assert.calledWith(route.router.replaceWith, 'authenticated.certifications.join');
+        assert.ok(true);
+      });
+    });
   });
 });

--- a/mon-pix/tests/unit/routes/authenticated/certifications/information_test.js
+++ b/mon-pix/tests/unit/routes/authenticated/certifications/information_test.js
@@ -1,0 +1,29 @@
+import Service from '@ember/service';
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | Certifications | Information', function (hooks) {
+  setupTest(hooks);
+
+  module('model', function () {
+    test('should return certification candidate', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const certificationCandidate = store.createRecord('certification-candidate', {
+        id: '1234',
+      });
+      const peekRecordStub = sinon.stub().resolves(certificationCandidate);
+      const storeStub = Service.create({ peekRecord: peekRecordStub });
+      const route = this.owner.lookup('route:authenticated/certifications.information');
+      route.set('store', storeStub);
+
+      // when
+      const model = await route.model(1234);
+
+      // then
+      assert.deepEqual(model, certificationCandidate);
+    });
+  });
+});

--- a/mon-pix/tests/unit/routes/authenticated/certifications/start_test.js
+++ b/mon-pix/tests/unit/routes/authenticated/certifications/start_test.js
@@ -11,12 +11,15 @@ module('Unit | Route | Certification | Start', function (hooks) {
       module('when hasSeenCertificationInstructions is false', function () {
         test('should redirect to certification information page', async function (assert) {
           // given
-          const certificationCandidateId = 'certification-candidate-id';
-          const params = { certification_candidate_id: certificationCandidateId };
           const store = this.owner.lookup('service:store');
+          const certificationCandidate = store.createRecord('certification-candidate', {
+            sessionId: 1234,
+            hasSeenCertificationInstructions: false,
+          });
+          const params = { certification_candidate_id: certificationCandidate.id };
 
           const certificationCandidateSubscription = store.createRecord('certification-candidate-subscription', {
-            id: certificationCandidateId,
+            id: certificationCandidate.id,
             sessionId: 1234,
             sessionVersion: 3,
           });
@@ -27,13 +30,13 @@ module('Unit | Route | Certification | Start', function (hooks) {
           });
 
           const findRecordStub = sinon.stub().returns(certificationCandidateSubscription);
-          const storeStub = Service.create({ findRecord: findRecordStub });
+          const peekRecordStub = sinon.stub().returns(certificationCandidate);
+          const storeStub = Service.create({ findRecord: findRecordStub, peekRecord: peekRecordStub });
 
           const route = this.owner.lookup('route:authenticated/certifications.start');
           route.set('store', storeStub);
           route.set('featureToggles', featureToggles);
           route.router = { replaceWith: sinon.stub() };
-          route.hasSeenCertificationInstructions = false;
 
           // when
           await route.model(params);
@@ -42,7 +45,7 @@ module('Unit | Route | Certification | Start', function (hooks) {
           sinon.assert.calledWithExactly(
             route.router.replaceWith,
             'authenticated.certifications.information',
-            certificationCandidateId,
+            certificationCandidate.id,
           );
           assert.ok(true);
         });
@@ -51,12 +54,15 @@ module('Unit | Route | Certification | Start', function (hooks) {
       module('when hasSeenCertificationInstructions is true', function () {
         test('should not redirect to certification information page', async function (assert) {
           // given
-          const certificationCandidateId = 'certification-candidate-id';
-          const params = { certification_candidate_id: certificationCandidateId };
           const store = this.owner.lookup('service:store');
+          const certificationCandidate = store.createRecord('certification-candidate', {
+            sessionId: 1234,
+            hasSeenCertificationInstructions: true,
+          });
+          const params = { certification_candidate_id: certificationCandidate.id };
 
           const certificationCandidateSubscription = store.createRecord('certification-candidate-subscription', {
-            id: certificationCandidateId,
+            id: certificationCandidate.id,
             sessionId: 1234,
             sessionVersion: 3,
           });
@@ -67,7 +73,8 @@ module('Unit | Route | Certification | Start', function (hooks) {
           });
 
           const findRecordStub = sinon.stub().returns(certificationCandidateSubscription);
-          const storeStub = Service.create({ findRecord: findRecordStub });
+          const peekRecordStub = sinon.stub().returns(certificationCandidate);
+          const storeStub = Service.create({ findRecord: findRecordStub, peekRecord: peekRecordStub });
 
           const route = this.owner.lookup('route:authenticated/certifications.start');
           route.set('store', storeStub);
@@ -88,12 +95,15 @@ module('Unit | Route | Certification | Start', function (hooks) {
     module('when session is V3 and toggle is not enabled', function () {
       test('should not redirect to certification information page', async function (assert) {
         // given
-        const certificationCandidateId = 'certification-candidate-id';
-        const params = { certification_candidate_id: certificationCandidateId };
         const store = this.owner.lookup('service:store');
+        const certificationCandidate = store.createRecord('certification-candidate', {
+          sessionId: 1234,
+          hasSeenCertificationInstructions: false,
+        });
+        const params = { certification_candidate_id: certificationCandidate.id };
 
         const certificationCandidateSubscription = store.createRecord('certification-candidate-subscription', {
-          id: certificationCandidateId,
+          id: certificationCandidate.id,
           sessionId: 1234,
           sessionVersion: 3,
         });
@@ -104,7 +114,8 @@ module('Unit | Route | Certification | Start', function (hooks) {
         });
 
         const findRecordStub = sinon.stub().returns(certificationCandidateSubscription);
-        const storeStub = Service.create({ findRecord: findRecordStub });
+        const peekRecordStub = sinon.stub().returns(certificationCandidate);
+        const storeStub = Service.create({ findRecord: findRecordStub, peekRecord: peekRecordStub });
 
         const route = this.owner.lookup('route:authenticated/certifications.start');
         route.set('store', storeStub);
@@ -123,12 +134,15 @@ module('Unit | Route | Certification | Start', function (hooks) {
     module('when session is not V3 and toggle is enabled', function () {
       test('should not redirect to certification information page', async function (assert) {
         // given
-        const certificationCandidateId = 'certification-candidate-id';
-        const params = { certification_candidate_id: certificationCandidateId };
         const store = this.owner.lookup('service:store');
+        const certificationCandidate = store.createRecord('certification-candidate', {
+          sessionId: 1234,
+          hasSeenCertificationInstructions: false,
+        });
+        const params = { certification_candidate_id: certificationCandidate.id };
 
         const certificationCandidateSubscription = store.createRecord('certification-candidate-subscription', {
-          id: certificationCandidateId,
+          id: certificationCandidate.id,
           sessionId: 1234,
           sessionVersion: 2,
         });
@@ -139,7 +153,8 @@ module('Unit | Route | Certification | Start', function (hooks) {
         });
 
         const findRecordStub = sinon.stub().returns(certificationCandidateSubscription);
-        const storeStub = Service.create({ findRecord: findRecordStub });
+        const peekRecordStub = sinon.stub().returns(certificationCandidate);
+        const storeStub = Service.create({ findRecord: findRecordStub, peekRecord: peekRecordStub });
 
         const route = this.owner.lookup('route:authenticated/certifications.start');
         route.set('store', storeStub);
@@ -158,12 +173,15 @@ module('Unit | Route | Certification | Start', function (hooks) {
     module('when session is not V3 and toggle is not enabled', function () {
       test('should not redirect to certification information page', async function (assert) {
         // given
-        const certificationCandidateId = 'certification-candidate-id';
-        const params = { certification_candidate_id: certificationCandidateId };
         const store = this.owner.lookup('service:store');
+        const certificationCandidate = store.createRecord('certification-candidate', {
+          sessionId: 1234,
+          hasSeenCertificationInstructions: false,
+        });
+        const params = { certification_candidate_id: certificationCandidate.id };
 
         const certificationCandidateSubscription = store.createRecord('certification-candidate-subscription', {
-          id: certificationCandidateId,
+          id: certificationCandidate.id,
           sessionId: 1234,
           sessionVersion: 2,
         });
@@ -174,7 +192,8 @@ module('Unit | Route | Certification | Start', function (hooks) {
         });
 
         const findRecordStub = sinon.stub().returns(certificationCandidateSubscription);
-        const storeStub = Service.create({ findRecord: findRecordStub });
+        const peekRecordStub = sinon.stub().returns(certificationCandidate);
+        const storeStub = Service.create({ findRecord: findRecordStub, peekRecord: peekRecordStub });
 
         const route = this.owner.lookup('route:authenticated/certifications.start');
         route.set('store', storeStub);


### PR DESCRIPTION
## :unicorn: Problème
Nous avons créé la route API permettant de confirmer que le candidat à pris connaissances des écrans d'instructions V3.
Il manque la partie front pour rendre l'enregistrement opérationnel.

## :robot: Proposition
Implémenter l'appel à la route coté Pix App

## :100: Pour tester
- Se connecter sur Pix App avec certif-success@example.net
- Récupérer les infos candidat d'une session V3
- Remplir ces infos dans le formulaire d'entrée en certification
- Passer tous les écrans, valider la checkbox et continuer
- Constater que l'on arrive au code candidat
- En BDD constater que le booléen dans la table certification-candidate est passé à true pour le candidat
- Revenir au formulaire d'entrée en certif et re-remplir les infos
- Constater que l'on ne passe plus par les écrans et direct au code candidat
