### PR TITLE
[TECH] Migrer la route DELETE /api/organizations/{id}/invitations/{organizationInvitationId} et /api/admin/organizations/{id}/invitations/{organizationInvitationId} dans src/team (PIX-13262)

### DIFF
--- a/api/config/server-setup-error-handling.js
+++ b/api/config/server-setup-error-handling.js
@@ -8,11 +8,13 @@ import { prescriptionDomainErrorMappingConfiguration } from '../src/prescription
 import { schoolDomainErrorMappingConfiguration } from '../src/school/application/http-error-mapper-configuration.js';
 import { domainErrorMapper } from '../src/shared/application/domain-error-mapper.js';
 import * as sharedPreResponseUtils from '../src/shared/application/pre-response-utils.js';
+import { teamDomainErrorMappingConfiguration } from '../src/team/application/http-error-mapper-configuration.js';
 
 const setupErrorHandling = function (server) {
   const configuration = [
     ...authenticationDomainErrorMappingConfiguration,
     ...organizationalEntitiesDomainErrorMappingConfiguration,
+    ...teamDomainErrorMappingConfiguration,
     ...certificationDomainErrorMappingConfiguration,
     ...devcompDomainErrorMappingConfiguration,
     ...evaluationDomainErrorMappingConfiguration,

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -287,10 +287,6 @@ function _mapToHttpError(error) {
     return new HttpErrors.ConflictError(error.message);
   }
 
-  if (error instanceof DomainErrors.UncancellableOrganizationInvitationError) {
-    return new HttpErrors.UnprocessableEntityError(error.message);
-  }
-
   if (error instanceof DomainErrors.UserShouldNotBeReconciledOnAnotherAccountError) {
     return new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta);
   }

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -4,6 +4,7 @@ const Joi = BaseJoi.extend(JoiDate);
 
 import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../src/shared/domain/types/identifiers-type.js';
+import { organizationInvitationController } from '../../../src/team/application/organization-invitations/organization-invitation.controller.js';
 import { BadRequestError, PayloadTooLargeError, sendJsonApiError } from '../http-errors.js';
 import { organizationController } from './organization-controller.js';
 
@@ -190,7 +191,7 @@ const register = async function (server) {
             organizationInvitationId: identifiersType.organizationInvitationId,
           }),
         },
-        handler: organizationController.cancelOrganizationInvitation,
+        handler: organizationInvitationController.cancelOrganizationInvitation,
         tags: ['api', 'admin', 'invitations', 'cancel'],
         notes: [
           "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -4,7 +4,6 @@ const Joi = BaseJoi.extend(JoiDate);
 
 import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../src/shared/domain/types/identifiers-type.js';
-import { organizationInvitationController } from '../../../src/team/application/organization-invitations/organization-invitation.controller.js';
 import { BadRequestError, PayloadTooLargeError, sendJsonApiError } from '../http-errors.js';
 import { organizationController } from './organization-controller.js';
 
@@ -167,35 +166,6 @@ const register = async function (server) {
         notes: [
           "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
             "- Elle permet de lister les invitations en attente d'acceptation d'une organisation",
-        ],
-      },
-    },
-    {
-      method: 'DELETE',
-      path: '/api/admin/organizations/{id}/invitations/{organizationInvitationId}',
-      config: {
-        pre: [
-          {
-            method: (request, h) =>
-              securityPreHandlers.hasAtLeastOneAccessOf([
-                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-                securityPreHandlers.checkAdminMemberHasRoleMetier,
-              ])(request, h),
-            assign: 'hasAuthorizationToAccessAdminScope',
-          },
-        ],
-        validate: {
-          params: Joi.object({
-            id: identifiersType.organizationId,
-            organizationInvitationId: identifiersType.organizationInvitationId,
-          }),
-        },
-        handler: organizationInvitationController.cancelOrganizationInvitation,
-        tags: ['api', 'admin', 'invitations', 'cancel'],
-        notes: [
-          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
-            "- Elle permet d'annuler une invitation envoyée mais non acceptée encore.",
         ],
       },
     },

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -454,30 +454,6 @@ const register = async function (server) {
       },
     },
     {
-      method: 'DELETE',
-      path: '/api/organizations/{id}/invitations/{organizationInvitationId}',
-      config: {
-        pre: [
-          {
-            method: securityPreHandlers.checkUserIsAdminInOrganization,
-            assign: 'isAdminInOrganization',
-          },
-        ],
-        validate: {
-          params: Joi.object({
-            id: identifiersType.organizationId,
-            organizationInvitationId: identifiersType.organizationInvitationId,
-          }),
-        },
-        handler: organizationController.cancelOrganizationInvitation,
-        tags: ['api', 'invitations', 'cancel'],
-        notes: [
-          "- **Cette route est restreinte aux utilisateurs authentifiés en tant qu'admin d'une organisation**\n" +
-            "- Elle permet à l'administrateur de l'organisation d'annuler une invitation envoyée mais non acceptée encore.",
-        ],
-      },
-    },
-    {
       method: 'GET',
       path: '/api/organizations/{id}/member-identities',
       config: {

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -104,12 +104,6 @@ const resendInvitation = async function (request, h) {
   return h.response(organizationInvitationSerializer.serialize(organizationInvitation));
 };
 
-const cancelOrganizationInvitation = async function (request, h) {
-  const organizationInvitationId = request.params.organizationInvitationId;
-  await usecases.cancelOrganizationInvitation({ organizationInvitationId });
-  return h.response().code(204);
-};
-
 const sendInvitationByLangAndRole = async function (request, h, dependencies = { organizationInvitationSerializer }) {
   const organizationId = request.params.id;
   const invitationInformation =
@@ -161,7 +155,6 @@ const findChildrenOrganizationsForAdmin = async function (
 
 const organizationController = {
   archiveOrganization,
-  cancelOrganizationInvitation,
   create,
   createInBatch,
   findChildrenOrganizationsForAdmin,

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -155,15 +155,6 @@ class CancelledInvitationError extends DomainError {
   }
 }
 
-class UncancellableOrganizationInvitationError extends DomainError {
-  constructor(
-    message = "L'invitation à cette organisation ne peut pas être annulée.",
-    code = 'UNCANCELLABLE_ORGANIZATION_INVITATION_CODE',
-  ) {
-    super(message, code);
-  }
-}
-
 class CantImproveCampaignParticipationError extends DomainError {
   constructor(message = 'Une campagne de collecte de profils ne peut pas être retentée.') {
     super(message);
@@ -1084,7 +1075,6 @@ export {
   TargetProfileCannotBeCreated,
   TargetProfileInvalidError,
   TooManyRows,
-  UncancellableOrganizationInvitationError,
   UnexpectedUserAccountError,
   UnknownCountryForStudentEnrolmentError,
   UserAlreadyExistsWithAuthenticationMethodError,

--- a/api/src/team/application/http-error-mapper-configuration.js
+++ b/api/src/team/application/http-error-mapper-configuration.js
@@ -1,0 +1,12 @@
+import { HttpErrors } from '../../shared/application/http-errors.js';
+import { DomainErrorMappingConfiguration } from '../../shared/application/models/domain-error-mapping-configuration.js';
+import { UncancellableOrganizationInvitationError } from '../domain/errors.js';
+
+const teamDomainErrorMappingConfiguration = [
+  {
+    name: UncancellableOrganizationInvitationError.name,
+    httpErrorFn: (error) => new HttpErrors.UnprocessableEntityError(error.message),
+  },
+].map((domainErrorMappingConfiguration) => new DomainErrorMappingConfiguration(domainErrorMappingConfiguration));
+
+export { teamDomainErrorMappingConfiguration };

--- a/api/src/team/application/organization-invitations/organization-invitation.admin.route.js
+++ b/api/src/team/application/organization-invitations/organization-invitation.admin.route.js
@@ -1,0 +1,37 @@
+import Joi from 'joi';
+
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
+import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { organizationInvitationController } from './organization-invitation.controller.js';
+
+export const organizationInvitationAdminRoutes = [
+  {
+    method: 'DELETE',
+    path: '/api/admin/organizations/{id}/invitations/{organizationInvitationId}',
+    config: {
+      pre: [
+        {
+          method: (request, h) =>
+            securityPreHandlers.hasAtLeastOneAccessOf([
+              securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+              securityPreHandlers.checkAdminMemberHasRoleSupport,
+              securityPreHandlers.checkAdminMemberHasRoleMetier,
+            ])(request, h),
+          assign: 'hasAuthorizationToAccessAdminScope',
+        },
+      ],
+      validate: {
+        params: Joi.object({
+          id: identifiersType.organizationId,
+          organizationInvitationId: identifiersType.organizationInvitationId,
+        }),
+      },
+      handler: (request, h) => organizationInvitationController.cancelOrganizationInvitation(request, h),
+      tags: ['team', 'api', 'admin', 'invitations', 'cancel'],
+      notes: [
+        "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
+          "- Elle permet d'annuler une invitation envoyée mais non acceptée encore.",
+      ],
+    },
+  },
+];

--- a/api/src/team/application/organization-invitations/organization-invitation.controller.js
+++ b/api/src/team/application/organization-invitations/organization-invitation.controller.js
@@ -1,10 +1,23 @@
 import _ from 'lodash';
 
 import { MissingQueryParamError } from '../../../../lib/application/http-errors.js';
+import { usecases as libUsecases } from '../../../../lib/domain/usecases/index.js';
 import * as requestResponseUtils from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../../domain/usecases/index.js';
 import { organizationInvitationSerializer as organizationInvitationSerializer } from '../../infrastructure/serializers/jsonapi/organization-invitation.serializer.js';
 import { serializer as scoOrganizationInvitationSerializer } from '../../infrastructure/serializers/jsonapi/sco-organization-invitation.serializer.js';
+
+/**
+ *
+ * @param request
+ * @param h
+ * @returns {Promise<any>}
+ */
+const cancelOrganizationInvitation = async function (request, h) {
+  const organizationInvitationId = request.params.organizationInvitationId;
+  await libUsecases.cancelOrganizationInvitation({ organizationInvitationId });
+  return h.response().code(204);
+};
 
 /**
  *
@@ -55,6 +68,7 @@ const sendScoInvitation = async function (
 };
 
 export const organizationInvitationController = {
+  cancelOrganizationInvitation,
   getOrganizationInvitation,
   sendScoInvitation,
 };

--- a/api/src/team/application/organization-invitations/organization-invitation.controller.js
+++ b/api/src/team/application/organization-invitations/organization-invitation.controller.js
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 
 import { MissingQueryParamError } from '../../../../lib/application/http-errors.js';
-import { usecases as libUsecases } from '../../../../lib/domain/usecases/index.js';
 import * as requestResponseUtils from '../../../shared/infrastructure/utils/request-response-utils.js';
 import { usecases } from '../../domain/usecases/index.js';
 import { organizationInvitationSerializer as organizationInvitationSerializer } from '../../infrastructure/serializers/jsonapi/organization-invitation.serializer.js';
@@ -15,7 +14,7 @@ import { serializer as scoOrganizationInvitationSerializer } from '../../infrast
  */
 const cancelOrganizationInvitation = async function (request, h) {
   const organizationInvitationId = request.params.organizationInvitationId;
-  await libUsecases.cancelOrganizationInvitation({ organizationInvitationId });
+  await usecases.cancelOrganizationInvitation({ organizationInvitationId });
   return h.response().code(204);
 };
 

--- a/api/src/team/application/organization-invitations/organization-invitation.route.js
+++ b/api/src/team/application/organization-invitations/organization-invitation.route.js
@@ -1,5 +1,7 @@
 import Joi from 'joi';
 
+import { organizationController } from '../../../../lib/application/organizations/organization-controller.js';
+import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { organizationInvitationController } from './organization-invitation.controller.js';
 
@@ -25,7 +27,7 @@ export const organizationInvitationRoutes = [
       notes: [
         "- Cette route permet d'envoyer une invitation pour rejoindre une organisation de type SCO en tant que ADMIN, en renseignant un **UAI**, un **NOM** et un **PRÉNOM**",
       ],
-      tags: ['api', 'invitations', 'SCO'],
+      tags: ['team', 'api', 'invitations', 'SCO'],
     },
   },
   {
@@ -45,7 +47,31 @@ export const organizationInvitationRoutes = [
       notes: [
         "- Cette route permet de récupérer les détails d'une invitation selon un **id d'invitation** et un **code**\n",
       ],
-      tags: ['api', 'invitations'],
+      tags: ['team', 'api', 'invitations'],
+    },
+  },
+  {
+    method: 'DELETE',
+    path: '/api/organizations/{id}/invitations/{organizationInvitationId}',
+    config: {
+      pre: [
+        {
+          method: (request, h) => securityPreHandlers.checkUserIsAdminInOrganization(request, h),
+          assign: 'isAdminInOrganization',
+        },
+      ],
+      validate: {
+        params: Joi.object({
+          id: identifiersType.organizationId,
+          organizationInvitationId: identifiersType.organizationInvitationId,
+        }),
+      },
+      handler: (request, h) => organizationController.cancelOrganizationInvitation(request, h),
+      tags: ['team', 'api', 'invitations', 'cancel'],
+      notes: [
+        "- **Cette route est restreinte aux utilisateurs authentifiés en tant qu'admin d'une organisation**\n" +
+          "- Elle permet à l'administrateur de l'organisation d'annuler une invitation envoyée mais non acceptée encore.",
+      ],
     },
   },
 ];

--- a/api/src/team/application/organization-invitations/organization-invitation.route.js
+++ b/api/src/team/application/organization-invitations/organization-invitation.route.js
@@ -1,6 +1,5 @@
 import Joi from 'joi';
 
-import { organizationController } from '../../../../lib/application/organizations/organization-controller.js';
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { organizationInvitationController } from './organization-invitation.controller.js';
@@ -66,7 +65,7 @@ export const organizationInvitationRoutes = [
           organizationInvitationId: identifiersType.organizationInvitationId,
         }),
       },
-      handler: (request, h) => organizationController.cancelOrganizationInvitation(request, h),
+      handler: (request, h) => organizationInvitationController.cancelOrganizationInvitation(request, h),
       tags: ['team', 'api', 'invitations', 'cancel'],
       notes: [
         "- **Cette route est restreinte aux utilisateurs authentifiés en tant qu'admin d'une organisation**\n" +

--- a/api/src/team/application/routes.js
+++ b/api/src/team/application/routes.js
@@ -1,5 +1,6 @@
 import { certificationCenterInvitationAdminRoutes } from './certification-center-invitation/certification-center-invitation.admin.route.js';
 import { certificationCenterInvitationRoutes } from './certification-center-invitation/certification-center-invitation.route.js';
+import { organizationInvitationAdminRoutes } from './organization-invitations/organization-invitation.admin.route.js';
 import { organizationInvitationRoutes } from './organization-invitations/organization-invitation.route.js';
 import { prescriberInformationsRoute } from './prescriber-informations.route.js';
 
@@ -9,6 +10,7 @@ const register = async function (server) {
     ...certificationCenterInvitationAdminRoutes,
     ...prescriberInformationsRoute,
     ...organizationInvitationRoutes,
+    ...organizationInvitationAdminRoutes,
   ]);
 };
 

--- a/api/src/team/domain/errors.js
+++ b/api/src/team/domain/errors.js
@@ -1,6 +1,6 @@
-import { DomainError } from '../../shared/domain/errors.js';
+import { DomainError } from '../../../lib/domain/errors.js';
 
-export class UncancellableCertificationCenterInvitationError extends DomainError {
+class UncancellableCertificationCenterInvitationError extends DomainError {
   constructor(
     message = "L'invitation à ce centre de certification ne peut pas être annulée.",
     code = 'UNCANCELLABLE_CERTIFICATION_CENTER_INVITATION_CODE',
@@ -9,4 +9,19 @@ export class UncancellableCertificationCenterInvitationError extends DomainError
   }
 }
 
-export class MembershipNotFound extends DomainError {}
+class UncancellableOrganizationInvitationError extends DomainError {
+  constructor(
+    message = "L'invitation à cette organisation ne peut pas être annulée.",
+    code = 'UNCANCELLABLE_ORGANIZATION_INVITATION_CODE',
+  ) {
+    super(message, code);
+  }
+}
+
+class MembershipNotFound extends DomainError {}
+
+export {
+  MembershipNotFound,
+  UncancellableCertificationCenterInvitationError,
+  UncancellableOrganizationInvitationError,
+};

--- a/api/src/team/domain/usecases/cancel-organization-invitation.js
+++ b/api/src/team/domain/usecases/cancel-organization-invitation.js
@@ -1,4 +1,4 @@
-import { UncancellableOrganizationInvitationError } from '../../domain/errors.js';
+import { UncancellableOrganizationInvitationError } from '../../../../lib/domain/errors.js';
 
 const cancelOrganizationInvitation = async function ({ organizationInvitationId, organizationInvitationRepository }) {
   const foundOrganizationInvitation = await organizationInvitationRepository.get(organizationInvitationId);

--- a/api/src/team/domain/usecases/cancel-organization-invitation.js
+++ b/api/src/team/domain/usecases/cancel-organization-invitation.js
@@ -1,4 +1,4 @@
-import { UncancellableOrganizationInvitationError } from '../../../../lib/domain/errors.js';
+import { UncancellableOrganizationInvitationError } from '../errors.js';
 
 const cancelOrganizationInvitation = async function ({ organizationInvitationId, organizationInvitationRepository }) {
   const foundOrganizationInvitation = await organizationInvitationRepository.get(organizationInvitationId);

--- a/api/tests/acceptance/application/organizations/cancel-organization-invitation-delete_test.js
+++ b/api/tests/acceptance/application/organizations/cancel-organization-invitation-delete_test.js
@@ -9,35 +9,6 @@ import {
 } from '../../../test-helper.js';
 
 describe('Acceptance | Route | Organizations', function () {
-  describe('DELETE /api/organizations/{id}/invitations/{invitationId}', function () {
-    it('should return 204 HTTP status code', async function () {
-      // given
-      const server = await createServer();
-
-      const { adminUser, organization } = await insertOrganizationUserWithRoleAdmin();
-      const invitation = databaseBuilder.factory.buildOrganizationInvitation({
-        organizationId: organization.id,
-        status: OrganizationInvitation.StatusType.PENDING,
-      });
-
-      const options = {
-        method: 'DELETE',
-        url: `/api/organizations/${organization.id}/invitations/${invitation.id}`,
-        headers: {
-          authorization: generateValidRequestAuthorizationHeader(adminUser.id),
-        },
-      };
-
-      await databaseBuilder.commit();
-
-      // when
-      const response = await server.inject(options);
-
-      // then
-      expect(response.statusCode).to.equal(204);
-    });
-  });
-
   describe('DELETE /api/admin/organizations/{organizationId}/invitations/{invitationId}', function () {
     it('should return 204 HTTP status code', async function () {
       // given

--- a/api/tests/integration/application/organizations/index_test.js
+++ b/api/tests/integration/application/organizations/index_test.js
@@ -105,29 +105,6 @@ describe('Integration | Application | Organizations | Routes', function () {
     });
   });
 
-  describe('DELETE /api/admin/organizations/:organizationId/invitations/:organizationInvitationId', function () {
-    it('should return an HTTP status code 204', async function () {
-      // given
-      const method = 'DELETE';
-      const url = '/api/admin/organizations/1/invitations/1';
-
-      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
-      sinon
-        .stub(organizationController, 'cancelOrganizationInvitation')
-        .returns((request, h) => h.response().code(204));
-
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const { statusCode } = await httpTestServer.request(method, url);
-
-      // then
-      expect(statusCode).to.equal(204);
-      expect(organizationController.cancelOrganizationInvitation).to.have.been.calledOnce;
-    });
-  });
-
   describe('POST /api/organizations/:id/invitations', function () {
     it('should call the organization controller to send invitations', async function () {
       // given

--- a/api/tests/team/acceptance/application/organization-invitations/organization-invitation.admin.route.test.js
+++ b/api/tests/team/acceptance/application/organization-invitations/organization-invitation.admin.route.test.js
@@ -1,4 +1,4 @@
-import { OrganizationInvitation } from '../../../../src/team/domain/models/OrganizationInvitation.js';
+import { OrganizationInvitation } from '../../../../../src/team/domain/models/OrganizationInvitation.js';
 import {
   createServer,
   databaseBuilder,
@@ -6,11 +6,11 @@ import {
   generateValidRequestAuthorizationHeader,
   insertOrganizationUserWithRoleAdmin,
   insertUserWithRoleSuperAdmin,
-} from '../../../test-helper.js';
+} from '../../../../../tests/test-helper.js';
 
-describe('Acceptance | Route | Organizations', function () {
+describe('Acceptance | Team | Route | Admin | organization-invitation', function () {
   describe('DELETE /api/admin/organizations/{organizationId}/invitations/{invitationId}', function () {
-    it('should return 204 HTTP status code', async function () {
+    it('returns 204 HTTP status code', async function () {
       // given
       const server = await createServer();
 

--- a/api/tests/team/acceptance/application/organization-invitations/organization-invitation.route.test.js
+++ b/api/tests/team/acceptance/application/organization-invitations/organization-invitation.route.test.js
@@ -1,5 +1,11 @@
 import { OrganizationInvitation } from '../../../../../src/team/domain/models/OrganizationInvitation.js';
-import { createServer, databaseBuilder, expect } from '../../../../../tests/test-helper.js';
+import {
+  createServer,
+  databaseBuilder,
+  expect,
+  generateValidRequestAuthorizationHeader,
+  insertOrganizationUserWithRoleAdmin,
+} from '../../../../../tests/test-helper.js';
 
 describe('Acceptance | Team | Application | Controller | organization-invitation', function () {
   let server;
@@ -102,6 +108,35 @@ describe('Acceptance | Team | Application | Controller | organization-invitation
         // then
         expect(response.statusCode).to.equal(412);
       });
+    });
+  });
+
+  describe('DELETE /api/organizations/{id}/invitations/{invitationId}', function () {
+    it('returns 204 HTTP status code', async function () {
+      // given
+      const server = await createServer();
+
+      const { adminUser, organization } = await insertOrganizationUserWithRoleAdmin();
+      const invitation = databaseBuilder.factory.buildOrganizationInvitation({
+        organizationId: organization.id,
+        status: OrganizationInvitation.StatusType.PENDING,
+      });
+
+      const options = {
+        method: 'DELETE',
+        url: `/api/organizations/${organization.id}/invitations/${invitation.id}`,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(adminUser.id),
+        },
+      };
+
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(204);
     });
   });
 });

--- a/api/tests/team/integration/application/organization-invitation/organization-invitation.admin.route.test.js
+++ b/api/tests/team/integration/application/organization-invitation/organization-invitation.admin.route.test.js
@@ -1,0 +1,29 @@
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
+import { organizationInvitationController } from '../../../../../src/team/application/organization-invitations/organization-invitation.controller.js';
+import { teamRoutes } from '../../../../../src/team/application/routes.js';
+import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
+
+describe('Integration | Team | Application | Route | Admin | organization-invitations', function () {
+  describe('DELETE /api/admin/organizations/:organizationId/invitations/:organizationInvitationId', function () {
+    it('returns an HTTP status code 204', async function () {
+      // given
+      const method = 'DELETE';
+      const url = '/api/admin/organizations/1/invitations/1';
+
+      sinon.stub(securityPreHandlers, 'hasAtLeastOneAccessOf').returns(() => true);
+      sinon
+        .stub(organizationInvitationController, 'cancelOrganizationInvitation')
+        .returns((request, h) => h.response().code(204));
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(teamRoutes[0]);
+
+      // when
+      const { statusCode } = await httpTestServer.request(method, url);
+
+      // then
+      expect(statusCode).to.equal(204);
+      expect(organizationInvitationController.cancelOrganizationInvitation).to.have.been.calledOnce;
+    });
+  });
+});

--- a/api/tests/team/unit/application/http-error-mapper-configuration.test.js
+++ b/api/tests/team/unit/application/http-error-mapper-configuration.test.js
@@ -1,0 +1,19 @@
+import { HttpErrors } from '../../../../src/shared/application/http-errors.js';
+import { teamDomainErrorMappingConfiguration } from '../../../../src/team/application/http-error-mapper-configuration.js';
+import { UncancellableOrganizationInvitationError } from '../../../../src/team/domain/errors.js';
+import { expect } from '../../../test-helper.js';
+
+describe('Unit | Team | Application | HttpErrorMapperConfiguration', function () {
+  it('instantiates UnprocessableEntityError when UncancellableOrganizationInvitationError', async function () {
+    //given
+    const httpErrorMapper = teamDomainErrorMappingConfiguration.find(
+      (httpErrorMapper) => httpErrorMapper.name === UncancellableOrganizationInvitationError.name,
+    );
+
+    //when
+    const error = httpErrorMapper.httpErrorFn(new UncancellableOrganizationInvitationError());
+
+    //then
+    expect(error).to.be.instanceOf(HttpErrors.UnprocessableEntityError);
+  });
+});

--- a/api/tests/team/unit/application/organization-invitation/organization-invitation.controller.test.js
+++ b/api/tests/team/unit/application/organization-invitation/organization-invitation.controller.test.js
@@ -1,7 +1,9 @@
 import { MissingQueryParamError } from '../../../../../lib/application/http-errors.js';
+import { usecases as libUsecases } from '../../../../../lib/domain/usecases/index.js';
 import { organizationInvitationController } from '../../../../../src/team/application/organization-invitations/organization-invitation.controller.js';
+import { OrganizationInvitation } from '../../../../../src/team/domain/models/OrganizationInvitation.js';
 import { usecases } from '../../../../../src/team/domain/usecases/index.js';
-import { catchErr, expect, hFake, sinon } from '../../../../../tests/test-helper.js';
+import { catchErr, domainBuilder, expect, hFake, sinon } from '../../../../../tests/test-helper.js';
 
 describe('Unit | Team | Application | Controller | organization-invitation', function () {
   describe('#getOrganizationInvitation', function () {
@@ -44,6 +46,35 @@ describe('Unit | Team | Application | Controller | organization-invitation', fun
 
       // then
       expect(errorCatched).to.be.instanceof(MissingQueryParamError);
+    });
+  });
+
+  describe('#cancelOrganizationInvitation', function () {
+    it('calls the use case to cancel invitation with organizationInvitationId', async function () {
+      //given
+      const organizationInvitationId = 123;
+
+      const request = {
+        auth: { credentials: { userId: 1 } },
+        params: { organizationInvitationId },
+      };
+      const cancelledOrganizationInvitation = domainBuilder.buildOrganizationInvitation({
+        id: organizationInvitationId,
+        status: OrganizationInvitation.StatusType.CANCELLED,
+      });
+
+      sinon
+        .stub(libUsecases, 'cancelOrganizationInvitation')
+        .withArgs({
+          organizationInvitationId: cancelledOrganizationInvitation.id,
+        })
+        .resolves(cancelledOrganizationInvitation);
+
+      // when
+      const response = await organizationInvitationController.cancelOrganizationInvitation(request, hFake);
+
+      // then
+      expect(response.statusCode).to.equal(204);
     });
   });
 });

--- a/api/tests/team/unit/application/organization-invitation/organization-invitation.controller.test.js
+++ b/api/tests/team/unit/application/organization-invitation/organization-invitation.controller.test.js
@@ -1,5 +1,4 @@
 import { MissingQueryParamError } from '../../../../../lib/application/http-errors.js';
-import { usecases as libUsecases } from '../../../../../lib/domain/usecases/index.js';
 import { organizationInvitationController } from '../../../../../src/team/application/organization-invitations/organization-invitation.controller.js';
 import { OrganizationInvitation } from '../../../../../src/team/domain/models/OrganizationInvitation.js';
 import { usecases } from '../../../../../src/team/domain/usecases/index.js';
@@ -64,7 +63,7 @@ describe('Unit | Team | Application | Controller | organization-invitation', fun
       });
 
       sinon
-        .stub(libUsecases, 'cancelOrganizationInvitation')
+        .stub(usecases, 'cancelOrganizationInvitation')
         .withArgs({
           organizationInvitationId: cancelledOrganizationInvitation.id,
         })

--- a/api/tests/team/unit/application/organization-invitation/organization-invitation.route.test.js
+++ b/api/tests/team/unit/application/organization-invitation/organization-invitation.route.test.js
@@ -1,3 +1,5 @@
+import { organizationController } from '../../../../../lib/application/organizations/organization-controller.js';
+import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { organizationInvitationController } from '../../../../../src/team/application/organization-invitations/organization-invitation.controller.js';
 import { teamRoutes } from '../../../../../src/team/application/routes.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
@@ -35,6 +37,29 @@ describe('Unit | Team | Application | Route | organization-invitation', function
 
       // then
       expect(response.statusCode).to.equal(400);
+    });
+  });
+
+  describe('DELETE /api/organizations/{id}/invitations/{invitationId}', function () {
+    it('calls the cancel organization invitation controller', async function () {
+      // given
+      sinon
+        .stub(organizationController, 'cancelOrganizationInvitation')
+        .callsFake((request, h) => h.response('ok').code(200));
+      sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization').returns(true);
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(teamRoutes[0]);
+
+      const method = 'DELETE';
+      const url = '/api/organizations/1/invitations/1';
+
+      // when
+      await httpTestServer.request(method, url);
+
+      // then
+      expect(securityPreHandlers.checkUserIsAdminInOrganization).to.have.be.called;
+      expect(organizationController.cancelOrganizationInvitation).to.have.been.calledOnce;
     });
   });
 });

--- a/api/tests/team/unit/application/organization-invitation/organization-invitation.route.test.js
+++ b/api/tests/team/unit/application/organization-invitation/organization-invitation.route.test.js
@@ -1,4 +1,3 @@
-import { organizationController } from '../../../../../lib/application/organizations/organization-controller.js';
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { organizationInvitationController } from '../../../../../src/team/application/organization-invitations/organization-invitation.controller.js';
 import { teamRoutes } from '../../../../../src/team/application/routes.js';
@@ -44,7 +43,7 @@ describe('Unit | Team | Application | Route | organization-invitation', function
     it('calls the cancel organization invitation controller', async function () {
       // given
       sinon
-        .stub(organizationController, 'cancelOrganizationInvitation')
+        .stub(organizationInvitationController, 'cancelOrganizationInvitation')
         .callsFake((request, h) => h.response('ok').code(200));
       sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization').returns(true);
 
@@ -59,7 +58,7 @@ describe('Unit | Team | Application | Route | organization-invitation', function
 
       // then
       expect(securityPreHandlers.checkUserIsAdminInOrganization).to.have.be.called;
-      expect(organizationController.cancelOrganizationInvitation).to.have.been.calledOnce;
+      expect(organizationInvitationController.cancelOrganizationInvitation).to.have.been.calledOnce;
     });
   });
 });

--- a/api/tests/team/unit/domain/usecases/cancel-organization-invitation_test.js
+++ b/api/tests/team/unit/domain/usecases/cancel-organization-invitation_test.js
@@ -1,9 +1,9 @@
-import { NotFoundError, UncancellableOrganizationInvitationError } from '../../../../lib/domain/errors.js';
-import { cancelOrganizationInvitation } from '../../../../lib/domain/usecases/cancel-organization-invitation.js';
-import { OrganizationInvitation } from '../../../../src/team/domain/models/OrganizationInvitation.js';
-import { catchErr, domainBuilder, expect, sinon } from '../../../test-helper.js';
+import { NotFoundError, UncancellableOrganizationInvitationError } from '../../../../../lib/domain/errors.js';
+import { OrganizationInvitation } from '../../../../../src/team/domain/models/OrganizationInvitation.js';
+import { cancelOrganizationInvitation } from '../../../../../src/team/domain/usecases/cancel-organization-invitation.js';
+import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.js';
 
-describe('Unit | UseCase | cancel-organization-invitation', function () {
+describe('Unit | Team | Domain | UseCase | cancel-organization-invitation', function () {
   let organizationInvitationRepository;
 
   beforeEach(function () {
@@ -14,7 +14,7 @@ describe('Unit | UseCase | cancel-organization-invitation', function () {
   });
 
   context("when invitation doesn't exist", function () {
-    it('should throw an error', async function () {
+    it('throws an error', async function () {
       // given
       organizationInvitationRepository.get.rejects(new NotFoundError());
 
@@ -30,7 +30,7 @@ describe('Unit | UseCase | cancel-organization-invitation', function () {
 
   context('when invitation exist ', function () {
     context('when invitation is not pending', function () {
-      it('should throw an uncancellable organization invitation error', async function () {
+      it('throws an uncancellable organization invitation error', async function () {
         // given
         const status = OrganizationInvitation.StatusType.ACCEPTED;
         const organizationInvitation = domainBuilder.buildOrganizationInvitation({ status });
@@ -48,7 +48,7 @@ describe('Unit | UseCase | cancel-organization-invitation', function () {
     });
 
     context('when invitation is pending', function () {
-      it('should return the cancelled organization invitation', async function () {
+      it('returns the cancelled organization invitation', async function () {
         // given
         const status = OrganizationInvitation.StatusType.PENDING;
         const organizationInvitation = domainBuilder.buildOrganizationInvitation({ status });

--- a/api/tests/team/unit/domain/usecases/cancel-organization-invitation_test.js
+++ b/api/tests/team/unit/domain/usecases/cancel-organization-invitation_test.js
@@ -1,4 +1,5 @@
-import { NotFoundError, UncancellableOrganizationInvitationError } from '../../../../../lib/domain/errors.js';
+import { NotFoundError } from '../../../../../lib/domain/errors.js';
+import { UncancellableOrganizationInvitationError } from '../../../../../src/team/domain/errors.js';
 import { OrganizationInvitation } from '../../../../../src/team/domain/models/OrganizationInvitation.js';
 import { cancelOrganizationInvitation } from '../../../../../src/team/domain/usecases/cancel-organization-invitation.js';
 import { catchErr, domainBuilder, expect, sinon } from '../../../../test-helper.js';

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -23,7 +23,6 @@ import {
   OrganizationLearnerCannotBeDissociatedError,
   SendingEmailToInvalidDomainError,
   SendingEmailToInvalidEmailAddressError,
-  UncancellableOrganizationInvitationError,
   UnexpectedUserAccountError,
   UserHasAlreadyLeftSCO,
   UserShouldNotBeReconciledOnAnotherAccountError,
@@ -216,19 +215,6 @@ describe('Unit | Application | ErrorManager', function () {
 
       // then
       expect(HttpErrors.ForbiddenError).to.have.been.calledWithExactly(error.message, error.code);
-    });
-
-    it('should instantiate UnprocessableEntityError when UncancellableOrganizationInvitationError', async function () {
-      // given
-      const error = new UncancellableOrganizationInvitationError();
-      sinon.stub(HttpErrors, 'UnprocessableEntityError');
-      const params = { request: {}, h: hFake, error };
-
-      // when
-      await handle(params.request, params.h, params.error);
-
-      // then
-      expect(HttpErrors.UnprocessableEntityError).to.have.been.calledWithExactly(error.message);
     });
 
     it('should instantiate UnprocessableEntityError when UserShouldNotBeReconciledOnAnotherAccountError', async function () {

--- a/api/tests/unit/application/organizations/index_test.js
+++ b/api/tests/unit/application/organizations/index_test.js
@@ -509,27 +509,4 @@ describe('Unit | Router | organization-router', function () {
       expect(response.result.data).to.deep.equal([]);
     });
   });
-
-  describe('DELETE /api/organizations/{id}/invitations/{invitationId}', function () {
-    it('should call the cancel organization invitation controller', async function () {
-      // given
-      sinon
-        .stub(organizationController, 'cancelOrganizationInvitation')
-        .callsFake((request, h) => h.response('ok').code(200));
-      sinon.stub(securityPreHandlers, 'checkUserIsAdminInOrganization').returns(true);
-
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      const method = 'DELETE';
-      const url = '/api/organizations/1/invitations/1';
-
-      // when
-      await httpTestServer.request(method, url);
-
-      // then
-      expect(securityPreHandlers.checkUserIsAdminInOrganization).to.have.be.called;
-      expect(organizationController.cancelOrganizationInvitation).to.have.been.calledOnce;
-    });
-  });
 });

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -1,5 +1,5 @@
 import { organizationController } from '../../../../lib/application/organizations/organization-controller.js';
-import { Membership, Organization, OrganizationInvitation } from '../../../../lib/domain/models/index.js';
+import { Membership, Organization } from '../../../../lib/domain/models/index.js';
 import { usecases } from '../../../../lib/domain/usecases/index.js';
 import { domainBuilder, expect, generateValidRequestAuthorizationHeader, hFake, sinon } from '../../../test-helper.js';
 
@@ -222,35 +222,6 @@ describe('Unit | Application | Organizations | organization-controller', functio
 
       // then
       expect(usecases.createOrganizationInvitations).to.have.been.calledWithExactly({ organizationId, emails, locale });
-    });
-  });
-
-  describe('#cancelOrganizationInvitation', function () {
-    it('should call the use case to cancel invitation with organizationInvitationId', async function () {
-      //given
-      const organizationInvitationId = 123;
-
-      const request = {
-        auth: { credentials: { userId: 1 } },
-        params: { organizationInvitationId },
-      };
-      const cancelledOrganizationInvitation = domainBuilder.buildOrganizationInvitation({
-        id: organizationInvitationId,
-        status: OrganizationInvitation.StatusType.CANCELLED,
-      });
-
-      sinon
-        .stub(usecases, 'cancelOrganizationInvitation')
-        .withArgs({
-          organizationInvitationId: cancelledOrganizationInvitation.id,
-        })
-        .resolves(cancelledOrganizationInvitation);
-
-      // when
-      const response = await organizationController.cancelOrganizationInvitation(request, hFake);
-
-      // then
-      expect(response.statusCode).to.equal(204);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Les routes DELETE /api/organizations/{id}/invitations/{organizationInvitationId} et /api/admin/organizations/{id}/invitations/{organizationInvitationId}  sont encore dans lib.

## :robot: Proposition
Les migrer dans src et 2 routes et le code associé (use case et repo)

## :rainbow: Remarques

N/A

## :100: Pour tester

Test de `DELETE /api/organizations/{id}/invitations/{organizationInvitationId}`
1. Se connecter à pix orga (ex: allorga@example.net)
2. Aller sur Equipes
3. Envoyer une invitation
4. Annuler l'invitation
> L'invitation est supprimée 

Test de `DELETE /api/admin/organizations/{id}/invitations/{organizationInvitationId}`
1. Se connecter à pix admin (ex: superadmin@example.net)
2. Aller sur une organisation 
3. Envoyer une invitation
4. Annuler l'invitation
> L'invitation est supprimée 
