### PR TITLE
[FEATURE] Ajouter dans le didacticiel un embed sans complétion requise (PIX-13091)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -321,6 +321,55 @@
       ]
     },
     {
+      "id": "46577fb1-aadb-49ba-b3fd-721a11da8eb4",
+      "type": "activity",
+      "title": "Embed non-auto",
+      "components": [
+        {
+          "type": "element",
+          "element": {
+            "id": "0e3315fd-98ad-492f-9046-4aa867495d84",
+            "type": "embed",
+            "isCompletionRequired": false,
+            "title": "Application",
+            "url": "https://epreuves.pix.fr/fake2.html",
+            "height": 640
+          }
+        },
+        {
+          "type": "element",
+          "element": {
+            "id": "74d63ec2-f3e3-4ffe-9806-208d33588553",
+            "type": "qcm",
+            "instruction": "<p>Parcourez ces photos trouvées sur le Web : lesquelles correspondent à des situations fictives&#8239;?</p>",
+            "proposals": [
+              {
+                "id": "1",
+                "content": "Photo 1"
+              },
+              {
+                "id": "2",
+                "content": "Photo 2"
+              },
+              {
+                "id": "3",
+                "content": "Photo 3"
+              },
+              {
+                "id": "4",
+                "content": "Photo 4"
+              }
+            ],
+            "feedbacks": {
+              "valid": "<span class=\"feedback__state\">Correct&#8239;!</span>",
+              "invalid": "<span class=\"feedback__state\">Et non&#8239;!</span>"
+            },
+            "solutions": ["1", "2", "4"]
+          }
+        }
+      ]
+    },
+    {
       "id": "7cf75e70-8749-4392-8081-f2c02badb0fb",
       "type": "activity",
       "title": "Le nom de ce produit",

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/embed.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/embed.js
@@ -1,0 +1,14 @@
+import Joi from 'joi';
+
+import { htmlNotAllowedSchema, uuidSchema } from '../utils.js';
+
+const embedSchema = Joi.object({
+  id: uuidSchema,
+  type: Joi.string().valid('embed').required(),
+  isCompletionRequired: Joi.boolean().valid(false).required(),
+  title: htmlNotAllowedSchema.required(),
+  url: Joi.string().uri().required(),
+  height: Joi.number().min(0).required(),
+}).required();
+
+export { embedSchema };

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/index.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/index.js
@@ -1,3 +1,4 @@
+import { embedSchema } from './embed.js';
 import { imageElementSchema } from './image.js';
 import { qcmElementSchema } from './qcm.js';
 import { qcuElementSchema } from './qcu.js';
@@ -8,6 +9,7 @@ import { videoElementSchema } from './video.js';
 export {
   blockInputSchema,
   blockSelectSchema,
+  embedSchema,
   imageElementSchema,
   qcmElementSchema,
   qcuElementSchema,

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module.js
@@ -1,6 +1,7 @@
 import Joi from 'joi';
 
 import {
+  embedSchema,
   imageElementSchema,
   qcmElementSchema,
   qcuElementSchema,
@@ -31,6 +32,7 @@ const elementSchema = Joi.alternatives().conditional('.type', {
     { is: 'qcm', then: qcmElementSchema },
     { is: 'qrocm', then: qrocmElementSchema },
     { is: 'video', then: videoElementSchema },
+    { is: 'embed', then: embedSchema },
   ],
 });
 

--- a/high-level-tests/e2e/cypress/integration/pix-app/modulix-a11y.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/modulix-a11y.feature
@@ -18,6 +18,7 @@ Fonctionnalité: Accessibilité de Modulix
     Quand je vais au grain suivant
     Quand je vais au grain suivant
     Quand je vais au grain suivant
+    Quand je vais au grain suivant
     Alors la page devrait être accessible
     Quand je clique sur "Terminer"
     Et que j'attends 500 ms


### PR DESCRIPTION
## :unicorn: Problème
Nous débutons l'implémentation au sein de Modulix d'`embed` ne nécessitant pas de complétion. Mais nous n'avons pas encore cette typologie d'élément dans le référentiel.

## :robot: Proposition
Ajouter cette typologie d'élément dans le référentiel.

## :rainbow: Remarques

### Revue du modèle de données

Suite au premier craquage sur le sujet, nous considérions deux types d'`embed`, ceux qui sont auto, et ceux qui sont _non-auto_.
En prenant de la hauteur fonctionnelle sur le sujet, il nous est venu que ces deux types ne remplissaient pas correctement les différents cas d'usage des `embed` dans Modulix.
Nous avons finalement opté pour un seul type "`embed`", et nous avons différencié deux cas d'usage via une propriété _boolean_ `isCompletionRequired`. Ces deux cas sont les suivants:

1. Les `embed` que l'utilisateur est invité **`à finir`** et qui annoncent lorsqu'ils sont complétés (cf. des simulateurs dans _pix-editor_ considérés comme `embed-auto`)
2. Les `embed` que l'utilisateur est invité **`à utiliser`** mais dont la complétion n'entre pas en ligne de compte (cf. des simulateurs qui permettent de répondre à un qcm, ou bien des simulateurs qui ne sont utilisés que pour de l'engagement).

Le premier cas aura donc `isCompletionRequired` à `true`
Le second cas aura donc `isCompletionRequired` à `false`

Bien que la complétion du simulateur n'est jamais réellement requise (car le user peut cliquer sur "_Passer_"), ce terme a été validé par le contenu métier. Néanmoins, il pourra être challengé par la suite si on trouve mieux.

### Validation Joi

Étant donné que nous commençons à implémenter les `embed` qui n'ont pas de complétion requise, nous avons fait le choix de forcer l'usage du `isCompletionRequired` à `false` lors de la validation _Joi_, cela afin d'éviter qu'on contribue à un nouvel `embed` qui aurait `isCompletionRequired` à `true` avant que ce genre de comportement ne soit implémenté.

Pour la hauteur d'un `embed`, nous avons proposé naïvement de mettre un minimum de 0 dans la validation Joi.

## :100: Pour tester

### Tests de non régression fonctionnels

1. Se rendre sur [le didacticiel](https://app-pr9445.review.pix.fr/modules/didacticiel-modulix)
2. Parcourir le module
4. Vérifier que rien n'est cassé

### Tests de non régression contribution

1. Récupérer cette branche en local
2. Lancer le script `npm run modulix:test`
3. S'assurer que tous les tests passent au vert
