### PR TITLE
[TECH] Utilisation de crypto.randomBytes de manière asynchrone

### DIFF
--- a/api/src/identity-access-management/domain/services/reset-password.service.js
+++ b/api/src/identity-access-management/domain/services/reset-password.service.js
@@ -1,14 +1,11 @@
-import crypto from 'node:crypto';
-import util from 'node:util';
-
 import jsonwebtoken from 'jsonwebtoken';
 
 import { config } from '../../../shared/config.js';
+import { cryptoService } from '../../../shared/domain/services/crypto-service.js';
 import * as passwordResetDemandRepository from '../../infrastructure/repositories/reset-password-demand.repository.js';
 
 const generateTemporaryKey = async function () {
-  const promisifiedRandomBytes = util.promisify(crypto.randomBytes);
-  const randomBytesBuffer = await promisifiedRandomBytes(16);
+  const randomBytesBuffer = await cryptoService.randomBytes(16);
   const base64RandomBytes = randomBytesBuffer.toString('base64');
   return jsonwebtoken.sign(
     {

--- a/api/src/identity-access-management/domain/services/reset-password.service.js
+++ b/api/src/identity-access-management/domain/services/reset-password.service.js
@@ -1,14 +1,18 @@
 import crypto from 'node:crypto';
+import util from 'node:util';
 
 import jsonwebtoken from 'jsonwebtoken';
 
 import { config } from '../../../shared/config.js';
 import * as passwordResetDemandRepository from '../../infrastructure/repositories/reset-password-demand.repository.js';
 
-const generateTemporaryKey = function () {
+const generateTemporaryKey = async function () {
+  const promisifiedRandomBytes = util.promisify(crypto.randomBytes);
+  const randomBytesBuffer = await promisifiedRandomBytes(16);
+  const base64RandomBytes = randomBytesBuffer.toString('base64');
   return jsonwebtoken.sign(
     {
-      data: crypto.randomBytes(16).toString('base64'),
+      data: base64RandomBytes,
     },
     config.temporaryKey.secret,
     { expiresIn: config.temporaryKey.tokenLifespan },

--- a/api/src/identity-access-management/domain/usecases/create-reset-password-demand.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/create-reset-password-demand.usecase.js
@@ -8,7 +8,7 @@ export const createResetPasswordDemand = async function ({
 }) {
   await userRepository.isUserExistingByEmail(email);
 
-  const temporaryKey = resetPasswordService.generateTemporaryKey();
+  const temporaryKey = await resetPasswordService.generateTemporaryKey();
   const passwordResetDemand = await resetPasswordDemandRepository.create({ email, temporaryKey });
 
   await mailService.sendResetPasswordDemandEmail({ email, locale, temporaryKey });

--- a/api/src/identity-access-management/domain/usecases/send-email-for-account-recovery.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/send-email-for-account-recovery.usecase.js
@@ -1,6 +1,9 @@
 import crypto from 'node:crypto';
+import util from 'node:util';
 
 import { AccountRecoveryDemand } from '../models/AccountRecoveryDemand.js';
+
+const randomBytes = util.promisify(crypto.randomBytes);
 
 /**
  * @param {{
@@ -26,7 +29,13 @@ export const sendEmailForAccountRecovery = async function ({
   userReconciliationService,
 }) {
   const { email: newEmail } = studentInformation;
-  const encodedTemporaryKey = temporaryKey || crypto.randomBytes(32).toString('hex');
+  let encodedTemporaryKey;
+  if (temporaryKey) {
+    encodedTemporaryKey = temporaryKey;
+  } else {
+    const bufferRandomBytes = await randomBytes(32);
+    encodedTemporaryKey = bufferRandomBytes.toString('hex');
+  }
 
   const {
     firstName,

--- a/api/src/identity-access-management/domain/usecases/send-email-for-account-recovery.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/send-email-for-account-recovery.usecase.js
@@ -1,9 +1,5 @@
-import crypto from 'node:crypto';
-import util from 'node:util';
-
+import { cryptoService } from '../../../shared/domain/services/crypto-service.js';
 import { AccountRecoveryDemand } from '../models/AccountRecoveryDemand.js';
-
-const randomBytes = util.promisify(crypto.randomBytes);
 
 /**
  * @param {{
@@ -33,8 +29,8 @@ export const sendEmailForAccountRecovery = async function ({
   if (temporaryKey) {
     encodedTemporaryKey = temporaryKey;
   } else {
-    const bufferRandomBytes = await randomBytes(32);
-    encodedTemporaryKey = bufferRandomBytes.toString('hex');
+    const randomBytesBuffer = await cryptoService.randomBytes(32);
+    encodedTemporaryKey = randomBytesBuffer.toString('hex');
   }
 
   const {

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js
@@ -1,15 +1,12 @@
-import crypto from 'node:crypto';
-import util from 'node:util';
-
 import _ from 'lodash';
 
 import { knex } from '../../../../../db/knex-database-connection.js';
+import { cryptoService } from '../../../../shared/domain/services/crypto-service.js';
 import * as skillRepository from '../../../../shared/infrastructure/repositories/skill-repository.js';
 import { ApplicationTransaction } from '../../../shared/infrastructure/ApplicationTransaction.js';
 import { UnknownCampaignId } from '../../domain/errors.js';
 import { Campaign } from '../../domain/models/Campaign.js';
 
-const randomBytes = util.promisify(crypto.randomBytes);
 const CAMPAIGN_ATTRIBUTES = [
   'deletedAt',
   'deletedBy',
@@ -119,8 +116,8 @@ const isCodeAvailable = async function ({ code }) {
 
 const swapCampaignCodes = async function ({ firstCampaignId, secondCampaignId }) {
   const trx = await knex.transaction();
-  const bufferRandomBytes = await randomBytes(16);
-  const temporaryCode = bufferRandomBytes.toString('base64');
+  const randomBytesBuffer = await cryptoService.randomBytes(16);
+  const temporaryCode = randomBytesBuffer.toString('base64');
 
   try {
     const [{ code: firstCode }, { code: secondCode }] = await Promise.all([

--- a/api/src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js
+++ b/api/src/prescription/campaign/infrastructure/repositories/campaign-administration-repository.js
@@ -1,4 +1,5 @@
 import crypto from 'node:crypto';
+import util from 'node:util';
 
 import _ from 'lodash';
 
@@ -8,6 +9,7 @@ import { ApplicationTransaction } from '../../../shared/infrastructure/Applicati
 import { UnknownCampaignId } from '../../domain/errors.js';
 import { Campaign } from '../../domain/models/Campaign.js';
 
+const randomBytes = util.promisify(crypto.randomBytes);
 const CAMPAIGN_ATTRIBUTES = [
   'deletedAt',
   'deletedBy',
@@ -117,7 +119,8 @@ const isCodeAvailable = async function ({ code }) {
 
 const swapCampaignCodes = async function ({ firstCampaignId, secondCampaignId }) {
   const trx = await knex.transaction();
-  const temporaryCode = crypto.randomBytes(16).toString('base64');
+  const bufferRandomBytes = await randomBytes(16);
+  const temporaryCode = bufferRandomBytes.toString('base64');
 
   try {
     const [{ code: firstCode }, { code: secondCode }] = await Promise.all([

--- a/api/src/shared/domain/services/crypto-service.js
+++ b/api/src/shared/domain/services/crypto-service.js
@@ -88,6 +88,7 @@ const decrypt = async function (phcText) {
 
 /**
  * @typedef {Object} CryptoService
+ * @property {function} randomBytes
  * @property {function} checkPassword
  * @property {function} decrypt
  * @property {function} encrypt
@@ -95,6 +96,6 @@ const decrypt = async function (phcText) {
  * @property {function} hashPasswordSync
  * @property {RegExp} phcRegexp
  */
-const cryptoService = { checkPassword, decrypt, encrypt, hashPassword, hashPasswordSync, phcRegexp };
+const cryptoService = { randomBytes, checkPassword, decrypt, encrypt, hashPassword, hashPasswordSync, phcRegexp };
 
 export { cryptoService };

--- a/api/tests/acceptance/application/passwords/password-controller_test.js
+++ b/api/tests/acceptance/application/passwords/password-controller_test.js
@@ -33,8 +33,8 @@ describe('Acceptance | Controller | password-controller', function () {
     context('when temporaryKey is valid', function () {
       let temporaryKey;
 
-      beforeEach(function () {
-        temporaryKey = resetPasswordService.generateTemporaryKey();
+      beforeEach(async function () {
+        temporaryKey = await resetPasswordService.generateTemporaryKey();
         options.url = `/api/password-reset-demands/${temporaryKey}`;
       });
 

--- a/api/tests/identity-access-management/integration/domain/services/reset-password.service.test.js
+++ b/api/tests/identity-access-management/integration/domain/services/reset-password.service.test.js
@@ -4,10 +4,10 @@ import { expect } from '../../../../test-helper.js';
 describe('Integration | Identity Access Management | Domain | Service | reset-password', function () {
   describe('#generateTemporaryKey', function () {
     context('when two users send a request at the same second', function () {
-      it('generates different temporaryKeys', function () {
+      it('generates different temporaryKeys', async function () {
         // when
-        const temporaryKeyUser1 = resetPasswordService.generateTemporaryKey();
-        const temporaryKeyUser2 = resetPasswordService.generateTemporaryKey();
+        const temporaryKeyUser1 = await resetPasswordService.generateTemporaryKey();
+        const temporaryKeyUser2 = await resetPasswordService.generateTemporaryKey();
 
         // then
         expect(temporaryKeyUser1).to.not.equal(temporaryKeyUser2);

--- a/api/tests/identity-access-management/unit/domain/services/reset-password.service.test.js
+++ b/api/tests/identity-access-management/unit/domain/services/reset-password.service.test.js
@@ -1,9 +1,8 @@
-import crypto from 'node:crypto';
-
 import jsonwebtoken from 'jsonwebtoken';
 
 import * as resetPasswordService from '../../../../../src/identity-access-management/domain/services/reset-password.service.js';
 import { config as settings } from '../../../../../src/shared/config.js';
+import { cryptoService } from '../../../../../src/shared/domain/services/crypto-service.js';
 import { expect, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Identity Access Management | Domain | Service | reset-password', function () {
@@ -13,7 +12,7 @@ describe('Unit | Identity Access Management | Domain | Service | reset-password'
     beforeEach(function () {
       sinon.stub(jsonwebtoken, 'sign');
       randomGeneratedString = 'aaaaaa';
-      sinon.stub(crypto, 'randomBytes').yields(null, randomGeneratedString);
+      sinon.stub(cryptoService, 'randomBytes').resolves(randomGeneratedString);
     });
 
     it('calls sign function from jwt', async function () {

--- a/api/tests/identity-access-management/unit/domain/services/reset-password.service.test.js
+++ b/api/tests/identity-access-management/unit/domain/services/reset-password.service.test.js
@@ -13,10 +13,10 @@ describe('Unit | Identity Access Management | Domain | Service | reset-password'
     beforeEach(function () {
       sinon.stub(jsonwebtoken, 'sign');
       randomGeneratedString = 'aaaaaa';
-      sinon.stub(crypto, 'randomBytes').returns(randomGeneratedString);
+      sinon.stub(crypto, 'randomBytes').yields(null, randomGeneratedString);
     });
 
-    it('calls sign function from jwt', function () {
+    it('calls sign function from jwt', async function () {
       // given
       const signParams = {
         payload: { data: randomGeneratedString },
@@ -25,7 +25,7 @@ describe('Unit | Identity Access Management | Domain | Service | reset-password'
       };
 
       // when
-      resetPasswordService.generateTemporaryKey();
+      await resetPasswordService.generateTemporaryKey();
 
       // then
       sinon.assert.calledOnce(jsonwebtoken.sign);

--- a/api/tests/integration/domain/usecases/get-user-by-reset-password-demand_test.js
+++ b/api/tests/integration/domain/usecases/get-user-by-reset-password-demand_test.js
@@ -19,7 +19,7 @@ describe('Integration | UseCases | get-user-by-reset-password-demand', function 
 
   it('should return an user', async function () {
     // given
-    temporaryKey = resetPasswordService.generateTemporaryKey();
+    temporaryKey = await resetPasswordService.generateTemporaryKey();
     databaseBuilder.factory.buildResetPasswordDemand({ email, temporaryKey });
     await databaseBuilder.commit();
 
@@ -51,7 +51,7 @@ describe('Integration | UseCases | get-user-by-reset-password-demand', function 
 
   it('should throws PasswordResetDemandNotFoundError if resetPasswordDemand does not exist', async function () {
     // given
-    const unknownTemporaryKey = resetPasswordService.generateTemporaryKey();
+    const unknownTemporaryKey = await resetPasswordService.generateTemporaryKey();
 
     // when
     const error = await catchErr(getUserByResetPasswordDemand)({
@@ -67,7 +67,7 @@ describe('Integration | UseCases | get-user-by-reset-password-demand', function 
 
   it('should throws UserNotFoundError if user with email does not exist', async function () {
     // given
-    temporaryKey = resetPasswordService.generateTemporaryKey();
+    temporaryKey = await resetPasswordService.generateTemporaryKey();
     databaseBuilder.factory.buildResetPasswordDemand({ temporaryKey });
 
     await databaseBuilder.commit();


### PR DESCRIPTION
## :unicorn: Problème
La fonction crypto.randomBytes est synchrone. Comme toutes les fonctions synchrones elle est bloquante et ne permet pas de tirer partie au mieux des capacités de Node.js.

## :robot: Proposition
Passer toutes les utilisation de crypto.randomBytes en asynchrone en utilisant util.promisify un peu comme ceci:
```javascript
import crypto from 'node:crypto';
import util from 'node:util';
const randomBytes = util.promisify(crypto.randomBytes);
const display = async () => {
	const bufferRandomBytes = await randomBytes(16);
	const base64RandomBytes = bufferRandomBytes.toString('base64');
	return base64RandomBytes;
};
```

cf. https://nodejs.org/en/learn/asynchronous-work/dont-block-the-event-loop

## :rainbow: Remarques
Dans [ce fichier](https://github.com/1024pix/pix/blob/async-crypto/api/src/identity-access-management/domain/services/reset-password.service.js), on déclare la variable randomBytes dans la fonction de génération de clef temporaire pour permettre son utilisation depuis les tests. Cela n'impacte pas le reste du code:)

## :100: Pour tester
Exécuter dans le dossier api:
```shell
npm test
```
Tous les tests doivent passer;)