### PR TITLE
[TECH] Éviter la purge de la table certification-center-features lors de l'éxécution du script d'ajout de centre pilote pour la séparation (PIX-13280)

### DIFF
--- a/api/scripts/certification/next-gen/import-complementary-alone-feature-pilot-certification-centers-from-csv.js
+++ b/api/scripts/certification/next-gen/import-complementary-alone-feature-pilot-certification-centers-from-csv.js
@@ -5,15 +5,16 @@ import lodash from 'lodash';
 import { disconnect, knex } from '../../../db/knex-database-connection.js';
 import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 /**
- * Usage: node scripts/certification/next-gen/import-pilot-certification-centers-from-csv.js path/file.csv
+ * Usage: node scripts/certification/next-gen/import-complementary-alone-feature-pilot-certification-centers-from-csv.js path/file.csv
  * File is semicolon separated values, headers being:
  * certification_center_id
  **/
 import { checkCsvHeader, parseCsv } from '../../helpers/csvHelpers.js';
-const { values } = lodash;
 import * as url from 'node:url';
 
 import { CERTIFICATION_FEATURES } from '../../../src/certification/shared/domain/constants.js';
+
+const { values } = lodash;
 
 const headers = {
   certificationCenterId: 'certification_center_id',

--- a/api/scripts/certification/next-gen/import-complementary-alone-feature-pilot-certification-centers-from-csv.js
+++ b/api/scripts/certification/next-gen/import-complementary-alone-feature-pilot-certification-centers-from-csv.js
@@ -1,8 +1,11 @@
 import 'dotenv/config';
 
+import * as url from 'node:url';
+
 import lodash from 'lodash';
 
 import { disconnect, knex } from '../../../db/knex-database-connection.js';
+import { CERTIFICATION_FEATURES } from '../../../src/certification/shared/domain/constants.js';
 import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
 /**
  * Usage: node scripts/certification/next-gen/import-complementary-alone-feature-pilot-certification-centers-from-csv.js path/file.csv
@@ -10,9 +13,6 @@ import { logger } from '../../../src/shared/infrastructure/utils/logger.js';
  * certification_center_id
  **/
 import { checkCsvHeader, parseCsv } from '../../helpers/csvHelpers.js';
-import * as url from 'node:url';
-
-import { CERTIFICATION_FEATURES } from '../../../src/certification/shared/domain/constants.js';
 
 const { values } = lodash;
 
@@ -88,7 +88,10 @@ async function main(filePath) {
 
     logger.info('Inserting pilot certification center ids in database... ');
     trx = await knex.transaction();
-    await trx('certification-center-features').del();
+    await trx('certification-center-features')
+      .leftJoin('features', 'features.id', 'certification-center-features.featureId')
+      .where('features.key', CERTIFICATION_FEATURES.CAN_REGISTER_FOR_A_COMPLEMENTARY_CERTIFICATION_ALONE.key)
+      .del();
     const batchInfo = await trx.batchInsert('certification-center-features', certificationCentersPilotsList);
     const insertedLines = _getInsertedLineNumber(batchInfo);
     logger.info('✅ ');

--- a/api/tests/integration/scripts/certification/next-gen/import-complementary-alone-feature-pilot-certification-centers-from-csv_test.js
+++ b/api/tests/integration/scripts/certification/next-gen/import-complementary-alone-feature-pilot-certification-centers-from-csv_test.js
@@ -1,4 +1,4 @@
-import { main } from '../../../../../scripts/certification/next-gen/import-pilot-certification-centers-from-csv.js';
+import { main } from '../../../../../scripts/certification/next-gen/import-complementary-alone-feature-pilot-certification-centers-from-csv.js';
 import { CERTIFICATION_FEATURES } from '../../../../../src/certification/shared/domain/constants.js';
 import { catchErr, createTempFile, databaseBuilder, expect, knex, removeTempFile } from '../../../../test-helper.js';
 

--- a/api/tests/integration/scripts/certification/next-gen/import-complementary-alone-feature-pilot-certification-centers-from-csv_test.js
+++ b/api/tests/integration/scripts/certification/next-gen/import-complementary-alone-feature-pilot-certification-centers-from-csv_test.js
@@ -18,7 +18,6 @@ describe('Integration | Scripts | Certification | import-pilot-certification-cen
 
       const certificationCenterId1 = 1001;
       const certificationCenterId2 = 1002;
-      const certificationCenterId3 = 1003;
 
       const featureId = databaseBuilder.factory.buildFeature({
         key: CERTIFICATION_FEATURES.CAN_REGISTER_FOR_A_COMPLEMENTARY_CERTIFICATION_ALONE.key,
@@ -26,9 +25,6 @@ describe('Integration | Scripts | Certification | import-pilot-certification-cen
 
       databaseBuilder.factory.buildCertificationCenter({ id: certificationCenterId1, isV3Pilot: true });
       databaseBuilder.factory.buildCertificationCenter({ id: certificationCenterId2, isV3Pilot: true });
-      databaseBuilder.factory.buildCertificationCenter({ id: certificationCenterId3, isV3Pilot: true });
-
-      databaseBuilder.factory.buildCertificationCenterFeature({ certificationCenterId1, featureId });
 
       await databaseBuilder.commit();
 
@@ -47,7 +43,84 @@ describe('Integration | Scripts | Certification | import-pilot-certification-cen
       ]);
     });
 
-    context('when there is a V3 certification center in the csv file', function () {
+    context('when pilot certification centers are already imported', function () {
+      it('should removes all pilot certification centers tied to the feature ', async function () {
+        // given
+        const file = 'pilot-certification-centers-valid.csv';
+        const dataWithSingleCertificationCenterId = 'certification_center_id;\n1002;\n';
+        const csvFilePath = await createTempFile(file, dataWithSingleCertificationCenterId);
+
+        const certificationCenterId1 = 1001;
+        const certificationCenterId2 = 1002;
+
+        const featureId = databaseBuilder.factory.buildFeature({
+          key: CERTIFICATION_FEATURES.CAN_REGISTER_FOR_A_COMPLEMENTARY_CERTIFICATION_ALONE.key,
+        }).id;
+
+        databaseBuilder.factory.buildCertificationCenter({ id: certificationCenterId1, isV3Pilot: true });
+        databaseBuilder.factory.buildCertificationCenter({ id: certificationCenterId2, isV3Pilot: true });
+
+        databaseBuilder.factory.buildCertificationCenterFeature({ certificationCenterId1, featureId });
+
+        await databaseBuilder.commit();
+
+        // when
+        await main(csvFilePath);
+
+        // then
+        const pilotCertificationCenterList = await knex('certification-center-features').select(
+          'certificationCenterId',
+          'featureId',
+        );
+
+        expect(pilotCertificationCenterList).to.deep.equal([
+          { certificationCenterId: certificationCenterId2, featureId },
+        ]);
+      });
+
+      it('should NOT removes pilot certification centers for another feature', async function () {
+        // given
+        const file = 'pilot-certification-centers-valid.csv';
+        const data = 'certification_center_id;\n1002;\n';
+        const csvFilePath = await createTempFile(file, data);
+
+        const certificationCenterId1 = 1001;
+        const certificationCenterId2 = 1002;
+
+        const complementaryAloneFeatureId = databaseBuilder.factory.buildFeature({
+          key: CERTIFICATION_FEATURES.CAN_REGISTER_FOR_A_COMPLEMENTARY_CERTIFICATION_ALONE.key,
+        }).id;
+        const anotherFeatureId = databaseBuilder.factory.buildFeature({
+          key: 'ANOTHER_FEATURE',
+        }).id;
+
+        databaseBuilder.factory.buildCertificationCenter({ id: certificationCenterId1, isV3Pilot: true });
+        databaseBuilder.factory.buildCertificationCenter({ id: certificationCenterId2, isV3Pilot: true });
+
+        databaseBuilder.factory.buildCertificationCenterFeature({
+          certificationCenterId: certificationCenterId1,
+          featureId: anotherFeatureId,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        await main(csvFilePath);
+
+        // then
+        const pilotCertificationCenterList = await knex('certification-center-features').select(
+          'certificationCenterId',
+          'featureId',
+        );
+
+        expect(pilotCertificationCenterList).to.deep.equal([
+          { certificationCenterId: certificationCenterId1, featureId: anotherFeatureId },
+          { certificationCenterId: certificationCenterId2, featureId: complementaryAloneFeatureId },
+        ]);
+      });
+    });
+
+    context('when there is a V2 certification center in the csv file', function () {
       it('should not import the certification center list', async function () {
         // given
         const file = 'pilot-certification-centers-invalid-v3-centers.csv';
@@ -55,23 +128,24 @@ describe('Integration | Scripts | Certification | import-pilot-certification-cen
         const csvFilePath = await createTempFile(file, data);
         const v2CertificationCenterId = 2001;
         const v3CertificationCenterId = 2002;
-        const v2CertificationCenterId2 = 2003;
 
         const featureId = databaseBuilder.factory.buildFeature({
           key: CERTIFICATION_FEATURES.CAN_REGISTER_FOR_A_COMPLEMENTARY_CERTIFICATION_ALONE.key,
         }).id;
 
-        databaseBuilder.factory.buildCertificationCenter({ id: v2CertificationCenterId, isV3Pilot: true });
-        databaseBuilder.factory.buildCertificationCenter({ id: v3CertificationCenterId, isV3Pilot: false });
-        databaseBuilder.factory.buildCertificationCenter({ id: v2CertificationCenterId2, isV3Pilot: true });
-        databaseBuilder.factory.buildCertificationCenterFeature({ v2CertificationCenterId, featureId });
+        databaseBuilder.factory.buildCertificationCenter({ id: v2CertificationCenterId, isV3Pilot: false });
+        databaseBuilder.factory.buildCertificationCenter({ id: v3CertificationCenterId, isV3Pilot: true });
+        databaseBuilder.factory.buildCertificationCenterFeature({
+          certificationCenterId: v3CertificationCenterId,
+          featureId,
+        });
         await databaseBuilder.commit();
 
         // when
         const error = await catchErr(main)(csvFilePath);
 
         // then
-        expect(error.message).to.equal('V2 certification centers : 2002 are not allowed as pilots');
+        expect(error.message).to.equal('V2 certification centers : 2001 are not allowed as pilots');
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'exécution du script d'ajout de centre pilote pour la feature de la séparation pix/pix+, la table `certification-center-features` était entièrement vidée avant de rajout les nouvelles entrées, et même si des centres pilotes pour d'autres features son enregistrés.

## :robot: Proposition
Écraser uniquement les centres pilotes pour la séparation pix/pix+

## :rainbow: Remarques
Difficile de tester la non suppression des centres pilotes pour d'autres features (s'appuyer sur les tests)

## :100: Pour tester
**Vérifier que le script fonctionne toujours comme prévu**
* Créer un centre pilote V3 sur Pix Admin avec `superadmin@example.net`
* Créer un centre **non pilote V3** sur Pix Admin
* Mettre ces deux centres dans un CSV (voir example ci-dessous)
* Lancer le script, vérifier que le script refuse le centre V2
* Enlever le centre V2 du CSV
* Relancer le script, vérifier que pas d'erreurs
* Vérifier sur Pix Admin (rafraichir la page) que le centre V3 a désormais bien l'habilitation pilote de séparation
* Vérifier sur Pix Admin que le centre V2 lui n'a **pas** l'habilitation

Exemple de CSV :
```csv
certification_center_id;
xxxx;
yyyyyy;
```