### PR TITLE
[FEATURE] Ajouter l'auto-scroll au `Stepper` (PIX-13201)

### DIFF
--- a/mon-pix/app/components/module/grain.js
+++ b/mon-pix/app/components/module/grain.js
@@ -1,10 +1,11 @@
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
-import ModulePassage from './passage';
-
 export default class ModuleGrain extends Component {
+  @service modulixAutoScroll;
+
   grain = this.args.grain;
 
   static AVAILABLE_ELEMENT_TYPES = ['text', 'image', 'video', 'qcu', 'qcm', 'qrocm'];
@@ -129,19 +130,12 @@ export default class ModuleGrain extends Component {
   }
 
   @action
-  focusAndScroll(element) {
+  focusAndScroll(htmlElement) {
     if (!this.args.hasJustAppeared) {
       return;
     }
 
-    element.focus({ preventScroll: true });
-
-    const newGrainY = element.getBoundingClientRect().top + window.scrollY;
-    const userPrefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
-    window.scroll({
-      top: newGrainY - ModulePassage.SCROLL_OFFSET_PX,
-      behavior: userPrefersReducedMotion.matches ? 'instant' : 'smooth',
-    });
+    this.modulixAutoScroll.focusAndScroll(htmlElement);
   }
 
   @action

--- a/mon-pix/app/components/module/passage.hbs
+++ b/mon-pix/app/components/module/passage.hbs
@@ -6,7 +6,11 @@
     <h1>{{@module.title}}</h1>
   </div>
 
-  <div class="module-passage__content" aria-live="assertive" {{did-insert this.setGrainScrollOffsetCssProperty}}>
+  <div
+    class="module-passage__content"
+    aria-live="assertive"
+    {{did-insert this.modulixAutoScroll.setHTMLElementScrollOffsetCssProperty}}
+  >
     {{#each this.grainsToDisplay as |grain index|}}
       <Module::Grain
         @grain={{grain}}

--- a/mon-pix/app/components/module/passage.js
+++ b/mon-pix/app/components/module/passage.js
@@ -9,15 +9,18 @@ export default class ModulePassage extends Component {
   @service router;
   @service metrics;
   @service store;
+  @service modulixAutoScroll;
 
   displayableGrains = this.args.module.grains.filter((grain) => ModuleGrain.getSupportedComponents(grain).length > 0);
   @tracked grainsToDisplay = this.displayableGrains.length > 0 ? [this.displayableGrains[0]] : [];
 
-  static SCROLL_OFFSET_PX = 70;
-
   @action
-  setGrainScrollOffsetCssProperty(element) {
-    element.style.setProperty('--scroll-offset', `${ModulePassage.SCROLL_OFFSET_PX}px`);
+  hasGrainJustAppeared(index) {
+    if (this.grainsToDisplay.length === 1) {
+      return false;
+    }
+
+    return this.grainsToDisplay.length - 1 === index;
   }
 
   get hasNextGrain() {
@@ -90,15 +93,6 @@ export default class ModulePassage extends Component {
   @action
   grainTransition(grainId) {
     return this.args.module.transitionTexts.find((transition) => transition.grainId === grainId);
-  }
-
-  @action
-  hasGrainJustAppeared(index) {
-    if (this.grainsToDisplay.length === 1) {
-      return false;
-    }
-
-    return this.grainsToDisplay.length - 1 === index;
   }
 
   @action

--- a/mon-pix/app/components/module/passage.js
+++ b/mon-pix/app/components/module/passage.js
@@ -17,7 +17,7 @@ export default class ModulePassage extends Component {
 
   @action
   setGrainScrollOffsetCssProperty(element) {
-    element.style.setProperty('--grain-scroll-offset', `${ModulePassage.SCROLL_OFFSET_PX}px`);
+    element.style.setProperty('--scroll-offset', `${ModulePassage.SCROLL_OFFSET_PX}px`);
   }
 
   get hasNextGrain() {

--- a/mon-pix/app/components/module/step.gjs
+++ b/mon-pix/app/components/module/step.gjs
@@ -1,9 +1,15 @@
+import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 import Element from 'mon-pix/components/module/element';
 import ModuleGrain from 'mon-pix/components/module/grain';
 
+import didInsert from '../../modifiers/modifier-did-insert';
+
 export default class ModulixStep extends Component {
+  @service modulixAutoScroll;
+
   get displayableElements() {
     return this.args.step.elements.filter((element) => ModuleGrain.AVAILABLE_ELEMENT_TYPES.includes(element.type));
   }
@@ -12,9 +18,18 @@ export default class ModulixStep extends Component {
     return this.displayableElements.length > 0;
   }
 
+  @action
+  focusAndScroll(htmlElement) {
+    if (!this.args.hasJustAppeared) {
+      return;
+    }
+
+    this.modulixAutoScroll.focusAndScroll(htmlElement);
+  }
+
   <template>
     {{#if this.hasDisplayableElements}}
-      <section class="stepper__step">
+      <section class="stepper__step" tabindex="-1" {{didInsert this.focusAndScroll}}>
         <h3
           class="stepper-step__position"
           aria-label="{{t 'pages.modulix.stepper.step.position' currentStep=@currentStep totalSteps=@totalSteps}}"

--- a/mon-pix/app/components/module/stepper.gjs
+++ b/mon-pix/app/components/module/stepper.gjs
@@ -1,5 +1,6 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
@@ -7,13 +8,26 @@ import ModuleGrain from 'mon-pix/components/module/grain';
 import Step from 'mon-pix/components/module/step';
 import { inc } from 'mon-pix/helpers/inc';
 
+import didInsert from '../../modifiers/modifier-did-insert';
+
 export default class ModulixStepper extends Component {
+  @service modulixAutoScroll;
+
   displayableSteps = this.args.steps.filter((step) =>
     step.elements.some((element) => ModuleGrain.AVAILABLE_ELEMENT_TYPES.includes(element.type)),
   );
 
   @tracked
   stepsToDisplay = [this.displayableSteps[0]];
+
+  @action
+  hasStepJustAppeared(index) {
+    if (this.stepsToDisplay.length === 1) {
+      return false;
+    }
+
+    return this.stepsToDisplay.length - 1 === index;
+  }
 
   get hasDisplayableSteps() {
     return this.displayableSteps.length > 0;
@@ -56,7 +70,11 @@ export default class ModulixStepper extends Component {
   }
 
   <template>
-    <div class="stepper">
+    <div
+      class="stepper"
+      aria-live="assertive"
+      {{didInsert this.modulixAutoScroll.setHTMLElementScrollOffsetCssProperty}}
+    >
       {{#if this.hasDisplayableSteps}}
         {{#each this.stepsToDisplay as |step index|}}
           <Step
@@ -66,6 +84,7 @@ export default class ModulixStepper extends Component {
             @submitAnswer={{@submitAnswer}}
             @retryElement={{@retryElement}}
             @getLastCorrectionForElement={{@getLastCorrectionForElement}}
+            @hasJustAppeared={{this.hasStepJustAppeared index}}
           />
         {{/each}}
         {{#if this.shouldDisplayNextButton}}

--- a/mon-pix/app/modifiers/modifier-did-insert.js
+++ b/mon-pix/app/modifiers/modifier-did-insert.js
@@ -1,0 +1,5 @@
+import { modifier } from 'ember-modifier';
+
+export default modifier(function didInsert(htmlElement, [action]) {
+  action(htmlElement);
+});

--- a/mon-pix/app/services/modulix-auto-scroll.js
+++ b/mon-pix/app/services/modulix-auto-scroll.js
@@ -1,0 +1,41 @@
+import { action } from '@ember/object';
+import Service from '@ember/service';
+
+export default class ModulixAutoScroll extends Service {
+  #SCROLL_OFFSET_PX = 70;
+
+  @action
+  setHTMLElementScrollOffsetCssProperty(htmlElement) {
+    htmlElement.style.setProperty('--scroll-offset', `${this.#SCROLL_OFFSET_PX}px`);
+  }
+
+  focusAndScroll(
+    htmlElement,
+    { scroll, userPrefersReducedMotion, getWindowScrollY } = {
+      scroll: this.#scroll,
+      userPrefersReducedMotion: this.#userPrefersReducedMotion,
+      getWindowScrollY: this.#getWindowScrollY,
+    },
+  ) {
+    htmlElement.focus({ preventScroll: true });
+
+    const elementY = htmlElement.getBoundingClientRect().top + getWindowScrollY();
+    scroll({
+      top: elementY - this.#SCROLL_OFFSET_PX,
+      behavior: userPrefersReducedMotion() ? 'instant' : 'smooth',
+    });
+  }
+
+  #scroll(args) {
+    window.scroll(args);
+  }
+
+  #userPrefersReducedMotion() {
+    const userPrefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+    return userPrefersReducedMotion.matches;
+  }
+
+  #getWindowScrollY() {
+    return window.scrollY;
+  }
+}

--- a/mon-pix/app/styles/components/module/_grain.scss
+++ b/mon-pix/app/styles/components/module/_grain.scss
@@ -2,12 +2,9 @@
   width: 100%;
 
   &--active {
-    min-height: calc(100vh - var(--grain-scroll-offset));
-    outline: none;
+    @extend .auto-scroll;
 
-    @supports (min-height: 100dvh) {
-      min-height: calc(100dvh - var(--grain-scroll-offset));
-    }
+    outline: none;
   }
 
   &:last-child {

--- a/mon-pix/app/styles/components/module/_passage.scss
+++ b/mon-pix/app/styles/components/module/_passage.scss
@@ -2,6 +2,14 @@
   max-width: var(--modulix-max-content-width);
   margin: 0 auto;
 
+  .auto-scroll {
+    min-height: calc(100vh - var(--scroll-offset));
+
+    @supports (min-height: 100dvh) {
+      min-height: calc(100dvh - var(--scroll-offset));
+    }
+  }
+
   h3,
   h4,
   p {
@@ -92,3 +100,4 @@
     justify-content: center;
   }
 }
+

--- a/mon-pix/app/styles/components/module/_stepper.scss
+++ b/mon-pix/app/styles/components/module/_stepper.scss
@@ -23,6 +23,12 @@
   &__step {
     margin-bottom: var(--pix-spacing-6x);
 
+    &--active {
+      @extend .auto-scroll;
+
+      outline: none;
+    }
+
     &:last-child {
       margin-bottom: 0;
     }

--- a/mon-pix/tests/integration/modifiers/modifier-did-insert_test.js
+++ b/mon-pix/tests/integration/modifiers/modifier-did-insert_test.js
@@ -1,0 +1,22 @@
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Integration | Modifier | did-insert', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('should call the given action', async function (assert) {
+    // given
+    const actionStub = sinon.stub();
+    this.set('action', actionStub);
+
+    // when
+    await render(hbs`<div {{modifier-did-insert this.action}}></div>`);
+
+    // then
+    sinon.assert.called(actionStub);
+    assert.ok(true);
+  });
+});

--- a/mon-pix/tests/unit/services/modulix-auto-scroll_test.js
+++ b/mon-pix/tests/unit/services/modulix-auto-scroll_test.js
@@ -1,0 +1,104 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Services | Module | ModulixAutoScroll', function (hooks) {
+  setupTest(hooks);
+
+  module('#setHTMLElementScrollOffsetCssProperty', function () {
+    test('should set --scroll-offset to the given html element', function (assert) {
+      // given
+      const modulixAutoScrollService = this.owner.lookup('service:modulix-auto-scroll');
+      const htmlElement = document.createElement('div');
+
+      // when
+      modulixAutoScrollService.setHTMLElementScrollOffsetCssProperty(htmlElement);
+
+      // then
+      assert.strictEqual(htmlElement.style.getPropertyValue('--scroll-offset'), '70px');
+    });
+  });
+
+  module('#focusAndScroll', function () {
+    test('should call focus on given html element', function (assert) {
+      // given
+      const modulixAutoScrollService = this.owner.lookup('service:modulix-auto-scroll');
+      const htmlElement = document.createElement('div');
+      htmlElement.focus = sinon.stub();
+
+      // when
+      modulixAutoScrollService.focusAndScroll(htmlElement);
+
+      // then
+      sinon.assert.calledWith(htmlElement.focus, { preventScroll: true });
+      assert.ok(true);
+    });
+
+    module('according to user preferences', function (hooks) {
+      let modulixAutoScrollService;
+      let htmlElement;
+      let scrollStub;
+      let getWindowScrollYStub;
+
+      hooks.beforeEach(function () {
+        modulixAutoScrollService = this.owner.lookup('service:modulix-auto-scroll');
+
+        const givenHtmlElementBoundingClientRectTop = 20;
+        htmlElement = document.createElement('div');
+        htmlElement.getBoundingClientRect = sinon.stub().returns({
+          top: givenHtmlElementBoundingClientRectTop,
+        });
+        scrollStub = sinon.stub();
+
+        const givenWindowScrollY = 5;
+        getWindowScrollYStub = sinon.stub();
+        getWindowScrollYStub.returns(givenWindowScrollY);
+      });
+
+      function executeFocusAndScroll(givenUserPrefersReducedMotion) {
+        const userPrefersReducedMotionStub = sinon.stub();
+        userPrefersReducedMotionStub.returns(givenUserPrefersReducedMotion);
+        modulixAutoScrollService.focusAndScroll(htmlElement, {
+          scroll: scrollStub,
+          userPrefersReducedMotion: userPrefersReducedMotionStub,
+          getWindowScrollY: getWindowScrollYStub,
+        });
+      }
+
+      function expectScrollCalledWith(expectedBehavior) {
+        const expectedScrollToTop = -45;
+        sinon.assert.calledWith(scrollStub, { top: expectedScrollToTop, behavior: expectedBehavior });
+      }
+
+      module('when user prefers reduced motions', function () {
+        test('should call scroll to the given html element with "instant" behavior', function (assert) {
+          // given
+          const givenUserPrefersReducedMotion = true;
+
+          // when
+          executeFocusAndScroll(givenUserPrefersReducedMotion);
+
+          // then
+          const expectedBehavior = 'instant';
+          expectScrollCalledWith(expectedBehavior);
+          assert.ok(true);
+        });
+      });
+
+      module('when user does not prefer reduced motions', function () {
+        test('should call scroll to the given html element with "smooth" behavior', function (assert) {
+          // given
+          const givenUserPrefersReducedMotion = false;
+
+          // when
+          executeFocusAndScroll(givenUserPrefersReducedMotion);
+
+          // then
+          const expectedBehavior = 'smooth';
+          expectScrollCalledWith(expectedBehavior);
+          assert.ok(true);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, parcourir un `Stepper` peut être pénible du point de vue de l'UX. En effet, durant la navigation nous n'avons pas systématiquement un focus satisfaisant sur la nouvelle `Step` affichée.

## :robot: Proposition
Avoir le même fonctionnement que pour les grains, c'est à dire un _auto-scroll_ à chaque `Step` du `Stepper` qui permet d’avoir chaque nouvelle `Step` en haut de page.

## :rainbow: Remarques
J'ai choisi d'extraire la logique d'_auto-scroll_ existante pour les grains dans un service afin de rester _DRY_.

### Création d'un modifier "did-insert"

J'ai dû créer un _modifier_ pour remplacer le `did-insert` natif.
Voir explications ci-dessous.

### Erreur du linter "ember/no-at-ember-render-modifiers"

L'erreur du linter `ember/no-at-ember-render-modifiers` est apparue au sein du composant `mon-pix/app/components/module/step.gjs`. Étant en **gjs**, j'ai dû importer `didInsert` via la librairie `ember-modifier`. C'est ce qui a généré cette erreur.

#### Qu'est-ce qui ne va pas avec {{did-insert}}, {{did-update}}, et {{will-destroy}} ?

[Cette page](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-at-ember-render-modifiers.md) du plugin `eslint` de _Ember_ explique pourquoi cette alerte du _linter_ a été créée.

**tldr;**
Ces modifiers avaient été implémenté **temporairement** pour faciliter la migration d'`Octane` vers `Glimmer`. Mais ils génèrent entre autre des effets de bords.

#### Que faire ?

> :rotating_light:Le repository de `ember-template-lint` [recommande](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-at-ember-render-modifiers.md) d'utiliser des `modifiers` _custom_
> Le repo de `ember/render-modifiers` [le recommande](https://github.com/emberjs/ember-render-modifiers#when-to-use-these-modifiers-and-when-not-to-use-them) aussi.

En ce sens, dans cette PR [ce commit](https://github.com/1024pix/pix/pull/9455/commits/22b547d608b53db48996c3a1c7ff0d1feeed4785) propose un `modifier` _custom_ pour le `did-insert`.
Je l'ai nommé `modifier-did-insert` pour éviter toute collision avec les `did-insert` natifs utilisés un peu partout dans la code base actuelle

## :100: Pour tester

1. Lancer [le didacticiel](https://app-pr9455.review.pix.fr/modules/didacticiel-modulix/passage)
2. Naviguer au sein des Stepper et constater que l'auto-scroll se fait bien
3. Naviguer de grain en grain et constater qu'il n'y a pas de régression sur le comportement d'auto-scroll
