### PR TITLE
[FEATURE] Autoriser l'accès à Pix Junior seulement si une session est active

### DIFF
--- a/api/src/school/application/school-route.js
+++ b/api/src/school/application/school-route.js
@@ -10,7 +10,10 @@ const register = async function (server) {
       method: 'GET',
       path: '/api/pix1d/schools',
       config: {
-        pre: [{ method: securityPreHandlers.checkPix1dActivated }],
+        pre: [
+          { method: securityPreHandlers.checkPix1dActivated },
+          { method: securityPreHandlers.checkSchoolSessionIsActive },
+        ],
         auth: false,
         validate: {
           query: Joi.object({

--- a/api/src/school/application/usecases/is-school-session-active.js
+++ b/api/src/school/application/usecases/is-school-session-active.js
@@ -1,9 +1,13 @@
 import * as schoolRepository from '../../infrastructure/repositories/school-repository.js';
 
 const execute = async function ({ schoolCode, dependencies = { schoolRepository } }) {
-  const result = await dependencies.schoolRepository.getSessionExpirationDate({ code: schoolCode });
+  const sessionExpirationDate = await dependencies.schoolRepository.getSessionExpirationDate({ code: schoolCode });
 
-  return result && new Date() < new Date(result) ? true : false;
+  return _isSessionActive(sessionExpirationDate);
 };
+
+function _isSessionActive(sessionExpirationDate) {
+  return new Date() < new Date(sessionExpirationDate);
+}
 
 export { execute };

--- a/api/src/school/application/usecases/is-school-session-active.js
+++ b/api/src/school/application/usecases/is-school-session-active.js
@@ -1,0 +1,9 @@
+import * as schoolRepository from '../../infrastructure/repositories/school-repository.js';
+
+const execute = async function ({ schoolCode, dependencies = { schoolRepository } }) {
+  const result = await dependencies.schoolRepository.getSessionExpirationDate({ code: schoolCode });
+
+  return result && new Date() < new Date(result) ? true : false;
+};
+
+export { execute };

--- a/api/src/school/infrastructure/repositories/school-repository.js
+++ b/api/src/school/infrastructure/repositories/school-repository.js
@@ -44,4 +44,20 @@ const getDivisions = async function ({ organizationId, organizationLearnerApi })
   return [...new Set(divisionLearners)].sort().map((divisionName) => new Division({ name: divisionName }));
 };
 
-export { getByCode, getById, getDivisions, isCodeAvailable, save, updateSessionExpirationDate };
+const getSessionExpirationDate = async function ({ code }) {
+  const [sessionExpirationDate] = await knex('schools')
+    .select('sessionExpirationDate')
+    .where({ code })
+    .pluck('sessionExpirationDate');
+  return sessionExpirationDate;
+};
+
+export {
+  getByCode,
+  getById,
+  getDivisions,
+  getSessionExpirationDate,
+  isCodeAvailable,
+  save,
+  updateSessionExpirationDate,
+};

--- a/api/tests/school/integration/infrastructure/repositories/school-repository_test.js
+++ b/api/tests/school/integration/infrastructure/repositories/school-repository_test.js
@@ -148,4 +148,24 @@ describe('Integration | Repository | School', function () {
       expect(divisions).to.be.empty;
     });
   });
+
+  describe('#getSessionExpirationDate', function () {
+    it('should return the session expiration date', async function () {
+      databaseBuilder.factory.buildSchool({ code: 'FRANCE998', sessionExpirationDate: '2022-07-04' });
+      await databaseBuilder.commit();
+      // when
+      const sessionExpirationDate = await repositories.schoolRepository.getSessionExpirationDate({ code: 'FRANCE998' });
+
+      // then
+      expect(sessionExpirationDate).to.deep.equal(new Date('2022-07-04'));
+    });
+
+    it('should return undefined when there is no expiration date for the school corresponding to the code', async function () {
+      // when
+      const sessionExpirationDate = await repositories.schoolRepository.getSessionExpirationDate({ code: 'FRANCE998' });
+
+      // then
+      expect(sessionExpirationDate).to.equal(undefined);
+    });
+  });
 });

--- a/api/tests/school/unit/application/school-route_test.js
+++ b/api/tests/school/unit/application/school-route_test.js
@@ -12,6 +12,7 @@ describe('Unit | Router | school-router', function () {
       sinon.stub(schoolController, 'getSchool').callsFake((request, h) => h.response('ok'));
 
       sinon.stub(securityPreHandlers, 'checkPix1dActivated').callsFake((request, h) => h.response());
+      sinon.stub(securityPreHandlers, 'checkSchoolSessionIsActive').callsFake((request, h) => h.response());
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 
@@ -20,6 +21,8 @@ describe('Unit | Router | school-router', function () {
 
       // then
       expect(response.statusCode).to.equal(200);
+      expect(securityPreHandlers.checkPix1dActivated).to.have.been.called;
+      expect(securityPreHandlers.checkSchoolSessionIsActive).to.have.been.called;
     });
   });
 

--- a/api/tests/school/unit/application/usecases/is-school-session-active_test.js
+++ b/api/tests/school/unit/application/usecases/is-school-session-active_test.js
@@ -1,0 +1,43 @@
+import { execute as isSchoolSessionActive } from '../../../../../src/school/application/usecases/is-school-session-active.js';
+import { expect, sinon } from '../../../../test-helper.js';
+
+describe('Unit | Domain | Use Cases | is-session-active', function () {
+  let clock;
+
+  beforeEach(function () {
+    const now = new Date('2022-08-04');
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
+  it('should return false if no sessionExpirationDate found for school', async function () {
+    const dependencies = { schoolRepository: { getSessionExpirationDate: sinon.stub() } };
+    dependencies.schoolRepository.getSessionExpirationDate.resolves(undefined);
+
+    const result = await isSchoolSessionActive({ schoolCode: 'CODE1', dependencies });
+
+    expect(dependencies.schoolRepository.getSessionExpirationDate).to.have.been.calledWithExactly({ code: 'CODE1' });
+    expect(result).to.be.false;
+  });
+
+  it('should return false if session is expired', async function () {
+    const dependencies = { schoolRepository: { getSessionExpirationDate: sinon.stub() } };
+    dependencies.schoolRepository.getSessionExpirationDate.resolves('2022-07-04T00:00:00.000Z');
+
+    const result = await isSchoolSessionActive({ schoolCode: 'CODE1', dependencies });
+
+    expect(result).to.be.false;
+  });
+
+  it('should return true if session is still active', async function () {
+    const dependencies = { schoolRepository: { getSessionExpirationDate: sinon.stub() } };
+    dependencies.schoolRepository.getSessionExpirationDate.resolves('2022-08-04T01:00:00.000Z');
+
+    const result = await isSchoolSessionActive({ schoolCode: 'CODE1', dependencies });
+
+    expect(result).to.be.true;
+  });
+});

--- a/junior/app/routes/school-error.js
+++ b/junior/app/routes/school-error.js
@@ -1,0 +1,14 @@
+import Route from '@ember/routing/route';
+
+import { styleToolkit } from '../utils/layout';
+
+export default class SchoolErrorRoute extends Route {
+  setupController() {
+    super.setupController(...arguments);
+    this.resetBackground();
+  }
+
+  resetBackground() {
+    styleToolkit.backgroundBlob.reset();
+  }
+}

--- a/junior/app/styles/components/bubble.scss
+++ b/junior/app/styles/components/bubble.scss
@@ -2,7 +2,7 @@
   position: relative;
   width: fit-content;
   height: fit-content;
-  margin: 8px 0 8px 8px;
+  margin: 8px 80px 8px 8px;
   padding: 12px 24px;
   font-size: 1.5rem;
   text-align: left;

--- a/junior/app/templates/school-error.hbs
+++ b/junior/app/templates/school-error.hbs
@@ -1,0 +1,2 @@
+{{! Cette page est affichée lorsqu'on souhaite aller sur une URL qui n'existe pas coté front }}
+<Issue @message={{t "pages.school.not-found"}} />

--- a/junior/tests/acceptance/access-school_test.js
+++ b/junior/tests/acceptance/access-school_test.js
@@ -88,7 +88,7 @@ module('Acceptance | School', function (hooks) {
       // when
       const screen = await visit('/schools/INVALID00');
       // then
-      assert.dom(screen.getByText(t('pages.error.message'))).exists();
+      assert.dom(screen.getByText(t('pages.school.not-found'))).exists();
     });
   });
 

--- a/junior/translations/fr.json
+++ b/junior/translations/fr.json
@@ -62,6 +62,7 @@
       "backHome": "Retour à l'accueil"
     },
     "school": {
+      "not-found":"Session inactive ou école non trouvée. Demande de l’aide à ton enseignant pour accéder à tes missions.",
       "division-list": {
         "page-title": "Liste des classes",
         "welcome": "Bienvenue sur la page de l'école : <strong>{schoolName}</strong><br>Maintenant, choisis ta classe."


### PR DESCRIPTION
## :unicorn: Problème
Pix Junior est accessible sans authentification et donne accès à la liste des élèves, importés dans une école, à partir d'un simple code école.
Ce code école peut être attaqué en force brute dans l'application.

## :robot: Proposition
Pour limiter la surface d'attaque de ce code, celui-ci ne sera rendu utilisable qu'à condition qu'une session ait été ouverte par l'enseignant.
Cette PR a pour objectif d'empêcher l'accès à Pix Junior lorsqu'il n'y a pas de session active pour l'école.

## :rainbow: Remarques
L'API doit se comporter de la même manière lorsqu'on lui fournit un code école erroné, ou un code école où aucune session n'est ouverte. Ceci pour ne pas donner d'information sur la validité du code école. 

## :100: Pour tester
Sur la page de saisie du code école de Pix Junior : 
* saisir un code inconnu : la page indiquant que le code école est erroné ou que la session de l'école est fermée.
* saisir un code école pour une école valide (sans session ouverte) : idem
* ouvrir une session et saisir le code école : la liste des classes s'affiche
* attendre la fermeture de session (ou aller changer la date de fin en bdd) : la page d'école non trouvée s'affiche de nouveau
