### PR TITLE
[FEATURE] Ajout d'une bordure à gauche des feedbacks (PIX-13261)

### DIFF
--- a/mon-pix/app/styles/components/modulix/_feedback.scss
+++ b/mon-pix/app/styles/components/modulix/_feedback.scss
@@ -1,10 +1,23 @@
 .feedback {
+  position: relative;
+  padding-left: var(--pix-spacing-4x);
+
   &--success {
     --modulix-feedback-state-color: var(--pix-success-700);
   }
 
   &--error {
     --modulix-feedback-state-color: var(--pix-error-700);
+  }
+
+  &::before {
+    position: absolute;
+    left: 0;
+    width: 6px;
+    height: 100%;
+    background-color: var(--modulix-feedback-state-color);
+    border-radius: var(--modulix-radius-full);
+    content: '';
   }
 
   &__state {

--- a/mon-pix/app/styles/pages/_module.scss
+++ b/mon-pix/app/styles/pages/_module.scss
@@ -3,6 +3,7 @@
 
   --modulix-max-content-width: 740px;
   --modulix-radius: 16px;
+  --modulix-radius-full: 100% / 10%;
 
   flex-grow: 1;
   color: var(--pix-neutral-900);


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, les feedbacks Modulix nécessitent une révision de leur UX pour qu'elles soient plus facilement identifiables comme un bloc à part entière.

## :robot: Proposition
Ajouter une bordure à gauche des feedbacks en suivant la maquette de Quentin.

## :rainbow: Remarques
J'ai fait différemment de ce qui a été implémenté sur Pix Admin afin de ne pas casser le CSS relatif à la contribution (conserver le _BEM_ de `.feedback__state`).

## :100: Pour tester

1. Se rendre sur [le didacticiel](https://app-pr9458.review.pix.fr/modules/didacticiel-modulix)
2. Répondre à des modalités
3. S'assurer que le rendu respecte les maquettes
