### PR TITLE
[BUGFIX] Ajouter les validations Joi sur les routes pour lesquelles il en manquait (PIX-13329)

### DIFF
--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
 import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
-import { identifiersType } from '../../../src/shared/domain/types/identifiers-type.js';
+import { identifiersType, optionalIdentifiersType } from '../../../src/shared/domain/types/identifiers-type.js';
 import { certificationCenterController } from './certification-center-controller.js';
 
 const register = async function (server) {
@@ -49,8 +49,16 @@ const register = async function (server) {
         ],
         validate: {
           query: Joi.object({
-            page: Joi.object().default({}),
-            filter: Joi.object().default({}),
+            page: Joi.object({
+              number: Joi.number().integer(),
+              size: Joi.number().integer(),
+            }).default({}),
+            filter: Joi.object({
+              id: optionalIdentifiersType.certificationCenterId,
+              name: Joi.string().trim().empty('').allow(null).optional(),
+              type: Joi.string().trim().empty('').allow(null).optional(),
+              externalId: Joi.string().trim().empty('').allow(null).optional(),
+            }).default({}),
           }),
         },
         notes: [

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -258,7 +258,12 @@ const register = async function (server) {
             id: identifiersType.organizationId,
           }),
           query: Joi.object({
-            filter: Joi.object({}).default({}),
+            filter: Joi.object({
+              firstName: Joi.string().empty('').allow(null).optional(),
+              lastName: Joi.string().empty('').allow(null).optional(),
+              email: Joi.string().empty('').allow(null).optional(),
+              organizationRole: Joi.string().empty('').allow(null).optional(),
+            }).default({}),
             page: Joi.object({
               number: Joi.number().integer().empty('').allow(null).optional(),
               size: Joi.number().integer().empty('').allow(null).optional(),
@@ -320,7 +325,12 @@ const register = async function (server) {
             id: identifiersType.organizationId,
           }),
           query: Joi.object({
-            filter: Joi.object({}).default({}),
+            filter: Joi.object({
+              firstName: Joi.string().empty('').allow(null).optional(),
+              lastName: Joi.string().empty('').allow(null).optional(),
+              email: Joi.string().empty('').allow(null).optional(),
+              organizationRole: Joi.string().empty('').allow(null).optional(),
+            }).default({}),
             page: Joi.object({
               number: Joi.number().integer().empty('').allow(null).optional(),
               size: Joi.number().integer().empty('').allow(null).optional(),

--- a/api/src/prescription/campaign/application/campaign-detail-route.js
+++ b/api/src/prescription/campaign/application/campaign-detail-route.js
@@ -80,7 +80,8 @@ const register = async function (server) {
             filter: Joi.object({
               name: Joi.string().empty(''),
               status: Joi.string().empty(''),
-              isOwnedByMe: Joi.boolean().empty(''),
+              isOwnedByMe: Joi.boolean().empty('').allow(null).optional(),
+              ownerName: Joi.string().empty('').allow(null).optional(),
             }).default({}),
           }),
         },

--- a/api/tests/acceptance/application/certification-centers/index_test.js
+++ b/api/tests/acceptance/application/certification-centers/index_test.js
@@ -15,6 +15,28 @@ describe('Acceptance | Route | Certification Centers', function () {
     server = await createServer();
   });
 
+  describe('GET /api/admin/certification-centers', function () {
+    it('should return an HTTP code 200 and a list of certification centers', async function () {
+      // given
+      const adminMember = await insertUserWithRoleSuperAdmin();
+      databaseBuilder.factory.buildCertificationCenter();
+
+      await databaseBuilder.commit();
+
+      //when
+      const { result, statusCode } = await server.inject({
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(adminMember.id),
+        },
+        method: 'GET',
+        url: `/api/admin/certification-centers`,
+      });
+
+      expect(statusCode).to.equal(200);
+      expect(result.data.length).to.equal(1);
+    });
+  });
+
   describe('PATCH /api/admin/certification-centers/{id}', function () {
     context('when an admin member updates a certification center information', function () {
       it('it should return an HTTP code 200 with the updated data', async function () {

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -546,7 +546,7 @@ describe('Acceptance | Application | organization-controller', function () {
         // when
         const response = await server.inject({
           method: 'GET',
-          url: `/api/organizations/${organizationId}/memberships`,
+          url: `/api/organizations/${organizationId}/memberships/?filter[email]=&filter[firstName]=&filter[lastName]=&filter[organizationRole]=`,
           headers: { authorization: generateValidRequestAuthorizationHeader(adminOfTheOrganization.id) },
         });
 
@@ -674,7 +674,7 @@ describe('Acceptance | Application | organization-controller', function () {
       // when
       const response = await server.inject({
         method: 'GET',
-        url: `/api/admin/organizations/${organization.id}/memberships`,
+        url: `/api/admin/organizations/${organization.id}/memberships?filter[email]=&filter[firstName]=&filter[lastName]=&filter[organizationRole]=`,
         headers: { authorization: generateValidRequestAuthorizationHeader(userSuperAdmin.id) },
       });
 


### PR DESCRIPTION
## :unicorn: Problème
Suite à la modification du parsing et de validation des query parameters dans https://github.com/1024pix/pix/pull/9416, certaines routes se retrouvent avec une validation de query non-exhaustive.
Cela entraine une réponse `400 - Bad request` à des appels qui fonctionnaient bien auparavant.

## :robot: Proposition
Ajouter la liste exhaustive des query supportés par les routes.
Les routes impactées sont les suivantes : 
- `/api/{organizationId}/memberships`
- `/api/admin/{organizationId}/memberships`
- `/api/admin/certification-centers`

## :rainbow: Remarques
RAS

## :100: Pour tester
Les tests au vert 
tour fonctionnel sur toutes les routes impactées par cette PR et celles impactées par la PR nommée dan la partie Problème
