### PR TITLE
[BUGFIX] Correction de la configuration de l'import onde (pix-13324)

### DIFF
--- a/api/db/migrations/20240708123814_update-import-onde.js
+++ b/api/db/migrations/20240708123814_update-import-onde.js
@@ -1,0 +1,59 @@
+const up = async function (knex) {
+  await knex('organization-learner-import-formats')
+    .where({ name: 'ONDE' })
+    .update({
+      config: {
+        acceptedEncoding: ['iso-8859-1', 'utf8'],
+        unicityColumns: ['INE'],
+        validationRules: {
+          formats: [
+            { name: 'Nom élève', type: 'string', required: true },
+            { name: 'Prénom élève', type: 'string', required: true },
+            { name: 'INE', type: 'string', required: true },
+            { name: 'Niveau', type: 'string', required: true },
+            { name: 'Libellé classe', type: 'string', required: true },
+            { name: 'Date naissance', type: 'date', format: 'YYYY-MM-DD', required: true },
+          ],
+        },
+        headers: [
+          { name: 'Nom élève', property: 'lastName', required: true },
+          { name: 'Prénom élève', property: 'firstName', required: true },
+          { name: 'INE', required: true },
+          { name: 'Niveau', required: true },
+          { name: 'Libellé classe', required: true },
+          { name: 'Date naissance', required: true },
+        ],
+      },
+    });
+};
+
+const down = async function (knex) {
+  await knex('organization-learner-import-formats')
+    .where({ name: 'ONDE' })
+    .update({
+      config: {
+        acceptedEncoding: ['utf8'],
+        unicityColumns: ['INE'],
+        validationRules: {
+          formats: [
+            { name: 'Nom élève', type: 'string', required: true },
+            { name: 'Prénom élève', type: 'string', required: true },
+            { name: 'INE', type: 'string', required: true },
+            { name: 'Niveau', type: 'string', required: true },
+            { name: 'Libellé classe', type: 'string', required: true },
+            { name: 'Date de naissance', type: 'date', format: 'DD/MM/YYYY', required: true },
+          ],
+        },
+        headers: [
+          { name: 'Nom élève', property: 'lastName', required: true },
+          { name: 'Prénom élève', property: 'firstName', required: true },
+          { name: 'INE', required: true },
+          { name: 'Niveau', required: true },
+          { name: 'Libellé classe', required: true },
+          { name: 'Date de naissance', required: true },
+        ],
+      },
+    });
+};
+
+export { down, up };

--- a/api/db/seeds/data/common/organization-learner-import-formats.js
+++ b/api/db/seeds/data/common/organization-learner-import-formats.js
@@ -6,7 +6,7 @@ export const organizationLearnerImportFormat = async function ({ databaseBuilder
     name: 'ONDE',
     fileType: 'csv',
     config: {
-      acceptedEncoding: ['utf8'],
+      acceptedEncoding: ['iso-8859-1', 'utf8'],
       unicityColumns: ['INE'],
       validationRules: {
         formats: [
@@ -15,7 +15,7 @@ export const organizationLearnerImportFormat = async function ({ databaseBuilder
           { name: 'INE', type: 'string', required: true },
           { name: 'Niveau', type: 'string', required: true },
           { name: 'Libellé classe', type: 'string', required: true },
-          { name: 'Date de naissance', type: 'date', format: 'DD/MM/YYYY', required: true },
+          { name: 'Date naissance', type: 'date', format: 'YYYY-MM-DD', required: true },
         ],
       },
       headers: [
@@ -24,7 +24,7 @@ export const organizationLearnerImportFormat = async function ({ databaseBuilder
         { name: 'INE', required: true },
         { name: 'Niveau', required: true },
         { name: 'Libellé classe', required: true },
-        { name: 'Date de naissance', required: true },
+        { name: 'Date naissance', required: true },
       ],
     },
     createdAt: new Date('2024-01-01'),


### PR DESCRIPTION
## :unicorn: Problème
Après un test fonctionnel avec un directeur d'école, il apparaît que la configuration de l'import onde ne correspondait pas aux points suivants:
- L'encodage défini n'était pas le bon (Encodagee requis: ISO-8859-1),
- Le nom de la colone date de naissance n'était pas le bon (date naissance),
- Le format de la date n'était pas le bon (YYYY-MM-DD).

## :robot: Proposition
Mettre à jour la configuration avec les paramètres souhaités.

## :100: Pour tester
- Ce rendre sur [Pix Orga](https://orga-pr9467.review.pix.org/),
- Se connecter avec le compte 1d-orga@example.net,
- Importer le  [fichier de donnée au format .csv](https://drive.google.com/drive/u/0/folders/1sKPfQ7IhwsGrz4pve56_jY13c9bHcZN9),
- Vérifier que tout se passe bien.