### PR TITLE
[FEATURE] ajoute la configuration de l'import sco fwb (Pix-12759)

### DIFF
--- a/api/db/migrations/20240708100245_add-fwb-organization-learner-import-format.js
+++ b/api/db/migrations/20240708100245_add-fwb-organization-learner-import-format.js
@@ -1,0 +1,48 @@
+const engineeringUserId = process.env.ENGINEERING_USER_ID;
+const importFormatName = 'SCO-FWB';
+
+const up = async function (knex) {
+  //Avoid fail migration when engineering user does not exist.
+  if (!engineeringUserId) return;
+  const user = await knex
+    .from('users')
+    .where({ id: parseInt(engineeringUserId) })
+    .first();
+  if (!user) return;
+  await knex('organization-learner-import-formats').insert({
+    name: importFormatName,
+    fileType: 'csv',
+    config: {
+      acceptedEncoding: ['utf8'],
+      unicityColumns: ['Nom', 'Prénom', 'Date de naissance (jj/mm/aaaa)'],
+      reconciliationMappingColumns: [
+        { key: 'reconcileField1', columnName: 'Nom' },
+        { key: 'reconcileField2', columnName: 'Prénom' },
+        { key: 'reconcileField3', columnName: 'Date de naissance (jj/mm/aaaa)' },
+      ],
+      validationRules: {
+        formats: [
+          { name: 'Nom', type: 'string', required: true },
+          { name: 'Prénom', type: 'string', required: true },
+          { name: 'Date de naissance (jj/mm/aaaa)', type: 'date', format: 'DD/MM/YYYY', required: true },
+          { name: 'Classe', type: 'string', required: true },
+        ],
+      },
+      headers: [
+        { name: 'Nom', property: 'lastName', required: true },
+        { name: 'Prénom', property: 'firstName', required: true },
+        { name: 'Date de naissance (jj/mm/aaaa)', required: true },
+        { name: 'Classe', required: true },
+      ],
+    },
+    createdAt: new Date(),
+    createdBy: parseInt(engineeringUserId),
+    updatedAt: new Date(),
+  });
+};
+
+const down = async function (knex) {
+  await knex('organization-learner-import-formats').where({ name: importFormatName }).delete();
+};
+
+export { down, up };

--- a/api/db/seeds/data/common/organization-learner-import-formats.js
+++ b/api/db/seeds/data/common/organization-learner-import-formats.js
@@ -38,26 +38,24 @@ export const organizationLearnerImportFormat = async function ({ databaseBuilder
     fileType: 'csv',
     config: {
       acceptedEncoding: ['utf8'],
-      unicityColumns: ['unicity key'],
+      unicityColumns: ['Nom apprenant', 'Prénom apprenant', 'Date de naissance'],
       reconciliationMappingColumns: [
         { key: 'reconcileField1', columnName: 'Nom apprenant' },
-        { key: 'reconcileField2', columnName: 'catégorie' },
+        { key: 'reconcileField2', columnName: 'Prénom apprenant' },
         { key: 'reconcileField3', columnName: 'Date de naissance' },
       ],
       validationRules: {
         formats: [
           { name: 'Nom apprenant', type: 'string', required: true },
           { name: 'Prénom apprenant', type: 'string', required: true },
-          { name: 'unicity key', type: 'string', required: true },
-          { name: 'catégorie', type: 'string', required: true },
+          { name: 'Classe', type: 'string', required: true },
           { name: 'Date de naissance', type: 'date', format: 'YYYY-MM-DD', required: true },
         ],
       },
       headers: [
         { name: 'Nom apprenant', property: 'lastName', required: true },
         { name: 'Prénom apprenant', property: 'firstName', required: true },
-        { name: 'unicity key', required: true },
-        { name: 'catégorie', required: true },
+        { name: 'Classe', required: true },
         { name: 'Date de naissance', required: true },
       ],
     },


### PR DESCRIPTION
## :unicorn: Problème
On souhaite realiser des import pour le sco fwb

## :robot: Proposition
Ajouter un migration qui ajoute la configuration de l'import à format pour le sco FWB
- Champs: Nom, Prénom, Date de naissance, Classe
- Contraintes d'unicité Nom + Prénom + Date de naissance,
- Reconciliation : Nom, Prénom, Date de naissance.

## :rainbow: Remarques?
N'ayant pas d'identifiant unique, on utilise l'association de 3 champs. Cela peut poser problème si on a un homonyme née le même jour dans la population de prescrits. Une réponse possible est re faire un import en rajoutant une info différenciante (ex : deuxieme prénom)  

## :100: Pour tester
- Se connecter sur scalingo et récupérer l'id du format d'import sco fwb 
- Se connecter sur admin pour créer une orga sco-fwb et lui activer la feature d'import (via l'activation en masse)
- Se connecter sur orga et afficher l'orga sco-fwb 
- réaliser un import de prescrit `Nom;Prénom;Date de naissance (jj/mm/aaaa);Classe`
