### PR TITLE
[FEATURE] Corrections dans le footer de Pix-App (pix-13335)

### DIFF
--- a/mon-pix/app/components/footer.hbs
+++ b/mon-pix/app/components/footer.hbs
@@ -37,6 +37,12 @@
           </li>
 
           <li>
+            <a href="{{this.legalNoticeUrl}}" target="_blank" class="footer-navigation__item" rel="noopener noreferrer">
+              {{t "navigation.footer.legal-notice"}}
+            </a>
+          </li>
+
+          <li>
             <a
               href="{{this.dataProtectionPolicyUrl}}"
               target="_blank"

--- a/mon-pix/app/components/footer.js
+++ b/mon-pix/app/components/footer.js
@@ -23,6 +23,10 @@ export default class Footer extends Component {
     return this.url.cguUrl;
   }
 
+  get legalNoticeUrl() {
+    return this.url.legalNoticeUrl;
+  }
+
   get dataProtectionPolicyUrl() {
     return this.url.dataProtectionPolicyUrl;
   }

--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -36,6 +36,23 @@ export default class Url extends Service {
     }
   }
 
+  get legalNoticeUrl() {
+    const currentLanguage = this.intl.primaryLocale;
+
+    if (this.currentDomain.isFranceDomain) {
+      return `https://pix.fr/mentions-legales`;
+    }
+
+    switch (currentLanguage) {
+      case ENGLISH_INTERNATIONAL_LOCALE:
+        return 'https://pix.org/en/legal-notice';
+      case DUTCH_INTERNATIONAL_LOCALE:
+        return 'https://pix.org/nl-be/wettelijke-vermeldingen';
+      default:
+        return 'https://pix.org/fr/mentions-legales';
+    }
+  }
+
   get dataProtectionPolicyUrl() {
     const currentLanguage = this.intl.primaryLocale;
 

--- a/mon-pix/tests/integration/components/footer_test.js
+++ b/mon-pix/tests/integration/components/footer_test.js
@@ -25,6 +25,7 @@ module('Integration | Component | Footer', function (hooks) {
     assert.ok(screen.getByRole('link', { name: this.intl.t('navigation.footer.data-protection-policy') }));
     assert.ok(screen.getByRole('link', { name: this.intl.t('navigation.footer.eula') }));
     assert.ok(screen.getByRole('link', { name: this.intl.t('navigation.footer.help-center') }));
+    assert.ok(screen.getByRole('link', { name: this.intl.t('navigation.footer.legal-notice') }));
     assert.ok(screen.getByRole('link', { name: this.intl.t('navigation.footer.sitemap') }));
   });
 

--- a/mon-pix/tests/unit/services/url_test.js
+++ b/mon-pix/tests/unit/services/url_test.js
@@ -99,28 +99,12 @@ module('Unit | Service | url', function (hooks) {
         assert.strictEqual(cguUrl, expectedCguUrl);
       });
 
-      module('when current language is "en"', function () {
+      module('when current language is not "fr"', function () {
         test('returns the French page URL', function (assert) {
           // given
           const service = this.owner.lookup('service:url');
           service.currentDomain = { isFranceDomain: true };
           service.intl = { primaryLocale: ENGLISH_INTERNATIONAL_LOCALE };
-          const expectedCguUrl = 'https://pix.fr/conditions-generales-d-utilisation';
-
-          // when
-          const cguUrl = service.cguUrl;
-
-          // then
-          assert.strictEqual(cguUrl, expectedCguUrl);
-        });
-      });
-
-      module('when current language is "nl"', function () {
-        test('returns the French page URL', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: true };
-          service.intl = { primaryLocale: DUTCH_INTERNATIONAL_LOCALE };
           const expectedCguUrl = 'https://pix.fr/conditions-generales-d-utilisation';
 
           // when
@@ -200,28 +184,12 @@ module('Unit | Service | url', function (hooks) {
         assert.strictEqual(dataProtectionPolicyUrl, expectedDataProtectionPolicyUrl);
       });
 
-      module('when current language is "en"', function () {
+      module('when current language is not "fr"', function () {
         test('returns the French page URL', function (assert) {
           // given
           const service = this.owner.lookup('service:url');
           service.currentDomain = { isFranceDomain: true };
           service.intl = { primaryLocale: ENGLISH_INTERNATIONAL_LOCALE };
-          const expectedDataProtectionPolicyUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
-
-          // when
-          const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
-
-          // then
-          assert.strictEqual(dataProtectionPolicyUrl, expectedDataProtectionPolicyUrl);
-        });
-      });
-
-      module('when current language is "nl"', function () {
-        test('returns the French page URL', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: true };
-          service.intl = { primaryLocale: DUTCH_INTERNATIONAL_LOCALE };
           const expectedDataProtectionPolicyUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
 
           // when
@@ -300,28 +268,12 @@ module('Unit | Service | url', function (hooks) {
         assert.strictEqual(legalNoticeUrl, expectedLegalNoticeUrl);
       });
 
-      module('when current language is "en"', function () {
+      module('when current language is not "fr"', function () {
         test('returns the French page URL', function (assert) {
           // given
           const service = this.owner.lookup('service:url');
           service.currentDomain = { isFranceDomain: true };
           service.intl = { primaryLocale: ENGLISH_INTERNATIONAL_LOCALE };
-          const expectedLegalNoticeUrl = 'https://pix.fr/mentions-legales';
-
-          // when
-          const legalNoticeUrl = service.legalNoticeUrl;
-
-          // then
-          assert.strictEqual(legalNoticeUrl, expectedLegalNoticeUrl);
-        });
-      });
-
-      module('when current language is "nl"', function () {
-        test('returns the French page URL', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: true };
-          service.intl = { primaryLocale: DUTCH_INTERNATIONAL_LOCALE };
           const expectedLegalNoticeUrl = 'https://pix.fr/mentions-legales';
 
           // when
@@ -400,28 +352,12 @@ module('Unit | Service | url', function (hooks) {
         assert.strictEqual(accessibilityUrl, expectedAccessibilityUrl);
       });
 
-      module('when current language is "en"', function () {
+      module('when current language is not "fr"', function () {
         test('returns the French page URL', function (assert) {
           // given
           const service = this.owner.lookup('service:url');
           service.currentDomain = { isFranceDomain: true };
           service.intl = { primaryLocale: ENGLISH_INTERNATIONAL_LOCALE };
-          const expectedAccessibilityUrl = 'https://pix.fr/accessibilite';
-
-          // when
-          const accessibilityUrl = service.accessibilityUrl;
-
-          // then
-          assert.strictEqual(accessibilityUrl, expectedAccessibilityUrl);
-        });
-      });
-
-      module('when current language is "nl"', function () {
-        test('returns the French page URL', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: true };
-          service.intl = { primaryLocale: DUTCH_INTERNATIONAL_LOCALE };
           const expectedAccessibilityUrl = 'https://pix.fr/accessibilite';
 
           // when
@@ -532,28 +468,12 @@ module('Unit | Service | url', function (hooks) {
         assert.strictEqual(supportHomeUrl, expectedSupportHomeUrl);
       });
 
-      module('when current language is "en"', function () {
+      module('when current language is not "fr"', function () {
         test('returns the French page URL', function (assert) {
           // given
           const service = this.owner.lookup('service:url');
           service.currentDomain = { isFranceDomain: true };
           service.intl = { primaryLocale: ENGLISH_INTERNATIONAL_LOCALE };
-          const expectedSupportHomeUrl = 'https://pix.fr/support';
-
-          // when
-          const supportHomeUrl = service.supportHomeUrl;
-
-          // then
-          assert.strictEqual(supportHomeUrl, expectedSupportHomeUrl);
-        });
-      });
-
-      module('when current language is "nl"', function () {
-        test('returns the French page URL', function (assert) {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.currentDomain = { isFranceDomain: true };
-          service.intl = { primaryLocale: DUTCH_INTERNATIONAL_LOCALE };
           const expectedSupportHomeUrl = 'https://pix.fr/support';
 
           // when

--- a/mon-pix/tests/unit/services/url_test.js
+++ b/mon-pix/tests/unit/services/url_test.js
@@ -285,6 +285,105 @@ module('Unit | Service | url', function (hooks) {
     });
   });
 
+  module('#legalNoticeUrl', function () {
+    module('when website is pix.fr', function () {
+      test('returns the French page URL', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url');
+        service.currentDomain = { isFranceDomain: true };
+        const expectedLegalNoticeUrl = 'https://pix.fr/mentions-legales';
+
+        // when
+        const legalNoticeUrl = service.legalNoticeUrl;
+
+        // then
+        assert.strictEqual(legalNoticeUrl, expectedLegalNoticeUrl);
+      });
+
+      module('when current language is "en"', function () {
+        test('returns the French page URL', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.currentDomain = { isFranceDomain: true };
+          service.intl = { primaryLocale: ENGLISH_INTERNATIONAL_LOCALE };
+          const expectedLegalNoticeUrl = 'https://pix.fr/mentions-legales';
+
+          // when
+          const legalNoticeUrl = service.legalNoticeUrl;
+
+          // then
+          assert.strictEqual(legalNoticeUrl, expectedLegalNoticeUrl);
+        });
+      });
+
+      module('when current language is "nl"', function () {
+        test('returns the French page URL', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.currentDomain = { isFranceDomain: true };
+          service.intl = { primaryLocale: DUTCH_INTERNATIONAL_LOCALE };
+          const expectedLegalNoticeUrl = 'https://pix.fr/mentions-legales';
+
+          // when
+          const legalNoticeUrl = service.legalNoticeUrl;
+
+          // then
+          assert.strictEqual(legalNoticeUrl, expectedLegalNoticeUrl);
+        });
+      });
+    });
+
+    module('when website is pix.org', function () {
+      module('when current language is "fr"', function () {
+        test('returns the French page URL', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.currentDomain = { isFranceDomain: false };
+          service.intl = { primaryLocale: FRENCH_INTERNATIONAL_LOCALE };
+          const expectedLegalNoticeUrl = 'https://pix.org/fr/mentions-legales';
+
+          // when
+          const legalNoticeUrl = service.legalNoticeUrl;
+
+          // then
+          assert.strictEqual(legalNoticeUrl, expectedLegalNoticeUrl);
+        });
+      });
+
+      module('when current language is "en"', function () {
+        test('returns the English page URL', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.currentDomain = { isFranceDomain: false };
+          service.intl = { primaryLocale: ENGLISH_INTERNATIONAL_LOCALE };
+          const expectedLegalNoticeUrl = 'https://pix.org/en/legal-notice';
+
+          // when
+          const legalNoticeUrl = service.legalNoticeUrl;
+
+          // then
+          assert.strictEqual(legalNoticeUrl, expectedLegalNoticeUrl);
+        });
+      });
+
+      module('when current language is "nl"', function () {
+        test('returns the Nederland page URL', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.currentDomain = { isFranceDomain: false };
+          service.intl = { primaryLocale: DUTCH_INTERNATIONAL_LOCALE };
+          const expectedLegalNoticeUrl = 'https://pix.org/nl-be/wettelijke-vermeldingen';
+
+          // when
+          const legalNoticeUrl = service.legalNoticeUrl;
+
+          // then
+          assert.strictEqual(legalNoticeUrl, expectedLegalNoticeUrl);
+        });
+      });
+    });
+  });
+
   module('#accessibilityUrl', function () {
     module('when website is pix.fr', function () {
       test('returns the French page URL', function (assert) {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -132,7 +132,8 @@
       "data-protection-policy": "Personal data protection policy",
       "eula": "Terms and conditions",
       "help-center": "Help center",
-      "label": "Secondary navigation",
+      "label": "Footer menu",
+      "legal-notice": "Legal notice",
       "sitemap": "Site map",
       "student-data-protection-policy": "Student data protection policy",
       "student-data-protection-policy-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -132,7 +132,8 @@
       "data-protection-policy": "Política de protección de datos",
       "eula": "CGU",
       "help-center": "Centro de ayuda",
-      "label": "Menú secundario",
+      "label": "Menú de pie de página",
+      "legal-notice": "Aviso legal",
       "sitemap": "Mapa del sitio",
       "student-data-protection-policy": "Política de protección de datos de los alumnos",
       "student-data-protection-policy-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -132,7 +132,8 @@
       "data-protection-policy": "Politique de protection des données",
       "eula": "CGU",
       "help-center": "Centre d'aide",
-      "label": "Menu secondaire",
+      "label": "Menu de bas de page",
+      "legal-notice": "Mentions légales",
       "sitemap": "Plan du site",
       "student-data-protection-policy": "Politique de protection des données des élèves",
       "student-data-protection-policy-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -132,7 +132,8 @@
       "data-protection-policy": "Gegevensbeschermingsbeleid",
       "eula": "UGC",
       "help-center": "Helpcentrum",
-      "label": "Secundair menu",
+      "label": "Menu van de voettekst",
+      "legal-notice": "Juridische informatie",
       "sitemap": "Kaart",
       "student-data-protection-policy": "Beleid gegevensbescherming studenten",
       "student-data-protection-policy-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39"


### PR DESCRIPTION
## :unicorn: Problème
Dans le footer de Pix-App, on avait un aria-label portant l'étiquette suivante: "Menu secondaire". Cela ne signifie pas grand chose, d'autant qu'en haut de page, il y a un lien qui déplace le curseur sur le footer qui porte l'aria-label "Aller au bas de page".
De plus, les mention légales ne sont pas présentes dans le footer de Pix-app.

## :robot: Proposition
- Modifier le terme "Menu secondaire" en le remplaçant par "Menu de bas de page".
- Adapter en conséquence les traductions.
- Ajouter les mentions légales,
- Ajouter le terme "Mentions légales" aux traductions en l'adaptant en fonction du site vitrine.

## :rainbow: Remarques
Y avait-il une bonne raison de ne pas mettre les mentions légales dans le footer de Pix-App?
Si le footer de Pix-App est fait ainsi, qu'en est-il de Certif et Orga?
Pourquoi le footer n'est-il pas présent sur la page de connexion?

## :100: Pour tester
- Se rendre sur app.fr,
- Se connecter,
- Constater que l'arria-label du footer s'appel désormais "Menu de bas de page",
- Constater la présence des mention légales dans le footer,
- Se rendre sur app.org,
- Répéter les opérations indiquées plus haut pour chacune des langues.