### PR TITLE
[TECH] Ajout des locales es et nl dans la config i18n de l'API

### DIFF
--- a/api/src/shared/infrastructure/plugins/i18n.js
+++ b/api/src/shared/infrastructure/plugins/i18n.js
@@ -4,7 +4,7 @@ import hapiI18n from 'hapi-i18n';
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 const plugin = hapiI18n;
 const options = {
-  locales: ['en', 'fr'],
+  locales: ['en', 'fr', 'es', 'nl'],
   directory: __dirname + '../../../../translations',
   defaultLocale: 'fr',
   queryParameter: 'lang',


### PR DESCRIPTION
## :unicorn: Problème

Toutes les langues supportées par Pix ne sont pas déclarées dans la configuration i18n de l'API.
**Il manque `es` et `nl`**

## :robot: Proposition

Ajouter `es` et `nl` dans la configuration i18n de l'API.

## :rainbow: Remarques

N/A

## :100: Pour tester

Les tests devraient passer dans aucun soucis particulier.