### PR TITLE
[FEATURE] Changement des seeds pour permettre de developper en local sans activer la session (Pix-13342)

### DIFF
--- a/api/db/seeds/data/team-1d/data-builder.js
+++ b/api/db/seeds/data/team-1d/data-builder.js
@@ -55,7 +55,14 @@ async function _createSco1dOrganizations(databaseBuilder) {
     ],
   });
 
-  await databaseBuilder.factory.buildSchool({ organizationId: TEAM_1D_ORGANIZATION_1_ID, code: 'MINIPIXOU' });
+  const sessionExpirationDate = new Date();
+  sessionExpirationDate.setFullYear(sessionExpirationDate.getFullYear() + 1);
+
+  await databaseBuilder.factory.buildSchool({
+    organizationId: TEAM_1D_ORGANIZATION_1_ID,
+    code: 'MINIPIXOU',
+    sessionExpirationDate,
+  });
 
   await _buildSchoolStudent({
     databaseBuilder,
@@ -139,7 +146,10 @@ async function _createSco1dOrganizations(databaseBuilder) {
     ],
   });
 
-  await databaseBuilder.factory.buildSchool({ organizationId: TEAM_1D_ORGANIZATION_2_ID, code: 'MAXIPIXOU' });
+  await databaseBuilder.factory.buildSchool({
+    organizationId: TEAM_1D_ORGANIZATION_2_ID,
+    code: 'MAXIPIXOU',
+  });
 
   await _buildSchoolStudent({
     databaseBuilder,


### PR DESCRIPTION
:unicorn: Problème
Pendant n'importe quel dev en local nous devons lancer l'app ORGA et activer une session.

## :robot: Proposition
Changer les seeds pour ajouter une date d'expiration de session très large afin de pouvoir dev sur le projet junior sans lancer d'autre projet non ciblé par le développement.

## :100: Pour tester
Lancer la RA sur l'url de junior et essayer d’accéder à la liste des élèves d'une classe.
Si il est impossible d'y accéder depuis junior. Cela veut dire que la session n'a pas été seedé correctement. 
Sinon C'est OK!