### PR TITLE
[FEATURE] Enlever les 20px supplémentaires sur la hauteur auto d'embed (PIX-13354)

### DIFF
--- a/mon-pix/app/components/challenge-embed-simulator.js
+++ b/mon-pix/app/components/challenge-embed-simulator.js
@@ -54,7 +54,7 @@ export default class ChallengeEmbedSimulator extends Component {
         iframe.focus();
       }
       if (isHeightMessage(data)) {
-        thisComponent.embedHeight = data.height + 20;
+        thisComponent.embedHeight = data.height;
       }
       if (isAutoLaunchMessage(data)) {
         thisComponent.launchSimulator();

--- a/mon-pix/tests/integration/components/challenge-embed-simulator_test.js
+++ b/mon-pix/tests/integration/components/challenge-embed-simulator_test.js
@@ -109,7 +109,7 @@ module('Integration | Component | Challenge Embed Simulator', function (hooks) {
 
         await new Promise((resolve) => setTimeout(resolve, 0));
 
-        assert.strictEqual(find('.embed__iframe').style.cssText, 'height: 500px;');
+        assert.strictEqual(find('.embed__iframe').style.cssText, 'height: 480px;');
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Quand la hauteur de l'embed est gérée automatiquement, les 20 pixels supplémentaires ne sont normalement plus nécessaires.

## :robot: Proposition
Enlever ces 20px.

## :rainbow: Remarques
Cette RA pointe sur les embeds de la RA 1024pix/pix-epreuves#1762

## :100: Pour tester
Faire des previews :
 - QCU image challenge1anilZTmbS1zAU challenge1eoAz0eI4Bckrh challenge1ERTH6ogOu8dMK
 - QCM image challenge1BURiczmw3FnRd challenge1BZzhLZJQKD7OS challenge1Df9SGWE0SB5oc
 - MQCUM image challenge11BxCwic0hMry5 challenge1a1CZjBpskfsAo
 - QCU install rec1AgQTH26rQM84P rec1TvGITOWagGD3P rec2rfg27l7nJ0Oyu