### PR TITLE
[FEATURE] Finaliser l'ajout des traduction en NL dans Pix Orga (PIX-13240).

### DIFF
--- a/api/src/shared/infrastructure/utils/url-builder.js
+++ b/api/src/shared/infrastructure/utils/url-builder.js
@@ -22,13 +22,17 @@ function getCampaignUrl(locale, campaignCode) {
   if (!campaignCode) {
     return null;
   }
-  if (locale === 'fr') {
-    return `${PIX_APP_DOMAIN_ORG}/campagnes/${campaignCode}/?lang=fr`;
+
+  switch (locale) {
+    case LOCALE.FRENCH_SPOKEN:
+      return `${PIX_APP_DOMAIN_ORG}/campagnes/${campaignCode}/?lang=fr`;
+    case LOCALE.ENGLISH_SPOKEN:
+      return `${PIX_APP_DOMAIN_ORG}/campagnes/${campaignCode}/?lang=en`;
+    case LOCALE.DUTCH_SPOKEN:
+      return `${PIX_APP_DOMAIN_ORG}/campagnes/${campaignCode}/?lang=nl`;
+    default:
+      return `${PIX_APP_DOMAIN_FR}/campagnes/${campaignCode}`;
   }
-  if (locale === 'en') {
-    return `${PIX_APP_DOMAIN_ORG}/campagnes/${campaignCode}/?lang=en`;
-  }
-  return `${PIX_APP_DOMAIN_FR}/campagnes/${campaignCode}`;
 }
 
 /**

--- a/api/src/shared/infrastructure/utils/url-builder.js
+++ b/api/src/shared/infrastructure/utils/url-builder.js
@@ -18,6 +18,11 @@ function getPixAppBaseUrl(locale) {
   return PIX_APP_DOMAIN_ORG;
 }
 
+/**
+ * @param {string} locale
+ * @param {string} campaignCode
+ * @returns {string|null} - Campaign URL according to the locale
+ */
 function getCampaignUrl(locale, campaignCode) {
   if (!campaignCode) {
     return null;

--- a/api/tests/shared/unit/infrastructure/utils/url-builder_test.js
+++ b/api/tests/shared/unit/infrastructure/utils/url-builder_test.js
@@ -33,28 +33,46 @@ describe('Unit | Shared | Infrastructure | Utils | url-builder', function () {
   });
 
   describe('#getCampaignUrl', function () {
-    it('should return null if campaignCode is not defined', function () {
+    it('returns null if campaignCode is not defined', function () {
       expect(urlBuilder.getCampaignUrl('fr', null)).to.be.null;
     });
 
     describe('when campaignCode is defined', function () {
       const campaignCode = 'AZERTY123';
 
-      it('should return campaignUrl with fr domain when locale is fr-fr', function () {
+      it('returns campaignUrl with fr domain when locale is not supported', function () {
+        expect(urlBuilder.getCampaignUrl('ru', campaignCode)).to.be.equal(
+          `https://app.pix.fr/campagnes/${campaignCode}`,
+        );
+      });
+
+      it('returns campaignUrl with fr domain when locale is not defined', function () {
+        expect(urlBuilder.getCampaignUrl(undefined, campaignCode)).to.be.equal(
+          `https://app.pix.fr/campagnes/${campaignCode}`,
+        );
+      });
+
+      it('returns campaignUrl with fr domain when locale is fr-fr', function () {
         expect(urlBuilder.getCampaignUrl('fr-fr', campaignCode)).to.be.equal(
           `https://app.pix.fr/campagnes/${campaignCode}`,
         );
       });
 
-      it('should return campaignUrl with org domain when locale is fr', function () {
+      it('returns campaignUrl with org domain when locale is fr', function () {
         expect(urlBuilder.getCampaignUrl('fr', campaignCode)).to.be.equal(
           `https://app.pix.org/campagnes/${campaignCode}/?lang=fr`,
         );
       });
 
-      it('should return campaignUrl with org domain when locale is en', function () {
+      it('returns campaignUrl with org domain when locale is en', function () {
         expect(urlBuilder.getCampaignUrl('en', campaignCode)).to.be.equal(
           `https://app.pix.org/campagnes/${campaignCode}/?lang=en`,
+        );
+      });
+
+      it('returns campaignUrl with org domain when locale is nl', function () {
+        expect(urlBuilder.getCampaignUrl('nl', campaignCode)).to.be.equal(
+          `https://app.pix.org/campagnes/${campaignCode}/?lang=nl`,
         );
       });
     });

--- a/orga/app/services/url.js
+++ b/orga/app/services/url.js
@@ -2,9 +2,12 @@ import Service, { inject as service } from '@ember/service';
 import ENV from 'pix-orga/config/environment';
 
 const FRENCH_LOCALE = 'fr';
+const ENGLISH_LOCALE = 'en';
+const DUTCH_LOCALE = 'nl';
 const PIX_FR_DOMAIN = 'https://pix.fr';
 const PIX_ORG_DOMAIN_FR_LOCALE = 'https://pix.org/fr';
 const PIX_ORG_DOMAIN_EN_LOCALE = 'https://pix.org/en-gb';
+const PIX_ORG_DOMAIN_NL_LOCALE = 'https://pix.org/nl-be';
 const PIX_STATUS_DOMAIN = 'https://status.pix.org';
 
 export default class Url extends Service {
@@ -16,6 +19,7 @@ export default class Url extends Service {
     ACCESSIBILITY: {
       en: '/accessibility-pix-orga',
       fr: '/accessibilite-pix-orga',
+      nl: '/toegankelijkheid-pix-orga',
     },
     CGU: {
       en: '/terms-and-conditions',
@@ -24,10 +28,12 @@ export default class Url extends Service {
     DATA_PROTECTION_POLICY: {
       en: '/personal-data-protection-policy',
       fr: '/politique-protection-donnees-personnelles-app',
+      nl: '/beleid-inzake-de-bescherming-van-persoonsgegevens',
     },
     LEGAL_NOTICE: {
       en: '/legal-notice',
       fr: '/mentions-legales',
+      nl: '/wettelijke-vermeldingen',
     },
   };
 
@@ -48,8 +54,8 @@ export default class Url extends Service {
   }
 
   get legalNoticeUrl() {
-    const { en, fr } = this.SHOWCASE_WEBSITE_LOCALE_PATH.LEGAL_NOTICE;
-    return this._computeShowcaseWebsiteUrl({ en, fr });
+    const { en, fr, nl } = this.SHOWCASE_WEBSITE_LOCALE_PATH.LEGAL_NOTICE;
+    return this._computeShowcaseWebsiteUrl({ en, fr, nl });
   }
 
   get cguUrl() {
@@ -58,13 +64,13 @@ export default class Url extends Service {
   }
 
   get dataProtectionPolicyUrl() {
-    const { en, fr } = this.SHOWCASE_WEBSITE_LOCALE_PATH.DATA_PROTECTION_POLICY;
-    return this._computeShowcaseWebsiteUrl({ en, fr });
+    const { en, fr, nl } = this.SHOWCASE_WEBSITE_LOCALE_PATH.DATA_PROTECTION_POLICY;
+    return this._computeShowcaseWebsiteUrl({ en, fr, nl });
   }
 
   get accessibilityUrl() {
-    const { en, fr } = this.SHOWCASE_WEBSITE_LOCALE_PATH.ACCESSIBILITY;
-    return this._computeShowcaseWebsiteUrl({ en, fr });
+    const { en, fr, nl } = this.SHOWCASE_WEBSITE_LOCALE_PATH.ACCESSIBILITY;
+    return this._computeShowcaseWebsiteUrl({ en, fr, nl });
   }
 
   get serverStatusUrl() {
@@ -91,15 +97,22 @@ export default class Url extends Service {
     return `${this.currentDomain.getJuniorBaseUrl()}/schools/${schoolCode}`;
   }
 
-  _computeShowcaseWebsiteUrl({ en: englishPath, fr: frenchPath }) {
+  _computeShowcaseWebsiteUrl({ en: englishPath, fr: frenchPath, nl: dutchPath }) {
     const currentLanguage = this.intl.primaryLocale;
 
     if (this.currentDomain.isFranceDomain) {
       return `${PIX_FR_DOMAIN}${frenchPath}`;
     }
 
-    return currentLanguage === FRENCH_LOCALE
-      ? `${PIX_ORG_DOMAIN_FR_LOCALE}${frenchPath}`
-      : `${PIX_ORG_DOMAIN_EN_LOCALE}${englishPath}`;
+    switch (currentLanguage) {
+      case FRENCH_LOCALE:
+        return `${PIX_ORG_DOMAIN_FR_LOCALE}${frenchPath}`;
+      case ENGLISH_LOCALE:
+        return `${PIX_ORG_DOMAIN_EN_LOCALE}${englishPath}`;
+      case DUTCH_LOCALE:
+        return dutchPath ? `${PIX_ORG_DOMAIN_NL_LOCALE}${dutchPath}` : `${PIX_ORG_DOMAIN_EN_LOCALE}${englishPath}`;
+      default:
+        return 'https://pix.org/fr/mentions-legales';
+    }
   }
 }

--- a/orga/tests/unit/services/url_test.js
+++ b/orga/tests/unit/services/url_test.js
@@ -55,234 +55,194 @@ module('Unit | Service | url', function (hooks) {
   });
 
   module('#legalNoticeUrl', function () {
-    test('returns "pix.fr" url when current domain contains pix.fr', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      const expectedUrl = 'https://pix.fr/mentions-legales';
-      service.currentDomain = { isFranceDomain: true };
-      service.intl = { primaryLocale: 'fr' };
+    module('when domain is pix.fr', function () {
+      test('returns "pix.fr" url', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url');
+        const expectedUrl = 'https://pix.fr/mentions-legales';
+        service.currentDomain = { isFranceDomain: true };
+        service.intl = { primaryLocale: 'fr' };
 
-      // when
-      const url = service.legalNoticeUrl;
+        // when
+        const url = service.legalNoticeUrl;
 
-      // then
-      assert.strictEqual(url, expectedUrl);
+        // then
+        assert.strictEqual(url, expectedUrl);
+      });
     });
 
-    test('returns "pix.org" english url when current language is en', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      const expectedUrl = 'https://pix.org/en-gb/legal-notice';
-      service.currentDomain = { isFranceDomain: false };
-      service.intl = { primaryLocale: 'en' };
+    module('when domain is pix.org', function () {
+      [
+        {
+          primaryLocale: 'en',
+          expectedUrl: 'https://pix.org/en-gb/legal-notice',
+        },
+        {
+          primaryLocale: 'fr',
+          expectedUrl: 'https://pix.org/fr/mentions-legales',
+        },
+        {
+          primaryLocale: 'nl',
+          expectedUrl: 'https://pix.org/nl-be/wettelijke-vermeldingen',
+        },
+      ].forEach(({ primaryLocale, expectedUrl }) => {
+        test(`returns "pix.org" ${primaryLocale} url when locale is ${primaryLocale}`, function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.currentDomain = { isFranceDomain: false };
+          service.intl = { primaryLocale };
 
-      // when
-      const url = service.legalNoticeUrl;
+          // when
+          const url = service.legalNoticeUrl;
 
-      // then
-      assert.strictEqual(url, expectedUrl);
-    });
-
-    test('returns "pix.org" dutch url when current language is nl', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      const expectedUrl = 'https://pix.org/nl-be/wettelijke-vermeldingen';
-      service.currentDomain = { isFranceDomain: false };
-      service.intl = { primaryLocale: 'nl' };
-
-      // when
-      const url = service.legalNoticeUrl;
-
-      // then
-      assert.strictEqual(url, expectedUrl);
-    });
-
-    test('returns "pix.org" french url when current language is fr and domain extension is .org', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      const expectedUrl = 'https://pix.org/fr/mentions-legales';
-      service.currentDomain = { isFranceDomain: false };
-      service.intl = { primaryLocale: 'fr' };
-
-      // when
-      const url = service.legalNoticeUrl;
-
-      // then
-      assert.strictEqual(url, expectedUrl);
+          // then
+          assert.strictEqual(url, expectedUrl);
+        });
+      });
     });
   });
 
   module('#dataProtectionPolicyUrl', function () {
-    test('returns "pix.fr" url when current domain contains pix.fr', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      const expectedCguUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
-      service.currentDomain = { isFranceDomain: true };
-      service.intl = { primaryLocale: 'fr' };
+    module('when domain is pix.fr', function () {
+      test('returns "pix.fr" url', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url');
+        const expectedUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
+        service.currentDomain = { isFranceDomain: true };
+        service.intl = { primaryLocale: 'fr' };
 
-      // when
-      const cguUrl = service.dataProtectionPolicyUrl;
+        // when
+        const cguUrl = service.dataProtectionPolicyUrl;
 
-      // then
-      assert.strictEqual(cguUrl, expectedCguUrl);
+        // then
+        assert.strictEqual(cguUrl, expectedUrl);
+      });
     });
 
-    test('returns "pix.org" english url when current language is en', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      const expectedCguUrl = 'https://pix.org/en-gb/personal-data-protection-policy';
-      service.currentDomain = { isFranceDomain: false };
-      service.intl = { primaryLocale: 'en' };
+    module('when domain is pix.org', function () {
+      [
+        {
+          primaryLocale: 'en',
+          expectedUrl: 'https://pix.org/en-gb/personal-data-protection-policy',
+        },
+        {
+          primaryLocale: 'fr',
+          expectedUrl: 'https://pix.org/fr/politique-protection-donnees-personnelles-app',
+        },
+        {
+          primaryLocale: 'nl',
+          expectedUrl: 'https://pix.org/nl-be/beleid-inzake-de-bescherming-van-persoonsgegevens',
+        },
+      ].forEach(({ primaryLocale, expectedUrl }) => {
+        test(`returns "pix.org" ${primaryLocale} url when locale is ${primaryLocale}`, function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.currentDomain = { isFranceDomain: false };
+          service.intl = { primaryLocale };
 
-      // when
-      const cguUrl = service.dataProtectionPolicyUrl;
+          // when
+          const url = service.dataProtectionPolicyUrl;
 
-      // then
-      assert.strictEqual(cguUrl, expectedCguUrl);
-    });
-
-    test('returns "pix.org" dutch url when current language is nl', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      const expectedCguUrl = 'https://pix.org/nl-be/beleid-inzake-de-bescherming-van-persoonsgegevens';
-      service.currentDomain = { isFranceDomain: false };
-      service.intl = { primaryLocale: 'nl' };
-
-      // when
-      const cguUrl = service.dataProtectionPolicyUrl;
-
-      // then
-      assert.strictEqual(cguUrl, expectedCguUrl);
-    });
-
-    test('returns "pix.org" french url when current language is fr', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      const expectedCguUrl = 'https://pix.org/fr/politique-protection-donnees-personnelles-app';
-      service.currentDomain = { isFranceDomain: false };
-      service.intl = { primaryLocale: 'fr' };
-
-      // when
-      const cguUrl = service.dataProtectionPolicyUrl;
-
-      // then
-      assert.strictEqual(cguUrl, expectedCguUrl);
+          // then
+          assert.strictEqual(url, expectedUrl);
+        });
+      });
     });
   });
 
   module('#cguUrl', function () {
-    test('returns "pix.fr" url when current domain contains pix.fr', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      const expectedCguUrl = 'https://pix.fr/conditions-generales-d-utilisation';
-      service.currentDomain = { isFranceDomain: true };
-      service.intl = { primaryLocale: 'fr' };
+    module('when domain is pix.fr', function () {
+      test('returns "pix.fr" url', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url');
+        const expectedUrl = 'https://pix.fr/conditions-generales-d-utilisation';
+        service.currentDomain = { isFranceDomain: true };
+        service.intl = { primaryLocale: 'fr' };
 
-      // when
-      const cguUrl = service.cguUrl;
+        // when
+        const url = service.cguUrl;
 
-      // then
-      assert.strictEqual(cguUrl, expectedCguUrl);
+        // then
+        assert.strictEqual(url, expectedUrl);
+      });
     });
 
-    test('returns "pix.org" english url when current language is en', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      const expectedCguUrl = 'https://pix.org/en-gb/terms-and-conditions';
-      service.currentDomain = { isFranceDomain: false };
-      service.intl = { primaryLocale: 'en' };
+    module('when domain is pix.org', function () {
+      [
+        {
+          primaryLocale: 'en',
+          expectedUrl: 'https://pix.org/en-gb/terms-and-conditions',
+        },
+        {
+          primaryLocale: 'fr',
+          expectedUrl: 'https://pix.org/fr/conditions-generales-d-utilisation',
+        },
+        {
+          primaryLocale: 'nl',
+          expectedUrl: 'https://pix.org/en-gb/terms-and-conditions',
+        },
+      ].forEach(({ primaryLocale, expectedUrl }) => {
+        test(`returns "pix.org" ${primaryLocale} url when locale is ${primaryLocale}`, function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.currentDomain = { isFranceDomain: false };
+          service.intl = { primaryLocale };
 
-      // when
-      const cguUrl = service.cguUrl;
+          // when
+          const url = service.cguUrl;
 
-      // then
-      assert.strictEqual(cguUrl, expectedCguUrl);
-    });
-
-    test('returns "pix.org" english url when current language is nl', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      const expectedCguUrl = 'https://pix.org/en-gb/terms-and-conditions';
-      service.currentDomain = { isFranceDomain: false };
-      service.intl = { primaryLocale: 'nl' };
-
-      // when
-      const cguUrl = service.cguUrl;
-
-      // then
-      assert.strictEqual(cguUrl, expectedCguUrl);
-    });
-
-    test('returns "pix.org" french url when current language is fr', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      const expectedCguUrl = 'https://pix.org/fr/conditions-generales-d-utilisation';
-      service.currentDomain = { isFranceDomain: false };
-      service.intl = { primaryLocale: 'fr' };
-
-      // when
-      const cguUrl = service.cguUrl;
-
-      // then
-      assert.strictEqual(cguUrl, expectedCguUrl);
+          // then
+          assert.strictEqual(url, expectedUrl);
+        });
+      });
     });
   });
 
   module('#accessibilityUrl', function () {
-    test('returns "pix.fr" when current domain contains pix.fr', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      const expectedUrl = 'https://pix.fr/accessibilite-pix-orga';
-      service.currentDomain = { isFranceDomain: true };
-      service.intl = { primaryLocale: 'fr' };
+    module('when domain is pix.fr', function () {
+      test('returns "pix.fr"', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url');
+        const expectedUrl = 'https://pix.fr/accessibilite-pix-orga';
+        service.currentDomain = { isFranceDomain: true };
+        service.intl = { primaryLocale: 'fr' };
 
-      // when
-      const url = service.accessibilityUrl;
+        // when
+        const url = service.accessibilityUrl;
 
-      // then
-      assert.strictEqual(url, expectedUrl);
+        // then
+        assert.strictEqual(url, expectedUrl);
+      });
     });
 
-    test('returns "pix.org" in english when current language is en', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      const expectedUrl = 'https://pix.org/en-gb/accessibility-pix-orga';
-      service.currentDomain = { isFranceDomain: false };
-      service.intl = { primaryLocale: 'en' };
+    module('when domain is pix.org', function () {
+      [
+        {
+          primaryLocale: 'en',
+          expectedUrl: 'https://pix.org/en-gb/accessibility-pix-orga',
+        },
+        {
+          primaryLocale: 'fr',
+          expectedUrl: 'https://pix.org/fr/accessibilite-pix-orga',
+        },
+        {
+          primaryLocale: 'nl',
+          expectedUrl: 'https://pix.org/nl-be/toegankelijkheid-pix-orga',
+        },
+      ].forEach(({ primaryLocale, expectedUrl }) => {
+        test(`returns "pix.org" ${primaryLocale} url when locale is ${primaryLocale}`, function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.currentDomain = { isFranceDomain: false };
+          service.intl = { primaryLocale };
 
-      // when
-      const url = service.accessibilityUrl;
+          // when
+          const url = service.accessibilityUrl;
 
-      // then
-      assert.strictEqual(url, expectedUrl);
-    });
-
-    test('returns "pix.org" in dutch when current language is nl', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      const expectedUrl = 'https://pix.org/nl-be/toegankelijkheid-pix-orga';
-      service.currentDomain = { isFranceDomain: false };
-      service.intl = { primaryLocale: 'nl' };
-
-      // when
-      const url = service.accessibilityUrl;
-
-      // then
-      assert.strictEqual(url, expectedUrl);
-    });
-
-    test('returns "pix.org" in french when current language is fr', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      const expectedUrl = 'https://pix.org/fr/accessibilite-pix-orga';
-      service.currentDomain = { isFranceDomain: false };
-      service.intl = { primaryLocale: 'fr' };
-
-      // when
-      const url = service.accessibilityUrl;
-
-      // then
-      assert.strictEqual(url, expectedUrl);
+          // then
+          assert.strictEqual(url, expectedUrl);
+        });
+      });
     });
   });
 

--- a/orga/tests/unit/services/url_test.js
+++ b/orga/tests/unit/services/url_test.js
@@ -83,6 +83,20 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(url, expectedUrl);
     });
 
+    test('returns "pix.org" dutch url when current language is nl', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      const expectedUrl = 'https://pix.org/nl-be/wettelijke-vermeldingen';
+      service.currentDomain = { isFranceDomain: false };
+      service.intl = { primaryLocale: 'nl' };
+
+      // when
+      const url = service.legalNoticeUrl;
+
+      // then
+      assert.strictEqual(url, expectedUrl);
+    });
+
     test('returns "pix.org" french url when current language is fr and domain extension is .org', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
@@ -119,6 +133,20 @@ module('Unit | Service | url', function (hooks) {
       const expectedCguUrl = 'https://pix.org/en-gb/personal-data-protection-policy';
       service.currentDomain = { isFranceDomain: false };
       service.intl = { primaryLocale: 'en' };
+
+      // when
+      const cguUrl = service.dataProtectionPolicyUrl;
+
+      // then
+      assert.strictEqual(cguUrl, expectedCguUrl);
+    });
+
+    test('returns "pix.org" dutch url when current language is nl', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      const expectedCguUrl = 'https://pix.org/nl-be/beleid-inzake-de-bescherming-van-persoonsgegevens';
+      service.currentDomain = { isFranceDomain: false };
+      service.intl = { primaryLocale: 'nl' };
 
       // when
       const cguUrl = service.dataProtectionPolicyUrl;
@@ -171,6 +199,20 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(cguUrl, expectedCguUrl);
     });
 
+    test('returns "pix.org" english url when current language is nl', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      const expectedCguUrl = 'https://pix.org/en-gb/terms-and-conditions';
+      service.currentDomain = { isFranceDomain: false };
+      service.intl = { primaryLocale: 'nl' };
+
+      // when
+      const cguUrl = service.cguUrl;
+
+      // then
+      assert.strictEqual(cguUrl, expectedCguUrl);
+    });
+
     test('returns "pix.org" french url when current language is fr', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
@@ -215,6 +257,20 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(url, expectedUrl);
     });
 
+    test('returns "pix.org" in dutch when current language is nl', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      const expectedUrl = 'https://pix.org/nl-be/toegankelijkheid-pix-orga';
+      service.currentDomain = { isFranceDomain: false };
+      service.intl = { primaryLocale: 'nl' };
+
+      // when
+      const url = service.accessibilityUrl;
+
+      // then
+      assert.strictEqual(url, expectedUrl);
+    });
+
     test('returns "pix.org" in french when current language is fr', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
@@ -244,7 +300,7 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(serverStatusUrl, expectedUrl);
     });
 
-    test('returns "status.pix.org" in french when current language is en', function (assert) {
+    test('returns "status.pix.org" in french when current language is fr', function (assert) {
       // given
       const expectedUrl = 'https://status.pix.org?locale=fr';
       const service = this.owner.lookup('service:url');
@@ -256,7 +312,21 @@ module('Unit | Service | url', function (hooks) {
       // then
       assert.strictEqual(serverStatusUrl, expectedUrl);
     });
+
+    test('returns "status.pix.org" in french when current language is nl', function (assert) {
+      // given
+      const expectedUrl = 'https://status.pix.org?locale=nl';
+      const service = this.owner.lookup('service:url');
+      service.intl = { primaryLocale: 'nl' };
+
+      // when
+      const serverStatusUrl = service.serverStatusUrl;
+
+      // then
+      assert.strictEqual(serverStatusUrl, expectedUrl);
+    });
   });
+
   module('#pixJuniorSchoolUrl', function () {
     test('returns pix junior url for current organization', function (assert) {
       const service = this.owner.lookup('service:url');

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -751,7 +751,7 @@
         }
       },
       "forgot-password": "Wachtwoord vergeten?",
-      "forgotten-password-url": "https://app.pix.fr/mot-de-passe-oublie",
+      "forgotten-password-url": "https://app.pix.org/mot-de-passe-oublie?lang=nl",
       "invitation-already-accepted": "Deze uitnodiging is al geaccepteerd. Log in of neem contact op met de beheerder van je Pix Orga-ruimte.",
       "invitation-was-cancelled": "Deze uitnodiging is niet langer geldig. Neem contact op met de beheerder van je Pix Orga-ruimte.",
       "is-only-accessible": "Toegang tot Pix Orga is beperkt tot uitgenodigde leden. Neem contact op met de Pix Orga-beheerder van je organisatie om je uit te nodigen.",


### PR DESCRIPTION
## :unicorn: Problème
Il manque des traductions pour la langue néerlandaise sur Pix Orga. Notamment, le liens pour rejoindre une campagne, les liens légaux dans le footer et la redirection du formulaire pour le mot de passe oublié. 

## :robot: Proposition
Les traduire.

## :rainbow: Remarques
Ras

## :100: Pour tester
- aller sur Pix Orga.org
- choisir la langue `Nederlands` et vérifier que le lien du `Mot de passe oublié` redirige bien vers la page de changement de mot de passe en néerlandais.
- ensuite se connecter avec le compte `allorga@example.net`
- vérifier que les 3 liens dans le footer redirige bien vers des pages en néerlandais
- enfin aller sur le sur le lien de campagne : https://app-pr9478.review.pix.org/campagnes/SCOBADGE1/?lang=nl et voir que le texte est bien traduit