### PR TITLE
[BUGFIX] Corriger l'ajout de plusieurs candidats à la certif complémentaire par la modale (PIX-13286).

### DIFF
--- a/certif/app/components/new-candidate-modal/index.gjs
+++ b/certif/app/components/new-candidate-modal/index.gjs
@@ -165,8 +165,13 @@ export default class NewCandidateModal extends Component {
 
   updateComplementaryCertification = (complementaryCertification) => {
     if (complementaryCertification?.key) {
-      this.selectedComplementaryCertification = complementaryCertification;
-      this.args.candidateData.complementaryCertification = complementaryCertification;
+      // The complementary certification parameter is passed by reference to the certification candidate
+      // Creating a copy of this complementary certification prevents the original object to be mutated in the CertificationCandidateSerializer file
+      // when the API call is being done and therefore prevents the hasComplementaryReferential property to be removed from the object
+      // TODO Send only the id of the complementary certification
+      const copiedComplementaryCertification = { ...complementaryCertification };
+      this.selectedComplementaryCertification = copiedComplementaryCertification;
+      this.args.candidateData.complementaryCertification = copiedComplementaryCertification;
     } else {
       this.selectedComplementaryCertification = undefined;
       this.args.candidateData.complementaryCertification = undefined;
@@ -202,6 +207,7 @@ export default class NewCandidateModal extends Component {
     document.getElementById('new-candidate-form').reset();
     this.selectedCountryInseeCode = FRANCE_INSEE_CODE;
     this.selectedBirthGeoCodeOption = INSEE_CODE_OPTION;
+    this.selectedComplementaryCertification = undefined;
   }
 
   _hasComplementaryReferential() {

--- a/certif/tests/acceptance/session-add-candidate_test.js
+++ b/certif/tests/acceptance/session-add-candidate_test.js
@@ -1,0 +1,69 @@
+import { visit as visitScreen } from '@1024pix/ember-testing-library';
+import { click, fillIn } from '@ember/test-helpers';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import { authenticateSession } from '../helpers/test-init';
+
+module('Acceptance | Session Add Candidate', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  module('When certification center is both pix/pix+ split and V3 pilot', function () {
+    module('when a candidate with a complementary certification has just been added', function () {
+      test('it should be possible to add another candidate with a complementary certification', async function (assert) {
+        // given
+        const allowedCertificationCenterAccess = server.create('allowed-certification-center-access', {
+          type: 'PRO',
+          habilitations: [
+            { id: '1', label: 'Certif complémentaire 2', key: 'COMP_2', hasComplementaryReferential: true },
+          ],
+          isComplementaryAlonePilot: true,
+        });
+
+        const certificationPointOfContact = server.create('certification-point-of-contact', {
+          firstName: 'Eddy',
+          lastName: 'Taurial',
+          allowedCertificationCenterAccesses: [allowedCertificationCenterAccess],
+          pixCertifTermsOfServiceAccepted: true,
+        });
+
+        const session = server.create('session-enrolment', {
+          certificationCenterId: allowedCertificationCenterAccess.id,
+        });
+
+        server.create('session-management', {
+          id: session.id,
+        });
+
+        server.createList('country', 1);
+
+        await authenticateSession(certificationPointOfContact.id);
+        const screen = await visitScreen(`/sessions/${session.id}/candidats`);
+
+        await _addCandidateWithComplementaryCertification({ screen, firstName: 'first' });
+
+        // when
+        await _addCandidateWithComplementaryCertification({ screen, firstName: 'second' });
+
+        // then
+        assert.dom(screen.getByText('second')).exists();
+      });
+    });
+  });
+});
+
+async function _addCandidateWithComplementaryCertification({ screen, firstName }) {
+  await click(screen.getByRole('button', { name: 'Inscrire un candidat' }));
+  await fillIn(screen.getByLabelText('* Nom de naissance'), 'candidate');
+  await fillIn(screen.getByLabelText('* Prénom'), firstName);
+  await click(screen.getByLabelText('Femme'));
+  await fillIn(screen.getByLabelText('* Date de naissance'), '01/01/2000');
+  await click(screen.getByLabelText('* Pays de naissance'));
+  await click(screen.getByText('Portugal'));
+  await fillIn(screen.getByLabelText('* Commune de naissance'), 'Paris');
+  await click(screen.getByLabelText('Certif complémentaire 2'));
+  await click(screen.getByLabelText('La certification Pix et Pix+'));
+  await click(screen.getByRole('button', { name: 'Inscrire le candidat' }));
+}


### PR DESCRIPTION
## :unicorn: Problème

Lorsque l'on ajoute un candidat à une certification complémentaire dans le cadre de la séparation Pix/Pix+ via la modale d'inscription, l'ajout du premier candidat se fait sans encombre mais un problème survient pour l'ajout d'un autre candidat.

En effet, la sélection d'une certification complémentaire ne fait pas apparaitre la deuxième section liée au choix de la façon dont sera passée la certif (Pix Coeur OU Pix coeur et Pix+)

Voir [la vidéo démo suivante](https://github.com/1024pix/pix/pull/9448#pullrequestreview-2159070121)

## :robot: Proposition

On duplique la complementary certification avant de l'ajouter au certification-candidate afin de ne pas supprimer par référence la propriété `hasComplementaryReferential` dans le serializer lors de l'envoi à l'API.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

- Se connecter sur pix-certif avec `certifv3@example.net`
- Séléctionner le centre de séparation Pix/Pix+
- Créer une session ou prendre une session déjà existante
- Ajouter un candidat via la modale en ajoutant la certification `Pix+ Droit` et l'une des deux options qui apparaissent (Pix coeur seul ou Pix Coeur & Pix+)

Vérifier qu'il est possible de réitérer l'opération pour un autre candidat
