### PR TITLE
[FEATURE] Permettre de récupérer un espace Pix Orga pour une orga de type SCO 1D (Pix-13141)

### DIFF
--- a/api/lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js
+++ b/api/lib/domain/usecases/create-organizations-with-tags-and-target-profiles.js
@@ -120,7 +120,9 @@ async function _createOrganizations({
 function _transformOrganizationsCsvData(organizationsCsvData) {
   const organizations = organizationsCsvData.map((organizationCsvData) => {
     const email =
-      organizationCsvData.type === Organization.types.SCO ? organizationCsvData.emailForSCOActivation : undefined;
+      organizationCsvData.type === Organization.types.SCO || organizationCsvData.type === Organization.types.SCO1D
+        ? organizationCsvData.emailForSCOActivation
+        : undefined;
     return {
       organization: new OrganizationForAdmin({
         ...organizationCsvData,

--- a/api/src/shared/infrastructure/repositories/organization-repository.js
+++ b/api/src/shared/infrastructure/repositories/organization-repository.js
@@ -163,7 +163,8 @@ const findScoOrganizationsByUai = async function ({ uai }) {
 
 const findActiveScoOrganizationsByExternalId = async function (externalId) {
   const organizationsDB = await knex(ORGANIZATIONS_TABLE_NAME)
-    .where({ type: Organization.types.SCO, archivedAt: null })
+    .where({ archivedAt: null })
+    .whereIn('type', [Organization.types.SCO, Organization.types.SCO1D])
     .whereRaw('LOWER("externalId") = ?', `${externalId.toLowerCase()}`);
 
   return organizationsDB.map((model) => _toDomain(model));

--- a/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
+++ b/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
@@ -782,7 +782,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           provinceCode: '123',
           tags: 'TAG1',
           credit: 0,
-          emailInvitations: 'youness@example.net',
+          emailForSCOActivation: 'youness@example.net',
           organizationInvitationRole: Membership.roles.ADMIN,
           locale: 'fr-fr',
           createdBy: userId,
@@ -825,6 +825,7 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
 
       const savedSco1dOrganizations = await knex('organizations').where({ type: 'SCO-1D' });
       expect(savedSco1dOrganizations.length).to.equal(1);
+      expect(savedSco1dOrganizations[0].email).to.equal('youness@example.net');
 
       expect(savedSchools[0].organizationId).to.equal(savedSco1dOrganizations[0].id);
     });

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -517,6 +517,26 @@ describe('Integration | Repository | Organization', function () {
       expect(activeOrganizations[0].archivedAt).to.be.null;
     });
 
+    context("When the organization' s type in SCO-1D", function () {
+      it('returns the organization SCO-1D', async function () {
+        const uai = '0587996b';
+        const school = databaseBuilder.factory.buildOrganization({
+          type: 'SCO-1D',
+          name: 'organization SCO-1D',
+          externalId: uai,
+          email: 'sco-1d.generic.account@example.net',
+        });
+        await databaseBuilder.commit();
+
+        const activeOrganizations = await organizationRepository.findActiveScoOrganizationsByExternalId(uai);
+
+        // then
+        expect(activeOrganizations).to.have.lengthOf(1);
+        expect(activeOrganizations[0].id).to.equal(school.id);
+        expect(activeOrganizations[0].archivedAt).to.be.null;
+      });
+    });
+
     context('when given UAI does not exist', function () {
       it('returns an empty array', async function () {
         // when


### PR DESCRIPTION
## :unicorn: Problème
On souhaite ouvrir des espaces pix Orga aux futurs directeurs/enseignant(e)s d'écoles dans le cadre du lancement de pix Junior.
Pour ce faire, on souhaite envoyer des mails aux directeurs pour qu'ils/elles puissent activer leur espace.
Ce processus existe déjà pour les orga de type SCO.

## :robot: Proposition
Mettre à jour la mécanique pour la rendre compatible avec les orgas de types SCO-1D

## :rainbow: Remarques
RAS

## :100: Pour tester
- Créer un ficher de création en masse d'orga avec des orga de types SCO-1D
- Importer ce fichier dans pix admin
- Voir que les orgas ont été créées et que les mails d'activation des espaces ont été envoyés.