### PR TITLE
[FEATURE] Pouvoir consommer des éléments `embed` sans complétion requise (PIX-13090)

### DIFF
--- a/api/src/devcomp/domain/models/element/Embed.js
+++ b/api/src/devcomp/domain/models/element/Embed.js
@@ -1,0 +1,20 @@
+import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asserts.js';
+import { Element } from './Element.js';
+
+class Embed extends Element {
+  constructor({ id, isCompletionRequired, title, url, height }) {
+    super({ id, type: 'embed' });
+
+    assertNotNullOrUndefined(isCompletionRequired, 'The isCompletionRequired attribute is required for an embed');
+    assertNotNullOrUndefined(title, 'The title is required for an embed');
+    assertNotNullOrUndefined(url, 'The url is required for an embed');
+    assertNotNullOrUndefined(height, 'The height is required for an embed');
+
+    this.isCompletionRequired = isCompletionRequired;
+    this.title = title;
+    this.url = url;
+    this.height = height;
+  }
+}
+
+export { Embed };

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -7,6 +7,7 @@ import { BlockText } from '../../domain/models/block/BlockText.js';
 import { ComponentElement } from '../../domain/models/component/ComponentElement.js';
 import { ComponentStepper } from '../../domain/models/component/ComponentStepper.js';
 import { Step } from '../../domain/models/component/Step.js';
+import { Embed } from '../../domain/models/element/Embed.js';
 import { Image } from '../../domain/models/element/Image.js';
 import { QCM } from '../../domain/models/element/QCM.js';
 import { QCU } from '../../domain/models/element/QCU.js';
@@ -102,6 +103,8 @@ export class ModuleFactory {
           : ModuleFactory.#buildQROCM(element);
       case 'video':
         return ModuleFactory.#buildVideo(element);
+      case 'embed':
+        return ModuleFactory.#buildEmbed(element);
       default:
         logger.warn({
           event: 'module_element_type_unknown',
@@ -134,6 +137,16 @@ export class ModuleFactory {
       url: element.url,
       subtitles: element.subtitles,
       transcription: element.transcription,
+    });
+  }
+
+  static #buildEmbed(element) {
+    return new Embed({
+      id: element.id,
+      isCompletionRequired: element.isCompletionRequired,
+      title: element.title,
+      url: element.url,
+      height: element.height,
     });
   }
 

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -85,10 +85,14 @@ export class ModuleFactory {
 
   static #buildElement(element, isForReferentialValidation) {
     switch (element.type) {
+      case 'embed':
+        return ModuleFactory.#buildEmbed(element);
       case 'image':
         return ModuleFactory.#buildImage(element);
       case 'text':
         return ModuleFactory.#buildText(element);
+      case 'video':
+        return ModuleFactory.#buildVideo(element);
       case 'qcm':
         return isForReferentialValidation
           ? ElementForVerificationFactory.build(element)
@@ -101,10 +105,6 @@ export class ModuleFactory {
         return isForReferentialValidation
           ? ElementForVerificationFactory.build(element)
           : ModuleFactory.#buildQROCM(element);
-      case 'video':
-        return ModuleFactory.#buildVideo(element);
-      case 'embed':
-        return ModuleFactory.#buildEmbed(element);
       default:
         logger.warn({
           event: 'module_element_type_unknown',
@@ -114,10 +114,13 @@ export class ModuleFactory {
     }
   }
 
-  static #buildText(element) {
-    return new Text({
+  static #buildEmbed(element) {
+    return new Embed({
       id: element.id,
-      content: element.content,
+      isCompletionRequired: element.isCompletionRequired,
+      title: element.title,
+      url: element.url,
+      height: element.height,
     });
   }
 
@@ -127,6 +130,13 @@ export class ModuleFactory {
       url: element.url,
       alt: element.alt,
       alternativeText: element.alternativeText,
+    });
+  }
+
+  static #buildText(element) {
+    return new Text({
+      id: element.id,
+      content: element.content,
     });
   }
 
@@ -140,13 +150,17 @@ export class ModuleFactory {
     });
   }
 
-  static #buildEmbed(element) {
-    return new Embed({
+  static #buildQCM(element) {
+    return new QCM({
       id: element.id,
-      isCompletionRequired: element.isCompletionRequired,
-      title: element.title,
-      url: element.url,
-      height: element.height,
+      instruction: element.instruction,
+      locales: element.locales,
+      proposals: element.proposals.map((proposal) => {
+        return new QcmProposal({
+          id: proposal.id,
+          content: proposal.content,
+        });
+      }),
     });
   }
 
@@ -157,20 +171,6 @@ export class ModuleFactory {
       locales: element.locales,
       proposals: element.proposals.map((proposal) => {
         return new QcuProposal({
-          id: proposal.id,
-          content: proposal.content,
-        });
-      }),
-    });
-  }
-
-  static #buildQCM(element) {
-    return new QCM({
-      id: element.id,
-      instruction: element.instruction,
-      locales: element.locales,
-      proposals: element.proposals.map((proposal) => {
-        return new QcmProposal({
           id: proposal.id,
           content: proposal.content,
         });

--- a/api/tests/devcomp/integration/repositories/module-repository_test.js
+++ b/api/tests/devcomp/integration/repositories/module-repository_test.js
@@ -1,19 +1,8 @@
-import { BlockInput } from '../../../../src/devcomp/domain/models/block/BlockInput.js';
-import { BlockSelect } from '../../../../src/devcomp/domain/models/block/BlockSelect.js';
-import { BlockText } from '../../../../src/devcomp/domain/models/block/BlockText.js';
-import { Image } from '../../../../src/devcomp/domain/models/element/Image.js';
-import { QCM } from '../../../../src/devcomp/domain/models/element/QCM.js';
-import { QCU } from '../../../../src/devcomp/domain/models/element/QCU.js';
-import { QROCM } from '../../../../src/devcomp/domain/models/element/QROCM.js';
-import { Text } from '../../../../src/devcomp/domain/models/element/Text.js';
-import { Video } from '../../../../src/devcomp/domain/models/element/Video.js';
-import { Grain } from '../../../../src/devcomp/domain/models/Grain.js';
 import { Module } from '../../../../src/devcomp/domain/models/module/Module.js';
-import { TransitionText } from '../../../../src/devcomp/domain/models/TransitionText.js';
 import moduleDatasource from '../../../../src/devcomp/infrastructure/datasources/learning-content/module-datasource.js';
+import { ModuleFactory } from '../../../../src/devcomp/infrastructure/factories/module-factory.js';
 import * as moduleRepository from '../../../../src/devcomp/infrastructure/repositories/module-repository.js';
 import { NotFoundError } from '../../../../src/shared/domain/errors.js';
-import { logger } from '../../../../src/shared/infrastructure/utils/logger.js';
 import { catchErr, expect, sinon } from '../../../test-helper.js';
 
 describe('Integration | DevComp | Repositories | ModuleRepository', function () {
@@ -53,515 +42,58 @@ describe('Integration | DevComp | Repositories | ModuleRepository', function () 
       });
     });
 
-    it('should return a module with grains if it exists', async function () {
-      // given
-      const existingModuleSlug = 'didacticiel-modulix';
+    it('should return a Module instance', async function () {
+      const existingModuleSlug = 'bien-ecrire-son-adresse-mail';
+      const expectedFoundModule = {
+        id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
+        slug: existingModuleSlug,
+        title: 'Bien écrire son adresse mail',
+        details: {
+          image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
+          description:
+            'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
+          duration: 12,
+          level: 'Débutant',
+          objectives: [
+            'Écrire une adresse mail correctement, en évitant les erreurs courantes',
+            'Connaître les parties d’une adresse mail et les identifier sur des exemples',
+            'Comprendre les fonctions des parties d’une adresse mail',
+          ],
+        },
+        grains: [
+          {
+            id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
+            type: 'lesson',
+            title: 'Explications : les parties d’une adresse mail',
+            components: [
+              {
+                type: 'element',
+                element: {
+                  id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
+                  type: 'text',
+                  content:
+                    "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
+                },
+              },
+            ],
+          },
+        ],
+      };
+      const moduleDatasourceStub = {
+        getBySlug: sinon.stub(),
+      };
+      moduleDatasourceStub.getBySlug.withArgs(existingModuleSlug).resolves(expectedFoundModule);
+      sinon.spy(ModuleFactory, 'build');
 
       // when
       const module = await moduleRepository.getBySlug({
         slug: existingModuleSlug,
-        moduleDatasource,
+        moduleDatasource: moduleDatasourceStub,
       });
 
       // then
-      expect(module).to.be.instanceOf(Module);
-      expect(module.grains.every((grain) => grain instanceof Grain)).to.be.true;
-    });
-
-    it('should return a module with transition texts if it exists', async function () {
-      // given
-      const existingModuleSlug = 'didacticiel-modulix';
-
-      // when
-      const module = await moduleRepository.getBySlug({
-        slug: existingModuleSlug,
-        moduleDatasource,
-      });
-
-      // then
-      expect(module.transitionTexts.every((transitionText) => transitionText instanceof TransitionText)).to.be.true;
-    });
-
-    describe('grain with componentElement', function () {
-      it('should return a module which contains a componentElement of type Text if it exists', async function () {
-        // given
-        const existingModuleSlug = 'bien-ecrire-son-adresse-mail';
-        const expectedFoundModule = {
-          id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
-          slug: 'bien-ecrire-son-adresse-mail',
-          title: 'Bien écrire son adresse mail',
-          details: {
-            image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
-            description:
-              'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
-            duration: 12,
-            level: 'Débutant',
-            objectives: [
-              'Écrire une adresse mail correctement, en évitant les erreurs courantes',
-              'Connaître les parties d’une adresse mail et les identifier sur des exemples',
-              'Comprendre les fonctions des parties d’une adresse mail',
-            ],
-          },
-          grains: [
-            {
-              id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
-              type: 'lesson',
-              title: 'Explications : les parties d’une adresse mail',
-              components: [
-                {
-                  type: 'element',
-                  element: {
-                    id: 'd9e8a7b6-5c4d-3e2f-1a0b-9f8e7d6c5b4a',
-                    type: 'text',
-                    content:
-                      "<h3 class='screen-reader-only'>L'arobase</h3><p>L’arobase est dans toutes les adresses mails. Il sépare l’identifiant et le fournisseur d’adresse mail.</p><p><span aria-hidden='true'>🇬🇧</span> En anglais, ce symbole se lit <i lang='en'>“at”</i> qui veut dire “chez”.</p><p><span aria-hidden='true'>🤔</span> Le saviez-vous : c’est un symbole qui était utilisé bien avant l’informatique ! Par exemple, pour compter des quantités.</p>",
-                  },
-                },
-              ],
-            },
-          ],
-        };
-        const moduleDatasourceStub = {
-          getBySlug: sinon.stub(),
-        };
-        moduleDatasourceStub.getBySlug.withArgs(existingModuleSlug).resolves(expectedFoundModule);
-
-        // when
-        const module = await moduleRepository.getBySlug({
-          slug: existingModuleSlug,
-          moduleDatasource: moduleDatasourceStub,
-        });
-
-        // then
-        expect(module.grains[0].components).to.have.lengthOf(1);
-        expect(module.grains[0].components[0].element).to.be.instanceOf(Text);
-      });
-
-      it('should return a module which contains a componentElement of type QCU if it exists', async function () {
-        // given
-        const existingModuleSlug = 'bien-ecrire-son-adresse-mail';
-        const expectedFoundModule = {
-          id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
-          slug: 'bien-ecrire-son-adresse-mail',
-          title: 'Bien écrire son adresse mail',
-          details: {
-            image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
-            description:
-              'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
-            duration: 12,
-            level: 'Débutant',
-            objectives: [
-              'Écrire une adresse mail correctement, en évitant les erreurs courantes',
-              'Connaître les parties d’une adresse mail et les identifier sur des exemples',
-              'Comprendre les fonctions des parties d’une adresse mail',
-            ],
-          },
-          grains: [
-            {
-              id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
-              type: 'lesson',
-              title: 'Explications : les parties d’une adresse mail',
-              components: [
-                {
-                  type: 'element',
-                  element: {
-                    id: 'ba78dead-a806-4954-b408-e8ef28d28fab',
-                    type: 'qcu',
-                    instruction: '<p>L’adresse mail M3g4Cool1415@gmail.com est correctement écrite ?</p>',
-                    proposals: [
-                      {
-                        id: '6d4db7f8-b783-473d-a1cc-73dac8411855',
-                        content: 'Vrai',
-                      },
-                      {
-                        id: '26d27fa3-3269-4d78-916c-3aa066976592',
-                        content: 'Faux',
-                      },
-                    ],
-                    feedbacks: {
-                      valid:
-                        '<p>On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>',
-                      invalid:
-                        '<p>On peut avoir des chiffres n’importe où dans l’identifiant. On peut aussi utiliser des majuscules.</p>',
-                    },
-                    solution: '6d4db7f8-b783-473d-a1cc-73dac8411855',
-                  },
-                },
-              ],
-            },
-          ],
-        };
-        const moduleDatasourceStub = {
-          getBySlug: sinon.stub(),
-        };
-        moduleDatasourceStub.getBySlug.withArgs(existingModuleSlug).resolves(expectedFoundModule);
-
-        // when
-        const module = await moduleRepository.getBySlug({
-          slug: existingModuleSlug,
-          moduleDatasource: moduleDatasourceStub,
-        });
-
-        // then
-        expect(module.grains[0].components).to.have.lengthOf(1);
-        expect(module.grains[0].components[0].element).to.be.instanceOf(QCU);
-      });
-
-      it('should return a module which contains a componentElement of type QCM if it exists', async function () {
-        // given
-        const existingModuleSlug = 'bien-ecrire-son-adresse-mail';
-        const expectedFoundModule = {
-          id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
-          slug: 'bien-ecrire-son-adresse-mail',
-          title: 'Bien écrire son adresse mail',
-          details: {
-            image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
-            description:
-              'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
-            duration: 12,
-            level: 'Débutant',
-            objectives: [
-              'Écrire une adresse mail correctement, en évitant les erreurs courantes',
-              'Connaître les parties d’une adresse mail et les identifier sur des exemples',
-              'Comprendre les fonctions des parties d’une adresse mail',
-            ],
-          },
-          grains: [
-            {
-              id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
-              type: 'lesson',
-              title: 'Explications : les parties d’une adresse mail',
-              components: [
-                {
-                  type: 'element',
-                  element: {
-                    id: '30701e93-1b4d-4da4-b018-fa756c07d53f',
-                    type: 'qcm',
-                    instruction: '<p>Quels sont les 3 piliers de Pix ?</p>',
-                    proposals: [
-                      {
-                        id: '1',
-                        content: 'Evaluer ses connaissances et savoir-faire sur 16 compétences du numérique',
-                      },
-                      {
-                        id: '2',
-                        content: 'Développer son savoir-faire sur les jeux de type TPS',
-                      },
-                      {
-                        id: '3',
-                        content: 'Développer ses compétences numériques',
-                      },
-                      {
-                        id: '4',
-                        content: 'Certifier ses compétences Pix',
-                      },
-                      {
-                        id: '5',
-                        content: 'Evaluer ses compétences de logique et compréhension mathématique',
-                      },
-                    ],
-                    feedbacks: {
-                      valid: '<p>Correct ! Vous nous avez bien cernés :)</p>',
-                      invalid: '<p>Et non ! Pix sert à évaluer, certifier et développer ses compétences numériques.',
-                    },
-                    solutions: ['1', '3', '4'],
-                  },
-                },
-              ],
-            },
-          ],
-        };
-        const moduleDatasourceStub = {
-          getBySlug: sinon.stub(),
-        };
-        moduleDatasourceStub.getBySlug.withArgs(existingModuleSlug).resolves(expectedFoundModule);
-
-        // when
-        const module = await moduleRepository.getBySlug({
-          slug: existingModuleSlug,
-          moduleDatasource: moduleDatasourceStub,
-        });
-
-        // then
-        expect(module.grains[0].components).to.have.lengthOf(1);
-        expect(module.grains[0].components[0].element).to.be.instanceOf(QCM);
-      });
-
-      it('should return a module which contains a componentElement of type Image if it exists', async function () {
-        // given
-        const existingModuleSlug = 'bien-ecrire-son-adresse-mail';
-        const expectedFoundModule = {
-          id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
-          slug: 'bien-ecrire-son-adresse-mail',
-          title: 'Bien écrire son adresse mail',
-          details: {
-            image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
-            description:
-              'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
-            duration: 12,
-            level: 'Débutant',
-            objectives: [
-              'Écrire une adresse mail correctement, en évitant les erreurs courantes',
-              'Connaître les parties d’une adresse mail et les identifier sur des exemples',
-              'Comprendre les fonctions des parties d’une adresse mail',
-            ],
-          },
-          grains: [
-            {
-              id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
-              type: 'lesson',
-              title: 'Explications : les parties d’une adresse mail',
-              components: [
-                {
-                  type: 'element',
-                  element: {
-                    id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
-                    type: 'image',
-                    url: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-explication-les-parties-dune-adresse-mail.svg',
-                    alt: 'missing alt',
-                    alternativeText: 'missing alternative instructions',
-                  },
-                },
-              ],
-            },
-          ],
-        };
-        const moduleDatasourceStub = {
-          getBySlug: sinon.stub(),
-        };
-        moduleDatasourceStub.getBySlug.withArgs(existingModuleSlug).resolves(expectedFoundModule);
-
-        // when
-        const module = await moduleRepository.getBySlug({
-          slug: existingModuleSlug,
-          moduleDatasource: moduleDatasourceStub,
-        });
-
-        // then
-        expect(module.grains[0].components).to.have.lengthOf(1);
-        expect(module.grains[0].components[0].element).to.be.instanceOf(Image);
-      });
-
-      it('should return a module which contains a componentElement of type Video if it exists', async function () {
-        // given
-        const existingModuleSlug = 'bien-ecrire-son-adresse-mail';
-        const expectedFoundModule = {
-          id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
-          slug: 'bien-ecrire-son-adresse-mail',
-          title: 'Bien écrire son adresse mail',
-          details: {
-            image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
-            description:
-              'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
-            duration: 12,
-            level: 'Débutant',
-            objectives: [
-              'Écrire une adresse mail correctement, en évitant les erreurs courantes',
-              'Connaître les parties d’une adresse mail et les identifier sur des exemples',
-              'Comprendre les fonctions des parties d’une adresse mail',
-            ],
-          },
-          grains: [
-            {
-              id: 'z1f3c8c7-6d5c-4c6c-9c4d-1a3d8f7e9f5d',
-              type: 'lesson',
-              title: 'Explications : les parties d’une adresse mail',
-              components: [
-                {
-                  type: 'element',
-                  element: {
-                    id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
-                    type: 'video',
-                    title: 'Le format des adress mail',
-                    url: 'https://videos.pix.fr/modulix/chat_animation_2.webm',
-                    subtitles: 'Insert subtitles here',
-                    transcription: 'Insert transcription here',
-                  },
-                },
-              ],
-            },
-          ],
-        };
-        const moduleDatasourceStub = {
-          getBySlug: sinon.stub(),
-        };
-        moduleDatasourceStub.getBySlug.withArgs(existingModuleSlug).resolves(expectedFoundModule);
-
-        // when
-        const module = await moduleRepository.getBySlug({
-          slug: existingModuleSlug,
-          moduleDatasource: moduleDatasourceStub,
-        });
-
-        // then
-        expect(module.grains[0].components).to.have.lengthOf(1);
-        expect(module.grains[0].components[0].element).to.be.instanceOf(Video);
-      });
-
-      it('should return a module which contains a componentElement of type QROCM if it exists', async function () {
-        // given
-        const existingModuleSlug = 'bien-ecrire-son-adresse-mail';
-        const expectedFoundModule = {
-          id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
-          slug: 'bien-ecrire-son-adresse-mail',
-          title: 'Bien écrire son adresse mail',
-          details: {
-            image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
-            description:
-              'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
-            duration: 12,
-            level: 'Débutant',
-            objectives: [
-              'Écrire une adresse mail correctement, en évitant les erreurs courantes',
-              'Connaître les parties d’une adresse mail et les identifier sur des exemples',
-              'Comprendre les fonctions des parties d’une adresse mail',
-            ],
-          },
-          grains: [
-            {
-              id: 'b7ea7630-824a-4a49-83d1-abb9b8d0d120',
-              type: 'activity',
-              title: 'Écrire une adresse mail correctement',
-              components: [
-                {
-                  type: 'element',
-                  element: {
-                    id: '98c51fa7-03b7-49b1-8c5e-49341d35909c',
-                    type: 'qrocm',
-                    instruction:
-                      "<p>Pour être sûr que tout est clair, complétez le texte ci-dessous <span aria-hidden='true'>🧩</span></p><p>Si vous avez besoin d’aide, revenez en arrière <span aria-hidden='true'>⬆️</span></p>",
-                    proposals: [
-                      {
-                        type: 'text',
-                        content: '<p>Le symbole</>',
-                      },
-                      {
-                        input: 'symbole',
-                        type: 'input',
-                        inputType: 'text',
-                        size: 1,
-                        display: 'inline',
-                        placeholder: '',
-                        ariaLabel: 'Réponse 1',
-                        defaultValue: '',
-                        tolerances: ['t1'],
-                        solutions: ['@'],
-                      },
-                      {
-                        input: 'premiere-partie',
-                        type: 'select',
-                        display: 'inline',
-                        placeholder: '',
-                        ariaLabel: 'Réponse 2',
-                        defaultValue: '',
-                        tolerances: [],
-                        options: [
-                          {
-                            id: '1',
-                            content: "l'identifiant",
-                          },
-                          {
-                            id: '2',
-                            content: "le fournisseur d'adresse mail",
-                          },
-                        ],
-                        solutions: ['1'],
-                      },
-                    ],
-                    feedbacks: {
-                      valid: '<p>Bravo ! 🎉 </p>',
-                      invalid: "<p class='pix-list-inline'>Et non !</p>",
-                    },
-                  },
-                },
-              ],
-            },
-          ],
-        };
-        const moduleDatasourceStub = {
-          getBySlug: sinon.stub(),
-        };
-        moduleDatasourceStub.getBySlug.withArgs(existingModuleSlug).resolves(expectedFoundModule);
-
-        const BLOCK_TEXT_INDEX = 0;
-        const BLOCK_INPUT_INDEX = 1;
-        const BLOCK_SELECT_INDEX = 2;
-
-        // when
-        const module = await moduleRepository.getBySlug({
-          slug: existingModuleSlug,
-          moduleDatasource: moduleDatasourceStub,
-        });
-
-        // then
-        expect(module.grains[0].components).to.have.lengthOf(1);
-        expect(module.grains[0].components[0].element).to.be.instanceOf(QROCM);
-        expect(module.grains[0].components[0].element.proposals[BLOCK_TEXT_INDEX]).to.be.instanceOf(BlockText);
-        expect(module.grains[0].components[0].element.proposals[BLOCK_INPUT_INDEX]).to.be.instanceOf(BlockInput);
-        expect(module.grains[0].components[0].element.proposals[BLOCK_SELECT_INDEX]).to.be.instanceOf(BlockSelect);
-      });
-
-      it('should log a warning if none of the componentElement types match and return an empty element', async function () {
-        // given
-        const existingModuleSlug = 'bien-ecrire-son-adresse-mail';
-        const expectedFoundModule = {
-          id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
-          slug: 'bien-ecrire-son-adresse-mail',
-          title: 'Bien écrire son adresse mail',
-          details: {
-            image: 'https://images.pix.fr/modulix/bien-ecrire-son-adresse-mail-details.svg',
-            description:
-              'Apprendre à rédiger correctement une adresse e-mail pour assurer une meilleure communication et éviter les erreurs courantes.',
-            duration: 12,
-            level: 'Débutant',
-            objectives: [
-              'Écrire une adresse mail correctement, en évitant les erreurs courantes',
-              'Connaître les parties d’une adresse mail et les identifier sur des exemples',
-              'Comprendre les fonctions des parties d’une adresse mail',
-            ],
-          },
-          grains: [
-            {
-              id: 'b7ea7630-824a-4a49-83d1-abb9b8d0d120',
-              type: 'activity',
-              title: 'Écrire une adresse mail correctement',
-              components: [
-                {
-                  type: 'element',
-                  element: {
-                    id: '98c51fa7-03b7-49b1-8c5e-49341d35909c',
-                    type: 'TOTO',
-                    instruction:
-                      "<p>Pour être sûr que tout est clair, complétez le texte ci-dessous <span aria-hidden='true'>🧩</span></p><p>Si vous avez besoin d’aide, revenez en arrière <span aria-hidden='true'>⬆️</span></p>",
-                    proposals: [''],
-                    feedbacks: {
-                      valid: '<p>Bravo ! 🎉 </p>',
-                      invalid: "<p class='pix-list-inline'>Et non !</p>",
-                    },
-                  },
-                },
-              ],
-            },
-          ],
-        };
-        const moduleDatasourceStub = {
-          getBySlug: sinon.stub(),
-        };
-        moduleDatasourceStub.getBySlug.withArgs(existingModuleSlug).resolves(expectedFoundModule);
-
-        const loggerMessage = { event: 'module_element_type_unknown', message: 'Element inconnu: TOTO' };
-        sinon.stub(logger, 'warn').returns();
-
-        // when
-        const module = await moduleRepository.getBySlug({
-          slug: existingModuleSlug,
-          moduleDatasource: moduleDatasourceStub,
-        });
-
-        // then
-        expect(logger.warn).to.have.been.calledWithExactly(loggerMessage);
-        expect(module.grains[0].components).to.be.deep.equal([]);
-      });
+      expect(ModuleFactory.build).to.have.been.calledWith(expectedFoundModule);
+      expect(module).to.be.instanceof(Module);
     });
   });
 });

--- a/api/tests/devcomp/unit/domain/models/element/Embed_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Embed_test.js
@@ -1,0 +1,60 @@
+import { Embed } from '../../../../../../src/devcomp/domain/models/element/Embed.js';
+import { expect } from '../../../../../test-helper.js';
+
+describe('Unit | Devcomp | Domain | Models | Element | Embed', function () {
+  describe('#constructor', function () {
+    it('should create an embed and keep attributes', function () {
+      // given
+      const props = { id: 'id', isCompletionRequired: false, title: 'title', url: 'https://embed.com', height: 150 };
+
+      // when
+      const embed = new Embed(props);
+
+      // then
+      expect(embed.id).to.equal('id');
+      expect(embed.type).to.equal('embed');
+      expect(embed.isCompletionRequired).to.equal(false);
+      expect(embed.title).to.equal('title');
+      expect(embed.url).to.equal('https://embed.com');
+      expect(embed.height).to.equal(150);
+    });
+
+    describe('errors', function () {
+      describe('An embed without an id', function () {
+        it('should throw an error', function () {
+          expect(() => new Embed({})).to.throw('The id is required for an element');
+        });
+      });
+
+      describe('An embed without the isCompletionRequired attribute', function () {
+        it('should throw an error', function () {
+          expect(() => new Embed({ id: 'id' })).to.throw('The isCompletionRequired attribute is required for an embed');
+        });
+      });
+
+      describe('An embed without a title', function () {
+        it('should throw an error', function () {
+          expect(() => new Embed({ id: 'id', isCompletionRequired: false })).to.throw(
+            'The title is required for an embed',
+          );
+        });
+      });
+
+      describe('An embed without an url', function () {
+        it('should throw an error', function () {
+          expect(() => new Embed({ id: 'id', isCompletionRequired: false, title: 'title' })).to.throw(
+            'The url is required for an embed',
+          );
+        });
+      });
+
+      describe('An embed without a height', function () {
+        it('should throw an error', function () {
+          expect(
+            () => new Embed({ id: 'id', isCompletionRequired: false, title: 'title', url: 'https://embed.com' }),
+          ).to.throw('The height is required for an embed');
+        });
+      });
+    });
+  });
+});

--- a/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
@@ -1,6 +1,7 @@
 import { ModuleInstantiationError } from '../../../../../src/devcomp/domain/errors.js';
 import { ComponentStepper } from '../../../../../src/devcomp/domain/models/component/ComponentStepper.js';
 import { Step } from '../../../../../src/devcomp/domain/models/component/Step.js';
+import { Embed } from '../../../../../src/devcomp/domain/models/element/Embed.js';
 import { Image } from '../../../../../src/devcomp/domain/models/element/Image.js';
 import { QCM } from '../../../../../src/devcomp/domain/models/element/QCM.js';
 import { QCU } from '../../../../../src/devcomp/domain/models/element/QCU.js';
@@ -439,6 +440,48 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         expect(module.grains[0].components[0].element).to.be.an.instanceOf(Video);
       });
 
+      it('should instantiate a Module with a ComponentElement which contains an Embed Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              components: [
+                {
+                  type: 'element',
+                  element: {
+                    id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
+                    type: 'embed',
+                    isCompletionRequired: false,
+                    title: "Simulateur d'adresse mail",
+                    url: 'https://embed.fr',
+                    height: 150,
+                  },
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = ModuleFactory.build(moduleData);
+
+        // then
+        expect(module.grains[0].components[0].element).to.be.an.instanceOf(Embed);
+      });
+
       it('should instantiate a Module with a ComponentElement which contains a QCU Element', function () {
         // given
         const moduleData = {
@@ -790,6 +833,56 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
         expect(module.grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
         expect(module.grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
         expect(module.grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Video);
+      });
+
+      it('should instantiate a Module with a ComponentStepper which contains an Embed Element', function () {
+        // given
+        const moduleData = {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'title',
+          title: 'title',
+          details: {
+            image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+            description: 'Description',
+            duration: 5,
+            level: 'Débutant',
+            objectives: ['Objective 1'],
+          },
+          grains: [
+            {
+              id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+              type: 'lesson',
+              title: 'title',
+              components: [
+                {
+                  type: 'stepper',
+                  steps: [
+                    {
+                      elements: [
+                        {
+                          id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
+                          type: 'embed',
+                          isCompletionRequired: false,
+                          title: "Simulateur d'adresse mail",
+                          url: 'https://embed.fr',
+                          height: 150,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
+
+        // when
+        const module = ModuleFactory.build(moduleData);
+
+        // then
+        expect(module.grains[0].components[0]).to.be.an.instanceOf(ComponentStepper);
+        expect(module.grains[0].components[0].steps[0]).to.be.an.instanceOf(Step);
+        expect(module.grains[0].components[0].steps[0].elements[0]).to.be.an.instanceOf(Embed);
       });
 
       it('should instantiate a Module with a ComponentStepper which contains a QCU Element', function () {

--- a/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
@@ -7,7 +7,9 @@ import { QCU } from '../../../../../src/devcomp/domain/models/element/QCU.js';
 import { QROCM } from '../../../../../src/devcomp/domain/models/element/QROCM.js';
 import { Text } from '../../../../../src/devcomp/domain/models/element/Text.js';
 import { Video } from '../../../../../src/devcomp/domain/models/element/Video.js';
+import { Grain } from '../../../../../src/devcomp/domain/models/Grain.js';
 import { Module } from '../../../../../src/devcomp/domain/models/module/Module.js';
+import { TransitionText } from '../../../../../src/devcomp/domain/models/TransitionText.js';
 import { ModuleFactory } from '../../../../../src/devcomp/infrastructure/factories/module-factory.js';
 import { logger } from '../../../../../src/shared/infrastructure/utils/logger.js';
 import { catchErrSync, expect, sinon } from '../../../../test-helper.js';
@@ -213,7 +215,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
       });
     });
 
-    it('should instantiate a Module with components', function () {
+    it('should instantiate a Module with a grain containing components', function () {
       // given
       const moduleData = {
         id: '6282925d-4775-4bca-b513-4c3009ec5886',
@@ -254,6 +256,62 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
       expect(module).to.be.an.instanceOf(Module);
       expect(module.grains).not.to.be.empty;
       for (const grain of module.grains) {
+        expect(grain).to.be.instanceof(Grain);
+        expect(grain.components).not.to.be.empty;
+      }
+    });
+
+    it('should instantiate a Module with transition text if exists', function () {
+      // given
+      const moduleData = {
+        id: '6282925d-4775-4bca-b513-4c3009ec5886',
+        slug: 'title',
+        title: 'title',
+        details: {
+          image: 'https://images.pix.fr/modulix/placeholder-details.svg',
+          description: 'Description',
+          duration: 5,
+          level: 'Débutant',
+          objectives: ['Objective 1'],
+        },
+        transitionTexts: [
+          {
+            content: '<p>Bonjour &#8239;!</p>',
+            grainId: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+          },
+        ],
+        grains: [
+          {
+            id: 'f312c33d-e7c9-4a69-9ba0-913957b8f7dd',
+            type: 'lesson',
+            title: 'title',
+            components: [
+              {
+                type: 'element',
+                element: {
+                  id: '8d7687c8-4a02-4d7e-bf6c-693a6d481c78',
+                  type: 'image',
+                  url: 'https://images.pix.fr/modulix/didacticiel/ordi-spatial.svg',
+                  alt: 'Alternative',
+                  alternativeText: 'Alternative textuelle',
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      // when
+      const module = ModuleFactory.build(moduleData);
+
+      // then
+      expect(module.transitionTexts).not.to.be.empty;
+      for (const transitionText of module.transitionTexts) {
+        expect(transitionText).to.be.an.instanceOf(TransitionText);
+      }
+      expect(module.grains).not.to.be.empty;
+      for (const grain of module.grains) {
+        expect(grain).to.be.instanceof(Grain);
         expect(grain.components).not.to.be.empty;
       }
     });

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -4,6 +4,7 @@ import { BlockSelectOption } from '../../../../../../src/devcomp/domain/models/b
 import { BlockText } from '../../../../../../src/devcomp/domain/models/block/BlockText.js';
 import { ComponentElement } from '../../../../../../src/devcomp/domain/models/component/ComponentElement.js';
 import { ComponentStepper } from '../../../../../../src/devcomp/domain/models/component/ComponentStepper.js';
+import { Embed } from '../../../../../../src/devcomp/domain/models/element/Embed.js';
 import { Image } from '../../../../../../src/devcomp/domain/models/element/Image.js';
 import { QCM } from '../../../../../../src/devcomp/domain/models/element/QCM.js';
 import { QCU } from '../../../../../../src/devcomp/domain/models/element/QCU.js';
@@ -213,6 +214,9 @@ function getComponents() {
       element: new Image({ id: '3', url: 'url', alt: 'alt', alternativeText: 'alternativeText' }),
     }),
     new ComponentElement({
+      element: new Embed({ id: '3', url: 'url', height: 400, title: 'title', isCompletionRequired: false }),
+    }),
+    new ComponentElement({
       element: new Video({
         id: '4',
         title: 'title',
@@ -340,6 +344,18 @@ function getAttributesComponents() {
         id: '3',
         isAnswerable: false,
         type: 'image',
+        url: 'url',
+      },
+    },
+    {
+      type: 'element',
+      element: {
+        height: 400,
+        title: 'title',
+        id: '3',
+        isAnswerable: false,
+        isCompletionRequired: false,
+        type: 'embed',
         url: 'url',
       },
     },


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, le référentiel Modulix peut contenir des `embed` sans complétion requise. Mais l'API ne permet pas de les consommer.

## :robot: Proposition
Ajouter la gestion d'un nouvel élément `embed` dans les modules, afin de les afficher.

## :rainbow: Remarques
Jusqu'ici, les tests du module repository traitaient encore des cas d'usage propre au module factory. Donc nous avons supprimé ces tests pour les déplacer avec ceux du module factory.

Nous avons aussi mis à jour les tests du module repository pour nous assurer que le module factory était bien appelé.

## :100: Pour tester

1. Lancer l'url https://api-pr9481.review.pix.fr/api/modules/didacticiel-modulix dans le navigateur
2. Constater que le json en réponse comporte bien l'embed avec l'id `0e3315fd-98ad-492f-9046-4aa867495d84`
