### PR TITLE
[FEATURE] Redirection sur la page d'accueil si l'utilisateur est en mode Preview (pix-13147)

### DIFF
--- a/junior/app/routes/assessment/resume.js
+++ b/junior/app/routes/assessment/resume.js
@@ -6,6 +6,9 @@ export default class ResumeRoute extends Route {
   @service store;
 
   redirect(assessment, transition) {
+    if (transition.from.name === 'challenge-preview') {
+      return this.router.replaceWith('/');
+    }
     if (transition.to.queryParams.assessmentHasNoMoreQuestions === 'true') {
       return this._routeToResults(assessment);
     }

--- a/junior/app/routes/assessment/resume_unit_test.js
+++ b/junior/app/routes/assessment/resume_unit_test.js
@@ -11,7 +11,10 @@ module('Unit | Route | AssessmentResumeRoute', function (hooks) {
       test('should call the assessment challenge route', function (assert) {
         const route = this.owner.lookup('route:assessment.resume');
         const assessment = { id: '2', missionId: '1' };
-        const transition = { to: { queryParams: { assessmentHasNoMoreQuestions: 'false' } } };
+        const transition = {
+          from: { name: 'assessment.challenge' },
+          to: { queryParams: { assessmentHasNoMoreQuestions: 'false' } },
+        };
         sinon.stub(route.router, 'replaceWith');
 
         route.redirect(assessment, transition);
@@ -24,7 +27,10 @@ module('Unit | Route | AssessmentResumeRoute', function (hooks) {
       test('should redirect to assessment result route', async function (assert) {
         const route = this.owner.lookup('route:assessment.resume');
         const assessment = { id: '2', missionId: '1', save: sinon.stub() };
-        const transition = { to: { queryParams: { assessmentHasNoMoreQuestions: 'true' } } };
+        const transition = {
+          from: { name: 'assessment.challenge' },
+          to: { queryParams: { assessmentHasNoMoreQuestions: 'true' } },
+        };
         sinon.stub(route.router, 'replaceWith');
 
         await route.redirect(assessment, transition);

--- a/junior/tests/acceptance/challenge-preview_test.js
+++ b/junior/tests/acceptance/challenge-preview_test.js
@@ -1,5 +1,5 @@
 import { visit } from '@1024pix/ember-testing-library';
-import { click, fillIn } from '@ember/test-helpers';
+import { click, currentURL, fillIn } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 
 import { setupApplicationTest, t } from '../helpers';
@@ -24,5 +24,14 @@ module('Acceptance | ChallengePreview', function (hooks) {
     await click(screen.getByRole('button', { name: t('pages.challenge.actions.check') }));
 
     assert.dom(screen.getByText(t('pages.challenge.messages.wrong-answer'))).exists();
+  });
+
+  test('action button should redirect to home', async function (assert) {
+    const challenge = this.server.create('challenge');
+
+    const screen = await visit(`/challenges/${challenge.id}/preview`);
+    await click(screen.getByRole('button', { name: t('pages.challenge.actions.skip') }));
+
+    assert.strictEqual(currentURL(), '/organization-code');
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on est en mode preview et qu'on clique sur "Je vérifie" ou "Je passe", on était redirigé sur la page d'erreur.

## :robot: Proposition
Faire en sorte d'être redirigé sur la page d'accueil après avoir validé/passé l'épreuve.

## :rainbow: Remarques
Pas de remarque.

## :100: Pour tester
### Dans le cas où l'utilisateur n'est pas identifié
- Aller sur Pix-Junior sur la page `/organization-code`,
- Mettre dans l'url `/challenges/challenge1JnwUb7O1fukJL/preview`
- Valider l'épreuve ou la passer,
- Vérifier qu'on est bien renvoyé sur la page pour entrer son code.

### Dans le cas où l'utilisateur est identifié
- Aller sur la page de Pix-Junior,
- Renseigner le code `minipixou`,
- Sélectionner une classe et un élève,
- Mettre dans l'url `/challenges/challenge1JnwUb7O1fukJL/preview`,
- Valider ou passer l'épreuve,
- Vérifier qu'on est bien revenu sur la page des missions.