### PR TITLE
[BUGFIX] Aficher les catégories de profiles cibles lors de la duplication d'une campagne (PIX-13265)

### DIFF
--- a/orga/app/components/campaign/create-form.js
+++ b/orga/app/components/campaign/create-form.js
@@ -9,14 +9,6 @@ export default class CreateForm extends Component {
   @service intl;
 
   @tracked wantIdPix = Boolean(this.args.campaign.idPixLabel);
-  @tracked targetProfiles = [];
-
-  constructor() {
-    super(...arguments);
-    Promise.resolve(this.args.targetProfiles).then((targetProfiles) => {
-      this.targetProfiles = targetProfiles;
-    });
-  }
 
   get isMultipleSendingAssessmentEnabled() {
     return this.currentUser.prescriber.enableMultipleSendingAssessment;
@@ -27,7 +19,7 @@ export default class CreateForm extends Component {
   }
 
   get targetOwnerOptions() {
-    const options = this.targetProfiles.map((targetProfile) => {
+    const options = this.args.targetProfiles.map((targetProfile) => {
       return {
         value: targetProfile.id,
         label: targetProfile.name,
@@ -94,7 +86,7 @@ export default class CreateForm extends Component {
 
   @action
   selectTargetProfile(targetProfileId) {
-    this.args.campaign.targetProfile = this.targetProfiles.find(
+    this.args.campaign.targetProfile = this.args.targetProfiles.find(
       (targetProfile) => targetProfile.id === targetProfileId,
     );
   }

--- a/orga/app/routes/authenticated/campaigns/new.js
+++ b/orga/app/routes/authenticated/campaigns/new.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import pick from 'lodash/pick';
+import RSVP from 'rsvp';
 
 export default class NewRoute extends Route {
   @service currentUser;
@@ -45,7 +46,7 @@ export default class NewRoute extends Route {
       }
     }
 
-    return {
+    return RSVP.hash({
       campaign: this.store.createRecord('campaign', {
         organization,
         ownerId: this.currentUser.prescriber.id,
@@ -53,7 +54,7 @@ export default class NewRoute extends Route {
       }),
       targetProfiles: organization.targetProfiles,
       membersSortedByFullName,
-    };
+    });
   }
 
   resetController(controller, isExiting) {

--- a/orga/tests/unit/routes/authenticated/campaigns/new_test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/new_test.js
@@ -91,6 +91,7 @@ module('Unit | Route | authenticated/campaigns/new', function (hooks) {
 
         const organization = EmberObject.create({
           id: 12345,
+          targetProfiles: new Promise((resolve) => resolve([])),
         });
 
         class CurrentUserStub extends Service {
@@ -142,6 +143,7 @@ module('Unit | Route | authenticated/campaigns/new', function (hooks) {
 
         assert.strictEqual(await model.campaign, duplicatedCampaignRecord);
         sinon.assert.calledWithExactly(createRecordStub, 'campaign', expectedCampaignAttributes);
+        assert.false(model.targetProfiles instanceof Promise);
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Le multiselect pour filter par catégories de profile cibles souhaitées était vide. Aucune catégorie ne s'affichait dedans

## :robot: Proposition
Corriger

## :rainbow: Remarques
Le model renvoyait un objet de valeur dont certaines était des promesses.
Nous avons entouré  le tout d'un hash RSVP pour que le model renvoi une l'objet sous forme d'une seule promesse

## :100: Pour tester
- se connecter à Pix Orga
- cliquer sur le bouton pour dupliquer une campagne d'évaluation
- avant de valider la duplication, aller dans le multiselect de catégories de profile cible et observer que les catégories y sont désormais notées et selectionnable.