### PR TITLE
[FEATURE] Afficher un simulateur dans Modulix (PIX-13092)

### DIFF
--- a/api/src/devcomp/domain/models/element/Embed.js
+++ b/api/src/devcomp/domain/models/element/Embed.js
@@ -2,7 +2,7 @@ import { assertNotNullOrUndefined } from '../../../../shared/domain/models/asser
 import { Element } from './Element.js';
 
 class Embed extends Element {
-  constructor({ id, isCompletionRequired, title, url, height }) {
+  constructor({ id, isCompletionRequired, title, url, instruction, height }) {
     super({ id, type: 'embed' });
 
     assertNotNullOrUndefined(isCompletionRequired, 'The isCompletionRequired attribute is required for an embed');
@@ -13,6 +13,7 @@ class Embed extends Element {
     this.isCompletionRequired = isCompletionRequired;
     this.title = title;
     this.url = url;
+    this.instruction = instruction;
     this.height = height;
   }
 }

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -333,6 +333,7 @@
             "isCompletionRequired": false,
             "title": "Application",
             "url": "https://epreuves.pix.fr/fake2.html",
+            "instruction": "<p>Parcourez ces photos trouvées sur le Web.</p>",
             "height": 640
           }
         },
@@ -341,7 +342,7 @@
           "element": {
             "id": "74d63ec2-f3e3-4ffe-9806-208d33588553",
             "type": "qcm",
-            "instruction": "<p>Parcourez ces photos trouvées sur le Web : lesquelles correspondent à des situations fictives&#8239;?</p>",
+            "instruction": "<p>Lesquelles correspondent à des situations fictives&#8239;?</p>",
             "proposals": [
               {
                 "id": "1",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/didacticiel-modulix.json
@@ -331,41 +331,40 @@
             "id": "0e3315fd-98ad-492f-9046-4aa867495d84",
             "type": "embed",
             "isCompletionRequired": false,
-            "title": "Application",
-            "url": "https://epreuves.pix.fr/fake2.html",
-            "instruction": "<p>Parcourez ces photos trouvées sur le Web.</p>",
-            "height": 640
+            "title": "Simulateur de visioconférence",
+            "url": "https://epreuves.pix.fr/visio.html?mode=visio3",
+            "instruction": "<p>Vous participez à la visioconférence ci-dessous.</p>",
+            "height": 600
           }
         },
         {
           "type": "element",
           "element": {
-            "id": "74d63ec2-f3e3-4ffe-9806-208d33588553",
-            "type": "qcm",
-            "instruction": "<p>Lesquelles correspondent à des situations fictives&#8239;?</p>",
+            "id": "7fe0bc5f-1988-4da6-8231-a987335f2ae5",
+            "type": "qrocm",
+            "instruction": "<p>Répondez à la question suivante</p>",
             "proposals": [
               {
-                "id": "1",
-                "content": "Photo 1"
+                "type": "text",
+                "content": "<span>Prénom de la personne qui est en train de parler&#8239;: </span>"
               },
               {
-                "id": "2",
-                "content": "Photo 2"
-              },
-              {
-                "id": "3",
-                "content": "Photo 3"
-              },
-              {
-                "id": "4",
-                "content": "Photo 4"
+                "input": "qui-parle",
+                "type": "input",
+                "inputType": "text",
+                "size": 10,
+                "display": "inline",
+                "placeholder": "",
+                "ariaLabel": "Remplir le prénom de la personne qui est en train de parler dans la visioconférence",
+                "defaultValue": "",
+                "tolerances": ["t1", "t2", "t3"],
+                "solutions": ["Katie"]
               }
             ],
             "feedbacks": {
               "valid": "<span class=\"feedback__state\">Correct&#8239;!</span>",
-              "invalid": "<span class=\"feedback__state\">Et non&#8239;!</span>"
-            },
-            "solutions": ["1", "2", "4"]
+              "invalid": "<span class=\"feedback__state\">Incorrect&#8239;!</span>"
+            }
           }
         }
       ]

--- a/api/src/devcomp/infrastructure/factories/module-factory.js
+++ b/api/src/devcomp/infrastructure/factories/module-factory.js
@@ -120,6 +120,7 @@ export class ModuleFactory {
       isCompletionRequired: element.isCompletionRequired,
       title: element.title,
       url: element.url,
+      instruction: element.instruction,
       height: element.height,
     });
   }

--- a/api/tests/devcomp/unit/domain/models/element/Embed_test.js
+++ b/api/tests/devcomp/unit/domain/models/element/Embed_test.js
@@ -5,7 +5,14 @@ describe('Unit | Devcomp | Domain | Models | Element | Embed', function () {
   describe('#constructor', function () {
     it('should create an embed and keep attributes', function () {
       // given
-      const props = { id: 'id', isCompletionRequired: false, title: 'title', url: 'https://embed.com', height: 150 };
+      const props = {
+        id: 'id',
+        isCompletionRequired: false,
+        title: 'title',
+        url: 'https://embed.com',
+        instruction: '<p>instruction</p>',
+        height: 150,
+      };
 
       // when
       const embed = new Embed(props);
@@ -16,6 +23,7 @@ describe('Unit | Devcomp | Domain | Models | Element | Embed', function () {
       expect(embed.isCompletionRequired).to.equal(false);
       expect(embed.title).to.equal('title');
       expect(embed.url).to.equal('https://embed.com');
+      expect(embed.instruction).to.equal('<p>instruction</p>');
       expect(embed.height).to.equal(150);
     });
 

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/embed.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/embed.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 
-import { htmlNotAllowedSchema, uuidSchema } from '../utils.js';
+import { htmlNotAllowedSchema, htmlSchema, uuidSchema } from '../utils.js';
 
 const embedSchema = Joi.object({
   id: uuidSchema,
@@ -8,6 +8,7 @@ const embedSchema = Joi.object({
   isCompletionRequired: Joi.boolean().valid(false).required(),
   title: htmlNotAllowedSchema.required(),
   url: Joi.string().uri().required(),
+  instruction: htmlSchema.optional(),
   height: Joi.number().min(0).required(),
 }).required();
 

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcm.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcm.js
@@ -5,7 +5,7 @@ import { htmlSchema, proposalIdSchema, uuidSchema } from '../utils.js';
 const qcmElementSchema = Joi.object({
   id: uuidSchema,
   type: Joi.string().valid('qcm').required(),
-  instruction: htmlSchema,
+  instruction: htmlSchema.required(),
   proposals: Joi.array()
     .items({
       id: proposalIdSchema,

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qcu.js
@@ -5,7 +5,7 @@ import { htmlSchema, proposalIdSchema, uuidSchema } from '../utils.js';
 const qcuElementSchema = Joi.object({
   id: uuidSchema,
   type: Joi.string().valid('qcu').required(),
-  instruction: htmlSchema,
+  instruction: htmlSchema.required(),
   proposals: Joi.array()
     .items({
       id: proposalIdSchema,

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qrocm.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/element/qrocm.js
@@ -45,7 +45,7 @@ const blockTextSchema = Joi.object({
 const qrocmElementSchema = Joi.object({
   id: uuidSchema,
   type: Joi.string().valid('qrocm').required(),
-  instruction: htmlSchema,
+  instruction: htmlSchema.required(),
   proposals: Joi.array()
     .items(Joi.alternatives().try(blockTextSchema, blockInputSchema, blockSelectSchema))
     .required(),

--- a/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/utils.js
+++ b/api/tests/devcomp/unit/infrastructure/datasources/learning-content/validation/utils.js
@@ -6,15 +6,17 @@ const uuidSchema = Joi.string().guid({ version: 'uuidv4' }).required();
 const proposalIdSchema = Joi.string().regex(/^\d+$/);
 
 const htmlValidate = new HtmlValidate();
-const htmlSchema = Joi.string()
-  .external(async (value, helpers) => {
-    const report = await htmlValidate.validateString(value);
+const htmlSchema = Joi.string().external(async (value, helpers) => {
+  if (!value) {
+    return;
+  }
 
-    if (!report.valid) {
-      return helpers.message('htmlvalidationerror', { value: report });
-    }
-  })
-  .required();
+  const report = await htmlValidate.validateString(value);
+
+  if (!report.valid) {
+    return helpers.message('htmlvalidationerror', { value: report });
+  }
+});
 
 const htmlNotAllowedSchema = Joi.string()
   .regex(/<.*?>/, { invert: true })

--- a/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
+++ b/api/tests/devcomp/unit/infrastructure/factories/module-factory_test.js
@@ -865,6 +865,7 @@ describe('Unit | Devcomp | Infrastructure | Factories | Module ', function () {
                           isCompletionRequired: false,
                           title: "Simulateur d'adresse mail",
                           url: 'https://embed.fr',
+                          instruction: '<p>Parcourez ces photos trouvées sur le Web.</p>',
                           height: 150,
                         },
                       ],

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -214,7 +214,14 @@ function getComponents() {
       element: new Image({ id: '3', url: 'url', alt: 'alt', alternativeText: 'alternativeText' }),
     }),
     new ComponentElement({
-      element: new Embed({ id: '3', url: 'url', height: 400, title: 'title', isCompletionRequired: false }),
+      element: new Embed({
+        id: '3',
+        url: 'url',
+        height: 400,
+        title: 'title',
+        instruction: '<p>instruction</p>',
+        isCompletionRequired: false,
+      }),
     }),
     new ComponentElement({
       element: new Video({
@@ -357,6 +364,7 @@ function getAttributesComponents() {
         isCompletionRequired: false,
         type: 'embed',
         url: 'url',
+        instruction: '<p>instruction</p>',
       },
     },
     {

--- a/mon-pix/app/components/module/element.gjs
+++ b/mon-pix/app/components/module/element.gjs
@@ -1,6 +1,7 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { eq } from 'ember-truth-helpers';
+import EmbedElement from 'mon-pix/components/module/element/embed';
 import ImageElement from 'mon-pix/components/module/element/image';
 import QcmElement from 'mon-pix/components/module/element/qcm';
 import QcuElement from 'mon-pix/components/module/element/qcu';
@@ -21,6 +22,8 @@ export default class ModulixElement extends Component {
       <ImageElement @image={{@element}} @moduleId={{@grain.module.id}} />
     {{else if (eq @element.type "video")}}
       <VideoElement @video={{@element}} @moduleId={{@grain.module.id}} />
+    {{else if (eq @element.type "embed")}}
+      <EmbedElement @embed={{@element}} />
     {{else if (eq @element.type "qcu")}}
       <QcuElement
         @element={{@element}}

--- a/mon-pix/app/components/module/element/embed.gjs
+++ b/mon-pix/app/components/module/element/embed.gjs
@@ -1,10 +1,10 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import { action } from '@ember/object';
-import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
+import { htmlUnsafe } from '../../../helpers/html-unsafe';
 import didInsert from '../../../modifiers/modifier-did-insert';
 
 export default class ModulixEmbed extends Component {
@@ -25,7 +25,7 @@ export default class ModulixEmbed extends Component {
   }
 
   get heightStyle() {
-    return htmlSafe(`height: ${this.embedHeight}px`);
+    return htmlUnsafe(`height: ${this.embedHeight}px`);
   }
 
   @action
@@ -36,26 +36,36 @@ export default class ModulixEmbed extends Component {
 
   <template>
     <div class="element-embed">
-      {{#unless this.isSimulatorLaunched}}
-        <div class="element-embed__overlay">
-          <PixButton
-            @triggerAction={{this.startSimulator}}
-            aria-label="{{t 'pages.modulix.buttons.embed.start.ariaLabel'}}"
-            @variant="primary-bis"
-            @size="large"
-          >
-            {{t "pages.modulix.buttons.embed.start.name"}}
-          </PixButton>
+      {{#if @embed.instruction}}
+        <div class="element-embed__instruction">
+          {{htmlUnsafe @embed.instruction}}
         </div>
-      {{/unless}}
+      {{/if}}
 
-      <iframe
-        class="element-embed__iframe {{unless this.isSimulatorLaunched 'element-embed__iframe--blurred'}}"
-        src={{@embed.url}}
-        title={{@embed.title}}
-        style={{this.heightStyle}}
-        {{didInsert this.setIframeHtmlElement}}
-      ></iframe>
+      <div class="element-embed__container">
+        {{#unless this.isSimulatorLaunched}}
+          <div class="element-embed-container__overlay">
+            <PixButton
+              @triggerAction={{this.startSimulator}}
+              aria-label="{{t 'pages.modulix.buttons.embed.start.ariaLabel'}}"
+              @variant="primary-bis"
+              @size="large"
+            >
+              {{t "pages.modulix.buttons.embed.start.name"}}
+            </PixButton>
+          </div>
+        {{/unless}}
+
+        <iframe
+          class="element-embed-container__iframe
+            {{unless this.isSimulatorLaunched 'element-embed-container__iframe--blurred'}}"
+          src={{@embed.url}}
+          title={{@embed.title}}
+          style={{this.heightStyle}}
+          {{didInsert this.setIframeHtmlElement}}
+        ></iframe>
+      </div>
+
       {{#if this.isSimulatorLaunched}}
         <div class="element-embed__reset">
           <PixButton

--- a/mon-pix/app/components/module/element/embed.gjs
+++ b/mon-pix/app/components/module/element/embed.gjs
@@ -1,0 +1,17 @@
+import { htmlSafe } from '@ember/template';
+import Component from '@glimmer/component';
+
+export default class ModulixEmbed extends Component {
+  embedHeight = this.args.embed.height;
+
+  get embedDocumentHeightStyle() {
+    return htmlSafe(`height: ${this.embedHeight}px`);
+  }
+
+  <template>
+    <div class="element-embed">
+      <iframe src={{@embed.url}} title={{@embed.title}} style={{this.embedDocumentHeightStyle}}>
+      </iframe>
+    </div>
+  </template>
+}

--- a/mon-pix/app/components/module/element/embed.gjs
+++ b/mon-pix/app/components/module/element/embed.gjs
@@ -1,17 +1,45 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { action } from '@ember/object';
 import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { t } from 'ember-intl';
 
 export default class ModulixEmbed extends Component {
+  @tracked
+  isSimulatorLaunched = false;
   embedHeight = this.args.embed.height;
 
-  get embedDocumentHeightStyle() {
+  get heightStyle() {
     return htmlSafe(`height: ${this.embedHeight}px`);
+  }
+
+  @action
+  startSimulator() {
+    this.isSimulatorLaunched = true;
   }
 
   <template>
     <div class="element-embed">
-      <iframe src={{@embed.url}} title={{@embed.title}} style={{this.embedDocumentHeightStyle}}>
-      </iframe>
+      {{#unless this.isSimulatorLaunched}}
+        <div class="element-embed__overlay">
+          <PixButton
+            @triggerAction={{this.startSimulator}}
+            aria-label="{{t 'pages.modulix.buttons.embed.start.ariaLabel'}}"
+            @variant="primary-bis"
+            @size="large"
+          >
+            {{t "pages.modulix.buttons.embed.start.name"}}
+          </PixButton>
+        </div>
+      {{/unless}}
+
+      <iframe
+        class="element-embed__iframe {{unless this.isSimulatorLaunched 'element-embed__iframe--blurred'}}"
+        src={{@embed.url}}
+        title={{@embed.title}}
+        style={{this.heightStyle}}
+      ></iframe>
     </div>
   </template>
 }

--- a/mon-pix/app/components/module/element/embed.gjs
+++ b/mon-pix/app/components/module/element/embed.gjs
@@ -5,10 +5,24 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
+import didInsert from '../../../modifiers/modifier-did-insert';
+
 export default class ModulixEmbed extends Component {
   @tracked
   isSimulatorLaunched = false;
   embedHeight = this.args.embed.height;
+  iframe;
+
+  @action
+  setIframeHtmlElement(htmlElement) {
+    this.iframe = htmlElement;
+  }
+
+  @action
+  resetEmbed() {
+    this.iframe.setAttribute('src', this.args.embed.url);
+    this.iframe.focus();
+  }
 
   get heightStyle() {
     return htmlSafe(`height: ${this.embedHeight}px`);
@@ -17,6 +31,7 @@ export default class ModulixEmbed extends Component {
   @action
   startSimulator() {
     this.isSimulatorLaunched = true;
+    this.iframe.focus();
   }
 
   <template>
@@ -39,7 +54,18 @@ export default class ModulixEmbed extends Component {
         src={{@embed.url}}
         title={{@embed.title}}
         style={{this.heightStyle}}
+        {{didInsert this.setIframeHtmlElement}}
       ></iframe>
+      {{#if this.isSimulatorLaunched}}
+        <div class="element-embed__reset">
+          <PixButton
+            @iconBefore="rotate-right"
+            @variant="tertiary"
+            @triggerAction={{this.resetEmbed}}
+            aria-label="{{t 'pages.modulix.buttons.embed.reset.ariaLabel'}}"
+          >{{t "pages.modulix.buttons.embed.reset.name"}}</PixButton>
+        </div>
+      {{/if}}
     </div>
   </template>
 }

--- a/mon-pix/app/components/module/grain.js
+++ b/mon-pix/app/components/module/grain.js
@@ -8,7 +8,7 @@ export default class ModuleGrain extends Component {
 
   grain = this.args.grain;
 
-  static AVAILABLE_ELEMENT_TYPES = ['text', 'image', 'video', 'qcu', 'qcm', 'qrocm'];
+  static AVAILABLE_ELEMENT_TYPES = ['text', 'image', 'video', 'embed', 'qcu', 'qcm', 'qrocm'];
   static AVAILABLE_GRAIN_TYPES = ['lesson', 'activity'];
 
   @tracked isStepperFinished = this.hasStepper === false;

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -68,6 +68,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @import 'components/module/stepper';
 @import 'components/module/image';
 @import 'components/module/video';
+@import 'components/module/embed';
 @import 'components/module/qcu';
 @import 'components/module/qcm';
 @import 'components/module/qrocm';

--- a/mon-pix/app/styles/components/module/_embed.scss
+++ b/mon-pix/app/styles/components/module/_embed.scss
@@ -1,3 +1,7 @@
+:root {
+  --embed-overlay-color: rgb(0 0 0 / 55%);
+}
+
 .element-embed {
   position: relative;
 
@@ -28,6 +32,7 @@
     }
   }
 
+
   &__overlay {
     position: absolute;
     top: 0;
@@ -38,6 +43,6 @@
     justify-content: center;
     width: 100%;
     height: 100%;
-    background-color: rgb(0 0 0 / 55%);
+    background-color: var(--embed-overlay-color);
   }
 }

--- a/mon-pix/app/styles/components/module/_embed.scss
+++ b/mon-pix/app/styles/components/module/_embed.scss
@@ -24,4 +24,9 @@
     height: 100%;
     background-color: rgb(0 0 0 / 55%);
   }
+
+  &__reset {
+    display: flex;
+    justify-content: flex-end;
+  }
 }

--- a/mon-pix/app/styles/components/module/_embed.scss
+++ b/mon-pix/app/styles/components/module/_embed.scss
@@ -1,0 +1,27 @@
+.element-embed {
+  position: relative;
+
+  &__iframe {
+    display: block;
+    width: 100%;
+    overflow: hidden;
+    border: none;
+
+    &--blurred {
+      filter: blur(5px);
+    }
+  }
+
+  &__overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    background-color: rgb(0 0 0 / 55%);
+  }
+}

--- a/mon-pix/app/styles/components/module/_embed.scss
+++ b/mon-pix/app/styles/components/module/_embed.scss
@@ -1,6 +1,22 @@
 .element-embed {
   position: relative;
 
+  &__container {
+    position: relative;
+  }
+
+  &__instruction {
+    margin-bottom: var(--pix-spacing-2x);
+    font-weight: var(--pix-font-medium);
+  }
+
+  &__reset {
+    display: flex;
+    justify-content: flex-end;
+  }
+}
+
+.element-embed-container {
   &__iframe {
     display: block;
     width: 100%;
@@ -23,10 +39,5 @@
     width: 100%;
     height: 100%;
     background-color: rgb(0 0 0 / 55%);
-  }
-
-  &__reset {
-    display: flex;
-    justify-content: flex-end;
   }
 }

--- a/mon-pix/tests/integration/components/module/element_test.gjs
+++ b/mon-pix/tests/integration/components/module/element_test.gjs
@@ -63,6 +63,24 @@ module('Integration | Component | Module | Element', function (hooks) {
     assert.dom(screen.getByRole('button', { name: 'Afficher la transcription' })).exists();
   });
 
+  test('should display an element with an embed element', async function (assert) {
+    // given
+    const element = {
+      id: '3a9f2269-99ba-4631-b6fd-6802c88d5c26',
+      type: 'embed',
+      title: 'Embed de présentation de Pix',
+      url: 'https://embed.pix.fr',
+      height: 340,
+      isCompletionRequired: false,
+    };
+
+    // when
+    const screen = await render(<template><ModulixElement @element={{element}} /></template>);
+
+    // then
+    assert.dom(screen.getByTitle(element.title)).exists();
+  });
+
   test('should display an element with a qcu element', async function (assert) {
     // given
     const element = {

--- a/mon-pix/tests/integration/components/module/embed_test.gjs
+++ b/mon-pix/tests/integration/components/module/embed_test.gjs
@@ -28,10 +28,13 @@ module('Integration | Component | Module | Embed', function (hooks) {
     assert
       .dom(screen.getByRole('button', { name: this.intl.t('pages.modulix.buttons.embed.start.ariaLabel') }))
       .exists();
+    assert
+      .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.embed.reset.ariaLabel') }))
+      .doesNotExist();
   });
 
   module('when user clicks on start button', function () {
-    test('should hide start button', async function (assert) {
+    test('should hide start button and display reset button', async function (assert) {
       // given
       const embed = {
         id: 'id',
@@ -48,6 +51,50 @@ module('Integration | Component | Module | Embed', function (hooks) {
       const startButtonName = this.intl.t('pages.modulix.buttons.embed.start.ariaLabel');
       await clickByName(startButtonName);
       assert.dom(screen.queryByRole('button', { name: startButtonName })).doesNotExist();
+      assert
+        .dom(screen.getByRole('button', { name: this.intl.t('pages.modulix.buttons.embed.reset.ariaLabel') }))
+        .exists();
+    });
+
+    test('should focus on the iframe', async function (assert) {
+      // given
+      const embed = {
+        id: 'id',
+        title: 'title',
+        isCompletionRequired: false,
+        url: 'https://embed-pix.com',
+        height: 800,
+      };
+      const screen = await render(<template><ModulixEmbed @embed={{embed}} /></template>);
+
+      // when
+      await clickByName(this.intl.t('pages.modulix.buttons.embed.start.ariaLabel'));
+
+      // then
+      const iframe = screen.getByTitle(embed.title);
+      assert.strictEqual(document.activeElement, iframe);
+    });
+  });
+
+  module('when user clicks on reset button', function () {
+    test('should focus on the iframe', async function (assert) {
+      // given
+      const embed = {
+        id: 'id',
+        title: 'title',
+        isCompletionRequired: false,
+        url: 'https://embed-pix.com',
+        height: 800,
+      };
+      const screen = await render(<template><ModulixEmbed @embed={{embed}} /></template>);
+
+      // when
+      await clickByName(this.intl.t('pages.modulix.buttons.embed.start.ariaLabel'));
+      await clickByName(this.intl.t('pages.modulix.buttons.embed.reset.ariaLabel'));
+
+      // then
+      const iframe = screen.getByTitle(embed.title);
+      assert.strictEqual(document.activeElement, iframe);
     });
   });
 });

--- a/mon-pix/tests/integration/components/module/embed_test.gjs
+++ b/mon-pix/tests/integration/components/module/embed_test.gjs
@@ -1,4 +1,4 @@
-import { render } from '@1024pix/ember-testing-library';
+import { clickByName, render } from '@1024pix/ember-testing-library';
 import ModulixEmbed from 'mon-pix/components/module/element/embed';
 import { module, test } from 'qunit';
 
@@ -25,5 +25,29 @@ module('Integration | Component | Module | Embed', function (hooks) {
     const expectedIframe = screen.getByTitle(embed.title);
     assert.strictEqual(expectedIframe.getAttribute('src'), embed.url);
     assert.strictEqual(expectedIframe.style.getPropertyValue('height'), '800px');
+    assert
+      .dom(screen.getByRole('button', { name: this.intl.t('pages.modulix.buttons.embed.start.ariaLabel') }))
+      .exists();
+  });
+
+  module('when user clicks on start button', function () {
+    test('should hide start button', async function (assert) {
+      // given
+      const embed = {
+        id: 'id',
+        title: 'title',
+        isCompletionRequired: false,
+        url: 'https://embed-pix.com',
+        height: 800,
+      };
+
+      // when
+      const screen = await render(<template><ModulixEmbed @embed={{embed}} /></template>);
+
+      // then
+      const startButtonName = this.intl.t('pages.modulix.buttons.embed.start.ariaLabel');
+      await clickByName(startButtonName);
+      assert.dom(screen.queryByRole('button', { name: startButtonName })).doesNotExist();
+    });
   });
 });

--- a/mon-pix/tests/integration/components/module/embed_test.gjs
+++ b/mon-pix/tests/integration/components/module/embed_test.gjs
@@ -1,0 +1,29 @@
+import { render } from '@1024pix/ember-testing-library';
+import ModulixEmbed from 'mon-pix/components/module/element/embed';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Module | Embed', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('should display an embed', async function (assert) {
+    // given
+    const embed = {
+      id: 'id',
+      title: 'title',
+      isCompletionRequired: false,
+      url: 'https://embed-pix.com',
+      height: 800,
+    };
+
+    // when
+    const screen = await render(<template><ModulixEmbed @embed={{embed}} /></template>);
+
+    // then
+    assert.ok(screen);
+    const expectedIframe = screen.getByTitle(embed.title);
+    assert.strictEqual(expectedIframe.getAttribute('src'), embed.url);
+    assert.strictEqual(expectedIframe.style.getPropertyValue('height'), '800px');
+  });
+});

--- a/mon-pix/tests/integration/components/module/embed_test.gjs
+++ b/mon-pix/tests/integration/components/module/embed_test.gjs
@@ -1,4 +1,6 @@
 import { clickByName, render } from '@1024pix/ember-testing-library';
+// eslint-disable-next-line no-restricted-imports
+import { find } from '@ember/test-helpers';
 import ModulixEmbed from 'mon-pix/components/module/element/embed';
 import { module, test } from 'qunit';
 
@@ -7,13 +9,14 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | Module | Embed', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('should display an embed', async function (assert) {
+  test('should display an embed with instruction', async function (assert) {
     // given
     const embed = {
       id: 'id',
       title: 'title',
       isCompletionRequired: false,
       url: 'https://embed-pix.com',
+      instruction: "<p>Instruction de l'embed</p>",
       height: 800,
     };
 
@@ -31,6 +34,24 @@ module('Integration | Component | Module | Embed', function (hooks) {
     assert
       .dom(screen.queryByRole('button', { name: this.intl.t('pages.modulix.buttons.embed.reset.ariaLabel') }))
       .doesNotExist();
+    assert.dom(screen.getByText("Instruction de l'embed")).exists();
+  });
+
+  test('should display an embed without instruction', async function (assert) {
+    // given
+    const embed = {
+      id: 'id',
+      title: 'title',
+      isCompletionRequired: false,
+      url: 'https://embed-pix.com',
+      height: 800,
+    };
+
+    // when
+    await render(<template><ModulixEmbed @embed={{embed}} /></template>);
+
+    // then
+    assert.dom(find('.element-embed__instruction')).doesNotExist();
   });
 
   module('when user clicks on start button', function () {

--- a/mon-pix/tests/unit/components/module/embed_test.gjs
+++ b/mon-pix/tests/unit/components/module/embed_test.gjs
@@ -1,0 +1,60 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+
+module('Unit | Component | Module | Embed', function (hooks) {
+  setupTest(hooks);
+
+  module('#setIframeHtmlElement', function () {
+    test('should set the iframe html element', async function (assert) {
+      // given
+      const embed = {
+        id: 'id',
+        title: 'title',
+        isCompletionRequired: false,
+        url: 'https://embed-pix.com',
+        height: 800,
+      };
+      const component = createGlimmerComponent('module/element/embed', {
+        embed,
+      });
+      const expectedComponentIFrame = Symbol('iframeHtmlElement');
+
+      // when
+      component.setIframeHtmlElement(expectedComponentIFrame);
+
+      // then
+      assert.deepEqual(component.iframe, expectedComponentIFrame);
+    });
+  });
+
+  module('#resetEmbed', function () {
+    test('should update the iframe src', async function (assert) {
+      // given
+      const embed = {
+        id: 'id',
+        title: 'title',
+        isCompletionRequired: false,
+        url: 'https://embed-pix.com',
+        height: 800,
+      };
+      const component = createGlimmerComponent('module/element/embed', {
+        embed,
+      });
+      component.iframe = {
+        setAttribute: sinon.stub(),
+        focus: sinon.stub(),
+      };
+
+      // when
+      component.resetEmbed();
+
+      // then
+      sinon.assert.calledWith(component.iframe.setAttribute, 'src', embed.url);
+      sinon.assert.called(component.iframe.focus);
+      assert.ok(true);
+    });
+  });
+});

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1311,6 +1311,12 @@
           "alternativeText": "Show alternative text",
           "transcription": "Show transcription"
         },
+        "embed": {
+          "start": {
+            "ariaLabel": "Start the simulator",
+            "name": "Start"
+          }
+        },
         "grain": {
           "continue": "Continue",
           "skip": "Skip",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1312,6 +1312,10 @@
           "transcription": "Show transcription"
         },
         "embed": {
+          "reset": {
+            "ariaLabel": "Reset the simulator",
+            "name": "Reset"
+          },
           "start": {
             "ariaLabel": "Start the simulator",
             "name": "Start"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1312,6 +1312,10 @@
           "transcription": "Ver transcripción"
         },
         "embed": {
+          "reset": {
+            "ariaLabel": "Reiniciar el simulador",
+            "name": "Reiniciar"
+          },
           "start": {
             "ariaLabel": "Iniciar el simulador",
             "name": "Comenzar"

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -1311,6 +1311,12 @@
           "alternativeText": "Mostrar el texto alternativo",
           "transcription": "Ver transcripción"
         },
+        "embed": {
+          "start": {
+            "ariaLabel": "Iniciar el simulador",
+            "name": "Comenzar"
+          }
+        },
         "grain": {
           "continue": "Continuar",
           "skip": "Ir a",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1311,6 +1311,12 @@
           "alternativeText": "Afficher l'alternative textuelle",
           "transcription": "Afficher la transcription"
         },
+        "embed": {
+          "start": {
+            "ariaLabel": "Commencer le simulateur",
+            "name": "Commencer"
+          }
+        },
         "grain": {
           "continue": "Continuer",
           "skip": "Passer",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1312,6 +1312,10 @@
           "transcription": "Afficher la transcription"
         },
         "embed": {
+          "reset": {
+            "ariaLabel": "Réinitialiser le simulateur",
+            "name": "Réinitialiser"
+          },
           "start": {
             "ariaLabel": "Commencer le simulateur",
             "name": "Commencer"

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1311,6 +1311,12 @@
           "alternativeText": "Het tekstalternatief tonen",
           "transcription": "Transcriptie weergeven"
         },
+        "embed": {
+          "start": {
+            "ariaLabel": "Start de simulator",
+            "name": "Beginnen"
+          }
+        },
         "grain": {
           "continue": "Ga verder met",
           "skip": "Overslaan",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -1312,6 +1312,10 @@
           "transcription": "Transcriptie weergeven"
         },
         "embed": {
+          "reset": {
+            "ariaLabel": "Reset de simulator",
+            "name": "Opnieuw instellen"
+          },
           "start": {
             "ariaLabel": "Start de simulator",
             "name": "Beginnen"


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, le référentiel Modulix peut contenir des embed sans complétion requise. L'API pouvant désormais les consommer, nous souhaitons pouvoir les afficher côté client.

## :robot: Proposition

Implémenter un composant `ModulixEmbed`.
Ce composant ne prend pas en compte les messages envoyés par l'_iframe_ qu'il contient.
Le composant contient un bouton "_commencer_" pour lancer l'`embed`, ainsi qu'un bouton "_réinitialiser_" afin de remettre l'`embed` à zéro.

- Ajouter un composant `Embed.gjs`
- Ajouter ce nouveau composant dans la gestion des éléments (switch/case)
- Afficher un embed dans un grain
- Ajouter un overlay sur l'embed avant qu'il ne soit lancer (iframe - blur)
- Ajouter un bouton Commencer + méthode pour commencer l'embed 
- Ajouter un bouton Réinitialiser + méthode pour réinitialiser l'embed
- Rajouter la consigne côté API
- Rajouter la consigne côté front
- Utiliser un embed + récent

## :rainbow: Remarques

### Ajout de la consigne dans le modèle

Dans les tâches précédentes, nous avions oublié de prendre en compte le besoin de consignes dans les `embed`.
Il a donc fallu l'ajouter dans cette PR pour qu'elle soit fonctionnellement complète.
Étant donné que dans l'existant, les `embed` ne comportent pas toujours de consigne, nous l'avons considéré optionnel dans notre modèle métier.

### Validation _Joi_

Dans la validation _Joi_, le `htmlSchema` était `required` par défaut. Mais étant donné que la consigne des `embed` est optionnelle, nous avons retiré le caractère requis du `htmlSchema`, et l'avons remonté spécifiquement dans la définition des schémas de `QCU`, `QCM` et `QROCM`.

## :100: Pour tester

1. Se rendre sur [le didacticiel](https://app-pr9488.review.pix.fr/modules/didacticiel-modulix)
2. Passer tous les grains jusqu'à celui comportant le simulateur
3. Commencer le simulateur en cliquant sur le bouton "Commencer"
4. Cliquer sur l'icône "caméra" au sein du simulateur
5. Cliquer sur le bouton "Réinitialiser"
6. Constater que le simulateur a retrouvé son état initial
7. Répondre à la question qui accompagne le simulateur
8. Constater qu'un feedback s'affiche
