### PR TITLE
[FEATURE] Création d'un mécanisme de correspondance des claims OIDC (PIX-13167)

### DIFF
--- a/api/src/identity-access-management/domain/constants/oidc-identity-providers.js
+++ b/api/src/identity-access-management/domain/constants/oidc-identity-providers.js
@@ -3,7 +3,7 @@ export const POLE_EMPLOI = {
   configKey: 'poleEmploi',
 };
 
-export const DEFAULT_CLAIMS_MAPPING = {
+export const DEFAULT_CLAIM_MAPPING = {
   firstName: ['given_name'],
   lastName: ['family_name'],
   externalIdentityId: ['sub'],

--- a/api/src/identity-access-management/domain/constants/oidc-identity-providers.js
+++ b/api/src/identity-access-management/domain/constants/oidc-identity-providers.js
@@ -2,3 +2,9 @@ export const POLE_EMPLOI = {
   code: 'POLE_EMPLOI',
   configKey: 'poleEmploi',
 };
+
+export const DEFAULT_CLAIMS_MAPPING = {
+  firstName: ['given_name'],
+  lastName: ['family_name'],
+  externalIdentityId: ['sub'],
+};

--- a/api/src/identity-access-management/domain/models/ClaimManager.js
+++ b/api/src/identity-access-management/domain/models/ClaimManager.js
@@ -1,0 +1,82 @@
+import flatten from 'lodash/flatten.js';
+import pickBy from 'lodash/pickBy.js';
+
+export class ClaimManager {
+  #claimMapping;
+  #additionalClaims;
+
+  /**
+   * @param {Object} options
+   * @param {Record<string, string[]>} options.claimMapping
+   * @param {string[]} options.additionalClaims
+   */
+  constructor({ claimMapping, additionalClaims } = {}) {
+    this.#claimMapping = claimMapping || {};
+    this.#additionalClaims = additionalClaims || [];
+  }
+
+  /**
+   * @returns boolean
+   */
+  get hasAdditionalClaims() {
+    return this.#additionalClaims.length > 0;
+  }
+
+  /**
+   * @param {Record<string, string>} userInfo
+   *
+   * @returns {Record<string, string>} Mapped claims from userInfo
+   */
+  mapClaims(userInfo = {}) {
+    return Object.entries(this.#claimMapping).reduce((result, [userKey, claimKeys]) => {
+      for (const claimKey of claimKeys) {
+        if (userInfo[claimKey]) {
+          return { ...result, [userKey]: userInfo[claimKey] };
+        }
+      }
+      return result;
+    }, {});
+  }
+
+  /**
+   * @param {Record<string, string>} userInfo
+   *
+   * @returns {Record<string, string>} Additional claims from userInfo
+   */
+  pickAdditionalClaims(userInfo = {}) {
+    return pickBy(userInfo, (value, key) => Boolean(value) && this.#additionalClaims.includes(key));
+  }
+
+  /**
+   * @param {Record<string, string>} userInfo
+   *
+   * @returns {boolean} true if required claims are missing from userInfo
+   */
+  hasMissingClaims(userInfo = {}) {
+    const missingClaims = this.getMissingClaims(userInfo);
+    return missingClaims.length > 0;
+  }
+
+  /**
+   * @param {Record<string, string>} userInfo
+   *
+   * @returns {string[]} missing required claims from userInfo
+   */
+  getMissingClaims(userInfo = {}) {
+    return [...this.#getMissingClaimsToMap(userInfo), ...this.#getMissingAdditionalClaims(userInfo)];
+  }
+
+  #getMissingClaimsToMap(userInfo = {}) {
+    const requiredKeys = Object.keys(this.#claimMapping);
+    const mappedKeys = Object.keys(this.mapClaims(userInfo));
+    return flatten(
+      requiredKeys.filter((required) => !mappedKeys.includes(required)).map((key) => this.#claimMapping[key]),
+    );
+  }
+
+  #getMissingAdditionalClaims(userInfo = {}) {
+    const requiredKeys = this.#additionalClaims;
+    const mappedKeys = Object.keys(this.pickAdditionalClaims(userInfo));
+    return requiredKeys.filter((required) => !mappedKeys.includes(required));
+  }
+}

--- a/api/src/identity-access-management/domain/models/OidcProvider.js
+++ b/api/src/identity-access-management/domain/models/OidcProvider.js
@@ -42,9 +42,10 @@ export class OidcProvider {
   /**
    *
    * @param {CryptoService} cryptoService
-   * @return {Promise<void>}
+   * @return {Promise<string | null}>}
    */
   async decryptClientSecret(cryptoService) {
+    if (!this.encryptedClientSecret) return null;
     this.clientSecret = await cryptoService.decrypt(this.encryptedClientSecret);
   }
 }

--- a/api/src/identity-access-management/domain/services/cnfpt-oidc-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/cnfpt-oidc-authentication-service.js
@@ -1,0 +1,13 @@
+import { OidcAuthenticationService } from './oidc-authentication-service.js';
+
+const CNFPT_CLAIM_MAPPING = {
+  firstName: ['given_name'],
+  lastName: ['name'],
+  externalIdentityId: ['sub'],
+};
+
+export class CnfptOidcAuthenticationService extends OidcAuthenticationService {
+  constructor(oidcProvider) {
+    super({ ...oidcProvider, claimMapping: CNFPT_CLAIM_MAPPING });
+  }
+}

--- a/api/src/identity-access-management/domain/services/google-oidc-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/google-oidc-authentication-service.js
@@ -1,18 +1,12 @@
-import jsonwebtoken from 'jsonwebtoken';
-
 import { OidcAuthenticationService } from './oidc-authentication-service.js';
+
+const GOOGLE_CLAIM_MAPPING = {
+  email: ['email'],
+  externalIdentityId: ['sub'],
+};
 
 export class GoogleOidcAuthenticationService extends OidcAuthenticationService {
   constructor(oidcProvider) {
-    super(oidcProvider);
-  }
-
-  async getUserInfo({ idToken }) {
-    const userInfo = jsonwebtoken.decode(idToken);
-
-    return {
-      externalIdentityId: userInfo.sub,
-      email: userInfo.email,
-    };
+    super({ ...oidcProvider, claimMapping: GOOGLE_CLAIM_MAPPING });
   }
 }

--- a/api/src/identity-access-management/domain/services/oidc-authentication-service-registry.js
+++ b/api/src/identity-access-management/domain/services/oidc-authentication-service-registry.js
@@ -1,6 +1,7 @@
 import { InvalidIdentityProviderError } from '../../../../lib/domain/errors.js';
 import { cryptoService } from '../../../shared/domain/services/crypto-service.js';
 import { oidcProviderRepository } from '../../infrastructure/repositories/oidc-provider-repository.js';
+import { CnfptOidcAuthenticationService } from './cnfpt-oidc-authentication-service.js';
 import { FwbOidcAuthenticationService } from './fwb-oidc-authentication-service.js';
 import { GoogleOidcAuthenticationService } from './google-oidc-authentication-service.js';
 import { OidcAuthenticationService } from './oidc-authentication-service.js';
@@ -74,6 +75,8 @@ export class OidcAuthenticationServiceRegistry {
               return new GoogleOidcAuthenticationService(oidcProvider);
             case 'POLE_EMPLOI':
               return new PoleEmploiOidcAuthenticationService(oidcProvider);
+            case 'CNFPT':
+              return new CnfptOidcAuthenticationService(oidcProvider);
             default:
               return new OidcAuthenticationService(oidcProvider);
           }

--- a/api/tests/identity-access-management/unit/domain/models/ClaimManager.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/ClaimManager.test.js
@@ -1,0 +1,158 @@
+import { ClaimManager } from '../../../../../src/identity-access-management/domain/models/ClaimManager.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Identity Access Management | Domain | Model | ClaimManager', function () {
+  describe('#mapClaims', function () {
+    it('maps all claims from user info', async function () {
+      // given
+      const claimMapping = { firstName: ['given_name'], lastName: ['last_name'] };
+      const additionalClaims = ['foo'];
+
+      // when
+      const claimManager = new ClaimManager({ claimMapping, additionalClaims });
+      const result = claimManager.mapClaims({ given_name: 'Bob', last_name: 'Uncle', foo: 'foo' });
+
+      // then
+      expect(result).to.deep.equal({ firstName: 'Bob', lastName: 'Uncle' });
+    });
+
+    it('maps claims from user info with multiple possible claims', async function () {
+      // given
+      const claimMapping = { firstName: ['given_name', 'username'] };
+
+      // when
+      const claimManager = new ClaimManager({ claimMapping });
+      const result = claimManager.mapClaims({ username: 'Bob' });
+
+      // then
+      expect(result).to.deep.equal({ firstName: 'Bob' });
+    });
+
+    it('returns an empty object when user info null', async function () {
+      // when
+      const claimManager = new ClaimManager();
+      const result = claimManager.mapClaims(null);
+
+      // then
+      expect(result).to.deep.equal({});
+    });
+  });
+
+  describe('#pickAdditionalClaims', function () {
+    it('picks additional claims from user info', async function () {
+      // given
+      const claimMapping = { firstName: ['given_name'] };
+      const additionalClaims = ['aWantedClaim', 'anotherWantedClaim'];
+
+      // when
+      const claimManager = new ClaimManager({ claimMapping, additionalClaims });
+      const result = claimManager.pickAdditionalClaims({
+        given_name: 'Bob',
+        aWantedClaim: 'Uncle',
+        anotherWantedClaim: 'Great',
+      });
+
+      // then
+      expect(result).to.deep.equal({ aWantedClaim: 'Uncle', anotherWantedClaim: 'Great' });
+    });
+
+    it('returns an empty object when user info are null', async function () {
+      // when
+      const claimManager = new ClaimManager();
+      const result = claimManager.pickAdditionalClaims(null);
+
+      // then
+      expect(result).to.deep.equal({});
+    });
+  });
+
+  describe('#hasMissingClaims', function () {
+    it('returns true when some claims are missing from user info', async function () {
+      // given
+      const claimMapping = { firstName: ['foo'], lastName: ['bar'] };
+
+      // when
+      const claimManager = new ClaimManager({ claimMapping });
+      const hasMissingClaims = claimManager.hasMissingClaims({ foo: 'foofoo' });
+
+      // then
+      expect(hasMissingClaims).to.equal(true);
+    });
+
+    it('returns true when some additional claims are missing from user info', async function () {
+      // given
+      const claimMapping = { firstName: ['foo'], lastName: ['bar'] };
+      const additionalClaims = ['aWantedClaim'];
+
+      // when
+      const claimManager = new ClaimManager({ claimMapping, additionalClaims });
+      const hasMissingClaims = claimManager.hasMissingClaims({ foo: 'foofoo', bar: 'barbar' });
+
+      // then
+      expect(hasMissingClaims).to.equal(true);
+    });
+
+    it('returns false when all claims are present from user info', async function () {
+      // given
+      const claimMapping = { firstName: ['foo'], lastName: ['bar'] };
+
+      // when
+      const claimManager = new ClaimManager({ claimMapping });
+      const hasMissingClaims = claimManager.hasMissingClaims({ foo: 'foofoo', bar: 'barbar' });
+
+      // then
+      expect(hasMissingClaims).to.equal(false);
+    });
+  });
+
+  describe('#getMissingClaims', function () {
+    it('returns the missing claims from user info', async function () {
+      // given
+      const claimMapping = { firstName: ['foo'], lastName: ['bar'], id: ['sub'] };
+      const additionalClaims = ['aWantedClaim', 'anotherWantedClaim'];
+
+      // when
+      const claimManager = new ClaimManager({ claimMapping, additionalClaims });
+      const result = claimManager.getMissingClaims({ sub: '', foo: 'foofoo', anotherWantedClaim: '' });
+
+      // then
+      expect(result).to.deep.equal(['bar', 'sub', 'aWantedClaim', 'anotherWantedClaim']);
+    });
+
+    it('returns an empty array when all claims are present from user info', async function () {
+      // given
+      const claimMapping = { firstName: ['foo'], lastName: ['bar'] };
+
+      // when
+      const claimManager = new ClaimManager({ claimMapping });
+      const result = claimManager.getMissingClaims({ foo: 'foofoo', bar: 'barbar' });
+
+      // then
+      expect(result).to.deep.equal([]);
+    });
+  });
+
+  describe('#hasAdditionalClaims', function () {
+    it('returns true if has additional claims', async function () {
+      // given
+      const additionalClaims = ['baz'];
+
+      // when
+      const claimManager = new ClaimManager({ additionalClaims });
+
+      // then
+      expect(claimManager.hasAdditionalClaims).to.be.true;
+    });
+
+    it('returns false if has additional claims', async function () {
+      // given
+      const additionalClaims = [];
+
+      // when
+      const claimManager = new ClaimManager({ additionalClaims });
+
+      // then
+      expect(claimManager.hasAdditionalClaims).to.be.false;
+    });
+  });
+});

--- a/api/tests/identity-access-management/unit/domain/services/cnfpt-oidc-authentication-service_test.js
+++ b/api/tests/identity-access-management/unit/domain/services/cnfpt-oidc-authentication-service_test.js
@@ -1,0 +1,33 @@
+import jsonwebtoken from 'jsonwebtoken';
+
+import { CnfptOidcAuthenticationService } from '../../../../../src/identity-access-management/domain/services/cnfpt-oidc-authentication-service.js';
+import { expect } from '../../../../test-helper.js';
+
+describe('Unit | Identity Access Management | Domain | Services | cnfpt-oidc-authentication-service', function () {
+  describe('#getUserInfo', function () {
+    it('returns email and external identity id', async function () {
+      // given
+      const idToken = jsonwebtoken.sign(
+        {
+          given_name: 'givenName',
+          name: 'familyName',
+          nonce: 'nonce-id',
+          sub: 'sub-id',
+        },
+        'secret',
+      );
+
+      const cnfptOidcAuthenticationService = new CnfptOidcAuthenticationService({});
+
+      // when
+      const result = await cnfptOidcAuthenticationService.getUserInfo({ idToken });
+
+      // then
+      expect(result).to.deep.equal({
+        firstName: 'givenName',
+        lastName: 'familyName',
+        externalIdentityId: 'sub-id',
+      });
+    });
+  });
+});

--- a/api/tests/identity-access-management/unit/domain/services/google-oidc-authentication-service_test.js
+++ b/api/tests/identity-access-management/unit/domain/services/google-oidc-authentication-service_test.js
@@ -7,33 +7,25 @@ describe('Unit | Identity Access Management | Domain | Services | google-oidc-au
   describe('#getUserInfo', function () {
     it('returns email and external identity id', async function () {
       // given
-      function generateIdToken(payload) {
-        return jsonwebtoken.sign(
-          {
-            ...payload,
-          },
-          'secret',
-        );
-      }
-
-      const idToken = generateIdToken({
-        given_name: 'givenName',
-        family_name: 'familyName',
-        nonce: 'bb041272-d6e6-457c-99fb-ff1aa02217fd',
-        sub: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
-        email: 'given.family@example.net',
-      });
+      const idToken = jsonwebtoken.sign(
+        {
+          given_name: 'givenName',
+          family_name: 'familyName',
+          nonce: 'nonce-id',
+          sub: 'sub-id',
+          email: 'given.family@example.net',
+        },
+        'secret',
+      );
 
       const googleOidcAuthenticationService = new GoogleOidcAuthenticationService({});
 
       // when
-      const result = await googleOidcAuthenticationService.getUserInfo({
-        idToken,
-      });
+      const result = await googleOidcAuthenticationService.getUserInfo({ idToken });
 
       // then
       expect(result).to.deep.equal({
-        externalIdentityId: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
+        externalIdentityId: 'sub-id',
         email: 'given.family@example.net',
       });
     });


### PR DESCRIPTION
## :unicorn: Problème

Certains SSO, comme Agent Connect et CNFPT, utilisent des claims OIDC autres que les claims retenus par Pix qui sont `family_name`, `given_name`.

Actuellement, par défaut, PIX map les claims OIDC suivant pour les informations de compte utilisateurs:
```
Pix attribute      = OIDC Claim
==================================
firstName          = given_name
lastName           = family_name
externalIdentityId = sub
```

Sur certains providers, Pix récupère également d'autres claims (`claimsToStore`)  qui sont stockés tels quels dans `authenticationComplement` sous forme de JSON.

## :robot: Proposition

Créer un mécanisme permettant de pouvoir changer le mapping des claims en fonction du provider d'authentification. Ce mécanisme gère également le mapping des claims par défaut et les claims additionnels à stocker (`claimsToStore`).

**Ce mécanisme est représenté par le modèle `ClaimManager`:**

Example:

```js
const claimMapping = {
  firstName: ['given_name', 'name'],
  lastName: ['family_name'],
  externalIdentityId: ['sub'],
}

const additionalClaims = ['employerNumber'] // eg. claimsToStore

const claimManager = new ClaimManager({ claimMapping, additionalClaims })

const mappedClaims = claimManager.mapClaims(userInfo)
```

Ce mapping permet de mapper les claims OIDC vers les informations de comptes utilisateur PIX. Si un attribut possède plusieurs claims OIDC, le mapper va prendre en priorité le premier claim trouvé (ici `given_name` pour le `firstName`). Si celui est vide, le claim suivant est testé.

Le `ClaimManager` fournit différentes méthodes:
```js
const claimManager = new ClaimManager({ claimMapping, additionalClaims })

// Map les claims de l'utilisateur
claimManager.mapClaims(userInfo)

// Récupère uniquement les additional claims de l'utilisateur
claimManager.pickAdditionalClaims(userInfo)

// Vérifie s'il manque des claims par rapport au mapping et additional claims
claimManager.hasMissingClaims(userInfo)

// Liste les claims manquantes par rapport au mapping et additional claims
claimManager.getMissingClaims(userInfo)
```

**Intégration dans `OidcAuthenticationService`:**

Ajout d'une nouvelle propriété `claimMapping` dans le constructeur de l'`OidcAuthenticationService` qui contient la définition du mapping. Dans le futur, cette propriété pourra être facilement intégrée en base de données.

Par défaut (si non fournie), cette propriété contient le mapping par défaut. Elle peut être surchargée à l'héritage (voir `GoogleOidcAuthenticationService` ou `CnfptOidcAuthenticationService`)

À l'instanciation du service, un `ClaimManager` est créé à partir des propriétés `claimMapping` et `claimsToStore`

## :rainbow: Remarques
- Le service `GoogleOidcAuthenticationService` a été modifié, car la surcharge de `getUserInfo` correspond à un mapping spécifique du provider.
- Le service `CnfptOidcAuthenticationService` a été ajouté avec son mapping spécifique:

```
const CNFPT_CLAIMS_MAPPING = {
  firstName: ['given_name'],
  lastName: ['name', 'family_name'],
  externalIdentityId: ['sub'],
}
```
- Des tests ont été ajoutés pour vérifier la correcte instanciation des OIDC provider services par le `OidcAuthenticationServiceRegistry`

## :100: Pour tester

- Se connecter avec le SSO Pôle emploi
> Vérifier les propriétés récupérées `firstName`, `lastName`, `externalIdentityId` et les `claimsToStore` (si configurés)

- Se connecter avec le SSO Google
> Vérifier les propriétés récupérées `firstName`, `lastName`, `externalIdentityId` et les `claimsToStore` (si configurés)

- Se connecter avec le SSO CNFPT
> Vérifier les propriétés récupérées `firstName`, `lastName`, `externalIdentityId` et les `claimsToStore` (si configurés)