### PR TITLE
[FEATURE] Ajout de filtre sur les Prénom/Nom des élèves d'une mission (Pix-11917)

### DIFF
--- a/api/src/prescription/organization-learner/application/api/organization-learners-api.js
+++ b/api/src/prescription/organization-learner/application/api/organization-learners-api.js
@@ -88,6 +88,7 @@ function _toAPIModel(input) {
 function _fromAPIModel(filter) {
   const filterMappings = {
     divisions: 'Libellé classe',
+    name: 'name',
   };
   return filter
     ? Object.entries(filter).reduce((acc, [key, value]) => {

--- a/api/src/school/application/mission-learner-route.js
+++ b/api/src/school/application/mission-learner-route.js
@@ -26,6 +26,7 @@ const register = async function (server) {
             },
             filter: Joi.object({
               divisions: [Joi.string(), Joi.array().items(Joi.string())],
+              name: Joi.string().empty(''),
             }).default({}),
           }),
         },

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -622,16 +622,16 @@ describe('Integration | Infrastructure | Repository | Organization Learner', fun
             organizationId,
             page: {
               size: 1,
-              number: 2,
+              number: 1,
             },
-            filter: { 'Libellé classe': ['Witch', 'Rogue'] },
+            filter: { 'Libellé classe': ['Witch', 'Rogue'], name: 'Zoé' },
           });
 
           expect(result.pagination).to.deep.equal({
-            page: 2,
+            page: 1,
             pageSize: 1,
-            rowCount: 2,
-            pageCount: 2,
+            rowCount: 1,
+            pageCount: 1,
           });
           expect(result.learners.length).to.equal(1);
           expect(result.learners[0].id).to.equal(rogueLearner.id);

--- a/api/tests/prescription/organization-learner/unit/application/api/organization-learners-api_test.js
+++ b/api/tests/prescription/organization-learner/unit/application/api/organization-learners-api_test.js
@@ -116,7 +116,7 @@ describe('Unit | API | Organization Learner', function () {
         // when
         const result = await organizationLearnersApi.find({
           organizationId,
-          filter: { divisions: ['div-2'] },
+          filter: { divisions: ['div-2'], name: 'Paul' },
         });
 
         // then
@@ -124,7 +124,7 @@ describe('Unit | API | Organization Learner', function () {
         expect(getPaginatedOrganizationLearnerStub).to.have.been.calledWith({
           organizationId,
           page: { size: 100, number: 1 },
-          filter: { 'Libellé classe': ['div-2'] },
+          filter: { 'Libellé classe': ['div-2'], name: 'Paul' },
         });
       });
     });

--- a/api/tests/school/integration/application/mission-learner-controller_test.js
+++ b/api/tests/school/integration/application/mission-learner-controller_test.js
@@ -33,7 +33,13 @@ describe('Integration | Controller | mission-learner-controller', function () {
             organizationId,
             missionId,
           },
-          query: { page: { size: 50, number: 1 }, filter: { divisions: 'CP' } },
+          query: {
+            page: { size: 50, number: 1 },
+            filter: {
+              divisions: 'CP',
+              name: 'Léa',
+            },
+          },
         },
         hFake,
       );
@@ -57,7 +63,7 @@ describe('Integration | Controller | mission-learner-controller', function () {
         organizationId,
         missionId,
         page: { size: 50, number: 1 },
-        filter: { divisions: ['CP'] },
+        filter: { divisions: ['CP'], name: 'Léa' },
       });
     });
 

--- a/api/tests/school/unit/application/mission-learner-route_test.js
+++ b/api/tests/school/unit/application/mission-learner-route_test.js
@@ -33,7 +33,7 @@ describe('Unit | Route | mission-learner-route', function () {
       // when
       const response = await httpTestServer.request(
         'GET',
-        `/api/organizations/4/missions/1/learners?filter[divisions][]=CM2-C&filter[divisions][]=CM2-B&page[number]=1&page[size]=25`,
+        `/api/organizations/4/missions/1/learners?filter[name]=Henry&filter[divisions][]=CM2-C&filter[divisions][]=CM2-B&page[number]=1&page[size]=25`,
       );
 
       // then
@@ -41,7 +41,7 @@ describe('Unit | Route | mission-learner-route', function () {
       expect(findPaginatedMissionLearnersStub).to.have.been.calledWith(
         sinon.match.has(
           'query',
-          sinon.match.has('filter', sinon.match.has('divisions', ['CM2-C', 'CM2-B'])),
+          sinon.match.has('filter', sinon.match.has('divisions', ['CM2-C', 'CM2-B']), sinon.match.has('name', 'Henry')),
           sinon.match.has('page', sinon.match.has('number', '1'), sinon.match.has('size', '25')),
         ),
       );

--- a/orga/app/components/campaign/filter/participation-filters.gjs
+++ b/orga/app/components/campaign/filter/participation-filters.gjs
@@ -191,8 +191,8 @@ export default class ParticipationFilters extends Component {
           <SearchInputFilter
             @field="search"
             @value={{@searchFilter}}
-            @placeholder={{t "pages.campaign-results.filters.type.search.placeholder"}}
-            @label={{t "pages.campaign-results.filters.type.search.title"}}
+            @placeholder={{t "common.filters.fullname.placeholder"}}
+            @label={{t "common.filters.fullname.label"}}
             @triggerFiltering={{@onFilter}}
           />
         {{/if}}

--- a/orga/app/components/organization-participant/learner-filters.hbs
+++ b/orga/app/components/organization-participant/learner-filters.hbs
@@ -10,8 +10,8 @@
   <Ui::SearchInputFilter
     @field="fullName"
     @value={{@fullName}}
-    @placeholder={{t "pages.organization-participants.filters.type.fullName.placeholder"}}
-    @label={{t "pages.organization-participants.filters.type.fullName.label"}}
+    @placeholder={{t "common.filters.fullname.placeholder"}}
+    @label={{t "common.filters.fullname.label"}}
     @triggerFiltering={{@onTriggerFiltering}}
   />
   <Ui::MultiSelectFilter

--- a/orga/app/components/sco-organization-participant/sco-learner-filters.hbs
+++ b/orga/app/components/sco-organization-participant/sco-learner-filters.hbs
@@ -10,8 +10,8 @@
   <Ui::SearchInputFilter
     @field="search"
     @value={{@searchFilter}}
-    @placeholder={{t "pages.sco-organization-participants.filter.search.placeholder"}}
-    @label={{t "pages.sco-organization-participants.filter.search.label"}}
+    @placeholder={{t "common.filters.fullname.placeholder"}}
+    @label={{t "common.filters.fullname.label"}}
     @triggerFiltering={{@onFilter}}
   />
 

--- a/orga/app/components/sup-organization-participant/sup-learner-filters.hbs
+++ b/orga/app/components/sup-organization-participant/sup-learner-filters.hbs
@@ -17,8 +17,8 @@
   <Ui::SearchInputFilter
     @field="search"
     @value={{@searchFilter}}
-    @placeholder={{t "pages.sup-organization-participants.filter.search.placeholder"}}
-    @label={{t "pages.sup-organization-participants.filter.search.label"}}
+    @placeholder={{t "common.filters.fullname.placeholder"}}
+    @label={{t "common.filters.fullname.label"}}
     @triggerFiltering={{@onFilter}}
   />
   <Ui::MultiSelectFilter

--- a/orga/app/controllers/authenticated/missions/details/learners.js
+++ b/orga/app/controllers/authenticated/missions/details/learners.js
@@ -10,6 +10,7 @@ export default class MissionLearnersController extends Controller {
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
   @tracked pageSize = 25;
   @tracked divisions = [];
+  @tracked name = '';
 
   get learnersCount() {
     return this.model.missionLearners.meta.rowCount;
@@ -34,8 +35,14 @@ export default class MissionLearnersController extends Controller {
   }
 
   @action
+  onFilter(inputText, value) {
+    this[inputText] = value;
+  }
+
+  @action
   onResetFilter() {
     this.divisions = [];
+    this.name = '';
   }
 
   @action

--- a/orga/app/routes/authenticated/missions/details/learners.js
+++ b/orga/app/routes/authenticated/missions/details/learners.js
@@ -9,6 +9,7 @@ export default class MissionLearnersRoute extends Route {
 
   queryParams = {
     divisions: { refreshModel: true },
+    name: { refreshModel: true },
     pageNumber: {
       refreshModel: true,
     },
@@ -22,6 +23,7 @@ export default class MissionLearnersRoute extends Route {
       controller.pageNumber = 1;
       controller.pageSize = 25;
       controller.divisions = undefined;
+      controller.name = undefined;
     }
   }
 
@@ -35,6 +37,7 @@ export default class MissionLearnersRoute extends Route {
         missionId: missionModel.mission.id,
         filter: {
           divisions: params.divisions,
+          name: params.name,
         },
         page: {
           number: params.pageNumber,

--- a/orga/app/templates/authenticated/missions/details/learners.hbs
+++ b/orga/app/templates/authenticated/missions/details/learners.hbs
@@ -1,20 +1,28 @@
 <h2 class="learners-title">{{t "pages.missions.details.learners.title"}}</h2>
+<PixFilterBanner
+  @title={{t "common.filters.title"}}
+  class="participant-filter-banner hide-on-mobile"
+  aria-label={{t "pages.missions.details.learners.list.filters.aria-label"}}
+  @details={{t "pages.missions.details.learners.list.filters.learners-count" count=this.learnersCount}}
+  @clearFiltersLabel={{t "common.filters.actions.clear"}}
+  @onClearFilters={{this.onResetFilter}}
+  @isClearFilterButtonDisabled={{this.isClearFiltersButtonDisabled}}
+>
+  <Ui::DivisionsFilter
+    @model={{@model.organization}}
+    @selected={{this.divisions}}
+    @onSelect={{this.onSelectDivisions}}
+  />
+  <Ui::SearchInputFilter
+    @field="name"
+    @value={{this.name}}
+    @placeholder={{t "common.filters.fullname.placeholder"}}
+    @label={{t "common.filters.fullname.label"}}
+    @triggerFiltering={{this.onFilter}}
+  />
+
+</PixFilterBanner>
 {{#if @model.missionLearners}}
-  <PixFilterBanner
-    @title={{t "common.filters.title"}}
-    class="participant-filter-banner hide-on-mobile"
-    aria-label={{t "pages.missions.details.learners.list.filters.aria-label"}}
-    @details={{t "pages.missions.details.learners.list.filters.learners-count" count=this.learnersCount}}
-    @clearFiltersLabel={{t "common.filters.actions.clear"}}
-    @onClearFilters={{this.onResetFilter}}
-    @isClearFilterButtonDisabled={{this.isClearFiltersButtonDisabled}}
-  >
-    <Ui::DivisionsFilter
-      @model={{@model.organization}}
-      @selected={{this.divisions}}
-      @onSelect={{this.onSelectDivisions}}
-    />
-  </PixFilterBanner>
   <div class="panel">
     <table class="table content-text content-text--small participation-list__table">
       <caption class="screen-reader-only">{{t

--- a/orga/mirage/handlers/find-paginated-mission-learners.js
+++ b/orga/mirage/handlers/find-paginated-mission-learners.js
@@ -4,11 +4,22 @@ export function findPaginatedMissionLearners(schema, request) {
   const organizationId = request.params.organization_id;
   const queryParams = request.queryParams;
   const divisionsFilter = queryParams['filter[divisions]'];
+  const nameFilter = queryParams['filter[name]'];
 
   let missionLearners = schema.missionLearners.where({ organizationId });
   if (divisionsFilter) {
-    missionLearners = schema.missionLearners.where((learner) => {
+    missionLearners = missionLearners.filter((learner) => {
       return divisionsFilter.includes(learner.division) && learner.organizationId === Number(organizationId);
+    });
+  }
+
+  if (nameFilter) {
+    missionLearners = missionLearners.filter((learner) => {
+      return (
+        (learner.firstName.toUpperCase().includes(nameFilter.toUpperCase()) ||
+          learner.lastName.toUpperCase().includes(nameFilter.toUpperCase())) &&
+        learner.organizationId === Number(organizationId)
+      );
     });
   }
   const rowCount = missionLearners.length;

--- a/orga/tests/acceptance/missions-details_test.js
+++ b/orga/tests/acceptance/missions-details_test.js
@@ -1,5 +1,5 @@
 import { visit } from '@1024pix/ember-testing-library';
-import { click } from '@ember/test-helpers';
+import { click, fillIn } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -190,6 +190,35 @@ module('Acceptance | Missions Detail', function (hooks) {
         assert.dom(screen.getByRole('cell', { name: participantCM2C.firstName })).exists();
         assert.dom(screen.getByRole('cell', { name: participantCM2A.firstName })).exists();
         assert.dom(screen.queryByRole('cell', { name: participantCM2B.firstName })).doesNotExist();
+      });
+      test('Should filter on the firstname name or lastname', async function (assert) {
+        server.create('mission-learner', {
+          firstName: 'Charles',
+          lastName: 'Pas-Xavier',
+          division: 'CM2-C',
+          status: 'completed',
+          organizationId: 1,
+        });
+        const xavierHenry = server.create('mission-learner', {
+          firstName: 'Xavier',
+          lastName: 'Henry',
+          division: 'CM2-B',
+          status: 'completed',
+          organizationId: 1,
+        });
+        server.create('mission-learner', {
+          firstName: 'Henry',
+          lastName: 'Charles',
+          division: 'CM2-A',
+          status: 'completed',
+          organizationId: 1,
+        });
+
+        const screen = await visit('/missions/1');
+        await fillIn(screen.getByPlaceholderText('Nom, prénom'), 'charles');
+
+        assert.strictEqual(screen.getAllByRole('cell', { name: 'Charles' }).length, 2);
+        assert.dom(screen.queryByRole('cell', { name: xavierHenry.firstName })).doesNotExist();
       });
     });
   });

--- a/orga/tests/integration/components/campaign/filter/participation-filters_test.js
+++ b/orga/tests/integration/components/campaign/filter/participation-filters_test.js
@@ -636,7 +636,7 @@ module('Integration | Component | Campaign::Filter::ParticipationFilters', funct
       await render(
         hbs`<Campaign::Filter::ParticipationFilters @campaign={{this.campaign}} @onFilter={{this.triggerFiltering}} />`,
       );
-      await fillByLabel(this.intl.t('pages.campaign-results.filters.type.search.title'), 'Sal');
+      await fillByLabel(this.intl.t('common.filters.fullname.label'), 'Sal');
 
       // then
       assert.ok(triggerFiltering.calledWith('search', 'Sal'));

--- a/orga/tests/integration/components/sco-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/list_test.js
@@ -355,7 +355,7 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       );
 
       // when
-      await fillByLabel(this.intl.t('pages.sco-organization-participants.filter.search.label'), 'Bob M');
+      await fillByLabel(this.intl.t('common.filters.fullname.label'), 'Bob M');
 
       // then
       sinon.assert.calledWithExactly(triggerFiltering, 'search', 'Bob M');

--- a/orga/tests/integration/components/sup-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/list_test.js
@@ -334,7 +334,7 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
       );
 
       // when
-      await fillByLabel(this.intl.t('pages.sup-organization-participants.filter.search.label'), 'Bob M');
+      await fillByLabel(this.intl.t('common.filters.fullname.label'), 'Bob M');
 
       // then
       sinon.assert.calledWithExactly(triggerFiltering, 'search', 'Bob M');
@@ -922,7 +922,7 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
 
       await click(firstLearnerSelected);
 
-      await fillByLabel(this.intl.t('pages.sup-organization-participants.filter.search.label'), 'Something');
+      await fillByLabel(this.intl.t('common.filters.fullname.label'), 'Something');
 
       // then
       assert.false(firstLearnerSelected.checked);

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -194,6 +194,10 @@
         "label": "Search by classes",
         "placeholder": "Classes"
       },
+      "fullname": {
+        "label": "Search by last name and first name",
+        "placeholder": "Last name, first name"
+      },
       "loading": "Loading..."
     },
     "form": {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -552,10 +552,6 @@
             "title": "Groups",
             "empty": "No group"
           },
-          "search": {
-            "title": "Search by last name and first name",
-            "placeholder": "Last name, first name"
-          },
           "stages": "Success rate",
           "status": {
             "title": "Status",
@@ -973,10 +969,6 @@
           "certificability": {
             "label": "Search by certificability",
             "placeholder": "Search by certificability"
-          },
-          "fullName": {
-            "label": "Search by last name and first name",
-            "placeholder": "Last name, first name"
           }
         }
       },
@@ -1184,10 +1176,6 @@
           "empty-option": "Log in method",
           "label": "Search by log in method"
         },
-        "search": {
-          "label": "Search by last name and first name",
-          "placeholder": "Last name, first name"
-        },
         "students-count": "{count, plural, =0 {0 students} =1 {1 student} other {{count} students}}"
       },
       "manage-authentication-method-modal": {
@@ -1331,10 +1319,6 @@
           "empty": "No group",
           "label": "Enter a group",
           "placeholder": "Search by group"
-        },
-        "search": {
-          "label": "Search by last name and first name",
-          "placeholder": "Last name, first name"
         },
         "student-number": {
           "label": "Enter a student number",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -194,6 +194,10 @@
         "label": "Rechercher par classes",
         "placeholder": "Classes"
       },
+      "fullname": {
+        "label": "Recherche sur le nom et prénom",
+        "placeholder": "Nom, prénom"
+      },
       "loading": "Chargement..."
     },
     "form": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -552,10 +552,6 @@
             "title": "Groupes",
             "empty": "Aucun groupe"
           },
-          "search": {
-            "title": "Recherche sur le nom et prénom",
-            "placeholder": "Nom, prénom"
-          },
           "stages": "Paliers",
           "status": {
             "title": "Statut",
@@ -973,10 +969,6 @@
           "certificability": {
             "label": "Rechercher par certificabilité",
             "placeholder": "Certificabilité"
-          },
-          "fullName": {
-            "label": "Recherche sur le nom et prénom",
-            "placeholder": "Nom, prénom"
           }
         }
       },
@@ -1184,10 +1176,6 @@
           "empty-option": "Méthode de connexion",
           "label": "Rechercher par méthode de connexion"
         },
-        "search": {
-          "label": "Recherche sur le nom et prénom",
-          "placeholder": "Nom, prénom"
-        },
         "students-count": "{count, plural, =0 {0 élève} =1 {1 élève} other {{count} élèves}}"
       },
       "manage-authentication-method-modal": {
@@ -1331,10 +1319,6 @@
           "empty": "Aucun groupe",
           "label": "Entrer un groupe",
           "placeholder": "Rechercher par groupe"
-        },
-        "search": {
-          "label": "Recherche sur le nom et prénom",
-          "placeholder": "Nom, prénom"
         },
         "student-number": {
           "label": "Entrer un numéro étudiant",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -193,6 +193,10 @@
         "label": "Zoeken op klasse",
         "placeholder": "Klassen"
       },
+      "fullname": {
+        "label": "Zoeken op voor- en achternaam",
+        "placeholder": "Achternaam, voornaam"
+      },
       "loading": "Laden...",
       "title": "Filters"
     },
@@ -506,10 +510,6 @@
           "groups": {
             "empty": "Geen groepen",
             "title": "Groepen"
-          },
-          "search": {
-            "placeholder": "Achternaam, voornaam",
-            "title": "Zoeken op voor- en achternaam"
           },
           "stages": "Lagers",
           "status": {
@@ -1004,10 +1004,6 @@
           "certificability": {
             "label": "Zoeken op certificeerbaarheid",
             "placeholder": "Certificering"
-          },
-          "fullName": {
-            "label": "Zoeken op voor- en achternaam",
-            "placeholder": "Achternaam, voornaam"
           }
         }
       },
@@ -1160,10 +1156,6 @@
           "empty-option": "Verbindingsmethode",
           "label": "Zoeken op verbindingsmethode"
         },
-        "search": {
-          "label": "Zoeken op voor- en achternaam",
-          "placeholder": "Achternaam, voornaam"
-        },
         "students-count": "{count, plural, =0 {0 student} =1 {1 student} other {{count} studenten}}"
       },
       "manage-authentication-method-modal": {
@@ -1309,10 +1301,6 @@
           "empty": "Geen groepen",
           "label": "Een groep invoeren",
           "placeholder": "Zoeken op groep"
-        },
-        "search": {
-          "label": "Zoeken op voor- en achternaam",
-          "placeholder": "Achternaam, voornaam"
         },
         "student-number": {
           "label": "Voer een studentnummer in",


### PR DESCRIPTION
## :unicorn: Problème
L'utilisateur de pix Orga à besoin de plus de filtre pour lire les tableau récapitulatifs.

## :robot: Proposition
Ajouter un filtre sur les nom et prénom.

## :rainbow: Remarques
L'input filtre à la fois sur les nom et les prénoms.

## :100: Pour tester
1 - Lancer orga sur la RA
2 - Aller se connecter avec l'utilisateur `member-orga@example.net`
3 - Passer dans l'onglet d'une mission, puis jouer avec le filtre Prénom/nom

Résultat attendu : Le filtre marche correctement sur le nom et le prénom