### PR TITLE
[BUGFIX] Ajout d'une icône manquante sur l'espace surveillant sur Pix Certif (PIX-13409).

### DIFF
--- a/certif/config/icons.js
+++ b/certif/config/icons.js
@@ -15,6 +15,7 @@ module.exports = function () {
       'plus-circle',
       'power-off',
       'redo',
+      'sign-out-alt',
       'trash-alt',
       'trash-can',
       'up-right-from-square',


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix Certif, dans l'espace de surveillance, l'icône présente a coté du bouton Quitter ne s'affiche plus.

<img width="124" alt="Capture d’écran 2024-07-11 à 17 58 49" src="https://github.com/1024pix/pix/assets/58915422/887df690-27e3-477f-9bb2-1d8c06689f0b">
<img width="625" alt="Capture d’écran 2024-07-11 à 17 58 42" src="https://github.com/1024pix/pix/assets/58915422/232e88a4-9b29-433d-ab7c-9dbeb5002e9a">


## :robot: Proposition
 Causé par la montée de version Pix UI. On ajoute coté icons.js

## :100: Pour tester

- Se connecter avec certif-pro
- Aller dans une session
- cliquer dans l'espace surveillant et y entrer les infos
- constater que le bouton a retrouvé son icône.
<img width="168" alt="Capture d’écran 2024-07-11 à 18 10 47" src="https://github.com/1024pix/pix/assets/58915422/78910572-3e0d-4c4b-8b7b-19866d3d7bfb">
