### PR TITLE
[BUGFIX] Afficher le propriétaire seulement dans la page `all-campaigns` (PIX-13402)

### DIFF
--- a/orga/app/templates/authenticated/campaigns/list/all-campaigns.hbs
+++ b/orga/app/templates/authenticated/campaigns/list/all-campaigns.hbs
@@ -7,6 +7,7 @@
     @canDelete={{@model.isAdmin}}
     @campaigns={{@model.campaigns}}
     @nameFilter={{this.name}}
+    @showCampaignOwner={{true}}
     @ownerNameFilter={{this.ownerName}}
     @statusFilter={{this.status}}
     @onFilter={{this.triggerFiltering}}

--- a/orga/app/templates/authenticated/campaigns/list/my-campaigns.hbs
+++ b/orga/app/templates/authenticated/campaigns/list/my-campaigns.hbs
@@ -12,7 +12,7 @@
     @onClear={{this.clearFilters}}
     @onClickCampaign={{this.goToCampaignPage}}
     @canDelete={{true}}
-    @showCampaignOwner={{true}}
+    @showCampaignOwner={{false}}
     @onDeleteCampaigns={{this.onDeleteCampaigns}}
   />
 {{else}}


### PR DESCRIPTION
## :unicorn: Problème
Suite à la mise ne place de la suppression de campagne , un oubli + coquille c'est glissé dans les deux pages campagnes

## :robot: Proposition
Corriger cette coquille afin de voir apparaître la propriétaire seulement dans la page `all-campaigns`

## :rainbow: Remarques
Etant du pur déclaratif, un test d'acceptance sur ces routes semble vraiment disproportionné

## :100: Pour tester
Vérifier que sur les pages 
* mes campagnes => pas de colonnes propriétaire
* toutes les campagnes => colonne propriétaire