### PR TITLE
[FEATURE] Ajout d'une description à PixOrga et autorisation du passage des google Bots (PIX-12633)

### DIFF
--- a/orga/app/index.html
+++ b/orga/app/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Pix Orga</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-pix_orga.png">

--- a/orga/app/routes/application.js
+++ b/orga/app/routes/application.js
@@ -6,6 +6,7 @@ export default class ApplicationRoute extends Route {
   @service currentDomain;
   @service currentUser;
   @service session;
+  @service intl;
 
   async beforeModel(transition) {
     await this.session.setup();
@@ -15,5 +16,12 @@ export default class ApplicationRoute extends Route {
     await this.currentUser.load();
     const userLocale = this.currentUser.prescriber?.lang;
     await this.session.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+  }
+
+  model() {
+    return {
+      title: this.currentDomain.isFranceDomain ? 'Pix Orga (France)' : 'Pix Orga (hors France)',
+      headElement: document.querySelector('head'),
+    };
   }
 }

--- a/orga/app/templates/application.hbs
+++ b/orga/app/templates/application.hbs
@@ -1,4 +1,8 @@
-{{page-title (t "navigation.pix-orga")}}
+{{page-title this.model.title}}
+{{#in-element this.model.headElement insertBefore=null}}
+  {{! template-lint-disable no-forbidden-elements }}
+  <meta name="description" content={{t "application.description"}} />
+{{/in-element}}
 
 <Banner::Communication />
 

--- a/orga/public/robots.txt
+++ b/orga/public/robots.txt
@@ -1,4 +1,3 @@
 # http://www.robotstxt.org
 User-agent: *
-Disallow: /
-Noindex: /
+Allow: /

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -56,6 +56,9 @@
       "uai-mismatched": "The UAI of your SIECLE file does not match your school."
     }
   },
+  "application": {
+    "description": "The platform dedicated to educational assessment and monitoring. Pix Orga lets you launch an assessment campaign or collect Pix profiles, track the progress of your students or learners in a campaign, or access their results."
+  },
   "banners": {
     "certification": {
       "message": "'<strong>'Certifications :'</strong>' n’oubliez pas de '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'finaliser les sessions dans Pix Certif'</a>' puis de télécharger les attestations ici via l'onglet “Certifications” avant la rentrée {year}."
@@ -320,7 +323,6 @@
       "sup-organization-participants": "Students",
       "team": "Team"
     },
-    "pix-orga": "Pix Orga",
     "places": {
       "link": "See details",
       "number": "{count, plural, =0 {0 seat available} =1 {1 seat available} other {{count, number} seats available}}"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -56,6 +56,9 @@
       "uai-mismatched": "L’UAI du fichier SIECLE ne correspond pas à celui de votre établissement."
     }
   },
+  "application": {
+    "description": "La plateforme dédiée à l’évaluation et au suivi pédagogique. Votre espace Pix Orga vous permet de lancer une campagne d’évaluation ou de collecte de profils Pix, suivre l’avancement de vos élèves ou apprenants dans une campagne, ou encore accéder à leurs résultats."
+  },
   "banners": {
     "certification": {
       "message": "'<strong>'Certifications :'</strong>' n’oubliez pas de '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'finaliser les sessions dans Pix Certif'</a>' puis de télécharger les attestations ici via l'onglet “Certifications” avant la rentrée {year}."
@@ -320,7 +323,6 @@
       "sup-organization-participants": "Étudiants",
       "team": "Équipe"
     },
-    "pix-orga": "Pix Orga",
     "places": {
       "link": "voir le détail",
       "number": "{count, plural, =0 {0 place disponible} =1 {1 place disponible} other {{count} places disponibles}}"


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu’on cherche PixOrga sur google,on trouve "Pix Orga (prof)"  sans description

On souhaite : 
- enlever le (prof) 
- modifier le texte descriptif 

## :robot: Proposition
Pour [orga.pix.fr](http://orga.pix.fr/)

Pix Orga (France)
La plateforme dédiée à l’évaluation et au suivi pédagogique. Votre espace Pix Orga vous permet de lancer une campagne d’évaluation ou de collecte de profils Pix, suivre l’avancement de vos élèves ou apprenants dans une campagne, ou encore accéder à leurs résultats.

Pour [orga.pix.org](http://orga.pix.org/) :

Pix Orga (hors France)
La plateforme dédiée à l’évaluation et au suivi pédagogique. Votre espace Pix Orga vous permet de lancer une campagne d’évaluation ou de collecte de profils Pix, suivre l’avancement de vos élèves ou apprenants dans une campagne, ou encore accéder à leurs résultats.

🇬🇧  
The platform dedicated to educational assessment and monitoring. Pix Orga lets you launch an assessment campaign or collect Pix profiles, track the progress of your students or learners in a campaign, or access their results.
## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- ?
- 🎉 