### PR TITLE
[BUGFIX] Remplacer la balise `a` par le composant de routing `LinkTo` (PIX-13283)

### DIFF
--- a/orga/app/components/layout/organization-places-or-credit-info.gjs
+++ b/orga/app/components/layout/organization-places-or-credit-info.gjs
@@ -1,4 +1,5 @@
 import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import Component from '@glimmer/component';
@@ -23,7 +24,9 @@ export default class OrganizationPlacesOrCreditInfo extends Component {
           <span>{{t "navigation.places.number" count=@placesCount}}</span>
         {{/if}}
         {{#if this.currentUser.isAdminInOrganization}}
-          <a href="/places" class="organization-places-or-credit-info__link">{{t "navigation.places.link"}}</a>
+          <LinkTo @route="authenticated.places" class="organization-places-or-credit-info__link">
+            {{t "navigation.places.link"}}
+          </LinkTo>
         {{/if}}
       </div>
     {{else if this.canShowCredit}}


### PR DESCRIPTION
## :unicorn: Problème
La balise a ne permet pas de garder la session courante ember, elle recharge une page. sans locale, elle prend du français

## :robot: Proposition
Utiliser la balise de routing ember LinkTo afin de rester dans l'application et conserver le state de l'app ( lang etc...)

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter en nl est vérifier qu'au clique sur le lien places dans le header, nous sommes toujours en nl sur l'application