### PR TITLE
[FEATURE] Ajout d'un FT pour la déclaration d'un besoin d'aménagement pour un candidat (PIX-13292)

### DIFF
--- a/api/lib/infrastructure/validate-environment-variables.js
+++ b/api/lib/infrastructure/validate-environment-variables.js
@@ -36,6 +36,7 @@ const schema = Joi.object({
   ENABLE_KNEX_PERFORMANCE_MONITORING: Joi.string().optional().valid('true', 'false'),
   FORCE_DROP_DATABASE: Joi.string().optional().valid('true', 'false'),
   FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE: Joi.string().optional().valid('true', 'false'),
+  FT_ENABLE_NEED_TO_ADJUST_CERTIFICATION_ACCESSIBILITY: Joi.string().optional().valid('true', 'false'),
   FT_ENABLE_PIX_PLUS_LOWER_LEVEL: Joi.string().optional().valid('true', 'false'),
   FT_ENABLE_TEXT_TO_SPEECH_BUTTON: Joi.string().optional().valid('true', 'false'),
   FT_ENABLE_V3_INFO_SCREENS: Joi.string().optional().valid('true', 'false'),

--- a/api/sample.env
+++ b/api/sample.env
@@ -753,6 +753,13 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: false
 # FT_ENABLE_TEXT_TO_SPEECH_BUTTON=false
 
+# Enable identification of the need to adjust certification accessibility
+#
+# presence: optional
+# type: boolean
+# default: false
+# FT_ENABLE_NEED_TO_ADJUST_CERTIFICATION_ACCESSIBILITY=false
+
 # =====
 # CPF
 # =====

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -192,6 +192,9 @@ const configuration = (function () {
       isCertificationTokenScopeEnabled: toBoolean(process.env.FT_ENABLE_CERTIF_TOKEN_SCOPE),
       deprecatePoleEmploiPushNotification: toBoolean(process.env.DEPRECATE_PE_PUSH_NOTIFICATION),
       isTextToSpeechButtonEnabled: toBoolean(process.env.FT_ENABLE_TEXT_TO_SPEECH_BUTTON),
+      isNeedToAdjustCertificationAccessibilityEnabled: toBoolean(
+        process.env.FT_ENABLE_NEED_TO_ADJUST_CERTIFICATION_ACCESSIBILITY,
+      ),
     },
     hapi: {
       options: {},
@@ -382,6 +385,7 @@ const configuration = (function () {
     config.featureToggles.isCertificationTokenScopeEnabled = false;
     config.featureToggles.isPixPlusLowerLeverEnabled = false;
     config.featureToggles.isTextToSpeechButtonEnabled = false;
+    config.featureToggles.isNeedToAdjustCertificationAccessibilityEnabled = false;
 
     config.mailing.enabled = false;
     config.mailing.provider = 'brevo';

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -27,6 +27,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
             'is-pix-plus-lower-lever-enabled': false,
             'is-certification-token-scope-enabled': false,
             'is-text-to-speech-button-enabled': false,
+            'is-need-to-adjust-certification-accessibility-enabled': false,
           },
         },
       };


### PR DESCRIPTION
## :unicorn: Problème
On va permettre à un centre de certification de déclarer un besoin d’aménagement pour un candidat à l’inscription.

## :robot: Proposition
Plusieurs étapes sont nécessaires avant de mettre à disposition cette fonctionnalité dans son ensemble à nos centres.

## :rainbow: Remarques
Créer un feature toggle pour cette fonctionnalité

## :100: Pour tester
- Les tests sont ✅
- Aller sur : https://api-pr9509.review.pix.fr/api/feature-toggles 
- et vérifier que `"is-need-to-adjust-certification-accessibility-enabled": false`