### PR TITLE
[FEATURE] Ne plus inclure le user id dans les champs NOM et PRENOM lors de l'anonymisation d'un utilisateur

### DIFF
--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -182,8 +182,8 @@ function routes() {
     const userId = request.params.id;
     const user = schema.users.findBy({ id: userId });
     return user.update({
-      firstName: `prenom_${userId}`,
-      lastName: `nom_${userId}`,
+      firstName: '(anonymised)',
+      lastName: '(anonymised)',
       email: `email_${userId}@example.net`,
       username: null,
       authenticationMethods: [],

--- a/admin/tests/acceptance/authenticated/users/get_test.js
+++ b/admin/tests/acceptance/authenticated/users/get_test.js
@@ -44,7 +44,7 @@ module('Acceptance | authenticated/users/get', function (hooks) {
     return user;
   }
 
-  test('should access on user details page by URL /users/:id', async function (assert) {
+  test('access to user details page by URL /users/:id', async function (assert) {
     // when
     const user = await buildAndAuthenticateUser(this.server, { email: 'john.harry@example.net', username: null });
     await visit(`/users/${user.id}`);
@@ -53,7 +53,7 @@ module('Acceptance | authenticated/users/get', function (hooks) {
     assert.deepEqual(currentURL(), `/users/${user.id}`);
   });
 
-  test('should display user detail information page', async function (assert) {
+  test('displays user detail information page', async function (assert) {
     // given
     const user = await buildAndAuthenticateUser(this.server, { email: 'john.harry@example.net', username: null });
     const expectedOrganizationMembershipsCount = 2;
@@ -80,7 +80,7 @@ module('Acceptance | authenticated/users/get', function (hooks) {
       .hasText(`Pix Orga (${expectedOrganizationMembershipsCount})`);
   });
 
-  test('should redirect to list users page when click page title', async function (assert) {
+  test('redirects to list users page when click page title', async function (assert) {
     // given
     const user = await buildAndAuthenticateUser(this.server, { email: 'john.harry@example.net', username: null });
     await visit(`/users/${user.id}`);
@@ -93,7 +93,7 @@ module('Acceptance | authenticated/users/get', function (hooks) {
   });
 
   module('when administrator click to edit users details', function () {
-    test('should update user language, username, firstName, lastName and email', async function (assert) {
+    test('updates user language, username, firstName, lastName and email', async function (assert) {
       // given
       const user = await buildAndAuthenticateUser(this.server, {
         email: 'john.harry@example.net',
@@ -125,7 +125,7 @@ module('Acceptance | authenticated/users/get', function (hooks) {
   });
 
   module('when administrator click on anonymize button and confirm modal', function () {
-    test('should anonymize the user and remove all authentication methods', async function (assert) {
+    test('anonymizes the user and remove all authentication methods', async function (assert) {
       // given
       await buildAndAuthenticateUser(this.server, {
         email: 'john.harry@example.net',
@@ -187,7 +187,7 @@ module('Acceptance | authenticated/users/get', function (hooks) {
   });
 
   module('when administrator click on unblock button', function () {
-    test('should unblock the user', async function (assert) {
+    test('unblocks the user', async function (assert) {
       // given
       await buildAndAuthenticateUser(this.server, {
         email: 'john.harry@example.net',
@@ -218,7 +218,7 @@ module('Acceptance | authenticated/users/get', function (hooks) {
   });
 
   module('when administrator click on dissociate button', function () {
-    test('should not display registration any more', async function (assert) {
+    test('not displays registration any more', async function (assert) {
       // given
       const user = await buildAndAuthenticateUser(this.server, { email: 'john.harry@example.net', username: null });
       const organizationName = 'Organisation_to_dissociate_of';
@@ -245,7 +245,7 @@ module('Acceptance | authenticated/users/get', function (hooks) {
   });
 
   module('when administrator click on remove authentication method button', function () {
-    test('should not display remove link and display unchecked icon', async function (assert) {
+    test('not displays remove link and display unchecked icon', async function (assert) {
       // given
       const user = await buildAndAuthenticateUser(this.server, { email: 'john.harry@example.net', username: null });
       const screen = await visit(`/users/${user.id}`);
@@ -264,7 +264,7 @@ module('Acceptance | authenticated/users/get', function (hooks) {
   });
 
   module('when administrator click on delete participation button', function () {
-    test('should mark participation as deleted', async function (assert) {
+    test('marks participation as deleted', async function (assert) {
       // given
       const userParticipation = this.server.create('user-participation', { deletedAt: null });
       const user = server.create('user');
@@ -293,7 +293,7 @@ module('Acceptance | authenticated/users/get', function (hooks) {
   });
 
   module('when administrator clicks on organizations tab', function () {
-    test('should display user’s organizations', async function (assert) {
+    test('displays user’s organizations', async function (assert) {
       // given
       const organization = this.server.create('organization');
       const organizationMembership1 = this.server.create('organization-membership', {
@@ -327,7 +327,7 @@ module('Acceptance | authenticated/users/get', function (hooks) {
   });
 
   module('when administrator clicks on certification centers tab', function () {
-    test('should display user’s certification centers', async function (assert) {
+    test('displays user’s certification centers', async function (assert) {
       // given
       const certificationCenter = this.server.create('certification-center', {
         name: 'Centre Kaede',

--- a/admin/tests/acceptance/authenticated/users/get_test.js
+++ b/admin/tests/acceptance/authenticated/users/get_test.js
@@ -165,9 +165,8 @@ module('Acceptance | authenticated/users/get', function (hooks) {
 
       // when & then #1
       await click(screen.getByRole('button', { name: 'Confirmer' }));
-
-      assert.dom(screen.getByText(`Prénom : prenom_${userToAnonymise.id}`)).exists();
-      assert.dom(screen.getByText(`Nom : nom_${userToAnonymise.id}`)).exists();
+      assert.dom(screen.getByText(`Prénom : (anonymised)`)).exists();
+      assert.dom(screen.getByText(`Nom : (anonymised)`)).exists();
       assert.dom(screen.getByText(`Adresse e-mail : email_${userToAnonymise.id}@example.net`)).exists();
 
       assert.dom(screen.getByLabelText("L'utilisateur n'a pas de méthode de connexion avec identifiant")).exists();

--- a/api/lib/domain/usecases/anonymize-user.js
+++ b/api/lib/domain/usecases/anonymize-user.js
@@ -13,8 +13,8 @@ const anonymizeUser = async function ({
   adminMemberRepository,
 }) {
   const anonymizedUser = {
-    firstName: `prenom_${userId}`,
-    lastName: `nom_${userId}`,
+    firstName: '(anonymised)',
+    lastName: '(anonymised)',
     email: `email_${userId}@example.net`,
     username: null,
     hasBeenAnonymised: true,

--- a/api/tests/acceptance/application/users/users-route_test.js
+++ b/api/tests/acceptance/application/users/users-route_test.js
@@ -50,8 +50,8 @@ describe('Acceptance | Route | users', function () {
 
       const updatedUserAttributes = response.result.data.attributes;
 
-      expect(updatedUserAttributes['first-name']).to.equal(`prenom_${userId}`);
-      expect(updatedUserAttributes['last-name']).to.equal(`nom_${userId}`);
+      expect(updatedUserAttributes['first-name']).to.equal('(anonymised)');
+      expect(updatedUserAttributes['last-name']).to.equal('(anonymised)');
       expect(updatedUserAttributes.email).to.equal(`email_${userId}@example.net`);
       expect(updatedUserAttributes.username).to.be.null;
 

--- a/api/tests/unit/domain/usecases/anonymize-user_test.js
+++ b/api/tests/unit/domain/usecases/anonymize-user_test.js
@@ -25,8 +25,8 @@ describe('Unit | UseCase | anonymize-user', function () {
     const updatedByUserId = 2;
     const role = 'SUPER_ADMIN';
     const anonymizedUser = {
-      firstName: `prenom_${userId}`,
-      lastName: `nom_${userId}`,
+      firstName: '(anonymised)',
+      lastName: '(anonymised)',
       email: `email_${userId}@example.net`,
       username: null,
       hasBeenAnonymised: true,


### PR DESCRIPTION
## :unicorn: Problème
Aujourd’hui, quand un user est supprimé depuis Pix Admin, alors:

“users.firstName” est vidé et remplacé par “prenom_{userID}”

 “users.lastName” est vidé et remplacé par “nom_{userID}”

MAIS Il ne faut plus garder le userID, car ces données sont directement identifiantes dès qu’elles sont présentes conjointement avec d’autres données encore disponibles en base, dans freshdesk etc.

## :robot: Proposition
TO DO:
Au clic du bouton 'Supprimer cet utilisateur':

“users.firstName” est vidé et remplacé par le texte "(anonymised)"

 “users.lastName” est vidé et remplacé par le texte "(anonymised)"

Exemple:

firstName 'Emmy' => "(anonymised)"

lastname ‘BARBIER' => "(anonymised)"

Mettre en place cette règle pour toutes les nouvelles anonymisations.

## :rainbow: Remarques
On devra aussi faire une migration pour toutes les anciennes lignes: ticket https://1024pix.atlassian.net/browse/PIX-4218

## :100: Pour tester
* Se connecter en tant que superAdmin sur Pix Admin
* Chercher un utilisateur (par exemple James Palédroits)
* Anonymiser cet utilisateur
* Vérifier en base que le nom et le prénom ont bien été remplacés par "(anonymised)"
* Vérifier que James Paledroits n'est plus membre des centres de certification Accessorium, Accessovolt et Accestral (le champ disabledAt de la table certification-center-memberships est rempli).
