### PR TITLE
[BUGFIX] Ajouter la clef oubliée de traduction pour le label de réinitialisation du simulateur (PIX-13425)

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -689,7 +689,8 @@
         "actions": {
           "launch": "Start",
           "launch-label": "Start simulation",
-          "reset": "Restart"
+          "reset": "Restart",
+          "reset-label": "Restart simulation"
         },
         "placeholder": "App loading"
       },

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -683,7 +683,8 @@
         "actions": {
           "launch": "Empezar",
           "launch-label": "Empezar simulación",
-          "reset": "Restablecer"
+          "reset": "Restablecer",
+          "reset-label": "Restablecer simulación"
         },
         "placeholder": "Cargando la aplicación"
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -689,7 +689,8 @@
         "actions": {
           "launch": "Commencer",
           "launch-label": "Commencer la simulation",
-          "reset": "Réinitialiser"
+          "reset": "Réinitialiser",
+          "reset-label": "Réinitialiser la simulation"
         },
         "placeholder": "Chargement de l'application en cours"
       },

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -683,7 +683,8 @@
         "actions": {
           "launch": "Start",
           "launch-label": "Simulatie starten",
-          "reset": "Reset"
+          "reset": "Reset",
+          "reset-label": "Reset de simulatie"
         },
         "placeholder": "De huidige toepassing laden"
       },


### PR DESCRIPTION
## :unicorn: Problème
Il manque les clefs de traduction pour l'aria-label de réinitialisation du simulateur.

## :robot: Proposition
Rajouter les clefs

## :rainbow: Remarques
Le problème n'existait pas l'année précédente, auraient-elles pu être supprimées par hasard?

## :100: Pour tester
Aller voir le challenge suivant : 
`challenge1Y8uhO17GLIcvy`
Puis vérifier que l'aria-label du bouton `Réinitialiser` indique bien `Réinitialiser la simulation`
