### PR TITLE
[BUGFIX] Rediriger vers la mire d'inscription pour les imports générique de type SCO (PIX-13446)

### DIFF
--- a/mon-pix/app/models/area.js
+++ b/mon-pix/app/models/area.js
@@ -9,7 +9,7 @@ export default class Area extends Model {
   @attr('string') color;
 
   // includes
-  @hasMany('resultCompetence', { async: false, inverse: 'area' }) resultCompetences;
+  @hasMany('result-competence', { async: false, inverse: 'area' }) resultCompetences;
   @hasMany('competence', { async: false, inverse: 'area' }) competences;
 
   get sortedCompetences() {

--- a/mon-pix/app/models/tutorial.js
+++ b/mon-pix/app/models/tutorial.js
@@ -17,8 +17,8 @@ export default class Tutorial extends Model {
 
   // includes
   @belongsTo('scorecard', { async: true, inverse: 'tutorials' }) scorecard;
-  @belongsTo('userSavedTutorial', { inverse: 'tutorial', async: false }) userSavedTutorial;
-  @belongsTo('tutorialEvaluation', { inverse: 'tutorial', async: false }) tutorialEvaluation;
+  @belongsTo('user-saved-tutorial', { inverse: 'tutorial', async: false }) userSavedTutorial;
+  @belongsTo('tutorial-evaluation', { inverse: 'tutorial', async: false }) tutorialEvaluation;
 
   @computed('userSavedTutorial')
   get isSaved() {

--- a/mon-pix/app/models/user.js
+++ b/mon-pix/app/models/user.js
@@ -29,7 +29,7 @@ export default class User extends Model {
   @belongsTo('profile', { async: true, inverse: null }) profile;
   @hasMany('certification', { async: true, inverse: 'user' }) certifications;
   @hasMany('scorecard', { async: true, inverse: null }) scorecards;
-  @hasMany('trainings', { async: true, inverse: null }) trainings;
+  @hasMany('training', { async: true, inverse: null }) trainings;
 
   // methods
   get fullName() {

--- a/mon-pix/app/routes/campaigns/access.js
+++ b/mon-pix/app/routes/campaigns/access.js
@@ -63,6 +63,7 @@ export default class AccessRoute extends Route {
     return (
       campaign.isRestricted &&
       campaign.organizationType === 'SCO' &&
+      !campaign.isReconciliationRequired &&
       !this.session.isAuthenticated &&
       (!isUserExternal || hasUserSeenJoinPage)
     );

--- a/mon-pix/app/services/store.js
+++ b/mon-pix/app/services/store.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data/store';

--- a/mon-pix/app/transforms/boolean.js
+++ b/mon-pix/app/transforms/boolean.js
@@ -1,0 +1,1 @@
+export { BooleanTransform as default } from '@ember-data/serializer/transform';

--- a/mon-pix/app/transforms/date.js
+++ b/mon-pix/app/transforms/date.js
@@ -1,0 +1,1 @@
+export { DateTransform as default } from '@ember-data/serializer/transform';

--- a/mon-pix/app/transforms/number.js
+++ b/mon-pix/app/transforms/number.js
@@ -1,0 +1,1 @@
+export { NumberTransform as default } from '@ember-data/serializer/transform';

--- a/mon-pix/app/transforms/string.js
+++ b/mon-pix/app/transforms/string.js
@@ -1,0 +1,1 @@
+export { StringTransform as default } from '@ember-data/serializer/transform';

--- a/mon-pix/tests/unit/routes/campaigns/access_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/access_test.js
@@ -58,7 +58,7 @@ module('Unit | Route | Access', function (hooks) {
       assert.strictEqual(route.authenticationRoute, 'inscription');
     });
 
-    test('should call parent’s beforeModel and transition to authenticationRoute', async function (assert) {
+    test("should call parent's beforeModel and transition to authenticationRoute", async function (assert) {
       // when
       await route.beforeModel({ from: 'campaigns.campaign-landing-page' });
 
@@ -124,6 +124,7 @@ module('Unit | Route | Access', function (hooks) {
           // given
           route.session.isAuthenticated = false;
           campaign.isRestricted = true;
+          campaign.isReconciliationRequired = false;
           campaign.organizationType = 'SCO';
           route.session.data.externalUser = undefined;
 
@@ -132,6 +133,21 @@ module('Unit | Route | Access', function (hooks) {
 
           // then
           assert.strictEqual(route.authenticationRoute, 'campaigns.join.student-sco');
+        });
+
+        test('should not override authentication route when campaign reconciliationRequired', async function (assert) {
+          // given
+          route.session.isAuthenticated = false;
+          campaign.isRestricted = true;
+          campaign.isReconciliationRequired = true;
+          campaign.organizationType = 'SCO';
+          route.session.data.externalUser = undefined;
+
+          // when
+          await route.beforeModel({ from: 'campaigns.campaign-landing-page' });
+
+          // then
+          assert.strictEqual(route.authenticationRoute, 'inscription');
         });
       },
     );


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'import à format est posé sur une organisation SCO, nous sommes rediriger vers la mire de connexion des orga SCO "SIECLE"

## :robot: Proposition
Rediriger seulement vers la mire d'inscription classique

## :rainbow: Remarques
Nettoyage un peu de pollution dans la console

## :100: Pour tester
Modifier le type de l'orga PRO générique en SCO
Tenter d'accèder à la camapgne sur PixAPP sans être connecter
Vérifier que nous avons simplement la page d'insciption sans la double mire SCO