### PR TITLE
[TECH] Migration du preHandler `user-existence-verification` vers `src` (PIX-13445)

### DIFF
--- a/api/src/identity-access-management/application/user/user-existence-verification-pre-handler.js
+++ b/api/src/identity-access-management/application/user/user-existence-verification-pre-handler.js
@@ -1,6 +1,6 @@
-import * as userRepository from '../../../src/identity-access-management/infrastructure/repositories/user.repository.js';
-import * as errorSerializer from '../../../src/shared/infrastructure/serializers/jsonapi/validation-error-serializer.js';
-import { UserNotFoundError } from '../../domain/errors.js';
+import { UserNotFoundError } from '../../../../lib/domain/errors.js';
+import * as errorSerializer from '../../../shared/infrastructure/serializers/jsonapi/validation-error-serializer.js';
+import * as userRepository from '../../infrastructure/repositories/user.repository.js';
 
 const verifyById = function (request, h, dependencies = { userRepository, errorSerializer }) {
   return dependencies.userRepository.get(request.params.id).catch((err) => {

--- a/api/src/identity-access-management/application/user/user.route.js
+++ b/api/src/identity-access-management/application/user/user.route.js
@@ -1,13 +1,13 @@
 import Joi from 'joi';
 import XRegExp from 'xregexp';
 
-import { userVerification } from '../../../../lib/application/preHandlers/user-existence-verification.js';
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { config } from '../../../shared/config.js';
 import { EntityValidationError } from '../../../shared/domain/errors.js';
 import { AVAILABLE_LANGUAGES } from '../../../shared/domain/services/language-service.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { userController } from './user.controller.js';
+import { userVerification } from './user-existence-verification-pre-handler.js';
 
 const { passwordValidationPattern } = config.account;
 

--- a/api/tests/identity-access-management/unit/application/user-existence-verification_test.js
+++ b/api/tests/identity-access-management/unit/application/user-existence-verification_test.js
@@ -1,5 +1,5 @@
-import { userVerification } from '../../../../lib/application/preHandlers/user-existence-verification.js';
 import { UserNotFoundError } from '../../../../lib/domain/errors.js';
+import { userVerification } from '../../../../src/identity-access-management/application/user/user-existence-verification-pre-handler.js';
 import { expect, hFake, sinon } from '../../../test-helper.js';
 
 describe('Unit | Pre-handler | User Verification', function () {

--- a/api/tests/identity-access-management/unit/application/user.route.test.js
+++ b/api/tests/identity-access-management/unit/application/user.route.test.js
@@ -1,6 +1,6 @@
-import { userVerification } from '../../../../lib/application/preHandlers/user-existence-verification.js';
 import { identityAccessManagementRoutes } from '../../../../src/identity-access-management/application/routes.js';
 import { userController } from '../../../../src/identity-access-management/application/user/user.controller.js';
+import { userVerification } from '../../../../src/identity-access-management/application/user/user-existence-verification-pre-handler.js';
 import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
 


### PR DESCRIPTION
## :unicorn: Problème

cf https://github.com/1024pix/pix/blob/dev/docs/adr/0051-nouvelle-arborescence-api.md

## :robot: Proposition

Déplacement du pré handler `user-exietence-verification` vers `src`

## :rainbow: Remarques

C'est étonnant d'avoir un terme « métier » à droite d'un terme « technique ». Est-ce que `user` ne serait un sous domaine plutôt ?

Autre remarque, pour le moment, nous n'avons pas renommé le fichier pour correspondre à l'expérimentation de notation de fichier de l'équipe Acces. Peut-être qu'au lieu d'avoir `user-existence-verification-pre-handler.js` nous pourrions avoir `user.pre-handler.existence-verification.js` ?

## :100: Pour tester
- Se créer un compte sur Pix App avec son adresse pix
- Valider son inscription
- Aller sur "Mot de passe oublié"
- Renseigner le champ avec son adresse mail
- Aller dans le mail reçu, cliquer sur réinitialiser son mot de passe
- Mettre à jour son nouveau mot de passe
