### PR TITLE
[TECH] Ne pas lever d'exception lors du lancement des seeds si le référentiel contient un acquis sans épreuve fr-fr validée (PIX-13451).

### DIFF
--- a/api/db/seeds/data/common/tooling/campaign-tooling.js
+++ b/api/db/seeds/data/common/tooling/campaign-tooling.js
@@ -629,6 +629,10 @@ async function _getKnowledgeElementFromSkills(skills, validatedSkill = 0) {
     const isOk = i < validatedSkill;
 
     const challenge = await learningContent.findFirstValidatedChallengeBySkillId(skill.id);
+    if (!challenge) {
+      continue;
+    }
+
     const answerData = {
       value: 'dummy value',
       result: isOk ? 'ok' : 'ko',

--- a/api/db/seeds/data/common/tooling/learning-content.js
+++ b/api/db/seeds/data/common/tooling/learning-content.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import { skillDatasource } from '../../../../../src/shared/infrastructure/datasources/learning-content/skill-datasource.js';
 import * as challengeRepository from '../../../../../src/shared/infrastructure/repositories/challenge-repository.js';
 import * as competenceRepository from '../../../../../src/shared/infrastructure/repositories/competence-repository.js';
+import { logger } from '../../../../../src/shared/infrastructure/utils/logger.js';
 
 let ALL_COMPETENCES, ALL_ACTIVE_SKILLS, ALL_CHALLENGES, ACTIVE_SKILLS_BY_COMPETENCE, ACTIVE_SKILLS_BY_TUBE;
 let VALIDATED_CHALLENGES_BY_SKILL;
@@ -51,6 +52,10 @@ async function findActiveSkillsByTubeId(tubeId) {
 
 async function findFirstValidatedChallengeBySkillId(skillId) {
   const validatedChallengesBySkill = await _getValidatedChallengesBySkill();
+  if (!validatedChallengesBySkill[skillId]) {
+    logger.warn(`Skill ${skillId} has no validated challenges`);
+    return null;
+  }
   return validatedChallengesBySkill[skillId][0] || null;
 }
 

--- a/api/db/seeds/data/common/tooling/profile-tooling.js
+++ b/api/db/seeds/data/common/tooling/profile-tooling.js
@@ -125,6 +125,10 @@ async function _getAnswersAndKnowledgeElementsForProfile({
     let currentPixScore = 0;
     for (const skill of orderedSkills) {
       const challenge = await learningContent.findFirstValidatedChallengeBySkillId(skill.id);
+      if (!challenge) {
+        continue;
+      }
+
       const answerData = {
         value: 'dummy value',
         result: 'ok',

--- a/api/db/seeds/data/common/tooling/session-tooling.js
+++ b/api/db/seeds/data/common/tooling/session-tooling.js
@@ -888,6 +888,10 @@ async function _makeCandidatesCoreCertifiable(databaseBuilder, certificationCand
     const orderedSkills = _.sortBy(skills, 'level').filter(({ level }) => level <= maxLevel);
     for (const skill of orderedSkills) {
       const challenge = await learningContent.findFirstValidatedChallengeBySkillId(skill.id);
+      if (!challenge){
+        continue;
+      }
+      
       coreProfileData[competence.id].threeMostDifficultSkillsAndChallenges.push({ challenge, skill });
       assessmentAndUserIds.forEach(({ assessmentId, userId }) => {
         const answerId = databaseBuilder.factory.buildAnswer({
@@ -1016,12 +1020,15 @@ async function _makeCandidatesComplementaryCertificationCertifiable(
   const areaForCompetence = {};
   for (const skill of allSkillsOfFramework) {
     const challenge = await learningContent.findFirstValidatedChallengeBySkillId(skill.id);
+    if (!challenge) continue;
+
     if (!areaForCompetence[skill.competenceId]) {
       const competence = await learningContent.findCompetence(skill.competenceId);
       areaForCompetence[skill.competenceId] = competence.areaId;
     }
-    if (!complementaryProfileData[areaForCompetence[skill.competenceId]])
+    if (!complementaryProfileData[areaForCompetence[skill.competenceId]]) {
       complementaryProfileData[areaForCompetence[skill.competenceId]] = { fourMostDifficultSkillsAndChallenges: [] };
+    }
     complementaryProfileData[areaForCompetence[skill.competenceId]].fourMostDifficultSkillsAndChallenges.push({
       skill,
       challenge,

--- a/api/db/seeds/data/common/tooling/session-tooling.js
+++ b/api/db/seeds/data/common/tooling/session-tooling.js
@@ -888,10 +888,10 @@ async function _makeCandidatesCoreCertifiable(databaseBuilder, certificationCand
     const orderedSkills = _.sortBy(skills, 'level').filter(({ level }) => level <= maxLevel);
     for (const skill of orderedSkills) {
       const challenge = await learningContent.findFirstValidatedChallengeBySkillId(skill.id);
-      if (!challenge){
+      if (!challenge) {
         continue;
       }
-      
+
       coreProfileData[competence.id].threeMostDifficultSkillsAndChallenges.push({ challenge, skill });
       assessmentAndUserIds.forEach(({ assessmentId, userId }) => {
         const answerId = databaseBuilder.factory.buildAnswer({

--- a/api/db/seeds/data/team-certification/data-builder.js
+++ b/api/db/seeds/data/team-certification/data-builder.js
@@ -6,7 +6,7 @@ import {
   PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
   PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
 } from '../common/complementary-certification-builder.js';
-import { COLLEGE_TAG, FEATURE_CAN_REGISTER_FOR_A_COMPLEMENTARY_CERTIFICATION_ALONE_ID } from '../common/constants.js';
+import { COLLEGE_TAG, FEATURE_CAN_REGISTER_FOR_A_COMPLEMENTARY_CERTIFICATION_ALONE_ID, REAL_PIX_SUPER_ADMIN_ID } from '../common/constants.js';
 import * as campaignTooling from '../common/tooling/campaign-tooling.js';
 import * as tooling from '../common/tooling/index.js';
 import { getV3CertificationChallenges } from '../common/tooling/learning-content.js';
@@ -765,7 +765,7 @@ async function _createAPublishedV3CertificationSession({ databaseBuilder }) {
     });
 
     const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
-      juryId: 9000,
+      juryId: REAL_PIX_SUPER_ADMIN_ID,
       assessmentId,
       certificationCourseId,
       pixScore: scores[candidateIndex],

--- a/api/db/seeds/data/team-certification/data-builder.js
+++ b/api/db/seeds/data/team-certification/data-builder.js
@@ -6,7 +6,11 @@ import {
   PIX_DROIT_COMPLEMENTARY_CERTIFICATION_ID,
   PIX_EDU_1ER_DEGRE_COMPLEMENTARY_CERTIFICATION_ID,
 } from '../common/complementary-certification-builder.js';
-import { COLLEGE_TAG, FEATURE_CAN_REGISTER_FOR_A_COMPLEMENTARY_CERTIFICATION_ALONE_ID, REAL_PIX_SUPER_ADMIN_ID } from '../common/constants.js';
+import {
+  COLLEGE_TAG,
+  FEATURE_CAN_REGISTER_FOR_A_COMPLEMENTARY_CERTIFICATION_ALONE_ID,
+  REAL_PIX_SUPER_ADMIN_ID,
+} from '../common/constants.js';
 import * as campaignTooling from '../common/tooling/campaign-tooling.js';
 import * as tooling from '../common/tooling/index.js';
 import { getV3CertificationChallenges } from '../common/tooling/learning-content.js';


### PR DESCRIPTION
## :unicorn: Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Lundi 15 juillet, nous avons été dans une situation où le réféerntiel contenait un acquis sans épreuve fr-fr validée.
Bien que cela nee devrait jamais arrivé, cela a mis en lumière que le script de seeds ne savait pas gérer cet état sans lever d'exception.
Cela est embêtant pour les environnements locaux et surtout pour les Review Apps.

Le script de seed s'arrêtait avec le message suivant :

```
Error while executing "/Users/alexandre/1024Pix/pix/api/db/seeds/seed.js" seed: Cannot read properties of undefined (reading '0')
Error: Error while executing "/Users/alexandre/1024Pix/pix/api/db/seeds/seed.js" seed: Cannot read properties of undefined (reading '0')
    at Seeder._waterfallBatch (/Users/alexandre/1024Pix/pix/api/node_modules/knex/lib/migrations/seed/Seeder.js:118:23)
TypeError: Cannot read properties of undefined (reading '0')
    at Module.findFirstValidatedChallengeBySkillId (file:///Users/alexandre/1024Pix/pix/api/db/seeds/data/common/tooling/learning-content.js:54:45)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async _makeCandidatesComplementaryCertificationCertifiable (file:///Users/alexandre/1024Pix/pix/api/db/seeds/data/common/tooling/session-tooling.js:1018:23)
    at async _makeCandidatesComplementaryCertifiable (file:///Users/alexandre/1024Pix/pix/api/db/seeds/data/common/tooling/session-tooling.js:939:9)
    at async _makeCandidatesCertifiable (file:///Users/alexandre/1024Pix/pix/api/db/seeds/data/common/tooling/session-tooling.js:865:45)
    at async Module.createPublishedSession (file:///Users/alexandre/1024Pix/pix/api/db/seeds/data/common/tooling/session-tooling.js:524:71)
    at async _createPublishedSession (file:///Users/alexandre/1024Pix/pix/api/db/seeds/data/team-certification/data-builder.js:477:3)
    at async teamCertificationDataBuilder (file:///Users/alexandre/1024Pix/pix/api/db/seeds/data/team-certification/data-builder.js:74:3)
    at async Module.seed (file:///Users/alexandre/1024Pix/pix/api/db/seeds/seed.js:67:5)
    at async Seeder._waterfallBatch (/Users/alexandre/1024Pix/pix/api/node_modules/knex/lib/migrations/seed/Seeder.js:115:9)
```

## :robot: Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

Faire en sorte que l'acquis ne contenant aucune épreuve fr-fr validée soit ignorée.
Ajouter un message d'avertissement (avec la fonction `logger.warn`) pour avertir qu'un acquis ne contient pas d'épreuve valide.
Le message est le suivant :

```
WARN: Skill <skillId> has no validated challenges
```

## :rainbow: Remarques

En exécutant le script de seed dans le contexte `CERTIF` uniquement, on constate que celui-ci se termine avec une erreur.
Après investigation, cela est du au fait qu'un `AssessmentResult` est créé avec comme `juryId` l'identifiant 9000 qui correspond à un utilisateur créé par le contexte Pix Junior.
Pour garantir l'isolation du contexte `CERTIF`, on change le `juryId` par un identifiant créé dans le contexte `CERTIF`.

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

Dans un environnement "neuf" (après avoir supprimé les conteneurs), exécuter le script `npm run db:seed` et vérifier que celui-ci se termine sans erreur.
