### PR TITLE
[TECH] Remplacer la locale "en-gb" obsolète par "en" (PIX-13458)

### DIFF
--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -25,7 +25,7 @@ const HELPDESK_FRENCH_FRANCE = 'https://pix.fr/support';
 // INTERNATIONAL
 const PIX_HOME_NAME_INTERNATIONAL = `pix${config.domain.tldOrg}`;
 const PIX_HOME_URL_INTERNATIONAL = {
-  en: `${config.domain.pix + config.domain.tldOrg}/en-gb/`,
+  en: `${config.domain.pix + config.domain.tldOrg}/en/`,
   fr: `${config.domain.pix + config.domain.tldOrg}/fr/`,
   nl: `${config.domain.pix + config.domain.tldOrg}/nl-be/`,
 };

--- a/api/src/shared/domain/services/locale-service.js
+++ b/api/src/shared/domain/services/locale-service.js
@@ -10,12 +10,6 @@ const getCanonicalLocale = function (locale) {
     throw new LocaleFormatError(locale);
   }
 
-  // Pix site uses en-GB as international English locale instead of en
-  // TODO remove this code after handling en as international English locale on Pix site
-  if (canonicalLocale === 'en-GB') {
-    canonicalLocale = 'en';
-  }
-
   if (!SUPPORTED_LOCALES.includes(canonicalLocale)) {
     throw new LocaleNotSupportedError(canonicalLocale);
   }

--- a/api/tests/shared/unit/domain/services/locale-service_test.js
+++ b/api/tests/shared/unit/domain/services/locale-service_test.js
@@ -27,13 +27,5 @@ describe('Unit | Shared | Domain | Service | Locale', function () {
       //then
       expect(locale).to.equal('fr-FR');
     });
-
-    it('transforms "en-GB" locale into "en"', function () {
-      // given
-      const locale = getCanonicalLocale('en-gb');
-
-      //then
-      expect(locale).to.equal('en');
-    });
   });
 });

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -156,7 +156,7 @@ describe('Unit | Service | MailService', function () {
           expect(options.fromName).to.equal('PIX - Noreply');
           expect(options.variables).to.include({
             homeName: 'pix.org',
-            homeUrl: 'https://pix.org/en-gb/',
+            homeUrl: 'https://pix.org/en/',
             helpdeskUrl: 'https://pix.org/en/support',
             displayNationalLogo: false,
             redirectionUrl: `https://app.pix.org/api/users/validate-email?${expectedParams.toString()}`,
@@ -210,7 +210,7 @@ describe('Unit | Service | MailService', function () {
           expect(options.fromName).to.equal('PIX - No contestar');
           expect(options.variables).to.include({
             homeName: 'pix.org',
-            homeUrl: 'https://pix.org/en-gb/',
+            homeUrl: 'https://pix.org/en/',
             helpdeskUrl: 'https://pix.org/en/support',
             displayNationalLogo: false,
             redirectionUrl: `https://app.pix.org/api/users/validate-email?${expectedParams.toString()}`,
@@ -269,7 +269,7 @@ describe('Unit | Service | MailService', function () {
             ...mainTranslationsMapping.en['certification-result-email'].params,
             title: translate({ phrase: 'certification-result-email.title', locale: 'en' }, { sessionId }),
             homeName: 'pix.org',
-            homeUrl: 'https://pix.org/en-gb/',
+            homeUrl: 'https://pix.org/en/',
             link: `${link}?lang=en`,
           },
           sessionId,
@@ -299,7 +299,7 @@ describe('Unit | Service | MailService', function () {
             locale: ENGLISH_SPOKEN,
             ...mainTranslationsMapping.en['reset-password-demand-email'].params,
             homeName: 'pix.org',
-            homeUrl: 'https://pix.org/en-gb/',
+            homeUrl: 'https://pix.org/en/',
             resetUrl: `https://app.pix.org/changer-mot-de-passe/${temporaryKey}/?lang=en`,
             helpdeskURL: 'https://pix.org/en/support',
           },
@@ -357,7 +357,7 @@ describe('Unit | Service | MailService', function () {
             locale: SPANISH_SPOKEN,
             ...mainTranslationsMapping.es['reset-password-demand-email'].params,
             homeName: 'pix.org',
-            homeUrl: 'https://pix.org/en-gb/',
+            homeUrl: 'https://pix.org/en/',
             resetUrl: `https://app.pix.org/changer-mot-de-passe/${temporaryKey}/?lang=es`,
             helpdeskURL: 'https://pix.org/en/support',
           },
@@ -623,7 +623,7 @@ describe('Unit | Service | MailService', function () {
           expect(options.subject).to.equal(mainTranslationsMapping.en['organization-invitation-email'].subject);
           expect(options.variables).to.include({
             pixHomeName: 'pix.org',
-            pixHomeUrl: 'https://pix.org/en-gb/',
+            pixHomeUrl: 'https://pix.org/en/',
             pixOrgaHomeUrl: 'https://orga.pix.org/?lang=en',
             redirectionUrl: `https://orga.pix.org/rejoindre?invitationId=${organizationInvitationId}&code=${code}&lang=en`,
             supportUrl: 'https://pix.org/en/support',
@@ -764,7 +764,7 @@ describe('Unit | Service | MailService', function () {
         expect(sendEmailParameters.variables).to.include({
           certificationCenterName: 'Centre Pixi',
           pixHomeName: 'pix.org',
-          pixHomeUrl: 'https://pix.org/en-gb/',
+          pixHomeUrl: 'https://pix.org/en/',
           pixCertifHomeUrl: 'https://certif.pix.org/?lang=en',
           redirectionUrl: `https://certif.pix.org/rejoindre?invitationId=777&code=LLLJJJVVV1&lang=en`,
           supportUrl: 'https://pix.org/en/support',
@@ -890,7 +890,7 @@ describe('Unit | Service | MailService', function () {
       expect(options.template).to.equal('test-email-verification-code-template-id');
       expect(options.variables).to.include({
         homeName: 'pix.org',
-        homeUrl: 'https://pix.org/en-gb/',
+        homeUrl: 'https://pix.org/en/',
         displayNationalLogo: false,
         code,
         ...mainTranslationsMapping.en['verification-code-email'].body,
@@ -950,7 +950,7 @@ describe('Unit | Service | MailService', function () {
       expect(options.template).to.equal('test-email-verification-code-template-id');
       expect(options.variables).to.include({
         homeName: 'pix.org',
-        homeUrl: 'https://pix.org/en-gb/',
+        homeUrl: 'https://pix.org/en/',
         displayNationalLogo: false,
         code,
         ...mainTranslationsMapping.es['verification-code-email'].body,

--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -13,12 +13,12 @@ export default class Url extends Service {
   }
 
   get cguUrl() {
-    if (this.#isEnglishSpoken()) return 'https://pix.org/en-gb/terms-and-conditions';
+    if (this.#isEnglishSpoken()) return 'https://pix.org/en/terms-and-conditions';
     return `https://pix.${this.currentDomain.getExtension()}/conditions-generales-d-utilisation`;
   }
 
   get dataProtectionPolicyUrl() {
-    if (this.#isEnglishSpoken()) return 'https://pix.org/en-gb/personal-data-protection-policy';
+    if (this.#isEnglishSpoken()) return 'https://pix.org/en/personal-data-protection-policy';
     return `https://pix.${this.currentDomain.getExtension()}/politique-protection-donnees-personnelles-app`;
   }
 
@@ -33,7 +33,7 @@ export default class Url extends Service {
   get legalNoticeUrl() {
     if (this.currentDomain.isFranceDomain) return 'https://pix.fr/mentions-legales';
 
-    return this.#isFrenchSpoken() ? 'https://pix.org/fr/mentions-legales' : 'https://pix.org/en-gb/legal-notice';
+    return this.#isFrenchSpoken() ? 'https://pix.org/fr/mentions-legales' : 'https://pix.org/en/legal-notice';
   }
 
   get accessibilityUrl() {
@@ -41,7 +41,7 @@ export default class Url extends Service {
 
     return this.#isFrenchSpoken()
       ? 'https://pix.org/fr/accessibilite-pix-certif'
-      : 'https://pix.org/en-gb/accessibility-pix-certif';
+      : 'https://pix.org/en/accessibility-pix-certif';
   }
 
   get supportUrl() {

--- a/certif/tests/unit/services/url_test.js
+++ b/certif/tests/unit/services/url_test.js
@@ -28,7 +28,7 @@ module('Unit | Service | url', function (hooks) {
     test('should get "pix.org" english url when current language is en', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
-      const expectedDataProtectionPolicyUrl = 'https://pix.org/en-gb/personal-data-protection-policy';
+      const expectedDataProtectionPolicyUrl = 'https://pix.org/en/personal-data-protection-policy';
       service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
       service.intl = { primaryLocale: 'en' };
 
@@ -71,7 +71,7 @@ module('Unit | Service | url', function (hooks) {
     test('should get "pix.org" english url when current language is en', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
-      const expectedCguUrl = 'https://pix.org/en-gb/terms-and-conditions';
+      const expectedCguUrl = 'https://pix.org/en/terms-and-conditions';
       service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
       service.intl = { primaryLocale: 'en' };
 
@@ -157,7 +157,7 @@ module('Unit | Service | url', function (hooks) {
 
     module('when current domain is org', function () {
       module('when current language is en', function () {
-        test('should return "pix.org/en-gb" url', function (assert) {
+        test('should return "pix.org/en" url', function (assert) {
           // given
           const service = this.owner.lookup('service:url');
           service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
@@ -167,7 +167,7 @@ module('Unit | Service | url', function (hooks) {
           const legalNoticeUrl = service.legalNoticeUrl;
 
           // then
-          assert.strictEqual(legalNoticeUrl, 'https://pix.org/en-gb/legal-notice');
+          assert.strictEqual(legalNoticeUrl, 'https://pix.org/en/legal-notice');
         });
       });
 
@@ -205,7 +205,7 @@ module('Unit | Service | url', function (hooks) {
 
     module('when current domain is org', function () {
       module('when current language is en', function () {
-        test('should return "pix.org/en-gb" url', function (assert) {
+        test('should return "pix.org/en" url', function (assert) {
           // given
           const service = this.owner.lookup('service:url');
           service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
@@ -215,7 +215,7 @@ module('Unit | Service | url', function (hooks) {
           const accessibilityUrl = service.accessibilityUrl;
 
           // then
-          assert.strictEqual(accessibilityUrl, 'https://pix.org/en-gb/accessibility-pix-certif');
+          assert.strictEqual(accessibilityUrl, 'https://pix.org/en/accessibility-pix-certif');
         });
       });
 

--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -28,7 +28,7 @@ export default class Url extends Service {
 
     switch (currentLanguage) {
       case ENGLISH_INTERNATIONAL_LOCALE:
-        return 'https://pix.org/en-gb/terms-and-conditions';
+        return 'https://pix.org/en/terms-and-conditions';
       case DUTCH_INTERNATIONAL_LOCALE:
         return 'https://pix.org/nl-be/algemene-gebruiksvoorwaarden';
       default:
@@ -62,7 +62,7 @@ export default class Url extends Service {
 
     switch (currentLanguage) {
       case ENGLISH_INTERNATIONAL_LOCALE:
-        return 'https://pix.org/en-gb/personal-data-protection-policy';
+        return 'https://pix.org/en/personal-data-protection-policy';
       case DUTCH_INTERNATIONAL_LOCALE:
         return 'https://pix.org/nl-be/beleid-inzake-de-bescherming-van-persoonsgegevens';
       default:
@@ -79,7 +79,7 @@ export default class Url extends Service {
 
     switch (currentLanguage) {
       case ENGLISH_INTERNATIONAL_LOCALE:
-        return 'https://pix.org/en-gb/accessibility';
+        return 'https://pix.org/en/accessibility';
       case DUTCH_INTERNATIONAL_LOCALE:
         return 'https://pix.org/nl-be/toegankelijkheid';
       default:
@@ -90,7 +90,7 @@ export default class Url extends Service {
   get accessibilityHelpUrl() {
     const currentLanguage = this.intl.primaryLocale;
     if (currentLanguage === ENGLISH_INTERNATIONAL_LOCALE) {
-      return `https://pix.${this.currentDomain.getExtension()}/en-gb/help-accessibility`;
+      return `https://pix.${this.currentDomain.getExtension()}/en/help-accessibility`;
     }
     return `https://pix.${this.currentDomain.getExtension()}/aide-accessibilite`;
   }
@@ -125,7 +125,7 @@ export default class Url extends Service {
     const currentLanguage = this.intl.primaryLocale;
 
     if (currentLanguage === ENGLISH_INTERNATIONAL_LOCALE) {
-      return `https://pix.${this.currentDomain.getExtension()}/en-gb`;
+      return `https://pix.${this.currentDomain.getExtension()}/en`;
     }
     return `https://pix.${this.currentDomain.getExtension()}`;
   }

--- a/mon-pix/tests/integration/components/data-protection-policy-information-banner_test.js
+++ b/mon-pix/tests/integration/components/data-protection-policy-information-banner_test.js
@@ -118,7 +118,7 @@ module('Integration | Component | data-protection-policy-information-banner', fu
               // then
               assert
                 .dom(screen.getByRole('link', { name: 'Personal data protection policy.' }))
-                .hasAttribute('href', 'https://pix.org/en-gb/personal-data-protection-policy');
+                .hasAttribute('href', 'https://pix.org/en/personal-data-protection-policy');
 
               const content = screen.getByText((content) =>
                 content.startsWith(

--- a/mon-pix/tests/unit/services/url_test.js
+++ b/mon-pix/tests/unit/services/url_test.js
@@ -57,13 +57,13 @@ module('Unit | Service | url', function (hooks) {
       {
         language: ENGLISH_INTERNATIONAL_LOCALE,
         currentDomainExtension: FRANCE_TLD,
-        expectedShowcaseUrl: 'https://pix.fr/en-gb',
+        expectedShowcaseUrl: 'https://pix.fr/en',
         expectedShowcaseLinkText: "Pix.fr's Homepage",
       },
       {
         language: ENGLISH_INTERNATIONAL_LOCALE,
         currentDomainExtension: INTERNATIONAL_TLD,
-        expectedShowcaseUrl: 'https://pix.org/en-gb',
+        expectedShowcaseUrl: 'https://pix.org/en',
         expectedShowcaseLinkText: "Pix.org's Homepage",
       },
     ].forEach(function (testCase) {
@@ -138,7 +138,7 @@ module('Unit | Service | url', function (hooks) {
           // given
           const service = this.owner.lookup('service:url');
           service.currentDomain = { isFranceDomain: false };
-          const expectedCguUrl = 'https://pix.org/en-gb/terms-and-conditions';
+          const expectedCguUrl = 'https://pix.org/en/terms-and-conditions';
           service.currentDomain = { getExtension: sinon.stub().returns(INTERNATIONAL_TLD) };
           service.intl = { primaryLocale: ENGLISH_INTERNATIONAL_LOCALE };
 
@@ -224,7 +224,7 @@ module('Unit | Service | url', function (hooks) {
           const service = this.owner.lookup('service:url');
           service.currentDomain = { isFranceDomain: false };
           service.intl = { primaryLocale: ENGLISH_INTERNATIONAL_LOCALE };
-          const expectedDataProtectionPolicyUrl = 'https://pix.org/en-gb/personal-data-protection-policy';
+          const expectedDataProtectionPolicyUrl = 'https://pix.org/en/personal-data-protection-policy';
 
           // when
           const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
@@ -392,7 +392,7 @@ module('Unit | Service | url', function (hooks) {
           const service = this.owner.lookup('service:url');
           service.currentDomain = { isFranceDomain: false };
           service.intl = { primaryLocale: ENGLISH_INTERNATIONAL_LOCALE };
-          const expectedAccessibilityUrl = 'https://pix.org/en-gb/accessibility';
+          const expectedAccessibilityUrl = 'https://pix.org/en/accessibility';
 
           // when
           const accessibilityUrl = service.accessibilityUrl;

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -786,7 +786,7 @@
           }
         },
         "information": {
-          "data-usage": "'<p>'Pix processes the data from this area to manage and analyse the difficulty encountered and benefit from your feedback. You have rights over your data which can be exercised via: <strong>dpo@pix.fr</strong>.'</p><p><a href=\"https://pix.org/en-gb/personal-data-reporting-test\" target=\"_blank\" class=\"link\">'To find out more about protecting your data and your rights.'</a></p>'",
+          "data-usage": "'<p>'Pix processes the data from this area to manage and analyse the difficulty encountered and benefit from your feedback. You have rights over your data which can be exercised via: <strong>dpo@pix.fr</strong>.'</p><p><a href=\"https://pix.org/en/personal-data-reporting-test\" target=\"_blank\" class=\"link\">'To find out more about protecting your data and your rights.'</a></p>'",
           "guidance": "'<p>'*Make sure you write in this zone: for your benefit and the benefit of others, please stay objective and keep to the facts.'</p><p>'Do not enter any information about yourself or third parties, or any information related to health; religion; political, or philosophical opinions; trade union affiliation; ethnic origins; or penalties and convictions.'</p>'"
         },
         "modal": {
@@ -1069,7 +1069,7 @@
       }
     },
     "error": {
-      "content-text": "'<p>'Please refresh the page or return to homepage.'</p><p>'You can also contact us via '<a href=\"https://pix.org/en-gb/contact-form\">'the help centre form'</a>'specifying the error code below in the description.'</p><p>'Please excuse any inconvenience caused.'</p><p>'The Pix team.'</p>'",
+      "content-text": "'<p>'Please refresh the page or return to homepage.'</p><p>'You can also contact us via '<a href=\"https://pix.org/en/contact-form\">'the help centre form'</a>'specifying the error code below in the description.'</p><p>'Please excuse any inconvenience caused.'</p><p>'The Pix team.'</p>'",
       "first-title": "Oops, an error occurred!"
     },
     "fill-in-campaign-code": {
@@ -1238,7 +1238,7 @@
               "placeholder": "YYYY"
             }
           },
-          "cgu": "I agree to the '<a href=\"https://pix.org/en-gb/terms-and-conditions\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\">'terms and conditions of use of the Pix platform'</a>'",
+          "cgu": "I agree to the '<a href=\"https://pix.org/en/terms-and-conditions\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\">'terms and conditions of use of the Pix platform'</a>'",
           "email": {
             "error": "Your email address is invalid.",
             "help": "(eg. name@example.org)",
@@ -1642,7 +1642,7 @@
       "net-promoter-score": {
         "title": "Your opinion counts!",
         "link": {
-          "href": "https://pix.org/en-gb",
+          "href": "https://pix.org/en",
           "label": "Give my feedback"
         },
         "text": "Take a few minutes to tell us what you thought of this test and help us improve it."
@@ -1679,7 +1679,7 @@
     },
     "terms-of-service": {
       "title": "Terms and conditions of use",
-      "cgu": "I agree to the '<a href=\"https://pix.org/en-gb/terms-and-conditions\" class=\"link\" target=\"_blank\">'terms and conditions of use of the Pix platform'</a>'",
+      "cgu": "I agree to the '<a href=\"https://pix.org/en/terms-and-conditions\" class=\"link\" target=\"_blank\">'terms and conditions of use of the Pix platform'</a>'",
       "form": {
         "button": "Continue",
         "error-message": "Please agree to the terms and conditions of use."

--- a/orga/app/services/url.js
+++ b/orga/app/services/url.js
@@ -6,7 +6,7 @@ const ENGLISH_LOCALE = 'en';
 const DUTCH_LOCALE = 'nl';
 const PIX_FR_DOMAIN = 'https://pix.fr';
 const PIX_ORG_DOMAIN_FR_LOCALE = 'https://pix.org/fr';
-const PIX_ORG_DOMAIN_EN_LOCALE = 'https://pix.org/en-gb';
+const PIX_ORG_DOMAIN_EN_LOCALE = 'https://pix.org/en';
 const PIX_ORG_DOMAIN_NL_LOCALE = 'https://pix.org/nl-be';
 const PIX_STATUS_DOMAIN = 'https://status.pix.org';
 

--- a/orga/tests/unit/services/url_test.js
+++ b/orga/tests/unit/services/url_test.js
@@ -75,7 +75,7 @@ module('Unit | Service | url', function (hooks) {
       [
         {
           primaryLocale: 'en',
-          expectedUrl: 'https://pix.org/en-gb/legal-notice',
+          expectedUrl: 'https://pix.org/en/legal-notice',
         },
         {
           primaryLocale: 'fr',
@@ -123,7 +123,7 @@ module('Unit | Service | url', function (hooks) {
       [
         {
           primaryLocale: 'en',
-          expectedUrl: 'https://pix.org/en-gb/personal-data-protection-policy',
+          expectedUrl: 'https://pix.org/en/personal-data-protection-policy',
         },
         {
           primaryLocale: 'fr',
@@ -171,7 +171,7 @@ module('Unit | Service | url', function (hooks) {
       [
         {
           primaryLocale: 'en',
-          expectedUrl: 'https://pix.org/en-gb/terms-and-conditions',
+          expectedUrl: 'https://pix.org/en/terms-and-conditions',
         },
         {
           primaryLocale: 'fr',
@@ -179,7 +179,7 @@ module('Unit | Service | url', function (hooks) {
         },
         {
           primaryLocale: 'nl',
-          expectedUrl: 'https://pix.org/en-gb/terms-and-conditions',
+          expectedUrl: 'https://pix.org/en/terms-and-conditions',
         },
       ].forEach(({ primaryLocale, expectedUrl }) => {
         test(`returns "pix.org" ${primaryLocale} url when locale is ${primaryLocale}`, function (assert) {
@@ -219,7 +219,7 @@ module('Unit | Service | url', function (hooks) {
       [
         {
           primaryLocale: 'en',
-          expectedUrl: 'https://pix.org/en-gb/accessibility-pix-orga',
+          expectedUrl: 'https://pix.org/en/accessibility-pix-orga',
         },
         {
           primaryLocale: 'fr',

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -209,7 +209,7 @@
       "mandatory-fields-title": "required"
     },
     "fullname": "{firstName} {lastName}",
-    "help-form": "https://pix.org/en-gb/contact-form",
+    "help-form": "https://pix.org/en/contact-form",
     "home-page": "Pix Orga home page",
     "loading": "Loading",
     "pagination": {
@@ -1045,7 +1045,7 @@
       "error-panel": {
         "title": "Errors in the last file imported :",
         "error-wrapper": "Import has failed. Please check or edit your file and try to import it again.",
-        "global-error": "Import has failed. Please try again or contact us through '<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://pix.org/en-gb/contact-form\">'the help form'</a>'."
+        "global-error": "Import has failed. Please try again or contact us through '<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://pix.org/en/contact-form\">'the help form'</a>'."
       },
       "file-type-separator": " or ",
       "global-success": "Last file successfully imported on {date} by {firstName} {lastName}.",


### PR DESCRIPTION
## :unicorn: Problème

Depuis que 1024pix/pix-site/pull/538 a été mise en production, la locale `en-gb` est devenue obsolète et ne fait plus référence à une locale existante ni à des URL existants. Les anciens URL de pix-site en `en-gb` ne font plus référence à des vraies pages web existantes et sont en fait gérés par des redirections Nginx pointant vers https://pix.org/en/.

La présence de cette mauvaise locale en-gb qui ne correspond à rien bloque la suite des efforts de rationalisation des locales.

## :robot: Proposition

Remplacer l’utilisation de la valeur `en-gb` par la valeur `en` dans les applications Pix. Cela simplifie le code et permet d’avancer dans l’implémentation de l’ADR https://github.com/1024pix/pix/blob/dev/docs/adr/0040-locales-languages.md.


## :rainbow: Remarques

Le mailing a été activée dans la RA de Pix Api pour facilement tester cette PR.

## :100: Pour tester

1. Vérifier sur https://app-pr9538.review.pix.org/?lang=en que la localisation en anglais de Pix App est fonctionnelle : 
   1. Se connecter avec n'importe quel compte existant (par exemple `james-paledroits@example.net`) et vérifier que les liens dans le footer pointent vers des pages existantes du site https://pix.org/en/.
   2. Créer un compte avec une adresse email non déjà prise dans la BDD et vérifier que les liens présents dans les courriels des notifications pointent vers des pages existantes du site https://pix.org/en/.
      * Vérifier les liens du courriel de confirmation de création de compte
      * Vérifier les liens du courriel de réinitialisation de mot de passe
2. Vérifier sur https://orga-pr9538.review.pix.org/?lang=en que la localisation en anglais de Pix Orga est fonctionnelle. Pour cela se connecter avec un utilisateur admin dans une organisation (par exemple `allorga@example.net`) et passer l'application en anglais en ajoutant `?lang=en` dans l'URL. 
   1. Vérifier que les liens dans le footer pointent vers des pages existantes du site https://pix.org/en/
   2. Envoyer une invitation et vérifier que les liens présents dans le courriel d'invitation pointent vers des pages existantes du site https://pix.org/en/.
3. Vérifier sur https://certif-pr9538.review.pix.org/?lang=en que la localisation en anglais de Pix Certif est fonctionnelle.
Pour cela se connecter avec un utilisateur admin dans un centre de certification (par exemple `james-paledroits@example.net`) et passer l'application en anglais en ajoutant `?lang=en` dans l'URL. 
   1. Vérifier que les liens dans le footer pointent vers des pages existantes du site https://pix.org/en/
   2. Envoyer une invitation et vérifier que les liens présents dans le courriel d'invitation pointent vers des pages existantes du site https://pix.org/en/