### PR TITLE
[BUGFIX] Corrige un bug empêchant de modifier les organisations ayant la feature d'import (PIX-13457).

### DIFF
--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -48,31 +48,34 @@ export default class Organization extends Model {
 
   get isComputeCertificabilityEnabled() {
     if (!this.features) return false;
-    return this.features[Organization.featureList.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY];
+    return this.features[Organization.featureList.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY].active;
   }
 
   get isMultipleSendingAssessmentEnabled() {
     if (!this.features) return false;
-    return this.features[Organization.featureList.MULTIPLE_SENDING_ASSESSMENT];
+    return this.features[Organization.featureList.MULTIPLE_SENDING_ASSESSMENT].active;
   }
 
   set isMultipleSendingAssessmentEnabled(value) {
     if (!this.features) {
       this.features = {};
+      this.features[Organization.featureList.MULTIPLE_SENDING_ASSESSMENT] = {};
     }
-    this.features[Organization.featureList.MULTIPLE_SENDING_ASSESSMENT] = value;
+    this.features[Organization.featureList.MULTIPLE_SENDING_ASSESSMENT].active = value;
   }
 
   get isPlacesManagementEnabled() {
     if (!this.features) return false;
-    return this.features[Organization.featureList.PLACES_MANAGEMENT];
+    return this.features[Organization.featureList.PLACES_MANAGEMENT].active;
   }
 
   set isPlacesManagementEnabled(value) {
     if (!this.features) {
       this.features = {};
+      this.features[Organization.featureList.PLACES_MANAGEMENT] = {};
     }
-    this.features[Organization.featureList.PLACES_MANAGEMENT] = value;
+
+    this.features[Organization.featureList.PLACES_MANAGEMENT].active = value;
   }
 
   async hasMember(userId) {

--- a/admin/tests/acceptance/authenticated/organizations/information-management_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management_test.js
@@ -16,7 +16,14 @@ module('Acceptance | Organizations | Information management', function (hooks) {
   module('editing organization', function () {
     test('should be able to edit organization information', async function (assert) {
       // given
-      const organization = this.server.create('organization', { name: 'oldOrganizationName' });
+      const organization = this.server.create('organization', {
+        name: 'oldOrganizationName',
+        features: {
+          PLACES_MANAGEMENT: { active: false },
+          MULTIPLE_SENDING_ASSESSMENT: { active: false },
+          COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY: { active: false },
+        },
+      });
       this.server.create('organization', { id: '1234' });
 
       const screen = await visit(`/organizations/${organization.id}`);

--- a/admin/tests/unit/components/organizations/information-section-edit_test.js
+++ b/admin/tests/unit/components/organizations/information-section-edit_test.js
@@ -11,7 +11,14 @@ module('Unit | Component | organizations/information-section-edit', function (ho
     test('it should set identityProviderForCampaigns to null', async function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const organization = store.createRecord('organization', { id: 1 });
+      const organization = store.createRecord('organization', {
+        id: 1,
+        features: {
+          PLACES_MANAGEMENT: { active: false },
+          MULTIPLE_SENDING_ASSESSMENT: { active: false },
+          COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY: { active: false },
+        },
+      });
       const component = createGlimmerComponent('component:organizations/information-section-edit', {
         organization,
         toggleEditMode: sinon.stub(),

--- a/admin/tests/unit/models/organization_test.js
+++ b/admin/tests/unit/models/organization_test.js
@@ -10,7 +10,7 @@ module('Unit | Model | organization', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const model = store.createRecord('organization', {
-          features: { ['COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY']: true },
+          features: { ['COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY']: { active: true } },
         });
 
         // when
@@ -24,7 +24,7 @@ module('Unit | Model | organization', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const model = store.createRecord('organization', {
-          features: { ['COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY']: false },
+          features: { ['COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY']: { active: false } },
         });
 
         // when
@@ -54,7 +54,7 @@ module('Unit | Model | organization', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const model = store.createRecord('organization', {
-          features: { ['PLACES_MANAGEMENT']: true },
+          features: { ['PLACES_MANAGEMENT']: { active: true } },
         });
 
         // when
@@ -67,7 +67,7 @@ module('Unit | Model | organization', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const model = store.createRecord('organization', {
-          features: { ['PLACES_MANAGEMENT']: false },
+          features: { ['PLACES_MANAGEMENT']: { active: false } },
         });
 
         // when
@@ -94,7 +94,7 @@ module('Unit | Model | organization', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const model = store.createRecord('organization', {
-          features: { ['PLACES_MANAGEMENT']: false },
+          features: { ['PLACES_MANAGEMENT']: { active: false } },
         });
 
         // when
@@ -108,7 +108,7 @@ module('Unit | Model | organization', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const model = store.createRecord('organization', {
-          features: { ['PLACES_MANAGEMENT']: true },
+          features: { ['PLACES_MANAGEMENT']: { active: true } },
         });
         // when
         model.isPlacesManagementEnabled = false;
@@ -138,7 +138,7 @@ module('Unit | Model | organization', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const model = store.createRecord('organization', {
-          features: { ['MULTIPLE_SENDING_ASSESSMENT']: true },
+          features: { ['MULTIPLE_SENDING_ASSESSMENT']: { active: true } },
         });
 
         // when
@@ -151,7 +151,7 @@ module('Unit | Model | organization', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const model = store.createRecord('organization', {
-          features: { ['MULTIPLE_SENDING_ASSESSMENT']: false },
+          features: { ['MULTIPLE_SENDING_ASSESSMENT']: { active: false } },
         });
 
         // when
@@ -178,7 +178,7 @@ module('Unit | Model | organization', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const model = store.createRecord('organization', {
-          features: { ['MULTIPLE_SENDING_ASSESSMENT']: false },
+          features: { ['MULTIPLE_SENDING_ASSESSMENT']: { active: false } },
         });
 
         // when
@@ -192,7 +192,7 @@ module('Unit | Model | organization', function (hooks) {
         // given
         const store = this.owner.lookup('service:store');
         const model = store.createRecord('organization', {
-          features: { ['MULTIPLE_SENDING_ASSESSMENT']: true },
+          features: { ['MULTIPLE_SENDING_ASSESSMENT']: { active: true } },
         });
         // when
         model.isMultipleSendingAssessmentEnabled = false;

--- a/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
+++ b/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
@@ -71,11 +71,17 @@ class OrganizationForAdmin {
     this.tagIds = tagIds;
     this.features = features;
     if (this.type === 'SCO' && this.isManagingStudents) {
-      this.features[ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key] = true;
+      this.features[ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key] = {
+        active: true,
+        params: null,
+      };
     }
     if (this.type === 'SCO-1D') {
-      this.features[ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT.key] = true;
-      this.features[ORGANIZATION_FEATURE.LEARNER_IMPORT.key] = ORGANIZATION_FEATURE.LEARNER_IMPORT.FORMAT.ONDE;
+      this.features[ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT.key] = { active: true, params: null };
+      this.features[ORGANIZATION_FEATURE.LEARNER_IMPORT.key] = {
+        active: true,
+        params: { name: ORGANIZATION_FEATURE.LEARNER_IMPORT.FORMAT.ONDE },
+      };
     }
     this.tagsToAdd = [];
     this.tagsToRemove = [];
@@ -148,8 +154,10 @@ class OrganizationForAdmin {
     this.updateIdentityProviderForCampaigns(organization.identityProviderForCampaigns);
     this.dataProtectionOfficer.updateInformation(dataProtectionOfficer);
     this.features = organization.features;
-    this.features[ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key] =
-      this.type === 'SCO' && (this.isManagingStudents || isAEFE);
+    this.features[ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key] = {
+      active: this.type === 'SCO' && (this.isManagingStudents || isAEFE),
+      params: null,
+    };
     this.tagsToAdd = differenceBy(tags, this.tags, 'id').map(({ id }) => ({ tagId: id, organizationId: this.id }));
     this.tagsToRemove = differenceBy(this.tags, tags, 'id').map(({ id }) => ({ tagId: id, organizationId: this.id }));
   }

--- a/api/tests/acceptance/application/organizations-administration/organization-administration-get_test.js
+++ b/api/tests/acceptance/application/organizations-administration/organization-administration-get_test.js
@@ -95,8 +95,8 @@ describe('Acceptance | Routes | organization-administration-controller', functio
               'creator-full-name': 'Tom Dereck',
               'identity-provider-for-campaigns': null,
               features: {
-                [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: false,
-                [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: true,
+                [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: { active: false, params: null },
+                [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: { active: true, params: null },
               },
             },
             id: organization.id.toString(),

--- a/api/tests/integration/application/organizations-administration/organization-administration-controller_test.js
+++ b/api/tests/integration/application/organizations-administration/organization-administration-controller_test.js
@@ -153,7 +153,7 @@ describe('Integration | Application | Controller | organization-administration-c
           id: organization.id,
           attributes: {
             features: {
-              [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: true,
+              [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: { active: true },
             },
           },
         },
@@ -169,9 +169,9 @@ describe('Integration | Application | Controller | organization-administration-c
 
     expect(organizationFeature.length).to.equal(1);
     expect(organizationFeature[0].key).to.equal(ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key);
-    expect(response.source.data.attributes['features'][ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]).to.equal(
-      true,
-    );
+    expect(
+      response.source.data.attributes['features'][ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key].active,
+    ).to.equal(true);
   });
 
   it('return deactivated feature sending multiple assessment of organization', async function () {
@@ -186,7 +186,7 @@ describe('Integration | Application | Controller | organization-administration-c
           id: organization.id,
           attributes: {
             features: {
-              [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: false,
+              [ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]: { active: false },
             },
           },
         },
@@ -201,8 +201,8 @@ describe('Integration | Application | Controller | organization-administration-c
       .where('organizationId', organization.id);
 
     expect(organizationFeature.length).to.equal(0);
-    expect(response.source.data.attributes['features'][ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key]).to.equal(
-      false,
-    );
+    expect(
+      response.source.data.attributes['features'][ORGANIZATION_FEATURE.MULTIPLE_SENDING_ASSESSMENT.key].active,
+    ).to.equal(false);
   });
 });

--- a/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
+++ b/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
@@ -18,8 +18,8 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
           const organization = new OrganizationForAdmin(expectedOrganization);
 
           // then
-          expect(organization.features).to.includes({
-            [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: true,
+          expect(organization.features).to.deep.includes({
+            [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: { active: true, params: null },
           });
         });
       });
@@ -52,8 +52,8 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
         const organization = new OrganizationForAdmin(expectedOrganization);
 
         // then
-        expect(organization.features).to.include({
-          [ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT.key]: true,
+        expect(organization.features).to.deep.includes({
+          [ORGANIZATION_FEATURE.MISSIONS_MANAGEMENT.key]: { active: true, params: null },
         });
       });
 
@@ -67,8 +67,8 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
         const organization = new OrganizationForAdmin(expectedOrganization);
 
         // then
-        expect(organization.features).to.include({
-          [ORGANIZATION_FEATURE.LEARNER_IMPORT.key]: 'ONDE',
+        expect(organization.features).to.deep.includes({
+          [ORGANIZATION_FEATURE.LEARNER_IMPORT.key]: { active: true, params: { name: 'ONDE' } },
         });
       });
     });
@@ -289,7 +289,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
         isManagingStudents: false,
         type: 'SCO',
         features: {
-          [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: false,
+          [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: { active: false, params: null },
         },
       });
 
@@ -301,7 +301,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
 
       // then
       expect(
-        givenOrganization.features[ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key],
+        givenOrganization.features[ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key].active,
       ).to.equal(true);
     });
 
@@ -312,7 +312,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
           isManagingStudents: false,
           type: 'SCO',
           features: {
-            [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: false,
+            [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: { active: false, params: null },
           },
         });
 
@@ -321,7 +321,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
 
         // then
         expect(
-          givenOrganization.features[ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key],
+          givenOrganization.features[ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key].active,
         ).to.equal(true);
       });
 
@@ -331,7 +331,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
           isManagingStudents: false,
           type: 'SCO',
           features: {
-            [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: true,
+            [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: { active: true, params: null },
           },
         });
 
@@ -340,7 +340,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
 
         // then
         expect(
-          givenOrganization.features[ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key],
+          givenOrganization.features[ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key].active,
         ).to.equal(false);
       });
 
@@ -350,7 +350,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
           isManagingStudents: false,
           type: 'SUP',
           features: {
-            [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: false,
+            [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: { active: false, params: null },
           },
         });
 
@@ -359,7 +359,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
 
         // then
         expect(
-          givenOrganization.features[ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key],
+          givenOrganization.features[ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key].active,
         ).to.equal(false);
       });
 
@@ -369,7 +369,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
           isManagingStudents: false,
           type: 'PRO',
           features: {
-            [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: false,
+            [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: { active: false, params: null },
           },
         });
 
@@ -378,7 +378,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
 
         // then
         expect(
-          givenOrganization.features[ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key],
+          givenOrganization.features[ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key].active,
         ).to.equal(false);
       });
     });
@@ -389,7 +389,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
         isManagingStudents: true,
         type: 'SCO',
         features: {
-          [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: true,
+          [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: { active: true, params: null },
         },
       });
 
@@ -401,7 +401,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
 
       // then
       expect(
-        givenOrganization.features[ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key],
+        givenOrganization.features[ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key].active,
       ).to.equal(false);
     });
 
@@ -411,7 +411,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
         isManagingStudents: false,
         type: 'SUP',
         features: {
-          [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: false,
+          [ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key]: { active: false, params: null },
         },
       });
 
@@ -423,7 +423,7 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
 
       // then
       expect(
-        givenOrganization.features[ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key],
+        givenOrganization.features[ORGANIZATION_FEATURE.COMPUTE_ORGANIZATION_LEARNER_CERTIFICABILITY.key].active,
       ).to.equal(false);
     });
 


### PR DESCRIPTION
## :unicorn: Problème
On ne peut plus mettre à jour les organisations avec un import à format ONDE

## :robot: Proposition
Permettre ces mise à jour d'orga à import à format ONDE et les autres

## :rainbow: Remarques
On a revu l'import à format pour tous les formats afin d'avoir une résultat fonctionnel pour tous.

## :100: Pour tester
- se connecter à Pix Admin
- Editer l'organisation Pro Managing
- Cliquer sur sauvegarder
- Faire la même chose avec d'autres orga