### PR TITLE
[TECH] Migrer la route GET api/admin/certification-center/{id}/invitations dans src (PIX-13459)

### DIFF
--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -2,7 +2,6 @@ import Joi from 'joi';
 
 import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { identifiersType, optionalIdentifiersType } from '../../../src/shared/domain/types/identifiers-type.js';
-import { certificationCenterInvitationController as srcCertificationCenterController } from '../../../src/team/application/certification-center-invitation/certification-center-invitation.controller.js';
 import { certificationCenterController } from './certification-center-controller.js';
 
 const register = async function (server) {
@@ -182,35 +181,6 @@ const register = async function (server) {
             '- Elle met à jour les informations d‘un centre de certification\n',
         ],
         tags: ['api', 'admin', 'certification-center'],
-      },
-    },
-    {
-      method: 'GET',
-      path: '/api/admin/certification-centers/{certificationCenterId}/invitations',
-      config: {
-        pre: [
-          {
-            method: (request, h) =>
-              securityPreHandlers.hasAtLeastOneAccessOf([
-                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-                securityPreHandlers.checkAdminMemberHasRoleCertif,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-                securityPreHandlers.checkAdminMemberHasRoleMetier,
-              ])(request, h),
-            assign: 'hasAuthorizationToAccessAdminScope',
-          },
-        ],
-        validate: {
-          params: Joi.object({
-            certificationCenterId: identifiersType.certificationCenterId,
-          }),
-        },
-        handler: srcCertificationCenterController.findPendingInvitations,
-        notes: [
-          '- **Cette route est restreinte aux utilisateurs authentifiés et ayant accès à Pix Admin**\n' +
-            '- Récupération de la liste des invitations en attente liée un centre de certification',
-        ],
-        tags: ['api', 'certification-center', 'invitations', 'admin'],
       },
     },
   ];

--- a/api/src/team/application/certification-center-invitation/certification-center-invitation.admin.route.js
+++ b/api/src/team/application/certification-center-invitation/certification-center-invitation.admin.route.js
@@ -27,7 +27,6 @@ export const certificationCenterInvitationAdminRoutes = [
           certificationCenterId: identifiersType.certificationCenterId,
         }),
       },
-      //quel handler?
       handler: certificationCenterInvitationController.findPendingInvitations,
       notes: [
         '- **Cette route est restreinte aux utilisateurs authentifiés et ayant accès à Pix Admin**\n' +

--- a/api/src/team/application/certification-center-invitation/certification-center-invitation.admin.route.js
+++ b/api/src/team/application/certification-center-invitation/certification-center-invitation.admin.route.js
@@ -3,8 +3,39 @@ import Joi from 'joi';
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
 import { certificationCenterInvitationAdminController } from './certification-center-invitation.admin.controller.js';
+import { certificationCenterInvitationController } from './certification-center-invitation.controller.js';
 
 export const certificationCenterInvitationAdminRoutes = [
+  {
+    method: 'GET',
+    path: '/api/admin/certification-centers/{certificationCenterId}/invitations',
+    config: {
+      pre: [
+        {
+          method: (request, h) =>
+            securityPreHandlers.hasAtLeastOneAccessOf([
+              securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+              securityPreHandlers.checkAdminMemberHasRoleCertif,
+              securityPreHandlers.checkAdminMemberHasRoleSupport,
+              securityPreHandlers.checkAdminMemberHasRoleMetier,
+            ])(request, h),
+          assign: 'hasAuthorizationToAccessAdminScope',
+        },
+      ],
+      validate: {
+        params: Joi.object({
+          certificationCenterId: identifiersType.certificationCenterId,
+        }),
+      },
+      //quel handler?
+      handler: certificationCenterInvitationController.findPendingInvitations,
+      notes: [
+        '- **Cette route est restreinte aux utilisateurs authentifiés et ayant accès à Pix Admin**\n' +
+          '- Récupération de la liste des invitations en attente liée un centre de certification',
+      ],
+      tags: ['api', 'certification-center', 'invitations', 'admin'],
+    },
+  },
   {
     method: 'POST',
     path: '/api/admin/certification-centers/{certificationCenterId}/invitations',

--- a/api/tests/acceptance/application/certification-centers/index_test.js
+++ b/api/tests/acceptance/application/certification-centers/index_test.js
@@ -1,11 +1,9 @@
-import { CertificationCenterInvitation } from '../../../../src/team/domain/models/CertificationCenterInvitation.js';
 import {
   createServer,
   databaseBuilder,
   expect,
   generateValidRequestAuthorizationHeader,
   insertUserWithRoleSuperAdmin,
-  sinon,
 } from '../../../test-helper.js';
 
 describe('Acceptance | Route | Certification Centers', function () {
@@ -75,57 +73,6 @@ describe('Acceptance | Route | Certification Centers', function () {
         expect(result.data.attributes['data-protection-officer-email']).to.equal('justin.ptipeu@example.net');
         expect(result.data.attributes['is-v3-pilot']).to.equal(true);
         expect(result.data.attributes.name).to.equal('Justin Ptipeu Orga');
-      });
-    });
-  });
-
-  describe('POST /api/admin/certification-centers/{certificationCenterId}/invitations', function () {
-    let clock;
-    const now = new Date('2021-05-01');
-
-    beforeEach(async function () {
-      clock = sinon.useFakeTimers({
-        now,
-        toFake: ['Date'],
-      });
-    });
-
-    afterEach(async function () {
-      clock.restore();
-    });
-
-    it('should return 201 HTTP status code with created invitation', async function () {
-      // given
-      const adminMember = await insertUserWithRoleSuperAdmin();
-      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-      await databaseBuilder.commit();
-
-      // when
-      const { result, statusCode } = await server.inject({
-        headers: {
-          authorization: generateValidRequestAuthorizationHeader(adminMember.id),
-        },
-        method: 'POST',
-        payload: {
-          data: {
-            attributes: {
-              email: 'some.user@example.net',
-              lang: 'fr-fr',
-              role: CertificationCenterInvitation.Roles.ADMIN,
-            },
-          },
-        },
-        url: `/api/admin/certification-centers/${certificationCenterId}/invitations`,
-      });
-
-      // then
-      expect(statusCode).to.equal(201);
-      expect(result.data.type).to.equal('certification-center-invitations');
-      expect(result.data).to.have.property('id');
-      expect(result.data.attributes).to.deep.equal({
-        'updated-at': now,
-        email: 'some.user@example.net',
-        role: 'ADMIN',
       });
     });
   });

--- a/api/tests/acceptance/application/certifications/index_test.js
+++ b/api/tests/acceptance/application/certifications/index_test.js
@@ -1,13 +1,11 @@
 import { generateCertificateVerificationCode } from '../../../../lib/domain/services/verify-certificate-code-service.js';
 import { AutoJuryCommentKeys } from '../../../../src/certification/shared/domain/models/JuryComment.js';
 import { Assessment } from '../../../../src/shared/domain/models/Assessment.js';
-import { CertificationCenterInvitation } from '../../../../src/team/domain/models/CertificationCenterInvitation.js';
 import {
   createServer,
   databaseBuilder,
   expect,
   generateValidRequestAuthorizationHeader,
-  insertUserWithRoleSuperAdmin,
   learningContentBuilder,
   mockLearningContent,
 } from '../../../test-helper.js';
@@ -447,66 +445,6 @@ describe('Acceptance | API | Certifications', function () {
         // then
         expect(response.statusCode).to.equal(404);
       });
-    });
-  });
-
-  describe('GET /api/admin/certification-centers/{certificationCenterId}/invitations', function () {
-    it('should return 200 HTTP status code and the list of invitations', async function () {
-      // given
-      const adminUser = await insertUserWithRoleSuperAdmin();
-
-      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-      const now = new Date();
-      const certificationCenterInvitation1 = databaseBuilder.factory.buildCertificationCenterInvitation({
-        certificationCenterId,
-        status: CertificationCenterInvitation.StatusType.PENDING,
-        email: 'alex.terieur@example.net',
-        role: 'MEMBER',
-        updatedAt: now,
-      });
-      const certificationCenterInvitation2 = databaseBuilder.factory.buildCertificationCenterInvitation({
-        certificationCenterId,
-        status: CertificationCenterInvitation.StatusType.PENDING,
-        email: 'sarah.pelle@example.net',
-        role: 'ADMIN',
-        updatedAt: now,
-      });
-      databaseBuilder.factory.buildCertificationCenterInvitation({
-        certificationCenterId,
-        status: CertificationCenterInvitation.StatusType.ACCEPTED,
-      });
-      await databaseBuilder.commit();
-
-      // when
-      const response = await server.inject({
-        method: 'GET',
-        url: `/api/admin/certification-centers/${certificationCenterId}/invitations`,
-        headers: { authorization: generateValidRequestAuthorizationHeader(adminUser.id) },
-      });
-
-      // then
-      expect(response.statusCode).to.equal(200);
-      expect(response.result.data.length).to.equal(2);
-      expect(response.result.data).to.deep.have.members([
-        {
-          type: 'certification-center-invitations',
-          id: certificationCenterInvitation1.id.toString(),
-          attributes: {
-            email: 'alex.terieur@example.net',
-            role: 'MEMBER',
-            'updated-at': now,
-          },
-        },
-        {
-          type: 'certification-center-invitations',
-          id: certificationCenterInvitation2.id.toString(),
-          attributes: {
-            email: 'sarah.pelle@example.net',
-            role: 'ADMIN',
-            'updated-at': now,
-          },
-        },
-      ]);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
La route GET api/admin/certification-center/{id}/invitations est encore dans lib

## :robot: Proposition
Déplacer cette route dans src

## :rainbow: Remarques
Cette route utilise le même handler que GET api/certification-center/{id}/invitations (nous n'avons pas modifié l'ancienne implémentation)

## :100: Pour tester
Se connecter sur Pix Admin
Aller dans un centre de certification, onglet invitations
inviter un membre (peu importe l'email)
constater l'affichage de l'adresse mail dans les invitations en attente, et en console, l'appel réalisé avec succès de la route GET api/admin/certification-center/{id}/invitations, qui retourne la liste des invitations en attente.
