### PR TITLE
[TECH] Migrer le prehandler d'autorisation d'accès aux certifications dans le contexte certification (PIX-13463).

### DIFF
--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -2,9 +2,9 @@ import JoiDate from '@joi/date';
 import BaseJoi from 'joi';
 const Joi = BaseJoi.extend(JoiDate);
 
+import { authorization } from '../../../src/certification/shared/application/pre-handlers/authorization.js';
 import { securityPreHandlers } from '../../../src/shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../src/shared/domain/types/identifiers-type.js';
-import { authorization } from '../preHandlers/authorization.js';
 import { finalizedSessionController } from './finalized-session-controller.js';
 import { sessionController } from './session-controller.js';
 import { sessionWithCleaCertifiedCandidateController } from './session-with-clea-certified-candidate-controller.js';

--- a/api/src/certification/enrolment/application/attendance-sheet-route.js
+++ b/api/src/certification/enrolment/application/attendance-sheet-route.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
-import { authorization } from '../../../../lib/application/preHandlers/authorization.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { authorization } from '../../shared/application/pre-handlers/authorization.js';
 import { attendanceSheetController } from './attendance-sheet-controller.js';
 
 const register = async function (server) {

--- a/api/src/certification/enrolment/application/certification-candidate-route.js
+++ b/api/src/certification/enrolment/application/certification-candidate-route.js
@@ -1,9 +1,9 @@
 import JoiDate from '@joi/date';
 import BaseJoi from 'joi';
 const Joi = BaseJoi.extend(JoiDate);
-import { authorization } from '../../../../lib/application/preHandlers/authorization.js';
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { authorization } from '../../shared/application/pre-handlers/authorization.js';
 import { certificationCandidateController } from './certification-candidate-controller.js';
 
 const register = async function (server) {

--- a/api/src/certification/enrolment/application/session-route.js
+++ b/api/src/certification/enrolment/application/session-route.js
@@ -1,8 +1,8 @@
 import Joi from 'joi';
 
-import { authorization } from '../../../../lib/application/preHandlers/authorization.js';
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { authorization } from '../../shared/application/pre-handlers/authorization.js';
 import { sessionController } from './session-controller.js';
 
 const register = async function (server) {

--- a/api/src/certification/results/application/certification-reports-route.js
+++ b/api/src/certification/results/application/certification-reports-route.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
-import { authorization } from '../../../../lib/application/preHandlers/authorization.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { authorization } from '../../shared/application/pre-handlers/authorization.js';
 import { certificationReportsController } from './certification-reports-controller.js';
 
 const register = async function (server) {

--- a/api/src/certification/session-management/application/certification-report-route.js
+++ b/api/src/certification/session-management/application/certification-report-route.js
@@ -1,8 +1,8 @@
 import Joi from 'joi';
 
-import { authorization } from '../../../../lib/application/preHandlers/authorization.js';
 import { securityPreHandlers } from '../../../shared/application/security-pre-handlers.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { authorization } from '../../shared/application/pre-handlers/authorization.js';
 import { certificationReportController } from './certification-report-controller.js';
 
 const register = async function (server) {

--- a/api/src/certification/session-management/application/finalize-route.js
+++ b/api/src/certification/session-management/application/finalize-route.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
-import { authorization } from '../../../../lib/application/preHandlers/authorization.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { authorization } from '../../shared/application/pre-handlers/authorization.js';
 import { finalizeController } from './finalize-controller.js';
 
 const register = async function (server) {

--- a/api/src/certification/session-management/application/invigilator-kit-route.js
+++ b/api/src/certification/session-management/application/invigilator-kit-route.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
-import { authorization } from '../../../../lib/application/preHandlers/authorization.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { authorization } from '../../shared/application/pre-handlers/authorization.js';
 import { invigilatorKitController } from './invigilator-kit-controller.js';
 
 const register = async function (server) {

--- a/api/src/certification/session-management/application/session-route.js
+++ b/api/src/certification/session-management/application/session-route.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
-import { authorization } from '../../../../lib/application/preHandlers/authorization.js';
 import { identifiersType } from '../../../shared/domain/types/identifiers-type.js';
+import { authorization } from '../../shared/application/pre-handlers/authorization.js';
 import { sessionController } from './session-controller.js';
 
 const register = async function (server) {

--- a/api/src/certification/shared/application/pre-handlers/authorization.js
+++ b/api/src/certification/shared/application/pre-handlers/authorization.js
@@ -1,6 +1,6 @@
-import * as sessionRepository from '../../../src/certification/session-management/infrastructure/repositories/session-repository.js';
-import * as certificationCourseRepository from '../../../src/certification/shared/infrastructure/repositories/certification-course-repository.js';
-import { NotFoundError } from '../http-errors.js';
+import { NotFoundError } from '../../../../shared/application/http-errors.js';
+import * as sessionRepository from '../../../session-management/infrastructure/repositories/session-repository.js';
+import * as certificationCourseRepository from '../../infrastructure/repositories/certification-course-repository.js';
 
 const verifySessionAuthorization = (request, h, dependencies = { sessionRepository }) => {
   const userId = request.auth.credentials.userId;

--- a/api/src/shared/application/error-manager.js
+++ b/api/src/shared/application/error-manager.js
@@ -76,6 +76,9 @@ function _formatInvalidAttribute(locale, { attribute, message }) {
 }
 
 function _mapToHttpError(error) {
+  if (error instanceof HttpErrors.BaseHttpError) {
+    return error;
+  }
   if (error instanceof DomainErrors.NotFoundError) {
     return new HttpErrors.NotFoundError(error.message);
   }

--- a/api/tests/certification/enrolment/unit/application/attendance-sheet-route_test.js
+++ b/api/tests/certification/enrolment/unit/application/attendance-sheet-route_test.js
@@ -1,6 +1,6 @@
-import { authorization } from '../../../../../lib/application/preHandlers/authorization.js';
 import { attendanceSheetController } from '../../../../../src/certification/enrolment/application/attendance-sheet-controller.js';
 import * as moduleUnderTest from '../../../../../src/certification/enrolment/application/attendance-sheet-route.js';
+import { authorization } from '../../../../../src/certification/shared/application/pre-handlers/authorization.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 

--- a/api/tests/certification/enrolment/unit/application/certification-candidate-route_test.js
+++ b/api/tests/certification/enrolment/unit/application/certification-candidate-route_test.js
@@ -1,7 +1,7 @@
-import { authorization } from '../../../../../lib/application/preHandlers/authorization.js';
 import { NotFoundError } from '../../../../../lib/domain/errors.js';
 import { certificationCandidateController } from '../../../../../src/certification/enrolment/application/certification-candidate-controller.js';
 import * as moduleUnderTest from '../../../../../src/certification/enrolment/application/certification-candidate-route.js';
+import { authorization } from '../../../../../src/certification/shared/application/pre-handlers/authorization.js';
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 

--- a/api/tests/certification/enrolment/unit/application/session-route_test.js
+++ b/api/tests/certification/enrolment/unit/application/session-route_test.js
@@ -1,6 +1,6 @@
-import { authorization } from '../../../../../lib/application/preHandlers/authorization.js';
 import { sessionController } from '../../../../../src/certification/enrolment/application/session-controller.js';
 import * as moduleUnderTest from '../../../../../src/certification/enrolment/application/session-route.js';
+import { authorization } from '../../../../../src/certification/shared/application/pre-handlers/authorization.js';
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 

--- a/api/tests/certification/session-management/unit/application/certification-report-route_test.js
+++ b/api/tests/certification/session-management/unit/application/certification-report-route_test.js
@@ -1,7 +1,7 @@
 import { NotFoundError } from '../../../../../lib/application/http-errors.js';
-import { authorization } from '../../../../../lib/application/preHandlers/authorization.js';
 import { certificationReportController } from '../../../../../src/certification/session-management/application/certification-report-controller.js';
 import * as moduleUnderTest from '../../../../../src/certification/session-management/application/certification-report-route.js';
+import { authorization } from '../../../../../src/certification/shared/application/pre-handlers/authorization.js';
 import { securityPreHandlers } from '../../../../../src/shared/application/security-pre-handlers.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 

--- a/api/tests/certification/session-management/unit/application/finalize-route_test.js
+++ b/api/tests/certification/session-management/unit/application/finalize-route_test.js
@@ -1,6 +1,6 @@
-import { authorization } from '../../../../../lib/application/preHandlers/authorization.js';
 import { finalizeController } from '../../../../../src/certification/session-management/application/finalize-controller.js';
 import * as moduleUnderTest from '../../../../../src/certification/session-management/application/finalize-route.js';
+import { authorization } from '../../../../../src/certification/shared/application/pre-handlers/authorization.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Router | session-route', function () {

--- a/api/tests/certification/session-management/unit/application/invigilator-kit-route_test.js
+++ b/api/tests/certification/session-management/unit/application/invigilator-kit-route_test.js
@@ -1,7 +1,7 @@
-import { authorization } from '../../../../../lib/application/preHandlers/authorization.js';
 import { NotFoundError } from '../../../../../lib/domain/errors.js';
 import { invigilatorKitController } from '../../../../../src/certification/session-management/application/invigilator-kit-controller.js';
 import * as moduleUnderTest from '../../../../../src/certification/session-management/application/invigilator-kit-route.js';
+import { authorization } from '../../../../../src/certification/shared/application/pre-handlers/authorization.js';
 import { expect, HttpTestServer, sinon } from '../../../../test-helper.js';
 
 describe('Unit | Router | invigilator-kit-route', function () {

--- a/api/tests/certification/shared/acceptance/application/pre-handlers/authorization_test.js
+++ b/api/tests/certification/shared/acceptance/application/pre-handlers/authorization_test.js
@@ -1,9 +1,9 @@
-import { NotFoundError } from '../../../../lib/application/http-errors.js';
 import {
   verifyCertificationSessionAuthorization,
   verifySessionAuthorization,
-} from '../../../../lib/application/preHandlers/authorization.js';
-import { catchErr, domainBuilder, expect, hFake, sinon } from '../../../test-helper.js';
+} from '../../../../../../src/certification/shared/application/pre-handlers/authorization.js';
+import { NotFoundError } from '../../../../../../src/shared/application/http-errors.js';
+import { catchErr, domainBuilder, expect, hFake, sinon } from '../../../../../test-helper.js';
 
 describe('Unit | Pre-handler | Authorization', function () {
   const userId = 1;

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -6,11 +6,11 @@ import FormData from 'form-data';
 import streamToPromise from 'stream-to-promise';
 
 import { NotFoundError } from '../../../../lib/application/http-errors.js';
-import { authorization } from '../../../../lib/application/preHandlers/authorization.js';
 import { finalizedSessionController } from '../../../../lib/application/sessions/finalized-session-controller.js';
 import * as moduleUnderTest from '../../../../lib/application/sessions/index.js';
 import { sessionController } from '../../../../lib/application/sessions/session-controller.js';
 import { sessionWithCleaCertifiedCandidateController } from '../../../../lib/application/sessions/session-with-clea-certified-candidate-controller.js';
+import { authorization } from '../../../../src/certification/shared/application/pre-handlers/authorization.js';
 import { securityPreHandlers } from '../../../../src/shared/application/security-pre-handlers.js';
 import { expect, HttpTestServer, sinon } from '../../../test-helper.js';
 


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre des tech days de migration de lib vers src, on souhaite déplacer le prehandler d'accès et gestion des sessions de certification.

## :robot: Proposition
Déplacer ce pre-handler dans le dossier certification/shared car il sert dans plusieurs sous-domaines de certification.

## :rainbow: Remarques
On a découvert, avec moultes douleurs, que les erreurs HTTP issues de src/shared n'étaient pas mappés et étaient donc remplacées par une erreur 400. 

## :100: Pour tester
- Pouvoir réaliser les actions de gestion d'une session de certification