### PR TITLE
[BUGFIX] Corriger l'initializer custom-inflector-rules dans Pix Admin

### DIFF
--- a/admin/app/initializers/custom-inflector-rules.js
+++ b/admin/app/initializers/custom-inflector-rules.js
@@ -8,6 +8,6 @@ export function initialize() {
 
 export default {
   name: 'custom-inflector-rules',
-  before: 'ember-cli-mirage',
+  before: process.env.NODE_ENV === 'production' ? undefined : 'ember-cli-mirage',
   initialize,
 };


### PR DESCRIPTION
## :unicorn: Problème
L'application buildée en mode production ne se lance pas. Cela est dû à la configuration de l'initializer `custom-inflector-rules` qui est censé se lancer après `ember-cli-mirage`. Or, bien que cela soit nécessaire pour les tests, mirage n'est pas présent pour un environnement de production ce qui cause une erreur au runtime. 

## :robot: Proposition
Ne pas utiliser de before lorsque l'environnement est `production`.

## :100: Pour tester
Vérifier que l'application est bien déployée sur Scalingo et que la CI passe.