### PR TITLE
[FEATURE] Ajout d'un feature toggle pour la nouvelle page de fin de parcours

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -760,6 +760,13 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: false
 # FT_ENABLE_NEED_TO_ADJUST_CERTIFICATION_ACCESSIBILITY=false
 
+# Display the new result page
+#
+# presence: optional
+# type: boolean
+# default: false
+# FT_SHOW_NEW_RESULT_PAGE=false
+
 # =====
 # CPF
 # =====

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -195,6 +195,7 @@ const configuration = (function () {
       isNeedToAdjustCertificationAccessibilityEnabled: toBoolean(
         process.env.FT_ENABLE_NEED_TO_ADJUST_CERTIFICATION_ACCESSIBILITY,
       ),
+      showNewResultPage: toBoolean(process.env.FT_SHOW_NEW_RESULT_PAGE),
     },
     hapi: {
       options: {},

--- a/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
+++ b/api/tests/shared/acceptance/application/feature-toggles/feature-toggle-controller_test.js
@@ -28,6 +28,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
             'is-certification-token-scope-enabled': false,
             'is-text-to-speech-button-enabled': false,
             'is-need-to-adjust-certification-accessibility-enabled': false,
+            'show-new-result-page': false,
           },
         },
       };


### PR DESCRIPTION
:swimmer: Pourquoi ?
Nous souhaitons entamer les travaux sur la nouvelle page de fin de parcours.

:hibiscus: Comment ?
Pour travailler sereinement, nous mettons en place un feature toggle pour pouvoir garder l'existant en parallèle et basculer le moment souhaite.

:rat: Est ce que ça marche ?
Ouvrir la console sur la RA "mon pix"
Debugger la route "feature-toggles"
Constater la presence du nouveau feature toggle "show-new-result-page"

:red_car::no_entry_sign::zebra::zebra::zebra:
