### PR TITLE
[BUGFIX] Mettre à jour la date de fin de la session lors de sa prolongation (PIX-13412).

### DIFF
--- a/orga/app/components/layout/school-session-management.gjs
+++ b/orga/app/components/layout/school-session-management.gjs
@@ -48,7 +48,7 @@ export default class SchoolSessionManagement extends Component {
       .adapterFor('organization')
       .activateSession({ organizationId: organization.id, token: this.session?.data?.authenticated?.access_token });
 
-    await this.args.refreshAuthenticatedModel();
+    await this.currentUser.load();
   }
 
   <template>

--- a/orga/app/components/layout/topbar.hbs
+++ b/orga/app/components/layout/topbar.hbs
@@ -1,5 +1,5 @@
 <div class="topbar">
   <Layout::OrganizationPlacesOrCreditInfo @placesCount={{@placesCount}} />
-  <Layout::SchoolSessionManagement @refreshAuthenticatedModel={{@refreshAuthenticatedModel}} />
+  <Layout::SchoolSessionManagement />
   <Layout::UserLoggedMenu class="topbar__user-logged-menu" @refreshAuthenticatedModel={{@refreshAuthenticatedModel}} />
 </div>

--- a/orga/app/routes/authenticated/missions/list.js
+++ b/orga/app/routes/authenticated/missions/list.js
@@ -7,9 +7,6 @@ export default class MissionListRoute extends Route {
   @service router;
   @service store;
 
-  async beforeModel() {
-    await this.currentUser.load();
-  }
   async model() {
     const pixJuniorSchoolUrl = this.url.pixJuniorSchoolUrl;
     const organization = this.currentUser.organization;


### PR DESCRIPTION
## :unicorn: Problème

Dans Pix Orga, lorsque l'activation de la session est fait depuis une autre page que la liste des missions, l'heure de fin n'est pas mise à jour et on ne voit pas que la session a été activée.

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## :robot: Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

La date de fin de la session étant une info de l'utilisateur courant, il ne faut pas rafraichir le modèle de la route mais uniquement l'utilisateur courant, avec `this.currentUser.laod()`.

## :rainbow: Remarques

Merci @frinyvonnick !

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

Se rendre sur Pix Orga.
Sélectionner une mission.
Activer ou prolonger la session.
Vérifier que l'heure fin de session a été mise à jour.
