### PR TITLE
[TECH] Enregistrer des jobs lors du lancement de script de scoring (PIX-13443)

### DIFF
--- a/api/lib/infrastructure/jobs/certification/CertificationRescoringByScriptHandler.js
+++ b/api/lib/infrastructure/jobs/certification/CertificationRescoringByScriptHandler.js
@@ -1,0 +1,19 @@
+import { CertificationRescoringByScriptJob } from './CertificationRescoringByScriptJob.js';
+
+class CertificationRescoringByScriptJobHandler {
+  constructor({ logger }) {
+    this.logger = logger;
+  }
+
+  handle(event) {
+    this.logger.info({
+      data: event.certificationCourseId,
+    });
+  }
+
+  get name() {
+    return CertificationRescoringByScriptJob.name;
+  }
+}
+
+export { CertificationRescoringByScriptJobHandler };

--- a/api/lib/infrastructure/jobs/certification/CertificationRescoringByScriptJob.js
+++ b/api/lib/infrastructure/jobs/certification/CertificationRescoringByScriptJob.js
@@ -1,0 +1,17 @@
+import { JobPgBoss } from '../JobPgBoss.js';
+
+export class CertificationRescoringByScriptJob extends JobPgBoss {
+  constructor(queryBuilder) {
+    super(
+      {
+        name: 'CertificationRescoringByScriptJob',
+      },
+      queryBuilder,
+    );
+  }
+
+  /** * @param {number} certificationCourseId */
+  async schedule(certificationCourseId) {
+    return super.schedule({ certificationCourseId, type: 'CertificationRescoringByScript' });
+  }
+}

--- a/api/scripts/certification/rescore-certifications.js
+++ b/api/scripts/certification/rescore-certifications.js
@@ -1,0 +1,54 @@
+import 'dotenv/config';
+
+import * as url from 'node:url';
+
+import { disconnect, knex } from '../../db/knex-database-connection.js';
+import { CertificationRescoringByScriptJob } from '../../lib/infrastructure/jobs/certification/CertificationRescoringByScriptJob.js';
+import { logger } from '../../src/shared/infrastructure/utils/logger.js';
+
+const modulePath = url.fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === modulePath;
+
+async function main(certificationCourseIds) {
+  const jobs = await _scheduleRescoringJobs(certificationCourseIds);
+
+  const errors = jobs.filter((result) => result.status === 'rejected');
+
+  if (errors.length) {
+    errors.forEach((result) => logger.error('Some jobs could not be published', result.reason));
+
+    // On informe la IIFE que on est pas bon
+    return 1;
+  }
+
+  // On informe la IIFE qu'on est bon
+  return 0;
+}
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      const certificationCourseIds = process.argv[2]
+        .split(',')
+        .map((str) => parseInt(str, 10))
+        .filter(Number.isInteger);
+      const exitCode = await main(certificationCourseIds);
+      return exitCode;
+    } catch (error) {
+      logger.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+    }
+  }
+})();
+
+async function _scheduleRescoringJobs(certificationCourseIds) {
+  const publisher = new CertificationRescoringByScriptJob(knex);
+  const promisefiedJobs = certificationCourseIds.map((certificationCourseId) =>
+    publisher.schedule(certificationCourseId),
+  );
+  return Promise.allSettled(promisefiedJobs);
+}
+
+export { main };

--- a/api/tests/integration/scripts/certification/rescore-certifications_test.js
+++ b/api/tests/integration/scripts/certification/rescore-certifications_test.js
@@ -1,0 +1,27 @@
+import { main } from '../../../../scripts/certification/rescore-certifications.js';
+import { expect, knex } from '../../../test-helper.js';
+
+describe('Integration | Scripts | Certification | rescore-certfication', function () {
+  it('should save pg boss jobs for each certification course ids', async function () {
+    // given
+    const certificationsCourseIdList = [1, 2];
+
+    // when
+    await main(certificationsCourseIdList);
+
+    // then
+    const [job1, job2] = await knex('pgboss.job')
+      .where({ name: 'CertificationRescoringByScriptJob' })
+      .orderBy('createdon', 'asc');
+
+    expect(job1.data).to.deep.equal({
+      type: 'CertificationRescoringByScript',
+      certificationCourseId: 1,
+    });
+
+    expect(job2.data).to.deep.equal({
+      type: 'CertificationRescoringByScript',
+      certificationCourseId: 2,
+    });
+  });
+});

--- a/api/worker.js
+++ b/api/worker.js
@@ -11,6 +11,8 @@ import { ParticipationResultCalculationJob } from './lib/infrastructure/jobs/cam
 import { ParticipationResultCalculationJobHandler } from './lib/infrastructure/jobs/campaign-result/ParticipationResultCalculationJobHandler.js';
 import { SendSharedParticipationResultsToPoleEmploiHandler } from './lib/infrastructure/jobs/campaign-result/SendSharedParticipationResultsToPoleEmploiHandler.js';
 import { SendSharedParticipationResultsToPoleEmploiJob } from './lib/infrastructure/jobs/campaign-result/SendSharedParticipationResultsToPoleEmploiJob.js';
+import { CertificationRescoringByScriptJobHandler } from './lib/infrastructure/jobs/certification/CertificationRescoringByScriptHandler.js';
+import { CertificationRescoringByScriptJob } from './lib/infrastructure/jobs/certification/CertificationRescoringByScriptJob.js';
 import { scheduleCpfJobs } from './lib/infrastructure/jobs/cpf-export/schedule-cpf-jobs.js';
 import { JobQueue } from './lib/infrastructure/jobs/JobQueue.js';
 import { LcmsRefreshCacheJob } from './lib/infrastructure/jobs/lcms/LcmsRefreshCacheJob.js';
@@ -98,6 +100,7 @@ export async function runJobs(dependencies = { startPgBoss, createMonitoredJobQu
 
   monitoredJobQueue.performJob(UserAnonymizedEventLoggingJob.name, UserAnonymizedEventLoggingJobHandler);
   monitoredJobQueue.performJob(GarAnonymizedBatchEventsLoggingJob.name, GarAnonymizedBatchEventsLoggingJobHandler);
+  monitoredJobQueue.performJob(CertificationRescoringByScriptJob.name, CertificationRescoringByScriptJobHandler);
 
   if (config.pgBoss.validationFileJobEnabled) {
     monitoredJobQueue.performJob(ValidateOrganizationImportFileJob.name, ValidateOrganizationImportFileJobHandler);


### PR DESCRIPTION
## :unicorn: Problème
Le rescoring de certification peut prendre du temps. On veut pouvoir rescorer beaucoup de certifications via un script prenant des id de courses en entrée.

Nous voulons pouvoir déléguer la traitement de ces multiples rescoring à PGboss

## :robot: Proposition
Créer autant de job PGBoss en base que d'id de certification course

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- Lancer le script `node scripts/certification/rescore-certifications.js 1,2,3,4
`
- Vérifier en base la présence de 4 jobs pgboss `CertificationRescoringByScriptJob` pour les ids 1,2,3,4