### PR TITLE
[TECH] Remplacer la dépendance `oppsy` par notre fork

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
+        "@1024pix/oppsy": "^1.0.1",
         "@aws-sdk/client-s3": "^3.121.0",
         "@aws-sdk/lib-storage": "^3.121.0",
         "@aws-sdk/s3-request-presigner": "^3.145.0",
@@ -56,7 +57,6 @@
         "node-stream-zip": "^1.15.0",
         "nodemailer": "^6.9.6",
         "openid-client": "^5.6.4",
-        "oppsy": "https://github.com/1024pix/oppsy#main",
         "papaparse": "^5.3.2",
         "pdf-lib": "^1.17.1",
         "pg": "^8.7.3",
@@ -130,6 +130,17 @@
       },
       "peerDependencies": {
         "eslint": ">=8.56.0"
+      }
+    },
+    "node_modules/@1024pix/oppsy": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/oppsy/-/oppsy-1.0.1.tgz",
+      "integrity": "sha512-sz5YQ3DgCd0Ius5W0Divbiu+AxQ39XwjPObq9zJkWXQBQrZheCeVhP4kOA9ZCWa2CZOEvRCmu/MTtElPsyTaIw==",
+      "dependencies": {
+        "@hapi/hoek": "11.x.x"
+      },
+      "engines": {
+        "node": "^16 || ^18 || ^20 || ^22"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -10575,17 +10586,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
-    },
-    "node_modules/oppsy": {
-      "version": "3.0.0",
-      "resolved": "git+ssh://git@github.com/1024pix/oppsy.git#76c8e7c7f532142f30662bd7000e535012d85fee",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "11.x.x"
-      },
-      "engines": {
-        "node": "^16 || ^18 || ^20"
-      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",

--- a/api/package.json
+++ b/api/package.json
@@ -16,6 +16,7 @@
   "main": "index.js",
   "homepage": "https://github.com/1024pix/pix#readme",
   "dependencies": {
+    "@1024pix/oppsy": "^1.0.1",
     "@aws-sdk/client-s3": "^3.121.0",
     "@aws-sdk/lib-storage": "^3.121.0",
     "@aws-sdk/s3-request-presigner": "^3.145.0",
@@ -62,7 +63,6 @@
     "node-stream-zip": "^1.15.0",
     "nodemailer": "^6.9.6",
     "openid-client": "^5.6.4",
-    "oppsy": "https://github.com/1024pix/oppsy#main",
     "papaparse": "^5.3.2",
     "pdf-lib": "^1.17.1",
     "pg": "^8.7.3",

--- a/api/server.js
+++ b/api/server.js
@@ -1,5 +1,5 @@
+import Oppsy from '@1024pix/oppsy';
 import Hapi from '@hapi/hapi';
-import Oppsy from 'oppsy';
 import Qs from 'qs';
 
 import { setupErrorHandling } from './config/server-setup-error-handling.js';


### PR DESCRIPTION
## :unicorn: Problème
On utilise un fork de [`oppsy`](https://github.com/hapijs/oppsy) depuis #5126. On précisait à npm de chercher cette dépendance sur notre fork via github.com. L'inconvénient est qu'on doit mettre à jour le package-lock.json manuellement quand on le fait évoluer, voir #5528.

## :robot: Proposition
Maintenant que `@1024pix/oppsy` existe, l'utiliser pour bénéficier des montées de version automatisée via Renovate.

## :rainbow: Remarques
RAS

## :100: Pour tester
CI verte ✅ 
