### PR TITLE
[FEATURE] Effacer l'email quand un utilisateur est anonymisé (PIX-4219)

### DIFF
--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -184,7 +184,7 @@ function routes() {
     return user.update({
       firstName: '(anonymised)',
       lastName: '(anonymised)',
-      email: `email_${userId}@example.net`,
+      email: null,
       username: null,
       authenticationMethods: [],
     });

--- a/admin/tests/acceptance/authenticated/users/get_test.js
+++ b/admin/tests/acceptance/authenticated/users/get_test.js
@@ -165,9 +165,8 @@ module('Acceptance | authenticated/users/get', function (hooks) {
 
       // when & then #1
       await click(screen.getByRole('button', { name: 'Confirmer' }));
-      assert.dom(screen.getByText(`Prénom : (anonymised)`)).exists();
-      assert.dom(screen.getByText(`Nom : (anonymised)`)).exists();
-      assert.dom(screen.getByText(`Adresse e-mail : email_${userToAnonymise.id}@example.net`)).exists();
+      assert.dom(screen.getByText('Prénom : (anonymised)')).exists();
+      assert.dom(screen.getByText('Nom : (anonymised)')).exists();
 
       assert.dom(screen.getByLabelText("L'utilisateur n'a pas de méthode de connexion avec identifiant")).exists();
       assert.dom(screen.getByLabelText("L'utilisateur n'a pas de méthode de connexion avec adresse e-mail")).exists();

--- a/api/lib/domain/usecases/anonymize-user.js
+++ b/api/lib/domain/usecases/anonymize-user.js
@@ -15,7 +15,7 @@ const anonymizeUser = async function ({
   const anonymizedUser = {
     firstName: '(anonymised)',
     lastName: '(anonymised)',
-    email: `email_${userId}@example.net`,
+    email: null,
     username: null,
     hasBeenAnonymised: true,
     hasBeenAnonymisedBy: updatedByUserId,

--- a/api/tests/acceptance/application/users/users-route_test.js
+++ b/api/tests/acceptance/application/users/users-route_test.js
@@ -52,7 +52,7 @@ describe('Acceptance | Route | users', function () {
 
       expect(updatedUserAttributes['first-name']).to.equal('(anonymised)');
       expect(updatedUserAttributes['last-name']).to.equal('(anonymised)');
-      expect(updatedUserAttributes.email).to.equal(`email_${userId}@example.net`);
+      expect(updatedUserAttributes.email).to.be.null;
       expect(updatedUserAttributes.username).to.be.null;
 
       expect(updatedUserAttributes['has-been-anonymised']).to.be.true;

--- a/api/tests/unit/domain/usecases/anonymize-user_test.js
+++ b/api/tests/unit/domain/usecases/anonymize-user_test.js
@@ -27,7 +27,7 @@ describe('Unit | UseCase | anonymize-user', function () {
     const anonymizedUser = {
       firstName: '(anonymised)',
       lastName: '(anonymised)',
-      email: `email_${userId}@example.net`,
+      email: null,
       username: null,
       hasBeenAnonymised: true,
       hasBeenAnonymisedBy: 2,


### PR DESCRIPTION
## :unicorn: Problème

Aujourd’hui, quand un user est supprimé depuis Pix Admin, alors:
- `users.username` est mis à `null`
- `users.email` est rempli par `email_{userID}@example.net`

Il ne faut plus garder le `userID` dans l'email, car ces données sont directement identifiantes dès qu’elles sont présentes conjointement avec d’autres données encore disponible en base. Et le fait de garder une fausse adresse email est complètement inutile et fausse notre compréhension.

## :robot: Proposition

Il faut faire une suppression complète de `users.email` quand l'utilisateur est anonymisé. 

```
emmy@pix.fr => NULL
```

## :rainbow: Remarques
N/A

## :100: Pour tester

1. Se connecter à Pix Admin avec `superadmin@example.net`
2. Chercher un utilisateur et aller sur sa page
3. Cliquer sur "Anonymiser" et confirmer

> L'email est supprimer (peut être vu sur la page de l'utilisateur. En base de donnée, l'email est null
