### PR TITLE
[FEATURE] Remplacement du wording coté orga, sur la page missions (Pix-13492)

### DIFF
--- a/orga/app/controllers/authenticated/missions/list.js
+++ b/orga/app/controllers/authenticated/missions/list.js
@@ -4,9 +4,14 @@ import { service } from '@ember/service';
 
 export default class MissionList extends Controller {
   @service router;
+  @service currentUser;
 
   @action
   goToMissionDetails(id) {
     this.router.transitionTo('authenticated.missions.details', id);
+  }
+
+  get schoolCode() {
+    return this.currentUser.organization.schoolCode ?? '';
   }
 }

--- a/orga/app/helpers/html-unsafe.js
+++ b/orga/app/helpers/html-unsafe.js
@@ -1,0 +1,7 @@
+import { helper } from '@ember/component/helper';
+import { htmlSafe as emberHtmlUnsafe } from '@ember/template';
+
+export function htmlUnsafe(text) {
+  return emberHtmlUnsafe(text);
+}
+export default helper(htmlUnsafe);

--- a/orga/app/styles/pages/authenticated/mission.scss
+++ b/orga/app/styles/pages/authenticated/mission.scss
@@ -10,9 +10,25 @@
     text-decoration: underline;
   }
 
+  li {
+    margin-top: 3px;
+    margin-bottom: 7px;
+    margin-left: 15px;
+    list-style: disc;
+
+    li {
+      margin-left: 15px;
+      list-style: circle;
+    }
+  }
+
   &__copypaste-container {
     display: flex;
+    text-align: start;
 
+    &__external-link {
+      margin-left: 10px;
+    }
   }
 }
 

--- a/orga/app/templates/authenticated/missions/list.hbs
+++ b/orga/app/templates/authenticated/missions/list.hbs
@@ -3,31 +3,54 @@
 <PixBanner class="mission-list-banner">
   {{t "pages.missions.list.banner.welcome"}}
   <br />
-  {{#if @model.isAdminOfTheCurrentOrganization}}
-    {{t "pages.missions.list.banner.admin.abstract"}}
-    <LinkTo @route="authenticated.import-organization-participants">{{t
-        "pages.missions.list.banner.admin.import-text"
-      }}</LinkTo>
-    {{t "pages.missions.list.banner.admin.info"}}
-  {{else}}
-    {{t "pages.missions.list.banner.non-admin.abstract"}}
-  {{/if}}
-  <br /><br />
-  <div class="mission-list-banner__copypaste-container">
-    {{t "pages.missions.list.banner.copypaste-container.abstract"}}
-    &nbsp;
+  <ul>
+    <li>
+      {{#if @model.isAdminOfTheCurrentOrganization}}
+        <span>{{html-unsafe (t "pages.missions.list.banner.step1.admin.head")}}
+          <LinkTo @route="authenticated.import-organization-participants">
+            <b>{{t "pages.missions.list.banner.step1.admin.link"}}</b>
+          </LinkTo>
+          {{html-unsafe (t "pages.missions.list.banner.step1.admin.tail")}}
+        </span>
+      {{else}}
+        <span>{{html-unsafe (t "pages.missions.list.banner.step1.non-admin")}}</span>
+      {{/if}}
+    </li>
+    <li>
+      <ul>
+        {{t "pages.missions.list.banner.step2.title"}}
+        <li>
+          <div class="mission-list-banner__copypaste-container">
+            <span>{{html-unsafe (t "pages.missions.list.banner.step2.option1" code=this.schoolCode)}}</span>
+            <CopyPasteButton
+              @clipBoardtext={{this.schoolCode}}
+              @successMessage="{{t 'pages.missions.list.banner.copypaste-container.button.success'}}"
+              @defaultMessage="{{t 'pages.missions.list.banner.copypaste-container.button.tooltip'}}"
+            />
 
-    <a href={{@model.pixJuniorSchoolUrl}} target="_blank" rel="noopener noreferrer">
-      {{t "pages.missions.list.banner.copypaste-container.import-text"}}
-    </a>
-
-    <CopyPasteButton
-      @clipBoardtext={{@model.pixJuniorSchoolUrl}}
-      @successMessage="{{t 'pages.missions.list.banner.copypaste-container.button.success'}}"
-      @defaultMessage="{{t 'pages.missions.list.banner.copypaste-container.button.tooltip'}}"
-    />
-  </div>
-  {{t "pages.missions.list.banner.copypaste-container.hint"}}
+          </div>
+        </li>
+        <li>
+          <div class="mission-list-banner__copypaste-container">
+            <span>{{html-unsafe
+                (t "pages.missions.list.banner.step2.option2" pixJuniorUrl=@model.pixJuniorSchoolUrl)
+              }}</span>
+            <a
+              href={{@model.pixJuniorSchoolUrl}}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="mission-list-banner__copypaste-container__external-link"
+            >
+              <FaIcon @icon="external-link-alt" />
+            </a>
+          </div>
+        </li>
+      </ul>
+    </li>
+    <li>
+      <span>{{html-unsafe (t "pages.missions.list.banner.step3")}}</span>
+    </li>
+  </ul>
 </PixBanner>
 
 <h1 class="mission-list__title page-title">{{t "pages.missions.title"}}</h1>

--- a/orga/tests/acceptance/missions-list_test.js
+++ b/orga/tests/acceptance/missions-list_test.js
@@ -49,9 +49,7 @@ module('Acceptance | Missions List', function (hooks) {
       // then
       assert.dom(screen.getByText('Super Mission')).exists();
       assert.dom(screen.getByText('Super competence')).exists();
-      assert
-        .dom(screen.getByRole('link', { name: t('pages.missions.list.banner.copypaste-container.import-text') }))
-        .hasAttribute('href', 'http://localhost/schools/BLABLA123');
+      assert.dom(screen.getByRole('link', { name: 'junior.pix.fr' })).hasAttribute('href', 'https://junior.pix.fr');
     });
 
     module('display divisions', function () {
@@ -101,7 +99,7 @@ module('Acceptance | Missions List', function (hooks) {
         assert
           .dom(
             screen.getByRole('link', {
-              name: t('pages.missions.list.banner.admin.import-text'),
+              name: t('pages.missions.list.banner.step1.admin.link'),
             }),
           )
           .hasAttribute('href', '/import-participants');

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -874,24 +874,28 @@
       "list": {
         "aria-label": "Mission",
         "banner": {
-          "admin": {
-            "abstract": "To get started, please ",
-            "import-text": "import students",
-            "info": "from Onde (exportable file in the menu Lists & documents > Extractions > School pupils or their supervisor)."
-          },
           "copypaste-container": {
             "abstract": "Start your missions with your students by activating a session with the above button and using this ",
             "button": {
               "success": "copied !",
-              "tooltip": "copy link"
+              "tooltip": "copy code"
+            }
+          },
+          "step1": {
+            "admin": {
+              "head": "Step 1 : <b>Please</b>",
+              "link": "importer the student database",
+              "tail": "<b>from Onde</b> (exportable file in the Lists & documents Extractions > School students or their supervisors menu)."
             },
-            "hint": "Please add it to your favorites",
-            "import-text": "school link"
+            "non-admin": "Step1 : <b>Ask the Pix Orga administrator</b> in your area to import students"
           },
-          "non-admin": {
-            "abstract": "To get started, ask your administrator to import students."
+          "step2": {
+            "title": "Step 2 :",
+            "option1": "Or &nbsp<b>by registering </b>&nbspthe&nbsp'<a href=\"https://junior.pix.fr\">junior.pix.fr</a>'&nbsplink on your workstations and entering your school's code: {code} ",
+            "option2": "Or by accessing&nbsp'<a href=\"{pixJuniorUrl}\" target=_blank >Pix Junior</a>'&nbspdirectly"
           },
-          "welcome": "Hello and welcome to Pix Orga!"
+          "step3": "Step 3 : <b> Activate the Pix Junior session </b> using the button above before your session on the day.",
+          "welcome": "To get started, please follow these steps :"
         },
         "caption": "List of missions",
         "empty-state": "There is not any mission",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -874,24 +874,30 @@
       "list": {
         "aria-label": "Mission",
         "banner": {
-          "admin": {
-            "abstract": "Pour commencer, veuillez ",
-            "import-text": "importer vos élèves",
-            "info": " depuis Onde (fichier exportable dans le menu Listes & documents > Extractions > Élèves de l’école ou leur responsable)."
-          },
           "copypaste-container": {
             "abstract": "Démarrez vos premières missions avec vos élèves en activant la session via le bouton ci-dessus et en utilisant le",
             "button": {
               "success": "copié !",
-              "tooltip": "copier le lien"
+              "tooltip": "copier le code"
+            }
+          },
+          "hint": "N’hésitez pas à le mettre en favori sur vos postes.",
+          "import-text": "lien de l'école",
+          "step1": {
+            "admin": {
+              "head": "Étape 1 : <b>Veuillez</b>",
+              "link": "importer la base élève",
+              "tail": "<b>depuis Onde</b> (fichier exportable dans le menu Listes & documents > Extractions > Élèves de l’école ou leurs responsables)."
             },
-            "hint": "N’hésitez pas à le mettre en favori sur vos postes.",
-            "import-text": "lien de l'école"
+            "non-admin": "Étape 1 : <b>Demandez à l'administrateur</b> Pix Orga de votre espace afin d’importer les élèves."
           },
-          "non-admin": {
-            "abstract": "Pour commencer, demandez à votre administrateur d’importer les élèves."
+          "step2": {
+            "title": "Étape 2 :",
+            "option1": "Soit en&nbsp<b>enregistrant le lien</b>&nbsp'<a href=\"https://junior.pix.fr\">'junior.pix.fr'</a>'&nbspsur vos postes et saisissez le code de votre établissement : {code} ",
+            "option2": "Soit en accédant directement à&nbsp'<a href=\"{pixJuniorUrl}\" target=_blank >Pix Junior</a>'"
           },
-          "welcome": "Bonjour et bienvenue dans Pix Orga !"
+          "step3": "Étape 3 : <b>Activez la session Pix Junior</b> via le bouton ci-dessus avant votre séance le jour J.",
+          "welcome": "Pour commencer, veuillez suivre ces étapes :"
         },
         "caption": "Liste des missions",
         "empty-state": "Il n'y a pas de missions",
@@ -900,7 +906,10 @@
           "name": "Mission",
           "started-by": "Commencé par"
         },
-        "no-division": "Aucune classe"
+        "no-division": "Aucune classe",
+        "non-admin": {
+          "abstract": "Pour commencer, demandez à votre administrateur d’importer les élèves."
+        }
       }
     },
     "organization-learner": {


### PR DESCRIPTION
## :unicorn: Problème
Le wording n'était pas compris.

## :robot: Proposition
Ordonner les indication en étape claire.

## :rainbow: Remarques
Le boutton copy-past se positionne mal sur de petit écrans.

## :100: Pour tester
Lancer orga avec un compte sco-1d.
Vérifier que le wording de la page mission à bien été changé