### PR TITLE
[FEATURE] Ajout de la bannière d'enquête utilisateur (pix-12693)

### DIFF
--- a/orga/app/components/banner/survey.gjs
+++ b/orga/app/components/banner/survey.gjs
@@ -1,0 +1,48 @@
+import PixBanner from '@1024pix/pix-ui/components/pix-banner';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+import ENV from 'pix-orga/config/environment';
+
+export default class SurveyBanner extends Component {
+  @service router;
+  @service currentDomain;
+
+  get shouldDisplayBanner() {
+    const routeNameWhereToDisplayBanner = [
+      'authenticated.campaigns.loading',
+      'authenticated.campaigns.list.my-campaigns',
+      'authenticated.campaigns.list.all-campaigns',
+      'authenticated.campaigns.campaign.loading',
+      'authenticated.campaigns.campaign.activity',
+      'authenticated.campaigns.campaign.assessment-results',
+      'authenticated.campaigns.campaign.profile-results',
+      'authenticated.campaigns.campaign.analysis',
+      'authenticated.campaigns.campaign.settings',
+      'authenticated.campaigns.update',
+      'authenticated.campaigns.participant-assessment.loading',
+      'authenticated.campaigns.participant-assessment.results',
+      'authenticated.campaigns.participant-assessment.analysis',
+      'authenticated.campaigns.participant-profile',
+    ];
+
+    return (
+      ENV.APP.SURVEY_BANNER_ENABLED &&
+      routeNameWhereToDisplayBanner.includes(this.router.currentRouteName) &&
+      this.currentDomain.isFranceDomain
+    );
+  }
+
+  <template>
+    {{#if this.shouldDisplayBanner}}
+      <PixBanner @type="information">
+        {{t
+          "banners.survey.message"
+          documentationLink=ENV.APP.SURVEY_LINK
+          linkClasses="link link--banner link--bold link--underlined"
+          htmlSafe=true
+        }}
+      </PixBanner>
+    {{/if}}
+  </template>
+}

--- a/orga/app/templates/authenticated.hbs
+++ b/orga/app/templates/authenticated.hbs
@@ -9,6 +9,7 @@
     <main class="main-content__body page">
       <Banner::Information />
       <Banner::LanguageAvailability />
+      <Banner::Survey />
       {{outlet}}
     </main>
 

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -94,6 +94,8 @@ module.exports = function (environment) {
       },
       COOKIE_LOCALE_LIFESPAN_IN_SECONDS: 31536000, // 1 year in seconds
       APP_VERSION: process.env.SOURCE_VERSION || 'development',
+      SURVEY_LINK: process.env.SURVEY_LINK || null,
+      SURVEY_BANNER_ENABLED: Boolean(process.env.SURVEY_BANNER_ENABLED) || false,
     },
 
     fontawesome: {
@@ -120,6 +122,8 @@ module.exports = function (environment) {
   if (environment === 'development') {
     ENV.APP.CAMPAIGNS_ROOT_URL = 'http://localhost:4200/campagnes/';
     ENV.APP.CERTIFICATION_BANNER_DISPLAY_DATES = '04 05 06 07';
+    ENV.APP.SURVEY_LINK = 'http://localhost:4200/campagnes/';
+    ENV.APP.SURVEY_BANNER_ENABLED = true;
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;
     // ENV.APP.LOG_TRANSITIONS = true;

--- a/orga/tests/integration/components/banner/survey_test.gjs
+++ b/orga/tests/integration/components/banner/survey_test.gjs
@@ -1,0 +1,145 @@
+import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import Survey from 'pix-orga/components/banner/survey';
+import ENV from 'pix-orga/config/environment';
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Banner::Survey', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('Survey Banner', function () {
+    module('should render the survey', function () {
+      test('when prescriber is on myCampaign page', async function (assert) {
+        // given
+        ENV.APP.SURVEY_BANNER_ENABLED = true;
+        ENV.APP.SURVEY_LINK = 'https://www.google.com';
+
+        class RouterStub extends Service {
+          currentRouteName = 'authenticated.campaigns.list.my-campaigns';
+        }
+        class CurrentDomainServiceStub extends Service {
+          get isFranceDomain() {
+            return true;
+          }
+        }
+
+        this.owner.register('service:router', RouterStub);
+        this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+
+        // when
+        const screen = await render(<template><Survey /></template>);
+
+        const link = screen.getByRole('link', { name: 'Accédez à l’enquête' });
+
+        // then
+        assert.strictEqual(link.href, 'https://www.google.com/');
+      });
+
+      test('when prescriber is on allCampaign page', async function (assert) {
+        // given
+        ENV.APP.SURVEY_BANNER_ENABLED = true;
+        ENV.APP.SURVEY_LINK = 'https://www.google.com';
+
+        class RouterStub extends Service {
+          currentRouteName = 'authenticated.campaigns.list.my-campaigns';
+        }
+
+        class CurrentDomainServiceStub extends Service {
+          get isFranceDomain() {
+            return true;
+          }
+        }
+
+        this.owner.register('service:router', RouterStub);
+        this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+
+        // when
+        const screen = await render(<template><Survey /></template>);
+
+        const link = screen.getByRole('link', { name: 'Accédez à l’enquête' });
+
+        // then
+        assert.strictEqual(link.href, 'https://www.google.com/');
+      });
+    });
+
+    module('should not render the survey', function () {
+      test('when prescriber is not on allCampaign or myCampaign page', async function (assert) {
+        // given
+        ENV.APP.SURVEY_BANNER_ENABLED = true;
+        ENV.APP.SURVEY_LINK = 'https://www.google.com';
+
+        class RouterStub extends Service {
+          currentRouteName = 'authenticated.sco-organization-participants.list';
+        }
+
+        class CurrentDomainServiceStub extends Service {
+          get isFranceDomain() {
+            return false;
+          }
+        }
+
+        this.owner.register('service:router', RouterStub);
+        this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+
+        // when
+        const screen = await render(<template><Survey /></template>);
+
+        // then
+        assert.notOk(screen.queryByRole('link', { name: 'Accédez à l’enquête' }));
+      });
+
+      test('when the environnement variable is not set', async function (assert) {
+        // given
+        ENV.APP.SURVEY_BANNER_ENABLED = false;
+        ENV.APP.SURVEY_LINK = 'https://www.google.com';
+
+        class RouterStub extends Service {
+          currentRouteName = 'authenticated.campaigns.list.my-campaigns';
+        }
+
+        class CurrentDomainServiceStub extends Service {
+          get isFranceDomain() {
+            return false;
+          }
+        }
+
+        this.owner.register('service:router', RouterStub);
+        this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+
+        // when
+        const screen = await render(<template><Survey /></template>);
+
+        // then
+        assert.notOk(screen.queryByRole('link', { name: 'Accédez à l’enquête' }));
+      });
+
+      test('when prescriber in not on fr domain', async function (assert) {
+        // given
+        ENV.APP.SURVEY_BANNER_ENABLED = true;
+        ENV.APP.SURVEY_LINK = 'https://www.google.com';
+
+        class RouterStub extends Service {
+          currentRouteName = 'authenticated.campaigns.list.my-campaigns';
+        }
+
+        class CurrentDomainServiceStub extends Service {
+          get isFranceDomain() {
+            return false;
+          }
+        }
+
+        this.owner.register('service:router', RouterStub);
+        this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+
+        // when
+        const screen = await render(<template><Survey /></template>);
+
+        // then
+        assert.notOk(screen.queryByRole('link', { name: 'Accédez à l’enquête' }));
+      });
+    });
+  });
+});

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -71,6 +71,9 @@
     },
     "over-capacity": {
       "message": "Attention, vous consommez plus de places que votre capacité totale."
+    },
+    "survey": {
+      "message": "Aidez Pix à faire évoluer Pix Orga en répondant à cette courte enquête sur vos usages des campagnes ! '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'Accédez à l’enquête'</a>'"
     }
   },
   "cards": {


### PR DESCRIPTION
## :unicorn: Problème
Nous souhaitons pousser une enquête pour mieux connaitre les usages de nos prescripteurs  (évaluation vs accompagnement, qu'est-ce qui fonctionne pas ... etc.) pour avoir plus de données pour travailler sur la problématique Points forts / points faibles.

Utiliser la [banner alert avec lien externe](https://ui.pix.fr/?path=/story/notification-banner--with-external-link) pour pousser l’enquête sur la page Campagnes de PixOrga, uniquement en .fr

## :robot: Proposition
Wording bandeau : Aidez Pix à faire évoluer Pix Orga en répondant à cette courte enquête sur vos usages des campagnes !
Bouton : Accédez à l’enquête

## :rainbow: Remarques
- Vérifiez que les variables d'env ne sont pas obligatoire pour que ça ne pète pas chez tous les collègues qui n'en on pas

Il nous faut ajouter les variables d'env en RA, integ/recette et prod ⚠️ 
    ENV.APP.SURVEY_LINK
    ENV.APP.SURVEY_BANNER_ENABLED

## :100: Pour tester
- ajouter les var d'env
- se rendre sur orga.fr
- vérifier la présence de la bannière sur les pages mes campagnes et toutes les campagnes
- vérifier son absence sur les autres pages
- tester que le lien amène bien là où vous l'avez définit en var d'env
- Vérifier sur Orga.org que ce ne soit pas présent
